### PR TITLE
feat: add interactive worktree management to shippable dashboard

### DIFF
--- a/internal/cli/dashboard/shippable_model.go
+++ b/internal/cli/dashboard/shippable_model.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/progress"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 
 	"stackit.dev/stackit/internal/app"
@@ -23,6 +24,9 @@ const (
 	// tickInterval is the interval for timer updates (for countdown display)
 	// Using 5s instead of 1s to reduce render frequency while still showing useful countdown
 	tickInterval = 5 * time.Second
+
+	// msgRefreshing is the status message shown during refresh operations.
+	msgRefreshing = "Refreshing..."
 )
 
 // renderCache stores precomputed data to avoid expensive git operations in the render loop.
@@ -52,6 +56,14 @@ type renderCache struct {
 	selectedCount  int
 	selectedStacks []shippable.Stack
 }
+
+// focusedPane indicates which pane has keyboard focus.
+type focusedPane int
+
+const (
+	paneLeft focusedPane = iota
+	paneRight
+)
 
 // dashboardState represents the current UI state of the dashboard.
 type dashboardState int
@@ -87,13 +99,16 @@ type shippableModel struct {
 	combination *shippable.CombinationResult
 
 	// UI state
-	state         dashboardState // Current UI state (replaces boolean flags)
-	stacks        []shippable.Stack
-	selectedIndex int
-	expanded      map[string]bool  // Tracks which stacks are expanded
-	selected      map[string]bool  // Tracks which stacks are selected for shipping
-	locked        map[string]bool  // Tracks which stacks are locked (during publish/ship)
-	focusedStack  *shippable.Stack // Currently focused stack for detail view
+	state             dashboardState // Current UI state (replaces boolean flags)
+	stacks            []shippable.Stack
+	selectedIndex     int
+	expanded          map[string]bool  // Tracks which stacks are expanded
+	selected          map[string]bool  // Tracks which stacks are selected for shipping
+	locked            map[string]bool  // Tracks which stacks are locked (during publish/ship)
+	focusedStack      *shippable.Stack // Currently focused stack for detail view
+	pane              focusedPane      // Which pane has keyboard focus
+	selectedBranchIdx int              // Index of highlighted branch in the details tree
+	detailsViewport   viewport.Model   // Viewport for scrollable details panel
 
 	// Status
 	initialLoad   bool // true until first refresh completes
@@ -121,6 +136,8 @@ type shippableModel struct {
 type keyMap struct {
 	Up        key.Binding
 	Down      key.Binding
+	Left      key.Binding
+	Right     key.Binding
 	Select    key.Binding
 	Expand    key.Binding
 	Ship      key.Binding
@@ -142,6 +159,14 @@ var keys = keyMap{
 	Down: key.NewBinding(
 		key.WithKeys(core.KeyDown, "j"),
 		key.WithHelp("↓/j", "move down"),
+	),
+	Left: key.NewBinding(
+		key.WithKeys(core.KeyLeft, "h"),
+		key.WithHelp("←/h", "focus stacks"),
+	),
+	Right: key.NewBinding(
+		key.WithKeys(core.KeyRight, "l"),
+		key.WithHelp("→/l", "focus details"),
 	),
 	Select: key.NewBinding(
 		key.WithKeys(" "),
@@ -201,19 +226,29 @@ func newShippableModel(ctx *app.Context, cfg config.Configurer, opts ShippableOp
 		progress.WithoutPercentage(),
 	)
 
+	// Create viewport for the details panel with default keybindings,
+	// but disable up/down/left/right since we handle those for branch selection.
+	vp := viewport.New(0, 0)
+	vp.KeyMap.Up.SetEnabled(false)
+	vp.KeyMap.Down.SetEnabled(false)
+	vp.KeyMap.Left.SetEnabled(false)
+	vp.KeyMap.Right.SetEnabled(false)
+	vp.MouseWheelEnabled = true
+
 	return &shippableModel{
-		ctx:         ctx,
-		engine:      ctx.Engine,
-		cfg:         cfg,
-		analyzer:    analyzer,
-		combiner:    combiner,
-		expanded:    make(map[string]bool),
-		selected:    make(map[string]bool),
-		locked:      make(map[string]bool),
-		initialLoad: true,
-		state:       stateLoading,
-		options:     opts,
-		progress:    p,
+		ctx:             ctx,
+		engine:          ctx.Engine,
+		cfg:             cfg,
+		analyzer:        analyzer,
+		combiner:        combiner,
+		expanded:        make(map[string]bool),
+		selected:        make(map[string]bool),
+		locked:          make(map[string]bool),
+		initialLoad:     true,
+		state:           stateLoading,
+		options:         opts,
+		progress:        p,
+		detailsViewport: vp,
 	}
 }
 

--- a/internal/cli/dashboard/shippable_update.go
+++ b/internal/cli/dashboard/shippable_update.go
@@ -178,11 +178,35 @@ func (m *shippableModel) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Handle normal navigation and actions
+	// Handle pane switching (available in both panes)
 	switch {
 	case key.Matches(msg, keys.Quit):
 		return m, tea.Quit
 
+	case key.Matches(msg, keys.Left):
+		m.pane = paneLeft
+		return m, nil
+
+	case key.Matches(msg, keys.Right):
+		if m.focusedStack != nil {
+			m.pane = paneRight
+			m.selectedBranchIdx = len(m.focusedStack.Stack.AllBranches) - 1
+		}
+		return m, nil
+	}
+
+	// Pane-specific key handling
+	switch m.pane {
+	case paneRight:
+		return m.handleRightPaneKey(msg)
+	default:
+		return m.handleLeftPaneKey(msg)
+	}
+}
+
+// handleLeftPaneKey handles keyboard input when the left (stacks) pane is focused.
+func (m *shippableModel) handleLeftPaneKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch {
 	case key.Matches(msg, keys.Up):
 		if m.selectedIndex > 0 {
 			m.selectedIndex--
@@ -224,7 +248,7 @@ func (m *shippableModel) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case key.Matches(msg, keys.Refresh):
 		m.state = stateLoading
-		m.statusMessage = "Refreshing..."
+		m.statusMessage = msgRefreshing
 		return m, m.refresh()
 
 	case key.Matches(msg, keys.Help):
@@ -233,6 +257,40 @@ func (m *shippableModel) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+// handleRightPaneKey handles keyboard input when the right (details) pane is focused.
+func (m *shippableModel) handleRightPaneKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, keys.Up):
+		if m.focusedStack != nil && m.selectedBranchIdx < len(m.focusedStack.Stack.AllBranches)-1 {
+			m.selectedBranchIdx++
+		}
+		return m, nil
+
+	case key.Matches(msg, keys.Down):
+		if m.selectedBranchIdx > 0 {
+			m.selectedBranchIdx--
+		}
+		return m, nil
+
+	case key.Matches(msg, keys.Help):
+		m.state = stateHelp
+		return m, nil
+
+	case key.Matches(msg, keys.Refresh):
+		m.state = stateLoading
+		m.statusMessage = msgRefreshing
+		return m, m.refresh()
+
+	case key.Matches(msg, keys.Publish):
+		return m.startPublish()
+	}
+
+	// Forward unhandled keys to the viewport for pgup/pgdown scrolling
+	var cmd tea.Cmd
+	m.detailsViewport, cmd = m.detailsViewport.Update(msg)
+	return m, cmd
 }
 
 // handleConfirmationKey handles keyboard input during confirmation dialog.

--- a/internal/cli/dashboard/shippable_view.go
+++ b/internal/cli/dashboard/shippable_view.go
@@ -132,6 +132,11 @@ func (m *shippableModel) renderStackList(width, height int) string {
 		Width(width - borderW).
 		Height(height - borderH)
 
+	// Highlight border when this pane has focus
+	if m.pane == paneLeft {
+		paneStyle = paneStyle.BorderForeground(lipgloss.Color(style.ColorDashboardFocusedBorder))
+	}
+
 	var sb strings.Builder
 	sb.WriteString(paneHeaderStyle.Render("STACKS") + "\n\n")
 
@@ -335,20 +340,54 @@ func (m *shippableModel) getStatusIcon(status shippable.Status) string {
 func (m *shippableModel) renderDetailsPanel(width, height int) string {
 	borderW := rightPaneStyle.GetHorizontalBorderSize()
 	borderH := rightPaneStyle.GetVerticalBorderSize()
+	paddingH := rightPaneStyle.GetVerticalPadding()
 	paneStyle := rightPaneStyle.
 		Width(width - borderW).
 		Height(height - borderH)
 
-	var sb strings.Builder
-	sb.WriteString(paneHeaderStyle.Render("DETAILS") + "\n\n")
-
-	if m.focusedStack != nil {
-		sb.WriteString(m.renderStackDetails(m.focusedStack))
-	} else {
-		sb.WriteString(commonStyles.Dim.Render("Select a stack to see details"))
+	// Highlight border when this pane has focus
+	if m.pane == paneRight {
+		paneStyle = paneStyle.BorderForeground(lipgloss.Color(style.ColorDashboardFocusedBorder))
 	}
 
-	return paneStyle.Render(sb.String())
+	header := paneHeaderStyle.Render("DETAILS") + "\n\n"
+	headerHeight := lipgloss.Height(header)
+
+	// Build details content
+	var content string
+	selectedLine := -1
+	selectedLineEnd := -1
+	if m.focusedStack != nil {
+		content, selectedLine, selectedLineEnd = m.renderStackDetails(m.focusedStack)
+	} else {
+		content = commonStyles.Dim.Render("Select a stack to see details")
+	}
+
+	// Size the viewport to fill the pane minus border, padding, and header
+	innerWidth := width - borderW - rightPaneStyle.GetHorizontalPadding()
+	innerHeight := height - borderH - paddingH - headerHeight
+	if innerHeight < 1 {
+		innerHeight = 1
+	}
+	m.detailsViewport.Width = innerWidth
+	m.detailsViewport.Height = innerHeight
+	m.detailsViewport.SetContent(content)
+
+	// Scroll the viewport to keep the selected branch visible.
+	// Uses selectedLineEnd to ensure trunk (main) stays visible when
+	// the bottommost branch is selected.
+	if selectedLine >= 0 {
+		const scrollMargin = 2
+		top := m.detailsViewport.YOffset
+		bottom := top + innerHeight - 1
+		if selectedLine < top+scrollMargin {
+			m.detailsViewport.SetYOffset(max(0, selectedLine-scrollMargin))
+		} else if selectedLineEnd > bottom-scrollMargin {
+			m.detailsViewport.SetYOffset(selectedLineEnd - innerHeight + 1 + scrollMargin)
+		}
+	}
+
+	return paneStyle.Render(header + m.detailsViewport.View())
 }
 
 // renderActionBar renders the compact action bar when stacks are selected.
@@ -384,8 +423,12 @@ func (m *shippableModel) renderActionBar(width int) string {
 }
 
 // renderStackDetails renders detailed info about a stack with tree view.
-func (m *shippableModel) renderStackDetails(stack *shippable.Stack) string {
+// Returns the rendered content, the line offset of the selected branch,
+// and the last line that should remain visible (for viewport scrolling).
+// Returns -1 for line values if no branch is selected.
+func (m *shippableModel) renderStackDetails(stack *shippable.Stack) (string, int, int) {
 	var sb strings.Builder
+	lineCount := 0
 
 	// Show stack description if present (matches st info --stack)
 	if desc := m.cache.stackDescriptions[stack.RootBranch()]; desc != nil {
@@ -398,6 +441,7 @@ func (m *shippableModel) renderStackDetails(stack *shippable.Stack) string {
 		}
 		rendered := style.RenderMarkdown(markdown)
 		sb.WriteString(rendered + "\n")
+		lineCount += lipgloss.Height(rendered) + 1
 	}
 
 	// Header: show commit title with status badge, branch name dimmed below
@@ -409,19 +453,31 @@ func (m *shippableModel) renderStackDetails(stack *shippable.Stack) string {
 	}
 	sb.WriteString(commonStyles.Bold.Render(title) + " " + statusBadge + "\n")
 	sb.WriteString(style.ColorDim(stack.RootBranch()) + "\n")
+	lineCount += 2
 
 	// Quick stats row
 	statsRow := m.renderQuickStats(stack)
 	sb.WriteString(statsRow + "\n\n")
+	lineCount += 2
 
 	// Stack tree visualization (blocking status is shown inline per branch)
 	sb.WriteString(style.ColorDim("Stack:") + "\n")
-	treeLines := m.renderStackTree(stack)
+	lineCount++ // "Stack:" label
+
+	treeLines, selectedLine, selectedLineEnd := m.renderStackTree(stack)
 	for _, line := range treeLines {
 		sb.WriteString(line + "\n")
 	}
 
-	return sb.String()
+	// Compute the absolute lines of the selected branch in the full content
+	selectedContentLine := -1
+	selectedContentLineEnd := -1
+	if selectedLine >= 0 {
+		selectedContentLine = lineCount + selectedLine
+		selectedContentLineEnd = lineCount + selectedLineEnd
+	}
+
+	return sb.String(), selectedContentLine, selectedContentLineEnd
 }
 
 // renderStatusBadge returns a colored badge for the stack status.
@@ -465,7 +521,9 @@ func (m *shippableModel) renderQuickStats(stack *shippable.Stack) string {
 }
 
 // renderStackTree renders the stack as a tree visualization.
-func (m *shippableModel) renderStackTree(stack *shippable.Stack) []string {
+// Returns the rendered lines, the line index of the selected branch (-1 if none),
+// and the last line that should remain visible (to keep trunk visible when selecting the bottommost branch).
+func (m *shippableModel) renderStackTree(stack *shippable.Stack) ([]string, int, int) {
 	// Use cached tree renderer if available, otherwise create one
 	var renderer *tree.StackTreeRenderer
 	if m.cache.treeRenderer != nil {
@@ -529,13 +587,53 @@ func (m *shippableModel) renderStackTree(stack *shippable.Stack) []string {
 
 	// Render tree in full mode with commit messages to match st info --stack
 	opts := tree.RenderOptions{
-		Mode:                tree.RenderModeFull,
-		HideSummary:         true,
-		SkipSelectionPrefix: true,
-		ShowCommitMessages:  true,
+		Mode:               tree.RenderModeFull,
+		HideSummary:        true,
+		ShowCommitMessages: true,
 	}
 
-	return renderer.RenderStack(stack.RootBranch(), opts)
+	// Always show a selected branch to avoid layout jank when switching panes.
+	// When right pane is focused, highlight the user-navigated branch.
+	// When left pane is focused, highlight the checked-out branch.
+	opts.SkipSelectionPrefix = false
+	if m.pane == paneRight && m.selectedBranchIdx >= 0 && m.selectedBranchIdx < len(stack.Stack.AllBranches) {
+		opts.SelectedBranch = stack.Stack.AllBranches[m.selectedBranchIdx]
+	} else {
+		opts.SelectedBranch = m.cache.currentBranch
+	}
+
+	// Use RenderStackDetailed to get per-branch line info for scroll tracking
+	rendered := renderer.RenderStackDetailed(stack.RootBranch(), opts)
+
+	var lines []string
+	selectedLine := -1
+	selectedLineEnd := -1
+	selectedIdx := -1
+	lineOffset := 0
+	for i, rb := range rendered {
+		if rb.Name == opts.SelectedBranch {
+			selectedLine = lineOffset + rb.CursorLineIndex
+			selectedIdx = i
+		}
+		lines = append(lines, rb.Lines...)
+		lineOffset += len(rb.Lines)
+	}
+
+	// When the selected branch is the last one before trunk, extend the
+	// visible range to include trunk's lines (so "main" stays visible).
+	if selectedIdx >= 0 && selectedIdx+1 < len(rendered) {
+		// Include the next branch's lines (typically trunk/main)
+		nextEnd := 0
+		for i := 0; i <= selectedIdx+1; i++ {
+			nextEnd += len(rendered[i].Lines)
+		}
+		selectedLineEnd = nextEnd - 1
+	}
+	if selectedLineEnd < selectedLine {
+		selectedLineEnd = selectedLine
+	}
+
+	return lines, selectedLine, selectedLineEnd
 }
 
 // renderFooter renders the footer with global shortcuts.
@@ -562,7 +660,7 @@ func (m *shippableModel) renderProgressFooter() string {
 	var message string
 	switch m.state {
 	case stateLoading:
-		message = "Refreshing..."
+		message = msgRefreshing
 	case stateAnalyzing:
 		message = "Analyzing..."
 	case stateShipping:
@@ -601,6 +699,7 @@ func (m *shippableModel) renderHelp() string {
 
 	sb.WriteString(helpSectionStyle.Render("Navigation") + "\n")
 	sb.WriteString(helpKeyStyle.Render("j/k, ↑/↓") + helpDescStyle.Render("Move selection up/down") + "\n")
+	sb.WriteString(helpKeyStyle.Render("h/l, ←/→") + helpDescStyle.Render("Switch pane focus") + "\n")
 	sb.WriteString(helpKeyStyle.Render("enter") + helpDescStyle.Render("Expand/collapse stack") + "\n")
 
 	sb.WriteString(helpSectionStyle.Render("Selection") + "\n")

--- a/internal/tui/core/base_model.go
+++ b/internal/tui/core/base_model.go
@@ -16,6 +16,8 @@ const (
 	KeyEnter = "enter"
 	KeyUp    = "up"
 	KeyDown  = "down"
+	KeyLeft  = "left"
+	KeyRight = "right"
 	KeyTab   = "tab"
 )
 

--- a/internal/tui/style/dashboard.go
+++ b/internal/tui/style/dashboard.go
@@ -42,6 +42,8 @@ const (
 	ColorDashboardDarkGray = "8"
 	// ColorDashboardBorder is dim gray for panel borders.
 	ColorDashboardBorder = "240"
+	// ColorDashboardFocusedBorder is brighter for the focused pane border.
+	ColorDashboardFocusedBorder = "252"
 )
 
 // DashboardStyles holds all styles for the shippable work dashboard.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Enhance shippable dashboard with worktree support and diagnostics**

Comprehensive improvements to the shippable dashboard interface, adding worktree integration, interactive management, and debugging capabilities.

Key changes by branch:
- **extract-dashboard-styles**: Centralized dashboard styling into `internal/tui/style/dashboard.go` (+178 lines) and added comprehensive shippable stories for TUI testing (+1090 lines)
- **worktree-integration**: Extended dashboard model to display worktree information, added update handlers for worktree state changes
- **formatting-improvements**: Refactored view layout for better readability and consistent formatting
- **error-handling**: Enhanced error display and status reporting in the dashboard UI
- **tracing-diagnostics**: Added git operation tracing and metadata cache diagnostics for debugging performance issues
- **interactive-worktree-management**: Added interactive worktree creation, attachment, and management capabilities directly from the dashboard

Implementation notes:
- New style package consolidates all dashboard-related styles in one place
- Worktree state is now part of the dashboard model and updates reactively
- Interactive commands allow users to create/attach worktrees without leaving the dashboard
- Tracing infrastructure helps identify bottlenecks in git operations
- All changes maintain backward compatibility with existing dashboard functionality

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `multi-stack/20260207-221615`.


* **PR #696**
  * **PR #710**
    * **PR #711**
      * **PR #712**
        * **PR #713**
          * **PR #714** 👈
            * **PR #715**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->