### PR TITLE
perf: batch PR body update marking to avoid N+1 git operations

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -31,6 +31,32 @@ const (
 )
 ```
 
+## Batch Operations (N+1 Prevention)
+
+**Always use batch APIs for git and GitHub operations.** Calling individual operations in a loop creates N+1 performance problems — each call spawns a separate git process or HTTP request.
+
+| Instead of | Use |
+|------------|-----|
+| `MarkNeedsPRBodyUpdate` in a loop | `BatchMarkNeedsPRBodyUpdate(branchNames)` |
+| `ReadLocalMetadata` in a loop | `BatchReadLocalMetadata(branchNames)` |
+| `UpdateRef` in a loop | `UpdateRefsBatch(ctx, updates)` |
+| `DeleteRef` in a loop | `DeleteRefsBatch(ctx, refNames)` |
+| `PushBranch` in a loop | `PushMetadataRefs(ctx, branches)` |
+
+**Why:** Each git command spawns a process (~2-5ms overhead). Each GitHub API call takes ~200-500ms. For N branches, a loop costs O(N × overhead) while a batch costs O(1) or O(N) with parallelism.
+
+```go
+// BAD - N git processes for N branches
+for _, name := range branchNames {
+    _ = eng.MarkNeedsPRBodyUpdate(name)
+}
+
+// GOOD - parallel reads + single atomic ref update
+_ = eng.BatchMarkNeedsPRBodyUpdate(branchNames)
+```
+
+When adding new operations that touch multiple branches or refs, prefer designing batch APIs from the start. Use `UpdateRefsBatch` for atomic multi-ref writes and `BatchReadLocalMetadata` / `BatchReadMetadata` for parallel reads.
+
 ## Error Handling
 
 - Always handle errors explicitly (never `_`)

--- a/.claude/rules/safety-invariants.md
+++ b/.claude/rules/safety-invariants.md
@@ -110,10 +110,12 @@ if err := actions.PushMetadataAndSyncPRs(ctx, branches); err != nil {
     out.Debug("Failed: %v", err)
 }
 
-// CORRECT - mark for update, sync handles GitHub
-for _, branch := range branches {
-    _ = eng.MarkNeedsPRBodyUpdate(branch.GetName())
+// CORRECT - batch mark for update, sync handles GitHub
+branchNames := make([]string, len(branches))
+for i, b := range branches {
+    branchNames[i] = b.GetName()
 }
+_ = eng.BatchMarkNeedsPRBodyUpdate(branchNames)
 if err := pushMetadataOnly(ctx, eng, branchName); err != nil {
     out.Debug("Failed: %v", err)
 }

--- a/internal/actions/describe/describe.go
+++ b/internal/actions/describe/describe.go
@@ -156,9 +156,12 @@ func markStackAndPushMetadata(ctx *app.Context, eng engine.Engine, stackRoot str
 	graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
 	root := eng.GetBranch(stackRoot)
 	if root.IsTracked() {
-		for _, branch := range graph.CollectBranches(root) {
-			_ = eng.MarkNeedsPRBodyUpdate(branch.GetName())
+		branches := graph.CollectBranches(root)
+		branchNames := make([]string, len(branches))
+		for i, b := range branches {
+			branchNames[i] = b.GetName()
 		}
+		_ = eng.BatchMarkNeedsPRBodyUpdate(branchNames)
 	}
 
 	// Push metadata refs (fast git operation)

--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -264,10 +264,8 @@ func Action(ctx *app.Context, opts Options, h Handler) error {
 	if oldParentName != eng.Trunk().GetName() {
 		affectedBranches = append(affectedBranches, oldParentName)
 	}
-	for _, branchName := range affectedBranches {
-		if err := eng.MarkNeedsPRBodyUpdate(branchName); err != nil {
-			out.Debug("Failed to mark %s for PR body update: %v", branchName, err)
-		}
+	if err := eng.BatchMarkNeedsPRBodyUpdate(affectedBranches); err != nil {
+		out.Debug("Failed to mark branches for PR body update: %v", err)
 	}
 
 	newName := ""

--- a/internal/actions/scope/action.go
+++ b/internal/actions/scope/action.go
@@ -70,7 +70,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		out.Info("Unset explicit scope for branch %s. It will now inherit from its parent.", style.ColorBranchName(currentBranch, false))
 
 		// Mark branch for PR update and push metadata (defer GitHub API calls to sync)
-		_ = eng.MarkNeedsPRBodyUpdate(currentBranch)
+		_ = eng.BatchMarkNeedsPRBodyUpdate([]string{currentBranch})
 		if err := actions.PushMetadataOnly(ctx, eng, []string{currentBranch}); err != nil {
 			out.Debug("Failed to push metadata changes: %v", err)
 		}
@@ -115,7 +115,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	// Mark branch for PR update and push metadata (defer GitHub API calls to sync)
-	_ = eng.MarkNeedsPRBodyUpdate(currentBranch)
+	_ = eng.BatchMarkNeedsPRBodyUpdate([]string{currentBranch})
 	if err := actions.PushMetadataOnly(ctx, eng, []string{currentBranch}); err != nil {
 		out.Debug("Failed to push metadata changes: %v", err)
 	}

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -982,14 +982,37 @@ func (e *engineImpl) IsInManagedWorktree() (bool, *WorktreeInfo, error) {
 	return false, nil, nil
 }
 
-// MarkNeedsPRBodyUpdate marks a branch as needing PR body update during next sync
-func (e *engineImpl) MarkNeedsPRBodyUpdate(branchName string) error {
-	localMeta, err := e.git.ReadLocalMetadata(branchName)
-	if err != nil {
-		localMeta = &git.LocalMeta{}
+// BatchMarkNeedsPRBodyUpdate marks multiple branches as needing PR body update in a single atomic operation.
+// It batch-reads local metadata, sets the flag, creates blobs, and atomically updates all refs.
+func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(branchNames []string) error {
+	if len(branchNames) == 0 {
+		return nil
 	}
-	localMeta.NeedsPRBodyUpdate = true
-	return e.git.WriteLocalMetadata(branchName, localMeta)
+
+	// Batch read all local metadata in parallel
+	allMeta := e.git.BatchReadLocalMetadata(branchNames)
+
+	// Create blobs and collect ref updates
+	updates := make([]git.RefUpdate, 0, len(branchNames))
+	for _, name := range branchNames {
+		meta := allMeta[name]
+		if meta == nil {
+			meta = &git.LocalMeta{}
+		}
+		meta.NeedsPRBodyUpdate = true
+
+		sha, err := e.git.WriteLocalMetadataBlob(meta)
+		if err != nil {
+			return fmt.Errorf("failed to create local metadata blob for %s: %w", name, err)
+		}
+		updates = append(updates, git.RefUpdate{
+			RefName: git.LocalMetadataRefName(name),
+			NewSHA:  sha,
+		})
+	}
+
+	// Atomic batch update all refs
+	return e.git.UpdateRefsBatch(context.Background(), updates)
 }
 
 // ClearNeedsPRBodyUpdate clears the PR body update flag for a branch

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -131,8 +131,8 @@ type BranchTracking interface {
 	SetLocked(ctx context.Context, branches []Branch, reason LockReason) (BatchLockResult, error)
 	SetFrozen(ctx context.Context, branches []Branch, frozen bool) (BatchFreezeResult, error)
 
-	// MarkNeedsPRBodyUpdate marks a branch as needing PR body update during next sync
-	MarkNeedsPRBodyUpdate(branchName string) error
+	// BatchMarkNeedsPRBodyUpdate marks multiple branches as needing PR body update in a single atomic operation
+	BatchMarkNeedsPRBodyUpdate(branchNames []string) error
 	// ClearNeedsPRBodyUpdate clears the PR body update flag for a branch
 	ClearNeedsPRBodyUpdate(branchName string) error
 	// GetBranchesNeedingPRBodyUpdate returns all branches that need PR body updates

--- a/internal/engine/pr_body_update_test.go
+++ b/internal/engine/pr_body_update_test.go
@@ -24,7 +24,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		require.Empty(t, needsUpdate)
 
 		// Mark branch as needing update
-		err := eng.MarkNeedsPRBodyUpdate("feature")
+		err := eng.BatchMarkNeedsPRBodyUpdate([]string{"feature"})
 		require.NoError(t, err)
 
 		// Now it should be in the list
@@ -42,7 +42,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark and then clear
-		err := eng.MarkNeedsPRBodyUpdate("feature")
+		err := eng.BatchMarkNeedsPRBodyUpdate([]string{"feature"})
 		require.NoError(t, err)
 
 		err = eng.ClearNeedsPRBodyUpdate("feature")
@@ -77,7 +77,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark branch
-		err := eng.MarkNeedsPRBodyUpdate("feature")
+		err := eng.BatchMarkNeedsPRBodyUpdate([]string{"feature"})
 		require.NoError(t, err)
 
 		// Rebuild engine to simulate fresh state
@@ -103,7 +103,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark only feature-a
-		err := eng.MarkNeedsPRBodyUpdate("feature-a")
+		err := eng.BatchMarkNeedsPRBodyUpdate([]string{"feature-a"})
 		require.NoError(t, err)
 
 		needsUpdate := eng.GetBranchesNeedingPRBodyUpdate()
@@ -111,7 +111,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		require.NotContains(t, needsUpdate, "feature-b")
 
 		// Mark feature-b too
-		err = eng.MarkNeedsPRBodyUpdate("feature-b")
+		err = eng.BatchMarkNeedsPRBodyUpdate([]string{"feature-b"})
 		require.NoError(t, err)
 
 		needsUpdate = eng.GetBranchesNeedingPRBodyUpdate()
@@ -125,5 +125,40 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		needsUpdate = eng.GetBranchesNeedingPRBodyUpdate()
 		require.NotContains(t, needsUpdate, "feature-a")
 		require.Contains(t, needsUpdate, "feature-b")
+	})
+
+	t.Run("batch marks multiple branches atomically", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit().
+			CreateBranch("feature-a").
+			Commit("a1").
+			TrackBranch("feature-a", "main").
+			Checkout("main").
+			CreateBranch("feature-b").
+			Commit("b1").
+			TrackBranch("feature-b", "main")
+
+		eng := s.Engine
+
+		// Mark both at once
+		err := eng.BatchMarkNeedsPRBodyUpdate([]string{"feature-a", "feature-b"})
+		require.NoError(t, err)
+
+		needsUpdate := eng.GetBranchesNeedingPRBodyUpdate()
+		require.Contains(t, needsUpdate, "feature-a")
+		require.Contains(t, needsUpdate, "feature-b")
+	})
+
+	t.Run("batch with empty list is no-op", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+
+		eng := s.Engine
+
+		err := eng.BatchMarkNeedsPRBodyUpdate([]string{})
+		require.NoError(t, err)
+
+		err = eng.BatchMarkNeedsPRBodyUpdate(nil)
+		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Replace individual MarkNeedsPRBodyUpdate calls with BatchMarkNeedsPRBodyUpdate
to eliminate N+1 git process spawns. For N branches, reduces 3N sequential
git commands to N parallel reads + 1 atomic batch ref update.

- Delete MarkNeedsPRBodyUpdate (single-branch method)
- Migrate describe, scope, move actions to batch API
- Add batch operation rules to prevent future N+1 issues
- Update tests with new batch method and edge cases

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `multi-stack/20260207-113000`.


* **PR #699**
  * **PR #700**
    * **PR #701**
      * **PR #702**
        * **PR #703**
          * **PR #704**
            * **PR #705**
              * **PR #706**
                * **PR #707** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->