### PR TITLE
bug: allow cleaning locked branches

### DIFF
--- a/internal/actions/clean_branches_test.go
+++ b/internal/actions/clean_branches_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"stackit.dev/stackit/internal/actions"
+	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/testhelpers"
 	"stackit.dev/stackit/testhelpers/scenario"
 )
@@ -102,5 +103,40 @@ func TestCleanBranches(t *testing.T) {
 		// Branch should still exist
 		require.True(t, s.Engine.GetBranch("branch1").IsTracked())
 		require.Empty(t, result.BranchesWithNewParents)
+	})
+
+	t.Run("deletes locked branch when merged", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"branch1": "main",
+			})
+
+		// Merge branch1 into main
+		s.Checkout("main").
+			RunGit("merge", "branch1")
+
+		// Rebuild to see changes
+		err := s.Engine.Rebuild("main")
+		require.NoError(t, err)
+
+		// Lock the branch (simulating consolidation)
+		branch := s.Engine.GetBranch("branch1")
+		_, err = s.Engine.SetLocked([]engine.Branch{branch}, engine.LockReasonConsolidating)
+		require.NoError(t, err)
+		require.True(t, branch.IsLocked(), "branch should be locked")
+
+		// Mark branch1 as merged via PR info
+		prInfo := testhelpers.NewTestPrInfoMerged(1, "main")
+		err = s.Engine.UpsertPrInfo(branch, prInfo)
+		require.NoError(t, err)
+
+		// Clean should delete the locked branch
+		_, err = actions.CleanBranches(s.Context, actions.CleanBranchesOptions{
+			Force: true,
+		})
+		require.NoError(t, err)
+
+		// branch1 should be deleted despite being locked
+		require.False(t, s.Engine.GetBranch("branch1").IsTracked())
 	})
 }

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -140,10 +140,6 @@ func (e *engineImpl) DeleteBranch(ctx context.Context, branch Branch) error {
 		return fmt.Errorf("cannot delete trunk branch")
 	}
 
-	if e.IsLocked(branch) {
-		return fmt.Errorf("cannot delete locked branch %s", branchName)
-	}
-
 	e.mu.Lock()
 	defer e.mu.Unlock()
 


### PR DESCRIPTION



<!-- STACKIT-SECTION-START -->
#### Stack

> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.


* **PR #259**
  * **PR #260**
    * **PR #261** 👈

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->