### PR TITLE
refactor: remove deprecated Short/SingleLine fields and callback constructor

### DIFF
--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -111,7 +111,7 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 	renderer.SetAnnotations(annotations)
 
 	stackLines := renderer.RenderStack(opts.BranchName, tree.RenderOptions{
-		Short:       false, // We want the full tree characters with stats
+		Mode:        tree.RenderModeFull, // We want the full tree characters with stats
 		Reverse:     opts.Reverse,
 		Steps:       opts.Steps,
 		ShowSHAs:    opts.ShowSHAs,

--- a/internal/tui/components/split/model.go
+++ b/internal/tui/components/split/model.go
@@ -540,7 +540,7 @@ func (m *Model) renderStackTree() string {
 	}
 
 	opts := tree.RenderOptions{
-		Short:               false,
+		Mode:                tree.RenderModeFull,
 		HideSummary:         true,
 		SkipSelectionPrefix: true,
 	}

--- a/internal/tui/components/tree/tree.go
+++ b/internal/tui/components/tree/tree.go
@@ -81,19 +81,10 @@ const (
 // RenderOptions configures rendering behavior
 type RenderOptions struct {
 	// Mode specifies the rendering style. Defaults to RenderModeFull.
-	// When Mode is set, it takes precedence over Short/SingleLine flags.
 	Mode RenderMode
 
 	// Reverse renders the tree with children above parents (trunk at bottom).
 	Reverse bool
-
-	// Short is deprecated - use Mode=RenderModeCompact instead.
-	// Kept for backward compatibility during migration.
-	Short bool
-
-	// SingleLine is deprecated - use Mode=RenderModeSelect instead.
-	// Kept for backward compatibility during migration.
-	SingleLine bool
 
 	// Steps limits traversal depth in each direction.
 	Steps *int
@@ -133,15 +124,13 @@ type RenderOptions struct {
 }
 
 // isShortMode returns true if the options indicate short/compact rendering.
-// This handles both the new Mode field and legacy Short field.
 func (o RenderOptions) isShortMode() bool {
-	return o.Mode == RenderModeCompact || o.Short
+	return o.Mode == RenderModeCompact
 }
 
 // isSingleLineMode returns true if the options indicate single-line rendering.
-// This handles both the new Mode field and legacy SingleLine field.
 func (o RenderOptions) isSingleLineMode() bool {
-	return o.Mode == RenderModeSelect || o.SingleLine
+	return o.Mode == RenderModeSelect
 }
 
 // Data provides the tree structure data for rendering.
@@ -187,29 +176,6 @@ func NewRenderer(data Data) *StackTreeRenderer {
 		getParent:     data.Parent,
 		isTrunk:       data.IsTrunk,
 		isBranchFixed: data.IsFixed,
-		Annotations:   make(map[string]BranchAnnotation),
-	}
-}
-
-// NewStackTreeRenderer creates a new tree renderer with explicit callback functions.
-//
-// Deprecated: Use NewRenderer with a Data implementation instead.
-// This constructor is kept for backward compatibility and will be removed in a future release.
-func NewStackTreeRenderer(
-	currentBranch string,
-	trunk string,
-	getChildren func(branchName string) []string,
-	getParent func(branchName string) string,
-	isTrunk func(branchName string) bool,
-	isBranchFixed func(branchName string) bool,
-) *StackTreeRenderer {
-	return &StackTreeRenderer{
-		currentBranch: currentBranch,
-		trunk:         trunk,
-		getChildren:   getChildren,
-		getParent:     getParent,
-		isTrunk:       isTrunk,
-		isBranchFixed: isBranchFixed,
 		Annotations:   make(map[string]BranchAnnotation),
 	}
 }

--- a/internal/tui/components/tree/tree_bench_test.go
+++ b/internal/tui/components/tree/tree_bench_test.go
@@ -98,7 +98,7 @@ func BenchmarkRenderStack_SmallTree(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		renderer.RenderStack(mock.TrunkVal, RenderOptions{Short: true})
+		renderer.RenderStack(mock.TrunkVal, RenderOptions{Mode: RenderModeCompact})
 	}
 }
 
@@ -108,7 +108,7 @@ func BenchmarkRenderStack_SmallTree_Full(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		renderer.RenderStack(mock.TrunkVal, RenderOptions{Short: false})
+		renderer.RenderStack(mock.TrunkVal, RenderOptions{Mode: RenderModeFull})
 	}
 }
 
@@ -118,7 +118,7 @@ func BenchmarkRenderStack_LargeTree_100Branches(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		renderer.RenderStack(mock.TrunkVal, RenderOptions{Short: true})
+		renderer.RenderStack(mock.TrunkVal, RenderOptions{Mode: RenderModeCompact})
 	}
 }
 
