### PR TITLE
perf: enable Go build cache by removing -a flag

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -49,7 +49,7 @@ run = """
   mkdir -p bin
   COMMIT=$(git rev-parse --short HEAD)
   DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  go build -a -ldflags "-X main.version=dev-local -X main.commit=$COMMIT -X main.date=$DATE" -o bin/stackit ./cmd/stackit
+  go build -ldflags "-X main.version=dev-local -X main.commit=$COMMIT -X main.date=$DATE" -o bin/stackit ./cmd/stackit
   if [ ! -L ./bin/st ] && [ ! -f ./bin/st ]; then
     ln -s stackit ./bin/st
     echo "Created symlink: bin/st -> stackit"


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #669**
  * **PR #668** 👈
    * **PR #670**
      * **PR #671**
        * **PR #672**
          * **PR #673**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->