### PR TITLE
feat(create): add -w/--worktree flag for dedicated stack worktrees

### DIFF
--- a/internal/actions/create/create.go
+++ b/internal/actions/create/create.go
@@ -3,6 +3,7 @@ package create
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"stackit.dev/stackit/internal/actions"
 	"stackit.dev/stackit/internal/app"
@@ -27,6 +28,8 @@ type Options struct {
 	// SelectedChildren is used to specify which children to move during insert
 	// in non-interactive mode (mostly for tests)
 	SelectedChildren []string
+	// Worktree creates a dedicated worktree for this stack (only valid from trunk)
+	Worktree bool
 }
 
 // Action creates a new branch stacked on top of the current branch
@@ -40,6 +43,13 @@ func Action(ctx *app.Context, opts Options) error {
 		return err
 	}
 
+	// Validate worktree flag - only allowed when creating from trunk
+	if opts.Worktree {
+		if !eng.IsTrunk(eng.GetBranch(currentBranch)) {
+			return fmt.Errorf("--worktree/-w flag is only valid when creating a new stack from trunk")
+		}
+	}
+
 	// Take snapshot before modifying the repository
 	snapshotOpts := actions.NewSnapshot("create",
 		actions.WithArg(opts.BranchName),
@@ -49,6 +59,7 @@ func Action(ctx *app.Context, opts Options) error {
 		actions.WithFlag(opts.Insert, "--insert"),
 		actions.WithFlag(opts.Patch, "--patch"),
 		actions.WithFlag(opts.Update, "--update"),
+		actions.WithFlag(opts.Worktree, "--worktree"),
 	)
 	if err := eng.TakeSnapshot(snapshotOpts); err != nil {
 		// Log but don't fail - snapshot is best effort
@@ -142,6 +153,24 @@ func Action(ctx *app.Context, opts Options) error {
 		out.Info("Warning: failed to track branch: %v", err)
 	}
 
+	// Create worktree if requested
+	if opts.Worktree {
+		// Checkout back to trunk first so we can create the worktree for the branch
+		trunkBranch := eng.Trunk()
+		if err := eng.CheckoutBranch(ctx.Context, trunkBranch); err != nil {
+			out.Debug("Warning: failed to checkout trunk before creating worktree: %v", err)
+		}
+
+		worktreePath, err := createWorktreeForStack(ctx, branchName)
+		if err != nil {
+			// Clean up branch on worktree failure
+			_ = eng.DeleteBranch(ctx.Context, branch)
+			return fmt.Errorf("failed to create worktree: %w", err)
+		}
+		out.Info("Created worktree at %s", worktreePath)
+		out.Tip("cd %s", worktreePath)
+	}
+
 	// Set scope: use provided scope if given, otherwise let it inherit from parent naturally
 	if opts.Scope != "" {
 		// Set explicit scope if provided
@@ -188,4 +217,36 @@ func determineBranch(ctx *app.Context, opts *Options, commitMessage string, scop
 	}
 
 	return ctx.Engine.GetBranch(branchName), nil
+}
+
+// createWorktreeForStack creates a worktree for the given stack root and registers it
+func createWorktreeForStack(ctx *app.Context, stackRoot string) (string, error) {
+	eng := ctx.Engine
+
+	// Get worktree base path from config, or use default
+	cfg, _ := config.LoadConfig(ctx.RepoRoot)
+	basePath := cfg.WorktreeBasePath()
+
+	// Default: sibling directory named {repo}-stacks
+	if basePath == "" {
+		repoName := filepath.Base(ctx.RepoRoot)
+		basePath = filepath.Join(filepath.Dir(ctx.RepoRoot), repoName+"-stacks")
+	}
+
+	// Worktree path: basePath/stackRoot
+	worktreePath := filepath.Join(basePath, stackRoot)
+
+	// Create the worktree (non-detached, pointing to the stack root branch)
+	if err := eng.AddWorktree(ctx.Context, worktreePath, stackRoot, false); err != nil {
+		return "", fmt.Errorf("failed to create worktree: %w", err)
+	}
+
+	// Register the worktree in local refs
+	if err := eng.RegisterWorktree(stackRoot, worktreePath); err != nil {
+		// Clean up worktree on registration failure
+		_ = eng.RemoveWorktree(ctx.Context, worktreePath)
+		return "", fmt.Errorf("failed to register worktree: %w", err)
+	}
+
+	return worktreePath, nil
 }

--- a/internal/actions/create/create_test.go
+++ b/internal/actions/create/create_test.go
@@ -284,3 +284,63 @@ func TestCreateAction_Insert_Deep(t *testing.T) {
 		require.True(t, isAncestor, "child1 should still be an ancestor of grandchild")
 	})
 }
