### PR TITLE
Merging 7 PRs

### DIFF
--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -4,7 +4,8 @@
 
 **Commands:**
 ```bash
-stackit merge              # Interactive wizard - choose strategy
+stackit merge              # Show your mergeable work, then wizard
+stackit merge --all        # Show entire team's mergeable work
 stackit merge next         # Merge bottom PR, enable automerge, return immediately
 stackit merge squash       # Consolidate stack into single atomic PR
 ```
@@ -27,6 +28,30 @@ stackit merge squash       # Consolidate stack into single atomic PR
 ## Overview
 
 Shipping stacked changes is fundamentally different from shipping linear PRs. Stackit provides two merge strategies optimized for different scenarios, plus advanced multi-stack consolidation for high-velocity teams.
+
+## Merge Status View
+
+When you run `stackit merge`, you first see a status overview of your mergeable work:
+
+```
+📦 Your Mergeable Work
+
+Ready (2):
+  ✅ add-oauth              3 branches  All approved, CI passing
+  ✅ fix-login              1 branch    All approved, CI passing
+
+Pending (1):
+  ⏳ new-dashboard          3 branches  CI running
+
+Blocked (1):
+  ❌ perf-improvements      2 branches  CI failed
+```
+
+This helps you understand what's ready to ship before diving into the merge wizard.
+
+**Filtering:**
+- By default, shows only your stacks (matched by PR author)
+- Use `--all` to see the entire team's work
 
 ## Merge Strategies
 
@@ -193,7 +218,14 @@ This PR was shipped as part of [#123](link) by @username
 
 ### `stackit merge`
 
-Interactive wizard that guides you through merge options.
+Shows your mergeable work status, then launches an interactive wizard.
+
+| Flag | Description |
+|------|-------------|
+| `--all` | Show all team members' stacks (default: your stacks only) |
+| `--dry-run` | Show merge plan without executing |
+| `--force` | Skip validation checks |
+| `--wait` | Wait for merge to complete |
 
 ### `stackit merge next`
 

--- a/internal/actions/stack_info.go
+++ b/internal/actions/stack_info.go
@@ -3,11 +3,12 @@ package actions
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"stackit.dev/stackit/internal/app"
 	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/tui/style"
+	"stackit.dev/stackit/internal/tui/components/tree"
 )
 
 // StackBranchInfo represents JSON-serializable info for a single branch in a stack
@@ -17,6 +18,8 @@ type StackBranchInfo struct {
 	IsLocked       bool      `json:"is_locked"`
 	IsFrozen       bool      `json:"is_frozen"`
 	Scope          string    `json:"scope"`
+	PRNumber       *int      `json:"pr_number,omitempty"`
+	PRURL          string    `json:"pr_url,omitempty"`
 	CommitMessages []string  `json:"commit_messages"`
 	DiffStats      DiffStats `json:"diff_stats"`
 }
@@ -91,6 +94,15 @@ func StackInfoAction(ctx *app.Context, opts StackInfoOptions) error {
 			}
 		}
 
+		// PR info
+		prStatus, err := branch.GetPRSubmissionStatus()
+		if err == nil && prStatus.PRNumber != nil {
+			info.PRNumber = prStatus.PRNumber
+			if prStatus.PRInfo != nil {
+				info.PRURL = prStatus.PRInfo.URL()
+			}
+		}
+
 		result = append(result, info)
 	}
 
