### PR TITLE
docs: enforce stackit workflow in agent templates

### DIFF
--- a/internal/cli/integrations/agents/templates/commands/stack-create.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-create.md
@@ -8,6 +8,26 @@ argument-hint: [optional-branch-name]
 
 Create a new stacked branch on top of the current branch.
 
+## CRITICAL: Required Workflow
+
+**You MUST stage changes BEFORE running `command stackit create`.** The command creates a branch AND commits staged changes in one atomic operation.
+
+```bash
+# CORRECT workflow:
+git add -A                                    # 1. Stage changes FIRST
+echo "message" | command stackit create --no-interactive  # 2. Then create
+
+# WRONG - NEVER do this:
+command stackit create -m "..."   # Creates empty branch!
+git commit -m "..."       # BYPASSES stackit - FORBIDDEN!
+```
+
+## FORBIDDEN Commands
+
+When creating new stacked branches, NEVER use:
+- `git commit` - Always use `command stackit create` instead
+- `git checkout -b` - Use `command stackit create` which handles both
+
 ## Context
 - Current branch: !`git branch --show-current`
 - Staged changes: !`git diff --cached --stat`
@@ -20,16 +40,17 @@ $ARGUMENTS
 
 ## Instructions
 
-1. If no staged changes, ask what to stage or offer `git add --all`
+1. **Check for staged changes first** - If no staged changes, ask what to stage or run `git add --all`
 2. If on trunk (main/master), confirm user wants to proceed
 3. Generate a commit message:
    - Analyze the staged diff to understand what changed
    - Check README.md or CONTRIBUTING.md for commit conventions
    - Consider matching the style of recent commits if present
-4. Run: `echo "commit message" | command stackit create [branch-name] --no-interactive`
+4. **Ensure changes are staged**, then run: `echo "commit message" | command stackit create [branch-name] --no-interactive`
    - Branch name is optional; stackit auto-generates from commit message
 5. Show new stack state
 
 ## Do NOT
-- Proceed without staged changes
+- Run `command stackit create` without staged changes (creates empty branch)
+- Use `git commit` after creating a branch - this bypasses stackit
 - Skip reading project conventions if they exist

--- a/internal/cli/integrations/agents/templates/skill/SKILL.md
+++ b/internal/cli/integrations/agents/templates/skill/SKILL.md
@@ -182,14 +182,28 @@ When generating PR descriptions:
 - Body has meaningful content (not placeholders)?
 - Test plan is specific?
 
+## FORBIDDEN Commands
+
+When working with stacks, NEVER use these git commands:
+
+| FORBIDDEN | USE INSTEAD |
+|-----------|-------------|
+| `git commit` (for new branches) | `command stackit create` |
+| `git checkout -b` | `command stackit create` |
+| `gh pr create` | `command stackit submit` |
+| `git rebase` | `command stackit restack` |
+
+**Exception:** `git commit` is allowed ONLY when adding additional commits to an existing stacked branch.
+
 ## Important Rules
 
-1. **Never use raw git for branch operations** - always use `command stackit` commands
-2. **Check state before destructive operations** - run `command stackit log` first
-3. **Always validate after absorb** - absorb can cause compilation errors, see fix-absorb workflow
-4. **Handle conflicts gracefully** - guide user through resolution, see conflict-resolution workflow
-5. **Keep PRs small and focused** - suggest splitting if too large
-6. **Use validation loops** - for commit messages, PR descriptions, and post-absorb builds
+1. **NEVER use `git commit` to create new stacked branches** - always use `command stackit create`
+2. **Stage changes BEFORE running `command stackit create`** - it requires staged changes to work correctly
+3. **Check state before destructive operations** - run `command stackit log` first
+4. **Always validate after absorb** - absorb can cause compilation errors, see fix-absorb workflow
+5. **Handle conflicts gracefully** - guide user through resolution, see conflict-resolution workflow
+6. **Keep PRs small and focused** - suggest splitting if too large
+7. **Use validation loops** - for commit messages, PR descriptions, and post-absorb builds
 
 ## Version {{VERSION}} Changes
 

--- a/internal/cli/integrations/agents/templates/skill/commands/branch.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/branch.md
@@ -2,7 +2,21 @@
 
 Commands for creating, modifying, and managing individual branches.
 
-> **CRITICAL:** Always run these commands with `command stackit ... --no-interactive`.
+> **CRITICAL:** Always run these commands with `command stackit ... --no-interactive`. For commands that require confirmation, include `--force` (for absorb) or `--yes` (for undo/merge).
+
+## FORBIDDEN Commands
+
+| FORBIDDEN | USE INSTEAD |
+|-----------|-------------|
+| `git commit` (new branches) | `command stackit create` |
+| `git checkout -b` | `command stackit create` |
+| `gh pr create` | `command stackit submit` |
+
+**Required workflow for new stacked branches:**
+```bash
+git add -A                                                # 1. Stage FIRST
+echo "message" | command stackit create --no-interactive  # 2. Then create
+```
 
 ## Creating and Modifying
 

--- a/internal/cli/integrations/agents/templates/skill/reference.md
+++ b/internal/cli/integrations/agents/templates/skill/reference.md
@@ -8,6 +8,20 @@ Quick reference for all stackit commands. For detailed documentation, see:
 
 > **CRITICAL:** Always run stackit with `command stackit ... --no-interactive`. For commands that require confirmation, include `--force` (for absorb) or `--yes` (for undo/merge).
 
+## FORBIDDEN Commands
+
+| FORBIDDEN | USE INSTEAD |
+|-----------|-------------|
+| `git commit` (new branches) | `command stackit create` |
+| `git checkout -b` | `command stackit create` |
+| `gh pr create` | `command stackit submit` |
+
+**Required workflow for new stacked branches:**
+```bash
+git add -A                                        # 1. Stage FIRST
+echo "message" | command stackit create --no-interactive  # 2. Then create
+```
+
 ## Utility Scripts
 
 Run these helper scripts for analysis:


### PR DESCRIPTION

Add FORBIDDEN Commands sections to agent templates to prevent
incorrect git commit usage when creating stacked branches.
Updated files:
- stack-create.md: Added CRITICAL workflow section
- SKILL.md: Added FORBIDDEN Commands table
- reference.md: Added FORBIDDEN Commands section
- branch.md: Added FORBIDDEN Commands section


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #468**
  * **PR #470** 👈

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->