### PR TITLE
perf: add revision cache and per-repository mutex for parallel operations

### DIFF
--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -69,6 +69,10 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 		renderer = tui.NewStackTreeRenderer(ctx.Engine)
 	}
 
+	// Pre-load metadata and revisions for all branches to eliminate per-branch
+	// cache misses during parallel annotation building.
+	ctx.Engine.PreloadBranchData()
+
 	// Render the stack
 	// First, collect annotations for all branches in the stack using a worker pool
 	annotations := make(map[string]tree.BranchAnnotation)

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -172,6 +172,10 @@ func (d *demoGitRunner) BatchGetRevisions(branchNames []string) (map[string]stri
 	return results, nil
 }
 
+func (d *demoGitRunner) LoadAllBranchRevisions() error {
+	return nil
+}
+
 func (d *demoGitRunner) GetMergeBase(_, _ string) (string, error) {
 	return "merge-base-sha", nil
 }

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -140,6 +140,31 @@ func (e *engineImpl) GetDiffStats(branch Branch) (int, int, error) {
 	return added, deleted, nil
 }
 
+// PreloadBranchData batch-loads metadata and revisions for all tracked branches
+// into their respective caches. This replaces N individual lookups (each requiring
+// mutex acquisition or subprocess spawning) with two bulk operations:
+//   - git show-ref --heads (one subprocess for all branch SHAs)
+//   - BatchReadMetadata (parallel metadata reads, cached via sync.Map)
+//
+// After calling this, parallel annotation building via utils.Run will find all
+// data cached, eliminating go-git mutex contention for revision lookups.
+func (e *engineImpl) PreloadBranchData() {
+	e.mu.RLock()
+	branches := make([]string, 0, len(e.branchState))
+	for name := range e.branchState {
+		branches = append(branches, name)
+	}
+	e.mu.RUnlock()
+
+	// Batch load all branch revisions via single git show-ref --heads call
+	_ = e.git.LoadAllBranchRevisions()
+
+	// Batch load all metadata (populates metadataCache via sync.Map)
+	if len(branches) > 0 {
+		e.git.BatchReadMetadata(branches)
+	}
+}
+
 // GetAllCommits returns commits for a branch in various formats
 func (e *engineImpl) GetAllCommits(branch Branch, format CommitFormat) ([]string, error) {
 	branchName := branch.GetName()

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -67,6 +67,10 @@ type BranchInfo interface {
 	// GetDivergencePoint returns the divergence point of a branch from its parent.
 	// Returns the ParentBranchRevision from metadata if valid, otherwise the parent's current revision.
 	GetDivergencePoint(branchName string) (string, error)
+	// PreloadBranchData batch-loads metadata and revisions for all branches
+	// into their respective caches. Call before parallel annotation building
+	// to eliminate per-branch cache misses and mutex contention.
+	PreloadBranchData()
 }
 
 // GitDiffer handles diff and merge operations

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -63,6 +63,7 @@ func (r *runner) DeleteBranch(ctx context.Context, branchName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to delete branch %s: %w", branchName, err)
 	}
+	r.revisionCache.Delete(branchName)
 	return nil
 }
 
@@ -71,6 +72,8 @@ func (r *runner) RenameBranch(ctx context.Context, oldName, newName string) erro
 	if err != nil {
 		return fmt.Errorf("failed to rename branch %s to %s: %w", oldName, newName, err)
 	}
+	r.revisionCache.Delete(oldName)
+	r.revisionCache.Delete(newName)
 	return nil
 }
 
