### PR TITLE
feat: cleanup worktree when deleting all branches in stack

### DIFF
--- a/internal/actions/checkout.go
+++ b/internal/actions/checkout.go
@@ -187,7 +187,7 @@ func handleWorktreeCheckout(ctx *app.Context, branch engine.Branch, branchName s
 	// Emit directives for shell wrapper to handle
 	ctx.Output.Info("Switching to worktree for stack %s.", style.ColorBranchName(targetStackRoot, false))
 	ctx.Output.DirectiveCD(targetWorktree.Path)
-	ctx.Output.DirectiveCheckout(branchName)
+	ctx.Output.DirectiveRerun()
 	return true
 }
 

--- a/internal/actions/delete/delete.go
+++ b/internal/actions/delete/delete.go
@@ -3,6 +3,7 @@ package delete
 
 import (
 	"fmt"
+	"os"
 
 	"stackit.dev/stackit/internal/actions"
 	"stackit.dev/stackit/internal/app"
@@ -105,6 +106,20 @@ func Action(ctx *app.Context, opts Options) error {
 		out.Info("Deleted branch %s", style.ColorBranchName(name, false))
 	}
 
+	// Identify stack roots that were deleted (branches whose parent is trunk)
+	// and clean up any associated worktrees
+	deletedStackRoots := []string{}
+	trunkName := eng.Trunk().GetName()
+	for _, b := range toDelete {
+		parent := b.GetParent()
+		if parent == nil || parent.GetName() == trunkName {
+			deletedStackRoots = append(deletedStackRoots, b.GetName())
+		}
+	}
+	if len(deletedStackRoots) > 0 {
+		cleanupWorktreesForDeletedStacks(ctx, deletedStackRoots)
+	}
+
 	// Restack children if any
 	if len(childrenToRestack) > 0 {
 		out.Info("Restacking children of deleted %s...", actions.Pluralize("branch", len(toDelete)))
@@ -119,4 +134,35 @@ func Action(ctx *app.Context, opts Options) error {
 	}
 
 	return nil
+}
+
+// cleanupWorktreesForDeletedStacks removes worktrees for stack roots that have been deleted.
+// This is best-effort - errors are logged but don't fail the delete operation.
+func cleanupWorktreesForDeletedStacks(ctx *app.Context, deletedStackRoots []string) {
+	for _, stackRoot := range deletedStackRoots {
+		wt, err := ctx.Engine.GetWorktreeForStack(stackRoot)
+		if err != nil || wt == nil {
+			continue // No worktree registered for this stack
+		}
+
+		// Check if user is in this worktree - emit CD directive to navigate back to main repo
+		if ctx.InManagedWorktree && ctx.WorktreeInfo != nil &&
+			ctx.WorktreeInfo.StackRoot == stackRoot {
+			ctx.Output.DirectiveCD(wt.MainRepoDir)
+		}
+
+		ctx.Output.Info("Removing worktree for deleted stack %s", style.ColorBranchName(stackRoot, false))
+
+		// Remove worktree directory if it exists
+		if _, statErr := os.Stat(wt.Path); statErr == nil {
+			if removeErr := ctx.Engine.RemoveWorktree(ctx.Context, wt.Path); removeErr != nil {
+				ctx.Output.Debug("Failed to remove worktree at %s: %v", wt.Path, removeErr)
+			}
+		}
+
+		// Unregister the worktree from the registry
+		if unregErr := ctx.Engine.UnregisterWorktree(stackRoot); unregErr != nil {
+			ctx.Output.Debug("Failed to unregister worktree for %s: %v", stackRoot, unregErr)
+		}
+	}
 }

--- a/internal/actions/delete/delete_test.go
+++ b/internal/actions/delete/delete_test.go
@@ -3,8 +3,10 @@ package delete
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"stackit.dev/stackit/testhelpers"
 	"stackit.dev/stackit/testhelpers/scenario"
 )
 
