### PR TITLE
feat: add worktree registry foundation (Phase 1)

### DIFF
--- a/internal/config/repo_config.go
+++ b/internal/config/repo_config.go
@@ -156,6 +156,33 @@ func (c *Config) SetUndoStackDepth(depth int) {
 	c.data.UndoStackDepth = &depth
 }
 
+// WorktreeBasePath returns the base path for worktrees, or empty string for default
+// Default is "../{repo-name}-stacks" relative to the repository root
+func (c *Config) WorktreeBasePath() string {
+	if c.data.WorktreeBasePath != nil {
+		return *c.data.WorktreeBasePath
+	}
+	return ""
+}
+
+// SetWorktreeBasePath sets the base path for worktrees
+func (c *Config) SetWorktreeBasePath(path string) {
+	c.data.WorktreeBasePath = &path
+}
+
+// WorktreeAutoClean returns whether worktrees should be auto-cleaned during sync, true by default
+func (c *Config) WorktreeAutoClean() bool {
+	if c.data.WorktreeAutoClean != nil {
+		return *c.data.WorktreeAutoClean
+	}
+	return true
+}
+
+// SetWorktreeAutoClean sets whether worktrees should be auto-cleaned during sync
+func (c *Config) SetWorktreeAutoClean(enabled bool) {
+	c.data.WorktreeAutoClean = &enabled
+}
+
 // GetBranchPattern returns the branch name pattern as a BranchPattern type
 func (c *Config) GetBranchPattern() BranchPattern {
 	return c.data.GetBranchPattern()
@@ -169,6 +196,8 @@ type RepoConfig struct {
 	BranchNamePattern          *string  `json:"branchNamePattern,omitempty"`
 	SubmitFooter               *bool    `json:"submit.footer,omitempty"`
 	UndoStackDepth             *int     `json:"undo.stackDepth,omitempty"`
+	WorktreeBasePath           *string  `json:"worktree.basePath,omitempty"`
+	WorktreeAutoClean          *bool    `json:"worktree.autoClean,omitempty"`
 }
 
 // GetBranchPattern returns the branch name pattern as a BranchPattern type

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -564,3 +564,19 @@ func (d *demoGitRunner) BatchDeleteRemoteMetadataRefs(_ []string) error {
 func (d *demoGitRunner) TestRemoteRefCompatibility() error {
 	return nil
 }
+
+func (d *demoGitRunner) ReadWorktreeMeta(_ string) (*git.WorktreeMeta, error) {
+	return nil, nil
+}
+
+func (d *demoGitRunner) WriteWorktreeMeta(_ string, _ *git.WorktreeMeta) error {
+	return nil
+}
+
+func (d *demoGitRunner) DeleteWorktreeMeta(_ string) error {
+	return nil
+}
+
+func (d *demoGitRunner) ListWorktreeMetas() (map[string]*git.WorktreeMeta, error) {
+	return make(map[string]*git.WorktreeMeta), nil
+}

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -7,9 +7,13 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"stackit.dev/stackit/internal/git"
 )
+
+// timeNow is a variable for time.Now to allow mocking in tests
+var timeNow = time.Now
 
 // CreateBranch creates a new branch at the given start point
 func (e *engineImpl) CreateBranch(ctx context.Context, branchName string, startPoint string) error {
@@ -573,6 +577,92 @@ func (e *engineImpl) CreateTemporaryWorktree(ctx context.Context, branch string,
 	}
 
 	return worktreePath, cleanup, nil
+}
+
+// RegisterWorktree registers a worktree for a stack root in local git refs
+func (e *engineImpl) RegisterWorktree(stackRoot string, path string) error {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	meta := &git.WorktreeMeta{
+		Path:        absPath,
+		StackRoot:   stackRoot,
+		CreatedAt:   timeNow(),
+		MainRepoDir: e.repoRoot,
+	}
+
+	return e.git.WriteWorktreeMeta(stackRoot, meta)
+}
+
+// UnregisterWorktree removes worktree registration for a stack root
+func (e *engineImpl) UnregisterWorktree(stackRoot string) error {
+	return e.git.DeleteWorktreeMeta(stackRoot)
+}
+
+// GetWorktreeForStack returns worktree info for a stack root, or nil if none
+func (e *engineImpl) GetWorktreeForStack(stackRoot string) (*WorktreeInfo, error) {
+	meta, err := e.git.ReadWorktreeMeta(stackRoot)
+	if err != nil {
+		return nil, err
+	}
+	if meta == nil {
+		return nil, nil
+	}
+
+	return &WorktreeInfo{
+		Path:        meta.Path,
+		StackRoot:   meta.StackRoot,
+		CreatedAt:   meta.CreatedAt,
+		MainRepoDir: meta.MainRepoDir,
+	}, nil
+}
+
+// ListManagedWorktrees returns all stackit-managed worktrees
+func (e *engineImpl) ListManagedWorktrees() ([]WorktreeInfo, error) {
+	metas, err := e.git.ListWorktreeMetas()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]WorktreeInfo, 0, len(metas))
+	for _, meta := range metas {
+		result = append(result, WorktreeInfo{
+			Path:        meta.Path,
+			StackRoot:   meta.StackRoot,
+			CreatedAt:   meta.CreatedAt,
+			MainRepoDir: meta.MainRepoDir,
+		})
+	}
+
+	return result, nil
+}
+
+// GetStackRootForBranch returns the stack root for a given branch.
+// The stack root is the first ancestor branch whose parent is trunk.
+func (e *engineImpl) GetStackRootForBranch(branch Branch) string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	current := branch.GetName()
+	for {
+		parent, ok := e.parentMap[current]
+		if !ok {
+			// No parent tracked, this branch is either trunk or not tracked
+			if current == e.trunk {
+				return ""
+			}
+			return current
+		}
+
+		// If parent is trunk, current is the stack root
+		if parent == e.trunk {
+			return current
+		}
+
+		current = parent
+	}
 }
 
 // setParentInternal updates parent without locking (caller must hold lock)

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -145,6 +145,28 @@ type WorktreeOperations interface {
 	CreateTemporaryWorktree(ctx context.Context, branch string, prefix string) (path string, cleanup func(), err error)
 }
 
