### PR TITLE
Implement stack-level metadata with garbage collection

### DIFF
--- a/.claude/rules/safety-invariants.md
+++ b/.claude/rules/safety-invariants.md
@@ -82,3 +82,57 @@ session.Engine.PushBranch(ctx, tempBranch, remote, opts)
 4. Worktree checks out main (succeeds because main not checked out elsewhere)
 5. Worktree creates merge commits (on main!)
 6. User switches to main - sees unexpected merge commits
+
+## GitHub Writes Only During Sync
+
+**Commands must NOT directly update GitHub PRs. Instead, mark branches for update and let `sync` handle it.**
+
+This applies to: describe, scope, lock, and any command that changes metadata affecting PR display.
+
+### Why This Matters
+
+- **Performance**: GitHub API calls are slow (~200-500ms each). Batching in `sync` is faster.
+- **Predictability**: Users expect `sync` to be the network-heavy command, not `describe` or `lock`.
+- **Offline support**: Users can work offline, then sync when connected.
+- **Consistency**: One place to handle GitHub rate limits, retries, and errors.
+
+### Exceptions (Acceptable GitHub Calls)
+
+1. **Read-only for display**: `log` showing CI status, `get` showing PR info
+2. **Primary purpose is GitHub**: `submit` creating/updating PRs, `merge` creating consolidation PRs
+3. **During sync**: All PR body/title updates should happen here
+
+### Implementation Pattern
+
+```go
+// WRONG - directly updates GitHub
+if err := actions.PushMetadataAndSyncPRs(ctx, branches); err != nil {
+    out.Debug("Failed: %v", err)
+}
+
+// CORRECT - mark for update, sync handles GitHub
+for _, branch := range branches {
+    _ = eng.MarkNeedsPRBodyUpdate(branch.GetName())
+}
+if err := pushMetadataOnly(ctx, eng, branchName); err != nil {
+    out.Debug("Failed: %v", err)
+}
+```
+
+### How Sync Processes Flags
+
+```go
+// In sync/github_sync.go - only updates flagged branches
+flaggedBranches := ctx.Engine.GetBranchesNeedingPRBodyUpdate()
+if len(flaggedBranches) > 0 {
+    actions.UpdateStackPRMetadata(ctx, flaggedBranches, owner, repo)
+}
+```
+
+### Commands That Should Use This Pattern
+
+| Command | What it changes | Should mark, not call GitHub |
+|---------|-----------------|------------------------------|
+| `describe` | Stack description in footer | ✅ Fixed |
+| `scope` | PR title prefix | ❌ TODO |
+| `lock` | Lock section in PR body | ❌ TODO |

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -1,104 +1,52 @@
 # Metadata Storage
 
-Stackit stores branch relationships and PR information as Git refs pointing to JSON blobs. This approach keeps metadata portable, versioned, and synchronized with `git push`/`git fetch`.
+This document describes the metadata system used by Stackit to track branch relationships, PR information, and stack-level data. All metadata is stored in Git refs, enabling atomic updates and sync across machines.
 
-## Storage Locations
+## Overview
 
-| Ref Pattern | Purpose | Pushed to Remote? |
-|-------------|---------|-------------------|
-| `refs/stackit/metadata/{branch}` | Branch relationships, PR info | Yes |
-| `refs/stackit/local-metadata/{branch}` | Local-only state | No |
-| `refs/stackit/remote-metadata/{branch}` | Cached remote metadata | No (fetched copy) |
+Stackit uses **Git refs** as the storage mechanism for all metadata. Metadata is stored as JSON blobs, with refs pointing to blob SHAs. This approach provides:
 
-### How It Works
+- **Atomic updates**: Multi-ref changes via `git update-ref --stdin`
+- **Version control**: Metadata history via reflog
+- **Sync capability**: Push/fetch metadata alongside code
+- **No external dependencies**: Everything lives in the Git repository
 
-1. Metadata is serialized as JSON
-2. JSON is stored as a Git blob (`git hash-object -w`)
-3. A ref points to that blob (`git update-ref`)
+## Ref Namespaces
 
-This means:
-- `git push origin refs/stackit/metadata/*` syncs metadata to remote
-- `git fetch origin refs/stackit/metadata/*:refs/stackit/remote-metadata/*` fetches remote metadata
-- Metadata is garbage collected like any other Git object
+Stackit uses four ref namespaces:
 
-## Main Metadata (`refs/stackit/metadata/`)
+| Namespace | Purpose | Synced to Remote |
+|-----------|---------|------------------|
+| `refs/stackit/metadata/{branch}` | Per-branch metadata (parent, PR info, scope, etc.) | Yes |
+| `refs/stackit/local-metadata/{branch}` | Local-only branch state (frozen, cached IDs) | No |
+| `refs/stackit/stacks/{stack-id}` | Stack-level metadata (title, description) | Yes |
+| `refs/stackit/remote-stacks/{stack-id}` | Fetched remote stack metadata (read-only) | N/A (fetched) |
 
-This is the primary metadata, pushed to remote and shared across collaborators.
+## Branch Metadata (`Meta`)
 
-### Fields
+**Ref**: `refs/stackit/metadata/{branch-name}`
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `parentBranchName` | string | Parent branch in the stack |
-| `parentBranchRevision` | string | SHA of parent when relationship was created |
-| `prInfo` | object | PR number, title, body, state, base, URL, draft status |
-| `scope` | string | Branch scope/prefix (e.g., "[PROJ-123]") |
-| `lockReason` | enum | Why PR is locked: `""`, `"user"`, `"consolidating"` |
-| `branchType` | enum | `"user"`, `"utility"`, `"worktree-anchor"` |
-| `lastModifiedBy` | object | Git user who last modified (name, email, GitHub username) |
-| `lastModifiedAt` | timestamp | When metadata was last changed |
-| `localOnlyHash` | string | Hash of local-only state for change detection |
-| `mergedDownstack` | array | Historical parents when branches merged (max 5) |
-| `stackDescription` | object | Stack-level title/description (root branch only) |
+**Source**: `internal/git/metadata.go:41-61`
 
-### PR Info Fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `number` | int | PR number on GitHub |
-| `base` | string | Base branch for the PR |
-| `url` | string | PR URL |
-| `title` | string | PR title |
-| `body` | string | PR body/description |
-| `state` | string | PR state (OPEN, MERGED, CLOSED) |
-| `isDraft` | bool | Whether PR is a draft |
-| `lockReason` | string | PR-level lock reason |
-| `mergeBranch` | string | Branch to merge into for consolidation |
-
-### Branch Types
-
-| Type | Description |
-|------|-------------|
-| `user` | Normal stacked branch created by user |
-| `utility` | Created by `stackit merge --consolidate` or internal operations |
-| `worktree-anchor` | Anchor branch for worktree, has no commits |
-
-### Lock Reasons
-
-| Reason | Description |
-|--------|-------------|
-| `""` (empty) | Branch is not locked |
-| `user` | Manually locked by user (`stackit lock`) |
-| `consolidating` | Being consolidated, locked automatically |
-
-## Local Metadata (`refs/stackit/local-metadata/`)
-
-Machine-specific state that should never be pushed to remote.
+Branch metadata stores the relationship between branches and associated PR information.
 
 ### Fields
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `frozen` | bool | Whether branch is frozen (excluded from restack) |
-| `needsPRBodyUpdate` | bool | Flag for syncing PR body on next submit |
-| `navigationCommentId` | int64 | GitHub comment ID for navigation comment |
+| `parentBranchName` | `*string` | Name of the parent branch |
+| `parentBranchRevision` | `*string` | Git SHA of parent at time of divergence (for detecting when restack is needed) |
+| `prInfo` | `*PrInfoPersistence` | PR information (number, title, body, state, etc.) |
+| `scope` | `*string` | Branch scope for inherited PR prefix (e.g., `"PROJ-123"`) |
+| `lockReason` | `LockReason` | Why the branch is locked: `""`, `"user"`, or `"consolidating"` |
+| `branchType` | `BranchType` | Type: `"user"`, `"utility"`, or `"worktree-anchor"` |
+| `lastModifiedBy` | `*ModifiedBy` | Who last changed this metadata |
+| `lastModifiedAt` | `*time.Time` | When metadata was last changed |
+| `localOnlyHash` | `*string` | Hash of local-only state for change detection (never pushed) |
+| `mergedDownstack` | `[]MergedParent` | Historical parents when reparented (max 5 entries) |
+| `stackId` | `*string` | Links branch to stack ref |
 
-## Remote Metadata (`refs/stackit/remote-metadata/`)
-
-Cached copy of remote metadata, fetched via:
-
-```bash
-git fetch origin 'refs/stackit/metadata/*:refs/stackit/remote-metadata/*'
-```
-
-Stackit automatically configures this refspec. Remote metadata is used for:
-- Detecting conflicts between local and remote changes
-- Syncing metadata from collaborators
-- Determining what needs to be pushed
-
-## JSON Examples
-
-### Branch Metadata
+### Example
 
 ```json
 {
@@ -108,92 +56,257 @@ Stackit automatically configures this refspec. Remote metadata is used for:
     "number": 42,
     "base": "main",
     "url": "https://github.com/org/repo/pull/42",
-    "title": "feat: add user authentication",
+    "title": "[PROJ-123] Add feature X",
+    "body": "## Summary\n\nAdds feature X...",
     "state": "OPEN",
     "isDraft": false
   },
+  "scope": "PROJ-123",
+  "lockReason": "",
   "branchType": "user",
-  "lastModifiedBy": {
-    "gitName": "Alice",
-    "gitEmail": "alice@example.com",
-    "githubUsername": "alice"
-  },
-  "lastModifiedAt": "2024-01-15T10:30:00Z"
+  "stackId": "1706789123456789-feature-x"
 }
 ```
 
-### Stack Description (Root Branch Only)
+### Lifecycle
+
+| Operation | Effect |
+|-----------|--------|
+| `stackit create` | Creates metadata with parent name/revision, inherits stack ID from parent |
+| `stackit submit` | Updates `prInfo` with PR number, URL, title, body, state |
+| `stackit restack` | Updates `parentBranchRevision` to current parent SHA |
+| `stackit lock` | Sets `lockReason` to `"user"` |
+| `stackit unlock` | Clears `lockReason` |
+| `stackit scope set` | Sets `scope` field |
+| Merged parent | Adds entry to `mergedDownstack`, updates `parentBranchName` |
+| `stackit delete` | Deletes the metadata ref |
+
+---
+
+## Local Metadata (`LocalMeta`)
+
+**Ref**: `refs/stackit/local-metadata/{branch-name}`
+
+**Source**: `internal/git/metadata.go:82-87`
+
+Local metadata is never pushed to remote. It stores per-machine state.
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `frozen` | `bool` | Branch is frozen locally (excluded from restack/submit) |
+| `needsPRBodyUpdate` | `bool` | Flag indicating PR body needs update during sync |
+| `navigationCommentId` | `*int64` | Cached GitHub comment ID for navigation commands |
+
+### Example
 
 ```json
 {
-  "parentBranchName": "main",
-  "stackDescription": {
-    "title": "User Authentication Feature",
-    "description": "Implements OAuth2 login flow with support for Google and GitHub providers."
-  }
+  "frozen": true,
+  "needsPRBodyUpdate": false,
+  "navigationCommentId": 12345678
 }
 ```
 
-### Local Metadata
+### Lifecycle
+
+| Operation | Effect |
+|-----------|--------|
+| `stackit freeze` | Sets `frozen` to `true` |
+| `stackit unfreeze` | Sets `frozen` to `false` |
+| `stackit sync` | May set `needsPRBodyUpdate` for deferred updates |
+| Navigation comment posted | Caches `navigationCommentId` |
+| `stackit delete` | Deletes the local metadata ref |
+
+---
+
+## Stack Metadata (`StackMeta`)
+
+**Ref**: `refs/stackit/stacks/{stack-id}`
+
+**Source**: `internal/git/stack_metadata.go:20-29`
+
+Stack metadata stores information about an entire stack. It survives branch operations like merging the root branch, because it's stored separately from branch metadata.
+
+### Stack ID Format
+
+```
+{timestamp-nanos}-{sanitized-root-branch}
+```
+
+**Example**: `1706789123456789-feature-x`
+
+The sanitized branch name:
+- Contains only alphanumeric characters and hyphens
+- Maximum 50 characters
+- No leading/trailing hyphens
+- Falls back to `"stack"` if all characters are invalid
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | Stack ID (matches ref name) |
+| `title` | `string` | Stack title (displayed in UI) |
+| `description` | `string` | Stack description (longer narrative) |
+| `createdAt` | `time.Time` | When the stack was created |
+| `createdBy` | `string` | Who created the stack (git user name) |
+
+### Example
 
 ```json
 {
-  "frozen": false,
-  "needsPRBodyUpdate": true,
-  "navigationCommentId": 123456789
+  "id": "1706789123456789-feature-x",
+  "title": "Add user authentication",
+  "description": "This stack implements OAuth2 authentication with Google and GitHub providers.\n\nPhase 1: Core auth flow\nPhase 2: Provider integrations\nPhase 3: Session management",
+  "createdAt": "2024-02-01T10:30:00Z",
+  "createdBy": "Jane Developer"
 }
 ```
 
-### Merged Downstack History
+### Lifecycle
 
-When branches are merged or deleted, their history is preserved:
+| Operation | Effect |
+|-----------|--------|
+| `stackit create` (first branch off trunk) | Generates new stack ID, creates stack ref |
+| `stackit create` (off tracked branch) | Inherits parent's stack ID |
+| `stackit describe` | Sets/updates `title` and `description` |
+| Reparenting to different stack | Updates branch's `stackId` to match new parent |
+| All branches deleted | Stack ref remains (for history) |
 
-```json
-{
-  "parentBranchName": "main",
-  "mergedDownstack": [
-    {
-      "branchName": "feat/auth-base",
-      "prNumber": 40,
-      "prState": "MERGED"
-    },
-    {
-      "branchName": "feat/auth-oauth",
-      "prNumber": 41,
-      "prState": "MERGED"
-    }
-  ]
-}
+---
+
+## Supporting Types
+
+### LockReason
+
+**Source**: `internal/git/metadata.go:13-23`
+
+| Value | Description |
+|-------|-------------|
+| `""` (empty) | Not locked |
+| `"user"` | Manually locked by user via `stackit lock` |
+| `"consolidating"` | Locked during merge consolidation operation |
+
+### BranchType
+
+**Source**: `internal/git/metadata.go:30-38`
+
+| Value | Description |
+|-------|-------------|
+| `"user"` | Normal stacked branch created by user |
+| `"utility"` | Created by `stackit merge --consolidate` or internal operations |
+| `"worktree-anchor"` | Anchor branch for worktree (has no commits of its own) |
+
+### PrInfoPersistence
+
+**Source**: `internal/git/metadata.go:96-107`
+
+PR information persisted in branch metadata.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `number` | `*int` | PR number |
+| `base` | `*string` | Base branch name |
+| `url` | `*string` | PR URL |
+| `title` | `*string` | PR title |
+| `body` | `*string` | PR description/body |
+| `state` | `*string` | PR state: `"OPEN"`, `"MERGED"`, `"CLOSED"` |
+| `isDraft` | `*bool` | Whether PR is a draft |
+| `lockReason` | `*LockReason` | Lock status parsed from PR footer |
+| `mergeBranch` | `*string` | Merge branch name for consolidated PRs |
+
+### MergedParent
+
+**Source**: `internal/git/metadata.go:76-80`
+
+Records historical parent relationships when branches are reparented.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `branchName` | `string` | Name of the former parent branch |
+| `prNumber` | `*int` | PR number of the merged/closed parent |
+| `prState` | `*string` | State when reparented: `"MERGED"`, `"CLOSED"` |
+
+Limited to 5 entries (oldest entries dropped when limit exceeded).
+
+### ModifiedBy
+
+**Source**: `internal/git/metadata.go:89-94`
+
+Tracks who last modified metadata.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `gitName` | `string` | Git user name |
+| `gitEmail` | `string` | Git user email |
+| `githubUsername` | `*string` | GitHub username (if known) |
+
+---
+
+## Scope Inheritance
+
+**Source**: `internal/engine/types.go:57-155`
+
+Scopes are inherited from parent branches. When a branch doesn't have an explicit scope, Stackit walks up the parent chain until it finds one.
+
+| Scope Value | Behavior |
+|-------------|----------|
+| `""` (empty) | No explicit scope, inherit from parent |
+| `"none"` or `"clear"` | Breaks inheritance, children don't inherit |
+| Any other string | Scope prefix (e.g., `"PROJ-123"`) |
+
+Scopes are applied to PR titles: `[PROJ-123] Feature description`
+
+---
+
+## Transactions
+
+**Source**: `internal/engine/transaction.go`
+
+Metadata updates use transactions for atomicity. A `MetadataTx`:
+
+1. Batches multiple ref updates
+2. Uses compare-and-swap (CAS) validation to detect concurrent modifications
+3. Commits all changes atomically via `git update-ref --stdin`
+4. Updates in-memory cache on success
+
+```go
+tx := e.BeginTx("set parent: feature -> main")
+tx.UpdateMeta(branchName, meta)
+tx.UpdateLocalMeta(branchName, localMeta)
+err := tx.Commit(ctx)  // All or nothing
 ```
 
-## Inspecting Metadata
+Concurrent modification errors trigger automatic retry with exponential backoff.
 
-### View metadata for a branch
+---
+
+## Viewing Metadata
+
+To inspect raw metadata:
 
 ```bash
