### PR TITLE
fix: refresh engine cache in dashboard UI to show latest stack state

### DIFF
--- a/internal/cli/dashboard/shippable_update.go
+++ b/internal/cli/dashboard/shippable_update.go
@@ -249,6 +249,10 @@ func (m *shippableModel) updateFocusedStack() {
 // refresh fetches the latest stack analysis.
 func (m *shippableModel) refresh() tea.Cmd {
 	return func() tea.Msg {
+		// Rebuild engine cache to pick up external changes (e.g., move operations in another terminal)
+		if err := m.engine.Rebuild(m.engine.Trunk().GetName()); err != nil {
+			return refreshCompleteMsg{err: err}
+		}
 		result, err := m.analyzer.AnalyzeAll(m.ctx.Context)
 		return refreshCompleteMsg{result: result, err: err}
 	}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #669**
  * **PR #668**
    * **PR #670** 👈
      * **PR #671**
        * **PR #672**
          * **PR #673**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->