### PR TITLE
[remotemeta] feat: enhance remote metadata cleanup and orphaned handling

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/git"
 	"stackit.dev/stackit/internal/runtime"
 	"stackit.dev/stackit/internal/tui"
 	"stackit.dev/stackit/internal/tui/style"
@@ -165,6 +166,11 @@ func greedilyDeleteUnblockedBranches(ctx context.Context, branchesToDelete map[s
 			if err := eng.DeleteBranch(ctx, branch); err != nil {
 				splog.Debug("Failed to delete %s: %v", branchName, err)
 				continue
+			}
+
+			// Delete remote metadata ref (best effort, don't fail if it doesn't exist)
+			if err := git.DeleteRemoteMetadataRef(branchName); err != nil {
+				splog.Debug("Failed to delete remote metadata for %s: %v", branchName, err)
 			}
 
 			splog.Info("Deleted branch %s", style.ColorBranchName(branchName, false))

--- a/internal/actions/sync/metadata_sync.go
+++ b/internal/actions/sync/metadata_sync.go
@@ -35,6 +35,11 @@ func syncRemoteMetadata(ctx *runtime.Context, opts *Options) error {
 		return nil
 	}
 
+	// Handle orphaned local metadata (dual-checkout scenario)
+	if err := handleOrphanedMetadata(ctx, opts); err != nil {
+		return err
+	}
+
 	// Compute diffs
 	diffs, err := eng.ComputeAllMetadataDiffs()
 	if err != nil {
@@ -55,6 +60,88 @@ func syncRemoteMetadata(ctx *runtime.Context, opts *Options) error {
 	for _, diff := range diffs {
 		if err := promptAndResolveConflict(ctx, diff); err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+// handleOrphanedMetadata handles branches where remote metadata was deleted but local exists
+func handleOrphanedMetadata(ctx *runtime.Context, opts *Options) error {
+	eng := ctx.Engine
+	splog := ctx.Splog
+
+	orphaned, err := eng.FindOrphanedLocalMetadata()
+	if err != nil {
+		splog.Debug("Failed to find orphaned metadata: %v", err)
+		return nil
+	}
+
+	if len(orphaned) == 0 {
+		return nil
+	}
+
+	// Handle --dry-run flag
+	if opts.DryRun {
+		splog.Info("\n=== Orphaned metadata (dry run) ===")
+		for _, info := range orphaned {
+			if info.HasLocalChanges {
+				splog.Info("  %s: has local changes, would prompt", style.ColorBranchName(info.BranchName, false))
+			} else {
+				splog.Info("  %s: no local changes, would delete sync state", style.ColorBranchName(info.BranchName, false))
+			}
+		}
+		return nil
+	}
+
+	for _, info := range orphaned {
+		if info.Action == engine.OrphanedActionDelete {
+			// No local changes - silently remove sync state
+			if err := eng.DeleteLocalMetadataHash(info.BranchName); err != nil {
+				splog.Debug("Failed to delete metadata hash for %s: %v", info.BranchName, err)
+			}
+		} else {
+			// Has local changes - prompt user
+			if err := promptOrphanedMetadata(ctx, info); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// promptOrphanedMetadata prompts the user about orphaned metadata with local changes
+func promptOrphanedMetadata(ctx *runtime.Context, info engine.OrphanedMetadataInfo) error {
+	eng := ctx.Engine
+	splog := ctx.Splog
+
+	splog.Info("\nRemote metadata for '%s' was deleted, but you have local changes:",
+		style.ColorBranchName(info.BranchName, false))
+	splog.Info("  locked: %v", info.LocalMeta.Locked)
+	if info.LocalMeta.Scope != nil {
+		splog.Info("  scope: %s", *info.LocalMeta.Scope)
+	}
+
+	accept, err := promptYesNo("Push your local metadata to remote?")
+	if err != nil {
+		return err
+	}
+
+	if accept {
+		// Push local metadata to remote
+		if err := eng.SetLastModifiedBy(info.BranchName); err != nil {
+			splog.Debug("Failed to set last modified by: %v", err)
+		}
+		if err := git.PushMetadataRefs([]string{info.BranchName}); err != nil {
+			splog.Debug("Failed to push metadata: %v", err)
+		} else {
+			splog.Info("Pushed metadata for %s", style.ColorBranchName(info.BranchName, false))
+		}
+	} else {
+		// Accept deletion - remove sync state
+		if err := eng.DeleteLocalMetadataHash(info.BranchName); err != nil {
+			splog.Debug("Failed to delete metadata hash: %v", err)
 		}
 	}
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -66,6 +66,8 @@ type RemoteMetadataManager interface {
 	AcceptRemoteMetadata(branch string) error
 	RejectRemoteMetadata(branch string)
 	HasLocalModifications(branch string) bool
+	FindOrphanedLocalMetadata() ([]OrphanedMetadataInfo, error)
+	DeleteLocalMetadataHash(branchName string) error
 }
 
 // ApplySplitOptions contains options for applying a split

--- a/internal/engine/engine_persistence.go
+++ b/internal/engine/engine_persistence.go
@@ -75,7 +75,9 @@ func (e *engineImpl) DeleteMetadataRef(branch Branch) error {
 	return e.git.DeleteRef(refName)
 }
 
-// RenameMetadataRef renames a metadata ref from one branch name to another
+// RenameMetadataRef copies metadata from old branch name to new branch name.
+// The old metadata ref is kept for potential cleanup by garbage collection
+// or for collaborative scenarios where others still reference the old name.
 func (e *engineImpl) RenameMetadataRef(oldBranch, newBranch Branch) error {
 	oldRefName := fmt.Sprintf("%s%s", MetadataRefPrefix, oldBranch.GetName())
 	newRefName := fmt.Sprintf("%s%s", MetadataRefPrefix, newBranch.GetName())
@@ -85,13 +87,14 @@ func (e *engineImpl) RenameMetadataRef(oldBranch, newBranch Branch) error {
 		return nil //nolint:nilerr // Nothing to rename
 	}
 
+	// Copy metadata to new ref (keep old ref for cleanup later)
 	if err := e.git.UpdateRef(newRefName, sha); err != nil {
 		return fmt.Errorf("failed to create new metadata ref: %w", err)
 	}
 
-	if err := e.git.DeleteRef(oldRefName); err != nil {
-		return fmt.Errorf("failed to delete old metadata ref: %w", err)
-	}
+	// Note: We intentionally keep the old ref around for collaborative scenarios.
+	// The old metadata will be cleaned up during garbage collection or when
+	// the orphaned metadata detection runs during sync.
 
 	return nil
 }

--- a/internal/engine/remote_sync.go
+++ b/internal/engine/remote_sync.go
@@ -263,3 +263,89 @@ type FieldDiff struct {
 	LocalValue  interface{}
 	RemoteValue interface{}
 }
+
+// OrphanedMetadataAction represents the action to take for orphaned metadata
+type OrphanedMetadataAction string
+
+const (
+	// OrphanedActionDelete indicates the local metadata should be deleted
+	OrphanedActionDelete OrphanedMetadataAction = "delete"
+	// OrphanedActionPrompt indicates the user should be prompted
+	OrphanedActionPrompt OrphanedMetadataAction = "prompt"
+)
+
+// OrphanedMetadataInfo contains information about orphaned local metadata
+type OrphanedMetadataInfo struct {
+	BranchName      string
+	Action          OrphanedMetadataAction
+	HasLocalChanges bool
+	LocalMeta       *Meta
+}
+
+// FindOrphanedLocalMetadata identifies branches that have local metadata but no remote metadata
+// This handles the "dual-checkout scenario" where someone else deleted the branch/metadata
+func (e *engineImpl) FindOrphanedLocalMetadata() ([]OrphanedMetadataInfo, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	// List all local metadata refs
+	localRefs, err := e.git.ListRefs("refs/stackit/metadata/")
+	if err != nil {
+		return nil, err
+	}
+
+	orphaned := make([]OrphanedMetadataInfo, 0, len(localRefs))
+
+	for refName := range localRefs {
+		branchName := refName[len("refs/stackit/metadata/"):]
+
+		// Skip if remote metadata exists for this branch
+		if _, hasRemote := e.remoteMetaCache[branchName]; hasRemote {
+			continue
+		}
+
+		// Check if this branch was previously synced (has LocalOnlyHash)
+		local, err := e.readMetadataRef(branchName)
+		if err != nil {
+			continue
+		}
+
+		// If LocalOnlyHash is nil, this branch was never synced from remote
+		// so it's not orphaned - it's just a local-only branch
+		if local.LocalOnlyHash == nil {
+			continue
+		}
+
+		// This is orphaned metadata - remote was deleted but local still exists
+		hasLocalChanges := e.computeMetadataHash(local) != *local.LocalOnlyHash
+
+		action := OrphanedActionDelete
+		if hasLocalChanges {
+			action = OrphanedActionPrompt
+		}
+
+		orphaned = append(orphaned, OrphanedMetadataInfo{
+			BranchName:      branchName,
+			Action:          action,
+			HasLocalChanges: hasLocalChanges,
+			LocalMeta:       local,
+		})
+	}
+
+	return orphaned, nil
+}
+
+// DeleteLocalMetadataHash removes the LocalOnlyHash from a branch's metadata
+// This effectively "un-syncs" the branch so it won't be considered orphaned
+func (e *engineImpl) DeleteLocalMetadataHash(branchName string) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	local, err := e.readMetadataRef(branchName)
+	if err != nil {
+		return err
+	}
+
+	local.LocalOnlyHash = nil
+	return e.writeMetadataRef(branchName, local)
+}


### PR DESCRIPTION



#### PR Dependency Tree

**Scope**: remotemeta


* **PR #225**
  * **PR #226**
    * **PR #227** 👈
      * **PR #228**
        * **PR #229**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)

---

## Stack Consolidation

This PR was part of a stack that was consolidated into a single merge.

Consolidated on 2025-12-30 as part of stack merge strategy.

The stack has been merged atomically to ensure consistency.