### PR TITLE
Merging 4 PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ internal/
 
 - `docs/config.md` - Configuration system, keys, layered config
 - `docs/tui.md` - TUI patterns, BaseModel, styling, components
+- `docs/worktree.md` - Worktree management, create vs attach, workflows
 
 ## Common Development Tasks
 
@@ -31,6 +32,7 @@ internal/
 | Add submit command config | See "Submit Command Config Flow" in `docs/config.md` |
 | Add a new CLI command | Follow patterns in `internal/cli/` |
 | Add TUI component | See `docs/tui.md` |
+| Add worktree functionality | See `docs/worktree.md` |
 
 ## CLI Tools
 

--- a/docs/worktree.md
+++ b/docs/worktree.md
@@ -1,0 +1,260 @@
+# Worktrees
+
+Worktrees allow you to work on multiple stacks in parallel, each in its own directory.
+
+## Quick Reference
+
+| Command | Description |
+|:---|:---|
+| `stackit worktree create <name>` | Create a new worktree with a fresh anchor branch |
+| `stackit worktree attach <branch>` | Create a worktree for an existing stack |
+| `stackit worktree list` | List all managed worktrees |
+| `stackit worktree open <name>` | Open/cd to a worktree |
+| `stackit worktree remove <name>` | Remove worktree and delete branches |
+| `stackit worktree detach <name>` | Remove worktree but keep branches |
+| `stackit worktree prune` | Clean up empty/stale worktrees |
+
+**Alias:** `wt` is a short alias for `worktree` (e.g., `stackit wt list`).
+
+---
+
+## Overview
+
+Git worktrees let you check out multiple branches simultaneously in separate directories. Stackit manages worktrees to give each stack its own isolated workspace.
+
+**Key concepts:**
+
+- **Anchor branch**: The root branch of a worktree's stack. For `wt create`, this is a special marker branch. For `wt attach`, it's the existing stack root.
+- **Main repo**: Your original repository checkout.
+- **Worktree**: A secondary checkout in a separate directory.
+
+**Default location:** Worktrees are created in a sibling directory named `{repo}-stacks/`. For example, if your repo is at `~/projects/myapp`, worktrees go to `~/projects/myapp-stacks/`.
+
+---
+
+## Commands
+
+### `worktree create` - Start a new stack in a worktree
+
+Creates a fresh worktree with an empty anchor branch. Use this when starting new work that you want isolated from your main checkout.
+
+```bash
+stackit worktree create my-feature
+# Creates:
+#   - Anchor branch: {pattern}-my-feature-wt (at trunk HEAD)
+#   - Worktree at: ../myapp-stacks/my-feature/
+```
+
+**Options:**
+- `--scope <name>`: Set a scope (Jira ticket, Linear ID) on the anchor branch
+- `--no-open`: Don't auto-cd to the new worktree
+
+**Workflow:**
+```bash
+stackit wt create auth-refactor
+# Now in ../myapp-stacks/auth-refactor/
+stackit create api-changes -m "refactor: update auth API"
+stackit create ui-updates -m "feat: new login UI"
+```
+
+### `worktree attach` - Move existing stack to a worktree
+
+Creates a worktree for a stack that already exists in your main repo. The stack root becomes the worktree anchor.
+
+```bash
+# You have a stack: main -> feature -> tests
+stackit worktree attach feature
+# Creates worktree at: ../myapp-stacks/feature/
+# Main repo switches to trunk
+```
+
+**Options:**
+- `--name <name>`: Custom worktree name (defaults to stack root name)
+- `--no-open`: Don't auto-cd to the new worktree
+
+**When to use:**
+- You started work in the main repo but want to isolate it
+- You want to work on a different stack without stashing/switching
+- You fetched someone's stack with `stackit get` and want a dedicated workspace
+
+### `worktree list` - Show all managed worktrees
+
+```bash
+stackit worktree list
+```
+
+Shows each worktree with:
+- Name and anchor branch
+- Path on disk
+- Stack size (number of branches)
+- Current branch in that worktree
+- Dirty status (uncommitted changes)
+
+### `worktree open` - Navigate to a worktree
+
+```bash
+stackit worktree open my-feature
+```
+
+With shell integration enabled, this changes your directory to the worktree. Without shell integration, it prints the path for use with `cd $(...)`.
+
+### `worktree remove` - Delete worktree and branches
+
+Removes the worktree directory and deletes the anchor branch (if it has no children).
+
+```bash
+stackit worktree remove my-feature
+```
+
+**Options:**
+- `--force`: Remove even with uncommitted changes
+- `--keep-branch`: Keep the anchor branch instead of deleting it
+
+**Use when:** The stack is fully merged or you want to discard all the work.
+
+### `worktree detach` - Remove worktree, keep branches
+
+Removes the worktree directory but preserves all stack branches in the main repo.
+
+```bash
+stackit worktree detach my-feature
+```
+
+**Behavior depends on how the worktree was created:**
+
+| Created with | What `detach` does |
+|:---|:---|
+| `wt create` | Reparents children to trunk, deletes empty anchor branch |
+| `wt attach` | Leaves all branches intact (they have real commits) |
+
+**Options:**
+- `--force`: Detach even with uncommitted changes
+
+**Use when:**
+- You want to continue work in the main repo instead
+- You need to free up disk space but keep your branches
+- You're done with the isolated workspace but not the code
+
+### `worktree prune` - Clean up stale worktrees
+
+Removes worktrees that are empty (no stacked branches) or have missing directories.
+
+```bash
+stackit worktree prune
+stackit worktree prune --dry-run  # Preview what would be removed
+```
+
+**Skips worktrees that:**
+- Have stacked branches
+- Have uncommitted changes
+- Are currently checked out
+
+---
+
+## Create vs Attach
+
+| | `wt create` | `wt attach` |
+|:---|:---|:---|
+| **Starting point** | Fresh (from trunk) | Existing stack |
+| **Anchor branch** | New empty marker branch | Stack root (has commits) |
+| **Main repo after** | Unchanged | Switches to trunk |
+| **On detach** | Anchor deleted, children reparented | Branches preserved as-is |
+
+**Rule of thumb:**
+- Use `create` when starting new work
+- Use `attach` when moving existing work to a worktree
+
+---
+
+## Configuration
+
+Configure worktree behavior in `.stackit.yaml` or via `stackit config`:
+
+```yaml
+# .stackit.yaml
+worktree:
+  basePath: "../my-stacks"  # Custom location (default: ../{repo}-stacks)
+  autoClean: true           # Auto-remove merged worktrees during sync
+```
+
+```bash
+stackit config set worktree.basePath "../my-stacks"
+stackit config set worktree.autoClean false
+```
+
+---
+
+## Shell Integration
+
+Enable shell integration to auto-cd when creating/opening worktrees:
+
+```bash
+# zsh (~/.zshrc)
+eval "$(stackit shell zsh)"
+
+# bash (~/.bashrc)
+eval "$(stackit shell bash)"
+
+# fish (~/.config/fish/config.fish)
+stackit shell fish | source
+```
+
+Without shell integration, use command substitution:
+```bash
+cd $(stackit worktree open my-feature)
+```
+
+---
+
+## Post-Create Hooks
+
+Run commands automatically after creating a worktree:
+
+```yaml
+# .stackit.yaml
+hooks:
+  post-worktree-create:
+    - npm install
+    - cp .env.example .env
+```
+
+**Security:** First-time hooks require approval (defaults to "No"). Approvals are stored in git config. Hooks have a 60-second timeout.
+
+---
+
+## Common Workflows
+
+### Start isolated feature work
+
+```bash
+stackit wt create payments
+# In worktree now
+stackit create api -m "feat: payment API"
+stackit create ui -m "feat: checkout UI"
+stackit submit
+```
+
+### Move in-progress work to worktree
+
+```bash
+# In main repo with stack: main -> auth -> tests
+stackit wt attach auth
+# Now in worktree, main repo is on trunk
+```
+
+### Finish and clean up
+
+```bash
+# After PRs merged
+stackit sync           # Cleans up merged worktrees if autoClean=true
+# Or manually:
+stackit wt remove my-feature
+```
+
+### Keep branches, remove worktree
+
+```bash
+stackit wt detach my-feature
+# Worktree gone, branches still in main repo
+stackit checkout my-feature  # Continue in main repo
+```

