### PR TITLE
[cleanup-performance] feat(git): add batch remote metadata deletion

### DIFF
--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -545,6 +545,10 @@ func (d *demoGitRunner) DeleteRemoteMetadataRef(_ string) error {
 	return nil
 }
 
+func (d *demoGitRunner) BatchDeleteRemoteMetadataRefs(_ []string) error {
+	return nil
+}
+
 func (d *demoGitRunner) TestRemoteRefCompatibility() error {
 	return nil
 }

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -37,6 +37,7 @@ type RemoteOperations interface {
 	PushMetadataRefs(branches []string) error
 	FetchMetadataRefs() error
 	DeleteRemoteMetadataRef(branch string) error
+	BatchDeleteRemoteMetadataRefs(branches []string) error
 	TestRemoteRefCompatibility() error
 }
 

--- a/internal/git/remote_metadata_test.go
+++ b/internal/git/remote_metadata_test.go
@@ -1,0 +1,92 @@
+package git_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"stackit.dev/stackit/internal/git"
+	"stackit.dev/stackit/testhelpers"
+)
+
+func TestBatchDeleteRemoteMetadataRefs(t *testing.T) {
+	t.Run("deletes multiple remote metadata refs", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, func(s *testhelpers.Scene) error {
+			return s.Repo.CreateChangeAndCommit("initial", "init")
+		})
+
+		// Create a bare remote
+		_, err := scene.Repo.CreateBareRemote("origin")
+		require.NoError(t, err)
+
+		// Create some metadata refs and push them
+		branches := []string{"branch1", "branch2", "branch3"}
+		runner := git.NewRunnerWithPath(scene.Dir)
+		for _, b := range branches {
+			refName := fmt.Sprintf("refs/stackit/metadata/%s", b)
+			// Create a blob for the ref
+			sha, err := runner.CreateBlob(fmt.Sprintf(`{"branch":"%s"}`, b))
+			require.NoError(t, err)
+
+			err = scene.Repo.RunGitCommand("update-ref", refName, sha)
+			require.NoError(t, err)
+
+			err = scene.Repo.RunGitCommand("push", "origin", refName)
+			require.NoError(t, err)
+		}
+
+		// Verify refs exist on remote
+		for _, b := range branches {
+			_, err := scene.Repo.RunGitCommandAndGetOutput("ls-remote", "origin", fmt.Sprintf("refs/stackit/metadata/%s", b))
+			require.NoError(t, err)
+		}
+
+		// Delete multiple refs
+		err = runner.BatchDeleteRemoteMetadataRefs(branches[0:2]) // branch1, branch2
+		require.NoError(t, err)
+
+		// Verify branch1 and branch2 are gone from remote, but branch3 remains
+		out1, _ := scene.Repo.RunGitCommandAndGetOutput("ls-remote", "origin", "refs/stackit/metadata/branch1")
+		require.Empty(t, out1)
+
+		out2, _ := scene.Repo.RunGitCommandAndGetOutput("ls-remote", "origin", "refs/stackit/metadata/branch2")
+		require.Empty(t, out2)
+
+		out3, err := scene.Repo.RunGitCommandAndGetOutput("ls-remote", "origin", "refs/stackit/metadata/branch3")
+		require.NoError(t, err)
+		require.NotEmpty(t, out3)
+	})
+
+	t.Run("handles single ref deletion", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, func(s *testhelpers.Scene) error {
+			return s.Repo.CreateChangeAndCommit("initial", "init")
+		})
+
+		_, err := scene.Repo.CreateBareRemote("origin")
+		require.NoError(t, err)
+
+		refName := "refs/stackit/metadata/branch1"
+		runner := git.NewRunnerWithPath(scene.Dir)
+		sha, err := runner.CreateBlob(`{"branch":"branch1"}`)
+		require.NoError(t, err)
+
+		err = scene.Repo.RunGitCommand("update-ref", refName, sha)
+		require.NoError(t, err)
+
+		err = scene.Repo.RunGitCommand("push", "origin", refName)
+		require.NoError(t, err)
+
+		err = runner.BatchDeleteRemoteMetadataRefs([]string{"branch1"})
+		require.NoError(t, err)
+
+		out, _ := scene.Repo.RunGitCommandAndGetOutput("ls-remote", "origin", refName)
+		require.Empty(t, out)
+	})
+
+	t.Run("handles empty slice gracefully", func(t *testing.T) {
+		runner := git.NewRunner()
+		err := runner.BatchDeleteRemoteMetadataRefs([]string{})
+		require.NoError(t, err)
+	})
+}

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -1371,6 +1371,19 @@ func (r *runner) DeleteRemoteMetadataRef(branch string) error {
 	return err
 }
 
+func (r *runner) BatchDeleteRemoteMetadataRefs(branches []string) error {
+	if len(branches) == 0 {
+		return nil
+	}
+	// git push origin --delete refs/stackit/metadata/branch1 refs/stackit/metadata/branch2 ...
+	args := []string{"push", "origin", "--delete"}
+	for _, branch := range branches {
+		args = append(args, fmt.Sprintf("refs/stackit/metadata/%s", branch))
+	}
+	_, err := r.runGitCommandInternal(args...)
+	return err
+}
+
 func (r *runner) TestRemoteRefCompatibility() error {
 	testRef := "refs/stackit/metadata/stackit-compat-test"
 	testContent := fmt.Sprintf(`{"test":true,"timestamp":%d}`, time.Now().Unix())


### PR DESCRIPTION



<!-- STACKIT-SECTION-START -->
#### Stack

**Scope**: cleanup-performance

> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.


* **PR #263** 👈
  * **PR #264**
    * **PR #265**
      * **PR #267**
        * **PR #268**
          * **PR #269**
            * **PR #270**
              * **PR #271**
                * **PR #282**
                  * **PR #283**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->