@@ -84,6 +87,9 @@ func (r *runner) CreateBranch(ctx context.Context, branchName, startPoint string
 
 func (r *runner) CreateBranchForce(ctx context.Context, branchName, revision string) error {
 	_, err := r.RunGitCommandWithContext(ctx, "branch", "-f", branchName, revision)
+	if err == nil {
+		r.revisionCache.Delete(branchName)
+	}
 	return err
 }
 
@@ -100,6 +106,7 @@ func (r *runner) UpdateBranchRef(ctx context.Context, branchName, revision strin
 	if err != nil {
 		return fmt.Errorf("failed to update branch ref: %w", err)
 	}
+	r.revisionCache.Delete(branchName)
 	return nil
 }
 

--- a/internal/git/cherry_pick.go
+++ b/internal/git/cherry_pick.go
@@ -13,8 +13,11 @@ func (r *runner) CherryPick(ctx context.Context, commitSHA, onto string) (string
 
 	if _, err := r.RunGitCommandWithContext(ctx, "cherry-pick", commitSHA); err != nil {
 		_, _ = r.RunGitCommandWithContext(ctx, "cherry-pick", "--abort")
+		r.revisionCache.InvalidateAll()
 		return "", fmt.Errorf("failed to cherry-pick %s: %w", commitSHA, err)
 	}
+
+	r.revisionCache.InvalidateAll()
 
 	newSHA, err := r.RunGitCommandWithContext(ctx, "rev-parse", "HEAD")
 	if err != nil {
@@ -26,10 +29,12 @@ func (r *runner) CherryPick(ctx context.Context, commitSHA, onto string) (string
 
 func (r *runner) CherryPickSimple(ctx context.Context, commitSHA string) error {
 	_, err := r.RunGitCommandWithContext(ctx, "cherry-pick", commitSHA)
+	r.revisionCache.InvalidateAll()
 	return err
 }
 
 func (r *runner) CherryPickAbort(ctx context.Context) error {
 	_, err := r.RunGitCommandWithContext(ctx, "cherry-pick", "--abort")
+	r.revisionCache.InvalidateAll()
 	return err
 }

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -50,10 +50,13 @@ func (r *runner) CommitWithOptions(opts CommitOptions) error {
 	// use the streaming runner to show hook output while capturing for error handling.
 	if !utils.IsInteractive() || (opts.Message != "" && !opts.Edit) || (opts.Amend && opts.NoEdit) {
 		_, err := r.runGitStreaming(context.Background(), args...)
+		r.revisionCache.InvalidateAll()
 		return err
 	}
 
-	return r.RunGitCommandInteractive(args...)
+	err := r.RunGitCommandInteractive(args...)
+	r.revisionCache.InvalidateAll()
+	return err
 }
 
 func (r *runner) Commit(message string, verbose int, noVerify bool) error {
@@ -66,5 +69,6 @@ func (r *runner) Commit(message string, verbose int, noVerify bool) error {
 
 func (r *runner) CommitAmendNoEdit(ctx context.Context) error {
 	_, err := r.RunGitCommandWithContext(ctx, "commit", "-a", "--amend", "--no-edit", "--no-verify")
+	r.revisionCache.InvalidateAll()
 	return err
 }

--- a/internal/git/commit_info.go
+++ b/internal/git/commit_info.go
@@ -15,8 +15,8 @@ import (
 
 func (r *runner) getCommitDate(repo *Repository, branchName string) (time.Time, error) {
 	// Synchronize go-git operations to prevent concurrent packfile access
-	goGitMu.Lock()
-	defer goGitMu.Unlock()
+	r.goGitMu.Lock()
+	defer r.goGitMu.Unlock()
 
 	hash, err := r.resolveRefHashInternal(repo, branchName)
 	if err != nil {
@@ -33,8 +33,8 @@ func (r *runner) getCommitDate(repo *Repository, branchName string) (time.Time, 
 
 func (r *runner) getCommitAuthor(repo *Repository, branchName string) (string, error) {
 	// Synchronize go-git operations to prevent concurrent packfile access
-	goGitMu.Lock()
-	defer goGitMu.Unlock()
+	r.goGitMu.Lock()
+	defer r.goGitMu.Unlock()
 
 	hash, err := r.resolveRefHashInternal(repo, branchName)
 	if err != nil {
@@ -50,9 +50,16 @@ func (r *runner) getCommitAuthor(repo *Repository, branchName string) (string, e
 }
 
 func (r *runner) getRevision(repo *Repository, branchName string) (string, error) {
+	// Check revision cache first to avoid go-git mutex contention.
+	// The cache is populated by LoadAllBranchRevisions (batch preload)
+	// but not on individual misses, to avoid stale entries from external mutations.
+	if cached, ok := r.revisionCache.Get(branchName); ok {
+		return cached, nil
+	}
+
 	// Synchronize go-git operations to prevent concurrent packfile access
-	goGitMu.Lock()
-	defer goGitMu.Unlock()
+	r.goGitMu.Lock()
+	defer r.goGitMu.Unlock()
 
 	hash, err := r.resolveRefHashInternal(repo, branchName)
 	if err != nil {
@@ -64,8 +71,8 @@ func (r *runner) getRevision(repo *Repository, branchName string) (string, error
 
 func (r *runner) getRemoteRevision(repo *Repository, branchName string) (string, error) {
 	// Synchronize go-git operations to prevent concurrent packfile access
-	goGitMu.Lock()
-	defer goGitMu.Unlock()
+	r.goGitMu.Lock()
+	defer r.goGitMu.Unlock()
 
 	// Try refs/remotes/origin/branchName
 	hash, err := r.resolveRefHashInternal(repo, "origin/"+branchName)
@@ -136,8 +143,8 @@ func (r *runner) getCommitRangeGitFallback(base, head string) ([]string, error) 
 // resolveRefHash resolves a ref (branch name, SHA, or ref path) to a hash
 func (r *runner) resolveRefHash(repo *Repository, ref string) (plumbing.Hash, error) {
 	// Synchronize go-git operations to prevent concurrent packfile access
-	goGitMu.Lock()
-	defer goGitMu.Unlock()
+	r.goGitMu.Lock()
+	defer r.goGitMu.Unlock()
 
 	return r.resolveRefHashInternal(repo, ref)
 }
@@ -181,6 +188,35 @@ func (r *runner) resolveRefHashInternal(repo *Repository, ref string) (plumbing.
 	}
 
 	return plumbing.ZeroHash, fmt.Errorf("failed to resolve ref %s: reference not found", ref)
+}
+
+// LoadAllBranchRevisions populates the revision cache for all local branches
+// using a single `git show-ref --heads` call. This replaces N individual
+// go-git ref resolutions (each requiring goGitMu) with one subprocess call.
+func (r *runner) LoadAllBranchRevisions() error {
+	output, err := r.RunGitCommandWithContext(context.Background(), "show-ref", "--heads")
+	if err != nil {
+		// show-ref returns exit code 1 if no refs found (empty repo)
+		return nil //nolint:nilerr
+	}
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		// Format: "SHA refs/heads/branchname"
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		sha := parts[0]
+		ref := parts[1]
+		if branchName, ok := strings.CutPrefix(ref, "refs/heads/"); ok {
+			r.revisionCache.Put(branchName, sha)
+		}
+	}
+	return nil
 }
 
 func (r *runner) batchGetRevisions(repo *Repository, branchNames []string) (map[string]string, []error) {

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -74,6 +74,10 @@ type CommitReader interface {
 	GetRevision(branchName string) (string, error)
 	GetCurrentRevision(ctx context.Context) (string, error)
 	BatchGetRevisions(branchNames []string) (map[string]string, []error)
+	// LoadAllBranchRevisions populates the revision cache for all local branches
+	// using a single `git show-ref --heads` call. Subsequent GetRevision calls
+	// for cached branches avoid go-git mutex contention entirely.
+	LoadAllBranchRevisions() error
 	GetCommitDate(branchName string) (time.Time, error)
 	GetCommitAuthor(branchName string) (string, error)
 	GetCommitRange(base, head, format string) ([]string, error)

--- a/internal/git/merge_base.go
+++ b/internal/git/merge_base.go
@@ -40,8 +40,8 @@ func (r *runner) getMergeBaseByRef(repo *Repository, ref1Name, ref2Name string) 
 
 func (r *runner) getMergeBaseGoGit(repo *Repository, hash1, hash2 plumbing.Hash) (string, error) {
 	// Synchronize go-git operations to prevent concurrent packfile access
-	goGitMu.Lock()
-	defer goGitMu.Unlock()
+	r.goGitMu.Lock()
+	defer r.goGitMu.Unlock()
 
 	commit1, err := repo.CommitObject(hash1)
 	if err != nil {
@@ -104,8 +104,8 @@ func (r *runner) isAncestor(repo *Repository, ancestor, descendant string) (bool
 
 func (r *runner) isAncestorGoGit(repo *Repository, ancestorHash, descendantHash plumbing.Hash) (bool, error) {
 	// Synchronize go-git operations to prevent concurrent packfile access
-	goGitMu.Lock()
-	defer goGitMu.Unlock()
+	r.goGitMu.Lock()
+	defer r.goGitMu.Unlock()
 
 	// Get commit objects
 	ancestorCommit, err := repo.CommitObject(ancestorHash)

--- a/internal/git/merge_detection.go
+++ b/internal/git/merge_detection.go
@@ -28,6 +28,7 @@ func (r *runner) Merge(ctx context.Context, branchName string, opts MergeOptions
 	if err != nil {
 		return fmt.Errorf("failed to merge %s: %w", branchName, err)
 	}
+	r.revisionCache.InvalidateAll()
 	return nil
 }
 
@@ -54,6 +55,7 @@ func (r *runner) MergeMultiple(ctx context.Context, branches []string, opts Merg
 	if err != nil {
 		return fmt.Errorf("failed to merge branches: %w", err)
 	}
+	r.revisionCache.InvalidateAll()
 	return nil
 }
 
@@ -68,6 +70,7 @@ func (r *runner) IsMergeInProgress(ctx context.Context) bool {
 
 func (r *runner) MergeAbort(ctx context.Context) error {
 	_, err := r.RunGitCommandWithContext(ctx, "merge", "--abort")
+	r.revisionCache.InvalidateAll()
 	if err != nil {
 		return fmt.Errorf("merge abort failed: %w", err)
 	}

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -23,6 +23,7 @@ func (r *runner) Rebase(ctx context.Context, branchName, upstream, oldUpstream s
 	// We use branchName~0 to force a detached checkout of the branch tip
 	_, err := r.RunGitCommandWithContext(ctx, "rebase", "--onto", upstream, oldUpstream, branchName+"~0")
 	if err != nil {
+		r.revisionCache.InvalidateAll()
 		if r.IsRebaseInProgress(ctx) {
 			return RebaseConflict, nil
 		}
@@ -31,6 +32,8 @@ func (r *runner) Rebase(ctx context.Context, branchName, upstream, oldUpstream s
 
 		return RebaseConflict, err
 	}
+
+	r.revisionCache.InvalidateAll()
 
 	// Since we rebased in detached HEAD, we must manually update the branch ref
 	newRev, err := r.GetCurrentRevision(ctx)
@@ -47,6 +50,7 @@ func (r *runner) Rebase(ctx context.Context, branchName, upstream, oldUpstream s
 
 func (r *runner) RebaseContinueNoEdit(ctx context.Context) (RebaseResult, error) {
 	_, err := r.RunGitCommandWithEnv(ctx, []string{"GIT_EDITOR=true"}, "rebase", "--continue")
+	r.revisionCache.InvalidateAll()
 	if err != nil {
 		if r.IsRebaseInProgress(ctx) {
 			return RebaseConflict, nil
@@ -58,6 +62,7 @@ func (r *runner) RebaseContinueNoEdit(ctx context.Context) (RebaseResult, error)
 
 func (r *runner) RebaseContinue(ctx context.Context) (RebaseResult, error) {
 	_, err := r.RunGitCommandWithEnv(ctx, []string{"GIT_EDITOR=true"}, "rebase", "--continue")
+	r.revisionCache.InvalidateAll()
 	if err != nil {
 		if r.IsRebaseInProgress(ctx) {
 			return RebaseConflict, nil
@@ -70,6 +75,7 @@ func (r *runner) RebaseContinue(ctx context.Context) (RebaseResult, error) {
 
 func (r *runner) RebaseAbort(ctx context.Context) error {
 	_, err := r.RunGitCommandWithContext(ctx, "rebase", "--abort")
+	r.revisionCache.InvalidateAll()
 	if err != nil {
 		return fmt.Errorf("rebase abort failed: %w", err)
 	}

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -15,8 +15,8 @@ const DefaultRemote = "origin"
 
 func (r *runner) getRemote(repo *Repository) string {
 	// Synchronize go-git operations to prevent concurrent packfile access
-	goGitMu.Lock()
-	defer goGitMu.Unlock()
+	r.goGitMu.Lock()
+	defer r.goGitMu.Unlock()
 
 	// Try to get current branch
 	head, err := repo.Head()
@@ -47,17 +47,17 @@ func (r *runner) fetchRemoteShas(ctx context.Context, repo *Repository, remote s
 	}
 
 	// Synchronize go-git operations to prevent concurrent packfile access
-	goGitMu.Lock()
+	r.goGitMu.Lock()
 	rem, err := repo.Remote(remote)
-	goGitMu.Unlock()
+	r.goGitMu.Unlock()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get remote %s: %w", remote, err)
 	}
 
 	// List remote references with context for timeout support
-	goGitMu.Lock()
+	r.goGitMu.Lock()
 	refs, err := rem.ListContext(ctx, &gogit.ListOptions{})
-	goGitMu.Unlock()
+	r.goGitMu.Unlock()
 	if err != nil {
 		if errors.Is(err, transport.ErrEmptyRemoteRepository) || errors.Is(err, gogit.NoErrAlreadyUpToDate) {
 			return make(map[string]string), nil
@@ -79,8 +79,8 @@ func (r *runner) fetchRemoteShas(ctx context.Context, repo *Repository, remote s
 
 func (r *runner) getRemoteSha(repo *Repository, remote, branchName string) (string, error) {
 	// Synchronize go-git operations to prevent concurrent packfile access
-	goGitMu.Lock()
-	defer goGitMu.Unlock()
+	r.goGitMu.Lock()
+	defer r.goGitMu.Unlock()
 
 	refName := plumbing.ReferenceName(fmt.Sprintf("refs/remotes/%s/%s", remote, branchName))
 	ref, err := repo.Reference(refName, true)

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -23,6 +24,9 @@ import (
 type Repository struct {
 	*gogit.Repository
 	path string
+	// goGitMu synchronizes go-git operations on this repository instance
+	// to prevent concurrent packfile access panics.
+	goGitMu sync.Mutex
 }
 
 // OpenRepository opens a git repository at the given path
@@ -65,8 +69,8 @@ func (r *Repository) GetRepoRoot() string {
 // GetReference returns a reference by name
 func (r *Repository) GetReference(name string) (*plumbing.Reference, error) {
 	// Synchronize go-git operations to prevent concurrent packfile access
-	goGitMu.Lock()
-	defer goGitMu.Unlock()
+	r.goGitMu.Lock()
+	defer r.goGitMu.Unlock()
 
 	return r.Reference(plumbing.ReferenceName(name), true)
 }
@@ -74,8 +78,8 @@ func (r *Repository) GetReference(name string) (*plumbing.Reference, error) {
 // GetBranchNames returns all branch names
 func (r *Repository) GetBranchNames() ([]string, error) {
 	// Synchronize go-git operations to prevent concurrent packfile access
-	goGitMu.Lock()
-	defer goGitMu.Unlock()
+	r.goGitMu.Lock()
+	defer r.goGitMu.Unlock()
 
 	branches, err := r.Branches()
 	if err != nil {
@@ -99,8 +103,8 @@ func (r *Repository) GetBranchNames() ([]string, error) {
 // GetCurrentBranch returns the current branch name
 func (r *Repository) GetCurrentBranch() (string, error) {
 	// Synchronize go-git operations to prevent concurrent packfile access
-	goGitMu.Lock()
-	defer goGitMu.Unlock()
+	r.goGitMu.Lock()
+	defer r.goGitMu.Unlock()
 
 	head, err := r.Head()
 	if err != nil {

--- a/internal/git/reset.go
+++ b/internal/git/reset.go
@@ -10,6 +10,7 @@ func (r *runner) ResetMerge(ctx context.Context, revision string) error {
 	if err != nil {
 		return fmt.Errorf("failed to reset --merge to %s: %w", revision, err)
 	}
+	r.revisionCache.InvalidateAll()
 	return nil
 }
 
@@ -18,6 +19,7 @@ func (r *runner) HardReset(ctx context.Context, revision string) error {
 	if err != nil {
 		return fmt.Errorf("failed to hard reset to %s: %w", revision, err)
 	}
+	r.revisionCache.InvalidateAll()
 	return nil
 }
 
@@ -26,10 +28,14 @@ func (r *runner) SoftReset(ctx context.Context, revision string) error {
 	if err != nil {
 		return fmt.Errorf("failed to soft reset to %s: %w", revision, err)
 	}
+	r.revisionCache.InvalidateAll()
 	return nil
 }
 
 func (r *runner) MixedReset(ctx context.Context, revision string) error {
 	_, err := r.RunGitCommandWithContext(ctx, "reset", revision)
+	if err == nil {
+		r.revisionCache.InvalidateAll()
+	}
 	return err
 }

--- a/internal/git/revision_cache.go
+++ b/internal/git/revision_cache.go
@@ -1,0 +1,38 @@
+package git
+
+import "sync"
+
+// revisionCache provides thread-safe caching of branch SHA revisions.
+// This avoids redundant go-git ref resolution calls (each acquires goGitMu).
+// Keyed by branch name, values are full SHA hex strings.
+type revisionCache struct {
+	entries sync.Map // map[string]string (branchName -> SHA)
+}
+
+// Get returns the cached revision for the given branch, or empty string if not cached.
+func (c *revisionCache) Get(branchName string) (string, bool) {
+	value, ok := c.entries.Load(branchName)
+	if !ok {
+		return "", false
+	}
+	return value.(string), true
+}
+
+// Put stores the revision in the cache.
+func (c *revisionCache) Put(branchName string, sha string) {
+	c.entries.Store(branchName, sha)
+}
+
+// Delete removes the cached revision for the given branch.
+func (c *revisionCache) Delete(branchName string) {
+	c.entries.Delete(branchName)
+}
+
+// InvalidateAll clears all cached revisions.
+// Used after bulk mutation operations (rebase, reset, etc.).
+func (c *revisionCache) InvalidateAll() {
+	c.entries.Range(func(key, _ any) bool {
+		c.entries.Delete(key)
+		return true
+	})
+}

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -25,11 +25,9 @@ type DebugLogger interface {
 	Debug(msg string, args ...any)
 }
 
-var (
-	// goGitMu synchronizes go-git operations that access packfiles to prevent
-	// "concurrent map iteration and map write" panics
-	goGitMu sync.Mutex
-)
+// Note: goGitMu was previously a package-level var, now moved to per-runner
+// and per-repository instances. This allows operations on different repositories
+// (e.g., main repo vs worktree) to proceed in parallel.
 
 // DefaultCommandTimeout is the default timeout for git commands
 const DefaultCommandTimeout = 5 * time.Minute
@@ -81,6 +79,7 @@ func (r *runner) UpdateRefsBatch(ctx context.Context, updates []RefUpdate) error
 		return fmt.Errorf("atomic ref update failed: %w", err)
 	}
 	r.metadataCache.InvalidateForRefs(updates)
+	r.invalidateRevisionCacheForRefs(updates)
 	return nil
 }
 
@@ -110,6 +109,7 @@ func (r *runner) UpdateRefsBatchWithLog(ctx context.Context, updates []RefUpdate
 		return fmt.Errorf("atomic ref update failed: %w", err)
 	}
 	r.metadataCache.InvalidateForRefs(updates)
+	r.invalidateRevisionCacheForRefs(updates)
 	return nil
 }
 
@@ -129,7 +129,22 @@ func (r *runner) DeleteRefsBatch(ctx context.Context, refNames []string) error {
 		return fmt.Errorf("atomic ref delete failed: %w", err)
 	}
 	r.metadataCache.InvalidateForRefNames(refNames)
+	for _, refName := range refNames {
+		if branchName, ok := strings.CutPrefix(refName, "refs/heads/"); ok {
+			r.revisionCache.Delete(branchName)
+		}
+	}
 	return nil
+}
+
+// invalidateRevisionCacheForRefs invalidates revision cache entries for any
+// refs/heads/* updates in the given ref updates.
+func (r *runner) invalidateRevisionCacheForRefs(updates []RefUpdate) {
+	for _, update := range updates {
+		if branchName, ok := strings.CutPrefix(update.RefName, "refs/heads/"); ok {
+			r.revisionCache.Delete(branchName)
+		}
+	}
 }
 
 func (r *runner) RunGitCommandWithEnv(ctx context.Context, env []string, args ...string) (string, error) {
@@ -392,12 +407,22 @@ type runner struct {
 	repo     *Repository
 	repoRoot string
 	repoMu   sync.Mutex
+	// goGitMu synchronizes go-git operations that access packfiles to prevent
+	// "concurrent map iteration and map write" panics. Per-runner (per-repository)
+	// so that operations on different repos (e.g., main repo vs worktree) are independent.
+	goGitMu  sync.Mutex
 	loggerMu sync.RWMutex
 	logger   DebugLogger
 
 	// Cached metadata to avoid redundant ReadMetadata calls (each spawns 2 git processes).
 	// Thread-safe: sync.Map handles concurrent reads from worker pools.
 	metadataCache metadataCache
+
+	// Cached branch revisions to avoid redundant go-git ref resolution.
+	// Thread-safe: sync.Map handles concurrent reads from worker pools.
+	// Keyed by branch name (e.g. "main"), values are SHA strings.
+	// Invalidated by any operation that mutates branch tips.
+	revisionCache revisionCache
 
 	// Cached git version info
 	gitVersionOnce   sync.Once
@@ -456,6 +481,7 @@ func (r *runner) ReloadRepository() error {
 	r.repoMu.Lock()
 	r.repo = nil // Clearing the cache forces the next ensureRepo() to re-open the repo
 	r.repoMu.Unlock()
+	r.revisionCache.InvalidateAll()
 	_, err := r.ensureRepo()
 	return err
 }
@@ -684,8 +710,8 @@ func (r *runner) GetCommitRange(base, head, format string) ([]string, error) {
 	}
 
 	// Synchronize go-git operations to prevent concurrent packfile access
-	goGitMu.Lock()
-	defer goGitMu.Unlock()
+	r.goGitMu.Lock()
+	defer r.goGitMu.Unlock()
 
 	headHash, err := r.resolveRefHashInternal(repo, head)
 	if err != nil {
@@ -797,8 +823,8 @@ func (r *runner) GetCommitSHA(branchName string, offset int) (string, error) {
 	}
 
 	// Synchronize go-git operations to prevent concurrent packfile access
-	goGitMu.Lock()
-	defer goGitMu.Unlock()
+	r.goGitMu.Lock()
+	defer r.goGitMu.Unlock()
 
 	// Resolve branch reference
 	hash, err := r.resolveRefHashInternal(repo, branchName)
@@ -1047,8 +1073,8 @@ func (r *runner) GetParentCommitSHA(commitSHA string) (string, error) {
 		return "", fmt.Errorf("failed to resolve commit: %w", err)
 	}
 
-	goGitMu.Lock()
-	defer goGitMu.Unlock()
+	r.goGitMu.Lock()
+	defer r.goGitMu.Unlock()
 
 	commit, err := repo.CommitObject(hash)
 	if err != nil {

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -364,6 +364,13 @@ func (t *tracingRunner) BatchGetRevisions(branchNames []string) (map[string]stri
 	return result, errs
 }
 
+func (t *tracingRunner) LoadAllBranchRevisions() error {
+	start := time.Now()
+	err := t.inner.LoadAllBranchRevisions()
+	t.trace("LoadAllBranchRevisions", time.Since(start), err == nil, err)
+	return err
+}
+
 func (t *tracingRunner) GetCommitDate(branchName string) (time.Time, error) {
 	start := time.Now()
 	result, err := t.inner.GetCommitDate(branchName)

--- a/internal/tui/log_ui.go
+++ b/internal/tui/log_ui.go
@@ -322,6 +322,10 @@ func (m *LogModel) enrichData() tea.Cmd {
 		// Detect worktrees (builds both empty and stack-root maps in one call)
 		wtData := GetWorktreeData(eng)
 
+		// Pre-load metadata and revisions for all branches to eliminate per-branch
+		// cache misses during parallel annotation building.
+		eng.PreloadBranchData()
+
 		// Collect full annotations
 		start := time.Now()
 		enrichment := &AnnotationEnrichment{


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Implements phases 1-4 of the performance improvement plan:

Phase 1 (Revision Cache):
- Add revisionCache sync.Map to runner, mirroring metadataCache pattern
- getRevision() checks cache (populated by batch preload) for cache hits
- Cache not self-populated on individual calls to avoid staleness

Phase 2 (Batch Ref Resolution):
- Add LoadAllBranchRevisions() using single 'git show-ref --heads'
- Replaces N×5 serialized go-git lookups with 1 subprocess (~5ms)

Phase 3 (Pre-loaded Annotation Data):
- Add PreloadBranchData() to engine to batch-load all metadata + revisions
- Wire into LogAction and TUI enrichData() before parallel annotation loops

Phase 4 (Per-Repository goGitMu):
- Move goGitMu from package-level to per-runner and per-repository
- Worktree operations no longer block main repo operations

Impact: For 'stackit log' with 20 branches, reduces ~60 redundant goGitMu
acquisitions and enables true parallelism across worktree operations.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `multi-stack/20260207-113000`.


* **PR #699**
  * **PR #700**
    * **PR #701**
      * **PR #702**
        * **PR #703**
          * **PR #704**
            * **PR #705** 👈
              * **PR #706**
                * **PR #707**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->