-# Get the ref SHA
-git show-ref refs/stackit/metadata/my-branch
+# List all metadata refs
+git for-each-ref refs/stackit/
 
-# Read the blob content
-git cat-file -p <sha>
+# Read branch metadata
+git show refs/stackit/metadata/feature-branch
+
+# Read stack metadata
+git show refs/stackit/stacks/1706789123456789-feature-x
+
+# Read local metadata
+git show refs/stackit/local-metadata/feature-branch
 ```
 
-### List all metadata refs
+---
 
-```bash
-git for-each-ref refs/stackit/metadata/
-```
+## Storage Details
 
-### View local metadata
-
-```bash
-git for-each-ref refs/stackit/local-metadata/
-```
-
-## Implementation
-
-The metadata system is implemented in:
-- `internal/git/metadata.go` - Low-level read/write operations
-- `internal/engine/` - Higher-level operations through the Engine interface
-
-Always use the Engine interface to query or modify metadata, never the git package directly from application code.
+- **JSON format**: All metadata is stored as pretty-printed JSON
+- **Blob storage**: JSON is stored in Git blobs (`git hash-object -w`)
+- **Ref pointing**: Refs point to blob SHAs (not commits)
+- **Atomic updates**: `git update-ref --stdin` for batch operations
+- **Reflog**: Updates are recorded in reflog with descriptive messages

--- a/internal/actions/describe/describe.go
+++ b/internal/actions/describe/describe.go
@@ -66,8 +66,8 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		}
 		out.Info("Cleared stack description for stack rooted at %s.", style.ColorBranchName(stackRoot, false))
 
-		// Push metadata changes
-		if err := actions.PushMetadataAndSyncPRs(ctx, []string{stackRoot}); err != nil {
+		// Mark stack for PR updates and push metadata
+		if err := markStackAndPushMetadata(ctx, eng, stackRoot); err != nil {
 			out.Debug("Failed to push metadata changes: %v", err)
 		}
 		return nil
@@ -88,8 +88,8 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 			out.Info("  Description: %s", style.ColorDim(opts.Description))
 		}
 
-		// Push metadata changes
-		if err := actions.PushMetadataAndSyncPRs(ctx, []string{stackRoot}); err != nil {
+		// Mark stack for PR updates and push metadata
+		if err := markStackAndPushMetadata(ctx, eng, stackRoot); err != nil {
 			out.Debug("Failed to push metadata changes: %v", err)
 		}
 		return nil
@@ -110,8 +110,8 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 					out.Info("  Description: %s", style.ColorDim(TruncateDescription(desc.Description, 60)))
 				}
 
-				// Push metadata changes
-				if err := actions.PushMetadataAndSyncPRs(ctx, []string{stackRoot}); err != nil {
+				// Mark stack for PR updates and push metadata
+				if err := markStackAndPushMetadata(ctx, eng, stackRoot); err != nil {
 					out.Debug("Failed to push metadata changes: %v", err)
 				}
 				return nil
@@ -141,12 +141,28 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		out.Info("  Description: %s", style.ColorDim(TruncateDescription(newDesc.Description, 60)))
 	}
 
-	// Push metadata changes
-	if err := actions.PushMetadataAndSyncPRs(ctx, []string{stackRoot}); err != nil {
+	// Mark stack for PR updates and push metadata
+	if err := markStackAndPushMetadata(ctx, eng, stackRoot); err != nil {
 		out.Debug("Failed to push metadata changes: %v", err)
 	}
 
 	return nil
+}
+
+// markStackAndPushMetadata marks all stack branches for PR update and pushes metadata refs.
+// Unlike PushMetadataAndSyncPRs, this does NOT immediately update GitHub PRs.
+func markStackAndPushMetadata(ctx *app.Context, eng engine.Engine, stackRoot string) error {
+	// Mark all branches in the stack for PR body update
+	graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
+	root := eng.GetBranch(stackRoot)
+	if root.IsTracked() {
+		for _, branch := range graph.CollectBranches(root) {
+			_ = eng.MarkNeedsPRBodyUpdate(branch.GetName())
+		}
+	}
+
+	// Push metadata refs (fast git operation)
+	return actions.PushMetadataOnly(ctx, eng, []string{stackRoot})
 }
 
 func showDescription(ctx *app.Context, branch engine.Branch, stackRoot string) error { //nolint:unparam // error return for API consistency

--- a/internal/actions/fold/fold_keep.go
+++ b/internal/actions/fold/fold_keep.go
@@ -51,10 +51,14 @@ func foldWithKeep(gctx context.Context, ctx *app.Context, currentBranch, parentB
 		return fmt.Errorf("failed to rebuild engine: %w", err)
 	}
 
-	// For each sibling, set parent to current branch
+	// For each sibling, set parent to current branch and sync stack ID
 	for _, sibling := range siblings {
 		if err := eng.SetParent(gctx, sibling, currentBranch); err != nil {
 			return fmt.Errorf("failed to reparent %s to %s: %w", sibling.GetName(), currentBranch.GetName(), err)
+		}
+		// Sync stack ID to match the new parent's stack
+		if err := eng.SyncStackIDFromParent(gctx, sibling); err != nil {
+			splog.Debug("Failed to sync stack ID for %s: %v", sibling.GetName(), err)
 		}
 	}
 

--- a/internal/actions/metadata.go
+++ b/internal/actions/metadata.go
@@ -1,0 +1,38 @@
+package actions
+
+import (
+	"stackit.dev/stackit/internal/app"
+	"stackit.dev/stackit/internal/engine"
+)
+
+// PushMetadataOnly pushes metadata refs without updating GitHub PRs.
+// Use this when you want to push metadata changes but defer PR updates to sync.
+func PushMetadataOnly(ctx *app.Context, eng engine.Engine, branchNames []string) error {
+	out := ctx.Output
+
+	// Update LastModifiedBy for all branches (parallel with config caching)
+	if err := eng.BatchSetLastModifiedBy(branchNames); err != nil {
+		out.Debug("Failed to update metadata: %v", err)
+	}
+
+	// Check if remote sync is enabled; if not, run compatibility test first
+	if !eng.IsRemoteSyncEnabled() {
+		if err := eng.Git().TestRemoteRefCompatibility(); err != nil {
+			out.Debug("Remote metadata sync not supported: %v", err)
+			return nil // Non-fatal
+		}
+		eng.SetRemoteSyncEnabled(true)
+		// Configure refspec so future git fetch commands also fetch metadata
+		if err := eng.Git().EnsureMetadataRefspecConfigured(); err != nil {
+			out.Debug("Failed to configure metadata refspec: %v", err)
+		}
+	}
+
+	// Push metadata refs
+	if err := eng.Git().PushMetadataRefs(ctx.Context, branchNames); err != nil {
+		out.Debug("Failed to push metadata refs: %v", err)
+		return err
+	}
+
+	return nil
+}

--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -201,6 +201,44 @@ func Action(ctx *app.Context, opts Options, h Handler) error {
 		return fmt.Errorf("failed to set parent: %w", err)
 	}
 
+	// Update stack IDs based on the move destination (only if parent actually changed):
+	// Stack IDs are only updated if the source branch already has a stack ID.
+	// If source has no stack ID, we don't auto-create one - stack IDs are created lazily
+	// when descriptions or scopes are set.
+	if oldParentName != onto {
+		oldStackID := eng.GetStackID(sourceBranch)
+
+		// Only sync stack IDs if the source branch already has one
+		if oldStackID != "" {
+			newStackID := eng.GetStackID(ontoBranch)
+
+			// Determine what stack ID the source should have after the move
+			var targetStackID string
+			switch {
+			case eng.IsTrunk(ontoBranch):
+				// Moving to trunk creates a new stack
+				targetStackID = eng.GenerateStackID(source)
+				// Create a new stack ref (nil meta uses engine's timeNow() for proper testability)
+				if err := eng.CreateStackRef(targetStackID, nil); err != nil {
+					out.Warn("Failed to create stack ref: %v", err)
+				}
+			case newStackID != "" && newStackID != oldStackID:
+				// Moving to a different stack - inherit that stack's ID
+				targetStackID = newStackID
+			}
+
+			// Update stack IDs if needed (descendants includes source via IncludeCurrent:true)
+			if targetStackID != "" {
+				for _, d := range descendants {
+					if err := eng.SetStackID(gctx, d, targetStackID); err != nil {
+						out.Warn("Failed to update stack ID for %s: %v", d.GetName(), err)
+					}
+				}
+				out.Info("Stack membership updated for %s", source)
+			}
+		}
+	}
+
 	// Rebuild graph after parent change for downstream traversals
 	graph = engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
 

--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -214,6 +214,34 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return fmt.Errorf("failed to set parent: %w", err)
 	}
 
+	// Update stack ID based on the pluck destination:
+	// 1. Plucking to trunk creates a new independent stack with a fresh ID
+	// 2. Plucking to a branch in a different stack inherits that stack's ID
+	// 3. Plucking within the same stack keeps the existing ID (no update needed)
+	oldStackID := eng.GetStackID(sourceBranch)
+	newStackID := eng.GetStackID(ontoBranch)
+
+	var targetStackID string
+	switch {
+	case eng.IsTrunk(ontoBranch):
+		// Plucking to trunk creates a new stack
+		targetStackID = eng.GenerateStackID(source)
+		if err := eng.CreateStackRef(targetStackID, nil); err != nil {
+			out.Warn("Failed to create stack ref: %v", err)
+		}
+	case newStackID != "" && newStackID != oldStackID:
+		// Plucking to a different stack - inherit that stack's ID
+		targetStackID = newStackID
+	}
+
+	// Update stack ID if needed (pluck only moves the source, not descendants)
+	if targetStackID != "" {
+		if err := eng.SetStackID(gctx, sourceBranch, targetStackID); err != nil {
+			out.Warn("Failed to update stack ID for %s: %v", source, err)
+		}
+		out.Info("Stack membership updated for %s", source)
+	}
+
 	out.Info("Plucked %s from %s to %s.",
 		style.ColorBranchName(source, true),
 		style.ColorBranchName(oldParentName, false),

--- a/internal/actions/scope/action.go
+++ b/internal/actions/scope/action.go
@@ -69,8 +69,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		}
 		out.Info("Unset explicit scope for branch %s. It will now inherit from its parent.", style.ColorBranchName(currentBranch, false))
 
-		// Push metadata changes to remote and update PRs to trigger CI re-evaluation
-		if err := actions.PushMetadataAndSyncPRs(ctx, []string{currentBranch}); err != nil {
+		// Mark branch for PR update and push metadata (defer GitHub API calls to sync)
+		_ = eng.MarkNeedsPRBodyUpdate(currentBranch)
+		if err := actions.PushMetadataOnly(ctx, eng, []string{currentBranch}); err != nil {
 			out.Debug("Failed to push metadata changes: %v", err)
 		}
 		return nil
@@ -113,8 +114,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		}
 	}
 
-	// Push metadata changes to remote and update PRs to trigger CI re-evaluation
-	if err := actions.PushMetadataAndSyncPRs(ctx, []string{currentBranch}); err != nil {
+	// Mark branch for PR update and push metadata (defer GitHub API calls to sync)
+	_ = eng.MarkNeedsPRBodyUpdate(currentBranch)
+	if err := actions.PushMetadataOnly(ctx, eng, []string{currentBranch}); err != nil {
 		out.Debug("Failed to push metadata changes: %v", err)
 	}
 

--- a/internal/actions/split/split_file.go
+++ b/internal/actions/split/split_file.go
@@ -86,7 +86,13 @@ func recoverToOriginalBranchAndRef(ctx context.Context, eng splitByFileEngine, b
 // Sibling mode (AsSibling=true):
 // Creates a new SIBLING branch containing the changes to the extracted files.
 // The original branch is unchanged (changes are NOT removed).
+//
+// Stack ID preservation:
+// All new branches created by split inherit the original branch's stack ID,
+// ensuring they remain part of the same logical stack.
 func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []string, eng splitByFileEngine, opts splitByFileOptions) (*Result, error) {
+	// Capture original stack ID to preserve on new branches
+	originalStackID := eng.GetStackID(branchToSplit)
 	// Get parent branch
 	parentBranchName := branchToSplit.GetParentPrecondition()
 	parentBranch := eng.GetBranch(parentBranchName)
@@ -157,12 +163,12 @@ func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []s
 
 	// For sibling mode, use simpler approach - create branch at parent and apply hunks directly
 	if opts.AsSibling {
-		return splitByFileSibling(ctx, branchToSplit, parentBranch, newBranchName, filteredHunks, commitMessage, eng, opts.DryRun)
+		return splitByFileSibling(ctx, branchToSplit, parentBranch, newBranchName, filteredHunks, commitMessage, eng, originalStackID, opts.DryRun)
 	}
 
 	// For above mode (upstack), extract to child branch
 	if opts.Direction == DirectionAbove {
-		return splitByFileAbove(ctx, branchToSplit, newBranchName, filteredHunks, defaultCommitMessage, commitMessage, eng, opts.DryRun)
+		return splitByFileAbove(ctx, branchToSplit, newBranchName, filteredHunks, defaultCommitMessage, commitMessage, eng, originalStackID, opts.DryRun)
 	}
 
 	// Dry-run mode: show what would happen without executing
@@ -305,6 +311,15 @@ func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []s
 		return nil, recoverWithRef(fmt.Errorf("failed to track parent branch: %w", err))
 	}
 
+	// Preserve stack ID from original branch
+	// TrackBranch may generate a new ID if parent is trunk, but split branches
+	// should stay in the same stack as the branch being split
+	if originalStackID != "" {
+		if err := eng.SetStackID(ctx, newBranch, originalStackID); err != nil {
+			return nil, recoverWithRef(fmt.Errorf("failed to preserve stack ID: %w", err))
+		}
+	}
+
 	// Update branchToSplit to have newBranch as its parent
 	if err := eng.SetParent(ctx, branchToSplit, newBranch); err != nil {
 		return nil, recoverWithRef(fmt.Errorf("failed to update parent of %s: %w", branchToSplit.GetName(), err))
@@ -337,7 +352,7 @@ func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []s
 //  9. Pop stash and commit (extracted files)
 //  10. Track child branch with original as parent
 //  11. Reparent existing children to new child
-func splitByFileAbove(ctx context.Context, branchToSplit engine.Branch, newBranchName string, hunks []git.Hunk, defaultCommitMessage string, childCommitMessage string, eng splitByFileEngine, dryRun bool) (*Result, error) {
+func splitByFileAbove(ctx context.Context, branchToSplit engine.Branch, newBranchName string, hunks []git.Hunk, defaultCommitMessage string, childCommitMessage string, eng splitByFileEngine, originalStackID string, dryRun bool) (*Result, error) {
 	// Dry-run mode: show what would happen without executing
 	if dryRun {
 		return &Result{
@@ -495,6 +510,13 @@ func splitByFileAbove(ctx context.Context, branchToSplit engine.Branch, newBranc
 		return nil, fmt.Errorf("failed to track child branch: %w", err)
 	}
 
+	// Preserve stack ID from original branch
+	if originalStackID != "" {
+		if err := eng.SetStackID(ctx, childBranch, originalStackID); err != nil {
+			return nil, fmt.Errorf("failed to preserve stack ID: %w", err)
+		}
+	}
+
 	// Child branch is now fully set up, don't clean it up on subsequent errors
 	childBranchCreated = false
 
@@ -514,7 +536,7 @@ func splitByFileAbove(ctx context.Context, branchToSplit engine.Branch, newBranc
 
 // splitByFileSibling creates a sibling branch with the specified file changes.
 // The original branch is unchanged.
-func splitByFileSibling(ctx context.Context, branchToSplit engine.Branch, parentBranch engine.Branch, newBranchName string, hunks []git.Hunk, commitMessage string, eng splitByFileEngine, dryRun bool) (*Result, error) {
+func splitByFileSibling(ctx context.Context, branchToSplit engine.Branch, parentBranch engine.Branch, newBranchName string, hunks []git.Hunk, commitMessage string, eng splitByFileEngine, originalStackID string, dryRun bool) (*Result, error) {
 	// Dry-run mode: show what would happen without executing
 	if dryRun {
 		return &Result{
@@ -569,6 +591,15 @@ func splitByFileSibling(ctx context.Context, branchToSplit engine.Branch, parent
 		_ = eng.DeleteBranch(ctx, newBranch)
 		_ = eng.CheckoutBranch(ctx, branchToSplit)
 		return nil, fmt.Errorf("failed to track branch: %w", err)
+	}
+
+	// Preserve stack ID from original branch
+	if originalStackID != "" {
+		if err := eng.SetStackID(ctx, newBranch, originalStackID); err != nil {
+			_ = eng.DeleteBranch(ctx, newBranch)
+			_ = eng.CheckoutBranch(ctx, branchToSplit)
+			return nil, fmt.Errorf("failed to preserve stack ID: %w", err)
+		}
 	}
 
 	// Return to original branch

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -604,6 +604,15 @@ func pushMetadataRefs(ctx *app.Context, branches []engine.Branch) error {
 		return fmt.Errorf("failed to push metadata refs: %w", err)
 	}
 
+	// Push stack metadata refs for any stacks that have branches being submitted
+	stackIDs := ctx.Engine.GetStackIDsForBranches(branches)
+	if len(stackIDs) > 0 {
+		if err := ctx.Git().PushStackMetaRefs(ctx.Context, stackIDs); err != nil {
+			ctx.Output.Debug("Failed to push stack metadata refs: %v", err)
+			// Non-fatal: stack metadata push failure shouldn't fail the submit
+		}
+	}
+
 	return nil
 }
 

--- a/internal/actions/sync/github_sync.go
+++ b/internal/actions/sync/github_sync.go
@@ -113,11 +113,24 @@ func processGitHubSyncResult(ctx *app.Context, result *GitHubSyncResult, dirtyAn
 		})
 	}
 
-	// Update PR body footers if needed
+	// Update PR body footers only for branches flagged as needing updates
 	if ctx.GitHubClient != nil && result.RepoOwner != "" && result.RepoName != "" {
-		updateMetaStart := time.Now()
-		actions.UpdateStackPRMetadata(ctx, result.BranchNames, result.RepoOwner, result.RepoName)
-		ctx.Logger.Info("update stack pr metadata completed durationMs=%d", time.Since(updateMetaStart).Milliseconds())
+		flaggedBranches := ctx.Engine.GetBranchesNeedingPRBodyUpdate()
+		if len(flaggedBranches) > 0 {
+			updateMetaStart := time.Now()
+			// Emit progress events for each branch being updated
+			for _, branchName := range flaggedBranches {
+				handler.EmitEvent(Event{
+					Phase:   PhaseGitHub,
+					Type:    EventProgress,
+					Branch:  branchName,
+					Message: fmt.Sprintf("Updating PR metadata for %s", branchName),
+				})
+			}
+			actions.UpdateStackPRMetadata(ctx, flaggedBranches, result.RepoOwner, result.RepoName)
+			ctx.Logger.Info("update stack pr metadata completed durationMs=%d branchCount=%d",
+				time.Since(updateMetaStart).Milliseconds(), len(flaggedBranches))
+		}
 	}
 
 	// Push local parent changes to GitHub PR bases

--- a/internal/actions/sync/metadata_sync.go
+++ b/internal/actions/sync/metadata_sync.go
@@ -39,6 +39,10 @@ func processRemoteMetadata(ctx *app.Context, opts *Options, handler Handler) err
 	if err := eng.ConfigureRemoteMetadataSync(ctx.Context); err != nil {
 		out.Debug("Failed to configure metadata refspec: %v", err)
 	}
+	// Also configure stack metadata refspec
+	if err := ctx.Git().EnsureStackMetaRefspecConfigured(); err != nil {
+		out.Debug("Failed to configure stack metadata refspec: %v", err)
+	}
 	ctx.Logger.Info("configure remote metadata sync completed durationMs=%d", time.Since(configStart).Milliseconds())
 
 	// Load remote metadata into cache

--- a/internal/actions/sync/stack_metadata_gc.go
+++ b/internal/actions/sync/stack_metadata_gc.go
@@ -1,0 +1,76 @@
+package sync
+
+import (
+	"stackit.dev/stackit/internal/app"
+)
+
+// StackMetadataGCResult contains the results of stack metadata garbage collection.
+type StackMetadataGCResult struct {
+	DeletedStackIDs []string // Stack IDs whose refs were deleted
+	Errors          []string // Any errors encountered (non-fatal)
+}
+
+// gcOrphanedStackMetadata removes stack metadata refs that have no associated branches.
+// This is called during sync after worktree cleanup to clean up refs for stacks
+// whose branches have all been deleted or merged.
+// This function is best-effort and will not fail sync on errors.
+func gcOrphanedStackMetadata(ctx *app.Context) *StackMetadataGCResult {
+	result := &StackMetadataGCResult{
+		DeletedStackIDs: []string{},
+		Errors:          []string{},
+	}
+
+	// 1. Get all local stack metadata refs (returns map[stackID]sha)
+	allStackRefs, err := ctx.Git().ListStackMetas()
+	if err != nil {
+		ctx.Logger.Debug("failed to list stack metadata refs", "error", err)
+		return result
+	}
+
+	if len(allStackRefs) == 0 {
+		return result
+	}
+
+	// 2. Get active stack IDs from tracked branches
+	activeIDs := make(map[string]bool)
+	for _, branch := range ctx.Engine.AllBranches() {
+		stackID := ctx.Engine.GetStackID(branch)
+		if stackID != "" {
+			activeIDs[stackID] = true
+		}
+	}
+
+	// 3. Find orphaned refs (in allStackRefs but not activeIDs)
+	var orphaned []string
+	for stackID := range allStackRefs {
+		if !activeIDs[stackID] {
+			orphaned = append(orphaned, stackID)
+		}
+	}
+
+	if len(orphaned) == 0 {
+		return result
+	}
+
+	ctx.Logger.Info("found orphaned stack metadata refs", "count", len(orphaned))
+
+	// 4. Delete local refs
+	for _, stackID := range orphaned {
+		if err := ctx.Git().DeleteStackMeta(stackID); err != nil {
+			result.Errors = append(result.Errors, "failed to delete local stack ref "+stackID+": "+err.Error())
+			ctx.Logger.Debug("failed to delete local stack ref", "stackID", stackID, "error", err)
+		} else {
+			result.DeletedStackIDs = append(result.DeletedStackIDs, stackID)
+		}
+	}
+
+	// 5. Delete remote refs (best-effort, non-fatal)
+	if len(result.DeletedStackIDs) > 0 {
+		if err := ctx.Git().DeleteRemoteStackMetaRefs(ctx.Context, result.DeletedStackIDs); err != nil {
+			// This is expected to fail if refs don't exist on remote, so just log it
+			ctx.Logger.Debug("failed to delete remote stack refs (may not exist)", "error", err)
+		}
+	}
+
+	return result
+}

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -113,6 +113,13 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		fetchStart := time.Now()
 		metadataFetchErr = ctx.RemoteMetadata().FetchRemoteMetadata(gctx)
 		ctx.Logger.Info("fetch remote metadata refs completed", "durationMs", time.Since(fetchStart).Milliseconds())
+
+		// Also fetch stack metadata refs (stack-level descriptions, etc.)
+		stackFetchStart := time.Now()
+		if err := ctx.Git().FetchStackMetaRefs(gctx); err != nil {
+			ctx.Logger.Debug("fetch stack metadata refs failed (non-fatal)", "error", err)
+		}
+		ctx.Logger.Info("fetch stack metadata refs completed", "durationMs", time.Since(stackFetchStart).Milliseconds())
 		return nil
 	})
 
@@ -183,6 +190,16 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Surface any worktree cleanup errors as warnings (non-fatal)
 	for _, errMsg := range worktreeResult.Errors {
 		ctx.Output.Warn("Worktree cleanup: %s", errMsg)
+	}
+
+	// GC orphaned stack metadata refs (after branch cleanup so we know what's been deleted)
+	gcResult := gcOrphanedStackMetadata(ctx)
+	if len(gcResult.DeletedStackIDs) > 0 {
+		ctx.Logger.Info("cleaned orphaned stack metadata", "count", len(gcResult.DeletedStackIDs))
+	}
+	// Surface any GC errors as warnings (non-fatal)
+	for _, errMsg := range gcResult.Errors {
+		ctx.Output.Warn("Stack metadata cleanup: %s", errMsg)
 	}
 
 	graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)

--- a/internal/cli/stack/move_test.go
+++ b/internal/cli/stack/move_test.go
@@ -37,6 +37,8 @@ func TestMoveCommand(t *testing.T) {
 		})
 
 		// 1. Move branch2 to main (downstack)
+		// Note: "Stack membership updated" messages only appear when branches have stack IDs
+		// which are only created when descriptions/scopes are set.
 		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "move", "--source", "branch2", "--onto", "main", "-y")
 		normalized := testhelpers.NormalizeOutput(output)
 		require.Equal(t, testhelpers.NormalizeOutput(`
