### PR TITLE
feat: enhance absorb with stash and restore support

### DIFF
--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -28,6 +28,7 @@ Examples:
 
 ## Technical Docs (`docs/`)
 
+- `docs/absorb.md` - Absorb command: target selection, stash/restore safety model, restack modes
 - `docs/architecture.md` - Runtime layering, action boundaries, adapters, bootstrap
 - `docs/config.md` - Configuration keys, layered config, adding new keys
 - `docs/tui.md` - TUI patterns, styling, components

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ api/openapi/       API contract source of truth
 
 ## Documentation
 
+- `docs/absorb.md` - Absorb command: target selection, stash/restore safety model, restack modes
 - `docs/config.md` - Configuration system, keys, layered config
 - `docs/hooks.md` - Lifecycle hook configuration, env vars, approval flow, recipes
 - `docs/multiplayer.md` - Collaboration: detecting landed work from non-stackit teammates, the un-pushed trunk guard, reparent invariants

--- a/docs/absorb.md
+++ b/docs/absorb.md
@@ -1,0 +1,192 @@
+# Absorb Command
+
+## Overview
+
+`stackit absorb` takes staged hunks from your working tree and amends them into the most relevant commits downstack.
+
+At a high level, absorb:
+
+1. Reads staged hunks.
+2. Finds the target commit for each absorbable hunk.
+3. Rewrites affected branch commits.
+4. Restacks upstack branches (configurable via `--restack`).
+5. Restores any hunks that could not be absorbed.
+
+Entry points:
+
+- CLI: `internal/cli/branch/absorb.go`
+- Action: `internal/actions/absorb/absorb.go`
+
+## Usage
+
+Common flow:
+
+```bash
+git add -A
+stackit absorb
+```
+
+Useful flags:
+
+- `--dry-run`: show what would be absorbed; no history rewrite.
+- `--force`: skip confirmation prompt.
+- `--patch`: interactively choose hunks to stage first (`git add -p` behavior).
+- `--all`: stage unstaged tracked changes (`git add -u`) before absorb.
+- `--restack`: `all` (default), `current`, `scope`, or `none`.
+- `--json`: print machine-readable absorb plan/summary.
+- `--show-conflict`: show absorb conflict diagnostics.
+
+## Preconditions
+
+Absorb validates:
+
+- you are on a branch (not detached HEAD),
+- current branch is not trunk,
+- current branch is tracked,
+- current branch is modifiable (not locked/frozen),
+- no rebase in progress.
+
+Validation chain: `internal/actions/validation/chains.go`
+
+## Target Selection
+
+For each staged hunk:
+
+1. Build candidate commit list from current branch plus downstack ancestors.
+2. Respect scope boundaries for downstack search.
+3. Skip hunks that are unsupported (`binary`, `new_file`, `deleted_file`).
+4. For remaining hunks, run commutation checks against candidate commits.
+5. First commit that does not commute is the target.
+6. Resolve target commit -> target branch.
+
+If no target is found, the hunk is unabsorbable (`commutes_with_all`).
+
+Unabsorbable types are in `internal/actions/absorb/unabsorbable.go`.
+
+## Apply Phase
+
+Absorb groups hunks by target branch and commit, then applies branch-by-branch in topological order.
+
+History rewrite happens in `engine.ApplyHunksToBranch`:
+
+- checkout parent base in detached HEAD,
+- cherry-pick branch commits oldest->newest,
+- apply selected hunks and amend when needed,
+- move branch ref to rewritten tip.
+
+Implementation: `internal/engine/engine_absorb.go`
+
+## Stash and Restore Safety Model
+
+Absorb protects user state by separating staged vs unstaged/untracked changes:
+
+- staged stash marker: `stackit-absorb-temp-staged`
+- unstaged stash marker: `stackit-absorb-temp-unstaged`
+
+Primary path:
+
+1. Stash staged changes with `git stash push --staged`.
+2. Stash unstaged/untracked changes separately (`git stash push -u`).
+3. Perform absorb rewrite.
+4. Restore the unstaged stash by marker.
+5. Restore unabsorbed hunks to the working tree **and** index.
+6. Drop the staged absorb stash only after every restore verifiably succeeds.
+
+Fallback path (when `--staged` stash errors, e.g. a file with both staged and
+unstaged changes — `MM` status):
+
+1. Detect whether the staged stash was still created despite the non-zero exit
+   (some Git versions create it anyway); keep it as the recovery net.
+2. Capture the unstaged (`index -> worktree`) delta with `git diff --binary`
+   **before** the reset, holding it in memory as a patch. The `--binary` form is
+   required: a tracked binary file with an unstaged edit would otherwise diff to
+   only a `Binary files ... differ` placeholder that `git apply` refuses
+   (`cannot apply binary patch ... without full index line`), silently losing
+   the edit after `reset --hard` — and, because `git apply` is atomic per
+   invocation, poisoning any coexisting text edits captured in the same patch.
+   `git diff --binary` embeds a `GIT binary patch` that reapplies cleanly.
+3. `reset --hard HEAD` to clear staged state before rewriting. This leaves
+   untracked files in place, so they need no separate stash.
+4. After the rewrite, reapply the captured patch with `git apply` (working tree
+   only). Unlike a `--keep-index` stash pop, `git apply` never three-way merges
+   against the now-absorbed content, so it cannot write conflict markers.
+
+Restoring is owned by `restoreStashedState` (in `restore.go`), which keeps the
+cleanup logic testable in isolation from the `Action` orchestration.
+
+Important details:
+
+- Stash refs are resolved by marker at cleanup time to avoid `stash@{n}` drift.
+  If the marker cannot be found, absorb **warns** rather than blindly popping
+  `stash@{0}`, which could be an unrelated user stash.
+- Non-binary unabsorbable hunks are restored to both the index (`git apply
+  --cached` via `StageHunks`, which also writes new files to disk) and the
+  working tree (`git apply`, working-tree only, per file). The per-file working
+  tree apply means an unappliable file (e.g. overlapping unstaged edits) warns
+  and does not block the rest; the content still lives in the index and the
+  kept staged stash.
+- Binary unabsorbable hunks are restored from the staged stash by whole-file
+  path checkout (worktree + index).
+- The staged safety stash is dropped only after **all** unabsorbable-hunk
+  restores succeed. If any restore falls short (binary, index, or working tree),
+  absorb keeps the staged stash and warns instead of silently dropping data.
+
+Helpers:
+
+- `internal/actions/absorb/stash.go`
+- `internal/actions/absorb/restore.go`
+
+## Restack Modes
+
+After rewriting, absorb can restack different branch sets:
+
+- `all`: restack descendants from oldest modified branch.
+- `current`: restack current branch descendants.
+- `scope`: restack within current scope only (falls back to `current` when scope is empty).
+- `none`: skip restack.
+
+Mode values are case-insensitive. For any mode narrower than `all`, absorb
+warns when descendants of the rewritten commits are left un-restacked
+("Skipped restacking N branches...") and points at `stackit restack --upstack`
+to finish the job.
+
+Implementation: `internal/actions/absorb/restack.go`
+
+## Conflict and Recovery
+
+When absorb conflicts or is interrupted:
+
+- `stackit absorb --show-conflict` provides context.
+- `stackit abort` recovers absorb state.
+
+Absorb-specific abort behavior:
+
+- detects absorb stashes by marker,
+- pops all absorb-related stash entries (staged + unstaged markers),
+- leaves unrelated stash entries untouched.
+
+Implementation: `internal/actions/absorb/conflict.go`
+
+## JSON Output
+
+`--json` emits a plan/summary with:
+
+- `current_branch`
+- `absorbed[]` (file, lines, target branch/commit, content)
+- `unabsorbable[]` (file, lines, reason, content)
+- `new_files[]`
+- `stack[]`
+
+Implementation: `internal/actions/absorb/plan.go`
+
+## Tests
+
+Primary absorb tests: `internal/actions/absorb/absorb_test.go`
+
+Notable coverage includes:
+
+- scope boundary targeting,
+- three-way/intervening commit behavior,
+- binary unabsorbable restoration,
+- stash fallback behavior when `stash push --staged` returns non-zero,
+- abort restoring multiple absorb stashes while preserving unrelated stashes.

--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -15,17 +15,20 @@ import (
 )
 
 const (
-	absorbStashMarker = "stackit-absorb-temp"
-	unknown           = "unknown"
+	absorbStashMarker         = "stackit-absorb-temp"
+	absorbStashStagedMarker   = absorbStashMarker + "-staged"
+	absorbStashUnstagedMarker = absorbStashMarker + "-unstaged"
+	unknown                   = "unknown"
 )
 
 // Options contains options for the absorb command
 type Options struct {
-	All    bool
-	DryRun bool
-	Force  bool
-	Patch  bool
-	JSON   bool // Output machine-readable JSON summary
+	All     bool
+	DryRun  bool
+	Force   bool
+	Patch   bool
+	JSON    bool // Output machine-readable JSON summary
+	Restack RestackMode
 }
 
 // Action performs the absorb operation
@@ -46,6 +49,10 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return err
 	}
 	currentBranch := eng.CurrentBranch()
+	opts.Restack = NormalizeRestackMode(opts.Restack)
+	if err := opts.Restack.Validate(); err != nil {
+		return err
+	}
 
 	// Take snapshot before modifying the repository
 	snapshotOpts := actions.NewSnapshot("absorb",
@@ -53,6 +60,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		actions.WithFlag(opts.DryRun, "--dry-run"),
 		actions.WithFlag(opts.Force, "--force"),
 		actions.WithFlag(opts.Patch, "--patch"),
+		actions.WithFlagValue("--restack", string(opts.Restack)),
 	)
 	actions.TakeBestEffortSnapshot(ctx, snapshotOpts)
 
@@ -65,10 +73,12 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return fmt.Errorf("failed to check staged changes: %w", err)
 	}
 
-	// Handle staging flags
+	// Handle staging flags. Unlike create/modify, --all stages tracked changes
+	// only (git add -u): untracked files can never be absorbed. When combined
+	// with --patch, --all wins, matching the pre-existing precedence.
 	stagingOpts := git.StagingOptions{
-		All:   opts.All,
-		Patch: opts.Patch,
+		Update: opts.All,
+		Patch:  opts.Patch && !opts.All,
 	}
 	if err := ctx.Engine.StageChanges(ctx.Context, stagingOpts); err != nil {
 		return err
@@ -96,6 +106,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		handler.Complete(Result{})
 		return nil
 	}
+	originalHunks := hunks
 
 	// Get all commits downstack from current branch
 	// We need commits from all branches downstack, not just current branch
@@ -123,17 +134,28 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		if err != nil {
 			return fmt.Errorf("failed to get commits for branch %s: %w", branch.GetName(), err)
 		}
-		// Commits are returned oldest to newest, but we want newest to oldest for search
-		for i := len(commits) - 1; i >= 0; i-- {
-			commitSHAs = append(commitSHAs, commits[i])
-		}
+		// GetAllCommits returns newest to oldest, which matches our search order.
+		commitSHAs = append(commitSHAs, commits...)
 	}
 
 	// Find target commit for each hunk
