### PR TITLE
feat: streamline single-branch merge confirmation in UI wizard

### DIFF
--- a/internal/actions/merge/interactive.go
+++ b/internal/actions/merge/interactive.go
@@ -96,6 +96,11 @@ type InteractiveHandler interface {
 	// are mergeable without conflicts.
 	// Returns true for individual merge, false for consolidation.
 	PromptIndividualMerge(branches []BranchMergeInfo) (bool, error)
+
+	// PromptSimpleMergeConfirm shows a simplified confirmation for single-branch merges.
+	// This provides a cleaner UX than ShowPlan + PromptConfirm for simple cases.
+	// Returns true to proceed, false to cancel.
+	PromptSimpleMergeConfirm(branch BranchMergeInfo, baseBranch string) (bool, error)
 }
 
 // GetAvailableScopes returns all unique non-empty scopes in the repository

--- a/internal/actions/merge/plan.go
+++ b/internal/actions/merge/plan.go
@@ -627,6 +627,19 @@ func formatSquashPlanSteps(plan *Plan) string {
 	return result.String()
 }
 
+// IsSingleBranchLeafMerge returns true if this is a simple merge of a single
+// leaf branch (no children, no upstack work needed). This is used to streamline
+// the UI for simple single-PR merges.
+func IsSingleBranchLeafMerge(plan *Plan, graph *engine.StackGraph) bool {
+	if len(plan.BranchesToMerge) != 1 {
+		return false
+	}
+	if len(plan.UpstackBranches) > 0 {
+		return false
+	}
+	return AllBranchesAreLeaves(graph, plan.BranchesToMerge)
+}
+
 // AllBranchesAreLeaves checks if all branches in the plan have no children in the stack graph.
 // This is used to determine if individual merging is possible (only leaf branches can be
 // merged individually without affecting other branches).

--- a/internal/actions/merge/plan_test.go
+++ b/internal/actions/merge/plan_test.go
@@ -451,3 +451,112 @@ func TestAllBranchesAreLeaves(t *testing.T) {
 		require.False(t, result)
 	})
 }
+
+func TestIsSingleBranchLeafMerge(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns true for single leaf branch with no upstack", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"feature": "main",
+			})
+
+		graph := engine.BuildStackGraph(s.Engine, engine.SortStrategyAlphabetical, nil)
+
+		plan := &merge.Plan{
+			BranchesToMerge: []merge.BranchMergeInfo{
+				{BranchName: "feature", PRNumber: 1},
+			},
+			UpstackBranches: []string{},
+		}
+
+		result := merge.IsSingleBranchLeafMerge(plan, graph)
+		require.True(t, result)
+	})
+
+	t.Run("returns false for multiple branches", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"branch1": "main",
+				"branch2": "branch1",
+			})
+
+		graph := engine.BuildStackGraph(s.Engine, engine.SortStrategyAlphabetical, nil)
+
+		plan := &merge.Plan{
+			BranchesToMerge: []merge.BranchMergeInfo{
+				{BranchName: "branch1", PRNumber: 1},
+				{BranchName: "branch2", PRNumber: 2},
+			},
+			UpstackBranches: []string{},
+		}
+
+		result := merge.IsSingleBranchLeafMerge(plan, graph)
+		require.False(t, result)
+	})
+
+	t.Run("returns false when branch has upstack work", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"parent": "main",
+				"child":  "parent",
+			})
+
+		graph := engine.BuildStackGraph(s.Engine, engine.SortStrategyAlphabetical, nil)
+
+		plan := &merge.Plan{
+			BranchesToMerge: []merge.BranchMergeInfo{
+				{BranchName: "parent", PRNumber: 1},
+			},
+			UpstackBranches: []string{"child"},
+		}
+
+		result := merge.IsSingleBranchLeafMerge(plan, graph)
+		require.False(t, result)
+	})
+
+	t.Run("returns false when single branch has children in graph", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"parent": "main",
+				"child":  "parent",
+			})
+
+		graph := engine.BuildStackGraph(s.Engine, engine.SortStrategyAlphabetical, nil)
+
+		// Even if upstack is empty, the branch itself has children in the graph
+		plan := &merge.Plan{
+			BranchesToMerge: []merge.BranchMergeInfo{
+				{BranchName: "parent", PRNumber: 1},
+			},
+			UpstackBranches: []string{},
+		}
+
+		result := merge.IsSingleBranchLeafMerge(plan, graph)
+		require.False(t, result)
+	})
+
+	t.Run("returns false for empty plan", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		graph := engine.BuildStackGraph(s.Engine, engine.SortStrategyAlphabetical, nil)
+
+		plan := &merge.Plan{
+			BranchesToMerge: []merge.BranchMergeInfo{},
+			UpstackBranches: []string{},
+		}
+
+		result := merge.IsSingleBranchLeafMerge(plan, graph)
+		require.False(t, result)
+	})
+}

--- a/internal/actions/merge/wizard.go
+++ b/internal/actions/merge/wizard.go
@@ -8,6 +8,7 @@ import (
 
 	"stackit.dev/stackit/internal/app"
 	"stackit.dev/stackit/internal/config"
+	"stackit.dev/stackit/internal/engine"
 	sterrors "stackit.dev/stackit/internal/errors"
 	"stackit.dev/stackit/internal/github"
 )
