### PR TITLE
Fix concurrent map panic in CleanBranches by synchronizing go-git operations

### DIFF
--- a/internal/git/absorb.go
+++ b/internal/git/absorb.go
@@ -139,6 +139,10 @@ func GetCommitDiff(commitSHA, parentSHA string) (string, error) {
 		return "", fmt.Errorf("failed to resolve commit: %w", err)
 	}
 
+	// Synchronize go-git operations to prevent concurrent packfile access
+	goGitMu.Lock()
+	defer goGitMu.Unlock()
+
 	c1, err := repo.CommitObject(h1)
 	if err != nil {
 		return "", fmt.Errorf("failed to get parent commit: %w", err)
@@ -168,6 +172,10 @@ func GetParentCommitSHA(commitSHA string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve commit: %w", err)
 	}
+
+	// Synchronize go-git operations to prevent concurrent packfile access
+	goGitMu.Lock()
+	defer goGitMu.Unlock()
 
 	commit, err := repo.CommitObject(hash)
 	if err != nil {
@@ -445,6 +453,10 @@ func GetCommitMessage(commitSHA string) (string, error) {
 		return "", fmt.Errorf("failed to resolve commit: %w", err)
 	}
 
+	// Synchronize go-git operations to prevent concurrent packfile access
+	goGitMu.Lock()
+	defer goGitMu.Unlock()
+
 	commit, err := repo.CommitObject(hash)
 	if err != nil {
 		return "", fmt.Errorf("failed to get commit: %w", err)
@@ -471,6 +483,10 @@ func GetCommitAuthorFromSHA(commitSHA string) (*CommitAuthor, error) {
 		return nil, fmt.Errorf("failed to resolve commit: %w", err)
 	}
 
+	// Synchronize go-git operations to prevent concurrent packfile access
+	goGitMu.Lock()
+	defer goGitMu.Unlock()
+
 	commit, err := repo.CommitObject(hash)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get commit: %w", err)
@@ -493,6 +509,10 @@ func GetCommitDateFromSHA(commitSHA string) (time.Time, error) {
 	if err != nil {
 		return time.Time{}, fmt.Errorf("failed to resolve commit: %w", err)
 	}
+
+	// Synchronize go-git operations to prevent concurrent packfile access
+	goGitMu.Lock()
+	defer goGitMu.Unlock()
 
 	commit, err := repo.CommitObject(hash)
 	if err != nil {

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -10,6 +10,9 @@ import (
 var (
 	defaultRepo   *Repository
 	defaultRepoMu sync.RWMutex
+	// goGitMu synchronizes go-git operations that access packfiles to prevent
+	// "concurrent map iteration and map write" panics
+	goGitMu sync.Mutex
 )
 
 // InitDefaultRepo initializes the default repository from the current directory

--- a/internal/git/commit_info.go
+++ b/internal/git/commit_info.go
@@ -21,6 +21,10 @@ func GetCommitDate(branchName string) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("failed to resolve branch reference: %w", err)
 	}
 
+	// Synchronize go-git operations to prevent concurrent packfile access
+	goGitMu.Lock()
+	defer goGitMu.Unlock()
+
 	commit, err := repo.CommitObject(hash)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("failed to get commit: %w", err)
@@ -83,6 +87,10 @@ func GetRemoteRevision(branchName string) (string, error) {
 // iterateCommits iterates commits from head to base (exclusive of base)
 // Returns commits in order from head to base (newest first)
 func iterateCommits(repo *Repository, headHash, baseHash plumbing.Hash) ([]*object.Commit, error) {
+	// Synchronize go-git operations to prevent concurrent packfile access
+	goGitMu.Lock()
+	defer goGitMu.Unlock()
+
 	var commits []*object.Commit
 	visited := make(map[plumbing.Hash]bool)
 

--- a/internal/git/commit_range.go
+++ b/internal/git/commit_range.go
@@ -83,6 +83,10 @@ func GetCommitSHA(branchName string, offset int) (string, error) {
 		return "", fmt.Errorf("failed to get branch reference: %w", err)
 	}
 
+	// Synchronize go-git operations to prevent concurrent packfile access
+	goGitMu.Lock()
+	defer goGitMu.Unlock()
+
 	commit, err := repo.CommitObject(branchRef.Hash())
 	if err != nil {
 		return "", fmt.Errorf("failed to get commit: %w", err)

--- a/internal/git/merge_base.go
+++ b/internal/git/merge_base.go
@@ -26,6 +26,10 @@ func GetMergeBaseByRef(ref1Name, ref2Name string) (string, error) {
 		return "", fmt.Errorf("failed to resolve ref2: %w", err)
 	}
 
+	// Synchronize go-git operations to prevent concurrent packfile access
+	goGitMu.Lock()
+	defer goGitMu.Unlock()
+
 	commit1, err := repo.CommitObject(hash1)
 	if err != nil {
 		return "", fmt.Errorf("failed to get commit1: %w", err)
@@ -70,6 +74,10 @@ func IsAncestor(ancestor, descendant string) (bool, error) {
 	if ancestorHash == descendantHash {
 		return true, nil
 	}
+
+	// Synchronize go-git operations to prevent concurrent packfile access
+	goGitMu.Lock()
+	defer goGitMu.Unlock()
 
 	// Get commit objects
 	ancestorCommit, err := repo.CommitObject(ancestorHash)


### PR DESCRIPTION



#### PR Dependency Tree


* **PR #167**
  * **PR #166**
    * **PR #169**
      * **PR #168**
        * **PR #171** 👈
          * **PR #172**
            * **PR #173**

This tree was auto-generated by [Stackit](https://github.com/jonnii/stackit)

---

## Stack Consolidation

This PR was part of a stack that was consolidated into a single merge.

Consolidated on 2025-12-24 as part of stack merge strategy.

The stack has been merged atomically to ensure consistency.