### PR TITLE
[desc] feat: use stack descriptions in consolidated PRs

### DIFF
--- a/internal/actions/merge/pr_generator.go
+++ b/internal/actions/merge/pr_generator.go
@@ -2,6 +2,7 @@ package merge
 
 import (
 	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/git"
 	"stackit.dev/stackit/internal/pr"
 )
 
@@ -10,6 +11,7 @@ type PRContentGenerator struct {
 	engine interface {
 		GetBranch(name string) engine.Branch
 		GetScope(branch engine.Branch) engine.Scope
+		GetStackDescription(branch engine.Branch) *git.StackDescription
 		Trunk() engine.Branch
 	}
 }
@@ -18,6 +20,7 @@ type PRContentGenerator struct {
 func NewPRContentGenerator(engine interface {
 	GetBranch(name string) engine.Branch
 	GetScope(branch engine.Branch) engine.Scope
+	GetStackDescription(branch engine.Branch) *git.StackDescription
 	Trunk() engine.Branch
 }) *PRContentGenerator {
 	return &PRContentGenerator{engine: engine}
@@ -39,14 +42,26 @@ func (g *PRContentGenerator) GenerateConsolidationPR(branches []BranchMergeInfo)
 	mergeBranches := g.convertBranchMergeInfo(branches)
 	scopes := g.collectScopes(mergeBranches)
 
-	title := pr.FormatMergeTitle(scopes, len(mergeBranches))
-	body := g.generateBody(mergeBranches, nil)
+	// Get stack description from the root branch (first branch in the list)
+	var stackDesc *git.StackDescription
+	if len(branches) > 0 {
+		rootBranch := g.engine.GetBranch(branches[0].BranchName)
+		stackDesc = g.engine.GetStackDescription(rootBranch)
+	}
+
+	title := pr.FormatMergeTitleWithDescription(stackDesc, scopes, len(mergeBranches))
+	body := g.generateBodyWithDescription(mergeBranches, nil, stackDesc)
 
 	return pr.Content{Title: title, Body: body}
 }
 
 // generateBody creates the PR body with branches, exclusions, and stack tree.
 func (g *PRContentGenerator) generateBody(branches []pr.MergeBranch, excluded []pr.ExcludedBranch) string {
+	return g.generateBodyWithDescription(branches, excluded, nil)
+}
+
+// generateBodyWithDescription creates the PR body with branches, exclusions, stack tree, and optional description.
+func (g *PRContentGenerator) generateBodyWithDescription(branches []pr.MergeBranch, excluded []pr.ExcludedBranch, stackDesc *git.StackDescription) string {
 	// Build stack tree
 	treeBranches := make([]pr.StackTreeBranch, len(branches))
 	for i, branch := range branches {
@@ -65,9 +80,10 @@ func (g *PRContentGenerator) generateBody(branches []pr.MergeBranch, excluded []
 	})
 
 	return pr.FormatMergeBody(pr.MergeBodyParams{
-		Branches:  branches,
-		Excluded:  excluded,
-		StackTree: stackTree,
+		Branches:         branches,
+		Excluded:         excluded,
+		StackTree:        stackTree,
+		StackDescription: stackDesc,
 	})
 }
 

--- a/internal/actions/merge/pr_generator_test.go
+++ b/internal/actions/merge/pr_generator_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/git"
 	"stackit.dev/stackit/testhelpers"
 	"stackit.dev/stackit/testhelpers/scenario"
 )
@@ -59,6 +60,71 @@ func TestPRContentGenerator_GenerateConsolidationPR(t *testing.T) {
 
 		assert.Equal(t, "Merging PROJ-123", content.Title)
 		assert.Contains(t, content.Body, "#1")
+	})
+}
+
+func TestPRContentGenerator_GenerateConsolidationPR_WithStackDescription(t *testing.T) {
+	t.Run("with_stack_description_uses_title", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithStack(map[string]string{
+			"feature-a": "main",
+		})
+
+		// Set stack description
+		_ = s.Engine.SetStackDescription(context.Background(), s.Engine.GetBranch("feature-a"), &git.StackDescription{
+			Title:       "Auth Feature",
+			Description: "Implements authentication",
+		})
+
+		gen := NewPRContentGenerator(s.Engine)
+		content := gen.GenerateConsolidationPR([]BranchMergeInfo{
+			{BranchName: "feature-a", PRNumber: 1},
+		})
+
+		assert.Equal(t, "Auth Feature", content.Title)
+		assert.Contains(t, content.Body, "**Auth Feature**")
+		assert.Contains(t, content.Body, "Implements authentication")
+	})
+
+	t.Run("with_stack_description_title_only", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithStack(map[string]string{
+			"feature-a":   "main",
+			"feature-a-1": "feature-a",
+		})
+
+		// Set stack description with title only
+		_ = s.Engine.SetStackDescription(context.Background(), s.Engine.GetBranch("feature-a"), &git.StackDescription{
+			Title: "My Feature Stack",
+		})
+
+		gen := NewPRContentGenerator(s.Engine)
+		content := gen.GenerateConsolidationPR([]BranchMergeInfo{
+			{BranchName: "feature-a", PRNumber: 1},
+			{BranchName: "feature-a-1", PRNumber: 2},
+		})
+
+		assert.Equal(t, "My Feature Stack", content.Title)
+		assert.Contains(t, content.Body, "**My Feature Stack**")
+	})
+
+	t.Run("no_description_fallback", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithStack(map[string]string{
+			"feature-a": "main",
+		})
+
+		// No stack description set
+
+		gen := NewPRContentGenerator(s.Engine)
+		content := gen.GenerateConsolidationPR([]BranchMergeInfo{
+			{BranchName: "feature-a", PRNumber: 1},
+		})
+
+		// Should fall back to default title
+		assert.Equal(t, "Merging 1 PRs", content.Title)
+		// Body should not contain description formatting
+		assert.NotContains(t, content.Body, "**Auth")
 	})
 }
 

