### PR TITLE
Homebrew tap 404 error

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,7 +56,7 @@ changelog:
 brews:
   - repository:
       owner: jonnii
-      name: homebrew-tap
+      name: tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Formula
     homepage: "https://github.com/jonnii/stackit"


### PR DESCRIPTION
Update Homebrew tap repository name to fix 404 error during release creation.

---
<a href="https://cursor.com/background-agent?bcId=bc-00f7031c-110c-4fad-945e-f89cdc713bd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-00f7031c-110c-4fad-945e-f89cdc713bd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