@@ -141,5 +143,102 @@ func TestDelete(t *testing.T) {
 		parent2 := branchparent2.GetParent()
 		require.NotNil(t, parent2)
 		require.Equal(t, "main", parent2.GetName())
+	})
+}
+
+func TestDeleteCleansUpWorktrees(t *testing.T) {
+	t.Run("cleans worktree when stack root is deleted", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		// Create a stack root branch
+		s.CreateBranch("feature-branch").Commit("feature change")
+		s.TrackBranch("feature-branch", "main")
+
+		// Register a fake worktree for this stack root
+		err := s.Engine.RegisterWorktree("feature-branch", "/tmp/fake-worktree-path")
+		require.NoError(t, err)
+
+		// Verify worktree is registered
+		wt, err := s.Engine.GetWorktreeForStack("feature-branch")
+		require.NoError(t, err)
+		require.NotNil(t, wt)
+
+		// Delete the stack root
+		s.Checkout("main")
+		err = Action(s.Context, Options{
+			BranchName: "feature-branch",
+			Force:      true,
+		})
+		require.NoError(t, err)
+
+		// Verify worktree registration was cleaned up
+		wt, err = s.Engine.GetWorktreeForStack("feature-branch")
+		require.NoError(t, err)
+		assert.Nil(t, wt, "worktree registration should be removed when stack root is deleted")
+	})
+
+	t.Run("does not clean worktree when non-root branch is deleted", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		// Create a stack with two branches
+		s.CreateBranch("stack-root").Commit("root change")
+		s.TrackBranch("stack-root", "main")
+		s.CreateBranch("child-branch").Commit("child change")
+		s.TrackBranch("child-branch", "stack-root")
+
+		// Register a worktree for the stack root
+		err := s.Engine.RegisterWorktree("stack-root", "/tmp/fake-worktree-path")
+		require.NoError(t, err)
+
+		// Verify worktree is registered
+		wt, err := s.Engine.GetWorktreeForStack("stack-root")
+		require.NoError(t, err)
+		require.NotNil(t, wt)
+
+		// Delete the child branch (not the stack root)
+		s.Checkout("stack-root")
+		err = Action(s.Context, Options{
+			BranchName: "child-branch",
+			Force:      true,
+		})
+		require.NoError(t, err)
+
+		// Verify worktree registration is preserved
+		wt, err = s.Engine.GetWorktreeForStack("stack-root")
+		require.NoError(t, err)
+		assert.NotNil(t, wt, "worktree registration should be preserved when non-root branch is deleted")
+	})
+
+	t.Run("cleans worktree when upstack deletes entire stack including root", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		// Create a stack with multiple branches
+		s.CreateBranch("stack-root").Commit("root change")
+		s.TrackBranch("stack-root", "main")
+		s.CreateBranch("child-branch").Commit("child change")
+		s.TrackBranch("child-branch", "stack-root")
+
+		// Register a worktree for the stack root
+		err := s.Engine.RegisterWorktree("stack-root", "/tmp/fake-worktree-path")
+		require.NoError(t, err)
+
+		// Verify worktree is registered
+		wt, err := s.Engine.GetWorktreeForStack("stack-root")
+		require.NoError(t, err)
+		require.NotNil(t, wt)
+
+		// Delete upstack from stack root (deletes all branches in the stack)
+		s.Checkout("main")
+		err = Action(s.Context, Options{
+			BranchName: "stack-root",
+			Upstack:    true,
+			Force:      true,
+		})
+		require.NoError(t, err)
+
+		// Verify worktree registration was cleaned up
+		wt, err = s.Engine.GetWorktreeForStack("stack-root")
+		require.NoError(t, err)
+		assert.Nil(t, wt, "worktree registration should be removed when entire stack is deleted with --upstack")
 	})
 }