@@ -45,7 +47,7 @@ Restacked branch2 on main.
 Restacked branch3 (current) on branch2.
 `), normalized)
 
-		// 2. Move current branch (branch3) to branch1
+		// 2. Move current branch (branch3) to branch1 (different stack)
 		err := scene.Repo.CheckoutBranch("branch3")
 		require.NoError(t, err)
 		output = runCliCommandSuccess(t, binaryPath, scene.Dir, "move", "--onto", "branch1", "-y")

--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -198,8 +198,15 @@ func (h *SimpleSyncHandler) printBranchSyncEvent(event syncAction.Event) {
 }
 
 func (h *SimpleSyncHandler) printGitHubEvent(event syncAction.Event) {
-	if event.Type == syncAction.EventCompleted && event.Message != "" {
-		h.Output.Info("  %s", event.Message)
+	switch event.Type {
+	case syncAction.EventProgress:
+		if event.Branch != "" {
+			h.Output.Info("  Updating PR for %s", style.ColorBranchName(event.Branch, false))
+		}
+	case syncAction.EventCompleted:
+		if event.Message != "" {
+			h.Output.Info("  %s", event.Message)
+		}
 	}
 }
 
@@ -449,8 +456,15 @@ func (h *InteractiveSyncHandler) formatEventDetail(event syncAction.Event) (deta
 			}
 		}
 	case syncAction.PhaseGitHub:
-		if event.Type == syncAction.EventCompleted && event.Message != "" {
-			return event.Message, false
+		switch event.Type {
+		case syncAction.EventProgress:
+			if event.Branch != "" {
+				return fmt.Sprintf("Updating PR for %s", event.Branch), false
+			}
+		case syncAction.EventCompleted:
+			if event.Message != "" {
+				return event.Message, false
+			}
 		}
 	case syncAction.PhaseClean:
 		if event.Type == syncAction.EventCompleted && event.Branch != "" {

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -79,6 +79,10 @@ func (d *demoGitRunner) EnsureMetadataRefspecConfigured() error {
 	return nil
 }
 
+func (d *demoGitRunner) EnsureStackMetaRefspecConfigured() error {
+	return nil
+}
+
 func (d *demoGitRunner) GetCurrentBranch() (string, error) {
 	return d.currentBranch, nil
 }
@@ -612,6 +616,18 @@ func (d *demoGitRunner) FetchMetadataRefs(_ context.Context) error {
 	return nil
 }
 
+func (d *demoGitRunner) PushStackMetaRefs(_ context.Context, _ []string) error {
+	return nil
+}
+
+func (d *demoGitRunner) FetchStackMetaRefs(_ context.Context) error {
+	return nil
+}
+
+func (d *demoGitRunner) DeleteRemoteStackMetaRefs(_ context.Context, _ []string) error {
+	return nil
+}
+
 func (d *demoGitRunner) DeleteRemoteMetadataRef(_ context.Context, _ string) error {
 	return nil
 }
@@ -668,4 +684,30 @@ func (d *demoGitRunner) GetMetadataRefSHA(_ string) string {
 func (d *demoGitRunner) GetLocalMetadataRefSHA(_ string) string {
 	// Return a mock SHA to simulate existing local metadata refs for CAS testing
 	return demoRefSHA
+}
+
+// StackMetadataOperations methods
+
+func (d *demoGitRunner) ReadStackMeta(_ string) (*git.StackMeta, error) {
+	return nil, nil
+}
+
+func (d *demoGitRunner) WriteStackMeta(_ string, _ *git.StackMeta) error {
+	return nil
+}
+
+func (d *demoGitRunner) DeleteStackMeta(_ string) error {
+	return nil
+}
+
+func (d *demoGitRunner) ListStackMetas() (map[string]string, error) {
+	return make(map[string]string), nil
+}
+
+func (d *demoGitRunner) WriteStackMetaBlob(_ *git.StackMeta) (string, error) {
+	return demoBlobSHA, nil
+}
+
+func (d *demoGitRunner) GetStackMetaRefSHA(_ string) string {
+	return ""
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -86,6 +86,9 @@ type RemoteMetadataManager interface {
 	DeleteMetadata(ctx context.Context, branchName string) error
 	FetchRemoteMetadata(ctx context.Context) error
 	ConfigureRemoteMetadataSync(ctx context.Context) error
+	// GetStackIDsForBranches returns the unique stack IDs for the given branches.
+	// This is used to determine which stack refs need to be pushed to remote.
+	GetStackIDsForBranches(branches []Branch) []string
 }
 
 // ApplySplitOptions contains options for applying a split

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -299,15 +299,9 @@ func (e *engineImpl) appendMergedDownstack(
 
 	// Build MergedParent from old parent
 	mp := git.MergedParent{BranchName: oldParent}
-	if oldParentMeta != nil {
-		if oldParentMeta.PrInfo != nil {
-			mp.PRNumber = oldParentMeta.PrInfo.Number
-			mp.PRState = oldParentMeta.PrInfo.State
-		}
-		// Capture stack description from deleted parent (if it was the root)
-		if oldParentMeta.StackDescription != nil && !oldParentMeta.StackDescription.IsEmpty() {
-			mp.StackDescription = oldParentMeta.StackDescription
-		}
+	if oldParentMeta != nil && oldParentMeta.PrInfo != nil {
+		mp.PRNumber = oldParentMeta.PrInfo.Number
+		mp.PRState = oldParentMeta.PrInfo.State
 	}
 
 	// Inherit old parent's history (for multi-level: A→B→C, if B merges)

--- a/internal/engine/engine_split.go
+++ b/internal/engine/engine_split.go
@@ -27,6 +27,12 @@ func (e *engineImpl) ApplySplitToCommits(ctx context.Context, opts ApplySplitOpt
 		return fmt.Errorf("branch %s has no parent", opts.BranchToSplit)
 	}
 
+	// Capture the original stack ID to preserve it on new branches
+	var originalStackID string
+	if meta.StackID != nil {
+		originalStackID = *meta.StackID
+	}
+
 	parentBranchName := *meta.ParentBranchName
 	parentRevision := *meta.ParentBranchRevision
 	children := e.childrenMap[opts.BranchToSplit]
@@ -77,6 +83,11 @@ func (e *engineImpl) ApplySplitToCommits(ctx context.Context, opts ApplySplitOpt
 		newMeta := &git.Meta{
 			ParentBranchName:     &branchParentName,
 			ParentBranchRevision: &branchParentRevision,
+		}
+
+		// Preserve stack ID from original branch
+		if originalStackID != "" {
+			newMeta.StackID = &originalStackID
 		}
 
 		// Preserve PR info if applicable

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -340,14 +340,7 @@ func (e *engineImpl) CreateAndCheckoutBranch(ctx context.Context, branch Branch)
 
 	e.currentBranch = branchName
 	// Add to branches list if not already there
-	found := false
-	for _, b := range e.branches {
-		if b == branchName {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !slices.Contains(e.branches, branchName) {
 		e.branches = append(e.branches, branchName)
 		e.branchNamesSet = nil // invalidate cache
 	}
@@ -1032,72 +1025,281 @@ func (e *engineImpl) GetBranchesNeedingPRBodyUpdate() []string {
 }
 
 // GetStackDescription returns the stack description for a branch's stack.
-// It first checks the stack root's metadata, then falls back to MergedDownstack history.
+// It reads from the stack ref using the branch's StackID.
+// Returns nil for untracked branches or if the stack has no description.
 func (e *engineImpl) GetStackDescription(branch Branch) *git.StackDescription {
-	// Find stack root
-	rootName := e.GetStackRootForBranch(branch)
-	if rootName == "" {
-		// Not on a tracked stack, check current branch's MergedDownstack
-		meta, err := e.git.ReadMetadata(branch.GetName())
-		if err != nil {
-			return nil
-		}
-		return findDescriptionInHistory(meta.MergedDownstack)
-	}
-
-	// Check root's StackDescription
-	meta, err := e.git.ReadMetadata(rootName)
-	if err != nil || meta == nil {
+	stackID := e.GetStackID(branch)
+	if stackID == "" {
 		return nil
 	}
 
-	if meta.StackDescription != nil && !meta.StackDescription.IsEmpty() {
-		return meta.StackDescription
+	stackMeta, err := e.git.ReadStackMeta(stackID)
+	if err != nil || stackMeta == nil {
+		return nil
 	}
 
-	// Check MergedDownstack for historical description
-	return findDescriptionInHistory(meta.MergedDownstack)
+	return stackMeta.StackDescription()
 }
 
-// findDescriptionInHistory searches MergedDownstack for the most recent description.
-// This is used to preserve stack descriptions when root branches are deleted/merged,
-// since the description is captured in MergedDownstack history during reparenting.
-// MergedDownstack is ordered oldest to newest, so we iterate from end to find most recent.
-func findDescriptionInHistory(history []git.MergedParent) *git.StackDescription {
-	for i := len(history) - 1; i >= 0; i-- {
-		if history[i].StackDescription != nil && !history[i].StackDescription.IsEmpty() {
-			return history[i].StackDescription
+// SetStackDescription sets the stack description in the stack ref for a branch.
+// Creates stack metadata lazily if it doesn't exist.
+// Returns an error if the branch is not tracked.
+func (e *engineImpl) SetStackDescription(ctx context.Context, branch Branch, desc *git.StackDescription) error {
+	if !e.IsTracked(branch) {
+		return fmt.Errorf("branch %s is not tracked", branch.GetName())
+	}
+
+	// Ensure stack ID exists (creates lazily if needed)
+	stackID, err := e.EnsureStackID(ctx, branch)
+	if err != nil {
+		return fmt.Errorf("failed to ensure stack ID: %w", err)
+	}
+
+	// Read existing stack meta or create new one
+	stackMeta, err := e.git.ReadStackMeta(stackID)
+	if err != nil {
+		return fmt.Errorf("failed to read stack metadata for %s: %w", stackID, err)
+	}
+
+	if stackMeta == nil {
+		stackMeta = &git.StackMeta{
+			ID:        stackID,
+			CreatedAt: timeNow(),
 		}
 	}
-	return nil
-}
 
-// SetStackDescription sets the stack description on the stack root for a branch.
-// Returns an error if the branch is not part of a tracked stack.
-func (e *engineImpl) SetStackDescription(_ context.Context, branch Branch, desc *git.StackDescription) error {
-	rootName := e.GetStackRootForBranch(branch)
-	if rootName == "" {
-		return fmt.Errorf("branch %s is not part of a tracked stack", branch.GetName())
+	// Update title and description
+	if desc != nil {
+		stackMeta.Title = desc.Title
+		stackMeta.Description = desc.Description
+	} else {
+		stackMeta.Title = ""
+		stackMeta.Description = ""
 	}
 
-	meta, err := e.git.ReadMetadata(rootName)
-	if err != nil {
-		return fmt.Errorf("failed to read metadata for %s: %w", rootName, err)
-	}
-	if meta == nil {
-		meta = &git.Meta{}
-	}
-
-	meta.StackDescription = desc
-
-	if err := e.git.WriteMetadata(rootName, meta); err != nil {
-		return fmt.Errorf("failed to write metadata for %s: %w", rootName, err)
+	if err := e.git.WriteStackMeta(stackID, stackMeta); err != nil {
+		return fmt.Errorf("failed to write stack metadata for %s: %w", stackID, err)
 	}
 
 	return nil
 }
 
-// ClearStackDescription removes the stack description from the stack root.
+// ClearStackDescription removes the stack description from the stack ref.
 func (e *engineImpl) ClearStackDescription(ctx context.Context, branch Branch) error {
 	return e.SetStackDescription(ctx, branch, nil)
+}
+
+// GenerateStackID creates a new stack ID for a new stack.
+// Format: {timestamp-nanos}-{sanitized-root-branch}
+func (e *engineImpl) GenerateStackID(rootBranch string) string {
+	timestamp := timeNow().UnixNano()
+	sanitized := sanitizeBranchNameForStackID(rootBranch)
+	return fmt.Sprintf("%d-%s", timestamp, sanitized)
+}
+
+// sanitizeBranchNameForStackID converts a branch name into a safe suffix for stack IDs.
+// Only allows alphanumeric characters and hyphens to ensure cross-platform compatibility
+// with Git ref names. Limited to 50 chars to keep ref names reasonable and avoid
+// filesystem path length issues on Windows.
+func sanitizeBranchNameForStackID(branchName string) string {
+	// Single-pass: replace unsafe chars with hyphens and collapse consecutive hyphens
+	var b strings.Builder
+	b.Grow(len(branchName))
+	prevHyphen := true // Start true to skip leading hyphens
+
+	for _, r := range branchName {
+		isAlphaNum := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+		if isAlphaNum {
+			b.WriteRune(r)
+			prevHyphen = false
+		} else if !prevHyphen {
+			b.WriteRune('-')
+			prevHyphen = true
+		}
+	}
+
+	result := b.String()
+
+	// Limit length first, then trim trailing hyphen once
+	if len(result) > 50 {
+		result = result[:50]
+	}
+	result = strings.TrimSuffix(result, "-")
+
+	// Fallback for empty result (branch name was all special chars)
+	if result == "" {
+		result = "stack"
+	}
+
+	return result
+}
+
+// GetStackID returns the stack ID for a branch.
+// Returns empty string for untracked branches or trunk.
+// For legacy branches without StackID, derives it from the stack root.
+func (e *engineImpl) GetStackID(branch Branch) string {
+	branchName := branch.GetName()
+
+	// Trunk has no stack ID
+	if branchName == e.trunk {
+		return ""
+	}
+
+	// Check if branch is tracked
+	if !e.IsTracked(branch) {
+		return ""
+	}
+
+	// Read branch metadata
+	meta, err := e.git.ReadMetadata(branchName)
+	if err != nil {
+		return ""
+	}
+
+	// Return explicit StackID if present
+	if meta.StackID != nil && *meta.StackID != "" {
+		return *meta.StackID
+	}
+
+	// Legacy fallback: derive stack ID from stack root
+	rootName := e.GetStackRootForBranch(branch)
+	if rootName == "" {
+		return ""
+	}
+
+	rootMeta, err := e.git.ReadMetadata(rootName)
+	if err != nil || rootMeta == nil || rootMeta.StackID == nil {
+		return ""
+	}
+
+	return *rootMeta.StackID
+}
+
+// EnsureStackID returns the stack ID for a branch, creating one if it doesn't exist.
+// This is used for lazy creation of stack metadata when setting descriptions or scopes.
+func (e *engineImpl) EnsureStackID(ctx context.Context, branch Branch) (string, error) {
+	// First check if stack ID already exists
+	existingID := e.GetStackID(branch)
+	if existingID != "" {
+		return existingID, nil
+	}
+
+	// Need to create a new stack ID
+	// Find the stack root to generate the ID
+	rootName := e.GetStackRootForBranch(branch)
+	if rootName == "" {
+		return "", fmt.Errorf("cannot determine stack root for branch %s", branch.GetName())
+	}
+
+	// Generate new stack ID based on the root branch
+	stackID := e.GenerateStackID(rootName)
+
+	// Create the stack metadata ref
+	stackMeta := &git.StackMeta{
+		ID:        stackID,
+		CreatedAt: timeNow(),
+	}
+
+	// Try to get user name for CreatedBy
+	if userName, err := e.git.GetUserName(ctx); err == nil {
+		stackMeta.CreatedBy = userName
+	}
+
+	if err := e.git.WriteStackMeta(stackID, stackMeta); err != nil {
+		return "", fmt.Errorf("failed to create stack ref: %w", err)
+	}
+
+	// Set the stack ID on all branches in the stack
+	if err := e.propagateStackID(ctx, rootName, stackID); err != nil {
+		return "", fmt.Errorf("failed to propagate stack ID: %w", err)
+	}
+
+	return stackID, nil
+}
+
+// propagateStackID sets the stack ID on a branch and all its descendants.
+func (e *engineImpl) propagateStackID(ctx context.Context, branchName string, stackID string) error {
+	branch := e.GetBranch(branchName)
+	if err := e.SetStackID(ctx, branch, stackID); err != nil {
+		return err
+	}
+
+	// Get children from the map
+	e.mu.RLock()
+	children := make([]string, len(e.childrenMap[branchName]))
+	copy(children, e.childrenMap[branchName])
+	e.mu.RUnlock()
+
+	// Recursively set on children
+	for _, childName := range children {
+		if err := e.propagateStackID(ctx, childName, stackID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// SetStackID sets the stack ID on a branch's metadata.
+func (e *engineImpl) SetStackID(ctx context.Context, branch Branch, stackID string) error {
+	branchName := branch.GetName()
+
+	return e.WithRetry(ctx, func() error {
+		meta, err := e.git.ReadMetadata(branchName)
+		if err != nil {
+			return fmt.Errorf("failed to read metadata: %w", err)
+		}
+		if meta == nil {
+			meta = &git.Meta{}
+		}
+
+		meta.StackID = &stackID
+
+		tx := e.BeginTx(fmt.Sprintf("set stack ID: %s -> %s", branchName, stackID))
+		if err := tx.UpdateMeta(branchName, meta); err != nil {
+			return err
+		}
+		return tx.Commit(ctx)
+	})
+}
+
+// CreateStackRef creates a new stack ref with the given metadata.
+func (e *engineImpl) CreateStackRef(stackID string, meta *git.StackMeta) error {
+	if meta == nil {
+		meta = &git.StackMeta{
+			ID:        stackID,
+			CreatedAt: timeNow(),
+		}
+	}
+	return e.git.WriteStackMeta(stackID, meta)
+}
+
+// GetStackMeta returns the stack metadata for a stack ID.
+func (e *engineImpl) GetStackMeta(stackID string) (*git.StackMeta, error) {
+	return e.git.ReadStackMeta(stackID)
+}
+
+// SyncStackIDFromParent updates a branch's stack ID to match its parent's.
+// This should be called after reparenting operations to keep stack IDs consistent.
+// Returns nil if the parent is trunk (keeps existing stack ID) or if no change is needed.
+func (e *engineImpl) SyncStackIDFromParent(ctx context.Context, branch Branch) error {
+	parent := branch.GetParent()
+	if parent == nil {
+		// Parent is trunk - keep existing stack ID
+		return nil
+	}
+
+	parentStackID := e.GetStackID(*parent)
+	if parentStackID == "" {
+		// Parent has no stack ID (legacy branch) - no action needed
+		return nil
+	}
+
+	currentStackID := e.GetStackID(branch)
+	if currentStackID == parentStackID {
+		// Already in sync - no change needed
+		return nil
+	}
+
+	return e.SetStackID(ctx, branch, parentStackID)
 }

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -135,13 +135,34 @@ type BranchTracking interface {
 	GetBranchesNeedingPRBodyUpdate() []string
 
 	// GetStackDescription returns the stack description for a branch's stack.
-	// It first checks the stack root's metadata, then falls back to MergedDownstack history.
+	// It first checks the stack ref, then falls back to legacy branch metadata.
 	GetStackDescription(branch Branch) *git.StackDescription
-	// SetStackDescription sets the stack description on the stack root for a branch.
+	// SetStackDescription sets the stack description in the stack ref for a branch.
 	// Returns an error if the branch is not part of a tracked stack.
 	SetStackDescription(ctx context.Context, branch Branch, desc *git.StackDescription) error
-	// ClearStackDescription removes the stack description from the stack root.
+	// ClearStackDescription removes the stack description from the stack ref.
 	ClearStackDescription(ctx context.Context, branch Branch) error
+
+	// GenerateStackID creates a new stack ID for a new stack.
+	// Format: {timestamp-nanos}-{sanitized-root-branch}
+	GenerateStackID(rootBranch string) string
+	// GetStackID returns the stack ID for a branch.
+	// Returns empty string for untracked branches or trunk.
+	// For legacy branches without StackID, derives it from the stack root.
+	GetStackID(branch Branch) string
+	// EnsureStackID returns the stack ID for a branch, creating one if it doesn't exist.
+	// This is used for lazy creation of stack metadata when setting descriptions or scopes.
+	EnsureStackID(ctx context.Context, branch Branch) (string, error)
+	// SetStackID sets the stack ID on a branch's metadata.
+	SetStackID(ctx context.Context, branch Branch, stackID string) error
+	// CreateStackRef creates a new stack ref with the given metadata.
+	CreateStackRef(stackID string, meta *git.StackMeta) error
+	// GetStackMeta returns the stack metadata for a stack ID.
+	GetStackMeta(stackID string) (*git.StackMeta, error)
+	// SyncStackIDFromParent updates a branch's stack ID to match its parent's.
+	// This should be called after reparenting operations to keep stack IDs consistent.
+	// Returns nil if the parent is trunk (keeps existing stack ID) or if no change is needed.
+	SyncStackIDFromParent(ctx context.Context, branch Branch) error
 }
 
 // BranchMutations handles branch lifecycle operations

--- a/internal/engine/remote_sync.go
+++ b/internal/engine/remote_sync.go
@@ -466,3 +466,20 @@ func (e *engineImpl) ConfigureRemoteMetadataSync(ctx context.Context) error {
 	_, err := e.git.RunGitCommandWithContext(ctx, "config", "--add", "remote.origin.fetch", "+refs/stackit/metadata/*:refs/stackit/remote-metadata/*")
 	return err
 }
+
+// GetStackIDsForBranches returns the unique stack IDs for the given branches.
+// This is used to determine which stack refs need to be pushed to remote.
+func (e *engineImpl) GetStackIDsForBranches(branches []Branch) []string {
+	seen := make(map[string]bool)
+	var stackIDs []string
+
+	for _, branch := range branches {
+		stackID := e.GetStackID(branch)
+		if stackID != "" && !seen[stackID] {
+			seen[stackID] = true
+			stackIDs = append(stackIDs, stackID)
+		}
+	}
+
+	return stackIDs
+}

--- a/internal/engine/sanitize_branch_name_test.go
+++ b/internal/engine/sanitize_branch_name_test.go
@@ -1,0 +1,67 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeBranchNameForStackID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "slashes replaced with hyphens",
+			input:    "feature/with/slashes",
+			expected: "feature-with-slashes",
+		},
+		{
+			name:     "consecutive hyphens collapsed",
+			input:    "a--b",
+			expected: "a-b",
+		},
+		{
+			name:     "leading and trailing hyphens trimmed",
+			input:    "-a-",
+			expected: "a",
+		},
+		{
+			name:     "special characters replaced with hyphen",
+			input:    "a!@#b",
+			expected: "a-b",
+		},
+		{
+			name:     "length truncated to 50 chars",
+			input:    strings.Repeat("a", 60),
+			expected: strings.Repeat("a", 50),
+		},
+		{
+			name:     "all special chars results in fallback",
+			input:    "///",
+			expected: "stack",
+		},
+		{
+			name:     "empty string returns fallback",
+			input:    "",
+			expected: "stack",
+		},
+		{
+			name:     "truncation removes trailing hyphen",
+			input:    strings.Repeat("a", 49) + "-b",
+			expected: strings.Repeat("a", 49),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := sanitizeBranchNameForStackID(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/engine/stack_description_test.go
+++ b/internal/engine/stack_description_test.go
@@ -147,7 +147,7 @@ func TestSetStackDescription(t *testing.T) {
 			Title: "Test",
 		})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "not part of a tracked stack")
+		require.Contains(t, err.Error(), "not tracked")
 	})
 }
 

--- a/internal/engine/stack_id_test.go
+++ b/internal/engine/stack_id_test.go
@@ -1,0 +1,367 @@
+package engine_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"stackit.dev/stackit/internal/git"
+	"stackit.dev/stackit/testhelpers"
+	"stackit.dev/stackit/testhelpers/scenario"
+)
+
+func TestGenerateStackID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("generates sortable ID with timestamp prefix", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+
+		id1 := s.Engine.GenerateStackID("feature")
+		id2 := s.Engine.GenerateStackID("another")
+
+		// IDs should be different
+		require.NotEqual(t, id1, id2)
+
+		// Both should contain a timestamp (large number prefix)
+		require.True(t, strings.Contains(id1, "-feature"))
+		require.True(t, strings.Contains(id2, "-another"))
+	})
+
+	t.Run("sanitizes branch name in ID", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+
+		id := s.Engine.GenerateStackID("feature/with/slashes")
+
+		// Slashes should be replaced with hyphens
+		require.NotContains(t, id, "/")
+		require.Contains(t, id, "feature-with-slashes")
+	})
+}
+
+func TestGetStackID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns empty for trunk", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+
+		trunk := s.Engine.Trunk()
+		stackID := s.Engine.GetStackID(trunk)
+		require.Empty(t, stackID)
+	})
+
+	t.Run("returns empty for untracked branch", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit().
+			CreateBranch("untracked").
+			Commit("untracked commit")
+
+		branch := s.Engine.GetBranch("untracked")
+		stackID := s.Engine.GetStackID(branch)
+		require.Empty(t, stackID)
+	})
+
+	t.Run("returns empty for tracked branch without explicit stack ID", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit().
+			CreateBranch("feature").
+			Commit("feature commit").
+			TrackBranch("feature", "main")
+
+		branch := s.Engine.GetBranch("feature")
+		// Stack IDs are not auto-created during TrackBranch
+		stackID := s.Engine.GetStackID(branch)
+		require.Empty(t, stackID)
+	})
+
+	t.Run("returns stack ID after EnsureStackID", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit().
+			CreateBranch("feature").
+			Commit("feature commit").
+			TrackBranch("feature", "main")
+
+		branch := s.Engine.GetBranch("feature")
+		stackID, err := s.Engine.EnsureStackID(context.Background(), branch)
+		require.NoError(t, err)
+		require.NotEmpty(t, stackID)
+		require.Contains(t, stackID, "feature")
+
+		// GetStackID should now return the same ID
+		readID := s.Engine.GetStackID(branch)
+		require.Equal(t, stackID, readID)
+	})
+
+	t.Run("child inherits parent stack ID after EnsureStackID", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit().
+			CreateBranch("root").
+			Commit("root commit").
+			TrackBranch("root", "main").
+			CreateBranch("child").
+			Commit("child commit").
+			TrackBranch("child", "root")
+
+		rootBranch := s.Engine.GetBranch("root")
+		childBranch := s.Engine.GetBranch("child")
+
+		// Ensure stack ID from child - should propagate to all branches in stack
+		childStackID, err := s.Engine.EnsureStackID(context.Background(), childBranch)
+		require.NoError(t, err)
+
+		rootStackID := s.Engine.GetStackID(rootBranch)
+
+		require.NotEmpty(t, rootStackID)
+		require.Equal(t, rootStackID, childStackID)
+	})
+}
+
+func TestSetStackID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sets stack ID on branch", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit().
+			CreateBranch("feature").
+			Commit("feature commit").
+			TrackBranch("feature", "main")
+
+		branch := s.Engine.GetBranch("feature")
+		newStackID := "new-stack-id"
+
+		err := s.Engine.SetStackID(context.Background(), branch, newStackID)
+		require.NoError(t, err)
+
+		// Verify it was set
+		readStackID := s.Engine.GetStackID(branch)
+		require.Equal(t, newStackID, readStackID)
+	})
+}
+
+func TestStackIDInheritance(t *testing.T) {
+	t.Parallel()
+
+	t.Run("multiple children inherit same stack ID after EnsureStackID", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit().
+			CreateBranch("root").
+			Commit("root commit").
+			TrackBranch("root", "main").
+			Checkout("root").
+			CreateBranch("child1").
+			Commit("child1 commit").
+			TrackBranch("child1", "root").
+			Checkout("root").
+			CreateBranch("child2").
+			Commit("child2 commit").
+			TrackBranch("child2", "root")
+
+		root := s.Engine.GetBranch("root")
+		child1 := s.Engine.GetBranch("child1")
+		child2 := s.Engine.GetBranch("child2")
+
+		// EnsureStackID from any branch propagates to whole stack
+		rootID, err := s.Engine.EnsureStackID(context.Background(), root)
+		require.NoError(t, err)
+
+		child1ID := s.Engine.GetStackID(child1)
+		child2ID := s.Engine.GetStackID(child2)
+
+		require.NotEmpty(t, rootID)
+		require.Equal(t, rootID, child1ID)
+		require.Equal(t, rootID, child2ID)
+	})
+
+	t.Run("grandchildren inherit same stack ID after EnsureStackID", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit().
+			CreateBranch("root").
+			Commit("root commit").
+			TrackBranch("root", "main").
+			CreateBranch("child").
+			Commit("child commit").
+			TrackBranch("child", "root").
+			CreateBranch("grandchild").
+			Commit("grandchild commit").
+			TrackBranch("grandchild", "child")
+
+		root := s.Engine.GetBranch("root")
+		grandchild := s.Engine.GetBranch("grandchild")
+
+		// EnsureStackID from grandchild propagates to all ancestors and descendants
+		grandchildID, err := s.Engine.EnsureStackID(context.Background(), grandchild)
+		require.NoError(t, err)
+
+		rootID := s.Engine.GetStackID(root)
+
+		require.NotEmpty(t, rootID)
+		require.Equal(t, rootID, grandchildID)
+	})
+
+	t.Run("separate stacks have different IDs after EnsureStackID", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit().
+			CreateBranch("stack1").
+			Commit("stack1 commit").
+			TrackBranch("stack1", "main").
+			Checkout("main").
+			CreateBranch("stack2").
+			Commit("stack2 commit").
+			TrackBranch("stack2", "main")
+
+		stack1 := s.Engine.GetBranch("stack1")
+		stack2 := s.Engine.GetBranch("stack2")
+
+		id1, err := s.Engine.EnsureStackID(context.Background(), stack1)
+		require.NoError(t, err)
+		id2, err := s.Engine.EnsureStackID(context.Background(), stack2)
+		require.NoError(t, err)
+
+		require.NotEmpty(t, id1)
+		require.NotEmpty(t, id2)
+		require.NotEqual(t, id1, id2)
+	})
+}
+
+func TestCreateStackRef(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates stack ref with provided metadata", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+
+		stackID := "test-stack-id"
+		createdAt := time.Now().Truncate(time.Second)
+		meta := &git.StackMeta{
+			ID:          stackID,
+			Title:       "Test Stack",
+			Description: "A test stack description",
+			CreatedAt:   createdAt,
+			CreatedBy:   "test-user",
+		}
+
+		err := s.Engine.CreateStackRef(stackID, meta)
+		require.NoError(t, err)
+
+		// Verify GetStackMeta returns the correct metadata
+		retrieved, err := s.Engine.GetStackMeta(stackID)
+		require.NoError(t, err)
+		require.NotNil(t, retrieved)
+		require.Equal(t, stackID, retrieved.ID)
+		require.Equal(t, "Test Stack", retrieved.Title)
+		require.Equal(t, "A test stack description", retrieved.Description)
+		require.Equal(t, createdAt, retrieved.CreatedAt)
+		require.Equal(t, "test-user", retrieved.CreatedBy)
+	})
+
+	t.Run("creates stack ref with nil metadata using defaults", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+
+		stackID := "default-meta-stack"
+
+		err := s.Engine.CreateStackRef(stackID, nil)
+		require.NoError(t, err)
+
+		// Verify GetStackMeta returns metadata with defaults
+		retrieved, err := s.Engine.GetStackMeta(stackID)
+		require.NoError(t, err)
+		require.NotNil(t, retrieved)
+		require.Equal(t, stackID, retrieved.ID)
+		require.False(t, retrieved.CreatedAt.IsZero())
+	})
+}
+
+func TestGetStackMeta(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil for non-existent stack ID", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+
+		meta, err := s.Engine.GetStackMeta("non-existent-stack-id")
+		require.NoError(t, err)
+		require.Nil(t, meta)
+	})
+
+	t.Run("returns correct metadata for existing stack", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+
+		stackID := "existing-stack"
+		createdAt := time.Now().Truncate(time.Second)
+		meta := &git.StackMeta{
+			ID:          stackID,
+			Title:       "Existing Stack",
+			Description: "This stack exists",
+			CreatedAt:   createdAt,
+			CreatedBy:   "author",
+		}
+
+		err := s.Engine.CreateStackRef(stackID, meta)
+		require.NoError(t, err)
+
+		// Retrieve and verify
+		retrieved, err := s.Engine.GetStackMeta(stackID)
+		require.NoError(t, err)
+		require.NotNil(t, retrieved)
+		require.Equal(t, stackID, retrieved.ID)
+		require.Equal(t, "Existing Stack", retrieved.Title)
+		require.Equal(t, "This stack exists", retrieved.Description)
+		require.Equal(t, createdAt, retrieved.CreatedAt)
+		require.Equal(t, "author", retrieved.CreatedBy)
+	})
+
+	t.Run("returns different metadata for different stacks", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+
+		stack1ID := "stack-1"
+		stack2ID := "stack-2"
+
+		meta1 := &git.StackMeta{
+			ID:        stack1ID,
+			Title:     "Stack One",
+			CreatedAt: time.Now().Truncate(time.Second),
+		}
+		meta2 := &git.StackMeta{
+			ID:        stack2ID,
+			Title:     "Stack Two",
+			CreatedAt: time.Now().Truncate(time.Second),
+		}
+
+		err := s.Engine.CreateStackRef(stack1ID, meta1)
+		require.NoError(t, err)
+		err = s.Engine.CreateStackRef(stack2ID, meta2)
+		require.NoError(t, err)
+
+		retrieved1, err := s.Engine.GetStackMeta(stack1ID)
+		require.NoError(t, err)
+		require.Equal(t, "Stack One", retrieved1.Title)
+
+		retrieved2, err := s.Engine.GetStackMeta(stack2ID)
+		require.NoError(t, err)
+		require.Equal(t, "Stack Two", retrieved2.Title)
+	})
+}

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -27,6 +27,7 @@ type RepositoryWriter interface {
 	SetConfig(key, value string) error
 	AddConfigValue(key, value string) error
 	EnsureMetadataRefspecConfigured() error
+	EnsureStackMetaRefspecConfigured() error
 }
 
 // RemoteOperations handles interaction with remote repositories.
@@ -43,6 +44,9 @@ type RemoteOperations interface {
 	DeleteRemoteMetadataRef(ctx context.Context, branch string) error
 	BatchDeleteRemoteMetadataRefs(ctx context.Context, branches []string) error
 	TestRemoteRefCompatibility() error
+	PushStackMetaRefs(ctx context.Context, stackIDs []string) error
+	FetchStackMetaRefs(ctx context.Context) error
+	DeleteRemoteStackMetaRefs(ctx context.Context, stackIDs []string) error
 }
 
 // BranchReader provides read access to branch information.
@@ -244,4 +248,17 @@ type MetadataOperations interface {
 	WriteLocalMetadataBlob(meta *LocalMeta) (string, error)
 	GetMetadataRefSHA(branchName string) string
 	GetLocalMetadataRefSHA(branchName string) string
+}
+
+// StackMetadataOperations handles stack-level metadata persistence.
+// Stack metadata is stored separately from branch metadata and survives branch operations.
+type StackMetadataOperations interface {
+	ReadStackMeta(stackID string) (*StackMeta, error)
+	WriteStackMeta(stackID string, meta *StackMeta) error
+	DeleteStackMeta(stackID string) error
+	ListStackMetas() (map[string]string, error)
+
+	// Transaction support methods
+	WriteStackMetaBlob(meta *StackMeta) (string, error)
+	GetStackMetaRefSHA(stackID string) string
 }

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -55,8 +55,9 @@ type Meta struct {
 	// due to merge/deletion. Ordered oldest to newest, limited to 5 entries max.
 	MergedDownstack []MergedParent `json:"mergedDownstack,omitempty"`
 
-	// StackDescription holds stack-level title and description (stored on root branch only)
-	StackDescription *StackDescription `json:"stackDescription,omitempty"`
+	// StackID links this branch to a stack ref (refs/stackit/stacks/{stack-id}).
+	// Generated when creating a new stack off trunk, inherited when creating off tracked branch.
+	StackID *string `json:"stackId,omitempty"`
 }
 
 // StackDescription holds stack-level title and description.
@@ -73,10 +74,9 @@ func (sd *StackDescription) IsEmpty() bool {
 
 // MergedParent represents a historical parent that was merged or deleted
 type MergedParent struct {
-	BranchName       string            `json:"branchName"`
-	PRNumber         *int              `json:"prNumber,omitempty"`
-	PRState          *string           `json:"prState,omitempty"`          // "MERGED", "CLOSED"
-	StackDescription *StackDescription `json:"stackDescription,omitempty"` // Captured from deleted root
+	BranchName string  `json:"branchName"`
+	PRNumber   *int    `json:"prNumber,omitempty"`
+	PRState    *string `json:"prState,omitempty"` // "MERGED", "CLOSED"
 }
 
 // LocalMeta represents branch metadata that is strictly local and never pushed

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -355,6 +355,7 @@ type Runner interface {
 	RefOperations
 	ObjectOperations
 	MetadataOperations
+	StackMetadataOperations
 
 	// Raw command execution
 	RunGitCommandWithContext(ctx context.Context, args ...string) (string, error)
@@ -544,6 +545,25 @@ func (r *runner) EnsureMetadataRefspecConfigured() error {
 
 	// Add refspec for metadata refs
 	return r.AddConfigValue("remote.origin.fetch", metadataRefspec)
+}
+
+func (r *runner) EnsureStackMetaRefspecConfigured() error {
+	const stackMetaRefspec = "+refs/stackit/stacks/*:refs/stackit/remote-stacks/*"
+
+	refspecs, err := r.GetConfigAll("remote.origin.fetch")
+	if err != nil {
+		return fmt.Errorf("failed to get fetch refspecs: %w", err)
+	}
+
+	// Check if already configured
+	for _, rs := range refspecs {
+		if rs == stackMetaRefspec {
+			return nil // Already configured
+		}
+	}
+
+	// Add refspec for stack metadata refs
+	return r.AddConfigValue("remote.origin.fetch", stackMetaRefspec)
 }
 
 func (r *runner) FindRemoteBranch(ctx context.Context, remote string) (string, error) {
@@ -926,6 +946,40 @@ func (r *runner) PushMetadataRefs(ctx context.Context, branches []string) error 
 func (r *runner) FetchMetadataRefs(ctx context.Context) error {
 	// git fetch origin 'refs/stackit/metadata/*:refs/stackit/remote-metadata/*'
 	_, err := r.RunGitCommandWithContext(ctx, "fetch", "origin", "+refs/stackit/metadata/*:refs/stackit/remote-metadata/*")
+	return err
+}
+
+func (r *runner) PushStackMetaRefs(ctx context.Context, stackIDs []string) error {
+	if len(stackIDs) == 0 {
+		return nil
+	}
+	// git push origin +refs/stackit/stacks/id1 +refs/stackit/stacks/id2 ...
+	// We use the '+' prefix to force the push because stack metadata refs point to blobs,
+	// and updates to non-commit objects are always considered non-fast-forward by Git.
+	args := []string{"push", "origin"}
+	for _, stackID := range stackIDs {
+		args = append(args, fmt.Sprintf("+refs/stackit/stacks/%s", stackID))
+	}
+	_, err := r.RunGitCommandWithContext(ctx, args...)
+	return err
+}
+
+func (r *runner) FetchStackMetaRefs(ctx context.Context) error {
+	// git fetch origin 'refs/stackit/stacks/*:refs/stackit/remote-stacks/*'
+	_, err := r.RunGitCommandWithContext(ctx, "fetch", "origin", "+refs/stackit/stacks/*:refs/stackit/remote-stacks/*")
+	return err
+}
+
+func (r *runner) DeleteRemoteStackMetaRefs(ctx context.Context, stackIDs []string) error {
+	if len(stackIDs) == 0 {
+		return nil
+	}
+	// git push origin --delete refs/stackit/stacks/id1 refs/stackit/stacks/id2 ...
+	args := []string{"push", "origin", "--delete"}
+	for _, stackID := range stackIDs {
+		args = append(args, fmt.Sprintf("refs/stackit/stacks/%s", stackID))
+	}
+	_, err := r.RunGitCommandWithContext(ctx, args...)
 	return err
 }
 

--- a/internal/git/stack_metadata.go
+++ b/internal/git/stack_metadata.go
@@ -1,0 +1,153 @@
+package git
+
+// Stack metadata is stored in Git refs at refs/stackit/stacks/{stack-id}.
+// This is separate from branch metadata (refs/stackit/metadata/{branch})
+// and survives branch operations like merging the root branch.
+//
+// Ref namespaces used by stackit:
+//   - refs/stackit/metadata/     - Per-branch metadata (parent, PR info, etc.)
+//   - refs/stackit/local-metadata/ - Local-only branch metadata (never pushed)
+//   - refs/stackit/stacks/       - Stack-level metadata (title, description, etc.)
+//   - refs/stackit/remote-stacks/ - Fetched remote stack metadata
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// StackMeta represents stack-level metadata stored in Git refs.
+// This is separate from branch metadata (Meta) and survives branch operations
+// like merging the root branch.
+type StackMeta struct {
+	ID          string    `json:"id"`                    // Matches ref name (timestamp-sanitized-root)
+	Title       string    `json:"title,omitempty"`       // Stack title
+	Description string    `json:"description,omitempty"` // Stack description
+	CreatedAt   time.Time `json:"createdAt"`             // When stack was created
+	CreatedBy   string    `json:"createdBy,omitempty"`   // Who created the stack (git user)
+}
+
+// StackDescription returns a StackDescription from the StackMeta fields.
+// This provides compatibility with the existing StackDescription type.
+func (sm *StackMeta) StackDescription() *StackDescription {
+	if sm == nil || (sm.Title == "" && sm.Description == "") {
+		return nil
+	}
+	return &StackDescription{
+		Title:       sm.Title,
+		Description: sm.Description,
+	}
+}
+
+// IsEmpty returns true if both title and description are empty.
+func (sm *StackMeta) IsEmpty() bool {
+	return sm.StackDescription() == nil
+}
+
+const (
+	// StackMetaRefPrefix is the prefix for Git refs where stack metadata is stored
+	StackMetaRefPrefix = "refs/stackit/stacks/"
+	// RemoteStackMetaRefPrefix is the prefix for remote stack metadata refs (fetched from remote)
+	RemoteStackMetaRefPrefix = "refs/stackit/remote-stacks/"
+)
+
+// ReadStackMeta reads stack metadata for a given stack ID.
+// Returns nil with no error if the stack doesn't exist.
+func (r *runner) ReadStackMeta(stackID string) (*StackMeta, error) {
+	refName := StackMetaRefName(stackID)
+
+	sha, err := r.GetRef(refName)
+	if err != nil {
+		// If ref doesn't exist, it's not an error, just means no metadata
+		return nil, nil //nolint:nilerr
+	}
+
+	content, err := r.ReadBlob(sha)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read stack metadata blob %s: %w", sha, err)
+	}
+
+	if content == "" {
+		return nil, nil
+	}
+
+	var meta StackMeta
+	if err := json.Unmarshal([]byte(content), &meta); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal stack metadata for %s: %w", stackID, err)
+	}
+
+	return &meta, nil
+}
+
+// WriteStackMeta writes stack metadata for a given stack ID.
+func (r *runner) WriteStackMeta(stackID string, meta *StackMeta) error {
+	jsonData, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("failed to marshal stack metadata: %w", err)
+	}
+
+	sha, err := r.CreateBlob(string(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create stack metadata blob: %w", err)
+	}
+
+	if err := r.UpdateRef(StackMetaRefName(stackID), sha); err != nil {
+		return fmt.Errorf("failed to write stack metadata ref: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteStackMeta deletes stack metadata for a given stack ID.
+func (r *runner) DeleteStackMeta(stackID string) error {
+	return r.DeleteRef(StackMetaRefName(stackID))
+}
+
+// ListStackMetas returns a map of stack IDs to their ref SHAs.
+func (r *runner) ListStackMetas() (map[string]string, error) {
+	refs, err := r.ListRefs(StackMetaRefPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove prefix from stack IDs
+	result := make(map[string]string)
+	for refName, sha := range refs {
+		stackID := strings.TrimPrefix(refName, StackMetaRefPrefix)
+		result[stackID] = sha
+	}
+	return result, nil
+}
+
+// WriteStackMetaBlob creates a blob containing the stack metadata JSON and returns its SHA.
+// This does NOT update any refs - use this for batched/transactional writes.
+func (r *runner) WriteStackMetaBlob(meta *StackMeta) (string, error) {
+	jsonData, err := json.Marshal(meta)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal stack metadata: %w", err)
+	}
+
+	sha, err := r.CreateBlob(string(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("failed to create stack metadata blob: %w", err)
+	}
+
+	return sha, nil
+}
+
+// GetStackMetaRefSHA returns the current SHA of a stack metadata ref, or empty string if not found.
+func (r *runner) GetStackMetaRefSHA(stackID string) string {
+	sha, err := r.GetRef(StackMetaRefName(stackID))
+	if err != nil {
+		return ""
+	}
+	return sha
+}
+
+// StackMetaRefName returns the full ref name for a stack's metadata.
+// Use this helper instead of concatenating StackMetaRefPrefix directly
+// to ensure consistent ref name construction across all stack metadata operations.
+func StackMetaRefName(stackID string) string {
+	return StackMetaRefPrefix + stackID
+}

--- a/internal/git/stack_metadata_test.go
+++ b/internal/git/stack_metadata_test.go
@@ -1,0 +1,302 @@
+package git_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"stackit.dev/stackit/internal/git"
+	"stackit.dev/stackit/testhelpers"
+)
+
+func TestStackMetaOperations(t *testing.T) {
+	t.Parallel()
+
+	t.Run("read returns nil for non-existent stack", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		runner := git.NewRunnerWithPath(scene.Dir, nil)
+
+		meta, err := runner.ReadStackMeta("nonexistent-stack-id")
+		require.NoError(t, err)
+		require.Nil(t, meta)
+	})
+
+	t.Run("write and read stack metadata", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		runner := git.NewRunnerWithPath(scene.Dir, nil)
+
+		stackID := "1234567890-test-stack"
+		meta := &git.StackMeta{
+			ID:          stackID,
+			Title:       "Test Stack",
+			Description: "This is a test stack",
+			CreatedAt:   time.Now().Truncate(time.Second),
+			CreatedBy:   "test-user",
+		}
+
+		// Write
+		err := runner.WriteStackMeta(stackID, meta)
+		require.NoError(t, err)
+
+		// Read back
+		readMeta, err := runner.ReadStackMeta(stackID)
+		require.NoError(t, err)
+		require.NotNil(t, readMeta)
+		require.Equal(t, stackID, readMeta.ID)
+		require.Equal(t, "Test Stack", readMeta.Title)
+		require.Equal(t, "This is a test stack", readMeta.Description)
+		require.Equal(t, "test-user", readMeta.CreatedBy)
+	})
+
+	t.Run("delete stack metadata", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		runner := git.NewRunnerWithPath(scene.Dir, nil)
+
+		stackID := "delete-test-stack"
+		meta := &git.StackMeta{
+			ID:        stackID,
+			Title:     "To Be Deleted",
+			CreatedAt: time.Now(),
+		}
+
+		// Write
+		err := runner.WriteStackMeta(stackID, meta)
+		require.NoError(t, err)
+
+		// Delete
+		err = runner.DeleteStackMeta(stackID)
+		require.NoError(t, err)
+
+		// Verify deleted
+		readMeta, err := runner.ReadStackMeta(stackID)
+		require.NoError(t, err)
+		require.Nil(t, readMeta)
+	})
+
+	t.Run("list stack metadata", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		runner := git.NewRunnerWithPath(scene.Dir, nil)
+
+		// Write multiple stacks
+		stacks := []string{"stack-1", "stack-2", "stack-3"}
+		for _, stackID := range stacks {
+			meta := &git.StackMeta{
+				ID:        stackID,
+				CreatedAt: time.Now(),
+			}
+			err := runner.WriteStackMeta(stackID, meta)
+			require.NoError(t, err)
+		}
+
+		// List
+		list, err := runner.ListStackMetas()
+		require.NoError(t, err)
+		require.Len(t, list, 3)
+
+		for _, stackID := range stacks {
+			_, exists := list[stackID]
+			require.True(t, exists, "stack %s should exist in list", stackID)
+		}
+	})
+}
+
+func TestStackMeta_StackDescription(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil for empty stack meta", func(t *testing.T) {
+		t.Parallel()
+		meta := &git.StackMeta{}
+		desc := meta.StackDescription()
+		require.Nil(t, desc)
+	})
+
+	t.Run("returns nil for nil stack meta", func(t *testing.T) {
+		t.Parallel()
+		var meta *git.StackMeta
+		desc := meta.StackDescription()
+		require.Nil(t, desc)
+	})
+
+	t.Run("returns description with title", func(t *testing.T) {
+		t.Parallel()
+		meta := &git.StackMeta{
+			Title: "Test Title",
+		}
+		desc := meta.StackDescription()
+		require.NotNil(t, desc)
+		require.Equal(t, "Test Title", desc.Title)
+		require.Empty(t, desc.Description)
+	})
+
+	t.Run("returns description with both fields", func(t *testing.T) {
+		t.Parallel()
+		meta := &git.StackMeta{
+			Title:       "Test Title",
+			Description: "Test Description",
+		}
+		desc := meta.StackDescription()
+		require.NotNil(t, desc)
+		require.Equal(t, "Test Title", desc.Title)
+		require.Equal(t, "Test Description", desc.Description)
+	})
+}
+
+func TestStackMeta_IsEmpty(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		meta *git.StackMeta
+		want bool
+	}{
+		{
+			name: "nil is empty",
+			meta: nil,
+			want: true,
+		},
+		{
+			name: "zero value is empty",
+			meta: &git.StackMeta{},
+			want: true,
+		},
+		{
+			name: "only ID set (no title/description) is empty",
+			meta: &git.StackMeta{ID: "test"},
+			want: true,
+		},
+		{
+			name: "title makes it not empty",
+			meta: &git.StackMeta{Title: "Test"},
+			want: false,
+		},
+		{
+			name: "description makes it not empty",
+			meta: &git.StackMeta{Description: "Test"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.meta.IsEmpty()
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestWriteStackMetaBlob(t *testing.T) {
+	t.Parallel()
+
+	t.Run("write blob and use SHA to create valid stack meta ref", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		runner := git.NewRunnerWithPath(scene.Dir, nil)
+
+		stackID := "blob-test-stack"
+		meta := &git.StackMeta{
+			ID:          stackID,
+			Title:       "Blob Test Stack",
+			Description: "Testing WriteStackMetaBlob",
+			CreatedAt:   time.Now().Truncate(time.Second),
+			CreatedBy:   "test-user",
+		}
+
+		// Write blob (does not create ref)
+		sha, err := runner.WriteStackMetaBlob(meta)
+		require.NoError(t, err)
+		require.NotEmpty(t, sha)
+
+		// Verify no ref exists yet
+		existingSHA := runner.GetStackMetaRefSHA(stackID)
+		require.Empty(t, existingSHA)
+
+		// Use UpdateRef to create the stack meta ref
+		refName := git.StackMetaRefName(stackID)
+		err = runner.UpdateRef(refName, sha)
+		require.NoError(t, err)
+
+		// Verify we can read the metadata back
+		readMeta, err := runner.ReadStackMeta(stackID)
+		require.NoError(t, err)
+		require.NotNil(t, readMeta)
+		require.Equal(t, stackID, readMeta.ID)
+		require.Equal(t, "Blob Test Stack", readMeta.Title)
+		require.Equal(t, "Testing WriteStackMetaBlob", readMeta.Description)
+		require.Equal(t, "test-user", readMeta.CreatedBy)
+	})
+}
+
+func TestGetStackMetaRefSHA(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns SHA for existing stack", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		runner := git.NewRunnerWithPath(scene.Dir, nil)
+
+		stackID := "sha-test-stack"
+		meta := &git.StackMeta{
+			ID:        stackID,
+			Title:     "SHA Test Stack",
+			CreatedAt: time.Now(),
+		}
+
+		// Write stack meta
+		err := runner.WriteStackMeta(stackID, meta)
+		require.NoError(t, err)
+
+		// Get SHA
+		sha := runner.GetStackMetaRefSHA(stackID)
+		require.NotEmpty(t, sha)
+		require.Len(t, sha, 40) // Git SHAs are 40 hex characters
+	})
+
+	t.Run("returns empty string for non-existent stack", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		runner := git.NewRunnerWithPath(scene.Dir, nil)
+
+		sha := runner.GetStackMetaRefSHA("nonexistent-stack-id")
+		require.Empty(t, sha)
+	})
+}
+
+func TestStackMetaRefName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		stackID  string
+		expected string
+	}{
+		{
+			name:     "simple stack ID",
+			stackID:  "test-id",
+			expected: "refs/stackit/stacks/test-id",
+		},
+		{
+			name:     "stack ID with timestamp prefix",
+			stackID:  "1234567890-my-feature",
+			expected: "refs/stackit/stacks/1234567890-my-feature",
+		},
+		{
+			name:     "stack ID with special characters",
+			stackID:  "feature/add-login",
+			expected: "refs/stackit/stacks/feature/add-login",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := git.StackMetaRefName(tt.stackID)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -132,6 +132,13 @@ func (t *tracingRunner) EnsureMetadataRefspecConfigured() error {
 	return err
 }
 
+func (t *tracingRunner) EnsureStackMetaRefspecConfigured() error {
+	start := time.Now()
+	err := t.inner.EnsureStackMetaRefspecConfigured()
+	t.trace("EnsureStackMetaRefspecConfigured", time.Since(start), err == nil, err)
+	return err
+}
+
 // RemoteOperations methods
 
 func (t *tracingRunner) FetchRemoteShas(ctx context.Context, remote string) (map[string]string, error) {
@@ -194,6 +201,27 @@ func (t *tracingRunner) FetchMetadataRefs(ctx context.Context) error {
 	start := time.Now()
 	err := t.inner.FetchMetadataRefs(ctx)
 	t.trace("FetchMetadataRefs", time.Since(start), err == nil, err)
+	return err
+}
+
+func (t *tracingRunner) PushStackMetaRefs(ctx context.Context, stackIDs []string) error {
+	start := time.Now()
+	err := t.inner.PushStackMetaRefs(ctx, stackIDs)
+	t.trace("PushStackMetaRefs", time.Since(start), err == nil, err, slog.Int("count", len(stackIDs)))
+	return err
+}
+
+func (t *tracingRunner) FetchStackMetaRefs(ctx context.Context) error {
+	start := time.Now()
+	err := t.inner.FetchStackMetaRefs(ctx)
+	t.trace("FetchStackMetaRefs", time.Since(start), err == nil, err)
+	return err
+}
+
+func (t *tracingRunner) DeleteRemoteStackMetaRefs(ctx context.Context, stackIDs []string) error {
+	start := time.Now()
+	err := t.inner.DeleteRemoteStackMetaRefs(ctx, stackIDs)
+	t.trace("DeleteRemoteStackMetaRefs", time.Since(start), err == nil, err, slog.Int("count", len(stackIDs)))
 	return err
 }
 
@@ -1140,4 +1168,44 @@ func (t *tracingRunner) RunGHCommandWithContext(ctx context.Context, args ...str
 
 func (t *tracingRunner) SetLogger(logger DebugLogger) {
 	t.inner.SetLogger(logger)
+}
+
+// StackMetadataOperations methods
+
+func (t *tracingRunner) ReadStackMeta(stackID string) (*StackMeta, error) {
+	start := time.Now()
+	result, err := t.inner.ReadStackMeta(stackID)
+	t.trace("ReadStackMeta", time.Since(start), err == nil, err, slog.String("stackID", stackID))
+	return result, err
+}
+
+func (t *tracingRunner) WriteStackMeta(stackID string, meta *StackMeta) error {
+	start := time.Now()
+	err := t.inner.WriteStackMeta(stackID, meta)
+	t.trace("WriteStackMeta", time.Since(start), err == nil, err, slog.String("stackID", stackID))
+	return err
+}
+
+func (t *tracingRunner) DeleteStackMeta(stackID string) error {
+	// Don't trace - delegates to DeleteRef which is traced
+	return t.inner.DeleteStackMeta(stackID)
+}
+
+func (t *tracingRunner) ListStackMetas() (map[string]string, error) {
+	start := time.Now()
+	result, err := t.inner.ListStackMetas()
+	t.trace("ListStackMetas", time.Since(start), err == nil, err)
+	return result, err
+}
+
+func (t *tracingRunner) WriteStackMetaBlob(meta *StackMeta) (string, error) {
+	start := time.Now()
+	result, err := t.inner.WriteStackMetaBlob(meta)
+	t.trace("WriteStackMetaBlob", time.Since(start), err == nil, err)
+	return result, err
+}
+
+func (t *tracingRunner) GetStackMetaRefSHA(stackID string) string {
+	// Don't trace - this is just a ref lookup, very fast
+	return t.inner.GetStackMetaRefSHA(stackID)
 }

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -743,3 +743,86 @@ func (s *TestShell) SetPrMetadata(branch string, pr PRMetadata) *TestShell {
 
 	return s
 }
+
+// GetStackID returns the stack ID for a branch from its metadata.
+// Returns empty string if the branch has no stack ID.
+func (s *TestShell) GetStackID(branch string) string {
+	s.t.Helper()
+
+	// Read metadata
+	refName := "refs/stackit/metadata/" + branch
+	cmd := exec.Command("git", "show-ref", "-s", refName)
+	cmd.Dir = s.scene.Dir
+	shaOutput, err := cmd.Output()
+	if err != nil {
+		// No metadata ref exists
+		return ""
+	}
+
+	sha := strings.TrimSpace(string(shaOutput))
+	cmd = exec.Command("git", "cat-file", "-p", sha)
+	cmd.Dir = s.scene.Dir
+	blobOutput, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	var meta struct {
+		StackID *string `json:"stackId"`
+	}
+	if err := json.Unmarshal(blobOutput, &meta); err != nil {
+		return ""
+	}
+
+	if meta.StackID == nil {
+		return ""
+	}
+	return *meta.StackID
+}
+
+// ExpectStackID asserts a branch has the expected stack ID.
+func (s *TestShell) ExpectStackID(branch, expectedStackID string) *TestShell {
+	s.t.Helper()
+	actualStackID := s.GetStackID(branch)
+	require.Equal(s.t, expectedStackID, actualStackID,
+		"branch %s expected stack ID %q, got %q", branch, expectedStackID, actualStackID)
+	return s
+}
+
+// ExpectStackIDNotEmpty asserts a branch has a non-empty stack ID.
+func (s *TestShell) ExpectStackIDNotEmpty(branch string) *TestShell {
+	s.t.Helper()
+	actualStackID := s.GetStackID(branch)
+	require.NotEmpty(s.t, actualStackID, "branch %s expected to have a stack ID, but got empty", branch)
+	return s
+}
+
+// ExpectStackIDsMatch asserts that all given branches have the same stack ID.
+func (s *TestShell) ExpectStackIDsMatch(branches ...string) *TestShell {
+	s.t.Helper()
+	if len(branches) < 2 {
+		return s
+	}
+
+	firstStackID := s.GetStackID(branches[0])
+	require.NotEmpty(s.t, firstStackID, "branch %s has no stack ID", branches[0])
+
+	for _, branch := range branches[1:] {
+		stackID := s.GetStackID(branch)
+		require.Equal(s.t, firstStackID, stackID,
+			"branch %s has stack ID %q, expected %q (same as %s)",
+			branch, stackID, firstStackID, branches[0])
+	}
+	return s
+}
+
+// ExpectStackIDsDiffer asserts that two branches have different stack IDs.
+func (s *TestShell) ExpectStackIDsDiffer(branch1, branch2 string) *TestShell {
+	s.t.Helper()
+	stackID1 := s.GetStackID(branch1)
+	stackID2 := s.GetStackID(branch2)
+	require.NotEqual(s.t, stackID1, stackID2,
+		"branch %s and %s both have stack ID %q, expected different IDs",
+		branch1, branch2, stackID1)
+	return s
+}

--- a/internal/integration/move_stack_id_test.go
+++ b/internal/integration/move_stack_id_test.go
@@ -1,0 +1,200 @@
+package integration
+
+import (
+	"testing"
+)
+
+func TestMoveStackID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("moving branch to trunk creates new stack ID", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a stack: main -> a -> b -> c
+		sh.CreateLinearStack3()
+
+		// Set a description to trigger stack ID creation
+		sh.Run("describe -m 'First stack'")
+
+		// Capture original stack ID
+		originalStackID := sh.GetStackID("a")
+
+		// Move b onto main (trunk)
+		sh.Checkout("b")
+		sh.Run("move --onto main --no-interactive --yes")
+
+		// After moving to trunk, b gets a new stack ID when a description is set
+		// Set description to trigger new stack ID creation for b's new stack
+		sh.Run("describe -m 'Second stack'")
+
+		// Verify b now has a different stack ID (new stack created)
+		newStackID := sh.GetStackID("b")
+		if newStackID == "" {
+			t.Fatal("expected b to have a stack ID after moving to trunk and setting description")
+		}
+		if newStackID == originalStackID {
+			t.Fatalf("expected b to have a new stack ID after moving to trunk, but got same ID: %s", originalStackID)
+		}
+
+		// Verify c (descendant of b) also has the new stack ID
+		sh.ExpectStackID("c", newStackID)
+
+		// Verify a still has the original stack ID
+		sh.ExpectStackID("a", originalStackID)
+	})
+
+	t.Run("moving branch to different stack inherits that stack ID", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create first stack: main -> a -> b
+		sh.Write("a.txt", "content for a").
+			Run("create a -m 'Add a'").
+			Write("b.txt", "content for b").
+			Run("create b -m 'Add b'")
+
+		// Set a description to trigger stack ID creation
+		sh.Run("describe -m 'First stack'")
+
+		// Capture first stack's ID
+		firstStackID := sh.GetStackID("a")
+		sh.ExpectStackID("b", firstStackID) // b should share a's stack ID
+
+		// Create second stack: main -> x -> y
+		sh.Checkout("main").
+			Write("x.txt", "content for x").
+			Run("create x -m 'Add x'").
+			Write("y.txt", "content for y").
+			Run("create y -m 'Add y'")
+
+		// Set a description to trigger stack ID creation for second stack
+		sh.Run("describe -m 'Second stack'")
+
+		// Capture second stack's ID
+		secondStackID := sh.GetStackID("x")
+		sh.ExpectStackID("y", secondStackID) // y should share x's stack ID
+		sh.ExpectStackIDsDiffer("a", "x")    // Different stacks should have different IDs
+
+		// Move b onto x (from first stack to second stack)
+		sh.Checkout("b")
+		sh.Run("move --onto x --no-interactive --yes")
+
+		// Verify b now has the second stack's ID
+		sh.ExpectStackID("b", secondStackID)
+
+		// Verify a still has the first stack ID
+		sh.ExpectStackID("a", firstStackID)
+	})
+
+	t.Run("moving branch and descendants updates all stack IDs", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create first stack: main -> a -> b -> c -> d
+		sh.Write("a.txt", "content for a").
+			Run("create a -m 'Add a'").
+			Write("b.txt", "content for b").
+			Run("create b -m 'Add b'").
+			Write("c.txt", "content for c").
+			Run("create c -m 'Add c'").
+			Write("d.txt", "content for d").
+			Run("create d -m 'Add d'")
+
+		// Set a description to trigger stack ID creation
+		sh.Run("describe -m 'First stack'")
+
+		// Capture first stack's ID
+		firstStackID := sh.GetStackID("a")
+		sh.ExpectStackIDsMatch("a", "b", "c", "d")
+
+		// Create second stack: main -> x
+		sh.Checkout("main").
+			Write("x.txt", "content for x").
+			Run("create x -m 'Add x'")
+
+		// Set a description to trigger stack ID creation for second stack
+		sh.Run("describe -m 'Second stack'")
+
+		// Capture second stack's ID
+		secondStackID := sh.GetStackID("x")
+		sh.ExpectStackIDsDiffer("a", "x")
+
+		// Move b onto x (should also move c and d as descendants)
+		sh.Checkout("b")
+		sh.Run("move --onto x --no-interactive --yes")
+
+		// Verify b, c, d all now have the second stack's ID
+		sh.ExpectStackID("b", secondStackID)
+		sh.ExpectStackID("c", secondStackID)
+		sh.ExpectStackID("d", secondStackID)
+
+		// Verify a still has the first stack ID
+		sh.ExpectStackID("a", firstStackID)
+	})
+
+	t.Run("moving entire first-level branch to trunk creates new stack", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create stack: main -> a -> b -> c
+		sh.CreateLinearStack3()
+
+		// Set a description to trigger stack ID creation
+		sh.Run("describe -m 'First stack'")
+
+		// Capture original stack ID
+		originalStackID := sh.GetStackID("a")
+		sh.ExpectStackIDsMatch("a", "b", "c")
+
+		// Move a to... well, it's already on trunk, so let's create a different scenario
+		// Create: main -> x -> a -> b -> c by moving a onto x
+		sh.Checkout("main").
+			Write("x.txt", "content for x").
+			Run("create x -m 'Add x'")
+
+		// Set a description to trigger stack ID creation for x
+		sh.Run("describe -m 'Second stack'")
+
+		secondStackID := sh.GetStackID("x")
+
+		// Move a onto x
+		sh.Checkout("a")
+		sh.Run("move --onto x --no-interactive --yes")
+
+		// Verify a, b, c all now have the second stack's ID
+		sh.ExpectStackIDsMatch("a", "b", "c")
+		sh.ExpectStackID("a", secondStackID)
+
+		// Verify original stack ID is no longer used (a, b, c should all have new ID)
+		if sh.GetStackID("a") == originalStackID {
+			t.Fatal("expected a to have a new stack ID after moving to x")
+		}
+	})
+
+	t.Run("moving within same stack does not change stack ID", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create stack: main -> a -> b -> c
+		sh.CreateLinearStack3()
+
+		// Set a description to trigger stack ID creation
+		sh.Run("describe -m 'Test stack'")
+
+		// Capture original stack ID
+		originalStackID := sh.GetStackID("a")
+		sh.ExpectStackIDsMatch("a", "b", "c")
+
+		// Move c onto a (within the same stack)
+		sh.Checkout("c")
+		sh.Run("move --onto a --no-interactive --yes")
+
+		// Verify stack structure changed
+		sh.ExpectBranchParent("c", "a")
+
+		// Verify all branches still have the same stack ID
+		sh.ExpectStackIDsMatch("a", "b", "c")
+		sh.ExpectStackID("a", originalStackID)
+	})
+}

--- a/internal/integration/pluck_stack_id_test.go
+++ b/internal/integration/pluck_stack_id_test.go
@@ -1,0 +1,171 @@
+package integration
+
+import (
+	"testing"
+)
+
+func TestPluckStackID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("plucking branch to trunk creates new stack ID", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a stack: main -> a -> b -> c
+		sh.CreateLinearStack3()
+
+		// Set a description to trigger stack ID creation
+		sh.Run("describe -m 'First stack'")
+
+		// Capture original stack ID
+		originalStackID := sh.GetStackID("a")
+		sh.ExpectStackIDsMatch("a", "b", "c")
+
+		// Pluck b onto main (trunk) - unlike move, children stay with grandparent
+		sh.Checkout("b")
+		sh.Run("pluck --onto main --yes")
+
+		// Set description on b to trigger new stack ID creation
+		sh.Run("describe -m 'Second stack'")
+
+		// Verify b now has a different stack ID (new stack created)
+		newStackID := sh.GetStackID("b")
+		if newStackID == "" {
+			t.Fatal("expected b to have a stack ID after plucking to trunk and setting description")
+		}
+		if newStackID == originalStackID {
+			t.Fatalf("expected b to have a new stack ID after plucking to trunk, but got same ID: %s", originalStackID)
+		}
+
+		// Verify c (was reparented to a, not moved with b) still has original stack ID
+		sh.ExpectStackID("c", originalStackID)
+
+		// Verify a still has the original stack ID
+		sh.ExpectStackID("a", originalStackID)
+
+		// Verify b is now on trunk (its own stack root)
+		sh.ExpectBranchParent("b", "main")
+	})
+
+	t.Run("plucking branch to different stack inherits that stack ID", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create first stack: main -> a -> b -> c
+		sh.Write("a.txt", "content for a").
+			Run("create a -m 'Add a'").
+			Write("b.txt", "content for b").
+			Run("create b -m 'Add b'").
+			Write("c.txt", "content for c").
+			Run("create c -m 'Add c'")
+
+		// Set a description to trigger stack ID creation
+		sh.Run("describe -m 'First stack'")
+
+		// Capture first stack's ID
+		firstStackID := sh.GetStackID("a")
+		sh.ExpectStackIDsMatch("a", "b", "c")
+
+		// Create second stack: main -> x
+		sh.Checkout("main").
+			Write("x.txt", "content for x").
+			Run("create x -m 'Add x'")
+
+		// Set a description to trigger stack ID creation for second stack
+		sh.Run("describe -m 'Second stack'")
+
+		// Capture second stack's ID
+		secondStackID := sh.GetStackID("x")
+		sh.ExpectStackIDsDiffer("a", "x")
+
+		// Pluck b onto x (from first stack to second stack)
+		// c should be reparented to a (stays in first stack)
+		sh.Checkout("b")
+		sh.Run("pluck --onto x --yes")
+
+		// Verify b now has the second stack's ID
+		sh.ExpectStackID("b", secondStackID)
+
+		// Verify a and c still have the first stack ID
+		sh.ExpectStackID("a", firstStackID)
+		sh.ExpectStackID("c", firstStackID)
+
+		// Verify c was reparented to a (not moved with b)
+		sh.ExpectBranchParent("c", "a")
+	})
+
+	t.Run("plucking within same stack does not change stack ID", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create stack: main -> a -> b -> c -> d
+		sh.Write("a.txt", "content for a").
+			Run("create a -m 'Add a'").
+			Write("b.txt", "content for b").
+			Run("create b -m 'Add b'").
+			Write("c.txt", "content for c").
+			Run("create c -m 'Add c'").
+			Write("d.txt", "content for d").
+			Run("create d -m 'Add d'")
+
+		// Set a description to trigger stack ID creation
+		sh.Run("describe -m 'Test stack'")
+
+		// Capture original stack ID
+		originalStackID := sh.GetStackID("a")
+		sh.ExpectStackIDsMatch("a", "b", "c", "d")
+
+		// Pluck c onto a (within the same stack)
+		// d should be reparented to b
+		sh.Checkout("c")
+		sh.Run("pluck --onto a --yes")
+
+		// Verify all branches still have the same stack ID
+		sh.ExpectStackIDsMatch("a", "b", "c", "d")
+		sh.ExpectStackID("a", originalStackID)
+
+		// Verify c is now on a
+		sh.ExpectBranchParent("c", "a")
+
+		// Verify d was reparented to b
+		sh.ExpectBranchParent("d", "b")
+	})
+
+	t.Run("plucking leaf branch to trunk creates new stack", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create stack: main -> a -> b -> c
+		sh.CreateLinearStack3()
+
+		// Set a description to trigger stack ID creation
+		sh.Run("describe -m 'First stack'")
+
+		// Capture original stack ID
+		originalStackID := sh.GetStackID("a")
+		sh.ExpectStackIDsMatch("a", "b", "c")
+
+		// Pluck c (leaf) onto trunk
+		sh.Checkout("c")
+		sh.Run("pluck --onto main --yes")
+
+		// Set description on c to trigger new stack ID creation
+		sh.Run("describe -m 'Second stack'")
+
+		// Verify c now has a new stack ID
+		newStackID := sh.GetStackID("c")
+		if newStackID == "" {
+			t.Fatal("expected c to have a stack ID after plucking to trunk and setting description")
+		}
+		if newStackID == originalStackID {
+			t.Fatalf("expected c to have a new stack ID after plucking to trunk, but got same ID: %s", originalStackID)
+		}
+
+		// Verify a and b still have the original stack ID
+		sh.ExpectStackID("a", originalStackID)
+		sh.ExpectStackID("b", originalStackID)
+
+		// Verify c is on trunk
+		sh.ExpectBranchParent("c", "main")
+	})
+}

--- a/internal/integration/stack_id_test.go
+++ b/internal/integration/stack_id_test.go
@@ -1,0 +1,156 @@
+package integration
+
+import (
+	"testing"
+)
+
+func TestStackIDPreservation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("restack preserves stack IDs", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a stack: main -> a -> b -> c
+		sh.CreateLinearStack3()
+
+		// Set a description to trigger stack ID creation
+		sh.Run("describe -m 'Test stack'")
+
+		// Capture original stack ID
+		originalStackID := sh.GetStackID("a")
+		sh.ExpectStackIDsMatch("a", "b", "c")
+
+		// Restack
+		sh.Checkout("a")
+		sh.Run("restack")
+
+		// Verify stack IDs are unchanged
+		sh.ExpectStackID("a", originalStackID)
+		sh.ExpectStackIDsMatch("a", "b", "c")
+	})
+
+	t.Run("fold preserves stack IDs", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a stack: main -> a -> b -> c
+		sh.CreateLinearStack3()
+
+		// Set a description to trigger stack ID creation
+		sh.Run("describe -m 'Test stack'")
+
+		// Capture original stack ID
+		originalStackID := sh.GetStackID("a")
+		sh.ExpectStackIDsMatch("a", "b", "c")
+
+		// Fold b into a (keeping a)
+		sh.Checkout("b")
+		sh.Run("fold --keep current")
+
+		// Verify remaining branches still have the same stack ID
+		sh.ExpectStackID("b", originalStackID)
+		sh.ExpectStackID("c", originalStackID)
+	})
+
+	t.Run("split preserves stack IDs via by-file", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a stack: main -> a (with 2 files in one commit)
+		// Note: Write() creates files with _test.txt suffix (e.g., "file1" becomes "file1_test.txt")
+		sh.Write("file1", "content 1").
+			Write("file2", "content 2").
+			Run("create a -m 'Add files'")
+
+		// Set a description to trigger stack ID creation
+		sh.Run("describe -m 'Test stack'")
+
+		// Capture original stack ID
+		originalStackID := sh.GetStackID("a")
+
+		// Split by extracting file2 to a new parent branch
+		// The actual filename is file2_test.txt due to the test helper naming convention
+		sh.Run("split --by-file file2_test.txt --name a-part1 -m 'Extract file2'")
+
+		// Verify both branches have the same stack ID
+		sh.ExpectStackID("a-part1", originalStackID)
+		sh.ExpectStackID("a", originalStackID)
+	})
+
+	t.Run("pluck changes stack ID when moving to different stack", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create first stack: main -> a -> b -> c
+		sh.Write("a.txt", "content for a").
+			Run("create a -m 'Add a'").
+			Write("b.txt", "content for b").
+			Run("create b -m 'Add b'").
+			Write("c.txt", "content for c").
+			Run("create c -m 'Add c'")
+
+		// Set a description to trigger stack ID creation
+		sh.Run("describe -m 'First stack'")
+
+		// Capture first stack's ID
+		firstStackID := sh.GetStackID("a")
+		sh.ExpectStackIDsMatch("a", "b", "c")
+
+		// Create second stack: main -> x
+		sh.Checkout("main").
+			Write("x.txt", "content for x").
+			Run("create x -m 'Add x'")
+
+		// Set a description to trigger stack ID creation for second stack
+		sh.Run("describe -m 'Second stack'")
+
+		// Capture second stack's ID
+		secondStackID := sh.GetStackID("x")
+		sh.ExpectStackIDsDiffer("a", "x")
+
+		// Pluck b onto x (unlike move, pluck doesn't bring descendants)
+		sh.Checkout("b")
+		sh.Run("pluck --onto x --yes")
+
+		// Verify b now has the second stack's ID
+		sh.ExpectStackID("b", secondStackID)
+
+		// Verify a still has the first stack ID
+		sh.ExpectStackID("a", firstStackID)
+
+		// Verify c is reparented to a and still has first stack ID
+		sh.ExpectBranchParent("c", "a")
+		sh.ExpectStackID("c", firstStackID)
+	})
+
+	t.Run("fold with siblings syncs stack IDs from new parent", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a diamond structure: main -> a -> [b, c]
+		// where b and c are siblings (both children of a)
+		sh.Write("a.txt", "content for a").
+			Run("create a -m 'Add a'").
+			Write("b.txt", "content for b").
+			Run("create b -m 'Add b'").
+			Checkout("a").
+			Write("c.txt", "content for c").
+			Run("create c -m 'Add c'")
+
+		// Set a description to trigger stack ID creation
+		sh.Run("describe -m 'Test stack'")
+
+		// Verify all have same stack ID
+		originalStackID := sh.GetStackID("a")
+		sh.ExpectStackIDsMatch("a", "b", "c")
+
+		// Fold a into b (keeping b) - this makes b the new parent of c
+		sh.Checkout("b")
+		sh.Run("fold --keep current")
+
+		// Verify b and c still share the same stack ID
+		sh.ExpectStackID("b", originalStackID)
+		sh.ExpectStackID("c", originalStackID)
+	})
+}

--- a/internal/integration/stack_metadata_gc_test.go
+++ b/internal/integration/stack_metadata_gc_test.go
@@ -1,0 +1,222 @@
+package integration
+
+import (
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStackMetadataGC(t *testing.T) {
+	t.Parallel()
+
+	t.Run("orphaned stack ref is cleaned after all branches deleted", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a stack: main -> a -> b
+		sh.CreateLinearStack("a", "b")
+
+		// Trigger stack ID creation by setting a description (stack IDs are created lazily)
+		sh.Run("describe -m 'Test stack for GC'")
+
+		// Capture the stack ID
+		stackID := sh.GetStackID("a")
+		require.NotEmpty(t, stackID, "stack should have a stack ID")
+
+		// Verify stack ref exists
+		sh.ExpectStackMetaRefExists(stackID)
+
+		// Delete the entire stack (a and all its children)
+		sh.Checkout("main")
+		sh.Run("delete a --force --upstack")
+
+		// Run sync to trigger GC
+		sh.Run("sync")
+
+		// Verify stack ref is gone
+		sh.ExpectStackMetaRefNotExists(stackID)
+	})
+
+	t.Run("active stack refs are NOT deleted", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a stack: main -> a -> b -> c
+		sh.CreateLinearStack3()
+
+		// Trigger stack ID creation by setting a description (stack IDs are created lazily)
+		sh.Run("describe -m 'Test stack for GC'")
+
+		// Capture the stack ID
+		stackID := sh.GetStackID("a")
+		require.NotEmpty(t, stackID, "stack should have a stack ID")
+
+		// Verify stack ref exists before sync
+		sh.ExpectStackMetaRefExists(stackID)
+
+		// Run sync (nothing should be deleted)
+		sh.Run("sync")
+
+		// Verify stack ref still exists
+		sh.ExpectStackMetaRefExists(stackID)
+		sh.ExpectStackIDsMatch("a", "b", "c")
+	})
+
+	t.Run("stack ref survives when some branches remain after partial deletion", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create a stack: main -> a -> b -> c
+		sh.CreateLinearStack3()
+
+		// Trigger stack ID creation by setting a description (stack IDs are created lazily)
+		sh.Run("describe -m 'Test stack for GC'")
+
+		// Capture the stack ID
+		stackID := sh.GetStackID("a")
+		require.NotEmpty(t, stackID, "stack should have a stack ID")
+		sh.ExpectStackIDsMatch("a", "b", "c")
+
+		// Verify stack ref exists
+		sh.ExpectStackMetaRefExists(stackID)
+
+		// Delete only the middle branch
+		sh.Checkout("a")
+		sh.Run("delete b --force")
+
+		// Run sync
+		sh.Run("sync")
+
+		// c should be reparented to a
+		sh.ExpectBranchParent("c", "a")
+
+		// Stack ref should STILL exist because a and c still have this stack ID
+		sh.ExpectStackMetaRefExists(stackID)
+		sh.ExpectStackIDsMatch("a", "c")
+	})
+
+	t.Run("multiple orphaned stacks are cleaned in one sync", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create first stack: main -> a
+		sh.Write("a.txt", "content for a").
+			Run("create a -m 'Add a'")
+
+		// Trigger stack ID creation for first stack
+		sh.Run("describe -m 'First stack'")
+		stackID1 := sh.GetStackID("a")
+		require.NotEmpty(t, stackID1)
+
+		// Create second stack: main -> x
+		sh.Checkout("main").
+			Write("x.txt", "content for x").
+			Run("create x -m 'Add x'")
+
+		// Trigger stack ID creation for second stack
+		sh.Run("describe -m 'Second stack'")
+		stackID2 := sh.GetStackID("x")
+		require.NotEmpty(t, stackID2)
+
+		// Verify both stack refs exist
+		sh.ExpectStackMetaRefExists(stackID1)
+		sh.ExpectStackMetaRefExists(stackID2)
+
+		// Delete both stacks
+		sh.Checkout("main")
+		sh.Run("delete a --force")
+		sh.Run("delete x --force")
+
+		// Run sync to trigger GC
+		sh.Run("sync")
+
+		// Verify both stack refs are gone
+		sh.ExpectStackMetaRefNotExists(stackID1)
+		sh.ExpectStackMetaRefNotExists(stackID2)
+	})
+}
+
+// ExpectStackMetaRefExists asserts that a stack metadata ref exists.
+func (s *TestShell) ExpectStackMetaRefExists(stackID string) *TestShell {
+	s.t.Helper()
+	refName := "refs/stackit/stacks/" + stackID
+	cmd := exec.Command("git", "show-ref", "-s", refName)
+	cmd.Dir = s.scene.Dir
+	_, err := cmd.Output()
+	require.NoError(s.t, err, "expected stack ref %s to exist, but it doesn't", stackID)
+	return s
+}
+
+// ExpectStackMetaRefNotExists asserts that a stack metadata ref does not exist.
+func (s *TestShell) ExpectStackMetaRefNotExists(stackID string) *TestShell {
+	s.t.Helper()
+	refName := "refs/stackit/stacks/" + stackID
+	cmd := exec.Command("git", "show-ref", "-s", refName)
+	cmd.Dir = s.scene.Dir
+	output, err := cmd.CombinedOutput()
+	require.Error(s.t, err, "expected stack ref %s to NOT exist, but got: %s", stackID, strings.TrimSpace(string(output)))
+	return s
+}
+
+// SimulateBranchMerged marks a branch as merged in its metadata.
+// This simulates what happens when a PR is merged on GitHub.
+func (s *TestShell) SimulateBranchMerged(branch string) *TestShell {
+	s.t.Helper()
+
+	// Read existing metadata
+	refName := "refs/stackit/metadata/" + branch
+	cmd := exec.Command("git", "show-ref", "-s", refName)
+	cmd.Dir = s.scene.Dir
+	shaOutput, err := cmd.Output()
+	require.NoError(s.t, err, "failed to get metadata ref for %s", branch)
+
+	sha := strings.TrimSpace(string(shaOutput))
+	cmd = exec.Command("git", "cat-file", "-p", sha)
+	cmd.Dir = s.scene.Dir
+	blobOutput, err := cmd.Output()
+	require.NoError(s.t, err, "failed to read metadata blob for %s", branch)
+
+	// Parse and modify metadata
+	var meta map[string]any
+	err = json.Unmarshal(blobOutput, &meta)
+	require.NoError(s.t, err, "failed to parse metadata for %s", branch)
+
+	// Set PR info to merged state
+	prInfo := map[string]any{
+		"number": 1,
+		"state":  "MERGED",
+		"base":   "main",
+	}
+	meta["prInfo"] = prInfo
+
+	// Write updated metadata
+	updatedMeta, err := json.Marshal(meta)
+	require.NoError(s.t, err, "failed to marshal updated metadata")
+
+	cmd = exec.Command("git", "hash-object", "-w", "--stdin")
+	cmd.Dir = s.scene.Dir
+	cmd.Stdin = strings.NewReader(string(updatedMeta))
+	newShaOutput, err := cmd.Output()
+	require.NoError(s.t, err, "failed to create metadata blob")
+
+	newSha := strings.TrimSpace(string(newShaOutput))
+	cmd = exec.Command("git", "update-ref", refName, newSha)
+	cmd.Dir = s.scene.Dir
+	err = cmd.Run()
+	require.NoError(s.t, err, "failed to update metadata ref")
+
+	return s
+}
+
+// ExpectBranchNotExists asserts that a branch does not exist.
+func (s *TestShell) ExpectBranchNotExists(branch string) *TestShell {
+	s.t.Helper()
+	cmd := exec.Command("git", "rev-parse", "--verify", "refs/heads/"+branch)
+	cmd.Dir = s.scene.Dir
+	err := cmd.Run()
+	require.Error(s.t, err, "expected branch %s to NOT exist, but it does", branch)
+	return s
+}


### PR DESCRIPTION
**Implement stack-level metadata with garbage collection**

Adds stack-level metadata infrastructure to enable shared data (like stack descriptions) across all branches in a stack, with automatic cleanup of orphaned metadata.

Key changes:
- **add-stack-level-metadata-refs**: Core infrastructure for stack-level metadata
  - New ref namespace `refs/stackit/stacks/{stack-id}` for stack-scoped data
  - Automatic stack ID generation and inheritance across branches
  - Integration points in create, submit, move, pluck, and split operations
  - Comprehensive test coverage including multi-stack scenarios

- **implement-stack-metadata-garbage-collection**: Automatic cleanup during sync
  - Identifies and removes orphaned stack metadata refs when all branches are deleted/merged
  - Best-effort cleanup that won't fail sync operations
  - Cleans up both local and remote stack metadata refs

- **defer-PR-updates-from-scope-to-sync**: Performance optimization
  - Defers GitHub API calls from `scope` command to `sync`
  - Follows same pattern as `describe` command
  - Adds shared `PushMetadataOnly` helper for metadata-only pushes
  - Documents safety invariant for GitHub writes
  - Adds progress output during sync for PR metadata updates

Implementation notes:
- Stack IDs are timestamp-based and include sanitized branch name
- Metadata stored as JSON blobs referenced by Git refs
- All operations maintain backward compatibility with existing branches
- Garbage collection runs automatically during `stackit sync`
- PR metadata updates now show progress in sync output

This PR merges the following changes:

1. **#689** feat: add stack-level metadata refs
2. **#690** feat: implement stack metadata garbage collection
3. **#691** refactor: defer PR updates from scope to sync

### Stack

```
main
  └─ jonnii/20260204024440/add-stack-level-metadata-refs (#689)
    └─ jonnii/20260204040556/implement-stack-metadata-garbage-collection (#690)
      └─ jonnii/20260205014109/defer-PR-updates-from-scope-to-sync (#691)
```
