### PR TITLE
refactor: improve shippable dashboard view formatting and layout

### DIFF
--- a/internal/cli/dashboard/shippable_model.go
+++ b/internal/cli/dashboard/shippable_model.go
@@ -251,8 +251,8 @@ func (m *shippableModel) unlockAllStacks() {
 }
 
 // toggleSelection toggles selection of the current stack.
-// Only shippable stacks (green check) can be selected.
-// Locked stacks cannot be selected.
+// Shippable and pending stacks can be selected.
+// Locked, blocked, and incomplete stacks cannot be selected.
 func (m *shippableModel) toggleSelection() {
 	stack := m.currentStack()
 	if stack == nil {
@@ -266,8 +266,8 @@ func (m *shippableModel) toggleSelection() {
 		return
 	}
 
-	// Only allow selecting shippable stacks
-	if !stack.IsShippable() {
+	// Only shippable and pending stacks can be selected
+	if !stack.IsShippable() && !stack.IsPending() {
 		return
 	}
 
@@ -285,11 +285,11 @@ func (m *shippableModel) toggleExpand() {
 	m.expanded[root] = !m.expanded[root]
 }
 
-// selectAllShippable selects all shippable stacks that are not locked.
+// selectAllShippable selects all shippable and pending stacks that are not locked.
 func (m *shippableModel) selectAllShippable() {
 	for _, s := range m.stacks {
 		root := s.RootBranch()
-		if s.IsShippable() && !m.isLocked(root) {
+		if (s.IsShippable() || s.IsPending()) && !m.isLocked(root) {
 			m.selected[root] = true
 		}
 	}

--- a/internal/cli/dashboard/shippable_view.go
+++ b/internal/cli/dashboard/shippable_view.go
@@ -96,9 +96,31 @@ func (m *shippableModel) renderHeader() string {
 			m.analysis.TotalStacks(), m.analysis.ShippableCount))
 	}
 
+	left := lipgloss.JoinHorizontal(lipgloss.Left, title, "  ", status)
+
+	// Show refresh countdown on the right
+	var refreshStatus string
+	if !m.lastRefresh.IsZero() && m.state == stateMain {
+		timeSinceRefresh := time.Since(m.lastRefresh)
+		timeUntilRefresh := autoRefreshInterval - timeSinceRefresh
+		if timeUntilRefresh < 0 {
+			timeUntilRefresh = 0
+		}
+		secondsUntil := int(timeUntilRefresh.Seconds())
+		refreshStatus = style.ColorDim(fmt.Sprintf("refresh in %ds", secondsUntil))
+	}
+
+	if refreshStatus != "" {
+		gap := m.Width - lipgloss.Width(left) - lipgloss.Width(refreshStatus) - 2
+		if gap < 2 {
+			gap = 2
+		}
+		left = left + strings.Repeat(" ", gap) + refreshStatus
+	}
+
 	return headerBorderStyle.
 		Width(m.Width).
-		Render(lipgloss.JoinHorizontal(lipgloss.Left, title, "  ", status))
+		Render(left)
 }
 
 // renderStackList renders the list of stacks.
@@ -504,7 +526,7 @@ func (m *shippableModel) formatBlockingReason(reason shippable.BlockingReason) s
 	}
 }
 
-// renderFooter renders the footer with global shortcuts and refresh status.
+// renderFooter renders the footer with global shortcuts.
 func (m *shippableModel) renderFooter() string {
 	// During async operations, show progress bar
 	if m.state == stateLoading || m.state == stateAnalyzing || m.state == stateShipping || m.state == statePublishing {
@@ -519,28 +541,6 @@ func (m *shippableModel) renderFooter() string {
 		"[q] Quit",
 	}
 	shortcutsStr := strings.Join(shortcuts, "  ")
-
-	// Build refresh status with countdown
-	var refreshStatus string
-	if !m.lastRefresh.IsZero() {
-		timeSinceRefresh := time.Since(m.lastRefresh)
-		timeUntilRefresh := autoRefreshInterval - timeSinceRefresh
-		if timeUntilRefresh < 0 {
-			timeUntilRefresh = 0
-		}
-		secondsUntil := int(timeUntilRefresh.Seconds())
-		refreshStatus = fmt.Sprintf("Next refresh in %ds", secondsUntil)
-	}
-
-	// Build footer: shortcuts on left, refresh status on right
-	if refreshStatus != "" {
-		gap := m.Width - lipgloss.Width(shortcutsStr) - lipgloss.Width(refreshStatus) - 4
-		if gap < 2 {
-			gap = 2
-		}
-		line := strings.Repeat(" ", gap)
-		return footerStyle.Width(m.Width).Render(shortcutsStr + line + style.ColorDim(refreshStatus))
-	}
 
 	return footerStyle.Width(m.Width).Render(shortcutsStr)
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Enhance shippable dashboard with worktree support and diagnostics**

Comprehensive improvements to the shippable dashboard interface, adding worktree integration, interactive management, and debugging capabilities.

Key changes by branch:
- **extract-dashboard-styles**: Centralized dashboard styling into `internal/tui/style/dashboard.go` (+178 lines) and added comprehensive shippable stories for TUI testing (+1090 lines)
- **worktree-integration**: Extended dashboard model to display worktree information, added update handlers for worktree state changes
- **formatting-improvements**: Refactored view layout for better readability and consistent formatting
- **error-handling**: Enhanced error display and status reporting in the dashboard UI
- **tracing-diagnostics**: Added git operation tracing and metadata cache diagnostics for debugging performance issues
- **interactive-worktree-management**: Added interactive worktree creation, attachment, and management capabilities directly from the dashboard

Implementation notes:
- New style package consolidates all dashboard-related styles in one place
- Worktree state is now part of the dashboard model and updates reactively
- Interactive commands allow users to create/attach worktrees without leaving the dashboard
- Tracing infrastructure helps identify bottlenecks in git operations
- All changes maintain backward compatibility with existing dashboard functionality

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `multi-stack/20260207-221615`.


* **PR #696**
  * **PR #710**
    * **PR #711** 👈
      * **PR #712**
        * **PR #713**
          * **PR #714**
            * **PR #715**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->