### PR TITLE
feat: add shippable work dashboard UI

### DIFF
--- a/internal/cli/dashboard/shippable.go
+++ b/internal/cli/dashboard/shippable.go
@@ -1,0 +1,30 @@
+package dashboard
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"stackit.dev/stackit/internal/app"
+	"stackit.dev/stackit/internal/config"
+	"stackit.dev/stackit/internal/utils"
+)
+
+// RunShippable starts the shippable work dashboard.
+func RunShippable(ctx *app.Context, opts ShippableOptions) error {
+	if !utils.IsInteractive() {
+		return fmt.Errorf("dashboard requires an interactive terminal")
+	}
+
+	// Load config for CI settings
+	cfg, err := config.LoadConfig(ctx.RepoRoot)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	m := newShippableModel(ctx, cfg, opts)
+
+	p := tea.NewProgram(m, tea.WithAltScreen())
+	_, err = p.Run()
+	return err
+}

--- a/internal/cli/dashboard/shippable_model.go
+++ b/internal/cli/dashboard/shippable_model.go
@@ -1,0 +1,227 @@
+package dashboard
+
+import (
+	"time"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"stackit.dev/stackit/internal/app"
+	"stackit.dev/stackit/internal/config"
+	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/shippable"
+)
+
+// ShippableOptions defines configuration for the shippable dashboard.
+type ShippableOptions struct {
+	// RunLocalCI enables local CI validation during combination checks.
+	RunLocalCI bool
+}
+
+// shippableModel is the main model for the shippable work dashboard.
+type shippableModel struct {
+	ctx    *app.Context
+	engine engine.Engine
+	cfg    *config.Config
+
+	// Dimensions
+	width  int
+	height int
+
+	// Analysis state
+	analyzer    *shippable.Analyzer
+	combiner    *shippable.Combiner
+	analysis    *shippable.AnalysisResult
+	combination *shippable.CombinationResult
+
+	// UI state
+	stacks        []shippable.Stack
+	selectedIndex int
+	expanded      map[string]bool  // Tracks which stacks are expanded
+	selected      map[string]bool  // Tracks which stacks are selected for shipping
+	focusedStack  *shippable.Stack // Currently focused stack for detail view
+
+	// Status
+	loading       bool
+	analyzing     bool
+	lastRefresh   time.Time
+	statusMessage string
+	errorMessage  string
+
+	// Confirmation dialog
+	showConfirmation bool
+	confirmAction    string
+
+	// Help overlay
+	showHelp bool
+
+	// Options
+	options ShippableOptions
+}
+
+// keyMap defines all keyboard shortcuts for the dashboard.
+type keyMap struct {
+	Up        key.Binding
+	Down      key.Binding
+	Select    key.Binding
+	Expand    key.Binding
+	Ship      key.Binding
+	Analyze   key.Binding
+	Refresh   key.Binding
+	Help      key.Binding
+	Quit      key.Binding
+	Confirm   key.Binding
+	Cancel    key.Binding
+	SelectAll key.Binding
+}
+
+var keys = keyMap{
+	Up: key.NewBinding(
+		key.WithKeys("up", "k"),
+		key.WithHelp("↑/k", "move up"),
+	),
+	Down: key.NewBinding(
+		key.WithKeys("down", "j"),
+		key.WithHelp("↓/j", "move down"),
+	),
+	Select: key.NewBinding(
+		key.WithKeys(" "),
+		key.WithHelp("space", "toggle selection"),
+	),
+	Expand: key.NewBinding(
+		key.WithKeys("enter"),
+		key.WithHelp("enter", "expand/collapse"),
+	),
+	Ship: key.NewBinding(
+		key.WithKeys("s"),
+		key.WithHelp("s", "ship selected"),
+	),
+	Analyze: key.NewBinding(
+		key.WithKeys("a"),
+		key.WithHelp("a", "analyze combination"),
+	),
+	Refresh: key.NewBinding(
+		key.WithKeys("r"),
+		key.WithHelp("r", "refresh"),
+	),
+	Help: key.NewBinding(
+		key.WithKeys("?"),
+		key.WithHelp("?", "help"),
+	),
+	Quit: key.NewBinding(
+		key.WithKeys("q", "ctrl+c"),
+		key.WithHelp("q", "quit"),
+	),
+	Confirm: key.NewBinding(
+		key.WithKeys("enter", "y"),
+		key.WithHelp("enter/y", "confirm"),
+	),
+	Cancel: key.NewBinding(
+		key.WithKeys("esc", "n"),
+		key.WithHelp("esc/n", "cancel"),
+	),
+	SelectAll: key.NewBinding(
+		key.WithKeys("A"),
+		key.WithHelp("A", "select all shippable"),
+	),
+}
+
+// newShippableModel creates a new shippable dashboard model.
+func newShippableModel(ctx *app.Context, cfg *config.Config, opts ShippableOptions) *shippableModel {
+	analyzer := shippable.NewAnalyzer(ctx.Engine, ctx.GitHubClient)
+	combiner := shippable.NewCombiner(ctx.Engine, cfg, ctx.Output)
+
+	return &shippableModel{
+		ctx:      ctx,
+		engine:   ctx.Engine,
+		cfg:      cfg,
+		analyzer: analyzer,
+		combiner: combiner,
+		expanded: make(map[string]bool),
+		selected: make(map[string]bool),
+		loading:  true,
+		options:  opts,
+	}
+}
+
+// selectedStacks returns the stacks that are currently selected.
+func (m *shippableModel) selectedStacks() []shippable.Stack {
+	var result []shippable.Stack
+	for _, s := range m.stacks {
+		if m.selected[s.RootBranch()] {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// selectedCount returns the number of selected stacks.
+func (m *shippableModel) selectedCount() int {
+	count := 0
+	for _, v := range m.selected {
+		if v {
+			count++
+		}
+	}
+	return count
+}
+
+// currentStack returns the currently focused stack, or nil if none.
+func (m *shippableModel) currentStack() *shippable.Stack {
+	if m.selectedIndex >= 0 && m.selectedIndex < len(m.stacks) {
+		return &m.stacks[m.selectedIndex]
+	}
+	return nil
+}
+
+// toggleSelection toggles selection of the current stack.
+func (m *shippableModel) toggleSelection() {
+	stack := m.currentStack()
+	if stack == nil {
+		return
+	}
+	root := stack.RootBranch()
+	m.selected[root] = !m.selected[root]
+}
+
+// toggleExpand toggles expansion of the current stack.
+func (m *shippableModel) toggleExpand() {
+	stack := m.currentStack()
+	if stack == nil {
+		return
+	}
+	root := stack.RootBranch()
+	m.expanded[root] = !m.expanded[root]
+}
+
+// selectAllShippable selects all shippable stacks.
+func (m *shippableModel) selectAllShippable() {
+	for _, s := range m.stacks {
+		if s.IsShippable() {
+			m.selected[s.RootBranch()] = true
+		}
+	}
+}
+
+// Init initializes the model.
+func (m *shippableModel) Init() tea.Cmd {
+	return m.refresh()
+}
+
+// Messages for async operations
+type (
+	analysisCompleteMsg struct {
+		result *shippable.AnalysisResult
+		err    error
+	}
+
+	combinationCompleteMsg struct {
+		result *shippable.CombinationResult
+		err    error
+	}
+
+	refreshCompleteMsg struct {
+		result *shippable.AnalysisResult
+		err    error
+	}
+)

--- a/internal/cli/dashboard/shippable_update.go
+++ b/internal/cli/dashboard/shippable_update.go
@@ -1,0 +1,213 @@
+package dashboard
+
+import (
+	"time"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"stackit.dev/stackit/internal/shippable"
+)
+
+// Update handles all messages and updates the model.
+func (m *shippableModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		return m.handleKeyMsg(msg)
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case refreshCompleteMsg:
+		m.loading = false
+		m.lastRefresh = time.Now()
+		if msg.err != nil {
+			m.errorMessage = msg.err.Error()
+			return m, nil
+		}
+		m.errorMessage = ""
+		m.analysis = msg.result
+		m.stacks = msg.result.Stacks
+		m.updateFocusedStack()
+		return m, nil
+
+	case analysisCompleteMsg:
+		m.analyzing = false
+		if msg.err != nil {
+			m.errorMessage = msg.err.Error()
+			return m, nil
+		}
+		m.analysis = msg.result
+		m.stacks = msg.result.Stacks
+		m.statusMessage = "Analysis complete"
+		return m, nil
+
+	case combinationCompleteMsg:
+		m.analyzing = false
+		if msg.err != nil {
+			m.errorMessage = msg.err.Error()
+			return m, nil
+		}
+		m.combination = msg.result
+		if msg.result.Combinable {
+			m.statusMessage = "Selected stacks can be combined"
+		} else {
+			m.statusMessage = "Some stacks conflict"
+		}
+		return m, nil
+	}
+
+	return m, nil
+}
+
+// handleKeyMsg handles keyboard input.
+func (m *shippableModel) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// If showing confirmation, handle confirm/cancel
+	if m.showConfirmation {
+		return m.handleConfirmationKey(msg)
+	}
+
+	// If showing help, any key closes it
+	if m.showHelp {
+		m.showHelp = false
+		return m, nil
+	}
+
+	// If loading or analyzing, only allow quit
+	if m.loading || m.analyzing {
+		if key.Matches(msg, keys.Quit) {
+			return m, tea.Quit
+		}
+		return m, nil
+	}
+
+	// Handle normal navigation and actions
+	switch {
+	case key.Matches(msg, keys.Quit):
+		return m, tea.Quit
+
+	case key.Matches(msg, keys.Up):
+		if m.selectedIndex > 0 {
+			m.selectedIndex--
+			m.updateFocusedStack()
+		}
+		return m, nil
+
+	case key.Matches(msg, keys.Down):
+		if m.selectedIndex < len(m.stacks)-1 {
+			m.selectedIndex++
+			m.updateFocusedStack()
+		}
+		return m, nil
+
+	case key.Matches(msg, keys.Select):
+		m.toggleSelection()
+		return m, nil
+
+	case key.Matches(msg, keys.Expand):
+		m.toggleExpand()
+		return m, nil
+
+	case key.Matches(msg, keys.SelectAll):
+		m.selectAllShippable()
+		return m, nil
+
+	case key.Matches(msg, keys.Ship):
+		return m.startShip()
+
+	case key.Matches(msg, keys.Analyze):
+		return m.startCombinationAnalysis()
+
+	case key.Matches(msg, keys.Refresh):
+		m.loading = true
+		m.statusMessage = "Refreshing..."
+		return m, m.refresh()
+
+	case key.Matches(msg, keys.Help):
+		m.showHelp = true
+		return m, nil
+	}
+
+	return m, nil
+}
+
+// handleConfirmationKey handles keyboard input during confirmation dialog.
+func (m *shippableModel) handleConfirmationKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, keys.Confirm):
+		m.showConfirmation = false
+		if m.confirmAction == "ship" {
+			return m.executeShip()
+		}
+		return m, nil
+
+	case key.Matches(msg, keys.Cancel):
+		m.showConfirmation = false
+		m.confirmAction = ""
+		return m, nil
+	}
+	return m, nil
+}
+
+// updateFocusedStack updates the focused stack based on selection.
+func (m *shippableModel) updateFocusedStack() {
+	m.focusedStack = m.currentStack()
+}
+
+// refresh fetches the latest stack analysis.
+func (m *shippableModel) refresh() tea.Cmd {
+	return func() tea.Msg {
+		result, err := m.analyzer.AnalyzeAll(m.ctx.Context)
+		return refreshCompleteMsg{result: result, err: err}
+	}
+}
+
+// startShip initiates the ship workflow.
+func (m *shippableModel) startShip() (tea.Model, tea.Cmd) {
+	selected := m.selectedStacks()
+	if len(selected) == 0 {
+		m.errorMessage = "No stacks selected"
+		return m, nil
+	}
+
+	// Check if all selected stacks are shippable
+	for _, s := range selected {
+		if !s.IsShippable() {
+			m.errorMessage = "Cannot ship: " + s.RootBranch() + " is not shippable"
+			return m, nil
+		}
+	}
+
+	// Show confirmation dialog
+	m.showConfirmation = true
+	m.confirmAction = "ship"
+	return m, nil
+}
+
+// executeShip executes the ship action after confirmation.
+func (m *shippableModel) executeShip() (tea.Model, tea.Cmd) {
+	// TODO: Implement actual ship action in Phase 4
+	m.statusMessage = "Ship action not yet implemented"
+	return m, nil
+}
+
+// startCombinationAnalysis checks if selected stacks can be combined.
+func (m *shippableModel) startCombinationAnalysis() (tea.Model, tea.Cmd) {
+	selected := m.selectedStacks()
+	if len(selected) == 0 {
+		m.errorMessage = "No stacks selected for analysis"
+		return m, nil
+	}
+
+	m.analyzing = true
+	m.statusMessage = "Analyzing combination..."
+
+	return m, func() tea.Msg {
+		result, err := m.combiner.CheckCombination(m.ctx.Context, selected, shippable.CheckCombinationOptions{
+			RunLocalCI: m.options.RunLocalCI,
+		})
+		return combinationCompleteMsg{result: result, err: err}
+	}
+}

