### PR TITLE
fix: close individual PRs after multi-stack merge

### DIFF
--- a/internal/actions/merge/cleanup.go
+++ b/internal/actions/merge/cleanup.go
@@ -1,0 +1,171 @@
+package merge
+
+import (
+	"context"
+	"fmt"
+
+	"stackit.dev/stackit/internal/actions"
+	"stackit.dev/stackit/internal/app"
+	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/github"
+)
+
+// prCleanupEngine is the minimal interface needed for PR cleanup
+type prCleanupEngine interface {
+	GetBranch(name string) engine.Branch
+	UpsertPrInfo(branch engine.Branch, prInfo *engine.PrInfo) error
+}
+
+// PRCleanupSource identifies how a consolidation happened (for footer text)
+type PRCleanupSource string
+
+const (
+	// CleanupSourceConsolidate is used when consolidating a single stack
+	CleanupSourceConsolidate PRCleanupSource = "consolidation"
+	// CleanupSourceMultiStack is used when consolidating multiple stacks
+	CleanupSourceMultiStack PRCleanupSource = "multi-stack consolidation"
+)
+
+// PRCleanupConfig configures the post-merge PR cleanup behavior
+type PRCleanupConfig struct {
+	// Source identifies the cleanup source for footer text
+	Source PRCleanupSource
+
+	// ConsolidationPRNumber is the PR number of the consolidation PR
+	ConsolidationPRNumber int
+
+	// UserName is the username to include in the footer (optional)
+	UserName string
+}
+
+// PRCleanupResult contains the results of PR cleanup
+type PRCleanupResult struct {
+	ClosedPRs  []int // PR numbers that were closed
+	FailedPRs  []int // PR numbers that failed to close
+	SkippedPRs []int // PR numbers that were already closed
+}
+
+// ClosedCount returns the number of PRs that were closed
+func (r PRCleanupResult) ClosedCount() int { return len(r.ClosedPRs) }
+
+// FailedCount returns the number of PRs that failed to close
+func (r PRCleanupResult) FailedCount() int { return len(r.FailedPRs) }
+
+// SkippedCount returns the number of PRs that were skipped (already closed)
+func (r PRCleanupResult) SkippedCount() int { return len(r.SkippedPRs) }
+
+// PRCleaner handles post-merge cleanup of individual PRs
+type PRCleaner struct {
+	ctx    *app.Context
+	engine prCleanupEngine
+	config PRCleanupConfig
+}
+
+// NewPRCleaner creates a new PR cleaner
+func NewPRCleaner(ctx *app.Context, eng prCleanupEngine, config PRCleanupConfig) *PRCleaner {
+	return &PRCleaner{
+		ctx:    ctx,
+		engine: eng,
+		config: config,
+	}
+}
+
+// CleanupBranches closes PRs for the given branch names and updates their bodies with a footer
+func (c *PRCleaner) CleanupBranches(ctx context.Context, branchNames []string) PRCleanupResult {
+	result := PRCleanupResult{}
+	out := c.ctx.Output
+	githubClient := c.ctx.GitHubClient
+
+	if githubClient == nil {
+		out.Debug("No GitHub client available for PR cleanup")
+		return result
+	}
+
+	repoOwner, repoName := githubClient.GetOwnerRepo()
+	if repoOwner == "" || repoName == "" {
+		out.Debug("Could not get repo owner/name for PR cleanup")
+		return result
+	}
+
+	affectedBranches := make([]string, 0, len(branchNames))
+
+	for _, branchName := range branchNames {
+		branch := c.engine.GetBranch(branchName)
+		prInfo, err := branch.GetPrInfo()
+		if err != nil || prInfo == nil || prInfo.Number() == nil {
+			continue
+		}
+
+		prNumber := *prInfo.Number()
+
+		// Get current PR state from GitHub
+		existingPR, err := githubClient.GetPullRequest(ctx, repoOwner, repoName, prNumber)
+		if err != nil {
+			out.Debug("Failed to get PR #%d for %s: %v", prNumber, branchName, err)
+			continue
+		}
+
+		// Skip if already closed/merged (e.g., by merge commit strategy)
+		if existingPR.State != "OPEN" {
+			out.Debug("PR #%d is already %s, skipping", prNumber, existingPR.State)
+			result.SkippedPRs = append(result.SkippedPRs, prNumber)
+			continue
+		}
+
+		// Build and append footer to PR body
+		footer := c.buildFooter()
+		newBody := existingPR.Body + footer
+		updateOpts := github.UpdatePROptions{Body: &newBody}
+
+		if err := githubClient.UpdatePullRequest(ctx, repoOwner, repoName, prNumber, updateOpts); err != nil {
+			out.Debug("Failed to update PR #%d body: %v", prNumber, err)
+		} else {
+			out.Debug("Updated PR #%d with consolidation footer", prNumber)
+		}
+
+		// Close the PR (handles squash/rebase merge strategies where GitHub doesn't auto-close)
+		if err := githubClient.ClosePullRequest(ctx, repoOwner, repoName, prNumber); err != nil {
+			out.Debug("Failed to close PR #%d: %v", prNumber, err)
+			result.FailedPRs = append(result.FailedPRs, prNumber)
+		} else {
+			result.ClosedPRs = append(result.ClosedPRs, prNumber)
+		}
+
+		// Upsert PR info to keep metadata in sync
+		if err := c.engine.UpsertPrInfo(branch, prInfo); err != nil {
+			out.Debug("Failed to upsert PR info for %s: %v", branchName, err)
+		}
+
+		affectedBranches = append(affectedBranches, branchName)
+	}
+
+	// Sync metadata to remote
+	if len(affectedBranches) > 0 {
+		if err := actions.PushMetadataAndSyncPRs(c.ctx, affectedBranches); err != nil {
+			out.Debug("Failed to sync PR metadata: %v", err)
+		}
+	}
+
+	return result
+}
+
+// buildFooter creates the footer text for closed PRs
+func (c *PRCleaner) buildFooter() string {
+	footer := fmt.Sprintf("\n\n---\n*Merged via %s into #%d", c.config.Source, c.config.ConsolidationPRNumber)
+	if c.config.UserName != "" {
+		footer += fmt.Sprintf(" by %s", c.config.UserName)
+	}
+	footer += "*"
+	return footer
+}
+
+// LogResult logs the cleanup result to output
+func (c *PRCleaner) LogResult(result PRCleanupResult) {
+	out := c.ctx.Output
+	if result.ClosedCount() > 0 {
+		out.Info("Closed %d individual PR(s)", result.ClosedCount())
+	}
+	if result.FailedCount() > 0 {
+		out.Warn("Failed to close %d PR(s): %v", result.FailedCount(), result.FailedPRs)
+	}
+}