@@ -128,7 +128,7 @@ func BenchmarkRenderStack_LargeTree_100Branches_Full(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		renderer.RenderStack(mock.TrunkVal, RenderOptions{Short: false})
+		renderer.RenderStack(mock.TrunkVal, RenderOptions{Mode: RenderModeFull})
 	}
 }
 
@@ -138,7 +138,7 @@ func BenchmarkRenderStack_DeepLinear_50Levels(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		renderer.RenderStack(mock.TrunkVal, RenderOptions{Short: true})
+		renderer.RenderStack(mock.TrunkVal, RenderOptions{Mode: RenderModeCompact})
 	}
 }
 
@@ -148,7 +148,7 @@ func BenchmarkRenderStack_DeepLinear_50Levels_Full(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		renderer.RenderStack(mock.TrunkVal, RenderOptions{Short: false})
+		renderer.RenderStack(mock.TrunkVal, RenderOptions{Mode: RenderModeFull})
 	}
 }
 
@@ -173,7 +173,7 @@ func BenchmarkRenderStack_WithAnnotations(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		renderer.RenderStack(mock.TrunkVal, RenderOptions{Short: false})
+		renderer.RenderStack(mock.TrunkVal, RenderOptions{Mode: RenderModeFull})
 	}
 }
 
@@ -183,7 +183,7 @@ func BenchmarkRenderStack_Reversed(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		renderer.RenderStack(mock.TrunkVal, RenderOptions{Short: true, Reverse: true})
+		renderer.RenderStack(mock.TrunkVal, RenderOptions{Mode: RenderModeCompact, Reverse: true})
 	}
 }
 
@@ -193,6 +193,6 @@ func BenchmarkRenderStackDetailed(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		renderer.RenderStackDetailed(mock.TrunkVal, RenderOptions{Short: false})
+		renderer.RenderStackDetailed(mock.TrunkVal, RenderOptions{Mode: RenderModeFull})
 	}
 }

--- a/internal/tui/components/tree/tree_golden_test.go
+++ b/internal/tui/components/tree/tree_golden_test.go
@@ -37,22 +37,22 @@ func buildGoldenTests() []goldenTest {
 		{
 			name: "linear_short",
 			mock: NewMockTreeData(),
-			opts: RenderOptions{Short: true},
+			opts: RenderOptions{Mode: RenderModeCompact},
 		},
 		{
 			name: "linear_full",
 			mock: NewMockTreeData(),
-			opts: RenderOptions{Short: false},
+			opts: RenderOptions{Mode: RenderModeFull},
 		},
 		{
 			name: "linear_reversed",
 			mock: NewMockTreeData(),
-			opts: RenderOptions{Short: true, Reverse: true},
+			opts: RenderOptions{Mode: RenderModeCompact, Reverse: true},
 		},
 		{
 			name: "linear_single_line",
 			mock: NewMockTreeData(),
-			opts: RenderOptions{SingleLine: true},
+			opts: RenderOptions{Mode: RenderModeSelect},
 		},
 
 		// Branching stacks
@@ -76,7 +76,7 @@ func buildGoldenTests() []goldenTest {
 					"feature-1b": true,
 				},
 			},
-			opts: RenderOptions{Short: true},
+			opts: RenderOptions{Mode: RenderModeCompact},
 		},
 		{
 			name: "branching_full",
@@ -98,7 +98,7 @@ func buildGoldenTests() []goldenTest {
 					"feature-1b": true,
 				},
 			},
