### PR TITLE
feat: implement validation-based conflict handling for sync operations

### DIFF
--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -50,139 +50,152 @@ type RestackProgressCallback func(branchName string, result engine.RestackResult
 
 // RestackBranches restacks a list of branches using the engine's batch restack method
 func RestackBranches(ctx *app.Context, branches []engine.Branch) error {
-	return RestackBranchesWithHandler(ctx, branches, nil)
+	return RestackBranchesWithHandler(ctx, branches, nil, true)
 }
 
 // RestackBranchesWithHandler restacks branches with optional progress callback
-func RestackBranchesWithHandler(ctx *app.Context, branches []engine.Branch, callback RestackProgressCallback) error {
-	batchResult, err := ctx.Engine.RestackBranches(ctx.Context, branches)
-	if err != nil {
-		if batchResult.ConflictBranch != "" {
-			currentBranch := ctx.Engine.CurrentBranch()
-			currentBranchName := ""
-			if currentBranch != nil {
-				currentBranchName = currentBranch.GetName()
-			}
-
-			// Report the conflict via callback if provided
-			if callback != nil {
-				callback(batchResult.ConflictBranch, engine.RestackConflict, "", true, engine.LockReasonNone, false, batchResult.ConflictBranch == currentBranchName, false, "", "")
-			}
-
-			continuation := &config.ContinuationState{
-				BranchesToRestack:     batchResult.RemainingBranches,
-				RebasedBranchBase:     batchResult.RebasedBranchBase,
-				CurrentBranchOverride: batchResult.ConflictBranch,
-			}
-
-			if err := config.PersistContinuationState(ctx.RepoRoot, continuation); err != nil {
-				return fmt.Errorf("failed to persist continuation: %w", err)
-			}
-
-			if err := PrintConflictStatus(ctx, batchResult.ConflictBranch); err != nil {
-				return fmt.Errorf("failed to print conflict status: %w", err)
-			}
-		}
-		return fmt.Errorf("batch restack failed: %w", err)
+// If shouldEnterConflictWorkflow is true, stops at first conflict and enters conflict workflow
+// If false, validates all branches first, restacks non-conflicting ones, and reports conflicts via callback
+func RestackBranchesWithHandler(ctx *app.Context, branches []engine.Branch, callback RestackProgressCallback, shouldEnterConflictWorkflow bool) error {
+	if len(branches) == 0 {
+		return nil
 	}
 
-	// Handle conflicts even when no error was returned
-	if batchResult.ConflictBranch != "" {
+	// Build rebase specs for validation
+	specs, branchMap := buildRebaseSpecs(ctx, branches)
+	if len(specs) == 0 {
+		return nil
+	}
+
+	// Validate all rebases in a temporary worktree (clean, no side effects)
+	validation, err := ctx.Engine.ValidateRebases(ctx.Context, specs)
+	if err != nil {
+		return fmt.Errorf("failed to validate rebases: %w", err)
+	}
+
+	// Check if validation failed due to a system error (not a conflict)
+	if !validation.Success {
+		if validation.ErrorType == engine.ValidationErrorSystem {
+			return fmt.Errorf("validation failed for %s: %s", validation.FailedBranch, validation.ErrorMessage)
+		}
+		// Else: conflict - continue with conflict workflow
+	}
+
+	// Split branches into successful and conflicting
+	var successBranches []engine.Branch
+	var conflictBranches []string
+
+	if validation.Success {
+		// All branches succeeded - add them all to success list
+		for _, branch := range branches {
+			if _, exists := branchMap[branch.GetName()]; exists {
+				successBranches = append(successBranches, branch)
+			}
+		}
+	} else {
+		// Build a position map for fast lookups
+		positionMap := make(map[string]int)
+		for i, spec := range specs {
+			positionMap[spec.Branch] = i
+		}
+
+		// Find position of failed branch
+		failedPos, failedExists := positionMap[validation.FailedBranch]
+		if !failedExists {
+			// This shouldn't happen, but handle gracefully
+			ctx.Logger.Warn("failed branch not found in specs", "branch", validation.FailedBranch)
+			failedPos = len(specs) // Treat as if it failed at the end
+		}
+
+		// Classify branches based on their position relative to the conflict
+		for _, branch := range branches {
+			branchName := branch.GetName()
+			if _, exists := branchMap[branchName]; !exists {
+				continue // Skip branches without specs
+			}
+
+			pos, ok := positionMap[branchName]
+			if !ok {
+				// Branch not in specs (shouldn't happen)
+				continue
+			}
+
+			if pos < failedPos {
+				// Branch comes before conflict - will succeed
+				successBranches = append(successBranches, branch)
+			} else if pos == failedPos {
+				// This is the conflicted branch
+				conflictBranches = append(conflictBranches, branchName)
+			}
+			// Branches after conflict (pos > failedPos) are not processed
+		}
+	}
+
+	// For standalone mode, enter conflict workflow on first conflict
+	if shouldEnterConflictWorkflow && len(conflictBranches) > 0 {
+		firstConflict := conflictBranches[0]
+
+		// Restack successfully up to the conflict
+		if len(successBranches) > 0 {
+			if _, err := ctx.Engine.RestackBranches(ctx.Context, successBranches); err != nil {
+				return fmt.Errorf("failed to restack branches before conflict: %w", err)
+			}
+		}
+
+		// Enter conflict workflow for the first conflict
+		return EnterConflictWorkflow(ctx, firstConflict, branches)
+	}
+
+	// For sync mode (or standalone with no conflicts), restack all successful branches
+	if len(successBranches) > 0 {
+		batchResult, err := ctx.Engine.RestackBranches(ctx.Context, successBranches)
+		if err != nil {
+			return fmt.Errorf("batch restack failed: %w", err)
+		}
+
+		// Report results via callback or output
 		currentBranch := ctx.Engine.CurrentBranch()
 		currentBranchName := ""
 		if currentBranch != nil {
 			currentBranchName = currentBranch.GetName()
 		}
 
-		// Report the conflict via callback if provided
-		if callback != nil {
-			callback(batchResult.ConflictBranch, engine.RestackConflict, "", true, engine.LockReasonNone, false, batchResult.ConflictBranch == currentBranchName, false, "", "")
-		}
+		for _, branch := range successBranches {
+			branchName := branch.GetName()
+			result, exists := batchResult.Results[branchName]
+			if !exists {
+				continue
+			}
 
-		continuation := &config.ContinuationState{
-			BranchesToRestack:     batchResult.RemainingBranches,
-			RebasedBranchBase:     batchResult.RebasedBranchBase,
-			CurrentBranchOverride: batchResult.ConflictBranch,
-		}
-
-		if err := config.PersistContinuationState(ctx.RepoRoot, continuation); err != nil {
-			return fmt.Errorf("failed to persist continuation: %w", err)
-		}
-
-		if err := PrintConflictStatus(ctx, batchResult.ConflictBranch); err != nil {
-			return fmt.Errorf("failed to print conflict status: %w", err)
-		}
-
-		return fmt.Errorf("restack stopped due to conflict on %s", batchResult.ConflictBranch)
-	}
-
-	currentBranch := ctx.Engine.CurrentBranch()
-	currentBranchName := ""
-	if currentBranch != nil {
-		currentBranchName = currentBranch.GetName()
-	}
-
-	for _, branch := range branches {
-		branchName := branch.GetName()
-		result, exists := batchResult.Results[branchName]
-		if !exists {
-			continue // Skip branches not processed (e.g., trunk)
-		}
-
-		// Get new revision if available
-		newRev := ""
-		if result.Result == engine.RestackDone {
-			if rev, err := branch.GetRevision(); err == nil {
-				if len(rev) > 7 {
-					newRev = rev[:7]
-				} else {
-					newRev = rev
+			// Get new revision if available
+			newRev := ""
+			if result.Result == engine.RestackDone {
+				if rev, err := branch.GetRevision(); err == nil {
+					if len(rev) > 7 {
+						newRev = rev[:7]
+					} else {
+						newRev = rev
+					}
 				}
 			}
-		}
 
-		// Report via callback if provided
-		if callback != nil {
-			callback(branchName, result.Result, newRev, false, result.LockReason, result.Frozen, branchName == currentBranchName, result.Reparented, result.OldParent, result.NewParent)
-			continue // Skip splog output when using callback handler
-		}
-
-		// Log via splog only when no callback is provided (backward compatibility)
-		if result.Reparented {
-			isCurrent := branchName == currentBranchName
-			ctx.Output.Info("Reparented %s from %s to %s (parent was merged/deleted).",
-				style.ColorBranchName(branchName, isCurrent),
-				style.ColorBranchName(result.OldParent, false),
-				style.ColorBranchName(result.NewParent, false))
-		}
-
-		switch result.Result {
-		case engine.RestackDone:
-			parent := branch.GetParent()
-			parentName := ""
-			if parent == nil {
-				parentName = ctx.Engine.Trunk().GetName()
-			} else {
-				parentName = parent.GetName()
+			// Report via callback if provided
+			if callback != nil {
+				callback(branchName, result.Result, newRev, false, result.LockReason, result.Frozen, branchName == currentBranchName, result.Reparented, result.OldParent, result.NewParent)
+				continue
 			}
-			isCurrent := branchName == currentBranchName
-			ctx.Output.Info("Restacked %s on %s.",
-				style.ColorBranchName(branchName, isCurrent),
-				style.ColorBranchName(parentName, false))
-		case engine.RestackConflict:
-			// This should not happen since conflicts are handled at the batch level
-			return fmt.Errorf("unexpected conflict in batch result for branch %s", branchName)
-		case engine.RestackUnneeded:
-			switch {
-			case !branch.CanModify():
-				if branch.IsLocked() {
-					ctx.Output.Info("Did not restack branch %s because it is locked: %s", style.ColorBranchName(branchName, branchName == currentBranchName), branch.GetLockReason())
-				} else {
-					ctx.Output.Info("Did not restack branch %s because it is frozen.", style.ColorBranchName(branchName, branchName == currentBranchName))
-				}
-			case branch.IsTrunk():
-				ctx.Output.Info("%s does not need to be restacked.", style.ColorBranchName(branchName, false))
-			default:
+
+			// Log via splog only when no callback is provided
+			if result.Reparented {
+				isCurrent := branchName == currentBranchName
+				ctx.Output.Info("Reparented %s from %s to %s (parent was merged/deleted).",
+					style.ColorBranchName(branchName, isCurrent),
+					style.ColorBranchName(result.OldParent, false),
+					style.ColorBranchName(result.NewParent, false))
+			}
+
+			switch result.Result {
+			case engine.RestackDone:
 				parent := branch.GetParent()
 				parentName := ""
 				if parent == nil {
@@ -191,14 +204,188 @@ func RestackBranchesWithHandler(ctx *app.Context, branches []engine.Branch, call
 					parentName = parent.GetName()
 				}
 				isCurrent := branchName == currentBranchName
-				ctx.Output.Info("%s does not need to be restacked on %s.",
+				ctx.Output.Info("Restacked %s on %s.",
 					style.ColorBranchName(branchName, isCurrent),
 					style.ColorBranchName(parentName, false))
+			case engine.RestackUnneeded:
+				switch {
+				case !branch.CanModify():
+					if branch.IsLocked() {
+						ctx.Output.Info("Did not restack branch %s because it is locked: %s", style.ColorBranchName(branchName, branchName == currentBranchName), branch.GetLockReason())
+					} else {
+						ctx.Output.Info("Did not restack branch %s because it is frozen.", style.ColorBranchName(branchName, branchName == currentBranchName))
+					}
+				case branch.IsTrunk():
+					ctx.Output.Info("%s does not need to be restacked.", style.ColorBranchName(branchName, false))
+				default:
+					parent := branch.GetParent()
+					parentName := ""
+					if parent == nil {
+						parentName = ctx.Engine.Trunk().GetName()
+					} else {
+						parentName = parent.GetName()
+					}
+					isCurrent := branchName == currentBranchName
+					ctx.Output.Info("%s does not need to be restacked on %s.",
+						style.ColorBranchName(branchName, isCurrent),
+						style.ColorBranchName(parentName, false))
+				}
+			}
+		}
+	}
+
+	// Report conflicts via callback for sync mode
+	if !shouldEnterConflictWorkflow && len(conflictBranches) > 0 {
+		currentBranch := ctx.Engine.CurrentBranch()
+		currentBranchName := ""
+		if currentBranch != nil {
+			currentBranchName = currentBranch.GetName()
+		}
+
+		for _, branchName := range conflictBranches {
+			if callback != nil {
+				callback(branchName, engine.RestackConflict, "", true, engine.LockReasonNone, false, branchName == currentBranchName, false, "", "")
 			}
 		}
 	}
 
 	return nil
+}
+
+// EnterConflictWorkflow performs the rebase to enter conflict state and persists continuation state.
+// This helper is shared between RestackBranchesWithHandler (standalone mode) and sync.RunSync (sync mode).
+func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches []engine.Branch) error {
+	// Perform rebase to enter conflict state
+	conflictBranch := ctx.Engine.GetBranch(firstConflict)
+	batchResult, err := ctx.Engine.RestackBranches(ctx.Context, []engine.Branch{conflictBranch})
+	if err != nil {
+		return fmt.Errorf("failed to enter conflict state for %s: %w", firstConflict, err)
+	}
+
+	// Verify we're actually in conflict state
+	if !ctx.Engine.Git().IsRebaseInProgress(ctx.Context) {
+		return fmt.Errorf("expected conflict on %s but rebase completed successfully", firstConflict)
+	}
+
+	// Note: We don't verify the current branch here because CurrentBranch() doesn't work
+	// correctly during an in-progress rebase. The IsRebaseInProgress check above is sufficient
+	// to verify we're in the expected state.
+
+	// Build remaining branches list
+	var remainingBranches []string
+	foundConflict := false
+	for _, branch := range allBranches {
+		if foundConflict {
+			remainingBranches = append(remainingBranches, branch.GetName())
+		} else if branch.GetName() == firstConflict {
+			foundConflict = true
+		}
+	}
+
+	// Get RebasedBranchBase from result
+	rebasedBranchBase := ""
+	if result, ok := batchResult.Results[firstConflict]; ok {
+		rebasedBranchBase = result.RebasedBranchBase
+	}
+
+	// Persist continuation state
+	continuation := &config.ContinuationState{
+		BranchesToRestack:     remainingBranches,
+		RebasedBranchBase:     rebasedBranchBase,
+		CurrentBranchOverride: firstConflict,
+	}
+
+	if err := config.PersistContinuationState(ctx.RepoRoot, continuation); err != nil {
+		return fmt.Errorf("failed to persist continuation: %w", err)
+	}
+
+	if err := PrintConflictStatus(ctx, firstConflict); err != nil {
+		return fmt.Errorf("failed to print conflict status: %w", err)
+	}
+
+	return fmt.Errorf("restack stopped due to conflict on %s", firstConflict)
+}
+
+// buildRebaseSpecs builds RebaseSpec list for validation
+func buildRebaseSpecs(ctx *app.Context, branches []engine.Branch) ([]engine.RebaseSpec, map[string]bool) {
+	specs := make([]engine.RebaseSpec, 0, len(branches))
+	branchMap := make(map[string]bool)
+
+	for _, branch := range branches {
+		branchName := branch.GetName()
+
+		// Check if parent exists or needs reparenting
+		parent := branch.GetParent()
+		var parentName string
+		if parent == nil {
+			trunk := ctx.Engine.Trunk()
+			parentName = trunk.GetName()
+		} else {
+			parentName = parent.GetName()
+			// Check if parent branch still exists by trying to get its revision
+			parentBranch := ctx.Engine.GetBranch(parentName)
+			if _, err := parentBranch.GetRevision(); err != nil {
+				// Parent doesn't exist, find nearest valid ancestor
+				ancestors, err := ctx.Engine.FindMostRecentTrackedAncestors(ctx.Context, branchName)
+				if err == nil && len(ancestors) > 0 {
+					parentName = ancestors[0]
+				} else {
+					// Fall back to trunk if no ancestors found
+					parentName = ctx.Engine.Trunk().GetName()
+				}
+			}
+		}
+
+		// Get old parent revision from metadata
+		meta, err := ctx.Engine.Git().ReadMetadata(branchName)
+		if err != nil {
+			continue // Skip if can't read metadata
+		}
+
+		var oldParentRev string
+		if meta.ParentBranchRevision != nil {
+			oldParentRev = *meta.ParentBranchRevision
+		}
+
+		// RESILIENCY: If oldParentRev is no longer an ancestor of branchName,
+		// or if it's empty, find the actual merge base. This handles cases where
+		// the parent was amended, rebased, or deleted.
+		if oldParentRev != "" {
+			isAncestor, err := ctx.Engine.Git().IsAncestor(oldParentRev, branchName)
+			if err != nil {
+				ctx.Logger.Warn("failed to check ancestry, will try merge-base",
+					"oldParent", oldParentRev, "branch", branchName, "error", err)
+				isAncestor = false
+			}
+			if !isAncestor {
+				if mergeBase, err := ctx.Engine.Git().GetMergeBase(branchName, parentName); err == nil {
+					oldParentRev = mergeBase
+				} else {
+					// Can't determine merge base - skip this branch
+					ctx.Logger.Warn("failed to determine merge base", "branch", branchName, "parent", parentName, "error", err)
+					continue
+				}
+			}
+		} else {
+			// No old parent revision in metadata, try to find merge base
+			if mergeBase, err := ctx.Engine.Git().GetMergeBase(branchName, parentName); err == nil {
+				oldParentRev = mergeBase
+			} else {
+				// Can't determine merge base - skip this branch
+				ctx.Logger.Warn("failed to determine merge base", "branch", branchName, "parent", parentName, "error", err)
+				continue
+			}
+		}
+
+		specs = append(specs, engine.RebaseSpec{
+			Branch:      branchName,
+			NewParent:   parentName,
+			OldUpstream: oldParentRev,
+		})
+		branchMap[branchName] = true
+	}
+
+	return specs, branchMap
 }
 
 // PluralSuffix returns the appropriate plural suffix for the given word if plural is true, otherwise empty string

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -384,7 +384,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 					conflicts = append(conflicts, branchName)
 					handler.OnRestackBranch(branchName, handlers.RestackConflict, "", prNumber, lockReason, frozen, isCurrent, parentName, reparented, oldParent, newParent)
 				}
-			}); err != nil {
+			}, true); err != nil {
 				handler.OnRestackComplete(restacked, skipped, conflicts)
 				return fmt.Errorf("restack failed: %w", err)
 			}

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -89,7 +89,7 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 		}
 
 		handler.OnRestackBranch(branchName, res, newRev, prNumber, lockReason, frozen, isCurrent, parentName, reparented, oldParent, newParent)
-	}); err != nil {
+	}, true); err != nil {
 		handler.OnRestackComplete(restacked, skipped, conflicts)
 		return fmt.Errorf("restack failed: %w", err)
 	}

--- a/internal/actions/sync/restack.go
+++ b/internal/actions/sync/restack.go
@@ -112,7 +112,7 @@ func restackBranches(ctx *app.Context, branchesToRestack []string, dirtyAnchors 
 					Parent:     parentName,
 				})
 			}
