### PR TITLE
fix: ensure terminal is always restored from raw mode

### DIFF
--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -38,7 +38,11 @@ type Restacker interface {
 // conflict: true if this is a conflict
 // lockReason: why the branch is locked (empty if not locked)
 // frozen: true if the branch is frozen
-type RestackProgressCallback func(branchName string, result engine.RestackResult, newRev string, conflict bool, lockReason engine.LockReason, frozen bool)
+// isCurrent: true if this is the current branch
+// reparented: true if the branch was reparented
+// oldParent: the old parent name if reparented
+// newParent: the new parent name if reparented
+type RestackProgressCallback func(branchName string, result engine.RestackResult, newRev string, conflict bool, lockReason engine.LockReason, frozen bool, isCurrent bool, reparented bool, oldParent, newParent string)
 
 // RestackBranches restacks a list of branches using the engine's batch restack method
 func RestackBranches(ctx *app.Context, branches []engine.Branch) error {
@@ -50,9 +54,15 @@ func RestackBranchesWithHandler(ctx *app.Context, branches []engine.Branch, call
 	batchResult, err := ctx.Engine.RestackBranches(ctx.Context, branches)
 	if err != nil {
 		if batchResult.ConflictBranch != "" {
+			currentBranch := ctx.Engine.CurrentBranch()
+			currentBranchName := ""
+			if currentBranch != nil {
+				currentBranchName = currentBranch.GetName()
+			}
+
 			// Report the conflict via callback if provided
 			if callback != nil {
-				callback(batchResult.ConflictBranch, engine.RestackConflict, "", true, engine.LockReasonNone, false)
+				callback(batchResult.ConflictBranch, engine.RestackConflict, "", true, engine.LockReasonNone, false, batchResult.ConflictBranch == currentBranchName, false, "", "")
 			}
 
 			continuation := &config.ContinuationState{
@@ -74,9 +84,15 @@ func RestackBranchesWithHandler(ctx *app.Context, branches []engine.Branch, call
 
 	// Handle conflicts even when no error was returned
 	if batchResult.ConflictBranch != "" {
+		currentBranch := ctx.Engine.CurrentBranch()
+		currentBranchName := ""
+		if currentBranch != nil {
+			currentBranchName = currentBranch.GetName()
+		}
+
 		// Report the conflict via callback if provided
 		if callback != nil {
-			callback(batchResult.ConflictBranch, engine.RestackConflict, "", true, engine.LockReasonNone, false)
+			callback(batchResult.ConflictBranch, engine.RestackConflict, "", true, engine.LockReasonNone, false, batchResult.ConflictBranch == currentBranchName, false, "", "")
 		}
 
 		continuation := &config.ContinuationState{
@@ -123,7 +139,7 @@ func RestackBranchesWithHandler(ctx *app.Context, branches []engine.Branch, call
 
 		// Report via callback if provided
 		if callback != nil {
-			callback(branchName, result.Result, newRev, false, result.LockReason, result.Frozen)
+			callback(branchName, result.Result, newRev, false, result.LockReason, result.Frozen, branchName == currentBranchName, result.Reparented, result.OldParent, result.NewParent)
 			continue // Skip splog output when using callback handler
 		}
 

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -88,7 +88,7 @@ func (h *GetNullHandler) Complete(_ GetSummary) {}
 func (h *GetNullHandler) OnRestackStart(_ int) {}
 
 // OnRestackBranch implements RestackHandler.
-func (h *GetNullHandler) OnRestackBranch(_ string, _ handlers.RestackResult, _ string, _ *int, _ engine.LockReason, _ bool) {
+func (h *GetNullHandler) OnRestackBranch(_ string, _ handlers.RestackResult, _ string, _ *int, _ engine.LockReason, _ bool, _ bool, _ string, _ bool, _, _ string) {
 }
 
 // OnRestackComplete implements RestackHandler.
@@ -359,19 +359,29 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 			// Use RestackHandler for consistent output
 			handler.OnRestackStart(len(sorted))
 
-			if err := RestackBranchesWithHandler(ctx, sorted, func(branchName string, result engine.RestackResult, newRev string, _ bool, lockReason engine.LockReason, frozen bool) {
+			if err := RestackBranchesWithHandler(ctx, sorted, func(branchName string, result engine.RestackResult, newRev string, _ bool, lockReason engine.LockReason, frozen bool, isCurrent bool, reparented bool, oldParent, newParent string) {
 				prNumber := getPRNumber(eng, branchName)
+
+				parentName := ""
+				br := eng.GetBranch(branchName)
+				if br.GetName() != "" {
+					if p := br.GetParent(); p != nil {
+						parentName = p.GetName()
+					} else {
+						parentName = eng.Trunk().GetName()
+					}
+				}
 
 				switch result {
 				case engine.RestackDone:
 					restacked++
-					handler.OnRestackBranch(branchName, handlers.RestackDone, newRev, prNumber, lockReason, frozen)
+					handler.OnRestackBranch(branchName, handlers.RestackDone, newRev, prNumber, lockReason, frozen, isCurrent, parentName, reparented, oldParent, newParent)
 				case engine.RestackUnneeded:
-					handler.OnRestackBranch(branchName, handlers.RestackUnneeded, "", prNumber, lockReason, frozen)
+					handler.OnRestackBranch(branchName, handlers.RestackUnneeded, "", prNumber, lockReason, frozen, isCurrent, parentName, reparented, oldParent, newParent)
 				case engine.RestackConflict:
 					skipped++
 					conflicts = append(conflicts, branchName)
-					handler.OnRestackBranch(branchName, handlers.RestackConflict, "", prNumber, lockReason, frozen)
+					handler.OnRestackBranch(branchName, handlers.RestackConflict, "", prNumber, lockReason, frozen, isCurrent, parentName, reparented, oldParent, newParent)
 				}
 			}); err != nil {
 				handler.OnRestackComplete(restacked, skipped, conflicts)

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -1,8 +1,11 @@
 package actions
 
 import (
+	"fmt"
+
 	"stackit.dev/stackit/internal/app"
 	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/handlers"
 )
 
 // RestackOptions contains options for the restack command
@@ -12,7 +15,7 @@ type RestackOptions struct {
 }
 
 // RestackAction performs the restack operation
-func RestackAction(ctx *app.Context, opts RestackOptions) error {
+func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.RestackHandler) error {
 	eng := ctx.Engine
 	splog := ctx.Splog
 
@@ -34,6 +37,60 @@ func RestackAction(ctx *app.Context, opts RestackOptions) error {
 		splog.Debug("Failed to take snapshot: %v", err)
 	}
 
-	// Call RestackBranches (from common.go)
-	return RestackBranches(ctx, branches)
+	// If no handler provided, use NullRestackHandler (silent)
+	if handler == nil {
+		handler = &handlers.NullRestackHandler{}
+	}
+
+	// For standalone restack, we need to sort branches topologically for correct restack order
+	sortedBranches := eng.SortBranchesTopologically(branches)
+
+	// Use RestackHandler for consistent output
+	handler.OnRestackStart(len(sortedBranches))
+
+	var restacked, skipped int
+	var conflicts []string
+
+	if err := RestackBranchesWithHandler(ctx, sortedBranches, func(branchName string, result engine.RestackResult, newRev string, _ bool, lockReason engine.LockReason, frozen bool, isCurrent bool, reparented bool, oldParent, newParent string) {
+		res := handlers.RestackDone
+		switch result {
+		case engine.RestackDone:
+			restacked++
+			res = handlers.RestackDone
+		case engine.RestackUnneeded:
+			res = handlers.RestackUnneeded
+		case engine.RestackConflict:
+			skipped++
+			conflicts = append(conflicts, branchName)
+			res = handlers.RestackConflict
+		}
+
+		// Determine parent name for consistent output
+		parentName := ""
+		br := eng.GetBranch(branchName)
+		if br.GetName() != "" {
+			if p := br.GetParent(); p != nil {
+				parentName = p.GetName()
+			} else {
+				parentName = eng.Trunk().GetName()
+			}
+		}
+
+		// PR number is not always available without extra fetching, but we can try
+		var prNumber *int
+		if br.GetName() != "" {
+			if pr, err := eng.GetPrInfo(br); err == nil && pr != nil {
+				num := pr.Number()
+				prNumber = num
+			}
+		}
+
+		handler.OnRestackBranch(branchName, res, newRev, prNumber, lockReason, frozen, isCurrent, parentName, reparented, oldParent, newParent)
+	}); err != nil {
+		handler.OnRestackComplete(restacked, skipped, conflicts)
+		return fmt.Errorf("restack failed: %w", err)
+	}
+
+	handler.OnRestackComplete(restacked, skipped, conflicts)
+	return nil
 }

--- a/internal/actions/sync/restack.go
+++ b/internal/actions/sync/restack.go
@@ -50,8 +50,18 @@ func restackBranches(ctx *app.Context, branchesToRestack []string, handler Handl
 
 	// Restack branches with handler for progress
 	if len(sortedBranches) > 0 {
-		if err := actions.RestackBranchesWithHandler(ctx, sortedBranches, func(branchName string, result engine.RestackResult, newRev string, _ bool, lockReason engine.LockReason, frozen bool) {
+		if err := actions.RestackBranchesWithHandler(ctx, sortedBranches, func(branchName string, result engine.RestackResult, newRev string, _ bool, lockReason engine.LockReason, frozen bool, isCurrent bool, _ bool, _, _ string) {
 			prNumber := getPRNumber(ctx.Status(), branchName)
+
+			parentName := ""
+			br := nav.GetBranch(branchName)
+			if br.GetName() != "" {
+				if p := br.GetParent(); p != nil {
+					parentName = p.GetName()
+				} else {
+					parentName = ctx.Engine.Trunk().GetName()
+				}
+			}
 
 			switch result {
 			case engine.RestackDone:
@@ -64,6 +74,8 @@ func restackBranches(ctx *app.Context, branchesToRestack []string, handler Handl
 					NewRevision: newRev,
 					LockReason:  lockReason,
 					Frozen:      frozen,
+					IsCurrent:   isCurrent,
+					Parent:      parentName,
 				})
 			case engine.RestackUnneeded:
 				handler.EmitEvent(Event{
@@ -73,6 +85,8 @@ func restackBranches(ctx *app.Context, branchesToRestack []string, handler Handl
 					PRNumber:   prNumber,
 					LockReason: lockReason,
 					Frozen:     frozen,
+					IsCurrent:  isCurrent,
+					Parent:     parentName,
 				})
 			case engine.RestackConflict:
 				summary.BranchesSkipped++
@@ -85,6 +99,8 @@ func restackBranches(ctx *app.Context, branchesToRestack []string, handler Handl
 					Conflict:   true,
 					LockReason: lockReason,
 					Frozen:     frozen,
+					IsCurrent:  isCurrent,
+					Parent:     parentName,
 				})
 			}
 		}); err != nil {

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -161,6 +161,8 @@ type Event struct {
 	Conflict    bool              // Is this a conflict?
 	LockReason  engine.LockReason // Why the branch is locked (empty if not locked)
 	Frozen      bool              // Is the branch frozen?
+	IsCurrent   bool              // Is this the current branch?
+	Parent      string            // Parent branch name (if applicable)
 	Error       error             // If non-nil, this step had an error
 }
 
@@ -225,7 +227,7 @@ func (h *NullHandler) Complete(_ Summary) {}
 func (h *NullHandler) OnRestackStart(_ int) {}
 
 // OnRestackBranch implements RestackHandler.
-func (h *NullHandler) OnRestackBranch(_ string, _ RestackResult, _ string, _ *int, _ engine.LockReason, _ bool) {
+func (h *NullHandler) OnRestackBranch(_ string, _ RestackResult, _ string, _ *int, _ engine.LockReason, _ bool, _ bool, _ string, _ bool, _, _ string) {
 }
 
 // OnRestackComplete implements RestackHandler.

--- a/internal/cli/branch/get_handlers.go
+++ b/internal/cli/branch/get_handlers.go
@@ -172,18 +172,27 @@ func (h *SimpleGetHandler) OnRestackStart(_ int) {
 }
 
 // OnRestackBranch implements RestackHandler for restack phase
-func (h *SimpleGetHandler) OnRestackBranch(branch string, result handlers.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool) {
+func (h *SimpleGetHandler) OnRestackBranch(branch string, result handlers.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, reparented bool, oldParent, newParent string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+
+	if reparented {
+		h.splog.Info("  Reparented %s from %s to %s",
+			style.ColorBranchName(branch, isCurrent),
+			style.ColorBranchName(oldParent, false),
+			style.ColorBranchName(newParent, false))
+	}
 
 	prInfo := h.formatPRInfo(prNumber)
 
 	switch result {
 	case handlers.RestackDone:
-		h.splog.Info("  Restacked %s%s -> %s",
-			style.ColorBranchName(branch, false),
-			prInfo,
-			style.ColorDim(newRev))
+		msg := fmt.Sprintf("Restacked %s%s", style.ColorBranchName(branch, isCurrent), prInfo)
+		if parent != "" {
+			msg += fmt.Sprintf(" on %s", style.ColorBranchName(parent, false))
+		}
+		msg += fmt.Sprintf(" -> %s", style.ColorDim(newRev))
+		h.splog.Info("  %s", msg)
 	case handlers.RestackUnneeded:
 		reason := "does not need restacking"
 		if lockReason.IsLocked() {
@@ -191,13 +200,18 @@ func (h *SimpleGetHandler) OnRestackBranch(branch string, result handlers.Restac
 		} else if frozen {
 			reason = "is frozen"
 		}
-		h.splog.Info("  %s%s %s",
-			style.ColorBranchName(branch, false),
-			prInfo,
-			reason)
+
+		msg := fmt.Sprintf("%s%s %s", style.ColorBranchName(branch, isCurrent), prInfo, reason)
+		if reason == "does not need restacking" && parent != "" {
+			msg = fmt.Sprintf("%s%s does not need to be restacked on %s.",
+				style.ColorBranchName(branch, isCurrent),
+				prInfo,
+				style.ColorBranchName(parent, false))
+		}
+		h.splog.Info("  %s", msg)
 	case handlers.RestackConflict:
 		h.splog.Warn("  Skipped %s%s (conflict)",
-			style.ColorBranchName(branch, false),
+			style.ColorBranchName(branch, isCurrent),
 			prInfo)
 	}
 }

--- a/internal/cli/stack/foreach_handlers.go
+++ b/internal/cli/stack/foreach_handlers.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"strings"
 	"sync"
+	"syscall"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -176,6 +178,7 @@ type InteractiveForeachHandler struct {
 	mu          sync.Mutex
 	stack       *tree.StackTree
 	command     string
+	cleanupDone bool
 }
 
 // NewInteractiveForeachHandler creates a new interactive foreach handler
@@ -222,13 +225,52 @@ func (h *InteractiveForeachHandler) ensureProgramStarted() {
 	h.splog.SetQuiet(true)
 
 	h.program = tea.NewProgram(h.model, tea.WithInput(os.Stdin), tea.WithOutput(os.Stdout))
+	h.cleanupDone = false
+
+	// Set up signal handler to ensure terminal is restored on interrupt
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		h.Cleanup()
+		// Re-raise the signal so the process can exit properly
+		signal.Stop(sigChan)
+	}()
 
 	// Run program in background
 	go func() {
 		if _, err := h.program.Run(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error running foreach TUI: %v\n", err)
 		}
+		// Ensure cleanup happens when program exits
+		h.Cleanup()
 	}()
+}
+
+// Cleanup ensures the terminal is restored to normal mode
+// This should be called on interrupt or error to prevent leaving the terminal in raw mode
+func (h *InteractiveForeachHandler) Cleanup() {
+	h.mu.Lock()
+	if h.cleanupDone {
+		h.mu.Unlock()
+		return
+	}
+
+	p := h.program
+	h.mu.Unlock()
+
+	if p != nil {
+		// Quit the program and wait for it to restore terminal state
+		p.Quit()
+		p.Wait()
+	}
+
+	h.mu.Lock()
+	h.program = nil
+	// Restore splog
+	h.splog.SetQuiet(false)
+	h.cleanupDone = true
+	h.mu.Unlock()
 }
 
 // OnEvent handles events from the foreach action

--- a/internal/cli/stack/merge_handlers.go
+++ b/internal/cli/stack/merge_handlers.go
@@ -2,6 +2,10 @@ package stack
 
 import (
 	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
 	"time"
 
 	"stackit.dev/stackit/internal/actions/merge"
@@ -65,11 +69,13 @@ func (h *SimpleMergeHandler) Complete(result *merge.ConsolidationResult) {
 
 // InteractiveMergeHandler provides a TUI for merge operations
 type InteractiveMergeHandler struct {
-	ctx      *app.Context
-	reporter *tui.ChannelMergeProgressReporter
-	done     chan bool
-	errChan  chan error
-	plan     *merge.Plan
+	ctx         *app.Context
+	reporter    *tui.ChannelMergeProgressReporter
+	done        chan bool
+	errChan     chan error
+	plan        *merge.Plan
+	cleanupDone bool
+	mu          sync.Mutex
 }
 
 // NewInteractiveMergeHandler creates a new InteractiveMergeHandler
@@ -85,10 +91,14 @@ func (h *InteractiveMergeHandler) Start(plan *merge.Plan) {
 }
 
 func (h *InteractiveMergeHandler) startTUI(plan *merge.Plan) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	h.plan = plan
 	h.reporter = tui.NewChannelMergeProgressReporter()
 	h.done = make(chan bool, 1)
 	h.errChan = make(chan error, 1)
+	h.cleanupDone = false
 
 	groups := CalculateMergeGroups(plan)
 	stepDescriptions := make([]string, len(plan.Steps))
@@ -98,12 +108,50 @@ func (h *InteractiveMergeHandler) startTUI(plan *merge.Plan) {
 
 	h.ctx.Splog.SetQuiet(true)
 
+	// Set up signal handler to ensure terminal is restored on interrupt
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		h.Cleanup()
+		// Re-raise the signal so the process can exit properly
+		signal.Stop(sigChan)
+	}()
+
 	go func() {
 		err := tui.RunMergeTUI(groups, stepDescriptions, h.reporter.Updates(), h.done)
 		if err != nil {
 			h.errChan <- err
 		}
+		h.Cleanup()
 	}()
+}
+
+// Cleanup ensures the terminal is restored to normal mode
+func (h *InteractiveMergeHandler) Cleanup() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.cleanupDone {
+		return
+	}
+
+	if h.reporter != nil {
+		h.reporter.Close()
+	}
+
+	if h.done != nil {
+		// Wait for TUI to finish and restore terminal
+		// Use a timeout to avoid hanging indefinitely if something goes wrong
+		select {
+		case <-h.done:
+		case <-time.After(2 * time.Second):
+		}
+		h.done = nil
+	}
+
+	h.ctx.Splog.SetQuiet(false)
+	h.cleanupDone = true
 }
 
 // StepStarted implements merge.Handler.
@@ -143,14 +191,7 @@ func (h *InteractiveMergeHandler) SetEstimatedDuration(duration time.Duration) {
 
 // Complete implements merge.Handler.
 func (h *InteractiveMergeHandler) Complete(result *merge.ConsolidationResult) {
-	if h.reporter != nil {
-		h.reporter.Close()
-		if h.done != nil {
-			<-h.done
-			h.done = nil
-		}
-		h.ctx.Splog.SetQuiet(false)
-	}
+	h.Cleanup()
 
 	if result != nil {
 		h.ctx.Splog.Info("✅ Created consolidation PR #%d: %s", result.PRNumber, result.PRURL)

--- a/internal/cli/stack/restack.go
+++ b/internal/cli/stack/restack.go
@@ -62,10 +62,11 @@ If conflicts are encountered, you will be prompted to resolve them via an intera
 				}
 
 				// Run restack action
+				handler := NewSyncHandler(ctx.Splog)
 				return actions.RestackAction(ctx, actions.RestackOptions{
 					BranchName: targetBranch,
 					Scope:      rng,
-				})
+				}, handler)
 			})
 		},
 	}

--- a/internal/cli/stack/restack_test.go
+++ b/internal/cli/stack/restack_test.go
@@ -157,7 +157,9 @@ func TestRestackCommand(t *testing.T) {
 
 		normalized := testhelpers.NormalizeOutput(string(output))
 		expected := testhelpers.NormalizeOutput(`
-feature (current) does not need to be restacked on main.
+  feature (current) does not need to be restacked on main.
+
+✨ All branches are up to date!
 `)
 		require.Equal(t, expected, normalized, "output format should match expected structure")
 	})
@@ -196,8 +198,10 @@ feature (current) does not need to be restacked on main.
 
 		normalized := testhelpers.NormalizeOutput(string(output))
 		expected := testhelpers.NormalizeOutput(`
-branch1 does not need to be restacked on main.
-branch2 (current) does not need to be restacked on branch1.
+  branch1 does not need to be restacked on main.
+  branch2 (current) does not need to be restacked on branch1.
+
+✨ All branches are up to date!
 `)
 		require.Equal(t, expected, normalized, "output format should match expected structure")
 	})
@@ -240,8 +244,10 @@ branch2 (current) does not need to be restacked on branch1.
 
 		normalized := testhelpers.NormalizeOutput(string(output))
 		expected := testhelpers.NormalizeOutput(`
-branch1 (current) does not need to be restacked on main.
-branch2 does not need to be restacked on branch1.
+  branch1 (current) does not need to be restacked on main.
+  branch2 does not need to be restacked on branch1.
+
+✨ All branches are up to date!
 `)
 		require.Equal(t, expected, normalized, "output format should match expected structure")
 	})
@@ -275,7 +281,9 @@ branch2 does not need to be restacked on branch1.
 
 		normalized := testhelpers.NormalizeOutput(string(output))
 		expected := testhelpers.NormalizeOutput(`
-branch1 does not need to be restacked on main.
+  branch1 does not need to be restacked on main.
+
+✨ All branches are up to date!
 `)
 		require.Equal(t, expected, normalized, "output format should match expected structure")
 	})
@@ -325,6 +333,7 @@ branch1 does not need to be restacked on main.
 		// Output should show branches being restacked
 		require.Contains(t, normalized, "Restacked branch1 on main", "should show branch1 restacked")
 		require.Contains(t, normalized, "Restacked branch2 (current) on branch1", "should show branch2 restacked")
+		require.Contains(t, normalized, "Summary: restacked 2")
 	})
 
 	t.Run("restack errors when multiple scope flags specified", func(t *testing.T) {

--- a/internal/cli/stack/submit.go
+++ b/internal/cli/stack/submit.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"sync"
+	"syscall"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
@@ -298,6 +300,7 @@ type InteractiveSubmitHandler struct {
 	mu            sync.Mutex
 	stack         *tree.StackTree
 	fixedMap      map[string]bool
+	cleanupDone   bool
 }
 
 // NewInteractiveSubmitHandler creates a new interactive submit handler
@@ -344,13 +347,52 @@ func (h *InteractiveSubmitHandler) ensureProgramStarted() {
 	h.splog.SetQuiet(true)
 
 	h.program = tea.NewProgram(h.model, tea.WithInput(os.Stdin), tea.WithOutput(os.Stdout))
+	h.cleanupDone = false
+
+	// Set up signal handler to ensure terminal is restored on interrupt
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		h.Cleanup()
+		// Re-raise the signal so the process can exit properly
+		signal.Stop(sigChan)
+	}()
 
 	// Run program in background
 	go func() {
 		if _, err := h.program.Run(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error running submit TUI: %v\n", err)
 		}
+		// Ensure cleanup happens when program exits
+		h.Cleanup()
 	}()
+}
+
+// Cleanup ensures the terminal is restored to normal mode
+// This should be called on interrupt or error to prevent leaving the terminal in raw mode
+func (h *InteractiveSubmitHandler) Cleanup() {
+	h.mu.Lock()
+	if h.cleanupDone {
+		h.mu.Unlock()
+		return
+	}
+
+	p := h.program
+	h.mu.Unlock()
+
+	if p != nil {
+		// Quit the program and wait for it to restore terminal state
+		p.Quit()
+		p.Wait()
+	}
+
+	h.mu.Lock()
+	h.program = nil
+	// Restore splog
+	h.splog.SetQuiet(false)
+	h.cleanupDone = true
+	h.mu.Unlock()
 }
 
 // OnEvent handles events from the submit action

--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -165,10 +165,12 @@ func (h *SimpleSyncHandler) printRestackEvent(event syncAction.Event) {
 	switch event.Type {
 	case syncAction.EventCompleted:
 		if event.NewRevision != "" {
-			h.splog.Info("  Restacked %s%s -> %s",
-				style.ColorBranchName(event.Branch, false),
-				prInfo,
-				style.ColorDim(event.NewRevision))
+			msg := fmt.Sprintf("Restacked %s%s", style.ColorBranchName(event.Branch, event.IsCurrent), prInfo)
+			if event.Parent != "" {
+				msg += fmt.Sprintf(" on %s", style.ColorBranchName(event.Parent, false))
+			}
+			msg += fmt.Sprintf(" -> %s", style.ColorDim(event.NewRevision))
+			h.splog.Info("  %s", msg)
 		} else {
 			reason := reasonNoRestackNeeded
 			if event.IsLocked() {
@@ -176,19 +178,24 @@ func (h *SimpleSyncHandler) printRestackEvent(event syncAction.Event) {
 			} else if event.Frozen {
 				reason = reasonFrozen
 			}
-			h.splog.Info("  %s%s %s",
-				style.ColorBranchName(event.Branch, false),
-				prInfo,
-				reason)
+
+			msg := fmt.Sprintf("%s%s %s", style.ColorBranchName(event.Branch, event.IsCurrent), prInfo, reason)
+			if reason == reasonNoRestackNeeded && event.Parent != "" {
+				msg = fmt.Sprintf("%s%s does not need to be restacked on %s.",
+					style.ColorBranchName(event.Branch, event.IsCurrent),
+					prInfo,
+					style.ColorBranchName(event.Parent, false))
+			}
+			h.splog.Info("  %s", msg)
 		}
 	case syncAction.EventSkipped:
 		if event.Conflict {
 			h.splog.Warn("Skipped %s%s (conflict)",
-				style.ColorBranchName(event.Branch, false),
+				style.ColorBranchName(event.Branch, event.IsCurrent),
 				prInfo)
 		} else {
 			h.splog.Info("  Skipped %s%s %s",
-				style.ColorBranchName(event.Branch, false),
+				style.ColorBranchName(event.Branch, event.IsCurrent),
 				prInfo,
 				style.ColorDim(event.Message))
 		}
@@ -216,7 +223,15 @@ func (h *SimpleSyncHandler) OnRestackStart(_ int) {
 }
 
 // OnRestackBranch implements RestackHandler for standalone restack operations
-func (h *SimpleSyncHandler) OnRestackBranch(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool) {
+func (h *SimpleSyncHandler) OnRestackBranch(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, reparented bool, oldParent, newParent string) {
+	// Log reparenting info if applicable
+	if reparented {
+		h.splog.Info("Reparented %s from %s to %s (parent was merged/deleted).",
+			style.ColorBranchName(branch, isCurrent),
+			style.ColorBranchName(oldParent, false),
+			style.ColorBranchName(newParent, false))
+	}
+
 	// Convert to Event and use existing printRestackEvent
 	event := syncAction.Event{
 		Phase:       syncAction.PhaseRestack,
@@ -225,6 +240,8 @@ func (h *SimpleSyncHandler) OnRestackBranch(branch string, result syncAction.Res
 		NewRevision: newRev,
 		LockReason:  lockReason,
 		Frozen:      frozen,
+		IsCurrent:   isCurrent,
+		Parent:      parent,
 	}
 
 	switch result {
@@ -388,10 +405,18 @@ func (h *InteractiveSyncHandler) formatEventDetail(event syncAction.Event) strin
 		if event.PRNumber != nil {
 			prInfo = fmt.Sprintf(" (PR #%d)", *event.PRNumber)
 		}
+
+		displayName := style.ColorBranchName(event.Branch, event.IsCurrent)
+
 		switch event.Type {
 		case syncAction.EventCompleted:
 			if event.NewRevision != "" {
-				return fmt.Sprintf("Restacked %s%s -> %s", event.Branch, prInfo, event.NewRevision)
+				msg := fmt.Sprintf("Restacked %s%s", displayName, prInfo)
+				if event.Parent != "" {
+					msg += fmt.Sprintf(" on %s", event.Parent)
+				}
+				msg += fmt.Sprintf(" -> %s", event.NewRevision)
+				return msg
 			}
 			reason := reasonNoRestackNeeded
 			if event.IsLocked() {
@@ -399,12 +424,19 @@ func (h *InteractiveSyncHandler) formatEventDetail(event syncAction.Event) strin
 			} else if event.Frozen {
 				reason = reasonFrozen
 			}
-			return fmt.Sprintf("%s%s %s", event.Branch, prInfo, reason)
+
+			if reason == reasonNoRestackNeeded && event.Parent != "" {
+				return fmt.Sprintf("%s%s does not need to be restacked on %s.",
+					displayName,
+					prInfo,
+					event.Parent)
+			}
+			return fmt.Sprintf("%s%s %s", displayName, prInfo, reason)
 		case syncAction.EventSkipped:
 			if event.Conflict {
-				return fmt.Sprintf("⚠️ Skipped %s%s (conflict)", event.Branch, prInfo)
+				return fmt.Sprintf("⚠️ Skipped %s%s (conflict)", displayName, prInfo)
 			}
-			return fmt.Sprintf("Skipped %s%s %s", event.Branch, prInfo, event.Message)
+			return fmt.Sprintf("Skipped %s%s %s", displayName, prInfo, event.Message)
 		}
 	}
 	return ""
@@ -498,7 +530,7 @@ func (h *InteractiveSyncHandler) OnRestackStart(branchCount int) {
 }
 
 // OnRestackBranch implements RestackHandler for standalone restack operations
-func (h *InteractiveSyncHandler) OnRestackBranch(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool) {
+func (h *InteractiveSyncHandler) OnRestackBranch(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, reparented bool, oldParent, newParent string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -507,8 +539,11 @@ func (h *InteractiveSyncHandler) OnRestackBranch(branch string, result syncActio
 	}
 
 	// Build detail message
-	detail := h.formatRestackDetail(branch, result, newRev, prNumber, lockReason, frozen)
+	detail := h.formatRestackDetail(branch, result, newRev, prNumber, lockReason, frozen, isCurrent, parent)
 	if detail != "" {
+		if reparented {
+			detail = fmt.Sprintf("Reparented %s -> %s. %s", oldParent, newParent, detail)
+		}
 		h.program.Send(syncComponent.PhaseDetailMsg{
 			Phase:   syncComponent.Phase(syncAction.PhaseRestack),
 			Message: detail,
@@ -524,15 +559,22 @@ func (h *InteractiveSyncHandler) OnRestackBranch(branch string, result syncActio
 }
 
 // formatRestackDetail formats a restack event into a detail string
-func (h *InteractiveSyncHandler) formatRestackDetail(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool) string {
+func (h *InteractiveSyncHandler) formatRestackDetail(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string) string {
 	prInfo := ""
 	if prNumber != nil {
 		prInfo = fmt.Sprintf(" (PR #%d)", *prNumber)
 	}
 
+	displayName := style.ColorBranchName(branch, isCurrent)
+
 	switch result {
 	case syncAction.RestackDone:
-		return fmt.Sprintf("Restacked %s%s -> %s", branch, prInfo, newRev)
+		msg := fmt.Sprintf("Restacked %s%s", displayName, prInfo)
+		if parent != "" {
+			msg += fmt.Sprintf(" on %s", parent)
+		}
+		msg += fmt.Sprintf(" -> %s", newRev)
+		return msg
 	case syncAction.RestackUnneeded:
 		reason := reasonNoRestackNeeded
 		if lockReason.IsLocked() {
@@ -540,9 +582,16 @@ func (h *InteractiveSyncHandler) formatRestackDetail(branch string, result syncA
 		} else if frozen {
 			reason = reasonFrozen
 		}
-		return fmt.Sprintf("%s%s %s", branch, prInfo, reason)
+
+		if reason == reasonNoRestackNeeded && parent != "" {
+			return fmt.Sprintf("%s%s does not need to be restacked on %s.",
+				displayName,
+				prInfo,
+				parent)
+		}
+		return fmt.Sprintf("%s%s %s", displayName, prInfo, reason)
 	case syncAction.RestackConflict:
-		return fmt.Sprintf("⚠️ Skipped %s%s (conflict)", branch, prInfo)
+		return fmt.Sprintf("⚠️ Skipped %s%s (conflict)", displayName, prInfo)
 	}
 	return ""
 }
@@ -573,21 +622,26 @@ func (h *InteractiveSyncHandler) OnRestackComplete(restacked, skipped int, confl
 // This should be called on interrupt or error to prevent leaving the terminal in raw mode
 func (h *InteractiveSyncHandler) Cleanup() {
 	h.mu.Lock()
-	defer h.mu.Unlock()
-
 	if h.cleanupDone {
+		h.mu.Unlock()
 		return
 	}
 
-	if h.program != nil {
-		// Quit the program to restore terminal state
-		h.program.Quit()
-		h.program = nil
+	p := h.program
+	h.mu.Unlock()
+
+	if p != nil {
+		// Quit the program and wait for it to restore terminal state
+		p.Quit()
+		p.Wait()
 	}
 
+	h.mu.Lock()
+	h.program = nil
 	// Restore splog
 	h.splog.SetQuiet(false)
 	h.cleanupDone = true
+	h.mu.Unlock()
 }
 
 // formatRestackSummary formats the restack summary

--- a/internal/cli/stack/sync_test.go
+++ b/internal/cli/stack/sync_test.go
@@ -57,7 +57,7 @@ func TestSyncCommand(t *testing.T) {
   PR info up to date
 🧹 Cleaning branches...
 📚 Restacking branches...
-  branch1 does not need restacking
+  branch1 (current) does not need to be restacked on main.
 ✨ Everything is up to date!
 `), normalized)
 
@@ -70,7 +70,8 @@ func TestSyncCommand(t *testing.T) {
 		require.NoError(t, err, "sync --restack (needed) failed: %s", output)
 		normalized = testhelpers.NormalizeOutput(output)
 		// We don't know the exact revision, so we'll check the structure
-		require.Contains(t, normalized, "Restacked branch1 ->")
+		require.Contains(t, normalized, "Restacked branch1")
+		require.Contains(t, normalized, "->")
 		require.Contains(t, normalized, "✅ Summary: restacked 1")
 	})
 

--- a/internal/handlers/restack.go
+++ b/internal/handlers/restack.go
@@ -24,7 +24,7 @@ type RestackHandler interface {
 	OnRestackStart(branchCount int)
 
 	// OnRestackBranch is called for each branch during restack
-	OnRestackBranch(branch string, result RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool)
+	OnRestackBranch(branch string, result RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, reparented bool, oldParent, newParent string)
 
 	// OnRestackComplete is called when restack finishes
 	OnRestackComplete(restacked, skipped int, conflicts []string)
@@ -37,7 +37,7 @@ type NullRestackHandler struct{}
 func (h *NullRestackHandler) OnRestackStart(_ int) {}
 
 // OnRestackBranch implements RestackHandler.
-func (h *NullRestackHandler) OnRestackBranch(_ string, _ RestackResult, _ string, _ *int, _ engine.LockReason, _ bool) {
+func (h *NullRestackHandler) OnRestackBranch(_ string, _ RestackResult, _ string, _ *int, _ engine.LockReason, _ bool, _ bool, _ string, _ bool, _, _ string) {
 }
 
 // OnRestackComplete implements RestackHandler.


### PR DESCRIPTION

Re-applied fixes for terminal restoration and added synchronous waiting for
TUI exit. Restored interactive `st restack` and improved reporting with
branch context. Added signal handlers to all interactive commands.


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #329** 👈
  * **PR #328**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->