### PR TITLE
feat: add worktree cleanup during sync (Phase 4)

### DIFF
--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -76,6 +76,12 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return fmt.Errorf("failed to clean branches: %w", err)
 	}
 
+	// Clean orphaned worktrees (after branch cleanup so we know what's been deleted)
+	worktreeResult := cleanOrphanedWorktrees(ctx)
+	if len(worktreeResult.RemovedWorktrees) > 0 {
+		summary.WorktreesCleaned = len(worktreeResult.RemovedWorktrees)
+	}
+
 	graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
 
 	// Add branches with new parents to restack list
@@ -185,6 +191,7 @@ type Summary struct {
 	BranchesSkipped   int      // Number of branches skipped (due to conflicts)
 	ConflictBranches  []string // Names of branches that conflicted
 	UpToDate          bool     // Everything was already current
+	WorktreesCleaned  int      // Number of orphaned worktrees cleaned up
 }
 
 // ParentsResult contains the result of synchronizing parents from GitHub
@@ -195,7 +202,7 @@ type ParentsResult struct {
 // HasChanges returns true if any operations were performed
 func (s *Summary) HasChanges() bool {
 	return s.TrunkUpdated || s.BranchesSynced > 0 || s.BranchesRestacked > 0 ||
-		s.BranchesDeleted > 0 || s.BranchesSkipped > 0
+		s.BranchesDeleted > 0 || s.BranchesSkipped > 0 || s.WorktreesCleaned > 0
 }
 
 // Handler abstracts TTY vs non-TTY output for sync operations
@@ -254,11 +261,22 @@ func FormatSummaryParts(summary Summary) []string {
 	if summary.BranchesDeleted > 0 {
 		parts = append(parts, fmt.Sprintf("deleted %d", summary.BranchesDeleted))
 	}
+	if summary.WorktreesCleaned > 0 {
+		parts = append(parts, fmt.Sprintf("cleaned %d worktree%s", summary.WorktreesCleaned, plural(summary.WorktreesCleaned)))
+	}
 	if summary.BranchesSkipped > 0 {
 		parts = append(parts, fmt.Sprintf("skipped %d (conflict)", summary.BranchesSkipped))
 	}
 
 	return parts
+}
+
+// plural returns "s" if count != 1, otherwise empty string
+func plural(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
 }
 
 // FormatSummaryString returns the full summary as a string

--- a/internal/actions/sync/worktree_cleanup.go
+++ b/internal/actions/sync/worktree_cleanup.go
@@ -1,0 +1,90 @@
+package sync
+
+import (
+	"os"
+
+	"stackit.dev/stackit/internal/app"
+	"stackit.dev/stackit/internal/config"
+)
+
+// WorktreeCleanupResult contains the results of worktree cleanup
+type WorktreeCleanupResult struct {
+	RemovedWorktrees []string // Stack roots whose worktrees were removed
+	Errors           []string // Any errors encountered (non-fatal)
+}
+
+// cleanOrphanedWorktrees removes worktrees for stacks that no longer exist.
+// This is called during sync after branch cleanup to remove worktrees for merged/deleted stacks.
+// This function is best-effort and will not fail sync on errors.
+func cleanOrphanedWorktrees(ctx *app.Context) *WorktreeCleanupResult {
+	result := &WorktreeCleanupResult{
+		RemovedWorktrees: []string{},
+		Errors:           []string{},
+	}
+
+	// Check if auto-clean is enabled
+	cfg, err := config.LoadConfig(ctx.RepoRoot)
+	if err != nil {
+		// If config can't be loaded, skip cleanup but don't fail
+		ctx.Output.Debug("Failed to load config for worktree cleanup: %v", err)
+		return result
+	}
+
+	if !cfg.WorktreeAutoClean() {
+		ctx.Output.Debug("Worktree auto-clean is disabled")
+		return result
+	}
+
+	// Get all managed worktrees
+	worktrees, err := ctx.Engine.ListManagedWorktrees()
+	if err != nil {
+		ctx.Output.Debug("Failed to list managed worktrees: %v", err)
+		return result
+	}
+
+	if len(worktrees) == 0 {
+		return result
+	}
+
+	// Check each worktree to see if its stack root still exists
+	for _, wt := range worktrees {
+		stackRootBranch := ctx.Engine.GetBranch(wt.StackRoot)
+
+		// Check if the stack root branch still exists and is tracked
+		// A branch "exists" if it's in the branch list (not just tracked)
+		branchExists := false
+		for _, b := range ctx.Engine.AllBranches() {
+			if b.GetName() == wt.StackRoot {
+				branchExists = true
+				break
+			}
+		}
+
+		if !branchExists || (!stackRootBranch.IsTrunk() && !stackRootBranch.IsTracked()) {
+			// Stack root no longer exists or is not tracked - clean up worktree
+			ctx.Output.Info("Removing worktree for deleted stack %s", wt.StackRoot)
+
+			// Check if worktree path still exists before trying to remove
+			if _, statErr := os.Stat(wt.Path); statErr == nil {
+				// Path exists, try to remove the worktree
+				if removeErr := ctx.Engine.RemoveWorktree(ctx.Context, wt.Path); removeErr != nil {
+					result.Errors = append(result.Errors,
+						"failed to remove worktree at "+wt.Path+": "+removeErr.Error())
+					ctx.Output.Debug("Failed to remove worktree at %s: %v", wt.Path, removeErr)
+					// Continue to unregister even if removal fails
+				}
+			}
+
+			// Unregister the worktree from the registry
+			if unregErr := ctx.Engine.UnregisterWorktree(wt.StackRoot); unregErr != nil {
+				result.Errors = append(result.Errors,
+					"failed to unregister worktree for "+wt.StackRoot+": "+unregErr.Error())
+				ctx.Output.Debug("Failed to unregister worktree for %s: %v", wt.StackRoot, unregErr)
+			} else {
+				result.RemovedWorktrees = append(result.RemovedWorktrees, wt.StackRoot)
+			}
+		}
+	}
+
+	return result
+}

--- a/internal/actions/sync/worktree_cleanup_test.go
+++ b/internal/actions/sync/worktree_cleanup_test.go
@@ -1,0 +1,71 @@
+package sync_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"stackit.dev/stackit/internal/actions/sync"
+	"stackit.dev/stackit/testhelpers"
+	"stackit.dev/stackit/testhelpers/scenario"
+)
+
+func TestSyncCleansOrphanedWorktrees(t *testing.T) {
+	t.Run("cleans worktree when stack root branch is deleted", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+
+		// Create a branch that will become a stack root
+		s.CreateBranch("feature-branch").Commit("feature change")
+		s.TrackBranch("feature-branch", "main")
+
+		// Register a fake worktree for this branch (we won't actually create the worktree dir)
+		err := s.Engine.RegisterWorktree("feature-branch", "/tmp/fake-worktree-path")
+		require.NoError(t, err)
+
+		// Verify worktree is registered
+		wt, err := s.Engine.GetWorktreeForStack("feature-branch")
+		require.NoError(t, err)
+		require.NotNil(t, wt)
+
+		// Delete the branch (simulating what happens when PR is merged and branch is cleaned)
+		s.Checkout("main")
+		err = s.Engine.DeleteBranch(s.Context.Context, s.Engine.GetBranch("feature-branch"))
+		require.NoError(t, err)
+
+		// Run sync - this should clean up the orphaned worktree registration
+		handler := &sync.NullHandler{}
+		err = sync.Action(s.Context, sync.Options{}, handler)
+		require.NoError(t, err)
+
+		// Verify worktree registration was cleaned up
+		wt, err = s.Engine.GetWorktreeForStack("feature-branch")
+		require.NoError(t, err)
+		assert.Nil(t, wt, "worktree registration should be removed after branch deletion")
+	})
+
+	t.Run("preserves worktree when stack root branch still exists", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+
+		// Create and track a branch
+		s.CreateBranch("feature-branch").Commit("feature change")
+		s.TrackBranch("feature-branch", "main")
+
+		// Register a worktree for this branch
+		err := s.Engine.RegisterWorktree("feature-branch", "/tmp/fake-worktree-path")
+		require.NoError(t, err)
+
+		// Go back to main and run sync
+		s.Checkout("main")
+		handler := &sync.NullHandler{}
+		err = sync.Action(s.Context, sync.Options{}, handler)
+		require.NoError(t, err)
+
+		// Verify worktree registration is preserved
+		wt, err := s.Engine.GetWorktreeForStack("feature-branch")
+		require.NoError(t, err)
+		assert.NotNil(t, wt, "worktree registration should be preserved when branch exists")
+	})
+}


### PR DESCRIPTION

- Add cleanOrphanedWorktrees() to remove worktrees for deleted stacks
- Integrate worktree cleanup into sync action after branch cleanup
- Add WorktreesCleaned field to sync Summary
- Respect worktree.autoClean config option (defaults to true)
- Add tests for worktree cleanup behavior


<!-- STACKIT-SECTION-START -->
#### Stack

> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.


* **PR #342**
  * **PR #345**
    * **PR #346**
      * **PR #347** 👈
        * **PR #348**
          * **PR #349**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #350 by jonnii*