### PR TITLE
refactor: consolidate engine state maps into BranchState struct

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,20 @@
+# Stackit Development Dependencies
+#
+# Install with: brew bundle
+#
+# Note: Runtime dependencies (git, gh) are documented in README.md
+# but not included here as they are typically already installed.
+
+# Task runner (used for all development commands)
+brew "just"
+
+# Linting (alternative to `go install`, provides system-wide binary)
+brew "golangci-lint"
+
+# CLI tools recommended in AGENTS.md
+brew "ripgrep"      # Fast text search (rg)
+brew "fd"           # Fast file search
+brew "ast-grep"     # AST-based code search and refactoring
+brew "jq"           # JSON processing
+brew "yq"           # YAML processing
+brew "tokei"        # Code statistics

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,15 @@ Thank you for your interest in contributing to Stackit! This document outlines t
 - **GitHub CLI (`gh`)** for PR operations
 - **[just](https://github.com/casey/just)** (optional, but recommended for running development commands)
 
+### Quick Setup (macOS/Linux)
+
+Install all development dependencies with Homebrew:
+```bash
+brew bundle
+```
+
+This installs: just, golangci-lint, ripgrep, fd, ast-grep, jq, yq, and tokei.
+
 ### Setting Up Your Development Environment
 
 1. Fork and clone the repository:

--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -27,6 +27,7 @@ type Context struct {
 	Logger       output.Logger
 	RepoRoot     string
 	GitHubClient github.Client
+	Config       *config.Config // Cached config to avoid repeated loading
 
 	// Global settings from flags
 	Interactive bool
@@ -293,6 +294,7 @@ func NewContextAutoWithWriter(ctx context.Context, repoRoot string, opts GlobalO
 
 	runtimeCtx := NewContext(eng, WithRepoRoot(repoRoot), WithGlobalOptions(opts), WithWriter(writer), WithLogger(logger))
 	runtimeCtx.Context = ctx
+	runtimeCtx.Config = cfg // Store config for reuse
 
 	// Try to create real GitHub client (may fail if no token)
 	ghClient, err := github.NewGitHubClient(ctx, runtimeCtx.Git())

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -39,11 +39,12 @@ func (e *engineImpl) GetCommitCount(branch Branch) (int, error) {
 	branchName := branch.GetName()
 	e.mu.RLock()
 	trunk := e.trunk
-	parent, ok := e.parentMap[branchName]
+	state := e.branchState.GetByName(branchName)
 	e.mu.RUnlock()
 
-	if !ok {
-		parent = trunk
+	parent := trunk
+	if state != nil {
+		parent = state.Parent
 	}
 
 	// Get base revision (stored parent revision)
@@ -83,11 +84,12 @@ func (e *engineImpl) GetDiffStats(branch Branch) (int, int, error) {
 	branchName := branch.GetName()
 	e.mu.RLock()
 	trunk := e.trunk
-	parent, ok := e.parentMap[branchName]
+	state := e.branchState.GetByName(branchName)
 	e.mu.RUnlock()
 
-	if !ok {
-		parent = trunk
+	parent := trunk
+	if state != nil {
+		parent = state.Parent
 	}
 
 	// Get base revision (stored parent revision)

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -15,13 +15,12 @@ func (e *engineImpl) IsTrunk(branch Branch) bool {
 	return branchName == e.trunk
 }
 
-// IsTracked checks if a branch is tracked (has metadata)
+// IsTracked checks if a branch is tracked (has a parent in metadata)
 func (e *engineImpl) IsTracked(branch Branch) bool {
-	branchName := branch.GetName()
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	_, ok := e.parentMap[branchName]
-	return ok
+	state := e.branchState.Get(branch)
+	return state != nil && state.Parent != ""
 }
 
 // GetScope returns the scope for a branch, inheriting from parent if not set
@@ -38,18 +37,21 @@ func (e *engineImpl) GetScope(branch Branch) Scope {
 		}
 		visited[current] = true
 
-		if scopeStr, ok := e.scopeMap[current]; ok && scopeStr != "" {
-			scope := NewScope(scopeStr)
+		state := e.branchState.GetByName(current)
+		if state == nil {
+			break
+		}
+		if state.HasScope() {
+			scope := state.GetScope()
 			if scope.IsNone() {
 				return Empty()
 			}
 			return scope
 		}
-		parent, ok := e.parentMap[current]
-		if !ok || parent == e.trunk {
+		if state.Parent == "" || state.Parent == e.trunk {
 			break
 		}
-		current = parent
+		current = state.Parent
 	}
 	return Empty()
 }
@@ -58,28 +60,40 @@ func (e *engineImpl) GetScope(branch Branch) Scope {
 func (e *engineImpl) IsLocked(branch Branch) bool {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	return LockReason(e.lockedMap[branch.GetName()]).IsLocked()
+	if state := e.branchState.Get(branch); state != nil {
+		return state.IsLocked()
+	}
+	return false
 }
 
 // GetLockReason returns the reason why a branch is locked
 func (e *engineImpl) GetLockReason(branch Branch) LockReason {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	return LockReason(e.lockedMap[branch.GetName()])
+	if state := e.branchState.Get(branch); state != nil {
+		return state.LockReason
+	}
+	return LockReasonNone
 }
 
 // IsFrozen checks if a branch is frozen
 func (e *engineImpl) IsFrozen(branch Branch) bool {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	return e.frozenMap[branch.GetName()]
+	if state := e.branchState.Get(branch); state != nil {
+		return state.Frozen
+	}
+	return false
 }
 
 // GetBranchType returns the branch type for a branch
 func (e *engineImpl) GetBranchType(branch Branch) git.BranchType {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	return git.BranchType(e.branchTypeMap[branch.GetName()])
+	if state := e.branchState.Get(branch); state != nil {
+		return state.BranchType
+	}
+	return ""
 }
 
 // IsWorktreeAnchor checks if a branch is a worktree anchor branch
@@ -108,11 +122,9 @@ func (e *engineImpl) SetBranchType(branch Branch, branchType git.BranchType) err
 		return fmt.Errorf("failed to write metadata: %w", err)
 	}
 
-	// Update in-memory map
-	if branchType != "" {
-		e.branchTypeMap[branchName] = string(branchType)
-	} else {
-		delete(e.branchTypeMap, branchName)
+	// Update in-memory state
+	if state := e.branchState.GetByName(branchName); state != nil {
+		state.BranchType = branchType
 	}
 
 	return nil
@@ -120,15 +132,13 @@ func (e *engineImpl) SetBranchType(branch Branch, branchType git.BranchType) err
 
 // GetExplicitScope returns the explicit scope set for a branch (no inheritance)
 func (e *engineImpl) GetExplicitScope(branch Branch) Scope {
-	branchName := branch.GetName()
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	scopeStr := e.scopeMap[branchName]
-	if scopeStr == "" {
-		return Empty()
+	if state := e.branchState.Get(branch); state != nil && state.HasScope() {
+		return state.GetScope()
 	}
-	return NewScope(scopeStr)
+	return Empty()
 }
 
 // getExplicitScope is an internal method for Branch type
@@ -145,15 +155,15 @@ func (e *engineImpl) IsUpToDate(branch Branch) bool {
 	}
 
 	e.mu.RLock()
-	parent, ok := e.parentMap[branchName]
+	state := e.branchState.GetByName(branchName)
 	e.mu.RUnlock()
 
-	if !ok {
+	if state == nil {
 		return true // Not tracked, consider it fixed
 	}
 
 	// Get current parent revision
-	parentRev, err := e.git.GetRevision(parent)
+	parentRev, err := e.git.GetRevision(state.Parent)
 	if err != nil {
 		return false // Can't determine, assume needs restack
 	}
@@ -176,7 +186,11 @@ func (e *engineImpl) IsUpToDate(branch Branch) bool {
 func (e *engineImpl) GetBranchRemoteStatus(branch Branch) (BranchRemoteStatus, error) {
 	branchName := branch.GetName()
 	e.mu.RLock()
-	remoteSha, hasCachedRemote := e.remoteShas[branchName]
+	state := e.branchState.Get(branch)
+	var remoteSha string
+	if state != nil {
+		remoteSha = state.RemoteSHA
+	}
 	e.mu.RUnlock()
 
 	localSha, err := e.git.GetRevision(branchName)
@@ -184,7 +198,7 @@ func (e *engineImpl) GetBranchRemoteStatus(branch Branch) (BranchRemoteStatus, e
 		localSha = "" // Branch doesn't exist locally
 	}
 
-	if !hasCachedRemote {
+	if remoteSha == "" {
 		// Fall back to local remote tracking branch
 		remoteSha, err = e.git.GetRemoteRevision(branchName)
 		if err != nil {
@@ -233,13 +247,13 @@ func (e *engineImpl) IsMergedIntoTrunk(ctx context.Context, branchName string) (
 // IsBranchEmpty checks if a branch has no changes compared to its parent
 func (e *engineImpl) IsBranchEmpty(ctx context.Context, branchName string) (bool, error) {
 	e.mu.RLock()
-	parent, ok := e.parentMap[branchName]
+	state := e.branchState.GetByName(branchName)
 	trunk := e.trunk
 	e.mu.RUnlock()
 
-	if !ok {
-		// If not tracked, compare to trunk
-		parent = trunk
+	parent := trunk
+	if state != nil {
+		parent = state.Parent
 	}
 
 	// Get parent revision

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -10,21 +10,87 @@ import (
 	"stackit.dev/stackit/internal/git"
 )
 
+// BranchState holds the cached metadata state for a single branch.
+// This consolidates what was previously stored in separate maps.
+type BranchState struct {
+	Parent        string         // Parent branch name
+	Scope         string         // Scope string (may be empty)
+	LockReason    git.LockReason // Lock reason (empty if not locked)
+	Frozen        bool           // Whether branch is frozen (local-only state)
+	BranchType    git.BranchType // Branch type (worktree-anchor, utility, etc.)
+	RemoteSHA     string         // Remote SHA (populated by PopulateRemoteShas)
+	LocalModified bool           // Has local metadata changes not yet pushed
+}
+
+// HasScope returns true if this branch has an explicit scope set.
+func (s *BranchState) HasScope() bool {
+	return s.Scope != ""
+}
+
+// GetScope returns the scope as a Scope type.
+func (s *BranchState) GetScope() Scope {
+	return NewScope(s.Scope)
+}
+
+// IsLocked returns true if this branch is locked.
+func (s *BranchState) IsLocked() bool {
+	return s.LockReason.IsLocked()
+}
+
+// BranchStateMap is a map of branch names to their state.
+type BranchStateMap map[string]*BranchState
+
+// Get returns the state for a branch, or nil if not found.
+func (m BranchStateMap) Get(branch Branch) *BranchState {
+	return m[branch.GetName()]
+}
+
+// GetByName returns the state for a branch name, or nil if not found.
+func (m BranchStateMap) GetByName(name string) *BranchState {
+	return m[name]
+}
+
+// Has returns true if the branch exists in the map.
+func (m BranchStateMap) Has(branch Branch) bool {
+	_, ok := m[branch.GetName()]
+	return ok
+}
+
+// HasByName returns true if the branch name exists in the map.
+func (m BranchStateMap) HasByName(name string) bool {
+	_, ok := m[name]
+	return ok
+}
+
+// Set sets the state for a branch.
+func (m BranchStateMap) Set(name string, state *BranchState) {
+	m[name] = state
+}
+
+// Delete removes a branch from the map.
+func (m BranchStateMap) Delete(name string) {
+	delete(m, name)
+}
+
+// GetOrCreate returns the state for a branch, creating it if it doesn't exist.
+func (m BranchStateMap) GetOrCreate(name string) *BranchState {
+	if state, ok := m[name]; ok {
+		return state
+	}
+	state := &BranchState{}
+	m[name] = state
+	return state
+}
+
 // engineImpl is a minimal implementation of the Engine interface
 type engineImpl struct {
 	repoRoot          string
 	trunk             string
 	currentBranch     string
 	branches          []string
-	parentMap         map[string]string    // branch -> parent
-	childrenMap       map[string][]string  // branch -> children
-	scopeMap          map[string]string    // branch -> scope
-	lockedMap         map[string]string    // branch -> lock reason (empty if not locked)
-	frozenMap         map[string]bool      // branch -> frozen (local-only)
-	branchTypeMap     map[string]string    // branch -> branch type (worktree-anchor, utility, etc.)
-	remoteShas        map[string]string    // branch -> remote SHA (populated by PopulateRemoteShas)
-	remoteMetaCache   map[string]*git.Meta // branch -> remote metadata
-	localModified     map[string]bool      // branches with local changes not yet pushed
+	branchState       BranchStateMap       // branch -> consolidated state
+	childrenMap       map[string][]string  // branch -> children (computed from parents)
+	remoteMetaCache   map[string]*git.Meta // branch -> remote metadata (can include non-local branches)
 	maxUndoStackDepth int
 	git               git.Runner
 	writer            io.Writer
@@ -63,14 +129,9 @@ func NewEngine(opts Options) (Engine, error) {
 	e := &engineImpl{
 		repoRoot:          opts.RepoRoot,
 		trunk:             opts.Trunk,
-		parentMap:         make(map[string]string),
+		branchState:       make(BranchStateMap),
 		childrenMap:       make(map[string][]string),
-		scopeMap:          make(map[string]string),
-		lockedMap:         make(map[string]string),
-		frozenMap:         make(map[string]bool),
-		remoteShas:        make(map[string]string),
 		remoteMetaCache:   make(map[string]*git.Meta),
-		localModified:     make(map[string]bool),
 		maxUndoStackDepth: maxDepth,
 		git:               g,
 		writer:            writer,
@@ -167,15 +228,21 @@ func (e *engineImpl) PopulateRemoteShas() error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	// Clear existing remote SHAs
+	for _, state := range e.branchState {
+		state.RemoteSHA = ""
+	}
+
 	if err != nil {
 		// Don't fail if we can't fetch remote SHAs (e.g., offline)
-		// But ensure the map is at least initialized
-		if e.remoteShas == nil {
-			e.remoteShas = make(map[string]string)
-		}
 		return nil
 	}
 
-	e.remoteShas = remoteShas
+	// Set RemoteSHA for tracked branches that have a remote
+	for branchName, sha := range remoteShas {
+		if state := e.branchState.GetByName(branchName); state != nil {
+			state.RemoteSHA = sha
+		}
+	}
 	return nil
 }

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -34,7 +34,7 @@ func (e *engineImpl) rebuildInternal(refreshCurrentBranch bool) error {
 	return nil
 }
 
-// applyRebuild updates the internal state maps from the provided metadata results.
+// applyRebuild updates the internal state from the provided metadata results.
 // The caller MUST hold the engine's write lock (e.mu).
 func (e *engineImpl) applyRebuild(branches []string, currentBranch string, allMeta map[string]*git.Meta, allLocalMeta map[string]*git.LocalMeta) {
 	e.branches = branches
@@ -42,42 +42,46 @@ func (e *engineImpl) applyRebuild(branches []string, currentBranch string, allMe
 		e.currentBranch = currentBranch
 	}
 
-	// Reset maps
-	e.parentMap = make(map[string]string)
+	// Reset state
+	e.branchState = make(BranchStateMap)
 	e.childrenMap = make(map[string][]string)
-	e.scopeMap = make(map[string]string)
-	e.lockedMap = make(map[string]string)
-	e.frozenMap = make(map[string]bool)
-	e.branchTypeMap = make(map[string]string)
 
-	// Collect results and populate maps sequentially to avoid lock contention/races
+	// Collect results and populate state sequentially to avoid lock contention/races
 	for name, meta := range allMeta {
 		if name == e.trunk {
 			continue // Trunk branches should never be tracked
 		}
 
-		if meta.ParentBranchName != nil {
-			parent := *meta.ParentBranchName
-			if parent == name {
-				continue // Skip self-parenting to avoid cycles
-			}
-			e.parentMap[name] = parent
-			e.childrenMap[parent] = append(e.childrenMap[parent], name)
+		if meta.ParentBranchName == nil {
+			continue // No parent means not tracked
+		}
+
+		parent := *meta.ParentBranchName
+		if parent == name {
+			continue // Skip self-parenting to avoid cycles
+		}
+
+		// Create or get branch state
+		state := &BranchState{
+			Parent:     parent,
+			LockReason: meta.LockReason,
+			BranchType: meta.BranchType,
 		}
 		if meta.Scope != nil {
-			e.scopeMap[name] = *meta.Scope
+			state.Scope = *meta.Scope
 		}
-		if meta.LockReason != LockReasonNone {
-			e.lockedMap[name] = string(meta.LockReason)
-		}
-		if meta.BranchType != "" {
-			e.branchTypeMap[name] = string(meta.BranchType)
-		}
+
+		e.branchState.Set(name, state)
+		e.childrenMap[parent] = append(e.childrenMap[parent], name)
 	}
 
+	// Apply local metadata (frozen state)
+	// Note: We create a BranchState entry for frozen branches even if they're not
+	// tracked, since frozen status is independent of tracked status.
 	for name, meta := range allLocalMeta {
 		if meta.Frozen {
-			e.frozenMap[name] = true
+			state := e.branchState.GetOrCreate(name)
+			state.Frozen = true
 		}
 	}
 
@@ -93,93 +97,77 @@ func (e *engineImpl) updateBranchInCache(branchName string) {
 		return
 	}
 
+	// Get the old parent before updating (for children map maintenance)
+	var oldParent string
+	if oldState := e.branchState.GetByName(branchName); oldState != nil {
+		oldParent = oldState.Parent
+	}
+
 	// Read metadata for this branch
 	meta, err := e.git.ReadMetadata(branchName)
 	if err != nil {
-		// If metadata doesn't exist, remove branch from all maps
-		if oldParent, exists := e.parentMap[branchName]; exists {
-			delete(e.parentMap, branchName)
-			// Remove from old parent's children list
-			if children, ok := e.childrenMap[oldParent]; ok {
-				if i := slices.Index(children, branchName); i >= 0 {
-					e.childrenMap[oldParent] = slices.Delete(children, i, i+1)
-				}
-				// Remove empty children lists
-				if len(e.childrenMap[oldParent]) == 0 {
-					delete(e.childrenMap, oldParent)
-				}
-			}
+		// If metadata doesn't exist, remove branch from state and children map
+		if oldParent != "" {
+			e.removeFromChildren(oldParent, branchName)
 		}
-		delete(e.scopeMap, branchName)
-		delete(e.lockedMap, branchName)
-		delete(e.frozenMap, branchName)
+		e.branchState.Delete(branchName)
+		return
 	}
 
 	// Read local metadata too
 	localMeta, _ := e.git.ReadLocalMetadata(branchName)
 
-	// Get the old parent before updating
-	oldParent := e.parentMap[branchName]
-
-	// Update parent map
-	if meta.ParentBranchName != nil {
-		e.parentMap[branchName] = *meta.ParentBranchName
-	} else {
-		delete(e.parentMap, branchName)
-	}
-
-	// Update scope map
-	if meta.Scope != nil {
-		e.scopeMap[branchName] = *meta.Scope
-	} else {
-		delete(e.scopeMap, branchName)
-	}
-
-	// Update locked map
-	if meta.LockReason != LockReasonNone {
-		e.lockedMap[branchName] = string(meta.LockReason)
-	} else {
-		delete(e.lockedMap, branchName)
-	}
-
-	// Update branch type map
-	if meta.BranchType != "" {
-		e.branchTypeMap[branchName] = string(meta.BranchType)
-	} else {
-		delete(e.branchTypeMap, branchName)
-	}
-
-	// Update frozen map
-	if localMeta != nil && localMeta.Frozen {
-		e.frozenMap[branchName] = true
-	} else {
-		delete(e.frozenMap, branchName)
-	}
-
-	// Update children map - remove from old parent, add to new parent
+	// Determine new parent
 	newParent := ""
 	if meta.ParentBranchName != nil {
 		newParent = *meta.ParentBranchName
 	}
 
-	// Remove from old parent's children if parent changed
-	if oldParent != "" && oldParent != newParent {
-		if children, ok := e.childrenMap[oldParent]; ok {
-			if i := slices.Index(children, branchName); i >= 0 {
-				e.childrenMap[oldParent] = slices.Delete(children, i, i+1)
-			}
-			// Remove empty children lists
-			if len(e.childrenMap[oldParent]) == 0 {
-				delete(e.childrenMap, oldParent)
-			}
+	// If no parent, branch is not tracked - remove it
+	if newParent == "" {
+		if oldParent != "" {
+			e.removeFromChildren(oldParent, branchName)
 		}
+		e.branchState.Delete(branchName)
+		return
 	}
 
-	// Add to new parent's children if it has a parent
-	if newParent != "" {
+	// Create or update branch state
+	state := &BranchState{
+		Parent:     newParent,
+		LockReason: meta.LockReason,
+		BranchType: meta.BranchType,
+	}
+	if meta.Scope != nil {
+		state.Scope = *meta.Scope
+	}
+	if localMeta != nil {
+		state.Frozen = localMeta.Frozen
+	}
+
+	e.branchState.Set(branchName, state)
+
+	// Update children map - remove from old parent, add to new parent
+	if oldParent != "" && oldParent != newParent {
+		e.removeFromChildren(oldParent, branchName)
+	}
+
+	// Add to new parent's children if not already there
+	if newParent != "" && (oldParent == "" || oldParent != newParent) {
 		e.childrenMap[newParent] = append(e.childrenMap[newParent], branchName)
-		// Sort for deterministic traversal
 		slices.Sort(e.childrenMap[newParent])
+	}
+}
+
+// removeFromChildren removes a branch from its parent's children list
+func (e *engineImpl) removeFromChildren(parent, child string) {
+	if children, ok := e.childrenMap[parent]; ok {
+		if i := slices.Index(children, child); i >= 0 {
+			e.childrenMap[parent] = slices.Delete(children, i, i+1)
+		}
+		if len(e.childrenMap[parent]) == 0 {
+			delete(e.childrenMap, parent)
+		}
 	}
 }
 
@@ -259,18 +247,23 @@ func (e *engineImpl) shouldReparentBranch(ctx context.Context, parentBranchName 
 // findNearestValidAncestor finds the nearest ancestor that hasn't been merged/deleted
 // Returns trunk if all ancestors have been merged
 func (e *engineImpl) findNearestValidAncestor(ctx context.Context, branchName string, metaMap map[string]*git.Meta) string {
-	current := e.parentMap[branchName]
+	// Get the starting parent from branchState
+	state := e.branchState.GetByName(branchName)
+	if state == nil {
+		return e.trunk
+	}
+	current := state.Parent
 
 	for current != "" && current != e.trunk {
 		if !e.shouldReparentBranch(ctx, current, metaMap) {
 			return current
 		}
 		// Move to the next parent
-		parent, ok := e.parentMap[current]
-		if !ok {
+		parentState := e.branchState.GetByName(current)
+		if parentState == nil {
 			break
 		}
-		current = parent
+		current = parentState.Parent
 	}
 
 	return e.trunk

--- a/internal/engine/engine_reader.go
+++ b/internal/engine/engine_reader.go
@@ -64,8 +64,8 @@ func (e *engineImpl) GetParent(branch Branch) *Branch {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	if parent, ok := e.parentMap[branch.GetName()]; ok {
-		b := NewBranch(parent, e)
+	if state := e.branchState.Get(branch); state != nil {
+		b := NewBranch(state.Parent, e)
 		return &b
 	}
 	return nil
@@ -106,7 +106,7 @@ func (e *engineImpl) FindMostRecentTrackedAncestors(ctx context.Context, branchN
 		}
 
 		// Only consider tracked branches
-		if _, ok := e.parentMap[candidate]; !ok {
+		if !e.branchState.HasByName(candidate) {
 			continue
 		}
 
@@ -189,18 +189,18 @@ func (e *engineImpl) SortBranchesTopologically(branches []Branch) []Branch {
 
 		e.mu.RLock()
 		isTrunk := branchName == e.trunk
-		parent := e.parentMap[branchName]
+		state := e.branchState.GetByName(branchName)
 		e.mu.RUnlock()
 
 		if isTrunk {
 			depths[branchName] = 0
 			return 0
 		}
-		if parent == "" || e.IsTrunk(NewBranch(parent, e)) {
+		if state == nil || state.Parent == "" || e.IsTrunk(NewBranch(state.Parent, e)) {
 			depths[branchName] = 1
 			return 1
 		}
-		depths[branchName] = getDepth(parent) + 1
+		depths[branchName] = getDepth(state.Parent) + 1
 		return depths[branchName]
 	}
 

--- a/internal/engine/engine_split.go
+++ b/internal/engine/engine_split.go
@@ -97,7 +97,9 @@ func (e *engineImpl) ApplySplitToCommits(ctx context.Context, opts ApplySplitOpt
 		}
 
 		// Update in-memory cache
-		e.parentMap[branchName] = branchParentName
+		e.branchState.Set(branchName, &BranchState{
+			Parent: branchParentName,
+		})
 		e.childrenMap[branchParentName] = append(e.childrenMap[branchParentName], branchName)
 		slices.Sort(e.childrenMap[branchParentName])
 
@@ -167,9 +169,9 @@ func (e *engineImpl) DetachAndResetBranchChanges(ctx context.Context, branchName
 	}
 
 	// Get the parent branch
-	parentBranchName := e.parentMap[branchName]
-	if parentBranchName == "" {
-		parentBranchName = e.trunk
+	parentBranchName := e.trunk
+	if state := e.branchState.GetByName(branchName); state != nil {
+		parentBranchName = state.Parent
 	}
 
 	// Get the merge base between this branch and its parent

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -113,21 +113,25 @@ func (e *engineImpl) restackBranch(
 	}
 
 	e.mu.RLock()
-	parent, ok := e.parentMap[branchName]
+	state := e.branchState.GetByName(branchName)
 	e.mu.RUnlock()
 
-	if !ok {
+	var parent string
+	tracked := state != nil
+	if tracked {
+		parent = state.Parent
+	} else {
 		// RESILIENCY: Try to auto-discover parent if branch is not tracked
 		ancestors, err := e.FindMostRecentTrackedAncestors(ctx, branchName)
 		if err == nil && len(ancestors) > 0 {
 			parent = ancestors[0]
 			// Auto-track the branch
 			if err := e.TrackBranch(ctx, branchName, parent); err == nil {
-				ok = true
+				tracked = true
 			}
 		}
 
-		if !ok {
+		if !tracked {
 			return RestackBranchResult{Result: RestackUnneeded}, fmt.Errorf("branch %s is not tracked", branchName)
 		}
 	}
@@ -535,15 +539,15 @@ func (e *engineImpl) RestackBranches(ctx context.Context, branches []Branch) (Re
 	allInvolvedBranches := make(map[string]bool)
 	for _, name := range branchNames {
 		allInvolvedBranches[name] = true
-		// Crawl up the parent map to find all ancestors
+		// Crawl up the branch state to find all ancestors
 		current := name
 		for {
-			parent, ok := e.parentMap[current]
-			if !ok || parent == e.trunk || allInvolvedBranches[parent] {
+			state := e.branchState.GetByName(current)
+			if state == nil || state.Parent == e.trunk || allInvolvedBranches[state.Parent] {
 				break
 			}
-			allInvolvedBranches[parent] = true
-			current = parent
+			allInvolvedBranches[state.Parent] = true
+			current = state.Parent
 		}
 	}
 	// Also include trunk

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -167,9 +167,9 @@ func (e *engineImpl) DeleteBranch(ctx context.Context, branch Branch) error {
 	copy(children, e.childrenMap[branchName])
 
 	// Get parent
-	parent, ok := e.parentMap[branchName]
-	if !ok {
-		parent = e.trunk
+	parent := e.trunk
+	if state := e.branchState.GetByName(branchName); state != nil {
+		parent = state.Parent
 	}
 
 	// If deleting current branch, switch to trunk first
@@ -215,7 +215,7 @@ func (e *engineImpl) DeleteBranch(ctx context.Context, branch Branch) error {
 	}
 
 	// Remove from maps
-	delete(e.parentMap, branchName)
+	e.branchState.Delete(branchName)
 	delete(e.childrenMap, branchName)
 
 	// Remove from branches list
@@ -369,11 +369,13 @@ func (e *engineImpl) SetScope(branch Branch, scope Scope) error {
 		return fmt.Errorf("failed to write metadata: %w", err)
 	}
 
-	// Update in-memory map
-	if scope.IsEmpty() {
-		delete(e.scopeMap, branchName)
-	} else {
-		e.scopeMap[branchName] = scope.String()
+	// Update in-memory state
+	if state := e.branchState.GetByName(branchName); state != nil {
+		if scope.IsEmpty() {
+			state.Scope = ""
+		} else {
+			state.Scope = scope.String()
+		}
 	}
 
 	return nil
@@ -402,11 +404,9 @@ func (e *engineImpl) SetLocked(branches []Branch, reason LockReason) (BatchLockR
 		// Update locked status
 		meta.LockReason = reason
 
-		// Update in-memory map
-		if reason.IsLocked() {
-			e.lockedMap[branchName] = string(reason)
-		} else {
-			delete(e.lockedMap, branchName)
+		// Update in-memory state
+		if state := e.branchState.GetByName(branchName); state != nil {
+			state.LockReason = reason
 		}
 
 		// Write metadata
@@ -454,12 +454,9 @@ func (e *engineImpl) SetFrozen(branches []Branch, frozen bool) (BatchFreezeResul
 			continue
 		}
 
-		// Update in-memory map
-		if frozen {
-			e.frozenMap[branchName] = true
-		} else {
-			delete(e.frozenMap, branchName)
-		}
+		// Update in-memory state (create entry if needed for untracked branches)
+		state := e.branchState.GetOrCreate(branchName)
+		state.Frozen = frozen
 
 		result.AffectedBranches = append(result.AffectedBranches, branchName)
 	}
@@ -680,24 +677,24 @@ func (e *engineImpl) GetStackRootForBranch(branch Branch) string {
 	}
 
 	// Check if branch is tracked at all
-	if _, ok := e.parentMap[branchName]; !ok {
+	if !e.branchState.HasByName(branchName) {
 		return "" // Untracked branch has no stack root
 	}
 
 	current := branchName
 	for {
-		parent, ok := e.parentMap[current]
-		if !ok {
+		state := e.branchState.GetByName(current)
+		if state == nil {
 			// Should not happen since we checked above, but handle gracefully
 			return ""
 		}
 
 		// If parent is trunk, current is the stack root
-		if parent == e.trunk {
+		if state.Parent == e.trunk {
 			return current
 		}
 
-		current = parent
+		current = state.Parent
 	}
 }
 
@@ -811,8 +808,9 @@ func (e *engineImpl) setParentInternal(ctx context.Context, branchName string, p
 		}
 	}
 
-	// Add to new parent's children
-	e.parentMap[branchName] = parentBranchName
+	// Update branchState with new parent
+	state := e.branchState.GetOrCreate(branchName)
+	state.Parent = parentBranchName
 	if e.childrenMap[parentBranchName] == nil {
 		e.childrenMap[parentBranchName] = []string{}
 	}

--- a/internal/engine/remote_sync.go
+++ b/internal/engine/remote_sync.go
@@ -154,14 +154,12 @@ func (e *engineImpl) ApplyRemoteMetadataIfExists(branchName string) error {
 		return nil
 	}
 
-	// Update local metadata maps
-	if remote.LockReason != git.LockReasonNone {
-		e.lockedMap[branchName] = string(remote.LockReason)
-	} else {
-		delete(e.lockedMap, branchName)
-	}
-	if remote.Scope != nil {
-		e.scopeMap[branchName] = *remote.Scope
+	// Update local branch state
+	if state := e.branchState.GetByName(branchName); state != nil {
+		state.LockReason = remote.LockReason
+		if remote.Scope != nil {
+			state.Scope = *remote.Scope
+		}
 	}
 
 	// Read existing local metadata to preserve fields not in remote (like PrInfo)
@@ -287,7 +285,9 @@ func (e *engineImpl) AcceptRemoteMetadata(branch string) error {
 func (e *engineImpl) RejectRemoteMetadata(branch string) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	e.localModified[branch] = true
+	if state := e.branchState.GetByName(branch); state != nil {
+		state.LocalModified = true
+	}
 }
 
 // HasLocalModifications checks if a branch has local metadata changes that differ from its original fetched state
@@ -295,7 +295,7 @@ func (e *engineImpl) HasLocalModifications(branch string) bool {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	if e.localModified[branch] {
+	if state := e.branchState.GetByName(branch); state != nil && state.LocalModified {
 		return true
 	}
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -216,6 +216,18 @@ func Run[T any](items []T, worker func(item T)) {
 	wg.Wait()
 }
 
+// ShortRevision returns a shortened version of a git revision hash.
+// Returns at most maxLen characters, defaulting to 7 if maxLen <= 0.
+func ShortRevision(rev string, maxLen int) string {
+	if maxLen <= 0 {
+		maxLen = 7
+	}
+	if len(rev) <= maxLen {
+		return rev
+	}
+	return rev[:maxLen]
+}
+
 // RunWithWorkers runs the given worker function for each item in the slice in parallel with a specified number of workers.
 func RunWithWorkers[T any](items []T, numWorkers int, worker func(item T)) {
 	if len(items) == 0 {


### PR DESCRIPTION

Replaces 5 separate maps (parentMap, scopeMap, lockedMap, frozenMap,
branchTypeMap) with a single branchState map containing BranchState
structs. This reduces cognitive load and makes updates less error-prone.

Also adds ShortRevision helper and Config field to app.Context.


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #520** 👈

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->