### PR TITLE
fix(ai): strip markdown code blocks from AI commit messages

### DIFF
--- a/internal/ai/client_cursor_test.go
+++ b/internal/ai/client_cursor_test.go
@@ -109,6 +109,58 @@ func TestBuildCommitMessagePrompt(t *testing.T) {
 	if !strings.Contains(prompt, "Conventional Commits") {
 		t.Error("Prompt should mention Conventional Commits")
 	}
+
+	if !strings.Contains(prompt, "no markdown") {
+		t.Error("Prompt should explicitly request no markdown formatting")
+	}
+}
+
+func TestStripMarkdownCodeBlocks(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no markdown",
+			input:    "feat: add new feature",
+			expected: "feat: add new feature",
+		},
+		{
+			name:     "with code block",
+			input:    "```\nfeat: add new feature\n```",
+			expected: "feat: add new feature",
+		},
+		{
+			name:     "with language in code block",
+			input:    "```text\nfeat: add new feature\n```",
+			expected: "feat: add new feature",
+		},
+		{
+			name:     "with single backticks",
+			input:    "`feat: add new feature`",
+			expected: "feat: add new feature",
+		},
+		{
+			name:     "multiline with code block",
+			input:    "```\nfix: enhance error reporting\nwith detailed output\n```",
+			expected: "fix: enhance error reporting\nwith detailed output",
+		},
+		{
+			name:     "code block with extra whitespace",
+			input:    "```\n  feat: add feature  \n```",
+			expected: "feat: add feature",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := stripMarkdownCodeBlocks(tt.input)
+			if result != tt.expected {
+				t.Errorf("Expected '%s', got '%s'", tt.expected, result)
+			}
+		})
+	}
 }
 
 func TestEnsureConventionalCommitFormat(t *testing.T) {

--- a/internal/utils/branch_name.go
+++ b/internal/utils/branch_name.go
@@ -56,8 +56,24 @@ func GenerateBranchNameFromMessage(message string) string {
 	lines := strings.Split(message, "\n")
 	subject := strings.TrimSpace(lines[0])
 
-	// Remove common prefixes like "feat:", "fix:", etc. if present
-	subject = regexp.MustCompile(`^(feat|fix|chore|docs|style|refactor|perf|test|build|ci):\s*`).ReplaceAllString(subject, "")
+	// Remove common prefixes like "feat:", "fix:", etc. if present (with optional scope)
+	subject = regexp.MustCompile(`^(feat|fix|chore|docs|style|refactor|perf|test|build|ci)(\([^)]+\))?:\s*`).ReplaceAllString(subject, "")
+
+	// Truncate to a reasonable length for branch names (before sanitization)
+	// Aim for ~50 characters to leave room for username/date prefixes
+	maxSubjectLength := 50
+	if len(subject) > maxSubjectLength {
+		// Try to truncate at word boundary
+		truncated := subject[:maxSubjectLength]
+		lastSpace := strings.LastIndex(truncated, " ")
+		if lastSpace > maxSubjectLength/2 {
+			// If we can find a space in the second half, truncate there
+			subject = truncated[:lastSpace]
+		} else {
+			// Otherwise just truncate
+			subject = truncated
+		}
+	}
 
 	// Sanitize and return
 	return SanitizeBranchName(subject)

--- a/internal/utils/branch_name_test.go
+++ b/internal/utils/branch_name_test.go
@@ -224,6 +224,16 @@ func TestGenerateBranchNameFromMessage(t *testing.T) {
 			message:  "feat:add feature",
 			expected: "add-feature",
 		},
+		{
+			name:     "long message gets truncated",
+			message:  "feat: add a very long feature description that should be truncated to fit in branch names",
+			expected: "add-a-very-long-feature-description-that-should",
+		},
+		{
+			name:     "message with scope prefix",
+			message:  "fix(ai): enhance error reporting",
+			expected: "enhance-error-reporting",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
fix(ai): strip markdown code blocks from AI commit messages

fix(ai): enhance cursor-agent error reporting with detailed output


#### PR Dependency Tree


* **PR #66** 👈

This tree was auto-generated by [Stackit](https://github.com/jonnii/stackit)