### PR TITLE
feat: add worktree-aware commands (Phase 3)

### DIFF
--- a/internal/actions/checkout.go
+++ b/internal/actions/checkout.go
@@ -70,6 +70,25 @@ func CheckoutAction(ctx *app.Context, opts CheckoutOptions) error {
 	}
 
 	branch := eng.GetBranch(branchName)
+
+	// Check for cross-worktree checkout and warn if applicable
+	if ctx.InManagedWorktree && ctx.WorktreeInfo != nil {
+		targetStackRoot := eng.GetStackRootForBranch(branch)
+		currentStackRoot := ctx.WorktreeInfo.StackRoot
+
+		// Warn if checking out a branch from a different stack
+		if targetStackRoot != "" && targetStackRoot != currentStackRoot {
+			// Check if the target stack has its own worktree
+			targetWorktree, err := eng.GetWorktreeForStack(targetStackRoot)
+			if err == nil && targetWorktree != nil {
+				out.Warn("Branch %s belongs to a different stack (%s) that has its own worktree.",
+					style.ColorBranchName(branchName, false),
+					style.ColorBranchName(targetStackRoot, false))
+				out.Tip("cd %s", targetWorktree.Path)
+			}
+		}
+	}
+
 	if err := eng.CheckoutBranch(context, branch); err != nil {
 		if git.IsLocalChangesError(err) {
 			return fmt.Errorf("cannot checkout branch %s because you have uncommitted changes that would be overwritten; please commit or stash your changes before switching branches", branchName)

--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -174,5 +174,13 @@ func getBranchAnnotation(ctx *app.Context, branchObj engine.Branch, opts LogOpti
 		}
 	}
 
+	// Check if this branch is a stack root with a managed worktree
+	stackRoot := ctx.Engine.GetStackRootForBranch(branchObj)
+	if stackRoot == branchObj.GetName() {
+		if wtInfo, err := ctx.Engine.GetWorktreeForStack(stackRoot); err == nil && wtInfo != nil {
+			annotation.WorktreePath = wtInfo.Path
+		}
+	}
+
 	return annotation
 }

--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -33,6 +33,10 @@ type Context struct {
 	Verify      bool
 	Debug       bool
 	Quiet       bool
+
+	// Worktree context
+	InManagedWorktree bool                 // True if running from a stackit-managed worktree
+	WorktreeInfo      *engine.WorktreeInfo // Info about current worktree (nil if not in managed worktree)
 }
 
 // Git returns the git runner from the engine.
@@ -76,6 +80,9 @@ func (c *Context) Undo() engine.UndoManager { return c.Engine }
 
 // RemoteMetadata returns the remote metadata manager from the engine.
 func (c *Context) RemoteMetadata() engine.RemoteMetadataManager { return c.Engine }
