### PR TITLE
feat: add owner and current user fields to stack and repo responses

### DIFF
--- a/internal/api/handlers/stacks.go
+++ b/internal/api/handlers/stacks.go
@@ -50,7 +50,7 @@ func (h *StacksHandler) listStacks(w http.ResponseWriter) {
 
 	summaries := make([]types.StackSummary, 0, len(stacks))
 	for _, stack := range stacks {
-		summary := types.MapStackSummary(h.eng, graph, stack.RootBranch, stack.AllBranches, stack.PRCount, stack.Scope)
+		summary := types.MapStackSummary(h.eng, graph, stack.RootBranch, stack.AllBranches, stack.PRCount, stack.Scope, "")
 		summaries = append(summaries, summary)
 	}
 

--- a/internal/api/handlers/view.go
+++ b/internal/api/handlers/view.go
@@ -30,8 +30,10 @@ func (h *ViewHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Build repo info
 	owner, repo := "", ""
+	var currentUser string
 	if h.gh != nil {
 		owner, repo = h.gh.GetOwnerRepo()
+		currentUser, _ = h.gh.GetCurrentUser(r.Context())
 	}
 	repoResp := types.RepoResponse{
 		Owner:         owner,
@@ -39,6 +41,7 @@ func (h *ViewHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Trunk:         h.eng.Trunk().GetName(),
 		CurrentBranch: h.eng.CurrentBranch().GetName(),
 		Remote:        h.remote,
+		CurrentUser:   currentUser,
 	}
 
 	// Discover all stacks

--- a/internal/api/types/mappers.go
+++ b/internal/api/types/mappers.go
@@ -82,7 +82,7 @@ func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.Stack
 }
 
 // MapStackSummary creates a StackSummary from stack discovery info.
-func MapStackSummary(eng engine.BranchReader, graph *engine.StackGraph, rootBranch string, allBranches []string, prCount int, scope string) StackSummary {
+func MapStackSummary(eng engine.BranchReader, graph *engine.StackGraph, rootBranch string, allBranches []string, prCount int, scope string, owner string) StackSummary {
 	currentBranch := eng.CurrentBranch().GetName()
 	isCurrent := slices.Contains(allBranches, currentBranch)
 
@@ -114,12 +114,21 @@ func MapStackSummary(eng engine.BranchReader, graph *engine.StackGraph, rootBran
 		PRCount:     prCount,
 		IsCurrent:   isCurrent,
 		Description: description,
+		Owner:       owner,
 	}
 }
 
 // MapStackDetail creates a full StackDetail with all branch info.
 func MapStackDetail(eng engine.BranchReader, graph *engine.StackGraph, rootBranch string, allBranches []string, prCount int, scope string, checksMap map[string]*github.CheckStatus) StackDetail {
-	summary := MapStackSummary(eng, graph, rootBranch, allBranches, prCount, scope)
+	// Derive owner from root branch's PR author
+	var owner string
+	if checksMap != nil {
+		if rootCheck := checksMap[rootBranch]; rootCheck != nil {
+			owner = rootCheck.Author
+		}
+	}
+
+	summary := MapStackSummary(eng, graph, rootBranch, allBranches, prCount, scope, owner)
 
 	branches := make([]BranchResponse, 0, len(allBranches))
 	for _, name := range allBranches {

--- a/internal/api/types/responses.go
+++ b/internal/api/types/responses.go
@@ -20,6 +20,7 @@ type RepoResponse struct {
 	Trunk         string `json:"trunk"`
 	CurrentBranch string `json:"currentBranch"`
 	Remote        string `json:"remote"`
+	CurrentUser   string `json:"currentUser,omitempty"`
 }
 
 // StackSummary is a lightweight summary of a stack for list views.
@@ -32,6 +33,7 @@ type StackSummary struct {
 	PRCount     int    `json:"prCount"`
 	IsCurrent   bool   `json:"isCurrent"`
 	Description string `json:"description,omitempty"`
+	Owner       string `json:"owner,omitempty"`
 }
 
 // StackDetail is a full stack with all branch details.


### PR DESCRIPTION


<hr/>

<!-- STACKIT-SECTION-START -->
**Add HTTP API server for stackit-web**

Adds a REST API server that exposes stack and branch data for the stackit-web frontend.

Key changes:
- **HTTP server** (`internal/api/server.go`): configurable port, CORS, graceful shutdown, and git ref watching that rebuilds engine state and pushes SSE refresh events when branches change
- **Endpoints**: `GET /api/repo` (repository metadata), `GET /api/stacks[/{root}]` (stack list and detail), `GET /api/branches[/{name}]` (branch list and detail), `GET /api/events` (SSE stream for live updates)
- **Response types** (`internal/api/types/`): JSON-serializable types decoupled from engine internals, including branch status, PR info, CI checks, remote status, and commit details
- **Mappers** (`internal/api/types/mappers.go`): converts engine branches and stack graph nodes into API responses; stacks are sorted with `SortStrategySmart` to match `stackit log` ordering
- **Ref watcher** (`internal/api/watcher/watcher.go`): debounced fsnotify watcher on `.git/refs/heads/`, `.git/refs/stackit/`, and `.git/HEAD`; triggers engine rebuild and SSE broadcast on change
- **Stack description** (`internal/api/types/mappers.go`): `StackSummary` includes the stack description when set via `stackit describe`

#### Stack


* **PR #743**
  * **PR #744**
    * **PR #745**
      * **PR #746**
        * **PR #747** 👈
          * **PR #764**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->