### PR TITLE
refactor: extract dashboard styles to centralized style package

### DIFF
--- a/internal/cli/dashboard/shippable_view.go
+++ b/internal/cli/dashboard/shippable_view.go
@@ -36,17 +36,14 @@ func (m *shippableModel) renderMain() string {
 	headerHeight := lipgloss.Height(header)
 	footerHeight := lipgloss.Height(footer)
 
-	// Cart panel height (only if items selected)
-	// Height: 1 header + N stacks + 1 summary + 2 padding/border
-	cartHeight := 0
+	// Action bar height (only if items selected)
+	// Fixed height: border(1) + content(1) + padding(1)
+	actionBarHeight := 0
 	if m.cache.selectedCount > 0 {
-		cartHeight = 4 + m.cache.selectedCount // Dynamic based on selection count
-		if cartHeight > 10 {
-			cartHeight = 10 // Cap at reasonable max
-		}
+		actionBarHeight = 3
 	}
 
-	contentHeight := m.Height - headerHeight - footerHeight - cartHeight
+	contentHeight := m.Height - headerHeight - footerHeight - actionBarHeight
 	if contentHeight < 5 {
 		contentHeight = 5
 	}
@@ -65,10 +62,10 @@ func (m *shippableModel) renderMain() string {
 	var sections []string
 	sections = append(sections, header, stackViewer)
 
-	// Add cart panel if items selected (bottom row)
+	// Add action bar if items selected (bottom row)
 	if m.cache.selectedCount > 0 {
-		cartPane := m.renderCartPanel(m.Width, cartHeight)
-		sections = append(sections, cartPane)
+		bar := m.renderActionBar(m.Width)
+		sections = append(sections, bar)
 	}
 
 	sections = append(sections, footer)
@@ -106,13 +103,15 @@ func (m *shippableModel) renderHeader() string {
 
 // renderStackList renders the list of stacks.
 func (m *shippableModel) renderStackList(width, height int) string {
+	// Width/Height include padding but not borders, so subtract border size only
+	borderW := leftPaneStyle.GetHorizontalBorderSize()
+	borderH := leftPaneStyle.GetVerticalBorderSize()
 	paneStyle := leftPaneStyle.
-		Width(width).
-		Height(height)
+		Width(width - borderW).
+		Height(height - borderH)
 
 	var sb strings.Builder
-	sb.WriteString(paneHeaderStyle.Render("STACKS") + "\n")
-	sb.WriteString(strings.Repeat("─", max(width-4, 0)) + "\n")
+	sb.WriteString(paneHeaderStyle.Render("STACKS") + "\n\n")
 
 	// Show appropriate content based on state
 	if len(m.stacks) == 0 {
@@ -156,6 +155,7 @@ func (m *shippableModel) renderStackLine(stack shippable.Stack, focused bool) st
 	root := stack.RootBranch()
 
 	// Selection checkbox - show lock icon if locked
+	// Pad to fixed width so columns align regardless of emoji width
 	var checkbox string
 	switch {
 	case m.isLocked(root):
@@ -165,9 +165,10 @@ func (m *shippableModel) renderStackLine(stack shippable.Stack, focused bool) st
 	default:
 		checkbox = "[ ]"
 	}
+	checkbox = style.PadToWidth(checkbox, style.CheckboxColumnWidth)
 
-	// Status icon
-	statusIcon := m.getStatusIcon(stack.Status)
+	// Status icon - pad to fixed width for alignment
+	statusIcon := style.PadToWidth(m.getStatusIcon(stack.Status), style.StatusIconColumnWidth)
 
 	// Stack title: use cached title (computed at refresh time)
 	name := m.cache.stackTitles[root]
@@ -191,9 +192,9 @@ func (m *shippableModel) renderStackLine(stack shippable.Stack, focused bool) st
 	}
 
 	// Calculate max name length based on available pane width
-	// Account for: cursor(2) + checkbox(3) + space(1) + icon(2) + space(1) + branchCount + expandIndicator + padding(4)
+	// Use lipgloss.Width() for accurate unicode measurement
 	paneWidth := m.Width / 2
-	overhead := 2 + 3 + 1 + 2 + 1 + len(branchCount) + len(expandIndicator) + 4
+	overhead := 2 + style.CheckboxColumnWidth + 1 + style.StatusIconColumnWidth + 1 + lipgloss.Width(branchCount) + lipgloss.Width(expandIndicator) + 6
 	maxNameLen := paneWidth - overhead
 	if maxNameLen < 20 {
 		maxNameLen = 20 // Minimum readable length
@@ -254,13 +255,14 @@ func (m *shippableModel) getStatusIcon(status shippable.Status) string {
 
 // renderDetailsPanel renders the right-side details panel (always shows stack details).
 func (m *shippableModel) renderDetailsPanel(width, height int) string {
+	borderW := rightPaneStyle.GetHorizontalBorderSize()
+	borderH := rightPaneStyle.GetVerticalBorderSize()
 	paneStyle := rightPaneStyle.
-		Width(width).
-		Height(height)
+		Width(width - borderW).
+		Height(height - borderH)
 
 	var sb strings.Builder
-	sb.WriteString(paneHeaderStyle.Render("DETAILS") + "\n")
-	sb.WriteString(strings.Repeat("─", max(width-4, 0)) + "\n")
+	sb.WriteString(paneHeaderStyle.Render("DETAILS") + "\n\n")
 
 	if m.focusedStack != nil {
 		sb.WriteString(m.renderStackDetails(m.focusedStack))
@@ -271,11 +273,9 @@ func (m *shippableModel) renderDetailsPanel(width, height int) string {
 	return paneStyle.Render(sb.String())
 }
 
-// renderCartPanel renders the bottom cart panel when stacks are selected.
-func (m *shippableModel) renderCartPanel(width, height int) string {
-	paneStyle := cartPaneStyle.
-		Width(width).
-		Height(height)
+// renderActionBar renders the compact action bar when stacks are selected.
+func (m *shippableModel) renderActionBar(width int) string {
+	barStyle := actionBarStyle.Width(width - actionBarStyle.GetHorizontalBorderSize())
 
 	// Use cached selected stacks
 	selected := m.cache.selectedStacks
@@ -284,59 +284,25 @@ func (m *shippableModel) renderCartPanel(width, height int) string {
 		totalBranches += s.BranchCount()
 	}
 
-	var sb strings.Builder
+	// Summary text
+	summary := fmt.Sprintf("%d stacks selected (%d branches)", len(selected), totalBranches)
 
-	// Header row: title, count badge, and actions
-	cartHeader := paneHeaderStyle.Render("SHIPPING")
-	countBadge := countBadgeStyle.Render(fmt.Sprintf("%d stacks", len(selected)))
-
-	// Ship button (all selected stacks are shippable by design now)
+	// Actions
 	shipAction := buttonPrimary.Render("[s] Ship")
 
-	// Combination status
-	var analysisStatus string
+	var analysisAction string
 	if m.combination != nil {
 		if m.combination.Combinable {
-			analysisStatus = style.ColorGreen("✓ Compatible")
+			analysisAction = style.ColorGreen("✓ Compatible")
 		} else {
-			analysisStatus = style.ColorRed("✗ Conflicts")
+			analysisAction = style.ColorRed("✗ Conflicts")
 		}
 	} else if len(selected) > 1 {
-		analysisStatus = style.ColorDim("[a] analyze compatibility")
+		analysisAction = style.ColorDim("[a] Analyze")
 	}
 
-	// Header line
-	headerLine := fmt.Sprintf("%s %s  %s  %s", cartHeader, countBadge, shipAction, analysisStatus)
-	sb.WriteString(headerLine + "\n")
-
-	// Vertical list of selected stacks
-	for _, s := range selected {
-		statusIcon := m.getStatusIcon(s.Status)
-		// Use cached title
-		title := m.cache.stackTitles[s.RootBranch()]
-		if title == "" {
-			title = s.RootBranch()
-		}
-		// Truncate if needed
-		maxLen := width - 10
-		if maxLen > 60 {
-			maxLen = 60
-		}
-		if len(title) > maxLen {
-			title = title[:maxLen-3] + "..."
-		}
-
-		branchInfo := ""
-		if s.BranchCount() > 1 {
-			branchInfo = style.ColorDim(fmt.Sprintf(" (%d branches)", s.BranchCount()))
-		}
-		sb.WriteString(fmt.Sprintf("  %s %s%s\n", statusIcon, title, branchInfo))
-	}
-
-	// Summary line
-	sb.WriteString(style.ColorDim(fmt.Sprintf("  Total: %d branches", totalBranches)))
-
-	return paneStyle.Render(sb.String())
+	line := fmt.Sprintf("%s  %s  %s", summary, shipAction, analysisAction)
+	return barStyle.Render(line)
 }
 
 // renderStackDetails renders detailed info about a stack with tree view.
@@ -354,7 +320,6 @@ func (m *shippableModel) renderStackDetails(stack *shippable.Stack) string {
 		}
 		rendered := style.RenderMarkdown(markdown)
 		sb.WriteString(rendered + "\n")
-		sb.WriteString(strings.Repeat("─", 40) + "\n\n")
 	}
 
 	// Header: show commit title with status badge, branch name dimmed below
@@ -649,7 +614,7 @@ func (m *shippableModel) renderConfirmation() string {
 	sb.WriteString("  - Create/update PR to main\n")
 	sb.WriteString("  - Merge when CI passes\n")
 
-	sb.WriteString("\n" + strings.Repeat("─", 40) + "\n")
+	sb.WriteString("\n" + style.ColorDim(strings.Repeat("─", 40)) + "\n")
 	sb.WriteString("[Enter/y] Confirm  [Esc/n] Cancel\n")
 
 	return dialogStyle.Render(sb.String())

--- a/internal/cli/dashboard/styles.go
+++ b/internal/cli/dashboard/styles.go
@@ -1,119 +1,38 @@
 package dashboard
 
-import (
-	"github.com/charmbracelet/lipgloss"
+import "stackit.dev/stackit/internal/tui/style"
 
-	"stackit.dev/stackit/internal/tui/style"
-)
+// All dashboard styles are defined in style.DefaultDashboardStyles() so that
+// the st-tui storyboard stays in sync with the real dashboard.
+var ds = style.DefaultDashboardStyles()
 
-// Color constants for dashboard-specific colors not in the style package.
-const (
-	// colorBackground is a dark gray for selected row backgrounds
-	colorBackground = "236"
-	// colorWhite is white for text on dark backgrounds
-	colorWhite = "15"
-	// colorBlack is black for text on light backgrounds
-	colorBlack = "0"
-	// colorGray is medium gray for disabled text
-	colorGray = "7"
-	// colorDarkGray is dark gray for disabled backgrounds
-	colorDarkGray = "8"
-)
-
-// Centralized styles for the dashboard TUI.
-// These use the style package helpers for consistency with other TUIs.
+// Re-export for convenient access within this package.
 var (
 	commonStyles = style.DefaultCommonStyles()
 
-	// Dashboard-specific styles
-	titleStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color(style.ColorAccent)).
-			Bold(true).
-			Padding(0, 1)
+	titleStyle        = ds.Title
+	headerStatusStyle = ds.HeaderStatus
+	headerBorderStyle = ds.HeaderBorder
+	paneHeaderStyle   = ds.PaneHeader
+	selectedRowStyle  = ds.SelectedRow
+	footerStyle       = ds.Footer
+	errorTextStyle    = ds.ErrorText
 
-	headerStatusStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color(style.ColorDimValue)).
-				Padding(0, 1)
+	leftPaneStyle  = ds.LeftPane
+	rightPaneStyle = ds.RightPane
+	actionBarStyle = ds.ActionBar
 
-	paneHeaderStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(lipgloss.Color(style.ColorAccent))
+	badgeReady      = ds.BadgeReady
+	badgePending    = ds.BadgePending
+	badgeBlocked    = ds.BadgeBlocked
+	badgeIncomplete = ds.BadgeIncomplete
 
-	selectedRowStyle = lipgloss.NewStyle().
-				Background(lipgloss.Color(colorBackground)).
-				Bold(true)
+	buttonPrimary = ds.ButtonPrimary
 
-	helpTitleStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(lipgloss.Color(style.ColorAccent)).
-			MarginBottom(1)
+	helpTitleStyle   = ds.HelpTitle
+	helpSectionStyle = ds.HelpSection
+	helpKeyStyle     = ds.HelpKey
+	helpDescStyle    = ds.HelpDesc
 
-	helpSectionStyle = lipgloss.NewStyle().
-				Bold(true).
-				Foreground(lipgloss.Color(style.ColorMerged)).
-				MarginTop(1)
-
-	helpKeyStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color(style.ColorWarningAlt)).
-			Width(12)
-
-	helpDescStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color(colorGray))
-
-	errorTextStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color(style.ColorErrorAlt))
-
-	footerStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color(style.ColorDimValue)).
-			Padding(0, 1)
-
-	// Badge styles for status indicators
-	badgeReady = lipgloss.NewStyle().
-			Background(lipgloss.Color(style.ColorSuccessAlt)).
-			Foreground(lipgloss.Color(colorBlack)).
-			Padding(0, 1)
-
-	badgePending = lipgloss.NewStyle().
-			Background(lipgloss.Color(style.ColorWarningAlt)).
-			Foreground(lipgloss.Color(colorBlack)).
-			Padding(0, 1)
-
-	badgeBlocked = lipgloss.NewStyle().
-			Background(lipgloss.Color(style.ColorErrorAlt)).
-			Foreground(lipgloss.Color(colorWhite)).
-			Padding(0, 1)
-
-	badgeIncomplete = lipgloss.NewStyle().
-			Background(lipgloss.Color(colorDarkGray)).
-			Foreground(lipgloss.Color(colorWhite)).
-			Padding(0, 1)
-
-	// Button styles
-	buttonPrimary = lipgloss.NewStyle().
-			Background(lipgloss.Color(style.ColorSuccessAlt)).
-			Foreground(lipgloss.Color(colorBlack)).
-			Padding(0, 2)
-
-	// Pane styles (moved from inline)
-	headerBorderStyle = lipgloss.NewStyle().
-				Border(lipgloss.NormalBorder(), false, false, true, false)
-
-	leftPaneStyle = lipgloss.NewStyle().
-			Border(lipgloss.NormalBorder(), false, true, false, false).
-			Padding(0, 1)
-
-	rightPaneStyle = lipgloss.NewStyle().
-			Padding(0, 1)
-
-	cartPaneStyle = lipgloss.NewStyle().
-			Border(lipgloss.NormalBorder(), true, false, false, false).
-			Padding(0, 1)
-
-	countBadgeStyle = lipgloss.NewStyle().
-			Background(lipgloss.Color(style.ColorAccent)).
-			Foreground(lipgloss.Color(colorBlack)).
-			Padding(0, 1)
-
-	dialogStyle = lipgloss.NewStyle().
-			Padding(2, 4)
+	dialogStyle = ds.Dialog
 )

--- a/internal/tui/shippable_stories.go
+++ b/internal/tui/shippable_stories.go
@@ -1,0 +1,1090 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"stackit.dev/stackit/internal/tui/core"
+	"stackit.dev/stackit/internal/tui/style"
+)
+
+// storyStack represents a simulated stack for the storyboard.
+// This mirrors shippable.Stack but avoids the import cycle.
+type storyStack struct {
+	rootBranch  string
+	allBranches []string
+	status      storyStackStatus
+	author      string
+	prTitle     string
+	stackTitle  string
+	stackDesc   string
+	approvalOK  bool
+	gitHubCIOK  bool
+	blockingPRs []storyBlockingPR
+}
+
+// storyStackStatus represents the shippability status.
+type storyStackStatus string
+
+const (
+	storyStatusShippable  storyStackStatus = "shippable"
+	storyStatusPending    storyStackStatus = "pending"
+	storyStatusBlocked    storyStackStatus = "blocked"
+	storyStatusIncomplete storyStackStatus = "incomplete"
+)
+
+// storyBlockingPR describes a blocking PR.
+type storyBlockingPR struct {
+	branch   string
+	prNumber int
+	reason   storyBlockingReason
+}
+
+// storyBlockingReason describes why a PR is blocking.
+type storyBlockingReason string
+
+const (
+	storyReasonChangesRequested storyBlockingReason = "changes_requested"
+	storyReasonCIFailing        storyBlockingReason = "ci_failing"
+	storyReasonCIPending        storyBlockingReason = "ci_pending"
+	storyReasonDraft            storyBlockingReason = "draft"
+	storyReasonNoPR             storyBlockingReason = "no_pr"
+	storyReasonReviewRequired   storyBlockingReason = "review_required"
+)
+
+// branchCount returns the number of branches in the stack.
+func (s *storyStack) branchCount() int {
+	return len(s.allBranches)
+}
+
+// shippableScenario defines a simulated dashboard state for the storyboard.
+type shippableScenario struct {
+	name        string
+	description string
+	stacks      []storyStack
+	// Optional: pre-selected stacks by root branch
+	selectedStacks []string
+	// Optional: simulate a dashboard state
+	state dashboardStoryState
+}
+
+// dashboardStoryState represents the simulated dashboard state.
+type dashboardStoryState int
+
+const (
+	stateStoryMain dashboardStoryState = iota
+	stateStoryLoading
+	stateStoryAnalyzing
+	stateStoryShipping
+)
+
+// Step status constants for merge simulation
+const (
+	stepStatusPending = "pending"
+	stepStatusRunning = "running"
+	stepStatusWaiting = "waiting"
+	stepStatusDone    = "done"
+	stepStatusError   = "error"
+)
+
+// Predefined scenarios for testing different dashboard states
+var shippableScenarios = []shippableScenario{
+	{
+		name:        "Mixed Stack States",
+		description: "Dashboard showing shippable, pending, blocked, and incomplete stacks",
+		stacks:      createMixedStacksScenario(),
+		state:       stateStoryMain,
+	},
+	{
+		name:        "All Shippable",
+		description: "Multiple stacks ready to ship",
+		stacks:      createAllShippableScenario(),
+		state:       stateStoryMain,
+	},
+	{
+		name:        "With Selection",
+		description: "Dashboard with stacks selected for shipping",
+		stacks:      createMixedStacksScenario(),
+		selectedStacks: []string{
+			"jonnii/20250101/add-auth-flow",
+			"jonnii/20250102/api-refactor",
+		},
+		state: stateStoryMain,
+	},
+	{
+		name:        "Analyzing Combination",
+		description: "Dashboard analyzing if selected stacks can ship together",
+		stacks:      createAllShippableScenario(),
+		selectedStacks: []string{
+			"jonnii/20250101/add-auth-flow",
+			"jonnii/20250102/api-refactor",
+		},
+		state: stateStoryAnalyzing,
+	},
+	{
+		name:        "Shipping In Progress",
+		description: "Dashboard with shipping operation in progress",
+		stacks:      createAllShippableScenario(),
+		selectedStacks: []string{
+			"jonnii/20250101/add-auth-flow",
+		},
+		state: stateStoryShipping,
+	},
+	{
+		name:        "Large Stack",
+		description: "A deeply nested stack with many branches",
+		stacks:      createLargeStackScenario(),
+		state:       stateStoryMain,
+	},
+	{
+		name:        "Stack Descriptions",
+		description: "Stacks with varied description content in the details panel",
+		stacks:      createStackDescriptionsScenario(),
+		state:       stateStoryMain,
+	},
+}
+
+// createMixedStacksScenario creates a scenario with different stack states.
+func createMixedStacksScenario() []storyStack {
+	return []storyStack{
+		{
+			rootBranch:  "jonnii/20250101/add-auth-flow",
+			allBranches: []string{"jonnii/20250101/add-auth-flow", "jonnii/20250101/add-auth-validation", "jonnii/20250101/add-auth-login"},
+			status:      storyStatusShippable,
+			author:      "jonnii",
+			prTitle:     "feat: Add authentication flow",
+			stackTitle:  "Authentication System",
+			stackDesc:   "Adds JWT-based authentication with **login**, **validation**, and **token refresh** endpoints.",
+			approvalOK:  true,
+			gitHubCIOK:  true,
+		},
+		{
+			rootBranch:  "jonnii/20250102/api-refactor",
+			allBranches: []string{"jonnii/20250102/api-refactor"},
+			status:      storyStatusShippable,
+			author:      "jonnii",
+			prTitle:     "refactor: Clean up API layer",
+			approvalOK:  true,
+			gitHubCIOK:  true,
+		},
+		{
+			rootBranch:  "jonnii/20250103/fix-ci-pipeline",
+			allBranches: []string{"jonnii/20250103/fix-ci-pipeline", "jonnii/20250103/fix-ci-caching"},
+			status:      storyStatusPending,
+			author:      "jonnii",
+			prTitle:     "fix: CI pipeline caching",
+			approvalOK:  true,
+			gitHubCIOK:  false,
+			blockingPRs: []storyBlockingPR{
+				{branch: "jonnii/20250103/fix-ci-caching", prNumber: 205, reason: storyReasonCIPending},
+			},
+		},
+		{
+			rootBranch:  "jonnii/20250104/database-migration",
+			allBranches: []string{"jonnii/20250104/database-migration"},
+			status:      storyStatusBlocked,
+			author:      "jonnii",
+			prTitle:     "feat: Database schema migration",
+			approvalOK:  false,
+			gitHubCIOK:  false,
+			blockingPRs: []storyBlockingPR{
+				{branch: "jonnii/20250104/database-migration", prNumber: 210, reason: storyReasonChangesRequested},
+			},
+		},
+		{
+			rootBranch:  "jonnii/20250105/wip-feature",
+			allBranches: []string{"jonnii/20250105/wip-feature"},
+			status:      storyStatusIncomplete,
+			author:      "jonnii",
+			prTitle:     "WIP: New feature exploration",
+			approvalOK:  false,
+			gitHubCIOK:  false,
+			blockingPRs: []storyBlockingPR{
+				{branch: "jonnii/20250105/wip-feature", reason: storyReasonDraft},
+			},
+		},
+	}
+}
+
+// createAllShippableScenario creates a scenario where all stacks are shippable.
+func createAllShippableScenario() []storyStack {
+	return []storyStack{
+		{
+			rootBranch:  "jonnii/20250101/add-auth-flow",
+			allBranches: []string{"jonnii/20250101/add-auth-flow", "jonnii/20250101/add-auth-validation", "jonnii/20250101/add-auth-login"},
+			status:      storyStatusShippable,
+			author:      "jonnii",
+			prTitle:     "feat: Add authentication flow",
+			approvalOK:  true,
+			gitHubCIOK:  true,
+		},
+		{
+			rootBranch:  "jonnii/20250102/api-refactor",
+			allBranches: []string{"jonnii/20250102/api-refactor", "jonnii/20250102/api-cleanup"},
+			status:      storyStatusShippable,
+			author:      "jonnii",
+			prTitle:     "refactor: Clean up API layer",
+			approvalOK:  true,
+			gitHubCIOK:  true,
+		},
+		{
+			rootBranch:  "jonnii/20250103/fix-tests",
+			allBranches: []string{"jonnii/20250103/fix-tests"},
+			status:      storyStatusShippable,
+			author:      "jonnii",
+			prTitle:     "fix: Flaky test suite",
+			approvalOK:  true,
+			gitHubCIOK:  true,
+		},
+	}
+}
+
+// createLargeStackScenario creates a deeply nested stack.
+func createLargeStackScenario() []storyStack {
+	return []storyStack{
+		{
+			rootBranch: "jonnii/20250110/large-feature",
+			allBranches: []string{
+				"jonnii/20250110/large-feature",
+				"jonnii/20250110/large-feature-part2",
+				"jonnii/20250110/large-feature-part3",
+				"jonnii/20250110/large-feature-part4",
+				"jonnii/20250110/large-feature-part5",
+				"jonnii/20250110/large-feature-tests",
+				"jonnii/20250110/large-feature-docs",
+			},
+			status:     storyStatusPending,
+			author:     "jonnii",
+			prTitle:    "feat: Large multi-part feature implementation",
+			approvalOK: true,
+			gitHubCIOK: false,
+			blockingPRs: []storyBlockingPR{
+				{branch: "jonnii/20250110/large-feature-part5", prNumber: 220, reason: storyReasonCIPending},
+			},
+		},
+	}
+}
+
+// createStackDescriptionsScenario creates stacks with varied description content.
+func createStackDescriptionsScenario() []storyStack {
+	return []storyStack{
+		{
+			rootBranch:  "jonnii/20250201/config-system",
+			allBranches: []string{"jonnii/20250201/config-system", "jonnii/20250201/config-validation"},
+			status:      storyStatusShippable,
+			author:      "jonnii",
+			prTitle:     "feat: Layered configuration system",
+			stackTitle:  "Configuration Overhaul",
+			stackDesc:   "Replaces the flat config with a **layered system** supporting:\n- Global defaults\n- Project-level overrides\n- Environment variables",
+			approvalOK:  true,
+			gitHubCIOK:  true,
+		},
+		{
+			rootBranch:  "jonnii/20250202/perf-improvements",
+			allBranches: []string{"jonnii/20250202/perf-improvements"},
+			status:      storyStatusShippable,
+			author:      "jonnii",
+			prTitle:     "perf: Reduce git operations",
+			stackTitle:  "Performance Pass",
+			approvalOK:  true,
+			gitHubCIOK:  true,
+		},
+		{
+			rootBranch:  "jonnii/20250203/error-handling",
+			allBranches: []string{"jonnii/20250203/error-handling", "jonnii/20250203/error-display"},
+			status:      storyStatusPending,
+			author:      "jonnii",
+			prTitle:     "fix: Better error messages",
+			stackTitle:  "Error Handling Improvements",
+			stackDesc:   "Wraps all git errors with **actionable context** so users know how to recover.",
+			approvalOK:  true,
+			gitHubCIOK:  false,
+			blockingPRs: []storyBlockingPR{
+				{branch: "jonnii/20250203/error-display", prNumber: 250, reason: storyReasonCIPending},
+			},
+		},
+	}
+}
+
+// shippableStoryModel is a simplified dashboard model for the storyboard.
+// It doesn't require real Engine or GitHub client.
+type shippableStoryModel struct {
+	scenario shippableScenario
+
+	// UI state
+	selectedIndex int
+	expanded      map[string]bool
+	selected      map[string]bool
+	width         int
+	height        int
+
+	// Spinner for loading states
+	spinner spinner.Model
+
+	// Styles - uses shared dashboard styles for consistency with real app
+	ds style.DashboardStyles
+}
+
+// storyBadges maps story status to the shared dashboard badge styles.
+var storyBadges = func() map[storyStackStatus]lipgloss.Style {
+	ds := style.DefaultDashboardStyles()
+	return map[storyStackStatus]lipgloss.Style{
+		storyStatusShippable:  ds.BadgeReady,
+		storyStatusPending:    ds.BadgePending,
+		storyStatusBlocked:    ds.BadgeBlocked,
+		storyStatusIncomplete: ds.BadgeIncomplete,
+	}
+}()
+
+func newShippableStoryModel(scenario shippableScenario) *shippableStoryModel {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+
+	m := &shippableStoryModel{
+		scenario: scenario,
+		expanded: make(map[string]bool),
+		selected: make(map[string]bool),
+		spinner:  s,
+		ds:       style.DefaultDashboardStyles(),
+	}
+
+	// Apply pre-selections
+	for _, root := range scenario.selectedStacks {
+		m.selected[root] = true
+	}
+
+	return m
+}
+
+func (m *shippableStoryModel) Init() tea.Cmd {
+	return m.spinner.Tick
+}
+
+func (m *shippableStoryModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case core.KeyQuit, core.KeyEsc:
+			return m, tea.Quit
+		case core.KeyUp, "k":
+			if m.selectedIndex > 0 {
+				m.selectedIndex--
+			}
+		case core.KeyDown, "j":
+			if m.selectedIndex < len(m.scenario.stacks)-1 {
+				m.selectedIndex++
+			}
+		case " ":
+			m.toggleSelection()
+		case core.KeyEnter:
+			m.toggleExpand()
+		case "A":
+			m.selectAllShippable()
+		}
+		return m, nil
+
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+func (m *shippableStoryModel) toggleSelection() {
+	if m.selectedIndex >= len(m.scenario.stacks) {
+		return
+	}
+	stack := m.scenario.stacks[m.selectedIndex]
+	if stack.status != storyStatusShippable {
+		return
+	}
+	root := stack.rootBranch
+	m.selected[root] = !m.selected[root]
+}
+
+func (m *shippableStoryModel) toggleExpand() {
+	if m.selectedIndex >= len(m.scenario.stacks) {
+		return
+	}
+	stack := m.scenario.stacks[m.selectedIndex]
+	root := stack.rootBranch
+	m.expanded[root] = !m.expanded[root]
+}
+
+func (m *shippableStoryModel) selectAllShippable() {
+	for _, s := range m.scenario.stacks {
+		if s.status == storyStatusShippable {
+			m.selected[s.rootBranch] = true
+		}
+	}
+}
+
+func (m *shippableStoryModel) View() string {
+	if m.width == 0 {
+		return "Loading..."
+	}
+
+	header := m.renderHeader()
+	footer := m.renderFooter()
+
+	headerHeight := lipgloss.Height(header)
+	footerHeight := lipgloss.Height(footer)
+
+	// Action bar height (fixed 3 lines when visible)
+	selectedCount := m.countSelected()
+	actionBarHeight := 0
+	if selectedCount > 0 {
+		actionBarHeight = 3
+	}
+
+	contentHeight := m.height - headerHeight - footerHeight - actionBarHeight
+	contentHeight = max(contentHeight, 5)
+
+	leftWidth := m.width / 2
+	rightWidth := m.width - leftWidth
+
+	leftPane := m.renderStackList(leftWidth, contentHeight)
+	rightPane := m.renderDetailsPanel(rightWidth, contentHeight)
+
+	stackViewer := lipgloss.JoinHorizontal(lipgloss.Top, leftPane, rightPane)
+
+	var sections []string
+	sections = append(sections, header, stackViewer)
+
+	if selectedCount > 0 {
+		bar := m.renderActionBar(m.width)
+		sections = append(sections, bar)
+	}
+
+	sections = append(sections, footer)
+
+	return lipgloss.JoinVertical(lipgloss.Left, sections...)
+}
+
+func (m *shippableStoryModel) renderHeader() string {
+	title := m.ds.Title.Render("SHIPPABLE WORK")
+
+	var status string
+	switch m.scenario.state {
+	case stateStoryLoading:
+		status = m.spinner.View() + " Loading..."
+	case stateStoryAnalyzing:
+		status = m.spinner.View() + " Analyzing combination..."
+	case stateStoryShipping:
+		status = m.spinner.View() + " Shipping..."
+	default:
+		shippableCount := 0
+		for _, s := range m.scenario.stacks {
+			if s.status == storyStatusShippable {
+				shippableCount++
+			}
+		}
+		status = fmt.Sprintf("%d stacks (%d shippable)", len(m.scenario.stacks), shippableCount)
+	}
+
+	return m.ds.HeaderBorder.
+		Width(m.width).
+		Render(lipgloss.JoinHorizontal(lipgloss.Left, title, "  ", status))
+}
+
+func (m *shippableStoryModel) renderStackList(width, height int) string {
+	borderW := m.ds.LeftPane.GetHorizontalBorderSize()
+	borderH := m.ds.LeftPane.GetVerticalBorderSize()
+	paneStyle := m.ds.LeftPane.
+		Width(width - borderW).
+		Height(height - borderH)
+
+	var sb strings.Builder
+	sb.WriteString(m.ds.PaneHeader.Render("STACKS") + "\n\n")
+
+	for i, stack := range m.scenario.stacks {
+		line := m.renderStackLine(stack, i == m.selectedIndex)
+		sb.WriteString(line + "\n")
+
+		if m.expanded[stack.rootBranch] {
+			for _, branch := range stack.allBranches {
+				sb.WriteString("    " + style.ColorDim("├── "+branch) + "\n")
+			}
+		}
+	}
+
+	sb.WriteString("\n" + style.ColorDim("↑/↓ navigate  space select  enter expand  A all"))
+
+	return paneStyle.Render(sb.String())
+}
+
+func (m *shippableStoryModel) renderStackLine(stack storyStack, focused bool) string {
+	cursor := "  "
+	if focused {
+		cursor = style.ColorCyan("▸ ")
+	}
+
+	root := stack.rootBranch
+
+	// Pad checkbox and status icon to fixed widths for alignment
+	var checkbox string
+	if m.selected[root] {
+		checkbox = style.ColorCyan("[x]")
+	} else {
+		checkbox = "[ ]"
+	}
+	checkbox = style.PadToWidth(checkbox, style.CheckboxColumnWidth)
+
+	statusIcon := style.PadToWidth(m.getStatusIcon(stack.status), style.StatusIconColumnWidth)
+
+	name := stack.prTitle
+	if name == "" {
+		name = root
+	}
+
+	branchCount := ""
+	if count := stack.branchCount(); count > 1 {
+		branchCount = fmt.Sprintf("(%d branches)", count)
+	}
+
+	expandIndicator := ""
+	if stack.branchCount() > 1 {
+		expandIndicator = "▶"
+		if m.expanded[root] {
+			expandIndicator = "▼"
+		}
+	}
+
+	var line string
+	if branchCount != "" {
+		line = fmt.Sprintf("%s%s %s %s %s %s", cursor, checkbox, statusIcon, name, branchCount, expandIndicator)
+	} else {
+		line = fmt.Sprintf("%s%s %s %s", cursor, checkbox, statusIcon, name)
+	}
+
+	if focused {
+		line = m.ds.SelectedRow.Render(line)
+	}
+
+	return line
+}
+
+func (m *shippableStoryModel) getStatusIcon(status storyStackStatus) string {
+	switch status {
+	case storyStatusShippable:
+		return style.ColorGreen("✓")
+	case storyStatusPending:
+		return style.ColorYellow("⏳")
+	case storyStatusBlocked:
+		return style.ColorRed("✗")
+	case storyStatusIncomplete:
+		return style.ColorDim("○")
+	default:
+		return "?"
+	}
+}
+
+func (m *shippableStoryModel) renderDetailsPanel(width, height int) string {
+	borderW := m.ds.RightPane.GetHorizontalBorderSize()
+	borderH := m.ds.RightPane.GetVerticalBorderSize()
+	paneStyle := m.ds.RightPane.
+		Width(width - borderW).
+		Height(height - borderH)
+
+	var sb strings.Builder
+	sb.WriteString(m.ds.PaneHeader.Render("DETAILS") + "\n\n")
+
+	if m.selectedIndex < len(m.scenario.stacks) {
+		stack := &m.scenario.stacks[m.selectedIndex]
+		sb.WriteString(m.renderStackDetails(stack))
+	} else {
+		sb.WriteString(style.ColorDim("Select a stack to see details"))
+	}
+
+	return paneStyle.Render(sb.String())
+}
+
+func (m *shippableStoryModel) renderStackDetails(stack *storyStack) string {
+	var sb strings.Builder
+
+	// Show stack description if present (matches real dashboard's logic)
+	if stack.stackTitle != "" {
+		var markdown string
+		if stack.stackDesc != "" {
+			markdown = "# " + stack.stackTitle + "\n\n" + stack.stackDesc
+		} else {
+			markdown = "# " + stack.stackTitle
+		}
+		rendered := style.RenderMarkdown(markdown)
+		sb.WriteString(rendered + "\n")
+	}
+
+	// Header
+	title := stack.prTitle
+	if title == "" {
+		title = stack.rootBranch
+	}
+	badge := storyBadges[stack.status].Render(strings.ToUpper(string(stack.status)))
+	sb.WriteString(lipgloss.NewStyle().Bold(true).Render(title) + " " + badge + "\n")
+	sb.WriteString(style.ColorDim(stack.rootBranch) + "\n\n")
+
+	// Quick stats
+	var parts []string
+	parts = append(parts, fmt.Sprintf("%d branches", stack.branchCount()))
+	if stack.approvalOK {
+		parts = append(parts, style.ColorGreen("✓ Approved"))
+	} else {
+		parts = append(parts, style.ColorYellow("○ Review needed"))
+	}
+	if stack.gitHubCIOK {
+		parts = append(parts, style.ColorGreen("✓ CI"))
+	} else {
+		parts = append(parts, style.ColorRed("✗ CI"))
+	}
+	sb.WriteString(style.ColorDim(strings.Join(parts, " • ")) + "\n\n")
+
+	// Stack tree (simplified)
+	sb.WriteString(style.ColorDim("Stack:") + "\n")
+	for i, branch := range stack.allBranches {
+		prefix := "├──"
+		if i == len(stack.allBranches)-1 {
+			prefix = "└──"
+		}
+		fmt.Fprintf(&sb, "  %s %s\n", style.ColorDim(prefix), branch)
+	}
+
+	// Blocking PRs
+	if len(stack.blockingPRs) > 0 {
+		sb.WriteString("\n" + style.ColorYellow("Blocking:") + "\n")
+		for _, bp := range stack.blockingPRs {
+			reason := m.formatBlockingReason(bp.reason)
+			fmt.Fprintf(&sb, "  %s %s\n", style.ColorDim("•"), bp.branch)
+			fmt.Fprintf(&sb, "    %s\n", reason)
+		}
+	}
+
+	return sb.String()
+}
+
+func (m *shippableStoryModel) formatBlockingReason(reason storyBlockingReason) string {
+	switch reason {
+	case storyReasonCIFailing:
+		return style.ColorRed("CI checks failing")
+	case storyReasonCIPending:
+		return style.ColorYellow("CI checks pending")
+	case storyReasonChangesRequested:
+		return style.ColorRed("Changes requested")
+	case storyReasonReviewRequired:
+		return style.ColorYellow("Review required")
+	case storyReasonDraft:
+		return style.ColorDim("PR is a draft")
+	case storyReasonNoPR:
+		return style.ColorDim("No PR created")
+	default:
+		return string(reason)
+	}
+}
+
+func (m *shippableStoryModel) countSelected() int {
+	count := 0
+	for _, s := range m.scenario.stacks {
+		if m.selected[s.rootBranch] {
+			count++
+		}
+	}
+	return count
+}
+
+func (m *shippableStoryModel) renderActionBar(width int) string {
+	barStyle := m.ds.ActionBar.Width(width - m.ds.ActionBar.GetHorizontalBorderSize())
+
+	totalBranches := 0
+	selectedCount := 0
+	for _, s := range m.scenario.stacks {
+		if m.selected[s.rootBranch] {
+			selectedCount++
+			totalBranches += s.branchCount()
+		}
+	}
+
+	summary := fmt.Sprintf("%d stacks selected (%d branches)", selectedCount, totalBranches)
+	shipAction := m.ds.ButtonPrimary.Render("[s] Ship")
+
+	var analysisAction string
+	if selectedCount > 1 {
+		analysisAction = style.ColorDim("[a] Analyze")
+	}
+
+	line := fmt.Sprintf("%s  %s  %s", summary, shipAction, analysisAction)
+	return barStyle.Render(line)
+}
+
+func (m *shippableStoryModel) renderFooter() string {
+	if m.scenario.state == stateStoryLoading || m.scenario.state == stateStoryAnalyzing || m.scenario.state == stateStoryShipping {
+		var message string
+		switch m.scenario.state {
+		case stateStoryLoading:
+			message = "Refreshing..."
+		case stateStoryAnalyzing:
+			message = "Analyzing combination..."
+		case stateStoryShipping:
+			message = "Shipping stacks..."
+		}
+		return m.ds.Footer.Width(m.width).Render(m.spinner.View() + " " + message)
+	}
+
+	shortcuts := "[p] Publish all  [r] Refresh  [?] Help  [q] Quit"
+	return m.ds.Footer.Width(m.width).Render(shortcuts)
+}
+
+// registerShippableStories registers all shippable dashboard stories.
+func registerShippableStories() {
+	for _, scenario := range shippableScenarios {
+		s := scenario // Capture for closure
+		RegisterStory(Story{
+			Name:        s.name,
+			Category:    "Shippable",
+			Description: s.description,
+			CreateModel: func() tea.Model {
+				return newShippableStoryModel(s)
+			},
+		})
+	}
+
+	// Also register merge progress flow stories
+	registerMergeProgressStories()
+}
+
+// registerMergeProgressStories adds stories for merge progress simulation.
+func registerMergeProgressStories() {
+	RegisterStory(Story{
+		Name:        "Merge Progress - Happy Path",
+		Category:    "Merge Flow",
+		Description: "Simulated merge progress with all steps succeeding",
+		CreateModel: func() tea.Model {
+			return newMergeProgressSimulation(mergeScenarioHappyPath)
+		},
+	})
+
+	RegisterStory(Story{
+		Name:        "Merge Progress - Waiting for CI",
+		Category:    "Merge Flow",
+		Description: "Simulated merge progress stuck waiting for CI checks",
+		CreateModel: func() tea.Model {
+			return newMergeProgressSimulation(mergeScenarioWaitingCI)
+		},
+	})
+
+	RegisterStory(Story{
+		Name:        "Merge Progress - Failure",
+		Category:    "Merge Flow",
+		Description: "Simulated merge progress with a failure",
+		CreateModel: func() tea.Model {
+			return newMergeProgressSimulation(mergeScenarioFailure)
+		},
+	})
+}
+
+// mergeScenarioType defines different merge progress scenarios
+type mergeScenarioType int
+
+const (
+	mergeScenarioHappyPath mergeScenarioType = iota
+	mergeScenarioWaitingCI
+	mergeScenarioFailure
+)
+
+// mergeProgressSimulation simulates the merge progress component
+type mergeProgressSimulation struct {
+	scenario  mergeScenarioType
+	step      int
+	startTime time.Time
+	spinner   spinner.Model
+
+	// Simulated state
+	groups []mergeGroup
+	steps  []mergeStep
+}
+
+type mergeGroup struct {
+	label       string
+	stepIndices []int
+}
+
+type mergeStep struct {
+	description string
+	status      string // pending, running, waiting, done, error
+	elapsed     time.Duration
+}
+
+func newMergeProgressSimulation(scenario mergeScenarioType) *mergeProgressSimulation {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+
+	// Create mock merge plan based on scenario
+	groups := []mergeGroup{
+		{label: "Merge feature/auth-base (#101)", stepIndices: []int{0}},
+		{label: "Merge feature/auth-validation (#102)", stepIndices: []int{1}},
+		{label: "Merge feature/auth-login (#103)", stepIndices: []int{2}},
+		{label: "Cleanup local branches", stepIndices: []int{3}},
+	}
+
+	steps := []mergeStep{
+		{description: "Merge PR #101", status: stepStatusPending},
+		{description: "Merge PR #102", status: stepStatusPending},
+		{description: "Merge PR #103", status: stepStatusPending},
+		{description: "Delete local branches", status: stepStatusPending},
+	}
+
+	return &mergeProgressSimulation{
+		scenario:  scenario,
+		startTime: time.Now(),
+		spinner:   s,
+		groups:    groups,
+		steps:     steps,
+	}
+}
+
+func (m *mergeProgressSimulation) Init() tea.Cmd {
+	return tea.Batch(
+		m.spinner.Tick,
+		m.nextTick(),
+	)
+}
+
+func (m *mergeProgressSimulation) nextTick() tea.Cmd {
+	delay := 1500 * time.Millisecond
+	if m.step == 0 {
+		delay = 500 * time.Millisecond
+	}
+	return tea.Tick(delay, func(_ time.Time) tea.Msg {
+		return mergeSimTickMsg(m.step)
+	})
+}
+
+type mergeSimTickMsg int
+
+func (m *mergeProgressSimulation) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if msg.String() == core.KeyQuit || msg.String() == core.KeyEsc {
+			return m, tea.Quit
+		}
+		if msg.String() == "r" {
+			// Reset simulation
+			m.step = 0
+			for i := range m.steps {
+				m.steps[i].status = stepStatusPending
+				m.steps[i].elapsed = 0
+			}
+			return m, m.nextTick()
+		}
+
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+
+	case mergeSimTickMsg:
+		return m.advanceSimulation()
+	}
+
+	return m, nil
+}
+
+func (m *mergeProgressSimulation) advanceSimulation() (tea.Model, tea.Cmd) {
+	m.step++
+
+	switch m.scenario {
+	case mergeScenarioHappyPath:
+		return m.advanceHappyPath()
+	case mergeScenarioWaitingCI:
+		return m.advanceWaitingCI()
+	case mergeScenarioFailure:
+		return m.advanceFailure()
+	}
+
+	return m, nil
+}
+
+func (m *mergeProgressSimulation) advanceHappyPath() (tea.Model, tea.Cmd) {
+	switch m.step {
+	case 1:
+		m.steps[0].status = stepStatusRunning
+	case 2:
+		m.steps[0].status = stepStatusDone
+		m.steps[1].status = stepStatusRunning
+	case 3:
+		m.steps[1].status = stepStatusDone
+		m.steps[2].status = stepStatusRunning
+	case 4:
+		m.steps[2].status = stepStatusDone
+		m.steps[3].status = stepStatusRunning
+	case 5:
+		m.steps[3].status = stepStatusDone
+		// All done, reset after a pause
+		return m, tea.Tick(3*time.Second, func(_ time.Time) tea.Msg {
+			return mergeSimTickMsg(-1)
+		})
+	case -1:
+		// Reset
+		m.step = 0
+		for i := range m.steps {
+			m.steps[i].status = stepStatusPending
+		}
+	}
+	return m, m.nextTick()
+}
+
+func (m *mergeProgressSimulation) advanceWaitingCI() (tea.Model, tea.Cmd) {
+	switch {
+	case m.step == 1:
+		m.steps[0].status = stepStatusRunning
+	case m.step == 2:
+		m.steps[0].status = stepStatusWaiting
+		m.steps[0].elapsed = 30 * time.Second
+	case m.step >= 3 && m.step <= 6:
+		// Continue waiting with increasing elapsed time
+		m.steps[0].elapsed = time.Duration(30*(m.step-1)) * time.Second
+	case m.step == 7:
+		m.steps[0].status = stepStatusDone
+		m.steps[1].status = stepStatusRunning
+	case m.step == 8:
+		m.steps[1].status = stepStatusDone
+		m.steps[2].status = stepStatusRunning
+	case m.step == 9:
+		m.steps[2].status = stepStatusDone
+		m.steps[3].status = stepStatusRunning
+	case m.step == 10:
+		m.steps[3].status = stepStatusDone
+		return m, tea.Tick(3*time.Second, func(_ time.Time) tea.Msg {
+			return mergeSimTickMsg(-1)
+		})
+	case m.step == -1:
+		m.step = 0
+		for i := range m.steps {
+			m.steps[i].status = stepStatusPending
+			m.steps[i].elapsed = 0
+		}
+	}
+	return m, m.nextTick()
+}
+
+func (m *mergeProgressSimulation) advanceFailure() (tea.Model, tea.Cmd) {
+	switch m.step {
+	case 1:
+		m.steps[0].status = stepStatusRunning
+	case 2:
+		m.steps[0].status = stepStatusDone
+		m.steps[1].status = stepStatusRunning
+	case 3:
+		m.steps[1].status = stepStatusError
+		// Stay in error state, then reset
+		return m, tea.Tick(3*time.Second, func(_ time.Time) tea.Msg {
+			return mergeSimTickMsg(-1)
+		})
+	case -1:
+		m.step = 0
+		for i := range m.steps {
+			m.steps[i].status = stepStatusPending
+		}
+	}
+	return m, m.nextTick()
+}
+
+func (m *mergeProgressSimulation) View() string {
+	var b strings.Builder
+	b.WriteString("\n")
+
+	// Header
+	completedCount := 0
+	for _, s := range m.steps {
+		if s.status == stepStatusDone {
+			completedCount++
+		}
+	}
+
+	header := lipgloss.NewStyle().Bold(true).Render("Merge Progress")
+	progress := style.ColorDim(fmt.Sprintf("  Step %d of %d", completedCount+1, len(m.groups)))
+	b.WriteString(header + progress + "\n\n")
+
+	// Render each group
+	for i, group := range m.groups {
+		step := m.steps[group.stepIndices[0]]
+		var icon string
+		var labelStyle lipgloss.Style
+
+		switch step.status {
+		case stepStatusDone:
+			icon = style.ColorGreen("✓")
+			labelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("34"))
+		case stepStatusRunning:
+			icon = m.spinner.View()
+			labelStyle = lipgloss.NewStyle().Bold(true)
+		case stepStatusWaiting:
+			icon = m.spinner.View()
+			labelStyle = lipgloss.NewStyle().Bold(true)
+		case stepStatusError:
+			icon = style.ColorRed("✗")
+			labelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+		default:
+			icon = style.ColorDim("○")
+			labelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+		}
+
+		line := fmt.Sprintf("  %s %s", icon, labelStyle.Render(group.label))
+
+		// Add waiting info
+		if step.status == stepStatusWaiting {
+			line += style.ColorYellow(fmt.Sprintf(" [waiting for CI: %v]", step.elapsed))
+		}
+
+		// Add error info
+		if step.status == stepStatusError {
+			line += style.ColorRed(" → merge conflict detected")
+		}
+
+		b.WriteString(line + "\n")
+
+		// Show CI details when waiting
+		if step.status == stepStatusWaiting {
+			b.WriteString("    └ " + style.ColorDim("lint (running), test (running), build (queued)") + "\n")
+		}
+
+		// Only show a few pending steps
+		if step.status == stepStatusPending && i > completedCount+2 {
+			remaining := len(m.groups) - i
+			fmt.Fprintf(&b, style.ColorDim("  ... %d more steps\n"), remaining)
+			break
+		}
+	}
+
+	// Summary
+	if allStepsDone(m.steps) {
+		b.WriteString("\n" + style.ColorGreen("✓ All steps completed successfully") + "\n")
+	}
+
+	b.WriteString("\n" + style.ColorDim("[r] restart simulation  [q] back"))
+
+	return b.String()
+}
+
+func allStepsDone(steps []mergeStep) bool {
+	for _, s := range steps {
+		if s.status != stepStatusDone {
+			return false
+		}
+	}
+	return true
+}
+
+func init() {
+	registerShippableStories()
+}