-			opts: RenderOptions{Short: false},
+			opts: RenderOptions{Mode: RenderModeFull},
 		},
 
 		// Deep branching
@@ -137,7 +137,7 @@ func buildGoldenTests() []goldenTest {
 					"grandchild": true,
 				},
 			},
-			opts: RenderOptions{Short: true},
+			opts: RenderOptions{Mode: RenderModeCompact},
 		},
 
 		// With selection cursor
@@ -145,7 +145,7 @@ func buildGoldenTests() []goldenTest {
 			name: "with_selection",
 			mock: NewMockTreeData(),
 			opts: RenderOptions{
-				Short:          true,
+				Mode:           RenderModeCompact,
 				SelectedBranch: "feature-1",
 			},
 		},
@@ -153,7 +153,7 @@ func buildGoldenTests() []goldenTest {
 			name: "with_selection_full",
 			mock: NewMockTreeData(),
 			opts: RenderOptions{
-				Short:          false,
+				Mode:           RenderModeFull,
 				SelectedBranch: "feature-1",
 			},
 		},
@@ -166,7 +166,7 @@ func buildGoldenTests() []goldenTest {
 				"feature-1": {PRNumber: intPtr(123)},
 				"feature-2": {PRNumber: intPtr(456)},
 			},
-			opts: RenderOptions{Short: true},
+			opts: RenderOptions{Mode: RenderModeCompact},
 		},
 		{
 			name: "with_check_status",
@@ -175,7 +175,7 @@ func buildGoldenTests() []goldenTest {
 				"feature-1": {CheckStatus: CheckStatusPassing},
 				"feature-2": {CheckStatus: CheckStatusFailing},
 			},
-			opts: RenderOptions{Short: true},
+			opts: RenderOptions{Mode: RenderModeCompact},
 		},
 		{
 			name: "with_full_annotations",
@@ -198,7 +198,7 @@ func buildGoldenTests() []goldenTest {
 					LinesDeleted: 0,
 				},
 			},
-			opts: RenderOptions{Short: false},
+			opts: RenderOptions{Mode: RenderModeFull},
 		},
 
 		// Needs restack indicator
@@ -219,7 +219,7 @@ func buildGoldenTests() []goldenTest {
 					"feature-1": false, // Not fixed
 				},
 			},
-			opts: RenderOptions{Short: true},
+			opts: RenderOptions{Mode: RenderModeCompact},
 		},
 
 		// Merged/Closed PRs (dimmed)
@@ -229,7 +229,7 @@ func buildGoldenTests() []goldenTest {
 			annotations: map[string]BranchAnnotation{
 				"feature-1": {PRNumber: intPtr(123), PRState: PRStateMerged},
 			},
-			opts: RenderOptions{Short: false},
+			opts: RenderOptions{Mode: RenderModeFull},
 		},
 		{
 			name: "closed_pr",
@@ -237,7 +237,7 @@ func buildGoldenTests() []goldenTest {
 			annotations: map[string]BranchAnnotation{
 				"feature-1": {PRNumber: intPtr(123), PRState: PRStateClosed},
 			},
-			opts: RenderOptions{Short: false},
+			opts: RenderOptions{Mode: RenderModeFull},
 		},
 
 		// With scopes
@@ -269,7 +269,7 @@ func buildGoldenTests() []goldenTest {
 				"feature-login":     {Scope: "AUTH"},
 				"feature-api":       {Scope: "API", ExplicitScope: "API"},
 			},
-			opts: RenderOptions{Short: false},
+			opts: RenderOptions{Mode: RenderModeFull},
 		},
 
 		// Non-selectable branches
