### PR TITLE
feat: fix split for new files and improve by-file semantics

### DIFF
--- a/internal/actions/split/split_file.go
+++ b/internal/actions/split/split_file.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/git"
 	"stackit.dev/stackit/internal/output"
 	"stackit.dev/stackit/internal/tui"
 	"stackit.dev/stackit/internal/tui/style"
@@ -17,6 +19,7 @@ import (
 type splitByFileEngine interface {
 	engine.BranchReader
 	engine.BranchWriter
+	engine.StackRewriter
 }
 
 // splitByFileOptions contains options for the splitByFile operation
@@ -33,32 +36,42 @@ type splitByFileOptions struct {
 	Message string
 }
 
-// splitByFile splits a branch by extracting specified files to a new branch.
+// recoverToOriginalBranch attempts to restore the user to the original branch after an error.
+// It wraps the original error with recovery guidance if the checkout fails.
+func recoverToOriginalBranch(ctx context.Context, eng splitByFileEngine, branch engine.Branch, originalErr error) error {
+	if err := eng.ForceCheckoutBranch(ctx, branch); err != nil {
+		// Include recovery instructions when checkout fails
+		recoveryMsg := fmt.Sprintf("run 'git checkout %s' to recover", branch.GetName())
+		return fmt.Errorf("%w (WARNING: failed to restore to %s: %s; %s)",
+			originalErr, branch.GetName(), err.Error(), recoveryMsg)
+	}
+	return originalErr
+}
+
+// splitByFile splits a branch by extracting CHANGES to specified files to a new branch.
+// Unlike the legacy behavior, this extracts only the diff hunks for the specified files,
+// not the complete file contents. This is the correct semantic for "split by file".
 //
 // Default behavior (AsSibling=false):
-// Creates a new PARENT branch containing the extracted files.
+// Creates a new PARENT branch containing the changes to the extracted files.
 // The original branch becomes a child of the split branch.
 // Algorithm:
-//  1. Determine the parent of the branch to split.
-//  2. Create a new "split" branch from the parent.
-//  3. Checkout the specified files from the original branch into the new split branch.
-//  4. Commit the extracted files on the new split branch.
-//  5. Checkout the original branch and remove the extracted files.
-//  6. Commit the removals on the original branch.
-//  7. Update the original branch's parent to be the new split branch.
+//  1. Get the diff between parent and branch, parse into hunks
+//  2. Filter hunks to only those for specified files
+//  3. Detach HEAD and soft reset to parent (all changes become unstaged)
+//  4. Stage the filtered hunks (changes go to new parent branch)
+//  5. Stash staged changes
+//  6. Commit remaining changes (stay on original branch)
+//  7. Pop stash, commit on new parent branch
+//  8. Update parent relationship
 //
 // Sibling mode (AsSibling=true):
-// Creates a new SIBLING branch containing the extracted files.
-// The original branch is unchanged (files are NOT removed).
-// Algorithm:
-//  1. Determine the parent of the branch to split.
-//  2. Create a new "split" branch from the parent.
-//  3. Checkout the specified files from the original branch into the new split branch.
-//  4. Commit the extracted files on the new split branch.
-//  5. Return to the original branch (no file removal, no reparenting).
+// Creates a new SIBLING branch containing the changes to the extracted files.
+// The original branch is unchanged (changes are NOT removed).
 func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []string, eng splitByFileEngine, opts splitByFileOptions) (*Result, error) {
 	// Get parent branch
 	parentBranchName := branchToSplit.GetParentPrecondition()
+	parentBranch := eng.GetBranch(parentBranchName)
 
 	// Generate new branch name
 	newBranchName := opts.Name
@@ -79,44 +92,243 @@ func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []s
 		return nil, fmt.Errorf("branch %s already exists", newBranchName)
 	}
 