-	hunkTargets := []git.HunkTarget{}
-	unabsorbedHunks := []git.Hunk{}
+	candidateTargets := []git.HunkTarget{}
+	absorbedTargets := []git.HunkTarget{}
+	unabsorbedHunks := []Unabsorbable{}
 
 	for _, hunk := range hunks {
+		switch {
+		case hunk.Binary:
+			unabsorbedHunks = append(unabsorbedHunks, Unabsorbable{Hunk: hunk, Reason: ReasonBinary})
+			continue
+		case hunk.IsNewFile:
+			unabsorbedHunks = append(unabsorbedHunks, Unabsorbable{Hunk: hunk, Reason: ReasonNewFile})
+			continue
+		case hunk.IsDeletedFile:
+			unabsorbedHunks = append(unabsorbedHunks, Unabsorbable{Hunk: hunk, Reason: ReasonDeletedFile})
+			continue
+		}
+
 		commitSHA, commitIndex, err := eng.FindTargetCommitForHunk(hunk, commitSHAs)
 		if err != nil {
 			return fmt.Errorf("failed to find target commit for hunk: %w", err)
@@ -141,11 +163,11 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 		if commitSHA == "" {
 			// Hunk commutes with all commits - can't be absorbed
-			unabsorbedHunks = append(unabsorbedHunks, hunk)
+			unabsorbedHunks = append(unabsorbedHunks, Unabsorbable{Hunk: hunk, Reason: ReasonCommutesWithAll})
 			continue
 		}
 
-		hunkTargets = append(hunkTargets, git.HunkTarget{
+		candidateTargets = append(candidateTargets, git.HunkTarget{
 			Hunk:        hunk,
 			CommitSHA:   commitSHA,
 			CommitIndex: commitIndex,
@@ -154,14 +176,19 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	// Group hunks by branch, then by commit. Resolve every target commit's
 	// owning branch in one batched scan instead of a git-log sweep per hunk.
-	commitBranches := eng.FindBranchesForCommits(targetCommitSHAs(hunkTargets))
+	commitBranches := eng.FindBranchesForCommits(targetCommitSHAs(candidateTargets))
 	hunksByBranch := make(map[string]map[string][]git.Hunk)
-	for _, target := range hunkTargets {
+	for _, target := range candidateTargets {
 		branchName := commitBranches[target.CommitSHA]
+		if branchName == "" {
+			unabsorbedHunks = append(unabsorbedHunks, Unabsorbable{Hunk: target.Hunk, Reason: ReasonUnknownBranch})
+			continue
+		}
 		if hunksByBranch[branchName] == nil {
 			hunksByBranch[branchName] = make(map[string][]git.Hunk)
 		}
 		hunksByBranch[branchName][target.CommitSHA] = append(hunksByBranch[branchName][target.CommitSHA], target.Hunk)
+		absorbedTargets = append(absorbedTargets, target)
 	}
 
 	// Check if any target branches are locked or frozen
@@ -174,9 +201,11 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	if len(hunksByBranch) == 0 {
 		if len(unabsorbedHunks) > 0 {
-			out.Warn("The following hunks could not be absorbed (they commute with all commits):")
-			for _, hunk := range unabsorbedHunks {
-				out.Info("  %s (lines %d-%d)", hunk.File, hunk.NewStart, hunk.NewStart+hunk.NewCount-1)
+			out.Warn("The following hunks could not be absorbed:")
+			for _, unabsorbable := range unabsorbedHunks {
+				hunk := unabsorbable.Hunk
+				start, end := hunkLineRange(hunk)
+				out.Info("  %s (lines %d-%d) [%s]", hunk.File, start, end, unabsorbable.Reason.Description())
 			}
 		} else {
 			out.Info("Nothing to absorb.")
@@ -203,7 +232,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 			planJSON, err := GeneratePlanJSON(
 				currentBranch.GetName(),
-				hunkTargets,
+				absorbedTargets,
 				unabsorbedHunks,
 				newFiles,
 				eng,
@@ -244,15 +273,89 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return nil
 	}
 
-	// Stash all changes (staged and unstaged) before starting to rewrite commits
-	// This ensures a clean working directory for checkouts and prevents losing changes
-	stashOutput, stashErr := eng.StashPush(ctx.Context, absorbStashMarker)
-	if stashErr == nil && !strings.Contains(stashOutput, "No local changes to save") {
-		defer func() {
-			// Restore stash after we're done
-			_ = eng.StashPop(ctx.Context)
-		}()
+	// Stash staged and unstaged changes separately to avoid reintroducing absorbed hunks.
+	hasUnstaged, err := eng.HasUnstagedChanges(ctx.Context)
+	if err != nil {
+		return fmt.Errorf("failed to check unstaged changes: %w", err)
 	}
+	hasUntracked, err := eng.HasUntrackedFiles(ctx.Context)
+	if err != nil {
+		return fmt.Errorf("failed to check untracked files: %w", err)
+	}
+	hasUnstagedOrUntracked := hasUnstaged || hasUntracked
+
+	var (
+		stashedStaged   bool
+		stashedUnstaged bool
+		stagedFallback  bool
+		absorbSucceeded bool
+		unstagedPatch   string
+	)
+
+	if hasStaged {
+		stashOutput, stashErr := eng.StashPushStaged(ctx.Context, absorbStashStagedMarker)
+		if stashErr != nil {
+			// Some Git versions can return a non-zero exit while still creating the stash entry.
+			stashList, listErr := eng.StashList(ctx.Context)
+			if listErr == nil {
+				if findStashRef(stashList, absorbStashStagedMarker) != "" {
+					stashedStaged = true
+				}
+			}
+			// Fallback: capture the unstaged delta as a patch, then reset staged changes.
+			stagedFallback = true
+		} else if !strings.Contains(stashOutput, "No local changes to save") {
+			stashedStaged = true
+		}
+	}
+
+	if stagedFallback {
+		// Capture the unstaged (index->worktree) delta before `reset --hard`
+		// wipes it. We reapply this patch with `git apply` (working tree only)
+		// after the rewrite instead of popping a `--keep-index` stash: that pop
+		// three-way merges against a tree already containing the absorbed
+		// content and writes literal conflict markers into the user's files.
+		// `git apply` applies atomically or not at all, so it never conflicts.
+		// `reset --hard` leaves untracked files in place, so they need no
+		// handling here.
+		//
+		// Capture with `git diff --binary`: a tracked binary file with unstaged
+		// edits would otherwise diff to only a "Binary files ... differ"
+		// placeholder that `git apply` cannot reapply, silently losing the edit
+		// (and, because git apply is atomic per invocation, poisoning any
+		// coexisting text edits too).
+		if hasUnstaged {
+			diff, diffErr := eng.GetUnstagedDiffBinary(ctx.Context)
+			if diffErr != nil {
+				return fmt.Errorf("failed to capture unstaged changes: %w", diffErr)
+			}
+			unstagedPatch = diff
+		}
+
+		if err := eng.ResetHard(ctx.Context, "HEAD"); err != nil {
+			return fmt.Errorf("failed to reset staged changes: %w", err)
+		}
+	} else if hasUnstagedOrUntracked {
+		stashOutput, stashErr := eng.StashPush(ctx.Context, absorbStashUnstagedMarker)
+		if stashErr != nil {
+			return fmt.Errorf("failed to stash unstaged changes: %w", stashErr)
+		}
+		if !strings.Contains(stashOutput, "No local changes to save") {
+			stashedUnstaged = true
+		}
+	}
+
+	defer func() {
+		restoreStashedState(ctx.Context, eng, out, restoreParams{
+			stashedStaged:   stashedStaged,
+			stashedUnstaged: stashedUnstaged,
+			stagedFallback:  stagedFallback,
+			absorbSucceeded: absorbSucceeded,
+			unstagedPatch:   unstagedPatch,
+			unabsorbedHunks: unabsorbedHunks,
+			originalHunks:   originalHunks,
+		})
+	}()
 
 	// Track the oldest modified branch to know where to start restacking from
 	var oldestModifiedBranch string
@@ -284,9 +387,11 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	// Warn about unabsorbed hunks
 	if len(unabsorbedHunks) > 0 {
-		out.Warn("The following hunks could not be absorbed (they commute with all commits):")
-		for _, hunk := range unabsorbedHunks {
-			out.Info("  %s (lines %d-%d)", hunk.File, hunk.NewStart, hunk.NewStart+hunk.NewCount-1)
+		out.Warn("The following hunks could not be absorbed:")
+		for _, unabsorbable := range unabsorbedHunks {
+			hunk := unabsorbable.Hunk
+			start, end := hunkLineRange(hunk)
+			out.Info("  %s (lines %d-%d) [%s]", hunk.File, start, end, unabsorbable.Reason.Description())
 		}
 	}
 
@@ -298,21 +403,35 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return fmt.Errorf("failed to refresh engine after absorb: %w", err)
 	}
 
-	// Restack all branches above the oldest modified branch
+	// Restack branches according to mode
 	if oldestModifiedBranch != "" {
 		// Rebuild graph with fresh engine state
 		graph = eng.Graph(engine.SortStrategyAlphabetical)
-		upstackBranches := graph.Range(eng.GetBranch(oldestModifiedBranch), engine.StackRange{RecursiveChildren: true})
+		upstackBranches := selectRestackBranches(graph, eng, opts.Restack, currentBranch.GetName(), oldestModifiedBranch, currentScope)
 
 		if len(upstackBranches) > 0 {
 			if err := actions.RestackBranches(ctx, upstackBranches); err != nil {
 				return fmt.Errorf("failed to restack upstack branches: %w", err)
 			}
 		}
+
+		// Narrower modes can leave descendants of the rewritten commits on
+		// stale parents with no visible signal; tell the user how to finish.
+		if opts.Restack != RestackAll {
+			allUpstack := selectRestackBranches(graph, eng, RestackAll, currentBranch.GetName(), oldestModifiedBranch, currentScope)
+			if skipped := len(allUpstack) - len(upstackBranches); skipped > 0 {
+				out.Warn(
+					"Skipped restacking %d %s above the rewritten commits; run 'stackit restack --upstack' to update them.",
+					skipped,
+					actions.Pluralize("branch", skipped),
+				)
+			}
+		}
 	}
 
+	absorbSucceeded = true
 	handler.Complete(Result{
-		Absorbed:    len(hunkTargets),
+		Absorbed:    len(absorbedTargets),
 		Unabsorbed:  len(unabsorbedHunks),
 		BranchCount: len(hunksByBranch),
 	})
@@ -326,7 +445,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 		jsonOutput, err := GeneratePlanJSON(
 			currentBranch.GetName(),
-			hunkTargets,
+			absorbedTargets,
 			unabsorbedHunks,
 			newFiles,
 			eng,

--- a/internal/actions/absorb/absorb_test.go
+++ b/internal/actions/absorb/absorb_test.go
@@ -2,6 +2,7 @@ package absorb
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -711,6 +712,390 @@ func DefaultConfig() *Config {
 	})
 }
 
+func TestAbsorbRestoresBinaryUnabsorbableHunks(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+	s.CreateBranch("branch-a")
+	s.TrackBranch("branch-a", "main")
+
+	textFile := filepath.Join(s.Scene.Dir, "text.txt")
+	binaryFile := filepath.Join(s.Scene.Dir, "asset.bin")
+
+	err := os.WriteFile(textFile, []byte("line one\nline two\n"), 0600)
+	require.NoError(t, err)
+	err = os.WriteFile(binaryFile, []byte{0x00, 0x01, 0x02, 0x03}, 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "text.txt", "asset.bin")
+	s.RunGit("commit", "-m", "add baseline text and binary files")
+	s.Rebuild()
+
+	err = os.WriteFile(textFile, []byte("line one\nline two absorbed\n"), 0600)
+	require.NoError(t, err)
+	err = os.WriteFile(binaryFile, []byte{0x10, 0x11, 0x12, 0x13}, 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "text.txt", "asset.bin")
+
+	err = Action(s.Context, Options{Force: true}, nil)
+	require.NoError(t, err)
+
+	cachedFiles, err := s.Scene.Repo.RunGitCommandAndGetOutput("diff", "--cached", "--name-only")
+	require.NoError(t, err)
+	require.Contains(t, cachedFiles, "asset.bin")
+	require.NotContains(t, cachedFiles, "text.txt")
+
+	headText, err := s.Scene.Repo.RunGitCommandAndGetOutput("show", "HEAD:text.txt")
+	require.NoError(t, err)
+	require.Contains(t, headText, "line two absorbed")
+
+	stashList, err := s.Scene.Repo.RunGitCommandAndGetOutput("stash", "list")
+	require.NoError(t, err)
+	require.NotContains(t, stashList, absorbStashStagedMarker)
+}
+
+func TestAbsorbCleansUpStashOnStashPushStagedError(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+	s.CreateBranch("branch-a")
+	s.TrackBranch("branch-a", "main")
+
+	textFile := filepath.Join(s.Scene.Dir, "text.txt")
+	err := os.WriteFile(textFile, []byte("line one\nline two\n"), 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "text.txt")
+	s.RunGit("commit", "-m", "add baseline file")
+	s.Rebuild()
+
+	// Create MM state in one file so git stash --staged returns non-zero.
+	err = os.WriteFile(textFile, []byte("line one\nline two staged\n"), 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "text.txt")
+	err = os.WriteFile(textFile, []byte("line one\nline two staged\nline three unstaged\n"), 0600)
+	require.NoError(t, err)
+
+	err = Action(s.Context, Options{Force: true}, nil)
+	require.NoError(t, err)
+
+	// No absorb stash of either marker may remain.
+	stashList, err := s.Scene.Repo.RunGitCommandAndGetOutput("stash", "list")
+	require.NoError(t, err)
+	require.NotContains(t, stashList, absorbStashStagedMarker)
+	require.NotContains(t, stashList, absorbStashUnstagedMarker)
+
+	// The staged edit landed in the commit; the unstaged edit did not.
+	headText, err := s.Scene.Repo.RunGitCommandAndGetOutput("show", "HEAD:text.txt")
+	require.NoError(t, err)
+	require.Contains(t, headText, "line two staged")
+	require.NotContains(t, headText, "line three unstaged")
+
+	// The unstaged edit survives in the working tree with no conflict markers.
+	currentText, err := os.ReadFile(textFile)
+	require.NoError(t, err)
+	require.Contains(t, string(currentText), "line three unstaged")
+	require.NotContains(t, string(currentText), "<<<<<<<")
+	require.NotContains(t, string(currentText), ">>>>>>>")
+	require.NotContains(t, string(currentText), "=======")
+
+	// No unmerged (UU) entries in the working tree.
+	status, err := s.Scene.Repo.RunGitCommandAndGetOutput("status", "--porcelain")
+	require.NoError(t, err)
+	require.NotContains(t, status, "UU ")
+}
+
+// TestAbsorbRestoresUnabsorbableTextHunkToWorktree covers the primary success
+// path: a staged text hunk that commutes with all downstack commits (its target
+// commit is trunk-owned, outside the search range) must be restored to BOTH the
+// index and the on-disk file, not just the index.
+func TestAbsorbRestoresUnabsorbableTextHunkToWorktree(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+	// trunk owns trunk.txt; absorb's search range is branch-a only, so a hunk
+	// targeting trunk.txt commutes with all searched commits -> unabsorbable.
+	trunkFile := filepath.Join(s.Scene.Dir, "trunk.txt")
+	err := os.WriteFile(trunkFile, []byte("trunk-line\n"), 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "trunk.txt")
+	s.RunGit("commit", "-m", "add trunk file")
+
+	s.CreateBranch("branch-a")
+	s.TrackBranch("branch-a", "main")
+
+	branchFile := filepath.Join(s.Scene.Dir, "branch.txt")
+	err = os.WriteFile(branchFile, []byte("branch-line\n"), 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "branch.txt")
+	s.RunGit("commit", "-m", "add branch file")
+	s.Rebuild()
+
+	// Stage an absorbable hunk (branch.txt -> branch-a's commit) and an
+	// unabsorbable hunk (trunk.txt, commutes with all searched commits).
+	err = os.WriteFile(branchFile, []byte("branch-line absorbed\n"), 0600)
+	require.NoError(t, err)
+	err = os.WriteFile(trunkFile, []byte("trunk-line unabsorbable\n"), 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "branch.txt", "trunk.txt")
+
+	err = Action(s.Context, Options{Force: true}, nil)
+	require.NoError(t, err)
+
+	// The unabsorbable hunk is staged in the index...
+	cachedDiff, err := s.Scene.Repo.RunGitCommandAndGetOutput("diff", "--cached")
+	require.NoError(t, err)
+	require.Contains(t, cachedDiff, "trunk-line unabsorbable")
+
+	// ...AND present in the on-disk file (the bug left it only in the index).
+	onDisk, err := os.ReadFile(trunkFile)
+	require.NoError(t, err)
+	require.Contains(t, string(onDisk), "trunk-line unabsorbable")
+
+	// The absorbable hunk landed in the commit and no absorb stash remains.
+	headBranch, err := s.Scene.Repo.RunGitCommandAndGetOutput("show", "HEAD:branch.txt")
+	require.NoError(t, err)
+	require.Contains(t, headBranch, "branch-line absorbed")
+
+	stashList, err := s.Scene.Repo.RunGitCommandAndGetOutput("stash", "list")
+	require.NoError(t, err)
+	require.NotContains(t, stashList, absorbStashStagedMarker)
+}
+
+// TestDropStagedStashIfRestored verifies the staged safety stash is dropped only
+// after the unabsorbable-hunk restore succeeds, and kept (as the recovery net)
+// when it fails. This mirrors the ordering guard in restoreStashedState.
+func TestDropStagedStashIfRestored(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+	f := filepath.Join(s.Scene.Dir, "f.txt")
+	err := os.WriteFile(f, []byte("base\n"), 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "f.txt")
+	s.RunGit("commit", "-m", "base")
+	s.Rebuild()
+
+	// Create a real staged absorb stash to act on.
+	err = os.WriteFile(f, []byte("base\nstaged\n"), 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "f.txt")
+	s.RunGit("stash", "push", "--staged", "-m", absorbStashStagedMarker)
+
+	resolve := func(marker string) string {
+		list, listErr := s.Engine.StashList(s.Context.Context)
+		require.NoError(t, listErr)
+		return findStashRef(list, marker)
+	}
+
+	// restoreOK=false keeps the stash for manual recovery.
+	dropStagedStashIfRestored(s.Context.Context, s.Engine, s.Context.Output, false, resolve)
+	list, err := s.Scene.Repo.RunGitCommandAndGetOutput("stash", "list")
+	require.NoError(t, err)
+	require.Contains(t, list, absorbStashStagedMarker, "stash must be kept when restore did not fully succeed")
+
+	// restoreOK=true drops it.
+	dropStagedStashIfRestored(s.Context.Context, s.Engine, s.Context.Output, true, resolve)
+	list, err = s.Scene.Repo.RunGitCommandAndGetOutput("stash", "list")
+	require.NoError(t, err)
+	require.NotContains(t, list, absorbStashStagedMarker, "stash must be dropped after a successful restore")
+}
+
+func TestAbsorbDryRunDoesNotMutateRepository(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+	s.CreateBranch("branch-a")
+	s.TrackBranch("branch-a", "main")
+
+	testFile := filepath.Join(s.Scene.Dir, "test.txt")
+	err := os.WriteFile(testFile, []byte("base\n"), 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "test.txt")
+	s.RunGit("commit", "-m", "add baseline file")
+	s.Rebuild()
+
+	err = os.WriteFile(testFile, []byte("base\nstaged\n"), 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "test.txt")
+
+	headBefore, err := s.Scene.Repo.RunGitCommandAndGetOutput("rev-parse", "HEAD")
+	require.NoError(t, err)
+	stashBefore, err := s.Scene.Repo.RunGitCommandAndGetOutput("stash", "list")
+	require.NoError(t, err)
+
+	err = Action(s.Context, Options{DryRun: true, Force: true}, nil)
+	require.NoError(t, err)
+
+	headAfter, err := s.Scene.Repo.RunGitCommandAndGetOutput("rev-parse", "HEAD")
+	require.NoError(t, err)
+	stashAfter, err := s.Scene.Repo.RunGitCommandAndGetOutput("stash", "list")
+	require.NoError(t, err)
+	cachedAfter, err := s.Scene.Repo.RunGitCommandAndGetOutput("diff", "--cached", "--name-only")
+	require.NoError(t, err)
+
+	require.Equal(t, headBefore, headAfter)
+	require.Equal(t, stashBefore, stashAfter)
+	require.Contains(t, cachedAfter, "test.txt")
+}
+
+func TestAbsorbAllAndPatchStagesTrackedOnly(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+	s.CreateBranch("branch-a")
+	s.TrackBranch("branch-a", "main")
+
+	trackedFile := filepath.Join(s.Scene.Dir, "tracked.txt")
+	untrackedFile := filepath.Join(s.Scene.Dir, "new.txt")
+
+	err := os.WriteFile(trackedFile, []byte("base\n"), 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "tracked.txt")
+	s.RunGit("commit", "-m", "add baseline tracked file")
+	s.Rebuild()
+
+	err = os.WriteFile(trackedFile, []byte("base\ntracked-change\n"), 0600)
+	require.NoError(t, err)
+	err = os.WriteFile(untrackedFile, []byte("new file\n"), 0600)
+	require.NoError(t, err)
+
+	err = Action(s.Context, Options{All: true, Patch: true, DryRun: true, Force: true}, nil)
+	require.NoError(t, err)
+
+	cached, err := s.Scene.Repo.RunGitCommandAndGetOutput("diff", "--cached", "--name-only")
+	require.NoError(t, err)
+	untracked, err := s.Scene.Repo.RunGitCommandAndGetOutput("ls-files", "--others", "--exclude-standard")
+	require.NoError(t, err)
+
+	require.Contains(t, cached, "tracked.txt")
+	require.NotContains(t, cached, "new.txt")
+	require.Contains(t, untracked, "new.txt")
+}
+
+func TestAbsorbPlanOutputIsUserFriendly(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+	s.CreateBranch("branch-a")
+	s.TrackBranch("branch-a", "main")
+
+	targetFile := filepath.Join(s.Scene.Dir, "target.txt")
+	newFile := filepath.Join(s.Scene.Dir, "new.txt")
+
+	err := os.WriteFile(targetFile, []byte("base\n"), 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "target.txt")
+	s.RunGit("commit", "-m", "add baseline target")
+	s.Rebuild()
+
+	err = os.WriteFile(targetFile, []byte("base\nabsorbed change\n"), 0600)
+	require.NoError(t, err)
+	err = os.WriteFile(newFile, []byte("new file content\n"), 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "target.txt", "new.txt")
+
+	s.Output.Reset()
+	err = Action(s.Context, Options{Force: false}, nil)
+	require.NoError(t, err)
+
+	out := s.Output.String()
+	require.Contains(t, out, "Absorb plan: 1 hunk into 1 commit, 1 skipped")
+	require.Contains(t, out, "Will absorb:")
+	require.Contains(t, out, "Skipped (1):")
+	require.Contains(t, out, "New files cannot be absorbed (1)")
+	require.Contains(t, out, "Tips:")
+	require.Contains(t, out, "Commit new files with create/modify, then rerun absorb.")
+	require.Contains(t, out, "\n    - new.txt:")
+	require.NotContains(t, out, "new_file")
+}
+
+func TestAbsorbDryRunJSONIncludesUnabsorbableReasons(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+	s.CreateBranch("branch-a")
+	s.TrackBranch("branch-a", "main")
+
+	targetFile := filepath.Join(s.Scene.Dir, "target.txt")
+	deleteFile := filepath.Join(s.Scene.Dir, "delete.txt")
+	binaryFile := filepath.Join(s.Scene.Dir, "asset.bin")
+	newFile := filepath.Join(s.Scene.Dir, "new.txt")
+
+	err := os.WriteFile(targetFile, []byte("target base\n"), 0600)
+	require.NoError(t, err)
+	err = os.WriteFile(deleteFile, []byte("delete me\n"), 0600)
+	require.NoError(t, err)
+	err = os.WriteFile(binaryFile, []byte{0x00, 0x01, 0x02, 0x03}, 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "target.txt", "delete.txt", "asset.bin")
+	s.RunGit("commit", "-m", "add baseline files")
+	s.Rebuild()
+
+	err = os.WriteFile(targetFile, []byte("target absorbed\n"), 0600)
+	require.NoError(t, err)
+	err = os.Remove(deleteFile)
+	require.NoError(t, err)
+	err = os.WriteFile(newFile, []byte("brand new\n"), 0600)
+	require.NoError(t, err)
+	err = os.WriteFile(binaryFile, []byte{0x10, 0x11, 0x12, 0x13}, 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "target.txt", "delete.txt", "new.txt", "asset.bin")
+
+	s.Output.Reset()
+	err = Action(s.Context, Options{DryRun: true, Force: true, JSON: true}, nil)
+	require.NoError(t, err)
+
+	out := s.Output.String()
+	start := strings.Index(out, "{\n  \"current_branch\"")
+	require.NotEqual(t, -1, start, "expected JSON output in absorb dry-run output")
+	end := strings.LastIndex(out, "}")
+	require.Greater(t, end, start, "expected complete JSON output")
+
+	var plan PlanJSON
+	err = json.Unmarshal([]byte(out[start:end+1]), &plan)
+	require.NoError(t, err)
+
+	reasons := make(map[string]bool)
+	for _, hunk := range plan.Unabsorbable {
+		reasons[hunk.Reason] = true
+	}
+	require.True(t, reasons[string(ReasonBinary)])
+	require.True(t, reasons[string(ReasonNewFile)])
+	require.True(t, reasons[string(ReasonDeletedFile)])
+}
+
+func TestAbsorbNonInteractiveWithoutForceSkipsApply(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+	s.CreateBranch("branch-a")
+	s.TrackBranch("branch-a", "main")
+
+	testFile := filepath.Join(s.Scene.Dir, "skip.txt")
+	err := os.WriteFile(testFile, []byte("base\n"), 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "skip.txt")
+	s.RunGit("commit", "-m", "add baseline file")
+	s.Rebuild()
+
+	err = os.WriteFile(testFile, []byte("base\nstaged\n"), 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "skip.txt")
+
+	headBefore, err := s.Scene.Repo.RunGitCommandAndGetOutput("rev-parse", "HEAD")
+	require.NoError(t, err)
+
+	err = Action(s.Context, Options{Force: false}, nil)
+	require.NoError(t, err)
+
+	headAfter, err := s.Scene.Repo.RunGitCommandAndGetOutput("rev-parse", "HEAD")
+	require.NoError(t, err)
+	cachedAfter, err := s.Scene.Repo.RunGitCommandAndGetOutput("diff", "--cached", "--name-only")
+	require.NoError(t, err)
+
+	require.Equal(t, headBefore, headAfter)
+	require.Contains(t, cachedAfter, "skip.txt")
+}
+
 func TestAbsorbConflictHandling(t *testing.T) {
 	t.Parallel()
 	t.Run("IsAbsorbInProgress returns false in normal state", func(t *testing.T) {
@@ -867,4 +1252,158 @@ func TestAbsorbConflictHandling(t *testing.T) {
 		// After abort, we should be on test-branch
 		require.Equal(t, "test-branch", strings.TrimSpace(output))
 	})
+
+	t.Run("Abort restores all absorb stashes and keeps unrelated stashes", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		s.CreateBranch("test-branch")
+		s.TrackBranch("test-branch", "main")
+
+		fileA := filepath.Join(s.Scene.Dir, "file-a.txt")
+		fileB := filepath.Join(s.Scene.Dir, "file-b.txt")
+		fileC := filepath.Join(s.Scene.Dir, "file-c.txt")
+
+		err := os.WriteFile(fileA, []byte("a-base\n"), 0600)
+		require.NoError(t, err)
+		err = os.WriteFile(fileB, []byte("b-base\n"), 0600)
+		require.NoError(t, err)
+		err = os.WriteFile(fileC, []byte("c-base\n"), 0600)
+		require.NoError(t, err)
+		s.RunGit("add", "file-a.txt", "file-b.txt", "file-c.txt")
+		s.RunGit("commit", "-m", "add baseline files")
+		s.Rebuild()
+
+		err = os.WriteFile(fileA, []byte("a-absorb-staged\n"), 0600)
+		require.NoError(t, err)
+		s.RunGit("add", "file-a.txt")
+		s.RunGit("stash", "push", "-m", absorbStashStagedMarker)
+
+		err = os.WriteFile(fileB, []byte("b-absorb-unstaged\n"), 0600)
+		require.NoError(t, err)
+		s.RunGit("add", "file-b.txt")
+		s.RunGit("stash", "push", "-m", absorbStashUnstagedMarker)
+
+		err = os.WriteFile(fileC, []byte("c-unrelated\n"), 0600)
+		require.NoError(t, err)
+		s.RunGit("add", "file-c.txt")
+		s.RunGit("stash", "push", "-m", "unrelated-stash")
+
+		stashListBefore, err := s.Scene.Repo.RunGitCommandAndGetOutput("stash", "list")
+		require.NoError(t, err)
+		require.Contains(t, stashListBefore, absorbStashStagedMarker)
+		require.Contains(t, stashListBefore, absorbStashUnstagedMarker)
+		require.Contains(t, stashListBefore, "unrelated-stash")
+
+		err = Abort(s.Context)
+		require.NoError(t, err)
+
+		stashListAfter, err := s.Scene.Repo.RunGitCommandAndGetOutput("stash", "list")
+		require.NoError(t, err)
+		require.NotContains(t, stashListAfter, absorbStashStagedMarker)
+		require.NotContains(t, stashListAfter, absorbStashUnstagedMarker)
+		require.Contains(t, stashListAfter, "unrelated-stash")
+
+		contentA, err := os.ReadFile(fileA)
+		require.NoError(t, err)
+		require.Contains(t, string(contentA), "a-absorb-staged")
+		contentB, err := os.ReadFile(fileB)
+		require.NoError(t, err)
+		require.Contains(t, string(contentB), "b-absorb-unstaged")
+		contentC, err := os.ReadFile(fileC)
+		require.NoError(t, err)
+		require.NotContains(t, string(contentC), "c-unrelated")
+	})
+}
+
+// TestAbsorbFallbackPreservesUnstagedBinaryEdit is the regression test for the
+// data-loss bug: on the stash fallback path (triggered by MM state on a text
+// file), a coexisting UNSTAGED edit to a tracked binary file must survive.
+// Plain `git diff` renders a binary change as only "Binary files ... differ",
+// which `git apply` cannot reapply after `reset --hard` has wiped it — losing
+// the bytes and, because git apply is atomic per invocation, poisoning the
+// text edits captured in the same patch. The fix captures with
+// `git diff --binary`, which round-trips through `git apply`.
+func TestAbsorbFallbackPreservesUnstagedBinaryEdit(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+	s.CreateBranch("branch-a")
+	s.TrackBranch("branch-a", "main")
+
+	textFile := filepath.Join(s.Scene.Dir, "text.txt")
+	binFile := filepath.Join(s.Scene.Dir, "blob.bin")
+	originalBinary := []byte{0x00, 0x01, 0x02, 0x03, 'B', 'I', 'N', 0xff, 0xfe}
+	editedBinary := []byte{0x00, 0x01, 0x02, 0x03, 'B', 'I', 'N', '-', 'E', 'D', 'I', 'T', 0xff, 0xfe, 0xaa}
+
+	err := os.WriteFile(textFile, []byte("line one\nline two\n"), 0600)
+	require.NoError(t, err)
+	err = os.WriteFile(binFile, originalBinary, 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "text.txt", "blob.bin")
+	s.RunGit("commit", "-m", "add baseline files")
+	s.Rebuild()
+
+	// Create MM state on the text file (staged + unstaged edits) so
+	// `git stash push --staged` returns non-zero and absorb takes the fallback.
+	err = os.WriteFile(textFile, []byte("line one\nline two staged\n"), 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "text.txt")
+	err = os.WriteFile(textFile, []byte("line one\nline two staged\nline three unstaged\n"), 0600)
+	require.NoError(t, err)
+
+	// Add an UNSTAGED binary edit — the byte sequence that must survive.
+	err = os.WriteFile(binFile, editedBinary, 0600)
+	require.NoError(t, err)
+
+	err = Action(s.Context, Options{Force: true}, nil)
+	require.NoError(t, err)
+
+	// The binary file's worktree bytes equal the unstaged edit exactly.
+	gotBinary, err := os.ReadFile(binFile)
+	require.NoError(t, err)
+	require.Equal(t, editedBinary, gotBinary, "unstaged binary edit must be restored byte-for-byte")
+
+	// The staged text line landed in HEAD; the unstaged text line did not.
+	headText, err := s.Scene.Repo.RunGitCommandAndGetOutput("show", "HEAD:text.txt")
+	require.NoError(t, err)
+	require.Contains(t, headText, "line two staged")
+	require.NotContains(t, headText, "line three unstaged")
+
+	// The unstaged text edit survives in the working tree with no conflict markers.
+	currentText, err := os.ReadFile(textFile)
+	require.NoError(t, err)
+	require.Contains(t, string(currentText), "line three unstaged")
+	require.NotContains(t, string(currentText), "<<<<<<<")
+	require.NotContains(t, string(currentText), ">>>>>>>")
+	require.NotContains(t, string(currentText), "=======")
+
+	// No absorb stash of either marker may remain.
+	stashList, err := s.Scene.Repo.RunGitCommandAndGetOutput("stash", "list")
+	require.NoError(t, err)
+	require.NotContains(t, stashList, absorbStashStagedMarker)
+	require.NotContains(t, stashList, absorbStashUnstagedMarker)
+}
+
+// TestAbsorbWarnsWhenSkippingRestack covers, end to end through Action, that the
+// "Skipped restacking" warning is emitted when a narrower restack mode leaves
+// descendants of the rewritten commits on stale parents. Here absorb rewrites a
+// downstack branch (a) while the user is on c with --restack none, so b and c
+// are left un-restacked and the warning must fire.
+func TestAbsorbWarnsWhenSkippingRestack(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).WithLinearStack3()
+
+	// On c, stage a modification to branch a's committed file so the hunk
+	// absorbs into a (the oldest modified branch).
+	s.Checkout("c")
+	fileA := filepath.Join(s.Scene.Dir, "a_test.txt")
+	err := os.WriteFile(fileA, []byte("change on a modified\n"), 0600)
+	require.NoError(t, err)
+	s.RunGit("add", "a_test.txt")
+
+	err = Action(s.Context, Options{Restack: RestackNone, Force: true}, nil)
+	require.NoError(t, err)
+
+	require.Contains(t, s.Output.String(), "Skipped restacking")
 }

--- a/internal/actions/absorb/conflict.go
+++ b/internal/actions/absorb/conflict.go
@@ -1,6 +1,7 @@
 package absorb
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -58,7 +59,7 @@ func ShowConflict(ctx *app.Context) error {
 	// Check if we're in a detached HEAD state (might be mid-absorb failure)
 	if eng.CurrentBranch() == nil {
 		out.Warn("Repository is in detached HEAD state.")
-		out.Info("This may be from a failed absorb. Run 'stackit absorb --abort' to recover.")
+		out.Info("This may be from a failed absorb. Run 'stackit abort' to recover.")
 		out.Info("")
 
 		// Show unmerged files if any
@@ -159,10 +160,11 @@ func Abort(ctx *app.Context) error {
 		stashList, _ := eng.StashList(ctx.Context)
 		if strings.Contains(stashList, absorbStashMarker) {
 			out.Info("Found stashed changes from previous absorb attempt.")
-			if err := eng.StashPop(ctx.Context); err != nil {
+			restored, err := popAllAbsorbStashes(ctx.Context, eng)
+			if err != nil {
 				out.Warn("Failed to restore stashed changes: %v", err)
 			} else {
-				out.Info("Restored your staged changes from stash.")
+				out.Info("Restored %d absorb stash entries.", restored)
 			}
 			return nil
 		}
@@ -210,13 +212,39 @@ func Abort(ctx *app.Context) error {
 	// Pop stash if there is one
 	stashList, _ := eng.StashList(ctx.Context)
 	if strings.Contains(stashList, absorbStashMarker) {
-		if err := eng.StashPop(ctx.Context); err != nil {
+		restored, err := popAllAbsorbStashes(ctx.Context, eng)
+		if err != nil {
 			out.Warn("Failed to restore stashed changes: %v", err)
 		} else {
-			out.Info("Restored your staged changes from stash.")
+			out.Info("Restored %d absorb stash entries.", restored)
 		}
 	}
 
 	out.Info("Abort complete.")
 	return nil
+}
+
+func popAllAbsorbStashes(gitCtx context.Context, eng engine.Engine) (int, error) {
+	restored := 0
+	for {
+		stashList, err := eng.StashList(gitCtx)
+		if err != nil {
+			return restored, err
+		}
+
+		stashRef := findStashRefByMarkers(
+			stashList,
+			absorbStashStagedMarker,
+			absorbStashUnstagedMarker,
+			absorbStashMarker,
+		)
+		if stashRef == "" {
+			return restored, nil
+		}
+
+		if err := eng.StashPopRef(gitCtx, stashRef); err != nil {
+			return restored, err
+		}
+		restored++
+	}
 }

--- a/internal/actions/absorb/output.go
+++ b/internal/actions/absorb/output.go
@@ -1,81 +1,227 @@
 package absorb
 
 import (
+	"sort"
+	"strings"
+
+	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/output"
 )
 
 // printDryRunOutput prints what would be absorbed in dry-run mode
-func printDryRunOutput(hunksByCommit map[string][]git.Hunk, unabsorbedHunks []git.Hunk, eng engine.Engine, splog output.Output) {
-	splog.Info("Would absorb the following changes:")
-	splog.Newline()
-
-	// Get commit info for display. Resolve owning branches in one batched scan.
-	commitBranches := eng.FindBranchesForCommits(commitSHAKeys(hunksByCommit))
-	for commitSHA, hunks := range hunksByCommit {
-		branchName := commitBranches[commitSHA]
-		if branchName == "" {
-			branchName = unknown
-		}
-
-		// Get commit message - show first commit message from the branch
-		branch := eng.GetBranch(branchName)
-		commits, err := branch.GetAllCommits(engine.CommitFormatReadable)
-		if err == nil && len(commits) > 0 {
-			splog.Info("  %s in %s:", commitSHA[:8], output.Branch(branchName, false))
-			splog.Info("    %s", commits[0])
-		} else {
-			splog.Info("  %s in %s:", commitSHA[:8], output.Branch(branchName, false))
-		}
-
-		for _, hunk := range hunks {
-			splog.Info("    - %s (lines %d-%d)", hunk.File, hunk.NewStart, hunk.NewStart+hunk.NewCount-1)
-		}
-	}
-
-	if len(unabsorbedHunks) > 0 {
-		splog.Newline()
-		splog.Warn("The following hunks would not be absorbed:")
-		for _, hunk := range unabsorbedHunks {
-			splog.Info("  %s (lines %d-%d)", hunk.File, hunk.NewStart, hunk.NewStart+hunk.NewCount-1)
-		}
-	}
-}
-
-// commitSHAKeys returns the commit SHAs keying the hunks-by-commit map, for a
-// single batched branch lookup instead of one resolution per commit.
-func commitSHAKeys(hunksByCommit map[string][]git.Hunk) []string {
-	shas := make([]string, 0, len(hunksByCommit))
-	for sha := range hunksByCommit {
-		shas = append(shas, sha)
-	}
-	return shas
+func printDryRunOutput(hunksByCommit map[string][]git.Hunk, unabsorbedHunks []Unabsorbable, eng engine.Engine, splog output.Output) {
+	printAbsorbPreview("Would absorb:", hunksByCommit, unabsorbedHunks, eng, splog)
 }
 
 // printAbsorbPlan prints the plan for absorbing changes
-func printAbsorbPlan(hunksByCommit map[string][]git.Hunk, unabsorbedHunks []git.Hunk, eng engine.Engine, splog output.Output) {
-	splog.Info("Will absorb the following changes:")
-	splog.Newline()
+func printAbsorbPlan(hunksByCommit map[string][]git.Hunk, unabsorbedHunks []Unabsorbable, eng engine.Engine, splog output.Output) {
+	printAbsorbPreview("Will absorb:", hunksByCommit, unabsorbedHunks, eng, splog)
+}
 
-	commitBranches := eng.FindBranchesForCommits(commitSHAKeys(hunksByCommit))
-	for commitSHA, hunks := range hunksByCommit {
+func printAbsorbPreview(
+	heading string,
+	hunksByCommit map[string][]git.Hunk,
+	unabsorbedHunks []Unabsorbable,
+	eng engine.Engine,
+	splog output.Output,
+) {
+	absorbedCount := 0
+	for _, hunks := range hunksByCommit {
+		absorbedCount += len(hunks)
+	}
+
+	splog.Info(
+		"Absorb plan: %d %s into %d %s, %d skipped",
+		absorbedCount,
+		actions.Pluralize("hunk", absorbedCount),
+		len(hunksByCommit),
+		actions.Pluralize("commit", len(hunksByCommit)),
+		len(unabsorbedHunks),
+	)
+	splog.Newline()
+	splog.Info(heading)
+
+	// Resolve owning branches in one batched scan instead of one lookup per commit.
+	commitSHAs := sortedCommitSHAs(hunksByCommit)
+	commitBranches := eng.FindBranchesForCommits(commitSHAs)
+	for _, commitSHA := range commitSHAs {
+		hunks := sortedHunks(hunksByCommit[commitSHA])
 		branchName := commitBranches[commitSHA]
 		if branchName == "" {
 			branchName = unknown
 		}
 
-		splog.Info("  Commit %s in %s:", commitSHA[:8], output.Branch(branchName, false))
+		splog.Info("  %s  %s", shortSHA(commitSHA), output.Branch(branchName, false))
+		if subject := commitSubject(eng, branchName, commitSHA); subject != "" {
+			splog.Info("    %s", subject)
+		}
 		for _, hunk := range hunks {
-			splog.Info("    - %s (lines %d-%d)", hunk.File, hunk.NewStart, hunk.NewStart+hunk.NewCount-1)
+			start, end := hunkLineRange(hunk)
+			splog.Info("    - %s:%d-%d", hunk.File, start, end)
 		}
 	}
 
 	if len(unabsorbedHunks) > 0 {
 		splog.Newline()
-		splog.Warn("The following hunks will not be absorbed:")
-		for _, hunk := range unabsorbedHunks {
-			splog.Info("  %s (lines %d-%d)", hunk.File, hunk.NewStart, hunk.NewStart+hunk.NewCount-1)
+		splog.Warn("Skipped (%d):", len(unabsorbedHunks))
+
+		grouped := groupUnabsorbedByReason(unabsorbedHunks)
+		for _, group := range grouped {
+			splog.Info("  %s (%d)", group.reason.Description(), len(group.hunks))
+			for _, hunk := range sortedHunks(group.hunks) {
+				start, end := hunkLineRange(hunk)
+				splog.Info("    - %s:%d-%d", hunk.File, start, end)
+			}
+		}
+
+		tips := tipsForReasons(grouped)
+		if len(tips) > 0 {
+			splog.Newline()
+			splog.Info("Tips:")
+			for _, tip := range tips {
+				splog.Info("  - %s", tip)
+			}
 		}
 	}
+}
+
+type unabsorbedGroup struct {
+	reason UnabsorbableReason
+	hunks  []git.Hunk
+}
+
+func groupUnabsorbedByReason(unabsorbed []Unabsorbable) []unabsorbedGroup {
+	byReason := make(map[UnabsorbableReason][]git.Hunk)
+	for _, item := range unabsorbed {
+		byReason[item.Reason] = append(byReason[item.Reason], item.Hunk)
+	}
+
+	reasons := make([]UnabsorbableReason, 0, len(byReason))
+	for reason := range byReason {
+		reasons = append(reasons, reason)
+	}
+	sort.Slice(reasons, func(i, j int) bool {
+		left := reasonSortIndex(reasons[i])
+		right := reasonSortIndex(reasons[j])
+		if left == right {
+			return reasons[i] < reasons[j]
+		}
+		return left < right
+	})
+
+	groups := make([]unabsorbedGroup, 0, len(reasons))
+	for _, reason := range reasons {
+		groups = append(groups, unabsorbedGroup{
+			reason: reason,
+			hunks:  byReason[reason],
+		})
+	}
+	return groups
+}
+
+func tipsForReasons(groups []unabsorbedGroup) []string {
+	tips := make([]string, 0, len(groups))
+	for _, group := range groups {
+		tip := group.reason.Tip()
+		if tip == "" {
+			continue
+		}
+		tips = append(tips, tip)
+	}
+	return tips
+}
+
+func reasonSortIndex(reason UnabsorbableReason) int {
+	switch reason {
+	case ReasonCommutesWithAll:
+		return 0
+	case ReasonNewFile:
+		return 1
+	case ReasonDeletedFile:
+		return 2
+	case ReasonBinary:
+		return 3
+	case ReasonUnknownBranch:
+		return 4
+	case ReasonUnsupported:
+		return 5
+	default:
+		return 1000
+	}
+}
+
+func sortedCommitSHAs(hunksByCommit map[string][]git.Hunk) []string {
+	commitSHAs := make([]string, 0, len(hunksByCommit))
+	for commitSHA := range hunksByCommit {
+		commitSHAs = append(commitSHAs, commitSHA)
+	}
+	sort.Strings(commitSHAs)
+	return commitSHAs
+}
+
+func sortedHunks(hunks []git.Hunk) []git.Hunk {
+	sorted := make([]git.Hunk, len(hunks))
+	copy(sorted, hunks)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].File != sorted[j].File {
+			return sorted[i].File < sorted[j].File
+		}
+		if sorted[i].NewStart != sorted[j].NewStart {
+			return sorted[i].NewStart < sorted[j].NewStart
+		}
+		if sorted[i].OldStart != sorted[j].OldStart {
+			return sorted[i].OldStart < sorted[j].OldStart
+		}
+		return sorted[i].Content < sorted[j].Content
+	})
+	return sorted
+}
+
+func hunkLineRange(hunk git.Hunk) (int, int) {
+	start := hunk.NewStart
+	count := hunk.NewCount
+	if count <= 0 || hunk.IsDeletedFile {
+		start = hunk.OldStart
+		count = hunk.OldCount
+	}
+	if start <= 0 {
+		start = 1
+	}
+	if count <= 0 {
+		count = 1
+	}
+	return start, start + count - 1
+}
+
+func shortSHA(commitSHA string) string {
+	if len(commitSHA) <= 8 {
+		return commitSHA
+	}
+	return commitSHA[:8]
+}
+
+func commitSubject(eng engine.Engine, branchName, commitSHA string) string {
+	if branchName == unknown {
+		return ""
+	}
+	branch := eng.GetBranch(branchName)
+	commits, err := branch.GetAllCommits(engine.CommitFormatReadable)
+	if err != nil {
+		return ""
+	}
+
+	for _, commit := range commits {
+		fields := strings.Fields(commit)
+		if len(fields) == 0 {
+			continue
+		}
+		short := fields[0]
+		if strings.HasPrefix(commitSHA, short) || strings.HasPrefix(short, commitSHA) {
+			return strings.TrimSpace(strings.TrimPrefix(commit, short))
+		}
+	}
+
+	return ""
 }

--- a/internal/actions/absorb/plan.go
+++ b/internal/actions/absorb/plan.go
@@ -47,7 +47,7 @@ type StackNode struct {
 func GeneratePlanJSON(
 	currentBranch string,
 	hunkTargets []git.HunkTarget,
-	unabsorbedHunks []git.Hunk,
+	unabsorbedHunks []Unabsorbable,
 	newFiles []string,
 	eng engine.Engine,
 ) ([]byte, error) {
@@ -76,12 +76,16 @@ func GeneratePlanJSON(
 		})
 	}
 
-	// Convert unabsorbable hunks
-	for _, hunk := range unabsorbedHunks {
+	// Convert unabsorbable hunks. Binary and deleted-file hunks carry no
+	// new-side line numbers, so derive the range the same way terminal output
+	// does instead of reporting a bogus "0".
+	for _, unabsorbable := range unabsorbedHunks {
+		hunk := unabsorbable.Hunk
+		start, end := hunkLineRange(hunk)
 		plan.Unabsorbable = append(plan.Unabsorbable, UnabsorbableHunk{
 			File:    hunk.File,
-			Lines:   formatLines(hunk.NewStart, hunk.NewCount),
-			Reason:  "commutes_with_all",
+			Lines:   formatLines(start, end-start+1),
+			Reason:  string(unabsorbable.Reason),
 			Content: hunk.Content,
 		})
 	}

--- a/internal/actions/absorb/plan_test.go
+++ b/internal/actions/absorb/plan_test.go
@@ -49,12 +49,15 @@ func TestGeneratePlanJSON(t *testing.T) {
 			},
 		}
 
-		unabsorbedHunks := []git.Hunk{
+		unabsorbedHunks := []Unabsorbable{
 			{
-				File:     "utils.go",
-				NewStart: 1,
-				NewCount: 5,
-				Content:  "+func helper() string {\n+  return \"help\"\n+}",
+				Hunk: git.Hunk{
+					File:     "utils.go",
+					NewStart: 1,
+					NewCount: 5,
+					Content:  "+func helper() string {\n+  return \"help\"\n+}",
+				},
+				Reason: ReasonCommutesWithAll,
 			},
 		}
 
@@ -126,7 +129,7 @@ func TestGeneratePlanJSON(t *testing.T) {
 		planJSON, err := GeneratePlanJSON(
 			"branch-a",
 			[]git.HunkTarget{},
-			[]git.Hunk{},
+			[]Unabsorbable{},
 			nil,
 			s.Engine,
 		)

--- a/internal/actions/absorb/restack.go
+++ b/internal/actions/absorb/restack.go
@@ -1,0 +1,78 @@
+package absorb
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/getstackit/stackit/internal/engine"
+)
+
+// RestackMode controls which branches are restacked after absorb.
+type RestackMode string
+
+const (
+	RestackAll     RestackMode = "all"
+	RestackCurrent RestackMode = "current"
+	RestackScope   RestackMode = "scope"
+	RestackNone    RestackMode = "none"
+)
+
+func (m RestackMode) Validate() error {
+	switch m {
+	case RestackAll, RestackCurrent, RestackScope, RestackNone:
+		return nil
+	default:
+		return fmt.Errorf("invalid restack mode %q (valid: all, current, scope, none)", string(m))
+	}
+}
+
+// NormalizeRestackMode canonicalizes user-supplied restack mode input,
+// defaulting to RestackAll when empty and folding case so `--restack ALL`
+// works.
+func NormalizeRestackMode(mode RestackMode) RestackMode {
+	normalized := RestackMode(strings.ToLower(strings.TrimSpace(string(mode))))
+	if normalized == "" {
+		return RestackAll
+	}
+	return normalized
+}
+
+func selectRestackBranches(graph *engine.StackGraph, eng engine.Engine, mode RestackMode, currentBranchName, oldestModifiedBranch string, currentScope engine.Scope) []engine.Branch {
+	if oldestModifiedBranch == "" || mode == RestackNone {
+		return nil
+	}
+
+	switch mode {
+	case RestackAll:
+		return graph.Range(eng.GetBranch(oldestModifiedBranch), engine.StackRange{RecursiveChildren: true})
+	case RestackCurrent:
+		current := eng.GetBranch(currentBranchName)
+		branches := graph.Range(current, engine.StackRange{RecursiveChildren: true, IncludeCurrent: true})
+		if oldestModifiedBranch == currentBranchName {
+			filtered := make([]engine.Branch, 0, len(branches))
+			for _, branch := range branches {
+				if branch.GetName() == currentBranchName {
+					continue
+				}
+				filtered = append(filtered, branch)
+			}
+			return filtered
+		}
+		return branches
+	case RestackScope:
+		if currentScope.IsEmpty() {
+			return selectRestackBranches(graph, eng, RestackCurrent, currentBranchName, oldestModifiedBranch, currentScope)
+		}
+
+		branches := graph.Range(eng.GetBranch(oldestModifiedBranch), engine.StackRange{RecursiveChildren: true})
+		filtered := make([]engine.Branch, 0, len(branches))
+		for _, branch := range branches {
+			if branch.GetScope().Equal(currentScope) {
+				filtered = append(filtered, branch)
+			}
+		}
+		return filtered
+	default:
+		return nil
+	}
+}

--- a/internal/actions/absorb/restack_test.go
+++ b/internal/actions/absorb/restack_test.go
@@ -1,0 +1,125 @@
+package absorb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+func TestSelectRestackBranches(t *testing.T) {
+	// Not parallel: subtests share a single scenario and one mutates scope.
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{
+			"a": "main",
+			"b": "a",
+			"c": "b",
+			"d": "a",
+		})
+
+	graph := engine.BuildStackGraph(s.Engine, engine.SortStrategyAlphabetical, nil)
+
+	t.Run("all mode uses descendants of oldest modified branch", func(t *testing.T) {
+		branches := selectRestackBranches(
+			graph,
+			s.Engine,
+			RestackAll,
+			"b",
+			"a",
+			engine.Scope{},
+		)
+		require.Equal(t, []string{"b", "c", "d"}, branchNames(branches))
+	})
+
+	t.Run("current mode excludes current when oldest modified is current", func(t *testing.T) {
+		branches := selectRestackBranches(
+			graph,
+			s.Engine,
+			RestackCurrent,
+			"b",
+			"b",
+			engine.Scope{},
+		)
+		require.Equal(t, []string{"c"}, branchNames(branches))
+	})
+
+	t.Run("current mode includes current subtree when oldest modified is downstack", func(t *testing.T) {
+		branches := selectRestackBranches(
+			graph,
+			s.Engine,
+			RestackCurrent,
+			"b",
+			"a",
+			engine.Scope{},
+		)
+		require.Equal(t, []string{"b", "c"}, branchNames(branches))
+	})
+
+	t.Run("scope mode filters branches outside current scope", func(t *testing.T) {
+		err := s.Engine.SetScope(context.Background(), s.Engine.GetBranch("a"), engine.NewScope("proj"))
+		require.NoError(t, err)
+		err = s.Engine.SetScope(context.Background(), s.Engine.GetBranch("b"), engine.NewScope("proj"))
+		require.NoError(t, err)
+		err = s.Engine.SetScope(context.Background(), s.Engine.GetBranch("c"), engine.NewScope("proj"))
+		require.NoError(t, err)
+		err = s.Engine.SetScope(context.Background(), s.Engine.GetBranch("d"), engine.NewScope("other"))
+		require.NoError(t, err)
+		s.Rebuild()
+
+		refreshedGraph := engine.BuildStackGraph(s.Engine, engine.SortStrategyAlphabetical, nil)
+		branches := selectRestackBranches(
+			refreshedGraph,
+			s.Engine,
+			RestackScope,
+			"b",
+			"a",
+			engine.NewScope("proj"),
+		)
+		require.Equal(t, []string{"b", "c"}, branchNames(branches))
+	})
+
+	t.Run("scope mode falls back to current mode when current scope is empty", func(t *testing.T) {
+		branches := selectRestackBranches(
+			graph,
+			s.Engine,
+			RestackScope,
+			"b",
+			"a",
+			engine.Scope{},
+		)
+		require.Equal(t, []string{"b", "c"}, branchNames(branches))
+	})
+
+	t.Run("none mode returns no branches", func(t *testing.T) {
+		branches := selectRestackBranches(
+			graph,
+			s.Engine,
+			RestackNone,
+			"b",
+			"a",
+			engine.Scope{},
+		)
+		require.Empty(t, branches)
+	})
+}
+
+func TestRestackModeValidate(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, RestackAll.Validate())
+	require.NoError(t, RestackCurrent.Validate())
+	require.NoError(t, RestackScope.Validate())
+	require.NoError(t, RestackNone.Validate())
+	require.Error(t, RestackMode("bad").Validate())
+}
+
+func branchNames(branches []engine.Branch) []string {
+	names := make([]string, 0, len(branches))
+	for _, branch := range branches {
+		names = append(names, branch.GetName())
+	}
+	return names
+}

--- a/internal/actions/absorb/restore.go
+++ b/internal/actions/absorb/restore.go
@@ -1,0 +1,240 @@
+package absorb
+
+import (
+	"context"
+
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/output"
+)
+
+// restoreParams captures everything restoreStashedState needs to put the
+// working tree and index back after an absorb attempt.
+type restoreParams struct {
+	// stashedStaged is true when a staged absorb stash exists (created on the
+	// primary path, or created despite the error on the fallback path).
+	stashedStaged bool
+	// stashedUnstaged is true when the primary path stashed unstaged/untracked
+	// changes as a separate stash.
+	stashedUnstaged bool
+	// stagedFallback is true when `git stash push --staged` errored and the
+	// fallback (capture unstaged diff + reset --hard) ran instead.
+	stagedFallback bool
+	// absorbSucceeded reports whether the rewrite completed.
+	absorbSucceeded bool
+	// unstagedPatch is the fallback-captured index->worktree diff, reapplied
+	// with `git apply` (never a merging pop, so no conflict markers).
+	unstagedPatch   string
+	unabsorbedHunks []Unabsorbable
+	originalHunks   []git.Hunk
+}
+
+// restoreStashedState restores the working tree and index after an absorb
+// attempt. It is the sole owner of the stash/hunk restore flow so the behavior
+// is testable in isolation from the (long) Action orchestration.
+func restoreStashedState(ctx context.Context, eng engine.Engine, out output.Output, p restoreParams) {
+	resolveStashRef := func(marker string) string {
+		stashList, err := eng.StashList(ctx)
+		if err != nil {
+			return ""
+		}
+		return findStashRef(stashList, marker)
+	}
+
+	// Restore unstaged changes stashed on the primary path first, so any
+	// unabsorbable-hunk restore below layers on top of them.
+	if p.stashedUnstaged {
+		restoreUnstagedStash(ctx, eng, out, resolveStashRef)
+	}
+
+	if p.absorbSucceeded {
+		restoreOK := restoreUnabsorbedHunks(ctx, eng, out, p.unabsorbedHunks, resolveStashRef)
+
+		// Reapply the fallback-captured unstaged diff last: by now the working
+		// tree again holds the absorbed + restored staged content, so the
+		// patch context matches and applies cleanly.
+		if p.unstagedPatch != "" {
+			if err := eng.ApplyPatchToWorktree(ctx, p.unstagedPatch); err != nil {
+				out.Warn("Failed to restore unstaged changes: %v", err)
+				restoreOK = false
+			}
+		}
+
+		if p.stashedStaged {
+			dropStagedStashIfRestored(ctx, eng, out, restoreOK, resolveStashRef)
+		}
+		return
+	}
+
+	// Failure path: put the original staged changes back.
+	switch {
+	case p.stashedStaged:
+		if ref := resolveStashRef(absorbStashStagedMarker); ref != "" {
+			if err := eng.StashPopRef(ctx, ref); err != nil {
+				out.Warn("Failed to restore staged changes from stash: %v", err)
+			}
+		} else {
+			warnStashNotFound(out, absorbStashStagedMarker)
+		}
+	case p.stagedFallback:
+		restoreHunks := filterRestorableHunksFromHunks(p.originalHunks)
+		if len(restoreHunks) > 0 {
+			if err := eng.StageHunks(ctx, restoreHunks); err != nil {
+				out.Warn("Failed to restore staged hunks after absorb failure: %v", err)
+			}
+		}
+	}
+
+	if p.unstagedPatch != "" {
+		if err := eng.ApplyPatchToWorktree(ctx, p.unstagedPatch); err != nil {
+			out.Warn("Failed to restore unstaged changes after absorb failure: %v", err)
+		}
+	}
+}
+
+// restoreUnstagedStash pops the primary-path unstaged stash by marker. When the
+// marker cannot be resolved it warns rather than blindly popping stash@{0},
+// which could be an unrelated user stash.
+func restoreUnstagedStash(ctx context.Context, eng engine.Engine, out output.Output, resolveStashRef func(string) string) {
+	if ref := resolveStashRef(absorbStashUnstagedMarker); ref != "" {
+		if err := eng.StashPopRef(ctx, ref); err != nil {
+			out.Warn("Failed to restore unstaged changes from stash: %v", err)
+		}
+		return
+	}
+	warnStashNotFound(out, absorbStashUnstagedMarker)
+}
+
+// restoreUnabsorbedHunks puts unabsorbable hunks back into the working tree and
+// index after a successful absorb. It returns true only when every hunk was
+// fully restored, so the caller knows whether the staged safety stash can be
+// dropped.
+func restoreUnabsorbedHunks(
+	ctx context.Context,
+	eng engine.Engine,
+	out output.Output,
+	unabsorbed []Unabsorbable,
+	resolveStashRef func(string) string,
+) bool {
+	ok := true
+
+	// Binary files cannot be applied as text patches; restore whole files from
+	// the staged stash (which updates both the working tree and the index).
+	binaryPaths := collectBinaryRestorePaths(unabsorbed)
+	if len(binaryPaths) > 0 {
+		switch ref := resolveStashRef(absorbStashStagedMarker); ref {
+		case "":
+			out.Warn("Failed to restore binary unabsorbable hunks: absorb stash not found.")
+			ok = false
+		default:
+			if err := eng.CheckoutPaths(ctx, ref, binaryPaths); err != nil {
+				out.Warn("Failed to restore binary unabsorbable hunks from stash: %v", err)
+				ok = false
+			}
+		}
+	}
+
+	// Non-binary hunks: stage them into the index (StageHunks also writes new
+	// files to disk), then materialize plain modification hunks in the working
+	// tree so the user's edit survives on disk, not just in the index.
+	restoreHunks := filterRestorableHunks(unabsorbed)
+	if len(restoreHunks) > 0 {
+		if err := eng.StageHunks(ctx, restoreHunks); err != nil {
+			out.Warn("Failed to restore unabsorbable hunks to the index: %v", err)
+			ok = false
+		}
+		if !applyModHunksToWorktree(ctx, eng, out, restoreHunks) {
+			ok = false
+		}
+	}
+
+	return ok
+}
+
+// applyModHunksToWorktree writes plain modification hunks into the working tree,
+// file by file so an unappliable file (e.g. overlapping unstaged edits) does not
+// block the rest. New-file hunks are already on disk via StageHunks, deleted
+// files leave nothing to write, and binary hunks are restored elsewhere.
+func applyModHunksToWorktree(ctx context.Context, eng engine.Engine, out output.Output, hunks []git.Hunk) bool {
+	byFile := make(map[string][]git.Hunk)
+	order := make([]string, 0, len(hunks))
+	for _, h := range hunks {
+		if h.Binary || h.IsNewFile || h.IsDeletedFile {
+			continue
+		}
+		if _, seen := byFile[h.File]; !seen {
+			order = append(order, h.File)
+		}
+		byFile[h.File] = append(byFile[h.File], h)
+	}
+
+	ok := true
+	for _, file := range order {
+		patch := git.BuildPatchFromHunks(byFile[file])
+		if patch == "" {
+			continue
+		}
+		if err := eng.ApplyPatchToWorktree(ctx, patch); err != nil {
+			out.Warn("Restored '%s' to the index but could not update the working copy (it has other edits); recover it from the kept absorb stash if needed.", file)
+			ok = false
+		}
+	}
+	return ok
+}
+
+// dropStagedStashIfRestored drops the staged safety stash only after every
+// unabsorbable-hunk restore has verifiably succeeded. If any restore fell short,
+// the stash is kept as the recovery net and the user is told.
+func dropStagedStashIfRestored(ctx context.Context, eng engine.Engine, out output.Output, restoreOK bool, resolveStashRef func(string) string) {
+	if !restoreOK {
+		out.Warn("Keeping the absorb staged stash for manual recovery because some changes could not be fully restored. Run 'git stash list' to find it.")
+		return
+	}
+
+	ref := resolveStashRef(absorbStashStagedMarker)
+	if ref == "" {
+		return
+	}
+	if err := eng.StashDrop(ctx, ref); err != nil {
+		out.Warn("Failed to drop staged absorb stash: %v", err)
+	}
+}
+
+func warnStashNotFound(out output.Output, marker string) {
+	out.Warn("Could not find the absorb stash (%s); leaving existing stashes untouched. Run 'git stash list' to recover manually.", marker)
+}
+
+func filterRestorableHunks(unabsorbed []Unabsorbable) []git.Hunk {
+	hunks := make([]git.Hunk, 0, len(unabsorbed))
+	for _, entry := range unabsorbed {
+		hunks = append(hunks, entry.Hunk)
+	}
+	return filterRestorableHunksFromHunks(hunks)
+}
+
+func filterRestorableHunksFromHunks(hunks []git.Hunk) []git.Hunk {
+	restorable := make([]git.Hunk, 0, len(hunks))
+	for _, hunk := range hunks {
+		if hunk.Binary {
+			continue
+		}
+		restorable = append(restorable, hunk)
+	}
+	return restorable
+}
+
+func collectBinaryRestorePaths(unabsorbed []Unabsorbable) []string {
+	seen := make(map[string]struct{})
+	paths := make([]string, 0, len(unabsorbed))
+	for _, entry := range unabsorbed {
+		if !entry.Hunk.Binary || entry.Hunk.IsDeletedFile {
+			continue
+		}
+		if _, ok := seen[entry.Hunk.File]; ok {
+			continue
+		}
+		seen[entry.Hunk.File] = struct{}{}
+		paths = append(paths, entry.Hunk.File)
+	}
+	return paths
+}

--- a/internal/actions/absorb/stash.go
+++ b/internal/actions/absorb/stash.go
@@ -1,0 +1,43 @@
+package absorb
+
+import "strings"
+
+func findStashRef(stashList, marker string) string {
+	for _, entry := range parseStashList(stashList) {
+		if strings.Contains(entry.Message, marker) {
+			return entry.Ref
+		}
+	}
+	return ""
+}
+
+func findStashRefByMarkers(stashList string, markers ...string) string {
+	for _, entry := range parseStashList(stashList) {
+		for _, marker := range markers {
+			if strings.Contains(entry.Message, marker) {
+				return entry.Ref
+			}
+		}
+	}
+	return ""
+}
+
+type stashEntry struct {
+	Ref     string
+	Message string
+}
+
+func parseStashList(stashList string) []stashEntry {
+	entries := []stashEntry{}
+	for _, line := range strings.Split(stashList, "\n") {
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		entries = append(entries, stashEntry{
+			Ref:     strings.TrimSpace(parts[0]),
+			Message: strings.TrimSpace(parts[1]),
+		})
+	}
+	return entries
+}

--- a/internal/actions/absorb/unabsorbable.go
+++ b/internal/actions/absorb/unabsorbable.go
@@ -1,0 +1,59 @@
+package absorb
+
+import "github.com/getstackit/stackit/internal/git"
+
+// UnabsorbableReason describes why a hunk could not be absorbed.
+type UnabsorbableReason string
+
+const (
+	ReasonCommutesWithAll UnabsorbableReason = "commutes_with_all"
+	ReasonUnknownBranch   UnabsorbableReason = "unknown_branch"
+	ReasonBinary          UnabsorbableReason = "binary"
+	ReasonNewFile         UnabsorbableReason = "new_file"
+	ReasonDeletedFile     UnabsorbableReason = "deleted_file"
+	ReasonUnsupported     UnabsorbableReason = "unsupported"
+)
+
+// Unabsorbable represents a hunk that could not be absorbed and why.
+type Unabsorbable struct {
+	Hunk   git.Hunk
+	Reason UnabsorbableReason
+}
+
+// Description returns a user-friendly explanation for why a hunk could not be absorbed.
+func (r UnabsorbableReason) Description() string {
+	switch r {
+	case ReasonCommutesWithAll:
+		return "No unique target commit found"
+	case ReasonUnknownBranch:
+		return "Target commit is not in a tracked branch"
+	case ReasonBinary:
+		return "Binary files cannot be absorbed"
+	case ReasonNewFile:
+		return "New files cannot be absorbed"
+	case ReasonDeletedFile:
+		return "Deleted files cannot be absorbed"
+	case ReasonUnsupported:
+		return "Unsupported change type"
+	default:
+		return string(r)
+	}
+}
+
+// Tip returns a short actionable hint for this unabsorbable reason.
+func (r UnabsorbableReason) Tip() string {
+	switch r {
+	case ReasonCommutesWithAll:
+		return "Use --patch to stage smaller hunks with clearer ownership, then rerun absorb."
+	case ReasonNewFile:
+		return "Commit new files with create/modify, then rerun absorb."
+	case ReasonDeletedFile:
+		return "Commit file deletions with modify, then rerun absorb."
+	case ReasonBinary:
+		return "Commit binary changes with modify, then rerun absorb."
+	case ReasonUnknownBranch:
+		return "Run stackit restack (or sync) to refresh branch metadata, then rerun absorb."
+	default:
+		return ""
+	}
+}

--- a/internal/actions/validation/chains.go
+++ b/internal/actions/validation/chains.go
@@ -41,6 +41,7 @@ func AbsorbChain(ctx context.Context, eng GitOperationEngine, operation string) 
 	return Chain{
 		MustBeOnBranch(eng),
 		CurrentBranchMustNotBeTrunk(eng, operation),
+		CurrentBranchMustBeTracked(eng),
 		CurrentBranchMustBeModifiable(eng),
 		MustNotHaveRebaseInProgress(ctx, eng),
 	}

--- a/internal/cli/branch/absorb.go
+++ b/internal/cli/branch/absorb.go
@@ -18,6 +18,7 @@ func NewAbsorbCmd() *cobra.Command {
 		patch        bool
 		showConflict bool
 		jsonOutput   bool
+		restackMode  string
 	)
 
 	cmd := &cobra.Command{
@@ -50,22 +51,24 @@ Use --show-conflict to see the current conflict state and what changes were bein
 
 				// Run absorb action
 				return absorb.Action(ctx, absorb.Options{
-					All:    all,
-					DryRun: dryRun,
-					Force:  force,
-					Patch:  patch,
-					JSON:   jsonOutput,
+					All:     all,
+					DryRun:  dryRun,
+					Force:   force,
+					Patch:   patch,
+					JSON:    jsonOutput,
+					Restack: absorb.RestackMode(restackMode),
 				}, handler)
 			})
 		},
 	}
 
-	cmd.Flags().BoolVarP(&all, "all", "a", false, "Stage all unstaged changes before absorbing. Unlike create and modify, this will not include untracked files, as file creations would never be absorbed.")
+	cmd.Flags().BoolVarP(&all, "all", "a", false, "Stage all unstaged tracked changes before absorbing. Unlike create and modify, this will not include untracked files, as file creations would never be absorbed.")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "Print which commits the hunks would be absorbed into, but do not actually absorb them.")
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Do not prompt for confirmation; apply the hunks to the commits immediately.")
 	cmd.Flags().BoolVarP(&patch, "patch", "p", false, "Pick hunks to stage before absorbing.")
 	cmd.Flags().BoolVar(&showConflict, "show-conflict", false, "Show the current absorb conflict state")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output machine-readable JSON summary (works with --dry-run for preview)")
+	cmd.Flags().StringVar(&restackMode, "restack", string(absorb.RestackAll), "Restack scope after absorb: all, current, scope, none")
 
 	return cmd
 }

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -256,7 +256,15 @@ func (d *demoGitRunner) StashPushStaged(_ context.Context, _ string) (string, er
 	return "stashed staged", nil
 }
 
+func (d *demoGitRunner) StashDrop(_ context.Context, _ string) error {
+	return nil
+}
+
 func (d *demoGitRunner) StashPop(_ context.Context) error {
+	return nil
+}
+
+func (d *demoGitRunner) StashPopRef(_ context.Context, _ string) error {
 	return nil
 }
 
@@ -429,6 +437,10 @@ func (d *demoGitRunner) GetUnstagedDiff(_ context.Context, _ ...string) (string,
 	return "", nil
 }
 
+func (d *demoGitRunner) GetUnstagedDiffBinary(_ context.Context, _ ...string) (string, error) {
+	return "", nil
+}
+
 func (d *demoGitRunner) GetDiffBetween(_ context.Context, _, _ string, _ ...string) (string, error) {
 	return "", nil
 }
@@ -518,6 +530,10 @@ func (d *demoGitRunner) CherryPickAbort(_ context.Context) error {
 }
 
 func (d *demoGitRunner) ApplyPatch(_ context.Context, _ string, _ bool) error {
+	return nil
+}
+
+func (d *demoGitRunner) ApplyPatchToWorktree(_ context.Context, _ string) error {
 	return nil
 }
 

--- a/internal/engine/commit_ops.go
+++ b/internal/engine/commit_ops.go
@@ -35,6 +35,11 @@ func (e *engineImpl) StageHunks(ctx context.Context, hunks []git.Hunk) error {
 	return e.git.StageHunks(ctx, hunks)
 }
 
+// ApplyPatchToWorktree applies a patch to the working tree only (not the index).
+func (e *engineImpl) ApplyPatchToWorktree(ctx context.Context, patch string) error {
+	return e.git.ApplyPatchToWorktree(ctx, patch)
+}
+
 // StageChanges stages changes according to the given staging options.
 func (e *engineImpl) StageChanges(ctx context.Context, opts git.StagingOptions) error {
 	return e.git.StageChanges(ctx, opts)
@@ -50,7 +55,17 @@ func (e *engineImpl) StashPushStaged(ctx context.Context, message string) (strin
 	return e.git.StashPushStaged(ctx, message)
 }
 
+// StashDrop drops a stash entry by ref.
+func (e *engineImpl) StashDrop(ctx context.Context, ref string) error {
+	return e.git.StashDrop(ctx, ref)
+}
+
 // StashPop pops the most recent stash
 func (e *engineImpl) StashPop(ctx context.Context) error {
 	return e.git.StashPop(ctx)
+}
+
+// StashPopRef pops a specific stash entry by ref.
+func (e *engineImpl) StashPopRef(ctx context.Context, ref string) error {
+	return e.git.StashPopRef(ctx, ref)
 }

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -57,6 +57,12 @@ func (e *engineImpl) GetUnstagedDiff(ctx context.Context, files ...string) (stri
 	return e.git.GetUnstagedDiff(ctx, files...)
 }
 
+// GetUnstagedDiffBinary returns the unstaged diff with full binary content
+// (`git diff --binary`), suitable for reapplying via `git apply`.
+func (e *engineImpl) GetUnstagedDiffBinary(ctx context.Context, files ...string) (string, error) {
+	return e.git.GetUnstagedDiffBinary(ctx, files...)
+}
+
 // HasStagedChanges checks if there are staged changes in the repository
 func (e *engineImpl) HasStagedChanges(ctx context.Context) (bool, error) {
 	return e.git.HasStagedChanges(ctx)

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -139,6 +139,10 @@ type WorkingTree interface {
 	// Prefer this over calling Has* individually when multiple flags are needed.
 	GetWorkingTreeStatus(ctx context.Context) (staged, unstaged, untracked bool, err error)
 	GetUnstagedDiff(ctx context.Context, files ...string) (string, error)
+	// GetUnstagedDiffBinary is like GetUnstagedDiff but includes full binary
+	// content (`git diff --binary`) so the result can be reapplied with
+	// `git apply`.
+	GetUnstagedDiffBinary(ctx context.Context, files ...string) (string, error)
 	GetUntrackedFileHunks(ctx context.Context) ([]git.Hunk, error)
 	GetPendingChanges(ctx context.Context) ([]PendingChange, error)
 	GetCommitTemplate(ctx context.Context) (string, error)
@@ -259,10 +263,15 @@ type CommitOperations interface {
 	StageAll(ctx context.Context) error
 	StagePatch(ctx context.Context) error
 	StageHunks(ctx context.Context, hunks []git.Hunk) error
+	// ApplyPatchToWorktree applies a patch to the working tree only (not the
+	// index). It applies atomically or fails without writing conflict markers.
+	ApplyPatchToWorktree(ctx context.Context, patch string) error
 	StageChanges(ctx context.Context, opts git.StagingOptions) error
 	StashPush(ctx context.Context, message string) (string, error)
 	StashPushStaged(ctx context.Context, message string) (string, error)
+	StashDrop(ctx context.Context, ref string) error
 	StashPop(ctx context.Context) error
+	StashPopRef(ctx context.Context, ref string) error
 }
 
 // WorktreeOperations handles worktree management

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -128,6 +128,22 @@ func (r *runner) GetUnstagedDiff(ctx context.Context, files ...string) (string, 
 	return r.RunGitCommandRawWithContext(ctx, args...)
 }
 
+// GetUnstagedDiffBinary returns the unstaged (index->worktree) diff with full
+// binary content (`git diff --binary`). Plain `git diff` emits only a
+// "Binary files ... differ" placeholder for binary files, which `git apply`
+// refuses ("cannot apply binary patch ... without full index line"). The
+// `--binary` form embeds a `GIT binary patch` that round-trips through
+// `git apply`, so callers that reapply the captured diff to the working tree
+// (e.g. absorb's stash fallback) must use this instead of GetUnstagedDiff.
+func (r *runner) GetUnstagedDiffBinary(ctx context.Context, files ...string) (string, error) {
+	args := []string{gitCmdDiff, "--binary"}
+	if len(files) > 0 {
+		args = append(args, "--")
+		args = append(args, files...)
+	}
+	return r.RunGitCommandRawWithContext(ctx, args...)
+}
+
 // GetDiffBetween returns the raw diff between two refs.
 // Unlike ShowDiff, this returns uncolored output suitable for parsing.
 func (r *runner) GetDiffBetween(ctx context.Context, base, head string, files ...string) (string, error) {

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -105,6 +105,10 @@ type DiffOperations interface {
 	GetDiffNumstat(base, head string) (string, error)
 	GetStagedDiff(ctx context.Context, files ...string) (string, error)
 	GetUnstagedDiff(ctx context.Context, files ...string) (string, error)
+	// GetUnstagedDiffBinary is like GetUnstagedDiff but includes full binary
+	// content (`git diff --binary`) so the result can be reapplied with
+	// `git apply`.
+	GetUnstagedDiffBinary(ctx context.Context, files ...string) (string, error)
 	// GetDiffBetween returns the raw diff between two refs, without color codes.
 	// This is suitable for parsing into hunks.
 	GetDiffBetween(ctx context.Context, base, head string, files ...string) (string, error)
@@ -165,7 +169,9 @@ type CherryPickOperations interface {
 type StashOperations interface {
 	StashPush(ctx context.Context, message string) (string, error)
 	StashPushStaged(ctx context.Context, message string) (string, error)
+	StashDrop(ctx context.Context, ref string) error
 	StashPop(ctx context.Context) error
+	StashPopRef(ctx context.Context, ref string) error
 	ListStash(ctx context.Context) (string, error)
 }
 
@@ -186,6 +192,10 @@ type PathOperations interface {
 // PatchOperations handles patch operations.
 type PatchOperations interface {
 	ApplyPatch(ctx context.Context, patchFile string, threeWay bool) error
+	// ApplyPatchToWorktree applies a patch (read from stdin) to the working
+	// tree only, never the index. It applies atomically or fails leaving the
+	// working tree untouched, so it can never write conflict markers.
+	ApplyPatchToWorktree(ctx context.Context, patch string) error
 	CheckCommutation(hunk Hunk, commitSHA, parentSHA string) (bool, error)
 }
 

--- a/internal/git/staging.go
+++ b/internal/git/staging.go
@@ -299,6 +299,21 @@ func extractContentFromHunk(h Hunk) string {
 	return result
 }
 
+// ApplyPatchToWorktree applies a patch to the working tree only (not the
+// index) by piping it to `git apply` via stdin. Unlike a stash pop, git apply
+// never performs a three-way merge here, so it can never leave conflict
+// markers: it applies the patch atomically or fails leaving the working tree
+// untouched. An empty patch is a no-op.
+func (r *runner) ApplyPatchToWorktree(ctx context.Context, patch string) error {
+	if strings.TrimSpace(patch) == "" {
+		return nil
+	}
+	if _, err := r.runGitInternal(ctx, patch, nil, true, "apply"); err != nil {
+		return fmt.Errorf("failed to apply patch to worktree: %w", err)
+	}
+	return nil
+}
+
 // UnstageAll removes all changes from the staging area.
 func (r *runner) UnstageAll(ctx context.Context) error {
 	if _, err := r.RunGitCommandWithContext(ctx, "reset"); err != nil {

--- a/internal/git/stash.go
+++ b/internal/git/stash.go
@@ -89,9 +89,37 @@ func (r *runner) parseGitVersion(ctx context.Context) {
 	r.gitVersionParsed = true
 }
 
+// StashDrop drops the stash entry at ref. It refuses an empty ref: bare
+// `git stash drop` would silently target stash@{0}, which may be an
+// unrelated user stash.
+func (r *runner) StashDrop(ctx context.Context, ref string) error {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return fmt.Errorf("stash drop requires an explicit stash ref")
+	}
+	if _, err := r.RunGitCommandWithContext(ctx, "stash", "drop", ref); err != nil {
+		return fmt.Errorf("stash drop failed: %w", err)
+	}
+	return nil
+}
+
 func (r *runner) StashPop(ctx context.Context) error {
 	_, err := r.RunGitCommandWithContext(ctx, "stash", "pop")
 	if err != nil {
+		return fmt.Errorf("stash pop failed: %w", err)
+	}
+	return nil
+}
+
+// StashPopRef pops the stash entry at ref. It refuses an empty ref: bare
+// `git stash pop` would silently target stash@{0}, which may be an
+// unrelated user stash.
+func (r *runner) StashPopRef(ctx context.Context, ref string) error {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return fmt.Errorf("stash pop requires an explicit stash ref")
+	}
+	if _, err := r.RunGitCommandWithContext(ctx, "stash", "pop", ref); err != nil {
 		return fmt.Errorf("stash pop failed: %w", err)
 	}
 	return nil

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -557,6 +557,13 @@ func (t *tracingRunner) GetUnstagedDiff(ctx context.Context, files ...string) (s
 	return result, err
 }
 
+func (t *tracingRunner) GetUnstagedDiffBinary(ctx context.Context, files ...string) (string, error) {
+	start := time.Now()
+	result, err := t.inner.GetUnstagedDiffBinary(ctx, files...)
+	t.trace("GetUnstagedDiffBinary", time.Since(start), err == nil, err)
+	return result, err
+}
+
 func (t *tracingRunner) GetDiffBetween(ctx context.Context, base, head string, files ...string) (string, error) {
 	start := time.Now()
 	result, err := t.inner.GetDiffBetween(ctx, base, head, files...)
@@ -803,10 +810,24 @@ func (t *tracingRunner) StashPushStaged(ctx context.Context, message string) (st
 	return result, err
 }
 
+func (t *tracingRunner) StashDrop(ctx context.Context, ref string) error {
+	start := time.Now()
+	err := t.inner.StashDrop(ctx, ref)
+	t.trace("StashDrop", time.Since(start), err == nil, err)
+	return err
+}
+
 func (t *tracingRunner) StashPop(ctx context.Context) error {
 	start := time.Now()
 	err := t.inner.StashPop(ctx)
 	t.trace("StashPop", time.Since(start), err == nil, err)
+	return err
+}
+
+func (t *tracingRunner) StashPopRef(ctx context.Context, ref string) error {
+	start := time.Now()
+	err := t.inner.StashPopRef(ctx, ref)
+	t.trace("StashPopRef", time.Since(start), err == nil, err)
 	return err
 }
 
@@ -869,6 +890,13 @@ func (t *tracingRunner) ApplyPatch(ctx context.Context, patchFile string, threeW
 	start := time.Now()
 	err := t.inner.ApplyPatch(ctx, patchFile, threeWay)
 	t.trace("ApplyPatch", time.Since(start), err == nil, err)
+	return err
+}
+
+func (t *tracingRunner) ApplyPatchToWorktree(ctx context.Context, patch string) error {
+	start := time.Now()
+	err := t.inner.ApplyPatchToWorktree(ctx, patch)
+	t.trace("ApplyPatchToWorktree", time.Since(start), err == nil, err)
 	return err
 }
 


### PR DESCRIPTION
Enhances `stackit absorb` with a safer stash/restore model, clearer reporting of unabsorbable hunks, and control over post-absorb restacking.

## What changed

### Stash and restore safety model
- Staged and unstaged changes are stashed separately (`stackit-absorb-temp-staged` / `-unstaged` markers) so absorbed hunks are never reintroduced when state is restored.
- When `git stash push --staged` fails (e.g. a file with both staged and unstaged edits — `MM` status), absorb falls back to capturing the unstaged `index → worktree` delta with `git diff --binary` before `reset --hard`, then reapplies it with `git apply` after the rewrite. Unlike a stash pop, this never three-way merges against the absorbed content, so it cannot write conflict markers — and the `--binary` capture round-trips unstaged edits to tracked binary files byte-for-byte.
- Unabsorbable hunks are restored to both the index and the working tree (previously index-only, which silently reverted the on-disk file). Binary unabsorbable files are restored by whole-file checkout from the staged stash.
- The staged safety stash is dropped only after every restore verifiably succeeds; on any shortfall it is kept and the user is told how to recover.
- Stash refs are always resolved by marker; absorb warns instead of blindly popping `stash@{0}`, and the low-level `StashDrop`/`StashPopRef` primitives now refuse an empty ref outright.
- `stackit abort` pops all absorb stashes (both markers) while leaving unrelated user stashes untouched.

### Unabsorbable hunk reporting
- Hunks that cannot be absorbed now carry typed reasons (`commutes_with_all`, `new_file`, `deleted_file`, `binary`, `unknown_branch`) surfaced in the plan output, grouped with actionable tips, and in `--json` (with correct line ranges for binary/deleted-file hunks).

### `--restack` flag
- New `--restack` flag (case-insensitive): `all` (default), `current`, `scope`, or `none`. When a narrower mode leaves descendants of the rewritten commits un-restacked, absorb warns with the count and points at `stackit restack --upstack`.

### Bug fixes
- **Target selection order**: the downstack commit search previously reversed `GetAllCommits` into oldest→newest based on a wrong assumption, so when multiple stacked commits touched the same lines, hunks were absorbed into the *oldest* matching commit instead of the newest. The search now runs newest→oldest as intended.
- **`--all` semantics**: now stages tracked changes only (`git add -u`) — untracked files can never be absorbed, so `git add -A` behavior only created noise.
- Hunks whose target commit resolved to no tracked branch were previously dropped silently (neither applied nor reported); they are now reported as `unknown_branch` and restored.
- Absorb now requires the current branch to be tracked (clean early error instead of failing mid-operation).

### Docs and tests
- New `docs/absorb.md` covering target selection, the stash/restore safety model, restack modes, and recovery, indexed from `AGENTS.md`.
- New coverage: binary unabsorbable restoration, the `MM` fallback path (asserting no conflict markers, no stranded stashes), unstaged-binary-edit preservation through the fallback, worktree survival of `commutes_with_all` hunks, guarded stash drop, restack mode selection for all four modes, and the skipped-restack warning end-to-end.

https://claude.ai/code/session_01GtDrSQBgW35SrjNFtUuLpF
