### PR TITLE
refactor: migrate components to use shared StatusStyles

### DIFF
--- a/internal/tui/components/foreach/foreach.go
+++ b/internal/tui/components/foreach/foreach.go
@@ -15,7 +15,8 @@ type Item struct {
 	Error      error
 }
 
-// Styles defines the visual styling for the foreach component
+// Styles defines the visual styling for the foreach component.
+// It uses the shared style definitions from internal/tui/style for consistency.
 type Styles struct {
 	SpinnerStyle lipgloss.Style
 	DoneStyle    lipgloss.Style
@@ -25,15 +26,18 @@ type Styles struct {
 	DimStyle     lipgloss.Style
 }
 
-// DefaultStyles returns the default styles for the foreach component
+// DefaultStyles returns the default styles for the foreach component,
+// using shared styles from the style package for consistency.
 func DefaultStyles() Styles {
+	statusStyles := style.DefaultStatusStyles()
+	commonStyles := style.DefaultCommonStyles()
 	return Styles{
-		SpinnerStyle: lipgloss.NewStyle().Foreground(lipgloss.Color("205")),
-		DoneStyle:    lipgloss.NewStyle().Foreground(lipgloss.Color("42")),
-		ErrorStyle:   lipgloss.NewStyle().Foreground(lipgloss.Color("196")),
-		BranchStyle:  style.BranchStyle(false, false, false).Bold(true),
-		OutputStyle:  style.DimStyle(),
-		DimStyle:     style.SubtleStyle(),
+		SpinnerStyle: commonStyles.Spinner,
+		DoneStyle:    statusStyles.Done,
+		ErrorStyle:   statusStyles.Error,
+		BranchStyle:  commonStyles.Branch.Bold(true),
+		OutputStyle:  commonStyles.Dim,
+		DimStyle:     commonStyles.Subtle,
 	}
 }
 

--- a/internal/tui/components/merge/model.go
+++ b/internal/tui/components/merge/model.go
@@ -58,6 +58,8 @@ type Model struct {
 	Summary           string
 }
 
+// styles holds the visual styling for the merge component.
+// Uses shared styles from internal/tui/style for consistency.
 type styles struct {
 	spinnerStyle lipgloss.Style
 	doneStyle    lipgloss.Style
@@ -65,6 +67,20 @@ type styles struct {
 	waitStyle    lipgloss.Style
 	dimStyle     lipgloss.Style
 	timeStyle    lipgloss.Style
+}
+
+// newStyles creates styles using the shared style definitions.
+func newStyles() styles {
+	statusStyles := style.DefaultStatusStyles()
+	commonStyles := style.DefaultCommonStyles()
+	return styles{
+		spinnerStyle: commonStyles.Spinner,
+		doneStyle:    statusStyles.Done,
+		errorStyle:   statusStyles.Error,
+		waitStyle:    statusStyles.Warning,
+		dimStyle:     commonStyles.Subtle,
+		timeStyle:    commonStyles.Dim,
+	}
 }
 
 const (
@@ -126,14 +142,7 @@ func NewModel() *Model {
 		Steps:      []StepItem{},
 		CurrentIdx: 0,
 		spinner:    s,
-		styles: styles{
-			spinnerStyle: lipgloss.NewStyle().Foreground(lipgloss.Color("205")),
-			doneStyle:    lipgloss.NewStyle().Foreground(lipgloss.Color("42")),
-			errorStyle:   lipgloss.NewStyle().Foreground(lipgloss.Color("196")),
-			waitStyle:    lipgloss.NewStyle().Foreground(lipgloss.Color("214")),
-			dimStyle:     style.SubtleStyle(),
-			timeStyle:    style.DimStyle(),
-		},
+		styles:     newStyles(),
 	}
 }
 

--- a/internal/tui/components/submit/submit.go
+++ b/internal/tui/components/submit/submit.go
@@ -19,7 +19,8 @@ type Item struct {
 	Error      error
 }
 
-// Styles defines the visual styling for the submit component
+// Styles defines the visual styling for the submit component.
+// It uses the shared style definitions from internal/tui/style for consistency.
 type Styles struct {
 	SpinnerStyle lipgloss.Style
 	DoneStyle    lipgloss.Style
@@ -29,15 +30,18 @@ type Styles struct {
 	DimStyle     lipgloss.Style
 }
 
-// DefaultStyles returns the default styles for the submit component
+// DefaultStyles returns the default styles for the submit component,
+// using shared styles from the style package for consistency.
 func DefaultStyles() Styles {
+	statusStyles := style.DefaultStatusStyles()
+	commonStyles := style.DefaultCommonStyles()
 	return Styles{
-		SpinnerStyle: lipgloss.NewStyle().Foreground(lipgloss.Color("205")),
-		DoneStyle:    lipgloss.NewStyle().Foreground(lipgloss.Color("42")),
-		ErrorStyle:   lipgloss.NewStyle().Foreground(lipgloss.Color("196")),
-		BranchStyle:  style.BranchStyle(false, false, false).Bold(true),
-		URLStyle:     style.DimStyle(),
-		DimStyle:     style.SubtleStyle(),
+		SpinnerStyle: commonStyles.Spinner,
+		DoneStyle:    statusStyles.Done,
+		ErrorStyle:   statusStyles.Error,
+		BranchStyle:  commonStyles.Branch.Bold(true),
+		URLStyle:     commonStyles.URL,
+		DimStyle:     commonStyles.Subtle,
 	}
 }
 

--- a/internal/tui/components/sync/model.go
+++ b/internal/tui/components/sync/model.go
@@ -8,7 +8,6 @@ import (
 	"github.com/charmbracelet/bubbles/progress"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 
 	"stackit.dev/stackit/internal/tui/core"
 	"stackit.dev/stackit/internal/tui/style"
@@ -76,9 +75,10 @@ func NewModel(totalOps int) *Model {
 		progress.WithoutPercentage(),
 	)
 
+	commonStyles := style.DefaultCommonStyles()
 	s := spinner.New()
 	s.Spinner = spinner.Dot
-	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
+	s.Style = commonStyles.Spinner
 
 	m := &Model{
 		Phases: []PhaseItem{
@@ -180,6 +180,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m *Model) View() string {
 	var b strings.Builder
 
+	// Get shared styles
+	statusStyles := style.DefaultStatusStyles()
+	commonStyles := style.DefaultCommonStyles()
+
 	// Progress bar at top (only when active and not done)
 	if !m.Done && m.TotalOps > 0 {
 		b.WriteString(m.Progress.View())
@@ -201,18 +205,17 @@ func (m *Model) View() string {
 
 		// Phase header
 		icon := "✓"
-		phaseStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
+		phaseStyle := statusStyles.Done
 		if phase.Status == core.StatusActive {
 			icon = m.spinner.View()
-			phaseStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
+			phaseStyle = statusStyles.Active
 		}
 
 		b.WriteString(fmt.Sprintf("%s %s\n", icon, phaseStyle.Render(phase.Message)))
 
 		// Phase details
-		dimStyle := style.SubtleStyle()
 		for _, detail := range phase.Details {
-			b.WriteString(fmt.Sprintf("  %s\n", dimStyle.Render(detail)))
+			b.WriteString(fmt.Sprintf("  %s\n", commonStyles.Subtle.Render(detail)))
 		}
 	}
 


### PR DESCRIPTION



<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #505**
  * **PR #504** 👈
    * **PR #502**
      * **PR #503**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->