### PR TITLE
refactor: migrate all call sites to Meta getters, With* methods, and constructors

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -241,7 +241,7 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[
 				mu.Lock()
 				deleteStatuses[name] = reason
 				// Track if this is a utility branch (e.g., consolidated merge branch)
-				if meta != nil && meta.BranchType == git.BranchTypeUtility {
+				if meta != nil && meta.GetBranchType() == git.BranchTypeUtility {
 					utilityBranches[name] = true
 				}
 				mu.Unlock()

--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -517,24 +517,27 @@ func ShouldDeleteBranchCached(ctx context.Context, branchName string, eng delete
 	}
 
 	// 1. Check PR info from cached metadata
-	if meta != nil && meta.PrInfo != nil {
-		const (
-			prStateClosed = "CLOSED"
-			prStateMerged = "MERGED"
-		)
-		if meta.PrInfo.State != nil {
-			if *meta.PrInfo.State == prStateClosed {
-				return true, "closed on GitHub"
-			}
-			if *meta.PrInfo.State == prStateMerged {
-				base := ""
-				if meta.PrInfo.Base != nil {
-					base = *meta.PrInfo.Base
+	if meta != nil {
+		prInfo := meta.GetPrInfo()
+		if prInfo != nil {
+			const (
+				prStateClosed = "CLOSED"
+				prStateMerged = "MERGED"
+			)
+			if prInfo.State != nil {
+				if *prInfo.State == prStateClosed {
+					return true, "closed on GitHub"
 				}
-				if base == "" {
-					base = eng.Trunk().GetName()
+				if *prInfo.State == prStateMerged {
+					base := ""
+					if prInfo.Base != nil {
+						base = *prInfo.Base
+					}
+					if base == "" {
+						base = eng.Trunk().GetName()
+					}
+					return true, fmt.Sprintf("merged into %s", base)
 				}
-				return true, fmt.Sprintf("merged into %s", base)
 			}
 		}
 	}
@@ -569,7 +572,8 @@ func ShouldDeleteBranchCached(ctx context.Context, branchName string, eng delete
 		empty, err := eng.IsDiffEmpty(ctx, branchName, parentRev)
 		if err == nil && empty { // IsDiffEmpty returns true if no diff
 			// Only delete empty branches if they have a PR
-			if meta != nil && meta.PrInfo != nil && meta.PrInfo.Number != nil && *meta.PrInfo.Number != 0 {
+			metaPrInfo := meta.GetPrInfo()
+			if meta != nil && metaPrInfo != nil && metaPrInfo.Number != nil && *metaPrInfo.Number != 0 {
 				return true, "empty"
 			}
 		}

--- a/internal/actions/debug.go
+++ b/internal/actions/debug.go
@@ -224,14 +224,14 @@ func DebugAction(ctx *app.Context, opts DebugOptions) error {
 		// But for now, let's just use the cache
 		remoteCache.Range(func(branch string, meta *git.Meta) bool {
 			info := RemoteRefInfo{}
-			if meta.LastModifiedAt != nil {
-				info.LastModified = meta.LastModifiedAt.Format(time.RFC3339)
+			if meta.GetLastModifiedAt() != nil {
+				info.LastModified = meta.GetLastModifiedAt().Format(time.RFC3339)
 			}
-			if meta.LastModifiedBy != nil {
-				info.ModifiedBy = fmt.Sprintf("%s <%s>", meta.LastModifiedBy.GitName, meta.LastModifiedBy.GitEmail)
+			if modBy := meta.GetLastModifiedBy(); modBy != nil {
+				info.ModifiedBy = fmt.Sprintf("%s <%s>", modBy.GitName, modBy.GitEmail)
 			}
-			if meta.Scope != nil {
-				info.Scope = *meta.Scope
+			if meta.GetScope() != nil {
+				info.Scope = *meta.GetScope()
 			}
 			remoteRefs[branch] = info
 			return true

--- a/internal/actions/doctor/stack_state.go
+++ b/internal/actions/doctor/stack_state.go
@@ -79,7 +79,7 @@ func checkStackState(ctx context.Context, eng engine.Engine, handler Handler, wa
 			errors++
 		} else if meta := allMeta[branchName]; meta != nil {
 			// Validate that if parent is set, it's not empty
-			if meta.ParentBranchName != nil && *meta.ParentBranchName == "" {
+			if meta.GetParentBranchName() != nil && *meta.GetParentBranchName() == "" {
 				corruptedCount++
 				errors++
 			}

--- a/internal/actions/flatten/flatten_test.go
+++ b/internal/actions/flatten/flatten_test.go
@@ -262,7 +262,7 @@ func TestFlattenAction(t *testing.T) {
 		// Clear B's ParentBranchRevision metadata to trigger the fallback path
 		meta, err := s.Engine.Git().ReadMetadata("B")
 		require.NoError(t, err)
-		meta.ParentBranchRevision = nil
+		meta = meta.WithParentBranchRevision(nil)
 		err = s.Engine.Git().WriteMetadata("B", meta)
 		require.NoError(t, err)
 

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -55,9 +55,9 @@ func TestActionWithMockedGitHub(t *testing.T) {
 		// Verify that metadata was updated with LastModifiedBy after submit
 		meta, err := s.Engine.Git().ReadMetadata("feature")
 		require.NoError(t, err, "Should be able to read metadata ref after submit")
-		require.NotNil(t, meta.LastModifiedBy, "LastModifiedBy should be set after submit")
-		require.NotEmpty(t, meta.LastModifiedBy.GitName, "LastModifiedBy.GitName should not be empty")
-		require.NotEmpty(t, meta.LastModifiedBy.GitEmail, "LastModifiedBy.GitEmail should not be empty")
+		require.NotNil(t, meta.GetLastModifiedBy(), "LastModifiedBy should be set after submit")
+		require.NotEmpty(t, meta.GetLastModifiedBy().GitName, "LastModifiedBy.GitName should not be empty")
+		require.NotEmpty(t, meta.GetLastModifiedBy().GitEmail, "LastModifiedBy.GitEmail should not be empty")
 	})
 
 	t.Run("updates existing PR", func(t *testing.T) {

--- a/internal/actions/sync/metadata_cleanup_test.go
+++ b/internal/actions/sync/metadata_cleanup_test.go
@@ -53,9 +53,9 @@ func TestMetadataCleanup(t *testing.T) {
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// 1. Simulate remote metadata for a branch that doesn't exist locally
-		remoteMeta := &git.Meta{
+		remoteMeta := git.NewMetaFrom(git.MetaFields{
 			LockReason: "locked",
-		}
+		})
 
 		// Serialize
 		data, err := json.Marshal(remoteMeta)

--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -107,11 +107,11 @@ func (h *SimpleSyncHandler) PromptOrphanedMetadata(info engine.OrphanedMetadataI
 	h.Output.Warn("Orphaned metadata for %s (accepting deletion):",
 		style.ColorBranchName(info.BranchName, false))
 	if info.LocalMeta != nil {
-		if info.LocalMeta.LockReason.IsLocked() {
-			h.Output.Warn("  lockReason: %s", info.LocalMeta.LockReason)
+		if info.LocalMeta.GetLockReason().IsLocked() {
+			h.Output.Warn("  lockReason: %s", info.LocalMeta.GetLockReason())
 		}
-		if info.LocalMeta.Scope != nil {
-			h.Output.Warn("  scope: %s", *info.LocalMeta.Scope)
+		if info.LocalMeta.GetScope() != nil {
+			h.Output.Warn("  scope: %s", *info.LocalMeta.GetScope())
 		}
 	}
 	h.Output.Info("  Use interactive mode to push local changes")
@@ -652,10 +652,12 @@ func (h *InteractiveSyncHandler) PromptMetadataConflict(diff *engine.MetadataDif
 	for _, fd := range diff.Differences {
 		h.output.Info("  %s: %v (local) → %v (remote)", fd.Field, fd.LocalValue, fd.RemoteValue)
 	}
-	if diff.RemoteMeta != nil && diff.RemoteMeta.LastModifiedBy != nil {
-		h.output.Info("  Last modified by: %s <%s>",
-			diff.RemoteMeta.LastModifiedBy.GitName,
-			diff.RemoteMeta.LastModifiedBy.GitEmail)
+	if diff.RemoteMeta != nil {
+		if modBy := diff.RemoteMeta.GetLastModifiedBy(); modBy != nil {
+			h.output.Info("  Last modified by: %s <%s>",
+				modBy.GitName,
+				modBy.GitEmail)
+		}
 	}
 
 	return tui.PromptConfirm("Accept remote metadata?", false)
@@ -669,11 +671,11 @@ func (h *InteractiveSyncHandler) PromptOrphanedMetadata(info engine.OrphanedMeta
 	h.output.Info("\nRemote metadata for '%s' was deleted, but you have local changes:",
 		style.ColorBranchName(info.BranchName, false))
 	if info.LocalMeta != nil {
-		if info.LocalMeta.LockReason.IsLocked() {
-			h.output.Info("  lockReason: %s", info.LocalMeta.LockReason)
+		if info.LocalMeta.GetLockReason().IsLocked() {
+			h.output.Info("  lockReason: %s", info.LocalMeta.GetLockReason())
 		}
-		if info.LocalMeta.Scope != nil {
-			h.output.Info("  scope: %s", *info.LocalMeta.Scope)
+		if info.LocalMeta.GetScope() != nil {
+			h.output.Info("  scope: %s", *info.LocalMeta.GetScope())
 		}
 	}
 

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -565,7 +565,7 @@ func (d *demoGitRunner) ListRefs(_ string) (map[string]string, error) {
 }
 
 func (d *demoGitRunner) ReadMetadata(_ string) (*git.Meta, error) {
-	return &git.Meta{}, nil
+	return git.NewMeta(), nil
 }
 
 func (d *demoGitRunner) WriteMetadata(_ string, _ *git.Meta) error {

--- a/internal/engine/engine_absorb.go
+++ b/internal/engine/engine_absorb.go
@@ -57,10 +57,10 @@ func (e *engineImpl) ApplyHunksToBranch(ctx context.Context, branch Branch, hunk
 	if err != nil {
 		return fmt.Errorf("failed to read metadata for %s: %w", branchName, err)
 	}
-	if meta.ParentBranchRevision == nil {
+	if meta.GetParentBranchRevision() == nil {
 		return fmt.Errorf("branch %s has no parent revision", branchName)
 	}
-	currentBase := *meta.ParentBranchRevision
+	currentBase := *meta.GetParentBranchRevision()
 
 	// Checkout base in detached HEAD
 	if err := e.git.CheckoutDetached(ctx, currentBase); err != nil {

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -115,7 +115,7 @@ func (e *engineImpl) SetBranchType(branch Branch, branchType git.BranchType) err
 	}
 
 	// Update branch type
-	meta.BranchType = branchType
+	meta = meta.WithBranchType(branchType)
 
 	// Write metadata
 	if err := e.git.WriteMetadata(branchName, meta); err != nil {
@@ -174,12 +174,12 @@ func (e *engineImpl) IsUpToDate(branch Branch) bool {
 		return false // No metadata, assume needs restack
 	}
 
-	if meta.ParentBranchRevision == nil {
+	if meta.GetParentBranchRevision() == nil {
 		return false // No stored revision, needs restack
 	}
 
 	// Branch is fixed if stored revision matches current parent revision
-	return *meta.ParentBranchRevision == parentRev
+	return *meta.GetParentBranchRevision() == parentRev
 }
 
 // GetBranchRemoteStatus returns the relationship between a local branch and its remote

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -53,11 +53,11 @@ func (e *engineImpl) applyRebuild(branches []string, currentBranch string, allMe
 			continue // Trunk branches should never be tracked
 		}
 
-		if meta.ParentBranchName == nil {
+		if meta.GetParentBranchName() == nil {
 			continue // No parent means not tracked
 		}
 
-		parent := *meta.ParentBranchName
+		parent := *meta.GetParentBranchName()
 		if parent == name {
 			continue // Skip self-parenting to avoid cycles
 		}
@@ -65,11 +65,11 @@ func (e *engineImpl) applyRebuild(branches []string, currentBranch string, allMe
 		// Create or get branch state
 		state := &BranchState{
 			Parent:     parent,
-			LockReason: meta.LockReason,
-			BranchType: meta.BranchType,
+			LockReason: meta.GetLockReason(),
+			BranchType: meta.GetBranchType(),
 		}
-		if meta.Scope != nil {
-			state.Scope = *meta.Scope
+		if meta.GetScope() != nil {
+			state.Scope = *meta.GetScope()
 		}
 
 		e.branchState.Set(name, state)
@@ -120,8 +120,8 @@ func (e *engineImpl) updateBranchInCache(branchName string) {
 
 	// Determine new parent
 	newParent := ""
-	if meta.ParentBranchName != nil {
-		newParent = *meta.ParentBranchName
+	if meta.GetParentBranchName() != nil {
+		newParent = *meta.GetParentBranchName()
 	}
 
 	// If no parent, branch is not tracked - remove it
@@ -136,11 +136,11 @@ func (e *engineImpl) updateBranchInCache(branchName string) {
 	// Create or update branch state
 	state := &BranchState{
 		Parent:     newParent,
-		LockReason: meta.LockReason,
-		BranchType: meta.BranchType,
+		LockReason: meta.GetLockReason(),
+		BranchType: meta.GetBranchType(),
 	}
-	if meta.Scope != nil {
-		state.Scope = *meta.Scope
+	if meta.GetScope() != nil {
+		state.Scope = *meta.GetScope()
 	}
 	if localMeta != nil {
 		state.Frozen = localMeta.Frozen
@@ -232,8 +232,9 @@ func (e *engineImpl) shouldReparentBranch(ctx context.Context, parentBranchName 
 
 	// Check if parent has "MERGED" PR state in metadata
 	if metaMap != nil {
-		if meta, ok := metaMap[parentBranchName]; ok && meta != nil && meta.PrInfo != nil {
-			if meta.PrInfo.State != nil && *meta.PrInfo.State == "MERGED" {
+		if meta, ok := metaMap[parentBranchName]; ok && meta != nil {
+			prInfo := meta.GetPrInfo()
+			if prInfo != nil && prInfo.State != nil && *prInfo.State == "MERGED" {
 				return true
 			}
 			// If metadata exists but state isn't MERGED, we don't need to check further
@@ -299,22 +300,25 @@ func (e *engineImpl) appendMergedDownstack(
 
 	// Build MergedParent from old parent
 	mp := git.MergedParent{BranchName: oldParent}
-	if oldParentMeta != nil && oldParentMeta.PrInfo != nil {
-		mp.PRNumber = oldParentMeta.PrInfo.Number
-		mp.PRState = oldParentMeta.PrInfo.State
+	if oldParentMeta != nil {
+		oldParentPrInfo := oldParentMeta.GetPrInfo()
+		if oldParentPrInfo != nil {
+			mp.PRNumber = oldParentPrInfo.Number
+			mp.PRState = oldParentPrInfo.State
+		}
 	}
 
 	// Inherit old parent's history (for multi-level: A→B→C, if B merges)
 	var history []git.MergedParent
 	if oldParentMeta != nil {
-		history = append(history, oldParentMeta.MergedDownstack...)
+		history = append(history, oldParentMeta.GetMergedDownstack()...)
 	}
 
 	// Check if oldParent already in history (prevent duplicates from retried operations)
 	for _, existing := range history {
 		if existing.BranchName == oldParent {
 			// Already captured, skip adding duplicate
-			meta.MergedDownstack = history
+			meta = meta.WithMergedDownstack(history)
 			if err := e.git.WriteMetadata(branchName, meta); err != nil {
 				return err
 			}
@@ -333,7 +337,7 @@ func (e *engineImpl) appendMergedDownstack(
 		history = history[len(history)-maxHistoryEntries:]
 	}
 
-	meta.MergedDownstack = history
+	meta = meta.WithMergedDownstack(history)
 
 	// Write and update cache
 	if err := e.git.WriteMetadata(branchName, meta); err != nil {

--- a/internal/engine/engine_merged_history_test.go
+++ b/internal/engine/engine_merged_history_test.go
@@ -71,7 +71,9 @@ func TestRestackBranch_CapturesMergedHistory(t *testing.T) {
 		meta, err := s.Engine.Git().ReadMetadata("branch1")
 		require.NoError(t, err)
 		mergedState := prStateMerged
-		meta.PrInfo.State = &mergedState
+		metaPrInfo := meta.GetPrInfo()
+		metaPrInfo.State = &mergedState
+		meta = meta.WithPrInfo(metaPrInfo)
 		err = s.Engine.Git().WriteMetadata("branch1", meta)
 		require.NoError(t, err)
 
@@ -169,7 +171,7 @@ func TestRestackBranch_LimitsHistoryGrowth(t *testing.T) {
 
 			// Mark branch as merged
 			meta, _ := s.Engine.Git().ReadMetadata(branchToMerge)
-			meta.PrInfo = &git.PrInfoPersistence{State: &mergedState}
+			meta = meta.WithPrInfo(&git.PrInfoPersistence{State: &mergedState})
 			_ = s.Engine.Git().WriteMetadata(branchToMerge, meta)
 
 			// Rebuild and restack child

--- a/internal/engine/engine_pr.go
+++ b/internal/engine/engine_pr.go
@@ -19,25 +19,26 @@ func (e *engineImpl) GetPrInfo(branch Branch) (*PrInfo, error) {
 
 // NewPrInfoFromMeta creates a PrInfo from git.Meta
 func NewPrInfoFromMeta(meta *git.Meta) *PrInfo {
-	if meta == nil || meta.PrInfo == nil {
+	prInfo := meta.GetPrInfo()
+	if meta == nil || prInfo == nil {
 		return nil
 	}
 
 	lockReason := ""
-	if meta.PrInfo.LockReason != nil {
-		lockReason = string(*meta.PrInfo.LockReason)
+	if prInfo.LockReason != nil {
+		lockReason = string(*prInfo.LockReason)
 	}
 
 	return NewPrInfoFull(
-		meta.PrInfo.Number,
-		getStringValue(meta.PrInfo.Title),
-		getStringValue(meta.PrInfo.Body),
-		getStringValue(meta.PrInfo.State),
-		getStringValue(meta.PrInfo.Base),
-		getStringValue(meta.PrInfo.URL),
-		getBoolValue(meta.PrInfo.IsDraft),
+		prInfo.Number,
+		getStringValue(prInfo.Title),
+		getStringValue(prInfo.Body),
+		getStringValue(prInfo.State),
+		getStringValue(prInfo.Base),
+		getStringValue(prInfo.URL),
+		getBoolValue(prInfo.IsDraft),
 		LockReason(lockReason),
-		getStringValue(meta.PrInfo.MergeBranch),
+		getStringValue(prInfo.MergeBranch),
 	)
 }
 
@@ -52,7 +53,7 @@ func (e *engineImpl) GetMergedDownstack(branch Branch) []git.MergedParent {
 	if err != nil {
 		return nil
 	}
-	return meta.MergedDownstack
+	return meta.GetMergedDownstack()
 }
 
 // getMergedDownstack is an internal method for Branch type
@@ -69,46 +70,48 @@ func (e *engineImpl) UpsertPrInfo(ctx context.Context, branch Branch, prInfo *Pr
 		// Read existing metadata (outside lock for performance)
 		meta, err := e.git.ReadMetadata(branchName)
 		if err != nil {
-			meta = &git.Meta{}
+			meta = git.NewMeta()
 		}
 
 		if prInfo == nil {
-			meta.PrInfo = nil
+			meta = meta.WithPrInfo(nil)
 		} else {
-			if meta.PrInfo == nil {
-				meta.PrInfo = &git.PrInfoPersistence{}
+			existing := meta.GetPrInfo()
+			if existing == nil {
+				existing = &git.PrInfoPersistence{}
 			}
 
 			// Update PR info fields
 			if prInfo.Number() != nil {
-				meta.PrInfo.Number = prInfo.Number()
+				existing.Number = prInfo.Number()
 			}
 			if prInfo.Title() != "" {
 				title := prInfo.Title()
-				meta.PrInfo.Title = &title
+				existing.Title = &title
 			}
 			if prInfo.Body() != "" {
 				body := prInfo.Body()
-				meta.PrInfo.Body = &body
+				existing.Body = &body
 			}
 			isDraft := prInfo.IsDraft()
-			meta.PrInfo.IsDraft = &isDraft
+			existing.IsDraft = &isDraft
 			if prInfo.State() != "" {
 				state := prInfo.State()
-				meta.PrInfo.State = &state
+				existing.State = &state
 			}
 			if prInfo.Base() != "" {
 				base := prInfo.Base()
-				meta.PrInfo.Base = &base
+				existing.Base = &base
 			}
 			if prInfo.URL() != "" {
 				url := prInfo.URL()
-				meta.PrInfo.URL = &url
+				existing.URL = &url
 			}
 			lr := prInfo.LockReason()
-			meta.PrInfo.LockReason = &lr
+			existing.LockReason = &lr
 			mergeBranch := prInfo.MergeBranch()
-			meta.PrInfo.MergeBranch = &mergeBranch
+			existing.MergeBranch = &mergeBranch
+			meta = meta.WithPrInfo(existing)
 		}
 
 		// Use transaction for atomic update
@@ -155,20 +158,26 @@ func (e *engineImpl) GetPRSubmissionStatus(branch Branch) (PRSubmissionStatus, e
 	lockStatusChanged := false
 	meta, err := e.git.ReadMetadata(branch.GetName())
 	if err == nil {
-		if meta.LockReason != prInfo.LockReason() {
+		if meta.GetLockReason() != prInfo.LockReason() {
 			lockStatusChanged = true
-		} else if meta.PrInfo != nil && meta.PrInfo.LockReason != nil && *meta.PrInfo.LockReason != prInfo.LockReason() {
-			lockStatusChanged = true
+		} else {
+			metaPrInfo := meta.GetPrInfo()
+			if metaPrInfo != nil && metaPrInfo.LockReason != nil && *metaPrInfo.LockReason != prInfo.LockReason() {
+				lockStatusChanged = true
+			}
 		}
 	}
 
 	// Check if merge branch changed
 	mergeBranchChanged := false
-	if err == nil && meta.PrInfo != nil {
-		oldBranch := getStringValue(meta.PrInfo.MergeBranch)
-		newBranch := prInfo.MergeBranch()
-		if oldBranch != newBranch {
-			mergeBranchChanged = true
+	if err == nil {
+		metaPrInfo := meta.GetPrInfo()
+		if metaPrInfo != nil {
+			oldBranch := getStringValue(metaPrInfo.MergeBranch)
+			newBranch := prInfo.MergeBranch()
+			if oldBranch != newBranch {
+				mergeBranchChanged = true
+			}
 		}
 	}
 

--- a/internal/engine/engine_split.go
+++ b/internal/engine/engine_split.go
@@ -23,18 +23,18 @@ func (e *engineImpl) ApplySplitToCommits(ctx context.Context, opts ApplySplitOpt
 		return fmt.Errorf("failed to read metadata: %w", err)
 	}
 
-	if meta.ParentBranchName == nil {
+	if meta.GetParentBranchName() == nil {
 		return fmt.Errorf("branch %s has no parent", opts.BranchToSplit)
 	}
 
 	// Capture the original stack ID to preserve it on new branches
 	var originalStackID string
-	if meta.StackID != nil {
-		originalStackID = *meta.StackID
+	if meta.GetStackID() != nil {
+		originalStackID = *meta.GetStackID()
 	}
 
-	parentBranchName := *meta.ParentBranchName
-	parentRevision := *meta.ParentBranchRevision
+	parentBranchName := *meta.GetParentBranchName()
+	parentRevision := *meta.GetParentBranchRevision()
 	children := e.childrenMap[opts.BranchToSplit]
 
 	// Reverse branch points (newest to oldest -> oldest to newest)
@@ -80,19 +80,19 @@ func (e *engineImpl) ApplySplitToCommits(ctx context.Context, opts ApplySplitOpt
 		}
 
 		// Track branch with parent
-		newMeta := &git.Meta{
+		newMeta := git.NewMetaFrom(git.MetaFields{
 			ParentBranchName:     &branchParentName,
 			ParentBranchRevision: &branchParentRevision,
-		}
+		})
 
 		// Preserve stack ID from original branch
 		if originalStackID != "" {
-			newMeta.StackID = &originalStackID
+			newMeta = newMeta.WithStackID(&originalStackID)
 		}
 
 		// Preserve PR info if applicable
 		if prInfo != nil {
-			newMeta.PrInfo = &git.PrInfoPersistence{
+			newMeta = newMeta.WithPrInfo(&git.PrInfoPersistence{
 				Number:  prInfo.Number(),
 				Title:   stringPtr(prInfo.Title()),
 				Body:    stringPtr(prInfo.Body()),
@@ -100,7 +100,7 @@ func (e *engineImpl) ApplySplitToCommits(ctx context.Context, opts ApplySplitOpt
 				State:   stringPtr(prInfo.State()),
 				Base:    stringPtr(prInfo.Base()),
 				URL:     stringPtr(prInfo.URL()),
-			}
+			})
 		}
 
 		if err := e.git.WriteMetadata(branchName, newMeta); err != nil {

--- a/internal/engine/engine_squash.go
+++ b/internal/engine/engine_squash.go
@@ -30,11 +30,11 @@ func (e *engineImpl) SquashCurrentBranch(ctx context.Context, opts SquashOptions
 		return fmt.Errorf("failed to read metadata: %w", err)
 	}
 
-	if meta.ParentBranchRevision == nil {
+	if meta.GetParentBranchRevision() == nil {
 		return fmt.Errorf("branch has no parent revision")
 	}
 
-	parentBranchRevision := *meta.ParentBranchRevision
+	parentBranchRevision := *meta.GetParentBranchRevision()
 
 	// Get current branch revision
 	branch := e.GetBranch(branchName)

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -169,10 +169,10 @@ func (e *engineImpl) restackBranch(
 			// Prepare metadata update
 			meta, err := e.git.ReadMetadata(branchName)
 			if err != nil {
-				meta = &git.Meta{}
+				meta = git.NewMeta()
 			}
 			if parentRev != "" {
-				meta.ParentBranchRevision = &parentRev
+				meta = meta.WithParentBranchRevision(&parentRev)
 			}
 			metadataJSON, err := json.Marshal(meta)
 			if err != nil {
@@ -242,9 +242,9 @@ func (e *engineImpl) restackBranch(
 		// Prepare metadata update with new parent revision
 		meta, err := e.git.ReadMetadata(branchName)
 		if err != nil {
-			meta = &git.Meta{}
+			meta = git.NewMeta()
 		}
-		meta.ParentBranchRevision = &trunkRev
+		meta = meta.WithParentBranchRevision(&trunkRev)
 		metadataJSON, err := json.Marshal(meta)
 		if err != nil {
 			return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to marshal metadata for anchor %s: %w", branchName, err)
@@ -341,8 +341,8 @@ func (e *engineImpl) restackBranch(
 
 	// Get oldParentRev from metadata (or use parentRev as default)
 	oldParentRev := parentRev
-	if meta.ParentBranchRevision != nil {
-		oldParentRev = *meta.ParentBranchRevision
+	if meta.GetParentBranchRevision() != nil {
+		oldParentRev = *meta.GetParentBranchRevision()
 	}
 
 	// RESILIENCY: If oldParentRev is no longer an ancestor of branchName,
@@ -415,9 +415,9 @@ func (e *engineImpl) restackBranch(
 	// Prepare metadata update
 	meta, metaReadErr := e.git.ReadMetadata(branchName)
 	if metaReadErr != nil {
-		meta = &git.Meta{}
+		meta = git.NewMeta()
 	}
-	meta.ParentBranchRevision = &parentRev
+	meta = meta.WithParentBranchRevision(&parentRev)
 	metadataJSON, err := json.Marshal(meta)
 	if err != nil {
 		return RestackBranchResult{

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -373,16 +373,16 @@ func (e *engineImpl) SetParent(ctx context.Context, branch Branch, parentBranch 
 
 		// Get old parent
 		oldParent := ""
-		if meta.ParentBranchName != nil {
-			oldParent = *meta.ParentBranchName
+		if meta.GetParentBranchName() != nil {
+			oldParent = *meta.GetParentBranchName()
 		}
 
 		// Only update ParentBranchRevision if it's currently nil, invalid, or if we're not
 		// in a "parent merged into trunk" situation.
 		shouldUpdateRevision := true
-		if oldParent != "" && oldParent != parentBranchName && meta.ParentBranchRevision != nil && *meta.ParentBranchRevision != "" {
+		if oldParent != "" && oldParent != parentBranchName && meta.GetParentBranchRevision() != nil && *meta.GetParentBranchRevision() != "" {
 			// Check if existing revision is still a valid ancestor of the branch
-			if isAncestor, _ := e.git.IsAncestor(*meta.ParentBranchRevision, branchName); isAncestor {
+			if isAncestor, _ := e.git.IsAncestor(*meta.GetParentBranchRevision(), branchName); isAncestor {
 				// Check if the old parent was merged into the new parent (the "merge" case)
 				if merged, _ := e.git.IsMerged(ctx, oldParent, parentBranchName); merged {
 					shouldUpdateRevision = false
@@ -390,9 +390,9 @@ func (e *engineImpl) SetParent(ctx context.Context, branch Branch, parentBranch 
 			}
 		}
 
-		meta.ParentBranchName = &parentBranchName
+		meta = meta.WithParentBranchName(&parentBranchName)
 		if shouldUpdateRevision {
-			meta.ParentBranchRevision = &parentRev
+			meta = meta.WithParentBranchRevision(&parentRev)
 		}
 
 		// Use transaction for atomic update (Commit handles in-memory cache updates)
@@ -434,7 +434,7 @@ func (e *engineImpl) UpdateParentRevision(ctx context.Context, branchName string
 			return fmt.Errorf("failed to read metadata: %w", err)
 		}
 
-		meta.ParentBranchRevision = &parentRev
+		meta = meta.WithParentBranchRevision(&parentRev)
 
 		// Use transaction for atomic update
 		tx := e.BeginTx(fmt.Sprintf("update parent revision: %s", branchName))
@@ -458,10 +458,10 @@ func (e *engineImpl) SetScope(ctx context.Context, branch Branch, scope Scope) e
 
 		// Update scope
 		if scope.IsEmpty() {
-			meta.Scope = nil
+			meta = meta.WithScope(nil)
 		} else {
 			scopeStr := scope.String()
-			meta.Scope = &scopeStr
+			meta = meta.WithScope(&scopeStr)
 		}
 
 		// Use transaction for atomic update
@@ -519,9 +519,9 @@ func (e *engineImpl) SetLocked(ctx context.Context, branches []Branch, reason Lo
 				continue // Skip branches that had read errors
 			}
 			if meta == nil {
-				meta = &git.Meta{}
+				meta = git.NewMeta()
 			}
-			meta.LockReason = reason
+			meta = meta.WithLockReason(reason)
 			if stageErr := tx.UpdateMeta(name, meta); stageErr != nil {
 				result.Errors[name] = fmt.Errorf("failed to stage update: %w", stageErr)
 			}
@@ -669,7 +669,7 @@ func (e *engineImpl) RenameBranch(ctx context.Context, oldBranch, newBranch Bran
 		if err != nil {
 			continue
 		}
-		childMeta.ParentBranchName = &newName
+		childMeta = childMeta.WithParentBranchName(&newName)
 		if err := e.git.WriteMetadata(child, childMeta); err != nil {
 			continue
 		}
@@ -1157,8 +1157,8 @@ func (e *engineImpl) GetStackID(branch Branch) string {
 	}
 
 	// Return explicit StackID if present
-	if meta.StackID != nil && *meta.StackID != "" {
-		return *meta.StackID
+	if meta.GetStackID() != nil && *meta.GetStackID() != "" {
+		return *meta.GetStackID()
 	}
 
 	// Legacy fallback: derive stack ID from stack root
@@ -1168,11 +1168,11 @@ func (e *engineImpl) GetStackID(branch Branch) string {
 	}
 
 	rootMeta, err := e.git.ReadMetadata(rootName)
-	if err != nil || rootMeta == nil || rootMeta.StackID == nil {
+	if err != nil || rootMeta == nil || rootMeta.GetStackID() == nil {
 		return ""
 	}
 
-	return *rootMeta.StackID
+	return *rootMeta.GetStackID()
 }
 
 // EnsureStackID returns the stack ID for a branch, creating one if it doesn't exist.
@@ -1250,10 +1250,10 @@ func (e *engineImpl) SetStackID(ctx context.Context, branch Branch, stackID stri
 			return fmt.Errorf("failed to read metadata: %w", err)
 		}
 		if meta == nil {
-			meta = &git.Meta{}
+			meta = git.NewMeta()
 		}
 
-		meta.StackID = &stackID
+		meta = meta.WithStackID(&stackID)
 
 		tx := e.BeginTx(fmt.Sprintf("set stack ID: %s -> %s", branchName, stackID))
 		if err := tx.UpdateMeta(branchName, meta); err != nil {

--- a/internal/engine/persistence_test.go
+++ b/internal/engine/persistence_test.go
@@ -15,7 +15,7 @@ func TestMetaSerialization(t *testing.T) {
 	scope := "feat/xyz"
 	now := time.Now().UTC().Truncate(time.Second) // JSON unmarshaling might lose sub-second precision
 
-	meta := &git.Meta{
+	meta := git.NewMetaFrom(git.MetaFields{
 		ParentBranchName: &parent,
 		Scope:            &scope,
 		LockReason:       git.LockReasonUser,
@@ -25,7 +25,7 @@ func TestMetaSerialization(t *testing.T) {
 			GitEmail: "john@example.com",
 		},
 		LastModifiedAt: &now,
-	}
+	})
 
 	// Marshal
 	data, err := json.Marshal(meta)
@@ -36,13 +36,13 @@ func TestMetaSerialization(t *testing.T) {
 	err = json.Unmarshal(data, &meta2)
 	assert.NoError(t, err)
 
-	assert.Equal(t, meta.ParentBranchName, meta2.ParentBranchName)
-	assert.Equal(t, meta.Scope, meta2.Scope)
-	assert.Equal(t, meta.LockReason, meta2.LockReason)
-	assert.Equal(t, meta.BranchType, meta2.BranchType)
-	assert.Equal(t, meta.LastModifiedBy.GitName, meta2.LastModifiedBy.GitName)
-	assert.Equal(t, meta.LastModifiedBy.GitEmail, meta2.LastModifiedBy.GitEmail)
-	assert.True(t, meta.LastModifiedAt.Equal(*meta2.LastModifiedAt))
+	assert.Equal(t, meta.GetParentBranchName(), meta2.GetParentBranchName())
+	assert.Equal(t, meta.GetScope(), meta2.GetScope())
+	assert.Equal(t, meta.GetLockReason(), meta2.GetLockReason())
+	assert.Equal(t, meta.GetBranchType(), meta2.GetBranchType())
+	assert.Equal(t, meta.GetLastModifiedBy().GitName, meta2.GetLastModifiedBy().GitName)
+	assert.Equal(t, meta.GetLastModifiedBy().GitEmail, meta2.GetLastModifiedBy().GitEmail)
+	assert.True(t, meta.GetLastModifiedAt().Equal(*meta2.GetLastModifiedAt()))
 }
 
 func TestLocalMetaSerialization(t *testing.T) {
@@ -70,9 +70,9 @@ func TestMetaBackwardCompatibility(t *testing.T) {
 	err := json.Unmarshal([]byte(jsonData), &meta)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "main", *meta.ParentBranchName)
-	assert.Equal(t, git.LockReason("locked"), meta.LockReason)
-	assert.Equal(t, git.BranchType(""), meta.BranchType) // Should be empty/default
-	assert.Nil(t, meta.LastModifiedBy)
-	assert.Nil(t, meta.LastModifiedAt)
+	assert.Equal(t, "main", *meta.GetParentBranchName())
+	assert.Equal(t, git.LockReason("locked"), meta.GetLockReason())
+	assert.Equal(t, git.BranchType(""), meta.GetBranchType()) // Should be empty/default
+	assert.Nil(t, meta.GetLastModifiedBy())
+	assert.Nil(t, meta.GetLastModifiedAt())
 }

--- a/internal/engine/remote_sync.go
+++ b/internal/engine/remote_sync.go
@@ -120,15 +120,14 @@ func (e *engineImpl) setLastModifiedByInternal(branchName string, modifiedBy *gi
 
 	meta, err := e.git.ReadMetadata(branchName)
 	if err != nil {
-		meta = &git.Meta{}
+		meta = git.NewMeta()
 	}
-	meta.LastModifiedBy = modifiedBy
 	now := time.Now()
-	meta.LastModifiedAt = &now
+	meta = meta.WithLastModifiedBy(modifiedBy).WithLastModifiedAt(&now)
 
 	// Update localOnlyHash for change detection
 	hash := e.computeMetadataHash(meta)
-	meta.LocalOnlyHash = &hash
+	meta = meta.WithLocalOnlyHash(&hash)
 
 	return e.git.WriteMetadata(branchName, meta)
 }
@@ -189,28 +188,29 @@ func (e *engineImpl) ApplyRemoteMetadataIfExists(branchName string) error {
 
 	// Update local branch state
 	if state := e.branchState.GetByName(branchName); state != nil {
-		state.LockReason = remote.LockReason
-		if remote.Scope != nil {
-			state.Scope = *remote.Scope
+		state.LockReason = remote.GetLockReason()
+		if remote.GetScope() != nil {
+			state.Scope = *remote.GetScope()
 		}
 	}
 
 	// Read existing local metadata to preserve fields not in remote (like PrInfo)
 	local, err := e.git.ReadMetadata(branchName)
 	if err != nil {
-		local = &git.Meta{}
+		local = git.NewMeta()
 	}
 
 	// Update local with remote values
-	local.LockReason = remote.LockReason
-	local.Scope = remote.Scope
-	local.BranchType = remote.BranchType
-	local.LastModifiedBy = remote.LastModifiedBy
-	local.LastModifiedAt = remote.LastModifiedAt
+	local = local.
+		WithLockReason(remote.GetLockReason()).
+		WithScope(remote.GetScope()).
+		WithBranchType(remote.GetBranchType()).
+		WithLastModifiedBy(remote.GetLastModifiedBy()).
+		WithLastModifiedAt(remote.GetLastModifiedAt())
 
 	// Store localOnlyHash for change detection
 	hash := e.computeMetadataHash(local)
-	local.LocalOnlyHash = &hash
+	local = local.WithLocalOnlyHash(&hash)
 
 	return e.git.WriteMetadata(branchName, local)
 }
@@ -248,21 +248,21 @@ func (e *engineImpl) ComputeMetadataDiff(branch string) (*MetadataDiff, error) {
 	}
 
 	// Compare syncable fields
-	if local.LockReason != remote.LockReason {
+	if local.GetLockReason() != remote.GetLockReason() {
 		diff.Differences = append(diff.Differences, FieldDiff{
 			Field:       "lockReason",
-			LocalValue:  local.LockReason,
-			RemoteValue: remote.LockReason,
+			LocalValue:  local.GetLockReason(),
+			RemoteValue: remote.GetLockReason(),
 		})
 	}
 
 	localScope := ""
-	if local.Scope != nil {
-		localScope = *local.Scope
+	if local.GetScope() != nil {
+		localScope = *local.GetScope()
 	}
 	remoteScope := ""
-	if remote.Scope != nil {
-		remoteScope = *remote.Scope
+	if remote.GetScope() != nil {
+		remoteScope = *remote.GetScope()
 	}
 
 	if localScope != remoteScope {
@@ -331,22 +331,22 @@ func (e *engineImpl) HasLocalModifications(branch string) bool {
 	}
 
 	local, err := e.git.ReadMetadata(branch)
-	if err != nil || local.LocalOnlyHash == nil {
+	if err != nil || local.GetLocalOnlyHash() == nil {
 		return false // Never synced or error, treat as not modified
 	}
 
 	currentHash := e.computeMetadataHash(local)
-	return currentHash != *local.LocalOnlyHash
+	return currentHash != *local.GetLocalOnlyHash()
 }
 
 // computeMetadataHash calculates a hash of the syncable fields for change detection
 func (e *engineImpl) computeMetadataHash(meta *git.Meta) string {
 	// Hash of lockReason + scope (fields user can modify locally)
 	scope := ""
-	if meta.Scope != nil {
-		scope = *meta.Scope
+	if meta.GetScope() != nil {
+		scope = *meta.GetScope()
 	}
-	data := fmt.Sprintf("lockReason:%s,scope:%s", string(meta.LockReason), scope)
+	data := fmt.Sprintf("lockReason:%s,scope:%s", string(meta.GetLockReason()), scope)
 	hash := sha256.Sum256([]byte(data))
 	return hex.EncodeToString(hash[:])
 }
@@ -425,7 +425,7 @@ func (e *engineImpl) FindOrphanedLocalMetadata() ([]OrphanedMetadataInfo, error)
 			continue
 		}
 
-		if existsLocally && local.LocalOnlyHash == nil {
+		if existsLocally && local.GetLocalOnlyHash() == nil {
 			continue
 		}
 
@@ -435,8 +435,8 @@ func (e *engineImpl) FindOrphanedLocalMetadata() ([]OrphanedMetadataInfo, error)
 
 		// Check for local changes relative to last sync
 		hasLocalChanges := false
-		if local.LocalOnlyHash != nil {
-			hasLocalChanges = e.computeMetadataHash(local) != *local.LocalOnlyHash
+		if local.GetLocalOnlyHash() != nil {
+			hasLocalChanges = e.computeMetadataHash(local) != *local.GetLocalOnlyHash()
 		}
 
 		action := OrphanedActionDelete
@@ -469,7 +469,7 @@ func (e *engineImpl) DeleteLocalMetadataHash(branchName string) error {
 		return err
 	}
 
-	local.LocalOnlyHash = nil
+	local = local.WithLocalOnlyHash(nil)
 	return e.git.WriteMetadata(branchName, local)
 }
 

--- a/internal/engine/transaction.go
+++ b/internal/engine/transaction.go
@@ -341,7 +341,7 @@ func (e *engineImpl) updateBranchStateFromMeta(branch string, meta *git.Meta) {
 			}
 		}
 
-		state.Parent = *meta.ParentBranchName
+		state.Parent = *meta.GetParentBranchName()
 
 		// Update children map for new parent
 		if state.Parent != "" {
@@ -351,14 +351,14 @@ func (e *engineImpl) updateBranchStateFromMeta(branch string, meta *git.Meta) {
 		}
 	}
 
-	if meta.Scope != nil {
-		state.Scope = *meta.Scope
+	if meta.GetScope() != nil {
+		state.Scope = *meta.GetScope()
 	} else {
 		state.Scope = ""
 	}
 
-	state.LockReason = meta.LockReason
-	state.BranchType = meta.BranchType
+	state.LockReason = meta.GetLockReason()
+	state.BranchType = meta.GetBranchType()
 }
 
 // updateBranchStateFromLocalMeta updates the in-memory branch state from local metadata.

--- a/internal/engine/transaction_test.go
+++ b/internal/engine/transaction_test.go
@@ -323,9 +323,9 @@ func TestTransaction_RollbackOnCommitFailure(t *testing.T) {
 
 	// Begin transaction and stage an update
 	tx := eng.BeginTx("test transaction")
-	newMeta := &git.Meta{
+	newMeta := git.NewMetaFrom(git.MetaFields{
 		LockReason: git.LockReasonUser,
-	}
+	})
 	err = tx.UpdateMeta("feature-1", newMeta)
 	require.NoError(t, err)
 
@@ -335,7 +335,7 @@ func TestTransaction_RollbackOnCommitFailure(t *testing.T) {
 	// Verify original metadata is unchanged (rollback is a no-op for uncommitted transactions)
 	currentMeta, err := eng.Git().ReadMetadata("feature-1")
 	require.NoError(t, err)
-	assert.Equal(t, originalMeta.LockReason, currentMeta.LockReason)
+	assert.Equal(t, originalMeta.GetLockReason(), currentMeta.GetLockReason())
 }
 
 func TestTransaction_DoubleCommitFails(t *testing.T) {
@@ -356,7 +356,7 @@ func TestTransaction_DoubleCommitFails(t *testing.T) {
 
 	// Begin transaction and stage an update
 	tx := eng.BeginTx("test transaction")
-	meta := &git.Meta{LockReason: git.LockReasonUser}
+	meta := git.NewMetaFrom(git.MetaFields{LockReason: git.LockReasonUser})
 	err = tx.UpdateMeta("feature-1", meta)
 	require.NoError(t, err)
 
@@ -436,15 +436,15 @@ func TestTransaction_ConcurrentModification(t *testing.T) {
 
 	// Begin transaction and stage an update (this captures the original SHA)
 	tx := eng.BeginTx("test transaction")
-	meta1 := &git.Meta{LockReason: git.LockReasonUser}
+	meta1 := git.NewMetaFrom(git.MetaFields{LockReason: git.LockReasonUser})
 	err = tx.UpdateMeta("feature-1", meta1)
 	require.NoError(t, err)
 
 	// Simulate another process modifying the metadata
 	// This changes the ref SHA, causing CAS to fail
-	meta2 := &git.Meta{
+	meta2 := git.NewMetaFrom(git.MetaFields{
 		LockReason: git.LockReasonConsolidating,
-	}
+	})
 	err = eng.Git().WriteMetadata("feature-1", meta2)
 	require.NoError(t, err)
 
@@ -522,7 +522,7 @@ func TestWithRetry_RetriesOnConcurrentModification(t *testing.T) {
 		attemptCount++
 
 		tx := eng.BeginTx("retry test")
-		meta := &git.Meta{LockReason: git.LockReasonUser}
+		meta := git.NewMetaFrom(git.MetaFields{LockReason: git.LockReasonUser})
 		if stageErr := tx.UpdateMeta("feature-1", meta); stageErr != nil {
 			return stageErr
 		}
@@ -531,7 +531,7 @@ func TestWithRetry_RetriesOnConcurrentModification(t *testing.T) {
 		// Use different scope values to ensure different blob SHAs
 		if attemptCount <= maxFailures {
 			scope := fmt.Sprintf("conflict-%d", attemptCount)
-			otherMeta := &git.Meta{Scope: &scope}
+			otherMeta := git.NewMetaFrom(git.MetaFields{Scope: &scope})
 			if writeErr := eng.Git().WriteMetadata("feature-1", otherMeta); writeErr != nil {
 				return writeErr
 			}
@@ -567,14 +567,14 @@ func TestWithRetry_ExhaustsRetries(t *testing.T) {
 		attemptCount++
 
 		tx := eng.BeginTx("exhaustion test")
-		meta := &git.Meta{LockReason: git.LockReasonUser}
+		meta := git.NewMetaFrom(git.MetaFields{LockReason: git.LockReasonUser})
 		if stageErr := tx.UpdateMeta("feature-1", meta); stageErr != nil {
 			return stageErr
 		}
 
 		// Always cause concurrent modification with unique content - never succeed
 		scope := fmt.Sprintf("conflict-%d", attemptCount)
-		otherMeta := &git.Meta{Scope: &scope}
+		otherMeta := git.NewMetaFrom(git.MetaFields{Scope: &scope})
 		if writeErr := eng.Git().WriteMetadata("feature-1", otherMeta); writeErr != nil {
 			return writeErr
 		}
@@ -624,7 +624,7 @@ func TestTransaction_UpdateAfterRollback(t *testing.T) {
 	tx.Rollback()
 
 	// Trying to update after rollback should fail
-	err := tx.UpdateMeta("any-branch", &git.Meta{})
+	err := tx.UpdateMeta("any-branch", git.NewMeta())
 	require.Error(t, err)
 	assert.ErrorIs(t, err, engine.ErrTransactionRolledBack)
 
@@ -704,7 +704,7 @@ func TestTransaction_MixedMetaAndLocalMeta(t *testing.T) {
 	tx := eng.BeginTx("mixed update")
 
 	// Update meta for feature-1
-	meta1 := &git.Meta{LockReason: git.LockReasonUser}
+	meta1 := git.NewMetaFrom(git.MetaFields{LockReason: git.LockReasonUser})
 	require.NoError(t, tx.UpdateMeta("feature-1", meta1))
 
 	// Update local meta for feature-2
@@ -820,7 +820,7 @@ func TestTransaction_UpdateAfterDelete(t *testing.T) {
 	// Stage delete then update - update should take precedence
 	tx := eng.BeginTx("update after delete")
 	require.NoError(t, tx.DeleteMeta("feature-1"))
-	newMeta := &git.Meta{LockReason: git.LockReasonUser}
+	newMeta := git.NewMetaFrom(git.MetaFields{LockReason: git.LockReasonUser})
 	require.NoError(t, tx.UpdateMeta("feature-1", newMeta))
 	require.NoError(t, tx.Commit(context.Background()))
 
@@ -845,7 +845,7 @@ func TestTransaction_DeleteAfterUpdate(t *testing.T) {
 
 	// Stage update then delete - delete should take precedence
 	tx := eng.BeginTx("delete after update")
-	newMeta := &git.Meta{LockReason: git.LockReasonUser}
+	newMeta := git.NewMetaFrom(git.MetaFields{LockReason: git.LockReasonUser})
 	require.NoError(t, tx.UpdateMeta("feature-1", newMeta))
 	require.NoError(t, tx.DeleteMeta("feature-1"))
 	require.NoError(t, tx.Commit(context.Background()))
@@ -877,10 +877,10 @@ func TestTransaction_MixedUpdatesAndDeletes(t *testing.T) {
 
 	// Mixed transaction: update feature-1, delete feature-2, update feature-3
 	tx := eng.BeginTx("mixed operations")
-	require.NoError(t, tx.UpdateMeta("feature-1", &git.Meta{LockReason: git.LockReasonUser}))
+	require.NoError(t, tx.UpdateMeta("feature-1", git.NewMetaFrom(git.MetaFields{LockReason: git.LockReasonUser})))
 	require.NoError(t, tx.DeleteMeta("feature-2"))
 	scope := "test-scope"
-	require.NoError(t, tx.UpdateMeta("feature-3", &git.Meta{Scope: &scope}))
+	require.NoError(t, tx.UpdateMeta("feature-3", git.NewMetaFrom(git.MetaFields{Scope: &scope})))
 	require.NoError(t, tx.Commit(context.Background()))
 
 	// Verify results

--- a/internal/git/meta_accessors.go
+++ b/internal/git/meta_accessors.go
@@ -48,7 +48,7 @@ func NewMetaFrom(f MetaFields) *Meta {
 // Simple value types (*string, LockReason, BranchType) return raw values.
 // Complex types (*PrInfoPersistence, *ModifiedBy, *time.Time, []MergedParent) return copies.
 
-// GetParentBranchName returns the parent branch name, or nil if the receiver is nil.
+// GetParentBranchName returns the parent branch name.
 func (m *Meta) GetParentBranchName() *string {
 	if m == nil {
 		return nil
@@ -56,7 +56,7 @@ func (m *Meta) GetParentBranchName() *string {
 	return m.ParentBranchName
 }
 
-// GetParentBranchRevision returns the parent branch revision, or nil if the receiver is nil.
+// GetParentBranchRevision returns the parent branch revision.
 func (m *Meta) GetParentBranchRevision() *string {
 	if m == nil {
 		return nil
@@ -64,7 +64,7 @@ func (m *Meta) GetParentBranchRevision() *string {
 	return m.ParentBranchRevision
 }
 
-// GetPrInfo returns a copy of the PR info, or nil if the receiver or field is nil.
+// GetPrInfo returns a shallow copy of the PR info.
 func (m *Meta) GetPrInfo() *PrInfoPersistence {
 	if m == nil || m.PrInfo == nil {
 		return nil
@@ -73,7 +73,7 @@ func (m *Meta) GetPrInfo() *PrInfoPersistence {
 	return &cp
 }
 
-// GetScope returns the scope, or nil if the receiver is nil.
+// GetScope returns the scope.
 func (m *Meta) GetScope() *string {
 	if m == nil {
 		return nil
@@ -81,7 +81,7 @@ func (m *Meta) GetScope() *string {
 	return m.Scope
 }
 
-// GetLockReason returns the lock reason, or LockReasonNone if the receiver is nil.
+// GetLockReason returns the lock reason.
 func (m *Meta) GetLockReason() LockReason {
 	if m == nil {
 		return LockReasonNone
@@ -89,7 +89,7 @@ func (m *Meta) GetLockReason() LockReason {
 	return m.LockReason
 }
 
-// GetBranchType returns the branch type, or empty string if the receiver is nil.
+// GetBranchType returns the branch type.
 func (m *Meta) GetBranchType() BranchType {
 	if m == nil {
 		return ""
@@ -97,7 +97,7 @@ func (m *Meta) GetBranchType() BranchType {
 	return m.BranchType
 }
 
-// GetLastModifiedBy returns a copy of the last modified by info, or nil if the receiver or field is nil.
+// GetLastModifiedBy returns a shallow copy of the last-modified-by info.
 func (m *Meta) GetLastModifiedBy() *ModifiedBy {
 	if m == nil || m.LastModifiedBy == nil {
 		return nil
@@ -106,7 +106,7 @@ func (m *Meta) GetLastModifiedBy() *ModifiedBy {
 	return &cp
 }
 
-// GetLastModifiedAt returns a copy of the last modified time, or nil if the receiver or field is nil.
+// GetLastModifiedAt returns a copy of the last-modified-at timestamp.
 func (m *Meta) GetLastModifiedAt() *time.Time {
 	if m == nil || m.LastModifiedAt == nil {
 		return nil
@@ -115,7 +115,7 @@ func (m *Meta) GetLastModifiedAt() *time.Time {
 	return &cp
 }
 
-// GetLocalOnlyHash returns the local-only hash, or nil if the receiver is nil.
+// GetLocalOnlyHash returns the local-only hash.
 func (m *Meta) GetLocalOnlyHash() *string {
 	if m == nil {
 		return nil
@@ -123,7 +123,7 @@ func (m *Meta) GetLocalOnlyHash() *string {
 	return m.LocalOnlyHash
 }
 
-// GetMergedDownstack returns a copy of the merged downstack slice, or nil if the receiver or field is nil.
+// GetMergedDownstack returns a copy of the merged downstack history.
 func (m *Meta) GetMergedDownstack() []MergedParent {
 	if m == nil || m.MergedDownstack == nil {
 		return nil
@@ -133,7 +133,7 @@ func (m *Meta) GetMergedDownstack() []MergedParent {
 	return cp
 }
 
-// GetStackID returns the stack ID, or nil if the receiver is nil.
+// GetStackID returns the stack ID.
 func (m *Meta) GetStackID() *string {
 	if m == nil {
 		return nil
@@ -144,77 +144,77 @@ func (m *Meta) GetStackID() *string {
 // --- With* methods ---
 // Each returns a new Meta with the specified field changed (shallow struct copy).
 
-// WithParentBranchName returns a new Meta with the parent branch name set to v.
+// WithParentBranchName returns a new Meta with the parent branch name set.
 func (m *Meta) WithParentBranchName(v *string) *Meta {
 	c := *m
 	c.ParentBranchName = v
 	return &c
 }
 
-// WithParentBranchRevision returns a new Meta with the parent branch revision set to v.
+// WithParentBranchRevision returns a new Meta with the parent branch revision set.
 func (m *Meta) WithParentBranchRevision(v *string) *Meta {
 	c := *m
 	c.ParentBranchRevision = v
 	return &c
 }
 
-// WithPrInfo returns a new Meta with the PR info set to v.
+// WithPrInfo returns a new Meta with the PR info set.
 func (m *Meta) WithPrInfo(v *PrInfoPersistence) *Meta {
 	c := *m
 	c.PrInfo = v
 	return &c
 }
 
-// WithScope returns a new Meta with the scope set to v.
+// WithScope returns a new Meta with the scope set.
 func (m *Meta) WithScope(v *string) *Meta {
 	c := *m
 	c.Scope = v
 	return &c
 }
 
-// WithLockReason returns a new Meta with the lock reason set to v.
+// WithLockReason returns a new Meta with the lock reason set.
 func (m *Meta) WithLockReason(v LockReason) *Meta {
 	c := *m
 	c.LockReason = v
 	return &c
 }
 
-// WithBranchType returns a new Meta with the branch type set to v.
+// WithBranchType returns a new Meta with the branch type set.
 func (m *Meta) WithBranchType(v BranchType) *Meta {
 	c := *m
 	c.BranchType = v
 	return &c
 }
 
-// WithLastModifiedBy returns a new Meta with the last modified by set to v.
+// WithLastModifiedBy returns a new Meta with the last-modified-by info set.
 func (m *Meta) WithLastModifiedBy(v *ModifiedBy) *Meta {
 	c := *m
 	c.LastModifiedBy = v
 	return &c
 }
 
-// WithLastModifiedAt returns a new Meta with the last modified time set to v.
+// WithLastModifiedAt returns a new Meta with the last-modified-at timestamp set.
 func (m *Meta) WithLastModifiedAt(v *time.Time) *Meta {
 	c := *m
 	c.LastModifiedAt = v
 	return &c
 }
 
-// WithLocalOnlyHash returns a new Meta with the local-only hash set to v.
+// WithLocalOnlyHash returns a new Meta with the local-only hash set.
 func (m *Meta) WithLocalOnlyHash(v *string) *Meta {
 	c := *m
 	c.LocalOnlyHash = v
 	return &c
 }
 
-// WithMergedDownstack returns a new Meta with the merged downstack set to v.
+// WithMergedDownstack returns a new Meta with the merged downstack history set.
 func (m *Meta) WithMergedDownstack(v []MergedParent) *Meta {
 	c := *m
 	c.MergedDownstack = v
 	return &c
 }
 
-// WithStackID returns a new Meta with the stack ID set to v.
+// WithStackID returns a new Meta with the stack ID set.
 func (m *Meta) WithStackID(v *string) *Meta {
 	c := *m
 	c.StackID = v

--- a/internal/git/meta_accessors_test.go
+++ b/internal/git/meta_accessors_test.go
@@ -13,7 +13,7 @@ import (
 const (
 	testBranchMain = "main"
 	testScopeAPI   = "api"
-	testStackID    = "stack-1"
+	testStackID1   = "stack-1"
 )
 
 func TestNewMeta(t *testing.T) {
@@ -30,7 +30,7 @@ func TestNewMetaFrom(t *testing.T) {
 	name := testBranchMain
 	rev := "abc123"
 	scope := testScopeAPI
-	stackID := testStackID
+	stackID := testStackID1
 
 	m := git.NewMetaFrom(git.MetaFields{
 		ParentBranchName:     &name,
@@ -75,7 +75,7 @@ func TestMetaGetters(t *testing.T) {
 		rev := "abc"
 		scope := testScopeAPI
 		hash := "xyz"
-		stackID := testStackID
+		stackID := testStackID1
 		now := time.Now().Truncate(time.Second)
 
 		m := git.NewMetaFrom(git.MetaFields{
@@ -240,7 +240,7 @@ func TestMetaJSONRoundTrip(t *testing.T) {
 		rev := "abc123"
 		scope := testScopeAPI
 		hash := "hash"
-		stackID := testStackID
+		stackID := testStackID1
 		now := time.Now().UTC().Truncate(time.Second)
 		num := 42
 		url := "https://github.com/test/pr/42"

--- a/internal/integration/merged_history_test.go
+++ b/internal/integration/merged_history_test.go
@@ -26,10 +26,10 @@ func TestMergedDownstackHistory(t *testing.T) {
 		prNum := 101
 		meta1, err := sh.Engine.Git().ReadMetadata("branch1")
 		require.NoError(t, err)
-		meta1.PrInfo = &git.PrInfoPersistence{
+		meta1 = meta1.WithPrInfo(&git.PrInfoPersistence{
 			Number: &prNum,
 			State:  stringPtr(prStateMerged),
-		}
+		})
 		err = sh.Engine.Git().WriteMetadata("branch1", meta1)
 		require.NoError(t, err)
 
@@ -64,10 +64,10 @@ func TestMergedDownstackHistory(t *testing.T) {
 		prNum := 99
 		meta1, err := sh.Engine.Git().ReadMetadata("branch1")
 		require.NoError(t, err)
-		meta1.PrInfo = &git.PrInfoPersistence{
+		meta1 = meta1.WithPrInfo(&git.PrInfoPersistence{
 			Number: &prNum,
 			State:  stringPtr(prStateMerged),
-		}
+		})
 		err = sh.Engine.Git().WriteMetadata("branch1", meta1)
 		require.NoError(t, err)
 
@@ -107,10 +107,10 @@ func TestMergedDownstackHistory(t *testing.T) {
 		// Merge branch1 first
 		prNum1 := 100
 		meta1, _ := sh.Engine.Git().ReadMetadata("branch1")
-		meta1.PrInfo = &git.PrInfoPersistence{
+		meta1 = meta1.WithPrInfo(&git.PrInfoPersistence{
 			Number: &prNum1,
 			State:  stringPtr(prStateMerged),
-		}
+		})
 		_ = sh.Engine.Git().WriteMetadata("branch1", meta1)
 
 		// Rebuild
@@ -123,10 +123,10 @@ func TestMergedDownstackHistory(t *testing.T) {
 		// Now merge branch2
 		prNum2 := 101
 		meta2, _ := sh.Engine.Git().ReadMetadata("branch2")
-		meta2.PrInfo = &git.PrInfoPersistence{
+		meta2 = meta2.WithPrInfo(&git.PrInfoPersistence{
 			Number: &prNum2,
 			State:  stringPtr(prStateMerged),
-		}
+		})
 		_ = sh.Engine.Git().WriteMetadata("branch2", meta2)
 
 		// Rebuild
@@ -154,10 +154,10 @@ func TestMergedDownstackHistory(t *testing.T) {
 
 		prNum := 50
 		meta1, _ := sh.Engine.Git().ReadMetadata("branch1")
-		meta1.PrInfo = &git.PrInfoPersistence{
+		meta1 = meta1.WithPrInfo(&git.PrInfoPersistence{
 			Number: &prNum,
 			State:  stringPtr(prStateMerged),
-		}
+		})
 		_ = sh.Engine.Git().WriteMetadata("branch1", meta1)
 
 		// Rebuild
@@ -170,10 +170,11 @@ func TestMergedDownstackHistory(t *testing.T) {
 		// Read metadata directly to verify it was persisted
 		meta2, err := sh.Engine.Git().ReadMetadata("branch2")
 		require.NoError(t, err)
-		require.Len(t, meta2.MergedDownstack, 1)
-		require.Equal(t, "branch1", meta2.MergedDownstack[0].BranchName)
-		require.NotNil(t, meta2.MergedDownstack[0].PRNumber)
-		require.Equal(t, 50, *meta2.MergedDownstack[0].PRNumber)
+		mergedDownstack := meta2.GetMergedDownstack()
+		require.Len(t, mergedDownstack, 1)
+		require.Equal(t, "branch1", mergedDownstack[0].BranchName)
+		require.NotNil(t, mergedDownstack[0].PRNumber)
+		require.Equal(t, 50, *mergedDownstack[0].PRNumber)
 
 		// Rebuild engine and verify history still accessible
 		err = sh.Engine.Rebuild("main")

--- a/internal/integration/remote_metadata_sync_test.go
+++ b/internal/integration/remote_metadata_sync_test.go
@@ -38,14 +38,14 @@ func TestRemoteMetadataSync(t *testing.T) {
 
 		// 2. Simulate remote metadata with different values (locked=true, scope="remote-scope")
 		// This simulates what would happen after `git fetch origin refs/stackit/metadata/*:refs/stackit/remote-metadata/*`
-		remoteMeta := &git.Meta{
+		remoteMeta := git.NewMetaFrom(git.MetaFields{
 			LockReason: git.LockReasonUser,
 			Scope:      strPtr("remote-scope"),
 			LastModifiedBy: &git.ModifiedBy{
 				GitName:  "Remote User",
 				GitEmail: "remote@example.com",
 			},
-		}
+		})
 		createRemoteMetadataRef(t, sh, "feature-a", remoteMeta)
 
 		// 3. Load remote metadata cache
@@ -92,10 +92,10 @@ func TestRemoteMetadataSync(t *testing.T) {
 		require.NoError(t, eng.SetScope(context.Background(), branch, engine.NewScope("same-scope")))
 
 		// Create identical remote metadata
-		remoteMeta := &git.Meta{
+		remoteMeta := git.NewMetaFrom(git.MetaFields{
 			LockReason: git.LockReasonUser,
 			Scope:      strPtr("same-scope"),
-		}
+		})
 		createRemoteMetadataRef(t, sh, "feature-b", remoteMeta)
 
 		// Load remote cache
@@ -172,10 +172,10 @@ func TestRemoteMetadataSync(t *testing.T) {
 		eng := sh.Engine
 
 		// 1. Simulate remote metadata for a branch that doesn't exist locally
-		remoteMeta := &git.Meta{
+		remoteMeta := git.NewMetaFrom(git.MetaFields{
 			LockReason: git.LockReasonUser,
 			Scope:      strPtr("remote-scope"),
-		}
+		})
 		createRemoteMetadataRef(t, sh, "non-existent-branch", remoteMeta)
 
 		// 2. Load remote metadata cache

--- a/internal/integration/sync_test.go
+++ b/internal/integration/sync_test.go
@@ -93,17 +93,19 @@ func TestSync(t *testing.T) {
 		for i, branch := range branchNames {
 			meta := metas[branch]
 			if meta == nil {
-				meta = &git.Meta{}
+				meta = git.NewMeta()
 			}
-			if meta.PrInfo == nil {
-				meta.PrInfo = &git.PrInfoPersistence{}
+			prInfo := meta.GetPrInfo()
+			if prInfo == nil {
+				prInfo = &git.PrInfoPersistence{}
 			}
 			prNum := i + 1
 			state := prStateMerged
 			base := mainBranchName
-			meta.PrInfo.Number = &prNum
-			meta.PrInfo.State = &state
-			meta.PrInfo.Base = &base
+			prInfo.Number = &prNum
+			prInfo.State = &state
+			prInfo.Base = &base
+			meta = meta.WithPrInfo(prInfo)
 			err := eng.Git().WriteMetadata(branch, meta)
 			require.NoError(t, err)
 		}
@@ -359,10 +361,10 @@ func TestSyncRemoteMetadata(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create remote metadata refs (simulating a successful fetch)
-		remoteMeta := &git.Meta{
+		remoteMeta := git.NewMetaFrom(git.MetaFields{
 			LockReason: git.LockReasonUser,
 			Scope:      scopePtr("remote-scope"),
-		}
+		})
 		createRemoteMetadataRefForSync(t, sh, "feature-a", remoteMeta)
 
 		// Load remote metadata cache (this is what sync does after fetching)
@@ -371,9 +373,10 @@ func TestSyncRemoteMetadata(t *testing.T) {
 
 		// Verify remote metadata cache was loaded
 		cache := eng.GetRemoteMetadataCache()
-		require.NotNil(t, cache.Get("feature-a"), "Remote metadata should be in cache")
-		require.Equal(t, git.LockReasonUser, cache.Get("feature-a").LockReason, "Remote metadata should show lock reason")
-		require.Equal(t, "remote-scope", *cache.Get("feature-a").Scope, "Remote metadata should have scope")
+		cachedMeta := cache.Get("feature-a")
+		require.NotNil(t, cachedMeta, "Remote metadata should be in cache")
+		require.Equal(t, git.LockReasonUser, cachedMeta.GetLockReason(), "Remote metadata should show lock reason")
+		require.Equal(t, "remote-scope", *cachedMeta.GetScope(), "Remote metadata should have scope")
 	})
 
 	t.Run("detects metadata conflicts", func(t *testing.T) {
@@ -391,9 +394,9 @@ func TestSyncRemoteMetadata(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create remote metadata refs: locked=true (conflict)
-		remoteMeta := &git.Meta{
+		remoteMeta := git.NewMetaFrom(git.MetaFields{
 			LockReason: git.LockReasonUser,
-		}
+		})
 		createRemoteMetadataRefForSync(t, sh, "feature-b", remoteMeta)
 
 		// Load remote metadata cache


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `multi-stack/20260207-113000`.


* **PR #699**
  * **PR #700**
    * **PR #701**
      * **PR #702**
        * **PR #703** 👈
          * **PR #704**
            * **PR #705**
              * **PR #706**
                * **PR #707**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->