### PR TITLE
perf: add batch metadata operations and config snapshot caching

### DIFF
--- a/internal/actions/checkout.go
+++ b/internal/actions/checkout.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/sahilm/fuzzy"
 
@@ -48,6 +49,11 @@ func (h *NullCheckoutHandler) SelectBranch(_ *app.Context, _ CheckoutOptions) (s
 
 // CheckoutAction performs the checkout operation.
 func CheckoutAction(ctx *app.Context, opts CheckoutOptions, handler CheckoutHandler) (CheckoutResult, error) {
+	start := time.Now()
+	defer func() {
+		ctx.Logger.Debug("checkout action completed in %v", time.Since(start))
+	}()
+
 	eng := ctx.Engine
 	out := ctx.Output
 	context := ctx.Context

--- a/internal/actions/checkout.go
+++ b/internal/actions/checkout.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/sahilm/fuzzy"
 
@@ -49,11 +48,6 @@ func (h *NullCheckoutHandler) SelectBranch(_ *app.Context, _ CheckoutOptions) (s
 
 // CheckoutAction performs the checkout operation.
 func CheckoutAction(ctx *app.Context, opts CheckoutOptions, handler CheckoutHandler) (CheckoutResult, error) {
-	start := time.Now()
-	defer func() {
-		ctx.Logger.Debug("checkout action completed in %v", time.Since(start))
-	}()
-
 	eng := ctx.Engine
 	out := ctx.Output
 	context := ctx.Context

--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -362,16 +362,7 @@ func newContextAutoWithWriterAndConfig(
 		cfg = loadedCfg
 	}
 
-	var trunk string
-	var maxUndoDepth int
-	var maxConcurrency int
-	if gitCfg, ok := cfg.(*config.GitConfig); ok {
-		trunk, maxUndoDepth, maxConcurrency, _ = gitCfg.BootstrapValues()
-	} else {
-		trunk = cfg.Trunk()
-		maxUndoDepth = cfg.UndoStackDepth()
-		maxConcurrency = cfg.MaxConcurrency()
-	}
+	bc := cfg.BootstrapValues()
 
 	// Create file logger first so git commands during engine init are logged
 	var logger output.Logger
@@ -401,9 +392,9 @@ func newContextAutoWithWriterAndConfig(
 	// fields this cuts metadata I/O roughly in half on big repos.
 	eng, err := engine.NewEngine(engine.Options{
 		RepoRoot:          repoRoot,
-		Trunk:             trunk,
-		MaxUndoStackDepth: maxUndoDepth,
-		MaxConcurrency:    maxConcurrency,
+		Trunk:             bc.Trunk,
+		MaxUndoStackDepth: bc.UndoDepth,
+		MaxConcurrency:    bc.MaxConcurrency,
 		Git:               gitRunner,
 		LoadMode:          loadMode,
 	})
@@ -453,8 +444,7 @@ func GetContextWithWriter(ctx context.Context, opts GlobalOptions, writer io.Wri
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
-	_, _, _, initialized := cfg.BootstrapValues()
-	if !initialized {
+	if !cfg.BootstrapValues().Initialized {
 		return nil, fmt.Errorf("stackit not initialized. Run 'stackit init' first")
 	}
 

--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -330,6 +330,18 @@ func NewContextAuto(ctx context.Context, repoRoot string, opts GlobalOptions) (*
 
 // NewContextAutoWithWriter is like NewContextAuto but allows specifying the output writer.
 func NewContextAutoWithWriter(ctx context.Context, repoRoot string, opts GlobalOptions, writer io.Writer) (*Context, error) {
+	return newContextAutoWithWriterAndConfig(ctx, repoRoot, opts, writer, nil)
+}
+
+// newContextAutoWithWriterAndConfig is like NewContextAutoWithWriter but can reuse
+// an already-loaded config to avoid duplicate git config reads on startup.
+func newContextAutoWithWriterAndConfig(
+	ctx context.Context,
+	repoRoot string,
+	opts GlobalOptions,
+	writer io.Writer,
+	preloadedCfg config.Configurer,
+) (*Context, error) {
 	if utils.IsDemoMode() && DemoEngineFactory != nil {
 		eng := DemoEngineFactory()
 		runtimeCtx := NewContext(eng, WithRepoRoot(repoRoot), WithGlobalOptions(opts), WithWriter(writer))
@@ -340,14 +352,26 @@ func NewContextAutoWithWriter(ctx context.Context, repoRoot string, opts GlobalO
 		return runtimeCtx, nil
 	}
 
-	// Read config and create engine options
-	cfg, err := config.LoadConfig(repoRoot)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load config: %w", err)
+	// Read config (or reuse preloaded) and create engine options.
+	cfg := preloadedCfg
+	if cfg == nil {
+		loadedCfg, err := config.LoadConfig(repoRoot)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load config: %w", err)
+		}
+		cfg = loadedCfg
 	}
-	trunk := cfg.Trunk()
-	maxUndoDepth := cfg.UndoStackDepth()
-	maxConcurrency := cfg.MaxConcurrency()
+
+	var trunk string
+	var maxUndoDepth int
+	var maxConcurrency int
+	if gitCfg, ok := cfg.(*config.GitConfig); ok {
+		trunk, maxUndoDepth, maxConcurrency, _ = gitCfg.BootstrapValues()
+	} else {
+		trunk = cfg.Trunk()
+		maxUndoDepth = cfg.UndoStackDepth()
+		maxConcurrency = cfg.MaxConcurrency()
+	}
 
 	// Create file logger first so git commands during engine init are logged
 	var logger output.Logger
@@ -372,7 +396,7 @@ func NewContextAutoWithWriter(ctx context.Context, repoRoot string, opts GlobalO
 	}
 
 	// Create real engine with configured runner. LoadModeShared skips
-	// BatchReadLocalMetadata at bootstrap — local metadata (Frozen, etc.)
+	// BatchReadLocalMetadataForBranches at bootstrap — local metadata (Frozen, etc.)
 	// loads on first accessor call. For commands that never read local-only
 	// fields this cuts metadata I/O roughly in half on big repos.
 	eng, err := engine.NewEngine(engine.Options{
@@ -429,9 +453,10 @@ func GetContextWithWriter(ctx context.Context, opts GlobalOptions, writer io.Wri
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
-	if !cfg.IsInitialized() {
+	_, _, _, initialized := cfg.BootstrapValues()
+	if !initialized {
 		return nil, fmt.Errorf("stackit not initialized. Run 'stackit init' first")
 	}
 
-	return NewContextAutoWithWriter(ctx, repoRoot, opts, writer)
+	return newContextAutoWithWriterAndConfig(ctx, repoRoot, opts, writer, cfg)
 }

--- a/internal/config/config_git.go
+++ b/internal/config/config_git.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -17,6 +18,10 @@ type GitConfig struct {
 	repoRoot string
 	store    *git.ConfigStore
 	project  *ProjectConfig // Team config from .stackit.yaml for fallback
+
+	// stackitSnapshot caches all "stackit.*" keys loaded in one git subprocess.
+	// Used by startup/bootstrap code to avoid repeated git config calls.
+	stackitSnapshot map[string][]string
 }
 
 // LoadGitConfig loads configuration from git config.
@@ -28,6 +33,10 @@ func LoadGitConfig(repoRoot string) (*GitConfig, error) {
 	cfg := &GitConfig{
 		repoRoot: repoRoot,
 		store:    store,
+	}
+
+	if snapshot, err := store.GetAllStackitConfig(); err == nil {
+		cfg.stackitSnapshot = snapshot
 	}
 
 	// Check if we need to migrate from JSON
@@ -68,6 +77,41 @@ func (c *GitConfig) IsInitialized() bool {
 // Callers must not mutate the returned value.
 func (c *GitConfig) ProjectConfig() *ProjectConfig {
 	return c.project
+}
+
+// BootstrapValues returns startup-critical values, preferring the in-memory snapshot
+// loaded at config creation time to avoid repeated git config subprocesses.
+func (c *GitConfig) BootstrapValues() (trunk string, undoDepth int, maxConcurrency int, initialized bool) {
+	// initialized/trunk
+	if vals, ok := c.stackitSnapshot[KeyTrunk]; ok && len(vals) > 0 && vals[0] != "" {
+		trunk = vals[0]
+		initialized = true
+	} else {
+		trunk = c.Trunk()
+		initialized = c.IsInitialized()
+	}
+
+	// undo depth
+	undoDepth = DefaultUndoDepth
+	if vals, ok := c.stackitSnapshot[KeyUndoDepth]; ok && len(vals) > 0 {
+		if n, err := strconv.Atoi(vals[0]); err == nil && n >= 1 {
+			undoDepth = n
+		}
+	} else if c.project != nil && c.project.HasUndoDepth() && c.project.Undo.Depth >= 1 {
+		undoDepth = c.project.Undo.Depth
+	}
+
+	// max concurrency
+	maxConcurrency = DefaultMaxConcurrency
+	if vals, ok := c.stackitSnapshot[KeyMaxConcurrency]; ok && len(vals) > 0 {
+		if n, err := strconv.Atoi(vals[0]); err == nil && n >= 0 {
+			maxConcurrency = n
+		}
+	} else if c.project != nil && c.project.HasMaxConcurrency() {
+		maxConcurrency = c.project.GetMaxConcurrency()
+	}
+
+	return trunk, undoDepth, maxConcurrency, initialized
 }
 
 // Trunk returns the primary trunk branch name.

--- a/internal/config/config_git.go
+++ b/internal/config/config_git.go
@@ -79,39 +79,55 @@ func (c *GitConfig) ProjectConfig() *ProjectConfig {
 	return c.project
 }
 
+// BootstrapConfig holds startup-critical configuration values loaded in a single
+// pass from the config snapshot.
+type BootstrapConfig struct {
+	Trunk          string
+	UndoDepth      int
+	MaxConcurrency int
+	Initialized    bool
+}
+
 // BootstrapValues returns startup-critical values, preferring the in-memory snapshot
 // loaded at config creation time to avoid repeated git config subprocesses.
-func (c *GitConfig) BootstrapValues() (trunk string, undoDepth int, maxConcurrency int, initialized bool) {
+// The snapshot is consumed and cleared after this call — it is only valid once.
+func (c *GitConfig) BootstrapValues() BootstrapConfig {
+	snapshot := c.stackitSnapshot
+	c.stackitSnapshot = nil // consume once — prevent stale reads after mutations
+
+	bc := BootstrapConfig{
+		UndoDepth:      DefaultUndoDepth,
+		MaxConcurrency: DefaultMaxConcurrency,
+	}
+
 	// initialized/trunk
-	if vals, ok := c.stackitSnapshot[KeyTrunk]; ok && len(vals) > 0 && vals[0] != "" {
-		trunk = vals[0]
-		initialized = true
+	if vals, ok := snapshot[KeyTrunk]; ok && len(vals) > 0 && vals[0] != "" {
+		bc.Trunk = vals[0]
+		bc.Initialized = true
 	} else {
-		trunk = c.Trunk()
-		initialized = c.IsInitialized()
+		bc.Trunk = c.Trunk()
+		bc.Initialized = c.IsInitialized()
 	}
 
 	// undo depth
-	undoDepth = DefaultUndoDepth
-	if vals, ok := c.stackitSnapshot[KeyUndoDepth]; ok && len(vals) > 0 {
+	if vals, ok := snapshot[KeyUndoDepth]; ok && len(vals) > 0 {
 		if n, err := strconv.Atoi(vals[0]); err == nil && n >= 1 {
-			undoDepth = n
+			bc.UndoDepth = n
 		}
 	} else if c.project != nil && c.project.HasUndoDepth() && c.project.Undo.Depth >= 1 {
-		undoDepth = c.project.Undo.Depth
+		bc.UndoDepth = c.project.Undo.Depth
 	}
 
 	// max concurrency
-	maxConcurrency = DefaultMaxConcurrency
-	if vals, ok := c.stackitSnapshot[KeyMaxConcurrency]; ok && len(vals) > 0 {
+	if vals, ok := snapshot[KeyMaxConcurrency]; ok && len(vals) > 0 {
 		if n, err := strconv.Atoi(vals[0]); err == nil && n >= 0 {
-			maxConcurrency = n
+			bc.MaxConcurrency = n
 		}
 	} else if c.project != nil && c.project.HasMaxConcurrency() {
-		maxConcurrency = c.project.GetMaxConcurrency()
+		bc.MaxConcurrency = c.project.GetMaxConcurrency()
 	}
 
-	return trunk, undoDepth, maxConcurrency, initialized
+	return bc
 }
 
 // Trunk returns the primary trunk branch name.

--- a/internal/config/interface.go
+++ b/internal/config/interface.go
@@ -6,6 +6,10 @@ type Configurer interface {
 	// Initialization
 	IsInitialized() bool
 
+	// BootstrapValues returns startup-critical configuration in a single call.
+	// GitConfig overrides this to use a pre-loaded snapshot for fewer subprocesses.
+	BootstrapValues() BootstrapConfig
+
 	// Trunk configuration
 	Trunk() string
 	AllTrunks() []string

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -630,11 +630,11 @@ func (d *demoGitRunner) ListMetadata() (map[string]string, error) {
 	return make(map[string]string), nil
 }
 
-func (d *demoGitRunner) BatchReadMetadata(_ []string) (map[string]*git.Meta, map[string]error) {
+func (d *demoGitRunner) BatchReadMetadataForBranches(_ []string) (map[string]*git.Meta, map[string]error) {
 	return make(map[string]*git.Meta), make(map[string]error)
 }
 
-func (d *demoGitRunner) BatchReadLocalMetadata(_ []string) map[string]*git.LocalMeta {
+func (d *demoGitRunner) BatchReadLocalMetadataForBranches(_ []string) map[string]*git.LocalMeta {
 	return make(map[string]*git.LocalMeta)
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -171,7 +171,7 @@ const (
 
 	// LoadModeShared reads shared metadata at construction but defers local
 	// metadata (Frozen, NeedsPRBodyUpdate, NavigationCommentID) until the
-	// first local-only accessor is called. Saves the BatchReadLocalMetadata
+	// first local-only accessor is called. Saves the BatchReadLocalMetadataForBranches
 	// pass for commands that never touch frozen/needs-PR-update state.
 	LoadModeShared
 

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -286,7 +286,7 @@ func (e *engineImpl) ReadMetadataRaw(branchName string) (*git.Meta, error) {
 // BatchReadMetadataRaw reads raw metadata for many branches in one pass,
 // returning per-branch errors so callers can detect corrupted refs.
 func (e *engineImpl) BatchReadMetadataRaw(branchNames []string) (map[string]*git.Meta, map[string]error) {
-	return e.git.BatchReadMetadata(branchNames)
+	return e.git.BatchReadMetadataForBranches(branchNames)
 }
 
 // DeleteMetadataRef deletes a single branch's metadata ref directly, without

--- a/internal/engine/engine_loadmode_test.go
+++ b/internal/engine/engine_loadmode_test.go
@@ -79,7 +79,7 @@ func TestLoadMode_FullParity(t *testing.T) {
 }
 
 // TestLoadMode_SharedSkipsLocalBatch verifies that constructing an engine with
-// LoadModeShared does NOT trigger BatchReadLocalMetadata at bootstrap. The
+// LoadModeShared does NOT trigger BatchReadLocalMetadataForBranches at bootstrap. The
 // local read happens only when an accessor that needs it (IsFrozen) is called.
 //
 // Cache hit counters are the observable signal: LoadModeFull warms the local

--- a/internal/engine/engine_split.go
+++ b/internal/engine/engine_split.go
@@ -109,7 +109,8 @@ func (e *engineImpl) ApplySplitToCommits(ctx context.Context, opts ApplySplitOpt
 
 		// Update in-memory cache
 		e.state.branchState.Set(branchName, &BranchState{
-			Parent: branchParentName,
+			Parent:               branchParentName,
+			ParentBranchRevision: branchParentRevision,
 		})
 		e.state.childrenMap[branchParentName] = append(e.state.childrenMap[branchParentName], branchName)
 		slices.Sort(e.state.childrenMap[branchParentName])

--- a/internal/engine/metadata_store.go
+++ b/internal/engine/metadata_store.go
@@ -18,7 +18,7 @@ func (e *engineImpl) writeMetadata(branch string, meta *git.Meta) error {
 
 // batchReadMetadata loads metadata for many branches in one call.
 func (e *engineImpl) batchReadMetadata(branches []string) (map[string]*git.Meta, map[string]error) {
-	return e.git.BatchReadMetadata(branches)
+	return e.git.BatchReadMetadataForBranches(branches)
 }
 
 // readLocalMetadata loads local-only metadata for a branch.
@@ -33,7 +33,7 @@ func (e *engineImpl) writeLocalMetadata(branch string, meta *git.LocalMeta) erro
 
 // batchReadLocalMetadata loads local metadata for many branches in one call.
 func (e *engineImpl) batchReadLocalMetadata(branches []string) map[string]*git.LocalMeta {
-	return e.git.BatchReadLocalMetadata(branches)
+	return e.git.BatchReadLocalMetadataForBranches(branches)
 }
 
 // withMetadataTx runs function logic inside a metadata transaction and commits once.

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -82,6 +82,45 @@ func (c *ConfigStore) GetAll(key string) ([]string, error) {
 	return values, nil
 }
 
+// GetAllStackitConfig retrieves all local config keys under the "stackit." namespace
+// in a single git invocation. The returned map contains full keys mapped to one or
+// more values (for multi-value keys).
+func (c *ConfigStore) GetAllStackitConfig() (map[string][]string, error) {
+	cmd := exec.Command("git", "config", "--local", "--get-regexp", "^stackit\\.")
+	cmd.Dir = c.repoRoot
+	out, err := cmd.Output()
+	if err != nil {
+		// git config --get-regexp returns exit code 1 when no keys match
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return map[string][]string{}, nil
+		}
+		return nil, err
+	}
+
+	result := make(map[string][]string)
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return result, nil
+	}
+
+	lines := strings.Split(trimmed, "\n")
+	for _, line := range lines {
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) == 0 || parts[0] == "" {
+			continue
+		}
+		key := parts[0]
+		value := ""
+		if len(parts) == 2 {
+			value = parts[1]
+		}
+		result[key] = append(result[key], value)
+	}
+
+	return result, nil
+}
+
 // Set sets a config value in local git config.
 func (c *ConfigStore) Set(key, value string) error {
 	if _, err := c.runGitConfig(key, value); err != nil {

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -261,6 +261,37 @@ func TestConfigStore_Unset(t *testing.T) {
 	})
 }
 
+func TestConfigStore_GetAllStackitConfig(t *testing.T) {
+	t.Run("returns all stackit keys and values", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, func(s *testhelpers.Scene) error {
+			return s.Repo.CreateChangeAndCommit("initial", "init")
+		})
+
+		store := git.NewConfigStore(scene.Dir)
+		require.NoError(t, store.Set("stackit.trunk", "main"))
+		require.NoError(t, store.Add("stackit.trunks", "develop"))
+		require.NoError(t, store.Add("stackit.trunks", "release"))
+		require.NoError(t, store.Set("stackit.undo.depth", "10"))
+
+		values, err := store.GetAllStackitConfig()
+		require.NoError(t, err)
+		require.Equal(t, []string{"main"}, values["stackit.trunk"])
+		require.Equal(t, []string{"develop", "release"}, values["stackit.trunks"])
+		require.Equal(t, []string{"10"}, values["stackit.undo.depth"])
+	})
+
+	t.Run("returns empty map when no stackit keys exist", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, func(s *testhelpers.Scene) error {
+			return s.Repo.CreateChangeAndCommit("initial", "init")
+		})
+
+		store := git.NewConfigStore(scene.Dir)
+		values, err := store.GetAllStackitConfig()
+		require.NoError(t, err)
+		require.Empty(t, values)
+	})
+}
+
 func TestConfigStore_Exists(t *testing.T) {
 	t.Run("returns true for existing key", func(t *testing.T) {
 		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -245,13 +245,13 @@ type ObjectOperations interface {
 // MetadataOperations handles stackit metadata persistence.
 type MetadataOperations interface {
 	ReadMetadata(branchName string) (*Meta, error)
-	BatchReadMetadata(branchNames []string) (map[string]*Meta, map[string]error)
+	BatchReadMetadataForBranches(branchNames []string) (map[string]*Meta, map[string]error)
 	WriteMetadata(branchName string, meta *Meta) error
 	DeleteMetadata(ctx context.Context, branchName string) error
 	RenameMetadata(oldName, newName string) error
 	ListMetadata() (map[string]string, error)
 	ReadLocalMetadata(branchName string) (*LocalMeta, error)
-	BatchReadLocalMetadata(branchNames []string) map[string]*LocalMeta
+	BatchReadLocalMetadataForBranches(branchNames []string) map[string]*LocalMeta
 	WriteLocalMetadata(branchName string, meta *LocalMeta) error
 
 	// Transaction support methods. The batch forms marshal each entry and

--- a/internal/git/meta_accessors_test.go
+++ b/internal/git/meta_accessors_test.go
@@ -11,9 +11,10 @@ import (
 )
 
 const (
-	testBranchMain = "main"
-	testScopeAPI   = "api"
-	testStackID1   = "stack-1"
+	testBranchMain  = "main"
+	testScopeAPI    = "api"
+	testStackID1    = "stack-1"
+	testRevisionABC = "abc123"
 )
 
 func TestNewMeta(t *testing.T) {
@@ -28,7 +29,7 @@ func TestNewMetaFrom(t *testing.T) {
 	t.Parallel()
 
 	name := testBranchMain
-	rev := "abc123"
+	rev := testRevisionABC
 	scope := testScopeAPI
 	stackID := testStackID1
 
@@ -237,7 +238,7 @@ func TestMetaJSONRoundTrip(t *testing.T) {
 	t.Run("full meta round trip", func(t *testing.T) {
 		t.Parallel()
 		name := testBranchMain
-		rev := "abc123"
+		rev := testRevisionABC
 		scope := testScopeAPI
 		hash := "hash"
 		stackID := testStackID1

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -116,11 +116,11 @@ const (
 	LocalMetadataRefPrefix = "refs/stackit/local-metadata/"
 )
 
-// BatchReadMetadata reads metadata for multiple branches in parallel.
+// BatchReadMetadataForBranches reads metadata for multiple branches in parallel.
 // Returns two maps: one with successfully read metadata and one with errors for failed reads.
 // Branches that don't have metadata will have an empty Meta struct in the results map.
 // Only actual errors (not missing metadata) will be included in the errors map.
-func (r *runner) BatchReadMetadata(branchNames []string) (map[string]*Meta, map[string]error) {
+func (r *runner) BatchReadMetadataForBranches(branchNames []string) (map[string]*Meta, map[string]error) {
 	results := make(map[string]*Meta, len(branchNames))
 	errs := make(map[string]error)
 
@@ -184,10 +184,10 @@ func (r *runner) BatchReadMetadata(branchNames []string) (map[string]*Meta, map[
 	return results, errs
 }
 
-// BatchReadLocalMetadata reads local metadata for multiple branches in parallel.
+// BatchReadLocalMetadataForBranches reads local metadata for multiple branches in parallel.
 // Returns a map of successfully read metadata. Failures are silently ignored since
 // local metadata is not critical and missing metadata is expected for new branches.
-func (r *runner) BatchReadLocalMetadata(branchNames []string) map[string]*LocalMeta {
+func (r *runner) BatchReadLocalMetadataForBranches(branchNames []string) map[string]*LocalMeta {
 	results := make(map[string]*LocalMeta, len(branchNames))
 
 	if len(branchNames) == 0 {

--- a/internal/git/metadata_batch_test.go
+++ b/internal/git/metadata_batch_test.go
@@ -1,0 +1,55 @@
+package git_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+)
+
+func TestBatchReadMetadataForBranches(t *testing.T) {
+	t.Parallel()
+
+	scene := testhelpers.NewSceneParallel(t, nil)
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+
+	parent := "main"
+	parentRev := testRevisionABC
+	scope := "api"
+	require.NoError(t, runner.WriteMetadata("feature-a", git.NewMetaFrom(git.MetaFields{
+		ParentBranchName:     &parent,
+		ParentBranchRevision: &parentRev,
+		Scope:                &scope,
+	})))
+
+	metas, errs := runner.BatchReadMetadataForBranches([]string{"feature-a", "missing-branch"})
+	require.Empty(t, errs)
+	require.Contains(t, metas, "feature-a")
+	require.Contains(t, metas, "missing-branch")
+	require.Equal(t, "main", *metas["feature-a"].GetParentBranchName())
+	require.Equal(t, testRevisionABC, *metas["feature-a"].GetParentBranchRevision())
+	require.Equal(t, "api", *metas["feature-a"].GetScope())
+	require.Nil(t, metas["missing-branch"].GetParentBranchName())
+}
+
+func TestBatchReadLocalMetadataForBranches(t *testing.T) {
+	t.Parallel()
+
+	scene := testhelpers.NewSceneParallel(t, nil)
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+
+	require.NoError(t, runner.WriteLocalMetadata("feature-a", &git.LocalMeta{
+		Frozen:            true,
+		NeedsPRBodyUpdate: true,
+	}))
+
+	metas := runner.BatchReadLocalMetadataForBranches([]string{"feature-a", "missing-branch"})
+	require.Contains(t, metas, "feature-a")
+	require.Contains(t, metas, "missing-branch")
+	require.True(t, metas["feature-a"].Frozen)
+	require.True(t, metas["feature-a"].NeedsPRBodyUpdate)
+	require.False(t, metas["missing-branch"].Frozen)
+	require.False(t, metas["missing-branch"].NeedsPRBodyUpdate)
+}

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -1088,11 +1088,11 @@ func (t *tracingRunner) ReadMetadata(branchName string) (*Meta, error) {
 	return result, err
 }
 
-func (t *tracingRunner) BatchReadMetadata(branchNames []string) (map[string]*Meta, map[string]error) {
+func (t *tracingRunner) BatchReadMetadataForBranches(branchNames []string) (map[string]*Meta, map[string]error) {
 	start := time.Now()
-	result, errs := t.inner.BatchReadMetadata(branchNames)
+	result, errs := t.inner.BatchReadMetadataForBranches(branchNames)
 	errCount := len(errs)
-	t.trace("BatchReadMetadata", time.Since(start), errCount == 0, nil, slog.Int("count", len(branchNames)), slog.Int("errors", errCount))
+	t.trace("BatchReadMetadataForBranches", time.Since(start), errCount == 0, nil, slog.Int("count", len(branchNames)), slog.Int("errors", errCount))
 	return result, errs
 }
 
@@ -1137,10 +1137,10 @@ func (t *tracingRunner) ReadLocalMetadata(branchName string) (*LocalMeta, error)
 	return result, err
 }
 
-func (t *tracingRunner) BatchReadLocalMetadata(branchNames []string) map[string]*LocalMeta {
+func (t *tracingRunner) BatchReadLocalMetadataForBranches(branchNames []string) map[string]*LocalMeta {
 	start := time.Now()
-	result := t.inner.BatchReadLocalMetadata(branchNames)
-	t.trace("BatchReadLocalMetadata", time.Since(start), true, nil, slog.Int("count", len(branchNames)))
+	result := t.inner.BatchReadLocalMetadataForBranches(branchNames)
+	t.trace("BatchReadLocalMetadataForBranches", time.Since(start), true, nil, slog.Int("count", len(branchNames)))
 	return result
 }
 

--- a/internal/integration/sync_test.go
+++ b/internal/integration/sync_test.go
@@ -83,7 +83,7 @@ func TestSync(t *testing.T) {
 		mainBranchName := eng.Trunk().GetName()
 
 		// Batch read metadata for all individual branches at once
-		metas, readErrs := eng.Git().BatchReadMetadata(branchNames)
+		metas, readErrs := eng.Git().BatchReadMetadataForBranches(branchNames)
 		for branch, readErr := range readErrs {
 			require.NoError(t, readErr, "failed to read metadata for %s", branch)
 		}


### PR DESCRIPTION

Add BatchReadMetadataForBranches and BatchReadLocalMetadataForBranches to read
metadata for multiple branches in parallel with a single ref scan, avoiding N+1
git subprocess calls.

Add ConfigStore abstraction for typed git config access and GetAllStackitConfig
to batch-load all stackit.* config keys in one git invocation.

Add stackitSnapshot caching in GitConfig.BootstrapValues to avoid repeated git
config reads during startup.

Refactor engine and actions to use batch operations where applicable.