### PR TITLE
feat: preserve child commit boundaries when deleting squash-merged branches

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -46,8 +46,9 @@ type BranchDeletionPlan struct {
 
 // branchDeletionInfo stores information about a branch marked for deletion
 type branchDeletionInfo struct {
-	reason   string
-	blockers map[string]bool
+	reason     string
+	reasonKind engine.DeletionReasonKind
+	blockers   map[string]bool
 }
 
 // deletionPlan manages the state of branches being deleted
@@ -61,10 +62,11 @@ func newDeletionPlan() *deletionPlan {
 	}
 }
 
-func (p *deletionPlan) add(name, reason string, blockers map[string]bool) {
+func (p *deletionPlan) add(name string, status engine.DeletionStatus, blockers map[string]bool) {
 	p.branches[name] = &branchDeletionInfo{
-		reason:   reason,
-		blockers: blockers,
+		reason:     status.Reason,
+		reasonKind: status.Kind,
+		blockers:   blockers,
 	}
 }
 
@@ -180,7 +182,7 @@ func ExecuteBranchDeletions(ctx *app.Context, plannedDeletion *BranchDeletionPla
 // identifyBranchesToDelete pre-calculates deletion status for all tracked branches.
 // Returns the branches to delete, any branches that were skipped due to being in a worktree,
 // and which branches are utility branches (e.g., consolidated merge branches).
-func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[string]string, []string, map[string]bool, error) {
+func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[string]engine.DeletionStatus, []string, map[string]bool, error) {
 	eng := ctx.Engine
 	c := ctx.Context
 
@@ -201,8 +203,8 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[
 		return nil, nil, nil, fmt.Errorf("failed to get deletion statuses: %w", err)
 	}
 
-	deleteStatuses := make(map[string]string) // name -> reason
-	utilityBranches := make(map[string]bool)  // branches that are utility type
+	deleteStatuses := make(map[string]engine.DeletionStatus) // name -> status
+	utilityBranches := make(map[string]bool)                 // branches that are utility type
 	var skippedInWorktree []string
 
 	for _, name := range candidateNames {
@@ -218,7 +220,7 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[
 			continue
 		}
 
-		deleteStatuses[name] = status.Reason
+		deleteStatuses[name] = status
 
 		// Track utility branches using in-memory branch state (no extra fetch)
 		branch := eng.GetBranch(name)
@@ -235,7 +237,7 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[
 }
 
 // buildDeletionPlanAndReparent constructs the deletion hierarchy and updates parents of surviving branches.
-func buildDeletionPlanAndReparent(ctx *app.Context, deleteReasons map[string]string) (*deletionPlan, []string, error) {
+func buildDeletionPlanAndReparent(ctx *app.Context, deleteStatuses map[string]engine.DeletionStatus) (*deletionPlan, []string, error) {
 	eng := ctx.Engine
 	out := ctx.Output
 	c := ctx.Context
@@ -264,7 +266,7 @@ func buildDeletionPlanAndReparent(ctx *app.Context, deleteReasons map[string]str
 		}
 		visited[branchName] = true
 
-		reason, shouldDelete := deleteReasons[branchName]
+		status, shouldDelete := deleteStatuses[branchName]
 		branch := eng.GetBranch(branchName)
 		children := graph.ChildBranches(branch)
 
@@ -279,8 +281,8 @@ func buildDeletionPlanAndReparent(ctx *app.Context, deleteReasons map[string]str
 			for _, child := range children {
 				blockers[child.GetName()] = true
 			}
-			plan.add(branchName, reason, blockers)
-			out.Debug("Marked %s for deletion. Reason: %s. Blockers: %v", branchName, reason, blockers)
+			plan.add(branchName, status, blockers)
+			out.Debug("Marked %s for deletion. Reason: %s. Blockers: %v", branchName, status.Reason, blockers)
 		} else {
 			// Branch is NOT being deleted. Check if it needs a new parent.
 			newParentName, err := reparentBranchIfNecessary(c, branch, plan, eng, out)
@@ -294,12 +296,12 @@ func buildDeletionPlanAndReparent(ctx *app.Context, deleteReasons map[string]str
 	}
 
 	// NEW: Handle "orphan" branches (untracked branches identified for deletion)
-	for branchName, reason := range deleteReasons {
+	for branchName, status := range deleteStatuses {
 		if !visited[branchName] {
 			// This branch is disconnected from the trunk hierarchy but should still be deleted
-			plan.add(branchName, reason, make(map[string]bool))
+			plan.add(branchName, status, make(map[string]bool))
 			visited[branchName] = true
-			out.Debug("Marked orphan branch %s for deletion. Reason: %s", branchName, reason)
+			out.Debug("Marked orphan branch %s for deletion. Reason: %s", branchName, status.Reason)
 		}
 	}
 
@@ -477,8 +479,12 @@ func shouldPreserveDivergenceOnReparent(plan *deletionPlan, oldParentName string
 		return false
 	}
 
-	reason := strings.ToLower(info.reason)
-	return strings.HasPrefix(reason, "merged into ") || reason == "empty"
+	switch info.reasonKind {
+	case engine.DeletionReasonMergedPR, engine.DeletionReasonMergedIntoTrunk, engine.DeletionReasonEmptyWithPR:
+		return true
+	default:
+		return false
+	}
 }
 
 func readDivergencePoint(eng engine.Engine, branchName string, out output.Output) string {

--- a/internal/actions/delete/delete.go
+++ b/internal/actions/delete/delete.go
@@ -77,16 +77,18 @@ func Action(ctx *app.Context, opts Options, handler Handler) (Result, error) {
 
 	handler.Start(len(toDelete))
 
+	// Precompute deletion statuses once (used for confirmation and divergence-preserving reparenting).
+	toDeleteNames := make([]string, len(toDelete))
+	for i, b := range toDelete {
+		toDeleteNames[i] = b.GetName()
+	}
+	statuses, err := eng.BatchGetDeletionStatuses(ctx.Context, toDeleteNames)
+	if err != nil {
+		return Result{}, fmt.Errorf("failed to check deletion statuses: %w", err)
+	}
+
 	// Confirm if not forced and not merged/closed
 	if !opts.Force {
-		toDeleteNames := make([]string, len(toDelete))
-		for i, b := range toDelete {
-			toDeleteNames[i] = b.GetName()
-		}
-		statuses, err := eng.BatchGetDeletionStatuses(ctx.Context, toDeleteNames)
-		if err != nil {
-			return Result{}, fmt.Errorf("failed to check deletion statuses: %w", err)
-		}
 		for _, b := range toDelete {
 			status := statuses[b.GetName()]
 			if !status.SafeToDelete {
@@ -108,6 +110,13 @@ func Action(ctx *app.Context, opts Options, handler Handler) (Result, error) {
 		}
 	}
 
+	// Preserve divergence for survivors whose parent is being deleted as merged/empty.
+	// This mirrors clean-branches behavior and avoids replaying already-merged parent commits.
+	preReparentedChildren, err := preReparentChildrenWithPreservedDivergence(ctx, toDelete, statuses)
+	if err != nil {
+		return Result{}, err
+	}
+
 	// Track children that will need restacking (only for the last branch in the stack if deleting multiple)
 	// Actually, if we delete a middle branch, its children are reparented to its parent.
 	// If we delete a whole stack, only children of the stack need restacking onto the stack's parent.
@@ -117,12 +126,10 @@ func Action(ctx *app.Context, opts Options, handler Handler) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
+	childrenToRestack = mergeUniqueBranchNames(childrenToRestack, preReparentedChildren)
 
 	// Batch delete remote metadata for deleted branches
-	branchNames := make([]string, len(toDelete))
-	for i, b := range toDelete {
-		branchNames[i] = b.GetName()
-	}
+	branchNames := toDeleteNames
 	if err := eng.Git().BatchDeleteRemoteMetadataRefs(ctx.Context, branchNames); err != nil {
 		out.Debug("Failed to batch delete remote metadata: %v", err)
 	}
@@ -165,6 +172,95 @@ func Action(ctx *app.Context, opts Options, handler Handler) (Result, error) {
 
 	handler.Complete(len(toDelete), 0)
 	return Result{MainRepoDirForSwitch: mainRepoDirForSwitch}, nil
+}
+
+func preReparentChildrenWithPreservedDivergence(ctx *app.Context, toDelete []engine.Branch, statuses map[string]engine.DeletionStatus) ([]string, error) {
+	eng := ctx.Engine
+	gctx := ctx.Context
+	out := ctx.Output
+
+	toDeleteSet := make(map[string]bool, len(toDelete))
+	for _, b := range toDelete {
+		toDeleteSet[b.GetName()] = true
+	}
+
+	graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
+	reparentedChildren := make([]string, 0)
+	reparentedSet := make(map[string]bool)
+
+	for _, deleted := range toDelete {
+		deletedName := deleted.GetName()
+		status := statuses[deletedName]
+		if !shouldPreserveDivergenceOnDelete(status.Kind) {
+			continue
+		}
+
+		targetParentName := deleted.GetParentOrTrunk()
+		targetParentName = findNearestNonDeletingAncestorForDelete(eng, toDeleteSet, targetParentName)
+
+		for _, child := range graph.ChildBranches(deleted) {
+			childName := child.GetName()
+			if toDeleteSet[childName] {
+				continue
+			}
+
+			oldDivergencePoint, _ := eng.GetDivergencePoint(childName)
+			if err := eng.SetParentPreservingDivergence(gctx, child, eng.GetBranch(targetParentName), oldDivergencePoint); err != nil {
+				return nil, fmt.Errorf("failed to preserve divergence while reparenting %s to %s: %w", childName, targetParentName, err)
+			}
+			out.Debug("Pre-reparented %s to %s while preserving divergence", childName, targetParentName)
+			if !reparentedSet[childName] {
+				reparentedSet[childName] = true
+				reparentedChildren = append(reparentedChildren, childName)
+			}
+		}
+	}
+
+	return reparentedChildren, nil
+}
+
+func shouldPreserveDivergenceOnDelete(kind engine.DeletionReasonKind) bool {
+	switch kind {
+	case engine.DeletionReasonMergedPR, engine.DeletionReasonMergedIntoTrunk, engine.DeletionReasonEmptyWithPR:
+		return true
+	default:
+		return false
+	}
+}
+
+func findNearestNonDeletingAncestorForDelete(eng engine.Engine, toDeleteSet map[string]bool, startParent string) string {
+	current := startParent
+	for toDeleteSet[current] {
+		parent := eng.GetBranch(current).GetParent()
+		if parent == nil {
+			return eng.Trunk().GetName()
+		}
+		current = parent.GetName()
+	}
+	return current
+}
+
+func mergeUniqueBranchNames(a []string, b []string) []string {
+	if len(b) == 0 {
+		return a
+	}
+
+	seen := make(map[string]bool, len(a)+len(b))
+	out := make([]string, 0, len(a)+len(b))
+	for _, name := range a {
+		if !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	for _, name := range b {
+		if !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+
+	return out
 }
 
 // cleanupWorktreesForDeletedStacks removes worktrees for stack roots that have been deleted.

--- a/internal/actions/delete/delete_test.go
+++ b/internal/actions/delete/delete_test.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -143,6 +144,43 @@ func TestDelete(t *testing.T) {
 		parent2 := branchparent2.GetParent()
 		require.NotNil(t, parent2)
 		require.Equal(t, "main", parent2.GetName())
+	})
+
+	t.Run("preserves child commit boundaries when deleting squash-merged parent", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		s.CreateBranch("branch1").
+			CommitChange("shared.txt", "branch1-v1").
+			CommitChange("shared.txt", "branch1-v2").
+			TrackBranch("branch1", "main")
+
+		s.CreateBranch("branch2").
+			CommitChange("child.txt", "branch2-change").
+			TrackBranch("branch2", "branch1")
+
+		// Simulate squash merge by adding branch1's final state to main in one commit.
+		s.Checkout("main")
+		s.CommitChange("shared.txt", "branch1-v2")
+
+		// Mark branch1 as merged so delete uses merged deletion semantics.
+		err := s.Engine.UpsertPrInfo(context.Background(), s.Engine.GetBranch("branch1"), testhelpers.NewTestPrInfoMerged(1, "main"))
+		require.NoError(t, err)
+
+		_, err = Action(s.Context, Options{
+			BranchName: "branch1",
+			Force:      true,
+		}, nil)
+		require.NoError(t, err)
+
+		require.False(t, s.Engine.GetBranch("branch1").IsTracked())
+		require.True(t, s.Engine.GetBranch("branch2").IsTracked())
+		parent := s.Engine.GetBranch("branch2").GetParent()
+		require.NotNil(t, parent)
+		require.Equal(t, "main", parent.GetName())
+
+		commitCount, err := s.Engine.GetCommitCount(s.Engine.GetBranch("branch2"))
+		require.NoError(t, err)
+		require.Equal(t, 1, commitCount)
 	})
 }
 

--- a/internal/actions/sync/branch_cleaning.go
+++ b/internal/actions/sync/branch_cleaning.go
@@ -71,8 +71,14 @@ func cleanBranches(ctx *app.Context, opts *Options, dirtyAnchors map[string]bool
 			len(plan.BranchesToDelete), strings.Join(logDetails, ", "))
 	}
 
-	// Phase 2: Get user confirmation for deletions (interactive mode only)
-	var branchesToDelete map[string]bool
+	// Phase 2: Build final deletion set.
+	// Always pass an explicit filter to ExecuteBranchDeletions so any upstream
+	// filtering (e.g. dirty stack exclusions) is enforced in both interactive
+	// and non-interactive flows.
+	branchesToDelete := make(map[string]bool, len(plan.BranchesToDelete))
+	for name := range plan.BranchesToDelete {
+		branchesToDelete[name] = true
+	}
 	if handler.IsInteractive() && len(plan.BranchesToDelete) > 0 {
 		// Auto-confirm utility branches (e.g., consolidated merge branches)
 		// These don't need user confirmation since their PRs are already closed/merged

--- a/internal/actions/sync/branch_cleaning_test.go
+++ b/internal/actions/sync/branch_cleaning_test.go
@@ -1,0 +1,39 @@
+package sync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"stackit.dev/stackit/testhelpers"
+	"stackit.dev/stackit/testhelpers/scenario"
+)
+
+func TestCleanBranchesNonInteractiveRespectsDirtyStackFilter(t *testing.T) {
+	t.Parallel()
+
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{
+			"branch1": "main",
+		})
+
+	// Mark branch as deletable.
+	s.Checkout("main").RunGit("merge", "branch1")
+	err := s.Engine.Rebuild("main")
+	require.NoError(t, err)
+	err = s.Engine.UpsertPrInfo(context.Background(), s.Engine.GetBranch("branch1"), testhelpers.NewTestPrInfoMerged(1, "main"))
+	require.NoError(t, err)
+
+	// Non-interactive path uses NullHandler. Dirty stack filter should prevent deletion.
+	result, err := cleanBranches(
+		s.Context,
+		&Options{Force: true},
+		map[string]bool{"branch1": true},
+		&NullHandler{},
+		&Summary{},
+	)
+	require.NoError(t, err)
+	require.Empty(t, result.DeletedBranches)
+	require.True(t, s.Engine.GetBranch("branch1").IsTracked())
+}

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -272,7 +272,7 @@ func (e *engineImpl) GetDeletionStatus(ctx context.Context, branchName string) (
 	if status, ok := statuses[branchName]; ok {
 		return status, nil
 	}
-	return DeletionStatus{SafeToDelete: false, Reason: ""}, nil
+	return DeletionStatus{SafeToDelete: false, Reason: "", Kind: DeletionReasonNone}, nil
 }
 
 // BatchGetDeletionStatuses checks deletion status for multiple branches in a single batch.
@@ -326,12 +326,12 @@ func (e *engineImpl) BatchGetDeletionStatuses(ctx context.Context, branchNames [
 func (e *engineImpl) evaluateDeletionStatus(ctx context.Context, branchName string, branch Branch, meta *git.Meta, revisions map[string]string, mergedBranches map[string]bool, trunkName string) DeletionStatus {
 	// 1. Never delete trunk
 	if e.IsTrunk(branch) {
-		return DeletionStatus{SafeToDelete: false, Reason: ""}
+		return DeletionStatus{SafeToDelete: false, Reason: "", Kind: DeletionReasonNone}
 	}
 
 	// 2. Never delete worktree anchor branches
 	if e.IsWorktreeAnchor(branch) {
-		return DeletionStatus{SafeToDelete: false, Reason: ""}
+		return DeletionStatus{SafeToDelete: false, Reason: "", Kind: DeletionReasonNone}
 	}
 
 	// 3. Check PR state from metadata
@@ -343,21 +343,29 @@ func (e *engineImpl) evaluateDeletionStatus(ctx context.Context, branchName stri
 				prStateMerged = "MERGED"
 			)
 			if prInfo.State() == prStateClosed {
-				return DeletionStatus{SafeToDelete: true, Reason: "closed on GitHub"}
+				return DeletionStatus{SafeToDelete: true, Reason: "closed on GitHub", Kind: DeletionReasonClosedPR}
 			}
 			if prInfo.State() == prStateMerged {
 				base := prInfo.Base()
 				if base == "" {
 					base = trunkName
 				}
-				return DeletionStatus{SafeToDelete: true, Reason: fmt.Sprintf("merged into %s", base)}
+				return DeletionStatus{
+					SafeToDelete: true,
+					Reason:       fmt.Sprintf("merged into %s", base),
+					Kind:         DeletionReasonMergedPR,
+				}
 			}
 		}
 	}
 
 	// 4. Check if merged into trunk
 	if mergedBranches != nil && mergedBranches[branchName] {
-		return DeletionStatus{SafeToDelete: true, Reason: fmt.Sprintf("merged into %s", trunkName)}
+		return DeletionStatus{
+			SafeToDelete: true,
+			Reason:       fmt.Sprintf("merged into %s", trunkName),
+			Kind:         DeletionReasonMergedIntoTrunk,
+		}
 	}
 
 	// 5. Check if empty (no diff from parent) with an associated PR
@@ -380,13 +388,13 @@ func (e *engineImpl) evaluateDeletionStatus(ctx context.Context, branchName stri
 			if meta != nil {
 				metaPrInfo := meta.GetPrInfo()
 				if metaPrInfo != nil && metaPrInfo.Number != nil && *metaPrInfo.Number != 0 {
-					return DeletionStatus{SafeToDelete: true, Reason: "empty"}
+					return DeletionStatus{SafeToDelete: true, Reason: "empty", Kind: DeletionReasonEmptyWithPR}
 				}
 			}
 		}
 	}
 
-	return DeletionStatus{SafeToDelete: false, Reason: ""}
+	return DeletionStatus{SafeToDelete: false, Reason: "", Kind: DeletionReasonNone}
 }
 
 // GetRemote returns the default remote name

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -157,9 +157,21 @@ func (s Scope) TitleNeedsUpdate(title string) bool {
 
 // DeletionStatus represents the deletion status of a branch
 type DeletionStatus struct {
-	SafeToDelete bool   // True if the branch is merged, closed, or empty (with PR)
-	Reason       string // Reason why it's safe (or not) to delete
+	SafeToDelete bool               // True if the branch is merged, closed, or empty (with PR)
+	Reason       string             // Human-readable reason why it's safe (or not) to delete
+	Kind         DeletionReasonKind // Machine-readable deletion reason
 }
+
+// DeletionReasonKind is a machine-readable reason for branch deletion eligibility.
+type DeletionReasonKind string
+
+const (
+	DeletionReasonNone            DeletionReasonKind = "none"
+	DeletionReasonClosedPR        DeletionReasonKind = "closed_pr"
+	DeletionReasonMergedPR        DeletionReasonKind = "merged_pr"
+	DeletionReasonMergedIntoTrunk DeletionReasonKind = "merged_into_trunk"
+	DeletionReasonEmptyWithPR     DeletionReasonKind = "empty_with_pr"
+)
 
 // PendingChange represents a changed file in the working directory
 type PendingChange struct {

--- a/internal/integration/sync_test.go
+++ b/internal/integration/sync_test.go
@@ -422,6 +422,71 @@ func TestSyncRemoteMetadata(t *testing.T) {
 	})
 }
 
+func TestSyncSquashMergedRootPreservesChildCommitBoundaries(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+	// Create stack: main -> A(2 commits) -> B -> C
+	sh.CreateBranch("branch-a").
+		CommitChange("shared.txt", "a-v1").
+		CommitChange("shared.txt", "a-v2").
+		TrackBranch("branch-a", "main")
+
+	sh.CreateBranch("branch-b").
+		CommitChange("child-b.txt", "b-change").
+		TrackBranch("branch-b", "branch-a")
+
+	sh.CreateBranch("branch-c").
+		CommitChange("child-c.txt", "c-change").
+		TrackBranch("branch-c", "branch-b")
+
+	eng := sh.Engine
+	mainBranchName := eng.Trunk().GetName()
+
+	// Simulate squash merge of branch-a: apply final A tree state on main as one commit.
+	sh.Checkout("main")
+	sh.CommitChange("shared.txt", "a-v2")
+
+	// Mark branch-a PR as merged so sync cleanup deletes it.
+	metaA, err := eng.Git().ReadMetadata("branch-a")
+	require.NoError(t, err)
+	prNum := 1
+	state := prStateMerged
+	base := mainBranchName
+	metaA = metaA.WithPrInfo(&git.PrInfoPersistence{
+		Number: &prNum,
+		State:  &state,
+		Base:   &base,
+	})
+	err = eng.Git().WriteMetadata("branch-a", metaA)
+	require.NoError(t, err)
+
+	// Run sync+restack from main.
+	sh.Checkout("main")
+	err = sync.Action(sh.Context, sync.Options{Restack: true}, nil)
+	require.NoError(t, err)
+
+	allLocalBranches, err := sh.Scene.Repo.GetLocalBranches()
+	require.NoError(t, err)
+	require.NotContains(t, allLocalBranches, "branch-a")
+
+	require.Equal(t, "main", eng.GetBranch("branch-b").GetParent().GetName())
+	require.Equal(t, "branch-b", eng.GetBranch("branch-c").GetParent().GetName())
+
+	// Core regression assertions: B and C keep their own commit boundaries.
+	// If A commits were replayed into B/C, these counts would be inflated.
+	bCount, err := eng.GetCommitCount(eng.GetBranch("branch-b"))
+	require.NoError(t, err)
+	require.Equal(t, 1, bCount)
+
+	cCount, err := eng.GetCommitCount(eng.GetBranch("branch-c"))
+	require.NoError(t, err)
+	require.Equal(t, 1, cCount)
+
+	sh.ExpectBranchFixed("branch-b").
+		ExpectBranchFixed("branch-c")
+}
+
 // createRemoteMetadataRefForSync creates a ref at refs/stackit/remote-metadata/<branch>
 func createRemoteMetadataRefForSync(t *testing.T, sh *scenario.Scenario, branchName string, meta *git.Meta) {
 	t.Helper()


### PR DESCRIPTION


<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #748**
  * **PR #749** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->