@@ -277,7 +277,7 @@ func buildGoldenTests() []goldenTest {
 			name: "non_selectable",
 			mock: NewMockTreeData(),
 			opts: RenderOptions{
-				Short:          true,
+				Mode:           RenderModeCompact,
 				SelectedBranch: "feature-2",
 				NonSelectable: map[string]bool{
 					"feature-1": true,
@@ -293,7 +293,7 @@ func buildGoldenTests() []goldenTest {
 				"feature-1": {CustomLabel: "<---- source branch"},
 				"feature-2": {CustomLabel: "(will be moved)"},
 			},
-			opts: RenderOptions{Short: true},
+			opts: RenderOptions{Mode: RenderModeCompact},
 		},
 
 		// Locked and frozen
@@ -304,7 +304,7 @@ func buildGoldenTests() []goldenTest {
 				"feature-1": {IsLocked: true},
 				"feature-2": {IsFrozen: true},
 			},
-			opts: RenderOptions{Short: true},
+			opts: RenderOptions{Mode: RenderModeCompact},
 		},
 
 		// Hide stats
@@ -315,7 +315,7 @@ func buildGoldenTests() []goldenTest {
 				"feature-1": {CommitCount: 5, LinesAdded: 100, LinesDeleted: 20},
 				"feature-2": {CommitCount: 3, LinesAdded: 50, LinesDeleted: 10},
 			},
-			opts: RenderOptions{Short: false, HideStats: true},
+			opts: RenderOptions{Mode: RenderModeFull, HideStats: true},
 		},
 
 		// Hide summary
@@ -326,7 +326,7 @@ func buildGoldenTests() []goldenTest {
 				"feature-1": {PRNumber: intPtr(123), CommitCount: 5},
 				"feature-2": {PRNumber: intPtr(456), CommitCount: 3},
 			},
-			opts: RenderOptions{Short: false, HideSummary: true},
+			opts: RenderOptions{Mode: RenderModeFull, HideSummary: true},
 		},
 
 		// RenderMode tests (new enum-based API)
@@ -455,7 +455,7 @@ func TestStackTreeRenderer_GoldenWithColors(t *testing.T) {
 		Scope:       "AUTH",
 	})
 
-	lines := renderer.RenderStack(mock.TrunkVal, RenderOptions{Short: false})
+	lines := renderer.RenderStack(mock.TrunkVal, RenderOptions{Mode: RenderModeFull})
 	output := strings.Join(lines, "\n")
 
 	// Verify ANSI codes are present (colors are being applied)

