### PR TITLE
feat: refresh engine on ref changes and sort stacks to match log order

### DIFF
--- a/internal/actions/merge/multistack_discover.go
+++ b/internal/actions/merge/multistack_discover.go
@@ -23,7 +23,13 @@ func FormatStackLabel(stack MultiStackInfo) string {
 // Each stack is represented by its root branch (direct child of trunk)
 // and includes all branches in the stack in topological order.
 func DiscoverStacks(eng engine.BranchReader) ([]MultiStackInfo, error) {
-	graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
+	return DiscoverStacksWithSort(eng, engine.SortStrategyAlphabetical)
+}
+
+// DiscoverStacksWithSort is like DiscoverStacks but allows specifying the sort strategy.
+// Use SortStrategySmart to match the ordering of `stackit log`.
+func DiscoverStacksWithSort(eng engine.BranchReader, strategy engine.SortStrategy) ([]MultiStackInfo, error) {
+	graph := engine.BuildStackGraph(eng, strategy, nil)
 	trunk := eng.Trunk()
 
 	// Get the trunk node to find its direct children (stack roots)

--- a/internal/api/handlers/stacks.go
+++ b/internal/api/handlers/stacks.go
@@ -40,13 +40,13 @@ func (h *StacksHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *StacksHandler) listStacks(w http.ResponseWriter) {
-	stacks, err := merge.DiscoverStacks(h.eng)
+	stacks, err := merge.DiscoverStacksWithSort(h.eng, engine.SortStrategySmart)
 	if err != nil {
 		http.Error(w, "failed to discover stacks: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	graph := engine.BuildStackGraph(h.eng, engine.SortStrategyAlphabetical, nil)
+	graph := engine.BuildStackGraph(h.eng, engine.SortStrategySmart, nil)
 
 	summaries := make([]types.StackSummary, 0, len(stacks))
 	for _, stack := range stacks {
@@ -58,7 +58,7 @@ func (h *StacksHandler) listStacks(w http.ResponseWriter) {
 }
 
 func (h *StacksHandler) getStack(w http.ResponseWriter, r *http.Request, rootBranch string) {
-	stacks, err := merge.DiscoverStacks(h.eng)
+	stacks, err := merge.DiscoverStacksWithSort(h.eng, engine.SortStrategySmart)
 	if err != nil {
 		http.Error(w, "failed to discover stacks: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -77,7 +77,7 @@ func (h *StacksHandler) getStack(w http.ResponseWriter, r *http.Request, rootBra
 		return
 	}
 
-	graph := engine.BuildStackGraph(h.eng, engine.SortStrategyAlphabetical, nil)
+	graph := engine.BuildStackGraph(h.eng, engine.SortStrategySmart, nil)
 
 	// Fetch CI checks if GitHub client is available
 	var checksMap map[string]*github.CheckStatus

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"stackit.dev/stackit/internal/api/handlers"
+	"stackit.dev/stackit/internal/api/watcher"
 	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/internal/github"
 )
@@ -28,6 +29,7 @@ type Server struct {
 	gh          github.Client
 	broadcaster *handlers.EventBroadcaster
 	httpServer  *http.Server
+	refWatcher  *watcher.RefWatcher
 }
 
 // NewServer creates a new API server.
@@ -61,6 +63,23 @@ func (s *Server) Start() error {
 	handler := corsMiddleware(s.config.CORSOrigins, mux)
 	handler = loggingMiddleware(handler)
 
+	// Start watching git refs for changes so the engine stays current
+	if s.config.RepoRoot != "" {
+		trunkName := s.eng.Trunk().GetName()
+		s.refWatcher = watcher.NewRefWatcher(s.config.RepoRoot, 200*time.Millisecond, func() {
+			if err := s.eng.Rebuild(trunkName); err != nil {
+				log.Printf("engine rebuild failed: %v", err)
+				return
+			}
+			s.broadcaster.Broadcast("refresh", "{}")
+		})
+		go func() {
+			if err := s.refWatcher.Start(); err != nil {
+				log.Printf("ref watcher stopped: %v", err)
+			}
+		}()
+	}
+
 	s.httpServer = &http.Server{
 		Addr:              fmt.Sprintf(":%d", s.config.Port),
 		Handler:           handler,
@@ -73,6 +92,9 @@ func (s *Server) Start() error {
 
 // Shutdown gracefully stops the server.
 func (s *Server) Shutdown(ctx context.Context) error {
+	if s.refWatcher != nil {
+		s.refWatcher.Stop()
+	}
 	if s.httpServer != nil {
 		return s.httpServer.Shutdown(ctx)
 	}


### PR DESCRIPTION


<hr/>

<!-- STACKIT-SECTION-START -->
**Add HTTP API server for stackit-web**

Adds a REST API server that exposes stack and branch data for the stackit-web frontend.

Key changes:
- **HTTP server** (`internal/api/server.go`): configurable port, CORS, graceful shutdown, and git ref watching that rebuilds engine state and pushes SSE refresh events when branches change
- **Endpoints**: `GET /api/repo` (repository metadata), `GET /api/stacks[/{root}]` (stack list and detail), `GET /api/branches[/{name}]` (branch list and detail), `GET /api/events` (SSE stream for live updates)
- **Response types** (`internal/api/types/`): JSON-serializable types decoupled from engine internals, including branch status, PR info, CI checks, remote status, and commit details
- **Mappers** (`internal/api/types/mappers.go`): converts engine branches and stack graph nodes into API responses; stacks are sorted with `SortStrategySmart` to match `stackit log` ordering
- **Ref watcher** (`internal/api/watcher/watcher.go`): debounced fsnotify watcher on `.git/refs/heads/`, `.git/refs/stackit/`, and `.git/HEAD`; triggers engine rebuild and SSE broadcast on change
- **Stack description** (`internal/api/types/mappers.go`): `StackSummary` includes the stack description when set via `stackit describe`

#### Stack


* **PR #743**
  * **PR #744**
    * **PR #745** 👈
      * **PR #746**
        * **PR #747**
          * **PR #764**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->