### PR TITLE
feat: add layered configuration with team settings support

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,338 @@
+# Configuration System
+
+This document describes how Stackit stores and manages configuration for technical contributors.
+
+## Overview
+
+Stackit uses a layered configuration system with the following priority order:
+
+1. **Personal Git Config** (highest priority) - Stored in `.git/config`, not shared
+2. **Team Project Config** - Stored in `.stackit.yaml`, committed and shared with team
+3. **Defaults** (lowest priority) - Built-in sensible defaults
+
+This allows teams to define shared settings that individual developers can override locally.
+
+## Repository Configuration (Git Config)
+
+Repository-level settings are stored in `.git/config` using git's native configuration system with a `stackit.` prefix.
+
+### Storage Mechanism
+
+All keys are namespaced under `stackit.*`:
+
+```bash
+# Reading a value
+git config --local stackit.trunk
+
+# Writing a value
+git config --local stackit.trunk main
+
+# Multi-value keys (like additional trunks)
+git config --local --add stackit.trunks develop
+```
+
+### Configuration Keys
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `stackit.trunk` | string | `main` | Primary trunk branch |
+| `stackit.trunks` | string[] | `[]` | Additional trunk branches |
+| `stackit.branch.pattern` | string | `{username}/{date}/{message}` | Branch naming template |
+| `stackit.submit.footer` | bool | `true` | Include PR footer in descriptions |
+| `stackit.undo.depth` | int | `10` | Max undo snapshots to retain |
+| `stackit.worktree.basePath` | string | `""` | Base directory for worktrees |
+| `stackit.worktree.autoClean` | bool | `true` | Auto-clean worktrees during sync |
+| `stackit.merge.method` | string | `""` | Merge strategy (squash/merge/rebase) |
+| `stackit.ci.command` | string | `""` | CI validation command |
+| `stackit.ci.timeout` | int | `600` | CI command timeout in seconds |
+| `stackit.split.hunkSelector` | string | `tui` | Hunk selector mode (tui/git) |
+| `stackit.maxConcurrency` | int | `0` | Max concurrent operations (0 = auto) |
+| `stackit.hooks.approvedPostWorktreeCreate` | string[] | `[]` | Approved post-worktree hooks |
+
+### Code Location
+
+The configuration system is implemented across several files:
+
+```
+internal/config/
+├── config_git.go      # GitConfig - high-level typed interface
+├── keys.go            # Configuration key constants and defaults
+├── interface.go       # Configurer interface definition
+├── branch_pattern.go  # Branch naming pattern parsing
+└── migrate.go         # Legacy JSON migration
+
+internal/git/
+└── config.go          # ConfigStore - low-level git config access
+```
+
+### ConfigStore (Low-Level)
+
+`internal/git/config.go` provides direct access to git config:
+
+```go
+type ConfigStore struct {
+    repoRoot string
+}
+
+// Core operations
+func (c *ConfigStore) Get(key string) string
+func (c *ConfigStore) GetAll(key string) []string           // Multi-value keys
+func (c *ConfigStore) Set(key, value string) error
+func (c *ConfigStore) Add(key, value string) error          // Add to multi-value
+func (c *ConfigStore) Unset(key string) error               // Remove all values
+
+// Typed helpers
+func (c *ConfigStore) GetBoolWithDefault(key string, def bool) bool
+func (c *ConfigStore) GetIntWithDefault(key string, def int) int
+func (c *ConfigStore) SetBool(key string, value bool) error
+func (c *ConfigStore) SetInt(key string, value int) error
+```
+
+### GitConfig (High-Level)
+
+`internal/config/config_git.go` wraps ConfigStore with typed methods:
+
+```go
+type GitConfig struct {
+    repoRoot string
+    store    *git.ConfigStore
+}
+
+// Example methods
+func (c *GitConfig) Trunk() string
+func (c *GitConfig) SetTrunk(trunk string) error
+func (c *GitConfig) AllTrunks() []string
+func (c *GitConfig) IsTrunk(branch string) bool
+func (c *GitConfig) BranchNamePattern() string
+func (c *GitConfig) SubmitFooter() bool
+func (c *GitConfig) UndoStackDepth() int
+```
+
+### Loading Configuration
+
+Configuration is loaded through `internal/app/context.go`:
+
+```go
+// Standard loading (includes auto-migration)
+cfg, err := config.LoadConfig(repoRoot)
+
+// Via app context
+ctx, err := app.NewContextAutoWithWriter(ctx, repoRoot, opts, writer)
+// Access via ctx.Config
+```
+
+## Project Configuration (.stackit.yaml)
+
+Team-shared configuration is stored in `.stackit.yaml` at the repository root. This file is committed to git and shared with all team members. These settings act as team defaults that can be overridden by personal git config.
+
+### File Format
+
+```yaml
+# Team trunk branch (most commonly changed)
+trunk: main
+
+# Additional trunk branches (e.g., release branches)
+trunks:
+  - develop
+  - staging
+
+# Branch naming pattern for the team
+branch:
+  pattern: "{username}/{date}/{message}"
+
+# PR submission settings
+submit:
+  footer: true  # Include stackit footer in PR descriptions
+
+# Merge method preference
+merge:
+  method: squash  # squash, merge, or rebase
+
+# CI validation settings
+ci:
+  command: "make test"
+  timeout: 600  # seconds
+
+# Worktree hooks
+hooks:
+  post-worktree-create:
+    - "npm install"
+    - "make deps"
+```
+
+### Configuration Options
+
+| Option | Type | Description | Can Override in Git Config |
+|--------|------|-------------|---------------------------|
+| `trunk` | string | Primary trunk branch | Yes |
+| `trunks` | string[] | Additional trunk branches (merged with git config) | Yes (additive) |
+| `branch.pattern` | string | Branch naming template | Yes |
+| `submit.footer` | bool | Include PR footer | Yes |
+| `merge.method` | string | Merge strategy (squash/merge/rebase) | Yes |
+| `ci.command` | string | CI validation command | Yes |
+| `ci.timeout` | int | CI timeout in seconds | Yes |
+| `hooks.post-worktree-create` | string[] | Post-worktree-create commands | No (requires approval) |
+
+### Layered Configuration Example
+
+```yaml
+# .stackit.yaml (committed, shared with team)
+trunk: develop
+branch:
+  pattern: "feature/{message}"
+merge:
+  method: squash
+```
+
+```bash
+# Personal override in git config
+git config --local stackit.trunk main
+git config --local stackit.branch.pattern "{username}/{message}"
+# merge.method still uses team setting: squash
+```
+
+### Code Location
+
+```
+internal/config/
+└── project_config.go  # ProjectConfig struct and loading
+```
+
+### Loading Project Config
+
+```go
+type ProjectConfig struct {
+    Trunk  string       `yaml:"trunk,omitempty"`
+    Trunks []string     `yaml:"trunks,omitempty"`
+    Branch BranchConfig `yaml:"branch,omitempty"`
+    Submit SubmitConfig `yaml:"submit,omitempty"`
+    Merge  MergeConfig  `yaml:"merge,omitempty"`
+    CI     CIConfig     `yaml:"ci,omitempty"`
+    Hooks  HooksConfig  `yaml:"hooks,omitempty"`
+}
+
+// Load from repo root
+cfg, err := config.LoadProjectConfig(repoRoot)
+if cfg.HasTrunk() {
+    // Use cfg.Trunk
+}
+```
+
+## Hook Approval System
+
+Post-worktree-create hooks defined in `.stackit.yaml` require user approval before execution. Approvals are stored in git config (not shared).
+
+### Flow
+
+1. Hook defined in `.stackit.yaml` (shared)
+2. User runs a command that creates a worktree
+3. Stackit prompts for approval if hook not yet approved
+4. Approval saved to `stackit.hooks.approvedPostWorktreeCreate` (local)
+5. Subsequent runs skip the prompt
+
+### Implementation
+
+See `internal/actions/worktree/hooks.go` for the hook execution logic.
+
+## Continuation State
+
+Interrupted operations (e.g., merge conflicts during restack) store state for resumption:
+
+**Location:** `.git/.stackit_continue`
+
+**Format:** JSON
+
+```go
+type ContinuationState struct {
+    BranchesToRestack     []string
+    BranchesToSync        []string
+    CurrentBranchOverride string
+    RebasedBranchBase     string
+}
+```
+
+**Code:** `internal/config/continuation.go`
+
+## Migration from Legacy JSON
+
+Older repositories may have configuration in `.git/.stackit_config` (JSON format). Stackit automatically migrates this to git config on first access.
+
+### Migration Process
+
+1. Check if `.git/.stackit_config` exists and `stackit.trunk` is not set
+2. Read values from JSON file
+3. Write to git config with `stackit.*` keys
+4. Rename JSON file to `.stackit_config.migrated`
+
+**Code:** `internal/config/migrate.go`
+
+## Worktree Handling
+
+For git worktrees, configuration is stored in the main repository's `.git` directory, ensuring all worktrees share the same configuration:
+
+```go
+// internal/config/repo_config.go
+func resolveGitDir(repoRoot string) string {
+    // Uses: git rev-parse --git-common-dir
+    // Returns shared .git directory
+}
+```
+
+## CLI Commands
+
+```bash
+# Interactive configuration editor
+stackit config
+
+# List all configuration
+stackit config --list
+
+# Get a specific value
+stackit config get branch.pattern
+stackit config get submit.footer
+
+# Set a value
+stackit config set branch.pattern "{username}/{date}/{message}"
+stackit config set submit.footer false
+```
+
+**Code:** `internal/cli/config.go`
+
+## Adding New Configuration
+
+To add a new configuration key:
+
+1. Add the key constant to `internal/config/keys.go`
+2. Add getter/setter methods to `GitConfig` in `internal/config/config_git.go`
+3. If part of the interface, add to `Configurer` in `internal/config/interface.go`
+4. Update the CLI if it should be user-configurable via `stackit config`
+
+Example:
+
+```go
+// keys.go
+const KeyMyNewSetting = "stackit.my.newSetting"
+const DefaultMyNewSetting = "default-value"
+
+// config_git.go
+func (c *GitConfig) MyNewSetting() string {
+    if val := c.store.Get(KeyMyNewSetting); val != "" {
+        return val
+    }
+    return DefaultMyNewSetting
+}
+
+func (c *GitConfig) SetMyNewSetting(value string) error {
+    return c.store.Set(KeyMyNewSetting, value)
+}
+```
+
+## Design Principles
+
+1. **Layered configuration** - Personal git config > team project config > defaults
+2. **Git-native storage** - Uses git config for personal settings, enabling standard git tooling
+3. **Team consistency** - `.stackit.yaml` provides team-wide defaults
+4. **Typed access** - High-level API provides type safety over raw string keys
+5. **Sensible defaults** - All settings have defaults; missing keys don't error
+6. **Automatic migration** - Legacy formats upgraded transparently
+7. **Personal overrides** - Developers can override team settings without affecting others