--- a/internal/cli/shell/shell.go
+++ b/internal/cli/shell/shell.go
@@ -79,7 +79,7 @@ const zshIntegration = `# stackit shell integration for zsh
 # This wraps the stackit command to enable auto-cd into worktrees
 
 __stackit_wrap() {
-    local output exit_code cd_path checkout_branch
+    local output exit_code cd_path rerun
 
     # Run the real stackit command and capture output
     # Set env var so stackit knows shell integration is available
@@ -88,27 +88,24 @@ __stackit_wrap() {
 
     # Print output, filtering out directives
     echo "$output" | while IFS= read -r line; do
-        if [[ "$line" == __STACKIT_CD__:* ]]; then
-            : # skip
-        elif [[ "$line" == __STACKIT_CHECKOUT__:* ]]; then
-            : # skip
+        if [[ "$line" == __STACKIT_CD__:* ]] || [[ "$line" == __STACKIT_RERUN__ ]]; then
+            : # skip directives
         else
             echo "$line"
         fi
     done
 
-    # Extract directives from output (in case the while loop runs in a subshell)
+    # Extract directives from output
     cd_path=$(echo "$output" | grep '^__STACKIT_CD__:' | head -1 | cut -d: -f2-)
-    checkout_branch=$(echo "$output" | grep '^__STACKIT_CHECKOUT__:' | head -1 | cut -d: -f2-)
+    rerun=$(echo "$output" | grep -q '^__STACKIT_RERUN__$' && echo 1)
 
     # Change directory if path was found and exists
     if [[ -n "$cd_path" && -d "$cd_path" ]]; then
         cd "$cd_path"
-    fi
-
-    # Checkout branch if specified (after cd)
-    if [[ -n "$checkout_branch" ]]; then
-        command stackit co "$checkout_branch"
+        # Re-run original command if requested
+        if [[ -n "$rerun" ]]; then
+            STACKIT_SHELL_INTEGRATION=1 command stackit "$@"
+        fi
     fi
 
     return $exit_code
@@ -124,7 +121,7 @@ const bashIntegration = `# stackit shell integration for bash
 # This wraps the stackit command to enable auto-cd into worktrees
 
 __stackit_wrap() {
-    local output exit_code cd_path checkout_branch
+    local output exit_code cd_path rerun
 
     # Run the real stackit command and capture output
     # Set env var so stackit knows shell integration is available
@@ -133,27 +130,24 @@ __stackit_wrap() {
 
     # Print output, filtering out directives
     echo "$output" | while IFS= read -r line; do
-        if [[ "$line" == __STACKIT_CD__:* ]]; then
-            : # skip
-        elif [[ "$line" == __STACKIT_CHECKOUT__:* ]]; then
-            : # skip
+        if [[ "$line" == __STACKIT_CD__:* ]] || [[ "$line" == __STACKIT_RERUN__ ]]; then
+            : # skip directives
         else
             echo "$line"
         fi
     done
 
-    # Extract directives from output (in case the while loop runs in a subshell)
+    # Extract directives from output
     cd_path=$(echo "$output" | grep '^__STACKIT_CD__:' | head -1 | cut -d: -f2-)
-    checkout_branch=$(echo "$output" | grep '^__STACKIT_CHECKOUT__:' | head -1 | cut -d: -f2-)
+    rerun=$(echo "$output" | grep -q '^__STACKIT_RERUN__$' && echo 1)
 
     # Change directory if path was found and exists
     if [[ -n "$cd_path" && -d "$cd_path" ]]; then
         cd "$cd_path"
-    fi
-
-    # Checkout branch if specified (after cd)
-    if [[ -n "$checkout_branch" ]]; then
-        command stackit co "$checkout_branch"
+        # Re-run original command if requested
+        if [[ -n "$rerun" ]]; then
+            STACKIT_SHELL_INTEGRATION=1 command stackit "$@"
+        fi
     fi
 
     return $exit_code
@@ -175,12 +169,12 @@ function stackit --wraps=stackit --description 'stackit with auto-cd support'
 
     # Print output, filtering out directives
     set -l cd_path ""
-    set -l checkout_branch ""
+    set -l rerun 0
     for line in $output
         if string match -q '__STACKIT_CD__:*' -- $line
             set cd_path (string replace '__STACKIT_CD__:' '' -- $line)
-        else if string match -q '__STACKIT_CHECKOUT__:*' -- $line
-            set checkout_branch (string replace '__STACKIT_CHECKOUT__:' '' -- $line)
+        else if test "$line" = "__STACKIT_RERUN__"
+            set rerun 1
         else
             echo $line
         end
@@ -189,11 +183,10 @@ function stackit --wraps=stackit --description 'stackit with auto-cd support'
     # Change directory if path was found and exists
     if test -n "$cd_path" -a -d "$cd_path"
         cd $cd_path
-    end
-
-    # Checkout branch if specified (after cd)
-    if test -n "$checkout_branch"
-        command stackit co $checkout_branch
+        # Re-run original command if requested
+        if test $rerun -eq 1
+            env STACKIT_SHELL_INTEGRATION=1 command stackit $argv
+        end
     end
 
     return $exit_code

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -23,8 +23,8 @@ type Output interface {
 	Newline()
 
 	// Shell integration directives (always output, parsed by shell wrapper)
-	DirectiveCD(path string)         // Output __STACKIT_CD__:<path> for shell integration
-	DirectiveCheckout(branch string) // Output __STACKIT_CHECKOUT__:<branch> for shell integration
+	DirectiveCD(path string) // Output __STACKIT_CD__:<path> for shell integration
+	DirectiveRerun()         // Output __STACKIT_RERUN__ to re-run command after cd
 
 	// Quiet mode for TUI coordination
 	SetQuiet(quiet bool)
@@ -130,11 +130,11 @@ func (c *ConsoleOutput) DirectiveCD(path string) {
 	_, _ = fmt.Fprintf(c.writer, "__STACKIT_CD__:%s\n", path)
 }
 
-// DirectiveCheckout outputs a shell integration directive for checking out a branch.
-// Used in combination with DirectiveCD for cross-worktree checkouts.
+// DirectiveRerun outputs a shell integration directive to re-run the original command.
+// Used in combination with DirectiveCD when the command should be retried after cd.
 // This is always output (even in quiet mode) as the shell wrapper needs to parse it.
-func (c *ConsoleOutput) DirectiveCheckout(branch string) {
-	_, _ = fmt.Fprintf(c.writer, "__STACKIT_CHECKOUT__:%s\n", branch)
+func (c *ConsoleOutput) DirectiveRerun() {
+	_, _ = fmt.Fprintln(c.writer, "__STACKIT_RERUN__")
 }
 
 // SetQuiet enables or disables quiet mode.


### PR DESCRIPTION

- Auto-cleanup worktree when stack root is deleted via 'st delete'
- Emit DirectiveCD to navigate user back to main repo if inside deleted worktree
- Replace DirectiveCheckout with DirectiveRerun for cleaner cross-worktree checkout


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #359** 👈

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->