### PR TITLE
refactor: defer PR updates from scope to sync

### DIFF
--- a/.claude/rules/safety-invariants.md
+++ b/.claude/rules/safety-invariants.md
@@ -82,3 +82,57 @@ session.Engine.PushBranch(ctx, tempBranch, remote, opts)
 4. Worktree checks out main (succeeds because main not checked out elsewhere)
 5. Worktree creates merge commits (on main!)
 6. User switches to main - sees unexpected merge commits
+
+## GitHub Writes Only During Sync
+
+**Commands must NOT directly update GitHub PRs. Instead, mark branches for update and let `sync` handle it.**
+
+This applies to: describe, scope, lock, and any command that changes metadata affecting PR display.
+
+### Why This Matters
+
+- **Performance**: GitHub API calls are slow (~200-500ms each). Batching in `sync` is faster.
+- **Predictability**: Users expect `sync` to be the network-heavy command, not `describe` or `lock`.
+- **Offline support**: Users can work offline, then sync when connected.
+- **Consistency**: One place to handle GitHub rate limits, retries, and errors.
+
+### Exceptions (Acceptable GitHub Calls)
+
+1. **Read-only for display**: `log` showing CI status, `get` showing PR info
+2. **Primary purpose is GitHub**: `submit` creating/updating PRs, `merge` creating consolidation PRs
+3. **During sync**: All PR body/title updates should happen here
+
+### Implementation Pattern
+
+```go
+// WRONG - directly updates GitHub
+if err := actions.PushMetadataAndSyncPRs(ctx, branches); err != nil {
+    out.Debug("Failed: %v", err)
+}
+
+// CORRECT - mark for update, sync handles GitHub
+for _, branch := range branches {
+    _ = eng.MarkNeedsPRBodyUpdate(branch.GetName())
+}
+if err := pushMetadataOnly(ctx, eng, branchName); err != nil {
+    out.Debug("Failed: %v", err)
+}
+```
+
+### How Sync Processes Flags
+
+```go
+// In sync/github_sync.go - only updates flagged branches
+flaggedBranches := ctx.Engine.GetBranchesNeedingPRBodyUpdate()
+if len(flaggedBranches) > 0 {
+    actions.UpdateStackPRMetadata(ctx, flaggedBranches, owner, repo)
+}
+```
+
+### Commands That Should Use This Pattern
+
+| Command | What it changes | Should mark, not call GitHub |
+|---------|-----------------|------------------------------|
+| `describe` | Stack description in footer | ✅ Fixed |
+| `scope` | PR title prefix | ❌ TODO |
+| `lock` | Lock section in PR body | ❌ TODO |

--- a/internal/actions/describe/describe.go
+++ b/internal/actions/describe/describe.go
@@ -66,8 +66,8 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		}
 		out.Info("Cleared stack description for stack rooted at %s.", style.ColorBranchName(stackRoot, false))
 
-		// Push metadata changes
-		if err := actions.PushMetadataAndSyncPRs(ctx, []string{stackRoot}); err != nil {
+		// Mark stack for PR updates and push metadata
+		if err := markStackAndPushMetadata(ctx, eng, stackRoot); err != nil {
 			out.Debug("Failed to push metadata changes: %v", err)
 		}
 		return nil
@@ -88,8 +88,8 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 			out.Info("  Description: %s", style.ColorDim(opts.Description))
 		}
 
-		// Push metadata changes
-		if err := actions.PushMetadataAndSyncPRs(ctx, []string{stackRoot}); err != nil {
+		// Mark stack for PR updates and push metadata
+		if err := markStackAndPushMetadata(ctx, eng, stackRoot); err != nil {
 			out.Debug("Failed to push metadata changes: %v", err)
 		}
 		return nil
@@ -110,8 +110,8 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 					out.Info("  Description: %s", style.ColorDim(TruncateDescription(desc.Description, 60)))
 				}
 
-				// Push metadata changes
-				if err := actions.PushMetadataAndSyncPRs(ctx, []string{stackRoot}); err != nil {
+				// Mark stack for PR updates and push metadata
+				if err := markStackAndPushMetadata(ctx, eng, stackRoot); err != nil {
 					out.Debug("Failed to push metadata changes: %v", err)
 				}
 				return nil
@@ -141,12 +141,28 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		out.Info("  Description: %s", style.ColorDim(TruncateDescription(newDesc.Description, 60)))
 	}
 
