### PR TITLE
feat: optimize command templates with model tiers and parallel review

### DIFF
--- a/internal/cli/integrations/agents/templates/commands/stack-absorb.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-absorb.md
@@ -143,6 +143,14 @@ $ command stackit foreach --stack "<build-command>"
 All branches pass!
 ```
 
+## Tool Trust
+
+Trust all tools work without error. Don't run exploratory commands to verify tool behavior.
+
+## Confidence Threshold
+
+Only apply fixes you're 90%+ confident about. When sourcing fixes from unabsorbable hunks or absorbed code, verify the fix matches the error before applying. Better to ask than to introduce new bugs.
+
 ## Do NOT
 - Skip the JSON analysis (it tells you where to find fixes)
 - Apply fixes to multiple branches manually (fix at source, restack propagates)

--- a/internal/cli/integrations/agents/templates/commands/stack-create.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-create.md
@@ -1,35 +1,13 @@
 ---
-description: Create a new stacked branch with intelligent naming
+description: Create a new stacked branch with commit
 model: claude-sonnet-4-20250514
-allowed-tools: Bash(stackit:*), Bash(git:*), Read, AskUserQuestion, Skill
+allowed-tools: Bash(stackit:*), Bash(git:*), AskUserQuestion, Skill
 argument-hint: [-m "message"] [branch-name]
 ---
 
 # Stack Create
 
-Create a new stacked branch on top of the current branch.
-
-## CRITICAL: Required Workflow
-
-**`command stackit create` requires staged changes.** It creates a branch AND commits staged changes in one atomic operation.
-
-```bash
-# CORRECT workflow:
-git add -A                                    # 1. Stage changes FIRST
-echo "message" | command stackit create --no-interactive  # 2. Then create
-
-# WRONG - NEVER do this:
-command stackit create -m "..."   # Creates empty branch!
-git commit -m "..."       # BYPASSES stackit - FORBIDDEN!
-```
-
-## FORBIDDEN Commands
-
-When creating new stacked branches, NEVER use:
-- `git commit` - Always use `command stackit create` instead
-- `git checkout -b` - Use `command stackit create` which handles both
-
-## Context (pre-staging)
+## Context
 - Current branch: !`git branch --show-current`
 - Unstaged changes: !`git diff --stat 2>&1 | head -20`
 - Staged changes: !`git diff --cached --stat 2>&1 | head -20`
@@ -38,97 +16,35 @@ When creating new stacked branches, NEVER use:
 ## Arguments
 $ARGUMENTS
 
-## Instructions
+## Task
 
-### Step 1: Ensure Changes Are Staged
+Create a new stacked branch with the current changes.
 
-**If staged changes already exist:** Skip to Step 2.
+**Critical:** `stackit create` requires staged changes. It creates a branch AND commits in one atomic operation.
 
-**If only unstaged changes exist:** Auto-stage all changes:
-```bash
-git add --all
-```
+1. If no staged changes, run `git add --all` first
+2. If no changes at all (staged or unstaged), inform user and stop
+3. **If changes span multiple unrelated concerns** (different features, mixed refactoring + features, many directories with different purposes), use `AskUserQuestion`:
+   - Header: "Large changes"
+   - Question: "These changes span multiple areas. How would you like to proceed?"
+   - Options:
+     - "Use /stack-plan (Recommended)" → Stop and tell user to run `/stack-plan`
+     - "Single commit" → Proceed with one commit
+     - "Let me describe" → Wait for user to provide message
+4. If user provided `-m "message"`, use that message
+5. Otherwise, generate a commit message matching the project's style (see recent commits)
+6. Run: `echo "<message>" | command stackit create [branch-name] --no-interactive`
 
-**If no changes at all:** Stop and inform the user there's nothing to commit.
+You can call multiple tools in a single response. Stage and create in one message.
 
-### Step 2: Gather Diff Context
-
-After staging is confirmed, get the diff for commit message generation:
-```bash
-git diff --cached
-```
-
-### Step 3: Get Commit Message
-
-**If user provided a message** (via $ARGUMENTS like `-m "message"`):
-- Use the provided message directly, skip to Step 4
-
-**Otherwise, generate the commit message inline:**
-
-Using the diff from Step 2 and the recent commits style from Context, generate a commit message:
-- Under 72 chars for first line
-- Follow Conventional Commits if the project uses them (check recent commits)
-- Imperative mood ("Add" not "Added")
-- Match the style of recent commits
-
-For simple/obvious changes (single-purpose diffs, documentation, bug fixes), generate directly.
-
-**For large, diverse changes** (many files across different directories, multiple unrelated features/concerns, or significant refactoring spanning multiple systems), use `AskUserQuestion`:
-- Header: "Large changes"
-- Question: "These changes span multiple areas and may benefit from being split into separate stacked branches. How would you like to proceed?"
-- Options:
-  - "Use /stack-plan" - Analyze and split into multiple focused branches (Recommended)
-  - "Single commit" - Combine all changes into one commit
-  - "Let me describe" - I'll provide the commit message
-
-If user selects "Use /stack-plan", inform them: "Run `/stack-plan` to analyze your changes and create a well-organized stack." Then stop - do not create a branch.
-
-For moderately complex changes (large diff but single concern), use `AskUserQuestion`:
-- Header: "Commit scope"
-- Question: "This is a large diff. How should I structure the commit?"
-- Options:
-  - "Single commit" - Combine all changes with a summary message
-  - "Let me describe" - I'll provide the commit message
-
-### Step 4: Create the Branch
-
-Run the create command. Use a heredoc for messages with special characters:
-
-```bash
-echo "<commit_message>" | command stackit create [branch-name] --no-interactive
-```
-
-Or with heredoc for complex messages:
-```bash
-command stackit create [branch-name] --no-interactive <<'EOF'
-<commit_message>
-EOF
-```
-
-- Branch name is optional; stackit auto-generates from commit message
-
-The command outputs the result including the new branch name. No additional commands needed.
-
-## Do NOT
-- Run `command stackit create` without staged changes (creates empty branch)
-- Use `git commit` after creating a branch - this bypasses stackit
-- Run `git status` or `git diff --stat` redundantly - trust the context
-- Run `stackit log` after create - the create output is sufficient
+**Never use:** `git commit` or `git checkout -b` — always use `stackit create`.
 
 ## Follow-up
 
-After successful branch creation, use `AskUserQuestion`:
+After successful creation, use `AskUserQuestion`:
 - Header: "Next step"
-- Question: "Branch created successfully. What would you like to do next?"
+- Question: "Branch created. What would you like to do next?"
 - Options:
-  - label: "Submit as PR (Recommended)"
-    description: "Push branch and create/update pull request"
-  - label: "Stack another change"
-    description: "Create another branch on top of this one"
-  - label: "Done for now"
-    description: "No follow-up action needed"
-
-Based on response:
-- **"Submit as PR"**: Invoke `/stack-submit` skill using the `Skill` tool
-- **"Stack another change"**: Tell user: "Make your changes, stage them with `git add -A`, then run `/stack-create`"
-- **"Done for now"**: End with summary: "Branch `<name>` created. Run `/stack-submit` when ready to create a PR."
+  - "Submit as PR (Recommended)" → Invoke `/stack-submit` using Skill tool
+  - "Stack another change" → Tell user to make changes and run `/stack-create`
+  - "Done for now" → End with summary

--- a/internal/cli/integrations/agents/templates/commands/stack-extract.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-extract.md
@@ -1,6 +1,6 @@
 ---
 description: Extract commits or files to an independent branch
-model: claude-sonnet-4-20250514
+model: claude-haiku-4-20250414
 allowed-tools: Bash(stackit:*), Bash(git:*), Read, Glob, Grep
 ---
 
@@ -69,6 +69,10 @@ command stackit log  # Both branches should be siblings on the same parent
 | Changes don't belong in this stack | Changes are a dependency for this stack |
 | You want an independent PR | The split should be merged first |
 | Files should exist on both branches | Files should only be on the split branch |
+
+## Tool Trust
+
+Trust all tools work without error. Don't run exploratory commands to verify tool behavior.
 
 ## Do NOT
 - Use raw git commands when stackit commands are available

--- a/internal/cli/integrations/agents/templates/commands/stack-fix.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-fix.md
@@ -1,7 +1,7 @@
 ---
 description: Diagnose and fix common stack issues
 model: claude-sonnet-4-20250514
-allowed-tools: Bash(stackit:*), Bash(git:*), Read, Edit, Glob, Grep, AskUserQuestion, Skill
+allowed-tools: Bash(stackit:*), Bash(git:*), Read, Edit, Glob, Grep, AskUserQuestion, Skill, Task
 ---
 
 # Stack Fix
@@ -189,9 +189,17 @@ The restack command automatically propagates your fix to all child branches.
 
 **Branching stack (multiple children)**: foreach handles this - all descendants are checked.
 
-**Multiple independent failures**: After fixing one, re-run foreach to find next failure.
+**Multiple independent failures**: After fixing one, re-run foreach to find next failure. For large error outputs with many distinct issues, consider spawning parallel haiku Task subagents to classify and prioritize errors before fixing.
 
 **After amending a commit**: Always run `command stackit restack --no-interactive` because child branches reference the old commit SHA.
+
+## Tool Trust
+
+Trust all tools work without error. Don't run exploratory commands to verify tool behavior or check if commands exist.
+
+## Confidence Threshold
+
+Only apply fixes you're 90%+ confident about. If unsure whether a fix is correct, ask the user rather than guessing. False fixes erode trust—better to ask than to introduce new bugs.
 
 ## Do NOT
 - Fix the same bug on multiple branches manually

--- a/internal/cli/integrations/agents/templates/commands/stack-fold.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-fold.md
@@ -37,6 +37,10 @@ Fold (squash) granular branches into their parent branches.
 7. Run `command stackit restack --no-interactive` after folding
 8. Show final stack state
 
+## Tool Trust
+
+Trust all tools work without error. Don't run exploratory commands to verify tool behavior.
+
 ## Do NOT
 - Fold into trunk unless user explicitly requests it
 - Fold locked or frozen branches

--- a/internal/cli/integrations/agents/templates/commands/stack-plan.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-plan.md
@@ -1,5 +1,6 @@
 ---
 description: Plan and create a stack from uncommitted working tree changes
+model: claude-opus-4-20250514
 allowed-tools: Bash(stackit:*), Bash(git:*), Read, Glob, Grep, AskUserQuestion
 argument-hint: [check-command]
 ---
@@ -448,6 +449,10 @@ Next steps:
 - **Recovery is always possible** via `git checkout <backup-branch>`
 - **No stash usage** - avoids stash's confusing behavior with staged files
 - **Empty branch detection** - stops immediately if `stackit create` produces empty branch
+
+## Tool Trust
+
+Trust all tools work without error. Don't run exploratory commands to verify tool behavior. Assume `stackit create` will succeed if staged changes exist.
 
 ## Do NOT
 - Create branches without user approval of the plan

--- a/internal/cli/integrations/agents/templates/commands/stack-restack.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-restack.md
@@ -1,47 +1,35 @@
 ---
 description: Rebase all branches to ensure proper ancestry
-model: claude-sonnet-4-20250514
+model: claude-haiku-4-20250414
 allowed-tools: Bash(stackit:*), Bash(git:*), AskUserQuestion, Skill
 ---
 
 # Stack Restack
-
-Rebase all branches in the stack to ensure proper parent-child ancestry.
 
 ## Context
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
 - Stack state: !`command stackit log --no-interactive 2>&1`
 
-## Instructions
+## Task
 
-1. Check preconditions from context above:
-   - If no current branch (detached HEAD): suggest `command stackit checkout <branch>`
-   - If uncommitted changes: suggest committing or stashing first
-2. Run `command stackit restack --no-interactive`
-3. If conflicts occur, guide user through resolution then `command stackit continue`
-4. Show final stack state
-5. Suggest `command stackit submit` to update PRs
+Rebase all branches in the stack to ensure proper parent-child ancestry.
 
-## Do NOT
-- Proceed with uncommitted changes
-- Proceed in detached HEAD state
-- Force through conflicts without user resolution
+**Preconditions** (check context above):
+- Must be on a branch (not detached HEAD)
+- Must have clean working directory (no uncommitted changes)
+
+If preconditions fail, inform user and stop.
+
+Otherwise, run `command stackit restack --no-interactive` and show the result.
+
+If conflicts occur, inform user they need to resolve conflicts and run `command stackit continue`.
 
 ## Follow-up
 
 After successful restack, use `AskUserQuestion`:
 - Header: "Next step"
-- Question: "Stack rebased successfully. What would you like to do next?"
+- Question: "Stack rebased. What would you like to do next?"
 - Options:
-  - label: "Submit to update PRs (Recommended)"
-    description: "Push rebased branches to update remote PRs"
-  - label: "View stack"
-    description: "Show current stack state"
-  - label: "Done for now"
-    description: "No follow-up action needed"
-
-Based on response:
-- **"Submit to update PRs"**: Invoke `/stack-submit` skill using the `Skill` tool
-- **"View stack"**: Run `command stackit log --no-interactive`
-- **"Done for now"**: End with summary of restacked branches
+  - "Submit to update PRs (Recommended)" → Invoke `/stack-submit` using Skill tool
+  - "Done for now" → End with summary

--- a/internal/cli/integrations/agents/templates/commands/stack-review.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-review.md
@@ -1,20 +1,209 @@
 ---
-description: Apply actionable PR review comments and mark them resolved
-allowed-tools: Bash(gh:*), Bash(stackit:*), Bash(git:*), Read, Edit, Grep, Glob, Task, AskUserQuestion
-argument-hint: [--dry-run]
+description: Code review PRs in the stack, finding bugs and reporting issues locally
+model: claude-sonnet-4-20250514
+allowed-tools: Bash(gh:*), Bash(stackit:*), Bash(git:*), Read, Grep, Glob, Task, Edit, AskUserQuestion
+argument-hint: [--apply | --branch <name>]
 ---
 
 # Stack Review
 
-Fetch PR review comments for the current branch, evaluate them, apply actionable changes, and mark resolved.
+Perform code reviews on PRs in the stack. Finds bugs, checks CLAUDE.md compliance, and reports issues locally.
+
+**Two modes:**
+- **Review mode** (default): Analyze PRs and report findings locally
+- **Apply mode** (`--apply`): Apply existing review comments from GitHub and mark resolved
 
 ## Context
 - Current branch: !`git branch --show-current`
 - Repo: !`gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null`
-- PR info: !`gh pr view --json number,url,state,reviewDecision,headRefName 2>/dev/null || echo "No PR for this branch"`
+- Stack state: !`command stackit log --no-interactive 2>&1`
 
 ## Arguments
 $ARGUMENTS
+
+---
+
+# REVIEW MODE (Default)
+
+Perform code reviews on stack PRs in parallel, reporting high-confidence issues locally.
+
+## Review Philosophy
+
+**High-Signal Only.** Only flag issues meeting strict criteria:
+- Compilation/parsing failures
+- Definitive logic errors that produce wrong results
+- Clear, quotable CLAUDE.md or project guideline violations
+- Security vulnerabilities (injection, auth bypass, etc.)
+
+**Exclude:**
+- Style preferences or subjective improvements
+- Speculative issues ("this might cause...")
+- Performance concerns without clear evidence
+- Input-dependent edge cases
+- "Nits" or minor suggestions
+
+**False positives erode trust.** Better to find 3 real bugs than 10 items where 7 are noise.
+
+## Instructions
+
+### Step 1: Gather Stack PRs
+
+Get all branches in the stack that have open PRs:
+
+```bash
+command stackit log --json --no-interactive 2>&1
+```
+
+Parse the JSON to identify branches with PRs. For each branch, check if the PR is reviewable:
+
+```bash
+gh pr view <branch> --json state,isDraft,number,url,headRefName 2>/dev/null
+```
+
+**Skip branches where:**
+- No PR exists
+- PR is closed or merged (`state != "OPEN"`)
+- PR is a draft (`isDraft == true`)
+
+If `--branch <name>` is specified, only review that single branch.
+
+### Step 2: Gather Context
+
+For each reviewable PR, collect:
+
+**A. CLAUDE.md files in affected directories:**
+```bash
+# Get changed files
+gh pr diff <number> --name-only
+
+# For each unique directory, check for CLAUDE.md
+# e.g., if src/auth/login.go changed, check src/auth/CLAUDE.md and src/CLAUDE.md
+```
+
+**B. PR diff summary:**
+```bash
+gh pr diff <number>
+```
+
+### Step 3: Parallel Review (Per Branch)
+
+For each branch with a reviewable PR, spawn a **parallel Task subagent** to perform the review.
+
+**Launch all reviews in parallel using the Task tool:**
+
+```
+For each branch:
+  Task(
+    subagent_type: "general-purpose",
+    model: "opus",  # Use opus for bug detection
+    prompt: "Review PR #<number> for <branch>. Find ONLY high-confidence bugs.
+
+    Context:
+    - PR diff: <diff>
+    - CLAUDE.md guidelines: <guidelines>
+    - Project: <repo-name>
+
+    Review criteria (ONLY flag these):
+    1. Compilation/parsing errors
+    2. Definitive logic bugs (null deref, off-by-one, wrong return value)
+    3. Clear CLAUDE.md violations with quotable rule
+    4. Security vulnerabilities
+
+    DO NOT flag:
+    - Style preferences
+    - Speculative issues
+    - Performance without evidence
+    - Subjective improvements
+
+    For each issue found, return JSON:
+    {
+      'issues': [
+        {
+          'file': 'path/to/file.go',
+          'line': 42,
+          'end_line': 45,  // optional, for multi-line
+          'severity': 'bug' | 'violation',
+          'title': 'Short title',
+          'body': 'Explanation with evidence',
+          'suggestion': 'optional code suggestion',
+          'confidence': 0.0-1.0
+        }
+      ]
+    }
+
+    Return empty issues array if nothing meets the high bar."
+  )
+```
+
+Wait for all parallel reviews to complete.
+
+### Step 4: Filter and Validate
+
+For each issue returned by subagents:
+
+**Confidence threshold:** Only keep issues with `confidence >= 0.9`
+
+**Validation step:** For remaining issues, spawn a **haiku** validation subagent:
+
+```
+Task(
+  subagent_type: "general-purpose",
+  model: "haiku",
+  prompt: "Validate this potential bug. Is it a DEFINITE issue or speculative?
+
+  Issue: <issue>
+  Code context: <surrounding code>
+
+  Return JSON: { 'valid': true/false, 'reason': 'why' }"
+)
+```
+
+Only report issues that pass validation.
+
+### Step 5: Report Results
+
+For each branch reviewed, display findings locally:
+
+```
+## Review Results
+
+### <branch-name> (PR #<number>)
+Status: Clean | Issues found
+
+#### Issues (if any)
+
+**[severity] <title>**
+File: <file>:<line>
+<body>
+
+Suggested fix:
+```<language>
+<suggestion>
+```
+
+---
+
+[Next issue...]
+```
+
+**Clean review message:** When no issues found:
+> "No issues found. Checked for bugs and CLAUDE.md compliance."
+
+**Summary at end:**
+```
+## Summary
+
+Branches reviewed: N
+Issues found: M
+- <branch-1>: X issues
+- <branch-2>: Clean
+```
+
+---
+
+# APPLY MODE (`--apply`)
+
+Apply existing review comments from GitHub PRs and mark them resolved.
 
 ## Instructions
 
@@ -22,21 +211,7 @@ $ARGUMENTS
 
 If there's no PR for the current branch, inform the user and stop.
 
-### Step 2: Parse Repository Information
-
-Extract owner and repo from the `nameWithOwner` context value (format: `owner/repo`):
-
-```bash
-# Example: if nameWithOwner is "myorg/myrepo"
-# owner = "myorg"
-# repo = "myrepo"
-```
-
-Extract the PR number from the PR info JSON's `number` field.
-
-### Step 3: Fetch Review Threads
-
-Get all review threads with their comments and resolution status:
+### Step 2: Fetch Review Threads
 
 ```bash
 gh api graphql -f query='