+// WorktreeInfo represents information about a stackit-managed worktree
+type WorktreeInfo struct {
+	Path        string    // Absolute path to worktree
+	StackRoot   string    // Stack root branch name
+	CreatedAt   time.Time // When worktree was created
+	MainRepoDir string    // Path to main repo
+}
+
+// WorktreeRegistry handles stackit-managed worktree tracking
+type WorktreeRegistry interface {
+	// RegisterWorktree registers a worktree for a stack root
+	RegisterWorktree(stackRoot string, path string) error
+	// UnregisterWorktree removes worktree registration for a stack root
+	UnregisterWorktree(stackRoot string) error
+	// GetWorktreeForStack returns worktree info for a stack root, or nil if none
+	GetWorktreeForStack(stackRoot string) (*WorktreeInfo, error)
+	// ListManagedWorktrees returns all stackit-managed worktrees
+	ListManagedWorktrees() ([]WorktreeInfo, error)
+	// GetStackRootForBranch returns the stack root for a given branch
+	GetStackRootForBranch(branch Branch) string
+}
+
 // Initializer handles repository initialization operations
 type Initializer interface {
 	Reset(newTrunkName string) error

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -174,6 +174,14 @@ type WorktreeOperations interface {
 	ListWorktrees(ctx context.Context) ([]string, error)
 }
 
+// WorktreeRegistryOperations handles stackit-managed worktree tracking (local-only refs).
+type WorktreeRegistryOperations interface {
+	ReadWorktreeMeta(stackRoot string) (*WorktreeMeta, error)
+	WriteWorktreeMeta(stackRoot string, meta *WorktreeMeta) error
+	DeleteWorktreeMeta(stackRoot string) error
+	ListWorktreeMetas() (map[string]*WorktreeMeta, error)
+}
+
 // StatusOperations provides repository status information.
 type StatusOperations interface {
 	GetStatusPorcelain(ctx context.Context) (string, error)

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -203,6 +203,7 @@ type Runner interface {
 
 	// Worktree management
 	WorktreeOperations
+	WorktreeRegistryOperations
 
 	// Repository status
 	StatusOperations

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -2,9 +2,22 @@ package git
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 )
+
+// WorktreeRefPrefix is the prefix for Git refs where worktree metadata is stored (local-only)
+const WorktreeRefPrefix = "refs/stackit/worktrees/"
+
+// WorktreeMeta represents worktree tracking metadata stored in local Git refs
+type WorktreeMeta struct {
+	Path        string    `json:"path"`        // Absolute path to worktree
+	StackRoot   string    `json:"stackRoot"`   // First branch created from trunk (stack root)
+	CreatedAt   time.Time `json:"createdAt"`   // When worktree was created
+	MainRepoDir string    `json:"mainRepoDir"` // Path to main repo (for detection)
+}
 
 func (r *runner) AddWorktree(ctx context.Context, path string, branch string, detach bool) error {
 	args := []string{"worktree", "add"}
@@ -49,4 +62,88 @@ func (r *runner) ListWorktrees(ctx context.Context) ([]string, error) {
 		}
 	}
 	return worktrees, nil
+}
+
+// ReadWorktreeMeta reads worktree metadata for a stack root from local git refs
+func (r *runner) ReadWorktreeMeta(stackRoot string) (*WorktreeMeta, error) {
+	refName := fmt.Sprintf("%s%s", WorktreeRefPrefix, stackRoot)
+
+	sha, err := r.GetRef(refName)
+	if err != nil {
+		// If ref doesn't exist, it's not an error, just means no worktree registered
+		return nil, nil //nolint:nilerr
+	}
+
+	content, err := r.ReadBlob(sha)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read worktree metadata blob %s: %w", sha, err)
+	}
+
+	if content == "" {
+		return nil, nil
+	}
+
+	var meta WorktreeMeta
+	if err := json.Unmarshal([]byte(content), &meta); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal worktree metadata for %s: %w", stackRoot, err)
+	}
+
+	return &meta, nil
+}
+
+// WriteWorktreeMeta writes worktree metadata for a stack root to local git refs
+func (r *runner) WriteWorktreeMeta(stackRoot string, meta *WorktreeMeta) error {
+	jsonData, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("failed to marshal worktree metadata: %w", err)
+	}
+
+	sha, err := r.CreateBlob(string(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create worktree metadata blob: %w", err)
+	}
+
+	refName := fmt.Sprintf("%s%s", WorktreeRefPrefix, stackRoot)
+	if err := r.UpdateRef(refName, sha); err != nil {
+		return fmt.Errorf("failed to write worktree metadata ref: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteWorktreeMeta deletes worktree metadata for a stack root
+func (r *runner) DeleteWorktreeMeta(stackRoot string) error {
+	refName := fmt.Sprintf("%s%s", WorktreeRefPrefix, stackRoot)
+	return r.DeleteRef(refName)
+}
+
+// ListWorktreeMetas lists all registered worktree metadata
+func (r *runner) ListWorktreeMetas() (map[string]*WorktreeMeta, error) {
+	refs, err := r.ListRefs(WorktreeRefPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]*WorktreeMeta)
+	for refName, sha := range refs {
+		stackRoot := strings.TrimPrefix(refName, WorktreeRefPrefix)
+
+		content, err := r.ReadBlob(sha)
+		if err != nil {
+			continue // Skip unreadable entries
+		}
+
+		if content == "" {
+			continue
+		}
+
+		var meta WorktreeMeta
+		if err := json.Unmarshal([]byte(content), &meta); err != nil {
+			continue // Skip invalid entries
+		}
+
+		result[stackRoot] = &meta
+	}
+
+	return result, nil
 }

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -78,3 +78,96 @@ func TestWorktree(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestWorktreeRegistry(t *testing.T) {
+	t.Run("write and read worktree metadata", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, func(s *testhelpers.Scene) error {
+			return s.Repo.CreateChangeAndCommit("initial", "init")
+		})
+		runner := git.NewRunnerWithPath(scene.Repo.Dir)
+
+		// Write worktree metadata
+		meta := &git.WorktreeMeta{
+			Path:        "/path/to/worktree",
+			StackRoot:   "feature-branch",
+			MainRepoDir: scene.Repo.Dir,
+		}
+		err := runner.WriteWorktreeMeta("feature-branch", meta)
+		require.NoError(t, err)
+
+		// Read it back
+		readMeta, err := runner.ReadWorktreeMeta("feature-branch")
+		require.NoError(t, err)
+		require.NotNil(t, readMeta)
+		require.Equal(t, "/path/to/worktree", readMeta.Path)
+		require.Equal(t, "feature-branch", readMeta.StackRoot)
+		require.Equal(t, scene.Repo.Dir, readMeta.MainRepoDir)
+	})
+
+	t.Run("read non-existent worktree metadata returns nil", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, func(s *testhelpers.Scene) error {
+			return s.Repo.CreateChangeAndCommit("initial", "init")
+		})
+		runner := git.NewRunnerWithPath(scene.Repo.Dir)
+
+		// Read non-existent metadata
+		meta, err := runner.ReadWorktreeMeta("non-existent")
+		require.NoError(t, err)
+		require.Nil(t, meta)
+	})
+
+	t.Run("delete worktree metadata", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, func(s *testhelpers.Scene) error {
+			return s.Repo.CreateChangeAndCommit("initial", "init")
+		})
+		runner := git.NewRunnerWithPath(scene.Repo.Dir)
+
+		// Write worktree metadata
+		meta := &git.WorktreeMeta{
+			Path:      "/path/to/worktree",
+			StackRoot: "feature-branch",
+		}
+		err := runner.WriteWorktreeMeta("feature-branch", meta)
+		require.NoError(t, err)
+
+		// Delete it
+		err = runner.DeleteWorktreeMeta("feature-branch")
+		require.NoError(t, err)
+
+		// Verify it's gone
+		readMeta, err := runner.ReadWorktreeMeta("feature-branch")
+		require.NoError(t, err)
+		require.Nil(t, readMeta)
+	})
+
+	t.Run("list worktree metadata", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, func(s *testhelpers.Scene) error {
+			return s.Repo.CreateChangeAndCommit("initial", "init")
+		})
+		runner := git.NewRunnerWithPath(scene.Repo.Dir)
+
+		// Write multiple worktree metadata
+		meta1 := &git.WorktreeMeta{
+			Path:      "/path/to/worktree1",
+			StackRoot: "feature-1",
+		}
+		err := runner.WriteWorktreeMeta("feature-1", meta1)
+		require.NoError(t, err)
+
+		meta2 := &git.WorktreeMeta{
+			Path:      "/path/to/worktree2",
+			StackRoot: "feature-2",
+		}
+		err = runner.WriteWorktreeMeta("feature-2", meta2)
+		require.NoError(t, err)
+
+		// List all
+		metas, err := runner.ListWorktreeMetas()
+		require.NoError(t, err)
+		require.Len(t, metas, 2)
+		require.Contains(t, metas, "feature-1")
+		require.Contains(t, metas, "feature-2")
+		require.Equal(t, "/path/to/worktree1", metas["feature-1"].Path)
+		require.Equal(t, "/path/to/worktree2", metas["feature-2"].Path)
+	})
+}


### PR DESCRIPTION

Add infrastructure for tracking stackit-managed worktrees:

- Add WorktreeMeta type and registry functions to git layer
- Add WorktreeRegistryOperations interface
- Add worktree.basePath and worktree.autoClean config options
- Add WorktreeRegistry interface to engine layer
- Implement RegisterWorktree, UnregisterWorktree, GetWorktreeForStack,
  ListManagedWorktrees, and GetStackRootForBranch methods
- Add tests for worktree registry CRUD operations

Worktree metadata is stored in local-only git refs at
refs/stackit/worktrees/{stack-root} and will never be pushed to remote.


<!-- STACKIT-SECTION-START -->
#### Stack

> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.


* **PR #342** 👈
  * **PR #345**
    * **PR #346**
      * **PR #347**
        * **PR #348**
          * **PR #349**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #350 by jonnii*