--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -480,6 +480,13 @@ type deleteBranchCachedEngine interface {
 
 // ShouldDeleteBranchCached checks if a branch should be deleted using pre-fetched metadata and revisions
 func ShouldDeleteBranchCached(ctx context.Context, branchName string, eng deleteBranchCachedEngine, force bool, meta *git.Meta, revisions map[string]string, mergedBranches map[string]bool) (bool, string) {
+	// 0. Never delete worktree anchor branches - they appear "merged" because they
+	// point to the same commit as trunk, but they're needed for worktree management
+	branch := eng.GetBranch(branchName)
+	if branch.IsWorktreeAnchor() {
+		return false, ""
+	}
+
 	// 1. Check PR info from cached metadata
 	if meta != nil && meta.PrInfo != nil {
 		const (
@@ -512,7 +519,6 @@ func ShouldDeleteBranchCached(ctx context.Context, branchName string, eng delete
 	// 3. Check if empty
 	// Need parent revision
 	var parentRev string
-	branch := eng.GetBranch(branchName)
 	parent := branch.GetParent()
 	parentName := trunkName
 	if parent != nil {

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -536,3 +536,257 @@ func PruneAction(ctx *app.Context, opts PruneOptions) (*PruneResult, error) {
 
 	return result, nil
 }
+
+// AttachOptions contains options for the attach action
+type AttachOptions struct {
+	Branch string // Any branch in the stack (we find the stack root)
+	Name   string // Optional worktree name (defaults to stack root name)
+}
+
+// AttachResult contains the results of attaching a worktree
+type AttachResult struct {
+	Name         string // The name of the worktree
+	AnchorBranch string // The stack root branch (serves as anchor)
+	Path         string // The path to the worktree
+}
+
+// AttachAction creates a worktree for an existing stack
+func AttachAction(ctx *app.Context, opts AttachOptions) (*AttachResult, error) {
+	eng := ctx.Engine
+	out := ctx.Output
+	repoRoot := ctx.RepoRoot
+
+	// Cannot attach from inside a managed worktree
+	if ctx.InManagedWorktree {
+		return nil, fmt.Errorf("cannot attach from inside a managed worktree")
+	}
+
+	// Get the branch and validate it exists and is tracked
+	branch := eng.GetBranch(opts.Branch)
+	if !branch.IsTracked() {
+		// Check if the branch exists at all
+		if _, err := eng.GetRevision(branch); err != nil {
+			return nil, fmt.Errorf("branch %s does not exist", style.ColorBranchName(opts.Branch, false))
+		}
+		return nil, fmt.Errorf("branch %s is not tracked by stackit", style.ColorBranchName(opts.Branch, false))
+	}
+
+	// Find the stack root
+	stackRootName := eng.GetStackRootForBranch(branch)
+	if stackRootName == "" {
+		return nil, fmt.Errorf("branch %s is not part of a stack (its parent must be trunk)", style.ColorBranchName(opts.Branch, false))
+	}
+	stackRoot := eng.GetBranch(stackRootName)
+
+	// Validate: stack root is not already a worktree anchor
+	if eng.IsWorktreeAnchor(stackRoot) {
+		return nil, fmt.Errorf("branch %s is already a worktree anchor", style.ColorBranchName(stackRootName, false))
+	}
+
+	// Validate: stack root doesn't already have a worktree
+	existingWt, err := eng.GetWorktreeForStack(stackRootName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check existing worktree: %w", err)
+	}
+	if existingWt != nil {
+		return nil, fmt.Errorf("stack already has a worktree at %s", existingWt.Path)
+	}
+
+	// Determine worktree name (default to stack root name)
+	name := opts.Name
+	if name == "" {
+		name = stackRootName
+	}
+
+	// Validate name doesn't contain path separators or other problematic characters
+	if strings.ContainsAny(name, "/\\:*?\"<>|") {
+		return nil, fmt.Errorf("worktree name cannot contain path separators or special characters: /\\:*?\"<>|")
+	}
+
+	// Check for duplicate worktree names
+	existingWorktrees, err := eng.ListManagedWorktrees()
+	if err != nil {
+		return nil, fmt.Errorf("failed to check existing worktrees: %w", err)
+	}
+	for _, wt := range existingWorktrees {
+		if wt.Name == name {
+			return nil, fmt.Errorf("worktree with name %q already exists", name)
+		}
+	}
+
+	// Get worktree base path from config, or use default
+	cfg, _ := config.LoadConfig(repoRoot)
+	basePath := cfg.WorktreeBasePath()
+
+	// Default: sibling directory named {repo}-stacks
+	if basePath == "" {
+		repoName := filepath.Base(repoRoot)
+		basePath = filepath.Join(filepath.Dir(repoRoot), repoName+"-stacks")
+	}
+
+	// Worktree path: basePath/name
+	worktreePath := filepath.Join(basePath, name)
+
+	// Check if path already exists
+	if _, err := os.Stat(worktreePath); err == nil {
+		return nil, fmt.Errorf("worktree path %s already exists; remove it first or choose a different name", worktreePath)
+	}
+
+	// Remember current branch for restoration on failure
+	currentBranch := eng.CurrentBranch()
+	trunk := eng.Trunk()
+
+	// If we're on a branch in the stack being attached, checkout trunk first
+	// Git doesn't allow creating a worktree with a branch that's currently checked out
+	needsCheckout := false
+	if currentBranch != nil {
+		currentStackRoot := eng.GetStackRootForBranch(*currentBranch)
+		if currentStackRoot == stackRootName {
+			needsCheckout = true
+			if err := eng.CheckoutBranch(ctx.Context, trunk); err != nil {
+				return nil, fmt.Errorf("failed to checkout trunk before creating worktree: %w", err)
+			}
+		}
+	}
+
+	// Create the worktree (non-detached, pointing to the stack root)
+	if err := eng.AddWorktree(ctx.Context, worktreePath, stackRootName, false); err != nil {
+		// Restore original branch on failure
+		if needsCheckout && currentBranch != nil {
+			_ = eng.CheckoutBranch(ctx.Context, *currentBranch)
+		}
+		return nil, fmt.Errorf("failed to create worktree: %w", err)
+	}
+
+	// Register the worktree in local refs with the name
+	if err := eng.RegisterWorktreeWithName(stackRootName, worktreePath, name); err != nil {
+		// Clean up worktree on registration failure
+		_ = eng.RemoveWorktree(ctx.Context, worktreePath)
+		if needsCheckout && currentBranch != nil {
+			_ = eng.CheckoutBranch(ctx.Context, *currentBranch)
+		}
+		return nil, fmt.Errorf("failed to register worktree: %w", err)
+	}
+
+	// If we weren't already on trunk, checkout trunk now (stack now "belongs" to worktree)
+	if !needsCheckout {
+		if err := eng.CheckoutBranch(ctx.Context, trunk); err != nil {
+			// Clean up on failure
+			_ = eng.UnregisterWorktree(stackRootName)
+			_ = eng.RemoveWorktree(ctx.Context, worktreePath)
+			// Try to restore original branch
+			if currentBranch != nil {
+				_ = eng.CheckoutBranch(ctx.Context, *currentBranch)
+			}
+			return nil, fmt.Errorf("failed to checkout trunk: %w", err)
+		}
+	}
+
+	out.Success("Attached stack %s to worktree", style.ColorBranchName(stackRootName, false))
+	out.Info("  Name: %s", style.ColorBranchName(name, false))
+	out.Info("  Path: %s", style.ColorDim(worktreePath))
+	out.Newline()
+
+	// Run post-create hooks
+	if err := RunPostCreateHooks(ctx, worktreePath); err != nil {
+		out.Warn("Post-create hooks failed: %v", err)
+	}
+
+	return &AttachResult{
+		Name:         name,
+		AnchorBranch: stackRootName,
+		Path:         worktreePath,
+	}, nil
+}
+
+// DetachOptions contains options for the detach action
+type DetachOptions struct {
+	NameOrBranch string // Worktree name or anchor branch
+	Force        bool   // Allow detach even with uncommitted changes
+}
+
+// DetachAction removes a worktree while preserving all branches
+func DetachAction(ctx *app.Context, opts DetachOptions) error {
+	out := ctx.Output
+
+	// Find worktree by name or anchor branch
+	wtInfo, err := findWorktreeByNameOrBranch(ctx, opts.NameOrBranch)
+	if err != nil {
+		return err
+	}
+
+	// Check if we're currently in this worktree
+	if ctx.InManagedWorktree && ctx.WorktreeInfo != nil {
+		if ctx.WorktreeInfo.AnchorBranch == wtInfo.AnchorBranch {
+			return fmt.Errorf("cannot detach from inside the worktree; cd to main repo first")
+		}
+	}
+
+	// Check if path exists and has uncommitted changes
+	if _, statErr := os.Stat(wtInfo.Path); statErr == nil {
+		isDirty, err := ctx.Git().WorktreeHasUncommittedChanges(ctx.Context, wtInfo.Path)
+		if err == nil && isDirty && !opts.Force {
+			return fmt.Errorf("worktree has uncommitted changes; use --force to override")
+		}
+	}
+
+	// Determine anchor branch type
+	anchorBranch := ctx.Engine.GetBranch(wtInfo.AnchorBranch)
+	isWorktreeAnchor := ctx.Engine.IsWorktreeAnchor(anchorBranch)
+
+	// Remove the git worktree directory
+	if _, statErr := os.Stat(wtInfo.Path); statErr == nil {
+		if removeErr := ctx.Engine.RemoveWorktree(ctx.Context, wtInfo.Path); removeErr != nil {
+			if !opts.Force {
+				return fmt.Errorf("failed to remove worktree at %s: %w (use --force to override)", wtInfo.Path, removeErr)
+			}
+			out.Warn("Failed to remove worktree directory, continuing with unregistration: %v", removeErr)
+		}
+	} else {
+		out.Debug("Worktree path %s does not exist, skipping removal", wtInfo.Path)
+		// Prune stale git worktree references
+		if pruneErr := ctx.Engine.PruneWorktrees(ctx.Context); pruneErr != nil {
+			out.Debug("Failed to prune worktrees: %v", pruneErr)
+		}
+	}
+
+	// Unregister from registry
+	if unregErr := ctx.Engine.UnregisterWorktree(wtInfo.AnchorBranch); unregErr != nil {
+		return fmt.Errorf("failed to unregister worktree: %w", unregErr)
+	}
+
+	// Handle anchor cleanup based on branch type
+	if isWorktreeAnchor {
+		// This was created by `wt create` - reparent children to trunk and delete anchor
+		graph := engine.BuildStackGraph(ctx.Engine, engine.SortStrategyAlphabetical, nil)
+		childNames := graph.Children(anchorBranch)
+
+		if len(childNames) > 0 {
+			trunk := ctx.Engine.Trunk()
+			// Reparent all children to trunk
+			for _, childName := range childNames {
+				childBranch := ctx.Engine.GetBranch(childName)
+				if err := ctx.Engine.SetParent(ctx.Context, childBranch, trunk); err != nil {
+					out.Warn("Failed to reparent %s to trunk: %v", childName, err)
+				} else {
+					out.Debug("Reparented %s to %s", childName, trunk.GetName())
+				}
+			}
+		}
+
+		// Delete the worktree-anchor branch
+		if err := ctx.Engine.DeleteBranch(ctx.Context, anchorBranch); err != nil {
+			out.Warn("Failed to delete anchor branch: %v", err)
+		} else {
+			out.Debug("Deleted anchor branch %s", wtInfo.AnchorBranch)
+		}
+	}
+	// For BranchTypeUser (from `wt attach`): leave the branch as-is since it has real commits
+
+	out.Success("Detached worktree %s", style.ColorBranchName(wtInfo.Name, false))
+	if !isWorktreeAnchor {
+		out.Info("  Stack branches preserved (branch %s has commits)", style.ColorBranchName(wtInfo.AnchorBranch, false))
+	}
+
+	return nil
+}

--- a/internal/cli/worktree/worktree.go
+++ b/internal/cli/worktree/worktree.go
@@ -15,8 +15,9 @@ import (
 // NewWorktreeCmd creates the worktree command group
 func NewWorktreeCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "worktree",
-		Short: "Manage stackit-managed worktrees",
+		Use:     "worktree",
+		Aliases: []string{"wt"},
+		Short:   "Manage stackit-managed worktrees",
 		Long: `Manage stackit-managed worktrees.
 
 Worktrees allow you to work on multiple stacks in parallel, each in its own
@@ -28,6 +29,8 @@ directory. Create a worktree with 'stackit worktree create' from trunk.`,
 	cmd.AddCommand(newRemoveCmd())
 	cmd.AddCommand(newOpenCmd())
 	cmd.AddCommand(newPruneCmd())
+	cmd.AddCommand(newAttachCmd())
+	cmd.AddCommand(newDetachCmd())
 
 	return cmd
 }
@@ -299,6 +302,98 @@ To enable shell integration, add to your shell config:
 			})
 		},
 	}
+
+	return cmd
+}
+
+// newAttachCmd creates the worktree attach command
+func newAttachCmd() *cobra.Command {
+	var name string
+	var noOpen bool
+
+	cmd := &cobra.Command{
+		Use:   "attach <branch>",
+		Short: "Create a worktree for an existing stack",
+		Long: `Create a worktree for an existing stack.
+
+Takes any branch in the stack and creates a worktree for the entire stack.
+The stack root branch serves as the anchor for the worktree.
+
+Examples:
+  stackit worktree attach feature      # Attach stack rooted at 'feature'
+  stackit wt attach feature --name wt  # Use custom worktree name
+  stackit wt attach child-branch       # Attach the stack containing 'child-branch'
+
+With shell integration enabled, automatically changes to the new worktree directory.
+Use --no-open to skip the automatic directory change.`,
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return common.Run(cmd, func(ctx *app.Context) error {
+				result, err := worktree.AttachAction(ctx, worktree.AttachOptions{
+					Branch: args[0],
+					Name:   name,
+				})
+				if err != nil {
+					return err
+				}
+
+				// Auto-cd to worktree by default when shell integration is available
+				if !noOpen && result.Path != "" && common.HasShellIntegration() {
+					ctx.Output.DirectiveCD(result.Path)
+				} else if result.Path != "" {
+					// User opted out or no shell integration
+					ctx.Output.Tip("cd %s", result.Path)
+				}
+
+				return nil
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Custom name for the worktree (defaults to stack root branch name)")
+	cmd.Flags().BoolVar(&noOpen, "no-open", false, "Don't change to the worktree directory after creation")
+
+	return cmd
+}
+
+// newDetachCmd creates the worktree detach command
+func newDetachCmd() *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "detach <name-or-branch>",
+		Short: "Remove a worktree while keeping stack branches",
+		Long: `Remove a worktree while preserving all stack branches.
+
+Unlike 'remove', this command preserves the branches in the main repository.
+Use this when you want to stop working in a worktree but keep all your branches.
+
+For worktrees created with 'wt create' (anchor-only worktrees):
+  - Reparents children of the anchor branch to trunk
+  - Deletes the anchor branch (which has no commits)
+
+For worktrees created with 'wt attach' (existing stack worktrees):
+  - Leaves all branches intact
+  - The stack remains usable in the main repository
+
+Examples:
+  stackit worktree detach my-feature   # Detach by worktree name
+  stackit wt detach feature-branch     # Detach by anchor branch name
+  stackit wt detach my-wt --force      # Force detach with uncommitted changes`,
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return common.Run(cmd, func(ctx *app.Context) error {
+				return worktree.DetachAction(ctx, worktree.DetachOptions{
+					NameOrBranch: args[0],
+					Force:        force,
+				})
+			})
+		},
+	}
+
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Force detach even with uncommitted changes")
 
 	return cmd
 }

--- a/internal/integration/worktree_attach_detach_test.go
+++ b/internal/integration/worktree_attach_detach_test.go
@@ -1,0 +1,445 @@
+package integration
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// =============================================================================
+// Attach Operations
+// =============================================================================
+
+func TestWorktreeAttach(t *testing.T) {
+	t.Parallel()
+
+	t.Run("attach existing stack to worktree", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a regular stack (not in a worktree)
+		sh.WriteFile("feature.txt", "feature content").
+			Run("create feature -m 'feature branch'")
+
+		// Should be on the feature branch
+		sh.OnBranch("feature")
+
+		// Attach the stack to a worktree
+		sh.Run("worktree attach feature")
+
+		// Should return to main after attaching
+		sh.OnBranch("main")
+
+		// Verify worktree was created
+		sh.Run("worktree list").
+			OutputContains("feature")
+
+		// Get worktree path and verify it exists
+		worktreePath := sh.GetWorktreePath("feature")
+		if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
+			t.Errorf("Worktree directory should exist at %s", worktreePath)
+		}
+
+		// Verify the branch is checked out in the worktree
+		shW := sh.InWorktree(worktreePath)
+		shW.OnBranch("feature")
+	})
+
+	t.Run("attach with custom name", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a stack
+		sh.WriteFile("feature.txt", "feature").
+			Run("create feature -m 'feature branch'")
+
+		// Attach with custom name
+		sh.Run("worktree attach feature --name my-wt")
+
+		// Verify worktree was created with custom name
+		sh.Run("worktree list").
+			OutputContains("my-wt")
+
+		// Verify the path uses the custom name (use worktree open to get path)
+		sh.Run("worktree open my-wt")
+		worktreePath := strings.TrimSpace(sh.Output())
+		if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
+			t.Errorf("Worktree directory should exist at %s", worktreePath)
+		}
+		// The path should contain "my-wt" as the directory name
+		if !strings.Contains(worktreePath, "my-wt") {
+			t.Errorf("Worktree path should contain custom name 'my-wt', got: %s", worktreePath)
+		}
+	})
+
+	t.Run("attach child branch attaches entire stack", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a stack with multiple branches
+		sh.WriteFile("root.txt", "root").
+			Run("create stack-root -m 'stack root'")
+		sh.WriteFile("child.txt", "child").
+			Run("create child -m 'child branch'")
+
+		// Attach by specifying the child branch
+		sh.Run("worktree attach child")
+
+		// Verify worktree was created with stack root name
+		sh.Run("worktree list").
+			OutputContains("stack-root")
+
+		// Verify the worktree exists and has the stack root checked out
+		worktreePath := sh.GetWorktreePath("stack-root")
+		shW := sh.InWorktree(worktreePath)
+		shW.OnBranch("stack-root")
+
+		// Both branches should be accessible in the worktree
+		sh.HasBranches("main", "stack-root", "child")
+	})
+
+	t.Run("attach fails for untracked branch", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a regular git branch (not tracked by stackit)
+		sh.Git("checkout -b untracked-branch")
+		sh.WriteFile("file.txt", "content")
+		sh.Git("add file.txt")
+		sh.Git("commit -m 'commit'")
+
+		// Attach should fail
+		sh.RunExpectError("worktree attach untracked-branch")
+	})
+
+	t.Run("attach fails for non-existent branch", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.RunExpectError("worktree attach nonexistent")
+	})
+
+	t.Run("attach fails for branch already in worktree", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a stack with worktree
+		sh.WriteFile("feature.txt", "feature").
+			Run("create feature -w -m 'feature branch'")
+
+		// Try to attach again - should fail
+		sh.RunExpectError("worktree attach feature")
+	})
+
+	t.Run("attach fails from inside worktree", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a worktree
+		sh.WriteFile("wt1.txt", "wt1").
+			Run("create wt1 -w -m 'worktree 1'")
+
+		worktreePath := sh.GetWorktreePath("wt1")
+		shW := sh.InWorktree(worktreePath)
+
+		// Create another stack in main repo
+		sh.WriteFile("stack2.txt", "stack2").
+			Run("create stack2 -m 'stack 2'")
+
+		// Try to attach from inside worktree - should fail
+		shW.RunExpectError("worktree attach stack2")
+	})
+}
+
+// =============================================================================
+// Detach Operations
+// =============================================================================
+
+func TestWorktreeDetach(t *testing.T) {
+	t.Parallel()
+
+	t.Run("detach preserves branches from attached worktree", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a regular stack
+		sh.WriteFile("feature.txt", "feature").
+			Run("create feature -m 'feature branch'")
+		sh.WriteFile("child.txt", "child").
+			Run("create child -m 'child branch'")
+
+		// Attach to worktree
+		sh.Run("worktree attach feature")
+
+		worktreePath := sh.GetWorktreePath("feature")
+
+		// Detach the worktree
+		sh.Run("worktree detach feature")
+
+		// Worktree should be removed
+		if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
+			t.Errorf("Worktree directory should be removed at %s", worktreePath)
+		}
+
+		// Worktree should not be listed
+		sh.Run("worktree list")
+		output := sh.Output()
+		if strings.Contains(output, "feature") && !strings.Contains(output, "No managed worktrees") {
+			t.Errorf("Worktree should be removed from list")
+		}
+
+		// Branches should still exist
+		sh.HasBranches("main", "feature", "child")
+
+		// Stack structure should be preserved
+		sh.ExpectStackStructure(map[string]string{
+			"feature": "main",
+			"child":   "feature",
+		})
+	})
+
+	t.Run("detach created worktree reparents children and deletes anchor", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create worktree with wt create (creates anchor branch)
+		sh.Run("worktree create my-wt")
+
+		// Get worktree path using worktree open (works with name, not anchor branch)
+		sh.Run("worktree open my-wt")
+		worktreePath := strings.TrimSpace(sh.Output())
+		shW := sh.InWorktree(worktreePath)
+
+		// Create a child branch in the worktree
+		shW.WriteFile("feature.txt", "feature").
+			Run("create feature -m 'feature branch'")
+
+		// Detach the worktree
+		sh.Run("worktree detach my-wt")
+
+		// Worktree should be removed
+		if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
+			t.Errorf("Worktree directory should be removed at %s", worktreePath)
+		}
+
+		// The anchor branch should be deleted (it was a worktree-anchor type)
+		branches, _ := sh.Scene().Repo.GetLocalBranches()
+		for _, b := range branches {
+			if strings.Contains(b, "my-wt") && strings.Contains(b, "-wt") {
+				t.Errorf("Anchor branch should be deleted, but found: %s", b)
+			}
+		}
+
+		// Feature branch should still exist and be reparented to main
+		sh.HasBranches("main", "feature")
+		sh.ExpectBranchParent("feature", "main")
+	})
+
+	t.Run("detach fails with uncommitted changes without force", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a stack and attach
+		sh.WriteFile("feature.txt", "feature").
+			Run("create feature -m 'feature branch'")
+		sh.Run("worktree attach feature")
+
+		worktreePath := sh.GetWorktreePath("feature")
+
+		// Create uncommitted changes in worktree
+		uncommittedFile := worktreePath + "/uncommitted.txt"
+		if err := os.WriteFile(uncommittedFile, []byte("uncommitted"), 0644); err != nil {
+			t.Fatalf("Failed to write file: %v", err)
+		}
+
+		// Detach without force should fail
+		sh.RunExpectError("worktree detach feature")
+
+		// Worktree should still exist
+		if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
+			t.Errorf("Worktree should still exist")
+		}
+	})
+
+	t.Run("detach with force removes worktree with uncommitted changes", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a stack and attach
+		sh.WriteFile("feature.txt", "feature").
+			Run("create feature -m 'feature branch'")
+		sh.Run("worktree attach feature")
+
+		worktreePath := sh.GetWorktreePath("feature")
+
+		// Create uncommitted changes in worktree
+		uncommittedFile := worktreePath + "/uncommitted.txt"
+		if err := os.WriteFile(uncommittedFile, []byte("uncommitted"), 0644); err != nil {
+			t.Fatalf("Failed to write file: %v", err)
+		}
+
+		// Detach with force should succeed
+		sh.Run("worktree detach feature --force")
+
+		// Worktree should be removed
+		if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
+			t.Errorf("Worktree directory should be removed at %s", worktreePath)
+		}
+
+		// Branches should still exist
+		sh.HasBranches("main", "feature")
+	})
+
+	t.Run("detach fails from inside worktree", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a stack and attach
+		sh.WriteFile("feature.txt", "feature").
+			Run("create feature -m 'feature branch'")
+		sh.Run("worktree attach feature")
+
+		worktreePath := sh.GetWorktreePath("feature")
+		shW := sh.InWorktree(worktreePath)
+
+		// Try to detach from inside the worktree - should fail
+		shW.RunExpectError("worktree detach feature")
+	})
+
+	t.Run("detach non-existent worktree fails", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.RunExpectError("worktree detach nonexistent")
+	})
+}
+
+// =============================================================================
+// Attach/Detach Round-Trip
+// =============================================================================
+
+func TestWorktreeAttachDetachRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("attach detach attach cycle works", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a stack
+		sh.WriteFile("feature.txt", "feature").
+			Run("create feature -m 'feature branch'")
+
+		// Attach
+		sh.Run("worktree attach feature")
+		sh.Run("worktree list").OutputContains("feature")
+
+		// Detach
+		sh.Run("worktree detach feature")
+		sh.Run("worktree list").OutputContains("No managed worktrees")
+
+		// Attach again (should work)
+		sh.Run("worktree attach feature")
+		sh.Run("worktree list").OutputContains("feature")
+
+		// Verify worktree works
+		worktreePath := sh.GetWorktreePath("feature")
+		shW := sh.InWorktree(worktreePath)
+		shW.OnBranch("feature")
+	})
+
+	t.Run("work in attached worktree then detach preserves work", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a stack
+		sh.WriteFile("feature.txt", "feature").
+			Run("create feature -m 'feature branch'")
+
+		// Attach to worktree
+		sh.Run("worktree attach feature")
+
+		worktreePath := sh.GetWorktreePath("feature")
+		shW := sh.InWorktree(worktreePath)
+
+		// Do work in the worktree - create child branches
+		shW.WriteFile("child1.txt", "child1").
+			Run("create child1 -m 'child 1'")
+		shW.WriteFile("child2.txt", "child2").
+			Run("create child2 -m 'child 2'")
+
+		// Detach
+		sh.Run("worktree detach feature")
+
+		// All branches should be preserved
+		sh.HasBranches("main", "feature", "child1", "child2")
+
+		// Stack structure should be preserved
+		sh.ExpectStackStructure(map[string]string{
+			"feature": "main",
+			"child1":  "feature",
+			"child2":  "child1",
+		})
+	})
+}
+
+// =============================================================================
+// Edge Cases
+// =============================================================================
+
+func TestWorktreeAttachDetachEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("attach stack with deep hierarchy", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create deep stack
+		sh.WriteFile("a.txt", "a").Run("create a -m 'branch a'")
+		sh.WriteFile("b.txt", "b").Run("create b -m 'branch b'")
+		sh.WriteFile("c.txt", "c").Run("create c -m 'branch c'")
+		sh.WriteFile("d.txt", "d").Run("create d -m 'branch d'")
+
+		// Attach from the leaf
+		sh.Run("worktree attach d")
+
+		// Should attach at stack root
+		worktreePath := sh.GetWorktreePath("a")
+		shW := sh.InWorktree(worktreePath)
+
+		// Verify we can navigate the full stack in worktree
+		shW.OnBranch("a")
+		shW.Checkout("d").OnBranch("d")
+		shW.Run("down").OnBranch("c")
+		shW.Run("down").OnBranch("b")
+		shW.Run("down").OnBranch("a")
+	})
+
+	t.Run("detach worktree with branch checked out elsewhere fails gracefully", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a stack
+		sh.WriteFile("feature.txt", "feature").
+			Run("create feature -m 'feature branch'")
+
+		// Attach to worktree
+		sh.Run("worktree attach feature")
+
+		// Checkout the same branch in main repo (this creates a conflict)
+		sh.Checkout("feature")
+
+		_ = sh.GetWorktreePath("feature") // Verify worktree exists
+
+		// Detach should still work (or fail gracefully)
+		// The git worktree remove might fail because the branch is checked out elsewhere
+		// but the unregistration should still happen
+		sh.Run("worktree detach feature --force")
+
+		// Regardless of git errors, the worktree should be unregistered
+		sh.Run("worktree list")
+		output := sh.Output()
+		if strings.Contains(output, "feature") && !strings.Contains(output, "No managed worktrees") {
+			t.Errorf("Worktree should be unregistered from list")
+		}
+	})
+}


### PR DESCRIPTION
This PR merges the following changes:

1. **#653** feat: add wt alias for worktree command
2. **#654** feat: add wt attach/detach commands for existing stacks
3. **#655** fix: prevent worktree anchor branches from being flagged as merged
4. **#657** docs: add comprehensive worktree documentation

### Stack

```
main
  └─ jonnii/20260130032012/add-wt-alias-for-worktree-command (#653)
    └─ jonnii/20260130034856/add-wt-attach/detach-commands-for-existing-stacks (#654)
      └─ jonnii/20260130040045/prevent-worktree-anchor-branches-from-being (#655)
        └─ jonnii/20260130041021/add-comprehensive-worktree-documentation (#657)
```