### PR TITLE
fix: improve split command error messages and UI robustness

### DIFF
--- a/internal/actions/split/interactive.go
+++ b/internal/actions/split/interactive.go
@@ -13,6 +13,19 @@ type DirectionContext struct {
 	Children      []string
 }
 
+// CommitMessageContext provides context for commit message prompting
+type CommitMessageContext struct {
+	// Files being extracted to the new branch
+	Files []string
+	// Direction of the split (above = child, below = parent)
+	Direction Direction
+	// CurrentBranch is the name of the branch being split
+	CurrentBranch string
+	// OriginalCommitMessage is the full message of the first commit on the branch
+	// (title + body). Used as the basis for the split commit message.
+	OriginalCommitMessage string
+}
+
 // TypeChoice represents an available split type option
 type TypeChoice struct {
 	Style       Style
@@ -51,6 +64,12 @@ type InteractiveHandler interface {
 	// defaultMsg is the suggested default (e.g., from original commit).
 	// Returns the final message or an error if canceled.
 	PromptCommitMessage(defaultMsg string) (string, error)
+
+	// PromptCommitMessageWithContext asks the user to enter a commit message
+	// with full context about the split operation displayed.
+	// The context includes files being extracted, direction, and current branch.
+	// Returns the commit message or an error if canceled.
+	PromptCommitMessageWithContext(ctx CommitMessageContext) (string, error)
 
 	// PromptBranchName asks the user to enter a branch name.
 	// defaultName is the auto-generated suggestion.

--- a/internal/actions/split/split_file.go
+++ b/internal/actions/split/split_file.go
@@ -136,7 +136,7 @@ func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []s
 		}
 	}
 	if len(binaryFiles) > 0 {
-		return nil, fmt.Errorf("cannot split binary files: %s. Binary files must be split as whole files using a different approach",
+		return nil, fmt.Errorf("cannot split binary files by hunk: %s. Exclude these files from the split, or use git commands directly to handle binary files",
 			strings.Join(binaryFiles, ", "))
 	}
 
@@ -221,7 +221,10 @@ func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []s
 		return nil, fmt.Errorf("failed to stash staged changes: %w", err)
 	}
 
