### PR TITLE
[desc] feat: add stack description to st info commands

### DIFF
--- a/internal/actions/info.go
+++ b/internal/actions/info.go
@@ -13,19 +13,21 @@ import (
 
 // SingleBranchInfo represents JSON-serializable info for a single branch (used by info --json)
 type SingleBranchInfo struct {
-	Name           string              `json:"name"`
-	IsCurrent      bool                `json:"is_current"`
-	IsTrunk        bool                `json:"is_trunk"`
-	IsLocked       bool                `json:"is_locked"`
-	IsFrozen       bool                `json:"is_frozen"`
-	NeedsRestack   bool                `json:"needs_restack"`
-	Scope          string              `json:"scope"`
-	CommitDate     string              `json:"commit_date,omitempty"`
-	Parent         string              `json:"parent,omitempty"`
-	Children       []string            `json:"children,omitempty"`
-	PR             *SingleBranchPRInfo `json:"pr,omitempty"`
-	CommitMessages []string            `json:"commit_messages"`
-	DiffStats      SingleBranchStats   `json:"diff_stats"`
+	Name             string              `json:"name"`
+	IsCurrent        bool                `json:"is_current"`
+	IsTrunk          bool                `json:"is_trunk"`
+	IsLocked         bool                `json:"is_locked"`
+	IsFrozen         bool                `json:"is_frozen"`
+	NeedsRestack     bool                `json:"needs_restack"`
+	Scope            string              `json:"scope"`
+	CommitDate       string              `json:"commit_date,omitempty"`
+	Parent           string              `json:"parent,omitempty"`
+	Children         []string            `json:"children,omitempty"`
+	PR               *SingleBranchPRInfo `json:"pr,omitempty"`
+	CommitMessages   []string            `json:"commit_messages"`
+	DiffStats        SingleBranchStats   `json:"diff_stats"`
+	StackTitle       string              `json:"stack_title,omitempty"`
+	StackDescription string              `json:"stack_description,omitempty"`
 }
 
 // SingleBranchPRInfo represents PR information for JSON output
@@ -127,6 +129,16 @@ func InfoAction(ctx *app.Context, opts InfoOptions) error {
 	}
 
 	outputLines = append(outputLines, coloredBranchName)
+
+	// Show stack description if present
+	stackDesc := eng.GetStackDescription(branch)
+	if stackDesc != nil && !stackDesc.IsEmpty() {
+		outputLines = append(outputLines, "")
+		outputLines = append(outputLines, fmt.Sprintf("Stack: %s", stackDesc.Title))
+		if stackDesc.Description != "" {
+			outputLines = append(outputLines, stackDesc.Description)
+		}
+	}
 
 	commitDate, err := branch.GetCommitDate()
 	if err == nil {
@@ -346,6 +358,13 @@ func outputBranchInfoJSON(ctx *app.Context, branch engine.Branch) error {
 				}
 			}
 		}
+	}
+
+	// Stack description
+	stackDesc := eng.GetStackDescription(branch)
+	if stackDesc != nil && !stackDesc.IsEmpty() {
+		info.StackTitle = stackDesc.Title
+		info.StackDescription = stackDesc.Description
 	}
 
 	data, err := json.MarshalIndent(info, "", "  ")

--- a/internal/actions/stack_info.go
+++ b/internal/actions/stack_info.go
@@ -31,6 +31,13 @@ type DiffStats struct {
 	Deletions    int `json:"deletions"`
 }
 
+// StackInfoOutput represents JSON-serializable output for the stack info command
+type StackInfoOutput struct {
+	StackTitle       string            `json:"stack_title,omitempty"`
+	StackDescription string            `json:"stack_description,omitempty"`
+	Branches         []StackBranchInfo `json:"branches"`
+}
+
 // StackInfoOptions contains options for the stack info logic
 type StackInfoOptions struct {
 	JSON bool
@@ -107,7 +114,15 @@ func StackInfoAction(ctx *app.Context, opts StackInfoOptions) error {
 	}
 
 	if opts.JSON {
-		data, err := json.MarshalIndent(result, "", "  ")
+		output := StackInfoOutput{
+			Branches: result,
+		}
+		stackDesc := eng.GetStackDescription(*currentBranch)
+		if stackDesc != nil && !stackDesc.IsEmpty() {
+			output.StackTitle = stackDesc.Title
+			output.StackDescription = stackDesc.Description
+		}
+		data, err := json.MarshalIndent(output, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal stack info to JSON: %w", err)
 		}

--- a/internal/actions/stack_info_test.go
+++ b/internal/actions/stack_info_test.go
@@ -32,16 +32,16 @@ func TestStackInfoAction(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, output)
 
-		var info []StackBranchInfo
+		var info StackInfoOutput
 		err = json.Unmarshal([]byte(output), &info)
 		require.NoError(t, err)
 
 		// Check branches
-		require.Len(t, info, 2)
+		require.Len(t, info.Branches, 2)
 
 		// Map by name for easier checking
 		branchMap := make(map[string]StackBranchInfo)
-		for _, b := range info {
+		for _, b := range info.Branches {
 			branchMap[b.Name] = b
 		}
 
@@ -106,11 +106,11 @@ func TestStackInfoAction(t *testing.T) {
 
 		require.NoError(t, err)
 
-		var info []StackBranchInfo
+		var info StackInfoOutput
 		err = json.Unmarshal([]byte(output), &info)
 		require.NoError(t, err)
-		require.Len(t, info, 1)
-		require.True(t, info[0].IsLocked)
-		require.True(t, info[0].IsFrozen)
+		require.Len(t, info.Branches, 1)
+		require.True(t, info.Branches[0].IsLocked)
+		require.True(t, info.Branches[0].IsFrozen)
 	})
 }


### PR DESCRIPTION
<!-- STACKIT-DESC-START -->
**Add AI-powered stack description feature**

Implements a comprehensive stack description system that allows users to document the purpose and changes in their stacked branches.

Key changes:
- **implement-stack-description-feature** (1223+ lines): Core implementation with `stackit describe` command, metadata storage, interactive editor support, and full test coverage
- **add-stack-description-to-st-info-commands** (55+ lines): Integrates stack descriptions into `stackit info` commands with JSON output support  
- **show-stack-description-in-PR** (278+ lines): Automatically displays stack descriptions in PR bodies as independent sections, visible even when navigation is hidden
- **add-/stack-describe-skill** (101+ lines): Adds `/stack-describe` AI skill that analyzes stack changes and generates descriptions automatically

Implementation notes:
- Descriptions stored in git metadata on stack root branch
- Supports both interactive (editor) and non-interactive (-m/-d flags) workflows
- PR integration ensures descriptions appear consistently across all PRs in the stack
- AI skill analyzes commits, diffs, and file changes to generate contextual descriptions
<!-- STACKIT-DESC-END -->

---
*Merged via consolidation into #685 by jonnii*