### PR TITLE
fix: deduplicate CI checks by name, keeping latest run

### DIFF
--- a/internal/github/status.go
+++ b/internal/github/status.go
@@ -241,9 +241,8 @@ func parseBranchStatus(data interface{}) *CheckStatus {
 
 // parseCheckRollup parses the statusCheckRollup data from the GraphQL response
 func parseCheckRollup(rollup map[string]interface{}, reviewDecision, author string) *CheckStatus {
-	hasPending := false
-	hasFailing := false
-	var checks []CheckDetail
+	// First pass: collect all checks and deduplicate by name, keeping the most recent
+	checksByName := make(map[string]*CheckDetail)
 
 	contexts, ok := rollup["contexts"].(map[string]interface{})
 	if ok && contexts != nil {
@@ -264,15 +263,29 @@ func parseCheckRollup(rollup map[string]interface{}, reviewDecision, author stri
 					continue
 				}
 
-				if detail.Status == "QUEUED" || detail.Status == checkStatusInProgress {
-					hasPending = true
+				// Deduplicate by name: keep the most recently finished check
+				// This handles re-runs where an older run failed but a newer one succeeded
+				existing, exists := checksByName[detail.Name]
+				if !exists || detail.FinishedAt.After(existing.FinishedAt) {
+					checksByName[detail.Name] = detail
 				}
-				if detail.Conclusion == checkConclusionFailure || detail.Conclusion == checkConclusionCanceled || detail.Conclusion == checkConclusionTimedOut || detail.Conclusion == checkConclusionActionRequired {
-					hasFailing = true
-				}
-				checks = append(checks, *detail)
 			}
 		}
+	}
+
+	// Second pass: evaluate status based on deduplicated checks
+	hasPending := false
+	hasFailing := false
+	checks := make([]CheckDetail, 0, len(checksByName))
+
+	for _, detail := range checksByName {
+		if detail.Status == "QUEUED" || detail.Status == checkStatusInProgress {
+			hasPending = true
+		}
+		if detail.Conclusion == checkConclusionFailure || detail.Conclusion == checkConclusionCanceled || detail.Conclusion == checkConclusionTimedOut || detail.Conclusion == checkConclusionActionRequired {
+			hasFailing = true
+		}
+		checks = append(checks, *detail)
 	}
 
 	return &CheckStatus{

--- a/internal/github/status_internal_test.go
+++ b/internal/github/status_internal_test.go
@@ -1,0 +1,167 @@
+package github
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCheckRollup_DeduplicatesByName(t *testing.T) {
+	t.Parallel()
+
+	// Simulate GitHub returning multiple runs of the same check
+	// (happens when a check is re-run after failure)
+	rollup := map[string]interface{}{
+		"contexts": map[string]interface{}{
+			"nodes": []interface{}{
+				// Older run that failed
+				map[string]interface{}{
+					"__typename":  "CheckRun",
+					"name":        "Test",
+					"status":      "COMPLETED",
+					"conclusion":  "FAILURE",
+					"startedAt":   "2024-01-01T10:00:00Z",
+					"completedAt": "2024-01-01T10:05:00Z",
+				},
+				// Newer run that succeeded (re-run)
+				map[string]interface{}{
+					"__typename":  "CheckRun",
+					"name":        "Test",
+					"status":      "COMPLETED",
+					"conclusion":  "SUCCESS",
+					"startedAt":   "2024-01-01T10:10:00Z",
+					"completedAt": "2024-01-01T10:15:00Z",
+				},
+			},
+		},
+	}
+
+	status := parseCheckRollup(rollup, "APPROVED", "author")
+
+	require.NotNil(t, status)
+	assert.True(t, status.Passing, "should use the newer successful run, not the older failed one")
+	assert.False(t, status.Pending)
+	assert.Len(t, status.Checks, 1, "should deduplicate to single check")
+	assert.Equal(t, "Test", status.Checks[0].Name)
+	assert.Equal(t, "SUCCESS", status.Checks[0].Conclusion)
+}
+
+func TestParseCheckRollup_KeepsLatestByFinishedAt(t *testing.T) {
+	t.Parallel()
+
+	// Test that we keep the most recently finished check, not just any check
+	rollup := map[string]interface{}{
+		"contexts": map[string]interface{}{
+			"nodes": []interface{}{
+				// This one finished later but started earlier
+				map[string]interface{}{
+					"__typename":  "CheckRun",
+					"name":        "Build",
+					"status":      "COMPLETED",
+					"conclusion":  "SUCCESS",
+					"startedAt":   "2024-01-01T10:00:00Z",
+					"completedAt": "2024-01-01T10:30:00Z", // finished last
+				},
+				// This one started later but finished earlier
+				map[string]interface{}{
+					"__typename":  "CheckRun",
+					"name":        "Build",
+					"status":      "COMPLETED",
+					"conclusion":  "FAILURE",
+					"startedAt":   "2024-01-01T10:10:00Z",
+					"completedAt": "2024-01-01T10:20:00Z", // finished first
+				},
+			},
+		},
+	}
+
+	status := parseCheckRollup(rollup, "APPROVED", "author")
+
+	require.NotNil(t, status)
+	assert.True(t, status.Passing, "should use the check that finished last")
+	require.Len(t, status.Checks, 1)
+	assert.Equal(t, "SUCCESS", status.Checks[0].Conclusion)
+	expectedTime, _ := time.Parse(time.RFC3339, "2024-01-01T10:30:00Z")
+	assert.Equal(t, expectedTime, status.Checks[0].FinishedAt)
+}
+
+func TestParseCheckRollup_FiltersStackitChecks(t *testing.T) {
+	t.Parallel()
+
+	rollup := map[string]interface{}{
+		"contexts": map[string]interface{}{
+			"nodes": []interface{}{
+				// Stackit's own checks that should be ignored
+				map[string]interface{}{
+					"__typename":  "CheckRun",
+					"name":        "Check Lock Status",
+					"status":      "COMPLETED",
+					"conclusion":  "FAILURE",
+					"completedAt": "2024-01-01T10:00:00Z",
+				},
+				map[string]interface{}{
+					"__typename":  "CheckRun",
+					"name":        "Check Stack Order",
+					"status":      "COMPLETED",
+					"conclusion":  "FAILURE",
+					"completedAt": "2024-01-01T10:00:00Z",
+				},
+				// Real CI check that passes
+				map[string]interface{}{
+					"__typename":  "CheckRun",
+					"name":        "CI",
+					"status":      "COMPLETED",
+					"conclusion":  "SUCCESS",
+					"completedAt": "2024-01-01T10:00:00Z",
+				},
+			},
+		},
+	}
+
+	status := parseCheckRollup(rollup, "APPROVED", "author")
+
+	require.NotNil(t, status)
+	assert.True(t, status.Passing, "should ignore stackit checks and report passing")
+	assert.Len(t, status.Checks, 1, "should only include the CI check")
+	assert.Equal(t, "CI", status.Checks[0].Name)
+}
+
+func TestParseCheckRollup_MultipleDistinctChecks(t *testing.T) {
+	t.Parallel()
+
+	rollup := map[string]interface{}{
+		"contexts": map[string]interface{}{
+			"nodes": []interface{}{
+				map[string]interface{}{
+					"__typename":  "CheckRun",
+					"name":        "Build",
+					"status":      "COMPLETED",
+					"conclusion":  "SUCCESS",
+					"completedAt": "2024-01-01T10:00:00Z",
+				},
+				map[string]interface{}{
+					"__typename":  "CheckRun",
+					"name":        "Test",
+					"status":      "COMPLETED",
+					"conclusion":  "SUCCESS",
+					"completedAt": "2024-01-01T10:00:00Z",
+				},
+				map[string]interface{}{
+					"__typename":  "CheckRun",
+					"name":        "Lint",
+					"status":      "COMPLETED",
+					"conclusion":  "SUCCESS",
+					"completedAt": "2024-01-01T10:00:00Z",
+				},
+			},
+		},
+	}
+
+	status := parseCheckRollup(rollup, "APPROVED", "author")
+
+	require.NotNil(t, status)
+	assert.True(t, status.Passing)
+	assert.Len(t, status.Checks, 3, "should include all distinct checks")
+}


### PR DESCRIPTION

When GitHub re-runs checks, multiple runs of the same check appear in the
status rollup. Previously, stackit would mark the PR as failing if ANY run
failed, even if the most recent run succeeded.

Now we deduplicate checks by name, keeping only the most recently finished
run based on completedAt timestamp. This ensures re-runs properly override
older results.