-	// Push metadata changes
-	if err := actions.PushMetadataAndSyncPRs(ctx, []string{stackRoot}); err != nil {
+	// Mark stack for PR updates and push metadata
+	if err := markStackAndPushMetadata(ctx, eng, stackRoot); err != nil {
 		out.Debug("Failed to push metadata changes: %v", err)
 	}
 
 	return nil
+}
+
+// markStackAndPushMetadata marks all stack branches for PR update and pushes metadata refs.
+// Unlike PushMetadataAndSyncPRs, this does NOT immediately update GitHub PRs.
+func markStackAndPushMetadata(ctx *app.Context, eng engine.Engine, stackRoot string) error {
+	// Mark all branches in the stack for PR body update
+	graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
+	root := eng.GetBranch(stackRoot)
+	if root.IsTracked() {
+		for _, branch := range graph.CollectBranches(root) {
+			_ = eng.MarkNeedsPRBodyUpdate(branch.GetName())
+		}
+	}
+
+	// Push metadata refs (fast git operation)
+	return actions.PushMetadataOnly(ctx, eng, []string{stackRoot})
 }
 
 func showDescription(ctx *app.Context, branch engine.Branch, stackRoot string) error { //nolint:unparam // error return for API consistency

--- a/internal/actions/metadata.go
+++ b/internal/actions/metadata.go
@@ -1,0 +1,38 @@
+package actions
+
+import (
+	"stackit.dev/stackit/internal/app"
+	"stackit.dev/stackit/internal/engine"
+)
+
+// PushMetadataOnly pushes metadata refs without updating GitHub PRs.
+// Use this when you want to push metadata changes but defer PR updates to sync.
+func PushMetadataOnly(ctx *app.Context, eng engine.Engine, branchNames []string) error {
+	out := ctx.Output
+
+	// Update LastModifiedBy for all branches (parallel with config caching)
+	if err := eng.BatchSetLastModifiedBy(branchNames); err != nil {
+		out.Debug("Failed to update metadata: %v", err)
+	}
+
+	// Check if remote sync is enabled; if not, run compatibility test first
+	if !eng.IsRemoteSyncEnabled() {
+		if err := eng.Git().TestRemoteRefCompatibility(); err != nil {
+			out.Debug("Remote metadata sync not supported: %v", err)
+			return nil // Non-fatal
+		}
+		eng.SetRemoteSyncEnabled(true)
+		// Configure refspec so future git fetch commands also fetch metadata
+		if err := eng.Git().EnsureMetadataRefspecConfigured(); err != nil {
+			out.Debug("Failed to configure metadata refspec: %v", err)
+		}
+	}
+
+	// Push metadata refs
+	if err := eng.Git().PushMetadataRefs(ctx.Context, branchNames); err != nil {
+		out.Debug("Failed to push metadata refs: %v", err)
+		return err
+	}
+
+	return nil
+}

--- a/internal/actions/scope/action.go
+++ b/internal/actions/scope/action.go
@@ -69,8 +69,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		}
 		out.Info("Unset explicit scope for branch %s. It will now inherit from its parent.", style.ColorBranchName(currentBranch, false))
 
-		// Push metadata changes to remote and update PRs to trigger CI re-evaluation
-		if err := actions.PushMetadataAndSyncPRs(ctx, []string{currentBranch}); err != nil {
+		// Mark branch for PR update and push metadata (defer GitHub API calls to sync)
+		_ = eng.MarkNeedsPRBodyUpdate(currentBranch)
+		if err := actions.PushMetadataOnly(ctx, eng, []string{currentBranch}); err != nil {
 			out.Debug("Failed to push metadata changes: %v", err)
 		}
 		return nil
@@ -113,8 +114,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		}
 	}
 
-	// Push metadata changes to remote and update PRs to trigger CI re-evaluation
-	if err := actions.PushMetadataAndSyncPRs(ctx, []string{currentBranch}); err != nil {
+	// Mark branch for PR update and push metadata (defer GitHub API calls to sync)
+	_ = eng.MarkNeedsPRBodyUpdate(currentBranch)
+	if err := actions.PushMetadataOnly(ctx, eng, []string{currentBranch}); err != nil {
 		out.Debug("Failed to push metadata changes: %v", err)
 	}
 

--- a/internal/actions/sync/github_sync.go
+++ b/internal/actions/sync/github_sync.go
@@ -113,11 +113,24 @@ func processGitHubSyncResult(ctx *app.Context, result *GitHubSyncResult, dirtyAn
 		})
 	}
 