--- a/internal/actions/merge/cleanup_test.go
+++ b/internal/actions/merge/cleanup_test.go
@@ -1,0 +1,105 @@
+package merge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPRCleanupResult(t *testing.T) {
+	t.Parallel()
+
+	t.Run("counts are correct", func(t *testing.T) {
+		t.Parallel()
+
+		result := PRCleanupResult{
+			ClosedPRs:  []int{1, 2, 3},
+			FailedPRs:  []int{4, 5},
+			SkippedPRs: []int{6},
+		}
+
+		require.Equal(t, 3, result.ClosedCount())
+		require.Equal(t, 2, result.FailedCount())
+		require.Equal(t, 1, result.SkippedCount())
+	})
+
+	t.Run("empty result has zero counts", func(t *testing.T) {
+		t.Parallel()
+
+		result := PRCleanupResult{}
+
+		require.Equal(t, 0, result.ClosedCount())
+		require.Equal(t, 0, result.FailedCount())
+		require.Equal(t, 0, result.SkippedCount())
+	})
+}
+
+func TestPRCleanerBuildFooter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("consolidation footer with username", func(t *testing.T) {
+		t.Parallel()
+
+		cleaner := &PRCleaner{
+			config: PRCleanupConfig{
+				Source:                CleanupSourceConsolidate,
+				ConsolidationPRNumber: 123,
+				UserName:              "testuser",
+			},
+		}
+
+		footer := cleaner.buildFooter()
+		require.Equal(t, "\n\n---\n*Merged via consolidation into #123 by testuser*", footer)
+	})
+
+	t.Run("consolidation footer without username", func(t *testing.T) {
+		t.Parallel()
+
+		cleaner := &PRCleaner{
+			config: PRCleanupConfig{
+				Source:                CleanupSourceConsolidate,
+				ConsolidationPRNumber: 456,
+				UserName:              "",
+			},
+		}
+
+		footer := cleaner.buildFooter()
+		require.Equal(t, "\n\n---\n*Merged via consolidation into #456*", footer)
+	})
+
+	t.Run("multi-stack footer with username", func(t *testing.T) {
+		t.Parallel()
+
+		cleaner := &PRCleaner{
+			config: PRCleanupConfig{
+				Source:                CleanupSourceMultiStack,
+				ConsolidationPRNumber: 789,
+				UserName:              "anotheruser",
+			},
+		}
+
+		footer := cleaner.buildFooter()
+		require.Equal(t, "\n\n---\n*Merged via multi-stack consolidation into #789 by anotheruser*", footer)
+	})
+}
+
+func TestPRCleanerWithNilGitHubClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns empty result when no GitHub client", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a cleaner with nil context (no GitHub client)
+		cleaner := NewPRCleaner(nil, nil, PRCleanupConfig{
+			Source:                CleanupSourceConsolidate,
+			ConsolidationPRNumber: 123,
+		})
+
+		// This should not panic and return empty result
+		// Note: We can't actually call CleanupBranches without a valid context
+		// but we can verify the cleaner is created correctly
+		require.NotNil(t, cleaner)
+		require.Equal(t, CleanupSourceConsolidate, cleaner.config.Source)
+		require.Equal(t, 123, cleaner.config.ConsolidationPRNumber)
+	})
+}

