### PR TITLE
[cleanup-performance] perf(actions): batch remote metadata deletions in CleanBranches

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -187,12 +187,11 @@ func greedilyDeleteUnblockedBranches(ctx context.Context, branchesToDelete map[s
 		}
 
 		// Post-deletion updates
-		for _, branchName := range batchNames {
-			// Delete remote metadata ref (best effort, individual for now - Phase 4 will batch this)
-			if err := eng.Git().DeleteRemoteMetadataRef(branchName); err != nil {
-				splog.Debug("Failed to delete remote metadata for %s: %v", branchName, err)
-			}
+		if err := eng.Git().BatchDeleteRemoteMetadataRefs(batchNames); err != nil {
+			splog.Debug("Failed to batch delete remote metadata: %v", err)
+		}
 
+		for _, branchName := range batchNames {
 			splog.Info("Deleted branch %s", style.ColorBranchName(branchName, false))
 
 			// Remove from deletion map


### PR DESCRIPTION



<!-- STACKIT-SECTION-START -->
#### Stack

**Scope**: cleanup-performance


* **PR #263**
  * **PR #264**
    * **PR #265**
      * **PR #266** 👈
        * **PR #267**
          * **PR #268**
            * **PR #269**
              * **PR #272**
              * **PR #270**
                * **PR #271**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->