### PR TITLE
[desc] feat: add stdin support to describe command

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/charmbracelet/glamour v0.10.0 h1:MtZvfwsYCx8jEPFJm3rIBFIMZUfUJ765oX8V
 github.com/charmbracelet/glamour v0.10.0/go.mod h1:f+uf+I/ChNmqo087elLnVdCiVgjSKWuXa/l6NU2ndYk=
 github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
 github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
+github.com/charmbracelet/lipgloss v1.1.0 h1:vYXsiLHVkK7fp74RkV7b2kq9+zDLoEU4MZoFqR/noCY=
+github.com/charmbracelet/lipgloss v1.1.0/go.mod h1:/6Q8FR2o+kj8rz4Dq0zQc3vYf7X+B0binUUBwA0aL30=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 h1:ZR7e0ro+SZZiIZD7msJyA+NjkCNNavuiPBLgerbOziE=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834/go.mod h1:aKC/t2arECF6rNOnaKaVU6y4t4ZeHQzqfxedE/VkVhA=
 github.com/charmbracelet/x/ansi v0.11.4 h1:6G65PLu6HjmE858CnTUQY1LXT3ZUWwfvqEROLF8vqHI=

--- a/internal/actions/describe/describe.go
+++ b/internal/actions/describe/describe.go
@@ -11,6 +11,7 @@ import (
 	"stackit.dev/stackit/internal/git"
 	"stackit.dev/stackit/internal/tui"
 	"stackit.dev/stackit/internal/tui/style"
+	"stackit.dev/stackit/internal/utils"
 )
 
 // Options contains options for the describe command
@@ -94,8 +95,28 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return nil
 	}
 
-	// Interactive mode - open editor
+	// Try reading from stdin when not interactive
 	if !handler.IsInteractive() {
+		stdinContent, err := utils.ReadFromStdin()
+		if err == nil && stdinContent != "" {
+			desc := ParseEditorContent(stdinContent)
+			if desc != nil {
+				if err := eng.SetStackDescription(ctx.Context, *currentBranch, desc); err != nil {
+					return fmt.Errorf("failed to set stack description: %w", err)
+				}
+				out.Info("Set stack description for stack rooted at %s:", style.ColorBranchName(stackRoot, false))
+				out.Info("  Title: %s", style.ColorDim(desc.Title))
+				if desc.Description != "" {
+					out.Info("  Description: %s", style.ColorDim(TruncateDescription(desc.Description, 60)))
+				}
+
+				// Push metadata changes
+				if err := actions.PushMetadataAndSyncPRs(ctx, []string{stackRoot}); err != nil {
+					out.Debug("Failed to push metadata changes: %v", err)
+				}
+				return nil
+			}
+		}
 		return fmt.Errorf("must specify --message or run in interactive mode")
 	}
 


### PR DESCRIPTION
<!-- STACKIT-DESC-START -->
**Add AI-powered stack description feature**

Implements a comprehensive stack description system that allows users to document the purpose and changes in their stacked branches.

Key changes:
- **implement-stack-description-feature** (1223+ lines): Core implementation with `stackit describe` command, metadata storage, interactive editor support, and full test coverage
- **add-stack-description-to-st-info-commands** (55+ lines): Integrates stack descriptions into `stackit info` commands with JSON output support  
- **show-stack-description-in-PR** (278+ lines): Automatically displays stack descriptions in PR bodies as independent sections, visible even when navigation is hidden
- **add-/stack-describe-skill** (101+ lines): Adds `/stack-describe` AI skill that analyzes stack changes and generates descriptions automatically

Implementation notes:
- Descriptions stored in git metadata on stack root branch
- Supports both interactive (editor) and non-interactive (-m/-d flags) workflows
- PR integration ensures descriptions appear consistently across all PRs in the stack
- AI skill analyzes commits, diffs, and file changes to generate contextual descriptions
<!-- STACKIT-DESC-END -->