@@ -50,16 +225,11 @@ query($owner: String!, $repo: String!, $pr: Int!) {
           isOutdated
           path
           line
-          startLine
-          originalLine
-          originalStartLine
-          diffSide
           comments(first: 20) {
             nodes {
               id
               body
               author { login }
-              createdAt
             }
           }
         }
@@ -69,178 +239,116 @@ query($owner: String!, $repo: String!, $pr: Int!) {
 }' -f owner=<OWNER> -f repo=<REPO> -F pr=<NUMBER>
 ```
 
-Replace `<OWNER>`, `<REPO>`, and `<NUMBER>` with the parsed values from Step 2.
-
-**Pagination note:** This query fetches up to 100 threads with 20 comments each. For PRs with more threads, you would need to paginate using `after` cursor, but this covers the vast majority of PRs.
-
-### Step 4: Filter Threads
+### Step 3: Filter Threads
 
 Focus only on threads that are:
-- **Not resolved** (`isResolved: false`)
-- **Not outdated** (`isOutdated: false`) - outdated means the code has changed
-- **Have a file path** (`path` is not null) - skip PR-level comments without file context
+- Not resolved (`isResolved: false`)
+- Not outdated (`isOutdated: false`)
+- Have a file path
+- Not from bots (filter `author.login` ending in `[bot]`)
 
-Also filter out bot comments by checking `author.login` for common bot patterns:
-- Names ending in `[bot]` (e.g., `dependabot[bot]`, `github-actions[bot]`)
-- Known CI bots: `codecov`, `sonarcloud`, `renovate`
+### Step 4: Classify as Actionable
 
-Skip threads that are already resolved, outdated, or only contain bot comments.
+**Actionable if:**
+- Requests specific code change ("rename X to Y", "add null check")
+- Points out bug with clear fix
+- Requests error handling or validation
 
-### Step 5: Batch Read Files
+**Not actionable if:**
+- Question without clear answer
+- Discussion or debate
+- Praise ("LGTM")
+- Vague about what change is needed
 
-**Optimization:** Before evaluating threads, collect all unique file paths and read them upfront:
+**Confidence threshold:** Only apply changes you're 90%+ confident about. Skip unclear comments.
 
-```bash
-# Get unique paths from filtered threads
-# Read each file once and cache for later use
-```
+### Step 5: Apply Changes
 
-This avoids reading the same file multiple times when multiple threads reference it.
+For each actionable comment:
+1. Read the file
+2. Locate the code at `path` and `line`
+3. Apply the change using Edit tool
+4. Track successful changes
 
-### Step 6: Evaluate Each Thread
-
-For each unresolved thread, examine the code from the cached file content.
-
-**Handle line number edge cases:**
-- If `line` is `null`: This is a file-level comment (applies to whole file, not a specific line)
-- If `startLine` differs from `line`: This is a multi-line comment spanning `startLine` to `line`
-- Use `diffSide` to determine if comment is on old (`LEFT`) or new (`RIGHT`) code
-- **Line drift:** If `line` differs from `originalLine`, the code may have shifted. Use the comment body and `originalLine` context to locate the actual code being referenced. Search for distinctive patterns mentioned in the comment.
-
-**For many threads (5+):** Use a **haiku** subagent with the `review-triage` template to batch-classify threads efficiently. The subagent returns JSON with actionable/not-actionable classifications.
-
-**Classify as ACTIONABLE if the comment:**
-- Requests a specific code change ("rename X to Y", "add null check", "remove this")
-- Points out a bug with a clear fix ("this will NPE", "missing return")
-- Requests error handling, validation, or safety improvements
-- Asks for documentation/comments on specific code
-
-**Classify as NOT ACTIONABLE if the comment:**
-- Is a question without a clear answer ("why is this here?")
-- Is a discussion or debate without resolution
-- Is praise or approval ("LGTM", "nice work")
-- Requires clarification from the author before acting
-- Is vague or ambiguous about what change is needed
-- Is a file-level comment without specific change request
-
-**Be conservative:** When in doubt, skip the comment rather than make an incorrect change.
-
-**When truly uncertain about actionability**, use `AskUserQuestion`:
-- Header: "Review comment"
-- Question: "I'm unsure how to handle this comment: '<short excerpt>'. What should I do?"
-- Options:
-  - "Apply it" - Treat as actionable, apply the change
-  - "Skip it" - Mark as not actionable
-  - "Show context" - Read surrounding code first
-
-### Step 7: Apply Changes (or Dry Run)
-
-**If `--dry-run` is specified:**
-- List each actionable comment and what change would be made
-- Do NOT modify any files
-- Do NOT resolve any threads
-- Stop here
-
-**If many actionable comments (5+)**, use `AskUserQuestion`:
-- Header: "Apply changes"
-- Question: "Ready to apply N changes from review comments?"
-- Options:
-  - "Apply all" - Proceed with all changes
-  - "Show summary" - List changes before applying
-  - "Dry run first" - Preview changes without modifying files
-
-**Otherwise, for each actionable comment:**
-
-1. Read the relevant file
-2. Locate the code using `path` and `line` from the thread
-3. Apply the suggested change using the Edit tool
-4. **Verify the edit succeeded** - if the Edit tool reports an error, mark this thread as failed
-5. Track successful changes for the commit message
-
-### Step 8: Commit Changes
-
-If any changes were successfully applied, stage and commit them.
-
-**Note:** Using `git commit` here is acceptable because we're adding to an existing stacked branch, not creating a new one. The `stackit create` command is for creating new branches with commits.
+### Step 6: Commit and Resolve
 
 ```bash
 git add -A
 git commit -m "refactor: apply PR review feedback
 
 Applied reviewer suggestions:
