### PR TITLE
feat: change merge commands to use fire-and-forget as default

### DIFF
--- a/internal/actions/merge/consolidate.go
+++ b/internal/actions/merge/consolidate.go
@@ -102,8 +102,19 @@ func (c *ConsolidateMergeExecutor) Execute(ctx context.Context, opts ExecuteOpti
 
 		splog.Info("🎉 Stack consolidation merge completed successfully!")
 	} else {
-		splog.Info("🎉 Consolidation PR created: %s", pr.HTMLURL)
-		splog.Info("   Individual PRs have been locked. Merge the consolidation PR manually to complete.")
+		// Fire-and-forget: enable auto-merge and return
+		mergeMethod, err := GetMergeMethod(c.ctx, c.ctx.GitHubClient)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get merge method: %w", err)
+		}
+		if err := github.EnableAutoMerge(ctx, c.engine.Git(), pr.NodeID, mergeMethod); err != nil {
+			splog.Warn("Could not enable automerge: %v", err)
+			splog.Tip("Enable automerge manually on the PR: %s", pr.HTMLURL)
+		} else {
+			splog.Success("Automerge enabled on PR #%d", pr.Number)
+		}
+		splog.Info("Individual PRs have been locked. The consolidation PR will merge when CI passes.")
+		splog.Tip("Run 'stackit sync --restack' after the PR merges to update your stack.")
 	}
 
 	result := &ConsolidationResult{

--- a/internal/cli/stack/merge/handlers.go
+++ b/internal/cli/stack/merge/handlers.go
@@ -398,8 +398,8 @@ func (h *InteractiveMergeEventHandler) PromptStrategy(plan *mergeAction.Plan, re
 		strategy = mergeAction.StrategyBottomUp
 	case "squash":
 		strategy = mergeAction.StrategySquash
-		// Prompt for wait if squashing
-		wait, err = tui.PromptConfirm("Wait for CI and automatically merge the squash PR?", false)
+		// Prompt for wait if squashing (default is fire-and-forget)
+		wait, err = tui.PromptConfirm("Wait for merge to complete? (default: fire-and-forget)", false)
 		if err != nil {
 			return mergeAction.StrategyChoice{}, fmt.Errorf("wait selection canceled: %w", err)
 		}

--- a/internal/cli/stack/merge/merge.go
+++ b/internal/cli/stack/merge/merge.go
@@ -22,7 +22,7 @@ func NewMergeCmd(postMergeHandler PostMergeHandler) *cobra.Command {
 	var (
 		dryRun bool
 		force  bool
-		noWait bool
+		wait   bool
 	)
 
 	cmd := &cobra.Command{
@@ -63,7 +63,7 @@ Examples:
 				err := mergeAction.RunWizard(ctx, interactiveHandler, mergeAction.WizardOptions{
 					DryRun: dryRun,
 					Force:  force,
-					Wait:   !noWait,
+					Wait:   wait,
 				})
 
 				// Handle post-merge follow-up action
@@ -81,7 +81,7 @@ Examples:
 
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show merge plan without executing")
 	cmd.Flags().BoolVar(&force, "force", false, "Skip validation checks (draft PRs, failing CI)")
-	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Don't wait for merge, return after enabling automerge")
+	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for merge to complete (default: fire-and-forget)")
 
 	// Add subcommands
 	cmd.AddCommand(NewNextCmd(postMergeHandler))

--- a/internal/cli/stack/merge/merge_test.go
+++ b/internal/cli/stack/merge/merge_test.go
@@ -40,8 +40,8 @@ func TestNewMergeCmd(t *testing.T) {
 		forceFlag := cmd.Flags().Lookup("force")
 		require.NotNil(t, forceFlag)
 
-		noWaitFlag := cmd.Flags().Lookup("no-wait")
-		require.NotNil(t, noWaitFlag)
+		waitFlag := cmd.Flags().Lookup("wait")
+		require.NotNil(t, waitFlag)
 	})
 }
 
@@ -60,8 +60,8 @@ func TestNewNextCmd(t *testing.T) {
 		forceFlag := cmd.Flags().Lookup("force")
 		require.NotNil(t, forceFlag)
 
-		noWaitFlag := cmd.Flags().Lookup("no-wait")
-		require.NotNil(t, noWaitFlag)
+		waitFlag := cmd.Flags().Lookup("wait")
+		require.NotNil(t, waitFlag)
 	})
 }
 
