### PR TITLE
feat: improve submit TUI with progress bar and sequential mode notice

### DIFF
--- a/internal/actions/submit/events.go
+++ b/internal/actions/submit/events.go
@@ -47,7 +47,8 @@ func (BranchPlanEvent) submitEvent() {}
 
 // SubmissionStartEvent indicates the submission phase is beginning.
 type SubmissionStartEvent struct {
-	Branches []BranchInfo
+	Branches     []BranchInfo
+	IsSequential bool // Sequential submission mode (all creates) for PR ordering
 }
 
 func (SubmissionStartEvent) submitEvent() {}

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -205,8 +205,18 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		}
 	}
 
+	// Check if this is a new stack (all creates) - use sequential submission
+	// to ensure PRs get sequential numbers in GitHub
+	allCreates := true
+	for _, info := range submissionInfos {
+		if info.Action != actionCreate {
+			allCreates = false
+			break
+		}
+	}
+
 	// Start submission phase with a worker pool to avoid spawning too many goroutines
-	handler.OnEvent(SubmissionStartEvent{Branches: branchInfos})
+	handler.OnEvent(SubmissionStartEvent{Branches: branchInfos, IsSequential: allCreates})
 
 	githubClient, err := getGitHubClient(ctx)
 	if err != nil {
@@ -219,16 +229,6 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	var errMu sync.Mutex
 
 	if len(submissionInfos) > 0 {
-		// Check if this is a new stack (all creates) - use sequential submission
-		// to ensure PRs get sequential numbers in GitHub
-		allCreates := true
-		for _, info := range submissionInfos {
-			if info.Action != actionCreate {
-				allCreates = false
-				break
-			}
-		}
-
 		if allCreates {
 			// Sequential submission for new stacks - ensures sequential PR numbers
 			for _, info := range submissionInfos {

--- a/internal/cli/stack/submit.go
+++ b/internal/cli/stack/submit.go
@@ -427,6 +427,11 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 			}
 		}
 
+		// Set sequential mode if all PRs are being created (preserves PR number ordering)
+		if ev.IsSequential {
+			h.runner.Send(submitComponent.SetSequentialMsg{IsSequential: true})
+		}
+
 		h.runner.Send(submitComponent.GlobalMessageMsg("Submitting..."))
 
 	case submit.BranchProgressEvent:

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -22,6 +22,7 @@ type Model struct {
 	spinner        spinner.Model // lowercase for custom style
 	Styles         Styles
 	GlobalMessage  string
+	IsSequential   bool // Sequential submission mode for PR ordering
 }
 
 // ProgressUpdateMsg is sent to update the status of a specific branch submission
@@ -51,6 +52,11 @@ type GlobalMessageMsg string
 
 // ProgressCompleteMsg is sent when all submissions are finished
 type ProgressCompleteMsg struct{}
+
+// SetSequentialMsg indicates sequential submission mode for PR ordering
+type SetSequentialMsg struct {
+	IsSequential bool
+}
 
 // NewModel creates a new submit model
 func NewModel(items []Item) *Model {
@@ -87,6 +93,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg := msg.(type) {
+	case SetSequentialMsg:
+		m.IsSequential = msg.IsSequential
+		return m, nil
+
 	case StartSubmitMsg:
 		// Update status for items that are in msg.Items
 		for _, newItem := range msg.Items {
@@ -161,6 +171,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m *Model) View() string {
 	var b strings.Builder
 
+	// Show sequential mode notice if applicable
+	if m.IsSequential && m.hasActiveSubmission() {
+		b.WriteString(m.Styles.DimStyle.Render("Creating PRs sequentially to preserve ordering..."))
+		b.WriteString("\n\n")
+	}
+
 	if m.Renderer != nil {
 		// Update annotations based on items
 		for _, item := range m.Items {
@@ -228,7 +244,7 @@ func (m *Model) View() string {
 			case StatusSubmitting:
 				icon = m.spinner.View()
 				action := "Creating"
-				if item.Action == "update" {
+				if item.Action == ActionUpdate {
 					action = "Updating"
 				}
 				status = m.Styles.SpinnerStyle.Render(action + "...")
@@ -264,9 +280,10 @@ func (m *Model) View() string {
 		completed := 0
 		failed := 0
 		for _, item := range m.Items {
-			if item.Status == StatusDone {
+			switch item.Status {
+			case StatusDone:
 				completed++
-			} else if item.Status == StatusError {
+			case StatusError:
 				failed++
 			}
 		}
@@ -278,4 +295,14 @@ func (m *Model) View() string {
 
 	b.WriteString("\n")
 	return b.String()
+}
+
+// hasActiveSubmission returns true if any item is currently being submitted
+func (m *Model) hasActiveSubmission() bool {
+	for _, item := range m.Items {
+		if item.Status == StatusSubmitting || item.Status == StatusSyncing {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/tui/components/submit/submit.go
+++ b/internal/tui/components/submit/submit.go
@@ -58,4 +58,6 @@ const (
 	StatusPending = "pending"
 	// SkipReasonNoChanges indicates the branch was skipped because it has no changes
 	SkipReasonNoChanges = "no changes"
+	// ActionUpdate indicates the branch will update an existing PR
+	ActionUpdate = "update"
 )


### PR DESCRIPTION

- Add progress bar showing submission progress (e.g., "2/5 branches")
- Use tea.Printf to print completed branches above TUI
- Show "Creating PRs sequentially..." notice for new stacks
- Switch to compact progress view during submission phase
- Print completion summary with error counts