### PR TITLE
feat: improve merge drain with scoped restack, no prompts, and branch locking

### DIFF
--- a/internal/actions/sync/restack.go
+++ b/internal/actions/sync/restack.go
@@ -9,32 +9,39 @@ import (
 	"stackit.dev/stackit/internal/engine"
 )
 
-// restackBranches handles restacking branches after sync operations
-func restackBranches(ctx *app.Context, branchesToRestack []string, dirtyAnchors map[string]bool, handler Handler, summary *Summary) error {
+// restackBranches handles restacking branches after sync operations.
+// When restackScope is non-nil, only those branches are restacked (skipping current-branch expansion).
+func restackBranches(ctx *app.Context, branchesToRestack []string, restackScope []string, dirtyAnchors map[string]bool, handler Handler, summary *Summary) error {
 	nav := ctx.Navigator()
-	graph := engine.BuildStackGraph(ctx.Engine, engine.SortStrategyAlphabetical, nil)
 
-	// Add current branch stack to restack list
-	currentBranch := nav.CurrentBranch()
-	if currentBranch != nil {
-		if currentBranch.IsTracked() {
-			// Get full stack (up to trunk)
-			stack := graph.Range(*currentBranch, engine.StackRange{
-				RecursiveParents:  true,
-				IncludeCurrent:    true,
-				RecursiveChildren: true,
-			})
-			// Add branches to restack list
-			for _, b := range stack {
-				branchesToRestack = append(branchesToRestack, b.GetName())
-			}
-		} else if currentBranch.IsTrunk() {
-			// If on trunk, restack all branches
-			stack := graph.Range(*currentBranch, engine.StackRange{
-				RecursiveChildren: true,
-			})
-			for _, b := range stack {
-				branchesToRestack = append(branchesToRestack, b.GetName())
+	if restackScope != nil {
+		// Scoped restack: use only the explicitly provided branches
+		branchesToRestack = append(branchesToRestack, restackScope...)
+	} else {
+		// Default behavior: expand from current branch position
+		graph := engine.BuildStackGraph(ctx.Engine, engine.SortStrategyAlphabetical, nil)
+
+		currentBranch := nav.CurrentBranch()
+		if currentBranch != nil {
+			if currentBranch.IsTracked() {
+				// Get full stack (up to trunk)
+				stack := graph.Range(*currentBranch, engine.StackRange{
+					RecursiveParents:  true,
+					IncludeCurrent:    true,
+					RecursiveChildren: true,
+				})
+				// Add branches to restack list
+				for _, b := range stack {
+					branchesToRestack = append(branchesToRestack, b.GetName())
+				}
+			} else if currentBranch.IsTrunk() {
+				// If on trunk, restack all branches
+				stack := graph.Range(*currentBranch, engine.StackRange{
+					RecursiveChildren: true,
+				})
+				for _, b := range stack {
+					branchesToRestack = append(branchesToRestack, b.GetName())
+				}
 			}
 		}
 	}

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -17,10 +17,11 @@ import (
 
 // Options contains options for the sync command
 type Options struct {
-	All     bool
-	Force   bool
-	Restack bool
-	DryRun  bool
+	All          bool
+	Force        bool
+	Restack      bool
+	DryRun       bool
+	RestackScope []string // When non-nil, only restack these branches (skip current-branch expansion)
 }
 
 // Action performs the sync operation
@@ -233,7 +234,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Phase 4: Restack branches
 	handler.EmitEvent(Event{Phase: PhaseRestack, Type: EventStarted})
 
-	if err := restackBranches(ctx, branchesToRestack, dirtyAnchors, handler, summary); err != nil {
+	if err := restackBranches(ctx, branchesToRestack, opts.RestackScope, dirtyAnchors, handler, summary); err != nil {
 		// Even on error, complete with summary
 		handler.Complete(*summary)
 		return err

--- a/internal/cli/stack/merge/drain.go
+++ b/internal/cli/stack/merge/drain.go
@@ -7,9 +7,12 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"stackit.dev/stackit/internal/actions"
 	mergeAction "stackit.dev/stackit/internal/actions/merge"
+	"stackit.dev/stackit/internal/actions/sync"
 	"stackit.dev/stackit/internal/app"
 	"stackit.dev/stackit/internal/cli/common"
+	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/internal/github"
 	"stackit.dev/stackit/internal/tui"
 )
@@ -17,7 +20,7 @@ import (
 // NewDrainCmd creates the merge drain subcommand.
 // This command merges all PRs in the stack bottom-up, waiting for each merge
 // to complete before proceeding to the next one.
-func NewDrainCmd(postMergeHandler PostMergeHandler) *cobra.Command {
+func NewDrainCmd() *cobra.Command {
 	var (
 		dryRun bool
 		yes    bool
@@ -59,7 +62,7 @@ Examples:
 					branch: branch,
 					scope:  scope,
 					count:  count,
-				}, postMergeHandler)
+				})
 			})
 		},
 	}
@@ -87,7 +90,7 @@ type mergeDrainOptions struct {
 	count  int // Maximum number of PRs to drain (0 = all)
 }
 
-func runMergeDrain(ctx *app.Context, opts mergeDrainOptions, postMergeHandler PostMergeHandler) error {
+func runMergeDrain(ctx *app.Context, opts mergeDrainOptions) error {
 	out := ctx.Output
 	eng := ctx.Engine
 
@@ -165,6 +168,16 @@ func runMergeDrain(ctx *app.Context, opts mergeDrainOptions, postMergeHandler Po
 		return err
 	}
 
+	// Lock all drain branches to prevent external modification
+	branchesToLock := make([]engine.Branch, len(plan.BranchesToMerge))
+	for i, b := range plan.BranchesToMerge {
+		branchesToLock[i] = eng.GetBranch(b.BranchName)
+	}
+	if _, err := eng.SetLocked(ctx.Context, branchesToLock, engine.LockReasonDraining); err != nil {
+		return fmt.Errorf("failed to lock drain branches: %w", err)
+	}
+	defer unlockDrainBranches(ctx, plan.BranchesToMerge)
+
 	// Drain loop: merge one PR at a time, bottom-up
 	merged := 0
 	for drainTarget == 0 || merged < drainTarget {
@@ -223,18 +236,70 @@ func runMergeDrain(ctx *app.Context, opts mergeDrainOptions, postMergeHandler Po
 
 		merged++
 
-		// Post-merge cleanup: sync trunk + restack for next iteration
-		if postMergeHandler != nil {
-			out.Info("Syncing trunk and restacking...")
-			if err := postMergeHandler(ctx, mergeAction.PostMergeSyncTrunk); err != nil {
-				return fmt.Errorf("post-merge sync failed after PR #%d: %w", bottomPR.PRNumber, err)
-			}
+		// Post-merge cleanup: checkout trunk, then scoped sync + restack
+		out.Info("Syncing trunk and restacking...")
+
+		// Checkout trunk
+		if _, checkoutErr := actions.CheckoutAction(ctx, actions.CheckoutOptions{
+			CheckoutTrunk: true,
+		}, nil); checkoutErr != nil {
+			return fmt.Errorf("post-merge checkout trunk failed after PR #%d: %w", bottomPR.PRNumber, checkoutErr)
+		}
+
+		// Compute remaining branches to restack (everything after the one we just merged)
+		restackScope := remainingBranchNames(plan.BranchesToMerge[1:])
+
+		// Run sync with scoped restack and no interactive prompts
+		drainHandler := &drainSyncHandler{}
+		if syncErr := sync.Action(ctx, sync.Options{
+			Restack:      true,
+			RestackScope: restackScope,
+		}, drainHandler); syncErr != nil {
+			return fmt.Errorf("post-merge sync failed after PR #%d: %w", bottomPR.PRNumber, syncErr)
+		}
+
+		// Check for conflicts in drain branches — hard error
+		if len(drainHandler.summary.ConflictBranches) > 0 {
+			return fmt.Errorf("restack conflict in %s — resolve before continuing drain", drainHandler.summary.ConflictBranches[0])
 		}
 	}
 
 	out.Newline()
 	out.Success("Drained %d PRs from the stack", merged)
 	return nil
+}
+
+// drainSyncHandler is a non-interactive sync handler that captures the summary.
+// It embeds sync.NullHandler so all prompts return non-interactive defaults.
+type drainSyncHandler struct {
+	sync.NullHandler
+	summary sync.Summary
+}
+
+// Complete captures the sync summary for conflict detection.
+func (h *drainSyncHandler) Complete(s sync.Summary) { h.summary = s }
+
+// remainingBranchNames extracts branch names from a slice of MergeBranch.
+func remainingBranchNames(branches []mergeAction.BranchMergeInfo) []string {
+	names := make([]string, len(branches))
+	for i, b := range branches {
+		names[i] = b.BranchName
+	}
+	return names
+}
+
+// unlockDrainBranches unlocks any remaining drain-locked branches that still exist.
+func unlockDrainBranches(ctx *app.Context, branches []mergeAction.BranchMergeInfo) {
+	var toUnlock []engine.Branch
+	for _, b := range branches {
+		branch := ctx.Engine.GetBranch(b.BranchName)
+		if branch.IsTracked() && branch.GetLockReason() == engine.LockReasonDraining {
+			toUnlock = append(toUnlock, branch)
+		}
+	}
+	if len(toUnlock) > 0 {
+		_, _ = ctx.Engine.SetLocked(ctx.Context, toUnlock, engine.LockReasonNone)
+	}
 }
 
 func resolveMergeMethod(ctx *app.Context, methodFlag string) (github.MergeMethod, error) {

--- a/internal/cli/stack/merge/merge.go
+++ b/internal/cli/stack/merge/merge.go
@@ -104,7 +104,7 @@ Examples:
 	cmd.AddCommand(NewStatusCmd())
 	cmd.AddCommand(NewNextCmd(postMergeHandler))
 	cmd.AddCommand(NewShipCmd(postMergeHandler))
-	cmd.AddCommand(NewDrainCmd(postMergeHandler))
+	cmd.AddCommand(NewDrainCmd())
 
 	return cmd
 }

--- a/internal/cli/stack/merge/merge_test.go
+++ b/internal/cli/stack/merge/merge_test.go
@@ -119,7 +119,7 @@ func TestNewShipCmd(t *testing.T) {
 
 func TestNewDrainCmd(t *testing.T) {
 	t.Run("has expected flags", func(t *testing.T) {
-		cmd := NewDrainCmd(nil)
+		cmd := NewDrainCmd()
 
 		require.Equal(t, "drain", cmd.Use)
 

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -136,8 +136,9 @@ func (e *engineImpl) restackBranch(
 		}
 	}
 
-	if e.IsLocked(branch) {
-		return RestackBranchResult{Result: RestackUnneeded, LockReason: e.GetLockReason(branch)}, nil
+	lockReason := e.GetLockReason(branch)
+	if lockReason.IsLocked() && lockReason != LockReasonDraining {
+		return RestackBranchResult{Result: RestackUnneeded, LockReason: lockReason}, nil
 	}
 
 	if e.IsFrozen(branch) {

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -31,6 +31,8 @@ const (
 	LockReasonUser LockReason = git.LockReasonUser
 	// LockReasonConsolidating indicates the branch is being consolidated
 	LockReasonConsolidating LockReason = git.LockReasonConsolidating
+	// LockReasonDraining indicates the branch is being drained (merge drain in progress)
+	LockReasonDraining LockReason = git.LockReasonDraining
 )
 
 // StackRange specifies the range of branches to include in stack operations

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -20,6 +20,8 @@ const (
 	LockReasonUser LockReason = "user"
 	// LockReasonConsolidating indicates the branch is being consolidated
 	LockReasonConsolidating LockReason = "consolidating"
+	// LockReasonDraining indicates the branch is being drained (merge drain in progress)
+	LockReasonDraining LockReason = "draining"
 )
 
 // IsLocked returns true if the lock reason indicates the branch is locked


### PR DESCRIPTION
## Summary

- **Scoped restack**: After each merge in `drain`, only the remaining drain branches are restacked — unrelated stacks are untouched
- **No interactive prompts**: Drain uses a `drainSyncHandler` (non-interactive) so it never stops to ask questions; conflicts cause a hard error with a clear message
- **Branch locking**: All drain branches are locked with `LockReasonDraining` before the loop starts and unlocked via `defer` when done, preventing concurrent modifications

## Changes

- `internal/git/metadata.go` + `internal/engine/types.go`: Added `LockReasonDraining` constant
- `internal/engine/engine_sync.go`: `restackBranch()` now skips only non-drain locks, so drain-locked branches can still be restacked
- `internal/actions/sync/sync.go` + `restack.go`: Added `RestackScope []string` to `Options`; when set, only those branches are restacked (skips current-branch expansion)
- `internal/cli/stack/merge/drain.go`: Removed `postMergeHandler` dependency; added lock/unlock lifecycle, direct checkout-trunk + `sync.Action` with scoped restack, conflict detection
- `internal/cli/stack/merge/merge.go` + `merge_test.go`: Updated `NewDrainCmd()` call (no longer takes a handler)

## Test plan

- [ ] `mise run check` passes (lint + fast tests)
- [ ] Manual: `st merge drain` on a stack with unrelated conflicting branches — drains without touching other stacks
- [ ] Manual: conflict in a drain branch produces a clear error and stops the drain