### PR TITLE
Merging 6 PRs

### DIFF
--- a/internal/actions/stack_info.go
+++ b/internal/actions/stack_info.go
@@ -3,11 +3,12 @@ package actions
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"stackit.dev/stackit/internal/app"
 	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/tui/style"
+	"stackit.dev/stackit/internal/tui/components/tree"
 )
 
 // StackBranchInfo represents JSON-serializable info for a single branch in a stack
@@ -17,6 +18,8 @@ type StackBranchInfo struct {
 	IsLocked       bool      `json:"is_locked"`
 	IsFrozen       bool      `json:"is_frozen"`
 	Scope          string    `json:"scope"`
+	PRNumber       *int      `json:"pr_number,omitempty"`
+	PRURL          string    `json:"pr_url,omitempty"`
 	CommitMessages []string  `json:"commit_messages"`
 	DiffStats      DiffStats `json:"diff_stats"`
 }
@@ -91,6 +94,15 @@ func StackInfoAction(ctx *app.Context, opts StackInfoOptions) error {
 			}
 		}
 
+		// PR info
+		prStatus, err := branch.GetPRSubmissionStatus()
+		if err == nil && prStatus.PRNumber != nil {
+			info.PRNumber = prStatus.PRNumber
+			if prStatus.PRInfo != nil {
+				info.PRURL = prStatus.PRInfo.URL()
+			}
+		}
+
 		result = append(result, info)
 	}
 