--- a/internal/tui/shippable_stories_test.go
+++ b/internal/tui/shippable_stories_test.go
@@ -1,0 +1,52 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShippableStoriesRegistered(t *testing.T) {
+	// Verify shippable stories are registered
+	shippableCount := 0
+	mergeFlowCount := 0
+
+	for _, s := range Stories {
+		switch s.Category {
+		case "Shippable":
+			shippableCount++
+		case "Merge Flow":
+			mergeFlowCount++
+		}
+	}
+
+	require.GreaterOrEqual(t, shippableCount, 7, "Expected at least 7 Shippable stories")
+	require.GreaterOrEqual(t, mergeFlowCount, 3, "Expected at least 3 Merge Flow stories")
+}
+
+func TestShippableStoryModelCreation(t *testing.T) {
+	// Verify each scenario creates a valid model
+	for _, scenario := range shippableScenarios {
+		model := newShippableStoryModel(scenario)
+		require.NotNil(t, model, "Model should be created for scenario: %s", scenario.name)
+
+		// Run Init
+		cmd := model.Init()
+		require.NotNil(t, cmd, "Init should return a command")
+	}
+}
+
+func TestMergeProgressSimulationCreation(t *testing.T) {
+	scenarios := []mergeScenarioType{
+		mergeScenarioHappyPath,
+		mergeScenarioWaitingCI,
+		mergeScenarioFailure,
+	}
+
+	for _, scenario := range scenarios {
+		model := newMergeProgressSimulation(scenario)
+		require.NotNil(t, model, "Model should be created for scenario")
+		require.Len(t, model.groups, 4, "Should have 4 merge groups")
+		require.Len(t, model.steps, 4, "Should have 4 steps")
+	}
+}