-	// Update PR body footers if needed
+	// Update PR body footers only for branches flagged as needing updates
 	if ctx.GitHubClient != nil && result.RepoOwner != "" && result.RepoName != "" {
-		updateMetaStart := time.Now()
-		actions.UpdateStackPRMetadata(ctx, result.BranchNames, result.RepoOwner, result.RepoName)
-		ctx.Logger.Info("update stack pr metadata completed durationMs=%d", time.Since(updateMetaStart).Milliseconds())
+		flaggedBranches := ctx.Engine.GetBranchesNeedingPRBodyUpdate()
+		if len(flaggedBranches) > 0 {
+			updateMetaStart := time.Now()
+			// Emit progress events for each branch being updated
+			for _, branchName := range flaggedBranches {
+				handler.EmitEvent(Event{
+					Phase:   PhaseGitHub,
+					Type:    EventProgress,
+					Branch:  branchName,
+					Message: fmt.Sprintf("Updating PR metadata for %s", branchName),
+				})
+			}
+			actions.UpdateStackPRMetadata(ctx, flaggedBranches, result.RepoOwner, result.RepoName)
+			ctx.Logger.Info("update stack pr metadata completed durationMs=%d branchCount=%d",
+				time.Since(updateMetaStart).Milliseconds(), len(flaggedBranches))
+		}
 	}
 
 	// Push local parent changes to GitHub PR bases

--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -198,8 +198,15 @@ func (h *SimpleSyncHandler) printBranchSyncEvent(event syncAction.Event) {
 }
 
 func (h *SimpleSyncHandler) printGitHubEvent(event syncAction.Event) {
-	if event.Type == syncAction.EventCompleted && event.Message != "" {
-		h.Output.Info("  %s", event.Message)
+	switch event.Type {
+	case syncAction.EventProgress:
+		if event.Branch != "" {
+			h.Output.Info("  Updating PR for %s", style.ColorBranchName(event.Branch, false))
+		}
+	case syncAction.EventCompleted:
+		if event.Message != "" {
+			h.Output.Info("  %s", event.Message)
+		}
 	}
 }
 
@@ -449,8 +456,15 @@ func (h *InteractiveSyncHandler) formatEventDetail(event syncAction.Event) (deta
 			}
 		}
 	case syncAction.PhaseGitHub:
-		if event.Type == syncAction.EventCompleted && event.Message != "" {
-			return event.Message, false
+		switch event.Type {
+		case syncAction.EventProgress:
+			if event.Branch != "" {
+				return fmt.Sprintf("Updating PR for %s", event.Branch), false
+			}
+		case syncAction.EventCompleted:
+			if event.Message != "" {
+				return event.Message, false
+			}
 		}
 	case syncAction.PhaseClean:
 		if event.Type == syncAction.EventCompleted && event.Branch != "" {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Implement stack-level metadata with garbage collection**

Adds stack-level metadata infrastructure to enable shared data (like stack descriptions) across all branches in a stack, with automatic cleanup of orphaned metadata.

Key changes:
- **add-stack-level-metadata-refs**: Core infrastructure for stack-level metadata
  - New ref namespace `refs/stackit/stacks/{stack-id}` for stack-scoped data
  - Automatic stack ID generation and inheritance across branches
  - Integration points in create, submit, move, pluck, and split operations
  - Comprehensive test coverage including multi-stack scenarios

- **implement-stack-metadata-garbage-collection**: Automatic cleanup during sync
  - Identifies and removes orphaned stack metadata refs when all branches are deleted/merged
  - Best-effort cleanup that won't fail sync operations
  - Cleans up both local and remote stack metadata refs

- **defer-PR-updates-from-scope-to-sync**: Performance optimization
  - Defers GitHub API calls from `scope` command to `sync`
  - Follows same pattern as `describe` command
  - Adds shared `PushMetadataOnly` helper for metadata-only pushes
  - Documents safety invariant for GitHub writes
  - Adds progress output during sync for PR metadata updates

Implementation notes:
- Stack IDs are timestamp-based and include sanitized branch name
- Metadata stored as JSON blobs referenced by Git refs
- All operations maintain backward compatibility with existing branches
- Garbage collection runs automatically during `stackit sync`
- PR metadata updates now show progress in sync output

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1770260070`.


* **PR #689**
  * **PR #690**
    * **PR #691** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->