### PR TITLE
feat: add /api/view endpoint combining repo and stack details

### DIFF
--- a/internal/api/handlers/view.go
+++ b/internal/api/handlers/view.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"net/http"
+
+	"stackit.dev/stackit/internal/actions/merge"
+	"stackit.dev/stackit/internal/api/types"
+	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/github"
+)
+
+// ViewHandler serves the combined view payload for the frontend.
+type ViewHandler struct {
+	eng    engine.BranchReader
+	gh     github.Client
+	remote string
+}
+
+// NewViewHandler creates a handler for /api/view.
+func NewViewHandler(eng engine.BranchReader, gh github.Client, remote string) *ViewHandler {
+	return &ViewHandler{eng: eng, gh: gh, remote: remote}
+}
+
+// ServeHTTP handles GET /api/view.
+func (h *ViewHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Build repo info
+	owner, repo := "", ""
+	if h.gh != nil {
+		owner, repo = h.gh.GetOwnerRepo()
+	}
+	repoResp := types.RepoResponse{
+		Owner:         owner,
+		Repo:          repo,
+		Trunk:         h.eng.Trunk().GetName(),
+		CurrentBranch: h.eng.CurrentBranch().GetName(),
+		Remote:        h.remote,
+	}
+
+	// Discover all stacks
+	stacks, err := merge.DiscoverStacksWithSort(h.eng, engine.SortStrategySmart)
+	if err != nil {
+		http.Error(w, "failed to discover stacks: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	graph := engine.BuildStackGraph(h.eng, engine.SortStrategySmart, nil)
+
+	// Collect all branch names across all stacks for a single batched CI check
+	var allBranches []string
+	for _, stack := range stacks {
+		allBranches = append(allBranches, stack.AllBranches...)
+	}
+
+	var checksMap map[string]*github.CheckStatus
+	if h.gh != nil && len(allBranches) > 0 {
+		checksMap, _ = h.gh.BatchGetPRChecksStatus(r.Context(), allBranches)
+	}
+
+	// Map all stack details using the shared checks map
+	details := make([]types.StackDetail, 0, len(stacks))
+	for _, stack := range stacks {
+		detail := types.MapStackDetail(h.eng, graph, stack.RootBranch, stack.AllBranches, stack.PRCount, stack.Scope, checksMap)
+		details = append(details, detail)
+	}
+
+	writeJSON(w, types.ViewResponse{
+		Repo:   repoResp,
+		Stacks: details,
+	})
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -52,6 +52,7 @@ func (s *Server) Start() error {
 	mux := http.NewServeMux()
 
 	// Register handlers
+	mux.Handle("/api/view", handlers.NewViewHandler(s.eng, s.gh, s.config.Remote))
 	mux.Handle("/api/repo", handlers.NewRepoHandler(s.eng, s.gh, s.config.Remote))
 	mux.Handle("/api/stacks", handlers.NewStacksHandler(s.eng, s.gh))
 	mux.Handle("/api/stacks/", handlers.NewStacksHandler(s.eng, s.gh))

--- a/internal/api/types/responses.go
+++ b/internal/api/types/responses.go
@@ -5,6 +5,14 @@
 // to evolve independently.
 package types
 
+// ViewResponse is the combined response for the frontend view.
+// It bundles repo metadata and all stack details into a single payload
+// to avoid N+1 API calls.
+type ViewResponse struct {
+	Repo   RepoResponse  `json:"repo"`
+	Stacks []StackDetail `json:"stacks"`
+}
+
 // RepoResponse contains repository metadata.
 type RepoResponse struct {
 	Owner         string `json:"owner"`


### PR DESCRIPTION


<hr/>

<!-- STACKIT-SECTION-START -->
**Add HTTP API server for stackit-web**

Adds a REST API server that exposes stack and branch data for the stackit-web frontend.

Key changes:
- **HTTP server** (`internal/api/server.go`): configurable port, CORS, graceful shutdown, and git ref watching that rebuilds engine state and pushes SSE refresh events when branches change
- **Endpoints**: `GET /api/repo` (repository metadata), `GET /api/stacks[/{root}]` (stack list and detail), `GET /api/branches[/{name}]` (branch list and detail), `GET /api/events` (SSE stream for live updates)
- **Response types** (`internal/api/types/`): JSON-serializable types decoupled from engine internals, including branch status, PR info, CI checks, remote status, and commit details
- **Mappers** (`internal/api/types/mappers.go`): converts engine branches and stack graph nodes into API responses; stacks are sorted with `SortStrategySmart` to match `stackit log` ordering
- **Ref watcher** (`internal/api/watcher/watcher.go`): debounced fsnotify watcher on `.git/refs/heads/`, `.git/refs/stackit/`, and `.git/HEAD`; triggers engine rebuild and SSE broadcast on change
- **Stack description** (`internal/api/types/mappers.go`): `StackSummary` includes the stack description when set via `stackit describe`

#### Stack


* **PR #743**
  * **PR #744**
    * **PR #745**
      * **PR #746** 👈
        * **PR #747**
          * **PR #764**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->