### PR TITLE
perf: unexport Meta fields and remove deep copies from metadata cache

### DIFF
--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -411,8 +411,8 @@ func buildRebaseSpecs(ctx *app.Context, branches []engine.Branch) ([]engine.Reba
 		}
 
 		var oldParentRev string
-		if meta.ParentBranchRevision != nil {
-			oldParentRev = *meta.ParentBranchRevision
+		if rev := meta.GetParentBranchRevision(); rev != nil {
+			oldParentRev = *rev
 		}
 
 		// RESILIENCY: If oldParentRev is no longer an ancestor of branchName,

--- a/internal/actions/debug.go
+++ b/internal/actions/debug.go
@@ -170,8 +170,8 @@ func DebugAction(ctx *app.Context, opts DebugOptions) error {
 		}
 
 		if meta, ok := allMeta[branchName]; ok && meta != nil {
-			if meta.ParentBranchRevision != nil {
-				branchInfo.ParentRevision = *meta.ParentBranchRevision
+			if rev := meta.GetParentBranchRevision(); rev != nil {
+				branchInfo.ParentRevision = *rev
 			}
 
 			branch := eng.GetBranch(branchName)

--- a/internal/actions/flatten/flatten_test.go
+++ b/internal/actions/flatten/flatten_test.go
@@ -271,7 +271,7 @@ func TestFlattenAction(t *testing.T) {
 		// Verify metadata was cleared
 		meta, err = s.Engine.Git().ReadMetadata("B")
 		require.NoError(t, err)
-		require.Nil(t, meta.ParentBranchRevision)
+		require.Nil(t, meta.GetParentBranchRevision())
 
 		// Run flatten
 		err = flatten.Action(s.Context, flatten.Options{BranchName: "B"}, nil)

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -163,7 +163,7 @@ func TestActionWithMockedGitHub(t *testing.T) {
 		for _, branchName := range []string{"P", "C1", "C2"} {
 			meta, err := s.Engine.Git().ReadMetadata(branchName)
 			require.NoError(t, err, "Should be able to read metadata for %s", branchName)
-			require.NotNil(t, meta.LastModifiedBy, "LastModifiedBy should be set for %s", branchName)
+			require.NotNil(t, meta.GetLastModifiedBy(), "LastModifiedBy should be set for %s", branchName)
 		}
 	})
 
@@ -281,5 +281,5 @@ func TestSubmitPreservesLockStatus(t *testing.T) {
 
 	meta, err := s.Engine.Git().ReadMetadata("feature")
 	require.NoError(t, err)
-	require.Equal(t, git.LockReasonUser, meta.LockReason, "Metadata LockReason field should be set")
+	require.Equal(t, git.LockReasonUser, meta.GetLockReason(), "Metadata LockReason field should be set")
 }

--- a/internal/cli/stack/move.go
+++ b/internal/cli/stack/move.go
@@ -120,8 +120,10 @@ func interactiveOntoSelection(ctx *app.Context, sourceBranch string) (string, er
 	// Get info needed for validation
 	oldParent := source.GetParent()
 	var oldParentRev string
-	if meta, err := eng.Git().ReadMetadata(sourceBranch); err == nil && meta.ParentBranchRevision != nil {
-		oldParentRev = *meta.ParentBranchRevision
+	if meta, err := eng.Git().ReadMetadata(sourceBranch); err == nil {
+		if rev := meta.GetParentBranchRevision(); rev != nil {
+			oldParentRev = *rev
+		}
 	}
 
 	// Create validation function that checks for conflicts when moving to a branch

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -50,8 +50,8 @@ func (e *engineImpl) GetCommitCount(branch Branch) (int, error) {
 	// Get base revision (stored parent revision)
 	meta, err := e.git.ReadMetadata(branchName)
 	var base string
-	if err == nil && meta.ParentBranchRevision != nil {
-		base = *meta.ParentBranchRevision
+	if rev := meta.GetParentBranchRevision(); err == nil && rev != nil {
+		base = *rev
 	} else {
 		// Fallback to current parent branch tip if metadata is missing
 		baseRev, err := e.git.GetRevision(parent)
@@ -95,8 +95,8 @@ func (e *engineImpl) GetDiffStats(branch Branch) (int, int, error) {
 	// Get base revision (stored parent revision)
 	meta, err := e.git.ReadMetadata(branchName)
 	var base string
-	if err == nil && meta.ParentBranchRevision != nil {
-		base = *meta.ParentBranchRevision
+	if rev := meta.GetParentBranchRevision(); err == nil && rev != nil {
+		base = *rev
 	} else {
 		baseRev, err := e.git.GetRevision(parent)
 		if err != nil {
@@ -166,8 +166,8 @@ func (e *engineImpl) GetAllCommits(branch Branch, format CommitFormat) ([]string
 
 	// Get parent revision (base)
 	var baseRevision string
-	if meta.ParentBranchRevision != nil {
-		baseRevision = *meta.ParentBranchRevision
+	if rev := meta.GetParentBranchRevision(); rev != nil {
+		baseRevision = *rev
 	}
 
 	// Use GetCommitRange directly — handles formatting in-process via go-git

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -1208,7 +1208,7 @@ func TestSetParentScenarios(t *testing.T) {
 		// VERIFY: ParentBranchRevision should still be branch1OriginalSHA
 		// because it's a valid ancestor and the old parent (branch1) was merged into main.
 		meta, _ := s.Engine.Git().ReadMetadata("branch2")
-		require.Equal(t, branch1OriginalSHA, *meta.ParentBranchRevision, "Divergence point should be preserved to avoid conflicts during restack")
+		require.Equal(t, branch1OriginalSHA, *meta.GetParentBranchRevision(), "Divergence point should be preserved to avoid conflicts during restack")
 	})
 
 	t.Run("updates divergence point when parent is folded into child (upward merge)", func(t *testing.T) {
@@ -1239,7 +1239,7 @@ func TestSetParentScenarios(t *testing.T) {
 		// try to re-apply branch1's changes which are already in branch2.
 		mainSHA, _ := s.Engine.Trunk().GetRevision()
 		meta, _ := s.Engine.Git().ReadMetadata("branch2")
-		require.Equal(t, mainSHA, *meta.ParentBranchRevision, "Divergence point should be updated to new parent when folding upward")
+		require.Equal(t, mainSHA, *meta.GetParentBranchRevision(), "Divergence point should be updated to new parent when folding upward")
 	})
 
 	t.Run("updates divergence point after manual rebase onto same parent", func(t *testing.T) {
@@ -1269,8 +1269,8 @@ func TestSetParentScenarios(t *testing.T) {
 		// VERIFY: ParentBranchRevision should be updated to mainNewSHA
 		// because the branch has moved forward relative to its parent.
 		meta, _ := s.Engine.Git().ReadMetadata("branch1")
-		require.Equal(t, mainNewSHA, *meta.ParentBranchRevision)
-		require.NotEqual(t, *originalMeta.ParentBranchRevision, *meta.ParentBranchRevision)
+		require.Equal(t, mainNewSHA, *meta.GetParentBranchRevision())
+		require.NotEqual(t, *originalMeta.GetParentBranchRevision(), *meta.GetParentBranchRevision())
 	})
 }
 

--- a/internal/engine/engine_merged_history_test.go
+++ b/internal/engine/engine_merged_history_test.go
@@ -111,7 +111,7 @@ func TestRestackBranch_InheritsMergedHistory(t *testing.T) {
 		// First: merge branch1 and reparent branch2 to main
 		meta1, _ := s.Engine.Git().ReadMetadata("branch1")
 		mergedState := prStateMerged
-		meta1.PrInfo = &git.PrInfoPersistence{State: &mergedState}
+		meta1 = meta1.WithPrInfo(&git.PrInfoPersistence{State: &mergedState})
 		_ = s.Engine.Git().WriteMetadata("branch1", meta1)
 
 		// Rebuild and restack branch2
@@ -126,7 +126,7 @@ func TestRestackBranch_InheritsMergedHistory(t *testing.T) {
 
 		// Second: merge branch2 and reparent branch3 to main
 		meta2, _ := s.Engine.Git().ReadMetadata("branch2")
-		meta2.PrInfo = &git.PrInfoPersistence{State: &mergedState}
+		meta2 = meta2.WithPrInfo(&git.PrInfoPersistence{State: &mergedState})
 		_ = s.Engine.Git().WriteMetadata("branch2", meta2)
 
 		// Rebuild and restack branch3
@@ -241,7 +241,7 @@ func TestRestackBranch_PreventsDuplicateHistory(t *testing.T) {
 		// Mark branch1 as merged
 		meta1, _ := s.Engine.Git().ReadMetadata("branch1")
 		mergedState := prStateMerged
-		meta1.PrInfo = &git.PrInfoPersistence{State: &mergedState}
+		meta1 = meta1.WithPrInfo(&git.PrInfoPersistence{State: &mergedState})
 		_ = s.Engine.Git().WriteMetadata("branch1", meta1)
 
 		// Rebuild and restack branch2 (first time)

--- a/internal/engine/engine_reader.go
+++ b/internal/engine/engine_reader.go
@@ -290,8 +290,8 @@ func (e *engineImpl) BranchesDepthFirst(startBranch Branch) iter.Seq2[Branch, in
 func (e *engineImpl) GetDivergencePoint(branchName string) (string, error) {
 	// First, try to get from metadata
 	meta, err := e.git.ReadMetadata(branchName)
-	if err == nil && meta.ParentBranchRevision != nil && *meta.ParentBranchRevision != "" {
-		return *meta.ParentBranchRevision, nil
+	if rev := meta.GetParentBranchRevision(); err == nil && rev != nil && *rev != "" {
+		return *rev, nil
 	}
 
 	// Get the parent branch

--- a/internal/engine/transaction.go
+++ b/internal/engine/transaction.go
@@ -329,9 +329,9 @@ func (tx *MetadataTx) IsCommitted() bool {
 func (e *engineImpl) updateBranchStateFromMeta(branch string, meta *git.Meta) {
 	state := e.branchState.GetOrCreate(branch)
 
-	if meta.ParentBranchName != nil {
+	if parentName := meta.GetParentBranchName(); parentName != nil {
 		// Update children map for old parent
-		if state.Parent != "" && state.Parent != *meta.ParentBranchName {
+		if state.Parent != "" && state.Parent != *parentName {
 			oldChildren := e.childrenMap[state.Parent]
 			for i, c := range oldChildren {
 				if c == branch {
@@ -341,7 +341,7 @@ func (e *engineImpl) updateBranchStateFromMeta(branch string, meta *git.Meta) {
 			}
 		}
 
-		state.Parent = *meta.GetParentBranchName()
+		state.Parent = *parentName
 
 		// Update children map for new parent
 		if state.Parent != "" {

--- a/internal/engine/transaction_test.go
+++ b/internal/engine/transaction_test.go
@@ -38,7 +38,7 @@ func TestSetLocked_SingleBranch(t *testing.T) {
 	impl := s.Engine.(interface{ Git() git.Runner })
 	readMeta, err := impl.Git().ReadMetadata("feature-1")
 	require.NoError(t, err)
-	assert.Equal(t, git.LockReasonUser, readMeta.LockReason)
+	assert.Equal(t, git.LockReasonUser, readMeta.GetLockReason())
 
 	// Verify in-memory cache is updated
 	assert.True(t, branch.IsLocked())
@@ -75,11 +75,11 @@ func TestSetLocked_UsesTransaction(t *testing.T) {
 	impl := s.Engine.(interface{ Git() git.Runner })
 	meta1, err := impl.Git().ReadMetadata("feature-1")
 	require.NoError(t, err)
-	assert.Equal(t, git.LockReasonUser, meta1.LockReason)
+	assert.Equal(t, git.LockReasonUser, meta1.GetLockReason())
 
 	meta2, err := impl.Git().ReadMetadata("feature-2")
 	require.NoError(t, err)
-	assert.Equal(t, git.LockReasonUser, meta2.LockReason)
+	assert.Equal(t, git.LockReasonUser, meta2.GetLockReason())
 }
 
 func TestSetFrozen_UsesTransaction(t *testing.T) {
@@ -162,7 +162,7 @@ func TestSetLocked_UnlockBranches(t *testing.T) {
 	impl := s.Engine.(interface{ Git() git.Runner })
 	meta, err := impl.Git().ReadMetadata("feature-1")
 	require.NoError(t, err)
-	assert.Equal(t, git.LockReasonUser, meta.LockReason)
+	assert.Equal(t, git.LockReasonUser, meta.GetLockReason())
 
 	// Unlock the branch
 	_, err = s.Engine.SetLocked(context.Background(), []engine.Branch{branch}, engine.LockReasonNone)
@@ -171,7 +171,7 @@ func TestSetLocked_UnlockBranches(t *testing.T) {
 	// Verify unlocked
 	meta, err = impl.Git().ReadMetadata("feature-1")
 	require.NoError(t, err)
-	assert.Equal(t, git.LockReasonNone, meta.LockReason)
+	assert.Equal(t, git.LockReasonNone, meta.GetLockReason())
 }
 
 func TestSetFrozen_UnfreezeBranches(t *testing.T) {
@@ -679,7 +679,7 @@ func TestSetLocked_LargeBatch(t *testing.T) {
 	for _, name := range branchNames {
 		meta, err := impl.Git().ReadMetadata(name)
 		require.NoError(t, err)
-		assert.Equal(t, git.LockReasonUser, meta.LockReason, "branch %s should be locked", name)
+		assert.Equal(t, git.LockReasonUser, meta.GetLockReason(), "branch %s should be locked", name)
 	}
 }
 
@@ -718,7 +718,7 @@ func TestTransaction_MixedMetaAndLocalMeta(t *testing.T) {
 	// Verify both updates persisted
 	readMeta1, err := eng.Git().ReadMetadata("feature-1")
 	require.NoError(t, err)
-	assert.Equal(t, git.LockReasonUser, readMeta1.LockReason)
+	assert.Equal(t, git.LockReasonUser, readMeta1.GetLockReason())
 
 	readLocalMeta2, err := eng.Git().ReadLocalMetadata("feature-2")
 	require.NoError(t, err)
@@ -741,7 +741,7 @@ func TestTransaction_DeleteMeta(t *testing.T) {
 	// Verify metadata exists
 	meta, err := eng.Git().ReadMetadata("feature-1")
 	require.NoError(t, err)
-	assert.NotNil(t, meta.ParentBranchName)
+	assert.NotNil(t, meta.GetParentBranchName())
 
 	// Delete metadata via transaction
 	tx := eng.BeginTx("delete metadata")
@@ -751,7 +751,7 @@ func TestTransaction_DeleteMeta(t *testing.T) {
 	// Verify metadata is gone (ReadMetadata returns empty Meta for missing refs)
 	meta, err = eng.Git().ReadMetadata("feature-1")
 	require.NoError(t, err)
-	assert.Nil(t, meta.ParentBranchName) // Empty meta has nil parent
+	assert.Nil(t, meta.GetParentBranchName()) // Empty meta has nil parent
 }
 
 func TestTransaction_DeleteLocalMeta(t *testing.T) {
@@ -827,7 +827,7 @@ func TestTransaction_UpdateAfterDelete(t *testing.T) {
 	// Verify update won (not deleted)
 	meta, err := eng.Git().ReadMetadata("feature-1")
 	require.NoError(t, err)
-	assert.Equal(t, git.LockReasonUser, meta.LockReason)
+	assert.Equal(t, git.LockReasonUser, meta.GetLockReason())
 }
 
 func TestTransaction_DeleteAfterUpdate(t *testing.T) {
@@ -853,7 +853,7 @@ func TestTransaction_DeleteAfterUpdate(t *testing.T) {
 	// Verify delete won (metadata gone)
 	meta, err := eng.Git().ReadMetadata("feature-1")
 	require.NoError(t, err)
-	assert.Nil(t, meta.ParentBranchName) // Empty meta
+	assert.Nil(t, meta.GetParentBranchName()) // Empty meta
 }
 
 func TestTransaction_MixedUpdatesAndDeletes(t *testing.T) {
@@ -886,16 +886,16 @@ func TestTransaction_MixedUpdatesAndDeletes(t *testing.T) {
 	// Verify results
 	meta1, err := eng.Git().ReadMetadata("feature-1")
 	require.NoError(t, err)
-	assert.Equal(t, git.LockReasonUser, meta1.LockReason)
+	assert.Equal(t, git.LockReasonUser, meta1.GetLockReason())
 
 	meta2, err := eng.Git().ReadMetadata("feature-2")
 	require.NoError(t, err)
-	assert.Nil(t, meta2.ParentBranchName) // Deleted
+	assert.Nil(t, meta2.GetParentBranchName()) // Deleted
 
 	meta3, err := eng.Git().ReadMetadata("feature-3")
 	require.NoError(t, err)
-	require.NotNil(t, meta3.Scope)
-	assert.Equal(t, "test-scope", *meta3.Scope)
+	require.NotNil(t, meta3.GetScope())
+	assert.Equal(t, "test-scope", *meta3.GetScope())
 }
 
 func TestTransaction_DeleteLocalMetaClearsFrozenState(t *testing.T) {

--- a/internal/git/meta_accessors.go
+++ b/internal/git/meta_accessors.go
@@ -29,17 +29,17 @@ func NewMeta() *Meta {
 // NewMetaFrom constructs a Meta from the given fields.
 func NewMetaFrom(f MetaFields) *Meta {
 	return &Meta{
-		ParentBranchName:     f.ParentBranchName,
-		ParentBranchRevision: f.ParentBranchRevision,
-		PrInfo:               f.PrInfo,
-		Scope:                f.Scope,
-		LockReason:           f.LockReason,
-		BranchType:           f.BranchType,
-		LastModifiedBy:       f.LastModifiedBy,
-		LastModifiedAt:       f.LastModifiedAt,
-		LocalOnlyHash:        f.LocalOnlyHash,
-		MergedDownstack:      f.MergedDownstack,
-		StackID:              f.StackID,
+		parentBranchName:     f.ParentBranchName,
+		parentBranchRevision: f.ParentBranchRevision,
+		prInfo:               f.PrInfo,
+		scope:                f.Scope,
+		lockReason:           f.LockReason,
+		branchType:           f.BranchType,
+		lastModifiedBy:       f.LastModifiedBy,
+		lastModifiedAt:       f.LastModifiedAt,
+		localOnlyHash:        f.LocalOnlyHash,
+		mergedDownstack:      f.MergedDownstack,
+		stackID:              f.StackID,
 	}
 }
 
@@ -53,7 +53,7 @@ func (m *Meta) GetParentBranchName() *string {
 	if m == nil {
 		return nil
 	}
-	return m.ParentBranchName
+	return m.parentBranchName
 }
 
 // GetParentBranchRevision returns the parent branch revision.
@@ -61,15 +61,15 @@ func (m *Meta) GetParentBranchRevision() *string {
 	if m == nil {
 		return nil
 	}
-	return m.ParentBranchRevision
+	return m.parentBranchRevision
 }
 
 // GetPrInfo returns a shallow copy of the PR info.
 func (m *Meta) GetPrInfo() *PrInfoPersistence {
-	if m == nil || m.PrInfo == nil {
+	if m == nil || m.prInfo == nil {
 		return nil
 	}
-	cp := *m.PrInfo
+	cp := *m.prInfo
 	return &cp
 }
 
@@ -78,7 +78,7 @@ func (m *Meta) GetScope() *string {
 	if m == nil {
 		return nil
 	}
-	return m.Scope
+	return m.scope
 }
 
 // GetLockReason returns the lock reason.
@@ -86,7 +86,7 @@ func (m *Meta) GetLockReason() LockReason {
 	if m == nil {
 		return LockReasonNone
 	}
-	return m.LockReason
+	return m.lockReason
 }
 
 // GetBranchType returns the branch type.
@@ -94,24 +94,24 @@ func (m *Meta) GetBranchType() BranchType {
 	if m == nil {
 		return ""
 	}
-	return m.BranchType
+	return m.branchType
 }
 
 // GetLastModifiedBy returns a shallow copy of the last-modified-by info.
 func (m *Meta) GetLastModifiedBy() *ModifiedBy {
-	if m == nil || m.LastModifiedBy == nil {
+	if m == nil || m.lastModifiedBy == nil {
 		return nil
 	}
-	cp := *m.LastModifiedBy
+	cp := *m.lastModifiedBy
 	return &cp
 }
 
 // GetLastModifiedAt returns a copy of the last-modified-at timestamp.
 func (m *Meta) GetLastModifiedAt() *time.Time {
-	if m == nil || m.LastModifiedAt == nil {
+	if m == nil || m.lastModifiedAt == nil {
 		return nil
 	}
-	cp := *m.LastModifiedAt
+	cp := *m.lastModifiedAt
 	return &cp
 }
 
@@ -120,16 +120,16 @@ func (m *Meta) GetLocalOnlyHash() *string {
 	if m == nil {
 		return nil
 	}
-	return m.LocalOnlyHash
+	return m.localOnlyHash
 }
 
 // GetMergedDownstack returns a copy of the merged downstack history.
 func (m *Meta) GetMergedDownstack() []MergedParent {
-	if m == nil || m.MergedDownstack == nil {
+	if m == nil || m.mergedDownstack == nil {
 		return nil
 	}
-	cp := make([]MergedParent, len(m.MergedDownstack))
-	copy(cp, m.MergedDownstack)
+	cp := make([]MergedParent, len(m.mergedDownstack))
+	copy(cp, m.mergedDownstack)
 	return cp
 }
 
@@ -138,7 +138,7 @@ func (m *Meta) GetStackID() *string {
 	if m == nil {
 		return nil
 	}
-	return m.StackID
+	return m.stackID
 }
 
 // --- With* methods ---
@@ -147,83 +147,83 @@ func (m *Meta) GetStackID() *string {
 // WithParentBranchName returns a new Meta with the parent branch name set.
 func (m *Meta) WithParentBranchName(v *string) *Meta {
 	c := *m
-	c.ParentBranchName = v
+	c.parentBranchName = v
 	return &c
 }
 
 // WithParentBranchRevision returns a new Meta with the parent branch revision set.
 func (m *Meta) WithParentBranchRevision(v *string) *Meta {
 	c := *m
-	c.ParentBranchRevision = v
+	c.parentBranchRevision = v
 	return &c
 }
 
 // WithPrInfo returns a new Meta with the PR info set.
 func (m *Meta) WithPrInfo(v *PrInfoPersistence) *Meta {
 	c := *m
-	c.PrInfo = v
+	c.prInfo = v
 	return &c
 }
 
 // WithScope returns a new Meta with the scope set.
 func (m *Meta) WithScope(v *string) *Meta {
 	c := *m
-	c.Scope = v
+	c.scope = v
 	return &c
 }
 
 // WithLockReason returns a new Meta with the lock reason set.
 func (m *Meta) WithLockReason(v LockReason) *Meta {
 	c := *m
-	c.LockReason = v
+	c.lockReason = v
 	return &c
 }
 
 // WithBranchType returns a new Meta with the branch type set.
 func (m *Meta) WithBranchType(v BranchType) *Meta {
 	c := *m
-	c.BranchType = v
+	c.branchType = v
 	return &c
 }
 
 // WithLastModifiedBy returns a new Meta with the last-modified-by info set.
 func (m *Meta) WithLastModifiedBy(v *ModifiedBy) *Meta {
 	c := *m
-	c.LastModifiedBy = v
+	c.lastModifiedBy = v
 	return &c
 }
 
 // WithLastModifiedAt returns a new Meta with the last-modified-at timestamp set.
 func (m *Meta) WithLastModifiedAt(v *time.Time) *Meta {
 	c := *m
-	c.LastModifiedAt = v
+	c.lastModifiedAt = v
 	return &c
 }
 
 // WithLocalOnlyHash returns a new Meta with the local-only hash set.
 func (m *Meta) WithLocalOnlyHash(v *string) *Meta {
 	c := *m
-	c.LocalOnlyHash = v
+	c.localOnlyHash = v
 	return &c
 }
 
 // WithMergedDownstack returns a new Meta with the merged downstack history set.
 func (m *Meta) WithMergedDownstack(v []MergedParent) *Meta {
 	c := *m
-	c.MergedDownstack = v
+	c.mergedDownstack = v
 	return &c
 }
 
 // WithStackID returns a new Meta with the stack ID set.
 func (m *Meta) WithStackID(v *string) *Meta {
 	c := *m
-	c.StackID = v
+	c.stackID = v
 	return &c
 }
 
 // --- JSON serialization ---
 // These methods use an alias to avoid infinite recursion and work
-// correctly regardless of whether fields are exported or unexported.
+// correctly with unexported fields.
 
 // metaJSON is the JSON wire format for Meta.
 type metaJSON struct {
@@ -242,7 +242,19 @@ type metaJSON struct {
 
 // MarshalJSON implements json.Marshaler for Meta.
 func (m Meta) MarshalJSON() ([]byte, error) {
-	return json.Marshal(metaJSON(m))
+	return json.Marshal(metaJSON{
+		ParentBranchName:     m.parentBranchName,
+		ParentBranchRevision: m.parentBranchRevision,
+		PrInfo:               m.prInfo,
+		Scope:                m.scope,
+		LockReason:           m.lockReason,
+		BranchType:           m.branchType,
+		LastModifiedBy:       m.lastModifiedBy,
+		LastModifiedAt:       m.lastModifiedAt,
+		LocalOnlyHash:        m.localOnlyHash,
+		MergedDownstack:      m.mergedDownstack,
+		StackID:              m.stackID,
+	})
 }
 
 // UnmarshalJSON implements json.Unmarshaler for Meta.
@@ -251,16 +263,16 @@ func (m *Meta) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &j); err != nil {
 		return err
 	}
-	m.ParentBranchName = j.ParentBranchName
-	m.ParentBranchRevision = j.ParentBranchRevision
-	m.PrInfo = j.PrInfo
-	m.Scope = j.Scope
-	m.LockReason = j.LockReason
-	m.BranchType = j.BranchType
-	m.LastModifiedBy = j.LastModifiedBy
-	m.LastModifiedAt = j.LastModifiedAt
-	m.LocalOnlyHash = j.LocalOnlyHash
-	m.MergedDownstack = j.MergedDownstack
-	m.StackID = j.StackID
+	m.parentBranchName = j.ParentBranchName
+	m.parentBranchRevision = j.ParentBranchRevision
+	m.prInfo = j.PrInfo
+	m.scope = j.Scope
+	m.lockReason = j.LockReason
+	m.branchType = j.BranchType
+	m.lastModifiedBy = j.LastModifiedBy
+	m.lastModifiedAt = j.LastModifiedAt
+	m.localOnlyHash = j.LocalOnlyHash
+	m.mergedDownstack = j.MergedDownstack
+	m.stackID = j.StackID
 	return nil
 }

--- a/internal/git/meta_accessors_test.go
+++ b/internal/git/meta_accessors_test.go
@@ -20,8 +20,8 @@ func TestNewMeta(t *testing.T) {
 	t.Parallel()
 	m := git.NewMeta()
 	require.NotNil(t, m)
-	require.Nil(t, m.ParentBranchName)
-	require.Equal(t, git.LockReasonNone, m.LockReason)
+	require.Nil(t, m.GetParentBranchName())
+	require.Equal(t, git.LockReasonNone, m.GetLockReason())
 }
 
 func TestNewMetaFrom(t *testing.T) {
@@ -41,13 +41,13 @@ func TestNewMetaFrom(t *testing.T) {
 		StackID:              &stackID,
 	})
 
-	require.Equal(t, &name, m.ParentBranchName)
-	require.Equal(t, &rev, m.ParentBranchRevision)
-	require.Equal(t, &scope, m.Scope)
-	require.Equal(t, git.LockReasonUser, m.LockReason)
-	require.Equal(t, git.BranchTypeUser, m.BranchType)
-	require.Equal(t, &stackID, m.StackID)
-	require.Nil(t, m.PrInfo)
+	require.Equal(t, &name, m.GetParentBranchName())
+	require.Equal(t, &rev, m.GetParentBranchRevision())
+	require.Equal(t, &scope, m.GetScope())
+	require.Equal(t, git.LockReasonUser, m.GetLockReason())
+	require.Equal(t, git.BranchTypeUser, m.GetBranchType())
+	require.Equal(t, &stackID, m.GetStackID())
+	require.Nil(t, m.GetPrInfo())
 }
 
 func TestMetaGetters(t *testing.T) {

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -37,27 +37,29 @@ const (
 	BranchTypeWorktreeAnchor BranchType = "worktree-anchor" // Anchor branch for worktree, has no commits
 )
 
-// Meta represents branch metadata stored in Git refs
+// Meta represents branch metadata stored in Git refs.
+// Fields are unexported to enforce immutability — use getters to read
+// and With* methods to create modified copies. Construct via NewMeta()
+// or NewMetaFrom(MetaFields{...}).
 type Meta struct {
-	ParentBranchName     *string            `json:"parentBranchName,omitempty"`
-	ParentBranchRevision *string            `json:"parentBranchRevision,omitempty"`
-	PrInfo               *PrInfoPersistence `json:"prInfo,omitempty"`
-	Scope                *string            `json:"scope,omitempty"`
-	LockReason           LockReason         `json:"lockReason,omitempty"`
+	parentBranchName     *string
+	parentBranchRevision *string
+	prInfo               *PrInfoPersistence
+	scope                *string
+	lockReason           LockReason
 
 	// Fields for remote sync
-	BranchType     BranchType  `json:"branchType,omitempty"`     // Type of branch (regular, consolidated)
-	LastModifiedBy *ModifiedBy `json:"lastModifiedBy,omitempty"` // Who last changed this metadata
-	LastModifiedAt *time.Time  `json:"lastModifiedAt,omitempty"` // When metadata was last changed
-	LocalOnlyHash  *string     `json:"localOnlyHash,omitempty"`  // Hash of local-only state for change detection
+	branchType     BranchType
+	lastModifiedBy *ModifiedBy
+	lastModifiedAt *time.Time
+	localOnlyHash  *string
 
-	// MergedDownstack preserves historical parent relationships when branches are reparented
+	// mergedDownstack preserves historical parent relationships when branches are reparented
 	// due to merge/deletion. Ordered oldest to newest, limited to 5 entries max.
-	MergedDownstack []MergedParent `json:"mergedDownstack,omitempty"`
+	mergedDownstack []MergedParent
 
-	// StackID links this branch to a stack ref (refs/stackit/stacks/{stack-id}).
-	// Generated when creating a new stack off trunk, inherited when creating off tracked branch.
-	StackID *string `json:"stackId,omitempty"`
+	// stackID links this branch to a stack ref (refs/stackit/stacks/{stack-id}).
+	stackID *string
 }
 
 // StackDescription holds stack-level title and description.
@@ -170,7 +172,7 @@ func (r *runner) BatchReadLocalMetadata(branchNames []string) map[string]*LocalM
 
 func (r *runner) ReadMetadata(branchName string) (*Meta, error) {
 	// Check cache first to avoid redundant git process spawns.
-	// Get returns a deep copy so callers can freely mutate the result.
+	// Meta is immutable, so returning the cached pointer is safe.
 	if cached := r.metadataCache.Get(branchName); cached != nil {
 		return cached, nil
 	}
@@ -180,8 +182,9 @@ func (r *runner) ReadMetadata(branchName string) (*Meta, error) {
 	sha, err := r.GetRef(refName)
 	if err != nil {
 		// If ref doesn't exist, it's not an error, just means no metadata
-		r.metadataCache.Put(branchName, &Meta{})
-		return &Meta{}, nil //nolint:nilerr
+		empty := NewMeta()
+		r.metadataCache.Put(branchName, empty)
+		return empty, nil //nolint:nilerr
 	}
 
 	content, err := r.ReadBlob(sha)
@@ -190,8 +193,9 @@ func (r *runner) ReadMetadata(branchName string) (*Meta, error) {
 	}
 
 	if content == "" {
-		r.metadataCache.Put(branchName, &Meta{})
-		return &Meta{}, nil
+		empty := NewMeta()
+		r.metadataCache.Put(branchName, empty)
+		return empty, nil
 	}
 
 	var meta Meta
@@ -200,7 +204,7 @@ func (r *runner) ReadMetadata(branchName string) (*Meta, error) {
 	}
 
 	r.metadataCache.Put(branchName, &meta)
-	return deepCopyMeta(&meta), nil
+	return &meta, nil
 }
 
 func (r *runner) WriteMetadata(branchName string, meta *Meta) error {

--- a/internal/git/metadata_cache.go
+++ b/internal/git/metadata_cache.go
@@ -6,27 +6,24 @@ import (
 )
 
 // metadataCache provides thread-safe caching of branch metadata.
-// Values stored in the cache are treated as immutable — callers receive
-// deep copies so mutations never affect cached state.
+// Meta values are immutable, so the cache can safely return shared pointers
+// without deep copying.
 type metadataCache struct {
 	entries sync.Map // map[string]*Meta
 }
 
-// Get returns a deep copy of the cached metadata for the given branch, or nil if not cached.
+// Get returns the cached metadata for the given branch, or nil if not cached.
 func (c *metadataCache) Get(branchName string) *Meta {
 	value, ok := c.entries.Load(branchName)
 	if !ok {
 		return nil
 	}
-	original := value.(*Meta)
-	return deepCopyMeta(original)
+	return value.(*Meta)
 }
 
-// Put stores a deep copy of the metadata in the cache.
-// The caller retains ownership of the original — subsequent mutations
-// to the passed-in Meta will not affect the cached value.
+// Put stores the metadata in the cache.
 func (c *metadataCache) Put(branchName string, meta *Meta) {
-	c.entries.Store(branchName, deepCopyMeta(meta))
+	c.entries.Store(branchName, meta)
 }
 
 // Delete removes the cached metadata for the given branch.
@@ -53,88 +50,4 @@ func (c *metadataCache) InvalidateForRefNames(refNames []string) {
 			c.entries.Delete(branchName)
 		}
 	}
-}
-
-// deepCopyMeta returns a fully independent copy of a Meta struct.
-// All pointer fields, slices, and nested structs are copied so that
-// mutations to the copy never affect the original (and vice versa).
-func deepCopyMeta(m *Meta) *Meta {
-	if m == nil {
-		return nil
-	}
-
-	out := *m // shallow copy of value types (LockReason, BranchType)
-
-	out.ParentBranchName = copyStringPtr(m.ParentBranchName)
-	out.ParentBranchRevision = copyStringPtr(m.ParentBranchRevision)
-	out.Scope = copyStringPtr(m.Scope)
-	out.LocalOnlyHash = copyStringPtr(m.LocalOnlyHash)
-	out.StackID = copyStringPtr(m.StackID)
-
-	if m.PrInfo != nil {
-		out.PrInfo = deepCopyPrInfo(m.PrInfo)
-	}
-
-	if m.LastModifiedBy != nil {
-		copied := *m.LastModifiedBy
-		copied.GitHubUsername = copyStringPtr(m.LastModifiedBy.GitHubUsername)
-		out.LastModifiedBy = &copied
-	}
-
-	if m.LastModifiedAt != nil {
-		copied := *m.LastModifiedAt
-		out.LastModifiedAt = &copied
-	}
-
-	if m.MergedDownstack != nil {
-		out.MergedDownstack = make([]MergedParent, len(m.MergedDownstack))
-		for i, mp := range m.MergedDownstack {
-			out.MergedDownstack[i] = MergedParent{
-				BranchName: mp.BranchName,
-				PRNumber:   copyIntPtr(mp.PRNumber),
-				PRState:    copyStringPtr(mp.PRState),
-			}
-		}
-	}
-
-	return &out
-}
-
-func deepCopyPrInfo(p *PrInfoPersistence) *PrInfoPersistence {
-	out := *p
-	out.Number = copyIntPtr(p.Number)
-	out.Base = copyStringPtr(p.Base)
-	out.URL = copyStringPtr(p.URL)
-	out.Title = copyStringPtr(p.Title)
-	out.Body = copyStringPtr(p.Body)
-	out.State = copyStringPtr(p.State)
-	out.MergeBranch = copyStringPtr(p.MergeBranch)
-
-	if p.IsDraft != nil {
-		copied := *p.IsDraft
-		out.IsDraft = &copied
-	}
-
-	if p.LockReason != nil {
-		copied := *p.LockReason
-		out.LockReason = &copied
-	}
-
-	return &out
-}
-
-func copyStringPtr(s *string) *string {
-	if s == nil {
-		return nil
-	}
-	copied := *s
-	return &copied
-}
-
-func copyIntPtr(n *int) *int {
-	if n == nil {
-		return nil
-	}
-	copied := *n
-	return &copied
 }

--- a/internal/integration/scope_integration_test.go
+++ b/internal/integration/scope_integration_test.go
@@ -119,6 +119,6 @@ func TestScopeSubmitSyncFlow(t *testing.T) {
 
 	cache := eng.GetRemoteMetadataCache()
 	require.NotNil(t, cache.Get("feature"), "Remote metadata for 'feature' should exist in cache")
-	require.NotNil(t, cache.Get("feature").Scope, "Scope should be set in remote metadata")
-	require.Equal(t, "JIRA-123", *cache.Get("feature").Scope, "Remote metadata scope should match JIRA-123")
+	require.NotNil(t, cache.Get("feature").GetScope(), "Scope should be set in remote metadata")
+	require.Equal(t, "JIRA-123", *cache.Get("feature").GetScope(), "Remote metadata scope should match JIRA-123")
 }

--- a/internal/integration/sync_test.go
+++ b/internal/integration/sync_test.go
@@ -46,11 +46,13 @@ func TestSync(t *testing.T) {
 		meta, err := eng.Git().ReadMetadata("feature-b")
 		require.NoError(t, err)
 
-		if meta.PrInfo == nil {
-			meta.PrInfo = &git.PrInfoPersistence{}
+		prInfo := meta.GetPrInfo()
+		if prInfo == nil {
+			prInfo = &git.PrInfoPersistence{}
 		}
 		newBase := mainBranchName
-		meta.PrInfo.Base = &newBase
+		prInfo.Base = &newBase
+		meta = meta.WithPrInfo(prInfo)
 
 		err = eng.Git().WriteMetadata("feature-b", meta)
 		require.NoError(t, err)
@@ -120,15 +122,14 @@ func TestSync(t *testing.T) {
 		// Mark merge branch as merged
 		meta, err := eng.Git().ReadMetadata(mergeBranch)
 		require.NoError(t, err)
-		if meta.PrInfo == nil {
-			meta.PrInfo = &git.PrInfoPersistence{}
-		}
 		prNum := 100
 		state := "CLOSED"
 		base := mainBranchName
-		meta.PrInfo.Number = &prNum
-		meta.PrInfo.State = &state
-		meta.PrInfo.Base = &base
+		meta = meta.WithPrInfo(&git.PrInfoPersistence{
+			Number: &prNum,
+			State:  &state,
+			Base:   &base,
+		})
 		err = eng.Git().WriteMetadata(mergeBranch, meta)
 		require.NoError(t, err)
 
@@ -160,28 +161,26 @@ func TestSync(t *testing.T) {
 
 		// a: MERGED into main
 		metaA, _ := eng.Git().ReadMetadata("a")
-		if metaA.PrInfo == nil {
-			metaA.PrInfo = &git.PrInfoPersistence{}
-		}
 		prNumA := 1
 		stateA := prStateMerged
 		baseA := mainBranchName
-		metaA.PrInfo.Number = &prNumA
-		metaA.PrInfo.State = &stateA
-		metaA.PrInfo.Base = &baseA
+		metaA = metaA.WithPrInfo(&git.PrInfoPersistence{
+			Number: &prNumA,
+			State:  &stateA,
+			Base:   &baseA,
+		})
 		_ = eng.Git().WriteMetadata("a", metaA)
 
 		// b: OPEN pointing to main
 		metaB, _ := eng.Git().ReadMetadata("b")
-		if metaB.PrInfo == nil {
-			metaB.PrInfo = &git.PrInfoPersistence{}
-		}
 		prNumB := 2
 		stateB := "OPEN"
 		baseB := mainBranchName
-		metaB.PrInfo.Number = &prNumB
-		metaB.PrInfo.State = &stateB
-		metaB.PrInfo.Base = &baseB
+		metaB = metaB.WithPrInfo(&git.PrInfoPersistence{
+			Number: &prNumB,
+			State:  &stateB,
+			Base:   &baseB,
+		})
 		_ = eng.Git().WriteMetadata("b", metaB)
 
 		// 1. Run sync
@@ -216,17 +215,16 @@ func TestSyncDraftPRs(t *testing.T) {
 	meta, err := eng.Git().ReadMetadata("branch-a")
 	require.NoError(t, err)
 
-	if meta.PrInfo == nil {
-		meta.PrInfo = &git.PrInfoPersistence{}
-	}
 	prNum := 1
 	state := "OPEN"
 	base := mainBranchName
 	isDraft := true
-	meta.PrInfo.Number = &prNum
-	meta.PrInfo.State = &state
-	meta.PrInfo.Base = &base
-	meta.PrInfo.IsDraft = &isDraft
+	meta = meta.WithPrInfo(&git.PrInfoPersistence{
+		Number:  &prNum,
+		State:   &state,
+		Base:    &base,
+		IsDraft: &isDraft,
+	})
 
 	err = eng.Git().WriteMetadata("branch-a", meta)
 	require.NoError(t, err)
@@ -260,28 +258,26 @@ func TestSyncCleanupDiamond(t *testing.T) {
 
 	// Mark 'a' as merged
 	metaA, _ := eng.Git().ReadMetadata("a")
-	if metaA.PrInfo == nil {
-		metaA.PrInfo = &git.PrInfoPersistence{}
-	}
 	prNum := 1
 	state := prStateMerged
 	base := mainBranchName
-	metaA.PrInfo.Number = &prNum
-	metaA.PrInfo.State = &state
-	metaA.PrInfo.Base = &base
+	metaA = metaA.WithPrInfo(&git.PrInfoPersistence{
+		Number: &prNum,
+		State:  &state,
+		Base:   &base,
+	})
 	_ = eng.Git().WriteMetadata("a", metaA)
 
 	// Mark 'b' as merged
 	metaB, _ := eng.Git().ReadMetadata("b")
-	if metaB.PrInfo == nil {
-		metaB.PrInfo = &git.PrInfoPersistence{}
-	}
 	prNumB := 2
 	stateB := "MERGED"
 	baseB := mainBranchName
-	metaB.PrInfo.Number = &prNumB
-	metaB.PrInfo.State = &stateB
-	metaB.PrInfo.Base = &baseB
+	metaB = metaB.WithPrInfo(&git.PrInfoPersistence{
+		Number: &prNumB,
+		State:  &stateB,
+		Base:   &baseB,
+	})
 	_ = eng.Git().WriteMetadata("b", metaB)
 
 	// Run sync
@@ -317,15 +313,14 @@ func TestSyncStaleDraftCleanup(t *testing.T) {
 
 	// Mark 'a' as merged in metadata
 	metaA, _ := eng.Git().ReadMetadata("a")
-	if metaA.PrInfo == nil {
-		metaA.PrInfo = &git.PrInfoPersistence{}
-	}
 	prNum := 1
 	state := prStateMerged
 	base := mainBranchName
-	metaA.PrInfo.Number = &prNum
-	metaA.PrInfo.State = &state
-	metaA.PrInfo.Base = &base
+	metaA = metaA.WithPrInfo(&git.PrInfoPersistence{
+		Number: &prNum,
+		State:  &state,
+		Base:   &base,
+	})
 	_ = eng.Git().WriteMetadata("a", metaA)
 
 	// 'a' is now empty relative to main
@@ -474,15 +469,14 @@ func TestSyncDoesNotLeaveIndexState(t *testing.T) {
 		// 3. Mark branch-a as merged
 		metaA, err := eng.Git().ReadMetadata("branch-a")
 		require.NoError(t, err)
-		if metaA.PrInfo == nil {
-			metaA.PrInfo = &git.PrInfoPersistence{}
-		}
 		prNum := 1
 		state := prStateMerged
 		base := mainBranchName
-		metaA.PrInfo.Number = &prNum
-		metaA.PrInfo.State = &state
-		metaA.PrInfo.Base = &base
+		metaA = metaA.WithPrInfo(&git.PrInfoPersistence{
+			Number: &prNum,
+			State:  &state,
+			Base:   &base,
+		})
 		err = eng.Git().WriteMetadata("branch-a", metaA)
 		require.NoError(t, err)
 
@@ -524,15 +518,14 @@ func TestSyncDoesNotLeaveIndexState(t *testing.T) {
 		// Mark feature as merged
 		meta, err := eng.Git().ReadMetadata("feature")
 		require.NoError(t, err)
-		if meta.PrInfo == nil {
-			meta.PrInfo = &git.PrInfoPersistence{}
-		}
 		prNum := 1
 		state := prStateMerged
 		base := mainBranchName
-		meta.PrInfo.Number = &prNum
-		meta.PrInfo.State = &state
-		meta.PrInfo.Base = &base
+		meta = meta.WithPrInfo(&git.PrInfoPersistence{
+			Number: &prNum,
+			State:  &state,
+			Base:   &base,
+		})
 		err = eng.Git().WriteMetadata("feature", meta)
 		require.NoError(t, err)
 
@@ -579,15 +572,14 @@ func TestSyncDoesNotLeaveIndexState(t *testing.T) {
 
 		metaF, err := eng.Git().ReadMetadata("feature")
 		require.NoError(t, err)
-		if metaF.PrInfo == nil {
-			metaF.PrInfo = &git.PrInfoPersistence{}
-		}
 		prNum := 1
 		state := prStateMerged
 		base := mainBranchName
-		metaF.PrInfo.Number = &prNum
-		metaF.PrInfo.State = &state
-		metaF.PrInfo.Base = &base
+		metaF = metaF.WithPrInfo(&git.PrInfoPersistence{
+			Number: &prNum,
+			State:  &state,
+			Base:   &base,
+		})
 		err = eng.Git().WriteMetadata("feature", metaF)
 		require.NoError(t, err)
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `multi-stack/20260207-113000`.


* **PR #699**
  * **PR #700**
    * **PR #701**
      * **PR #702**
        * **PR #703**
          * **PR #704** 👈
            * **PR #705**
              * **PR #706**
                * **PR #707**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->