### PR TITLE
refactor: extract move selection logic and optimize rebase validation

### DIFF
--- a/internal/actions/checkout.go
+++ b/internal/actions/checkout.go
@@ -157,7 +157,7 @@ func printBranchInfo(ctx *app.Context, branch engine.Branch) {
 	}
 
 	if !branch.IsBranchUpToDate() {
-		parent := branch.GetParentPrecondition()
+		parent := branch.GetParentOrTrunk()
 		ctx.Output.Info("This branch has fallen behind %s - you may want to %s.",
 			style.ColorBranchName(parent, false),
 			style.ColorCyan("stackit upstack restack"))
@@ -185,7 +185,7 @@ func printBranchInfo(ctx *app.Context, branch engine.Branch) {
 	for i := len(downstack) - 1; i >= startIdx; i-- {
 		ancestor := downstack[i]
 		if !ancestor.IsBranchUpToDate() {
-			parent := ancestor.GetParentPrecondition()
+			parent := ancestor.GetParentOrTrunk()
 			ctx.Output.Info("The downstack branch %s has fallen behind %s - you may want to %s.",
 				style.ColorBranchName(ancestor.GetName(), false),
 				style.ColorBranchName(parent, false),

--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -428,7 +428,7 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 
 // getParentName returns the name of the parent branch or trunk if no parent exists
 func getParentName(branch engine.Branch, _ engine.Engine) string {
-	return branch.GetParentPrecondition()
+	return branch.GetParentOrTrunk()
 }
 
 // findNonDeletingAncestor finds the nearest ancestor that is not marked for deletion

--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -234,7 +234,7 @@ func RestackBranchesWithHandler(ctx *app.Context, branches []engine.Branch, call
 
 			switch result.Result {
 			case engine.RestackDone:
-				parentName := branch.GetParentPrecondition()
+				parentName := branch.GetParentOrTrunk()
 				isCurrent := branchName == currentBranchName
 				ctx.Output.Info("Restacked %s on %s.",
 					style.ColorBranchName(branchName, isCurrent),

--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -40,7 +40,7 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 		if currentBranch == nil {
 			return errors.ErrNotOnBranch
 		}
-		parentName := currentBranch.GetParentPrecondition()
+		parentName := currentBranch.GetParentOrTrunk()
 		parentBranch := eng.GetBranch(parentName)
 		parentRev, err := parentBranch.GetRevision()
 		if err != nil {

--- a/internal/actions/flatten/flatten.go
+++ b/internal/actions/flatten/flatten.go
@@ -442,7 +442,7 @@ func buildFlattenPlan(ctx *app.Context, eng engine.Engine, branches []engine.Bra
 		}
 
 		// Get current parent info
-		origParentName := b.GetParentPrecondition()
+		origParentName := b.GetParentOrTrunk()
 
 		// Get the branch's base (divergence point from parent)
 		oldUpstream, err := eng.GetDivergencePoint(bName)

--- a/internal/actions/fold/fold.go
+++ b/internal/actions/fold/fold.go
@@ -49,7 +49,7 @@ func showDryRun(ctx *app.Context, current, parent engine.Branch) {
 	// Show combined diff stat
 	out.Info("%s", style.ColorCyan("Combined Diff Stat:"))
 	// Base is parent's parent (or trunk)
-	grandparentName := parent.GetParentPrecondition()
+	grandparentName := parent.GetParentOrTrunk()
 	baseRev, err := eng.GetRevision(eng.GetBranch(grandparentName))
 	if err != nil {
 		out.Debug("Failed to get revision for grandparent %s: %v", grandparentName, err)
@@ -109,7 +109,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	// Get parent branch
-	parentName := currentBranchObj.GetParentPrecondition()
+	parentName := currentBranchObj.GetParentOrTrunk()
 
 	parentBranch := eng.GetBranch(parentName)
 	if !parentBranch.IsTrunk() {

--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -296,7 +296,7 @@ func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecut
 		actualParent := result.NewParent
 		if actualParent == "" {
 			branch := eng.GetBranch(step.BranchName)
-			actualParent = branch.GetParentPrecondition()
+			actualParent = branch.GetParentOrTrunk()
 		}
 
 		switch result.Result {

--- a/internal/actions/merge/execute_steps.go
+++ b/internal/actions/merge/execute_steps.go
@@ -90,7 +90,7 @@ func executeUpdatePRBase(ctx *app.Context, eng mergeExecuteEngine, step PlanStep
 
 	// Get the parent revision (old base)
 	branch := eng.GetBranch(step.BranchName)
-	parentName := branch.GetParentPrecondition()
+	parentName := branch.GetParentOrTrunk()
 
 	// Get the old parent revision
 	parentBranch := eng.GetBranch(parentName)

--- a/internal/actions/move/handler.go
+++ b/internal/actions/move/handler.go
@@ -1,6 +1,12 @@
 package move
 
-import "stackit.dev/stackit/internal/actions/handler"
+import (
+	"errors"
+
+	"stackit.dev/stackit/internal/actions/handler"
+	"stackit.dev/stackit/internal/app"
+	"stackit.dev/stackit/internal/engine"
+)
 
 // Step represents a step in the move process
 type Step string
@@ -61,6 +67,10 @@ type Handler interface {
 	// Returns true to proceed with the move, false to cancel.
 	// In non-interactive mode, returns true (auto-confirm).
 	PromptConfirmMove(preview Preview) (bool, error)
+
+	// PromptSelectOnto prompts user to select a new parent when --onto is not provided.
+	// Returns the selected branch and any precomputed rebase specs.
+	PromptSelectOnto(ctx *app.Context, sourceBranch string) (string, []engine.RebaseSpec, error)
 }
 
 // NullHandler is a no-op handler for when nil is passed.
@@ -84,3 +94,8 @@ func (h *NullHandler) PromptRename(string, string, string) (bool, error) { retur
 
 // PromptConfirmMove implements Handler. Returns true (auto-confirm) for null handler.
 func (h *NullHandler) PromptConfirmMove(Preview) (bool, error) { return true, nil }
+
+// PromptSelectOnto implements Handler. Returns error for null handler.
+func (h *NullHandler) PromptSelectOnto(*app.Context, string) (string, []engine.RebaseSpec, error) {
+	return "", nil, errors.New("target branch must be specified for move")
+}

--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -21,6 +21,19 @@ type Options struct {
 	SkipConfirm bool   // Skip confirmation prompt (--yes flag)
 	DryRun      bool   // If true, only shows what would happen without making changes
 	AutoRename  bool   // Auto-rename branch when scope changes (non-interactive mode)
+	// RebaseSpecs optionally provides precomputed specs (e.g. from interactive selection).
+	RebaseSpecs []engine.RebaseSpec
+}
+
+type movePlan struct {
+	source        string
+	onto          string
+	sourceBranch  engine.Branch
+	ontoBranch    engine.Branch
+	descendants   []engine.Branch
+	oldParentName string
+	oldParentRev  string
+	rebaseSpecs   []engine.RebaseSpec
 }
 
 // Action performs the move operation
@@ -35,19 +48,85 @@ func Action(ctx *app.Context, opts Options, h Handler) error {
 	}
 	defer h.Cleanup()
 
-	graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
+	source, err := resolveSource(eng, opts.Source)
+	if err != nil {
+		return err
+	}
 
-	// Default source to current branch
-	source := opts.Source
+	if err := ensureOnto(ctx, &opts, h, source); err != nil {
+		return err
+	}
+
+	takeSnapshot(eng, out, opts)
+
+	if err := validateMoveTargets(eng, source, opts.Onto); err != nil {
+		return err
+	}
+
+	plan, err := buildMovePlan(eng, out, source, opts.Onto, opts.RebaseSpecs)
+	if err != nil {
+		return err
+	}
+
+	if opts.DryRun {
+		return dryRun(ctx, plan.source, plan.oldParentName, plan.onto, plan.sourceBranch, plan.descendants, plan.rebaseSpecs)
+	}
+
+	if err := validateForExecution(ctx, h, plan, opts.SkipConfirm); err != nil {
+		return err
+	}
+
+	renamed, source, sourceBranch := maybeRename(ctx, h, opts, plan)
+	plan.source = source
+	plan.sourceBranch = sourceBranch
+
+	h.Start(plan.source, plan.oldParentName, plan.onto)
+
+	if err := eng.SetParentPreservingDivergence(gctx, plan.sourceBranch, plan.ontoBranch, plan.oldParentRev); err != nil {
+		return fmt.Errorf("failed to set parent: %w", err)
+	}
+
+	updateStackIDsAfterMove(ctx, plan, plan.source, plan.sourceBranch)
+
+	if err := restackAndMark(ctx, plan, plan.sourceBranch); err != nil {
+		return err
+	}
+
+	completeMove(h, plan, renamed)
+	return nil
+}
+
+func resolveSource(eng engine.Engine, source string) (string, error) {
 	if source == "" {
 		currentBranch := eng.CurrentBranch()
 		if currentBranch == nil {
-			return fmt.Errorf("not on a branch and no source branch specified")
+			return "", fmt.Errorf("not on a branch and no source branch specified")
 		}
-		source = currentBranch.GetName()
+		return currentBranch.GetName(), nil
 	}
+	return source, nil
+}
 
-	// Take snapshot before modifying the repository
+func ensureOnto(ctx *app.Context, opts *Options, h Handler, source string) error {
+	if opts.Onto != "" {
+		return nil
+	}
+	if opts.DryRun {
+		return fmt.Errorf("--onto flag is required when using --dry-run")
+	}
+	if !h.IsInteractive() {
+		return validation.ValidateTargetBranch(ctx.Engine, source, "", "move")
+	}
+	selected, rebaseSpecs, err := h.PromptSelectOnto(ctx, source)
+	if err != nil {
+		return err
+	}
+	opts.Onto = selected
+	opts.RebaseSpecs = rebaseSpecs
+	return nil
+}
+
+func takeSnapshot(eng engine.Engine, out output.Output, opts Options) {
 	snapshotOpts := actions.NewSnapshot("move",
 		actions.WithFlagValue("--source", opts.Source),
 		actions.WithFlagValue("--onto", opts.Onto),
@@ -56,116 +135,140 @@ func Action(ctx *app.Context, opts Options, h Handler) error {
 		// Log but don't fail - snapshot is best effort
 		out.Debug("Failed to take snapshot: %v", err)
 	}
+}
 
-	// Validate source branch
+func validateMoveTargets(eng engine.Engine, source, onto string) error {
 	if err := validation.ValidateSourceBranch(eng, source, "move"); err != nil {
 		return err
 	}
-
-	// Validate target branch
-	onto := opts.Onto
 	if err := validation.ValidateTargetBranch(eng, source, onto, "move"); err != nil {
 		return err
 	}
+	return nil
+}
+
+func buildMovePlan(eng engine.Engine, out output.Output, source, onto string, rebaseSpecs []engine.RebaseSpec) (*movePlan, error) {
+	graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
 
 	sourceBranch := eng.GetBranch(source)
 	ontoBranch := eng.GetBranch(onto)
 
-	// Cycle detection: ensure onto is not a descendant of source
-	if graph.IsDescendant(sourceBranch, onto) {
-		return fmt.Errorf("cannot move %s onto its own descendant %s", source, onto)
+	if graph.IsDescendant(sourceBranch, ontoBranch) {
+		return nil, fmt.Errorf("cannot move %s onto its own descendant %s", source, onto)
 	}
 
-	// Get descendants for rebase validation
 	descendants := graph.Range(sourceBranch, engine.StackRange{
 		RecursiveChildren: true,
 		IncludeCurrent:    true,
 		RecursiveParents:  false,
 	})
 
-	// Get current parent for preview
 	oldParent := sourceBranch.GetParent()
-	oldParentName := sourceBranch.GetParentPrecondition()
-
-	// Capture old divergence point to preserve it after reparenting
-	// This ensures we only move the commits that belong to this branch.
+	oldParentName := sourceBranch.GetParentOrTrunk()
 	oldParentRev, _ := eng.GetDivergencePoint(source)
 
-	// Build rebase specs for validation (needed for both preview conflict detection and actual move)
-	rebaseSpecs := BuildRebaseSpecs(eng, out, source, onto, oldParent, oldParentRev, descendants)
-
-	// Dry-run mode: validate and print what would happen without making changes
-	if opts.DryRun {
-		return dryRun(ctx, source, oldParentName, onto, sourceBranch, descendants, rebaseSpecs)
+	if len(rebaseSpecs) == 0 {
+		rebaseSpecs = BuildRebaseSpecs(eng, out, source, onto, oldParent, oldParentRev, descendants)
 	}
 
-	// Prompt for confirmation in interactive mode (unless --yes flag is set)
-	if h.IsInteractive() && !opts.SkipConfirm {
-		// Validate rebases BEFORE showing preview so user can see conflict info
-		validation, validationErr := eng.ValidateRebases(gctx, rebaseSpecs)
+	return &movePlan{
+		source:        source,
+		onto:          onto,
+		sourceBranch:  sourceBranch,
+		ontoBranch:    ontoBranch,
+		descendants:   descendants,
+		oldParentName: oldParentName,
+		oldParentRev:  oldParentRev,
+		rebaseSpecs:   rebaseSpecs,
+	}, nil
+}
 
-		// Get commits that will be moved
-		commits, _ := eng.GetAllCommits(sourceBranch, engine.CommitFormatSubject)
+func validateForExecution(ctx *app.Context, h Handler, plan *movePlan, skipConfirm bool) error {
+	if h.IsInteractive() && !skipConfirm {
+		return confirmInteractive(ctx, h, plan)
+	}
+	return validateNonInteractive(ctx, h, plan)
+}
 
-		// Get descendant names (excluding source itself)
-		var descendantNames []string
-		for _, d := range descendants {
-			if d.GetName() != source {
-				descendantNames = append(descendantNames, d.GetName())
-			}
-		}
+func confirmInteractive(ctx *app.Context, h Handler, plan *movePlan) error {
+	eng := ctx.Engine
+	out := ctx.Output
 
-		preview := Preview{
-			SourceBranch: source,
-			OldParent:    oldParentName,
-			NewParent:    onto,
-			Commits:      commits,
-			Descendants:  descendantNames,
-		}
+	validation, validationErr := eng.ValidateRebases(ctx.Context, plan.rebaseSpecs)
+	commits, _ := eng.GetAllCommits(plan.sourceBranch, engine.CommitFormatSubject)
 
-		// Add conflict info to preview if validation succeeded (even if there are conflicts)
-		if validationErr == nil && !validation.Success {
-			preview.HasConflicts = true
-			preview.ConflictBranch = validation.FailedBranch
-			preview.ConflictError = validation.ErrorMessage
-			preview.ConflictingFiles = validation.ConflictingFiles
-		}
+	preview := buildPreview(plan, commits, validation, validationErr)
 
-		confirmed, err := h.PromptConfirmMove(preview)
-		if err != nil {
-			return fmt.Errorf("failed to prompt for confirmation: %w", err)
-		}
-		if !confirmed {
-			out.Info("Move canceled.")
-			return nil
-		}
-
-		// If validation itself failed (not conflicts, but actual error), return error now
-		if validationErr != nil {
-			return fmt.Errorf("failed to validate rebases: %w", validationErr)
-		}
-
-		// If there are conflicts, return error after user has seen the preview
-		if preview.HasConflicts {
-			return fmt.Errorf("move would cause conflicts: %s on branch %s", preview.ConflictError, preview.ConflictBranch)
-		}
-	} else {
-		// Non-interactive mode: validate and fail immediately if there are conflicts
-		h.OnStep(StepValidating, handler.StatusStarted, "Validating rebases...")
-		validation, err := eng.ValidateRebases(gctx, rebaseSpecs)
-		if err != nil {
-			h.OnStep(StepValidating, handler.StatusFailed, err.Error())
-			return fmt.Errorf("failed to validate rebases: %w", err)
-		}
-		if !validation.Success {
-			h.OnStep(StepValidating, handler.StatusFailed, validation.ErrorMessage)
-			return fmt.Errorf("move would cause conflicts: %s on branch %s", validation.ErrorMessage, validation.FailedBranch)
-		}
-		h.OnStep(StepValidating, handler.StatusCompleted, "Validation passed")
+	confirmed, err := h.PromptConfirmMove(preview)
+	if err != nil {
+		return fmt.Errorf("failed to prompt for confirmation: %w", err)
+	}
+	if !confirmed {
+		out.Info("Move canceled.")
+		return nil
 	}
 
-	// Check for scope change and potential rename
-	var renamed bool
+	if validationErr != nil {
+		return fmt.Errorf("failed to validate rebases: %w", validationErr)
+	}
+	if preview.HasConflicts {
+		return fmt.Errorf("move would cause conflicts: %s on branch %s", preview.ConflictError, preview.ConflictBranch)
+	}
+	return nil
+}
+
+func validateNonInteractive(ctx *app.Context, h Handler, plan *movePlan) error {
+	h.OnStep(StepValidating, handler.StatusStarted, "Validating rebases...")
+	validation, err := ctx.Engine.ValidateRebases(ctx.Context, plan.rebaseSpecs)
+	if err != nil {
+		h.OnStep(StepValidating, handler.StatusFailed, err.Error())
+		return fmt.Errorf("failed to validate rebases: %w", err)
+	}
+	if !validation.Success {
+		h.OnStep(StepValidating, handler.StatusFailed, validation.ErrorMessage)
+		return fmt.Errorf("move would cause conflicts: %s on branch %s", validation.ErrorMessage, validation.FailedBranch)
+	}
+	h.OnStep(StepValidating, handler.StatusCompleted, "Validation passed")
+	return nil
+}
+
+func buildPreview(plan *movePlan, commits []string, validation *engine.RebaseValidation, validationErr error) Preview {
+	preview := Preview{
+		SourceBranch: plan.source,
+		OldParent:    plan.oldParentName,
+		NewParent:    plan.onto,
+		Commits:      commits,
+		Descendants:  descendantNames(plan.descendants, plan.source),
+	}
+
+	if validationErr == nil && validation != nil && !validation.Success {
+		preview.HasConflicts = true
+		preview.ConflictBranch = validation.FailedBranch
+		preview.ConflictError = validation.ErrorMessage
+		preview.ConflictingFiles = validation.ConflictingFiles
+	}
+
+	return preview
+}
+
+func descendantNames(descendants []engine.Branch, source string) []string {
+	var names []string
+	for _, d := range descendants {
+		if d.GetName() != source {
+			names = append(names, d.GetName())
+		}
+	}
+	return names
+}
+
+func maybeRename(ctx *app.Context, h Handler, opts Options, plan *movePlan) (bool, string, engine.Branch) {
+	eng := ctx.Engine
+	out := ctx.Output
+
+	source := plan.source
+	sourceBranch := plan.sourceBranch
+	ontoBranch := plan.ontoBranch
+
 	sourceScope := sourceBranch.GetScope()
 	ontoScope := ontoBranch.GetScope()
 	if sourceScope.IsDefined() && ontoScope.IsDefined() && !sourceScope.Equal(ontoScope) {
@@ -181,105 +284,103 @@ func Action(ctx *app.Context, opts Options, h Handler) error {
 
 		if shouldRename {
 			newName := strings.Replace(source, sourceScope.String(), ontoScope.String(), 1)
-			if err := eng.RenameBranch(gctx, eng.GetBranch(source), eng.GetBranch(newName)); err != nil {
+			if err := eng.RenameBranch(ctx.Context, eng.GetBranch(source), eng.GetBranch(newName)); err != nil {
 				out.Info("Warning: failed to rename branch: %v", err)
 			} else {
 				h.OnRename(source, newName)
 				out.Info("Renamed branch %s to %s.", style.ColorBranchName(source, false), style.ColorBranchName(newName, true))
 				source = newName
 				sourceBranch = eng.GetBranch(source)
-				renamed = true
+				return true, source, sourceBranch
 			}
 		}
 	}
 
-	// Start handler with branch info (oldParentName computed earlier for preview)
-	h.Start(source, oldParentName, onto)
+	return false, source, sourceBranch
+}
 
-	// Update parent in engine, preserving the divergence point
-	if err := eng.SetParentPreservingDivergence(gctx, sourceBranch, ontoBranch, oldParentRev); err != nil {
-		return fmt.Errorf("failed to set parent: %w", err)
+func updateStackIDsAfterMove(ctx *app.Context, plan *movePlan, source string, sourceBranch engine.Branch) {
+	eng := ctx.Engine
+	out := ctx.Output
+
+	if plan.oldParentName == plan.onto {
+		return
 	}
 
-	// Update stack IDs based on the move destination (only if parent actually changed):
-	// Stack IDs are only updated if the source branch already has a stack ID.
-	// If source has no stack ID, we don't auto-create one - stack IDs are created lazily
-	// when descriptions or scopes are set.
-	if oldParentName != onto {
-		oldStackID := eng.GetStackID(sourceBranch)
+	oldStackID := eng.GetStackID(sourceBranch)
+	if oldStackID == "" {
+		return
+	}
 
-		// Only sync stack IDs if the source branch already has one
-		if oldStackID != "" {
-			newStackID := eng.GetStackID(ontoBranch)
+	newStackID := eng.GetStackID(plan.ontoBranch)
 
-			// Determine what stack ID the source should have after the move
-			var targetStackID string
-			switch {
-			case eng.IsTrunk(ontoBranch):
-				// Moving to trunk creates a new stack
-				targetStackID = eng.GenerateStackID(source)
-				// Create a new stack ref (nil meta uses engine's timeNow() for proper testability)
-				if err := eng.CreateStackRef(targetStackID, nil); err != nil {
-					out.Warn("Failed to create stack ref: %v", err)
-				}
-			case newStackID != "" && newStackID != oldStackID:
-				// Moving to a different stack - inherit that stack's ID
-				targetStackID = newStackID
-			}
+	var targetStackID string
+	switch {
+	case eng.IsTrunk(plan.ontoBranch):
+		targetStackID = eng.GenerateStackID(source)
+		if err := eng.CreateStackRef(targetStackID, nil); err != nil {
+			out.Warn("Failed to create stack ref: %v", err)
+		}
+	case newStackID != "" && newStackID != oldStackID:
+		targetStackID = newStackID
+	}
 
-			// Update stack IDs if needed (descendants includes source via IncludeCurrent:true)
-			if targetStackID != "" {
-				for _, d := range descendants {
-					if err := eng.SetStackID(gctx, d, targetStackID); err != nil {
-						out.Warn("Failed to update stack ID for %s: %v", d.GetName(), err)
-					}
-				}
-				out.Info("Stack membership updated for %s", source)
-			}
+	if targetStackID == "" {
+		return
+	}
+
+	for _, d := range plan.descendants {
+		if err := eng.SetStackID(ctx.Context, d, targetStackID); err != nil {
+			out.Warn("Failed to update stack ID for %s: %v", d.GetName(), err)
 		}
 	}
+	out.Info("Stack membership updated for %s", source)
+}
 
-	// Rebuild graph after parent change for downstream traversals
-	graph = engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
+func restackAndMark(ctx *app.Context, plan *movePlan, sourceBranch engine.Branch) error {
+	eng := ctx.Engine
+	out := ctx.Output
+
+	graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
 
 	out.Info("Moved %s from %s to %s.",
-		style.ColorBranchName(source, true),
-		style.ColorBranchName(oldParentName, false),
-		style.ColorBranchName(onto, false))
+		style.ColorBranchName(plan.source, true),
+		style.ColorBranchName(plan.oldParentName, false),
+		style.ColorBranchName(plan.onto, false))
 
-	// Get all branches that need restacking: source and all its descendants
 	branchesToRestack := graph.Range(sourceBranch, engine.StackRange{
 		RecursiveChildren: true,
 		IncludeCurrent:    true,
 		RecursiveParents:  false,
 	})
 
-	// Restack source and all its descendants
 	if err := actions.RestackBranches(ctx, branchesToRestack); err != nil {
 		return fmt.Errorf("failed to restack branches: %w", err)
 	}
 
-	// Mark affected branches as needing PR body update during next sync
-	affectedBranches := []string{source}
-	if oldParentName != eng.Trunk().GetName() {
-		affectedBranches = append(affectedBranches, oldParentName)
+	affectedBranches := []string{plan.source}
+	if plan.oldParentName != eng.Trunk().GetName() {
+		affectedBranches = append(affectedBranches, plan.oldParentName)
 	}
 	if err := eng.BatchMarkNeedsPRBodyUpdate(affectedBranches); err != nil {
 		out.Debug("Failed to mark branches for PR body update: %v", err)
 	}
 
+	return nil
+}
+
+func completeMove(h Handler, plan *movePlan, renamed bool) {
 	newName := ""
 	if renamed {
-		newName = source
+		newName = plan.source
 	}
 	h.Complete(Result{
-		SourceBranch: source,
-		OldParent:    oldParentName,
-		NewParent:    onto,
+		SourceBranch: plan.source,
+		OldParent:    plan.oldParentName,
+		NewParent:    plan.onto,
 		Renamed:      renamed,
 		NewName:      newName,
 	})
-	return nil
 }
 
 // dryRun validates and prints what the move would do without making changes.

--- a/internal/actions/move/selection.go
+++ b/internal/actions/move/selection.go
@@ -1,0 +1,81 @@
+package move
+
+import (
+	"context"
+	"fmt"
+
+	"stackit.dev/stackit/internal/app"
+	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/output"
+)
+
+// Selection contains precomputed data for validating potential move targets.
+type Selection struct {
+	eng          engine.Engine
+	out          output.Output
+	source       string
+	sourceBranch engine.Branch
+	descendants  []engine.Branch
+	oldParent    *engine.Branch
+	oldParentRev string
+}
+
+// PrepareSelection builds the data needed for interactive onto validation.
+func PrepareSelection(ctx *app.Context, source string) (*Selection, error) {
+	if source == "" {
+		return nil, fmt.Errorf("source branch is required")
+	}
+
+	eng := ctx.Engine
+	sourceBranch := eng.GetBranch(source)
+
+	graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
+	descendants := graph.Range(sourceBranch, engine.StackRange{
+		RecursiveChildren: true,
+		IncludeCurrent:    true,
+		RecursiveParents:  false,
+	})
+
+	oldParent := sourceBranch.GetParent()
+
+	// Match move.Action behavior: capture divergence point, allow empty fallback.
+	oldParentRev, _ := eng.GetDivergencePoint(source)
+
+	return &Selection{
+		eng:          eng,
+		out:          ctx.Output,
+		source:       source,
+		sourceBranch: sourceBranch,
+		descendants:  descendants,
+		oldParent:    oldParent,
+		oldParentRev: oldParentRev,
+	}, nil
+}
+
+// Descendants returns the descendant branches (including the source).
+func (s *Selection) Descendants() []engine.Branch {
+	return s.descendants
+}
+
+// OldParent returns the current parent branch (nil if trunk).
+func (s *Selection) OldParent() *engine.Branch {
+	return s.oldParent
+}
+
+// OldParentRev returns the captured old parent revision.
+func (s *Selection) OldParentRev() string {
+	return s.oldParentRev
+}
+
+// ValidateOnto validates a potential move target and returns validation, commits, and rebase specs.
+func (s *Selection) ValidateOnto(ctx context.Context, onto string) (*engine.RebaseValidation, []string, []engine.RebaseSpec, error) {
+	rebaseSpecs := BuildRebaseSpecs(s.eng, s.out, s.source, onto, s.oldParent, s.oldParentRev, s.descendants)
+
+	validation, err := s.eng.ValidateRebases(ctx, rebaseSpecs)
+	if err != nil {
+		return nil, nil, rebaseSpecs, err
+	}
+
+	commits, _ := s.eng.GetAllCommits(s.sourceBranch, engine.CommitFormatSubject)
+	return validation, commits, rebaseSpecs, nil
+}

--- a/internal/actions/move/selection_interactive.go
+++ b/internal/actions/move/selection_interactive.go
@@ -1,0 +1,62 @@
+package move
+
+import (
+	"fmt"
+
+	"stackit.dev/stackit/internal/app"
+	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/tui"
+)
+
+// SelectOntoInteractive shows an interactive branch selector for choosing the "onto" branch
+// and returns precomputed rebase specs for the final selection.
+// This uses a compact inline bubbletea model that combines selection and confirmation.
+func SelectOntoInteractive(ctx *app.Context, sourceBranch string) (string, []engine.RebaseSpec, error) {
+	selection, err := PrepareSelection(ctx, sourceBranch)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// Create validation function that checks for conflicts when moving to a branch.
+	validator := func(ontoBranch string) (*tui.MoveValidation, error) {
+		validation, commits, rebaseSpecs, err := selection.ValidateOnto(ctx.Context, ontoBranch)
+		if err != nil {
+			return nil, err
+		}
+
+		if !validation.Success {
+			return &tui.MoveValidation{
+				Valid:          false,
+				Message:        fmt.Sprintf("Conflicts on %s: %s", validation.FailedBranch, validation.ErrorMessage),
+				Commits:        commits,
+				HasConflicts:   true,
+				ConflictBranch: validation.FailedBranch,
+				ConflictError:  validation.ErrorMessage,
+				RebaseSpecs:    rebaseSpecs,
+			}, nil
+		}
+
+		return &tui.MoveValidation{
+			Valid:       true,
+			Message:     "Move will complete without conflicts",
+			Commits:     commits,
+			RebaseSpecs: rebaseSpecs,
+		}, nil
+	}
+
+	// Use the compact move model with selection + confirmation.
+	config := tui.MoveModelConfig{
+		SourceBranch: sourceBranch,
+		Descendants:  selection.Descendants(),
+		OldParent:    selection.OldParent(),
+		OldParentRev: selection.OldParentRev(),
+		Validator:    validator,
+	}
+
+	result, err := tui.PromptMoveSelect(ctx.Engine, config)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return result.SelectedParent, result.RebaseSpecs, nil
+}

--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -73,7 +73,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	children := graph.ChildBranches(sourceBranch)
 
 	// Cycle detection: ensure onto is not a descendant of source
-	if graph.IsDescendant(sourceBranch, onto) {
+	if graph.IsDescendant(sourceBranch, ontoBranch) {
 		return fmt.Errorf("cannot pluck %s onto its own descendant %s", source, onto)
 	}
 

--- a/internal/actions/pop.go
+++ b/internal/actions/pop.go
@@ -32,7 +32,7 @@ func PopAction(ctx *app.Context, _ PopOptions) error {
 	currentBranchObj := eng.GetBranch(currentBranch)
 
 	// Get parent branch
-	parentName := currentBranchObj.GetParentPrecondition()
+	parentName := currentBranchObj.GetParentOrTrunk()
 
 	// Get parent branch revision
 	parentBranch := eng.GetBranch(parentName)

--- a/internal/actions/split/split.go
+++ b/internal/actions/split/split.go
@@ -109,7 +109,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	currentBranchObj := eng.GetBranch(currentBranch.GetName())
 	if !currentBranchObj.IsTracked() {
 		// Auto-track the branch
-		parentName := currentBranch.GetParentPrecondition()
+		parentName := currentBranch.GetParentOrTrunk()
 		if err := eng.TrackBranch(context, currentBranch.GetName(), parentName); err != nil {
 			return fmt.Errorf("failed to track branch: %w", err)
 		}

--- a/internal/actions/split/split_file.go
+++ b/internal/actions/split/split_file.go
@@ -94,7 +94,7 @@ func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []s
 	// Capture original stack ID to preserve on new branches
 	originalStackID := eng.GetStackID(branchToSplit)
 	// Get parent branch
-	parentBranchName := branchToSplit.GetParentPrecondition()
+	parentBranchName := branchToSplit.GetParentOrTrunk()
 	parentBranch := eng.GetBranch(parentBranchName)
 
 	// Generate new branch name
@@ -636,7 +636,7 @@ func promptForFiles(ctx context.Context, branchToSplit engine.Branch, eng splitB
 		return nil, fmt.Errorf("file selection must be specified via pathspecs in non-interactive mode")
 	}
 	// Get the parent branch to compare against
-	parentBranchName := branchToSplit.GetParentPrecondition()
+	parentBranchName := branchToSplit.GetParentOrTrunk()
 
 	// Get merge base between branch and parent
 	mergeBase, err := eng.GetMergeBase(branchToSplit.GetName(), parentBranchName)

--- a/internal/actions/split/wizard.go
+++ b/internal/actions/split/wizard.go
@@ -54,7 +54,7 @@ func RunWizard(ctx *app.Context, handler InteractiveHandler, opts WizardOptions)
 	// Ensure branch is tracked
 	currentBranchObj := eng.GetBranch(currentBranch.GetName())
 	if !currentBranchObj.IsTracked() {
-		parentName := currentBranch.GetParentPrecondition()
+		parentName := currentBranch.GetParentOrTrunk()
 		if err := eng.TrackBranch(ctx.Context, currentBranch.GetName(), parentName); err != nil {
 			return fmt.Errorf("failed to track branch: %w", err)
 		}

--- a/internal/actions/stack_info.go
+++ b/internal/actions/stack_info.go
@@ -69,7 +69,7 @@ func StackInfoAction(ctx *app.Context, opts StackInfoOptions) error {
 
 		info := StackBranchInfo{
 			Name:           branch.GetName(),
-			Parent:         branch.GetParentPrecondition(),
+			Parent:         branch.GetParentOrTrunk(),
 			IsLocked:       branch.IsLocked(),
 			IsFrozen:       branch.IsFrozen(),
 			Scope:          branch.GetScope().String(),
@@ -90,7 +90,7 @@ func StackInfoAction(ctx *app.Context, opts StackInfoOptions) error {
 		}
 
 		// Files changed
-		parentName := branch.GetParentPrecondition()
+		parentName := branch.GetParentOrTrunk()
 		parentRev, err := eng.GetRevision(eng.GetBranch(parentName))
 		if err == nil {
 			branchRev, err := branch.GetRevision()

--- a/internal/actions/submit/planning.go
+++ b/internal/actions/submit/planning.go
@@ -97,7 +97,7 @@ func prepareBranchesForSubmit(ctx *app.Context, branches []engine.Branch, opts O
 
 		// Get SHAs
 		headSHA, _ := branch.GetRevision()
-		parentBranchName := branch.GetParentPrecondition()
+		parentBranchName := branch.GetParentOrTrunk()
 		parentBranch := nav.GetBranch(parentBranchName)
 		baseSHA, _ := parentBranch.GetRevision()
 

--- a/internal/actions/submit/submit_validation.go
+++ b/internal/actions/submit/submit_validation.go
@@ -74,7 +74,7 @@ func validateBaseRevisions(branches []string, eng engine.BranchStatus, ctx *app.
 
 	for _, branchName := range branches {
 		branch := eng.GetBranch(branchName)
-		parentBranchName := branch.GetParentPrecondition()
+		parentBranchName := branch.GetParentOrTrunk()
 
 		parentBranch := eng.GetBranch(parentBranchName)
 		switch {

--- a/internal/cli/stack/move.go
+++ b/internal/cli/stack/move.go
@@ -9,8 +9,6 @@ import (
 	"stackit.dev/stackit/internal/actions/move"
 	"stackit.dev/stackit/internal/app"
 	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/tui"
 )
 
 // NewMoveCmd creates the move command
@@ -53,23 +51,7 @@ If no --onto is specified, opens an interactive selector to choose the target.`,
 					sourceBranch = currentBranch.GetName()
 				}
 
-				// Handle interactive selection for onto if not provided
 				ontoBranch := onto
-				if ontoBranch == "" {
-					// Dry-run requires --onto to be specified
-					if dryRun {
-						return fmt.Errorf("--onto flag is required when using --dry-run")
-					}
-					// Non-interactive mode requires --onto to be specified
-					if !ctx.Interactive {
-						return fmt.Errorf("--onto flag is required in non-interactive mode")
-					}
-					var err error
-					ontoBranch, err = interactiveOntoSelection(ctx, sourceBranch)
-					if err != nil {
-						return err
-					}
-				}
 
 				// Create runner and handler
 				runner, handler := NewMoveUI(ctx.Output, ctx.Logger, ctx.Interactive)
@@ -101,76 +83,4 @@ If no --onto is specified, opens an interactive selector to choose the target.`,
 	_ = cmd.RegisterFlagCompletionFunc("source", common.CompleteBranches)
 
 	return cmd
-}
-
-// interactiveOntoSelection shows an interactive branch selector for choosing the "onto" branch
-// This uses a compact inline bubbletea model that combines selection and confirmation.
-func interactiveOntoSelection(ctx *app.Context, sourceBranch string) (string, error) {
-	eng := ctx.Engine
-
-	// Get descendants of source (will be restacked after move)
-	graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
-	source := eng.GetBranch(sourceBranch)
-	descendants := graph.Range(source, engine.StackRange{
-		RecursiveChildren: true,
-		IncludeCurrent:    true,
-		RecursiveParents:  false,
-	})
-
-	// Get info needed for validation
-	oldParent := source.GetParent()
-	var oldParentRev string
-	if meta, err := eng.Git().ReadMetadata(sourceBranch); err == nil {
-		if rev := meta.GetParentBranchRevision(); rev != nil {
-			oldParentRev = *rev
-		}
-	}
-
-	// Create validation function that checks for conflicts when moving to a branch
-	validator := func(ontoBranch string) (*tui.MoveValidation, error) {
-		// Build rebase specs for this potential move
-		rebaseSpecs := move.BuildRebaseSpecs(eng, ctx.Output, sourceBranch, ontoBranch, oldParent, oldParentRev, descendants)
-
-		// Validate the rebases
-		validation, err := eng.ValidateRebases(ctx.Context, rebaseSpecs)
-		if err != nil {
-			return nil, err
-		}
-
-		// Get commits that will be moved
-		commits, _ := eng.GetAllCommits(source, engine.CommitFormatSubject)
-
-		if !validation.Success {
-			return &tui.MoveValidation{
-				Valid:          false,
-				Message:        fmt.Sprintf("Conflicts on %s: %s", validation.FailedBranch, validation.ErrorMessage),
-				Commits:        commits,
-				HasConflicts:   true,
-				ConflictBranch: validation.FailedBranch,
-				ConflictError:  validation.ErrorMessage,
-			}, nil
-		}
-
-		return &tui.MoveValidation{
-			Valid:   true,
-			Message: "Move will complete without conflicts",
-			Commits: commits,
-		}, nil
-	}
-
-	// Use the compact move model with selection + confirmation
-	config := tui.MoveModelConfig{
-		SourceBranch: sourceBranch,
-		Descendants:  descendants,
-		OldParent:    oldParent,
-		OldParentRev: oldParentRev,
-		Validator:    validator,
-	}
-
-	selected, err := tui.PromptMoveSelect(ctx.Engine, config)
-	if err != nil {
-		return "", err
-	}
-
-	return selected, nil
 }

--- a/internal/cli/stack/move_handlers.go
+++ b/internal/cli/stack/move_handlers.go
@@ -5,7 +5,9 @@ import (
 
 	"stackit.dev/stackit/internal/actions/handler"
 	"stackit.dev/stackit/internal/actions/move"
+	"stackit.dev/stackit/internal/app"
 	"stackit.dev/stackit/internal/cli/common"
+	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/internal/output"
 	"stackit.dev/stackit/internal/tui"
 	"stackit.dev/stackit/internal/tui/style"
@@ -78,6 +80,11 @@ func (h *SimpleMoveHandler) PromptConfirmMove(_ move.Preview) (bool, error) {
 	return true, nil
 }
 
+// PromptSelectOnto returns error for simple handler (non-interactive).
+func (h *SimpleMoveHandler) PromptSelectOnto(_ *app.Context, _ string) (string, []engine.RebaseSpec, error) {
+	return "", nil, fmt.Errorf("target branch must be specified for move")
+}
+
 // InteractiveMoveHandler provides interactive prompts for move operations
 type InteractiveMoveHandler struct {
 	SimpleMoveHandler
@@ -126,4 +133,9 @@ func (h *InteractiveMoveHandler) PromptConfirmMove(preview move.Preview) (bool, 
 	}
 
 	return tui.PromptConfirm("Proceed with move?", true)
+}
+
+// PromptSelectOnto prompts user to select a new parent when --onto is not provided.
+func (h *InteractiveMoveHandler) PromptSelectOnto(ctx *app.Context, sourceBranch string) (string, []engine.RebaseSpec, error) {
+	return move.SelectOntoInteractive(ctx, sourceBranch)
 }

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -585,7 +585,7 @@ func TestIsTrunk(t *testing.T) {
 	})
 }
 
-func TestGetParentPrecondition(t *testing.T) {
+func TestGetParentOrTrunk(t *testing.T) {
 	t.Parallel()
 	t.Run("returns parent when exists", func(t *testing.T) {
 		t.Parallel()
@@ -595,7 +595,7 @@ func TestGetParentPrecondition(t *testing.T) {
 			})
 
 		branch := s.Engine.GetBranch("branch1")
-		parent := branch.GetParentPrecondition()
+		parent := branch.GetParentOrTrunk()
 		require.Equal(t, "main", parent)
 	})
 
@@ -608,7 +608,7 @@ func TestGetParentPrecondition(t *testing.T) {
 
 		// Don't track branch1
 		branch := s.Engine.GetBranch("branch1")
-		parent := branch.GetParentPrecondition()
+		parent := branch.GetParentOrTrunk()
 		require.Equal(t, "main", parent) // Should return trunk
 	})
 }
@@ -975,9 +975,9 @@ func TestEdgeCases(t *testing.T) {
 		parent := branch.GetParent()
 		require.Empty(t, parent)
 
-		// GetParentPrecondition should return trunk
+		// GetParentOrTrunk should return trunk
 		// branch already declared above
-		parentName := branch.GetParentPrecondition()
+		parentName := branch.GetParentOrTrunk()
 		require.Equal(t, "main", parentName)
 	})
 

--- a/internal/engine/stack_graph.go
+++ b/internal/engine/stack_graph.go
@@ -212,13 +212,13 @@ func (g *StackGraph) Parent(branch Branch) string {
 
 // IsDescendant returns true if potentialDescendant is a descendant of branch.
 // This is useful for cycle detection when moving branches.
-func (g *StackGraph) IsDescendant(branch Branch, potentialDescendant string) bool {
+func (g *StackGraph) IsDescendant(branch Branch, potentialDescendant Branch) bool {
 	descendants := g.Range(branch, StackRange{
 		RecursiveChildren: true,
 		IncludeCurrent:    false,
 	})
 	for _, d := range descendants {
-		if d.GetName() == potentialDescendant {
+		if d.GetName() == potentialDescendant.GetName() {
 			return true
 		}
 	}

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -247,9 +247,9 @@ func (b Branch) GetScope() Scope {
 	return b.reader.GetScope(b)
 }
 
-// GetParentPrecondition returns the parent branch name, or trunk if no parent
+// GetParentOrTrunk returns the parent branch name, or trunk if no parent
 // This is used for validation where we expect a parent to exist
-func (b Branch) GetParentPrecondition() string {
+func (b Branch) GetParentOrTrunk() string {
 	parent := b.reader.GetParent(b)
 	if parent == nil {
 		return b.reader.Trunk().GetName()

--- a/internal/integration/move_noninteractive_test.go
+++ b/internal/integration/move_noninteractive_test.go
@@ -17,7 +17,7 @@ func TestMoveNonInteractive(t *testing.T) {
 
 		// Running move without --onto in non-interactive mode should fail
 		sh.RunExpectError("move --no-interactive").
-			OutputContains("--onto flag is required in non-interactive mode")
+			OutputContains("target branch must be specified")
 	})
 
 	t.Run("works with onto flag in non-interactive mode", func(t *testing.T) {

--- a/internal/tui/components/tree/stack_tree.go
+++ b/internal/tui/components/tree/stack_tree.go
@@ -28,7 +28,7 @@ func NewStackTree(branches []engine.Branch, currentBranch, trunkBranch string) *
 	for i, branch := range branches {
 		branchName := branch.GetName()
 		branchNames[i] = branchName
-		parentName := branch.GetParentPrecondition()
+		parentName := branch.GetParentOrTrunk()
 		parentMap[branchName] = parentName
 
 		// Build children map (inverse of parent map)

--- a/internal/tui/move_model.go
+++ b/internal/tui/move_model.go
@@ -33,8 +33,9 @@ const (
 
 // MoveResult contains the result of the interactive move selection
 type MoveResult struct {
-	SelectedParent string // The branch selected as new parent
-	Canceled       bool   // Whether the user canceled
+	SelectedParent string              // The branch selected as new parent
+	RebaseSpecs    []engine.RebaseSpec // Precomputed rebase specs for the selection
+	Canceled       bool                // Whether the user canceled
 }
 
 // MoveModelConfig contains configuration for the move model
@@ -51,12 +52,13 @@ type MoveValidator func(ontoBranch string) (*MoveValidation, error)
 
 // MoveValidation contains the result of validating a move
 type MoveValidation struct {
-	Valid          bool     // Whether the move is valid (no conflicts)
-	Message        string   // Status message
-	Commits        []string // Commits that will be moved
-	HasConflicts   bool     // Whether conflicts were detected
-	ConflictBranch string   // Branch with conflicts
-	ConflictError  string   // Conflict error message
+	Valid          bool                // Whether the move is valid (no conflicts)
+	Message        string              // Status message
+	Commits        []string            // Commits that will be moved
+	HasConflicts   bool                // Whether conflicts were detected
+	ConflictBranch string              // Branch with conflicts
+	ConflictError  string              // Conflict error message
+	RebaseSpecs    []engine.RebaseSpec // Precomputed rebase specs for this selection
 }
 
 // branchItem represents a selectable branch in the list
@@ -86,6 +88,7 @@ type MoveModel struct {
 	validationPending bool
 	validationTag     int // For debouncing
 	validator         MoveValidator
+	rebaseSpecs       []engine.RebaseSpec
 
 	// Keybindings
 	keys moveKeyMap
@@ -304,8 +307,14 @@ func (m *MoveModel) updateSelecting(msg tea.Msg) (tea.Model, tea.Cmd) {
 				Valid:   false,
 				Message: fmt.Sprintf("Error: %v", msg.err),
 			}
+			m.rebaseSpecs = nil
 		} else {
 			m.validation = msg.validation
+			if msg.validation != nil {
+				m.rebaseSpecs = msg.validation.RebaseSpecs
+			} else {
+				m.rebaseSpecs = nil
+			}
 		}
 	}
 
@@ -337,8 +346,14 @@ func (m *MoveModel) updateConfirming(msg tea.Msg) (tea.Model, tea.Cmd) {
 				Valid:   false,
 				Message: fmt.Sprintf("Error: %v", msg.err),
 			}
+			m.rebaseSpecs = nil
 		} else {
 			m.validation = msg.validation
+			if msg.validation != nil {
+				m.rebaseSpecs = msg.validation.RebaseSpecs
+			} else {
+				m.rebaseSpecs = nil
+			}
 		}
 	}
 
@@ -547,14 +562,15 @@ func (m *MoveModel) viewConfirming() string {
 func (m *MoveModel) Result() MoveResult {
 	return MoveResult{
 		SelectedParent: m.selectedBranch(),
+		RebaseSpecs:    m.rebaseSpecs,
 		Canceled:       m.state == moveStateCanceled,
 	}
 }
 
-// PromptMoveSelect runs the interactive move selection and returns the selected parent
-func PromptMoveSelect(eng engine.Engine, config MoveModelConfig) (string, error) {
+// PromptMoveSelect runs the interactive move selection and returns the selection result.
+func PromptMoveSelect(eng engine.Engine, config MoveModelConfig) (MoveResult, error) {
 	if err := CheckInteractiveAllowed(); err != nil {
-		return "", err
+		return MoveResult{}, err
 	}
 
 	model := NewMoveModel(eng, config)
@@ -562,13 +578,13 @@ func PromptMoveSelect(eng engine.Engine, config MoveModelConfig) (string, error)
 	p := tea.NewProgram(model)
 	finalModel, err := p.Run()
 	if err != nil {
-		return "", err
+		return MoveResult{}, err
 	}
 
 	result := finalModel.(*MoveModel).Result()
 	if result.Canceled {
-		return "", errors.ErrCanceled
+		return MoveResult{}, errors.ErrCanceled
 	}
 
-	return result.SelectedParent, nil
+	return result, nil
 }


### PR DESCRIPTION

Improve move action architecture by:
- Extract selection logic to move/selection.go and selection_interactive.go
- Add RebaseSpecs field to avoid duplicate validation computation
- Move interactiveOntoSelection from CLI to actions layer
- Pass precomputed rebase specs from TUI back to action
- Fix cycle detection to use branch object instead of string
- Fix GetParentPrecondition → GetParentOrTrunk for consistency

This eliminates redundant rebase validation when using interactive selection
and better separates concerns between CLI, actions, and TUI layers.