@@ -209,34 +210,59 @@ func RunWizard(ctx *app.Context, handler InteractiveHandler, opts WizardOptions)
 	}
 	out.Debug("merge wizard: final plan has %d branches, %d steps", len(plan.BranchesToMerge), len(plan.Steps))
 
-	// Show the final plan with the selected strategy
-	handler.ShowPlan(plan, validation)
+	// Check for simple single-branch merge case for streamlined UX
+	graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
+	isSimpleMerge := IsSingleBranchLeafMerge(plan, graph) &&
+		len(validation.Errors) == 0 &&
+		len(validation.Warnings) == 0
 
-	// Re-validate with new strategy
-	if !validation.Valid && !opts.Force {
-		out.Debug("merge wizard: validation failed")
-		return formatValidationError(validation.Errors, validation.Warnings)
-	}
+	if isSimpleMerge && !opts.DryRun {
+		// Use simplified confirmation for single-branch merges
+		branch := plan.BranchesToMerge[0]
+		baseBranch := eng.Trunk().GetName()
+		out.Debug("merge wizard: simple single-branch merge detected, using simplified confirmation")
 
-	// If dry-run, stop here
-	if opts.DryRun {
-		out.Debug("merge wizard: dry-run mode, stopping before execution")
-		out.Info("Dry-run mode: plan displayed above. Use without --dry-run to execute.")
-		return nil
-	}
+		confirmed, err := handler.PromptSimpleMergeConfirm(branch, baseBranch)
+		if err != nil {
+			out.Debug("merge wizard: simple confirmation error: %v", err)
+			return fmt.Errorf("confirmation canceled: %w", err)
+		}
+		if !confirmed {
+			out.Debug("merge wizard: user declined simple confirmation")
+			out.Info("Merge canceled")
+			return nil
+		}
+		out.Debug("merge wizard: user confirmed simple merge")
+	} else {
+		// Show the full plan for complex merges or when there are warnings/errors
+		handler.ShowPlan(plan, validation)
 
-	// Confirm before executing
-	confirmed, err := handler.PromptConfirm("Proceed with merge?", false)
-	if err != nil {
-		out.Debug("merge wizard: confirmation error: %v", err)
-		return fmt.Errorf("confirmation canceled: %w", err)
+		// Re-validate with new strategy
+		if !validation.Valid && !opts.Force {
+			out.Debug("merge wizard: validation failed")
+			return formatValidationError(validation.Errors, validation.Warnings)
+		}
+
+		// If dry-run, stop here
+		if opts.DryRun {
+			out.Debug("merge wizard: dry-run mode, stopping before execution")
+			out.Info("Dry-run mode: plan displayed above. Use without --dry-run to execute.")
+			return nil
+		}
+
+		// Confirm before executing
+		confirmed, err := handler.PromptConfirm("Proceed with merge?", false)
+		if err != nil {
+			out.Debug("merge wizard: confirmation error: %v", err)
+			return fmt.Errorf("confirmation canceled: %w", err)
+		}
+		if !confirmed {
+			out.Debug("merge wizard: user declined confirmation")
+			out.Info("Merge canceled")
+			return nil
+		}
+		out.Debug("merge wizard: user confirmed, proceeding with merge")
 	}
-	if !confirmed {
-		out.Debug("merge wizard: user declined confirmation")
-		out.Info("Merge canceled")
-		return nil
-	}
-	out.Debug("merge wizard: user confirmed, proceeding with merge")
 
 	// Get config values
 	cfg, _ := config.LoadConfig(ctx.RepoRoot)

--- a/internal/cli/stack/merge/handlers.go
+++ b/internal/cli/stack/merge/handlers.go
@@ -136,6 +136,11 @@ func (h *SimpleMergeEventHandler) PromptIndividualMerge(_ []mergeAction.BranchMe
 	return false, fmt.Errorf("interactive mode required for individual merge selection")
 }
 
+// PromptSimpleMergeConfirm implements InteractiveHandler. Returns error in non-interactive mode.
+func (h *SimpleMergeEventHandler) PromptSimpleMergeConfirm(_ mergeAction.BranchMergeInfo, _ string) (bool, error) {
+	return false, fmt.Errorf("interactive mode required for confirmation")
+}
+
 // InteractiveMergeEventHandler provides a TUI for merge operations using runner.Send()
 type InteractiveMergeEventHandler struct {
 	runner *tui.Runner
@@ -516,6 +521,18 @@ func (h *InteractiveMergeEventHandler) PromptIndividualMerge(branches []mergeAct
 	}
 
 	return selected == "individual", nil
+}
+
+// PromptSimpleMergeConfirm implements InteractiveHandler.
+func (h *InteractiveMergeEventHandler) PromptSimpleMergeConfirm(branch mergeAction.BranchMergeInfo, baseBranch string) (bool, error) {
+	h.runner.Pause()
+	defer h.runner.Resume()
+
+	fmt.Println()
+	fmt.Printf("Ready to merge PR #%d: %s\n", branch.PRNumber, branch.BranchName)
+	fmt.Printf("Target: %s\n\n", baseBranch)
+
+	return tui.PromptConfirm("Proceed?", false)
 }
 
 // Group represents a group of steps that should be displayed as a single line.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #634** 👈
  * **PR #637**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->