### PR TITLE
feat: add wt alias for worktree command

### DIFF
--- a/internal/cli/worktree/worktree.go
+++ b/internal/cli/worktree/worktree.go
@@ -15,8 +15,9 @@ import (
 // NewWorktreeCmd creates the worktree command group
 func NewWorktreeCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "worktree",
-		Short: "Manage stackit-managed worktrees",
+		Use:     "worktree",
+		Aliases: []string{"wt"},
+		Short:   "Manage stackit-managed worktrees",
 		Long: `Manage stackit-managed worktrees.
 
 Worktrees allow you to work on multiple stacks in parallel, each in its own


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #653** 👈
  * **PR #654**
    * **PR #655**
      * **PR #657**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->