### PR TITLE
feat: protect branches with unpushed changes during sync cleanup

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -26,6 +26,7 @@ type CleanBranchesResult struct {
 	DeletedBranches        map[string]string // name -> reason
 	BranchesWithNewParents []string
 	SkippedInWorktree      []string // branches that couldn't be deleted from worktree
+	SkippedUnpushed        []string // branches skipped due to unpushed local changes
 }
 
 // BranchDeletionPlan contains the planned branch deletions before execution
@@ -40,6 +41,9 @@ type BranchDeletionPlan struct {
 	// (e.g., consolidated merge branches). These can be auto-confirmed for deletion
 	// when their associated PR is closed/merged.
 	UtilityBranches map[string]bool
+	// UnpushedBranches tracks which branches in BranchesToDelete have unpushed local changes
+	// (local branch is ahead of or diverged from remote)
+	UnpushedBranches map[string]bool
 	// internal plan for execution
 	plan *deletionPlan
 }
@@ -135,8 +139,14 @@ func PlanBranchDeletions(ctx *app.Context, opts CleanBranchesOptions) (*BranchDe
 
 	// Build the public plan
 	branchesToDelete := make(map[string]string)
+	unpushedBranches := make(map[string]bool)
 	for name, info := range plan.branches {
 		branchesToDelete[name] = info.reason
+	}
+	for name, status := range deleteStatuses {
+		if status.HasUnpushedChanges {
+			unpushedBranches[name] = true
+		}
 	}
 
 	return &BranchDeletionPlan{
@@ -144,6 +154,7 @@ func PlanBranchDeletions(ctx *app.Context, opts CleanBranchesOptions) (*BranchDe
 		BranchesWithNewParents: branchesWithNewParents,
 		SkippedInWorktree:      skippedInWorktree,
 		UtilityBranches:        utilityBranches,
+		UnpushedBranches:       unpushedBranches,
 		plan:                   plan,
 	}, nil
 }
@@ -220,15 +231,22 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[
 			continue
 		}
 
+		// Check if local branch has unpushed changes relative to remote
+		branch := eng.GetBranch(name)
+		remoteStatus, err := eng.GetBranchRemoteStatus(branch)
+		if err == nil && (remoteStatus.Ahead() || remoteStatus.Diverged()) {
+			status.HasUnpushedChanges = true
+			ctx.Logger.Info("identifyBranchesToDelete branch has unpushed changes branch=%v ahead=%v diverged=%v", name, remoteStatus.Ahead(), remoteStatus.Diverged())
+		}
+
 		deleteStatuses[name] = status
 
 		// Track utility branches using in-memory branch state (no extra fetch)
-		branch := eng.GetBranch(name)
 		if eng.GetBranchType(branch) == git.BranchTypeUtility {
 			utilityBranches[name] = true
 		}
 
-		ctx.Logger.Info("identifyBranchesToDelete marked for deletion branch=%v reason=%v", name, status.Reason)
+		ctx.Logger.Info("identifyBranchesToDelete marked for deletion branch=%v reason=%v unpushed=%v", name, status.Reason, status.HasUnpushedChanges)
 	}
 
 	ctx.Logger.Info("identifyBranchesToDelete completed toDeleteCount=%v skippedCount=%v", len(deleteStatuses), len(skippedInWorktree))

--- a/internal/actions/clean_branches_test.go
+++ b/internal/actions/clean_branches_test.go
@@ -197,6 +197,80 @@ func TestCleanBranches(t *testing.T) {
 		require.True(t, s.Engine.GetBranch("branch1").IsTracked())
 	})
 
