### PR TITLE
feat: add worktree integration to shippable dashboard model

### DIFF
--- a/internal/cli/dashboard/shippable_model.go
+++ b/internal/cli/dashboard/shippable_model.go
@@ -40,6 +40,11 @@ type renderCache struct {
 	// treeRenderer is the pre-built tree renderer, reused across renders
 	treeRenderer *tree.StackTreeRenderer
 
+	// currentBranch is the name of the currently checked-out branch
+	currentBranch string
+	// currentStackRoot is the root branch of the stack containing the checked-out branch
+	currentStackRoot string
+
 	// Cached selection state to avoid recomputing
 	selectedCount  int
 	selectedStacks []shippable.Stack
@@ -88,6 +93,7 @@ type shippableModel struct {
 	focusedStack  *shippable.Stack // Currently focused stack for detail view
 
 	// Status
+	initialLoad   bool // true until first refresh completes
 	lastRefresh   time.Time
 	statusMessage string
 	errorMessage  string
@@ -193,17 +199,18 @@ func newShippableModel(ctx *app.Context, cfg config.Configurer, opts ShippableOp
 	)
 
 	return &shippableModel{
-		ctx:      ctx,
-		engine:   ctx.Engine,
-		cfg:      cfg,
-		analyzer: analyzer,
-		combiner: combiner,
-		expanded: make(map[string]bool),
-		selected: make(map[string]bool),
-		locked:   make(map[string]bool),
-		state:    stateLoading,
-		options:  opts,
-		progress: p,
+		ctx:         ctx,
+		engine:      ctx.Engine,
+		cfg:         cfg,
+		analyzer:    analyzer,
+		combiner:    combiner,
+		expanded:    make(map[string]bool),
+		selected:    make(map[string]bool),
+		locked:      make(map[string]bool),
+		initialLoad: true,
+		state:       stateLoading,
+		options:     opts,
+		progress:    p,
 	}
 }
 
@@ -315,6 +322,24 @@ func (m *shippableModel) rebuildCache() {
 	m.cache.stackTitles = make(map[string]string)
 	m.cache.stackDescriptions = make(map[string]*git.StackDescription)
 	m.cache.branchAnnotations = make(map[string]tree.BranchAnnotation)
+
+	// Determine which stack contains the currently checked-out branch
+	m.cache.currentBranch = ""
+	m.cache.currentStackRoot = ""
+	if current := m.engine.CurrentBranch(); current != nil {
+		m.cache.currentBranch = current.GetName()
+		for _, stack := range m.stacks {
+			for _, branchName := range stack.Stack.AllBranches {
+				if branchName == m.cache.currentBranch {
+					m.cache.currentStackRoot = stack.RootBranch()
+					break
+				}
+			}
+			if m.cache.currentStackRoot != "" {
+				break
+			}
+		}
+	}
 
 	// Precompute titles, descriptions, and annotations for all stacks
 	for _, stack := range m.stacks {

--- a/internal/cli/dashboard/shippable_update.go
+++ b/internal/cli/dashboard/shippable_update.go
@@ -79,6 +79,18 @@ func (m *shippableModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.analysis = msg.result
 		m.stacks = msg.result.Stacks
 		m.rebuildCache() // Precompute titles, annotations, and tree renderer
+
+		// On initial load, auto-focus the stack containing the checked-out branch
+		if m.initialLoad && m.cache.currentStackRoot != "" {
+			for i, stack := range m.stacks {
+				if stack.RootBranch() == m.cache.currentStackRoot {
+					m.selectedIndex = i
+					break
+				}
+			}
+			m.initialLoad = false
+		}
+
 		m.updateFocusedStack()
 		return m, nil
 

--- a/internal/cli/dashboard/shippable_view.go
+++ b/internal/cli/dashboard/shippable_view.go
@@ -176,6 +176,9 @@ func (m *shippableModel) renderStackLine(stack shippable.Stack, focused bool) st
 		name = root // Fallback if cache not populated
 	}
 
+	// Mark the stack containing the checked-out branch
+	isCurrentStack := m.cache.currentStackRoot == root
+
 	// Only show branch count if more than 1 branch
 	branchCount := ""
 	if count := stack.BranchCount(); count > 1 {
@@ -205,10 +208,15 @@ func (m *shippableModel) renderStackLine(stack shippable.Stack, focused bool) st
 		name = name[:maxNameLen-3] + "..."
 	}
 
+	// Apply current stack styling to the name
+	if isCurrentStack {
+		name = style.ColorGreen(name)
+	}
+
 	// Build line
 	var line string
 	if branchCount != "" {
-		line = fmt.Sprintf("%s%s %s %s %s %s", cursor, checkbox, statusIcon, name, branchCount, expandIndicator)
+		line = fmt.Sprintf("%s%s %s %s %s %s", cursor, checkbox, statusIcon, name, style.ColorDim(branchCount), expandIndicator)
 	} else {
 		line = fmt.Sprintf("%s%s %s %s", cursor, checkbox, statusIcon, name)
 	}
@@ -223,9 +231,14 @@ func (m *shippableModel) renderStackLine(stack shippable.Stack, focused bool) st
 
 // renderBranchLine renders a single branch within an expanded stack.
 func (m *shippableModel) renderBranchLine(branchName string) string {
+	isCurrent := branchName == m.cache.currentBranch
+
 	// Use cached annotation for PR info
 	ann, hasCached := m.cache.branchAnnotations[branchName]
 	if !hasCached {
+		if isCurrent {
+			return style.ColorDim("├── ") + style.ColorGreen(branchName) + style.ColorDim(" (current)")
+		}
 		return style.ColorDim("├── " + branchName)
 	}
 
@@ -234,7 +247,14 @@ func (m *shippableModel) renderBranchLine(branchName string) string {
 		prInfo = fmt.Sprintf(" #%d", *ann.PRNumber)
 	}
 
-	return style.ColorDim("├── ") + branchName + style.ColorDim(prInfo)
+	displayName := branchName
+	suffix := style.ColorDim(prInfo)
+	if isCurrent {
+		displayName = style.ColorGreen(branchName)
+		suffix = style.ColorDim(prInfo) + style.ColorDim(" (current)")
+	}
+
+	return style.ColorDim("├── ") + displayName + suffix
 }
 
 // getStatusIcon returns the icon for a stack status.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Enhance shippable dashboard with worktree support and diagnostics**

Comprehensive improvements to the shippable dashboard interface, adding worktree integration, interactive management, and debugging capabilities.

Key changes by branch:
- **extract-dashboard-styles**: Centralized dashboard styling into `internal/tui/style/dashboard.go` (+178 lines) and added comprehensive shippable stories for TUI testing (+1090 lines)
- **worktree-integration**: Extended dashboard model to display worktree information, added update handlers for worktree state changes
- **formatting-improvements**: Refactored view layout for better readability and consistent formatting
- **error-handling**: Enhanced error display and status reporting in the dashboard UI
- **tracing-diagnostics**: Added git operation tracing and metadata cache diagnostics for debugging performance issues
- **interactive-worktree-management**: Added interactive worktree creation, attachment, and management capabilities directly from the dashboard

Implementation notes:
- New style package consolidates all dashboard-related styles in one place
- Worktree state is now part of the dashboard model and updates reactively
- Interactive commands allow users to create/attach worktrees without leaving the dashboard
- Tracing infrastructure helps identify bottlenecks in git operations
- All changes maintain backward compatibility with existing dashboard functionality

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `multi-stack/20260207-221615`.


* **PR #696**
  * **PR #710** 👈
    * **PR #711**
      * **PR #712**
        * **PR #713**
          * **PR #714**
            * **PR #715**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->