-		}); err != nil {
+		}, false); err != nil {
 			return fmt.Errorf("failed to restack branches: %w", err)
 		}
 		ctx.Logger.Info("restack branches completed durationMs=%d branchCount=%d", time.Since(restackStart).Milliseconds(), len(sortedBranches))

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"stackit.dev/stackit/internal/actions"
 	"stackit.dev/stackit/internal/app"
 	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/internal/handlers"
@@ -220,6 +221,23 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return err
 	}
 
+	// Check for conflicts and prompt user if interactive
+	if len(summary.ConflictBranches) > 0 && handler.IsInteractive() {
+		resolve, err := handler.PromptResolveConflicts(summary.ConflictBranches)
+		if err != nil {
+			handler.Complete(*summary)
+			return fmt.Errorf("failed to prompt for conflict resolution: %w", err)
+		}
+
+		if resolve {
+			// User wants to resolve conflicts - enter conflict workflow for the first conflict
+			firstConflict := summary.ConflictBranches[0]
+			allBranches := ctx.Navigator().AllBranches()
+			return actions.EnterConflictWorkflow(ctx, firstConflict, allBranches)
+		}
+		// User chose to skip conflicts - continue with summary
+	}
+
 	// Check if everything was up to date
 	if !summary.HasChanges() {
 		summary.UpToDate = true
@@ -349,6 +367,11 @@ type Handler interface {
 	// In non-interactive mode, returns all branches (auto-confirm).
 	PromptBranchDeletions(branches map[string]string) (confirmed map[string]bool, err error)
 
+	// PromptResolveConflicts asks user if they want to resolve restack conflicts now or skip them.
+	// Returns true to start conflict resolution workflow, false to skip and continue.
+	// In non-interactive mode, returns (false, nil) to skip conflicts.
+	PromptResolveConflicts(conflictBranches []string) (resolve bool, err error)
+
 	// RestackHandler methods are available for restack-specific output
 	// This allows the same handler to be used for standalone restack operations
 	RestackHandler
@@ -389,6 +412,11 @@ func (h *NullHandler) PromptMetadataConflict(_ *engine.MetadataDiff) (bool, erro
 
 // PromptOrphanedMetadata implements Handler. Returns false (accept deletion) in non-interactive mode.
 func (h *NullHandler) PromptOrphanedMetadata(_ engine.OrphanedMetadataInfo) (bool, error) {
+	return false, nil
+}
+
+// PromptResolveConflicts implements Handler. Returns false (skip) in non-interactive mode.
+func (h *NullHandler) PromptResolveConflicts(_ []string) (bool, error) {
 	return false, nil
 }
 

--- a/internal/actions/sync/sync_test.go
+++ b/internal/actions/sync/sync_test.go
@@ -159,18 +159,18 @@ func TestSyncAction(t *testing.T) {
 
 		s.Checkout("P")
 
+		handler := &NullHandler{}
 		err = Action(s.Context, Options{
 			All:     true,
 			Restack: true,
-		}, nil)
+		}, handler)
 
-		// Should error due to conflict in 1-Failure
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "conflict")
+		// Should NOT error - conflicts are detected via validation and skipped
+		require.NoError(t, err)
 
-		// 0-Success should still have been restacked successfully
+		// 0-Success should have been restacked successfully
 		s.ExpectBranchFixed("0-Success")
-		// 1-Failure should NOT be fixed
+		// 1-Failure should NOT be fixed (conflict detected via validation)
 		s.ExpectBranchNotFixed("1-Failure")
 	})
 }

