### PR TITLE
feat: add individual merge option for independent PRs in squash mode

### DIFF
--- a/internal/actions/merge/interactive.go
+++ b/internal/actions/merge/interactive.go
@@ -89,6 +89,13 @@ type InteractiveHandler interface {
 	// Called after successful merge execution.
 	// Returns ErrCanceled if user cancels (treated as "done").
 	PromptPostMerge(hasUncommittedChanges bool, trunkName string) (PostMergeAction, error)
+
+	// PromptIndividualMerge asks user if they want to merge PRs individually
+	// when consolidation was requested but individual merge is possible.
+	// This is offered when all branches are leaves (no children) and all PRs
+	// are mergeable without conflicts.
+	// Returns true for individual merge, false for consolidation.
+	PromptIndividualMerge(branches []BranchMergeInfo) (bool, error)
 }
 
 // GetAvailableScopes returns all unique non-empty scopes in the repository

--- a/internal/actions/merge/plan.go
+++ b/internal/actions/merge/plan.go
@@ -626,3 +626,72 @@ func formatSquashPlanSteps(plan *Plan) string {
 
 	return result.String()
 }
+
+// AllBranchesAreLeaves checks if all branches in the plan have no children in the stack graph.
+// This is used to determine if individual merging is possible (only leaf branches can be
+// merged individually without affecting other branches).
+func AllBranchesAreLeaves(graph *engine.StackGraph, branches []BranchMergeInfo) bool {
+	for _, branchInfo := range branches {
+		node := graph.Nodes[branchInfo.BranchName]
+		if node != nil && len(node.Children) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// IndividualMergeStatus contains the result of checking if individual merge is possible
+type IndividualMergeStatus struct {
+	CanMerge       bool            // True if all PRs can be merged individually
+	MergeableState map[string]bool // Per-branch mergeable state (true = mergeable)
+	BlockingReason string          // Reason why individual merge is blocked (if any)
+}
+
+// CanMergeIndividually checks if all PRs can be merged individually by verifying:
+// 1. All branches are leaf branches (no children)
+// 2. All PRs have GitHub mergeable state = MERGEABLE (no conflicts with trunk)
+//
+// Returns the status including per-branch mergeable states for display purposes.
+func CanMergeIndividually(ctx context.Context, gitRunner git.Runner, githubClient github.Client, graph *engine.StackGraph, branches []BranchMergeInfo) (*IndividualMergeStatus, error) {
+	status := &IndividualMergeStatus{
+		MergeableState: make(map[string]bool),
+	}
+
+	// Check 1: All branches must be leaves
+	if !AllBranchesAreLeaves(graph, branches) {
+		status.BlockingReason = "some branches have children"
+		return status, nil
+	}
+
+	// Check 2: All PRs must have MERGEABLE state
+	owner, repo := githubClient.GetOwnerRepo()
+
+	for _, branchInfo := range branches {
+		// Get the PR info from GitHub to obtain NodeID
+		prInfo, err := githubClient.GetPullRequest(ctx, owner, repo, branchInfo.PRNumber)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get PR #%d for %s: %w", branchInfo.PRNumber, branchInfo.BranchName, err)
+		}
+
+		if prInfo == nil || prInfo.NodeID == "" {
+			status.BlockingReason = fmt.Sprintf("branch %s has no PR node ID", branchInfo.BranchName)
+			return status, nil
+		}
+
+		// Check mergeable state via GraphQL
+		mergeState, err := github.GetPRMergeableState(ctx, gitRunner, prInfo.NodeID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get mergeable state for %s: %w", branchInfo.BranchName, err)
+		}
+
+		status.MergeableState[branchInfo.BranchName] = mergeState.Mergeable
+
+		if !mergeState.Mergeable {
+			status.BlockingReason = fmt.Sprintf("PR for %s has conflicts with trunk", branchInfo.BranchName)
+		}
+	}
+
+	// All checks passed if no blocking reason was set
+	status.CanMerge = status.BlockingReason == ""
+	return status, nil
+}

--- a/internal/actions/merge/plan_test.go
+++ b/internal/actions/merge/plan_test.go
@@ -356,3 +356,98 @@ func TestCreateMergePlan(t *testing.T) {
 		require.Equal(t, merge.StepDeleteBranch, plan.Steps[3].StepType)
 	})
 }