--- a/internal/config/config_git.go
+++ b/internal/config/config_git.go
@@ -9,13 +9,16 @@ import (
 
 // GitConfig provides typed access to stackit configuration stored in git config.
 // This replaces the JSON-based config storage with native git config.
+// Configuration follows a layered system: personal git config > team project config > defaults.
 type GitConfig struct {
 	repoRoot string
 	store    *git.ConfigStore
+	project  *ProjectConfig // Team config from .stackit.yaml for fallback
 }
 
 // LoadGitConfig loads configuration from git config.
 // If JSON config exists and needs migration, it will be migrated automatically.
+// This function does NOT load project config (.stackit.yaml) - use LoadGitConfigWithProject for that.
 func LoadGitConfig(repoRoot string) (*GitConfig, error) {
 	store := git.NewConfigStore(repoRoot)
 
@@ -34,18 +37,43 @@ func LoadGitConfig(repoRoot string) (*GitConfig, error) {
 	return cfg, nil
 }
 
+// LoadGitConfigWithProject loads configuration from git config with project config fallback.
+// The layered system follows: personal git config > team project config (.stackit.yaml) > defaults.
+func LoadGitConfigWithProject(repoRoot string) (*GitConfig, error) {
+	cfg, err := LoadGitConfig(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load project config for fallback
+	project, err := LoadProjectConfig(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load project config: %w", err)
+	}
+
+	cfg.project = project
+	return cfg, nil
+}
+
 // IsInitialized checks if stackit has been initialized (trunk is set).
 func (c *GitConfig) IsInitialized() bool {
 	return c.store.Exists(KeyTrunk)
 }
 
 // Trunk returns the primary trunk branch name.
+// Priority: personal git config > team project config > default.
 func (c *GitConfig) Trunk() string {
+	// Check personal git config first
 	trunk, _ := c.store.Get(KeyTrunk)
-	if trunk == "" {
-		return DefaultTrunk
+	if trunk != "" {
+		return trunk
 	}
-	return trunk
+	// Fall back to team project config
+	if c.project != nil && c.project.HasTrunk() {
+		return c.project.Trunk
+	}
+	// Return default
+	return DefaultTrunk
 }
 
 // SetTrunk sets the primary trunk branch name.
@@ -54,13 +82,24 @@ func (c *GitConfig) SetTrunk(trunk string) error {
 }
 
 // AllTrunks returns all configured trunk branches (primary + additional).
+// Merges trunks from git config and project config (deduplicated).
 func (c *GitConfig) AllTrunks() []string {
 	trunks := []string{c.Trunk()}
 
+	// Add additional trunks from git config
 	additional, _ := c.store.GetAll(KeyTrunks)
 	for _, t := range additional {
 		if !slices.Contains(trunks, t) {
 			trunks = append(trunks, t)
+		}
+	}
+
+	// Add additional trunks from project config
+	if c.project != nil && c.project.HasTrunks() {
+		for _, t := range c.project.Trunks {
+			if !slices.Contains(trunks, t) {
+				trunks = append(trunks, t)
+			}
 		}
 	}
 
@@ -81,16 +120,24 @@ func (c *GitConfig) AddTrunk(trunk string) error {
 }
 
 // BranchNamePattern returns the branch name pattern.
+// Priority: personal git config > team project config > default.
 func (c *GitConfig) BranchNamePattern() string {
+	// Check personal git config first
 	pattern, _ := c.store.Get(KeyBranchPattern)
-	if pattern == "" {
-		return DefaultBranchPattern.String()
+	if pattern != "" {
+		// Validate
+		if _, err := NewBranchPattern(pattern); err != nil {
+			return DefaultBranchPattern.String()
+		}
+		return pattern
 	}
-	// Validate
-	if _, err := NewBranchPattern(pattern); err != nil {
-		return DefaultBranchPattern.String()
+	// Fall back to team project config
+	if c.project != nil && c.project.HasBranchPattern() {
+		// Already validated during LoadProjectConfig
+		return c.project.Branch.Pattern
 	}
-	return pattern
+	// Return default
+	return DefaultBranchPattern.String()
 }
 
 // SetBranchNamePattern sets the branch name pattern.
@@ -112,8 +159,18 @@ func (c *GitConfig) GetBranchPattern() BranchPattern {
 }
 
 // SubmitFooter returns whether to include PR footer.
+// Priority: personal git config > team project config > default.
 func (c *GitConfig) SubmitFooter() bool {
-	return c.store.GetBoolWithDefault(KeySubmitFooter, DefaultSubmitFooter)
+	// Check personal git config first
+	if c.store.Exists(KeySubmitFooter) {
+		return c.store.GetBoolWithDefault(KeySubmitFooter, DefaultSubmitFooter)
+	}
+	// Fall back to team project config
+	if c.project != nil && c.project.HasSubmitFooter() {
+		return c.project.GetSubmitFooter()
+	}
+	// Return default
+	return DefaultSubmitFooter
 }
 
 // SetSubmitFooter sets whether to include PR footer.
@@ -160,9 +217,19 @@ func (c *GitConfig) SetWorktreeAutoClean(enabled bool) error {
 }
 
 // MergeMethod returns the configured merge method (empty if not set).
+// Priority: personal git config > team project config > empty (not set).
 func (c *GitConfig) MergeMethod() string {
+	// Check personal git config first
 	method, _ := c.store.Get(KeyMergeMethod)
-	return method
+	if method != "" {
+		return method
+	}
+	// Fall back to team project config
+	if c.project != nil && c.project.HasMergeMethod() {
+		return c.project.Merge.Method
+	}
+	// Return empty (not set)
+	return ""
 }
 
 // SetMergeMethod sets the merge method preference.
@@ -174,9 +241,19 @@ func (c *GitConfig) SetMergeMethod(method string) error {
 }
 
 // CICommand returns the CI validation command.
+// Priority: personal git config > team project config > empty (not set).
 func (c *GitConfig) CICommand() string {
+	// Check personal git config first
 	cmd, _ := c.store.Get(KeyCICommand)
-	return cmd
+	if cmd != "" {
+		return cmd
+	}
+	// Fall back to team project config
+	if c.project != nil && c.project.HasCICommand() {
+		return c.project.CI.Command
+	}
+	// Return empty (not set)
+	return ""
 }
 
 // SetCICommand sets the CI validation command.
@@ -185,12 +262,22 @@ func (c *GitConfig) SetCICommand(cmd string) error {
 }
 
 // CITimeout returns the CI timeout in seconds.
+// Priority: personal git config > team project config > default.
 func (c *GitConfig) CITimeout() int {
-	timeout := c.store.GetIntWithDefault(KeyCITimeout, DefaultCITimeout)
-	if timeout < 1 {
-		return DefaultCITimeout
+	// Check personal git config first
+	if c.store.Exists(KeyCITimeout) {
+		timeout := c.store.GetIntWithDefault(KeyCITimeout, DefaultCITimeout)
+		if timeout < 1 {
+			return DefaultCITimeout
+		}
+		return timeout
 	}
-	return timeout
+	// Fall back to team project config
+	if c.project != nil && c.project.HasCITimeout() {
+		return c.project.CI.Timeout
+	}
+	// Return default
+	return DefaultCITimeout
 }
 
 // SetCITimeout sets the CI timeout in seconds.

--- a/internal/config/config_git_test.go
+++ b/internal/config/config_git_test.go
@@ -551,3 +551,227 @@ func TestGitConfigSaveNoop(t *testing.T) {
 		require.Equal(t, "main", cfg2.Trunk())
 	})
 }
+
+func TestGitConfigWithProjectFallback(t *testing.T) {
+	t.Parallel()
+
+	t.Run("trunk falls back to project config", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		removeDefaultConfig(t, scene.Dir)
+
+		// Create project config with trunk
+		projectConfig := "trunk: develop\n"
+		err := os.WriteFile(filepath.Join(scene.Dir, ProjectConfigFileName), []byte(projectConfig), 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadGitConfigWithProject(scene.Dir)
+		require.NoError(t, err)
+
+		// Should use project config value
+		require.Equal(t, "develop", cfg.Trunk())
+
+		// Set personal config
+		err = cfg.SetTrunk("personal-main")
+		require.NoError(t, err)
+
+		// Should now use personal config
+		require.Equal(t, "personal-main", cfg.Trunk())
+	})
+
+	t.Run("all trunks merges git and project config", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		removeDefaultConfig(t, scene.Dir)
+
+		// Create project config with trunks
+		projectConfig := `trunk: main
+trunks:
+  - staging
+  - production
+`
+		err := os.WriteFile(filepath.Join(scene.Dir, ProjectConfigFileName), []byte(projectConfig), 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadGitConfigWithProject(scene.Dir)
+		require.NoError(t, err)
+
+		// Should include trunk and project trunks
+		require.Equal(t, []string{"main", "staging", "production"}, cfg.AllTrunks())
+
+		// Add personal trunk
+		err = cfg.AddTrunk("develop")
+		require.NoError(t, err)
+
+		// Should include all trunks (deduplicated)
+		require.Equal(t, []string{"main", "develop", "staging", "production"}, cfg.AllTrunks())
+	})
+
+	t.Run("branch pattern falls back to project config", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		removeDefaultConfig(t, scene.Dir)
+
+		// Create project config with branch pattern
+		projectConfig := `branch:
+  pattern: "feature/{message}"
+`
+		err := os.WriteFile(filepath.Join(scene.Dir, ProjectConfigFileName), []byte(projectConfig), 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadGitConfigWithProject(scene.Dir)
+		require.NoError(t, err)
+
+		// Should use project config pattern
+		require.Equal(t, "feature/{message}", cfg.BranchNamePattern())
+
+		// Set personal pattern
+		err = cfg.SetBranchNamePattern("{username}/{message}")
+		require.NoError(t, err)
+
+		// Should now use personal pattern
+		require.Equal(t, "{username}/{message}", cfg.BranchNamePattern())
+	})
+
+	t.Run("submit footer falls back to project config", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		removeDefaultConfig(t, scene.Dir)
+
+		// Create project config with footer disabled
+		projectConfig := `submit:
+  footer: false
+`
+		err := os.WriteFile(filepath.Join(scene.Dir, ProjectConfigFileName), []byte(projectConfig), 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadGitConfigWithProject(scene.Dir)
+		require.NoError(t, err)
+
+		// Should use project config value
+		require.False(t, cfg.SubmitFooter())
+
+		// Set personal override
+		err = cfg.SetSubmitFooter(true)
+		require.NoError(t, err)
+
+		// Should now use personal config
+		require.True(t, cfg.SubmitFooter())
+	})
+
+	t.Run("merge method falls back to project config", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		removeDefaultConfig(t, scene.Dir)
+
+		// Create project config with merge method
+		projectConfig := `merge:
+  method: squash
+`
+		err := os.WriteFile(filepath.Join(scene.Dir, ProjectConfigFileName), []byte(projectConfig), 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadGitConfigWithProject(scene.Dir)
+		require.NoError(t, err)
+
+		// Should use project config value
+		require.Equal(t, "squash", cfg.MergeMethod())
+
+		// Set personal override
+		err = cfg.SetMergeMethod("rebase")
+		require.NoError(t, err)
+
+		// Should now use personal config
+		require.Equal(t, "rebase", cfg.MergeMethod())
+	})
+
+	t.Run("CI command falls back to project config", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		removeDefaultConfig(t, scene.Dir)
+
+		// Create project config with CI command
+		projectConfig := `ci:
+  command: "make test"
+`
+		err := os.WriteFile(filepath.Join(scene.Dir, ProjectConfigFileName), []byte(projectConfig), 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadGitConfigWithProject(scene.Dir)
+		require.NoError(t, err)
+
+		// Should use project config value
+		require.Equal(t, "make test", cfg.CICommand())
+
+		// Set personal override
+		err = cfg.SetCICommand("npm test")
+		require.NoError(t, err)
+
+		// Should now use personal config
+		require.Equal(t, "npm test", cfg.CICommand())
+	})
+
+	t.Run("CI timeout falls back to project config", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		removeDefaultConfig(t, scene.Dir)
+
+		// Create project config with CI timeout
+		projectConfig := `ci:
+  timeout: 300
+`
+		err := os.WriteFile(filepath.Join(scene.Dir, ProjectConfigFileName), []byte(projectConfig), 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadGitConfigWithProject(scene.Dir)
+		require.NoError(t, err)
+
+		// Should use project config value
+		require.Equal(t, 300, cfg.CITimeout())
+
+		// Set personal override
+		err = cfg.SetCITimeout(120)
+		require.NoError(t, err)
+
+		// Should now use personal config
+		require.Equal(t, 120, cfg.CITimeout())
+	})
+
+	t.Run("returns defaults when neither git nor project config set", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		removeDefaultConfig(t, scene.Dir)
+
+		// No project config
+		cfg, err := LoadGitConfigWithProject(scene.Dir)
+		require.NoError(t, err)
+
+		require.Equal(t, DefaultTrunk, cfg.Trunk())
+		require.Equal(t, DefaultBranchPattern.String(), cfg.BranchNamePattern())
+		require.Equal(t, DefaultSubmitFooter, cfg.SubmitFooter())
+		require.Equal(t, DefaultCITimeout, cfg.CITimeout())
+		require.Empty(t, cfg.MergeMethod())
+		require.Empty(t, cfg.CICommand())
+	})
+
+	t.Run("LoadConfig uses project fallback", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		removeDefaultConfig(t, scene.Dir)
+
+		// Create project config
+		projectConfig := `trunk: develop
+merge:
+  method: squash
+`
+		err := os.WriteFile(filepath.Join(scene.Dir, ProjectConfigFileName), []byte(projectConfig), 0600)
+		require.NoError(t, err)
+
+		// LoadConfig should use project fallback
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+
+		require.Equal(t, "develop", cfg.Trunk())
+		require.Equal(t, "squash", cfg.MergeMethod())
+	})
+}

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"gopkg.in/yaml.v3"
 )
@@ -11,10 +12,39 @@ import (
 // ProjectConfigFileName is the name of the project configuration file
 const ProjectConfigFileName = ".stackit.yaml"
 
+// BranchConfig contains branch naming configuration
+type BranchConfig struct {
+	Pattern string `yaml:"pattern,omitempty"`
+}
+
+// SubmitConfig contains PR submission configuration
+type SubmitConfig struct {
+	Footer *bool `yaml:"footer,omitempty"` // Pointer to distinguish unset from false
+}
+
+// MergeConfig contains merge method configuration
+type MergeConfig struct {
+	Method string `yaml:"method,omitempty"`
+}
+
+// CIConfig contains CI validation configuration
+type CIConfig struct {
+	Command string `yaml:"command,omitempty"`
+	Timeout int    `yaml:"timeout,omitempty"`
+}
+
 // ProjectConfig represents the project-level configuration stored in .stackit.yaml
 // This file is committed to the repository and shared across the team.
+// Team settings can be overridden by personal git config (git config > project config > defaults).
 type ProjectConfig struct {
-	Hooks HooksConfig `yaml:"hooks"`
+	Trunk  string   `yaml:"trunk,omitempty"`
+	Trunks []string `yaml:"trunks,omitempty"`
+
+	Branch BranchConfig `yaml:"branch,omitempty"`
+	Submit SubmitConfig `yaml:"submit,omitempty"`
+	Merge  MergeConfig  `yaml:"merge,omitempty"`
+	CI     CIConfig     `yaml:"ci,omitempty"`
+	Hooks  HooksConfig  `yaml:"hooks,omitempty"`
 }
 
 // HooksConfig contains hook configurations
@@ -42,10 +72,82 @@ func LoadProjectConfig(repoRoot string) (*ProjectConfig, error) {
 		return nil, fmt.Errorf("failed to parse %s: %w (content: %q)", ProjectConfigFileName, err, string(data))
 	}
 
+	// Validate the configuration
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
 	return &config, nil
 }
 
 // HasPostWorktreeCreateHooks returns true if there are any post-worktree-create hooks configured
 func (c *ProjectConfig) HasPostWorktreeCreateHooks() bool {
 	return len(c.Hooks.PostWorktreeCreate) > 0
+}
+
+// HasTrunk returns true if a trunk branch is configured
+func (c *ProjectConfig) HasTrunk() bool {
+	return c.Trunk != ""
+}
+
+// HasTrunks returns true if additional trunk branches are configured
+func (c *ProjectConfig) HasTrunks() bool {
+	return len(c.Trunks) > 0
+}
+
+// HasBranchPattern returns true if a branch naming pattern is configured
+func (c *ProjectConfig) HasBranchPattern() bool {
+	return c.Branch.Pattern != ""
+}
+
+// HasSubmitFooter returns true if the submit footer setting is configured
+func (c *ProjectConfig) HasSubmitFooter() bool {
+	return c.Submit.Footer != nil
+}
+
+// GetSubmitFooter returns the submit footer value (caller should check HasSubmitFooter first)
+func (c *ProjectConfig) GetSubmitFooter() bool {
+	if c.Submit.Footer == nil {
+		return true // Default
+	}
+	return *c.Submit.Footer
+}
+
+// HasMergeMethod returns true if a merge method is configured
+func (c *ProjectConfig) HasMergeMethod() bool {
+	return c.Merge.Method != ""
+}
+
+// HasCICommand returns true if a CI command is configured
+func (c *ProjectConfig) HasCICommand() bool {
+	return c.CI.Command != ""
+}
+
+// HasCITimeout returns true if a CI timeout is configured
+func (c *ProjectConfig) HasCITimeout() bool {
+	return c.CI.Timeout > 0
+}
+
+// Validate checks the configuration for invalid values
+func (c *ProjectConfig) Validate() error {
+	// Validate branch pattern if set
+	if c.HasBranchPattern() {
+		if _, err := NewBranchPattern(c.Branch.Pattern); err != nil {
+			return fmt.Errorf("invalid branch.pattern in %s: %w", ProjectConfigFileName, err)
+		}
+	}
+
+	// Validate merge method if set
+	if c.HasMergeMethod() {
+		if !slices.Contains(ValidMergeMethods, c.Merge.Method) {
+			return fmt.Errorf("invalid merge.method in %s: %q (must be one of %v)", ProjectConfigFileName, c.Merge.Method, ValidMergeMethods)
+		}
+	}
+
+	// Validate CI timeout if set
+	if c.CI.Timeout < 0 {
+		return fmt.Errorf("invalid ci.timeout in %s: must be >= 0", ProjectConfigFileName)
+	}
+
+	return nil
 }

--- a/internal/config/project_config_test.go
+++ b/internal/config/project_config_test.go
@@ -112,3 +112,207 @@ func TestHasPostWorktreeCreateHooks(t *testing.T) {
 		assert.False(t, cfg.HasPostWorktreeCreateHooks())
 	})
 }
+
+func TestLoadProjectConfigNewFields(t *testing.T) {
+	t.Run("loads config with all team settings", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		configContent := `trunk: develop
+trunks:
+  - staging
+  - production
+
+branch:
+  pattern: "feature/{message}"
+
+submit:
+  footer: false
+
+merge:
+  method: squash
+
+ci:
+  command: "make test"
+  timeout: 300
+
+hooks:
+  post-worktree-create:
+    - npm install
+`
+		err := os.WriteFile(filepath.Join(tmpDir, ProjectConfigFileName), []byte(configContent), 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadProjectConfig(tmpDir)
+		require.NoError(t, err)
+
+		assert.Equal(t, "develop", cfg.Trunk)
+		assert.Equal(t, []string{"staging", "production"}, cfg.Trunks)
+		assert.Equal(t, "feature/{message}", cfg.Branch.Pattern)
+		assert.False(t, cfg.GetSubmitFooter())
+		assert.Equal(t, "squash", cfg.Merge.Method)
+		assert.Equal(t, "make test", cfg.CI.Command)
+		assert.Equal(t, 300, cfg.CI.Timeout)
+		assert.Equal(t, []string{"npm install"}, cfg.Hooks.PostWorktreeCreate)
+	})
+
+	t.Run("loads partial config", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		configContent := `trunk: main
+merge:
+  method: rebase
+`
+		err := os.WriteFile(filepath.Join(tmpDir, ProjectConfigFileName), []byte(configContent), 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadProjectConfig(tmpDir)
+		require.NoError(t, err)
+
+		assert.Equal(t, "main", cfg.Trunk)
+		assert.Empty(t, cfg.Trunks)
+		assert.Empty(t, cfg.Branch.Pattern)
+		assert.Nil(t, cfg.Submit.Footer)
+		assert.Equal(t, "rebase", cfg.Merge.Method)
+		assert.Empty(t, cfg.CI.Command)
+		assert.Zero(t, cfg.CI.Timeout)
+	})
+}
+
+func TestProjectConfigHelpers(t *testing.T) {
+	t.Run("HasTrunk", func(t *testing.T) {
+		cfg := &ProjectConfig{}
+		assert.False(t, cfg.HasTrunk())
+
+		cfg.Trunk = "main"
+		assert.True(t, cfg.HasTrunk())
+	})
+
+	t.Run("HasTrunks", func(t *testing.T) {
+		cfg := &ProjectConfig{}
+		assert.False(t, cfg.HasTrunks())
+
+		cfg.Trunks = []string{"staging"}
+		assert.True(t, cfg.HasTrunks())
+	})
+
+	t.Run("HasBranchPattern", func(t *testing.T) {
+		cfg := &ProjectConfig{}
+		assert.False(t, cfg.HasBranchPattern())
+
+		cfg.Branch.Pattern = "feature/{message}"
+		assert.True(t, cfg.HasBranchPattern())
+	})
+
+	t.Run("HasSubmitFooter and GetSubmitFooter", func(t *testing.T) {
+		cfg := &ProjectConfig{}
+		assert.False(t, cfg.HasSubmitFooter())
+		assert.True(t, cfg.GetSubmitFooter()) // Default is true
+
+		footer := true
+		cfg.Submit.Footer = &footer
+		assert.True(t, cfg.HasSubmitFooter())
+		assert.True(t, cfg.GetSubmitFooter())
+
+		footer = false
+		cfg.Submit.Footer = &footer
+		assert.True(t, cfg.HasSubmitFooter())
+		assert.False(t, cfg.GetSubmitFooter())
+	})
+
+	t.Run("HasMergeMethod", func(t *testing.T) {
+		cfg := &ProjectConfig{}
+		assert.False(t, cfg.HasMergeMethod())
+
+		cfg.Merge.Method = "squash"
+		assert.True(t, cfg.HasMergeMethod())
+	})
+
+	t.Run("HasCICommand", func(t *testing.T) {
+		cfg := &ProjectConfig{}
+		assert.False(t, cfg.HasCICommand())
+
+		cfg.CI.Command = "make test"
+		assert.True(t, cfg.HasCICommand())
+	})
+
+	t.Run("HasCITimeout", func(t *testing.T) {
+		cfg := &ProjectConfig{}
+		assert.False(t, cfg.HasCITimeout())
+
+		cfg.CI.Timeout = 300
+		assert.True(t, cfg.HasCITimeout())
+	})
+}
+
+func TestProjectConfigValidation(t *testing.T) {
+	t.Run("rejects invalid branch pattern", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Pattern without {slug} or {message} is invalid
+		configContent := `branch:
+  pattern: "feature/"
+`
+		err := os.WriteFile(filepath.Join(tmpDir, ProjectConfigFileName), []byte(configContent), 0600)
+		require.NoError(t, err)
+
+		_, err = LoadProjectConfig(tmpDir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid branch.pattern")
+	})
+
+	t.Run("rejects invalid merge method", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		configContent := `merge:
+  method: invalid
+`
+		err := os.WriteFile(filepath.Join(tmpDir, ProjectConfigFileName), []byte(configContent), 0600)
+		require.NoError(t, err)
+
+		_, err = LoadProjectConfig(tmpDir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid merge.method")
+	})
+
+	t.Run("rejects negative CI timeout", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		configContent := `ci:
+  timeout: -1
+`
+		err := os.WriteFile(filepath.Join(tmpDir, ProjectConfigFileName), []byte(configContent), 0600)
+		require.NoError(t, err)
+
+		_, err = LoadProjectConfig(tmpDir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid ci.timeout")
+	})
+
+	t.Run("accepts valid merge methods", func(t *testing.T) {
+		for _, method := range []string{"squash", "merge", "rebase"} {
+			tmpDir := t.TempDir()
+
+			configContent := "merge:\n  method: " + method + "\n"
+			err := os.WriteFile(filepath.Join(tmpDir, ProjectConfigFileName), []byte(configContent), 0600)
+			require.NoError(t, err)
+
+			cfg, err := LoadProjectConfig(tmpDir)
+			require.NoError(t, err)
+			assert.Equal(t, method, cfg.Merge.Method)
+		}
+	})
+
+	t.Run("accepts valid branch pattern", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		configContent := `branch:
+  pattern: "feature/{message}"
+`
+		err := os.WriteFile(filepath.Join(tmpDir, ProjectConfigFileName), []byte(configContent), 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadProjectConfig(tmpDir)
+		require.NoError(t, err)
+		assert.Equal(t, "feature/{message}", cfg.Branch.Pattern)
+	})
+}

--- a/internal/config/repo_config.go
+++ b/internal/config/repo_config.go
@@ -32,10 +32,11 @@ func resolveGitDir(repoRoot string) string {
 }
 
 // LoadConfig loads the repository configuration.
-// This function delegates to LoadGitConfig for the new git-based config storage.
+// This function delegates to LoadGitConfigWithProject for git-based config storage
+// with project config (.stackit.yaml) fallback support.
 // It automatically migrates any existing JSON config to git config.
 func LoadConfig(repoRoot string) (*GitConfig, error) {
-	return LoadGitConfig(repoRoot)
+	return LoadGitConfigWithProject(repoRoot)
 }
 
 // RepoConfig represents the legacy JSON-based repository configuration.


### PR DESCRIPTION

Extend .stackit.yaml to support team-configurable settings with personal
git config overrides. Settings follow priority: personal > team > defaults.

- Add team settings: trunk, trunks, branch.pattern, submit.footer,
  merge.method, ci.command, ci.timeout
- Implement fallback system in GitConfig getters
- Add validation for project config values
- Maintain backwards compatibility with existing git config
- Add comprehensive test coverage for layered behavior


<!-- STACKIT-SECTION-START -->
#### Stack



This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #584 by jonnii*