### PR TITLE
feat: add worktree anchor branch cleanup and --keep-branch option

### DIFF
--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -104,6 +104,7 @@ func ListAction(ctx *app.Context, _ ListOptions) (*ListResult, error) {
 type RemoveOptions struct {
 	AnchorBranch string // Anchor branch name to remove worktree for
 	Force        bool   // Force removal even if worktree has uncommitted changes
+	KeepBranch   bool   // Keep the anchor branch instead of deleting it
 }
 
 // findWorktreeByNameOrBranch looks up a worktree by name or anchor branch
@@ -152,11 +153,34 @@ func RemoveAction(ctx *app.Context, opts RemoveOptions) error {
 		}
 	} else {
 		out.Debug("Worktree path %s does not exist, skipping removal", wtInfo.Path)
+		// Prune stale git worktree references to allow branch deletion later
+		if pruneErr := ctx.Engine.PruneWorktrees(ctx.Context); pruneErr != nil {
+			out.Debug("Failed to prune worktrees: %v", pruneErr)
+		}
 	}
 
 	// Unregister from registry (use the anchor branch from worktree info)
 	if unregErr := ctx.Engine.UnregisterWorktree(wtInfo.AnchorBranch); unregErr != nil {
 		return fmt.Errorf("failed to unregister worktree: %w", unregErr)
+	}
+
+	// Delete anchor branch unless --keep-branch is set
+	if !opts.KeepBranch {
+		anchorBranch := ctx.Engine.GetBranch(wtInfo.AnchorBranch)
+		if anchorBranch.IsTracked() {
+			// Check for children using stack graph
+			graph := engine.BuildStackGraph(ctx.Engine, engine.SortStrategyAlphabetical, nil)
+			children := graph.Children(anchorBranch)
+			if len(children) > 0 {
+				out.Warn("Anchor branch %s has children, not deleting", style.ColorBranchName(wtInfo.AnchorBranch, false))
+			} else {
+				if err := ctx.Engine.DeleteBranch(ctx.Context, anchorBranch); err != nil {
+					out.Warn("Failed to delete anchor branch: %v", err)
+				} else {
+					out.Debug("Deleted anchor branch %s", wtInfo.AnchorBranch)
+				}
+			}
+		}
 	}
 
 	out.Success("Removed worktree for stack %s", style.ColorBranchName(wtInfo.AnchorBranch, false))
@@ -426,12 +450,39 @@ func PruneAction(ctx *app.Context, opts PruneOptions) (*PruneResult, error) {
 			name = wt.AnchorBranch
 		}
 
-		// Skip missing worktrees (they should be cleaned up separately)
+		// Clean up missing worktrees (directory deleted but registration remains)
 		if !wt.Exists {
-			result.Skipped = append(result.Skipped, SkippedEntry{
-				Name:   name,
-				Reason: "worktree directory missing",
-			})
+			if opts.DryRun {
+				result.Pruned = append(result.Pruned, name)
+				continue
+			}
+
+			// Check if anchor branch has children before deleting
+			anchorBranch := ctx.Engine.GetBranch(wt.AnchorBranch)
+			if anchorBranch.IsTracked() {
+				graph := engine.BuildStackGraph(ctx.Engine, engine.SortStrategyAlphabetical, nil)
+				children := graph.Children(anchorBranch)
+				if len(children) > 0 {
+					result.Skipped = append(result.Skipped, SkippedEntry{
+						Name:   name,
+						Reason: fmt.Sprintf("anchor branch has %d children", len(children)),
+					})
+					continue
+				}
+			}
+
+			// Unregister and delete anchor branch
+			if err := RemoveAction(ctx, RemoveOptions{
+				AnchorBranch: wt.AnchorBranch,
+				Force:        true, // Force since directory is missing
+			}); err != nil {
+				result.Skipped = append(result.Skipped, SkippedEntry{
+					Name:   name,
+					Reason: fmt.Sprintf("cleanup failed: %v", err),
+				})
+				continue
+			}
+			result.Pruned = append(result.Pruned, name)
 			continue
 		}
 