@@ -101,41 +113,42 @@ func StackInfoAction(ctx *app.Context, opts StackInfoOptions) error {
 		}
 		ctx.Output.Info("%s", string(data))
 	} else {
-		currentBranchName := ""
-		if currentBranch != nil {
-			currentBranchName = currentBranch.GetName()
+		// Build tree data structure for rendering
+		trunkName := eng.Trunk().GetName()
+		stackTree := tree.NewStackTree(stackBranches, currentBranch.GetName(), trunkName)
+		stackTree.FixedMap = make(map[string]bool)
+		for _, branch := range stackBranches {
+			// IsFixed means it does NOT need restack
+			stackTree.FixedMap[branch.GetName()] = !branch.NeedsRestack()
 		}
+		stackTree.FixedMap[trunkName] = true
 
-		for i, info := range result {
-			coloredName := style.ColorBranchName(info.Name, info.Name == currentBranchName)
-			ctx.Output.Info("%s", coloredName)
+		renderer := tree.NewRenderer(stackTree)
 
-			var coloredParent string
-			if info.Parent != "" {
-				parentBranch := eng.GetBranch(info.Parent)
-				coloredParent = style.ColorBranchNameWithTrunk(info.Parent, false, eng.IsTrunk(parentBranch))
-			} else {
-				coloredParent = style.ColorDim("(none)")
-			}
-			ctx.Output.Info("  %s %s", style.ColorCyan("Parent:"), coloredParent)
-
-			if info.IsLocked {
-				ctx.Output.Info("  %s %s", style.IconLocked(), style.ColorDim("(locked)"))
-			}
-			if info.IsFrozen {
-				ctx.Output.Info("  %s %s", style.IconFrozen(), style.ColorDim("(frozen)"))
-			}
-			if info.Scope != "" {
-				ctx.Output.Info("  %s %s", style.ColorCyan("Scope:"), style.ColorScope(info.Scope))
-			}
-
-			ctx.Output.Info("  %s %d", style.ColorCyan("Commits:"), len(info.CommitMessages))
-			ctx.Output.Info("  %s +%d -%d in %d files", style.ColorCyan("Changes:"), info.DiffStats.Additions, info.DiffStats.Deletions, info.DiffStats.FilesChanged)
-
-			if i < len(result)-1 {
-				ctx.Output.Newline()
+		// Build annotations with commit messages and PR info
+		annotations := make(map[string]tree.BranchAnnotation)
+		for _, info := range result {
+			annotations[info.Name] = tree.BranchAnnotation{
+				CommitMessages: info.CommitMessages,
+				LinesAdded:     info.DiffStats.Additions,
+				LinesDeleted:   info.DiffStats.Deletions,
+				Scope:          info.Scope,
+				IsLocked:       info.IsLocked,
+				IsFrozen:       info.IsFrozen,
+				PRNumber:       info.PRNumber,
+				PRURL:          info.PRURL,
 			}
 		}
+		renderer.SetAnnotations(annotations)
+
+		// Render the tree with commit messages
+		lines := renderer.RenderStack(currentBranch.GetName(), tree.RenderOptions{
+			ShowCommitMessages:  true,
+			HideSummary:         true,
+			SkipSelectionPrefix: true,
+		})
+
+		ctx.Output.Info("%s", strings.Join(lines, "\n"))
 	}
 
 	return nil

--- a/internal/actions/stack_info_test.go
+++ b/internal/actions/stack_info_test.go
@@ -69,7 +69,7 @@ func TestStackInfoAction(t *testing.T) {
 		require.Contains(t, err.Error(), "not on a branch")
 	})
 
-	t.Run("returns simple text info when JSON flag is false", func(t *testing.T) {
+	t.Run("returns tree view with commit messages when JSON flag is false", func(t *testing.T) {
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -80,9 +80,12 @@ func TestStackInfoAction(t *testing.T) {
 		output := s.Output.String()
 
 		require.NoError(t, err)
+		// Tree format includes branch name with symbol
 		require.Contains(t, output, "branch1")
-		require.Contains(t, output, "Parent: main")
-		require.Contains(t, output, "Commits: 1")
+		// Tree format shows trunk at bottom
+		require.Contains(t, output, "main")
+		// Tree format shows commit messages
+		require.Contains(t, output, "change on branch1")
 	})
 
 	t.Run("includes lock and frozen state", func(t *testing.T) {

--- a/internal/cli/dashboard/shippable_update.go
+++ b/internal/cli/dashboard/shippable_update.go
@@ -249,6 +249,10 @@ func (m *shippableModel) updateFocusedStack() {
 // refresh fetches the latest stack analysis.
 func (m *shippableModel) refresh() tea.Cmd {
 	return func() tea.Msg {
+		// Rebuild engine cache to pick up external changes (e.g., move operations in another terminal)
+		if err := m.engine.Rebuild(m.engine.Trunk().GetName()); err != nil {
+			return refreshCompleteMsg{err: err}
+		}
 		result, err := m.analyzer.AnalyzeAll(m.ctx.Context)
 		return refreshCompleteMsg{result: result, err: err}
 	}

--- a/internal/cli/dashboard/shippable_view.go
+++ b/internal/cli/dashboard/shippable_view.go
@@ -474,11 +474,12 @@ func (m *shippableModel) renderStackTree(stack *shippable.Stack) []string {
 		renderer.SetAnnotation(branchName, ann)
 	}
 
-	// Render tree in full mode to match st log full
+	// Render tree in full mode with commit messages to match st info --stack
 	opts := tree.RenderOptions{
 		Mode:                tree.RenderModeFull,
-		HideSummary:         false,
+		HideSummary:         true,
 		SkipSelectionPrefix: true,
+		ShowCommitMessages:  true,
 	}
 
 	return renderer.RenderStack(stack.RootBranch(), opts)

--- a/internal/cli/stack/merge/handlers.go
+++ b/internal/cli/stack/merge/handlers.go
@@ -10,6 +10,7 @@ import (
 	mergeAction "stackit.dev/stackit/internal/actions/merge"
 	sterrors "stackit.dev/stackit/internal/errors"
 	"stackit.dev/stackit/internal/output"
+	"stackit.dev/stackit/internal/shippable"
 	"stackit.dev/stackit/internal/tui"
 	mergeComponent "stackit.dev/stackit/internal/tui/components/merge"
 	"stackit.dev/stackit/internal/tui/style"
@@ -673,4 +674,123 @@ func appendBottomUpGroups(groups []Group, plan *mergeAction.Plan, assigned map[i
 	}
 
 	return groups
+}
+
+// DisplayMergeStatus renders the shippability status of stacks.
+// Shows stacks grouped by status (Ready, Pending, Blocked, Incomplete).
+func DisplayMergeStatus(out output.Output, result *shippable.AnalysisResult) {
+	styles := style.DefaultStatusStyles()
+
+	// Empty state
+	if result.TotalStacks() == 0 {
+		out.Print("\n")
+		out.Print(style.ColorDim("No active stacks found.") + "\n")
+		out.Print(style.ColorDim("Create a stack with: stackit create -m \"description\"") + "\n")
+		out.Print("\n")
+		return
+	}
+
+	out.Print("\n")
+	out.Print(style.ColorMagenta("📦 Your Mergeable Work") + "\n")
+	out.Print("\n")
+
+	// Ready stacks
+	if ready := result.GetShippable(); len(ready) > 0 {
+		out.Print(styles.Done.Render(fmt.Sprintf("Ready (%d):", len(ready))) + "\n")
+		for _, s := range ready {
+			out.Print(fmt.Sprintf("  ✅ %-40s %d branches  All approved, CI passing\n",
+				truncateTitle(s.DisplayTitle()),
+				s.BranchCount()))
+		}
+		out.Print("\n")
+	}
+
+	// Pending stacks
+	if pending := result.GetPending(); len(pending) > 0 {
+		out.Print(style.ColorYellow(fmt.Sprintf("Pending (%d):", len(pending))) + "\n")
+		for _, s := range pending {
+			reason := getPendingReason(s)
+			out.Print(fmt.Sprintf("  ⏳ %-40s %d branches  %s\n",
+				truncateTitle(s.DisplayTitle()),
+				s.BranchCount(),
+				reason))
+		}
+		out.Print("\n")
+	}
+
+	// Blocked stacks
+	if blocked := result.GetBlocked(); len(blocked) > 0 {
+		out.Print(styles.Error.Render(fmt.Sprintf("Blocked (%d):", len(blocked))) + "\n")
+		for _, s := range blocked {
+			reason := getBlockedReason(s)
+			out.Print(fmt.Sprintf("  ❌ %-40s %d branches  %s\n",
+				truncateTitle(s.DisplayTitle()),
+				s.BranchCount(),
+				reason))
+		}
+		out.Print("\n")
+	}
+
+	// Incomplete stacks
+	if incomplete := result.GetIncomplete(); len(incomplete) > 0 {
+		out.Print(style.ColorDim(fmt.Sprintf("Incomplete (%d):", len(incomplete))) + "\n")
+		for _, s := range incomplete {
+			reason := getIncompleteReason(s)
+			out.Print(fmt.Sprintf("  ○ %-40s %d branches  %s\n",
+				truncateTitle(s.DisplayTitle()),
+				s.BranchCount(),
+				reason))
+		}
+		out.Print("\n")
+	}
+}
+
+// truncateTitle truncates a title to 40 chars with ellipsis
+func truncateTitle(title string) string {
+	const maxLen = 40
+	if len(title) <= maxLen {
+		return title
+	}
+	return title[:maxLen-3] + "..."
+}
+
+// getPendingReason returns a human-readable reason for pending status
+func getPendingReason(s shippable.Stack) string {
+	for _, bp := range s.BlockingPRs {
+		switch bp.Reason {
+		case shippable.ReasonCIPending:
+			return "CI running"
+		case shippable.ReasonReviewRequired:
+			return "Review required"
+		}
+	}
+	return "Waiting"
+}
+
+// getBlockedReason returns a human-readable reason for blocked status
+func getBlockedReason(s shippable.Stack) string {
+	for _, bp := range s.BlockingPRs {
+		switch bp.Reason {
+		case shippable.ReasonCIFailing:
+			return "CI failed"
+		case shippable.ReasonChangesRequested:
+			return "Changes requested"
+		case shippable.ReasonNotPushed:
+			return "Not pushed"
+		}
+	}
+	return "Blocked"
+}
+
+// getIncompleteReason returns a human-readable reason for incomplete status
+func getIncompleteReason(s shippable.Stack) string {
+	for _, bp := range s.BlockingPRs {
+		switch bp.Reason {
+		case shippable.ReasonNoPR:
+			return "Missing PR"
+		case shippable.ReasonDraft:
+			return "Draft PR"
+		}
+	}
+	return "Incomplete"
 }

--- a/internal/cli/stack/merge/merge.go
+++ b/internal/cli/stack/merge/merge.go
@@ -10,6 +10,7 @@ import (
 	mergeAction "stackit.dev/stackit/internal/actions/merge"
 	"stackit.dev/stackit/internal/app"
 	"stackit.dev/stackit/internal/cli/common"
+	"stackit.dev/stackit/internal/shippable"
 )
 
 // PostMergeHandler handles post-merge actions like syncing trunk.
@@ -20,9 +21,10 @@ type PostMergeHandler func(ctx *app.Context, action mergeAction.PostMergeAction)
 // postMergeHandler is called when a post-merge action is required (e.g., syncing trunk).
 func NewMergeCmd(postMergeHandler PostMergeHandler) *cobra.Command {
 	var (
-		dryRun bool
-		force  bool
-		wait   bool
+		dryRun  bool
+		force   bool
+		wait    bool
+		showAll bool
 	)
 
 	cmd := &cobra.Command{
@@ -30,14 +32,18 @@ func NewMergeCmd(postMergeHandler PostMergeHandler) *cobra.Command {
 		Short: "Merge pull requests for a stack",
 		Long: `Merge pull requests associated with your stack.
 
-When run without a subcommand, an interactive wizard guides you through the merge process.
+When run without a subcommand, shows your mergeable work status and guides you
+through the merge process with an interactive wizard.
+
+By default, shows only your own stacks. Use --all to see the entire team's work.
 
 Subcommands:
   next    Merge the next (bottom-most) unmerged PR in the stack
   squash  Consolidate all branches into a single PR and merge atomically
 
 Examples:
-  stackit merge             # Interactive wizard
+  stackit merge             # Show your mergeable work, then wizard
+  stackit merge --all       # Show entire team's mergeable work
   stackit merge next        # Merge bottom PR, restack, stop
   stackit merge squash      # Consolidate all branches into single PR`,
 		SilenceUsage: true,
@@ -46,6 +52,24 @@ Examples:
 				// Must be interactive for wizard mode
 				if !ctx.Interactive {
 					return fmt.Errorf("merge wizard requires a TTY. Use 'merge next' or 'merge squash' for non-interactive mode")
+				}
+
+				// Fetch and display shippability status before wizard
+				analyzer := shippable.NewAnalyzer(ctx.Engine, ctx.GitHubClient)
+				analysisResult, err := analyzer.AnalyzeAll(ctx.Context)
+				if err != nil {
+					ctx.Output.Debug("failed to analyze shippable stacks: %v", err)
+					// Continue without status display
+				} else {
+					// Filter by current user unless --all is specified
+					if !showAll && ctx.GitHubClient != nil {
+						currentUser, userErr := ctx.GitHubClient.GetCurrentUser(ctx.Context)
+						if userErr == nil && currentUser != "" {
+							analysisResult = analysisResult.FilterByAuthor(currentUser)
+						}
+					}
+
+					DisplayMergeStatus(ctx.Output, analysisResult)
 				}
 
 				runner, handler := NewMergeUI(ctx.Output, ctx.Logger)
@@ -60,7 +84,7 @@ Examples:
 					return fmt.Errorf("failed to initialize interactive handler")
 				}
 
-				err := mergeAction.RunWizard(ctx, interactiveHandler, mergeAction.WizardOptions{
+				err = mergeAction.RunWizard(ctx, interactiveHandler, mergeAction.WizardOptions{
 					DryRun: dryRun,
 					Force:  force,
 					Wait:   wait,
@@ -82,6 +106,7 @@ Examples:
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show merge plan without executing")
 	cmd.Flags().BoolVar(&force, "force", false, "Skip validation checks (draft PRs, failing CI)")
 	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for merge to complete (default: fire-and-forget)")
+	cmd.Flags().BoolVar(&showAll, "all", false, "Show all team members' stacks (default: your stacks only)")
 
 	// Add subcommands
 	cmd.AddCommand(NewNextCmd(postMergeHandler))

--- a/internal/demo/demo_github_client.go
+++ b/internal/demo/demo_github_client.go
@@ -217,3 +217,8 @@ func (c *GitHubClient) ListPRComments(_ context.Context, _, _ string, _ int) ([]
 	// In demo mode, return empty list
 	return []github.PRComment{}, nil
 }
+
+// GetCurrentUser returns a simulated GitHub username
+func (c *GitHubClient) GetCurrentUser(_ context.Context) (string, error) {
+	return "demouser", nil
+}

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -97,6 +97,7 @@ type engineImpl struct {
 	git               git.Runner
 	writer            io.Writer
 	mu                sync.RWMutex
+	worktreeMu        sync.Mutex // serializes worktree creation to avoid git races on .git/worktrees/
 }
 
 // NewEngine creates a new engine instance

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -790,66 +790,39 @@ func (e *engineImpl) CreateTemporaryWorktreeWithOptions(ctx context.Context, bra
 	// intermittent failures when stale entries remained after incomplete cleanup.
 	worktreePath := filepath.Join(tmpDir, filepath.Base(tmpDir))
 
-	// Retry worktree creation with exponential backoff to handle transient failures
-	// that can occur when multiple goroutines create worktrees concurrently.
-	// Git's worktree operations can race on .git/worktrees/ directory access.
-	const maxRetries = 3
-	var lastErr error
-	for attempt := range maxRetries {
-		err := e.git.AddWorktreeWithOptions(ctx, worktreePath, branch, true, checkout == WorktreeCheckoutShallow)
-		if err == nil {
-			break
-		}
-		lastErr = err
-		// Only retry on transient errors (race conditions on .git/worktrees/).
-		// Permanent errors (branch not found, permission denied, etc.) should fail immediately.
-		if attempt < maxRetries-1 && isTransientWorktreeError(err) {
-			// Exponential backoff: 10ms, 20ms
-			time.Sleep(time.Duration(10<<attempt) * time.Millisecond)
-			continue
-		}
-		break
-	}
+	// Serialize worktree creation to prevent races on .git/worktrees/ directory.
+	// Git's `worktree add` command is not concurrency-safe - when multiple goroutines
+	// run it simultaneously on the same repo, they can race on reading/writing the
+	// .git/worktrees/ directory, causing "failed to read commondir" errors.
+	//
+	// The mutex ensures only one worktree is being created at a time per engine (repo).
+	// This is acceptable because:
+	// 1. Temp directory creation (above) is still parallel
+	// 2. The actual rebase validation (after worktree creation) is still parallel
+	// 3. Only the brief `git worktree add` command is serialized
+	e.worktreeMu.Lock()
+	err = e.git.AddWorktreeWithOptions(ctx, worktreePath, branch, true, checkout == WorktreeCheckoutShallow)
+	e.worktreeMu.Unlock()
 
-	if lastErr != nil {
+	if err != nil {
 		_ = os.RemoveAll(tmpDir)
-		return "", nil, fmt.Errorf("failed to add worktree: %w", lastErr)
+		return "", nil, fmt.Errorf("failed to add worktree: %w", err)
 	}
 
 	cleanup := func() {
 		// Use context.Background for cleanup to ensure it runs even if ctx is canceled
-		_ = e.RemoveWorktree(context.Background(), worktreePath)
+		cleanupCtx := context.Background()
+		removeErr := e.RemoveWorktree(cleanupCtx, worktreePath)
 		_ = os.RemoveAll(tmpDir)
+		// If worktree removal failed, prune to clean up any dangling entries.
+		// This prevents stale entries from accumulating and causing "commondir" errors
+		// in subsequent worktree operations, especially on busy build servers.
+		if removeErr != nil {
+			_ = e.git.PruneWorktrees(cleanupCtx)
+		}
 	}
 
 	return worktreePath, cleanup, nil
-}
-
-// isTransientWorktreeError returns true if the error is likely a transient race condition
-// that may succeed on retry. These typically occur when multiple goroutines create worktrees
-// concurrently and race on .git/worktrees/ directory access.
-func isTransientWorktreeError(err error) bool {
-	if err == nil {
-		return false
-	}
-	errStr := err.Error()
-	// Transient errors from git worktree operations during concurrent access:
-	// - "commondir" errors: stale entries in .git/worktrees/ that haven't been pruned yet
-	// - "lock" errors: another process is modifying .git/worktrees/
-	// - "busy" errors: resource temporarily unavailable
-	transientIndicators := []string{
-		"commondir",
-		"lock",
-		"busy",
-		"text file busy",
-		"resource temporarily unavailable",
-	}
-	for _, indicator := range transientIndicators {
-		if strings.Contains(strings.ToLower(errStr), indicator) {
-			return true
-		}
-	}
-	return false
 }
 
 // RegisterWorktree registers a worktree for a stack root in local git refs

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -47,6 +47,7 @@ type CheckStatus struct {
 	Pending        bool
 	Checks         []CheckDetail
 	ReviewDecision string // "APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", ""
+	Author         string // GitHub username of PR author
 }
 
 // MergeMethod represents a GitHub PR merge method
@@ -113,6 +114,9 @@ type Client interface {
 
 	// ListPRComments lists all comments on a pull request
 	ListPRComments(ctx context.Context, owner, repo string, prNumber int) ([]PRComment, error)
+
+	// GetCurrentUser returns the authenticated GitHub username
+	GetCurrentUser(ctx context.Context) (string, error)
 }
 
 // PRComment represents a comment on a pull request

--- a/internal/github/client_real.go
+++ b/internal/github/client_real.go
@@ -4,6 +4,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/go-github/v62/github"
 
@@ -239,4 +240,13 @@ func (c *StackitGitHubClient) ListPRComments(ctx context.Context, owner, repo st
 	}
 
 	return allComments, nil
+}
+
+// GetCurrentUser returns the authenticated GitHub username
+func (c *StackitGitHubClient) GetCurrentUser(ctx context.Context) (string, error) {
+	output, err := c.runner.RunGHCommandWithContext(ctx, "api", "user", "-q", ".login")
+	if err != nil {
+		return "", fmt.Errorf("failed to get current GitHub user: %w", err)
+	}
+	return strings.TrimSpace(output), nil
 }

--- a/internal/github/status.go
+++ b/internal/github/status.go
@@ -109,6 +109,7 @@ func buildPRStatusQuery(aliasMap map[string]string) string {
 	for branch, alias := range aliasMap {
 		fmt.Fprintf(&queryBuilder, "    %s: pullRequests(headRefName: \"%s\", first: 1, states: [OPEN]) {\n", alias, branch)
 		queryBuilder.WriteString("      nodes {\n")
+		queryBuilder.WriteString("        author { login }\n")
 		queryBuilder.WriteString("        reviewDecision\n")
 		queryBuilder.WriteString("        commits(last: 1) {\n")
 		queryBuilder.WriteString("          nodes {\n")
@@ -195,6 +196,14 @@ func parseBranchStatus(data interface{}) *CheckStatus {
 		return nil
 	}
 
+	// Extract author
+	var author string
+	if authorData, ok := prNode["author"].(map[string]interface{}); ok {
+		if login, ok := authorData["login"].(string); ok {
+			author = login
+		}
+	}
+
 	// Extract review decision
 	var reviewDecision string
 	if rd, ok := prNode["reviewDecision"].(string); ok {
@@ -204,34 +213,34 @@ func parseBranchStatus(data interface{}) *CheckStatus {
 	// Navigate to commit's statusCheckRollup
 	commits, ok := prNode["commits"].(map[string]interface{})
 	if !ok {
-		return &CheckStatus{Passing: true, Pending: false, ReviewDecision: reviewDecision}
+		return &CheckStatus{Passing: true, Pending: false, ReviewDecision: reviewDecision, Author: author}
 	}
 
 	commitNodes, ok := commits["nodes"].([]interface{})
 	if !ok || len(commitNodes) == 0 {
-		return &CheckStatus{Passing: true, Pending: false, ReviewDecision: reviewDecision}
+		return &CheckStatus{Passing: true, Pending: false, ReviewDecision: reviewDecision, Author: author}
 	}
 
 	commitNode, ok := commitNodes[0].(map[string]interface{})
 	if !ok {
-		return &CheckStatus{Passing: true, Pending: false, ReviewDecision: reviewDecision}
+		return &CheckStatus{Passing: true, Pending: false, ReviewDecision: reviewDecision, Author: author}
 	}
 	commit, ok := commitNode["commit"].(map[string]interface{})
 	if !ok {
-		return &CheckStatus{Passing: true, Pending: false, ReviewDecision: reviewDecision}
+		return &CheckStatus{Passing: true, Pending: false, ReviewDecision: reviewDecision, Author: author}
 	}
 
 	rollup, ok := commit["statusCheckRollup"].(map[string]interface{})
 	if !ok || rollup == nil {
 		// No status checks
-		return &CheckStatus{Passing: true, Pending: false, ReviewDecision: reviewDecision}
+		return &CheckStatus{Passing: true, Pending: false, ReviewDecision: reviewDecision, Author: author}
 	}
 
-	return parseCheckRollup(rollup, reviewDecision)
+	return parseCheckRollup(rollup, reviewDecision, author)
 }
 
 // parseCheckRollup parses the statusCheckRollup data from the GraphQL response
-func parseCheckRollup(rollup map[string]interface{}, reviewDecision string) *CheckStatus {
+func parseCheckRollup(rollup map[string]interface{}, reviewDecision, author string) *CheckStatus {
 	hasPending := false
 	hasFailing := false
 	var checks []CheckDetail
@@ -271,6 +280,7 @@ func parseCheckRollup(rollup map[string]interface{}, reviewDecision string) *Che
 		Pending:        hasPending,
 		Checks:         checks,
 		ReviewDecision: reviewDecision,
+		Author:         author,
 	}
 }
 

--- a/internal/shippable/analyzer.go
+++ b/internal/shippable/analyzer.go
@@ -106,8 +106,26 @@ func (a *Analyzer) analyzeStack(stack merge.MultiStackInfo, statusMap map[string
 		BlockingPRs: make([]BlockingPR, 0),
 	}
 
+	// Get display title from root branch (PR title > commit subject > branch name)
+	if stack.RootBranch != "" {
+		rootBranch := a.eng.GetBranch(stack.RootBranch)
+		if prInfo, err := rootBranch.GetPrInfo(); err == nil && prInfo != nil && prInfo.Title() != "" {
+			result.PRTitle = prInfo.Title()
+		} else {
+			// Fall back to commit subject (DefaultPRTitle returns commit subject or branch name)
+			result.PRTitle = rootBranch.DefaultPRTitle()
+		}
+	}
+
 	// Check each branch in the stack
 	for _, branchName := range stack.AllBranches {
+		// Extract author from first branch with PR status
+		if result.Author == "" {
+			if status, ok := statusMap[branchName]; ok && status != nil && status.Author != "" {
+				result.Author = status.Author
+			}
+		}
+
 		blocking := a.analyzeBranch(branchName, statusMap)
 		if blocking != nil {
 			result.BlockingPRs = append(result.BlockingPRs, *blocking)

--- a/internal/shippable/types.go
+++ b/internal/shippable/types.go
@@ -50,8 +50,10 @@ type BlockingPR struct {
 
 // Stack represents a stack with its shippability analysis.
 type Stack struct {
-	Stack  merge.MultiStackInfo // The underlying stack
-	Status Status               // Overall shippability status
+	Stack   merge.MultiStackInfo // The underlying stack
+	Status  Status               // Overall shippability status
+	Author  string               // GitHub username of stack author (from first PR)
+	PRTitle string               // PR title of the root branch (for display)
 
 	// Breakdown of shippability components
 	ApprovalOK bool  // All PRs have been approved
@@ -93,6 +95,16 @@ func (s *Stack) BranchCount() int {
 
 // RootBranch returns the root branch name of this stack.
 func (s *Stack) RootBranch() string {
+	return s.Stack.RootBranch
+}
+
+// DisplayTitle returns the best title for displaying this stack.
+// The analyzer populates PRTitle with: PR title > commit subject > branch name.
+// Falls back to branch name if PRTitle is empty (e.g., in tests).
+func (s *Stack) DisplayTitle() string {
+	if s.PRTitle != "" {
+		return s.PRTitle
+	}
 	return s.Stack.RootBranch
 }
 
@@ -157,6 +169,35 @@ func (r *AnalysisResult) HasShippable() bool {
 // TotalStacks returns the total number of stacks analyzed.
 func (r *AnalysisResult) TotalStacks() int {
 	return len(r.Stacks)
+}
+
+// FilterByAuthor returns a new AnalysisResult containing only stacks by the given author.
+func (r *AnalysisResult) FilterByAuthor(author string) *AnalysisResult {
+	if author == "" {
+		return r
+	}
+
+	result := &AnalysisResult{
+		Stacks: make([]Stack, 0),
+	}
+
+	for _, s := range r.Stacks {
+		if s.Author == author {
+			result.Stacks = append(result.Stacks, s)
+			switch s.Status {
+			case StatusShippable:
+				result.ShippableCount++
+			case StatusPending:
+				result.PendingCount++
+			case StatusBlocked:
+				result.BlockedCount++
+			case StatusIncomplete:
+				result.IncompleteCount++
+			}
+		}
+	}
+
+	return result
 }
 
 // CombinationResult contains the result of checking if stacks can be merged together.

--- a/internal/shippable/types_test.go
+++ b/internal/shippable/types_test.go
@@ -144,6 +144,32 @@ func TestStack_RootBranch(t *testing.T) {
 	assert.Equal(t, "feature/my-stack", s.RootBranch())
 }
 
+func TestStack_DisplayTitle(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns PR title when available", func(t *testing.T) {
+		t.Parallel()
+		s := &Stack{
+			Stack: merge.MultiStackInfo{
+				RootBranch: "jonnii/20260131/feature",
+			},
+			PRTitle: "feat: add user authentication",
+		}
+		assert.Equal(t, "feat: add user authentication", s.DisplayTitle())
+	})
+
+	t.Run("falls back to branch name when no PR title", func(t *testing.T) {
+		t.Parallel()
+		s := &Stack{
+			Stack: merge.MultiStackInfo{
+				RootBranch: "jonnii/20260131/feature",
+			},
+			PRTitle: "",
+		}
+		assert.Equal(t, "jonnii/20260131/feature", s.DisplayTitle())
+	})
+}
+
 func TestAnalysisResult_GetShippable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/components/tree/tree.go
+++ b/internal/tui/components/tree/tree.go
@@ -69,6 +69,13 @@ type BranchAnnotation struct {
 
 	// MergedDownstack holds historical merged parents for display
 	MergedDownstack []MergedParentDisplay
+
+	// CommitMessages holds formatted commit messages (e.g., "abc123 Commit message")
+	// Used when ShowCommitMessages is enabled in RenderOptions
+	CommitMessages []string
+
+	// PRURL is the GitHub PR URL for this branch
+	PRURL string
 }
 
 // RenderMode specifies the rendering style for the tree.
@@ -110,6 +117,10 @@ type RenderOptions struct {
 
 	// ShowSHAs shows commit SHAs next to branch names (for debugging).
 	ShowSHAs bool
+
+	// ShowCommitMessages shows commit messages below each branch.
+	// Uses CommitMessages from BranchAnnotation.
+	ShowCommitMessages bool
 
 	// SelectedBranch is the name of the currently selected branch (for cursor).
 	SelectedBranch string
@@ -411,6 +422,7 @@ func (r *StackTreeRenderer) RenderStackDetailed(branchName string, opts RenderOp
 		hideStats:           opts.HideStats,
 		hideSummary:         opts.HideSummary,
 		showSHAs:            opts.ShowSHAs,
+		showCommitMessages:  opts.ShowCommitMessages,
 		skipSelectionPrefix: opts.SkipSelectionPrefix,
 		selectedBranch:      opts.SelectedBranch,
 		currentBranch:       r.currentBranch,
@@ -461,6 +473,7 @@ type treeRenderArgs struct {
 	hideStats           bool
 	hideSummary         bool
 	showSHAs            bool
+	showCommitMessages  bool
 	skipSelectionPrefix bool
 	selectedBranch      string
 	currentBranch       string
@@ -493,6 +506,7 @@ func (a treeRenderArgs) childArgs(branchName string, indentLevel int, parentScop
 		hideStats:           a.hideStats,
 		hideSummary:         a.hideSummary,
 		showSHAs:            a.showSHAs,
+		showCommitMessages:  a.showCommitMessages,
 		skipSelectionPrefix: a.skipSelectionPrefix,
 		selectedBranch:      a.selectedBranch,
 		currentBranch:       a.currentBranch,
@@ -523,6 +537,7 @@ func (a treeRenderArgs) downstackArgs(branchName string) treeRenderArgs {
 		hideStats:           a.hideStats,
 		hideSummary:         a.hideSummary,
 		showSHAs:            a.showSHAs,
+		showCommitMessages:  a.showCommitMessages,
 		skipSelectionPrefix: a.skipSelectionPrefix,
 		selectedBranch:      a.selectedBranch,
 		currentBranch:       a.currentBranch,
@@ -996,7 +1011,7 @@ func (r *StackTreeRenderer) getInfoLines(args treeRenderArgs) []string {
 
 	// Add SHA if requested (useful for debugging/diagnostics)
 	if args.showSHAs && annotation.LocalSHA != "" {
-		coloredBranchName += " " + style.ColorDim("("+annotation.LocalSHA+")")
+		coloredBranchName += " " + style.ColorDim("(") + style.ColorSHA(annotation.LocalSHA) + style.ColorDim(")")
 	}
 
 	// Add scope (colored to match tree)
@@ -1049,8 +1064,46 @@ func (r *StackTreeRenderer) getInfoLines(args treeRenderArgs) []string {
 		return result
 	}
 
-	// LINE 2: Summary line with PR# → Review → CI → Stats (skip if hideSummary)
-	if !args.hideSummary {
+	// Show commit messages when enabled (info mode)
+	if args.showCommitMessages && len(annotation.CommitMessages) > 0 {
+		branchPipe := styleObj.Render("│")
+		// Show diff stats and PR info first (above commits)
+		var statsLine string
+		if annotation.LinesAdded > 0 || annotation.LinesDeleted > 0 {
+			statsLine = r.formatContextualStats(annotation)
+		}
+		// Add PR info if available
+		if annotation.PRNumber != nil {
+			prInfo := style.ColorPRNumberByState(*annotation.PRNumber, annotation.PRState, annotation.IsDraft)
+			if annotation.PRURL != "" {
+				prInfo += " " + style.ColorDim(annotation.PRURL)
+			}
+			if statsLine != "" {
+				statsLine += " " + style.ColorDim("|") + " " + prInfo
+			} else {
+				statsLine = prInfo
+			}
+		}
+		if statsLine != "" {
+			result = append(result, selectionPadding+prefix+branchPipe+"  "+statsLine)
+		}
+		// Then show commit messages
+		for _, msg := range annotation.CommitMessages {
+			// Color the SHA (first word), rest dimmed
+			var formattedMsg string
+			if spaceIdx := strings.Index(msg, " "); spaceIdx > 0 {
+				sha := msg[:spaceIdx]
+				rest := msg[spaceIdx:]
+				formattedMsg = style.ColorSHA(sha) + style.ColorDim(rest)
+			} else {
+				formattedMsg = style.ColorDim(msg)
+			}
+			result = append(result, selectionPadding+prefix+branchPipe+"  "+formattedMsg)
+		}
+	}
+
+	// LINE 2: Summary line with PR# → Review → CI → Stats (skip if hideSummary or showCommitMessages)
+	if !args.hideSummary && !args.showCommitMessages {
 		branchPipe := styleObj.Render("│")
 		summaryLine := r.formatSummaryLine(annotation, isTrunk, args.hideStats)
 

--- a/internal/tui/move_preview.go
+++ b/internal/tui/move_preview.go
@@ -28,13 +28,13 @@ func RenderMovePreviewSimple(preview MovePreviewData) string {
 	var sb strings.Builder
 
 	// Header
-	sb.WriteString(style.ColorDim("─────────────────────────────────────\n"))
+	sb.WriteString(style.ColorDim("─────────────────────────────────────") + "\n")
 	sb.WriteString("Move Preview:\n")
-	sb.WriteString(style.ColorDim("─────────────────────────────────────\n"))
+	sb.WriteString(style.ColorDim("─────────────────────────────────────") + "\n")
 	sb.WriteString("\n")
 
 	// Current position (dimmed)
-	sb.WriteString(style.ColorDim("Current position:\n"))
+	sb.WriteString(style.ColorDim("Current position:") + "\n")
 	sb.WriteString(fmt.Sprintf("  %s → %s %s\n",
 		style.ColorDim(preview.OldParent),
 		style.ColorDim(preview.SourceBranch),
@@ -68,7 +68,7 @@ func RenderMovePreviewSimple(preview MovePreviewData) string {
 	}
 
 	// Conflict status
-	sb.WriteString(style.ColorDim("─────────────────────────────────────\n"))
+	sb.WriteString(style.ColorDim("─────────────────────────────────────") + "\n")
 	if preview.HasConflicts {
 		sb.WriteString(style.ColorRed("✗ ") + style.ColorRed("Conflicts detected") + "\n")
 		sb.WriteString(fmt.Sprintf("  Branch: %s\n", style.ColorBranchName(preview.ConflictBranch, false)))
@@ -76,7 +76,7 @@ func RenderMovePreviewSimple(preview MovePreviewData) string {
 	} else {
 		sb.WriteString(style.ColorGreen("✓ ") + style.ColorGreen("Move will complete without conflicts") + "\n")
 	}
-	sb.WriteString(style.ColorDim("─────────────────────────────────────\n"))
+	sb.WriteString(style.ColorDim("─────────────────────────────────────") + "\n")
 
 	return sb.String()
 }

--- a/internal/tui/style/formatter.go
+++ b/internal/tui/style/formatter.go
@@ -125,6 +125,13 @@ func ColorDim(text string) string {
 		Render(text)
 }
 
+// ColorSHA colors a git SHA (yellow)
+func ColorSHA(sha string) string {
+	return lipgloss.NewStyle().
+		Foreground(lipgloss.Color("3")).
+		Render(sha)
+}
+
 // ColorMagenta colors text magenta
 func ColorMagenta(text string) string {
 	return lipgloss.NewStyle().

--- a/internal/tui/tree_renderer.go
+++ b/internal/tui/tree_renderer.go
@@ -200,6 +200,12 @@ func GetBranchAnnotation(eng engine.BranchReader, branch engine.Branch) tree.Bra
 			ann.PRNumber = prInfo.Number()
 			ann.PRState = prInfo.State()
 			ann.IsDraft = prInfo.IsDraft()
+			ann.PRURL = prInfo.URL()
+		}
+
+		// Commit messages for detailed view
+		if commits, err := branch.GetAllCommits(engine.CommitFormatReadable); err == nil {
+			ann.CommitMessages = commits
 		}
 
 		// Merged downstack history

--- a/mise.toml
+++ b/mise.toml
@@ -49,7 +49,7 @@ run = """
   mkdir -p bin
   COMMIT=$(git rev-parse --short HEAD)
   DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  go build -a -ldflags "-X main.version=dev-local -X main.commit=$COMMIT -X main.date=$DATE" -o bin/stackit ./cmd/stackit
+  go build -ldflags "-X main.version=dev-local -X main.commit=$COMMIT -X main.date=$DATE" -o bin/stackit ./cmd/stackit
   if [ ! -L ./bin/st ] && [ ! -f ./bin/st ]; then
     ln -s stackit ./bin/st
     echo "Created symlink: bin/st -> stackit"

--- a/testhelpers/github_mock_client.go
+++ b/testhelpers/github_mock_client.go
@@ -209,3 +209,8 @@ func (c *MockGitHubClient) ListPRComments(ctx context.Context, owner, repo strin
 	}
 	return result, nil
 }
+
+// GetCurrentUser returns a mock GitHub username
+func (c *MockGitHubClient) GetCurrentUser(_ context.Context) (string, error) {
+	return "testuser", nil
+}


### PR DESCRIPTION
This PR merges the following changes:

1. **#665** docs: add merge status view with author filtering
2. **#669** fix: serialize worktree creation to prevent git races
3. **#668** perf: enable Go build cache by removing -a flag
4. **#670** fix: refresh engine cache in dashboard UI to show latest stack state
5. **#671** fix: move newlines outside lipgloss styled blocks in move preview
6. **#672** feat: add tree visualization with commit messages to st info --stack
7. **#673** feat: make st ui details tab match st info --stack format

### Stack

```
main
  └─ jonnii/20260131034336/improve-agent-install-with-stacking-workflow-split (#665)
  └─ jonnii/20260202023507/serialize-worktree-creation-to-prevent-git-races (#669)
    └─ jonnii/20260202015919/enable-Go-build-cache-by-removing-a-flag (#668)
      └─ jonnii/20260202030602/refresh-engine-cache-in-dashboard-UI-to-show (#670)
        └─ jonnii/20260202030954/move-newlines-outside-lipgloss-styled-blocks-in (#671)
          └─ jonnii/20260202033512/add-tree-visualization-with-commit-messages-to-st (#672)
            └─ jonnii/20260202035625/make-st-ui-details-tab-match-st-info-stack (#673)
```