+
+func TestAllBranchesAreLeaves(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns true when all branches are leaves", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"leaf1": "main",
+				"leaf2": "main",
+			})
+
+		graph := engine.BuildStackGraph(s.Engine, engine.SortStrategyAlphabetical, nil)
+
+		branches := []merge.BranchMergeInfo{
+			{BranchName: "leaf1", PRNumber: 1},
+			{BranchName: "leaf2", PRNumber: 2},
+		}
+
+		result := merge.AllBranchesAreLeaves(graph, branches)
+		require.True(t, result)
+	})
+
+	t.Run("returns false when a branch has children", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"parent": "main",
+				"child":  "parent",
+			})
+
+		graph := engine.BuildStackGraph(s.Engine, engine.SortStrategyAlphabetical, nil)
+
+		branches := []merge.BranchMergeInfo{
+			{BranchName: "parent", PRNumber: 1},
+		}
+
+		result := merge.AllBranchesAreLeaves(graph, branches)
+		require.False(t, result)
+	})
+
+	t.Run("returns true for single leaf branch", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"only-branch": "main",
+			})
+
+		graph := engine.BuildStackGraph(s.Engine, engine.SortStrategyAlphabetical, nil)
+
+		branches := []merge.BranchMergeInfo{
+			{BranchName: "only-branch", PRNumber: 1},
+		}
+
+		result := merge.AllBranchesAreLeaves(graph, branches)
+		require.True(t, result)
+	})
+
+	t.Run("returns true for empty branch list", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		graph := engine.BuildStackGraph(s.Engine, engine.SortStrategyAlphabetical, nil)
+
+		branches := []merge.BranchMergeInfo{}
+
+		result := merge.AllBranchesAreLeaves(graph, branches)
+		require.True(t, result)
+	})
+
+	t.Run("returns false when one of multiple branches has children", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"leaf":   "main",
+				"parent": "main",
+				"child":  "parent",
+			})
+
+		graph := engine.BuildStackGraph(s.Engine, engine.SortStrategyAlphabetical, nil)
+
+		branches := []merge.BranchMergeInfo{
+			{BranchName: "leaf", PRNumber: 1},
+			{BranchName: "parent", PRNumber: 2},
+		}
+
+		result := merge.AllBranchesAreLeaves(graph, branches)
+		require.False(t, result)
+	})
+}

--- a/internal/cli/stack/merge/handlers.go
+++ b/internal/cli/stack/merge/handlers.go
@@ -131,6 +131,11 @@ func (h *SimpleMergeEventHandler) PromptPostMerge(_ bool, _ string) (mergeAction
 	return mergeAction.PostMergeDone, nil
 }
 
+// PromptIndividualMerge implements InteractiveHandler. Returns error in non-interactive mode.
+func (h *SimpleMergeEventHandler) PromptIndividualMerge(_ []mergeAction.BranchMergeInfo) (bool, error) {
+	return false, fmt.Errorf("interactive mode required for individual merge selection")
+}
+
 // InteractiveMergeEventHandler provides a TUI for merge operations using runner.Send()
 type InteractiveMergeEventHandler struct {
 	runner *tui.Runner
@@ -469,6 +474,48 @@ func (h *InteractiveMergeEventHandler) PromptPostMerge(hasUncommittedChanges boo
 	default:
 		return mergeAction.PostMergeDone, nil
 	}
+}
+
+// PromptIndividualMerge implements InteractiveHandler.
+func (h *InteractiveMergeEventHandler) PromptIndividualMerge(branches []mergeAction.BranchMergeInfo) (bool, error) {
+	h.runner.Pause()
+	defer h.runner.Resume()
+
+	// Build descriptive prompt
+	branchCount := len(branches)
+	var branchList strings.Builder
+	for i, b := range branches {
+		if i > 0 {
+			branchList.WriteString(", ")
+		}
+		branchList.WriteString(fmt.Sprintf("PR #%d (%s)", b.PRNumber, b.BranchName))
+		if i >= 2 && branchCount > 3 {
+			fmt.Fprintf(&branchList, ", and %d more", branchCount-i-1)
+			break
+		}
+	}
+
+	fmt.Println()
+	fmt.Printf("All %d PRs are independent branches with no conflicts.\n", branchCount)
+	fmt.Printf("Branches: %s\n\n", branchList.String())
+
+	options := []tui.SelectOption{
+		{
+			Label: "🔄 Merge individually — Merge each PR one at a time (recommended)",
+			Value: "individual",
+		},
+		{
+			Label: "🔀 Create consolidated PR — Combine all into a single merge commit",
+			Value: "consolidate",
+		},
+	}
+
+	selected, err := tui.PromptSelect("How would you like to merge these PRs?", options, 0)
+	if err != nil {
+		return false, err
+	}
+
+	return selected == "individual", nil
 }
 
 // Group represents a group of steps that should be displayed as a single line.

