### PR TITLE
perf: optimize stackit log with metadata cache and batch operations

### DIFF
--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -54,14 +54,14 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 		}
 	}
 
-	// Detect empty worktrees (worktree anchors with no children)
-	emptyWorktrees := tui.GetEmptyWorktrees(ctx.Engine)
+	// Detect worktrees (builds both empty and stack-root maps in one call)
+	wtData := tui.GetWorktreeData(ctx.Engine)
 
 	// Create tree renderer - use empty worktrees-aware version if we have any
 	var renderer *tree.StackTreeRenderer
-	if len(emptyWorktrees) > 0 {
+	if len(wtData.EmptyWorktrees) > 0 {
 		emptyWorktreeNames := make(map[string]bool)
-		for name := range emptyWorktrees {
+		for name := range wtData.EmptyWorktrees {
 			emptyWorktreeNames[name] = true
 		}
 		renderer = tui.NewStackTreeRendererWithEmptyWorktrees(ctx.Engine, emptyWorktreeNames)
@@ -89,8 +89,9 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 	}
 
 	enrichment := &tui.AnnotationEnrichment{
-		CIStatuses:     ciStatuses,
-		EmptyWorktrees: emptyWorktrees,
+		CIStatuses:          ciStatuses,
+		EmptyWorktrees:      wtData.EmptyWorktrees,
+		WorktreeByStackRoot: wtData.WorktreeByStackRoot,
 	}
 
 	type result struct {

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -170,32 +170,7 @@ func (e *engineImpl) GetAllCommits(branch Branch, format CommitFormat) ([]string
 		baseRevision = *meta.ParentBranchRevision
 	}
 
-	// Get SHAs first
-	shas, err := e.git.GetCommitRangeSHAs(baseRevision, branchRevision)
-	if err != nil {
-		return nil, err
-	}
-
-	if format == CommitFormatSHA {
-		return shas, nil
-	}
-
-	// Format results
-	result := make([]string, len(shas))
-	for i, sha := range shas {
-		var formatted string
-		switch format {
-		case CommitFormatSubject:
-			formatted, _ = e.git.GetCommitLog(sha, "%s")
-		case CommitFormatMessage:
-			formatted, _ = e.git.GetCommitLog(sha, "%B")
-		case CommitFormatReadable:
-			formatted, _ = e.git.GetCommitLog(sha, "%h %s")
-		default:
-			return nil, fmt.Errorf("unknown commit format: %s", format)
-		}
-		result[i] = strings.TrimSpace(formatted)
-	}
-
-	return result, nil
+	// Use GetCommitRange directly — handles formatting in-process via go-git
+	// (with CLI fallback), avoiding per-commit git process spawns
+	return e.git.GetCommitRange(baseRevision, branchRevision, string(format))
 }

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -169,11 +169,20 @@ func (r *runner) BatchReadLocalMetadata(branchNames []string) map[string]*LocalM
 }
 
 func (r *runner) ReadMetadata(branchName string) (*Meta, error) {
+	// Check cache first to avoid redundant git process spawns
+	if cached, ok := r.metadataCache.Load(branchName); ok {
+		// Return a shallow copy so callers can't mutate the cached value
+		original := cached.(*Meta)
+		cloned := *original
+		return &cloned, nil
+	}
+
 	refName := fmt.Sprintf("%s%s", MetadataRefPrefix, branchName)
 
 	sha, err := r.GetRef(refName)
 	if err != nil {
 		// If ref doesn't exist, it's not an error, just means no metadata
+		r.metadataCache.Store(branchName, &Meta{})
 		return &Meta{}, nil //nolint:nilerr
 	}
 
@@ -183,6 +192,7 @@ func (r *runner) ReadMetadata(branchName string) (*Meta, error) {
 	}
 
 	if content == "" {
+		r.metadataCache.Store(branchName, &Meta{})
 		return &Meta{}, nil
 	}
 
@@ -191,7 +201,10 @@ func (r *runner) ReadMetadata(branchName string) (*Meta, error) {
 		return nil, fmt.Errorf("failed to unmarshal metadata for %s: %w", branchName, err)
 	}
 
-	return &meta, nil
+	r.metadataCache.Store(branchName, &meta)
+	// Return a copy so callers can't mutate the cached value
+	cloned := meta
+	return &cloned, nil
 }
 
 func (r *runner) WriteMetadata(branchName string, meta *Meta) error {
@@ -210,12 +223,15 @@ func (r *runner) WriteMetadata(branchName string, meta *Meta) error {
 		return fmt.Errorf("failed to write metadata ref: %w", err)
 	}
 
+	r.metadataCache.Store(branchName, meta)
 	return nil
 }
 
 func (r *runner) DeleteMetadata(branchName string) error {
 	refName := fmt.Sprintf("%s%s", MetadataRefPrefix, branchName)
-	return r.DeleteRef(refName)
+	err := r.DeleteRef(refName)
+	r.metadataCache.Delete(branchName)
+	return err
 }
 
 func (r *runner) RenameMetadata(oldName, newName string) error {
@@ -232,6 +248,8 @@ func (r *runner) RenameMetadata(oldName, newName string) error {
 		return fmt.Errorf("failed to create new metadata ref: %w", err)
 	}
 
+	r.metadataCache.Delete(oldName)
+	r.metadataCache.Delete(newName)
 	return nil
 }
 
@@ -345,6 +363,17 @@ func (r *runner) GetLocalMetadataRefSHA(branchName string) string {
 		return ""
 	}
 	return sha
+}
+
+// invalidateMetadataCacheForRefs clears cached metadata for any refs
+// in the given batch that are metadata refs. This ensures that batch
+// operations (transactions) don't leave stale cache entries.
+func (r *runner) invalidateMetadataCacheForRefs(updates []RefUpdate) {
+	for _, update := range updates {
+		if branchName, ok := strings.CutPrefix(update.RefName, MetadataRefPrefix); ok {
+			r.metadataCache.Delete(branchName)
+		}
+	}
 }
 
 // MetadataRefName returns the full ref name for a branch's metadata.

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -80,6 +80,7 @@ func (r *runner) UpdateRefsBatch(ctx context.Context, updates []RefUpdate) error
 	if err != nil {
 		return fmt.Errorf("atomic ref update failed: %w", err)
 	}
