### PR TITLE
Merging 2 PRs

### DIFF
--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -19,11 +19,12 @@ import (
 const (
 	LogStyleNormal = "NORMAL"
 	LogStyleFull   = "FULL"
+	LogStyleShort  = "SHORT"
 )
 
 // LogOptions contains options for the log command
 type LogOptions struct {
-	Style         string // LogStyleNormal or LogStyleFull
+	Style         string // LogStyleNormal, LogStyleFull, or LogStyleShort
 	Reverse       bool
 	Steps         *int
 	BranchName    string
@@ -55,8 +56,20 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 		}
 	}
 
-	// Create tree renderer
-	renderer := tui.NewStackTreeRenderer(ctx.Engine)
+	// Detect empty worktrees (worktree anchors with no children)
+	emptyWorktrees := getEmptyWorktrees(ctx)
+
+	// Create tree renderer - use empty worktrees-aware version if we have any
+	var renderer *tree.StackTreeRenderer
+	if len(emptyWorktrees) > 0 {
+		emptyWorktreeNames := make(map[string]bool)
+		for name := range emptyWorktrees {
+			emptyWorktreeNames[name] = true
+		}
+		renderer = tui.NewStackTreeRendererWithEmptyWorktrees(ctx.Engine, emptyWorktreeNames)
+	} else {
+		renderer = tui.NewStackTreeRenderer(ctx.Engine)
+	}
 
 	// Render the stack
 	// First, collect annotations for all branches in the stack using a worker pool
@@ -85,7 +98,7 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 
 	if len(allBranches) > 0 {
 		utils.Run(allBranches, func(branchObj engine.Branch) {
-			annotation := getBranchAnnotation(ctx, branchObj, opts, ciStatuses)
+			annotation := getBranchAnnotation(ctx, branchObj, opts, ciStatuses, emptyWorktrees)
 			results <- result{branchObj.GetName(), annotation}
 		})
 	}
@@ -98,10 +111,11 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 	renderer.SetAnnotations(annotations)
 
 	stackLines := renderer.RenderStack(opts.BranchName, tree.RenderOptions{
-		Short:    false, // We want the full tree characters with stats
-		Reverse:  opts.Reverse,
-		Steps:    opts.Steps,
-		ShowSHAs: opts.ShowSHAs,
+		Short:       false, // We want the full tree characters with stats
+		Reverse:     opts.Reverse,
+		Steps:       opts.Steps,
+		ShowSHAs:    opts.ShowSHAs,
+		HideSummary: opts.Style == LogStyleShort,
 	})
 
 	// Add summary footer
@@ -161,7 +175,41 @@ func getUntrackedBranchNames(ctx *app.Context) []string {
 	return untracked
 }
 
-func getBranchAnnotation(ctx *app.Context, branchObj engine.Branch, opts LogOptions, ciStatuses map[string]*github.CheckStatus) tree.BranchAnnotation {
+// getEmptyWorktrees returns a map of worktree anchor branch names to their WorktreeInfo
+// for worktrees that have no child branches (empty worktrees).
+func getEmptyWorktrees(ctx *app.Context) map[string]*engine.WorktreeInfo {
+	emptyWorktrees := make(map[string]*engine.WorktreeInfo)
+
+	worktrees, err := ctx.Engine.ListManagedWorktrees()
+	if err != nil {
+		return emptyWorktrees
+	}
+
+	for i := range worktrees {
+		wt := &worktrees[i]
+		anchor := ctx.Engine.GetBranch(wt.AnchorBranch)
+		if !anchor.IsTracked() || !anchor.IsWorktreeAnchor() {
+			continue
+		}
+
+		// Check if anchor has any children
+		hasChildren := false
+		for _, depth := range ctx.Engine.BranchesDepthFirst(anchor) {
+			if depth > 0 {
+				hasChildren = true
+				break
+			}
+		}
+
+		if !hasChildren {
+			emptyWorktrees[wt.AnchorBranch] = wt
+		}
+	}
+
+	return emptyWorktrees
+}
+
+func getBranchAnnotation(ctx *app.Context, branchObj engine.Branch, opts LogOptions, ciStatuses map[string]*github.CheckStatus, emptyWorktrees map[string]*engine.WorktreeInfo) tree.BranchAnnotation {
 	annotation := tui.GetBranchAnnotation(ctx.Engine, branchObj)
 
 	// CI status (only in FULL mode)
@@ -175,6 +223,13 @@ func getBranchAnnotation(ctx *app.Context, branchObj engine.Branch, opts LogOpti
 				annotation.CheckStatus = tree.CheckStatusFailing
 			}
 		}
+	}
+
+	// Check if this is an empty worktree anchor
+	if wtInfo, ok := emptyWorktrees[branchObj.GetName()]; ok {
+		annotation.IsEmptyWorktree = true
+		annotation.WorktreePath = wtInfo.Path
+		return annotation
 	}
 
 	// Check if this branch is a stack root with a managed worktree