--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -118,6 +118,11 @@ func (h *SimpleSyncHandler) PromptOrphanedMetadata(info engine.OrphanedMetadataI
 	return false, nil
 }
 
+// PromptResolveConflicts implements Handler. In non-interactive mode, skips conflicts.
+func (h *SimpleSyncHandler) PromptResolveConflicts(_ []string) (bool, error) {
+	return false, nil
+}
+
 // PromptBranchDeletions implements Handler. In non-interactive mode, auto-confirms all deletions.
 func (h *SimpleSyncHandler) PromptBranchDeletions(branches map[string]string) (map[string]bool, error) {
 	confirmed := make(map[string]bool)
@@ -657,6 +662,25 @@ func (h *InteractiveSyncHandler) PromptOrphanedMetadata(info engine.OrphanedMeta
 	}
 
 	return tui.PromptConfirm("Push your local metadata to remote?", false)
+}
+
+// PromptResolveConflicts implements Handler. Pauses TUI, displays conflicts, prompts user.
+func (h *InteractiveSyncHandler) PromptResolveConflicts(conflictBranches []string) (bool, error) {
+	h.runner.Pause()
+	defer h.runner.Resume()
+
+	h.output.Newline()
+	h.output.Warn("⚠️  Found conflicts in %d %s during restack:",
+		len(conflictBranches),
+		map[bool]string{true: "branch", false: "branches"}[len(conflictBranches) == 1])
+	for _, name := range conflictBranches {
+		h.output.Warn("  • %s", style.ColorBranchName(name, false))
+	}
+	h.output.Newline()
+	h.output.Info("Branches that could be restacked cleanly have been restacked.")
+	h.output.Newline()
+
+	return tui.PromptConfirm("Resolve conflicts now?", false)
 }
 
 // PromptBranchDeletions implements Handler. Pauses TUI, displays planned deletions, prompts for each.