+	r.invalidateMetadataCacheForRefs(updates)
 	return nil
 }
 
@@ -108,6 +109,7 @@ func (r *runner) UpdateRefsBatchWithLog(ctx context.Context, updates []RefUpdate
 	if err != nil {
 		return fmt.Errorf("atomic ref update failed: %w", err)
 	}
+	r.invalidateMetadataCacheForRefs(updates)
 	return nil
 }
 
@@ -125,6 +127,11 @@ func (r *runner) DeleteRefsBatch(ctx context.Context, refNames []string) error {
 	_, err := r.runGitInternal(ctx, stdin.String(), nil, true, "update-ref", "--stdin")
 	if err != nil {
 		return fmt.Errorf("atomic ref delete failed: %w", err)
+	}
+	for _, refName := range refNames {
+		if branchName, ok := strings.CutPrefix(refName, MetadataRefPrefix); ok {
+			r.metadataCache.Delete(branchName)
+		}
 	}
 	return nil
 }
@@ -391,6 +398,10 @@ type runner struct {
 	repoMu   sync.Mutex
 	loggerMu sync.RWMutex
 	logger   DebugLogger
+
+	// Cached metadata to avoid redundant ReadMetadata calls (each spawns 2 git processes).
+	// Thread-safe: sync.Map handles concurrent reads from worker pools.
+	metadataCache sync.Map // map[string]*Meta
 
 	// Cached git version info
 	gitVersionOnce   sync.Once
@@ -716,7 +727,7 @@ func formatCommits(commits []*object.Commit, format string) ([]string, error) {
 			// Oneline format: short SHA + subject
 			shortHash := commit.Hash.String()[:7]
 			subject := strings.Split(strings.TrimSpace(commit.Message), "\n")[0]
-			formatted = fmt.Sprintf("%s - %s", shortHash, subject)
+			formatted = fmt.Sprintf("%s %s", shortHash, subject)
 		case "MESSAGE":
 			formatted = strings.TrimSpace(commit.Message)
 		case "SUBJECT":
@@ -752,7 +763,7 @@ func (r *runner) getCommitRangeWithFallback(base, head, format string) ([]string
 		switch format {
 		case "READABLE":
 			// Oneline format: short SHA + subject
-			formatted, err = r.GetCommitLog(sha, "%h - %s")
+			formatted, err = r.GetCommitLog(sha, "%h %s")
 		case "MESSAGE":
 			formatted, err = r.GetCommitLog(sha, "%B")
 		case "SUBJECT":

--- a/internal/tui/log_ui.go
+++ b/internal/tui/log_ui.go
@@ -108,17 +108,17 @@ func NewLogModel(ctx context.Context, eng engine.Engine, ghClient github.Client,
 		}
 	}
 
-	// Detect empty worktrees
+	// Detect worktrees (builds both empty and stack-root maps in one call)
 	start := time.Now()
-	emptyWorktrees := GetEmptyWorktrees(eng)
+	wtData := GetWorktreeData(eng)
 	var emptyWorktreeNames map[string]bool
-	if len(emptyWorktrees) > 0 {
+	if len(wtData.EmptyWorktrees) > 0 {
 		emptyWorktreeNames = make(map[string]bool)
-		for name := range emptyWorktrees {
+		for name := range wtData.EmptyWorktrees {
 			emptyWorktreeNames[name] = true
 		}
 	}
-	logDebug("GetEmptyWorktrees completed in %v, found %d", time.Since(start), len(emptyWorktrees))
+	logDebug("GetWorktreeData completed in %v, found %d empty worktrees", time.Since(start), len(wtData.EmptyWorktrees))
 
 	// Create renderer synchronously for instant display
 	start = time.Now()
@@ -129,7 +129,7 @@ func NewLogModel(ctx context.Context, eng engine.Engine, ghClient github.Client,
 	start = time.Now()
 	annotations := make(map[string]tree.BranchAnnotation)
 	for _, b := range eng.AllBranches() {
-		annotations[b.GetName()] = GetMinimalAnnotationWithWorktreeAndEmpty(eng, b, emptyWorktrees)
+		annotations[b.GetName()] = GetMinimalAnnotationWithWorktreeAndEmpty(eng, b, wtData)
 	}
 	// Apply annotation overrides (e.g., custom labels for move operation)
 	if opts.AnnotationOverrides != nil {
@@ -319,14 +319,15 @@ func (m *LogModel) enrichData() tea.Cmd {
 		}
 		ciStatuses := ciRes.statuses
 
-		// Detect empty worktrees
-		emptyWorktrees := GetEmptyWorktrees(eng)
+		// Detect worktrees (builds both empty and stack-root maps in one call)
+		wtData := GetWorktreeData(eng)
 
 		// Collect full annotations
 		start := time.Now()
 		enrichment := &AnnotationEnrichment{
-			CIStatuses:     ciStatuses,
-			EmptyWorktrees: emptyWorktrees,
+			CIStatuses:          ciStatuses,
+			EmptyWorktrees:      wtData.EmptyWorktrees,
+			WorktreeByStackRoot: wtData.WorktreeByStackRoot,
 		}
 		annotations := make(map[string]tree.BranchAnnotation)
 		utils.Run(allBranches, func(b engine.Branch) {

--- a/internal/tui/tree_renderer.go
+++ b/internal/tui/tree_renderer.go
@@ -109,19 +109,32 @@ func newStackTreeRendererInternal(eng engine.BranchReader, strategy engine.SortS
 	return tree.NewRenderer(data)
 }
 
-// GetEmptyWorktrees returns a map of worktree anchor branch names to their WorktreeInfo
-// for worktrees that have no child branches (empty worktrees).
-func GetEmptyWorktrees(eng engine.Engine) map[string]*engine.WorktreeInfo {
-	emptyWorktrees := make(map[string]*engine.WorktreeInfo)
+// WorktreeData holds pre-computed worktree information from a single ListManagedWorktrees call.
+type WorktreeData struct {
+	EmptyWorktrees      map[string]*engine.WorktreeInfo // Anchor branches with no children
+	WorktreeByStackRoot map[string]*engine.WorktreeInfo // Stack root -> worktree info
+}
+
+// GetWorktreeData builds both empty worktree and stack-root worktree maps from a single
+// ListManagedWorktrees call, avoiding redundant lookups.
+func GetWorktreeData(eng engine.Engine) *WorktreeData {
+	data := &WorktreeData{
+		EmptyWorktrees:      make(map[string]*engine.WorktreeInfo),
+		WorktreeByStackRoot: make(map[string]*engine.WorktreeInfo),
+	}
 
 	worktrees, err := eng.ListManagedWorktrees()
 	if err != nil {
-		return emptyWorktrees
+		return data
 	}
 
 	for i := range worktrees {
 		wt := &worktrees[i]
 		anchor := eng.GetBranch(wt.AnchorBranch)
+
+		// Build stack-root map for all worktrees (used by addWorktreeInfo)
+		data.WorktreeByStackRoot[wt.AnchorBranch] = wt
+
 		if !anchor.IsTracked() || !anchor.IsWorktreeAnchor() {
 			continue
 		}
@@ -136,18 +149,24 @@ func GetEmptyWorktrees(eng engine.Engine) map[string]*engine.WorktreeInfo {
 		}
 
 		if !hasChildren {
-			emptyWorktrees[wt.AnchorBranch] = wt
+			data.EmptyWorktrees[wt.AnchorBranch] = wt
 		}
 	}
 
-	return emptyWorktrees
+	return data
+}
+
+// GetEmptyWorktrees returns a map of worktree anchor branch names to their WorktreeInfo
+// for worktrees that have no child branches (empty worktrees).
+func GetEmptyWorktrees(eng engine.Engine) map[string]*engine.WorktreeInfo {
+	return GetWorktreeData(eng).EmptyWorktrees
 }
 
 // GetMinimalAnnotationWithWorktreeAndEmpty returns minimal annotations plus worktree info,
 // with support for marking empty worktrees.
 // This is used for fast initial rendering before full data is loaded.
 // Only includes cached/instant fields - no git or network calls.
-func GetMinimalAnnotationWithWorktreeAndEmpty(eng engine.Engine, branch engine.Branch, emptyWorktrees map[string]*engine.WorktreeInfo) tree.BranchAnnotation {
+func GetMinimalAnnotationWithWorktreeAndEmpty(eng engine.Engine, branch engine.Branch, wtData *WorktreeData) tree.BranchAnnotation {
 	ann := tree.BranchAnnotation{
 		IsLocked:      branch.IsLocked(),
 		IsFrozen:      branch.IsFrozen(),
@@ -155,7 +174,13 @@ func GetMinimalAnnotationWithWorktreeAndEmpty(eng engine.Engine, branch engine.B
 		ExplicitScope: branch.GetExplicitScope().String(),
 	}
 
-	addWorktreeInfo(eng, branch, &ann, emptyWorktrees)
+	var emptyWorktrees map[string]*engine.WorktreeInfo
+	var worktreeByRoot map[string]*engine.WorktreeInfo
+	if wtData != nil {
+		emptyWorktrees = wtData.EmptyWorktrees
+		worktreeByRoot = wtData.WorktreeByStackRoot
+	}
+	addWorktreeInfo(eng, branch, &ann, emptyWorktrees, worktreeByRoot)
 
 	return ann
 }
@@ -163,7 +188,8 @@ func GetMinimalAnnotationWithWorktreeAndEmpty(eng engine.Engine, branch engine.B
 // addWorktreeInfo populates worktree-related fields on a BranchAnnotation.
 // If the branch is an empty worktree anchor, it sets IsEmptyWorktree and WorktreePath.
 // Otherwise, if the branch is a stack root with a managed worktree, it sets WorktreePath.
-func addWorktreeInfo(eng engine.Engine, branch engine.Branch, ann *tree.BranchAnnotation, emptyWorktrees map[string]*engine.WorktreeInfo) {
+// When worktreeByRoot is provided, uses O(1) map lookup instead of calling GetWorktreeForStack.
+func addWorktreeInfo(eng engine.Engine, branch engine.Branch, ann *tree.BranchAnnotation, emptyWorktrees map[string]*engine.WorktreeInfo, worktreeByRoot map[string]*engine.WorktreeInfo) {
 	if emptyWorktrees != nil {
 		if wtInfo, ok := emptyWorktrees[branch.GetName()]; ok {
 			ann.IsEmptyWorktree = true
@@ -174,7 +200,12 @@ func addWorktreeInfo(eng engine.Engine, branch engine.Branch, ann *tree.BranchAn
 
 	stackRoot := eng.GetStackRootForBranch(branch)
 	if stackRoot == branch.GetName() {
-		if wtInfo, err := eng.GetWorktreeForStack(stackRoot); err == nil && wtInfo != nil {
+		// Use pre-built map if available, otherwise fall back to engine call
+		if worktreeByRoot != nil {
+			if wtInfo, ok := worktreeByRoot[stackRoot]; ok {
+				ann.WorktreePath = wtInfo.Path
+			}
+		} else if wtInfo, err := eng.GetWorktreeForStack(stackRoot); err == nil && wtInfo != nil {
 			ann.WorktreePath = wtInfo.Path
 		}
 	}
@@ -184,8 +215,9 @@ func addWorktreeInfo(eng engine.Engine, branch engine.Branch, ann *tree.BranchAn
 // This allows CI statuses and worktree info to be computed once and shared
 // across all branches, avoiding redundant lookups.
 type AnnotationEnrichment struct {
-	CIStatuses     map[string]*github.CheckStatus
-	EmptyWorktrees map[string]*engine.WorktreeInfo
+	CIStatuses          map[string]*github.CheckStatus
+	EmptyWorktrees      map[string]*engine.WorktreeInfo
+	WorktreeByStackRoot map[string]*engine.WorktreeInfo
 }
 
 // BuildFullAnnotation returns a fully populated BranchAnnotation including
@@ -220,7 +252,7 @@ func BuildFullAnnotation(eng engine.Engine, branch engine.Branch, enrichment *An
 	}
 
 	// Apply worktree info
-	addWorktreeInfo(eng, branch, &ann, enrichment.EmptyWorktrees)
+	addWorktreeInfo(eng, branch, &ann, enrichment.EmptyWorktrees, enrichment.WorktreeByStackRoot)
 
 	return ann
 }
@@ -252,6 +284,7 @@ func GetBranchAnnotation(eng engine.BranchReader, branch engine.Branch) tree.Bra
 		// Commit messages for detailed view
 		if commits, err := branch.GetAllCommits(engine.CommitFormatReadable); err == nil {
 			ann.CommitMessages = commits
+			ann.CommitCount = len(commits)
 		}
 
 		// Merged downstack history
@@ -269,9 +302,6 @@ func GetBranchAnnotation(eng engine.BranchReader, branch engine.Branch) tree.Bra
 		}
 
 		// Local stats
-		if count, err := branch.GetCommitCount(); err == nil {
-			ann.CommitCount = count
-		}
 		if added, deleted, err := branch.GetDiffStats(); err == nil {
 			ann.LinesAdded = added
 			ann.LinesDeleted = deleted


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Reduce git process spawns in stackit log from ~75 to ~10-15 for a stack
of 5 branches with 2 commits each (4-6x speedup in annotation building).

Changes:
- Add metadata cache to git runner to avoid redundant ReadMetadata calls
  (each spawns 2 git processes). Cache invalidated on write/delete/batch ops.
- Use GetCommitRange directly in GetAllCommits instead of per-commit
  GetCommitLog calls, eliminating N git spawns per branch.
- Derive commit count from already-fetched commit list instead of separate
  GetCommitCount call.
- Add GetWorktreeData to build both empty worktree and stack-root maps from
  a single ListManagedWorktrees call, eliminating duplicate lookups.

ReadMetadata now returns shallow copies to prevent caller mutations from
affecting cached values.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `multi-stack/20260207-113000`.


* **PR #699**
  * **PR #700** 👈
    * **PR #701**
      * **PR #702**
        * **PR #703**
          * **PR #704**
            * **PR #705**
              * **PR #706**
                * **PR #707**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->