@@ -80,8 +80,8 @@ func TestNewSquashCmd(t *testing.T) {
 		forceFlag := cmd.Flags().Lookup("force")
 		require.NotNil(t, forceFlag)
 
-		noWaitFlag := cmd.Flags().Lookup("no-wait")
-		require.NotNil(t, noWaitFlag)
+		waitFlag := cmd.Flags().Lookup("wait")
+		require.NotNil(t, waitFlag)
 
 		scopeFlag := cmd.Flags().Lookup("scope")
 		require.NotNil(t, scopeFlag)

--- a/internal/cli/stack/merge/next.go
+++ b/internal/cli/stack/merge/next.go
@@ -32,7 +32,7 @@ func NewNextCmd(postMergeHandler PostMergeHandler) *cobra.Command {
 		dryRun bool
 		yes    bool
 		force  bool
-		noWait bool
+		wait   bool
 		method string
 	)
 
@@ -41,13 +41,12 @@ func NewNextCmd(postMergeHandler PostMergeHandler) *cobra.Command {
 		Short: "Merge the next (bottom-most) unmerged PR in the stack",
 		Long: `Merge the bottom-most unmerged PR in the stack using GitHub automerge.
 
-After the PR is merged, the command will:
+After enabling automerge, the command returns immediately (fire-and-forget).
+
+Use --wait to block until the PR is merged, then automatically:
 1. Pull the latest trunk
 2. Restack the remaining branches in the stack
-3. Stop (run again to merge the next PR)
-
-By default, the command waits for the PR to be merged. Use --no-wait to return
-immediately after enabling automerge.`,
+3. Stop (run again to merge the next PR)`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
@@ -55,7 +54,7 @@ immediately after enabling automerge.`,
 					dryRun: dryRun,
 					yes:    yes,
 					force:  force,
-					noWait: noWait,
+					wait:   wait,
 					method: method,
 				}, postMergeHandler)
 			})