@@ -101,41 +113,42 @@ func StackInfoAction(ctx *app.Context, opts StackInfoOptions) error {
 		}
 		ctx.Output.Info("%s", string(data))
 	} else {
-		currentBranchName := ""
-		if currentBranch != nil {
-			currentBranchName = currentBranch.GetName()
+		// Build tree data structure for rendering
+		trunkName := eng.Trunk().GetName()
+		stackTree := tree.NewStackTree(stackBranches, currentBranch.GetName(), trunkName)
+		stackTree.FixedMap = make(map[string]bool)
+		for _, branch := range stackBranches {
+			// IsFixed means it does NOT need restack
+			stackTree.FixedMap[branch.GetName()] = !branch.NeedsRestack()
 		}
+		stackTree.FixedMap[trunkName] = true
 
-		for i, info := range result {
-			coloredName := style.ColorBranchName(info.Name, info.Name == currentBranchName)
-			ctx.Output.Info("%s", coloredName)
+		renderer := tree.NewRenderer(stackTree)
 
-			var coloredParent string
-			if info.Parent != "" {
-				parentBranch := eng.GetBranch(info.Parent)
-				coloredParent = style.ColorBranchNameWithTrunk(info.Parent, false, eng.IsTrunk(parentBranch))
-			} else {
-				coloredParent = style.ColorDim("(none)")
-			}
-			ctx.Output.Info("  %s %s", style.ColorCyan("Parent:"), coloredParent)
-
-			if info.IsLocked {
-				ctx.Output.Info("  %s %s", style.IconLocked(), style.ColorDim("(locked)"))
-			}
-			if info.IsFrozen {
-				ctx.Output.Info("  %s %s", style.IconFrozen(), style.ColorDim("(frozen)"))
-			}
-			if info.Scope != "" {
-				ctx.Output.Info("  %s %s", style.ColorCyan("Scope:"), style.ColorScope(info.Scope))
-			}
-
-			ctx.Output.Info("  %s %d", style.ColorCyan("Commits:"), len(info.CommitMessages))
-			ctx.Output.Info("  %s +%d -%d in %d files", style.ColorCyan("Changes:"), info.DiffStats.Additions, info.DiffStats.Deletions, info.DiffStats.FilesChanged)
-
-			if i < len(result)-1 {
-				ctx.Output.Newline()
+		// Build annotations with commit messages and PR info
+		annotations := make(map[string]tree.BranchAnnotation)
+		for _, info := range result {
+			annotations[info.Name] = tree.BranchAnnotation{
+				CommitMessages: info.CommitMessages,
+				LinesAdded:     info.DiffStats.Additions,
+				LinesDeleted:   info.DiffStats.Deletions,
+				Scope:          info.Scope,
+				IsLocked:       info.IsLocked,
+				IsFrozen:       info.IsFrozen,
+				PRNumber:       info.PRNumber,
+				PRURL:          info.PRURL,
 			}
 		}
+		renderer.SetAnnotations(annotations)
+
+		// Render the tree with commit messages
+		lines := renderer.RenderStack(currentBranch.GetName(), tree.RenderOptions{
+			ShowCommitMessages:  true,
+			HideSummary:         true,
+			SkipSelectionPrefix: true,
+		})
+
+		ctx.Output.Info("%s", strings.Join(lines, "\n"))
 	}
 
 	return nil

--- a/internal/actions/stack_info_test.go
+++ b/internal/actions/stack_info_test.go
@@ -69,7 +69,7 @@ func TestStackInfoAction(t *testing.T) {
 		require.Contains(t, err.Error(), "not on a branch")
 	})
 
-	t.Run("returns simple text info when JSON flag is false", func(t *testing.T) {
+	t.Run("returns tree view with commit messages when JSON flag is false", func(t *testing.T) {
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -80,9 +80,12 @@ func TestStackInfoAction(t *testing.T) {
 		output := s.Output.String()
 
 		require.NoError(t, err)
+		// Tree format includes branch name with symbol
 		require.Contains(t, output, "branch1")
-		require.Contains(t, output, "Parent: main")
-		require.Contains(t, output, "Commits: 1")
+		// Tree format shows trunk at bottom
+		require.Contains(t, output, "main")
+		// Tree format shows commit messages
+		require.Contains(t, output, "change on branch1")
 	})
 
 	t.Run("includes lock and frozen state", func(t *testing.T) {

--- a/internal/cli/dashboard/shippable_update.go
+++ b/internal/cli/dashboard/shippable_update.go
@@ -249,6 +249,10 @@ func (m *shippableModel) updateFocusedStack() {
 // refresh fetches the latest stack analysis.
 func (m *shippableModel) refresh() tea.Cmd {
 	return func() tea.Msg {
+		// Rebuild engine cache to pick up external changes (e.g., move operations in another terminal)
+		if err := m.engine.Rebuild(m.engine.Trunk().GetName()); err != nil {
+			return refreshCompleteMsg{err: err}
+		}
 		result, err := m.analyzer.AnalyzeAll(m.ctx.Context)
 		return refreshCompleteMsg{result: result, err: err}
 	}

--- a/internal/cli/dashboard/shippable_view.go
+++ b/internal/cli/dashboard/shippable_view.go
@@ -474,11 +474,12 @@ func (m *shippableModel) renderStackTree(stack *shippable.Stack) []string {
 		renderer.SetAnnotation(branchName, ann)
 	}
 
-	// Render tree in full mode to match st log full
+	// Render tree in full mode with commit messages to match st info --stack
 	opts := tree.RenderOptions{
 		Mode:                tree.RenderModeFull,
-		HideSummary:         false,
+		HideSummary:         true,
 		SkipSelectionPrefix: true,
+		ShowCommitMessages:  true,
 	}
 
 	return renderer.RenderStack(stack.RootBranch(), opts)

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -97,6 +97,7 @@ type engineImpl struct {
 	git               git.Runner
 	writer            io.Writer
 	mu                sync.RWMutex
+	worktreeMu        sync.Mutex // serializes worktree creation to avoid git races on .git/worktrees/
 }
 
 // NewEngine creates a new engine instance

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -790,66 +790,39 @@ func (e *engineImpl) CreateTemporaryWorktreeWithOptions(ctx context.Context, bra
 	// intermittent failures when stale entries remained after incomplete cleanup.
 	worktreePath := filepath.Join(tmpDir, filepath.Base(tmpDir))
 
-	// Retry worktree creation with exponential backoff to handle transient failures
-	// that can occur when multiple goroutines create worktrees concurrently.
-	// Git's worktree operations can race on .git/worktrees/ directory access.
-	const maxRetries = 3
-	var lastErr error
-	for attempt := range maxRetries {
-		err := e.git.AddWorktreeWithOptions(ctx, worktreePath, branch, true, checkout == WorktreeCheckoutShallow)
-		if err == nil {
-			break
-		}
-		lastErr = err
-		// Only retry on transient errors (race conditions on .git/worktrees/).
-		// Permanent errors (branch not found, permission denied, etc.) should fail immediately.
-		if attempt < maxRetries-1 && isTransientWorktreeError(err) {
-			// Exponential backoff: 10ms, 20ms
-			time.Sleep(time.Duration(10<<attempt) * time.Millisecond)
-			continue
-		}
-		break
-	}
+	// Serialize worktree creation to prevent races on .git/worktrees/ directory.
+	// Git's `worktree add` command is not concurrency-safe - when multiple goroutines
+	// run it simultaneously on the same repo, they can race on reading/writing the
+	// .git/worktrees/ directory, causing "failed to read commondir" errors.
+	//
+	// The mutex ensures only one worktree is being created at a time per engine (repo).
+	// This is acceptable because:
+	// 1. Temp directory creation (above) is still parallel
+	// 2. The actual rebase validation (after worktree creation) is still parallel
+	// 3. Only the brief `git worktree add` command is serialized
+	e.worktreeMu.Lock()
+	err = e.git.AddWorktreeWithOptions(ctx, worktreePath, branch, true, checkout == WorktreeCheckoutShallow)
+	e.worktreeMu.Unlock()
 
-	if lastErr != nil {
+	if err != nil {
 		_ = os.RemoveAll(tmpDir)
-		return "", nil, fmt.Errorf("failed to add worktree: %w", lastErr)
+		return "", nil, fmt.Errorf("failed to add worktree: %w", err)
 	}
 
 	cleanup := func() {
 		// Use context.Background for cleanup to ensure it runs even if ctx is canceled
-		_ = e.RemoveWorktree(context.Background(), worktreePath)
+		cleanupCtx := context.Background()
+		removeErr := e.RemoveWorktree(cleanupCtx, worktreePath)
 		_ = os.RemoveAll(tmpDir)
+		// If worktree removal failed, prune to clean up any dangling entries.
+		// This prevents stale entries from accumulating and causing "commondir" errors
+		// in subsequent worktree operations, especially on busy build servers.
+		if removeErr != nil {
+			_ = e.git.PruneWorktrees(cleanupCtx)
+		}
 	}
 
 	return worktreePath, cleanup, nil
-}
-
-// isTransientWorktreeError returns true if the error is likely a transient race condition
-// that may succeed on retry. These typically occur when multiple goroutines create worktrees
-// concurrently and race on .git/worktrees/ directory access.
-func isTransientWorktreeError(err error) bool {
-	if err == nil {
-		return false
-	}
-	errStr := err.Error()
-	// Transient errors from git worktree operations during concurrent access:
-	// - "commondir" errors: stale entries in .git/worktrees/ that haven't been pruned yet
-	// - "lock" errors: another process is modifying .git/worktrees/
-	// - "busy" errors: resource temporarily unavailable
-	transientIndicators := []string{
-		"commondir",
-		"lock",
-		"busy",
-		"text file busy",
-		"resource temporarily unavailable",
-	}
-	for _, indicator := range transientIndicators {
-		if strings.Contains(strings.ToLower(errStr), indicator) {
-			return true
-		}
-	}
-	return false
 }
 
 // RegisterWorktree registers a worktree for a stack root in local git refs

--- a/internal/tui/components/tree/tree.go
+++ b/internal/tui/components/tree/tree.go
@@ -69,6 +69,13 @@ type BranchAnnotation struct {
 
 	// MergedDownstack holds historical merged parents for display
 	MergedDownstack []MergedParentDisplay
+
+	// CommitMessages holds formatted commit messages (e.g., "abc123 Commit message")
+	// Used when ShowCommitMessages is enabled in RenderOptions
+	CommitMessages []string
+
+	// PRURL is the GitHub PR URL for this branch
+	PRURL string
 }
 
 // RenderMode specifies the rendering style for the tree.
@@ -110,6 +117,10 @@ type RenderOptions struct {
 
 	// ShowSHAs shows commit SHAs next to branch names (for debugging).
 	ShowSHAs bool
+
+	// ShowCommitMessages shows commit messages below each branch.
+	// Uses CommitMessages from BranchAnnotation.
+	ShowCommitMessages bool
 
 	// SelectedBranch is the name of the currently selected branch (for cursor).
 	SelectedBranch string
@@ -411,6 +422,7 @@ func (r *StackTreeRenderer) RenderStackDetailed(branchName string, opts RenderOp
 		hideStats:           opts.HideStats,
 		hideSummary:         opts.HideSummary,
 		showSHAs:            opts.ShowSHAs,
+		showCommitMessages:  opts.ShowCommitMessages,
 		skipSelectionPrefix: opts.SkipSelectionPrefix,
 		selectedBranch:      opts.SelectedBranch,
 		currentBranch:       r.currentBranch,
@@ -461,6 +473,7 @@ type treeRenderArgs struct {
 	hideStats           bool
 	hideSummary         bool
 	showSHAs            bool
+	showCommitMessages  bool
 	skipSelectionPrefix bool
 	selectedBranch      string
 	currentBranch       string
@@ -493,6 +506,7 @@ func (a treeRenderArgs) childArgs(branchName string, indentLevel int, parentScop
 		hideStats:           a.hideStats,
 		hideSummary:         a.hideSummary,
 		showSHAs:            a.showSHAs,
+		showCommitMessages:  a.showCommitMessages,
 		skipSelectionPrefix: a.skipSelectionPrefix,
 		selectedBranch:      a.selectedBranch,
 		currentBranch:       a.currentBranch,
@@ -523,6 +537,7 @@ func (a treeRenderArgs) downstackArgs(branchName string) treeRenderArgs {
 		hideStats:           a.hideStats,
 		hideSummary:         a.hideSummary,
 		showSHAs:            a.showSHAs,
+		showCommitMessages:  a.showCommitMessages,
 		skipSelectionPrefix: a.skipSelectionPrefix,
 		selectedBranch:      a.selectedBranch,
 		currentBranch:       a.currentBranch,
@@ -996,7 +1011,7 @@ func (r *StackTreeRenderer) getInfoLines(args treeRenderArgs) []string {
 
 	// Add SHA if requested (useful for debugging/diagnostics)
 	if args.showSHAs && annotation.LocalSHA != "" {
-		coloredBranchName += " " + style.ColorDim("("+annotation.LocalSHA+")")
+		coloredBranchName += " " + style.ColorDim("(") + style.ColorSHA(annotation.LocalSHA) + style.ColorDim(")")
 	}
 
 	// Add scope (colored to match tree)
@@ -1049,8 +1064,46 @@ func (r *StackTreeRenderer) getInfoLines(args treeRenderArgs) []string {
 		return result
 	}
 
-	// LINE 2: Summary line with PR# → Review → CI → Stats (skip if hideSummary)
-	if !args.hideSummary {
+	// Show commit messages when enabled (info mode)
+	if args.showCommitMessages && len(annotation.CommitMessages) > 0 {
+		branchPipe := styleObj.Render("│")
+		// Show diff stats and PR info first (above commits)
+		var statsLine string
+		if annotation.LinesAdded > 0 || annotation.LinesDeleted > 0 {
+			statsLine = r.formatContextualStats(annotation)
+		}
+		// Add PR info if available
+		if annotation.PRNumber != nil {
+			prInfo := style.ColorPRNumberByState(*annotation.PRNumber, annotation.PRState, annotation.IsDraft)
+			if annotation.PRURL != "" {
+				prInfo += " " + style.ColorDim(annotation.PRURL)
+			}
+			if statsLine != "" {
+				statsLine += " " + style.ColorDim("|") + " " + prInfo
+			} else {
+				statsLine = prInfo
+			}
+		}
+		if statsLine != "" {
+			result = append(result, selectionPadding+prefix+branchPipe+"  "+statsLine)
+		}
+		// Then show commit messages
+		for _, msg := range annotation.CommitMessages {
+			// Color the SHA (first word), rest dimmed
+			formattedMsg := msg
+			if spaceIdx := strings.Index(msg, " "); spaceIdx > 0 {
+				sha := msg[:spaceIdx]
+				rest := msg[spaceIdx:]
+				formattedMsg = style.ColorSHA(sha) + style.ColorDim(rest)
+			} else {
+				formattedMsg = style.ColorDim(msg)
+			}
+			result = append(result, selectionPadding+prefix+branchPipe+"  "+formattedMsg)
+		}
+	}
+
+	// LINE 2: Summary line with PR# → Review → CI → Stats (skip if hideSummary or showCommitMessages)
+	if !args.hideSummary && !args.showCommitMessages {
 		branchPipe := styleObj.Render("│")
 		summaryLine := r.formatSummaryLine(annotation, isTrunk, args.hideStats)
 

--- a/internal/tui/move_preview.go
+++ b/internal/tui/move_preview.go
@@ -28,13 +28,13 @@ func RenderMovePreviewSimple(preview MovePreviewData) string {
 	var sb strings.Builder
 
 	// Header
-	sb.WriteString(style.ColorDim("─────────────────────────────────────\n"))
+	sb.WriteString(style.ColorDim("─────────────────────────────────────") + "\n")
 	sb.WriteString("Move Preview:\n")
-	sb.WriteString(style.ColorDim("─────────────────────────────────────\n"))
+	sb.WriteString(style.ColorDim("─────────────────────────────────────") + "\n")
 	sb.WriteString("\n")
 
 	// Current position (dimmed)
-	sb.WriteString(style.ColorDim("Current position:\n"))
+	sb.WriteString(style.ColorDim("Current position:") + "\n")
 	sb.WriteString(fmt.Sprintf("  %s → %s %s\n",
 		style.ColorDim(preview.OldParent),
 		style.ColorDim(preview.SourceBranch),
@@ -68,7 +68,7 @@ func RenderMovePreviewSimple(preview MovePreviewData) string {
 	}
 
 	// Conflict status
-	sb.WriteString(style.ColorDim("─────────────────────────────────────\n"))
+	sb.WriteString(style.ColorDim("─────────────────────────────────────") + "\n")
 	if preview.HasConflicts {
 		sb.WriteString(style.ColorRed("✗ ") + style.ColorRed("Conflicts detected") + "\n")
 		sb.WriteString(fmt.Sprintf("  Branch: %s\n", style.ColorBranchName(preview.ConflictBranch, false)))
@@ -76,7 +76,7 @@ func RenderMovePreviewSimple(preview MovePreviewData) string {
 	} else {
 		sb.WriteString(style.ColorGreen("✓ ") + style.ColorGreen("Move will complete without conflicts") + "\n")
 	}
-	sb.WriteString(style.ColorDim("─────────────────────────────────────\n"))
+	sb.WriteString(style.ColorDim("─────────────────────────────────────") + "\n")
 
 	return sb.String()
 }

--- a/internal/tui/style/formatter.go
+++ b/internal/tui/style/formatter.go
@@ -125,6 +125,13 @@ func ColorDim(text string) string {
 		Render(text)
 }
 
+// ColorSHA colors a git SHA (yellow)
+func ColorSHA(sha string) string {
+	return lipgloss.NewStyle().
+		Foreground(lipgloss.Color("3")).
+		Render(sha)
+}
+
 // ColorMagenta colors text magenta
 func ColorMagenta(text string) string {
 	return lipgloss.NewStyle().

--- a/internal/tui/tree_renderer.go
+++ b/internal/tui/tree_renderer.go
@@ -200,6 +200,12 @@ func GetBranchAnnotation(eng engine.BranchReader, branch engine.Branch) tree.Bra
 			ann.PRNumber = prInfo.Number()
 			ann.PRState = prInfo.State()
 			ann.IsDraft = prInfo.IsDraft()
+			ann.PRURL = prInfo.URL()
+		}
+
+		// Commit messages for detailed view
+		if commits, err := branch.GetAllCommits(engine.CommitFormatReadable); err == nil {
+			ann.CommitMessages = commits
 		}
 
 		// Merged downstack history

--- a/mise.toml
+++ b/mise.toml
@@ -49,7 +49,7 @@ run = """
   mkdir -p bin
   COMMIT=$(git rev-parse --short HEAD)
   DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  go build -a -ldflags "-X main.version=dev-local -X main.commit=$COMMIT -X main.date=$DATE" -o bin/stackit ./cmd/stackit
+  go build -ldflags "-X main.version=dev-local -X main.commit=$COMMIT -X main.date=$DATE" -o bin/stackit ./cmd/stackit
   if [ ! -L ./bin/st ] && [ ! -f ./bin/st ]; then
     ln -s stackit ./bin/st
     echo "Created symlink: bin/st -> stackit"


### PR DESCRIPTION
This PR merges the following changes:

1. **#669** fix: serialize worktree creation to prevent git races
2. **#668** perf: enable Go build cache by removing -a flag
3. **#670** fix: refresh engine cache in dashboard UI to show latest stack state
4. **#671** fix: move newlines outside lipgloss styled blocks in move preview
5. **#672** feat: add tree visualization with commit messages to st info --stack
6. **#673** feat: make st ui details tab match st info --stack format

### Stack

```
main
  └─ jonnii/20260202023507/serialize-worktree-creation-to-prevent-git-races (#669)
    └─ jonnii/20260202015919/enable-Go-build-cache-by-removing-a-flag (#668)
      └─ jonnii/20260202030602/refresh-engine-cache-in-dashboard-UI-to-show (#670)
        └─ jonnii/20260202030954/move-newlines-outside-lipgloss-styled-blocks-in (#671)
          └─ jonnii/20260202033512/add-tree-visualization-with-commit-messages-to-st (#672)
            └─ jonnii/20260202035625/make-st-ui-details-tab-match-st-info-stack (#673)
```