-	// Track stash state for cleanup
+	// Track stash state for cleanup.
+	// Note: cleanupStash is called during error recovery, so we intentionally
+	// ignore the StashPop error to avoid masking the original error.
+	// If StashPop fails, the stash remains in 'git stash list' for manual recovery.
 	stashPopped := false
 	cleanupStash := func() {
 		if !stashPopped {
@@ -393,7 +396,10 @@ func splitByFileAbove(ctx context.Context, branchToSplit engine.Branch, newBranc
 			fmt.Errorf("failed to stash staged changes: %w", err))
 	}
 
-	// Track stash state for cleanup
+	// Track stash state for cleanup.
+	// Note: cleanupStash is called during error recovery, so we intentionally
+	// ignore the StashPop error to avoid masking the original error.
+	// If StashPop fails, the stash remains in 'git stash list' for manual recovery.
 	stashPopped := false
 	cleanupStash := func() {
 		if !stashPopped {
@@ -618,7 +624,7 @@ func promptForFiles(ctx context.Context, branchToSplit engine.Branch, eng splitB
 	}
 
 	if len(changedFiles) == 1 {
-		return nil, fmt.Errorf("only one file changed in branch - nothing to split")
+		return nil, fmt.Errorf("only one file changed in branch - use --by-hunk to split by individual changes")
 	}
 
 	// Show instructions based on mode
@@ -644,7 +650,7 @@ func promptForFiles(ctx context.Context, branchToSplit engine.Branch, eng splitB
 
 	// Validate that not all files were selected (only in default mode where files are removed)
 	if !asSibling && len(selectedFiles) == len(changedFiles) {
-		return nil, fmt.Errorf("cannot extract all files - at least one must remain on the original branch")
+		return nil, fmt.Errorf("cannot extract all files - at least one must remain on the original branch; use --as-sibling to extract without modifying the original branch")
 	}
 
 	return selectedFiles, nil

--- a/internal/actions/split/wizard.go
+++ b/internal/actions/split/wizard.go
@@ -3,8 +3,11 @@ package split
 import (
 	"fmt"
 
+	"stackit.dev/stackit/internal/actions"
 	"stackit.dev/stackit/internal/app"
+	"stackit.dev/stackit/internal/config"
 	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/errors"
 )
 
 // WizardOptions configures the interactive split wizard
@@ -69,54 +72,68 @@ func RunWizard(ctx *app.Context, handler InteractiveHandler, opts WizardOptions)
 	}
 	hasMultipleCommits := len(commits) > 1
 
-	// Step 1: Choose split type (if not pre-selected)
+	// Step 1 & 2: Choose split type and direction (with back navigation support)
 	style := opts.Style
-	if style == "" {
-		handler.OnStep(StepChoosingType, StatusStarted, "Choose split type")
-
-		availableTypes := buildTypeChoices(hasMultipleCommits)
-		selectedStyle, err := handler.PromptSplitType(availableTypes)
-		if err != nil {
-			return err
-		}
-		style = selectedStyle
-
-		handler.OnStep(StepChoosingType, StatusCompleted, string(style))
-		out.Debug("split wizard: user selected style: %s", style)
-	}
-
-	// Step 2: Choose direction (if not pre-selected)
 	direction := opts.Direction
-	if direction == "" {
-		handler.OnStep(StepChoosingDirection, StatusStarted, "Choose direction")
+	availableTypes := buildTypeChoices(hasMultipleCommits)
 
-		// Build context for direction prompt
-		parentName := ""
-		if parent := currentBranch.GetParent(); parent != nil {
-			parentName = parent.GetName()
-		} else {
-			parentName = eng.Trunk().GetName()
+	// Loop to allow going back from direction to type selection
+	for {
+		// Step 1: Choose split type (if not pre-selected)
+		if style == "" {
+			handler.OnStep(StepChoosingType, StatusStarted, "Choose split type")
+
+			selectedStyle, err := handler.PromptSplitType(availableTypes)
+			if err != nil {
+				return err
+			}
+			style = selectedStyle
+
+			handler.OnStep(StepChoosingType, StatusCompleted, string(style))
+			out.Debug("split wizard: user selected style: %s", style)
 		}
 
-		// Get children of current branch
-		graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
-		childNames := graph.Children(*currentBranch)
+		// Step 2: Choose direction (if not pre-selected)
+		if direction == "" {
+			handler.OnStep(StepChoosingDirection, StatusStarted, "Choose direction")
 
-		dirCtx := DirectionContext{
-			Engine:        eng,
-			CurrentBranch: currentBranch.GetName(),
-			ParentBranch:  parentName,
-			Children:      childNames,
+			// Build context for direction prompt
+			parentName := ""
+			if parent := currentBranch.GetParent(); parent != nil {
+				parentName = parent.GetName()
+			} else {
+				parentName = eng.Trunk().GetName()
+			}
+
+			// Get children of current branch
+			graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
+			childNames := graph.Children(*currentBranch)
+
+			dirCtx := DirectionContext{
+				Engine:        eng,
+				CurrentBranch: currentBranch.GetName(),
+				ParentBranch:  parentName,
+				Children:      childNames,
+			}
+
+			selectedDirection, err := handler.PromptDirection(dirCtx)
+			if errors.Is(err, errors.ErrBack) {
+				// User wants to go back to type selection
+				style = ""
+				out.Debug("split wizard: user pressed back, returning to type selection")
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			direction = selectedDirection
+
+			handler.OnStep(StepChoosingDirection, StatusCompleted, string(direction))
+			out.Debug("split wizard: user selected direction: %s", direction)
 		}
 
-		selectedDirection, err := handler.PromptDirection(dirCtx)
-		if err != nil {
-			return err
-		}
-		direction = selectedDirection
-
-		handler.OnStep(StepChoosingDirection, StatusCompleted, string(direction))
-		out.Debug("split wizard: user selected direction: %s", direction)
+		// Both selections made, break out of the loop
+		break
 	}
 
 	// Start handler with branch info and style
@@ -138,10 +155,105 @@ func RunWizard(ctx *app.Context, handler InteractiveHandler, opts WizardOptions)
 			useGitAddP: opts.HunkSelector == "git",
 		}
 		return splitByHunkWithHandler(ctx, *currentBranch, eng, out, handler, direction, hunkOpts)
-	case StyleCommit, StyleFile:
-		// For now, these don't support the new wizard flow with direction
-		// Fall back to the existing implementation
-		return fmt.Errorf("style %s with direction is not yet implemented in wizard mode", style)
+
+	case StyleFile:
+		// Prompt for files to extract
+		pathspecs, err := promptForFiles(ctx.Context, *currentBranch, eng, out, false, direction)
+		if err != nil {
+			return err
+		}
+		if len(pathspecs) == 0 {
+			return fmt.Errorf("no files selected")
+		}
+
+		// Get the original commit message from the first commit on this branch
+		// GetAllCommits returns newest to oldest, so the first commit is the last element
+		var originalCommitMessage string
+		commitMessages, err := currentBranch.GetAllCommits(engine.CommitFormatMessage)
+		if err == nil && len(commitMessages) > 0 {
+			// Use the first (oldest) commit's message
+			originalCommitMessage = commitMessages[len(commitMessages)-1]
+		}
+
+		// Prompt for commit message with context (shows files being extracted)
+		handler.OnStep(StepCommitMessage, StatusStarted, "Enter commit message")
+		commitMsgCtx := CommitMessageContext{
+			Files:                 pathspecs,
+			Direction:             direction,
+			CurrentBranch:         currentBranch.GetName(),
+			OriginalCommitMessage: originalCommitMessage,
+		}
+		commitMessage, err := handler.PromptCommitMessageWithContext(commitMsgCtx)
+		if err != nil {
+			return err
+		}
+		handler.OnStep(StepCommitMessage, StatusCompleted, "Commit message set")
+
+		// Generate default branch name from commit message using the branch pattern
+		cfg, _ := config.LoadConfig(ctx.RepoRoot)
+		branchPatternStr := cfg.BranchNamePattern()
+		branchPattern, patternErr := config.NewBranchPattern(branchPatternStr)
+		var defaultBranchName string
+		if patternErr == nil {
+			defaultBranchName, err = branchPattern.GetBranchName(ctx, commitMessage, "")
+		}
+		if patternErr != nil || err != nil {
+			// Fallback to simpler default if pattern fails
+			defaultBranchName = currentBranch.GetName() + "_split"
+		}
+
+		// Build list of existing branch names for validation
+		existingBranchNames := make(map[string]bool)
+		for _, b := range eng.AllBranches() {
+			existingBranchNames[b.GetName()] = true
+		}
+
+		// Prompt for branch name
+		handler.OnStep(StepBranchName, StatusStarted, "Enter branch name")
+		branchName, err := handler.PromptBranchName(defaultBranchName, []string{}, existingBranchNames, currentBranch.GetName())
+		if err != nil {
+			return err
+		}
+		handler.OnStep(StepBranchName, StatusCompleted, branchName)
+
+		// Execute the file split with the provided name and message
+		fileResult, err := splitByFile(ctx.Context, *currentBranch, pathspecs, eng, splitByFileOptions{
+			AsSibling: false,
+			Direction: direction,
+			Name:      branchName,
+			Message:   commitMessage,
+		})
+		if err != nil {
+			return err
+		}
+
+		// Restack upstack branches if needed (not needed for --above since splitByFileAbove handles it)
+		if direction != DirectionAbove {
+			rng := engine.StackRange{
+				RecursiveParents:  false,
+				IncludeCurrent:    false,
+				RecursiveChildren: true,
+			}
+			graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
+			upstackBranches := graph.Range(*currentBranch, rng)
+			if len(upstackBranches) > 0 {
+				if err := actions.RestackBranches(ctx, upstackBranches); err != nil {
+					return fmt.Errorf("failed to restack upstack branches: %w", err)
+				}
+			}
+		}
+
+		handler.Complete(ActionResult{
+			OriginalBranch: currentBranch.GetName(),
+			NewBranches:    fileResult.BranchNames,
+			Style:          style,
+		})
+		return nil
+
+	case StyleCommit:
+		// Commit split doesn't use direction in the same way
+		return fmt.Errorf("style %s is not yet implemented in wizard mode", style)
+
 	default:
 		return fmt.Errorf("unknown split style: %s", style)
 	}

--- a/internal/cli/branch/split.go
+++ b/internal/cli/branch/split.go
@@ -81,13 +81,9 @@ Examples:
 					style = split.StyleCommit
 				case byHunk || cmd.Flags().Changed("hunk"):
 					style = split.StyleHunk
-				case byFileInteractive || len(byFile) > 0 || cmd.Flags().Changed("file"):
+				case byFileInteractive || len(byFile) > 0:
 					// -F triggers interactive file selection
 					// --by-file with pathspecs uses those files directly
-					if cmd.Flags().Changed("file") {
-						filePaths, _ := cmd.Flags().GetStringSlice("file")
-						byFile = filePaths
-					}
 					style = split.StyleFile
 				case patchFile != "":
 					// --patch implies --by-hunk

--- a/internal/cli/branch/split_handlers.go
+++ b/internal/cli/branch/split_handlers.go
@@ -78,6 +78,11 @@ func (h *SimpleSplitHandler) Complete(result split.ActionResult) {
 	}
 }
 
+// PromptCommitMessageWithContext returns a generated default message in non-interactive mode
+func (h *SimpleSplitHandler) PromptCommitMessageWithContext(ctx split.CommitMessageContext) (string, error) {
+	return splitcomp.GenerateDefaultCommitMessage(ctx.Files, ctx.OriginalCommitMessage), nil
+}
+
 // TUISplitHandler provides interactive TUI prompts for split operations.
 // It uses a unified model with state machine for type/direction selection,
 // and delegates to full-screen TUI components for hunk selection.
@@ -134,8 +139,8 @@ func (h *TUISplitHandler) PromptSplitType(availableTypes []split.TypeChoice) (sp
 	}
 	model := splitcomp.NewModel(cfg)
 
-	// Run as standalone program
-	p := tea.NewProgram(model, tea.WithAltScreen(), tea.WithInput(os.Stdin), tea.WithOutput(os.Stdout))
+	// Run as standalone program (no alt screen to avoid flashing between views)
+	p := tea.NewProgram(model, tea.WithInput(os.Stdin), tea.WithOutput(os.Stdout))
 	finalModel, err := p.Run()
 	if err != nil {
 		return "", err
@@ -198,6 +203,47 @@ func (h *TUISplitHandler) PromptCommitMessage(defaultMsg string) (string, error)
 		return "", err
 	}
 	return utils.CleanCommitMessage(msg), nil
+}
+
+// PromptCommitMessageWithContext prompts for commit message with full context displayed.
+// Uses an inline textarea editor that shows the split context (files, direction, etc.).
+func (h *TUISplitHandler) PromptCommitMessageWithContext(ctx split.CommitMessageContext) (string, error) {
+	if !utils.IsInteractive() {
+		// In non-interactive mode, generate a sensible default
+		return splitcomp.GenerateDefaultCommitMessage(ctx.Files, ctx.OriginalCommitMessage), nil
+	}
+
+	// Generate a sensible default commit message based on original commit
+	defaultMsg := splitcomp.GenerateDefaultCommitMessage(ctx.Files, ctx.OriginalCommitMessage)
+
+	// Create the inline commit editor model
+	editorCfg := splitcomp.CommitEditorConfig{
+		DefaultMessage: defaultMsg,
+		Files:          ctx.Files,
+		Direction:      splitcomp.Direction(ctx.Direction),
+		CurrentBranch:  ctx.CurrentBranch,
+	}
+	model := splitcomp.NewCommitEditorModel(editorCfg)
+
+	// Run as standalone program
+	p := tea.NewProgram(model, tea.WithInput(os.Stdin), tea.WithOutput(os.Stdout))
+	finalModel, err := p.Run()
+	if err != nil {
+		return "", err
+	}
+
+	if m, ok := finalModel.(*splitcomp.CommitEditorModel); ok {
+		if m.Canceled() {
+			return "", errors.ErrCanceled
+		}
+		msg := m.Message()
+		if msg == "" {
+			return "", fmt.Errorf("commit message cannot be empty")
+		}
+		return msg, nil
+	}
+
+	return "", fmt.Errorf("unexpected model type")
 }
 
 // PromptBranchName asks the user to enter a branch name

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -39,6 +39,9 @@ var (
 
 	// ErrCanceled indicates that an interactive operation was canceled by the user
 	ErrCanceled = errors.New("canceled")
+
+	// ErrBack indicates that the user wants to go back to the previous step
+	ErrBack = errors.New("back")
 )
 
 // BranchNotFoundError represents an error when a branch is not found

--- a/internal/tui/components/split/commit_editor.go
+++ b/internal/tui/components/split/commit_editor.go
@@ -1,0 +1,360 @@
+package split
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"stackit.dev/stackit/internal/tui/style"
+	"stackit.dev/stackit/internal/utils"
+)
+
+// CommitEditorConfig configures the commit message editor
+type CommitEditorConfig struct {
+	// DefaultMessage is the initial commit message
+	DefaultMessage string
+	// Files being extracted (for context display)
+	Files []string
+	// Direction of the split (above/below)
+	Direction Direction
+	// CurrentBranch name for context
+	CurrentBranch string
+}
+
+// editorFinishedMsg is sent when the external editor closes
+type editorFinishedMsg struct {
+	content string
+	err     error
+}
+
+// commitEditorKeyMap defines the keybindings for the commit editor
+type commitEditorKeyMap struct {
+	Edit   key.Binding
+	Submit key.Binding
+	Cancel key.Binding
+}
+
+func (k commitEditorKeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Edit, k.Submit, k.Cancel}
+}
+
+func (k commitEditorKeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{{k.Edit, k.Submit, k.Cancel}}
+}
+
+var defaultCommitEditorKeys = commitEditorKeyMap{
+	Edit: key.NewBinding(
+		key.WithKeys("e"),
+		key.WithHelp("e", "edit commit message"),
+	),
+	Submit: key.NewBinding(
+		key.WithKeys("enter"),
+		key.WithHelp("enter", "confirm"),
+	),
+	Cancel: key.NewBinding(
+		key.WithKeys("esc", "q"),
+		key.WithHelp("esc", "cancel"),
+	),
+}
+
+// CommitEditorModel is a bubbletea model for editing commit messages
+// It shows context and launches external EDITOR for editing
+type CommitEditorModel struct {
+	config   CommitEditorConfig
+	message  string
+	help     help.Model
+	keys     commitEditorKeyMap
+	width    int
+	height   int
+	ready    bool
+	done     bool
+	canceled bool
+	editing  bool
+	tempFile string
+}
+
+// NewCommitEditorModel creates a new commit message editor model
+func NewCommitEditorModel(cfg CommitEditorConfig) *CommitEditorModel {
+	h := help.New()
+	h.Styles.ShortKey = style.HelpKeyStyle()
+	h.Styles.ShortDesc = style.HelpDescStyle()
+	h.Styles.ShortSeparator = style.HelpSeparatorStyle()
+
+	return &CommitEditorModel{
+		config:  cfg,
+		message: cfg.DefaultMessage,
+		help:    h,
+		keys:    defaultCommitEditorKeys,
+	}
+}
+
+// Init implements tea.Model
+func (m *CommitEditorModel) Init() tea.Cmd {
+	return nil
+}
+
+// Update implements tea.Model
+func (m *CommitEditorModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.ready = true
+
+	case editorFinishedMsg:
+		m.editing = false
+		if msg.err != nil {
+			// Editor failed, keep the current message
+			return m, nil
+		}
+		// Clean the message (remove comments, trailing whitespace)
+		m.message = utils.CleanCommitMessage(msg.content)
+		return m, nil
+
+	case tea.KeyMsg:
+		if m.editing {
+			// Ignore key presses while editor is open
+			return m, nil
+		}
+
+		switch {
+		case key.Matches(msg, m.keys.Edit):
+			m.editing = true
+			return m, m.openEditor()
+		case key.Matches(msg, m.keys.Submit):
+			if strings.TrimSpace(m.message) == "" {
+				// Don't allow empty messages
+				return m, nil
+			}
+			m.done = true
+			return m, tea.Quit
+		case key.Matches(msg, m.keys.Cancel):
+			m.canceled = true
+			m.done = true
+			return m, tea.Quit
+		}
+	}
+
+	return m, nil
+}
+
+// openEditor launches the external EDITOR with the current message
+func (m *CommitEditorModel) openEditor() tea.Cmd {
+	// Create a temp file with the current message
+	tmpFile, err := os.CreateTemp("", "COMMIT_EDITMSG-*")
+	if err != nil {
+		return func() tea.Msg {
+			return editorFinishedMsg{err: err}
+		}
+	}
+	m.tempFile = tmpFile.Name()
+
+	// Write the current message and git-style comments
+	content := m.message + "\n\n" +
+		"# Enter the commit message for your changes.\n" +
+		"# Lines starting with '#' will be ignored.\n"
+	if _, err := tmpFile.WriteString(content); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(m.tempFile)
+		return func() tea.Msg {
+			return editorFinishedMsg{err: err}
+		}
+	}
+	_ = tmpFile.Close()
+
+	// Get editor from environment
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = os.Getenv("VISUAL")
+	}
+	if editor == "" {
+		editor = "vim"
+	}
+
+	// Create the command
+	c := exec.Command(editor, m.tempFile) //nolint:gosec
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+
+	tempFile := m.tempFile
+	return tea.ExecProcess(c, func(err error) tea.Msg {
+		if err != nil {
+			_ = os.Remove(tempFile)
+			return editorFinishedMsg{err: err}
+		}
+
+		// Read the result
+		content, readErr := os.ReadFile(tempFile)
+		_ = os.Remove(tempFile)
+		if readErr != nil {
+			return editorFinishedMsg{err: readErr}
+		}
+
+		return editorFinishedMsg{content: string(content)}
+	})
+}
+
+// View implements tea.Model
+func (m *CommitEditorModel) View() string {
+	if m.done {
+		return ""
+	}
+
+	if !m.ready {
+		return "Loading..."
+	}
+
+	if m.editing {
+		return "Opening editor..."
+	}
+
+	var sb strings.Builder
+	headerStyles := style.DefaultHeaderStyles()
+
+	// Title
+	sb.WriteString(headerStyles.Title.Render("Commit Message"))
+	sb.WriteString("\n\n")
+
+	// Context panel showing what's being split
+	sb.WriteString(m.renderContext())
+	sb.WriteString("\n")
+
+	// Current message in a box
+	sb.WriteString(m.renderMessage())
+	sb.WriteString("\n\n")
+
+	// Help
+	sb.WriteString(m.help.View(m.keys))
+
+	return style.DefaultLayoutStyles().Container.Render(sb.String())
+}
+
+// renderContext shows the split context (files, direction, etc.)
+func (m *CommitEditorModel) renderContext() string {
+	var lines []string
+	subtleStyle := style.SubtleStyle()
+
+	// Show direction
+	directionLabel := "child"
+	if m.config.Direction == DirectionBelow {
+		directionLabel = "parent"
+	}
+	lines = append(lines, subtleStyle.Render(fmt.Sprintf("Creating %s branch of %s", directionLabel, m.config.CurrentBranch)))
+	lines = append(lines, "") // blank line
+
+	// Show files being extracted
+	if len(m.config.Files) > 0 {
+		lines = append(lines, subtleStyle.Render("Extracting files:"))
+		maxFiles := 5
+		for i, f := range m.config.Files {
+			if i >= maxFiles {
+				lines = append(lines, subtleStyle.Render(fmt.Sprintf("  ... and %d more", len(m.config.Files)-maxFiles)))
+				break
+			}
+			lines = append(lines, subtleStyle.Render(fmt.Sprintf("  %s", f)))
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// renderMessage shows the current commit message in a styled box
+func (m *CommitEditorModel) renderMessage() string {
+	// Calculate width, ensuring reasonable minimum
+	width := 70
+	if m.width > 10 {
+		width = min(70, m.width-4)
+	}
+
+	messageStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("62")).
+		Padding(0, 1).
+		Width(width)
+
+	msg := m.message
+	if msg == "" {
+		msg = "(empty - press 'e' to edit)"
+	}
+
+	return messageStyle.Render(msg)
+}
+
+// Message returns the commit message entered by the user
+func (m *CommitEditorModel) Message() string {
+	return strings.TrimSpace(m.message)
+}
+
+// Canceled returns true if the user canceled the editor
+func (m *CommitEditorModel) Canceled() bool {
+	return m.canceled
+}
+
+// GenerateDefaultCommitMessage generates a sensible default commit message
+// based on the original commit message and files being extracted.
+//
+// Format:
+//
+//	<original title> (split)
+//
+//	<original body>
+//
+//	 * file1
+//	 * file2
+func GenerateDefaultCommitMessage(files []string, originalCommitMessage string) string {
+	var sb strings.Builder
+
+	// Parse original commit message into title and body
+	title, body := parseCommitMessage(originalCommitMessage)
+
+	// Write title with (split) suffix
+	if title != "" {
+		sb.WriteString(title)
+		sb.WriteString(" (split)")
+	} else {
+		sb.WriteString("Split changes")
+	}
+
+	// Write body if present
+	if body != "" {
+		sb.WriteString("\n\n")
+		sb.WriteString(body)
+	}
+
+	// Write file list
+	if len(files) > 0 {
+		sb.WriteString("\n\n")
+		for _, f := range files {
+			sb.WriteString(" * ")
+			sb.WriteString(f)
+			sb.WriteString("\n")
+		}
+	}
+
+	return strings.TrimSpace(sb.String())
+}
+
+// parseCommitMessage splits a commit message into title (first line) and body (rest).
+func parseCommitMessage(msg string) (title, body string) {
+	msg = strings.TrimSpace(msg)
+	if msg == "" {
+		return "", ""
+	}
+
+	// Split on first newline
+	parts := strings.SplitN(msg, "\n", 2)
+	title = strings.TrimSpace(parts[0])
+
+	if len(parts) > 1 {
+		body = strings.TrimSpace(parts[1])
+	}
+
+	return title, body
+}

--- a/internal/tui/components/split/model.go
+++ b/internal/tui/components/split/model.go
@@ -107,7 +107,7 @@ func NewModel(cfg Config) *Model {
 		branchInput: ti,
 		keys:        DefaultKeyMap,
 		styles:      DefaultStyles(),
-		direction:   DirectionBelow, // Default
+		direction:   DirectionAbove, // Default to above (extract to child branch)
 	}
 
 	// Determine initial state based on preselected values
@@ -266,22 +266,42 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 // updateSelectingType handles input during type selection
 func (m *Model) updateSelectingType(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Guard against empty availableTypes
+	if len(m.availableTypes) == 0 {
+		return m, nil
+	}
+
 	switch {
 	case key.Matches(msg, m.keys.Up):
-		m.typeCursor = max(0, m.typeCursor-1)
-		// Skip unavailable options
-		for m.typeCursor > 0 && !m.availableTypes[m.typeCursor].Available {
-			m.typeCursor--
+		// Find the previous available option
+		newCursor := m.typeCursor - 1
+		for newCursor >= 0 && !m.availableTypes[newCursor].Available {
+			newCursor--
+		}
+		// Only move if we found an available option
+		if newCursor >= 0 {
+			m.typeCursor = newCursor
 		}
 	case key.Matches(msg, m.keys.Down):
-		m.typeCursor = min(len(m.availableTypes)-1, m.typeCursor+1)
-		// Skip unavailable options
-		for m.typeCursor < len(m.availableTypes)-1 && !m.availableTypes[m.typeCursor].Available {
-			m.typeCursor++
+		// Find the next available option
+		newCursor := m.typeCursor + 1
+		for newCursor < len(m.availableTypes) && !m.availableTypes[newCursor].Available {
+			newCursor++
+		}
+		// Only move if we found an available option
+		if newCursor < len(m.availableTypes) {
+			m.typeCursor = newCursor
 		}
 	case key.Matches(msg, m.keys.Select):
 		if m.typeCursor < len(m.availableTypes) && m.availableTypes[m.typeCursor].Available {
 			m.result.Style = m.availableTypes[m.typeCursor].Style
+			// If we're in type-selection-only mode (no engine configured),
+			// complete immediately after type selection. This happens when
+			// the model is used by PromptSplitType() which only needs the type.
+			if m.config.Engine == nil {
+				m.state = StateComplete
+				return m, tea.Quit
+			}
 			m.state = StateSelectingDirection
 		}
 	case key.Matches(msg, m.keys.Cancel):
@@ -335,7 +355,7 @@ func (m *Model) updateBranchNameInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Validate the name
 		if err := m.validateBranchName(name); err != nil {
 			m.errorMessage = err.Error()
-			return m, nil
+			return m, textinput.Blink
 		}
 		m.errorMessage = ""
 		m.sessionNames = append(m.sessionNames, name)

--- a/internal/tui/direction_select.go
+++ b/internal/tui/direction_select.go
@@ -158,15 +158,16 @@ type directionSelectKeyMap struct {
 	Up     key.Binding
 	Down   key.Binding
 	Submit key.Binding
+	Back   key.Binding
 	Cancel key.Binding
 }
 
 func (k directionSelectKeyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Up, k.Down, k.Submit, k.Cancel}
+	return []key.Binding{k.Up, k.Down, k.Submit, k.Back, k.Cancel}
 }
 
 func (k directionSelectKeyMap) FullHelp() [][]key.Binding {
-	return [][]key.Binding{{k.Up, k.Down, k.Submit, k.Cancel}}
+	return [][]key.Binding{{k.Up, k.Down, k.Submit, k.Back, k.Cancel}}
 }
 
 var defaultDirectionKeys = directionSelectKeyMap{
@@ -182,6 +183,10 @@ var defaultDirectionKeys = directionSelectKeyMap{
 		key.WithKeys("enter"),
 		key.WithHelp("enter", "select"),
 	),
+	Back: key.NewBinding(
+		key.WithKeys("backspace", "left", "h"),
+		key.WithHelp("←/backspace", "back"),
+	),
 	Cancel: key.NewBinding(
 		key.WithKeys("ctrl+c", "esc", "q"),
 		key.WithHelp("esc", "cancel"),
@@ -196,6 +201,7 @@ type DirectionSelectModel struct {
 	direction     Direction
 	done          bool
 	ready         bool
+	back          bool
 	err           error
 	help          help.Model
 	keys          directionSelectKeyMap
@@ -226,7 +232,7 @@ func NewDirectionSelectModel(eng engine.BranchReader, currentBranch, parentBranc
 		currentBranch: currentBranch,
 		parentBranch:  parentBranch,
 		children:      children,
-		direction:     DirectionBelow, // Default to below
+		direction:     DirectionAbove, // Default to above (extract to child branch)
 		help:          help.New(),
 		keys:          defaultDirectionKeys,
 		stackPath:     stackPath,
@@ -251,6 +257,10 @@ func (m *DirectionSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, m.keys.Down):
 			m.direction = DirectionBelow
 		case key.Matches(msg, m.keys.Submit):
+			m.done = true
+			return m, tea.Quit
+		case key.Matches(msg, m.keys.Back):
+			m.back = true
 			m.done = true
 			return m, tea.Quit
 		case key.Matches(msg, m.keys.Cancel):
@@ -309,7 +319,7 @@ func (m *DirectionSelectModel) renderOptions() string {
 	}
 	sb.WriteString("\n")
 
-	// Below option (default)
+	// Below option
 	if m.direction == DirectionBelow {
 		sb.WriteString(selectionStyles.Highlighted.Render("▸ Below"))
 		sb.WriteString(normalStyle.Render(" - Insert between parent and current"))
@@ -392,6 +402,11 @@ func (m *DirectionSelectModel) Err() error {
 	return m.err
 }
 
+// Back returns true if the user pressed back
+func (m *DirectionSelectModel) Back() bool {
+	return m.back
+}
+
 // PromptDirectionSelect shows an interactive direction selector and returns the chosen direction
 func PromptDirectionSelect(eng engine.BranchReader, currentBranch, parentBranch string, children []string) (Direction, error) {
 	if err := CheckInteractiveAllowed(); err != nil {
@@ -400,13 +415,16 @@ func PromptDirectionSelect(eng engine.BranchReader, currentBranch, parentBranch 
 
 	m := NewDirectionSelectModel(eng, currentBranch, parentBranch, children)
 
-	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithInput(os.Stdin), tea.WithOutput(os.Stdout))
+	p := tea.NewProgram(m, tea.WithInput(os.Stdin), tea.WithOutput(os.Stdout))
 	model, err := p.Run()
 	if err != nil {
 		return "", err
 	}
 
 	if finalModel, ok := model.(*DirectionSelectModel); ok {
+		if finalModel.Back() {
+			return "", errors.ErrBack
+		}
 		if finalModel.Err() != nil {
 			return "", finalModel.Err()
 		}

--- a/internal/tui/style/colors.go
+++ b/internal/tui/style/colors.go
@@ -85,9 +85,9 @@ func colorDimValue() lipgloss.Color {
 
 func colorSubtleValue() lipgloss.Color {
 	if IsDarkBackground() {
-		return lipgloss.Color("240") // Medium gray for dark backgrounds
+		return lipgloss.Color("246") // Medium gray for dark backgrounds (was 240, too faint)
 	}
-	return lipgloss.Color("245") // Medium-dark gray for light backgrounds
+	return lipgloss.Color("243") // Medium-dark gray for light backgrounds
 }
 
 // DimColor returns the dim color value (adaptive to terminal background)

--- a/internal/tui/style/theme.go
+++ b/internal/tui/style/theme.go
@@ -146,3 +146,20 @@ func DefaultSelectionStyles() SelectionStyles {
 func InsertStyle() lipgloss.Style {
 	return lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ColorInsert))
 }
+
+// HelpKeyStyle returns a style for help key bindings.
+// Uses a more visible color than the default bubbles help style.
+func HelpKeyStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(colorSubtleValue())
+}
+
+// HelpDescStyle returns a style for help descriptions.
+// Uses a more visible color than the default bubbles help style.
+func HelpDescStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(colorDimValue())
+}
+
+// HelpSeparatorStyle returns a style for help separators (the • between items).
+func HelpSeparatorStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(colorDimValue())
+}


### PR DESCRIPTION

- Enhance error messages with actionable guidance for common scenarios
- Add guard against empty type arrays in split TUI cursor navigation
- Fix textinput cursor to remain active after validation errors
- Fix split model to complete after type selection when used standalone
- Change direction selector default from "below" to "above"
- Implement "by file" split in wizard mode with direction support
- Remove alt screen from split/direction selectors to prevent flashing
- Add back navigation (backspace/left/h) from direction to type selection
- Remove redundant flag handling in CLI
- Document intentional stash cleanup behavior during error recovery