--- a/internal/tui/components/tree/tree_mock.go
+++ b/internal/tui/components/tree/tree_mock.go
@@ -69,23 +69,3 @@ func (m *MockTreeData) IsTrunk(branchName string) bool {
 func (m *MockTreeData) IsFixed(branchName string) bool {
 	return m.FixedMap[branchName]
 }
-
-// Deprecated method aliases for backwards compatibility with existing tests
-
-// GetChildren returns the children of a branch.
-// Deprecated: Use Children instead.
-func (m *MockTreeData) GetChildren(branchName string) []string {
-	return m.Children(branchName)
-}
-
-// GetParent returns the parent of a branch.
-// Deprecated: Use Parent instead.
-func (m *MockTreeData) GetParent(branchName string) string {
-	return m.Parent(branchName)
-}
-
-// IsBranchFixed returns whether a branch is fixed.
-// Deprecated: Use IsFixed instead.
-func (m *MockTreeData) IsBranchFixed(branchName string) bool {
-	return m.IsFixed(branchName)
-}

--- a/internal/tui/components/tree/tree_model.go
+++ b/internal/tui/components/tree/tree_model.go
@@ -20,7 +20,7 @@ func NewModel(renderer *StackTreeRenderer) *Model {
 	return &Model{
 		Renderer: renderer,
 		Options: RenderOptions{
-			Short: false,
+			Mode: RenderModeFull,
 		},
 	}
 }
@@ -36,7 +36,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "s":
-			m.Options.Short = !m.Options.Short
+			if m.Options.Mode == RenderModeFull {
+				m.Options.Mode = RenderModeCompact
+			} else {
+				m.Options.Mode = RenderModeFull
+			}
 			return m, nil
 		case "r":
 			m.Options.Reverse = !m.Options.Reverse

--- a/internal/tui/components/tree/tree_test.go
+++ b/internal/tui/components/tree/tree_test.go
@@ -17,18 +17,10 @@ func init() {
 
 func TestStackTreeRenderer_RenderStack_LinearStack(t *testing.T) {
 	mock := NewMockTreeData()
-
-	renderer := NewStackTreeRenderer(
-		mock.CurrentBranch(),
-		mock.Trunk(),
-		mock.GetChildren,
-		mock.GetParent,
-		mock.IsTrunk,
-		mock.IsBranchFixed,
-	)
+	renderer := NewRenderer(mock)
 
 	lines := renderer.RenderStack("main", RenderOptions{
-		Short: true,
+		Mode: RenderModeCompact,
 	})
 
 	// Should have 3 branches: main, feature-1, feature-2
@@ -47,15 +39,7 @@ func TestStackTreeRenderer_RenderStack_LinearStack(t *testing.T) {
 
 func TestStackTreeRenderer_RenderStack_WithAnnotations(t *testing.T) {
 	mock := NewMockTreeData()
-
-	renderer := NewStackTreeRenderer(
-		mock.CurrentBranch(),
-		mock.Trunk(),
-		mock.GetChildren,
-		mock.GetParent,
-		mock.IsTrunk,
-		mock.IsBranchFixed,
-	)
+	renderer := NewRenderer(mock)
 
 	prNum := 123
 	renderer.SetAnnotation("feature-1", BranchAnnotation{
@@ -64,7 +48,7 @@ func TestStackTreeRenderer_RenderStack_WithAnnotations(t *testing.T) {
 	})
 
 	lines := renderer.RenderStack("main", RenderOptions{
-		Short: true,
+		Mode: RenderModeCompact,
 	})
 
 	output := strings.Join(lines, "\n")
@@ -94,17 +78,10 @@ func TestStackTreeRenderer_RenderStack_BranchingStack(t *testing.T) {
 		},
 	}
 
-	renderer := NewStackTreeRenderer(
-		mock.CurrentBranch(),
-		mock.Trunk(),
-		mock.GetChildren,
-		mock.GetParent,
-		mock.IsTrunk,
-		mock.IsBranchFixed,
-	)
+	renderer := NewRenderer(mock)
 
 	lines := renderer.RenderStack("main", RenderOptions{
-		Short: true,
+		Mode: RenderModeCompact,
 	})
 
 	// Should have 3 branches
@@ -121,18 +98,10 @@ func TestStackTreeRenderer_RenderStack_BranchingStack(t *testing.T) {
 
 func TestStackTreeRenderer_RenderStack_FullFormat(t *testing.T) {
 	mock := NewMockTreeData()
-
-	renderer := NewStackTreeRenderer(
-		mock.CurrentBranch(),
-		mock.Trunk(),
-		mock.GetChildren,
-		mock.GetParent,
-		mock.IsTrunk,
-		mock.IsBranchFixed,
-	)
+	renderer := NewRenderer(mock)
 
 	lines := renderer.RenderStack("main", RenderOptions{
-		Short: false,
+		Mode: RenderModeFull,
 	})
 
 	// Full format has more lines (branch line + trailing │ line for each)
@@ -149,22 +118,14 @@ func TestStackTreeRenderer_RenderStack_FullFormat(t *testing.T) {
 
 func TestStackTreeRenderer_RenderStack_Reversed(t *testing.T) {
 	mock := NewMockTreeData()
-
-	renderer := NewStackTreeRenderer(
-		mock.CurrentBranch(),
-		mock.Trunk(),
-		mock.GetChildren,
-		mock.GetParent,
-		mock.IsTrunk,
-		mock.IsBranchFixed,
-	)
+	renderer := NewRenderer(mock)
 
 	normalLines := renderer.RenderStack("main", RenderOptions{
-		Short: true,
+		Mode: RenderModeCompact,
 	})
 
 	reversedLines := renderer.RenderStack("main", RenderOptions{
-		Short:   true,
+		Mode:    RenderModeCompact,
 		Reverse: true,
 	})
 
@@ -190,15 +151,7 @@ func TestStackTreeRenderer_RenderStack_Reversed(t *testing.T) {
 
 func TestStackTreeRenderer_RenderBranchList(t *testing.T) {
 	mock := NewMockTreeData()
-
-	renderer := NewStackTreeRenderer(
-		mock.CurrentBranch(),
-		mock.Trunk(),
-		mock.GetChildren,
-		mock.GetParent,
-		mock.IsTrunk,
-		mock.IsBranchFixed,
-	)
+	renderer := NewRenderer(mock)
 
 	prNum := 42
 	renderer.SetAnnotation("feature-1", BranchAnnotation{
@@ -234,17 +187,10 @@ func TestStackTreeRenderer_NeedsRestack(t *testing.T) {
 		},
 	}
 
-	renderer := NewStackTreeRenderer(
-		mock.CurrentBranch(),
-		mock.Trunk(),
-		mock.GetChildren,
-		mock.GetParent,
-		mock.IsTrunk,
-		mock.IsBranchFixed,
-	)
+	renderer := NewRenderer(mock)
 
 	lines := renderer.RenderStack("main", RenderOptions{
-		Short: true,
+		Mode: RenderModeCompact,
 	})
 
 	output := strings.Join(lines, "\n")
@@ -255,15 +201,7 @@ func TestStackTreeRenderer_NeedsRestack(t *testing.T) {
 
 func TestBranchAnnotation_CheckStatus(t *testing.T) {
 	mock := NewMockTreeData()
-
-	renderer := NewStackTreeRenderer(
-		mock.CurrentBranch(),
-		mock.Trunk(),
-		mock.GetChildren,
-		mock.GetParent,
-		mock.IsTrunk,
-		mock.IsBranchFixed,
-	)
+	renderer := NewRenderer(mock)
 
 	renderer.SetAnnotation("feature-1", BranchAnnotation{
 		CheckStatus: CheckStatusPassing,
@@ -273,7 +211,7 @@ func TestBranchAnnotation_CheckStatus(t *testing.T) {
 	})
 
 	lines := renderer.RenderStack("main", RenderOptions{
-		Short: true,
+		Mode: RenderModeCompact,
 	})
 
 	output := strings.Join(lines, "\n")
@@ -309,14 +247,7 @@ func TestStackTreeRenderer_ScopeColoring(t *testing.T) {
 		},
 	}
 
-	renderer := NewStackTreeRenderer(
-		mock.CurrentBranch(),
-		mock.Trunk(),
-		mock.GetChildren,
-		mock.GetParent,
-		mock.IsTrunk,
-		mock.IsBranchFixed,
-	)
+	renderer := NewRenderer(mock)
 
 	// Set scopes
 	renderer.SetAnnotation("feature-auth-base", BranchAnnotation{Scope: "AUTH", ExplicitScope: "AUTH"})
@@ -324,7 +255,7 @@ func TestStackTreeRenderer_ScopeColoring(t *testing.T) {
 	renderer.SetAnnotation("feature-api-v1", BranchAnnotation{Scope: "API", ExplicitScope: "API"})
 
 	lines := renderer.RenderStack("main", RenderOptions{
-		Short: false,
+		Mode: RenderModeFull,
 	})
 
 	output := strings.Join(lines, "\n")
@@ -368,14 +299,7 @@ func TestStackTreeRenderer_InheritedScopeColoring(t *testing.T) {
 		},
 	}
 
-	renderer := NewStackTreeRenderer(
-		mock.CurrentBranch(),
-		mock.Trunk(),
-		mock.GetChildren,
-		mock.GetParent,
-		mock.IsTrunk,
-		mock.IsBranchFixed,
-	)
+	renderer := NewRenderer(mock)
 
 	// Set scope only on the base branch
 	renderer.SetAnnotation("feature-auth-base", BranchAnnotation{Scope: "AUTH", ExplicitScope: "AUTH"})
@@ -383,7 +307,7 @@ func TestStackTreeRenderer_InheritedScopeColoring(t *testing.T) {
 	renderer.SetAnnotation("feature-login", BranchAnnotation{Scope: "AUTH"})
 
 	lines := renderer.RenderStack("main", RenderOptions{
-		Short: false,
+		Mode: RenderModeFull,
 	})
 
 	output := strings.Join(lines, "\n")
@@ -448,14 +372,7 @@ func TestStackTreeRenderer_BranchingScopeColoring(t *testing.T) {
 		},
 	}
 
-	renderer := NewStackTreeRenderer(
-		mock.CurrentBranch(),
-		mock.Trunk(),
-		mock.GetChildren,
-		mock.GetParent,
-		mock.IsTrunk,
-		mock.IsBranchFixed,
-	)
+	renderer := NewRenderer(mock)
 
 	// Set scope on main
 	renderer.SetAnnotation("main", BranchAnnotation{Scope: "AUTH", ExplicitScope: "AUTH"})
@@ -463,7 +380,7 @@ func TestStackTreeRenderer_BranchingScopeColoring(t *testing.T) {
 	renderer.SetAnnotation("feature-1b", BranchAnnotation{Scope: "AUTH"})
 
 	lines := renderer.RenderStack("main", RenderOptions{
-		Short: false,
+		Mode: RenderModeFull,
 	})
 
 	output := strings.Join(lines, "\n")
@@ -508,14 +425,7 @@ func TestStackTreeRenderer_ScopeColoringBoundaries(t *testing.T) {
 		},
 	}
 
-	renderer := NewStackTreeRenderer(
-		mock.CurrentBranch(),
-		mock.Trunk(),
-		mock.GetChildren,
-		mock.GetParent,
-		mock.IsTrunk,
-		mock.IsBranchFixed,
-	)
+	renderer := NewRenderer(mock)
 
 	// Only scoped-branch has the scope
 	renderer.SetAnnotation("scoped-branch", BranchAnnotation{
@@ -526,7 +436,7 @@ func TestStackTreeRenderer_ScopeColoringBoundaries(t *testing.T) {
 	renderer.SetAnnotation("unscoped-branch", BranchAnnotation{Scope: ""})
 
 	lines := renderer.RenderStack("main", RenderOptions{
-		Short: false,
+		Mode: RenderModeFull,
 	})
 
 	// Get colors
@@ -592,7 +502,7 @@ func TestStackTreeRenderer_EmptyTree(t *testing.T) {
 	}
 
 	renderer := NewRenderer(mock)
-	lines := renderer.RenderStack("main", RenderOptions{Short: true})
+	lines := renderer.RenderStack("main", RenderOptions{Mode: RenderModeCompact})
 
 	// Should have exactly 1 line (just main)
 	if len(lines) != 1 {
@@ -623,7 +533,7 @@ func TestStackTreeRenderer_SingleBranch(t *testing.T) {
 	}
 
 	renderer := NewRenderer(mock)
-	lines := renderer.RenderStack("main", RenderOptions{Short: true})
+	lines := renderer.RenderStack("main", RenderOptions{Mode: RenderModeCompact})
 
 	// Should have 2 lines
 	if len(lines) != 2 {
@@ -668,7 +578,7 @@ func TestStackTreeRenderer_DeeplyNested(t *testing.T) {
 	}
 
 	renderer := NewRenderer(mock)
-	lines := renderer.RenderStack("main", RenderOptions{Short: true})
+	lines := renderer.RenderStack("main", RenderOptions{Mode: RenderModeCompact})
 
 	// Should have all 15 branches
 	if len(lines) != depth {
@@ -708,11 +618,11 @@ func TestStackTreeRenderer_CollapsedBranch(t *testing.T) {
 	renderer := NewRenderer(mock)
 
 	// Without collapse
-	linesExpanded := renderer.RenderStack("main", RenderOptions{Short: true})
+	linesExpanded := renderer.RenderStack("main", RenderOptions{Mode: RenderModeCompact})
 
 	// With collapse on feature-1
 	linesCollapsed := renderer.RenderStack("main", RenderOptions{
-		Short:     true,
+		Mode:      RenderModeCompact,
 		Collapsed: map[string]bool{"feature-1": true},
 	})
 
@@ -771,7 +681,7 @@ func TestStackTreeRenderer_WideBranching(t *testing.T) {
 	}
 
 	renderer := NewRenderer(mock)
-	lines := renderer.RenderStack("main", RenderOptions{Short: true})
+	lines := renderer.RenderStack("main", RenderOptions{Mode: RenderModeCompact})
 
 	// Should have 6 lines (main + 5 children)
 	if len(lines) != 6 {
@@ -820,7 +730,7 @@ func TestStackTreeRenderer_RenderFromMiddleBranch(t *testing.T) {
 	renderer := NewRenderer(mock)
 
 	// Render from feature-2 (middle of stack)
-	lines := renderer.RenderStack("feature-2", RenderOptions{Short: true})
+	lines := renderer.RenderStack("feature-2", RenderOptions{Mode: RenderModeCompact})
 
 	output := strings.Join(lines, "\n")
 
@@ -859,7 +769,7 @@ func TestStackTreeRenderer_CacheIsCleared(t *testing.T) {
 	renderer := NewRenderer(mock)
 
 	// First render
-	lines1 := renderer.RenderStack("main", RenderOptions{Short: true})
+	lines1 := renderer.RenderStack("main", RenderOptions{Mode: RenderModeCompact})
 
 	// Modify the tree (add a new child)
 	mock.ChildrenMap["feature-1"] = []string{"feature-2"}
@@ -868,7 +778,7 @@ func TestStackTreeRenderer_CacheIsCleared(t *testing.T) {
 	mock.FixedMap["feature-2"] = true
 
 	// Second render should include the new branch
-	lines2 := renderer.RenderStack("main", RenderOptions{Short: true})
+	lines2 := renderer.RenderStack("main", RenderOptions{Mode: RenderModeCompact})
 
 	if len(lines2) <= len(lines1) {
 		t.Errorf("second render should have more lines after adding branch: got %d, want > %d",

--- a/internal/tui/log_ui.go
+++ b/internal/tui/log_ui.go
@@ -579,10 +579,14 @@ func (m *LogModel) renderTree() {
 
 	trunk := m.engine.Trunk().GetName()
 	// Render with selection - the tree component handles cursor prefix and branch name styling
+	mode := tree.RenderModeFull
+	if m.mode == LogModeSelect {
+		mode = tree.RenderModeSelect
+	}
 	opts := tree.RenderOptions{
+		Mode:           mode,
 		SelectedBranch: m.selectedBranch,
 		Collapsed:      m.collapsed,
-		SingleLine:     m.mode == LogModeSelect,
 		SearchQuery:    m.searchQuery,
 		SearchMatches:  m.searchMatches,
 		NonSelectable:  m.nonSelectable,
@@ -731,10 +735,14 @@ func (m *LogModel) View() string {
 	default:
 		// Fallback: render tree directly for immediate display before first renderTree call
 		trunk := m.engine.Trunk().GetName()
+		mode := tree.RenderModeFull
+		if m.mode == LogModeSelect {
+			mode = tree.RenderModeSelect
+		}
 		opts := tree.RenderOptions{
+			Mode:           mode,
 			SelectedBranch: m.selectedBranch,
 			Collapsed:      m.collapsed,
-			SingleLine:     m.mode == LogModeSelect,
 			SearchQuery:    m.searchQuery,
 			SearchMatches:  m.searchMatches,
 			NonSelectable:  m.nonSelectable,

--- a/internal/tui/move_model.go
+++ b/internal/tui/move_model.go
@@ -163,7 +163,7 @@ func NewMoveModel(eng engine.Engine, config MoveModelConfig) *MoveModel {
 	// Use SkipSelectionPrefix so we can add our own cursor indicators in viewSelecting
 	opts := tree.RenderOptions{
 		Reverse:             false,
-		SingleLine:          true,
+		Mode:                tree.RenderModeSelect,
 		NonSelectable:       nonSelectable,
 		SkipSelectionPrefix: true,
 	}


### PR DESCRIPTION



<!-- STACKIT-SECTION-START -->
#### Stack



This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #564 by jonnii*