### PR TITLE
feat: implement combination analysis for shippable stacks

### DIFF
--- a/internal/shippable/combiner.go
+++ b/internal/shippable/combiner.go
@@ -1,0 +1,330 @@
+package shippable
+
+import (
+	"context"
+	"fmt"
+
+	"stackit.dev/stackit/internal/actions/merge"
+	"stackit.dev/stackit/internal/config"
+	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/output"
+	"stackit.dev/stackit/internal/worktree"
+)
+
+// Combiner analyzes whether multiple stacks can be merged together.
+type Combiner struct {
+	eng       engine.Engine
+	cfg       *config.Config
+	output    output.Output
+	validator *merge.LocalCIValidator
+}
+
+// NewCombiner creates a new stack combiner.
+func NewCombiner(eng engine.Engine, cfg *config.Config, out output.Output) *Combiner {
+	return &Combiner{
+		eng:       eng,
+		cfg:       cfg,
+		output:    out,
+		validator: merge.NewLocalCIValidator(cfg, out),
+	}
+}
+
+// CheckCombinationOptions configures how combination checking is performed.
+type CheckCombinationOptions struct {
+	// RunLocalCI determines whether to run local CI validation after merge.
+	RunLocalCI bool
+}
+
+// CheckCombination checks if the given stacks can be merged together.
+// It creates a temporary worktree, attempts to merge all stacks, and optionally
+// runs local CI to verify the combined code compiles/passes tests.
+func (c *Combiner) CheckCombination(ctx context.Context, stacks []Stack, opts CheckCombinationOptions) (*CombinationResult, error) {
+	if len(stacks) == 0 {
+		return &CombinationResult{
+			Combinable:    true,
+			WorkingStacks: nil,
+		}, nil
+	}
+
+	// Convert shippable.Stack to merge.MultiStackInfo for the worktree executor
+	multiStacks := make([]merge.MultiStackInfo, len(stacks))
+	for i, s := range stacks {
+		multiStacks[i] = s.Stack
+	}
+
+	// Create worktree executor and attempt merge
+	executor := merge.NewMultiStackWorktreeExecutor(c.eng, c.output)
+	result, err := executor.ExecuteInWorktree(ctx, multiStacks)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute merge in worktree: %w", err)
+	}
+	defer result.Cleanup()
+
+	// Build the combination result
+	combResult := &CombinationResult{
+		WorkingStacks:     make([]Stack, 0, len(result.MergedStacks)),
+		ConflictingStacks: make([]ExcludedStack, 0, len(result.ConflictStacks)),
+	}
+
+	// Map merged stacks back to shippable.Stack
+	mergedRoots := make(map[string]bool)
+	for _, ms := range result.MergedStacks {
+		mergedRoots[ms.RootBranch] = true
+	}
+
+	for _, s := range stacks {
+		if mergedRoots[s.RootBranch()] {
+			combResult.WorkingStacks = append(combResult.WorkingStacks, s)
+		} else {
+			combResult.ConflictingStacks = append(combResult.ConflictingStacks, ExcludedStack{
+				Stack:  s,
+				Reason: ReasonMergeConflict,
+			})
+		}
+	}
+
+	combResult.Combinable = len(combResult.ConflictingStacks) == 0
+
+	// Optionally run local CI
+	if opts.RunLocalCI && c.validator.IsConfigured() && len(combResult.WorkingStacks) > 0 {
+		err := c.validator.Validate(ctx, result.WorktreePath)
+		passed := err == nil
+		combResult.LocalCIPassed = &passed
+		if err != nil {
+			combResult.LocalCIError = err
+			combResult.Combinable = false
+		}
+	}
+
+	return combResult, nil
+}
+
+// FindLargestCompatibleOptions configures how the search is performed.
+type FindLargestCompatibleOptions struct {
+	// RunLocalCI determines whether to run local CI for each candidate set.
+	RunLocalCI bool
+}
+
+// FindLargestCompatible finds the largest subset of stacks that can be merged together.
+// It uses a greedy approach: try adding stacks one by one, keeping those that merge cleanly.
+// If RunLocalCI is true, it also validates that the combined code passes local CI.
+func (c *Combiner) FindLargestCompatible(ctx context.Context, stacks []Stack, opts FindLargestCompatibleOptions) (*CombinationResult, error) {
+	if len(stacks) == 0 {
+		return &CombinationResult{
+			Combinable:    true,
+			WorkingStacks: nil,
+		}, nil
+	}
+
+	// Convert shippable.Stack to merge.MultiStackInfo
+	multiStacks := make([]merge.MultiStackInfo, len(stacks))
+	stackMap := make(map[string]Stack) // Map root branch to Stack
+	for i, s := range stacks {
+		multiStacks[i] = s.Stack
+		stackMap[s.RootBranch()] = s
+	}
+
+	// Create worktree session
+	wtExecutor := worktree.NewExecutor(c.eng, c.output)
+	session, err := wtExecutor.CreateSession(ctx, worktree.CreateSessionOptions{
+		NamePattern: "stackit-combine-*",
+		PullTrunk:   true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create worktree session: %w", err)
+	}
+	defer session.Close()
+
+	// First, try all stacks together
+	allResult, err := c.tryMergeStacks(ctx, session, multiStacks)
+	if err != nil {
+		return nil, err
+	}
+
+	// If all merge cleanly, check CI if requested
+	if len(allResult.ConflictStacks) == 0 {
+		result := &CombinationResult{
+			Combinable:    true,
+			WorkingStacks: stacks,
+		}
+
+		if opts.RunLocalCI && c.validator.IsConfigured() {
+			ciErr := c.validator.Validate(ctx, session.Path)
+			passed := ciErr == nil
+			result.LocalCIPassed = &passed
+			if ciErr != nil {
+				result.LocalCIError = ciErr
+				// CI failed - need to find subset that passes
+				c.output.Warn("All stacks merge but CI fails, searching for passing subset...")
+			} else {
+				return result, nil
+			}
+		} else {
+			return result, nil
+		}
+	}
+
+	// Greedy search: try adding stacks one by one
+	c.output.Info("Finding largest compatible subset...")
+
+	var working []merge.MultiStackInfo
+	var excluded []ExcludedStack
+
+	for _, stack := range multiStacks {
+		// Reset to trunk
+		if err := session.ResetToTrunk(ctx); err != nil {
+			return nil, fmt.Errorf("failed to reset worktree: %w", err)
+		}
+
+		// Try merging all working stacks plus this candidate
+		testSet := make([]merge.MultiStackInfo, len(working)+1)
+		copy(testSet, working)
+		testSet[len(working)] = stack
+
+		mergeResult, err := c.tryMergeStacks(ctx, session, testSet)
+		if err != nil {
+			return nil, err
+		}
+
+		// Check if this stack conflicts
+		if len(mergeResult.ConflictStacks) > 0 {
+			excluded = append(excluded, ExcludedStack{
+				Stack:  stackMap[stack.RootBranch],
+				Reason: ReasonMergeConflict,
+			})
+			c.output.Debug("  - %s conflicts", stack.RootBranch)
+			continue
+		}
+
+		// Optionally run CI
+		if opts.RunLocalCI && c.validator.IsConfigured() {
+			if ciErr := c.validator.Validate(ctx, session.Path); ciErr != nil {
+				excluded = append(excluded, ExcludedStack{
+					Stack:  stackMap[stack.RootBranch],
+					Reason: ReasonLocalCIFailed,
+				})
+				c.output.Debug("  - %s fails CI", stack.RootBranch)
+				continue
+			}
+		}
+
+		// This stack works
+		working = testSet
+		c.output.Debug("  + %s compatible", stack.RootBranch)
+	}
+
+	// Build final result
+	workingStacks := make([]Stack, len(working))
+	for i, ms := range working {
+		workingStacks[i] = stackMap[ms.RootBranch]
+	}
+
+	result := &CombinationResult{
+		Combinable:        len(excluded) == 0,
+		WorkingStacks:     workingStacks,
+		ConflictingStacks: excluded,
+	}
+
+	// Final CI check on the combined result
+	if opts.RunLocalCI && c.validator.IsConfigured() && len(working) > 0 {
+		passed := true
+		result.LocalCIPassed = &passed
+	}
+
+	return result, nil
+}
+
+// tryMergeStacks attempts to merge the given stacks in the worktree session.
+// It resets to trunk first, then tries to merge all stacks.
+func (c *Combiner) tryMergeStacks(
+	ctx context.Context,
+	session *worktree.Session,
+	stacks []merge.MultiStackInfo,
+) (*merge.MultiStackWorktreeResult, error) {
+	// Reset to trunk first
+	if err := session.ResetToTrunk(ctx); err != nil {
+		return nil, fmt.Errorf("failed to reset worktree: %w", err)
+	}
+
+	// Create a new result to track this attempt
+	result := &merge.MultiStackWorktreeResult{
+		MergedStacks:   make([]merge.MultiStackInfo, 0),
+		ConflictStacks: make([]merge.MultiStackExcluded, 0),
+		WorktreePath:   session.Path,
+		WorktreeEngine: session.Engine,
+	}
+
+	// Try to merge each stack
+	for _, stack := range stacks {
+		baseline, err := session.GetCurrentRevision(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to capture worktree state: %w", err)
+		}
+
+		// Try octopus merge
+		msg := fmt.Sprintf("Merge stack %s (%d branches)", stack.RootBranch, len(stack.AllBranches))
+		err = session.Engine.MergeMultiple(ctx, stack.AllBranches, engine.MergeOptions{
+			NoFF:    true,
+			NoEdit:  true,
+			Message: msg,
+		})
+
+		if err != nil {
+			// Abort merge if in progress
+			git := session.Engine.Git()
+			if git.IsMergeInProgress(ctx) {
+				_ = git.MergeAbort(ctx)
+			}
+
+			// Reset to baseline
+			if resetErr := session.ResetToRef(ctx, baseline); resetErr != nil {
+				c.output.Debug("Failed to reset after conflict: %v", resetErr)
+			}
+
+			result.ConflictStacks = append(result.ConflictStacks, merge.MultiStackExcluded{
+				Stack:  stack,
+				Reason: "conflict",
+			})
+		} else {
+			result.MergedStacks = append(result.MergedStacks, stack)
+		}
+	}
+
+	return result, nil
+}
+
+// UpdateCompatibility updates the compatibility information for each stack
+// based on a combination result.
+func UpdateCompatibility(stacks []Stack, result *CombinationResult) {
+	workingRoots := make(map[string]bool)
+	for _, s := range result.WorkingStacks {
+		workingRoots[s.RootBranch()] = true
+	}
+
+	conflictingRoots := make(map[string]bool)
+	for _, es := range result.ConflictingStacks {
+		conflictingRoots[es.Stack.RootBranch()] = true
+	}
+
+	for i := range stacks {
+		root := stacks[i].RootBranch()
+
+		// Clear existing compatibility info
+		stacks[i].CompatibleWith = nil
+		stacks[i].ConflictsWith = nil
+
+		// Add compatible stacks (other working stacks)
+		for _, ws := range result.WorkingStacks {
+			if ws.RootBranch() != root {
+				stacks[i].CompatibleWith = append(stacks[i].CompatibleWith, ws.RootBranch())
+			}
+		}
+
+		// Add conflicting stacks
+		for _, es := range result.ConflictingStacks {
+			if es.Stack.RootBranch() != root {
+				stacks[i].ConflictsWith = append(stacks[i].ConflictsWith, es.Stack.RootBranch())
+			}
+		}
+	}
+}

--- a/internal/shippable/combiner_test.go
+++ b/internal/shippable/combiner_test.go
@@ -1,0 +1,236 @@
+package shippable
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"stackit.dev/stackit/internal/actions/merge"
+)
+
+func TestCombinationResult_IncludedCount(t *testing.T) {
+	result := &CombinationResult{
+		WorkingStacks: []Stack{
+			{Stack: merge.MultiStackInfo{RootBranch: "a"}},
+			{Stack: merge.MultiStackInfo{RootBranch: "b"}},
+		},
+	}
+	assert.Equal(t, 2, result.IncludedCount())
+}
+
+func TestCombinationResult_ExcludedCount(t *testing.T) {
+	result := &CombinationResult{
+		ConflictingStacks: []ExcludedStack{
+			{Stack: Stack{Stack: merge.MultiStackInfo{RootBranch: "c"}}},
+		},
+	}
+	assert.Equal(t, 1, result.ExcludedCount())
+}
+
+func TestCombinationResult_AllCombined(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   *CombinationResult
+		expected bool
+	}{
+		{
+			name: "all combined",
+			result: &CombinationResult{
+				WorkingStacks:     []Stack{{Stack: merge.MultiStackInfo{RootBranch: "a"}}},
+				ConflictingStacks: nil,
+			},
+			expected: true,
+		},
+		{
+			name: "some excluded",
+			result: &CombinationResult{
+				WorkingStacks: []Stack{{Stack: merge.MultiStackInfo{RootBranch: "a"}}},
+				ConflictingStacks: []ExcludedStack{
+					{Stack: Stack{Stack: merge.MultiStackInfo{RootBranch: "b"}}},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "empty result",
+			result: &CombinationResult{
+				WorkingStacks:     nil,
+				ConflictingStacks: nil,
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.result.AllCombined())
+		})
+	}
+}
+
+func TestCombinationResult_GetWorkingRoots(t *testing.T) {
+	result := &CombinationResult{
+		WorkingStacks: []Stack{
+			{Stack: merge.MultiStackInfo{RootBranch: "stack-a"}},
+			{Stack: merge.MultiStackInfo{RootBranch: "stack-b"}},
+		},
+	}
+
+	roots := result.GetWorkingRoots()
+	assert.Equal(t, []string{"stack-a", "stack-b"}, roots)
+}
+
+func TestCombinationResult_GetConflictingRoots(t *testing.T) {
+	result := &CombinationResult{
+		ConflictingStacks: []ExcludedStack{
+			{Stack: Stack{Stack: merge.MultiStackInfo{RootBranch: "stack-c"}}},
+			{Stack: Stack{Stack: merge.MultiStackInfo{RootBranch: "stack-d"}}},
+		},
+	}
+
+	roots := result.GetConflictingRoots()
+	assert.Equal(t, []string{"stack-c", "stack-d"}, roots)
+}
+
+func TestExclusionReason_Constants(t *testing.T) {
+	// Verify exclusion reason constants are defined correctly
+	assert.Equal(t, ExclusionReason("merge_conflict"), ReasonMergeConflict)
+	assert.Equal(t, ExclusionReason("local_ci_failed"), ReasonLocalCIFailed)
+}
+
+func TestUpdateCompatibility(t *testing.T) {
+	tests := []struct {
+		name                string
+		stacks              []Stack
+		result              *CombinationResult
+		expectedCompatibleA []string
+		expectedConflictsA  []string
+	}{
+		{
+			name: "all stacks compatible",
+			stacks: []Stack{
+				{Stack: merge.MultiStackInfo{RootBranch: "a"}},
+				{Stack: merge.MultiStackInfo{RootBranch: "b"}},
+				{Stack: merge.MultiStackInfo{RootBranch: "c"}},
+			},
+			result: &CombinationResult{
+				WorkingStacks: []Stack{
+					{Stack: merge.MultiStackInfo{RootBranch: "a"}},
+					{Stack: merge.MultiStackInfo{RootBranch: "b"}},
+					{Stack: merge.MultiStackInfo{RootBranch: "c"}},
+				},
+				ConflictingStacks: nil,
+			},
+			expectedCompatibleA: []string{"b", "c"},
+			expectedConflictsA:  nil,
+		},
+		{
+			name: "one stack conflicts",
+			stacks: []Stack{
+				{Stack: merge.MultiStackInfo{RootBranch: "a"}},
+				{Stack: merge.MultiStackInfo{RootBranch: "b"}},
+				{Stack: merge.MultiStackInfo{RootBranch: "c"}},
+			},
+			result: &CombinationResult{
+				WorkingStacks: []Stack{
+					{Stack: merge.MultiStackInfo{RootBranch: "a"}},
+					{Stack: merge.MultiStackInfo{RootBranch: "b"}},
+				},
+				ConflictingStacks: []ExcludedStack{
+					{Stack: Stack{Stack: merge.MultiStackInfo{RootBranch: "c"}}},
+				},
+			},
+			expectedCompatibleA: []string{"b"},
+			expectedConflictsA:  []string{"c"},
+		},
+		{
+			name: "single stack",
+			stacks: []Stack{
+				{Stack: merge.MultiStackInfo{RootBranch: "a"}},
+			},
+			result: &CombinationResult{
+				WorkingStacks: []Stack{
+					{Stack: merge.MultiStackInfo{RootBranch: "a"}},
+				},
+			},
+			expectedCompatibleA: nil,
+			expectedConflictsA:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a copy of stacks to avoid mutating test data
+			stacks := make([]Stack, len(tt.stacks))
+			copy(stacks, tt.stacks)
+
+			UpdateCompatibility(stacks, tt.result)
+
+			// Find stack "a" and check its compatibility
+			for _, s := range stacks {
+				if s.RootBranch() == "a" {
+					assert.Equal(t, tt.expectedCompatibleA, s.CompatibleWith)
+					assert.Equal(t, tt.expectedConflictsA, s.ConflictsWith)
+					break
+				}
+			}
+		})
+	}
+}
+
+func TestCombinationResult_EmptyStacks(t *testing.T) {
+	result := &CombinationResult{
+		Combinable:        true,
+		WorkingStacks:     nil,
+		ConflictingStacks: nil,
+	}
+
+	assert.Equal(t, 0, result.IncludedCount())
+	assert.Equal(t, 0, result.ExcludedCount())
+	assert.True(t, result.AllCombined())
+	assert.Empty(t, result.GetWorkingRoots())
+	assert.Empty(t, result.GetConflictingRoots())
+}
+
+func TestCombinationResult_LocalCIFields(t *testing.T) {
+	tests := []struct {
+		name          string
+		localCIPassed *bool
+		localCIError  error
+		expectPassed  *bool
+	}{
+		{
+			name:          "CI not run",
+			localCIPassed: nil,
+			localCIError:  nil,
+			expectPassed:  nil,
+		},
+		{
+			name:          "CI passed",
+			localCIPassed: boolPtr(true),
+			localCIError:  nil,
+			expectPassed:  boolPtr(true),
+		},
+		{
+			name:          "CI failed",
+			localCIPassed: boolPtr(false),
+			localCIError:  assert.AnError,
+			expectPassed:  boolPtr(false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := &CombinationResult{
+				LocalCIPassed: tt.localCIPassed,
+				LocalCIError:  tt.localCIError,
+			}
+
+			assert.Equal(t, tt.expectPassed, result.LocalCIPassed)
+		})
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/internal/shippable/types.go
+++ b/internal/shippable/types.go
@@ -156,3 +156,71 @@ func (r *AnalysisResult) HasShippable() bool {
 func (r *AnalysisResult) TotalStacks() int {
 	return len(r.Stacks)
 }
+
+// CombinationResult contains the result of checking if stacks can be merged together.
+type CombinationResult struct {
+	// Combinable indicates whether the selected stacks can be merged without conflicts.
+	Combinable bool
+
+	// WorkingStacks are stacks that can be merged together.
+	WorkingStacks []Stack
+
+	// ConflictingStacks are stacks that conflict and cannot be included.
+	ConflictingStacks []ExcludedStack
+
+	// LocalCIPassed indicates whether local CI passed on the combined code.
+	// nil means local CI was not run.
+	LocalCIPassed *bool
+
+	// LocalCIError contains the error if local CI failed.
+	LocalCIError error
+}
+
+// ExcludedStack represents a stack that was excluded from a combination.
+type ExcludedStack struct {
+	Stack  Stack           // The excluded stack
+	Reason ExclusionReason // Why it was excluded
+}
+
+// ExclusionReason describes why a stack was excluded from a combination.
+type ExclusionReason string
+
+const (
+	// ReasonMergeConflict indicates the stack has merge conflicts with others.
+	ReasonMergeConflict ExclusionReason = "merge_conflict"
+	// ReasonLocalCIFailed indicates local CI failed when this stack was included.
+	ReasonLocalCIFailed ExclusionReason = "local_ci_failed"
+)
+
+// IncludedCount returns the number of stacks that can be combined.
+func (r *CombinationResult) IncludedCount() int {
+	return len(r.WorkingStacks)
+}
+
+// ExcludedCount returns the number of stacks that were excluded.
+func (r *CombinationResult) ExcludedCount() int {
+	return len(r.ConflictingStacks)
+}
+
+// AllCombined returns true if all stacks could be combined.
+func (r *CombinationResult) AllCombined() bool {
+	return len(r.ConflictingStacks) == 0
+}
+
+// GetWorkingRoots returns the root branch names of working stacks.
+func (r *CombinationResult) GetWorkingRoots() []string {
+	roots := make([]string, len(r.WorkingStacks))
+	for i, s := range r.WorkingStacks {
+		roots[i] = s.RootBranch()
+	}
+	return roots
+}
+
+// GetConflictingRoots returns the root branch names of conflicting stacks.
+func (r *CombinationResult) GetConflictingRoots() []string {
+	roots := make([]string, len(r.ConflictingStacks))
+	for i, s := range r.ConflictingStacks {
+		roots[i] = s.Stack.RootBranch()
+	}
+	return roots
+}


### PR DESCRIPTION

Add Combiner to analyze whether multiple stacks can be merged together:
- CheckCombination: test if given stacks can merge without conflicts
- FindLargestCompatible: find the largest subset that works together
- Supports optional local CI validation during combination checking

Adds CombinationResult, ExcludedStack, and related types to track
which stacks were combined vs excluded and why.


<!-- STACKIT-SECTION-START -->
#### Stack



This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #488 by jonnii*