--- a/internal/cli/worktree/worktree.go
+++ b/internal/cli/worktree/worktree.go
@@ -175,15 +175,18 @@ func renderWorktreeEntry(ctx *app.Context, wt worktree.Entry, currentAnchor stri
 // newRemoveCmd creates the worktree remove command
 func newRemoveCmd() *cobra.Command {
 	var force bool
+	var keepBranch bool
 
 	cmd := &cobra.Command{
 		Use:   "remove <name-or-anchor-branch>",
 		Short: "Remove a managed worktree",
 		Long: `Remove a stackit-managed worktree.
 
-This removes both the worktree directory and unregisters it from stackit.
-The stack's branches remain intact. You can specify either the worktree
-name or the anchor branch name.`,
+This removes the worktree directory, unregisters it from stackit, and deletes
+the anchor branch. You can specify either the worktree name or the anchor
+branch name.
+
+Use --keep-branch to preserve the anchor branch after removing the worktree.`,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -191,12 +194,14 @@ name or the anchor branch name.`,
 				return worktree.RemoveAction(ctx, worktree.RemoveOptions{
 					AnchorBranch: args[0],
 					Force:        force,
+					KeepBranch:   keepBranch,
 				})
 			})
 		},
 	}
 
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Force removal even if there are errors")
+	cmd.Flags().BoolVar(&keepBranch, "keep-branch", false, "Keep the anchor branch instead of deleting it")
 
 	return cmd
 }

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -205,6 +205,12 @@ func (e *engineImpl) shouldReparentBranch(ctx context.Context, parentBranchName 
 		return false
 	}
 
+	// Worktree anchor branches should never be reparented - they are permanent parents
+	// for their stacks, even though they may be at trunk HEAD
+	if e.IsWorktreeAnchor(e.GetBranch(parentBranchName)) {
+		return false
+	}
+
 	// Check if parent branch still exists locally
 	parentExists := false
 	for _, name := range e.branches {

--- a/internal/integration/worktree_comprehensive_test.go
+++ b/internal/integration/worktree_comprehensive_test.go
@@ -872,3 +872,164 @@ func TestWorktreeErrorHandling(t *testing.T) {
 			RunExpectError("create child -w -m 'child with worktree'")
 	})
 }
