### PR TITLE
feat: return stack description in stacks API endpoint

### DIFF
--- a/internal/api/types/mappers.go
+++ b/internal/api/types/mappers.go
@@ -98,6 +98,13 @@ func MapStackSummary(eng engine.BranchReader, graph *engine.StackGraph, rootBran
 	// Compute stack status
 	status := computeStackStatus(graph, allBranches)
 
+	var description string
+	if rootNode != nil {
+		if stackDesc := eng.GetStackDescription(rootNode.Branch); stackDesc != nil && !stackDesc.IsEmpty() {
+			description = stackDesc.Description
+		}
+	}
+
 	return StackSummary{
 		RootBranch:  rootBranch,
 		Title:       title,
@@ -106,6 +113,7 @@ func MapStackSummary(eng engine.BranchReader, graph *engine.StackGraph, rootBran
 		BranchCount: len(allBranches),
 		PRCount:     prCount,
 		IsCurrent:   isCurrent,
+		Description: description,
 	}
 }
 


### PR DESCRIPTION


<hr/>

<!-- STACKIT-SECTION-START -->
**Add HTTP API server for stackit-web**

Adds a REST API server that exposes stack and branch data for the stackit-web frontend.

Key changes:
- **HTTP server** (`internal/api/server.go`): configurable port, CORS, graceful shutdown, and git ref watching that rebuilds engine state and pushes SSE refresh events when branches change
- **Endpoints**: `GET /api/repo` (repository metadata), `GET /api/stacks[/{root}]` (stack list and detail), `GET /api/branches[/{name}]` (branch list and detail), `GET /api/events` (SSE stream for live updates)
- **Response types** (`internal/api/types/`): JSON-serializable types decoupled from engine internals, including branch status, PR info, CI checks, remote status, and commit details
- **Mappers** (`internal/api/types/mappers.go`): converts engine branches and stack graph nodes into API responses; stacks are sorted with `SortStrategySmart` to match `stackit log` ordering
- **Ref watcher** (`internal/api/watcher/watcher.go`): debounced fsnotify watcher on `.git/refs/heads/`, `.git/refs/stackit/`, and `.git/HEAD`; triggers engine rebuild and SSE broadcast on change
- **Stack description** (`internal/api/types/mappers.go`): `StackSummary` includes the stack description when set via `stackit describe`

#### Stack


* **PR #743**
  * **PR #744** 👈
    * **PR #745**
      * **PR #746**
        * **PR #747**
          * **PR #764**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->