### PR TITLE
bug: worktree syncs leave branches with changes

### DIFF
--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -421,6 +421,14 @@ func (d *demoGitRunner) ListWorktrees(_ context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
+func (d *demoGitRunner) GetWorktreePathForBranch(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+
+func (d *demoGitRunner) ResetWorktreeWorkingDir(_ context.Context, _ string) error {
+	return nil
+}
+
 func (d *demoGitRunner) UpdateRefWithLog(_ context.Context, _, _, _ string) error {
 	return nil
 }

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -156,11 +156,16 @@ func (e *engineImpl) restackBranch(
 				return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to update branch ref for frozen branch %s: %w", branchName, err)
 			}
 
-			// If the branch is currently checked out, we also need to reset the working tree
+			// If the branch is currently checked out in this context, reset the working tree
 			current := e.CurrentBranch()
 			if current != nil && current.GetName() == branchName {
 				if err := e.git.HardReset(ctx, "HEAD"); err != nil {
 					return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to reset working tree for frozen branch %s: %w", branchName, err)
+				}
+			} else {
+				// If the branch is checked out in a different worktree, reset that worktree
+				if worktreePath, err := e.git.GetWorktreePathForBranch(ctx, branchName); err == nil && worktreePath != "" {
+					_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath)
 				}
 			}
 
@@ -343,6 +348,14 @@ func (e *engineImpl) restackBranch(
 			OldParent:         oldParent,
 			NewParent:         parent,
 		}, fmt.Errorf("failed to update branch reference %s: %w", branchName, err)
+	}
+
+	// If this branch is checked out in a worktree, reset that worktree's working directory
+	// to match the new branch content. Without this, the worktree would have stale content
+	// that appears as staged changes reverting the rebased commits.
+	if worktreePath, err := e.git.GetWorktreePathForBranch(ctx, branchName); err == nil && worktreePath != "" {
+		// Best-effort: don't fail restack if worktree reset fails
+		_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath)
 	}
 
 	// Update metadata

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -176,6 +176,8 @@ type WorktreeOperations interface {
 	AddWorktree(ctx context.Context, path string, branch string, detach bool) error
 	RemoveWorktree(ctx context.Context, path string) error
 	ListWorktrees(ctx context.Context) ([]string, error)
+	GetWorktreePathForBranch(ctx context.Context, branchName string) (string, error)
+	ResetWorktreeWorkingDir(ctx context.Context, worktreePath string) error
 }
 
 // WorktreeRegistryOperations handles stackit-managed worktree tracking (local-only refs).

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -117,6 +117,52 @@ func (r *runner) DeleteWorktreeMeta(stackRoot string) error {
 	return r.DeleteRef(refName)
 }
 
+// GetWorktreePathForBranch returns the worktree path where a branch is checked out.
+// Returns empty string if the branch is not checked out in any worktree.
+func (r *runner) GetWorktreePathForBranch(ctx context.Context, branchName string) (string, error) {
+	output, err := r.RunGitCommandWithContext(ctx, "worktree", "list", "--porcelain")
+	if err != nil {
+		return "", fmt.Errorf("failed to list worktrees: %w", err)
+	}
+
+	if output == "" {
+		return "", nil
+	}
+
+	// Parse porcelain output to find worktree with this branch
+	// Format:
+	// worktree /path/to/worktree
+	// HEAD abc123
+	// branch refs/heads/branchname
+	// (blank line)
+	lines := strings.Split(output, "\n")
+	var currentWorktree string
+	targetRef := "refs/heads/" + branchName
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "worktree ") {
+			currentWorktree = strings.TrimPrefix(line, "worktree ")
+		} else if strings.HasPrefix(line, "branch ") {
+			branch := strings.TrimPrefix(line, "branch ")
+			if branch == targetRef && currentWorktree != "" {
+				return currentWorktree, nil
+			}
+		}
+	}
+
+	return "", nil
+}
+
+// ResetWorktreeWorkingDir resets a worktree's working directory to match HEAD.
+// This is used after updating a branch ref to sync the worktree's working directory.
+func (r *runner) ResetWorktreeWorkingDir(ctx context.Context, worktreePath string) error {
+	_, err := r.RunGitCommandWithContext(ctx, "-C", worktreePath, "reset", "--hard", "HEAD")
+	if err != nil {
+		return fmt.Errorf("failed to reset worktree at %s: %w", worktreePath, err)
+	}
+	return nil
+}
+
 // ListWorktreeMetas lists all registered worktree metadata
 func (r *runner) ListWorktreeMetas() (map[string]*WorktreeMeta, error) {
 	refs, err := r.ListRefs(WorktreeRefPrefix)

--- a/internal/integration/worktree_sync_test.go
+++ b/internal/integration/worktree_sync_test.go
@@ -4,6 +4,61 @@ import (
 	"testing"
 )
 
+// TestWorktreeWorkingDirAfterRestack tests that when a branch is restacked
+// from a different context, the worktree's working directory is properly updated.
+func TestWorktreeWorkingDirAfterRestack(t *testing.T) {
+	t.Run("worktree working dir updated after restack from main repo", func(t *testing.T) {
+		// This test reproduces a bug where:
+		// 1. Branch B is checked out in Worktree W
+		// 2. Main advances with new commits
+		// 3. Sync runs from main repo (not the worktree)
+		// 4. Branch B is rebased (ref updated via UpdateBranchRef)
+		// 5. But Worktree W's working directory is NOT updated
+		// 6. Result: git shows staged changes that "revert" the new content
+
+		sh := NewTestShellWithRemoteInProcess(t)
+
+		// Create a branch with worktree
+		sh.Log("Creating branch with worktree...")
+		sh.WriteFile("feature.txt", "feature content").
+			Run("create feature -w -m 'feature branch'").
+			OnBranch("main")
+
+		// Get worktree path
+		worktreePath := sh.GetWorktreePath("feature")
+		shW := sh.InWorktree(worktreePath)
+		shW.OnBranch("feature")
+
+		// Advance main with a change to a file that the worktree will see after restack
+		sh.Log("Advancing main with new file...")
+		sh.WriteFile("new-from-main.txt", "content from main").
+			Git("add new-from-main.txt").
+			Git("commit -m 'Add new file from main'").
+			Git("push origin main")
+
+		// Run sync from main repo - this will restack feature onto new main
+		sh.Log("Running sync from main repo...")
+		sh.Run("sync")
+
+		// Check worktree status - it should be clean after restack
+		sh.Log("Checking worktree status...")
+		shW.Git("status --porcelain")
+		output := shW.Output()
+
+		// The bug: worktree shows staged changes reverting main's content
+		// After fix: worktree should be clean
+		if output != "" {
+			t.Errorf("Worktree should be clean after sync, but has changes:\n%s", output)
+		}
+
+		// Verify the new file exists in worktree after restack
+		shW.Git("ls-files new-from-main.txt")
+		if shW.Output() == "" {
+			t.Error("New file from main should exist in worktree after sync/restack")
+		}
+	})
+}
+
 // TestSyncWithMultipleWorktrees tests the sync command behavior when working
 // with multiple worktrees and stacked branches.
 func TestSyncWithMultipleWorktrees(t *testing.T) {


### PR DESCRIPTION



<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #367** 👈

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->