-- <bullet list of successful changes>"
+- <list of changes>"
 ```
 
-### Step 9: Mark Threads as Resolved
-
-**Only resolve threads where:**
-- The edit was successfully applied (verified in Step 7)
-- The commit succeeded (verified in Step 8)
-
-For efficiency, batch multiple thread resolutions into a single GraphQL mutation using aliases:
-
+Batch-resolve threads:
 ```bash
 gh api graphql -f query='
 mutation {
-  t1: resolveReviewThread(input: {threadId: "THREAD_ID_1"}) {
-    thread { isResolved }
-  }
-  t2: resolveReviewThread(input: {threadId: "THREAD_ID_2"}) {
-    thread { isResolved }
-  }
+  t1: resolveReviewThread(input: {threadId: "ID1"}) { thread { isResolved } }
+  t2: resolveReviewThread(input: {threadId: "ID2"}) { thread { isResolved } }
 }'
 ```
 
-Replace `THREAD_ID_1`, `THREAD_ID_2`, etc. with the actual thread IDs. Use unique aliases (`t1`, `t2`, etc.) for each mutation.
-
-**Do NOT resolve threads where:**
-- The edit failed or was skipped
-- The commit failed
-- The change couldn't be verified
-
-### Step 10: Restack
-
-If changes were committed, restack to update dependent branches:
+### Step 7: Restack
 
 ```bash
 command stackit restack --no-interactive
 ```
 
-If restack fails with conflicts:
-1. Check `git status` for conflicted files
-2. Read each conflicted file
-3. Resolve conflicts keeping the review feedback changes where appropriate
-4. Continue with `command stackit continue --no-interactive`
-
-### Step 11: Report Results
-
-Provide a summary:
+### Step 8: Report
 
 ```
