### PR TITLE
[cleanup-performance] perf(actions): pre-fetch metadata and revisions in CleanBranches

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -40,16 +40,30 @@ func CleanBranches(ctx *app.Context, opts CleanBranchesOptions) (*CleanBranchesR
 
 	// Filter out trunk branches before processing
 	branchesToProcessPool := []engine.Branch{}
+	branchNames := []string{}
+	allRevisionsToFetch := []string{eng.Trunk().GetName()}
 	for _, branch := range allTrackedBranches {
+		name := branch.GetName()
+		allRevisionsToFetch = append(allRevisionsToFetch, name)
 		if !branch.IsTrunk() {
 			branchesToProcessPool = append(branchesToProcessPool, branch)
+			branchNames = append(branchNames, name)
+
+			parent := branch.GetParent()
+			if parent != nil {
+				allRevisionsToFetch = append(allRevisionsToFetch, parent.GetName())
+			}
 		}
 	}
+
+	// Pre-fetch metadata and revisions in batch to avoid O(N) git calls in worker pool
+	metadataMap, _ := eng.Git().BatchReadMetadata(branchNames)
+	revisionsMap, _ := eng.Git().BatchGetRevisions(allRevisionsToFetch)
 
 	if len(branchesToProcessPool) > 0 {
 		utils.Run(branchesToProcessPool, func(branch engine.Branch) {
 			name := branch.GetName()
-			shouldDelete, reason := ShouldDeleteBranch(c, name, eng, opts.Force)
+			shouldDelete, reason := ShouldDeleteBranchCached(c, name, eng, opts.Force, metadataMap[name], revisionsMap)
 			mu.Lock()
 			deleteStatuses[name] = deleteStatus{shouldDelete: shouldDelete, reason: reason}
 			mu.Unlock()

--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -21,6 +21,7 @@ import (
 	"stackit.dev/stackit/internal/app"
 	"stackit.dev/stackit/internal/config"
 	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/git"
 	"stackit.dev/stackit/internal/tui/style"
 )
 
@@ -212,6 +213,76 @@ func ShouldDeleteBranch(ctx context.Context, branchName string, eng engine.Engin
 	}
 
 	// Interactive prompting not yet implemented
+	return false, ""
+}
+
+// ShouldDeleteBranchCached checks if a branch should be deleted using pre-fetched metadata and revisions
+func ShouldDeleteBranchCached(ctx context.Context, branchName string, eng engine.Engine, force bool, meta *git.Meta, revisions map[string]string) (bool, string) {
+	// 1. Check PR info from cached metadata
+	if meta != nil && meta.PrInfo != nil {
+		const (
+			prStateClosed = "CLOSED"
+			prStateMerged = "MERGED"
+		)
+		if meta.PrInfo.State != nil {
+			if *meta.PrInfo.State == prStateClosed {
+				return true, fmt.Sprintf("%s is closed on GitHub", branchName)
+			}
+			if *meta.PrInfo.State == prStateMerged {
+				base := ""
+				if meta.PrInfo.Base != nil {
+					base = *meta.PrInfo.Base
+				}
+				if base == "" {
+					base = eng.Trunk().GetName()
+				}
+				return true, fmt.Sprintf("%s is merged into %s", branchName, base)
+			}
+		}
+	}
+
+	// 2. Check if merged into trunk
+	trunkName := eng.Trunk().GetName()
+	merged, err := eng.Git().IsMerged(ctx, branchName, trunkName)
+	if err == nil && merged {
+		return true, fmt.Sprintf("%s is merged into %s", branchName, trunkName)
+	}
+
+	// 3. Check if empty
+	// Need parent revision
+	var parentRev string
+	branch := eng.GetBranch(branchName)
+	parent := branch.GetParent()
+	parentName := trunkName
+	if parent != nil {
+		parentName = parent.GetName()
+	}
+
+	// Use cached revisions to avoid eng.git.GetRevision calls
+	if rev, ok := revisions[parentName]; ok {
+		parentRev = rev
+	} else {
+		// Fallback
+		rev, err := eng.Git().GetRevision(parentName)
+		if err == nil {
+			parentRev = rev
+		}
+	}
+
+	if parentRev != "" {
+		empty, err := eng.Git().IsDiffEmpty(ctx, branchName, parentRev)
+		if err == nil && empty {
+			// Only delete empty branches if they have a PR
+			if meta != nil && meta.PrInfo != nil && meta.PrInfo.Number != nil && *meta.PrInfo.Number != 0 {
+				return true, fmt.Sprintf("%s is empty", branchName)
+			}
+		}
+	}
+
+	if force {
+		return false, ""
+	}
+
 	return false, ""
 }
 


### PR DESCRIPTION



<!-- STACKIT-SECTION-START -->
#### Stack

**Scope**: cleanup-performance

> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.


* **PR #263**
  * **PR #264**
    * **PR #265**
      * **PR #267** 👈
        * **PR #268**
          * **PR #269**
            * **PR #270**
              * **PR #271**
                * **PR #282**
                  * **PR #283**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->