### PR TITLE
refactor: unify CI config to ci.command

### DIFF
--- a/internal/actions/merge/multistack.go
+++ b/internal/actions/merge/multistack.go
@@ -95,7 +95,7 @@ func ExecuteMultiStack(ctx *app.Context, opts MultiStackOptions) (*MultiStackRes
 		validator := NewLocalCIValidator(cfg, out)
 		if !validator.IsConfigured() {
 			out.Debug("multistack: CI not configured, skipping")
-			out.Warn("CI validation skipped (no combine.ciCommand configured)")
+			out.Warn("CI validation skipped (no ci.command configured)")
 		} else {
 			// Run CI on merged stacks
 			out.Debug("multistack: running CI validation")

--- a/internal/actions/merge/multistack_ci.go
+++ b/internal/actions/merge/multistack_ci.go
@@ -18,11 +18,12 @@ type LocalCIValidator struct {
 	output  output.Output
 }
 
-// NewLocalCIValidator creates a new local CI validator from config
+// NewLocalCIValidator creates a new local CI validator from config.
+// Uses the unified ci.command config, with fallback to combine.ciCommand for backwards compatibility.
 func NewLocalCIValidator(cfg *config.Config, out output.Output) *LocalCIValidator {
 	return &LocalCIValidator{
-		Command: cfg.CombineCICommand(),
-		Timeout: time.Duration(cfg.CombineCITimeout()) * time.Second,
+		Command: cfg.CICommand(),
+		Timeout: time.Duration(cfg.CITimeout()) * time.Second,
 		output:  out,
 	}
 }
@@ -35,7 +36,7 @@ func (v *LocalCIValidator) IsConfigured() bool {
 // Validate runs the CI command in the specified directory
 func (v *LocalCIValidator) Validate(ctx context.Context, workdir string) error {
 	if !v.IsConfigured() {
-		return fmt.Errorf("CI command not configured. Set it with: stackit config set combine.ciCommand \"your-command\"")
+		return fmt.Errorf("CI command not configured. Set it with: stackit config set ci.command \"your-command\"")
 	}
 
 	v.output.Info("Running local CI validation: %s", v.Command)

--- a/internal/cli/stack/combine.go
+++ b/internal/cli/stack/combine.go
@@ -36,8 +36,8 @@ them together into a single PR. It handles:
   - Binary search: If CI fails, finds the largest subset that passes
 
 Configuration:
-  Set the CI command with: stackit config set combine.ciCommand "your-command"
-  Set the CI timeout with: stackit config set combine.ciTimeout 600
+  Set the CI command with: stackit config set ci.command "your-command"
+  Set the CI timeout with: stackit config set ci.timeout 600
 
 Examples:
   stackit merge --multi-stack                          # Interactive (recommended)

--- a/internal/config/repo_config.go
+++ b/internal/config/repo_config.go
@@ -229,7 +229,47 @@ func (c *Config) SetMergeMethod(method string) error {
 	}
 }
 
+// CICommand returns the CI command to run for validation.
+// This is the unified config that should be used by all CI validation.
+// It checks ci.command first, then falls back to combine.ciCommand for backwards compatibility.
+func (c *Config) CICommand() string {
+	// Check new unified config first
+	if c.data.CICommand != nil {
+		return *c.data.CICommand
+	}
+	// Fall back to legacy combine.ciCommand
+	if c.data.CombineCICommand != nil {
+		return *c.data.CombineCICommand
+	}
+	return ""
+}
+
+// SetCICommand sets the unified CI command for validation
+func (c *Config) SetCICommand(cmd string) {
+	c.data.CICommand = &cmd
+}
+
+// CITimeout returns the timeout in seconds for CI validation (default: 600)
+// Checks ci.timeout first, then falls back to combine.ciTimeout for backwards compatibility.
+func (c *Config) CITimeout() int {
+	// Check new unified config first
+	if c.data.CITimeout != nil {
+		return *c.data.CITimeout
+	}
+	// Fall back to legacy combine.ciTimeout
+	if c.data.CombineCITimeout != nil {
+		return *c.data.CombineCITimeout
+	}
+	return 600 // 10 minutes default
+}
+
+// SetCITimeout sets the timeout in seconds for CI validation
+func (c *Config) SetCITimeout(seconds int) {
+	c.data.CITimeout = &seconds
+}
+
 // CombineCICommand returns the CI command to run for combine validation
+// Deprecated: Use CICommand() instead. This is kept for backwards compatibility.
 func (c *Config) CombineCICommand() string {
 	if c.data.CombineCICommand != nil {
 		return *c.data.CombineCICommand
@@ -238,11 +278,13 @@ func (c *Config) CombineCICommand() string {
 }
 
 // SetCombineCICommand sets the CI command for combine validation
+// Deprecated: Use SetCICommand() instead. This is kept for backwards compatibility.
 func (c *Config) SetCombineCICommand(cmd string) {
 	c.data.CombineCICommand = &cmd
 }
 
 // CombineCITimeout returns the timeout in seconds for combine CI validation (default: 600)
+// Deprecated: Use CITimeout() instead. This is kept for backwards compatibility.
 func (c *Config) CombineCITimeout() int {
 	if c.data.CombineCITimeout != nil {
 		return *c.data.CombineCITimeout
@@ -251,6 +293,7 @@ func (c *Config) CombineCITimeout() int {
 }
 
 // SetCombineCITimeout sets the timeout in seconds for combine CI validation
+// Deprecated: Use SetCITimeout() instead. This is kept for backwards compatibility.
 func (c *Config) SetCombineCITimeout(seconds int) {
 	c.data.CombineCITimeout = &seconds
 }
@@ -266,8 +309,10 @@ type RepoConfig struct {
 	WorktreeBasePath           *string  `json:"worktree.basePath,omitempty"`
 	WorktreeAutoClean          *bool    `json:"worktree.autoClean,omitempty"`
 	MergeMethod                *string  `json:"merge.method,omitempty"`
-	CombineCICommand           *string  `json:"combine.ciCommand,omitempty"`
-	CombineCITimeout           *int     `json:"combine.ciTimeout,omitempty"`
+	CombineCICommand           *string  `json:"combine.ciCommand,omitempty"` // Deprecated: use CICommand
+	CombineCITimeout           *int     `json:"combine.ciTimeout,omitempty"` // Deprecated: use CITimeout
+	CICommand                  *string  `json:"ci.command,omitempty"`        // Unified CI command for all validation
+	CITimeout                  *int     `json:"ci.timeout,omitempty"`        // Unified CI timeout in seconds
 }
 
 // GetBranchPattern returns the branch name pattern as a BranchPattern type

--- a/internal/config/repo_config_test.go
+++ b/internal/config/repo_config_test.go
@@ -235,6 +235,190 @@ func TestConfigWorktreeSupport(t *testing.T) {
 	})
 }
 
+func TestConfigCICommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns empty string when nothing configured", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		require.Equal(t, "", cfg.CICommand())
+	})
+
+	t.Run("returns ci.command when set", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
+		config := &RepoConfig{
+			Trunk:     stringPtr("main"),
+			CICommand: stringPtr("just check"),
+		}
+		configJSON, err := json.MarshalIndent(config, "", "  ")
+		require.NoError(t, err)
+		err = os.WriteFile(configPath, configJSON, 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		require.Equal(t, "just check", cfg.CICommand())
+	})
+
+	t.Run("falls back to combine.ciCommand for backwards compatibility", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
+		config := &RepoConfig{
+			Trunk:            stringPtr("main"),
+			CombineCICommand: stringPtr("npm test"),
+		}
+		configJSON, err := json.MarshalIndent(config, "", "  ")
+		require.NoError(t, err)
+		err = os.WriteFile(configPath, configJSON, 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		require.Equal(t, "npm test", cfg.CICommand())
+	})
+
+	t.Run("ci.command takes precedence over combine.ciCommand", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
+		config := &RepoConfig{
+			Trunk:            stringPtr("main"),
+			CICommand:        stringPtr("just check"),
+			CombineCICommand: stringPtr("npm test"),
+		}
+		configJSON, err := json.MarshalIndent(config, "", "  ")
+		require.NoError(t, err)
+		err = os.WriteFile(configPath, configJSON, 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		require.Equal(t, "just check", cfg.CICommand())
+	})
+}
+
+func TestConfigSetCICommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sets ci.command", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		cfg.SetCICommand("make test")
+		err = cfg.Save()
+		require.NoError(t, err)
+
+		cfg2, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		require.Equal(t, "make test", cfg2.CICommand())
+	})
+}
+
+func TestConfigCITimeout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns default 600 when nothing configured", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		require.Equal(t, 600, cfg.CITimeout())
+	})
+
+	t.Run("returns ci.timeout when set", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
+		timeout := 300
+		config := &RepoConfig{
+			Trunk:     stringPtr("main"),
+			CITimeout: &timeout,
+		}
+		configJSON, err := json.MarshalIndent(config, "", "  ")
+		require.NoError(t, err)
+		err = os.WriteFile(configPath, configJSON, 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		require.Equal(t, 300, cfg.CITimeout())
+	})
+
+	t.Run("falls back to combine.ciTimeout for backwards compatibility", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
+		timeout := 120
+		config := &RepoConfig{
+			Trunk:            stringPtr("main"),
+			CombineCITimeout: &timeout,
+		}
+		configJSON, err := json.MarshalIndent(config, "", "  ")
+		require.NoError(t, err)
+		err = os.WriteFile(configPath, configJSON, 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		require.Equal(t, 120, cfg.CITimeout())
+	})
+
+	t.Run("ci.timeout takes precedence over combine.ciTimeout", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
+		newTimeout := 180
+		legacyTimeout := 300
+		config := &RepoConfig{
+			Trunk:            stringPtr("main"),
+			CITimeout:        &newTimeout,
+			CombineCITimeout: &legacyTimeout,
+		}
+		configJSON, err := json.MarshalIndent(config, "", "  ")
+		require.NoError(t, err)
+		err = os.WriteFile(configPath, configJSON, 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		require.Equal(t, 180, cfg.CITimeout())
+	})
+}
+
+func TestConfigSetCITimeout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sets ci.timeout", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		cfg.SetCITimeout(900)
+		err = cfg.Save()
+		require.NoError(t, err)
+
+		cfg2, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		require.Equal(t, 900, cfg2.CITimeout())
+	})
+}
+
 // Helper function to create string pointer
 func stringPtr(s string) *string {
 	return &s


### PR DESCRIPTION

Add unified ci.command and ci.timeout config options that will be used
for all CI validation. The new config maintains backwards compatibility
by falling back to legacy combine.ciCommand and combine.ciTimeout when
the new config is not set.

Changes:
- Add CICommand() and CITimeout() methods with fallback to legacy config
- Add SetCICommand() and SetCITimeout() setter methods
- Update LocalCIValidator to use unified CICommand() and CITimeout()
- Update documentation and warning messages to reference ci.command
- Add comprehensive tests for new config methods

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


<!-- STACKIT-SECTION-START -->
#### Stack



This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->