--- a/internal/cli/navigation/log.go
+++ b/internal/cli/navigation/log.go
@@ -28,6 +28,7 @@ func NewLogCmd() *cobra.Command {
 
 	// Add subcommands
 	cmd.AddCommand(newLogFullCmd())
+	cmd.AddCommand(newLogShortCmd())
 
 	return cmd
 }
@@ -40,6 +41,20 @@ func newLogFullCmd() *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return executeLog(cmd, f, actions.LogStyleFull)
+		},
+	}
+	addLogFlags(cmd, f)
+	return cmd
+}
+
+func newLogShortCmd() *cobra.Command {
+	f := &logFlags{}
+	cmd := &cobra.Command{
+		Use:          "short",
+		Short:        "Log branches showing only the branch tree (no stats or PR info)",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executeLog(cmd, f, actions.LogStyleShort)
 		},
 	}
 	addLogFlags(cmd, f)

--- a/internal/tui/components/tree/tree.go
+++ b/internal/tui/components/tree/tree.go
@@ -54,6 +54,9 @@ type BranchAnnotation struct {
 	// WorktreePath is set if this branch is the stack root of a managed worktree
 	WorktreePath string
 
+	// IsEmptyWorktree indicates this is a worktree anchor with no child branches
+	IsEmptyWorktree bool
+
 	// LocalSHA is the short commit SHA of the branch head (for debugging/diagnostics)
 	LocalSHA string
 }