-## Review Summary
+## Apply Summary
 
 **Threads processed:** N
 **Changes applied:** N
 **Threads resolved:** N
-**Threads skipped:** N
-**Threads failed:** N
-
-### Applied Changes
-- file.go:42 - Added error handling per @reviewer
-- utils.go:15 - Renamed variable for clarity
-
-### Skipped Threads
-- file.go:88 - Question about design (needs discussion)
-- main.go:12 - File-level comment without specific change
-
-### Failed Threads (if any)
-- config.go:23 - Edit failed: could not locate code block
+**Threads skipped:** N (with reasons)
 ```
 
+---
+
+## Tool Trust
+
+Trust all tools work without error. Don't run exploratory commands to verify tool behavior.
+
 ## Do NOT
-- Apply changes from vague or unclear comments - skip them
-- Guess at what a reviewer meant - if unclear, skip
-- Modify files when `--dry-run` is specified
-- Resolve threads that weren't actually addressed or where edits failed
-- Apply changes that would break compilation without fixing
-- Force push or modify history that's already been reviewed
+
+**In Review mode:**
+- Flag style nits or subjective preferences
+- Flag speculative or input-dependent issues
+- Post comments to GitHub (report locally only)
+- Review closed or draft PRs
+
+**In Apply mode:**
+- Apply vague or unclear comments
+- Resolve threads where edits failed
+- Force push or modify reviewed history
+
+## Follow-up
+
+After review completes, use `AskUserQuestion`:
+
+**If issues were found:**
+- Header: "Next step"
+- Question: "Review found issues. What would you like to do?"
+- Options:
+  - label: "Fix issues (Recommended)"
+    description: "Apply the suggested fixes to the code"
+  - label: "View details"
+    description: "Show more context about each issue"
+  - label: "Done for now"
+    description: "I'll review manually"
+
+**If no issues found:**
+- Header: "Next step"
+- Question: "All PRs are clean. What would you like to do?"
+- Options:
+  - label: "Submit/update PRs (Recommended)"
+    description: "Push any pending changes"
+  - label: "Done for now"
+    description: "No action needed"
+
+Based on response:
+- **"Fix issues"**: For each issue with a suggestion, apply the fix using Edit tool, then offer to commit
+- **"Submit/update PRs"**: Invoke `/stack-submit` skill using the `Skill` tool

--- a/internal/cli/integrations/agents/templates/commands/stack-split.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-split.md
@@ -1,5 +1,6 @@
 ---
 description: Split committed changes between current branch and a new branch (parent or child)
+model: claude-opus-4-20250514
 allowed-tools: Bash(stackit:*), Bash(git:*), Read, Write, Glob, Grep, AskUserQuestion
 argument-hint: [check-command]
 ---
@@ -425,6 +426,14 @@ new file mode 100644
 - `--by-commit`: Splits at commit boundaries
 
 **Note:** `--by-file` extracts entire files to the new branch, not just the changes to those files. Use `--patch` or `--by-hunk` for hunk-level splitting.
+
+## Tool Trust
+
+Trust all tools work without error. Don't run exploratory commands to verify tool behavior.
+
+## Confidence Threshold
+
+Only classify hunks you're 90%+ confident about. For ambiguous hunks, ask the user rather than guessing. Incorrect splits require manual cleanup.
 
 ## Do NOT
 - Proceed if there are uncommitted changes in the working directory

--- a/internal/cli/integrations/agents/templates/commands/stack-status.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-status.md
@@ -1,12 +1,10 @@
 ---
-description: View current stack state, branch position, and health status
-model: claude-sonnet-4-20250514
+description: View current stack state and health
+model: claude-haiku-4-20250414
 allowed-tools: Bash(stackit:*), Bash(git:*)
 ---
 
 # Stack Status
-
-Show the current stack state and identify any issues.
 
 ## Context
 - Current branch: !`git branch --show-current`
@@ -14,10 +12,12 @@ Show the current stack state and identify any issues.
 - Stack state: !`command stackit log --no-interactive 2>&1`
 - Branch info: !`command stackit info --json --no-interactive 2>&1`
 
-## Instructions
+## Task
 
-Based on the context above:
-- If branches need restack: suggest `command stackit restack`
-- If branches have no PR: suggest `command stackit submit`
-- If uncommitted changes: note them
-- If stack is healthy: confirm status is good
+Summarize the stack state from the context above. Note any issues:
+- Branches needing restack
+- Branches without PRs
+- Uncommitted changes
+- Detached HEAD state
+
+If healthy, confirm the stack is in good state. Do not run additional commands.

--- a/internal/cli/integrations/agents/templates/commands/stack-sync.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-sync.md
@@ -1,53 +1,32 @@
 ---
-description: Sync with trunk, cleanup merged branches, and restack
-model: claude-sonnet-4-20250514
+description: Sync with trunk and cleanup merged branches
+model: claude-haiku-4-20250414
 allowed-tools: Bash(stackit:*), Bash(git:*), AskUserQuestion, Skill
 ---
 
 # Stack Sync
 
-Sync stack with remote: pull trunk, cleanup merged branches, restack.
-
 ## Context
 - Current branch: !`git branch --show-current`
 - Stack state: !`command stackit log --no-interactive 2>&1`
 
-## Instructions
+## Task
 
-1. Run `command stackit sync --dry-run --no-interactive` and show user what will be deleted
-2. If ALL branches would be deleted, use `AskUserQuestion`:
-   - Header: "Delete all"
-   - Question: "Sync will delete ALL branches in your stack. Are you sure?"
-   - Options:
-     - "Yes, delete all" - Proceed with full cleanup
-     - "Cancel" - Abort sync
+Sync the stack with trunk: pull latest, cleanup merged branches, restack.
+
+1. Run `command stackit sync --dry-run --no-interactive` to preview
+2. If ALL branches would be deleted, confirm with user first using `AskUserQuestion`
 3. Run `command stackit sync --no-interactive`
 4. If branches remain, run `command stackit restack --no-interactive`
-5. Show final stack state
+5. Show final state with `command stackit log --no-interactive`
 
-## Do NOT
-- Skip the dry-run preview
-- Proceed without confirmation if all branches will be deleted
+You can call multiple tools in a single response.
 
 ## Follow-up
 
-After successful sync, check if branches remain and use `AskUserQuestion`:
-
-**If branches remain with changes:**
+After sync completes, if branches remain, use `AskUserQuestion`:
 - Header: "Next step"
 - Question: "Stack synced. What would you like to do next?"
 - Options:
-  - label: "Submit updates (Recommended)"
-    description: "Push rebased branches to update PRs"
-  - label: "View stack"
-    description: "Show current stack state"
-  - label: "Done for now"
-    description: "No follow-up action needed"
-
-**If all branches were merged/deleted:**
-- End with summary: "All branches have been merged and cleaned up. Your stack is empty."
-
-Based on response:
-- **"Submit updates"**: Invoke `/stack-submit` skill using the `Skill` tool
-- **"View stack"**: Run `command stackit log --no-interactive`
-- **"Done for now"**: End with summary of synced state
+  - "Submit updates (Recommended)" → Invoke `/stack-submit` using Skill tool
+  - "Done for now" → End with summary

--- a/internal/cli/integrations/agents/templates/commands/stack-verify.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-verify.md
@@ -1,7 +1,7 @@
 ---
 description: Verify stack health by running checks on all branches
 model: claude-sonnet-4-20250514
-allowed-tools: Bash(stackit:*), Bash(git:*), AskUserQuestion, Skill
+allowed-tools: Bash(stackit:*), Bash(git:*), AskUserQuestion, Skill, Task
 argument-hint: [check-command]
 ---
 
@@ -49,6 +49,8 @@ command stackit foreach --upstack "<check-command>" 2>&1
 ```bash
 command stackit foreach --upstack --no-fail-fast "<check-command>" 2>&1
 ```
+
+**Parallel mode** - For large stacks (5+ branches) with independent branches, consider spawning parallel Task subagents to verify sibling branches simultaneously. Only use this when branches don't have linear dependencies.
 
 If uncertain which mode to use, prompt with `AskUserQuestion`:
 - Header: "Verify mode"
@@ -113,6 +115,10 @@ First failure: branch-name-3
 **All branches pass**: Clearly report success, suggest `/stack-submit`.
 
 **Check command fails immediately**: Suggest verifying command works manually first.
+
+## Tool Trust
+
+Trust all tools work without error. Don't run exploratory commands to verify tool behavior.
 
 ## Do NOT
 - Attempt to fix any issues (that's /stack-fix's job)


### PR DESCRIPTION

- Rewrite stack-review for comprehensive code review in parallel
- Add model specifications: Haiku for simple, Sonnet for moderate, Opus for complex
- Add 'Tool Trust' sections to reduce defensive code patterns
- Add confidence thresholds to action-taking commands
- Enable parallel subagent patterns where beneficial