### PR TITLE
feat: check managed worktrees for uncommitted changes during sync

### DIFF
--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -30,14 +30,6 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	ctx.Logger.Info("sync started", "restack", opts.Restack, "force", opts.Force)
 
-	// Debug: capture initial state
-	currentBranch := eng.CurrentBranch()
-	currentBranchName := ""
-	if currentBranch != nil {
-		currentBranchName = currentBranch.GetName()
-	}
-	ctx.Logger.Info("[sync-debug] initial state: currentBranch=%s", currentBranchName)
-
 	// Use null handler if none provided
 	if handler == nil {
 		handler = &NullHandler{}
@@ -53,12 +45,22 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		out.Info("Syncing branches across all configured trunks...")
 	}
 
-	// Check for uncommitted changes
+	// Check for uncommitted changes in main repo
 	uncommittedStart := time.Now()
 	hasUncommitted := ctx.Reader().HasUncommittedChanges(gctx)
 	ctx.Logger.Info("check uncommitted changes completed", "durationMs", time.Since(uncommittedStart).Milliseconds())
 	if hasUncommitted {
 		return fmt.Errorf("you have uncommitted changes. Please commit or stash them before syncing")
+	}
+
+	// Check for uncommitted changes in managed worktrees
+	managedWorktrees, err := eng.ListManagedWorktrees()
+	if err == nil {
+		for _, wt := range managedWorktrees {
+			if hasChanges, _ := eng.Git().WorktreeHasUncommittedChanges(gctx, wt.Path); hasChanges {
+				return fmt.Errorf("worktree at %s has uncommitted changes. Please commit or stash them before syncing", wt.Path)
+			}
+		}
 	}
 
 	// Calculate total operations for progress (rough estimate)
@@ -147,31 +149,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	// Phase 3: Clean branches (delete merged/closed)
-	// Debug: capture git status before cleanBranches
-	if statusBefore, err := eng.Git().RunGitCommandWithContext(gctx, "status", "--porcelain"); err == nil && statusBefore != "" {
-		ctx.Logger.Info("[sync-debug] git status BEFORE cleanBranches:\n%s", statusBefore)
-	}
-
 	cleanResult, err := cleanBranches(ctx, &opts, handler, summary)
 	if err != nil {
 		return fmt.Errorf("failed to clean branches: %w", err)
-	}
-
-	// Debug: capture git status after cleanBranches
-	if statusAfter, err := eng.Git().RunGitCommandWithContext(gctx, "status", "--porcelain"); err == nil && statusAfter != "" {
-		ctx.Logger.Info("[sync-debug] git status AFTER cleanBranches:\n%s", statusAfter)
-	}
-
-	// Debug: log branches deleted and reparented
-	if len(cleanResult.DeletedBranches) > 0 {
-		deletedNames := make([]string, 0, len(cleanResult.DeletedBranches))
-		for name := range cleanResult.DeletedBranches {
-			deletedNames = append(deletedNames, name)
-		}
-		ctx.Logger.Info("[sync-debug] deleted branches: %v", deletedNames)
-	}
-	if len(cleanResult.BranchesWithNewParents) > 0 {
-		ctx.Logger.Info("[sync-debug] branches reparented: %v", cleanResult.BranchesWithNewParents)
 	}
 
 	// Clean orphaned worktrees (after branch cleanup so we know what's been deleted)
@@ -212,43 +192,15 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Phase 4: Restack branches
 	handler.EmitEvent(Event{Phase: PhaseRestack, Type: EventStarted})
 
-	// Debug: log branches to be restacked
-	if len(branchesToRestack) > 0 {
-		ctx.Logger.Info("[sync-debug] branches to restack: %v", branchesToRestack)
-	}
-
-	// Debug: capture git status before restackBranches
-	if statusBefore, err := eng.Git().RunGitCommandWithContext(gctx, "status", "--porcelain"); err == nil && statusBefore != "" {
-		ctx.Logger.Info("[sync-debug] git status BEFORE restackBranches:\n%s", statusBefore)
-	}
-
 	if err := restackBranches(ctx, branchesToRestack, handler, summary); err != nil {
 		// Even on error, complete with summary
 		handler.Complete(*summary)
 		return err
 	}
 