--- a/internal/cli/stack/merge/squash.go
+++ b/internal/cli/stack/merge/squash.go
@@ -11,6 +11,7 @@ import (
 	"stackit.dev/stackit/internal/app"
 	"stackit.dev/stackit/internal/cli/common"
 	"stackit.dev/stackit/internal/config"
+	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/internal/github"
 	"stackit.dev/stackit/internal/tui"
 )
@@ -122,6 +123,70 @@ func runMergeSquash(ctx *app.Context, opts mergeSquashOptions, postMergeHandler 
 	if opts.dryRun {
 		out.Info("Dry-run mode: No changes were made.")
 		return nil
+	}
+
+	// Check if individual merge is possible (only in interactive mode without --yes)
+	if !opts.yes && ctx.Interactive && len(plan.BranchesToMerge) > 0 {
+		graph := engine.BuildStackGraph(ctx.Engine, engine.SortStrategyAlphabetical, nil)
+		if mergeAction.AllBranchesAreLeaves(graph, plan.BranchesToMerge) {
+			// All branches are leaves - check if they're all mergeable
+			status, err := mergeAction.CanMergeIndividually(ctx.Context, ctx.Engine.Git(), ctx.GitHubClient, graph, plan.BranchesToMerge)
+			if err != nil {
+				out.Debug("Failed to check individual merge possibility: %v", err)
+			} else if status.CanMerge {
+				// Create a TUI handler for the prompt
+				runner, eventHandler := NewMergeUI(ctx.Output, ctx.Logger)
+				if runner != nil {
+					defer runner.Cleanup()
+				}
+
+				// Cast to InteractiveHandler to access the prompt method
+				if interactiveHandler, ok := eventHandler.(mergeAction.InteractiveHandler); ok && interactiveHandler.IsInteractive() {
+					useIndividual, err := interactiveHandler.PromptIndividualMerge(plan.BranchesToMerge)
+					if err != nil {
+						return fmt.Errorf("selection canceled: %w", err)
+					}
+
+					if useIndividual {
+						// Switch to bottom-up strategy
+						out.Info("Switching to individual merge mode...")
+						plan, _, err = mergeAction.CreateMergePlan(ctx.Context, ctx.Engine, ctx.Output, ctx.GitHubClient, mergeAction.CreatePlanOptions{
+							Strategy: mergeAction.StrategyBottomUp,
+							Force:    opts.force,
+							Scope:    opts.scope,
+							Wait:     true, // Individual merge always waits
+						})
+						if err != nil {
+							return err
+						}
+
+						// Execute bottom-up merge
+						cfg, _ := config.LoadConfig(ctx.RepoRoot)
+						actionOpts := mergeAction.Options{
+							DryRun:         false,
+							Confirm:        false,
+							Strategy:       mergeAction.StrategyBottomUp,
+							Force:          opts.force,
+							Wait:           true,
+							Scope:          opts.scope,
+							Plan:           plan,
+							UndoStackDepth: cfg.UndoStackDepth(),
+							Handler:        mergeAction.NewLegacyHandlerAdapter(eventHandler),
+						}
+
+						if err := mergeAction.Action(ctx, actionOpts); err != nil {
+							return err
+						}
+
+						// Post-merge cleanup
+						if postMergeHandler != nil {
+							return postMergeHandler(ctx, mergeAction.PostMergeSyncTrunk)
+						}
+						return nil
+					}
+				}
+			}
+		}
 	}
 
 	// Confirm unless --yes


### PR DESCRIPTION

When using 'stackit merge squash' and all selected branches are leaf
branches (no children) with no merge conflicts, offer the user a choice
to merge them individually instead of creating a consolidated PR.

- Add AllBranchesAreLeaves() and CanMergeIndividually() detection functions
- Add PromptIndividualMerge() to InteractiveHandler interface
- Implement TUI prompt with individual vs consolidated options
- Switch to bottom-up strategy when user chooses individual merge
- Add comprehensive unit tests for detection logic

This preserves individual commit history on trunk for simple independent
PRs while still allowing consolidation for complex stacks.


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #633** 👈
  * **PR #634**
    * **PR #637**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->