### PR TITLE
fix: checkout branch after rebase continue to avoid detached HEAD

### DIFF
--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -92,7 +92,11 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 		return fmt.Errorf("rebase conflict is not yet resolved")
 	}
 
-	// Success - inform user
+	// Success - checkout the branch (rebase leaves us in detached HEAD)
+	if err := eng.Git().CheckoutBranch(ctx.Context, result.BranchName); err != nil {
+		return fmt.Errorf("failed to checkout branch %s: %w", result.BranchName, err)
+	}
+
 	out.Info("Resolved rebase conflict for %s.", style.ColorBranchName(result.BranchName, true))
 
 	// Continue with remaining branches to restack

--- a/internal/cli/continue_test.go
+++ b/internal/cli/continue_test.go
@@ -293,6 +293,11 @@ func TestContinueCommand(t *testing.T) {
 			_, err = os.Stat(continuationPath)
 			require.Error(t, err, "continuation state file should be deleted")
 			require.True(t, os.IsNotExist(err))
+
+			// Verify we're on the branch, not in detached HEAD
+			currentBranch, err := s.Scene.Repo.CurrentBranchName()
+			require.NoError(t, err)
+			require.Equal(t, "branch1", currentBranch, "should be on branch1 after continue, not detached HEAD")
 		} else {
 			// If it fails, log the output for debugging
 			t.Logf("Continue command output: %s", output)


### PR DESCRIPTION



<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #547** 👈

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->