+
+// Worktree returns the worktree registry from the engine.
+func (c *Context) Worktree() engine.WorktreeRegistry { return c.Engine }
 
 // GlobalOptions holds settings from global flags
 type GlobalOptions struct {

--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -36,6 +36,15 @@ func Run(cmd *cobra.Command, fn func(ctx *app.Context) error) error {
 	if err != nil {
 		return err
 	}
+
+	// Populate worktree context
+	if ctx.Engine != nil {
+		if isManaged, wtInfo, err := ctx.Engine.IsInManagedWorktree(); err == nil && isManaged {
+			ctx.InManagedWorktree = true
+			ctx.WorktreeInfo = wtInfo
+		}
+	}
+
 	err = fn(ctx)
 	if err != nil {
 		return HandleCommandError(err)

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -665,6 +665,57 @@ func (e *engineImpl) GetStackRootForBranch(branch Branch) string {
 	}
 }
 
+// IsInManagedWorktree checks if the current directory is a stackit-managed worktree.
+// Returns true and worktree info if in a managed worktree, false otherwise.
+func (e *engineImpl) IsInManagedWorktree() (bool, *WorktreeInfo, error) {
+	// Check if .git is a file (worktree) vs directory (main repo)
+	gitPath := filepath.Join(e.repoRoot, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil, nil // Not in a git repo
+		}
+		return false, nil, fmt.Errorf("failed to stat .git: %w", err)
+	}
+
+	// If .git is a directory, we're in the main repo, not a worktree
+	if info.IsDir() {
+		return false, nil, nil
+	}
+
+	// .git is a file - we're in a worktree. Now check if it's stackit-managed.
+	// Get the current working directory (worktree path)
+	currentPath, err := filepath.Abs(e.repoRoot)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	// List all managed worktrees and check if current path matches
+	worktrees, err := e.ListManagedWorktrees()
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to list managed worktrees: %w", err)
+	}
+
+	for _, wt := range worktrees {
+		// Compare paths (normalize both)
+		wtPath, err := filepath.Abs(wt.Path)
+		if err != nil {
+			continue
+		}
+		if wtPath == currentPath {
+			return true, &WorktreeInfo{
+				Path:        wt.Path,
+				StackRoot:   wt.StackRoot,
+				CreatedAt:   wt.CreatedAt,
+				MainRepoDir: wt.MainRepoDir,
+			}, nil
+		}
+	}
+
+	// It's a worktree but not managed by stackit
+	return false, nil, nil
+}
+
 // setParentInternal updates parent without locking (caller must hold lock)
 func (e *engineImpl) setParentInternal(ctx context.Context, branchName string, parentBranchName string) error {
 	if branchName == parentBranchName {

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -165,6 +165,9 @@ type WorktreeRegistry interface {
 	ListManagedWorktrees() ([]WorktreeInfo, error)
 	// GetStackRootForBranch returns the stack root for a given branch
 	GetStackRootForBranch(branch Branch) string
+	// IsInManagedWorktree checks if the current directory is a stackit-managed worktree
+	// Returns true and worktree info if in a managed worktree, false otherwise
+	IsInManagedWorktree() (bool, *WorktreeInfo, error)
 }
 
 // Initializer handles repository initialization operations

--- a/internal/engine/worktree_test.go
+++ b/internal/engine/worktree_test.go
@@ -12,6 +12,45 @@ import (
 	"stackit.dev/stackit/testhelpers/scenario"
 )
 
+func TestIsInManagedWorktree_MainRepo(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithInitialCommit()
+
+	// When running from the main repo, IsInManagedWorktree should return false
+	isManaged, info, err := s.Engine.IsInManagedWorktree()
+	require.NoError(t, err)
+	assert.False(t, isManaged)
+	assert.Nil(t, info)
+}
+
+func TestWorktreeRegistry_StackRootForBranch(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithInitialCommit()
+
+	// Create a stack: main -> branch1 -> branch2
+	s.CreateBranch("branch1").Commit("branch1 change")
+	s.TrackBranch("branch1", "main")
+	s.CreateBranch("branch2").Commit("branch2 change")
+	s.TrackBranch("branch2", "branch1")
+
+	// Register a worktree for branch1 (as if it were the stack root)
+	err := s.Engine.RegisterWorktree("branch1", "/tmp/test-worktree-branch1")
+	require.NoError(t, err)
+
+	// Stack root for branch2 should be branch1 (the first branch whose parent is trunk)
+	branch2 := s.Engine.GetBranch("branch2")
+	stackRoot := s.Engine.GetStackRootForBranch(branch2)
+	assert.Equal(t, "branch1", stackRoot)
+
+	// Stack root for branch1 should be branch1 itself (its parent is trunk)
+	branch1 := s.Engine.GetBranch("branch1")
+	stackRoot = s.Engine.GetStackRootForBranch(branch1)
+	assert.Equal(t, "branch1", stackRoot)
+
+	// Clean up
+	_ = s.Engine.UnregisterWorktree("branch1")
+}
+
 func TestCreateTemporaryWorktree(t *testing.T) {
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 

--- a/internal/tui/components/tree/tree.go
+++ b/internal/tui/components/tree/tree.go
@@ -50,6 +50,9 @@ type BranchAnnotation struct {
 	LinesAdded   int
 	LinesDeleted int
 	PRState      string // "OPEN", "MERGED", "CLOSED"
+
+	// WorktreePath is set if this branch is the stack root of a managed worktree
+	WorktreePath string
 }
 
 // RenderOptions configures rendering behavior
@@ -648,6 +651,11 @@ func (r *StackTreeRenderer) formatSummaryLine(annotation BranchAnnotation, isTru
 	var prParts []string
 	var statsParts []string
 	var actionParts []string
+
+	// Worktree indicator (if this stack root has a managed worktree)
+	if annotation.WorktreePath != "" {
+		prParts = append(prParts, style.ColorDim("📂 worktree"))
+	}
 
 	// PR number (colored by state)
 	if annotation.PRNumber != nil {


### PR DESCRIPTION

- Add IsInManagedWorktree() to detect running from a managed worktree
- Add worktree context fields (InManagedWorktree, WorktreeInfo) to app.Context
- Populate worktree context automatically when commands run
- Add cross-worktree warning in checkout action
- Add worktree indicator to log output for stack roots with worktrees
- Add tests for worktree-aware behavior


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #342**
  * **PR #343**
    * **PR #344** 👈

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->