+	t.Run("marks branch with unpushed changes when merged", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"branch1": "main",
+			})
+
+		// Set up remote and push
+		_, err := s.Scene.Repo.CreateBareRemote("origin")
+		require.NoError(t, err)
+		err = s.Scene.Repo.PushBranch("origin", "main")
+		require.NoError(t, err)
+		err = s.Scene.Repo.PushBranch("origin", "branch1")
+		require.NoError(t, err)
+
+		// Add an unpushed local commit
+		s.Checkout("branch1").
+			CommitChange("extra.txt", "unpushed work")
+
+		// Mark branch1 as merged via PR info
+		prInfo := testhelpers.NewTestPrInfoMerged(1, "main")
+		branch := s.Engine.GetBranch("branch1")
+		err = s.Engine.UpsertPrInfo(context.Background(), branch, prInfo)
+		require.NoError(t, err)
+
+		// Populate remote SHAs so GetBranchRemoteStatus works
+		err = s.Engine.PopulateRemoteShas()
+		require.NoError(t, err)
+
+		s.Checkout("main")
+
+		plan, err := actions.PlanBranchDeletions(s.Context, actions.CleanBranchesOptions{
+			Force: true,
+		})
+		require.NoError(t, err)
+
+		// branch1 should be in BranchesToDelete but also in UnpushedBranches
+		require.Contains(t, plan.BranchesToDelete, "branch1")
+		require.True(t, plan.UnpushedBranches["branch1"], "branch1 should be marked as having unpushed changes")
+	})
+
+	t.Run("does not mark branch without unpushed changes as unpushed", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"branch1": "main",
+			})
+
+		// Set up remote and push
+		_, err := s.Scene.Repo.CreateBareRemote("origin")
+		require.NoError(t, err)
+		err = s.Scene.Repo.PushBranch("origin", "main")
+		require.NoError(t, err)
+		err = s.Scene.Repo.PushBranch("origin", "branch1")
+		require.NoError(t, err)
+
+		// Mark branch1 as merged via PR info (no extra local commits)
+		prInfo := testhelpers.NewTestPrInfoMerged(1, "main")
+		branch := s.Engine.GetBranch("branch1")
+		err = s.Engine.UpsertPrInfo(context.Background(), branch, prInfo)
+		require.NoError(t, err)
+
+		// Populate remote SHAs
+		err = s.Engine.PopulateRemoteShas()
+		require.NoError(t, err)
+
+		plan, err := actions.PlanBranchDeletions(s.Context, actions.CleanBranchesOptions{
+			Force: true,
+		})
+		require.NoError(t, err)
+
+		// branch1 should be in BranchesToDelete but NOT in UnpushedBranches
+		require.Contains(t, plan.BranchesToDelete, "branch1")
+		require.False(t, plan.UnpushedBranches["branch1"], "branch1 should not be marked as having unpushed changes")
+	})
+
 	t.Run("preserves divergence when reparenting after squash-merged parent deletion", func(t *testing.T) {
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 

--- a/internal/actions/sync/branch_cleaning.go
+++ b/internal/actions/sync/branch_cleaning.go
@@ -99,11 +99,16 @@ func cleanBranches(ctx *app.Context, opts *Options, dirtyAnchors map[string]bool
 
 		// Prompt user for non-utility branches only
 		if len(branchesToPrompt) > 0 {
-			confirmed, err := handler.PromptBranchDeletions(branchesToPrompt)
+			confirmed, err := handler.PromptBranchDeletions(branchesToPrompt, plan.UnpushedBranches)
 			if err != nil {
 				return nil, err
 			}
 			maps.Copy(branchesToDelete, confirmed)
+		}
+	} else if len(plan.UnpushedBranches) > 0 {
+		// Non-interactive: skip unpushed branches by default
+		for name := range plan.UnpushedBranches {
+			delete(branchesToDelete, name)
 		}
 	}
 
@@ -111,6 +116,13 @@ func cleanBranches(ctx *app.Context, opts *Options, dirtyAnchors map[string]bool
 	result, err := actions.ExecuteBranchDeletions(ctx, plan, branchesToDelete)
 	if err != nil {
 		return nil, err
+	}
+
+	// Collect branches that were skipped due to unpushed changes
+	for name := range plan.UnpushedBranches {
+		if _, wasDeleted := result.DeletedBranches[name]; !wasDeleted {
+			result.SkippedUnpushed = append(result.SkippedUnpushed, name)
+		}
 	}
 
 	ctx.Logger.Info("clean branches completed durationMs=%d deletedCount=%d", time.Since(cleanStart).Milliseconds(), len(result.DeletedBranches))
@@ -130,6 +142,12 @@ func cleanBranches(ctx *app.Context, opts *Options, dirtyAnchors map[string]bool
 	for _, name := range result.SkippedInWorktree {
 		ctx.Output.Warn("Cannot delete %s from worktree. Run sync from the main repository to clean up.",
 			style.ColorBranchName(name, true))
+	}
+
+	// Warn about branches skipped due to unpushed changes
+	for _, name := range result.SkippedUnpushed {
+		ctx.Output.Warn("Skipped %s — has unpushed local changes. Push first or delete manually with 'git branch -D %s'.",
+			style.ColorBranchName(name, false), name)
 	}
 
 	return result, nil

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -377,9 +377,10 @@ type Handler interface {
 	PromptOrphanedMetadata(info engine.OrphanedMetadataInfo) (pushLocal bool, err error)
 
 	// PromptBranchDeletions displays planned branch deletions and asks user to confirm each one.
+	// unpushedBranches identifies branches with local commits not yet pushed to remote.
 	// Returns a map of branch names that the user confirmed for deletion.
-	// In non-interactive mode, returns all branches (auto-confirm).
-	PromptBranchDeletions(branches map[string]string) (confirmed map[string]bool, err error)
+	// In non-interactive mode, returns all branches except unpushed ones (which are skipped by default).
+	PromptBranchDeletions(branches map[string]string, unpushedBranches map[string]bool) (confirmed map[string]bool, err error)
 
 	// PromptResolveConflicts asks user if they want to resolve restack conflicts now or skip them.
 	// Returns true to start conflict resolution workflow, false to skip and continue.
@@ -432,11 +433,11 @@ func (h *NullHandler) PromptResolveConflicts(_ []string) (bool, error) {
 	return false, nil
 }
 
-// PromptBranchDeletions implements Handler. Returns all branches (auto-confirm) in non-interactive mode.
-func (h *NullHandler) PromptBranchDeletions(branches map[string]string) (map[string]bool, error) {
+// PromptBranchDeletions implements Handler. Skips unpushed branches, auto-confirms the rest.
+func (h *NullHandler) PromptBranchDeletions(branches map[string]string, unpushedBranches map[string]bool) (map[string]bool, error) {
 	confirmed := make(map[string]bool)
 	for name := range branches {
-		confirmed[name] = true
+		confirmed[name] = !unpushedBranches[name]
 	}
 	return confirmed, nil
 }

--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -123,11 +123,11 @@ func (h *SimpleSyncHandler) PromptResolveConflicts(_ []string) (bool, error) {
 	return false, nil
 }
 
-// PromptBranchDeletions implements Handler. In non-interactive mode, auto-confirms all deletions.
-func (h *SimpleSyncHandler) PromptBranchDeletions(branches map[string]string) (map[string]bool, error) {
+// PromptBranchDeletions implements Handler. In non-interactive mode, skips unpushed branches and auto-confirms the rest.
+func (h *SimpleSyncHandler) PromptBranchDeletions(branches map[string]string, unpushedBranches map[string]bool) (map[string]bool, error) {
 	confirmed := make(map[string]bool)
 	for name := range branches {
-		confirmed[name] = true
+		confirmed[name] = !unpushedBranches[name]
 	}
 	return confirmed, nil
 }
@@ -702,7 +702,7 @@ func (h *InteractiveSyncHandler) PromptResolveConflicts(conflictBranches []strin
 }
 
 // PromptBranchDeletions implements Handler. Pauses TUI, displays planned deletions, prompts for each.
-func (h *InteractiveSyncHandler) PromptBranchDeletions(branches map[string]string) (map[string]bool, error) {
+func (h *InteractiveSyncHandler) PromptBranchDeletions(branches map[string]string, unpushedBranches map[string]bool) (map[string]bool, error) {
 	h.runner.Pause()
 	defer h.runner.Resume()
 
@@ -731,8 +731,11 @@ func (h *InteractiveSyncHandler) PromptBranchDeletions(branches map[string]strin
 	preSelected := make([]bool, len(names))
 	for i, name := range names {
 		reason := branches[name]
+		if unpushedBranches[name] {
+			reason += " — has unpushed changes"
+		}
 		options[i] = fmt.Sprintf("%s (%s)", style.ColorBranchName(name, false), style.ColorDim(reason))
-		preSelected[i] = true // Pre-select all for deletion
+		preSelected[i] = !unpushedBranches[name] // Don't pre-select branches with unpushed changes
 	}
 
 	h.output.Newline()

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -157,9 +157,10 @@ func (s Scope) TitleNeedsUpdate(title string) bool {
 
 // DeletionStatus represents the deletion status of a branch
 type DeletionStatus struct {
-	SafeToDelete bool               // True if the branch is merged, closed, or empty (with PR)
-	Reason       string             // Human-readable reason why it's safe (or not) to delete
-	Kind         DeletionReasonKind // Machine-readable deletion reason
+	SafeToDelete       bool               // True if the branch is merged, closed, or empty (with PR)
+	Reason             string             // Human-readable reason why it's safe (or not) to delete
+	Kind               DeletionReasonKind // Machine-readable deletion reason
+	HasUnpushedChanges bool               // Local branch is ahead of or diverged from remote
 }
 
 // DeletionReasonKind is a machine-readable reason for branch deletion eligibility.

--- a/internal/integration/sync_test.go
+++ b/internal/integration/sync_test.go
@@ -685,4 +685,65 @@ func TestSyncDoesNotLeaveIndexState(t *testing.T) {
 		require.NotNil(t, childBranch.GetParent())
 		require.Equal(t, mainBranchName, childBranch.GetParent().GetName())
 	})
+
+	t.Run("sync skips deletion of branch with unpushed commits", func(t *testing.T) {
+		t.Parallel()
+		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		// Create a branch and track it
+		sh.CreateBranch("feature").
+			CommitChange("feature-file", "content").
+			TrackBranch("feature", "main")
+
+		eng := sh.Engine
+		mainBranchName := eng.Trunk().GetName()
+
+		// Set up remote and push everything
+		_, err := sh.Scene.Repo.CreateBareRemote("origin")
+		require.NoError(t, err)
+		sh.Checkout("main")
+		err = sh.Scene.Repo.PushBranch("origin", "main")
+		require.NoError(t, err)
+		sh.Checkout("feature")
+		err = sh.Scene.Repo.PushBranch("origin", "feature")
+		require.NoError(t, err)
+
+		// Add an unpushed local commit
+		sh.CommitChange("extra.txt", "unpushed work")
+
+		// Mark feature as merged via PR metadata
+		meta, err := eng.Git().ReadMetadata("feature")
+		require.NoError(t, err)
+		prNum := 1
+		state := prStateMerged
+		base := mainBranchName
+		meta = meta.WithPrInfo(&git.PrInfoPersistence{
+			Number: &prNum,
+			State:  &state,
+			Base:   &base,
+		})
+		err = eng.Git().WriteMetadata("feature", meta)
+		require.NoError(t, err)
+
+		// Go back to main for sync
+		sh.Checkout("main")
+
+		// Populate remote SHAs so GetBranchRemoteStatus can detect ahead
+		err = eng.PopulateRemoteShas()
+		require.NoError(t, err)
+
+		// Run sync (non-interactive - should skip unpushed branches)
+		err = sync.Action(sh.Context, sync.Options{}, nil)
+		require.NoError(t, err)
+
+		// Feature branch should NOT be deleted because it has unpushed commits
+		allLocalBranches, err := sh.Scene.Repo.GetLocalBranches()
+		require.NoError(t, err)
+		require.Contains(t, allLocalBranches, "feature",
+			"branch with unpushed changes should not be deleted during sync")
+
+		// A warning should have been emitted (check output buffer)
+		require.Contains(t, sh.Output.String(), "unpushed",
+			"sync should warn about branches with unpushed changes")
+	})
 }


### PR DESCRIPTION
## Summary

- Adds detection of local branches that are **ahead of or diverged from** their remote tracking branch, so `sync` doesn't silently delete work that was never pushed
- In non-interactive mode, branches with unpushed commits are **skipped by default** with a clear warning message
- In interactive mode, these branches appear **un-pre-selected** in the multi-select deletion prompt so the user must explicitly opt in

## Details

### New field: `DeletionStatus.HasUnpushedChanges`

After `BatchGetDeletionStatuses` identifies which branches are safe to delete, we call `GetBranchRemoteStatus` on each candidate. If the local branch is `Ahead()` or `Diverged()` from remote, `HasUnpushedChanges` is set. This keeps the hot path unchanged — the extra check is only O(N) over the small set of branches actually scheduled for deletion.

### `BranchDeletionPlan.UnpushedBranches`

The plan now carries an `UnpushedBranches map[string]bool` so callers (branch_cleaning.go) can act on this without re-querying.

### Handler interface update

`PromptBranchDeletions` gains an `unpushedBranches map[string]bool` parameter:
- **Interactive**: appends `" — has unpushed changes"` to the reason string; `preSelected[i] = false` for those branches
- **Non-interactive / NullHandler / SimpleSyncHandler**: sets `confirmed[name] = false` for unpushed branches

### Warning messages

After execution, `branch_cleaning.go` emits a `Warn` for each skipped unpushed branch pointing the user toward `git branch -D` if they want to delete manually.

## Test plan

- [x] `TestCleanBranches/marks_branch_with_unpushed_changes_when_merged` — creates remote, pushes, adds local commit, verifies `UnpushedBranches` is populated
- [x] `TestCleanBranches/does_not_mark_branch_without_unpushed_changes_as_unpushed` — same setup without extra local commit, verifies flag is clear
- [x] `TestSync/sync_skips_deletion_of_branch_with_unpushed_commits` (integration) — full end-to-end: remote + pushed branch + local commit + PR marked merged → sync must leave branch intact and emit warning
- [x] `mise run check` — 1948 tests, 0 failures