### PR TITLE
perf: optimize worktree setup/teardown with snapshot engine and command-only runner

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -151,4 +151,8 @@ type Engine interface {
 	RemoteMetadataManager
 	WorktreeRegistry
 	Git() git.Runner
+
+	// SnapshotForWorktree creates a deep copy of engine state for initializing
+	// worktree engines without the cost of rebuildInternal.
+	SnapshotForWorktree() WorktreeSnapshot
 }

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"sync"
 
 	"stackit.dev/stackit/internal/git"
@@ -97,7 +98,121 @@ type engineImpl struct {
 	git               git.Runner
 	writer            io.Writer
 	mu                sync.RWMutex
-	worktreeMu        sync.Mutex // serializes worktree creation to avoid git races on .git/worktrees/
+	worktreeMu        sync.Mutex // serializes worktree add/remove/prune to avoid git races on .git/worktrees/
+
+	// Temporary worktree cleanup tracking.
+	tempWorktreeNeedsPrune bool
+	tempWorktreePrunedOnce bool
+}
+
+// WorktreeSnapshot holds a deep copy of engine state for initializing worktree engines.
+// This avoids the cost of rebuildInternal (which reads all branches + metadata from git)
+// since worktrees share .git with the parent and the data is identical.
+type WorktreeSnapshot struct {
+	Trunk           string
+	Branches        []string
+	BranchState     BranchStateMap
+	ChildrenMap     map[string][]string
+	RemoteMetaCache map[string]*git.Meta
+	MaxConcurrency  int
+}
+
+// SnapshotForWorktree creates a deep copy of the engine's mutable state for use in
+// worktree sessions. The snapshot is safe to use from another goroutine since all
+// maps and slices are deep-copied.
+func (e *engineImpl) SnapshotForWorktree() WorktreeSnapshot {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	// Deep copy branches slice
+	branches := make([]string, len(e.branches))
+	copy(branches, e.branches)
+
+	// Deep copy branchState map
+	branchState := make(BranchStateMap, len(e.branchState))
+	for name, state := range e.branchState {
+		copied := *state
+		branchState[name] = &copied
+	}
+
+	// Deep copy childrenMap
+	childrenMap := make(map[string][]string, len(e.childrenMap))
+	for parent, children := range e.childrenMap {
+		childrenCopy := make([]string, len(children))
+		copy(childrenCopy, children)
+		childrenMap[parent] = childrenCopy
+	}
+
+	// Shallow copy remoteMetaCache — Meta values are treated as immutable
+	remoteMetaCache := make(map[string]*git.Meta, len(e.remoteMetaCache))
+	for name, meta := range e.remoteMetaCache {
+		remoteMetaCache[name] = meta
+	}
+
+	return WorktreeSnapshot{
+		Trunk:           e.trunk,
+		Branches:        branches,
+		BranchState:     branchState,
+		ChildrenMap:     childrenMap,
+		RemoteMetaCache: remoteMetaCache,
+		MaxConcurrency:  e.maxConcurrency,
+	}
+}
+
+// WorktreeEngineOptions configures NewEngineForWorktree.
+type WorktreeEngineOptions struct {
+	// WorktreePath is the root directory of the worktree.
+	WorktreePath string
+
+	// Snapshot is the parent engine's state snapshot.
+	Snapshot WorktreeSnapshot
+
+	// Writer is the output writer for warnings. If nil, os.Stderr is used.
+	Writer io.Writer
+}
+
+// NewEngineForWorktree creates an engine for a worktree session using a snapshot
+// from the parent engine. This skips rebuildInternal and maybeAutoFetchRemoteMetadata
+// since worktrees share .git with the parent and the metadata is identical.
+func NewEngineForWorktree(opts WorktreeEngineOptions) (Engine, error) {
+	g := git.NewRunnerWithPath(opts.WorktreePath, nil)
+
+	if err := g.InitDefaultRepo(); err != nil {
+		return nil, fmt.Errorf("failed to initialize worktree git repository: %w", err)
+	}
+
+	writer := opts.Writer
+	if writer == nil {
+		writer = os.Stderr
+	}
+
+	// Sort children for deterministic traversal (snapshot should already be sorted,
+	// but ensure consistency)
+	for _, children := range opts.Snapshot.ChildrenMap {
+		slices.Sort(children)
+	}
+
+	e := &engineImpl{
+		repoRoot:          opts.WorktreePath,
+		trunk:             opts.Snapshot.Trunk,
+		branches:          opts.Snapshot.Branches,
+		branchState:       opts.Snapshot.BranchState,
+		childrenMap:       opts.Snapshot.ChildrenMap,
+		remoteMetaCache:   opts.Snapshot.RemoteMetaCache,
+		maxUndoStackDepth: 0, // No undo in temporary worktrees
+		maxConcurrency:    opts.Snapshot.MaxConcurrency,
+		git:               g,
+		writer:            writer,
+	}
+
+	// Get current branch (1 cheap git call — needed for worktree's HEAD)
+	currentBranch, err := g.GetCurrentBranch()
+	if err != nil {
+		currentBranch = ""
+	}
+	e.currentBranch = currentBranch
+
+	return e, nil
 }
 
 // NewEngine creates a new engine instance

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -737,7 +737,16 @@ func (e *engineImpl) RemoveWorktree(ctx context.Context, path string) error {
 // This cleans up worktree information for worktrees whose working directory
 // has been deleted or is otherwise unavailable.
 func (e *engineImpl) PruneWorktrees(ctx context.Context) error {
-	return e.git.PruneWorktrees(ctx)
+	e.worktreeMu.Lock()
+	defer e.worktreeMu.Unlock()
+
+	if err := e.git.PruneWorktrees(ctx); err != nil {
+		return err
+	}
+
+	e.tempWorktreeNeedsPrune = false
+	e.tempWorktreePrunedOnce = true
+	return nil
 }
 
 // CreateTemporaryWorktree creates a temporary directory and adds a detached worktree
@@ -765,14 +774,6 @@ func (e *engineImpl) CreateTemporaryWorktreeSkipPrune(ctx context.Context, branc
 // Note: Callers that create multiple worktrees in parallel (like ValidateRebasesParallel) should call
 // PruneWorktrees() once before starting parallel worktree creation and pass WorktreePruneSkip to avoid race conditions.
 func (e *engineImpl) CreateTemporaryWorktreeWithOptions(ctx context.Context, branch string, prefix string, checkout WorktreeCheckoutMode, prune WorktreePruneMode) (string, func(), error) {
-	// Prune stale worktree entries before creating new ones.
-	// This cleans up entries in .git/worktrees/ that may be left behind from
-	// incomplete cleanup after failed or canceled operations.
-	// Skip if caller has already pruned (e.g., parallel worktree creation).
-	if prune == WorktreePruneAuto {
-		_ = e.git.PruneWorktrees(ctx)
-	}
-
 	tmpDir, err := os.MkdirTemp("", prefix)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to create temporary directory: %w", err)
@@ -783,7 +784,7 @@ func (e *engineImpl) CreateTemporaryWorktreeWithOptions(ctx context.Context, bra
 	// intermittent failures when stale entries remained after incomplete cleanup.
 	worktreePath := filepath.Join(tmpDir, filepath.Base(tmpDir))
 
-	// Serialize worktree creation to prevent races on .git/worktrees/ directory.
+	// Serialize worktree operations to prevent races on .git/worktrees/ directory.
 	// Git's `worktree add` command is not concurrency-safe - when multiple goroutines
 	// run it simultaneously on the same repo, they can race on reading/writing the
 	// .git/worktrees/ directory, causing "failed to read commondir" errors.
@@ -792,9 +793,10 @@ func (e *engineImpl) CreateTemporaryWorktreeWithOptions(ctx context.Context, bra
 	// This is acceptable because:
 	// 1. Temp directory creation (above) is still parallel
 	// 2. The actual rebase validation (after worktree creation) is still parallel
-	// 3. Only the brief `git worktree add` command is serialized
+	// 3. Only the brief `git worktree` commands are serialized
 	e.worktreeMu.Lock()
-	err = e.git.AddWorktreeWithOptions(ctx, worktreePath, branch, true, checkout == WorktreeCheckoutShallow)
+	e.maybePruneTempWorktreesLocked(ctx, prune)
+	err = e.addWorktreeWithRetryLocked(ctx, worktreePath, branch, true, checkout == WorktreeCheckoutShallow)
 	e.worktreeMu.Unlock()
 
 	if err != nil {
@@ -803,19 +805,61 @@ func (e *engineImpl) CreateTemporaryWorktreeWithOptions(ctx context.Context, bra
 	}
 
 	cleanup := func() {
-		// Use context.Background for cleanup to ensure it runs even if ctx is canceled
-		cleanupCtx := context.Background()
-		removeErr := e.RemoveWorktree(cleanupCtx, worktreePath)
+		// Fast cleanup: remove directories and defer pruning until next creation.
+		e.worktreeMu.Lock()
+		e.tempWorktreeNeedsPrune = true
+		e.worktreeMu.Unlock()
+
+		_ = os.RemoveAll(worktreePath)
 		_ = os.RemoveAll(tmpDir)
-		// If worktree removal failed, prune to clean up any dangling entries.
-		// This prevents stale entries from accumulating and causing "commondir" errors
-		// in subsequent worktree operations, especially on busy build servers.
-		if removeErr != nil {
-			_ = e.git.PruneWorktrees(cleanupCtx)
-		}
 	}
 
 	return worktreePath, cleanup, nil
+}
+
+// maybePruneTempWorktreesLocked prunes stale temp worktrees if needed.
+// Caller must hold worktreeMu.
+func (e *engineImpl) maybePruneTempWorktreesLocked(ctx context.Context, prune WorktreePruneMode) {
+	if prune == WorktreePruneSkip && !e.tempWorktreeNeedsPrune {
+		return
+	}
+
+	if prune == WorktreePruneAuto && !e.tempWorktreeNeedsPrune && e.tempWorktreePrunedOnce {
+		return
+	}
+
+	if err := e.git.PruneWorktrees(ctx); err != nil {
+		return
+	}
+
+	e.tempWorktreeNeedsPrune = false
+	e.tempWorktreePrunedOnce = true
+}
+
+// addWorktreeWithRetryLocked attempts to add a worktree, pruning and retrying once on failure.
+// Caller must hold worktreeMu.
+func (e *engineImpl) addWorktreeWithRetryLocked(ctx context.Context, path string, branch string, detach bool, noCheckout bool) error {
+	if err := e.git.AddWorktreeWithOptions(ctx, path, branch, detach, noCheckout); err == nil {
+		return nil
+	}
+
+	pruneErr := e.git.PruneWorktrees(ctx)
+	if pruneErr == nil {
+		e.tempWorktreeNeedsPrune = false
+		e.tempWorktreePrunedOnce = true
+	} else {
+		e.tempWorktreeNeedsPrune = true
+	}
+
+	retryErr := e.git.AddWorktreeWithOptions(ctx, path, branch, detach, noCheckout)
+	if retryErr == nil {
+		return nil
+	}
+
+	if pruneErr != nil {
+		return fmt.Errorf("failed to add worktree at %s after prune attempt (%w): %w", path, pruneErr, retryErr)
+	}
+	return fmt.Errorf("failed to add worktree at %s after prune retry: %w", path, retryErr)
 }
 
 // RegisterWorktree registers a worktree for a stack root in local git refs

--- a/internal/engine/rebase_validator.go
+++ b/internal/engine/rebase_validator.go
@@ -339,8 +339,9 @@ func (e *engineImpl) validateSingleSpec(
 	}
 	defer cleanup()
 
-	// Create a git runner for the worktree
-	wtGit := git.NewRunnerWithPath(worktreePath, nil)
+	// Create a command-only git runner for the worktree — validation only uses CLI
+	// operations (rebase, rev-parse, status), so skip go-git initialization (~2-5ms)
+	wtGit := git.NewRunnerCommandOnly(worktreePath)
 
 	// Resolve NewParent to handle rebased parents
 	newParent := spec.NewParent

--- a/internal/engine/worktree_test.go
+++ b/internal/engine/worktree_test.go
@@ -3,6 +3,7 @@ package engine_test
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -87,4 +88,43 @@ func TestCreateTemporaryWorktree(t *testing.T) {
 	tmpDir := worktreePath[:len(worktreePath)-9] // "/worktree" is 9 chars
 	_, err = os.Stat(tmpDir)
 	assert.True(t, os.IsNotExist(err))
+}
+
+func TestCreateTemporaryWorktree_FastCleanup_AllowsNextCreate(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.CreateBranch("feature").
+		Commit("feature change").
+		Checkout("main")
+
+	ctx := context.Background()
+	worktreePath, cleanup, err := s.Engine.CreateTemporaryWorktree(ctx, "feature", "stackit-test-*")
+	require.NoError(t, err)
+	require.NotEmpty(t, worktreePath)
+	cleanup()
+
+	worktreePath2, cleanup2, err := s.Engine.CreateTemporaryWorktree(ctx, "feature", "stackit-test-*")
+	require.NoError(t, err)
+	require.NotEmpty(t, worktreePath2)
+	cleanup2()
+}
+
+func TestCreateTemporaryWorktree_RetryAfterStaleEntry(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.CreateBranch("feature").
+		Commit("feature change").
+		Checkout("main")
+
+	ctx := context.Background()
+	worktreePath, _, err := s.Engine.CreateTemporaryWorktree(ctx, "feature", "stackit-test-*")
+	require.NoError(t, err)
+	require.NotEmpty(t, worktreePath)
+
+	// Simulate an abrupt deletion without cleanup to leave a stale git worktree entry.
+	tmpDir := filepath.Dir(worktreePath)
+	require.NoError(t, os.RemoveAll(tmpDir))
+
+	worktreePath2, cleanup2, err := s.Engine.CreateTemporaryWorktreeSkipPrune(ctx, "feature", "stackit-test-*")
+	require.NoError(t, err)
+	require.NotEmpty(t, worktreePath2)
+	cleanup2()
 }

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -408,6 +408,18 @@ func NewRunnerWithPath(repoRoot string, logger DebugLogger) Runner {
 	return &runner{repoRoot: repoRoot, logger: logger}
 }
 
+// NewRunnerCommandOnly returns a Runner that only supports command-line git operations.
+// It skips go-git repository initialization (OpenRepository), saving ~2-5ms.
+// Use this for worktrees that only need CLI operations (rebase, rev-parse, status, etc.).
+// Any operation that requires go-git (ensureRepo) will return an error.
+func NewRunnerCommandOnly(repoRoot string) Runner {
+	abs, err := filepath.Abs(repoRoot)
+	if err == nil {
+		repoRoot = abs
+	}
+	return &runner{repoRoot: repoRoot, commandOnly: true}
+}
+
 // runner implements Runner by calling the actual git package functions
 type runner struct {
 	repo     *Repository
@@ -419,6 +431,12 @@ type runner struct {
 	goGitMu  sync.Mutex
 	loggerMu sync.RWMutex
 	logger   DebugLogger
+
+	// commandOnly disables go-git repository initialization. When true, ensureRepo()
+	// returns an error and InitDefaultRepo() is a no-op. Use this for worktrees that
+	// only need command-line git operations (rebase, rev-parse, status, etc.),
+	// saving ~2-5ms from OpenRepository().
+	commandOnly bool
 
 	// Cached metadata to avoid redundant ReadMetadata calls (each spawns 2 git processes).
 	// Thread-safe: sync.Map handles concurrent reads from worker pools.
@@ -455,6 +473,10 @@ func (r *runner) debugLog(format string, args ...any) {
 }
 
 func (r *runner) ensureRepo() (*Repository, error) {
+	if r.commandOnly {
+		return nil, fmt.Errorf("go-git repository access not available in command-only mode")
+	}
+
 	r.repoMu.Lock()
 	defer r.repoMu.Unlock()
 
@@ -493,6 +515,9 @@ func (r *runner) ReloadRepository() error {
 }
 
 func (r *runner) InitDefaultRepo() error {
+	if r.commandOnly {
+		return nil // No-op: worktree is already valid from `git worktree add`
+	}
 	_, err := r.ensureRepo()
 	return err
 }
@@ -650,6 +675,9 @@ func (r *runner) GetCurrentRevision(ctx context.Context) (string, error) {
 }
 
 func (r *runner) GetRevision(branchName string) (string, error) {
+	if r.commandOnly {
+		return r.RunGitCommandWithContext(context.Background(), "rev-parse", "--verify", branchName)
+	}
 	repo, err := r.ensureRepo()
 	if err != nil {
 		return "", err

--- a/internal/worktree/executor.go
+++ b/internal/worktree/executor.go
@@ -75,11 +75,10 @@ func (e *Executor) CreateSession(ctx context.Context, opts CreateSessionOptions)
 
 	e.output.Debug("Created worktree at %s", worktreePath)
 
-	// Create engine for worktree
-	worktreeEng, err := engine.NewEngine(engine.Options{
-		RepoRoot:          worktreePath,
-		Trunk:             e.eng.Trunk().GetName(),
-		MaxUndoStackDepth: 0, // No undo needed in worktrees
+	// Create engine for worktree using parent's snapshot to skip rebuildInternal
+	worktreeEng, err := engine.NewEngineForWorktree(engine.WorktreeEngineOptions{
+		WorktreePath: worktreePath,
+		Snapshot:     e.eng.SnapshotForWorktree(),
 	})
 	if err != nil {
 		cleanup()


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Reduces per-worktree overhead by eliminating redundant operations:

Phase 1: Lightweight engine for worktree sessions
- Add WorktreeSnapshot type with deep-copied engine state
- Add NewEngineForWorktree() that skips rebuildInternal and maybeAutoFetchRemoteMetadata
- Worktrees share .git with parent, so metadata reads are redundant
- Savings: ~8-20ms per worktree session

Phase 2: Command-only git runner
- Add NewRunnerCommandOnly() for validation worktrees that only use CLI operations
- Skip OpenRepository() call (~2-5ms) since rebase validation doesn't need go-git
- Savings: ~2-5ms per validation worktree (20-50ms for 10 branches)

Benefits merge operations, multistack merge, combination analysis, and parallel rebase validation.