### PR TITLE
fix: prevent intermittent worktree test failures by pruning stale entries

### DIFF
--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -437,6 +437,10 @@ func (d *demoGitRunner) ListWorktrees(_ context.Context) ([]string, error) {
 	return []string{}, nil
 }
 
+func (d *demoGitRunner) PruneWorktrees(_ context.Context) error {
+	return nil
+}
+
 func (d *demoGitRunner) GetWorktreePathForBranch(_ context.Context, _ string) (string, error) {
 	return "", nil
 }

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -723,6 +723,11 @@ func (e *engineImpl) CreateTemporaryWorktree(ctx context.Context, branch string,
 // If shallow is true, uses --no-checkout to create a worktree without checking out files to the working tree.
 // This is faster for validation-only operations that don't need actual files.
 func (e *engineImpl) CreateTemporaryWorktreeWithOptions(ctx context.Context, branch string, prefix string, shallow bool) (string, func(), error) {
+	// Prune stale worktree entries before creating new ones.
+	// This cleans up entries in .git/worktrees/ that may be left behind from
+	// incomplete cleanup after failed or canceled operations.
+	_ = e.git.PruneWorktrees(ctx)
+
 	tmpDir, err := os.MkdirTemp("", prefix)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to create temporary directory: %w", err)

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -182,6 +182,7 @@ type WorktreeOperations interface {
 	AddWorktreeWithOptions(ctx context.Context, path string, branch string, detach bool, noCheckout bool) error
 	RemoveWorktree(ctx context.Context, path string) error
 	ListWorktrees(ctx context.Context) ([]string, error)
+	PruneWorktrees(ctx context.Context) error
 	GetWorktreePathForBranch(ctx context.Context, branchName string) (string, error)
 	GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error)
 	ResetWorktreeWorkingDir(ctx context.Context, worktreePath string) error

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -73,6 +73,17 @@ func (r *runner) ListWorktrees(ctx context.Context) ([]string, error) {
 	return worktrees, nil
 }
 
+// PruneWorktrees removes stale worktree entries from .git/worktrees.
+// This cleans up worktree information for worktrees whose working directory
+// has been deleted or is otherwise unavailable.
+func (r *runner) PruneWorktrees(ctx context.Context) error {
+	_, err := r.RunGitCommandWithContext(ctx, "worktree", "prune")
+	if err != nil {
+		return fmt.Errorf("failed to prune worktrees: %w", err)
+	}
+	return nil
+}
+
 // ReadWorktreeMeta reads worktree metadata for a stack root from local git refs
 func (r *runner) ReadWorktreeMeta(stackRoot string) (*WorktreeMeta, error) {
 	refName := fmt.Sprintf("%s%s", WorktreeRefPrefix, stackRoot)


### PR DESCRIPTION

Add PruneWorktrees method to clean up stale .git/worktrees entries before
creating new temporary worktrees, preventing 'failed to read commondir'
errors in validation operations.