+
+func TestCreateAction_Worktree(t *testing.T) {
+	t.Run("creates worktree when -w flag is used from trunk", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+
+		// Create a change to stage
+		err := s.Scene.Repo.CreateChange("feature content", "feature.txt", false)
+		require.NoError(t, err)
+
+		// Create branch with worktree from trunk
+		opts := Options{
+			BranchName: "feature-branch",
+			Message:    "Add feature",
+			Worktree:   true,
+		}
+		err = Action(s.Context, opts)
+		require.NoError(t, err)
+
+		// Verify we're back on trunk (main repo stays on trunk, worktree has the branch)
+		currentBranch, err := s.Scene.Repo.CurrentBranchName()
+		require.NoError(t, err)
+		require.Equal(t, "main", currentBranch)
+
+		// Verify worktree was registered
+		eng := s.Context.Engine
+		worktreeInfo, err := eng.GetWorktreeForStack("feature-branch")
+		require.NoError(t, err)
+		require.NotNil(t, worktreeInfo)
+		require.Equal(t, "feature-branch", worktreeInfo.StackRoot)
+		require.Contains(t, worktreeInfo.Path, "feature-branch")
+
+		// Clean up worktree
+		_ = eng.RemoveWorktree(s.Context.Context, worktreeInfo.Path)
+		_ = eng.UnregisterWorktree("feature-branch")
+	})
+
+	t.Run("fails with -w flag when not on trunk", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+
+		// Create a child branch first (without worktree)
+		err := s.Scene.Repo.CreateChange("child1 content", "file1", false)
+		require.NoError(t, err)
+		err = Action(s.Context, Options{BranchName: "child1", Message: "Add child1"})
+		require.NoError(t, err)
+
+		// Now try to create another branch with -w from child1 (not trunk)
+		err = s.Scene.Repo.CreateChange("child2 content", "file2", false)
+		require.NoError(t, err)
+		opts := Options{
+			BranchName: "child2",
+			Message:    "Add child2",
+			Worktree:   true,
+		}
+		err = Action(s.Context, opts)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "only valid when creating a new stack from trunk")
+	})
+}

--- a/internal/cli/branch/create.go
+++ b/internal/cli/branch/create.go
@@ -13,13 +13,14 @@ import (
 // NewCreateCmd creates the create command
 func NewCreateCmd() *cobra.Command {
 	var (
-		all     bool
-		insert  bool
-		message string
-		patch   bool
-		scope   string
-		update  bool
-		verbose int
+		all      bool
+		insert   bool
+		message  string
+		patch    bool
+		scope    string
+		update   bool
+		verbose  int
+		worktree bool
 	)
 
 	cmd := &cobra.Command{
@@ -54,6 +55,7 @@ If you have any unstaged changes, you will be asked whether you'd like to stage 
 					Update:        update,
 					Verbose:       verbose,
 					BranchPattern: branchPattern,
+					Worktree:      worktree,
 				}
 
 				// Execute create action
@@ -70,6 +72,7 @@ If you have any unstaged changes, you will be asked whether you'd like to stage 
 	cmd.Flags().StringVar(&scope, "scope", "", "Set a scope (e.g., Jira ticket ID, Linear ID) for the new branch. If not provided, inherits from parent branch")
 	cmd.Flags().BoolVarP(&update, "update", "u", false, "Stage all updates to tracked files before creating the branch")
 	cmd.Flags().CountVarP(&verbose, "verbose", "v", "Show unified diff between the HEAD commit and what would be committed at the bottom of the commit message template. If specified twice, show in addition the unified diff between what would be committed and the worktree files")
+	cmd.Flags().BoolVarP(&worktree, "worktree", "w", false, "Create a dedicated worktree for this stack (only valid when creating a new stack from trunk)")
 
 	return cmd
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -128,5 +128,6 @@ type Engine interface {
 	Absorber
 	UndoManager
 	RemoteMetadataManager
+	WorktreeRegistry
 	Git() git.Runner
 }


### PR DESCRIPTION
Recreated PR after fixing stack structure


<!-- STACKIT-SECTION-START -->
#### Stack

> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.


* **PR #342**
  * **PR #345** 👈
    * **PR #346**
      * **PR #347**
        * **PR #348**
          * **PR #349**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #350 by jonnii*