@@ -65,7 +64,7 @@ immediately after enabling automerge.`,
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show merge plan without executing")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVar(&force, "force", false, "Skip validation checks (draft PRs, failing CI)")
-	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Don't wait for merge, return after enabling automerge")
+	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for merge to complete (default: fire-and-forget)")
 	cmd.Flags().StringVar(&method, "method", "", "Merge method (squash, merge, rebase). Uses config merge.method if not specified")
 
 	return cmd
@@ -75,7 +74,7 @@ type mergeNextOptions struct {
 	dryRun bool
 	yes    bool
 	force  bool
-	noWait bool
+	wait   bool
 	method string
 }
 
@@ -181,31 +180,31 @@ func runMergeNext(ctx *app.Context, opts mergeNextOptions, postMergeHandler Post
 	}
 	out.Success("Automerge enabled on PR #%d", bottomPR.PRNumber)
 
-	// If --no-wait, return immediately
-	if opts.noWait {
-		out.Info("PR will be merged automatically when CI passes and requirements are met.")
-		out.Tip("Run 'stackit sync --restack' after the PR is merged to update your stack.")
-		return nil
+	// If --wait, wait for merge and perform cleanup
+	if opts.wait {
+		out.Info("Waiting for PR #%d to be merged...", bottomPR.PRNumber)
+		if err := github.WaitForPRMerge(ctx.Context, eng.Git(), prInfo.NodeID, DefaultMergeTimeout, DefaultMergePollInterval); err != nil {
+			return fmt.Errorf("failed waiting for merge: %w", err)
+		}
+		out.Success("PR #%d merged successfully!", bottomPR.PRNumber)
+
+		// Perform post-merge cleanup
+		out.Newline()
+		out.Info("Performing post-merge cleanup...")
+
+		// Use post-merge handler for cleanup (checkout trunk, sync, restack)
+		if postMergeHandler != nil {
+			return postMergeHandler(ctx, mergeAction.PostMergeSyncTrunk)
+		}
+
+		// Fallback: manual cleanup if no handler
+		return performPostMergeCleanup(ctx, bottomPR.BranchName, upstackBranches)
 	}
 
-	// Wait for merge
-	out.Info("Waiting for PR #%d to be merged...", bottomPR.PRNumber)
-	if err := github.WaitForPRMerge(ctx.Context, eng.Git(), prInfo.NodeID, DefaultMergeTimeout, DefaultMergePollInterval); err != nil {
-		return fmt.Errorf("failed waiting for merge: %w", err)
-	}
-	out.Success("PR #%d merged successfully!", bottomPR.PRNumber)
-
-	// Perform post-merge cleanup
-	out.Newline()
-	out.Info("Performing post-merge cleanup...")
-
-	// Use post-merge handler for cleanup (checkout trunk, sync, restack)
-	if postMergeHandler != nil {
-		return postMergeHandler(ctx, mergeAction.PostMergeSyncTrunk)
-	}
-
-	// Fallback: manual cleanup if no handler
-	return performPostMergeCleanup(ctx, bottomPR.BranchName, upstackBranches)
+	// Fire-and-forget: return immediately after enabling automerge
+	out.Info("PR will be merged automatically when CI passes and requirements are met.")
+	out.Tip("Run 'stackit sync --restack' after the PR is merged to update your stack.")
+	return nil
 }
 
 // findBottomUnmergedPR finds the bottom-most unmerged PR in the current stack.

--- a/internal/cli/stack/merge/squash.go
+++ b/internal/cli/stack/merge/squash.go
@@ -23,7 +23,7 @@ func NewSquashCmd(postMergeHandler PostMergeHandler) *cobra.Command {
 		dryRun      bool
 		yes         bool
 		force       bool
-		noWait      bool
+		wait        bool
 		scope       string
 		stacks      []string
 		skipLocalCI bool
@@ -35,15 +35,13 @@ func NewSquashCmd(postMergeHandler PostMergeHandler) *cobra.Command {
 		Long: `Consolidate all branches in the stack into a single PR for atomic merging.
 
 This creates a new "consolidation" branch that contains all the commits from the stack,
-opens a PR for it, and uses GitHub's automerge to merge it when ready.
+opens a PR for it, and enables GitHub's automerge.
 
-After the PR is merged, the command will:
+By default, the command returns immediately after enabling automerge (fire-and-forget).
+Use --wait to block until the PR is merged, then automatically:
 1. Pull the latest trunk
 2. Delete the merged branches
 3. Restack any remaining upstack branches
-
-By default, the command waits for the PR to be merged. Use --no-wait to return
-immediately after enabling automerge.
 
 Use --scope to consolidate all branches within a specific scope.
 Use --stacks to combine multiple independent stacks into a single PR.`,
@@ -55,7 +53,7 @@ Use --stacks to combine multiple independent stacks into a single PR.`,
 					return runMultiStackSquash(ctx, squashMultiStackOptions{
 						stacks:      stacks,
 						skipLocalCI: skipLocalCI,
-						noWait:      noWait,
+						wait:        wait,
 						yes:         yes,
 					})
 				}
@@ -64,7 +62,7 @@ Use --stacks to combine multiple independent stacks into a single PR.`,
 					dryRun: dryRun,
 					yes:    yes,
 					force:  force,
-					noWait: noWait,
+					wait:   wait,
 					scope:  scope,
 				}, postMergeHandler)
 			})
@@ -74,7 +72,7 @@ Use --stacks to combine multiple independent stacks into a single PR.`,
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show merge plan without executing")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVar(&force, "force", false, "Skip validation checks (draft PRs, failing CI)")
-	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Don't wait for merge, return after enabling automerge")
+	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for merge to complete (default: fire-and-forget)")
 	cmd.Flags().StringVar(&scope, "scope", "", "Consolidate all branches within the specified scope")
 	cmd.Flags().StringSliceVar(&stacks, "stacks", nil, "Combine multiple stacks (comma-separated stack roots)")
 	cmd.Flags().BoolVar(&skipLocalCI, "skip-local-ci", false, "Skip local CI validation for multi-stack merge")