+	// Get the diff between parent and branchToSplit (raw output for parsing)
+	diffOutput, err := eng.GetDiffBetween(ctx, parentBranchName, branchToSplit.GetName())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get diff: %w", err)
+	}
+
+	// Parse diff into hunks
+	allHunks, err := git.ParseDiffOutput(diffOutput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse diff: %w", err)
+	}
+
+	// Filter hunks to only those for specified files
+	filteredHunks := filterHunksByFiles(allHunks, pathspecs)
+	if len(filteredHunks) == 0 {
+		return nil, fmt.Errorf("no changes found for files: %s", strings.Join(pathspecs, ", "))
+	}
+
+	// Check for binary files and reject them
+	var binaryFiles []string
+	for _, h := range filteredHunks {
+		if h.Binary {
+			binaryFiles = append(binaryFiles, h.File)
+		}
+	}
+	if len(binaryFiles) > 0 {
+		return nil, fmt.Errorf("cannot split binary files: %s. Binary files must be split as whole files using a different approach",
+			strings.Join(binaryFiles, ", "))
+	}
+
+	// Get commit message
+	commitMessages, err := branchToSplit.GetAllCommits(engine.CommitFormatMessage)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get commit messages: %w", err)
+	}
+	defaultCommitMessage := strings.Join(commitMessages, "\n\n")
+	if defaultCommitMessage == "" {
+		defaultCommitMessage = fmt.Sprintf("Split from %s", branchToSplit.GetName())
+	}
+
+	commitMessage := opts.Message
+	if commitMessage == "" {
+		commitMessage = defaultCommitMessage
+	}
+
+	// For sibling mode, use simpler approach - create branch at parent and apply hunks directly
+	if opts.AsSibling {
+		return splitByFileSibling(ctx, branchToSplit, parentBranch, newBranchName, filteredHunks, commitMessage, eng)
+	}
+
+	// Default mode: extract to parent branch
+
+	// Detach and reset branch changes (all changes become unstaged)
+	if err := eng.DetachAndResetBranchChanges(ctx, branchToSplit.GetName()); err != nil {
+		return nil, fmt.Errorf("failed to detach and reset: %w", err)
+	}
+
+	// Stage the filtered hunks (these will go to the new parent branch)
+	if err := eng.StageHunks(ctx, filteredHunks); err != nil {
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit,
+			fmt.Errorf("failed to stage hunks: %w", err))
+	}
+
+	// Check if anything was staged
+	hasStaged, err := eng.HasStagedChanges(ctx)
+	if err != nil {
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit,
+			fmt.Errorf("failed to check staged changes: %w", err))
+	}
+	if !hasStaged {
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit,
+			fmt.Errorf("no changes staged for files: %s", strings.Join(pathspecs, ", ")))
+	}
+
+	// Check if there are remaining changes (to keep on branchToSplit)
+	hasUnstaged, err := eng.HasUnstagedChanges(ctx)
+	if err != nil {
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit,
+			fmt.Errorf("failed to check unstaged changes: %w", err))
+	}
+	hasUntracked, err := eng.HasUntrackedFiles(ctx)
+	if err != nil {
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit,
+			fmt.Errorf("failed to check untracked files: %w", err))
+	}
+	if !hasUnstaged && !hasUntracked {
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit,
+			fmt.Errorf("all changes were selected - nothing would remain on %s", branchToSplit.GetName()))
+	}
+
+	// Stash the staged changes (these will become the new parent branch content)
+	stashName := fmt.Sprintf("stackit-split-file-parent-%d", time.Now().UnixNano())
+	_, err = eng.StashPushStaged(ctx, stashName)
+	if err != nil {
+		_ = eng.ForceCheckoutBranch(ctx, branchToSplit)
+		return nil, fmt.Errorf("failed to stash staged changes: %w", err)
+	}
+
+	// Track stash state for cleanup
+	stashPopped := false
+	cleanupStash := func() {
+		if !stashPopped {
+			_ = eng.StashPop(ctx)
+			stashPopped = true
+		}
+	}
+
+	// Stage and commit remaining changes - these stay on branchToSplit
+	if err := eng.StageAll(ctx); err != nil {
+		cleanupStash()
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit,
+			fmt.Errorf("failed to stage remaining changes: %w", err))
+	}
+
+	if err := eng.CommitWithOptions(ctx, git.CommitOptions{
+		Message:  defaultCommitMessage,
+		NoVerify: true,
+	}); err != nil {
+		cleanupStash()
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit,
+			fmt.Errorf("failed to commit remaining changes: %w", err))
+	}
+
+	// Update branchToSplit to point to this commit (contains remaining changes)
+	if err := eng.UpdateBranchRef(ctx, branchToSplit.GetName(), "HEAD"); err != nil {
+		cleanupStash()
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit,
+			fmt.Errorf("failed to update branch reference: %w", err))
+	}
+
+	// Reset to original parent to create the new parent branch
+	if err := eng.ResetHard(ctx, parentBranchName); err != nil {
+		cleanupStash()
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit,
+			fmt.Errorf("failed to reset to original parent: %w", err))
+	}
+
+	// Pop the stash to get the parent branch changes
+	if err := eng.StashPop(ctx); err != nil {
+		return nil, fmt.Errorf("failed to pop stash: %w. Recovery: run 'git stash pop' to restore changes", err)
+	}
+	stashPopped = true
+
+	// Stage and commit - this becomes the NEW PARENT branch content
+	if err := eng.StageAll(ctx); err != nil {
+		// Changes are in the working tree after stash pop, not staged
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit,
+			fmt.Errorf("failed to stage parent branch changes: %w; changes are in working tree", err))
+	}
+
+	if err := eng.CommitWithOptions(ctx, git.CommitOptions{
+		Message:  commitMessage,
+		NoVerify: true,
+	}); err != nil {
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit,
+			fmt.Errorf("failed to commit parent branch changes: %w", err))
+	}
+
+	// Create the new parent branch at HEAD
+	if err := eng.CreateBranch(ctx, newBranchName, "HEAD"); err != nil {
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit,
+			fmt.Errorf("failed to create parent branch: %w", err))
+	}
+
+	// Track the new parent branch with originalParent as its parent
+	newBranch := eng.GetBranch(newBranchName)
+	if err := eng.TrackBranch(ctx, newBranchName, parentBranchName); err != nil {
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit,
+			fmt.Errorf("failed to track parent branch: %w", err))
+	}
+
+	// Update branchToSplit to have newBranch as its parent
+	if err := eng.SetParent(ctx, branchToSplit, newBranch); err != nil {
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit,
+			fmt.Errorf("failed to update parent of %s: %w", branchToSplit.GetName(), err))
+	}
+
+	// Checkout branchToSplit (we end up on the original branch)
+	if err := eng.CheckoutBranch(ctx, branchToSplit); err != nil {
+		return nil, fmt.Errorf("failed to checkout original branch: %w", err)
+	}
+
+	return &Result{
+		BranchNames:  []string{newBranchName},
+		BranchPoints: []int{0},
+	}, nil
+}
+
+// splitByFileSibling creates a sibling branch with the specified file changes.
+// The original branch is unchanged.
+func splitByFileSibling(ctx context.Context, branchToSplit engine.Branch, parentBranch engine.Branch, newBranchName string, hunks []git.Hunk, commitMessage string, eng splitByFileEngine) (*Result, error) {
 	// First checkout the parent branch so the new branch starts from there
-	parentBranch := eng.GetBranch(parentBranchName)
 	if err := eng.CheckoutBranch(ctx, parentBranch); err != nil {
 		return nil, fmt.Errorf("failed to checkout parent branch: %w", err)
 	}
 
-	// Create new branch from parent (GetBranch just wraps the name, branch doesn't need to exist yet)
+	// Create new branch from parent
 	newBranch := eng.GetBranch(newBranchName)
 	if err := eng.CreateAndCheckoutBranch(ctx, newBranch); err != nil {
+		_ = eng.CheckoutBranch(ctx, branchToSplit)
 		return nil, fmt.Errorf("failed to create branch: %w", err)
 	}
 
-	// Checkout files from branchToSplit
-	if err := eng.CheckoutPaths(ctx, branchToSplit.GetName(), pathspecs); err != nil {
-		// Cleanup: delete the new branch
+	// Stage the hunks directly
+	if err := eng.StageHunks(ctx, hunks); err != nil {
 		_ = eng.DeleteBranch(ctx, newBranch)
-		return nil, fmt.Errorf("failed to checkout files: %w", err)
+		_ = eng.CheckoutBranch(ctx, branchToSplit)
+		return nil, fmt.Errorf("failed to stage hunks: %w", err)
 	}
 
-	// Stage all changes
-	if err := eng.StageAll(ctx); err != nil {
+	// Check if anything was staged
+	hasStaged, err := eng.HasStagedChanges(ctx)
+	if err != nil {
 		_ = eng.DeleteBranch(ctx, newBranch)
-		return nil, fmt.Errorf("failed to stage changes: %w", err)
+		_ = eng.CheckoutBranch(ctx, branchToSplit)
+		return nil, fmt.Errorf("failed to check staged changes: %w", err)
+	}
+	if !hasStaged {
+		_ = eng.DeleteBranch(ctx, newBranch)
+		_ = eng.CheckoutBranch(ctx, branchToSplit)
+		return nil, fmt.Errorf("no changes staged")
 	}
 
 	// Commit
-	commitMessage := opts.Message
-	if commitMessage == "" {
-		commitMessage = fmt.Sprintf("Extract %s from %s", strings.Join(pathspecs, ", "), branchToSplit.GetName())
-	}
-	if err := eng.Commit(ctx, commitMessage, 0, true); err != nil {
+	if err := eng.CommitWithOptions(ctx, git.CommitOptions{
+		Message:  commitMessage,
+		NoVerify: true,
+	}); err != nil {
 		_ = eng.DeleteBranch(ctx, newBranch)
+		_ = eng.CheckoutBranch(ctx, branchToSplit)
 		return nil, fmt.Errorf("failed to commit: %w", err)
 	}
 
 	// Track the new branch
-	if err := eng.TrackBranch(ctx, newBranchName, parentBranchName); err != nil {
+	if err := eng.TrackBranch(ctx, newBranchName, parentBranch.GetName()); err != nil {
 		_ = eng.DeleteBranch(ctx, newBranch)
+		_ = eng.CheckoutBranch(ctx, branchToSplit)
 		return nil, fmt.Errorf("failed to track branch: %w", err)
 	}
 
@@ -125,37 +337,27 @@ func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []s
 		return nil, fmt.Errorf("failed to checkout original branch: %w", err)
 	}
 
-	// In sibling mode, we're done - the original branch is unchanged
-	if opts.AsSibling {
-		return &Result{
-			BranchNames:  []string{newBranchName},
-			BranchPoints: []int{0}, // Single commit
-		}, nil
-	}
-
-	// Default mode: remove files from original and reparent
-
-	// Remove the files from the original branch (both index and working directory)
-	if err := eng.RemovePaths(ctx, pathspecs); err != nil {
-		return nil, fmt.Errorf("failed to remove files: %w", err)
-	}
-
-	// Commit the removal
-	commitMessage = fmt.Sprintf("Remove %s (moved to %s)", strings.Join(pathspecs, ", "), newBranchName)
-	if err := eng.Commit(ctx, commitMessage, 0, true); err != nil {
-		return nil, fmt.Errorf("failed to commit removal: %w", err)
-	}
-
-	// Update original branch's parent to be the new split branch
-	// This creates the hierarchy: parent -> newBranch -> originalBranch
-	if err := eng.SetParent(ctx, branchToSplit, newBranch); err != nil {
-		return nil, fmt.Errorf("failed to update parent: %w", err)
-	}
-
 	return &Result{
 		BranchNames:  []string{newBranchName},
-		BranchPoints: []int{0}, // Single commit
+		BranchPoints: []int{0},
 	}, nil
+}
+
+// filterHunksByFiles filters hunks to only those affecting the specified files.
+func filterHunksByFiles(hunks []git.Hunk, files []string) []git.Hunk {
+	// Create a map for O(1) lookup
+	fileSet := make(map[string]bool)
+	for _, f := range files {
+		fileSet[f] = true
+	}
+
+	var filtered []git.Hunk
+	for _, h := range hunks {
+		if fileSet[h.File] {
+			filtered = append(filtered, h)
+		}
+	}
+	return filtered
 }
 
 // promptForFiles shows an interactive file selector for split --by-file

--- a/internal/cli/branch/split_test.go
+++ b/internal/cli/branch/split_test.go
@@ -346,8 +346,8 @@ func TestSplitCommand(t *testing.T) {
 		cmd := exec.Command(binaryPath, "split", "--by-file", "nonexistent.txt", "--no-interactive")
 		cmd.Dir = scene.Dir
 		output, err := cmd.CombinedOutput()
-		// Git checkout will fail if file doesn't exist, which is expected
+		// Split should fail if file doesn't exist
 		require.Error(t, err, "split should fail with non-existent file")
-		require.Contains(t, string(output), "error", "should show error for non-existent file")
+		require.Contains(t, string(output), "no changes found", "should show error for non-existent file")
 	})
 }

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -405,6 +405,10 @@ func (d *demoGitRunner) GetUnstagedDiff(_ context.Context, _ ...string) (string,
 	return "", nil
 }
 
+func (d *demoGitRunner) GetDiffBetween(_ context.Context, _, _ string, _ ...string) (string, error) {
+	return "", nil
+}
+
 func (d *demoGitRunner) GetDiffNumstat(_, _ string) (string, error) {
 	return "1\t1\ttest.txt", nil
 }

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -151,6 +151,12 @@ func (e *engineImpl) ShowDiff(ctx context.Context, left, right string, stat bool
 	return e.git.ShowDiff(ctx, left, right, stat)
 }
 
+// GetDiffBetween returns the raw diff between two refs, suitable for parsing.
+// Unlike ShowDiff, this returns uncolored output.
+func (e *engineImpl) GetDiffBetween(ctx context.Context, base, head string, files ...string) (string, error) {
+	return e.git.GetDiffBetween(ctx, base, head, files...)
+}
+
 // ShowCommits returns commit log with optional patches/stat
 func (e *engineImpl) ShowCommits(ctx context.Context, base, head string, patch, stat bool) (string, error) {
 	return e.git.ShowCommits(ctx, base, head, patch, stat)

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -75,6 +75,8 @@ type GitDiffer interface {
 	ShowDiff(ctx context.Context, left, right string, stat bool) (string, error)
 	ShowCommits(ctx context.Context, base, head string, patch, stat bool) (string, error)
 	IsAncestor(ancestor, descendant string) (bool, error)
+	// GetDiffBetween returns raw diff between two refs, suitable for parsing into hunks.
+	GetDiffBetween(ctx context.Context, base, head string, files ...string) (string, error)
 }
 
 // WorkingTree handles worktree and staging area operations

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -78,3 +78,14 @@ func (r *runner) GetUnstagedDiff(ctx context.Context, files ...string) (string, 
 	}
 	return r.RunGitCommandRawWithContext(ctx, args...)
 }
+
+// GetDiffBetween returns the raw diff between two refs.
+// Unlike ShowDiff, this returns uncolored output suitable for parsing.
+func (r *runner) GetDiffBetween(ctx context.Context, base, head string, files ...string) (string, error) {
+	args := []string{"diff", base, head}
+	if len(files) > 0 {
+		args = append(args, "--")
+		args = append(args, files...)
+	}
+	return r.RunGitCommandRawWithContext(ctx, args...)
+}

--- a/internal/git/hunk_split_test.go
+++ b/internal/git/hunk_split_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 const testNewFileName = "newfile.go"
+const testDeletedFileName = "deleted.go"
 
 func TestCanSplitHunk(t *testing.T) {
 	tests := []struct {
@@ -623,6 +624,27 @@ index 0000000..abc1234
 			},
 		},
 		{
+			name: "new file detected via /dev/null without new file mode header",
+			// Some git diff formats (like git diff branch..branch) may not include
+			// the "new file mode" line but will still have "--- /dev/null"
+			diff: `diff --git a/newfile.go b/newfile.go
+index 0000000..abc1234
+--- /dev/null
++++ b/newfile.go
+@@ -0,0 +1,2 @@
++package main
++func main() {}`,
+			expectedCount: 1,
+			validateHunks: func(t *testing.T, hunks []Hunk) {
+				if hunks[0].File != testNewFileName {
+					t.Errorf("Expected file '%s', got '%s'", testNewFileName, hunks[0].File)
+				}
+				if !hunks[0].IsNewFile {
+					t.Error("Expected IsNewFile to be true (fallback detection via --- /dev/null)")
+				}
+			},
+		},
+		{
 			name: "new file with executable mode",
 			diff: `diff --git a/script.sh b/script.sh
 new file mode 100755
@@ -839,6 +861,20 @@ func TestExtractContentFromHunk(t *testing.T) {
 			},
 			expected: "",
 		},
+		{
+			name: "respects no newline at end of file marker",
+			hunk: Hunk{
+				Content: "@@ -0,0 +1,1 @@\n+no trailing newline\n\\ No newline at end of file",
+			},
+			expected: "no trailing newline",
+		},
+		{
+			name: "multi-line file without trailing newline",
+			hunk: Hunk{
+				Content: "@@ -0,0 +1,3 @@\n+line1\n+line2\n+line3\n\\ No newline at end of file",
+			},
+			expected: "line1\nline2\nline3",
+		},
 	}
 
 	for _, tt := range tests {
@@ -949,7 +985,7 @@ index abc1234..0000000
 -func deleted() {}`,
 			expectedCount: 1,
 			validateHunks: func(t *testing.T, hunks []Hunk) {
-				if hunks[0].File != "deleted.go" {
+				if hunks[0].File != testDeletedFileName {
 					t.Errorf("Expected file 'deleted.go', got '%s'", hunks[0].File)
 				}
 				if !hunks[0].IsDeletedFile {
@@ -957,6 +993,27 @@ index abc1234..0000000
 				}
 				if hunks[0].FileMode != "100644" {
 					t.Errorf("Expected FileMode '100644', got '%s'", hunks[0].FileMode)
+				}
+			},
+		},
+		{
+			name: "deleted file detected via /dev/null without deleted file mode header",
+			// Some git diff formats may not include the "deleted file mode" line
+			// but will still have "+++ /dev/null"
+			diff: `diff --git a/deleted.go b/deleted.go
+index abc1234..0000000
+--- a/deleted.go
++++ /dev/null
+@@ -1,2 +0,0 @@
+-package main
+-func deleted() {}`,
+			expectedCount: 1,
+			validateHunks: func(t *testing.T, hunks []Hunk) {
+				if hunks[0].File != testDeletedFileName {
+					t.Errorf("Expected file 'deleted.go', got '%s'", hunks[0].File)
+				}
+				if !hunks[0].IsDeletedFile {
+					t.Error("Expected IsDeletedFile to be true (fallback detection via +++ /dev/null)")
 				}
 			},
 		},
@@ -1014,7 +1071,7 @@ index abc123..def456 100644
 					t.Error("First hunk should be a new file")
 				}
 				// Second hunk should be deleted file
-				if hunks[1].File != "deleted.go" {
+				if hunks[1].File != testDeletedFileName {
 					t.Errorf("Second hunk file should be 'deleted.go', got '%s'", hunks[1].File)
 				}
 				if !hunks[1].IsDeletedFile {

--- a/internal/git/hunks.go
+++ b/internal/git/hunks.go
@@ -94,6 +94,19 @@ func ParseDiffOutput(diffOutput string) ([]Hunk, error) {
 			continue
 		}
 
+		// Detect new file via "--- /dev/null" as fallback when "new file mode" is missing.
+		// This can happen with certain git diff formats (e.g., git diff main..HEAD).
+		if line == "--- /dev/null" {
+			currentIsNewFile = true
+			continue
+		}
+
+		// Detect deleted file via "+++ /dev/null" as fallback when "deleted file mode" is missing.
+		if line == "+++ /dev/null" {
+			currentIsDeletedFile = true
+			continue
+		}
+
 		// Check for binary file marker
 		// Format: "Binary files a/path and b/path differ"
 		if strings.HasPrefix(line, "Binary files ") && strings.HasSuffix(line, " differ") {

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -95,6 +95,9 @@ type DiffOperations interface {
 	GetDiffNumstat(base, head string) (string, error)
 	GetStagedDiff(ctx context.Context, files ...string) (string, error)
 	GetUnstagedDiff(ctx context.Context, files ...string) (string, error)
+	// GetDiffBetween returns the raw diff between two refs, without color codes.
+	// This is suitable for parsing into hunks.
+	GetDiffBetween(ctx context.Context, base, head string, files ...string) (string, error)
 }
 
 // StagingOperations handles staging area operations.

--- a/internal/git/staging.go
+++ b/internal/git/staging.go
@@ -118,29 +118,8 @@ func (r *runner) StageHunks(ctx context.Context, hunks []Hunk) error {
 
 	// Handle new files: extract content and write to disk, then stage with git add
 	for _, h := range newFileHunks {
-		content := extractContentFromHunk(h)
-		filePath := filepath.Join(r.repoRoot, h.File)
-
-		// Create parent directories if they don't exist
-		if dir := filepath.Dir(filePath); dir != "." {
-			if err := os.MkdirAll(dir, 0o750); err != nil {
-				return fmt.Errorf("failed to create directory for new file %s: %w", h.File, err)
-			}
-		}
-
-		// Determine file mode (default to 0644 for regular files)
-		fileMode := os.FileMode(0o644)
-		if h.FileMode == "100755" {
-			fileMode = 0o755
-		}
-
-		if err := os.WriteFile(filePath, []byte(content), fileMode); err != nil {
-			return fmt.Errorf("failed to write new file %s: %w", h.File, err)
-		}
-
-		// Stage the new file
-		if _, err := r.RunGitCommandWithContext(ctx, "add", h.File); err != nil {
-			return fmt.Errorf("failed to stage new file %s: %w", h.File, err)
+		if err := r.stageNewFileHunk(ctx, h); err != nil {
+			return err
 		}
 	}
 
@@ -155,6 +134,27 @@ func (r *runner) StageHunks(ctx context.Context, hunks []Hunk) error {
 				// Try without --3way as a fallback (some git versions have issues with --3way)
 				_, fallbackErr := r.runGitInternal(ctx, patch, nil, true, "apply", "--cached")
 				if fallbackErr != nil {
+					// Check if any files are misdetected new files and handle them
+					rescuedHunks, remainingHunks := r.rescueMisdetectedNewFiles(ctx, modHunks)
+					if len(rescuedHunks) > 0 {
+						// Stage the rescued new files
+						for _, h := range rescuedHunks {
+							if err := r.stageNewFileHunk(ctx, h); err != nil {
+								return fmt.Errorf("failed to stage misdetected new file %s: %w", h.File, err)
+							}
+						}
+						// Try to apply remaining modifications if any
+						if len(remainingHunks) > 0 {
+							remainingPatch := BuildPatchFromHunks(remainingHunks)
+							if remainingPatch != "" {
+								_, retryErr := r.runGitInternal(ctx, remainingPatch, nil, true, "apply", "--cached")
+								if retryErr != nil {
+									return fmt.Errorf("failed to apply patch after rescuing new files: %w", retryErr)
+								}
+							}
+						}
+						return nil
+					}
 					return fmt.Errorf("failed to apply patch: %w (note: --3way also failed)", fallbackErr)
 				}
 			}
@@ -164,13 +164,103 @@ func (r *runner) StageHunks(ctx context.Context, hunks []Hunk) error {
 	return nil
 }
 
+// stageNewFileHunk handles staging a single new file hunk by writing content to disk and staging it.
+func (r *runner) stageNewFileHunk(ctx context.Context, h Hunk) error {
+	content := extractContentFromHunk(h)
+	filePath := filepath.Join(r.repoRoot, h.File)
+
+	// Create parent directories if they don't exist
+	if dir := filepath.Dir(filePath); dir != "." {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			return fmt.Errorf("failed to create directory for new file %s: %w", h.File, err)
+		}
+	}
+
+	// Handle symlinks specially (FileMode 120000)
+	if h.FileMode == "120000" {
+		// For symlinks, the content is the target path
+		target := strings.TrimSpace(content)
+		if err := os.Symlink(target, filePath); err != nil {
+			return fmt.Errorf("failed to create symlink %s: %w", h.File, err)
+		}
+	} else {
+		// Regular file - determine mode (default to 0644)
+		fileMode := os.FileMode(0o644)
+		if h.FileMode == "100755" {
+			fileMode = 0o755
+		}
+
+		if err := os.WriteFile(filePath, []byte(content), fileMode); err != nil {
+			return fmt.Errorf("failed to write new file %s: %w", h.File, err)
+		}
+	}
+
+	// Stage the new file
+	if _, err := r.RunGitCommandWithContext(ctx, "add", h.File); err != nil {
+		return fmt.Errorf("failed to stage new file %s: %w", h.File, err)
+	}
+	return nil
+}
+
+// rescueMisdetectedNewFiles checks if any modification hunks are actually for new files
+// that weren't properly detected. Returns hunks that should be treated as new files
+// and the remaining modification hunks.
+func (r *runner) rescueMisdetectedNewFiles(ctx context.Context, modHunks []Hunk) (newFiles, remaining []Hunk) {
+	// Group hunks by file to check each file once
+	fileHunks := make(map[string][]Hunk)
+	for _, h := range modHunks {
+		fileHunks[h.File] = append(fileHunks[h.File], h)
+	}
+
+	for file, hunks := range fileHunks {
+		// Check if file exists in working tree but not in index
+		// This indicates a new file that wasn't properly detected
+		existsInIndex, err := r.fileExistsInIndex(ctx, file)
+		if err != nil {
+			// On error, keep as modification to preserve original behavior
+			remaining = append(remaining, hunks...)
+			continue
+		}
+
+		if !existsInIndex {
+			// File doesn't exist in index - treat as new file
+			for _, h := range hunks {
+				h.IsNewFile = true
+				newFiles = append(newFiles, h)
+			}
+		} else {
+			remaining = append(remaining, hunks...)
+		}
+	}
+	return newFiles, remaining
+}
+
+// fileExistsInIndex checks if a file exists in the git index.
+func (r *runner) fileExistsInIndex(ctx context.Context, file string) (bool, error) {
+	// Use ls-files without --error-unmatch and check output instead.
+	// This is more robust across git versions and locales than parsing error messages.
+	output, err := r.RunGitCommandWithContext(ctx, "ls-files", "--", file)
+	if err != nil {
+		return false, fmt.Errorf("failed to check index for %s: %w", file, err)
+	}
+	// If file is in index, ls-files outputs the filename
+	return strings.TrimSpace(output) != "", nil
+}
+
 // extractContentFromHunk extracts the file content from a new file hunk.
 // It parses the unified diff format and returns only the added lines (without the + prefix).
+// Respects the "\ No newline at end of file" marker to preserve files without trailing newlines.
 func extractContentFromHunk(h Hunk) string {
 	var lines []string
+	hasNoNewlineMarker := false
 	for _, line := range strings.Split(h.Content, "\n") {
 		// Skip the hunk header line (@@ ... @@)
 		if strings.HasPrefix(line, "@@") {
+			continue
+		}
+		// Check for the "no newline at end of file" marker
+		if line == "\\ No newline at end of file" {
+			hasNoNewlineMarker = true
 			continue
 		}
 		// Include lines that start with + (but not the +++ header)
@@ -179,8 +269,8 @@ func extractContentFromHunk(h Hunk) string {
 		}
 	}
 	result := strings.Join(lines, "\n")
-	// Ensure file ends with newline if there was content
-	if len(lines) > 0 && !strings.HasSuffix(result, "\n") {
+	// Add trailing newline only if the original file had one (no marker present)
+	if len(lines) > 0 && !hasNoNewlineMarker {
 		result += "\n"
 	}
 	return result

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -481,6 +481,13 @@ func (t *tracingRunner) GetUnstagedDiff(ctx context.Context, files ...string) (s
 	return result, err
 }
 
+func (t *tracingRunner) GetDiffBetween(ctx context.Context, base, head string, files ...string) (string, error) {
+	start := time.Now()
+	result, err := t.inner.GetDiffBetween(ctx, base, head, files...)
+	t.trace("GetDiffBetween", time.Since(start), err == nil, err)
+	return result, err
+}
+
 // StagingOperations methods
 
 func (t *tracingRunner) StageAll(ctx context.Context) error {

--- a/internal/integration/split_test.go
+++ b/internal/integration/split_test.go
@@ -167,10 +167,11 @@ func TestSplitWorkflow(t *testing.T) {
 		sh.Run("split --by-file extract_test.txt")
 
 		// split creates:
-		// - feature_split: 1 commit (extract files from feature)
-		// - feature: 2 commits (original commit + removal commit)
+		// - feature_split: 1 commit (extracted file changes)
+		// - feature: 1 commit (remaining file changes)
+		// Note: The new hunk-based approach doesn't need a removal commit
 		sh.CommitCount("main", "feature_split", 1)
-		sh.CommitCount("feature_split", "feature", 2) // original + removal commit
+		sh.CommitCount("feature_split", "feature", 1)
 	})
 
 	t.Run("split --by-commit accepts the flag and shows interactive prompt", func(t *testing.T) {
@@ -479,6 +480,113 @@ func verifyFilesNotExist(t *testing.T, sh *TestShell, filenames []string) {
 		require.False(t, strings.Contains(outputStr, filename),
 			"expected file %s to NOT exist on current branch", filename)
 	}
+}
+
+// =============================================================================
+// Split by File - Hunk-Based Extraction Tests
+//
+// These tests verify that --by-file extracts CHANGES to files, not whole files.
+// This is the correct semantic for modified files.
+// =============================================================================
+
+func TestSplitByFileExtractsChanges(t *testing.T) {
+	t.Parallel()
+
+	t.Run("by-file extracts changes not whole file for modified files", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Setup: create a file with existing content
+		sh.Write("base", "line1\nline2\nline3\n").
+			Run("create setup -m 'Setup file with content'")
+
+		// Feature: modify the existing file and add a new file
+		sh.Write("base", "line1\nmodified line2\nline3\n").
+			Write("newfile", "new content").
+			Run("create feature -m 'Modify existing and add new'")
+
+		// Split out only the base file changes
+		sh.Run("split --by-file base_test.txt")
+
+		// Verify branches exist
+		sh.HasBranches("main", "setup", "feature", "feature_split")
+
+		// Verify feature_split has the base file changes
+		sh.Checkout("feature_split").
+			Git("show HEAD:base_test.txt").
+			OutputContains("modified line2")
+
+		// Verify feature still has the new file but NOT the base file modification
+		sh.Checkout("feature").
+			Git("show HEAD:newfile_test.txt").
+			OutputContains("new content")
+		// The base file on feature should be inherited from feature_split
+		// but feature's commit diff should NOT include base_test.txt changes
+		sh.Git("show HEAD --stat").
+			OutputContains("newfile_test.txt").
+			OutputNotContains("base_test.txt")
+	})
+
+	t.Run("by-file extracts whole file for new files", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Setup: create a base branch
+		sh.Write("existing", "existing content").
+			Run("create setup -m 'Setup'")
+
+		// Feature: add two new files
+		sh.Write("file1", "file1 content").
+			Write("file2", "file2 content").
+			Run("create feature -m 'Add two files'")
+
+		// Split out file1 only
+		sh.Run("split --by-file file1_test.txt")
+
+		// Verify feature_split has file1
+		sh.Checkout("feature_split").
+			Git("show HEAD:file1_test.txt").
+			OutputContains("file1 content")
+
+		// Verify feature_split does NOT have file2
+		sh.Git("ls-tree HEAD --name-only").
+			OutputNotContains("file2_test.txt")
+
+		// Verify feature has file2
+		sh.Checkout("feature").
+			Git("show HEAD:file2_test.txt").
+			OutputContains("file2 content")
+	})
+
+	t.Run("by-file with mixed new and modified files", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Setup: create a base file
+		sh.Write("existing", "original\n").
+			Run("create setup -m 'Setup'")
+
+		// Feature: modify existing and add new file
+		sh.Write("existing", "modified\n").
+			Write("newfile", "new content").
+			Run("create feature -m 'Modify and add'")
+
+		// Split out the new file (leave modification on feature)
+		sh.Run("split --by-file newfile_test.txt")
+
+		// feature_split should have the new file
+		sh.Checkout("feature_split").
+			Git("show HEAD:newfile_test.txt").
+			OutputContains("new content")
+		// feature_split should NOT have the existing file modification
+		sh.Git("show HEAD:existing_test.txt").
+			OutputContains("original") // inherits from setup
+
+		// feature should have the modification
+		sh.Checkout("feature").
+			Git("show HEAD:existing_test.txt").
+			OutputContains("modified")
+	})
 }
 
 // =============================================================================
@@ -1027,5 +1135,196 @@ new file mode 100644
 		// New file should not be in feature's commit
 		sh.Git("show HEAD -- newfile_test.txt").
 			OutputNotContains("new file content")
+	})
+}
+
+// =============================================================================
+// Split Edge Case Tests
+//
+// These tests cover edge cases and error handling for split operations.
+// =============================================================================
+
+func TestSplitEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("by-file works with multi-commit branch", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Setup
+		sh.Write("base", "base content").
+			Run("create setup -m 'Setup'")
+
+		// Create feature with first commit
+		sh.Write("file1", "v1").
+			Run("create feature -m 'Add file1'")
+
+		// Add more commits to same branch
+		sh.Commit("file2", "Add file2")
+		sh.Write("file1", "v2").
+			Git("add file1_test.txt").
+			Git("commit -m 'Update file1 v2'")
+
+		// Verify feature has multiple commits
+		sh.CommitCount("setup", "feature", 3)
+
+		// Split out file1 (should include changes from all commits)
+		sh.Run("split --by-file file1_test.txt")
+
+		// feature_split should have file1 with v2 content
+		sh.Checkout("feature_split").
+			Git("show HEAD:file1_test.txt").
+			OutputContains("v2")
+
+		// feature should have file2 but not file1 changes
+		sh.Checkout("feature").
+			Git("show HEAD --stat").
+			OutputContains("file2_test.txt").
+			OutputNotContains("file1_test.txt")
+	})
+
+	t.Run("by-file with deleted file", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Setup with two files (add trailing newlines to match patch format)
+		sh.Write("keep", "keep content\n").
+			Write("todelete", "will be deleted\n").
+			Run("create setup -m 'Setup with files'")
+
+		// Feature: modify one, delete another
+		sh.Write("keep", "modified keep\n").
+			Git("rm todelete_test.txt").
+			Run("create feature -m 'Modify and delete'")
+
+		// Split out the deletion
+		sh.Run("split --by-file todelete_test.txt")
+
+		// feature_split should NOT have todelete_test.txt (it was deleted)
+		sh.Checkout("feature_split").
+			Git("ls-tree HEAD --name-only").
+			OutputNotContains("todelete_test.txt")
+
+		// feature should still have keep modifications
+		sh.Checkout("feature").
+			Git("show HEAD:keep_test.txt").
+			OutputContains("modified keep")
+	})
+
+	t.Run("split creates snapshot for undo recovery", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("file1", "content1").
+			Write("file2", "content2").
+			Run("create feature -m 'Add files'")
+
+		// Verify initial state
+		sh.HasBranches("main", "feature")
+
+		// Successful split should create snapshot
+		sh.Run("split --by-file file1_test.txt")
+
+		// Verify split happened
+		sh.HasBranches("main", "feature", "feature_split")
+
+		// Verify we can undo using the snapshot
+		sh.UndoLatest()
+
+		// Should be back on original feature with both files
+		sh.OnBranch("feature")
+
+		// Split branch should be removed
+		sh.HasBranches("main", "feature")
+
+		// Verify both files exist in the tree
+		verifyFilesExist(t, sh, []string{"file1_test.txt", "file2_test.txt"})
+	})
+
+	t.Run("by-file with special characters in filename", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("normal", "normal content").
+			Run("create setup -m 'Setup'")
+
+		// Create files with special characters (dashes and underscores)
+		sh.Write("file-with-dashes", "dashes content").
+			Write("file_with_underscores", "underscores content").
+			Run("create feature -m 'Add files with special chars'")
+
+		// Split one of them
+		sh.Run("split --by-file file-with-dashes_test.txt")
+
+		sh.Checkout("feature_split").
+			Git("show HEAD:file-with-dashes_test.txt").
+			OutputContains("dashes content")
+
+		// feature should have the other file
+		sh.Checkout("feature").
+			Git("show HEAD:file_with_underscores_test.txt").
+			OutputContains("underscores content")
+	})
+
+	t.Run("sibling mode extracts changes not whole files", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Setup with existing file
+		sh.Write("existing", "original line1\noriginal line2\n").
+			Run("create setup -m 'Setup'")
+
+		// Feature modifies existing and adds new
+		sh.Write("existing", "modified line1\noriginal line2\n").
+			Write("newfile", "new content").
+			Run("create feature -m 'Modify and add'")
+
+		// Split with sibling - extracts the change to new sibling
+		sh.Run("split --by-file existing_test.txt --as-sibling")
+
+		// feature_split should have the modification
+		sh.Checkout("feature_split").
+			Git("show HEAD:existing_test.txt").
+			OutputContains("modified line1")
+
+		// feature should be UNCHANGED (sibling mode)
+		sh.Checkout("feature").
+			Git("show HEAD:existing_test.txt").
+			OutputContains("modified line1")
+		// Also verify newfile is still there
+		sh.Git("show HEAD:newfile_test.txt").
+			OutputContains("new content")
+	})
+
+	t.Run("split returns to original branch on error", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Setup with a single file
+		sh.Write("onlyfile", "content").
+			Run("create feature -m 'Add file'")
+
+		// Trying to split the only file should fail
+		sh.RunExpectError("split --by-file onlyfile_test.txt").
+			OutputContains("nothing would remain")
+
+		// Should still be on feature branch (safety invariant)
+		sh.OnBranch("feature")
+	})
+
+	t.Run("split fails gracefully with nonexistent file", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("file1", "content1").
+			Write("file2", "content2").
+			Run("create feature -m 'Add files'")
+
+		// Trying to split a file that doesn't exist
+		sh.RunExpectError("split --by-file nonexistent.txt").
+			OutputContains("no changes found")
+
+		// Should still be on feature branch
+		sh.OnBranch("feature")
 	})
 }


### PR DESCRIPTION

- Add fallback detection for new files via "--- /dev/null" in ParseDiffOutput
- Add fileExistsInIndex helper and improve StageHunks error handling
- Refactor splitByFile to use hunk-based extraction instead of whole files
- Add GetDiffBetween method for raw diff output suitable for parsing
- Update --by-file to extract only changes, not complete file contents
- Add comprehensive unit and integration tests for new file scenarios
- Fix test expectations to match new single-commit behavior

This ensures new files are properly handled in split --patch and
makes --by-file semantics more intuitive by extracting changes
rather than whole files for modified files.