+
+// =============================================================================
+// Anchor Branch Cleanup
+// =============================================================================
+
+func TestWorktreeAnchorBranchCleanup(t *testing.T) {
+	t.Run("worktree remove deletes anchor branch", func(t *testing.T) {
+		sh := NewTestShellInProcess(t)
+
+		// Create worktree
+		sh.WriteFile("mystack.txt", "mystack").
+			Run("create mystack -w -m 'mystack branch'")
+
+		// Verify anchor branch exists
+		sh.HasBranches("main", "mystack")
+
+		worktreePath := sh.GetWorktreePath("mystack")
+
+		// Remove the worktree
+		sh.Run("worktree remove mystack")
+
+		// Worktree should be removed
+		if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
+			t.Errorf("Worktree directory should be removed at %s", worktreePath)
+		}
+
+		// Anchor branch should also be deleted
+		sh.HasBranches("main")
+	})
+
+	t.Run("worktree remove with --keep-branch preserves anchor", func(t *testing.T) {
+		sh := NewTestShellInProcess(t)
+
+		// Create worktree
+		sh.WriteFile("mystack.txt", "mystack").
+			Run("create mystack -w -m 'mystack branch'")
+
+		// Verify anchor branch exists
+		sh.HasBranches("main", "mystack")
+
+		worktreePath := sh.GetWorktreePath("mystack")
+
+		// Remove the worktree with --keep-branch
+		sh.Run("worktree remove mystack --keep-branch")
+
+		// Worktree should be removed
+		if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
+			t.Errorf("Worktree directory should be removed at %s", worktreePath)
+		}
+
+		// Anchor branch should still exist
+		sh.HasBranches("main", "mystack")
+	})
+
+	t.Run("worktree remove skips deletion when anchor has children", func(t *testing.T) {
+		sh := NewTestShellInProcess(t)
+
+		// Create worktree with child branches
+		sh.WriteFile("feature.txt", "feature").
+			Run("create feature -w -m 'feature branch'")
+
+		worktreePath := sh.GetWorktreePath("feature")
+		shW := sh.InWorktree(worktreePath)
+
+		// Create a child branch
+		shW.WriteFile("child.txt", "child").
+			Run("create child -m 'child branch'")
+
+		// Checkout main in worktree so we can remove it
+		shW.Git("checkout --detach HEAD")
+
+		// Remove the worktree - should warn about children and not delete anchor
+		sh.Run("worktree remove feature")
+
+		// Anchor branch and child should still exist
+		sh.HasBranches("main", "feature", "child")
+	})
+
+	t.Run("worktree prune cleans up missing directories", func(t *testing.T) {
+		sh := NewTestShellInProcess(t)
+
+		// Create worktree
+		sh.WriteFile("test-wt.txt", "test-wt").
+			Run("create test-wt -w -m 'test worktree'")
+
+		// Verify anchor branch exists
+		sh.HasBranches("main", "test-wt")
+
+		worktreePath := sh.GetWorktreePath("test-wt")
+
+		// Manually delete the worktree directory (simulating external deletion)
+		if err := os.RemoveAll(worktreePath); err != nil {
+			t.Fatalf("Failed to remove worktree directory: %v", err)
+		}
+
+		// Worktree list should show missing worktree
+		sh.Run("worktree list").
+			OutputContains("missing")
+
+		// Prune should clean up the missing worktree
+		sh.Run("worktree prune")
+
+		// Worktree list should be empty
+		sh.Run("worktree list").
+			OutputContains("No managed worktrees")
+
+		// Anchor branch should be deleted
+		sh.HasBranches("main")
+	})
+
+	t.Run("worktree prune dry-run shows what would be cleaned", func(t *testing.T) {
+		sh := NewTestShellInProcess(t)
+
+		// Create worktree
+		sh.WriteFile("test-wt.txt", "test-wt").
+			Run("create test-wt -w -m 'test worktree'")
+
+		worktreePath := sh.GetWorktreePath("test-wt")
+
+		// Manually delete the worktree directory
+		if err := os.RemoveAll(worktreePath); err != nil {
+			t.Fatalf("Failed to remove worktree directory: %v", err)
+		}
+
+		// Prune with dry-run should show what would be cleaned
+		sh.Run("worktree prune --dry-run").
+			OutputContains("Would prune").
+			OutputContains("test-wt")
+
+		// But nothing should actually be deleted
+		sh.HasBranches("main", "test-wt")
+	})
+
+	t.Run("worktree prune skips missing worktrees with children", func(t *testing.T) {
+		sh := NewTestShellInProcess(t)
+
+		// Create worktree with child branches
+		sh.WriteFile("feature.txt", "feature").
+			Run("create feature -w -m 'feature branch'")
+
+		worktreePath := sh.GetWorktreePath("feature")
+		shW := sh.InWorktree(worktreePath)
+
+		// Create a child branch
+		shW.WriteFile("child.txt", "child").
+			Run("create child -m 'child branch'")
+
+		// Manually delete the worktree directory
+		if err := os.RemoveAll(worktreePath); err != nil {
+			t.Fatalf("Failed to remove worktree directory: %v", err)
+		}
+
+		// Prune should skip because anchor has children
+		sh.Run("worktree prune").
+			OutputContains("Skipped").
+			OutputContains("children")
+
+		// Anchor branch and child should still exist
+		sh.HasBranches("main", "feature", "child")
+	})
+}


### PR DESCRIPTION

- Add automatic anchor branch deletion when removing worktrees
- Add --keep-branch flag to preserve anchor branch during removal
- Fix worktree prune to clean up missing directories instead of skipping
- Add safety check to prevent deletion when anchor has children
- Fix shouldReparentBranch to avoid reparenting children of worktree anchors
- Add comprehensive tests for all cleanup scenarios