### PR TITLE
fix: prevent duplicate GitHub URL display in submit output

### DIFF
--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -203,7 +203,8 @@ func (m *Model) View() string {
 		}
 
 		lines := m.Renderer.RenderStack(m.RootBranch, tree.RenderOptions{
-			HideStats: true,
+			HideStats:   true,
+			HideSummary: true,
 		})
 		b.WriteString(strings.Join(lines, "\n"))
 	} else {


### PR DESCRIPTION



<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #576** 👈

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->