### PR TITLE
feat: preserve TTY and enable bidirectional worktree switching

### DIFF
--- a/internal/actions/checkout.go
+++ b/internal/actions/checkout.go
@@ -143,26 +143,69 @@ func printBranchInfo(ctx *app.Context, branch engine.Branch) {
 	}
 }
 
-// handleWorktreeCheckout checks if the target branch belongs to a stack with a worktree.
-// If shell integration is available, emits DirectiveCD + DirectiveCheckout for the shell wrapper.
+// handleWorktreeCheckout checks if the target branch belongs to a stack with a worktree,
+// or if we need to switch back to the main repo from a worktree.
+// If shell integration is available, emits DirectiveCD + DirectiveRerun for the shell wrapper.
 // Otherwise, shows a warning with cd tip.
 // Returns true if handled via directives (caller should skip git checkout).
 func handleWorktreeCheckout(ctx *app.Context, branch engine.Branch, branchName string) bool {
 	// Get target branch's stack root
 	targetStackRoot := ctx.Engine.GetStackRootForBranch(branch)
+
+	// Case 1: We're in a worktree and checking out a branch NOT in this worktree's stack
+	// (either trunk, or a branch from a different stack)
+	if ctx.InManagedWorktree && ctx.WorktreeInfo != nil {
+		currentStackRoot := ctx.WorktreeInfo.StackRoot
+
+		// Check if target is in a different location than current worktree
+		needsSwitch := false
+		var switchTarget string
+		var switchMessage string
+
+		if targetStackRoot == "" {
+			// Target is trunk or untracked - switch to main repo
+			needsSwitch = true
+			switchTarget = ctx.WorktreeInfo.MainRepoDir
+			switchMessage = "Switching to main repository."
+		} else if targetStackRoot != currentStackRoot {
+			// Target is in a different stack - check if that stack has a worktree
+			targetWorktree, err := ctx.Engine.GetWorktreeForStack(targetStackRoot)
+			if err == nil && targetWorktree != nil {
+				needsSwitch = true
+				switchTarget = targetWorktree.Path
+				switchMessage = fmt.Sprintf("Switching to worktree for stack %s.", style.ColorBranchName(targetStackRoot, false))
+			} else {
+				// Target stack has no worktree - switch to main repo
+				needsSwitch = true
+				switchTarget = ctx.WorktreeInfo.MainRepoDir
+				switchMessage = "Switching to main repository."
+			}
+		}
+
+		if needsSwitch {
+			if !hasShellIntegration() {
+				ctx.Output.Warn("Branch %s is not in this worktree's stack.", style.ColorBranchName(branchName, false))
+				ctx.Output.Tip("cd %s && stackit co %s", switchTarget, branchName)
+				return false
+			}
+			ctx.Output.Info(switchMessage)
+			ctx.Output.DirectiveCD(switchTarget)
+			ctx.Output.DirectiveRerun("co", branchName)
+			return true
+		}
+		// Target is in current worktree's stack - proceed with normal checkout
+		return false
+	}
+
+	// Case 2: We're in main repo and checking out a branch that has a worktree
 	if targetStackRoot == "" {
-		return false // Not a tracked branch or is trunk
+		return false // Target is trunk or untracked, no worktree needed
 	}
 
 	// Check if this stack has a registered worktree
 	targetWorktree, err := ctx.Engine.GetWorktreeForStack(targetStackRoot)
 	if err != nil || targetWorktree == nil {
 		return false // No worktree for this stack
-	}
-
-	// Check if we're already in the target worktree (prevents recursion)
-	if ctx.InManagedWorktree && ctx.WorktreeInfo != nil && ctx.WorktreeInfo.StackRoot == targetStackRoot {
-		return false // Already in correct worktree, proceed with normal checkout
 	}
 
 	// Verify worktree path exists
@@ -187,7 +230,7 @@ func handleWorktreeCheckout(ctx *app.Context, branch engine.Branch, branchName s
 	// Emit directives for shell wrapper to handle
 	ctx.Output.Info("Switching to worktree for stack %s.", style.ColorBranchName(targetStackRoot, false))
 	ctx.Output.DirectiveCD(targetWorktree.Path)
-	ctx.Output.DirectiveRerun()
+	ctx.Output.DirectiveRerun("co", branchName)
 	return true
 }
 

--- a/internal/cli/shell/shell.go
+++ b/internal/cli/shell/shell.go
@@ -79,7 +79,7 @@ const zshIntegration = `# stackit shell integration for zsh
 # This wraps the stackit command to enable auto-cd into worktrees
 
 __stackit_wrap() {
-    local exit_code cd_path rerun directive_file
+    local exit_code cd_path rerun_line rerun_args directive_file
 
     # Create temp file for directives (preserves TTY for interactive commands)
     directive_file=$(mktemp)
@@ -92,16 +92,25 @@ __stackit_wrap() {
     # Read directives from temp file
     if [[ -f "$directive_file" ]]; then
         cd_path=$(grep '^__STACKIT_CD__:' "$directive_file" 2>/dev/null | head -1 | cut -d: -f2-)
-        rerun=$(grep -q '^__STACKIT_RERUN__$' "$directive_file" 2>/dev/null && echo 1)
+        rerun_line=$(grep '^__STACKIT_RERUN__' "$directive_file" 2>/dev/null | head -1)
         rm -f "$directive_file"
     fi
 
     # Change directory if path was found and exists
     if [[ -n "$cd_path" && -d "$cd_path" ]]; then
         cd "$cd_path"
-        # Re-run original command if requested
-        if [[ -n "$rerun" ]]; then
-            STACKIT_SHELL_INTEGRATION=1 STACKIT_DIRECTIVE_FILE="" command stackit "$@"
+        # Run follow-up command if requested
+        if [[ -n "$rerun_line" ]]; then
+            # Extract args after __STACKIT_RERUN__: (if present)
+            rerun_args="${rerun_line#__STACKIT_RERUN__}"
+            rerun_args="${rerun_args#:}"
+            if [[ -n "$rerun_args" ]]; then
+                # Use specific args provided by stackit
+                eval "STACKIT_SHELL_INTEGRATION=1 STACKIT_DIRECTIVE_FILE='' command stackit $rerun_args"
+            else
+                # No args: re-run original command
+                STACKIT_SHELL_INTEGRATION=1 STACKIT_DIRECTIVE_FILE="" command stackit "$@"
+            fi
         fi
     fi
 
@@ -117,7 +126,7 @@ const bashIntegration = `# stackit shell integration for bash
 # This wraps the stackit command to enable auto-cd into worktrees
 
 __stackit_wrap() {
-    local exit_code cd_path rerun directive_file
+    local exit_code cd_path rerun_line rerun_args directive_file
 
     # Create temp file for directives (preserves TTY for interactive commands)
     directive_file=$(mktemp)
@@ -130,16 +139,25 @@ __stackit_wrap() {
     # Read directives from temp file
     if [[ -f "$directive_file" ]]; then
         cd_path=$(grep '^__STACKIT_CD__:' "$directive_file" 2>/dev/null | head -1 | cut -d: -f2-)
-        rerun=$(grep -q '^__STACKIT_RERUN__$' "$directive_file" 2>/dev/null && echo 1)
+        rerun_line=$(grep '^__STACKIT_RERUN__' "$directive_file" 2>/dev/null | head -1)
         rm -f "$directive_file"
     fi
 
     # Change directory if path was found and exists
     if [[ -n "$cd_path" && -d "$cd_path" ]]; then
         cd "$cd_path"
-        # Re-run original command if requested
-        if [[ -n "$rerun" ]]; then
-            STACKIT_SHELL_INTEGRATION=1 STACKIT_DIRECTIVE_FILE="" command stackit "$@"
+        # Run follow-up command if requested
+        if [[ -n "$rerun_line" ]]; then
+            # Extract args after __STACKIT_RERUN__: (if present)
+            rerun_args="${rerun_line#__STACKIT_RERUN__}"
+            rerun_args="${rerun_args#:}"
+            if [[ -n "$rerun_args" ]]; then
+                # Use specific args provided by stackit
+                eval "STACKIT_SHELL_INTEGRATION=1 STACKIT_DIRECTIVE_FILE='' command stackit $rerun_args"
+            else
+                # No args: re-run original command
+                STACKIT_SHELL_INTEGRATION=1 STACKIT_DIRECTIVE_FILE="" command stackit "$@"
+            fi
         fi
     fi
 
@@ -165,21 +183,27 @@ function __stackit_wrap --description 'stackit wrapper with auto-cd support'
 
     # Read directives from temp file
     set -l cd_path ""
-    set -l rerun 0
+    set -l rerun_line ""
     if test -f "$directive_file"
         set cd_path (grep '^__STACKIT_CD__:' "$directive_file" 2>/dev/null | head -1 | cut -d: -f2-)
-        if grep -q '^__STACKIT_RERUN__$' "$directive_file" 2>/dev/null
-            set rerun 1
-        end
+        set rerun_line (grep '^__STACKIT_RERUN__' "$directive_file" 2>/dev/null | head -1)
         rm -f "$directive_file"
     end
 
     # Change directory if path was found and exists
     if test -n "$cd_path" -a -d "$cd_path"
         cd $cd_path
-        # Re-run original command if requested
-        if test $rerun -eq 1
-            env STACKIT_SHELL_INTEGRATION=1 STACKIT_DIRECTIVE_FILE="" command stackit $argv
+        # Run follow-up command if requested
+        if test -n "$rerun_line"
+            # Extract args after __STACKIT_RERUN__: (if present)
+            set -l rerun_args (string replace '__STACKIT_RERUN__:' '' -- $rerun_line)
+            if test -n "$rerun_args" -a "$rerun_args" != "$rerun_line"
+                # Use specific args provided by stackit
+                eval "env STACKIT_SHELL_INTEGRATION=1 STACKIT_DIRECTIVE_FILE='' command stackit $rerun_args"
+            else
+                # No args: re-run original command
+                env STACKIT_SHELL_INTEGRATION=1 STACKIT_DIRECTIVE_FILE="" command stackit $argv
+            end
         end
     end
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 )
 
 // Output handles user-facing console messages.
@@ -23,8 +24,8 @@ type Output interface {
 	Newline()
 
 	// Shell integration directives (always output, parsed by shell wrapper)
-	DirectiveCD(path string) // Output __STACKIT_CD__:<path> for shell integration
-	DirectiveRerun()         // Output __STACKIT_RERUN__ to re-run command after cd
+	DirectiveCD(path string)       // Output __STACKIT_CD__:<path> for shell integration
+	DirectiveRerun(args ...string) // Output __STACKIT_RERUN__[:args] to run command after cd
 
 	// Quiet mode for TUI coordination
 	SetQuiet(quiet bool)
@@ -132,12 +133,35 @@ func (c *ConsoleOutput) DirectiveCD(path string) {
 	writeDirective(c.writer, directive)
 }
 
-// DirectiveRerun outputs a shell integration directive to re-run the original command.
-// Used in combination with DirectiveCD when the command should be retried after cd.
+// DirectiveRerun outputs a shell integration directive to run a command after cd.
+// If args are provided, runs "stackit <args...>". Otherwise re-runs the original command.
 // This is always output (even in quiet mode) as the shell wrapper needs to parse it.
 // If STACKIT_DIRECTIVE_FILE is set, writes to that file instead of stdout.
-func (c *ConsoleOutput) DirectiveRerun() {
-	writeDirective(c.writer, "__STACKIT_RERUN__\n")
+func (c *ConsoleOutput) DirectiveRerun(args ...string) {
+	if len(args) == 0 {
+		writeDirective(c.writer, "__STACKIT_RERUN__\n")
+	} else {
+		// Join args with spaces for shell to parse
+		directive := fmt.Sprintf("__STACKIT_RERUN__:%s\n", joinArgs(args))
+		writeDirective(c.writer, directive)
+	}
+}
+
+// joinArgs joins arguments, quoting any that contain spaces.
+func joinArgs(args []string) string {
+	var result string
+	for i, arg := range args {
+		if i > 0 {
+			result += " "
+		}
+		// Quote args containing spaces
+		if strings.Contains(arg, " ") {
+			result += fmt.Sprintf("%q", arg)
+		} else {
+			result += arg
+		}
+	}
+	return result
 }
 
 // writeDirective writes a directive to the directive file if set, otherwise to the writer.


### PR DESCRIPTION

Shell integration now uses temp file for directives instead of stdout
capture, preserving TTY for interactive commands. Also adds st() wrapper
and enables switching from worktree back to main repo when checking out
trunk or branches from other stacks.


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #363** 👈

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->