@@ -86,14 +84,14 @@ type mergeSquashOptions struct {
 	dryRun bool
 	yes    bool
 	force  bool
-	noWait bool
+	wait   bool
 	scope  string
 }
 
 type squashMultiStackOptions struct {
 	stacks      []string
 	skipLocalCI bool
-	noWait      bool
+	wait        bool
 	yes         bool
 }
 
@@ -105,7 +103,7 @@ func runMergeSquash(ctx *app.Context, opts mergeSquashOptions, postMergeHandler 
 		Strategy: mergeAction.StrategySquash,
 		Force:    opts.force,
 		Scope:    opts.scope,
-		Wait:     !opts.noWait,
+		Wait:     opts.wait,
 	})
 	if err != nil {
 		return err
@@ -154,7 +152,7 @@ func runMergeSquash(ctx *app.Context, opts mergeSquashOptions, postMergeHandler 
 		Confirm:        false, // Already confirmed
 		Strategy:       mergeAction.StrategySquash,
 		Force:          opts.force,
-		Wait:           !opts.noWait,
+		Wait:           opts.wait,
 		Scope:          opts.scope,
 		Plan:           plan,
 		UndoStackDepth: undoStackDepth,
@@ -166,7 +164,7 @@ func runMergeSquash(ctx *app.Context, opts mergeSquashOptions, postMergeHandler 
 	}
 
 	// If waiting, use post-merge handler for cleanup
-	if !opts.noWait && postMergeHandler != nil {
+	if opts.wait && postMergeHandler != nil {
 		return postMergeHandler(ctx, mergeAction.PostMergeSyncTrunk)
 	}
 
@@ -225,7 +223,7 @@ func runMultiStackSquash(ctx *app.Context, opts squashMultiStackOptions) error {
 	result, err := mergeAction.ExecuteMultiStack(ctx, mergeAction.MultiStackOptions{
 		SelectedStacks: opts.stacks,
 		SkipLocalCI:    opts.skipLocalCI,
-		Wait:           !opts.noWait,
+		Wait:           opts.wait,
 	})
 	if err != nil {
 		return err
@@ -240,8 +238,8 @@ func runMultiStackSquash(ctx *app.Context, opts squashMultiStackOptions) error {
 		out.Warn("  Excluded: %d stacks", len(result.ExcludedStacks))
 	}
 
-	// If --no-wait was used, enable automerge and return immediately
-	if opts.noWait {
+	// Fire-and-forget (default): enable automerge and return immediately
+	if !opts.wait {
 		prNodeID, err := getPRNodeID(ctx, result.PRNumber)
 		if err != nil {
 			out.Warn("Could not enable automerge: %v", err)
@@ -257,7 +255,7 @@ func runMultiStackSquash(ctx *app.Context, opts squashMultiStackOptions) error {
 		out.Newline()
 		out.Tip("Run 'stackit sync --restack' after the PR is merged to update your stack.")
 	}
-	// When Wait=true (default), ExecuteMultiStack already waits for CI and merges the PR
+	// When Wait=true (opt-in), ExecuteMultiStack already waited for CI and merged the PR
 
 	return nil
 }

--- a/internal/integration/merge_subcommands_test.go
+++ b/internal/integration/merge_subcommands_test.go
@@ -235,7 +235,7 @@ func TestMergeCommand(t *testing.T) {
 
 		sh.OutputContains("bottom-most").
 			OutputContains("--dry-run").
-			OutputContains("--no-wait")
+			OutputContains("--wait")
 	})
 
 	t.Run("squash subcommand is accessible", func(t *testing.T) {


### PR DESCRIPTION

Changes --no-wait flag to --wait and inverts the default behavior.
Fire-and-forget (auto-merge enabled, return immediately) is now the default.
Use --wait flag to opt into waiting for merge completion.