--- a/internal/cli/dashboard/shippable_view.go
+++ b/internal/cli/dashboard/shippable_view.go
@@ -1,0 +1,400 @@
+package dashboard
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"stackit.dev/stackit/internal/shippable"
+	"stackit.dev/stackit/internal/tui/style"
+)
+
+// View renders the dashboard.
+func (m *shippableModel) View() string {
+	if m.loading {
+		return m.renderLoading()
+	}
+
+	if m.showHelp {
+		return m.renderHelp()
+	}
+
+	if m.showConfirmation {
+		return m.renderConfirmation()
+	}
+
+	return m.renderMain()
+}
+
+// renderLoading shows the loading state.
+func (m *shippableModel) renderLoading() string {
+	return lipgloss.NewStyle().
+		Padding(2, 4).
+		Render("Loading shippable work...")
+}
+
+// renderMain renders the main dashboard view.
+func (m *shippableModel) renderMain() string {
+	// Calculate dimensions
+	headerHeight := 3
+	footerHeight := 4
+	contentHeight := m.height - headerHeight - footerHeight
+	if contentHeight < 5 {
+		contentHeight = 5
+	}
+
+	leftWidth := m.width * 2 / 3
+	rightWidth := m.width - leftWidth
+
+	// Build sections
+	header := m.renderHeader()
+	leftPane := m.renderStackList(leftWidth, contentHeight)
+	rightPane := m.renderDetailsPanel(rightWidth, contentHeight)
+	footer := m.renderFooter()
+
+	// Combine panes
+	content := lipgloss.JoinHorizontal(lipgloss.Top, leftPane, rightPane)
+
+	return lipgloss.JoinVertical(lipgloss.Left, header, content, footer)
+}
+
+// renderHeader renders the dashboard header.
+func (m *shippableModel) renderHeader() string {
+	titleStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("6")).
+		Bold(true).
+		Padding(0, 1)
+
+	statusStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("241")).
+		Padding(0, 1)
+
+	title := titleStyle.Render("SHIPPABLE WORK")
+
+	var status string
+	switch {
+	case m.analyzing:
+		status = statusStyle.Render("Analyzing...")
+	case m.errorMessage != "":
+		status = lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Render(m.errorMessage)
+	case m.statusMessage != "":
+		status = statusStyle.Render(m.statusMessage)
+	case m.analysis != nil:
+		status = statusStyle.Render(fmt.Sprintf("%d stacks (%d shippable)",
+			m.analysis.TotalStacks(), m.analysis.ShippableCount))
+	}
+
+	return lipgloss.NewStyle().
+		Border(lipgloss.NormalBorder(), false, false, true, false).
+		Width(m.width).
+		Render(lipgloss.JoinHorizontal(lipgloss.Left, title, "  ", status))
+}
+
+// renderStackList renders the list of stacks.
+func (m *shippableModel) renderStackList(width, height int) string {
+	paneStyle := lipgloss.NewStyle().
+		Border(lipgloss.NormalBorder(), false, true, false, false).
+		Padding(0, 1).
+		Width(width).
+		Height(height)
+
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
+
+	if len(m.stacks) == 0 {
+		return paneStyle.Render(headerStyle.Render("STACKS") + "\n\n" +
+			style.ColorDim("No stacks found. Create one with `stackit create`"))
+	}
+
+	var sb strings.Builder
+	sb.WriteString(headerStyle.Render("STACKS") + "\n")
+	sb.WriteString(strings.Repeat("─", width-4) + "\n")
+
+	for i, stack := range m.stacks {
+		line := m.renderStackLine(stack, i == m.selectedIndex)
+		sb.WriteString(line + "\n")
+
+		// If expanded, show branches
+		if m.expanded[stack.RootBranch()] {
+			for _, branch := range stack.Stack.AllBranches {
+				branchLine := "    " + m.renderBranchLine(branch)
+				sb.WriteString(branchLine + "\n")
+			}
+		}
+	}
+
+	return paneStyle.Render(sb.String())
+}
+
+// renderStackLine renders a single stack in the list.
+func (m *shippableModel) renderStackLine(stack shippable.Stack, selected bool) string {
+	// Selection checkbox
+	var checkbox string
+	if m.selected[stack.RootBranch()] {
+		checkbox = style.ColorCyan("[x]")
+	} else {
+		checkbox = "[ ]"
+	}
+
+	// Status icon
+	statusIcon := m.getStatusIcon(stack.Status)
+
+	// Stack name and branch count
+	name := stack.RootBranch()
+	branchCount := fmt.Sprintf("(%d branches)", stack.BranchCount())
+
+	// Expand indicator
+	expandIndicator := "▶"
+	if m.expanded[stack.RootBranch()] {
+		expandIndicator = "▼"
+	}
+
+	// Build line
+	line := fmt.Sprintf("%s %s %s %s %s", checkbox, statusIcon, name, branchCount, expandIndicator)
+
+	// Highlight if selected
+	if selected {
+		line = lipgloss.NewStyle().
+			Background(lipgloss.Color("236")).
+			Render(line)
+	}
+
+	return line
+}
+
+// renderBranchLine renders a single branch within an expanded stack.
+func (m *shippableModel) renderBranchLine(branchName string) string {
+	branch := m.engine.GetBranch(branchName)
+	if branch.GetName() == "" {
+		return style.ColorDim("├── " + branchName)
+	}
+
+	// Get PR info if available
+	prStatus, err := branch.GetPRSubmissionStatus()
+	var prInfo string
+	if err == nil && prStatus.PRNumber != nil && *prStatus.PRNumber > 0 {
+		prInfo = fmt.Sprintf(" #%d", *prStatus.PRNumber)
+	}
+
+	return style.ColorDim("├── ") + branchName + style.ColorDim(prInfo)
+}
+
+// getStatusIcon returns the icon for a stack status.
+func (m *shippableModel) getStatusIcon(status shippable.Status) string {
+	switch status {
+	case shippable.StatusShippable:
+		return style.ColorGreen("✓")
+	case shippable.StatusPending:
+		return style.ColorYellow("⏳")
+	case shippable.StatusBlocked:
+		return style.ColorRed("✗")
+	case shippable.StatusIncomplete:
+		return style.ColorDim("○")
+	default:
+		return "?"
+	}
+}
+
+// renderDetailsPanel renders the right-side details panel.
+func (m *shippableModel) renderDetailsPanel(width, height int) string {
+	paneStyle := lipgloss.NewStyle().
+		Padding(0, 1).
+		Width(width).
+		Height(height)
+
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
+
+	var sb strings.Builder
+
+	// Selection summary
+	selectedCount := m.selectedCount()
+	if selectedCount > 0 {
+		sb.WriteString(headerStyle.Render("SELECTION") + "\n")
+		sb.WriteString(strings.Repeat("─", width-4) + "\n")
+		sb.WriteString(fmt.Sprintf("Selected: %d stacks\n\n", selectedCount))
+
+		for _, s := range m.selectedStacks() {
+			sb.WriteString(fmt.Sprintf("  %s (%d branches)\n", s.RootBranch(), s.BranchCount()))
+		}
+
+		sb.WriteString("\n")
+
+		// Combination status
+		if m.combination != nil {
+			if m.combination.Combinable {
+				sb.WriteString(style.ColorGreen("Combinable: Yes") + "\n")
+			} else {
+				sb.WriteString(style.ColorRed("Combinable: No") + "\n")
+				if len(m.combination.ConflictingStacks) > 0 {
+					sb.WriteString("Conflicts:\n")
+					for _, es := range m.combination.ConflictingStacks {
+						sb.WriteString(fmt.Sprintf("  - %s\n", es.Stack.RootBranch()))
+					}
+				}
+			}
+
+			if m.combination.LocalCIPassed != nil {
+				if *m.combination.LocalCIPassed {
+					sb.WriteString(style.ColorGreen("Local CI: Passed") + "\n")
+				} else {
+					sb.WriteString(style.ColorRed("Local CI: Failed") + "\n")
+				}
+			} else {
+				sb.WriteString(style.ColorDim("Local CI: Not run") + "\n")
+			}
+		}
+
+		sb.WriteString("\n" + strings.Repeat("─", width-4) + "\n")
+		sb.WriteString(style.ColorCyan("[S]") + " Ship selected\n")
+		sb.WriteString(style.ColorCyan("[A]") + " Analyze combination\n")
+	} else {
+		sb.WriteString(headerStyle.Render("DETAILS") + "\n")
+		sb.WriteString(strings.Repeat("─", width-4) + "\n")
+
+		if m.focusedStack != nil {
+			sb.WriteString(m.renderStackDetails(m.focusedStack))
+		} else {
+			sb.WriteString(style.ColorDim("Select a stack to see details"))
+		}
+	}
+
+	return paneStyle.Render(sb.String())
+}
+
+// renderStackDetails renders detailed info about a stack.
+func (m *shippableModel) renderStackDetails(stack *shippable.Stack) string {
+	labelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Width(12)
+
+	var sb strings.Builder
+	sb.WriteString(lipgloss.NewStyle().Bold(true).Render(stack.RootBranch()) + "\n\n")
+
+	// Status
+	sb.WriteString(labelStyle.Render("Status:") + " " + m.getStatusLabel(stack.Status) + "\n")
+
+	// Branch count
+	sb.WriteString(labelStyle.Render("Branches:") + " " + fmt.Sprintf("%d", stack.BranchCount()) + "\n")
+
+	// Approval status
+	if stack.ApprovalOK {
+		sb.WriteString(labelStyle.Render("Approval:") + " " + style.ColorGreen("Approved") + "\n")
+	} else {
+		sb.WriteString(labelStyle.Render("Approval:") + " " + style.ColorYellow("Pending") + "\n")
+	}
+
+	// CI status
+	if stack.GitHubCIOK {
+		sb.WriteString(labelStyle.Render("GitHub CI:") + " " + style.ColorGreen("Passing") + "\n")
+	} else {
+		sb.WriteString(labelStyle.Render("GitHub CI:") + " " + style.ColorRed("Failing/Pending") + "\n")
+	}
+
+	// Blocking PRs
+	if len(stack.BlockingPRs) > 0 {
+		sb.WriteString("\n" + lipgloss.NewStyle().Bold(true).Render("Blocking:") + "\n")
+		for _, bp := range stack.BlockingPRs {
+			sb.WriteString(fmt.Sprintf("  %s: %s\n", bp.Branch, bp.Reason))
+		}
+	}
+
+	return sb.String()
+}
+
+// getStatusLabel returns a styled label for a status.
+func (m *shippableModel) getStatusLabel(status shippable.Status) string {
+	switch status {
+	case shippable.StatusShippable:
+		return style.ColorGreen("Shippable")
+	case shippable.StatusPending:
+		return style.ColorYellow("Pending")
+	case shippable.StatusBlocked:
+		return style.ColorRed("Blocked")
+	case shippable.StatusIncomplete:
+		return style.ColorDim("Incomplete")
+	default:
+		return "Unknown"
+	}
+}
+
+// renderFooter renders the footer with keyboard shortcuts.
+func (m *shippableModel) renderFooter() string {
+	helpStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("241")).
+		Padding(0, 1).
+		Width(m.width)
+
+	shortcuts := []string{
+		"[Space] Toggle",
+		"[Enter] Expand",
+		"[j/k] Navigate",
+		"[s] Ship",
+		"[a] Analyze",
+		"[r] Refresh",
+		"[?] Help",
+		"[q] Quit",
+	}
+
+	return helpStyle.Render(strings.Join(shortcuts, "  "))
+}
+
+// renderHelp renders the help overlay.
+func (m *shippableModel) renderHelp() string {
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6")).MarginBottom(1)
+	sectionStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("5")).MarginTop(1)
+	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Width(12)
+	descStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("7"))
+
+	var sb strings.Builder
+	sb.WriteString(titleStyle.Render("Shippable Work Dashboard Help") + "\n\n")
+
+	sb.WriteString(sectionStyle.Render("Navigation") + "\n")
+	sb.WriteString(keyStyle.Render("j/k, ↑/↓") + descStyle.Render("Move selection up/down") + "\n")
+	sb.WriteString(keyStyle.Render("enter") + descStyle.Render("Expand/collapse stack") + "\n")
+
+	sb.WriteString(sectionStyle.Render("Selection") + "\n")
+	sb.WriteString(keyStyle.Render("space") + descStyle.Render("Toggle stack selection") + "\n")
+	sb.WriteString(keyStyle.Render("A") + descStyle.Render("Select all shippable") + "\n")
+
+	sb.WriteString(sectionStyle.Render("Actions") + "\n")
+	sb.WriteString(keyStyle.Render("s") + descStyle.Render("Ship selected stacks") + "\n")
+	sb.WriteString(keyStyle.Render("a") + descStyle.Render("Analyze combination") + "\n")
+	sb.WriteString(keyStyle.Render("r") + descStyle.Render("Refresh analysis") + "\n")
+
+	sb.WriteString(sectionStyle.Render("Other") + "\n")
+	sb.WriteString(keyStyle.Render("?") + descStyle.Render("Toggle this help") + "\n")
+	sb.WriteString(keyStyle.Render("q") + descStyle.Render("Quit") + "\n")
+
+	sb.WriteString("\n" + style.ColorDim("Press any key to close"))
+
+	return lipgloss.NewStyle().Padding(2, 4).Render(sb.String())
+}
+
+// renderConfirmation renders the ship confirmation dialog.
+func (m *shippableModel) renderConfirmation() string {
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6")).MarginBottom(1)
+
+	selected := m.selectedStacks()
+	totalBranches := 0
+	for _, s := range selected {
+		totalBranches += s.BranchCount()
+	}
+
+	var sb strings.Builder
+	sb.WriteString(titleStyle.Render("SHIP CONFIRMATION") + "\n\n")
+
+	sb.WriteString(fmt.Sprintf("About to ship %d stacks (%d branches total):\n\n",
+		len(selected), totalBranches))
+
+	for _, s := range selected {
+		sb.WriteString(fmt.Sprintf("  %s (%d branches)\n", s.RootBranch(), s.BranchCount()))
+	}
+
+	sb.WriteString("\nThis will:\n")
+	sb.WriteString("  - Create consolidation branch\n")
+	sb.WriteString("  - Create/update PR to main\n")
+	sb.WriteString("  - Merge when CI passes\n")
+
+	sb.WriteString("\n" + strings.Repeat("─", 40) + "\n")
+	sb.WriteString("[Enter/y] Confirm  [Esc/n] Cancel\n")
+
+	return lipgloss.NewStyle().Padding(2, 4).Render(sb.String())
+}


### PR DESCRIPTION

New dashboard focused on shipping work to trunk:
- Stack list with selection and status icons
- Expand/collapse to show branch details
- Selection panel showing selected stacks
- Combination analysis integration
- Ship confirmation dialog (action pending Phase 4)

Files:
- shippable.go: Entry point (RunShippable)
- shippable_model.go: BubbleTea model and key bindings
- shippable_update.go: Message handling and commands
- shippable_view.go: Rendering logic

This is the new UI for `st ui` replacing the current dashboard.


<!-- STACKIT-SECTION-START -->
#### Stack



This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->