### PR TITLE
feat: skip dirty worktree stacks during sync instead of failing

### DIFF
--- a/internal/actions/sync/branch_cleaning.go
+++ b/internal/actions/sync/branch_cleaning.go
@@ -11,7 +11,7 @@ import (
 )
 
 // cleanBranches handles cleaning merged/closed branches
-func cleanBranches(ctx *app.Context, opts *Options, handler Handler, summary *Summary) (*actions.CleanBranchesResult, error) {
+func cleanBranches(ctx *app.Context, opts *Options, dirtyAnchors map[string]bool, handler Handler, summary *Summary) (*actions.CleanBranchesResult, error) {
 	// Only emit phase start if we have branches that might need cleaning
 	allBranches := ctx.Engine.AllBranches()
 	hasBranchesToCheck := false
@@ -42,6 +42,13 @@ func cleanBranches(ctx *app.Context, opts *Options, handler Handler, summary *Su
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	// Filter out branches in dirty stacks - don't delete them while worktree has uncommitted changes
+	for name := range plan.BranchesToDelete {
+		if isInDirtyStack(ctx, name, dirtyAnchors) {
+			delete(plan.BranchesToDelete, name)
+		}
 	}
 
 	// Log each branch and its deletion reason

--- a/internal/actions/sync/github_sync.go
+++ b/internal/actions/sync/github_sync.go
@@ -69,7 +69,7 @@ func syncGitHubPRInfo(ctx *app.Context) (*GitHubSyncResult, error) {
 // This must run after syncGitHubPRInfo completes
 //
 //nolint:unparam // error return is for future error handling
-func processGitHubSyncResult(ctx *app.Context, result *GitHubSyncResult, branchesToRestack *[]string, handler Handler) error {
+func processGitHubSyncResult(ctx *app.Context, result *GitHubSyncResult, branchesToRestack *[]string, dirtyAnchors map[string]bool, handler Handler) error {
 	eng := ctx.PR()
 	nav := ctx.Navigator()
 	out := ctx.Output
@@ -122,14 +122,17 @@ func processGitHubSyncResult(ctx *app.Context, result *GitHubSyncResult, branche
 
 	// Synchronize local parents with GitHub PR base branches
 	parentsStart := time.Now()
-	syncResult, err := ParentsFromGitHubBase(ctx)
+	syncResult, err := ParentsFromGitHubBase(ctx, dirtyAnchors)
 	ctx.Logger.Info("sync parents from github base completed durationMs=%d", time.Since(parentsStart).Milliseconds())
 	if err != nil {
 		out.Debug("Failed to sync parents from GitHub: %v", err)
 	} else if len(syncResult.BranchesReparented) > 0 {
 		graph := engine.BuildStackGraph(ctx.Engine, engine.SortStrategyAlphabetical, nil)
-		// Add reparented branches to restack list
+		// Add reparented branches to restack list (skip dirty stacks)
 		for _, branchName := range syncResult.BranchesReparented {
+			if isInDirtyStack(ctx, branchName, dirtyAnchors) {
+				continue
+			}
 			*branchesToRestack = append(*branchesToRestack, branchName)
 			// Also add descendants
 			branch := nav.GetBranch(branchName)
@@ -146,7 +149,7 @@ func processGitHubSyncResult(ctx *app.Context, result *GitHubSyncResult, branche
 }
 
 // ParentsFromGitHubBase synchronizes local parents with GitHub PR base branches
-func ParentsFromGitHubBase(ctx *app.Context) (*ParentsResult, error) {
+func ParentsFromGitHubBase(ctx *app.Context, dirtyAnchors map[string]bool) (*ParentsResult, error) {
 	eng := ctx.Engine // Using Engine here because it needs multiple interfaces (Status, Navigator, Differ, Tracking)
 	out := ctx.Output
 	gctx := ctx.Context
@@ -163,6 +166,11 @@ func ParentsFromGitHubBase(ctx *app.Context) (*ParentsResult, error) {
 
 	for _, branch := range allBranches {
 		if branch.IsTrunk() {
+			continue
+		}
+
+		// Skip branches in dirty stacks - we don't want to reparent them
+		if isInDirtyStack(ctx, branch.GetName(), dirtyAnchors) {
 			continue
 		}
 

--- a/internal/actions/sync/restack.go
+++ b/internal/actions/sync/restack.go
@@ -10,7 +10,7 @@ import (
 )
 
 // restackBranches handles restacking branches after sync operations
-func restackBranches(ctx *app.Context, branchesToRestack []string, handler Handler, summary *Summary) error {
+func restackBranches(ctx *app.Context, branchesToRestack []string, dirtyAnchors map[string]bool, handler Handler, summary *Summary) error {
 	nav := ctx.Navigator()
 	graph := engine.BuildStackGraph(ctx.Engine, engine.SortStrategyAlphabetical, nil)
 
@@ -39,11 +39,11 @@ func restackBranches(ctx *app.Context, branchesToRestack []string, handler Handl
 		}
 	}
 
-	// Remove duplicates and filter out non-existent/untracked branches
+	// Remove duplicates and filter out non-existent/untracked branches and dirty stacks
 	seen := make(map[string]bool)
 	uniqueBranches := []engine.Branch{}
 	for _, branchName := range branchesToRestack {
-		if !seen[branchName] {
+		if !seen[branchName] && !isInDirtyStack(ctx, branchName, dirtyAnchors) {
 			seen[branchName] = true
 			branch := nav.GetBranch(branchName)
 			// Only include branches that exist, are tracked, and are not trunks

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -45,20 +45,28 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		out.Info("Syncing branches across all configured trunks...")
 	}
 
-	// Check for uncommitted changes in main repo
+	// Check for uncommitted changes in main repo (not worktrees - those are handled below)
+	// If we're in a worktree with uncommitted changes, the worktree dirty check will skip that stack
 	uncommittedStart := time.Now()
 	hasUncommitted := ctx.Reader().HasUncommittedChanges(gctx)
 	ctx.Logger.Info("check uncommitted changes completed", "durationMs", time.Since(uncommittedStart).Milliseconds())
-	if hasUncommitted {
+	if hasUncommitted && !ctx.InManagedWorktree {
 		return fmt.Errorf("you have uncommitted changes. Please commit or stash them before syncing")
 	}
 
-	// Check for uncommitted changes in managed worktrees
+	// Collect dirty worktree anchors (stacks to skip entirely)
+	// Rather than failing on dirty worktrees, we skip their entire stack to allow
+	// parallel work in other worktrees while preserving consistency.
+	var dirtyAnchors map[string]bool
 	managedWorktrees, err := eng.ListManagedWorktrees()
 	if err == nil {
 		for _, wt := range managedWorktrees {
 			if hasChanges, _ := eng.Git().WorktreeHasUncommittedChanges(gctx, wt.Path); hasChanges {
-				return fmt.Errorf("worktree at %s has uncommitted changes. Please commit or stash them before syncing", wt.Path)
+				if dirtyAnchors == nil {
+					dirtyAnchors = make(map[string]bool)
+				}
+				dirtyAnchors[wt.AnchorBranch] = true
+				out.Warn("Skipping stack rooted at %s (worktree has uncommitted changes)", wt.AnchorBranch)
 			}
 		}
 	}
@@ -132,10 +140,15 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return githubErr
 	}
 
+	// Populate skipped stacks in summary
+	for anchor := range dirtyAnchors {
+		summary.SkippedStacks = append(summary.SkippedStacks, anchor)
+	}
+
 	// Process GitHub PR info results (sequential - depends on PR info)
 	branchesToRestack := []string{}
 	if githubSyncResult != nil {
-		if err := processGitHubSyncResult(ctx, githubSyncResult, &branchesToRestack, handler); err != nil {
+		if err := processGitHubSyncResult(ctx, githubSyncResult, &branchesToRestack, dirtyAnchors, handler); err != nil {
 			return err
 		}
 	}
@@ -149,13 +162,13 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	// Phase 3: Clean branches (delete merged/closed)
-	cleanResult, err := cleanBranches(ctx, &opts, handler, summary)
+	cleanResult, err := cleanBranches(ctx, &opts, dirtyAnchors, handler, summary)
 	if err != nil {
 		return fmt.Errorf("failed to clean branches: %w", err)
 	}
 
 	// Clean orphaned worktrees (after branch cleanup so we know what's been deleted)
-	worktreeResult := cleanOrphanedWorktrees(ctx)
+	worktreeResult := cleanOrphanedWorktrees(ctx, dirtyAnchors)
 	if len(worktreeResult.RemovedWorktrees) > 0 {
 		summary.WorktreesCleaned = len(worktreeResult.RemovedWorktrees)
 	}
@@ -166,8 +179,11 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
 
-	// Add branches with new parents to restack list
+	// Add branches with new parents to restack list (skip dirty stacks)
 	for _, branchName := range cleanResult.BranchesWithNewParents {
+		if isInDirtyStack(ctx, branchName, dirtyAnchors) {
+			continue
+		}
 		branch := eng.GetBranch(branchName)
 		upstack := graph.Range(branch, engine.StackRange{
 			RecursiveChildren: true,
@@ -192,7 +208,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Phase 4: Restack branches
 	handler.EmitEvent(Event{Phase: PhaseRestack, Type: EventStarted})
 
-	if err := restackBranches(ctx, branchesToRestack, handler, summary); err != nil {
+	if err := restackBranches(ctx, branchesToRestack, dirtyAnchors, handler, summary); err != nil {
 		// Even on error, complete with summary
 		handler.Complete(*summary)
 		return err
@@ -282,6 +298,7 @@ type Summary struct {
 	ConflictBranches  []string // Names of branches that conflicted
 	UpToDate          bool     // Everything was already current
 	WorktreesCleaned  int      // Number of orphaned worktrees cleaned up
+	SkippedStacks     []string // Stacks skipped due to dirty worktrees
 }
 
 // ParentsResult contains the result of synchronizing parents from GitHub
@@ -292,7 +309,8 @@ type ParentsResult struct {
 // HasChanges returns true if any operations were performed
 func (s *Summary) HasChanges() bool {
 	return s.TrunkUpdated || s.BranchesSynced > 0 || s.BranchesRestacked > 0 ||
-		s.BranchesDeleted > 0 || s.BranchesSkipped > 0 || s.WorktreesCleaned > 0
+		s.BranchesDeleted > 0 || s.BranchesSkipped > 0 || s.WorktreesCleaned > 0 ||
+		len(s.SkippedStacks) > 0
 }
 
 // Handler abstracts TTY vs non-TTY output for sync operations
@@ -404,6 +422,9 @@ func FormatSummaryParts(summary Summary) []string {
 	if summary.BranchesSkipped > 0 {
 		parts = append(parts, fmt.Sprintf("skipped %d (conflict)", summary.BranchesSkipped))
 	}
+	if len(summary.SkippedStacks) > 0 {
+		parts = append(parts, fmt.Sprintf("skipped %d stack%s (dirty worktree)", len(summary.SkippedStacks), plural(len(summary.SkippedStacks))))
+	}
 
 	return parts
 }
@@ -443,4 +464,16 @@ func pluralES(count int) string {
 		return ""
 	}
 	return "es"
+}
+
+// isInDirtyStack returns true if the branch belongs to a dirty worktree's stack.
+// A branch is in a dirty stack if its stack root (first ancestor whose parent is trunk)
+// matches the anchor branch of a dirty worktree.
+func isInDirtyStack(ctx *app.Context, branchName string, dirtyAnchors map[string]bool) bool {
+	if len(dirtyAnchors) == 0 {
+		return false
+	}
+	branch := ctx.Engine.GetBranch(branchName)
+	stackRoot := ctx.Engine.GetStackRootForBranch(branch)
+	return dirtyAnchors[stackRoot]
 }

--- a/internal/actions/sync/sync_diamond_test.go
+++ b/internal/actions/sync/sync_diamond_test.go
@@ -132,7 +132,7 @@ func TestSyncDiamondStackParentPreservation(t *testing.T) {
 
 		// Now call SyncParentsFromGitHubBase directly to test if it incorrectly reparents
 		// based on the stale PR info we stored
-		syncResult, err := ParentsFromGitHubBase(s.Context)
+		syncResult, err := ParentsFromGitHubBase(s.Context, nil)
 		require.NoError(t, err)
 
 		// Rebuild engine to pick up any changes

--- a/internal/actions/sync/worktree_cleanup.go
+++ b/internal/actions/sync/worktree_cleanup.go
@@ -19,7 +19,8 @@ type WorktreeCleanupResult struct {
 // If a stack root is deleted but has surviving children (reparented to trunk), the worktree
 // registry is updated to point to the new stack root instead of deleting the worktree.
 // This function is best-effort and will not fail sync on errors.
-func cleanOrphanedWorktrees(ctx *app.Context) *WorktreeCleanupResult {
+// Worktrees with dirty anchors (uncommitted changes) are skipped to preserve work in progress.
+func cleanOrphanedWorktrees(ctx *app.Context, dirtyAnchors map[string]bool) *WorktreeCleanupResult {
 	result := &WorktreeCleanupResult{
 		RemovedWorktrees: []string{},
 		Errors:           []string{},
@@ -55,6 +56,11 @@ func cleanOrphanedWorktrees(ctx *app.Context) *WorktreeCleanupResult {
 
 	// Check each worktree to see if its stack root still exists
 	for _, wt := range worktrees {
+		// Skip dirty worktrees - don't clean up while there are uncommitted changes
+		if dirtyAnchors[wt.AnchorBranch] {
+			continue
+		}
+
 		stackRootBranch := ctx.Engine.GetBranch(wt.AnchorBranch)
 
 		// Check if the stack root branch still exists and is tracked

--- a/internal/integration/worktree_sync_test.go
+++ b/internal/integration/worktree_sync_test.go
@@ -321,6 +321,143 @@ func TestSyncWithMultipleWorktrees(t *testing.T) {
 		sh.ExpectBranchParent("branchD", "branchC")
 	})
 
+	t.Run("sync from dirty worktree skips own stack", func(t *testing.T) {
+		// Test scenario:
+		// 1. Create a worktree with a stack
+		// 2. Add uncommitted changes to the worktree
+		// 3. Run sync FROM that dirty worktree
+		// Expected:
+		// - Sync should complete without error
+		// - The worktree's stack should be skipped
+
+		sh := NewTestShellWithRemoteInProcess(t)
+
+		// Create a stack with worktree
+		sh.Log("Creating stack with worktree...")
+		sh.WriteFile("feature.txt", "feature content").
+			Run("create feature -w -m 'feature branch'").
+			OnBranch("main")
+
+		worktree := sh.GetWorktreePath("feature")
+		shW := sh.InWorktree(worktree)
+		shW.OnBranch("feature")
+
+		// Record SHA before sync
+		sh.Git("rev-parse feature")
+		featureBefore := sh.Output()
+
+		// Add uncommitted changes to the worktree
+		sh.Log("Adding uncommitted changes to worktree...")
+		shW.WriteFile("dirty.txt", "uncommitted content")
+		// Don't commit - this makes it dirty
+
+		// Advance main
+		sh.Log("Advancing main...")
+		sh.WriteFile("main-update.txt", "main change").
+			Git("add main-update.txt").
+			Git("commit -m 'Main advanced'").
+			Git("push origin main")
+
+		// Run sync from the dirty worktree
+		sh.Log("Running sync from dirty worktree...")
+		shW.Run("sync")
+
+		// Sync should complete without error
+		shW.OutputContains("Skipping stack")
+
+		// Feature branch should NOT be restacked (we're in it with uncommitted changes)
+		sh.Git("rev-parse feature")
+		featureAfter := sh.Output()
+		if featureBefore != featureAfter {
+			t.Errorf("Feature branch should NOT have been restacked (dirty), but SHA changed from %s to %s", featureBefore, featureAfter)
+		}
+
+		// Uncommitted changes should still be present
+		shW.Git("status --porcelain")
+		if shW.Output() == "" {
+			t.Error("Worktree should still have uncommitted changes")
+		}
+	})
+
+	t.Run("sync skips dirty worktree stack and syncs clean stack", func(t *testing.T) {
+		// Test scenario:
+		// 1. Create two worktrees with separate stacks
+		// 2. Add uncommitted changes to one worktree (making it "dirty")
+		// 3. Run sync from main repo
+		// Expected:
+		// - Clean worktree stack should be synced normally
+		// - Dirty worktree stack should be skipped
+		// - Sync should complete without error
+
+		sh := NewTestShellWithRemoteInProcess(t)
+
+		// Create Stack A (will be clean)
+		sh.Log("Creating Stack A with worktree (clean)...")
+		sh.WriteFile("stackA.txt", "stack A content").
+			Run("create stackA -w -m 'Stack A root'").
+			OnBranch("main")
+
+		worktreeA := sh.GetWorktreePath("stackA")
+		shA := sh.InWorktree(worktreeA)
+		shA.OnBranch("stackA")
+
+		// Create Stack B (will be dirty)
+		sh.Log("Creating Stack B with worktree (will be dirty)...")
+		sh.WriteFile("stackB.txt", "stack B content").
+			Run("create stackB -w -m 'Stack B root'").
+			OnBranch("main")
+
+		worktreeB := sh.GetWorktreePath("stackB")
+		shB := sh.InWorktree(worktreeB)
+		shB.OnBranch("stackB")
+
+		// Record the branch SHA before sync
+		sh.Git("rev-parse stackA")
+		stackABefore := sh.Output()
+		sh.Git("rev-parse stackB")
+		stackBBefore := sh.Output()
+
+		// Add uncommitted changes to worktree B (making it dirty)
+		sh.Log("Adding uncommitted changes to worktree B...")
+		shB.WriteFile("dirty.txt", "uncommitted content")
+		// Don't commit - this makes it dirty
+
+		// Advance main
+		sh.Log("Advancing main...")
+		sh.WriteFile("main-update.txt", "main change").
+			Git("add main-update.txt").
+			Git("commit -m 'Main advanced'").
+			Git("push origin main")
+
+		// Run sync from main repo
+		sh.Log("Running sync from main repo...")
+		sh.OnBranch("main").
+			Run("sync")
+
+		// Sync should complete without error (output check)
+		sh.OutputContains("Skipping stack")
+
+		// Stack A should be restacked (SHA changed)
+		sh.Git("rev-parse stackA")
+		stackAAfter := sh.Output()
+		if stackABefore == stackAAfter {
+			t.Errorf("Stack A should have been restacked, but SHA unchanged: %s", stackABefore)
+		}
+
+		// Stack B should NOT be restacked (SHA unchanged)
+		sh.Git("rev-parse stackB")
+		stackBAfter := sh.Output()
+		if stackBBefore != stackBAfter {
+			t.Errorf("Stack B should NOT have been restacked (dirty), but SHA changed from %s to %s", stackBBefore, stackBAfter)
+		}
+
+		// Worktree B should still have the uncommitted changes
+		shB.Git("status --porcelain")
+		if shB.Output() == "" {
+			t.Error("Worktree B should still have uncommitted changes")
+		}
+	})
+
 	t.Run("forked stack in worktree - bottom branch merged", func(t *testing.T) {
 		// Test scenario: forked stack where A has two children B and C
 		// Structure: main -> A -> B


### PR DESCRIPTION

When a managed worktree has uncommitted changes, sync now skips that
entire stack rather than failing. This allows parallel work across
multiple worktrees - clean stacks sync normally while dirty stacks
are preserved.

Changes:
- Collect dirty worktree anchors instead of returning error
- Filter branches in dirty stacks from restack, cleanup, and reparenting
- Add SkippedStacks to sync summary for visibility
- Allow sync from dirty worktree (skips own stack, syncs others)


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #487** 👈

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->