--- a/internal/engine/rebase_validator.go
+++ b/internal/engine/rebase_validator.go
@@ -7,6 +7,18 @@ import (
 	"stackit.dev/stackit/internal/git"
 )
 
+// ValidationErrorType distinguishes between conflict errors and system errors
+type ValidationErrorType int
+
+const (
+	// ValidationErrorNone indicates no error occurred
+	ValidationErrorNone ValidationErrorType = iota
+	// ValidationErrorConflict indicates a merge conflict occurred
+	ValidationErrorConflict
+	// ValidationErrorSystem indicates a system error (not a conflict)
+	ValidationErrorSystem
+)
+
 // RebaseSpec describes a planned rebase operation
 type RebaseSpec struct {
 	Branch      string // Branch to rebase
@@ -16,10 +28,11 @@ type RebaseSpec struct {
 
 // RebaseValidation is the result of dry-run validation
 type RebaseValidation struct {
-	Success      bool              // Whether all rebases would succeed
-	FailedBranch string            // Which branch caused the conflict (if any)
-	ErrorMessage string            // Error message describing the failure
-	NewSHAs      map[string]string // Branch -> resulting SHA after rebase (if successful)
+	Success      bool                // Whether all rebases would succeed
+	FailedBranch string              // Which branch caused the conflict (if any)
+	ErrorType    ValidationErrorType // Type of error (conflict vs system error)
+	ErrorMessage string              // Error message describing the failure
+	NewSHAs      map[string]string   // Branch -> resulting SHA after rebase (if successful)
 }
 
 // ValidateRebases tests if a sequence of rebases will succeed by performing them
@@ -80,8 +93,10 @@ func (e *engineImpl) ValidateRebases(ctx context.Context, specs []RebaseSpec) (*
 			result.FailedBranch = spec.Branch
 			if err != nil {
 				result.ErrorMessage = fmt.Sprintf("rebase failed: %v", err)
+				result.ErrorType = ValidationErrorSystem
 			} else {
 				result.ErrorMessage = fmt.Sprintf("conflict rebasing onto %s", spec.NewParent)
+				result.ErrorType = ValidationErrorConflict
 			}
 
 			// Abort the in-progress rebase if any

--- a/internal/engine/rebase_validator_test.go
+++ b/internal/engine/rebase_validator_test.go
@@ -273,4 +273,76 @@ func TestValidateRebases(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, originalSHA, currentSHA, "branch ref should not be modified by validation")
 	})
+
+	t.Run("sets ValidationErrorConflict for merge conflicts", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		// Create a file on main first
+		s.Checkout("main").
+			CommitChange("conflicting-file.txt", "original version")
+
+		// Save this as the old base
+		oldBase, err := s.Engine.GetRevision(s.Engine.Trunk())
+		require.NoError(t, err)
+
+		// Create branch1 from main and modify the file
+		s.CreateBranch("branch1").
+			CommitChange("conflicting-file.txt", "branch1 version").
+			TrackBranch("branch1", "main")
+
+		// Now update main with a DIFFERENT conflicting change
+		s.Checkout("main").
+			CommitChange("conflicting-file.txt", "main conflicting version")
+
+		mainRev, err := s.Engine.GetRevision(s.Engine.Trunk())
+		require.NoError(t, err)
+
+		specs := []engine.RebaseSpec{
+			{
+				Branch:      "branch1",
+				NewParent:   mainRev,
+				OldUpstream: oldBase,
+			},
+		}
+
+		result, err := s.Engine.ValidateRebases(context.Background(), specs)
+		require.NoError(t, err)
+		require.False(t, result.Success)
+		require.Equal(t, "branch1", result.FailedBranch)
+		require.Equal(t, engine.ValidationErrorConflict, result.ErrorType, "should set ValidationErrorConflict for merge conflicts")
+		require.Contains(t, result.ErrorMessage, "conflict")
+	})
+
+	t.Run("sets ValidationErrorNone for successful validation", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"branch1": "main",
+			})
+
+		// Add a commit to main so rebase actually does something
+		s.Checkout("main").
+			Commit("main update").
+			Checkout("branch1")
+
+		// Get revisions
+		mainRev, err := s.Engine.GetRevision(s.Engine.Trunk())
+		require.NoError(t, err)
+		branch1OldBase, err := s.Engine.Git().GetMergeBase("main", "branch1")
+		require.NoError(t, err)
+
+		specs := []engine.RebaseSpec{
+			{
+				Branch:      "branch1",
+				NewParent:   mainRev,
+				OldUpstream: branch1OldBase,
+			},
+		}
+
+		result, err := s.Engine.ValidateRebases(context.Background(), specs)
+		require.NoError(t, err)
+		require.True(t, result.Success)
+		require.Equal(t, engine.ValidationErrorNone, result.ErrorType, "should set ValidationErrorNone for successful validation")
+	})
 }


### PR DESCRIPTION

- Add early conflict detection using ValidateRebases in temp worktree
- Restack successful branches automatically during sync
- Prompt users for conflict resolution after successful restacks
- Support both interactive and non-interactive sync workflows
- Maintain compatibility with standalone restack behavior


<!-- STACKIT-SECTION-START -->
#### Stack



This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #574 by jonnii*