--- a/internal/pr/merge.go
+++ b/internal/pr/merge.go
@@ -3,7 +3,18 @@ package pr
 import (
 	"fmt"
 	"strings"
+
+	"stackit.dev/stackit/internal/git"
 )
+
+// FormatMergeTitleWithDescription formats a merge PR title, using the stack description if present.
+// If the description has a title, it is used directly. Otherwise, falls back to FormatMergeTitle.
+func FormatMergeTitleWithDescription(desc *git.StackDescription, scopes []string, totalCount int) string {
+	if desc != nil && desc.Title != "" {
+		return desc.Title
+	}
+	return FormatMergeTitle(scopes, totalCount)
+}
 
 // FormatMergeTitle formats a unified title for merge PRs (both multi-stack and consolidation).
 // scopes contains the scope values for each branch (may include empty strings for unscoped branches).
@@ -51,6 +62,10 @@ type MergeBodyParams struct {
 	// StackTree is the ASCII tree representation of the stack structure.
 	// Optional - if empty, no tree section is rendered.
 	StackTree string
+
+	// StackDescription is the description of the stack being merged.
+	// Optional - if present, it appears at the top of the body.
+	StackDescription *git.StackDescription
 }
 
 // MergeBranch represents a branch being merged.
@@ -70,6 +85,15 @@ type ExcludedBranch struct {
 // This unified format works for both consolidation and multi-stack merges.
 func FormatMergeBody(params MergeBodyParams) string {
 	var body strings.Builder
+
+	// Stack description (if present)
+	if params.StackDescription != nil && !params.StackDescription.IsEmpty() {
+		descContent := formatStackDescription(params.StackDescription)
+		if descContent != "" {
+			body.WriteString(descContent)
+			body.WriteString("\n\n")
+		}
+	}
 
 	// Header
 	body.WriteString("This PR merges the following changes:\n\n")

--- a/internal/pr/merge_test.go
+++ b/internal/pr/merge_test.go
@@ -4,7 +4,33 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"stackit.dev/stackit/internal/git"
 )
+
+func TestFormatMergeTitleWithDescription(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses description title when present", func(t *testing.T) {
+		t.Parallel()
+		desc := &git.StackDescription{Title: "Add user authentication"}
+		result := FormatMergeTitleWithDescription(desc, []string{"PROJ-123"}, 2)
+		assert.Equal(t, "Add user authentication", result)
+	})
+
+	t.Run("falls back when description is nil", func(t *testing.T) {
+		t.Parallel()
+		result := FormatMergeTitleWithDescription(nil, []string{"PROJ-123"}, 1)
+		assert.Equal(t, "Merging PROJ-123", result)
+	})
+
+	t.Run("falls back when description title is empty", func(t *testing.T) {
+		t.Parallel()
+		desc := &git.StackDescription{Title: "", Description: "Some description"}
+		result := FormatMergeTitleWithDescription(desc, []string{}, 3)
+		assert.Equal(t, "Merging 3 PRs", result)
+	})
+}
 
 func TestFormatMergeTitle(t *testing.T) {
 	tests := []struct {
@@ -182,6 +208,87 @@ main
 		expected := `This PR merges the following changes:
 
 1. **#1** Add feature A
+`
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("with stack description", func(t *testing.T) {
+		result := FormatMergeBody(MergeBodyParams{
+			Branches: []MergeBranch{
+				{Name: "feature-a", PRNumber: 1, PRTitle: "Add feature A"},
+			},
+			StackTree: "main\n  └─ feature-a (#1)\n",
+			StackDescription: &git.StackDescription{
+				Title:       "Add user authentication",
+				Description: "This stack implements JWT-based auth.",
+			},
+		})
+
+		expected := `**Add user authentication**
+
+This stack implements JWT-based auth.
+
+This PR merges the following changes:
+
+1. **#1** Add feature A
+
+### Stack
+
+` + "```" + `
+main
+  └─ feature-a (#1)
+` + "```" + `
+`
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("with stack description title only", func(t *testing.T) {
+		result := FormatMergeBody(MergeBodyParams{
+			Branches: []MergeBranch{
+				{Name: "feature-a", PRNumber: 1, PRTitle: "Add feature A"},
+			},
+			StackTree: "main\n  └─ feature-a (#1)\n",
+			StackDescription: &git.StackDescription{
+				Title: "Add user authentication",
+			},
+		})
+
+		expected := `**Add user authentication**
+
+This PR merges the following changes:
+
+1. **#1** Add feature A
+
+### Stack
+
+` + "```" + `
+main
+  └─ feature-a (#1)
+` + "```" + `
+`
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("with empty stack description", func(t *testing.T) {
+		result := FormatMergeBody(MergeBodyParams{
+			Branches: []MergeBranch{
+				{Name: "feature-a", PRNumber: 1, PRTitle: "Add feature A"},
+			},
+			StackTree:        "main\n  └─ feature-a (#1)\n",
+			StackDescription: &git.StackDescription{},
+		})
+
+		// Should fall back to no description
+		expected := `This PR merges the following changes:
+
+1. **#1** Add feature A
+
+### Stack
+
+` + "```" + `
+main
+  └─ feature-a (#1)
+` + "```" + `
 `
 		assert.Equal(t, expected, result)
 	})


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

---
*Merged via consolidation into #685 by jonnii*