### PR TITLE
feat: enhance worktree list display and add prune command

### DIFF
--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -23,15 +23,19 @@ type ListOptions struct {
 
 // ListResult contains the results of listing worktrees
 type ListResult struct {
-	Worktrees []Entry
+	Worktrees     []Entry
+	CurrentAnchor string // Anchor branch of the worktree we're currently in (if any)
 }
 
 // Entry represents a single managed worktree
 type Entry struct {
-	Name         string // User-provided name (empty for legacy worktrees)
-	AnchorBranch string // Anchor branch name
-	Path         string
-	Exists       bool // Whether the path still exists on disk
+	Name          string // User-provided name (empty for legacy worktrees)
+	AnchorBranch  string // Anchor branch name
+	Path          string
+	Exists        bool   // Whether the path still exists on disk
+	StackSize     int    // Number of branches in the stack (excluding anchor)
+	CurrentBranch string // Branch currently checked out in this worktree
+	IsDirty       bool   // Has uncommitted changes
 }
 
 // ListAction lists all managed worktrees
@@ -45,19 +49,52 @@ func ListAction(ctx *app.Context, _ ListOptions) (*ListResult, error) {
 		Worktrees: make([]Entry, 0, len(worktrees)),
 	}
 
-	for _, wt := range worktrees {
-		// Check if path exists
-		exists := true
-		if _, statErr := os.Stat(wt.Path); os.IsNotExist(statErr) {
-			exists = false
-		}
+	// Check if we're in a managed worktree
+	if ctx.InManagedWorktree && ctx.WorktreeInfo != nil {
+		result.CurrentAnchor = ctx.WorktreeInfo.AnchorBranch
+	}
 
-		result.Worktrees = append(result.Worktrees, Entry{
+	// Build stack graph once to get stack sizes
+	graph := engine.BuildStackGraph(ctx.Engine, engine.SortStrategyAlphabetical, nil)
+
+	for _, wt := range worktrees {
+		entry := Entry{
 			Name:         wt.Name,
 			AnchorBranch: wt.AnchorBranch,
 			Path:         wt.Path,
-			Exists:       exists,
-		})
+			Exists:       true,
+		}
+
+		// Check if path exists
+		if _, statErr := os.Stat(wt.Path); os.IsNotExist(statErr) {
+			entry.Exists = false
+			result.Worktrees = append(result.Worktrees, entry)
+			continue
+		}
+
+		// Get stack size (descendants of anchor branch)
+		anchorBranch := ctx.Engine.GetBranch(wt.AnchorBranch)
+		if anchorBranch.IsTracked() {
+			descendants := graph.Range(anchorBranch, engine.StackRange{
+				RecursiveChildren: true,
+				IncludeCurrent:    false,
+			})
+			entry.StackSize = len(descendants)
+		}
+
+		// Get current branch in worktree
+		currentBranch, err := ctx.Git().GetWorktreeCurrentBranch(ctx.Context, wt.Path)
+		if err == nil && currentBranch != "" {
+			entry.CurrentBranch = currentBranch
+		}
+
+		// Check for uncommitted changes
+		isDirty, err := ctx.Git().WorktreeHasUncommittedChanges(ctx.Context, wt.Path)
+		if err == nil {
+			entry.IsDirty = isDirty
+		}
+
+		result.Worktrees = append(result.Worktrees, entry)
 	}
 
 	return result, nil
@@ -350,4 +387,101 @@ func cleanupAnchorBranch(ctx context.Context, eng engine.Engine, branchName stri
 	if err := eng.DeleteBranch(ctx, eng.GetBranch(branchName)); err != nil {
 		out.Warn("Failed to clean up anchor branch %s: %v", branchName, err)
 	}
+}
+
+// PruneOptions contains options for the prune action
+type PruneOptions struct {
+	DryRun bool // If true, only show what would be pruned
+}
+
+// PruneResult contains the results of pruning worktrees
+type PruneResult struct {
+	Pruned  []string       // Names of pruned worktrees
+	Skipped []SkippedEntry // Worktrees that were skipped and why
+}
+
+// SkippedEntry represents a worktree that was skipped during pruning
+type SkippedEntry struct {
+	Name   string
+	Reason string
+}
+
+// PruneAction removes all empty worktrees
+func PruneAction(ctx *app.Context, opts PruneOptions) (*PruneResult, error) {
+	// Get list of all worktrees with their details
+	listResult, err := ListAction(ctx, ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	result := &PruneResult{
+		Pruned:  make([]string, 0),
+		Skipped: make([]SkippedEntry, 0),
+	}
+
+	for _, wt := range listResult.Worktrees {
+		// Determine display name
+		name := wt.Name
+		if name == "" {
+			name = wt.AnchorBranch
+		}
+
+		// Skip missing worktrees (they should be cleaned up separately)
+		if !wt.Exists {
+			result.Skipped = append(result.Skipped, SkippedEntry{
+				Name:   name,
+				Reason: "worktree directory missing",
+			})
+			continue
+		}
+
+		// Skip worktrees with stacked branches
+		if wt.StackSize > 0 {
+			result.Skipped = append(result.Skipped, SkippedEntry{
+				Name:   name,
+				Reason: fmt.Sprintf("has %d stacked branches", wt.StackSize),
+			})
+			continue
+		}
+
+		// Skip worktrees with uncommitted changes
+		if wt.IsDirty {
+			result.Skipped = append(result.Skipped, SkippedEntry{
+				Name:   name,
+				Reason: "has uncommitted changes",
+			})
+			continue
+		}
+
+		// Skip if we're currently in this worktree
+		if listResult.CurrentAnchor != "" && wt.AnchorBranch == listResult.CurrentAnchor {
+			result.Skipped = append(result.Skipped, SkippedEntry{
+				Name:   name,
+				Reason: "currently in this worktree",
+			})
+			continue
+		}
+
+		// This worktree is empty and can be pruned
+		if opts.DryRun {
+			result.Pruned = append(result.Pruned, name)
+			continue
+		}
+
+		// Actually remove the worktree
+		if err := RemoveAction(ctx, RemoveOptions{
+			AnchorBranch: wt.AnchorBranch,
+			Force:        false,
+		}); err != nil {
+			result.Skipped = append(result.Skipped, SkippedEntry{
+				Name:   name,
+				Reason: fmt.Sprintf("removal failed: %v", err),
+			})
+			continue
+		}
+
+		result.Pruned = append(result.Pruned, name)
+	}
+
+	return result, nil
 }

--- a/internal/cli/worktree/worktree.go
+++ b/internal/cli/worktree/worktree.go
@@ -27,6 +27,7 @@ directory. Create a worktree with 'stackit worktree create' from trunk.`,
 	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(newRemoveCmd())
 	cmd.AddCommand(newOpenCmd())
+	cmd.AddCommand(newPruneCmd())
 
 	return cmd
 }
@@ -88,8 +89,7 @@ func newListCmd() *cobra.Command {
 		Short: "List all managed worktrees",
 		Long: `List all stackit-managed worktrees.
 
-Shows each worktree's anchor branch and path, with an indicator if the
-worktree directory no longer exists on disk.`,
+Shows each worktree's name, stack size, current branch, and status.`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
@@ -104,16 +104,9 @@ worktree directory no longer exists on disk.`,
 					return nil
 				}
 
-				ctx.Output.Info("Managed worktrees:")
 				for _, wt := range result.Worktrees {
-					stackName := style.ColorBranchName(wt.AnchorBranch, false)
-					if wt.Exists {
-						ctx.Output.Print(fmt.Sprintf("  %s %s", stackName, style.ColorDim(wt.Path)))
-					} else {
-						ctx.Output.Print(fmt.Sprintf("  %s %s %s", stackName, style.ColorDim(wt.Path), style.ColorRed("(missing)")))
-					}
+					renderWorktreeEntry(ctx, wt, result.CurrentAnchor)
 				}
-				ctx.Output.Newline()
 
 				return nil
 			})
@@ -121,6 +114,62 @@ worktree directory no longer exists on disk.`,
 	}
 
 	return cmd
+}
+
+// renderWorktreeEntry renders a single worktree entry
+func renderWorktreeEntry(ctx *app.Context, wt worktree.Entry, currentAnchor string) {
+	// Indicator for current worktree
+	indicator := "  "
+	isCurrent := currentAnchor != "" && wt.AnchorBranch == currentAnchor
+	if isCurrent {
+		indicator = style.ColorGreen("@ ")
+	}
+
+	// Name (use worktree name if available, otherwise anchor branch)
+	name := wt.Name
+	if name == "" {
+		name = wt.AnchorBranch
+	}
+	coloredName := style.ColorBranchName(name, isCurrent)
+
+	// Handle missing worktrees
+	if !wt.Exists {
+		ctx.Output.Println(fmt.Sprintf("%s%s  %s", indicator, coloredName, style.ColorRed("(missing)")))
+		return
+	}
+
+	// Stack size
+	stackInfo := style.ColorDim("empty")
+	if wt.StackSize > 0 {
+		branchWord := "branch"
+		if wt.StackSize > 1 {
+			branchWord = "branches"
+		}
+		stackInfo = fmt.Sprintf("%d %s", wt.StackSize, branchWord)
+	}
+
+	// Current branch in worktree (only show if different from anchor)
+	branchInfo := ""
+	if wt.CurrentBranch != "" && wt.CurrentBranch != wt.AnchorBranch {
+		branchInfo = style.ColorCyan(wt.CurrentBranch)
+	}
+
+	// Status indicator
+	status := ""
+	if wt.IsDirty {
+		status = style.ColorYellow("*")
+	}
+
+	// Build the output line
+	line := fmt.Sprintf("%s%s  %s", indicator, coloredName, stackInfo)
+	if branchInfo != "" {
+		line += fmt.Sprintf("  on %s", branchInfo)
+	}
+	if status != "" {
+		line += " " + status
+	}
+
+	ctx.Output.Println(line)
 }
 
 // newRemoveCmd creates the worktree remove command
@@ -148,6 +197,58 @@ name or the anchor branch name.`,
 	}
 
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Force removal even if there are errors")
+
+	return cmd
+}
+
+// newPruneCmd creates the worktree prune command
+func newPruneCmd() *cobra.Command {
+	var dryRun bool
+
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Remove empty worktrees",
+		Long: `Remove all worktrees that have no stacked branches.
+
+Empty worktrees are those with only the anchor branch and no work in progress.
+Worktrees with uncommitted changes are skipped unless --force is used.`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return common.Run(cmd, func(ctx *app.Context) error {
+				result, err := worktree.PruneAction(ctx, worktree.PruneOptions{
+					DryRun: dryRun,
+				})
+				if err != nil {
+					return err
+				}
+
+				if len(result.Pruned) == 0 && len(result.Skipped) == 0 {
+					ctx.Output.Info("No empty worktrees to prune.")
+					return nil
+				}
+
+				if dryRun {
+					ctx.Output.Info("Would prune:")
+				}
+
+				for _, name := range result.Pruned {
+					if dryRun {
+						ctx.Output.Println(fmt.Sprintf("  %s", style.ColorBranchName(name, false)))
+					} else {
+						ctx.Output.Success("Pruned %s", style.ColorBranchName(name, false))
+					}
+				}
+
+				for _, entry := range result.Skipped {
+					ctx.Output.Info("Skipped %s: %s", style.ColorBranchName(entry.Name, false), style.ColorDim(entry.Reason))
+				}
+
+				return nil
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would be pruned without removing")
 
 	return cmd
 }


### PR DESCRIPTION

- Show stack size, current branch, and dirty status in worktree list
- Add @ indicator for current worktree
- Implement worktree prune command to remove empty worktrees
- Skip worktrees with stacked branches or uncommitted changes