-	// Debug: capture git status after restackBranches
-	if statusAfter, err := eng.Git().RunGitCommandWithContext(gctx, "status", "--porcelain"); err == nil && statusAfter != "" {
-		ctx.Logger.Info("[sync-debug] git status AFTER restackBranches:\n%s", statusAfter)
-	}
-
 	// Check if everything was up to date
 	if !summary.HasChanges() {
 		summary.UpToDate = true
-	}
-
-	// Debug: capture final state
-	finalBranch := eng.CurrentBranch()
-	finalBranchName := ""
-	if finalBranch != nil {
-		finalBranchName = finalBranch.GetName()
-	}
-	ctx.Logger.Info("[sync-debug] final state: currentBranch=%s", finalBranchName)
-
-	// Debug: final git status check
-	if statusFinal, err := eng.Git().RunGitCommandWithContext(gctx, "status", "--porcelain"); err == nil && statusFinal != "" {
-		ctx.Logger.Info("[sync-debug] FINAL git status (this indicates a BUG if non-empty):\n%s", statusFinal)
 	}
 
 	ctx.Logger.Info("sync completed",

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -12,6 +12,7 @@ import (
 	"stackit.dev/stackit/internal/config"
 	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/internal/git"
+	"stackit.dev/stackit/internal/output"
 	"stackit.dev/stackit/internal/tui/style"
 )
 
@@ -236,18 +237,18 @@ func CreateAction(ctx *app.Context, opts CreateOptions) (*CreateResult, error) {
 	anchorBranch := eng.GetBranch(anchorBranchName)
 	if err := eng.SetParent(ctx.Context, anchorBranch, trunk); err != nil {
 		// Clean up branch on failure
-		_ = cleanupAnchorBranch(ctx.Context, eng, anchorBranchName)
+		cleanupAnchorBranch(ctx.Context, eng, anchorBranchName, out)
 		return nil, fmt.Errorf("failed to set parent: %w", err)
 	}
 
 	if err := eng.SetBranchType(anchorBranch, git.BranchTypeWorktreeAnchor); err != nil {
-		_ = cleanupAnchorBranch(ctx.Context, eng, anchorBranchName)
+		cleanupAnchorBranch(ctx.Context, eng, anchorBranchName, out)
 		return nil, fmt.Errorf("failed to set branch type: %w", err)
 	}
 
 	if opts.Scope != "" {
 		if err := eng.SetScope(anchorBranch, engine.NewScope(opts.Scope)); err != nil {
-			_ = cleanupAnchorBranch(ctx.Context, eng, anchorBranchName)
+			cleanupAnchorBranch(ctx.Context, eng, anchorBranchName, out)
 			return nil, fmt.Errorf("failed to set scope: %w", err)
 		}
 	}
@@ -255,7 +256,7 @@ func CreateAction(ctx *app.Context, opts CreateOptions) (*CreateResult, error) {
 	// Create the worktree
 	worktreePath, err := createWorktreeForAnchor(ctx, opts.Name, anchorBranchName)
 	if err != nil {
-		_ = cleanupAnchorBranch(ctx.Context, eng, anchorBranchName)
+		cleanupAnchorBranch(ctx.Context, eng, anchorBranchName, out)
 		return nil, err
 	}
 
@@ -292,6 +293,11 @@ func createWorktreeForAnchor(ctx *app.Context, name string, anchorBranch string)
 	// Worktree path: basePath/name
 	worktreePath := filepath.Join(basePath, name)
 
+	// Check if path already exists
+	if _, err := os.Stat(worktreePath); err == nil {
+		return "", fmt.Errorf("worktree path %s already exists; remove it first or choose a different name", worktreePath)
+	}
+
 	// Create the worktree (non-detached, pointing to the anchor branch)
 	if err := eng.AddWorktree(ctx.Context, worktreePath, anchorBranch, false); err != nil {
 		return "", fmt.Errorf("failed to create worktree: %w", err)
@@ -307,7 +313,9 @@ func createWorktreeForAnchor(ctx *app.Context, name string, anchorBranch string)
 	return worktreePath, nil
 }
 
-// cleanupAnchorBranch cleans up an anchor branch on failure
-func cleanupAnchorBranch(ctx context.Context, eng engine.Engine, branchName string) error {
-	return eng.DeleteBranch(ctx, eng.GetBranch(branchName))
+// cleanupAnchorBranch cleans up an anchor branch on failure and logs any cleanup errors
+func cleanupAnchorBranch(ctx context.Context, eng engine.Engine, branchName string, out output.Output) {
+	if err := eng.DeleteBranch(ctx, eng.GetBranch(branchName)); err != nil {
+		out.Warn("Failed to clean up anchor branch %s: %v", branchName, err)
+	}
 }

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -437,6 +437,10 @@ func (d *demoGitRunner) ResetWorktreeWorkingDir(_ context.Context, _ string) err
 	return nil
 }
 
+func (d *demoGitRunner) WorktreeHasUncommittedChanges(_ context.Context, _ string) (bool, error) {
+	return false, nil
+}
+
 func (d *demoGitRunner) UpdateRefWithLog(_ context.Context, _, _, _ string) error {
 	return nil
 }

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -195,9 +195,12 @@ func (e *engineImpl) restackBranch(
 					return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to reset working tree for frozen branch %s: %w", branchName, err)
 				}
 			} else {
-				// If the branch is checked out in a different worktree, reset that worktree
-				if worktreePath, err := e.git.GetWorktreePathForBranch(ctx, branchName); err == nil && worktreePath != "" {
-					_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath)
+				// If the branch is checked out in a different worktree, reset that worktree.
+				// This is best-effort: sync checks for uncommitted changes before proceeding,
+				// so failure here just means the worktree may be briefly out of sync with HEAD.
+				// The ResetWorktreeWorkingDir command itself is logged via debugLog.
+				if worktreePath, wtErr := e.git.GetWorktreePathForBranch(ctx, branchName); wtErr == nil && worktreePath != "" {
+					_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
 				}
 			}
 
@@ -263,9 +266,11 @@ func (e *engineImpl) restackBranch(
 				return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to reset working tree for anchor %s: %w", branchName, err)
 			}
 		} else {
-			// If the branch is checked out in a different worktree, reset that worktree
-			if worktreePath, err := e.git.GetWorktreePathForBranch(ctx, branchName); err == nil && worktreePath != "" {
-				_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath)
+			// If the branch is checked out in a different worktree, reset that worktree.
+			// This is best-effort: sync checks for uncommitted changes before proceeding,
+			// so failure here just means the worktree may be briefly out of sync with HEAD.
+			if worktreePath, wtErr := e.git.GetWorktreePathForBranch(ctx, branchName); wtErr == nil && worktreePath != "" {
+				_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
 			}
 		}
 
@@ -445,9 +450,10 @@ func (e *engineImpl) restackBranch(
 	// If this branch is checked out in a worktree, reset that worktree's working directory
 	// to match the new branch content. Without this, the worktree would have stale content
 	// that appears as staged changes reverting the rebased commits.
-	if worktreePath, err := e.git.GetWorktreePathForBranch(ctx, branchName); err == nil && worktreePath != "" {
-		// Best-effort: don't fail restack if worktree reset fails
-		_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath)
+	// This is best-effort: sync checks for uncommitted changes before proceeding,
+	// so failure here just means the worktree may be briefly out of sync with HEAD.
+	if worktreePath, wtErr := e.git.GetWorktreePathForBranch(ctx, branchName); wtErr == nil && worktreePath != "" {
+		_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
 	}
 
 	metadataSHA, err := e.git.CreateBlob(string(metadataJSON))

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -180,6 +180,7 @@ type WorktreeOperations interface {
 	GetWorktreePathForBranch(ctx context.Context, branchName string) (string, error)
 	GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error)
 	ResetWorktreeWorkingDir(ctx context.Context, worktreePath string) error
+	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)
 }
 
 // WorktreeRegistryOperations handles stackit-managed worktree tracking (local-only refs).

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -369,18 +369,24 @@ type runner struct {
 	repo     *Repository
 	repoRoot string
 	repoMu   sync.Mutex
+	loggerMu sync.RWMutex
 	logger   DebugLogger
 }
 
 // SetLogger sets the debug logger for git command logging
 func (r *runner) SetLogger(logger DebugLogger) {
+	r.loggerMu.Lock()
 	r.logger = logger
+	r.loggerMu.Unlock()
 }
 
 // debugLog logs a git command if a debug logger is set
 func (r *runner) debugLog(format string, args ...any) {
-	if r.logger != nil {
-		r.logger.Debug(format, args...)
+	r.loggerMu.RLock()
+	logger := r.logger
+	r.loggerMu.RUnlock()
+	if logger != nil {
+		logger.Debug(format, args...)
 	}
 }
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -164,6 +164,15 @@ func (r *runner) ResetWorktreeWorkingDir(ctx context.Context, worktreePath strin
 	return nil
 }
 
+// WorktreeHasUncommittedChanges checks if a worktree has uncommitted changes.
+func (r *runner) WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error) {
+	output, err := r.RunGitCommandWithContext(ctx, "-C", worktreePath, "status", "--porcelain")
+	if err != nil {
+		return false, fmt.Errorf("failed to check status in worktree %s: %w", worktreePath, err)
+	}
+	return strings.TrimSpace(output) != "", nil
+}
+
 // GetWorktreeCurrentBranch returns the name of the branch currently checked out in a worktree.
 // Returns empty string if the worktree is in detached HEAD state.
 func (r *runner) GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error) {


### PR DESCRIPTION

Add validation to ensure managed worktrees don't have uncommitted changes
before running sync. Also removes temporary debug logging, fixes thread
safety for runner logger, and improves error handling in worktree creation.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


<!-- STACKIT-SECTION-START -->
#### Stack



This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->