--- a/internal/tui/style/dashboard.go
+++ b/internal/tui/style/dashboard.go
@@ -1,0 +1,178 @@
+package style
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Column width constants for alignment in the stack list.
+// These ensure columns stay aligned regardless of unicode character widths.
+const (
+	// CheckboxColumnWidth is the display width for the checkbox column.
+	// Widest value is "[🔒]" which renders as 4 display columns.
+	CheckboxColumnWidth = 4
+
+	// StatusIconColumnWidth is the display width for the status icon column.
+	// Widest value is "⏳" which renders as 2 display columns.
+	StatusIconColumnWidth = 2
+)
+
+// PadToWidth pads a rendered string with spaces to reach targetWidth display columns.
+// It uses lipgloss.Width() to measure actual display width, handling unicode correctly.
+func PadToWidth(rendered string, targetWidth int) string {
+	actual := lipgloss.Width(rendered)
+	if actual >= targetWidth {
+		return rendered
+	}
+	return rendered + strings.Repeat(" ", targetWidth-actual)
+}
+
+// Dashboard color constants shared between the real dashboard and story previews.
+const (
+	// ColorDashboardBackground is a dark gray for selected row backgrounds.
+	ColorDashboardBackground = "236"
+	// ColorDashboardWhite is white for text on dark backgrounds.
+	ColorDashboardWhite = "15"
+	// ColorDashboardBlack is black for text on light backgrounds.
+	ColorDashboardBlack = "0"
+	// ColorDashboardGray is medium gray for disabled text.
+	ColorDashboardGray = "7"
+	// ColorDashboardDarkGray is dark gray for disabled backgrounds.
+	ColorDashboardDarkGray = "8"
+	// ColorDashboardBorder is dim gray for panel borders.
+	ColorDashboardBorder = "240"
+)
+
+// DashboardStyles holds all styles for the shippable work dashboard.
+// Both the real dashboard and st-tui stories use these to stay in sync.
+type DashboardStyles struct {
+	Title        lipgloss.Style
+	HeaderStatus lipgloss.Style
+	HeaderBorder lipgloss.Style
+	PaneHeader   lipgloss.Style
+	SelectedRow  lipgloss.Style
+	Footer       lipgloss.Style
+	ErrorText    lipgloss.Style
+
+	// Pane styles
+	LeftPane  lipgloss.Style
+	RightPane lipgloss.Style
+	ActionBar lipgloss.Style
+
+	// Badge styles
+	BadgeReady      lipgloss.Style
+	BadgePending    lipgloss.Style
+	BadgeBlocked    lipgloss.Style
+	BadgeIncomplete lipgloss.Style
+
+	// Button styles
+	ButtonPrimary lipgloss.Style
+
+	// Help styles
+	HelpTitle   lipgloss.Style
+	HelpSection lipgloss.Style
+	HelpKey     lipgloss.Style
+	HelpDesc    lipgloss.Style
+
+	// Dialog
+	Dialog lipgloss.Style
+}
+
+// DefaultDashboardStyles returns the canonical dashboard styles.
+func DefaultDashboardStyles() DashboardStyles {
+	return DashboardStyles{
+		Title: lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorAccent)).
+			Bold(true).
+			Padding(0, 1),
+
+		HeaderStatus: lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorDimValue)).
+			Padding(0, 1),
+
+		HeaderBorder: lipgloss.NewStyle().
+			Border(lipgloss.NormalBorder(), false, false, true, false).
+			BorderForeground(lipgloss.Color(ColorDashboardBorder)),
+
+		PaneHeader: lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color(ColorAccent)),
+
+		SelectedRow: lipgloss.NewStyle().
+			Background(lipgloss.Color(ColorDashboardBackground)).
+			Bold(true),
+
+		Footer: lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorDimValue)).
+			Padding(0, 1),
+
+		ErrorText: lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorErrorAlt)),
+
+		// Pane styles
+		LeftPane: lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color(ColorDashboardBorder)).
+			Padding(1),
+
+		RightPane: lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color(ColorDashboardBorder)).
+			Padding(1),
+
+		ActionBar: lipgloss.NewStyle().
+			Border(lipgloss.NormalBorder(), true, false, false, false).
+			BorderForeground(lipgloss.Color(ColorDashboardBorder)).
+			Padding(0, 1),
+
+		// Badge styles
+		BadgeReady: lipgloss.NewStyle().
+			Background(lipgloss.Color(ColorSuccessAlt)).
+			Foreground(lipgloss.Color(ColorDashboardBlack)).
+			Padding(0, 1),
+
+		BadgePending: lipgloss.NewStyle().
+			Background(lipgloss.Color(ColorWarningAlt)).
+			Foreground(lipgloss.Color(ColorDashboardBlack)).
+			Padding(0, 1),
+
+		BadgeBlocked: lipgloss.NewStyle().
+			Background(lipgloss.Color(ColorErrorAlt)).
+			Foreground(lipgloss.Color(ColorDashboardWhite)).
+			Padding(0, 1),
+
+		BadgeIncomplete: lipgloss.NewStyle().
+			Background(lipgloss.Color(ColorDashboardDarkGray)).
+			Foreground(lipgloss.Color(ColorDashboardWhite)).
+			Padding(0, 1),
+
+		// Button styles
+		ButtonPrimary: lipgloss.NewStyle().
+			Background(lipgloss.Color(ColorSuccessAlt)).
+			Foreground(lipgloss.Color(ColorDashboardBlack)).
+			Padding(0, 2),
+
+		// Help styles
+		HelpTitle: lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color(ColorAccent)).
+			MarginBottom(1),
+
+		HelpSection: lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color(ColorMerged)).
+			MarginTop(1),
+
+		HelpKey: lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorWarningAlt)).
+			Width(12),
+
+		HelpDesc: lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorDashboardGray)),
+
+		// Dialog
+		Dialog: lipgloss.NewStyle().
+			Padding(2, 4),
+	}
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Enhance shippable dashboard with worktree support and diagnostics**