@@ -67,6 +70,7 @@ type RenderOptions struct {
 	OmitCurrentBranch bool
 	NoStyleBranchName bool
 	HideStats         bool
+	HideSummary       bool // Hide the summary line (stats, PR info, CI status)
 	ShowSHAs          bool // Show commit SHAs next to branch names
 	SelectedBranch    string
 	Collapsed         map[string]bool
@@ -156,6 +160,7 @@ func (r *StackTreeRenderer) RenderStackDetailed(branchName string, opts RenderOp
 		omitCurrentBranch: opts.OmitCurrentBranch,
 		noStyleBranchName: opts.NoStyleBranchName,
 		hideStats:         opts.HideStats,
+		hideSummary:       opts.HideSummary,
 		showSHAs:          opts.ShowSHAs,
 		overallIndent:     &overallIndent,
 		selectedBranch:    opts.SelectedBranch,
@@ -199,6 +204,7 @@ type treeRenderArgs struct {
 	omitCurrentBranch bool
 	noStyleBranchName bool
 	hideStats         bool
+	hideSummary       bool
 	showSHAs          bool
 	skipBranchingLine bool
 	overallIndent     *int
@@ -266,6 +272,7 @@ func (r *StackTreeRenderer) getUpstackExclusiveRendered(args treeRenderArgs) []R
 			omitCurrentBranch: args.omitCurrentBranch,
 			noStyleBranchName: args.noStyleBranchName,
 			hideStats:         args.hideStats,
+			hideSummary:       args.hideSummary,
 			showSHAs:          args.showSHAs,
 			overallIndent:     args.overallIndent,
 			selectedBranch:    args.selectedBranch,
@@ -335,6 +342,7 @@ func (r *StackTreeRenderer) getDownstackExclusiveRendered(args treeRenderArgs) [
 			branchName:        branchName,
 			indentLevel:       args.indentLevel,
 			parentScopes:      args.parentScopes,
+			hideSummary:       args.hideSummary,
 			showSHAs:          args.showSHAs,
 			skipBranchingLine: true,
 			overallIndent:     args.overallIndent,
@@ -412,6 +420,15 @@ func (r *StackTreeRenderer) getBranchLines(args treeRenderArgs) []string {
 		// Add annotation
 		annotation := r.Annotations[args.branchName]
 		line += r.formatAnnotation(annotation, args.noStyleBranchName)
+
+		// Add empty worktree indicator
+		if annotation.IsEmptyWorktree {
+			line += " " + style.ColorDim("<empty>")
+		}
+		// Add worktree indicator
+		if annotation.WorktreePath != "" {
+			line += " " + style.ColorDim("📂 worktree")
+		}
 
 		// Add restack indicator
 		if !args.noStyleBranchName && !r.isBranchFixed(args.branchName) {
@@ -638,7 +655,11 @@ func (r *StackTreeRenderer) getInfoLines(args treeRenderArgs) []string {
 	if annotation.IsFrozen {
 		coloredBranchName += " " + style.IconFrozen() + " " + style.ColorDim("(frozen)")
 	}
-	// Worktree indicator (only for stack roots with managed worktrees)
+	// Empty worktree indicator
+	if annotation.IsEmptyWorktree {
+		coloredBranchName += " " + style.ColorDim("<empty>")
+	}
+	// Worktree indicator (for stack roots with managed worktrees or empty worktree anchors)
 	if annotation.WorktreePath != "" {
 		coloredBranchName += " " + style.ColorDim("📂 worktree")
 	}
@@ -654,12 +675,14 @@ func (r *StackTreeRenderer) getInfoLines(args treeRenderArgs) []string {
 		return result
 	}
 
-	// LINE 2: Summary line with PR# → Review → CI → Stats
-	branchPipe := styleObj.Render("│")
-	summaryLine := r.formatSummaryLine(annotation, isTrunk, args.hideStats)
+	// LINE 2: Summary line with PR# → Review → CI → Stats (skip if hideSummary)
+	if !args.hideSummary {
+		branchPipe := styleObj.Render("│")
+		summaryLine := r.formatSummaryLine(annotation, isTrunk, args.hideStats)
 
-	if summaryLine != "" {
-		result = append(result, style.SelectionPadding+prefix+branchPipe+"  "+summaryLine)
+		if summaryLine != "" {
+			result = append(result, style.SelectionPadding+prefix+branchPipe+"  "+summaryLine)
+		}
 	}
 
 	// Trailing spacer line

--- a/internal/tui/log_ui.go
+++ b/internal/tui/log_ui.go
@@ -92,16 +92,28 @@ func NewLogModel(ctx context.Context, eng engine.Engine, ghClient github.Client,
 		}
 	}
 
-	// Create renderer synchronously for instant display
+	// Detect empty worktrees
 	start := time.Now()
-	renderer := NewStackTreeRendererWithStrategy(eng, engine.SortStrategySmart, filter)
-	logDebug("NewStackTreeRendererWithStrategy completed in %v", time.Since(start))
+	emptyWorktrees := GetEmptyWorktrees(eng)
+	var emptyWorktreeNames map[string]bool
+	if len(emptyWorktrees) > 0 {
+		emptyWorktreeNames = make(map[string]bool)
+		for name := range emptyWorktrees {
+			emptyWorktreeNames[name] = true
+		}
+	}
+	logDebug("GetEmptyWorktrees completed in %v, found %d", time.Since(start), len(emptyWorktrees))
+
+	// Create renderer synchronously for instant display
+	start = time.Now()
+	renderer := NewStackTreeRendererWithOptions(eng, engine.SortStrategySmart, filter, emptyWorktreeNames)
+	logDebug("NewStackTreeRendererWithOptions completed in %v", time.Since(start))
 
 	// Build minimal annotations synchronously (includes worktree info, no git/network calls)
 	start = time.Now()
 	annotations := make(map[string]tree.BranchAnnotation)
 	for _, b := range eng.AllBranches() {
-		annotations[b.GetName()] = GetMinimalAnnotationWithWorktree(eng, b)
+		annotations[b.GetName()] = GetMinimalAnnotationWithWorktreeAndEmpty(eng, b, emptyWorktrees)
 	}
 	renderer.SetAnnotations(annotations)
 	logDebug("Minimal annotations with worktree completed in %v", time.Since(start))
@@ -262,6 +274,9 @@ func (m *LogModel) enrichData() tea.Cmd {
 		}
 		ciStatuses := ciRes.statuses
 
+		// Detect empty worktrees
+		emptyWorktrees := GetEmptyWorktrees(eng)
+
 		// Collect full annotations
 		start := time.Now()
 		annotations := make(map[string]tree.BranchAnnotation)
@@ -286,11 +301,18 @@ func (m *LogModel) enrichData() tea.Cmd {
 					}
 				}
 			}
-			// Check if this branch is a stack root with a managed worktree
-			stackRoot := eng.GetStackRootForBranch(b)
-			if stackRoot == b.GetName() {
-				if wtInfo, err := eng.GetWorktreeForStack(stackRoot); err == nil && wtInfo != nil {
-					ann.WorktreePath = wtInfo.Path
+
+			// Check if this is an empty worktree anchor
+			if wtInfo, ok := emptyWorktrees[b.GetName()]; ok {
+				ann.IsEmptyWorktree = true
+				ann.WorktreePath = wtInfo.Path
+			} else {
+				// Check if this branch is a stack root with a managed worktree
+				stackRoot := eng.GetStackRootForBranch(b)
+				if stackRoot == b.GetName() {
+					if wtInfo, err := eng.GetWorktreeForStack(stackRoot); err == nil && wtInfo != nil {
+						ann.WorktreePath = wtInfo.Path
+					}
 				}
 			}
 			annotations[b.GetName()] = ann

--- a/internal/tui/tree_renderer.go
+++ b/internal/tui/tree_renderer.go
@@ -18,9 +18,27 @@ func NewStackTreeRendererWithFilter(eng engine.BranchReader, filter func(string)
 
 // NewStackTreeRendererWithStrategy creates a tree renderer with a specific sorting strategy and optional filter
 func NewStackTreeRendererWithStrategy(eng engine.BranchReader, strategy engine.SortStrategy, filter func(string) bool) *tree.StackTreeRenderer {
+	return newStackTreeRendererInternal(eng, strategy, filter, nil)
+}
+
+// NewStackTreeRendererWithEmptyWorktrees creates a tree renderer that shows empty worktree anchors
+func NewStackTreeRendererWithEmptyWorktrees(eng engine.BranchReader, emptyWorktrees map[string]bool) *tree.StackTreeRenderer {
+	return newStackTreeRendererInternal(eng, engine.SortStrategySmart, nil, emptyWorktrees)
+}
+
+// NewStackTreeRendererWithOptions creates a tree renderer with all options
+func NewStackTreeRendererWithOptions(eng engine.BranchReader, strategy engine.SortStrategy, filter func(string) bool, emptyWorktrees map[string]bool) *tree.StackTreeRenderer {
+	return newStackTreeRendererInternal(eng, strategy, filter, emptyWorktrees)
+}
+
+// newStackTreeRendererInternal is the internal implementation that handles all renderer options
+func newStackTreeRendererInternal(eng engine.BranchReader, strategy engine.SortStrategy, filter func(string) bool, emptyWorktrees map[string]bool) *tree.StackTreeRenderer {
 	branchFilter := func(b engine.Branch) bool {
-		// Always filter out worktree anchor branches from the tree display
 		if b.IsWorktreeAnchor() {
+			// Show empty worktree anchors if they're in the set
+			if emptyWorktrees != nil {
+				return emptyWorktrees[b.GetName()]
+			}
 			return false
 		}
 		// Apply user-provided filter if any
@@ -60,15 +78,64 @@ func NewStackTreeRendererWithStrategy(eng engine.BranchReader, strategy engine.S
 	)
 }
 
+// GetEmptyWorktrees returns a map of worktree anchor branch names to their WorktreeInfo
+// for worktrees that have no child branches (empty worktrees).
+func GetEmptyWorktrees(eng engine.Engine) map[string]*engine.WorktreeInfo {
+	emptyWorktrees := make(map[string]*engine.WorktreeInfo)
+
+	worktrees, err := eng.ListManagedWorktrees()
+	if err != nil {
+		return emptyWorktrees
+	}
+
+	for i := range worktrees {
+		wt := &worktrees[i]
+		anchor := eng.GetBranch(wt.AnchorBranch)
+		if !anchor.IsTracked() || !anchor.IsWorktreeAnchor() {
+			continue
+		}
+
+		// Check if anchor has any children
+		hasChildren := false
+		for _, depth := range eng.BranchesDepthFirst(anchor) {
+			if depth > 0 {
+				hasChildren = true
+				break
+			}
+		}
+
+		if !hasChildren {
+			emptyWorktrees[wt.AnchorBranch] = wt
+		}
+	}
+
+	return emptyWorktrees
+}
+
 // GetMinimalAnnotationWithWorktree returns minimal annotations plus worktree info.
 // This is used for fast initial rendering before full data is loaded.
 // Only includes cached/instant fields - no git or network calls.
 func GetMinimalAnnotationWithWorktree(eng engine.Engine, branch engine.Branch) tree.BranchAnnotation {
+	return GetMinimalAnnotationWithWorktreeAndEmpty(eng, branch, nil)
+}
+
+// GetMinimalAnnotationWithWorktreeAndEmpty returns minimal annotations plus worktree info,
+// with support for marking empty worktrees.
+func GetMinimalAnnotationWithWorktreeAndEmpty(eng engine.Engine, branch engine.Branch, emptyWorktrees map[string]*engine.WorktreeInfo) tree.BranchAnnotation {
 	ann := tree.BranchAnnotation{
 		IsLocked:      branch.IsLocked(),
 		IsFrozen:      branch.IsFrozen(),
 		Scope:         eng.GetScope(branch).String(),
 		ExplicitScope: branch.GetExplicitScope().String(),
+	}
+
+	// Check if this is an empty worktree anchor
+	if emptyWorktrees != nil {
+		if wtInfo, ok := emptyWorktrees[branch.GetName()]; ok {
+			ann.IsEmptyWorktree = true
+			ann.WorktreePath = wtInfo.Path
+			return ann
+		}
 	}
 
 	// Add worktree info if this branch is a stack root with a managed worktree


### PR DESCRIPTION
This PR merges the following changes:

1. **#525** feat: add log short subcommand for minimal branch tree output
2. **#526** feat: show empty worktrees in log with <empty> indicator

### Stack

```
main
  └─ jonnii/20260115023839/add-log-short-subcommand-for-minimal-branch-tree (#525)
    └─ jonnii/20260115030155/show-empty-worktrees-in-log-with-empty-indicator (#526)
```


<!-- STACKIT-SECTION-START -->
#### Stack



This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->