### PR TITLE
Merging 2 PRs

### DIFF
--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -125,11 +125,11 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	} else {
 		// Check if it's a PR number
 		if prNum, err := strconv.Atoi(branchOrPR); err == nil {
-			if ctx.GitHubClient == nil {
+			if ctx.GitHub() == nil {
 				return fmt.Errorf("GitHub client not configured; cannot resolve PR #%d", prNum)
 			}
-			owner, repo := ctx.GitHubClient.GetOwnerRepo()
-			pr, err := ctx.GitHubClient.GetPullRequest(gctx, owner, repo, prNum)
+			owner, repo := ctx.GitHub().GetOwnerRepo()
+			pr, err := ctx.GitHub().GetPullRequest(gctx, owner, repo, prNum)
 			if err != nil {
 				return fmt.Errorf("failed to get PR #%d: %w", prNum, err)
 			}
@@ -168,11 +168,11 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	parentMap := make(map[string]string)
 
 	// Crawl ancestors using GitHub PR info if possible
-	if ctx.GitHubClient != nil {
+	if ctx.GitHub() != nil {
 		current := targetBranch
-		owner, repo := ctx.GitHubClient.GetOwnerRepo()
+		owner, repo := ctx.GitHub().GetOwnerRepo()
 		for {
-			pr, err := ctx.GitHubClient.GetPullRequestByBranch(gctx, owner, repo, current)
+			pr, err := ctx.GitHub().GetPullRequestByBranch(gctx, owner, repo, current)
 			if err != nil || pr == nil {
 				break
 			}
@@ -217,8 +217,8 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	branchFrozenStatus := make(map[string]bool) // branch -> is frozen
 
 	// Fetch PR info for branches in parallel if possible
-	if ctx.GitHubClient != nil {
-		owner, repo := ctx.GitHubClient.GetOwnerRepo()
+	if ctx.GitHub() != nil {
+		owner, repo := ctx.GitHub().GetOwnerRepo()
 		trunkName := eng.Trunk().GetName()
 
 		// Filter out trunk before parallel fetch
@@ -231,7 +231,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 
 		var mu sync.Mutex
 		utils.Run(branchesToFetch, func(branchName string) {
-			if pr, err := ctx.GitHubClient.GetPullRequestByBranch(gctx, owner, repo, branchName); err == nil && pr != nil {
+			if pr, err := ctx.GitHub().GetPullRequestByBranch(gctx, owner, repo, branchName); err == nil && pr != nil {
 				prNum := pr.Number
 				mu.Lock()
 				branchPRInfo[branchName] = &prNum

--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -37,7 +37,7 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 	// If interactive mode is requested or auto-detected
 	if opts.Interactive || (utils.IsInteractive() && opts.Steps == nil) {
 		// Run interactive TUI
-		m := tui.NewLogModel(ctx.Context, ctx.Engine, ctx.GitHubClient, tui.LogOptions{
+		m := tui.NewLogModel(ctx.Context, ctx.Engine, ctx.GitHub(), tui.LogOptions{
 			Style:         opts.Style,
 			ShowUntracked: opts.ShowUntracked,
 			Logger:        ctx.Logger,
@@ -81,7 +81,7 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 
 	// Prefetch CI status in batch if in FULL style
 	var ciStatuses map[string]*github.CheckStatus
-	if opts.Style == LogStyleFull && ctx.GitHubClient != nil {
+	if opts.Style == LogStyleFull && ctx.GitHub() != nil {
 		branchNames := make([]string, 0, len(allBranches))
 		for _, b := range allBranches {
 			if !b.IsTrunk() {
@@ -89,7 +89,7 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 			}
 		}
 		if len(branchNames) > 0 {
-			ciStatuses, _ = ctx.GitHubClient.BatchGetPRChecksStatus(ctx.Context, branchNames)
+			ciStatuses, _ = ctx.GitHub().BatchGetPRChecksStatus(ctx.Context, branchNames)
 		}
 	}
 

--- a/internal/actions/merge/cleanup.go
+++ b/internal/actions/merge/cleanup.go
@@ -74,7 +74,7 @@ func NewPRCleaner(ctx *app.Context, eng prCleanupEngine, config PRCleanupConfig)
 func (c *PRCleaner) CleanupBranches(ctx context.Context, branchNames []string) PRCleanupResult {
 	result := PRCleanupResult{}
 	out := c.ctx.Output
-	githubClient := c.ctx.GitHubClient
+	githubClient := c.ctx.GitHub()
 
 	if githubClient == nil {
 		out.Debug("No GitHub client available for PR cleanup")

--- a/internal/actions/merge/consolidate.go
+++ b/internal/actions/merge/consolidate.go
@@ -227,7 +227,7 @@ func (c *ConsolidateMergeExecutor) createConsolidationPR(ctx context.Context, br
 		Draft: false,
 	}
 
-	pr, err := c.ctx.GitHubClient.CreatePullRequest(ctx, owner, repo, opts)
+	pr, err := c.ctx.GitHub().CreatePullRequest(ctx, owner, repo, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create PR: %w", err)
 	}
@@ -246,7 +246,7 @@ func (c *ConsolidateMergeExecutor) waitForConsolidationMerge(ctx context.Context
 	}
 
 	waiter := NewCIWaiter(CIWaiterOptions{
-		Client: c.ctx.GitHubClient,
+		Client: c.ctx.GitHub(),
 		Output: c.ctx.Output,
 	})
 	waiter.SetProgressHandler(c.handler, c.stepIndex)
@@ -335,7 +335,7 @@ func (c *ConsolidateMergeExecutor) getStackScope() string {
 }
 
 func (c *ConsolidateMergeExecutor) getOwnerRepo() (owner, repo string) {
-	return c.ctx.GitHubClient.GetOwnerRepo()
+	return c.ctx.GitHub().GetOwnerRepo()
 }
 
 // resolveMergeMethod returns the merge method to use, preferring the override if set.
@@ -343,5 +343,5 @@ func (c *ConsolidateMergeExecutor) resolveMergeMethod() (github.MergeMethod, err
 	if c.mergeMethod != "" {
 		return c.mergeMethod, nil
 	}
-	return getMergeMethodWithPause(c.ctx, c.ctx.GitHubClient, c.handler)
+	return getMergeMethodWithPause(c.ctx, c.ctx.GitHub(), c.handler)
 }

--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -150,7 +150,7 @@ type ExecuteOptions struct {
 // Execute executes a validated merge plan step by step
 func Execute(ctx *app.Context, eng mergeExecuteEngine, opts ExecuteOptions) error {
 	plan := opts.Plan
-	githubClient := ctx.GitHubClient
+	githubClient := ctx.GitHub()
 	out := ctx.Output
 
 	// Use null handler if none provided
@@ -210,7 +210,7 @@ func executeSteps(ctx *app.Context, eng mergeExecuteEngine, opts ExecuteOptions)
 		})
 
 		// 1. Re-validate preconditions for this step
-		if err := validateStepPreconditions(ctx.Context, step, eng, ctx.GitHubClient, opts); err != nil {
+		if err := validateStepPreconditions(ctx.Context, step, eng, ctx.GitHub(), opts); err != nil {
 			opts.Handler.EmitEvent(Event{
 				Phase:     phaseFromStep(stepRef),
 				Type:      EventFailed,
@@ -258,7 +258,7 @@ func executeStepWithProgress(ctx *app.Context, step PlanStep, stepIndex int, eng
 // executeStep executes a single step
 func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecuteEngine, opts ExecuteOptions) error {
 	trunk := eng.Trunk() // Cache trunk for this function scope
-	githubClient := ctx.GitHubClient
+	githubClient := ctx.GitHub()
 	out := ctx.Output
 	repoRoot := ctx.RepoRoot
 

--- a/internal/actions/merge/execute_steps.go
+++ b/internal/actions/merge/execute_steps.go
@@ -86,7 +86,7 @@ func validateStepPreconditions(ctx context.Context, step PlanStep, eng mergeExec
 func executeUpdatePRBase(ctx *app.Context, eng mergeExecuteEngine, step PlanStep) error {
 	trunk := eng.Trunk()
 	trunkName := trunk.GetName()
-	githubClient := ctx.GitHubClient
+	githubClient := ctx.GitHub()
 
 	// Get the parent revision (old base)
 	branch := eng.GetBranch(step.BranchName)
@@ -214,7 +214,7 @@ func executeWaitCIWithProgress(ctx *app.Context, step PlanStep, stepIndex int, e
 	}
 
 	waiter := NewCIWaiter(CIWaiterOptions{
-		Client:  ctx.GitHubClient,
+		Client:  ctx.GitHub(),
 		Output:  ctx.Output,
 		Timeout: timeout,
 	})

--- a/internal/actions/merge/merge.go
+++ b/internal/actions/merge/merge.go
@@ -31,7 +31,7 @@ func Action(ctx *app.Context, opts Options) error {
 		var validation *PlanValidation
 		if plan == nil {
 			var err error
-			plan, validation, err = CreateMergePlan(ctx.Context, eng, ctx.Output, ctx.GitHubClient, CreatePlanOptions{
+			plan, validation, err = CreateMergePlan(ctx.Context, eng, ctx.Output, ctx.GitHub(), CreatePlanOptions{
 				Strategy:     opts.Strategy,
 				Force:        opts.Force,
 				Scope:        opts.Scope,

--- a/internal/actions/merge/multistack_pr.go
+++ b/internal/actions/merge/multistack_pr.go
@@ -62,11 +62,11 @@ func (p *MultiStackPRCreator) CreateAndPushBranch(ctx context.Context, branchNam
 
 // CreatePR creates the multi-stack pull request
 func (p *MultiStackPRCreator) CreatePR(ctx context.Context, branchName string, included []MultiStackInfo, excluded []MultiStackExcluded) (*github.PullRequestInfo, error) {
-	if p.ctx.GitHubClient == nil {
+	if p.ctx.GitHub() == nil {
 		return nil, fmt.Errorf("GitHub client not available")
 	}
 
-	owner, repo := p.ctx.GitHubClient.GetOwnerRepo()
+	owner, repo := p.ctx.GitHub().GetOwnerRepo()
 	if owner == "" || repo == "" {
 		return nil, fmt.Errorf("could not determine repository owner/name")
 	}
@@ -81,7 +81,7 @@ func (p *MultiStackPRCreator) CreatePR(ctx context.Context, branchName string, i
 		Draft: false,
 	}
 
-	pr, err := p.ctx.GitHubClient.CreatePullRequest(ctx, owner, repo, opts)
+	pr, err := p.ctx.GitHub().CreatePullRequest(ctx, owner, repo, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create PR: %w", err)
 	}
@@ -91,7 +91,7 @@ func (p *MultiStackPRCreator) CreatePR(ctx context.Context, branchName string, i
 
 // WaitAndMerge waits for CI to pass and auto-merges the PR
 func (p *MultiStackPRCreator) WaitAndMerge(ctx context.Context, branchName string, pr *github.PullRequestInfo) error {
-	if p.ctx.GitHubClient == nil {
+	if p.ctx.GitHub() == nil {
 		return fmt.Errorf("GitHub client not available for wait")
 	}
 
@@ -112,7 +112,7 @@ func (p *MultiStackPRCreator) WaitAndMerge(ctx context.Context, branchName strin
 	}
 
 	waiter := NewCIWaiter(CIWaiterOptions{
-		Client: p.ctx.GitHubClient,
+		Client: p.ctx.GitHub(),
 		Output: p.ctx.Output,
 	})
 

--- a/internal/actions/merge/wizard.go
+++ b/internal/actions/merge/wizard.go
@@ -116,7 +116,7 @@ func RunWizard(ctx *app.Context, handler InteractiveHandler, opts WizardOptions)
 
 	// Collect branches once (expensive: GitHub API calls, CI status checks)
 	out.Debug("merge wizard: collecting branches with scope=%q, targetBranch=%q", scope, targetBranch)
-	collected, err := CollectMergeBranches(ctx.Context, eng, out, ctx.GitHubClient, CreatePlanOptions{
+	collected, err := CollectMergeBranches(ctx.Context, eng, out, ctx.GitHub(), CreatePlanOptions{
 		Strategy:     StrategyBottomUp,
 		Force:        opts.Force,
 		Scope:        scope,

--- a/internal/actions/merge/worktree.go
+++ b/internal/actions/merge/worktree.go
@@ -50,7 +50,7 @@ func ExecuteInWorktree(ctx *app.Context, eng mergeExecuteEngine, opts ExecuteOpt
 	}
 
 	// Create a sub-context for the worktree
-	worktreeCtx := *ctx
+	worktreeCtx := *ctx //nolint:govet // copylocks: sync.Once is zero-valued here; both copies independently lazy-init
 	worktreeCtx.Engine = worktreeEng
 	worktreeCtx.RepoRoot = worktreePath
 
@@ -80,7 +80,7 @@ func ExecuteInWorktree(ctx *app.Context, eng mergeExecuteEngine, opts ExecuteOpt
 	if plan == nil {
 		// Create plan in worktree
 		var err error
-		plan, _, err = CreateMergePlan(ctx.Context, worktreeEng, out, ctx.GitHubClient, CreatePlanOptions{
+		plan, _, err = CreateMergePlan(ctx.Context, worktreeEng, out, ctx.GitHub(), CreatePlanOptions{
 			Strategy:     opts.Strategy,
 			Force:        opts.Force,
 			Scope:        scope,

--- a/internal/actions/pr_updates.go
+++ b/internal/actions/pr_updates.go
@@ -32,7 +32,7 @@ func UpdateBranchPRMetadata(ctx *app.Context, name string, repoOwner, repoName s
 	prNumber := *prInfo.Number()
 
 	// 1. Fetch latest PR state from GitHub (Option 1)
-	latestPR, err := ctx.GitHubClient.GetPullRequest(ctx.Context, repoOwner, repoName, prNumber)
+	latestPR, err := ctx.GitHub().GetPullRequest(ctx.Context, repoOwner, repoName, prNumber)
 	if err != nil {
 		ctx.Output.Debug("Failed to fetch PR #%d for %s: %v", prNumber, name, err)
 		return
@@ -89,7 +89,7 @@ func UpdateBranchPRMetadata(ctx *app.Context, name string, repoOwner, repoName s
 		}
 
 		ctx.Output.Debug("Updating PR #%d for %s: titleChanged=%v, bodyChanged=%v", prNumber, name, updatedTitle != currentTitle, shouldUpdateBody)
-		warnings, err := ctx.GitHubClient.UpdatePullRequest(ctx.Context, repoOwner, repoName, prNumber, updateOpts)
+		warnings, err := ctx.GitHub().UpdatePullRequest(ctx.Context, repoOwner, repoName, prNumber, updateOpts)
 		if err != nil {
 			ctx.Output.Debug("Failed to update PR #%d for %s: %v", prNumber, name, err)
 			return
@@ -127,7 +127,7 @@ func deleteNavigationComment(ctx *app.Context, branchName string, prNumber int, 
 	// Try cached comment ID first
 	commentID, err := ctx.Engine.GetNavigationCommentID(branch)
 	if err == nil && commentID != 0 {
-		if err := ctx.GitHubClient.DeletePRComment(ctx.Context, repoOwner, repoName, commentID); err == nil {
+		if err := ctx.GitHub().DeletePRComment(ctx.Context, repoOwner, repoName, commentID); err == nil {
 			_ = ctx.Engine.ClearNavigationCommentID(branch)
 			ctx.Output.Debug("Deleted navigation comment %d on PR #%d", commentID, prNumber)
 			return
@@ -137,7 +137,7 @@ func deleteNavigationComment(ctx *app.Context, branchName string, prNumber int, 
 	}
 
 	// Fall back to search for existing comment
-	comments, err := ctx.GitHubClient.ListPRComments(ctx.Context, repoOwner, repoName, prNumber)
+	comments, err := ctx.GitHub().ListPRComments(ctx.Context, repoOwner, repoName, prNumber)
 	if err != nil {
 		ctx.Output.Debug("Failed to list comments on PR #%d: %v", prNumber, err)
 		return
@@ -145,7 +145,7 @@ func deleteNavigationComment(ctx *app.Context, branchName string, prNumber int, 
 
 	for _, c := range comments {
 		if pr.IsStackitComment(c.Body) {
-			if err := ctx.GitHubClient.DeletePRComment(ctx.Context, repoOwner, repoName, c.ID); err == nil {
+			if err := ctx.GitHub().DeletePRComment(ctx.Context, repoOwner, repoName, c.ID); err == nil {
 				ctx.Output.Debug("Deleted navigation comment %d on PR #%d", c.ID, prNumber)
 			}
 			break
@@ -170,7 +170,7 @@ func updateNavigationComment(ctx *app.Context, branchName string, prNumber int, 
 	commentID, _ := ctx.Engine.GetNavigationCommentID(branch)
 	if commentID != 0 {
 		// Try to update existing comment
-		if err := ctx.GitHubClient.UpdatePRComment(ctx.Context, repoOwner, repoName, commentID, commentBody); err == nil {
+		if err := ctx.GitHub().UpdatePRComment(ctx.Context, repoOwner, repoName, commentID, commentBody); err == nil {
 			ctx.Output.Debug("Updated navigation comment %d on PR #%d", commentID, prNumber)
 			return
 		}
@@ -179,7 +179,7 @@ func updateNavigationComment(ctx *app.Context, branchName string, prNumber int, 
 	}
 
 	// Search for existing comment (cache miss or stale)
-	comments, err := ctx.GitHubClient.ListPRComments(ctx.Context, repoOwner, repoName, prNumber)
+	comments, err := ctx.GitHub().ListPRComments(ctx.Context, repoOwner, repoName, prNumber)
 	if err != nil {
 		ctx.Output.Debug("Failed to list comments on PR #%d: %v", prNumber, err)
 		return
@@ -188,7 +188,7 @@ func updateNavigationComment(ctx *app.Context, branchName string, prNumber int, 
 	for _, c := range comments {
 		if pr.IsStackitComment(c.Body) {
 			// Found existing - update it and cache ID
-			if err := ctx.GitHubClient.UpdatePRComment(ctx.Context, repoOwner, repoName, c.ID, commentBody); err == nil {
+			if err := ctx.GitHub().UpdatePRComment(ctx.Context, repoOwner, repoName, c.ID, commentBody); err == nil {
 				_ = ctx.Engine.SetNavigationCommentID(branch, c.ID)
 				ctx.Output.Debug("Updated navigation comment %d on PR #%d", c.ID, prNumber)
 			}
@@ -197,7 +197,7 @@ func updateNavigationComment(ctx *app.Context, branchName string, prNumber int, 
 	}
 
 	// No existing comment - create new one and cache ID
-	newID, err := ctx.GitHubClient.CreatePRComment(ctx.Context, repoOwner, repoName, prNumber, commentBody)
+	newID, err := ctx.GitHub().CreatePRComment(ctx.Context, repoOwner, repoName, prNumber, commentBody)
 	if err == nil {
 		_ = ctx.Engine.SetNavigationCommentID(branch, newID)
 		ctx.Output.Debug("Created navigation comment %d on PR #%d", newID, prNumber)
@@ -240,8 +240,8 @@ func PushMetadataAndSyncPRs(ctx *app.Context, branchNames []string) error {
 	}
 
 	// If GitHub client is available, update PRs to trigger CI checks (and update footers/titles)
-	if ctx.GitHubClient != nil {
-		owner, repo := ctx.GitHubClient.GetOwnerRepo()
+	if ctx.GitHub() != nil {
+		owner, repo := ctx.GitHub().GetOwnerRepo()
 		if owner != "" && repo != "" {
 			UpdateStackPRMetadata(ctx, branchNames, owner, repo)
 		}

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -385,8 +385,11 @@ func submitBranch(ctx *app.Context, info Info, opts Options, handler Handler, re
 
 // getGitHubClient returns the GitHub client from context
 func getGitHubClient(ctx *app.Context) (github.Client, error) {
-	if ctx.GitHubClient != nil {
-		return ctx.GitHubClient, nil
+	if client := ctx.GitHub(); client != nil {
+		return client, nil
+	}
+	if err := ctx.GitHubError(); err != nil {
+		return nil, fmt.Errorf("GitHub client initialization failed: %w", err)
 	}
 	return nil, fmt.Errorf("no GitHub client available - check your GITHUB_TOKEN")
 }
@@ -438,7 +441,7 @@ func createPullRequestQuiet(ctx *app.Context, submissionInfo Info, repoOwner, re
 		Labels:        submissionInfo.Metadata.Labels,
 		Assignees:     submissionInfo.Metadata.Assignees,
 	}
-	prResult, err := ctx.GitHubClient.CreatePullRequest(ctx.Context, repoOwner, repoName, createOpts)
+	prResult, err := ctx.GitHub().CreatePullRequest(ctx.Context, repoOwner, repoName, createOpts)
 	if err != nil {
 		return "", fmt.Errorf("failed to create PR for %s: %w", submissionInfo.BranchName, err)
 	}
@@ -523,7 +526,7 @@ func updatePullRequestQuiet(ctx *app.Context, submissionInfo Info, opts Options,
 		}
 	}
 
-	updateWarnings, err := ctx.GitHubClient.UpdatePullRequest(ctx.Context, repoOwner, repoName, *submissionInfo.PRNumber, updateOpts)
+	updateWarnings, err := ctx.GitHub().UpdatePullRequest(ctx.Context, repoOwner, repoName, *submissionInfo.PRNumber, updateOpts)
 	if err != nil {
 		return "", fmt.Errorf("failed to update PR for %s: %w", submissionInfo.BranchName, err)
 	}
@@ -540,7 +543,7 @@ func updatePullRequestQuiet(ctx *app.Context, submissionInfo Info, opts Options,
 		prURL = prInfo.URL()
 	} else {
 		// Get from GitHub
-		prResult, err := ctx.GitHubClient.GetPullRequestByBranch(ctx.Context, repoOwner, repoName, submissionInfo.BranchName)
+		prResult, err := ctx.GitHub().GetPullRequestByBranch(ctx.Context, repoOwner, repoName, submissionInfo.BranchName)
 		if err == nil && prResult != nil {
 			prURL = prResult.HTMLURL
 		}

--- a/internal/actions/submit/submit_metadata.go
+++ b/internal/actions/submit/submit_metadata.go
@@ -80,10 +80,10 @@ func PreparePRMetadata(branch engine.Branch, opts MetadataOptions, ctx *app.Cont
 	shouldEditBody := opts.EditDescription || (opts.Edit && !opts.NoEditDescription)
 
 	// If PR exists and local metadata is missing title or body, fetch from GitHub
-	if prInfo != nil && prInfo.Number() != nil && (metadata.Title == "" || metadata.Body == "") && ctx.GitHubClient != nil {
-		repoOwner, repoName := ctx.GitHubClient.GetOwnerRepo()
+	if prInfo != nil && prInfo.Number() != nil && (metadata.Title == "" || metadata.Body == "") && ctx.GitHub() != nil {
+		repoOwner, repoName := ctx.GitHub().GetOwnerRepo()
 		if repoOwner != "" && repoName != "" {
-			currentPR, err := ctx.GitHubClient.GetPullRequest(ctx.Context, repoOwner, repoName, *prInfo.Number())
+			currentPR, err := ctx.GitHub().GetPullRequest(ctx.Context, repoOwner, repoName, *prInfo.Number())
 			if err == nil && currentPR != nil {
 				if metadata.Title == "" {
 					metadata.Title = currentPR.Title

--- a/internal/actions/sync/github_sync.go
+++ b/internal/actions/sync/github_sync.go
@@ -114,7 +114,7 @@ func processGitHubSyncResult(ctx *app.Context, result *GitHubSyncResult, dirtyAn
 	}
 
 	// Update PR body footers only for branches flagged as needing updates
-	if ctx.GitHubClient != nil && result.RepoOwner != "" && result.RepoName != "" {
+	if ctx.GitHub() != nil && result.RepoOwner != "" && result.RepoName != "" {
 		flaggedBranches := ctx.Engine.GetBranchesNeedingPRBodyUpdate()
 		if len(flaggedBranches) > 0 {
 			updateMetaStart := time.Now()
@@ -136,7 +136,7 @@ func processGitHubSyncResult(ctx *app.Context, result *GitHubSyncResult, dirtyAn
 	// Push local parent changes to GitHub PR bases
 	// Local metadata is authoritative - if local parent differs from GitHub PR base, update GitHub
 	parentsStart := time.Now()
-	if ctx.GitHubClient != nil && result.RepoOwner != "" && result.RepoName != "" {
+	if ctx.GitHub() != nil && result.RepoOwner != "" && result.RepoName != "" {
 		syncResult, err := PushParentsToGitHub(ctx, result, dirtyAnchors)
 		ctx.Logger.Info("sync parents to github completed durationMs=%d", time.Since(parentsStart).Milliseconds())
 		if err != nil {
@@ -160,7 +160,7 @@ func PushParentsToGitHub(ctx *app.Context, result *GitHubSyncResult, dirtyAnchor
 	eng := ctx.Engine
 	out := ctx.Output
 	gctx := ctx.Context
-	githubClient := ctx.GitHubClient
+	githubClient := ctx.GitHub()
 
 	allBranches := eng.AllBranches()
 	updated := []string{}

--- a/internal/actions/track/action.go
+++ b/internal/actions/track/action.go
@@ -124,7 +124,7 @@ func trackBranchRecursively(ctx *app.Context, branchName string, handler Handler
 
 		// If auto-detection didn't find a valid parent, prompt interactively
 		if parentBranch == "" {
-			parentBranch, err = handler.PromptSelectParent(ctx.Context, ctx.Engine, ctx.GitHubClient, ctx.Logger, branchName)
+			parentBranch, err = handler.PromptSelectParent(ctx.Context, ctx.Engine, ctx.GitHub(), ctx.Logger, branchName)
 			if err != nil {
 				return err
 			}

--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 
 	"stackit.dev/stackit/internal/config"
 	"stackit.dev/stackit/internal/engine"
@@ -29,6 +30,9 @@ type Context struct {
 	GitHubClient github.Client
 	Config       config.Configurer // Cached config to avoid repeated loading
 
+	// Lazy GitHub client initialization (pointer so Context is safe to copy)
+	githubLazy *githubLazy
+
 	// Global settings from flags
 	Interactive bool
 	Verify      bool
@@ -40,6 +44,14 @@ type Context struct {
 	WorktreeInfo      *engine.WorktreeInfo // Info about current worktree (nil if not in managed worktree)
 }
 
+// githubLazy holds the lazy-initialization state for the GitHub client.
+// Stored as a pointer in Context so copying Context is safe (no sync.Once copy).
+type githubLazy struct {
+	once     sync.Once
+	initFunc func() (github.Client, error)
+	initErr  error
+}
+
 // Git returns the git runner from the engine.
 // Panics if the Engine is nil, which indicates a programming error.
 func (c *Context) Git() git.Runner {
@@ -47,6 +59,34 @@ func (c *Context) Git() git.Runner {
 		panic("Context.Git() called with nil Engine - this is a programming error")
 	}
 	return c.Engine.Git()
+}
+
+// GitHub returns the GitHub client, lazily initializing it on first access.
+// If GitHubClient was set directly (e.g. in tests), it is returned immediately.
+// Returns nil if initialization failed; use GitHubError() to get the reason.
+func (c *Context) GitHub() github.Client {
+	if c.GitHubClient != nil {
+		return c.GitHubClient
+	}
+	if c.githubLazy != nil {
+		c.githubLazy.once.Do(func() {
+			client, err := c.githubLazy.initFunc()
+			if err != nil {
+				c.githubLazy.initErr = err
+				return
+			}
+			c.GitHubClient = client
+		})
+	}
+	return c.GitHubClient
+}
+
+// GitHubError returns the error from lazy GitHub client initialization, if any.
+func (c *Context) GitHubError() error {
+	if c.githubLazy != nil {
+		return c.githubLazy.initErr
+	}
+	return nil
 }
 
 // Navigator returns the stack navigator from the engine.
@@ -298,10 +338,11 @@ func NewContextAutoWithWriter(ctx context.Context, repoRoot string, opts GlobalO
 	runtimeCtx.Context = ctx
 	runtimeCtx.Config = cfg // Store config for reuse
 
-	// Try to create real GitHub client (may fail if no token)
-	ghClient, err := github.NewGitHubClient(ctx, runtimeCtx.Git())
-	if err == nil {
-		runtimeCtx.GitHubClient = ghClient
+	// Lazy-initialize GitHub client on first access via GitHub()
+	runtimeCtx.githubLazy = &githubLazy{
+		initFunc: func() (github.Client, error) {
+			return github.NewGitHubClient(context.Background(), gitRunner)
+		},
 	}
 
 	return runtimeCtx, nil

--- a/internal/cli/dashboard/shippable_model.go
+++ b/internal/cli/dashboard/shippable_model.go
@@ -235,7 +235,7 @@ var keys = keyMap{
 
 // newShippableModel creates a new shippable dashboard model.
 func newShippableModel(ctx *app.Context, cfg config.Configurer, opts ShippableOptions) *shippableModel {
-	analyzer := shippable.NewAnalyzer(ctx.Engine, ctx.GitHubClient)
+	analyzer := shippable.NewAnalyzer(ctx.Engine, ctx.GitHub())
 	combiner := shippable.NewCombiner(ctx.Engine, cfg, output.NewNullOutput())
 
 	// Create progress bar
@@ -286,7 +286,7 @@ func (m *shippableModel) selectedStacks() []shippable.Stack {
 // Use this for actions running inside tea.Cmd to prevent stdout writes
 // from conflicting with the running bubbletea program.
 func (m *shippableModel) quietCtx() *app.Context {
-	ctx := *m.ctx
+	ctx := *m.ctx //nolint:govet // copylocks: sync.Once is zero-valued here; both copies independently lazy-init
 	ctx.Output = output.NewNullOutput()
 	return &ctx
 }

--- a/internal/cli/navigation/checkout_handlers.go
+++ b/internal/cli/navigation/checkout_handlers.go
@@ -24,7 +24,7 @@ type InteractiveCheckoutHandler struct{}
 
 // SelectBranch prompts the user to select a branch using the interactive log selector
 func (h *InteractiveCheckoutHandler) SelectBranch(ctx *app.Context, opts actions.CheckoutOptions) (string, error) {
-	branchName, err := tui.PromptLogSelect(ctx.Context, ctx.Engine, ctx.GitHubClient, tui.LogOptions{
+	branchName, err := tui.PromptLogSelect(ctx.Context, ctx.Engine, ctx.GitHub(), tui.LogOptions{
 		ShowUntracked:  opts.ShowUntracked,
 		SkipEnrichment: true, // Skip GitHub/git enrichment for faster startup
 		Inline:         true, // Run inline without taking over the terminal

--- a/internal/cli/stack/merge/drain.go
+++ b/internal/cli/stack/merge/drain.go
@@ -99,7 +99,7 @@ func runMergeDrain(ctx *app.Context, opts mergeDrainOptions) error {
 	}
 
 	// Create initial plan to discover what needs to be merged
-	plan, validation, err := mergeAction.CreateMergePlan(ctx.Context, eng, out, ctx.GitHubClient, mergeAction.CreatePlanOptions{
+	plan, validation, err := mergeAction.CreateMergePlan(ctx.Context, eng, out, ctx.GitHub(), mergeAction.CreatePlanOptions{
 		Strategy:     mergeAction.StrategyBottomUp,
 		Force:        opts.force,
 		TargetBranch: opts.branch,
@@ -143,7 +143,7 @@ func runMergeDrain(ctx *app.Context, opts mergeDrainOptions) error {
 	}
 
 	// Fail fast if no GitHub client
-	if ctx.GitHubClient == nil {
+	if ctx.GitHub() == nil {
 		return fmt.Errorf("GitHub client not available - check your GITHUB_TOKEN or gh auth login")
 	}
 
@@ -183,7 +183,7 @@ func runMergeDrain(ctx *app.Context, opts mergeDrainOptions) error {
 	merged := 0
 	for drainTarget == 0 || merged < drainTarget {
 		// Re-read state each iteration (branches change after merges + sync)
-		plan, _, err = mergeAction.CreateMergePlan(ctx.Context, eng, out, ctx.GitHubClient, mergeAction.CreatePlanOptions{
+		plan, _, err = mergeAction.CreateMergePlan(ctx.Context, eng, out, ctx.GitHub(), mergeAction.CreatePlanOptions{
 			Strategy:     mergeAction.StrategyBottomUp,
 			Force:        opts.force,
 			TargetBranch: targetBranch,
@@ -213,8 +213,8 @@ func runMergeDrain(ctx *app.Context, opts mergeDrainOptions) error {
 		out.Info("Merging PR #%d (%s) [%d/%d]...", bottomPR.PRNumber, bottomPR.BranchName, merged+1, displayTotal)
 
 		// Get the PR's NodeID for merge operations
-		owner, repo := ctx.GitHubClient.GetOwnerRepo()
-		prInfo, err := ctx.GitHubClient.GetPullRequest(ctx.Context, owner, repo, bottomPR.PRNumber)
+		owner, repo := ctx.GitHub().GetOwnerRepo()
+		prInfo, err := ctx.GitHub().GetPullRequest(ctx.Context, owner, repo, bottomPR.PRNumber)
 		if err != nil {
 			return fmt.Errorf("failed to get PR #%d info: %w", bottomPR.PRNumber, err)
 		}
@@ -326,7 +326,7 @@ func resolveMergeMethod(ctx *app.Context, methodFlag string) (github.MergeMethod
 			return "", fmt.Errorf("invalid merge method: %s (must be squash, merge, or rebase)", methodFlag)
 		}
 	}
-	return mergeAction.GetMergeMethod(ctx, ctx.GitHubClient)
+	return mergeAction.GetMergeMethod(ctx, ctx.GitHub())
 }
 
 func formatMergeDrainPlan(plan *mergeAction.Plan, validation *mergeAction.PlanValidation) string {

--- a/internal/cli/stack/merge/next.go
+++ b/internal/cli/stack/merge/next.go
@@ -81,7 +81,7 @@ func runMergeNext(ctx *app.Context, opts mergeNextOptions, postMergeHandler Post
 	eng := ctx.Engine
 
 	// Use CreateMergePlan with bottom-up strategy to find what to merge
-	plan, validation, err := mergeAction.CreateMergePlan(ctx.Context, eng, out, ctx.GitHubClient, mergeAction.CreatePlanOptions{
+	plan, validation, err := mergeAction.CreateMergePlan(ctx.Context, eng, out, ctx.GitHub(), mergeAction.CreatePlanOptions{
 		Strategy:     mergeAction.StrategyBottomUp,
 		Force:        opts.force,
 		TargetBranch: opts.branch,
@@ -117,7 +117,7 @@ func runMergeNext(ctx *app.Context, opts mergeNextOptions, postMergeHandler Post
 	}
 
 	// Fail fast if no GitHub client
-	if ctx.GitHubClient == nil {
+	if ctx.GitHub() == nil {
 		return fmt.Errorf("GitHub client not available - check your GITHUB_TOKEN or gh auth login")
 	}
 
@@ -140,8 +140,8 @@ func runMergeNext(ctx *app.Context, opts mergeNextOptions, postMergeHandler Post
 	}
 
 	// Get the PR's NodeID for merge operations
-	owner, repo := ctx.GitHubClient.GetOwnerRepo()
-	prInfo, err := ctx.GitHubClient.GetPullRequest(ctx.Context, owner, repo, bottomPR.PRNumber)
+	owner, repo := ctx.GitHub().GetOwnerRepo()
+	prInfo, err := ctx.GitHub().GetPullRequest(ctx.Context, owner, repo, bottomPR.PRNumber)
 	if err != nil {
 		return fmt.Errorf("failed to get PR info: %w", err)
 	}

--- a/internal/cli/stack/merge/orchestrate.go
+++ b/internal/cli/stack/merge/orchestrate.go
@@ -82,7 +82,7 @@ func (d *defaultPRMergeAPI) mergePR(ctx context.Context, branchName string, meth
 //     - "not enabled on repo" + wait → poll until mergeable, then merge directly.
 //     - "not enabled on repo" + no wait → error with --wait suggestion.
 func orchestrateMerge(ctx *app.Context, opts orchestrateMergeOptions) (Outcome, error) {
-	api := &defaultPRMergeAPI{client: ctx.GitHubClient}
+	api := &defaultPRMergeAPI{client: ctx.GitHub()}
 	return doOrchestrateMerge(ctx.Context, ctx.Output, ctx.Engine.Git(), api, opts)
 }
 

--- a/internal/cli/stack/merge/ship.go
+++ b/internal/cli/stack/merge/ship.go
@@ -115,7 +115,7 @@ func runMergeShip(ctx *app.Context, opts mergeShipOptions, postMergeHandler Post
 	out := ctx.Output
 
 	// Collect branches once (expensive: GitHub API calls) then build plan
-	collected, err := mergeAction.CollectMergeBranches(ctx.Context, ctx.Engine, ctx.Output, ctx.GitHubClient, mergeAction.CreatePlanOptions{
+	collected, err := mergeAction.CollectMergeBranches(ctx.Context, ctx.Engine, ctx.Output, ctx.GitHub(), mergeAction.CreatePlanOptions{
 		Strategy:     mergeAction.StrategyShip,
 		Force:        opts.force,
 		Scope:        opts.scope,
@@ -145,7 +145,7 @@ func runMergeShip(ctx *app.Context, opts mergeShipOptions, postMergeHandler Post
 	}
 
 	// Fail fast if no GitHub client
-	if ctx.GitHubClient == nil {
+	if ctx.GitHub() == nil {
 		return fmt.Errorf("GitHub client not available - check your GITHUB_TOKEN or gh auth login")
 	}
 
@@ -221,7 +221,7 @@ func runMultiStackShip(ctx *app.Context, opts shipMultiStackOptions) error {
 		return fmt.Errorf("no independent stacks found rooted at trunk")
 	}
 
-	if !opts.dryRun && ctx.GitHubClient == nil {
+	if !opts.dryRun && ctx.GitHub() == nil {
 		return fmt.Errorf("GitHub client not available - check your GITHUB_TOKEN or gh auth login")
 	}
 
@@ -311,7 +311,7 @@ func runMultiStackShip(ctx *app.Context, opts shipMultiStackOptions) error {
 			out.Warn("Could not enable automerge: %v", err)
 			out.Tip("Enable automerge manually on the PR: %s", result.PRURL)
 		} else {
-			mergeMethod, methodErr := mergeAction.GetMergeMethod(ctx, ctx.GitHubClient)
+			mergeMethod, methodErr := mergeAction.GetMergeMethod(ctx, ctx.GitHub())
 			if methodErr != nil {
 				out.Warn("Could not determine merge method: %v", methodErr)
 				out.Tip("Enable automerge manually on the PR: %s", result.PRURL)
@@ -334,8 +334,8 @@ func runMultiStackShip(ctx *app.Context, opts shipMultiStackOptions) error {
 
 // getPRNodeID fetches the NodeID for a PR by number
 func getPRNodeID(ctx *app.Context, prNumber int) (string, error) {
-	owner, repo := ctx.GitHubClient.GetOwnerRepo()
-	prInfo, err := ctx.GitHubClient.GetPullRequest(ctx.Context, owner, repo, prNumber)
+	owner, repo := ctx.GitHub().GetOwnerRepo()
+	prInfo, err := ctx.GitHub().GetPullRequest(ctx.Context, owner, repo, prNumber)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cli/stack/merge/status.go
+++ b/internal/cli/stack/merge/status.go
@@ -27,15 +27,15 @@ Examples:
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
-				analyzer := shippable.NewAnalyzer(ctx.Engine, ctx.GitHubClient)
+				analyzer := shippable.NewAnalyzer(ctx.Engine, ctx.GitHub())
 				analysisResult, err := analyzer.AnalyzeAll(ctx.Context)
 				if err != nil {
 					return err
 				}
 
 				// Filter by current user unless --all is specified
-				if !showAll && ctx.GitHubClient != nil {
-					currentUser, userErr := ctx.GitHubClient.GetCurrentUser(ctx.Context)
+				if !showAll && ctx.GitHub() != nil {
+					currentUser, userErr := ctx.GitHub().GetCurrentUser(ctx.Context)
 					if userErr == nil && currentUser != "" {
 						analysisResult = analysisResult.FilterByAuthor(currentUser)
 					}

--- a/internal/cli/stack/pluck.go
+++ b/internal/cli/stack/pluck.go
@@ -107,7 +107,7 @@ func interactivePluckOntoSelection(ctx *app.Context, sourceBranch string) (strin
 
 	// Show interactive selector
 	header := fmt.Sprintf("Select new parent for '%s' (children will be reparented to grandparent)", sourceBranch)
-	selected, err := tui.PromptLogSelect(ctx.Context, ctx.Engine, ctx.GitHubClient, tui.LogOptions{
+	selected, err := tui.PromptLogSelect(ctx.Context, ctx.Engine, ctx.GitHub(), tui.LogOptions{
 		Style:   "FULL",
 		Exclude: excludedBranches,
 		Logger:  ctx.Logger,


### PR DESCRIPTION
This PR merges the following changes:

1. **#756** feat: lazy-initialize GitHub client in Context
2. **#757** refactor: migrate GitHubClient reads to lazy GitHub() accessor

### Stack

```
main
  └─ jonnii/20260225213731/lazy-initialize-GitHub-client-in-Context (#756)
    └─ jonnii/20260225215205/migrate-GitHubClient-reads-to-lazy-GitHub (#757)
```