Comprehensive improvements to the shippable dashboard interface, adding worktree integration, interactive management, and debugging capabilities.

Key changes by branch:
- **extract-dashboard-styles**: Centralized dashboard styling into `internal/tui/style/dashboard.go` (+178 lines) and added comprehensive shippable stories for TUI testing (+1090 lines)
- **worktree-integration**: Extended dashboard model to display worktree information, added update handlers for worktree state changes
- **formatting-improvements**: Refactored view layout for better readability and consistent formatting
- **error-handling**: Enhanced error display and status reporting in the dashboard UI
- **tracing-diagnostics**: Added git operation tracing and metadata cache diagnostics for debugging performance issues
- **interactive-worktree-management**: Added interactive worktree creation, attachment, and management capabilities directly from the dashboard

Implementation notes:
- New style package consolidates all dashboard-related styles in one place
- Worktree state is now part of the dashboard model and updates reactively
- Interactive commands allow users to create/attach worktrees without leaving the dashboard
- Tracing infrastructure helps identify bottlenecks in git operations
- All changes maintain backward compatibility with existing dashboard functionality

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `multi-stack/20260207-221615`.


* **PR #696** 👈
  * **PR #710**
    * **PR #711**
      * **PR #712**
        * **PR #713**
          * **PR #714**
            * **PR #715**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->