--- a/internal/actions/merge/consolidate.go
+++ b/internal/actions/merge/consolidate.go
@@ -243,95 +243,27 @@ func (c *ConsolidateMergeExecutor) postMergeCleanup(_ context.Context) {
 }
 
 func (c *ConsolidateMergeExecutor) updateIndividualPRs() {
-	splog := c.ctx.Output
-	ctx := c.ctx.Context
-	githubClient := c.ctx.GitHubClient
-
 	// Skip if we don't have consolidation PR info
 	if c.consolidationPR == nil || c.consolidationPR.Number == 0 {
-		splog.Debug("No consolidation PR info available for footer updates")
+		c.ctx.Output.Debug("No consolidation PR info available for footer updates")
 		return
 	}
 
-	repoOwner, repoName := githubClient.GetOwnerRepo()
-	if repoOwner == "" || repoName == "" {
-		splog.Debug("Could not get repo owner/name for PR updates")
-		return
+	// Collect branch names
+	branchNames := make([]string, len(c.plan.BranchesToMerge))
+	for i, b := range c.plan.BranchesToMerge {
+		branchNames[i] = b.BranchName
 	}
 
-	affectedBranches := []string{}
-	var closedPRs []int
-	var failedPRs []int
+	// Use shared PR cleaner
+	cleaner := NewPRCleaner(c.ctx, c.engine, PRCleanupConfig{
+		Source:                CleanupSourceConsolidate,
+		ConsolidationPRNumber: c.consolidationPR.Number,
+		UserName:              c.consolidationUser,
+	})
 
-	for _, branchInfo := range c.plan.BranchesToMerge {
-		branch := c.engine.GetBranch(branchInfo.BranchName)
-		prInfo, err := branch.GetPrInfo()
-		if err != nil || prInfo == nil || prInfo.Number() == nil {
-			continue
-		}
-
-		prNumber := *prInfo.Number()
-
-		// Get current PR to check state and get body
-		existingPR, err := githubClient.GetPullRequest(ctx, repoOwner, repoName, prNumber)
-		if err != nil {
-			splog.Debug("Failed to get PR #%d for %s: %v", prNumber, branchInfo.BranchName, err)
-			continue
-		}
-
-		// Skip if already closed/merged (e.g., by merge commit strategy)
-		if existingPR.State != "OPEN" {
-			splog.Debug("PR #%d is already %s, skipping", prNumber, existingPR.State)
-			continue
-		}
-
-		// Build footer
-		footer := fmt.Sprintf("\n\n---\n*Merged via consolidation into #%d", c.consolidationPR.Number)
-		if c.consolidationUser != "" {
-			footer += fmt.Sprintf(" by %s", c.consolidationUser)
-		}
-		footer += "*"
-
-		// Append footer to existing body
-		newBody := existingPR.Body + footer
-		updateOpts := github.UpdatePROptions{
-			Body: &newBody,
-		}
-
-		if err := githubClient.UpdatePullRequest(ctx, repoOwner, repoName, prNumber, updateOpts); err != nil {
-			splog.Debug("Failed to update PR #%d body: %v", prNumber, err)
-		} else {
-			splog.Debug("Updated PR #%d with consolidation footer", prNumber)
-		}
-
-		// Close the PR (handles squash/rebase merge strategies where GitHub doesn't auto-close)
-		if err := githubClient.ClosePullRequest(ctx, repoOwner, repoName, prNumber); err != nil {
-			splog.Debug("Failed to close PR #%d: %v", prNumber, err)
-			failedPRs = append(failedPRs, prNumber)
-		} else {
-			closedPRs = append(closedPRs, prNumber)
-		}
-
-		// Keep the consolidation PR number so the footer knows it was consolidated
-		if err := c.engine.UpsertPrInfo(branch, prInfo); err != nil {
-			splog.Debug("Failed to upsert PR info for %s: %v", branchInfo.BranchName, err)
-		}
-		affectedBranches = append(affectedBranches, branchInfo.BranchName)
-	}
-
-	if len(affectedBranches) > 0 {
-		if err := actions.PushMetadataAndSyncPRs(c.ctx, affectedBranches); err != nil {
-			splog.Warn("Failed to sync individual PRs: %v", err)
-		}
-	}
-
-	// Report summary
-	if len(closedPRs) > 0 {
-		splog.Info("Closed %d individual PR(s)", len(closedPRs))
-	}
-	if len(failedPRs) > 0 {
-		splog.Warn("Failed to close %d PR(s): %v", len(failedPRs), failedPRs)
-	}
+	result := cleaner.CleanupBranches(c.ctx.Context, branchNames)
+	cleaner.LogResult(result)
 }
 
 func (c *ConsolidateMergeExecutor) lockAndNotifyIndividualPRs(_ context.Context, consolidationBranch string) error {

--- a/internal/actions/merge/multistack.go
+++ b/internal/actions/merge/multistack.go
@@ -174,6 +174,23 @@ func ExecuteMultiStack(ctx *app.Context, opts MultiStackOptions) (*MultiStackRes
 		}
 		out.Success("PR merged successfully!")
 		out.Debug("multistack: merge complete")
+
+		// 8. Clean up individual PRs from all included stacks
+		out.Debug("multistack: cleaning up individual PRs")
+		var branchNames []string
+		for _, stack := range result.IncludedStacks {
+			branchNames = append(branchNames, stack.AllBranches...)
+		}
+
+		userName, _ := eng.Git().GetUserName(ctx.Context)
+		cleaner := NewPRCleaner(ctx, eng, PRCleanupConfig{
+			Source:                CleanupSourceMultiStack,
+			ConsolidationPRNumber: pr.Number,
+			UserName:              userName,
+		})
+
+		cleanupResult := cleaner.CleanupBranches(ctx.Context, branchNames)
+		cleaner.LogResult(cleanupResult)
 	}
 
 	out.Debug("multistack: completed successfully")


### PR DESCRIPTION

Multi-stack merge was not closing individual PRs after the consolidated
PR was merged. This caused orphaned branches when sync detected them as
'merged into main' and deleted their metadata.

Extract shared PRCleaner abstraction used by both consolidate and
multi-stack flows to ensure consistent post-merge PR cleanup.


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #486** 👈

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->