### PR TITLE
feat: add visual flair to web UI with animations, dark mode toggle, and confetti

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
-api: go run ./apps/api --port 8080
+api: watchexec -r -e go -w apps/api -w internal -w api -- go run ./apps/api --port 8080
 web: pnpm --filter @stackit/web dev

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,0 +1,1130 @@
+{
+  "name": "@stackit/web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@stackit/web",
+      "version": "0.1.0",
+      "dependencies": {
+        "canvas-confetti": "^1.9.4",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.574.0",
+        "motion": "^12.34.3",
+        "next": "16.1.6",
+        "radix-ui": "^1.4.3",
+        "react": "19.2.3",
+        "react-dom": "19.2.3",
+        "tailwind-merge": "^3.5.0"
+      },
+      "devDependencies": {
+        "@tailwindcss/postcss": "^4",
+        "@types/canvas-confetti": "^1.9.0",
+        "@types/node": "^20",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "eslint": "^9",
+        "eslint-config-next": "16.1.6",
+        "shadcn": "^3.8.5",
+        "tailwindcss": "^4",
+        "tw-animate-css": "^1.4.0",
+        "typescript": "^5"
+      }
+    },
+    "../../node_modules/.pnpm/@tailwindcss+postcss@4.2.1/node_modules/@tailwindcss/postcss": {
+      "version": "4.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.2.1",
+        "@tailwindcss/oxide": "4.2.1",
+        "postcss": "^8.5.6",
+        "tailwindcss": "4.2.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.19.0",
+        "@types/postcss-import": "14.0.3",
+        "dedent": "1.7.1",
+        "internal-example-plugin": "0.0.0",
+        "postcss-import": "^16.1.1"
+      }
+    },
+    "../../node_modules/.pnpm/@types+node@20.19.35/node_modules/@types/node": {
+      "version": "20.19.35",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "../../node_modules/.pnpm/@types+react-dom@19.2.3_@types+react@19.2.14/node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "../../node_modules/.pnpm/@types+react@19.2.14/node_modules/@types/react": {
+      "version": "19.2.14",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "../../node_modules/.pnpm/class-variance-authority@0.7.1/node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "devDependencies": {
+        "@swc/cli": "0.3.12",
+        "@swc/core": "1.4.16",
+        "@types/node": "20.12.7",
+        "@types/react": "18.2.79",
+        "@types/react-dom": "18.2.25",
+        "bundlesize": "0.18.2",
+        "npm-run-all": "4.1.5",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "ts-node": "10.9.2",
+        "typescript": "5.4.5"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "../../node_modules/.pnpm/clsx@2.1.1/node_modules/clsx": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "devDependencies": {
+        "esm": "3.2.25",
+        "terser": "4.8.0",
+        "uvu": "0.5.4"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../node_modules/.pnpm/eslint-config-next@16.1.6_@typescript-eslint+parser@8.56.1_eslint@9.39.3_jiti@2.6.1__ty_1a644ca6cd285757337f773c4aa1c81d/node_modules/eslint-config-next": {
+      "version": "16.1.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/eslint-plugin-next": "16.1.6",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-import-resolver-typescript": "^3.5.2",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
+        "eslint-plugin-react": "^7.37.0",
+        "eslint-plugin-react-hooks": "^7.0.0",
+        "globals": "16.4.0",
+        "typescript-eslint": "^8.46.0"
+      },
+      "devDependencies": {
+        "@types/eslint": "9.6.1",
+        "@types/eslint-plugin-jsx-a11y": "6.10.1",
+        "typescript": "5.9.2"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0",
+        "typescript": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/eslint@9.39.3_jiti@2.6.1/node_modules/eslint": {
+      "version": "9.39.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.39.3",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "devDependencies": {
+        "@arethetypeswrong/cli": "^0.18.0",
+        "@babel/core": "^7.4.3",
+        "@babel/preset-env": "^7.4.3",
+        "@cypress/webpack-preprocessor": "^6.0.2",
+        "@eslint/json": "^0.13.2",
+        "@trunkio/launcher": "^1.3.4",
+        "@types/esquery": "^1.5.4",
+        "@types/node": "^22.13.14",
+        "@typescript-eslint/parser": "^8.4.0",
+        "babel-loader": "^8.0.5",
+        "c8": "^7.12.0",
+        "chai": "^4.0.1",
+        "cheerio": "^0.22.0",
+        "common-tags": "^1.8.0",
+        "core-js": "^3.1.3",
+        "cypress": "^14.1.0",
+        "ejs": "^3.0.2",
+        "eslint": "file:.",
+        "eslint-config-eslint": "file:packages/eslint-config-eslint",
+        "eslint-plugin-eslint-plugin": "^6.0.0",
+        "eslint-plugin-expect-type": "^0.6.0",
+        "eslint-plugin-yml": "^1.14.0",
+        "eslint-release": "^3.3.0",
+        "eslint-rule-composer": "^0.3.0",
+        "eslump": "^3.0.0",
+        "esprima": "^4.0.1",
+        "fast-glob": "^3.2.11",
+        "fs-teardown": "^0.1.3",
+        "glob": "^10.0.0",
+        "globals": "^16.2.0",
+        "got": "^11.8.3",
+        "gray-matter": "^4.0.3",
+        "jiti": "^2.6.1",
+        "jiti-v2.0": "npm:jiti@2.0.x",
+        "jiti-v2.1": "npm:jiti@2.1.x",
+        "knip": "^5.60.2",
+        "lint-staged": "^11.0.0",
+        "markdown-it": "^12.2.0",
+        "markdown-it-container": "^3.0.0",
+        "marked": "^4.0.8",
+        "metascraper": "^5.25.7",
+        "metascraper-description": "^5.25.7",
+        "metascraper-image": "^5.29.3",
+        "metascraper-logo": "^5.25.7",
+        "metascraper-logo-favicon": "^5.25.7",
+        "metascraper-title": "^5.25.7",
+        "mocha": "^11.7.1",
+        "node-polyfill-webpack-plugin": "^1.0.3",
+        "npm-license": "^0.3.3",
+        "pirates": "^4.0.5",
+        "progress": "^2.0.3",
+        "proxyquire": "^2.0.1",
+        "recast": "^0.23.0",
+        "regenerator-runtime": "^0.14.0",
+        "semver": "^7.5.3",
+        "shelljs": "^0.10.0",
+        "sinon": "^11.0.0",
+        "typescript": "^5.3.3",
+        "webpack": "^5.23.0",
+        "webpack-cli": "^4.5.0",
+        "yorkie": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/lucide-react@0.574.0_react@19.2.3/node_modules/lucide-react": {
+      "version": "0.574.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@lucide/build-icons": "1.1.0",
+        "@lucide/rollup-plugins": "1.0.0",
+        "@lucide/shared": "1.0.0",
+        "@testing-library/jest-dom": "^6.8.0",
+        "@testing-library/react": "^14.1.2",
+        "@types/react": "^18.2.37",
+        "@vitejs/plugin-react": "^4.4.1",
+        "jest-serializer-html": "^7.1.0",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "rollup": "^4.53.3",
+        "rollup-plugin-dts": "^6.2.3",
+        "rollup-plugin-preserve-directives": "^0.4.0",
+        "typescript": "^5.8.3",
+        "vite": "^7.2.4",
+        "vitest": "^4.0.12"
+      },
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "../../node_modules/.pnpm/next@16.1.6_@babel+core@7.29.0_react-dom@19.2.3_react@19.2.3__react@19.2.3/node_modules/next": {
+      "version": "16.1.6",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.1.6",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.8.3",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "devDependencies": {
+        "@babel/code-frame": "7.26.2",
+        "@babel/core": "7.26.10",
+        "@babel/eslint-parser": "7.24.6",
+        "@babel/generator": "7.27.0",
+        "@babel/plugin-syntax-bigint": "7.8.3",
+        "@babel/plugin-syntax-dynamic-import": "7.8.3",
+        "@babel/plugin-syntax-import-attributes": "7.26.0",
+        "@babel/plugin-syntax-jsx": "7.25.9",
+        "@babel/plugin-syntax-typescript": "7.25.4",
+        "@babel/plugin-transform-class-properties": "7.25.9",
+        "@babel/plugin-transform-export-namespace-from": "7.25.9",
+        "@babel/plugin-transform-modules-commonjs": "7.26.3",
+        "@babel/plugin-transform-numeric-separator": "7.25.9",
+        "@babel/plugin-transform-object-rest-spread": "7.25.9",
+        "@babel/plugin-transform-runtime": "7.26.10",
+        "@babel/preset-env": "7.26.9",
+        "@babel/preset-react": "7.26.3",
+        "@babel/preset-typescript": "7.27.0",
+        "@babel/runtime": "7.27.0",
+        "@babel/traverse": "7.27.0",
+        "@babel/types": "7.27.0",
+        "@base-ui-components/react": "1.0.0-beta.2",
+        "@capsizecss/metrics": "3.4.0",
+        "@edge-runtime/cookies": "6.0.0",
+        "@edge-runtime/ponyfill": "4.0.0",
+        "@edge-runtime/primitives": "6.0.0",
+        "@hapi/accept": "5.0.2",
+        "@jest/transform": "29.5.0",
+        "@jest/types": "29.5.0",
+        "@modelcontextprotocol/sdk": "1.18.1",
+        "@mswjs/interceptors": "0.23.0",
+        "@napi-rs/triples": "1.2.0",
+        "@next/font": "16.1.6",
+        "@next/polyfill-module": "16.1.6",
+        "@next/polyfill-nomodule": "16.1.6",
+        "@next/react-refresh-utils": "16.1.6",
+        "@next/swc": "16.1.6",
+        "@opentelemetry/api": "1.6.0",
+        "@playwright/test": "1.51.1",
+        "@rspack/core": "1.6.7",
+        "@storybook/addon-a11y": "8.6.0",
+        "@storybook/addon-essentials": "8.6.0",
+        "@storybook/addon-interactions": "8.6.0",
+        "@storybook/addon-webpack5-compiler-swc": "3.0.0",
+        "@storybook/blocks": "8.6.0",
+        "@storybook/react": "8.6.0",
+        "@storybook/react-webpack5": "8.6.0",
+        "@storybook/test": "8.6.0",
+        "@storybook/test-runner": "0.21.0",
+        "@swc/core": "1.11.24",
+        "@swc/types": "0.1.7",
+        "@taskr/clear": "1.1.0",
+        "@taskr/esnext": "1.1.0",
+        "@types/babel__code-frame": "7.0.6",
+        "@types/babel__core": "7.20.5",
+        "@types/babel__generator": "7.27.0",
+        "@types/babel__template": "7.4.4",
+        "@types/babel__traverse": "7.20.7",
+        "@types/bytes": "3.1.1",
+        "@types/ci-info": "2.0.0",
+        "@types/compression": "0.0.36",
+        "@types/content-disposition": "0.5.4",
+        "@types/content-type": "1.1.3",
+        "@types/cookie": "0.3.3",
+        "@types/cross-spawn": "6.0.0",
+        "@types/debug": "4.1.5",
+        "@types/express-serve-static-core": "4.17.33",
+        "@types/fresh": "0.5.0",
+        "@types/glob": "7.1.1",
+        "@types/jsonwebtoken": "9.0.0",
+        "@types/lodash": "4.14.198",
+        "@types/lodash.curry": "4.1.6",
+        "@types/path-to-regexp": "1.7.0",
+        "@types/picomatch": "2.3.3",
+        "@types/platform": "1.3.4",
+        "@types/react": "19.0.8",
+        "@types/react-dom": "19.0.3",
+        "@types/react-is": "18.2.4",
+        "@types/semver": "7.3.1",
+        "@types/send": "0.14.4",
+        "@types/serve-handler": "6.1.4",
+        "@types/shell-quote": "1.7.1",
+        "@types/tar": "6.1.5",
+        "@types/text-table": "0.2.1",
+        "@types/ua-parser-js": "0.7.36",
+        "@types/webpack-sources1": "npm:@types/webpack-sources@0.1.5",
+        "@types/ws": "8.2.0",
+        "@vercel/ncc": "0.34.0",
+        "@vercel/nft": "0.27.1",
+        "@vercel/routing-utils": "5.2.0",
+        "@vercel/turbopack-ecmascript-runtime": "*",
+        "acorn": "8.14.0",
+        "anser": "1.4.9",
+        "arg": "4.1.0",
+        "assert": "2.0.0",
+        "async-retry": "1.2.3",
+        "async-sema": "3.0.0",
+        "axe-playwright": "2.0.3",
+        "babel-loader": "10.0.0",
+        "babel-plugin-react-compiler": "0.0.0-experimental-3fde738-20250918",
+        "babel-plugin-transform-define": "2.0.0",
+        "babel-plugin-transform-react-remove-prop-types": "0.4.24",
+        "browserify-zlib": "0.2.0",
+        "browserslist": "4.28.0",
+        "buffer": "5.6.0",
+        "busboy": "1.6.0",
+        "bytes": "3.1.1",
+        "ci-info": "watson/ci-info#f43f6a1cefff47fb361c88cf4b943fdbcaafe540",
+        "cli-select": "1.1.2",
+        "client-only": "0.0.1",
+        "commander": "12.1.0",
+        "comment-json": "3.0.3",
+        "compression": "1.7.4",
+        "conf": "5.0.0",
+        "constants-browserify": "1.0.0",
+        "content-disposition": "0.5.3",
+        "content-type": "1.0.4",
+        "cookie": "0.4.1",
+        "cross-env": "6.0.3",
+        "cross-spawn": "7.0.3",
+        "crypto-browserify": "3.12.0",
+        "css-loader": "7.1.2",
+        "css.escape": "1.5.1",
+        "cssnano-preset-default": "7.0.6",
+        "data-uri-to-buffer": "3.0.1",
+        "debug": "4.1.1",
+        "devalue": "2.0.1",
+        "domain-browser": "4.19.0",
+        "edge-runtime": "4.0.1",
+        "events": "3.3.0",
+        "find-up": "4.1.0",
+        "fresh": "0.5.2",
+        "glob": "7.1.7",
+        "gzip-size": "5.1.1",
+        "http-proxy": "1.18.1",
+        "http-proxy-agent": "5.0.0",
+        "https-browserify": "1.0.0",
+        "https-proxy-agent": "5.0.1",
+        "icss-utils": "5.1.0",
+        "ignore-loader": "0.1.2",
+        "image-size": "1.2.1",
+        "ipaddr.js": "2.2.0",
+        "is-docker": "2.0.0",
+        "is-wsl": "2.2.0",
+        "jest-worker": "27.5.1",
+        "json5": "2.2.3",
+        "jsonwebtoken": "9.0.0",
+        "loader-runner": "4.3.0",
+        "loader-utils2": "npm:loader-utils@2.0.4",
+        "loader-utils3": "npm:loader-utils@3.1.3",
+        "lodash.curry": "4.1.1",
+        "mini-css-extract-plugin": "2.4.4",
+        "msw": "2.3.0",
+        "nanoid": "3.1.32",
+        "native-url": "0.3.4",
+        "neo-async": "2.6.1",
+        "node-html-parser": "5.3.3",
+        "ora": "4.0.4",
+        "os-browserify": "0.3.0",
+        "p-limit": "3.1.0",
+        "p-queue": "6.6.2",
+        "path-browserify": "1.0.1",
+        "path-to-regexp": "6.3.0",
+        "picomatch": "4.0.1",
+        "postcss-flexbugs-fixes": "5.0.2",
+        "postcss-modules-extract-imports": "3.0.0",
+        "postcss-modules-local-by-default": "4.2.0",
+        "postcss-modules-scope": "3.0.0",
+        "postcss-modules-values": "4.0.0",
+        "postcss-preset-env": "7.4.3",
+        "postcss-safe-parser": "6.0.0",
+        "postcss-scss": "4.0.3",
+        "postcss-value-parser": "4.2.0",
+        "process": "0.11.10",
+        "punycode": "2.1.1",
+        "querystring-es3": "0.2.1",
+        "raw-body": "2.4.1",
+        "react-refresh": "0.12.0",
+        "recast": "0.23.11",
+        "regenerator-runtime": "0.13.4",
+        "safe-stable-stringify": "2.5.0",
+        "sass-loader": "16.0.5",
+        "schema-utils2": "npm:schema-utils@2.7.1",
+        "schema-utils3": "npm:schema-utils@3.0.0",
+        "semver": "7.3.2",
+        "send": "0.18.0",
+        "serve-handler": "6.1.6",
+        "server-only": "0.0.1",
+        "setimmediate": "1.0.5",
+        "shell-quote": "1.7.3",
+        "source-map": "0.6.1",
+        "source-map-loader": "5.0.0",
+        "source-map08": "npm:source-map@0.8.0-beta.0",
+        "stacktrace-parser": "0.1.10",
+        "storybook": "8.6.0",
+        "stream-browserify": "3.0.0",
+        "stream-http": "3.1.1",
+        "strict-event-emitter": "0.5.0",
+        "string_decoder": "1.3.0",
+        "string-hash": "1.1.3",
+        "strip-ansi": "6.0.0",
+        "style-loader": "4.0.0",
+        "superstruct": "1.0.3",
+        "tar": "6.1.15",
+        "taskr": "1.1.0",
+        "terser": "5.27.0",
+        "terser-webpack-plugin": "5.3.9",
+        "text-table": "0.2.0",
+        "timers-browserify": "2.0.12",
+        "tty-browserify": "0.0.1",
+        "typescript": "5.9.2",
+        "ua-parser-js": "1.0.35",
+        "unistore": "3.4.1",
+        "util": "0.12.4",
+        "vm-browserify": "1.1.2",
+        "watchpack": "2.4.0",
+        "web-vitals": "4.2.1",
+        "webpack": "5.98.0",
+        "webpack-sources1": "npm:webpack-sources@1.4.3",
+        "webpack-sources3": "npm:webpack-sources@3.2.3",
+        "ws": "8.2.3",
+        "zod": "3.25.76",
+        "zod-validation-error": "3.4.0"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.1.6",
+        "@next/swc-darwin-x64": "16.1.6",
+        "@next/swc-linux-arm64-gnu": "16.1.6",
+        "@next/swc-linux-arm64-musl": "16.1.6",
+        "@next/swc-linux-x64-gnu": "16.1.6",
+        "@next/swc-linux-x64-musl": "16.1.6",
+        "@next/swc-win32-arm64-msvc": "16.1.6",
+        "@next/swc-win32-x64-msvc": "16.1.6",
+        "sharp": "^0.34.4"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/radix-ui@1.4.3_@types+react-dom@19.2.3_@types+react@19.2.14__@types+react@19.2.14_react_5d533b4983dc5c891c8cde1f5968d5b9/node_modules/radix-ui": {
+      "version": "1.4.3",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-accessible-icon": "1.1.7",
+        "@radix-ui/react-accordion": "1.2.12",
+        "@radix-ui/react-alert-dialog": "1.1.15",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-aspect-ratio": "1.1.7",
+        "@radix-ui/react-avatar": "1.1.10",
+        "@radix-ui/react-checkbox": "1.3.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-context-menu": "2.2.16",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-dropdown-menu": "2.1.16",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-form": "0.1.8",
+        "@radix-ui/react-hover-card": "1.1.15",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-menubar": "1.1.16",
+        "@radix-ui/react-navigation-menu": "1.2.14",
+        "@radix-ui/react-one-time-password-field": "0.1.8",
+        "@radix-ui/react-password-toggle-field": "0.1.3",
+        "@radix-ui/react-popover": "1.1.15",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-progress": "1.1.7",
+        "@radix-ui/react-radio-group": "1.3.8",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-scroll-area": "1.2.10",
+        "@radix-ui/react-select": "2.2.6",
+        "@radix-ui/react-separator": "1.1.7",
+        "@radix-ui/react-slider": "1.3.6",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-switch": "1.2.6",
+        "@radix-ui/react-tabs": "1.1.13",
+        "@radix-ui/react-toast": "1.2.15",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-toggle-group": "1.1.11",
+        "@radix-ui/react-toolbar": "1.1.11",
+        "@radix-ui/react-tooltip": "1.2.8",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "devDependencies": {
+        "@repo/builder": "0.0.0",
+        "@repo/eslint-config": "0.0.0",
+        "@repo/typescript-config": "0.0.0",
+        "@types/react": "^19.0.7",
+        "@types/react-dom": "^19.0.3",
+        "eslint": "^9.18.0",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
+        "typescript": "^5.7.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/react-dom@19.2.3_react@19.2.3/node_modules/react-dom": {
+      "version": "19.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.3"
+      }
+    },
+    "../../node_modules/.pnpm/react@19.2.3/node_modules/react": {
+      "version": "19.2.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/.pnpm/shadcn@3.8.5_@types+node@20.19.35_typescript@5.9.3/node_modules/shadcn": {
+      "version": "3.8.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/ni": "^25.0.0",
+        "@babel/core": "^7.28.0",
+        "@babel/parser": "^7.28.0",
+        "@babel/plugin-transform-typescript": "^7.28.0",
+        "@babel/preset-typescript": "^7.27.1",
+        "@dotenvx/dotenvx": "^1.48.4",
+        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@types/validate-npm-package-name": "^4.0.2",
+        "browserslist": "^4.26.2",
+        "commander": "^14.0.0",
+        "cosmiconfig": "^9.0.0",
+        "dedent": "^1.6.0",
+        "deepmerge": "^4.3.1",
+        "diff": "^8.0.2",
+        "execa": "^9.6.0",
+        "fast-glob": "^3.3.3",
+        "fs-extra": "^11.3.1",
+        "fuzzysort": "^3.1.0",
+        "https-proxy-agent": "^7.0.6",
+        "kleur": "^4.1.5",
+        "msw": "^2.10.4",
+        "node-fetch": "^3.3.2",
+        "open": "^11.0.0",
+        "ora": "^8.2.0",
+        "postcss": "^8.5.6",
+        "postcss-selector-parser": "^7.1.0",
+        "prompts": "^2.4.2",
+        "recast": "^0.23.11",
+        "stringify-object": "^5.0.0",
+        "tailwind-merge": "^3.0.1",
+        "ts-morph": "^26.0.0",
+        "tsconfig-paths": "^4.2.0",
+        "validate-npm-package-name": "^7.0.1",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "shadcn": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/babel__core": "^7.20.5",
+        "@types/fs-extra": "^11.0.4",
+        "@types/prompts": "^2.4.9",
+        "@types/stringify-object": "^4.0.5",
+        "rimraf": "^6.0.1",
+        "tsup": "^8.5.0",
+        "type-fest": "^4.41.0",
+        "typescript": "^5.9.2"
+      }
+    },
+    "../../node_modules/.pnpm/tailwind-merge@3.5.0/node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/preset-env": "^7.29.0",
+        "@codspeed/vitest-plugin": "^5.1.0",
+        "@rollup/plugin-babel": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^16.0.3",
+        "@rollup/plugin-typescript": "^12.3.0",
+        "@types/node": "^24.10.9",
+        "@vitest/coverage-v8": "^4.0.18",
+        "@vitest/eslint-plugin": "^1.6.6",
+        "babel-plugin-annotate-pure-calls": "^0.5.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.6",
+        "eslint": "^9.39.2",
+        "eslint-plugin-import": "^2.32.0",
+        "globby": "^16.1.0",
+        "prettier": "^3.8.1",
+        "rollup": "^4.57.1",
+        "rollup-plugin-delete": "^3.0.2",
+        "rollup-plugin-dts": "^6.3.0",
+        "tslib": "^2.8.1",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.54.0",
+        "vitest": "^4.0.18",
+        "zx": "^8.8.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "../../node_modules/.pnpm/tailwindcss@4.2.1/node_modules/tailwindcss": {
+      "version": "4.2.1",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "@tailwindcss/oxide": "^4.2.1",
+        "@types/node": "^20.19.0",
+        "dedent": "1.7.1",
+        "lightningcss": "1.31.1",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "../../node_modules/.pnpm/tw-animate-css@1.4.0/node_modules/tw-animate-css": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@commitlint/cli": "^19.8.1",
+        "@commitlint/config-conventional": "^19.8.1",
+        "@types/node": "^24.5.2",
+        "lint-staged": "^16.2.0",
+        "prettier": "^3.6.2",
+        "simple-git-hooks": "^2.13.1",
+        "sort-package-json": "^3.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Wombosvideo"
+      }
+    },
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript": {
+      "version": "5.9.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "devDependencies": {
+        "@dprint/formatter": "^0.4.1",
+        "@dprint/typescript": "0.93.4",
+        "@esfx/canceltoken": "^1.0.0",
+        "@eslint/js": "^9.20.0",
+        "@octokit/rest": "^21.1.1",
+        "@types/chai": "^4.3.20",
+        "@types/diff": "^7.0.1",
+        "@types/minimist": "^1.2.5",
+        "@types/mocha": "^10.0.10",
+        "@types/ms": "^0.7.34",
+        "@types/node": "latest",
+        "@types/source-map-support": "^0.5.10",
+        "@types/which": "^3.0.4",
+        "@typescript-eslint/rule-tester": "^8.24.1",
+        "@typescript-eslint/type-utils": "^8.24.1",
+        "@typescript-eslint/utils": "^8.24.1",
+        "azure-devops-node-api": "^14.1.0",
+        "c8": "^10.1.3",
+        "chai": "^4.5.0",
+        "chokidar": "^4.0.3",
+        "diff": "^7.0.0",
+        "dprint": "^0.49.0",
+        "esbuild": "^0.25.0",
+        "eslint": "^9.20.1",
+        "eslint-formatter-autolinkable-stylish": "^1.4.0",
+        "eslint-plugin-regexp": "^2.7.0",
+        "fast-xml-parser": "^4.5.2",
+        "glob": "^10.4.5",
+        "globals": "^15.15.0",
+        "hereby": "^1.10.0",
+        "jsonc-parser": "^3.3.1",
+        "knip": "^5.44.4",
+        "minimist": "^1.2.8",
+        "mocha": "^10.8.2",
+        "mocha-fivemat-progress-reporter": "^0.1.0",
+        "monocart-coverage-reports": "^2.12.1",
+        "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
+        "playwright": "^1.50.1",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.8.1",
+        "typescript": "^5.7.3",
+        "typescript-eslint": "^8.24.1",
+        "which": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "resolved": "../../node_modules/.pnpm/@tailwindcss+postcss@4.2.1/node_modules/@tailwindcss/postcss",
+      "link": true
+    },
+    "node_modules/@types/canvas-confetti": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz",
+      "integrity": "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "resolved": "../../node_modules/.pnpm/@types+node@20.19.35/node_modules/@types/node",
+      "link": true
+    },
+    "node_modules/@types/react": {
+      "resolved": "../../node_modules/.pnpm/@types+react@19.2.14/node_modules/@types/react",
+      "link": true
+    },
+    "node_modules/@types/react-dom": {
+      "resolved": "../../node_modules/.pnpm/@types+react-dom@19.2.3_@types+react@19.2.14/node_modules/@types/react-dom",
+      "link": true
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.4.tgz",
+      "integrity": "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "resolved": "../../node_modules/.pnpm/class-variance-authority@0.7.1/node_modules/class-variance-authority",
+      "link": true
+    },
+    "node_modules/clsx": {
+      "resolved": "../../node_modules/.pnpm/clsx@2.1.1/node_modules/clsx",
+      "link": true
+    },
+    "node_modules/eslint": {
+      "resolved": "../../node_modules/.pnpm/eslint@9.39.3_jiti@2.6.1/node_modules/eslint",
+      "link": true
+    },
+    "node_modules/eslint-config-next": {
+      "resolved": "../../node_modules/.pnpm/eslint-config-next@16.1.6_@typescript-eslint+parser@8.56.1_eslint@9.39.3_jiti@2.6.1__ty_1a644ca6cd285757337f773c4aa1c81d/node_modules/eslint-config-next",
+      "link": true
+    },
+    "node_modules/framer-motion": {
+      "version": "12.34.3",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.3.tgz",
+      "integrity": "sha512-v81ecyZKYO/DfpTwHivqkxSUBzvceOpoI+wLfgCgoUIKxlFKEXdg0oR9imxwXumT4SFy8vRk9xzJ5l3/Du/55Q==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.34.3",
+        "motion-utils": "^12.29.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lucide-react": {
+      "resolved": "../../node_modules/.pnpm/lucide-react@0.574.0_react@19.2.3/node_modules/lucide-react",
+      "link": true
+    },
+    "node_modules/motion": {
+      "version": "12.34.3",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.34.3.tgz",
+      "integrity": "sha512-xZIkBGO7v/Uvm+EyaqYd+9IpXu0sZqLywVlGdCFrrMiaO9JI4Kx51mO9KlHSWwll+gZUVY5OJsWgYI5FywJ/tw==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.34.3",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.34.3",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.3.tgz",
+      "integrity": "sha512-sYgFe+pR9aIM7o4fhs2aXtOI+oqlUd33N9Yoxcgo1Fv7M20sRkHtCmzE/VRNIcq7uNJ+qio+Xubt1FXH3pQ+eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.29.2"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.29.2",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
+      "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
+      "license": "MIT"
+    },
+    "node_modules/next": {
+      "resolved": "../../node_modules/.pnpm/next@16.1.6_@babel+core@7.29.0_react-dom@19.2.3_react@19.2.3__react@19.2.3/node_modules/next",
+      "link": true
+    },
+    "node_modules/radix-ui": {
+      "resolved": "../../node_modules/.pnpm/radix-ui@1.4.3_@types+react-dom@19.2.3_@types+react@19.2.14__@types+react@19.2.14_react_5d533b4983dc5c891c8cde1f5968d5b9/node_modules/radix-ui",
+      "link": true
+    },
+    "node_modules/react": {
+      "resolved": "../../node_modules/.pnpm/react@19.2.3/node_modules/react",
+      "link": true
+    },
+    "node_modules/react-dom": {
+      "resolved": "../../node_modules/.pnpm/react-dom@19.2.3_react@19.2.3/node_modules/react-dom",
+      "link": true
+    },
+    "node_modules/shadcn": {
+      "resolved": "../../node_modules/.pnpm/shadcn@3.8.5_@types+node@20.19.35_typescript@5.9.3/node_modules/shadcn",
+      "link": true
+    },
+    "node_modules/tailwind-merge": {
+      "resolved": "../../node_modules/.pnpm/tailwind-merge@3.5.0/node_modules/tailwind-merge",
+      "link": true
+    },
+    "node_modules/tailwindcss": {
+      "resolved": "../../node_modules/.pnpm/tailwindcss@4.2.1/node_modules/tailwindcss",
+      "link": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tw-animate-css": {
+      "resolved": "../../node_modules/.pnpm/tw-animate-css@1.4.0/node_modules/tw-animate-css",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "resolved": "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript",
+      "link": true
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
+      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
+      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
+      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
+      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
+      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
+      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
+      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
+      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    }
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,9 +11,11 @@
     "test": "echo \"No frontend tests configured yet\""
   },
   "dependencies": {
+    "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.574.0",
+    "motion": "^12.34.3",
     "next": "16.1.6",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
@@ -22,6 +24,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -49,6 +49,11 @@
 
 :root {
   --radius: 0.625rem;
+  --glow-color: oklch(0.6 0.15 250);
+  --glow-color-current: oklch(0.7 0.18 80);
+  --gradient-start: oklch(0.7 0.15 250);
+  --gradient-mid: oklch(0.7 0.15 300);
+  --gradient-end: oklch(0.7 0.15 200);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -83,6 +88,11 @@
 }
 
 .dark {
+  --glow-color: oklch(0.5 0.2 250);
+  --glow-color-current: oklch(0.6 0.22 80);
+  --gradient-start: oklch(0.5 0.2 250);
+  --gradient-mid: oklch(0.5 0.2 300);
+  --gradient-end: oklch(0.5 0.2 200);
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
@@ -122,5 +132,111 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+/* === Keyframe Animations === */
+
+@keyframes shimmer {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(0.85); }
+}
+
+@keyframes breathe-glow {
+  0%, 100% { box-shadow: 0 0 8px var(--glow-color-current); }
+  50% { box-shadow: 0 0 20px var(--glow-color-current); }
+}
+
+@keyframes checkmark-draw {
+  0% { stroke-dashoffset: 24; }
+  100% { stroke-dashoffset: 0; }
+}
+
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  20% { transform: translateX(-2px); }
+  40% { transform: translateX(2px); }
+  60% { transform: translateX(-1px); }
+  80% { transform: translateX(1px); }
+}
+
+@keyframes edge-flow {
+  0% { stroke-dashoffset: 0; }
+  100% { stroke-dashoffset: -20; }
+}
+
+@keyframes gradient-shift {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+@keyframes mesh-float {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33% { transform: translate(30px, -20px) scale(1.05); }
+  66% { transform: translate(-20px, 15px) scale(0.95); }
+}
+
+@keyframes fade-in-up {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* === Utility Classes === */
+
+.animate-shimmer {
+  animation: shimmer 2s infinite;
+}
+
+.animate-pulse-dot {
+  animation: pulse-dot 1.5s ease-in-out infinite;
+}
+
+.animate-breathe-glow {
+  animation: breathe-glow 3s ease-in-out infinite;
+}
+
+.animate-shake {
+  animation: shake 0.4s ease-in-out;
+}
+
+.animate-gradient-shift {
+  background-size: 200% 200%;
+  animation: gradient-shift 6s ease infinite;
+}
+
+.animate-fade-in-up {
+  animation: fade-in-up 0.3s ease-out both;
+}
+
+.animate-edge-flow {
+  animation: edge-flow 1s linear infinite;
+}
+
+.animate-edge-flow-fast {
+  animation: edge-flow 0.5s linear infinite reverse;
+}
+
+/* === Reduced Motion === */
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-shimmer,
+  .animate-pulse-dot,
+  .animate-breathe-glow,
+  .animate-shake,
+  .animate-gradient-shift,
+  .animate-fade-in-up,
+  .animate-edge-flow,
+  .animate-edge-flow-fast {
+    animation: none !important;
+  }
+
+  * {
+    transition-duration: 0.01ms !important;
   }
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { RepoProvider } from "@/components/providers/repo-provider";
+import { ThemeProvider } from "@/components/providers/theme-provider";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -25,13 +26,15 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <TooltipProvider>
-          <RepoProvider>{children}</RepoProvider>
-        </TooltipProvider>
+        <ThemeProvider>
+          <TooltipProvider>
+            <RepoProvider>{children}</RepoProvider>
+          </TooltipProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { AnimatePresence, motion } from "motion/react";
 import { useRepo } from "@/components/providers/repo-provider";
 import { OwnerSwimlane, getLastActiveDate } from "@/components/owner-swimlane";
 import { BranchDetail } from "@/components/branch-detail/branch-detail";
 import { RecentlyMerged } from "@/components/recently-merged";
 import { Separator } from "@/components/ui/separator";
+import { BackgroundMesh } from "@/components/ui/background-mesh";
+import { SkeletonSwimlane } from "@/components/ui/skeleton-shimmer";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
 import type { BranchResponse, StackDetail } from "@/lib/api";
 import { formatTimeAgo } from "@/lib/time";
 
@@ -19,9 +23,32 @@ export default function Home() {
     lastUpdated,
     refresh,
   } = useRepo();
-  const [selectedBranch, setSelectedBranch] = useState<BranchResponse | null>(
-    null
+  const [selectedBranchName, setSelectedBranchName] = useState<string | null>(
+    () => {
+      if (typeof window === "undefined") return null;
+      return new URLSearchParams(window.location.search).get("branch");
+    }
   );
+
+  const selectedBranch = useMemo(() => {
+    if (!selectedBranchName) return null;
+    for (const stack of stackDetails) {
+      const found = stack.branches.find((b) => b.name === selectedBranchName);
+      if (found) return found;
+    }
+    return null;
+  }, [selectedBranchName, stackDetails]);
+
+  const handleSelectBranch = useCallback((branch: BranchResponse | null) => {
+    setSelectedBranchName(branch?.name ?? null);
+    const url = new URL(window.location.href);
+    if (branch) {
+      url.searchParams.set("branch", branch.name);
+    } else {
+      url.searchParams.delete("branch");
+    }
+    window.history.replaceState({}, "", url.toString());
+  }, []);
 
   const currentUser = repo?.currentUser;
 
@@ -48,9 +75,10 @@ export default function Home() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-screen text-muted-foreground">
-        Loading...
-      </div>
+      <>
+        <BackgroundMesh />
+        <SkeletonSwimlane />
+      </>
     );
   }
 
@@ -74,8 +102,9 @@ export default function Home() {
 
   return (
     <div className="flex flex-col h-screen">
+      <BackgroundMesh />
       {/* Header */}
-      <header className="flex items-center justify-between px-4 py-2 border-b shrink-0">
+      <header className="relative flex items-center justify-between px-4 py-2 border-b shrink-0">
         <div className="flex items-center gap-3">
           <span className="font-semibold text-sm">stackit</span>
           {repo && (
@@ -90,6 +119,7 @@ export default function Home() {
               {formatTimeAgo(lastUpdated)}
             </span>
           )}
+          <ThemeToggle />
           <button
             onClick={refresh}
             className="text-xs text-muted-foreground hover:text-foreground"
@@ -98,6 +128,13 @@ export default function Home() {
             &#x21BB;
           </button>
         </div>
+        {/* Animated gradient accent bar */}
+        <div
+          className="absolute bottom-0 left-0 right-0 h-0.5 animate-gradient-shift"
+          style={{
+            background: "linear-gradient(90deg, var(--gradient-start), var(--gradient-mid), var(--gradient-end), var(--gradient-start))",
+          }}
+        />
       </header>
 
       {/* Main content: stacks area + detail panel */}
@@ -113,7 +150,7 @@ export default function Home() {
                     label="You"
                     stacks={yourStacks}
                     selectedBranch={selectedBranch?.name ?? null}
-                    onSelectBranch={setSelectedBranch}
+                    onSelectBranch={handleSelectBranch}
                   />
                 )}
 
@@ -125,7 +162,7 @@ export default function Home() {
                     lastActive={getLastActiveDate(stacks)}
                     stacks={stacks}
                     selectedBranch={selectedBranch?.name ?? null}
-                    onSelectBranch={setSelectedBranch}
+                    onSelectBranch={handleSelectBranch}
                   />
                 ))}
               </div>
@@ -152,14 +189,23 @@ export default function Home() {
         </div>
 
         {/* Right: branch detail */}
-        {selectedBranch && (
-          <>
-            <Separator orientation="vertical" />
-            <div className="w-[400px] shrink-0 overflow-auto p-4">
-              <BranchDetail branch={selectedBranch} />
-            </div>
-          </>
-        )}
+        <AnimatePresence>
+          {selectedBranch && (
+            <motion.div
+              key="detail-panel"
+              className="flex shrink-0"
+              initial={{ width: 0, opacity: 0 }}
+              animate={{ width: 400, opacity: 1 }}
+              exit={{ width: 0, opacity: 0 }}
+              transition={{ duration: 0.2, ease: "easeInOut" }}
+            >
+              <Separator orientation="vertical" />
+              <div className="w-[400px] shrink-0 overflow-auto p-4">
+                <BranchDetail branch={selectedBranch} />
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
     </div>
   );

--- a/apps/web/src/components/branch-detail/branch-detail.tsx
+++ b/apps/web/src/components/branch-detail/branch-detail.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { motion } from "motion/react";
 import type { BranchResponse } from "@/lib/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
@@ -18,6 +19,12 @@ interface BranchDetailProps {
 
 export function BranchDetail({ branch }: BranchDetailProps) {
   return (
+    <motion.div
+      key={branch.name}
+      initial={{ opacity: 0, x: 20 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.2, ease: "easeOut" }}
+    >
     <Card>
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
@@ -56,6 +63,7 @@ export function BranchDetail({ branch }: BranchDetailProps) {
         <CIChecks ci={branch.ci} />
       </CardContent>
     </Card>
+    </motion.div>
   );
 }
 

--- a/apps/web/src/components/branch-detail/ci-checks.tsx
+++ b/apps/web/src/components/branch-detail/ci-checks.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { CIResponse } from "@/lib/api";
+import { AnimatedCheckmark, AnimatedX, PulsingDot } from "@/components/ui/animated-ci-icons";
 
 export function CIChecks({ ci }: { ci?: CIResponse }) {
   if (!ci || !ci.checks || ci.checks.length === 0) return null;
@@ -11,9 +12,13 @@ export function CIChecks({ ci }: { ci?: CIResponse }) {
         CI Checks
       </h4>
       <div className="space-y-0.5">
-        {ci.checks.map((check) => (
-          <div key={check.name} className="flex items-center gap-2 text-sm">
-            <span>{getCheckIcon(check.conclusion)}</span>
+        {ci.checks.map((check, i) => (
+          <div
+            key={check.name}
+            className="flex items-center gap-2 text-sm animate-fade-in-up"
+            style={{ animationDelay: `${i * 50}ms` }}
+          >
+            <CheckIcon conclusion={check.conclusion} status={check.status} />
             <span className="truncate">{check.name}</span>
             <span className="text-xs text-muted-foreground ml-auto">
               {check.status === "COMPLETED" ? check.conclusion : check.status}
@@ -25,15 +30,18 @@ export function CIChecks({ ci }: { ci?: CIResponse }) {
   );
 }
 
-function getCheckIcon(conclusion: string): string {
+function CheckIcon({ conclusion, status }: { conclusion: string; status: string }) {
+  if (status !== "COMPLETED") {
+    return <PulsingDot />;
+  }
   switch (conclusion) {
     case "SUCCESS":
-      return "\u2705";
+      return <AnimatedCheckmark />;
     case "FAILURE":
-      return "\u274C";
+      return <AnimatedX />;
     case "NEUTRAL":
-      return "\u26AA";
+      return <span className="inline-block w-2.5 h-2.5 rounded-full bg-muted-foreground/40" />;
     default:
-      return "\u23F3";
+      return <PulsingDot />;
   }
 }

--- a/apps/web/src/components/branch-detail/commit-list.tsx
+++ b/apps/web/src/components/branch-detail/commit-list.tsx
@@ -11,8 +11,12 @@ export function CommitList({ commits }: { commits?: CommitResponse[] }) {
         Commits
       </h4>
       <div className="space-y-0.5">
-        {commits.map((commit) => (
-          <div key={commit.sha} className="flex items-baseline gap-2 text-sm">
+        {commits.map((commit, i) => (
+          <div
+            key={commit.sha}
+            className="flex items-baseline gap-2 text-sm animate-fade-in-up"
+            style={{ animationDelay: `${i * 40}ms` }}
+          >
             <code className="text-xs text-muted-foreground font-mono shrink-0">
               {commit.sha}
             </code>

--- a/apps/web/src/components/owner-swimlane.tsx
+++ b/apps/web/src/components/owner-swimlane.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
 import type { BranchResponse, StackDetail } from "@/lib/api";
 import { StackColumn } from "@/components/stack-column";
 import { SwimlaneLabel, swimlaneColor } from "@/components/swimlane-label";
@@ -33,29 +34,48 @@ export function OwnerSwimlane({
 
   return (
     <div className="flex flex-col shrink-0">
-      <div
+      <motion.div
         className="flex gap-4 items-end px-3 pt-3"
         style={{ backgroundColor: color }}
+        initial="hidden"
+        animate="visible"
+        variants={{
+          hidden: {},
+          visible: { transition: { staggerChildren: 0.08 } },
+        }}
       >
-        {visibleStacks.map((stack) => (
-          <StackColumn
-            key={stack.rootBranch}
-            stack={stack}
-            selectedBranch={selectedBranch}
-            onSelectBranch={onSelectBranch}
-          />
-        ))}
+        <AnimatePresence mode="popLayout">
+          {visibleStacks.map((stack) => (
+            <motion.div
+              key={stack.rootBranch}
+              layout
+              variants={{
+                hidden: { opacity: 0, y: 12 },
+                visible: { opacity: 1, y: 0 },
+              }}
+              exit={{ opacity: 0, scale: 0.95 }}
+              transition={{ duration: 0.2 }}
+            >
+              <StackColumn
+                stack={stack}
+                selectedBranch={selectedBranch}
+                onSelectBranch={onSelectBranch}
+              />
+            </motion.div>
+          ))}
+        </AnimatePresence>
         {canCollapse && (
-          <button
+          <motion.button
+            layout
             onClick={() => setExpanded(!expanded)}
             className="flex items-center justify-center w-8 shrink-0 self-stretch rounded border border-dashed border-muted-foreground/30 text-xs text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground transition-colors"
           >
             <span className="-rotate-90 whitespace-nowrap">
               {expanded ? "Show less" : `+${hiddenCount} more`}
             </span>
-          </button>
+          </motion.button>
         )}
-      </div>
+      </motion.div>
       <SwimlaneLabel label={label} lastActive={lastActive} color={color} />
     </div>
   );

--- a/apps/web/src/components/providers/theme-provider.tsx
+++ b/apps/web/src/components/providers/theme-provider.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+type Theme = "light" | "dark" | "system";
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: "system",
+  setTheme: () => {},
+});
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+const STORAGE_KEY = "stackit-theme";
+
+function getSystemPreference(): "light" | "dark" {
+  if (typeof window === "undefined") return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+function applyTheme(theme: Theme) {
+  const resolved = theme === "system" ? getSystemPreference() : theme;
+  document.documentElement.classList.toggle("dark", resolved === "dark");
+  // Set color-scheme so light-dark() CSS function works
+  document.documentElement.style.colorScheme = resolved;
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>("system");
+
+  // Initialize from localStorage on mount
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+    const initial = stored && ["light", "dark", "system"].includes(stored)
+      ? stored
+      : "system";
+    setThemeState(initial);
+    applyTheme(initial);
+  }, []);
+
+  // Listen for system preference changes when in "system" mode
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => {
+      if (theme === "system") applyTheme("system");
+    };
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [theme]);
+
+  const setTheme = useCallback((next: Theme) => {
+    setThemeState(next);
+    localStorage.setItem(STORAGE_KEY, next);
+    applyTheme(next);
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/apps/web/src/components/stack-column.tsx
+++ b/apps/web/src/components/stack-column.tsx
@@ -2,6 +2,7 @@
 
 import type { BranchResponse, StackDetail } from "@/lib/api";
 import { PRBadge, DiffStats, StackStatusBadge } from "@/components/status/status-badge";
+import { AnimatedCheckmark, AnimatedX, PulsingDot } from "@/components/ui/animated-ci-icons";
 
 interface StackColumnProps {
   stack: StackDetail;
@@ -43,7 +44,7 @@ export function StackColumn({
       </div>
 
       {/* Stacked branch cards */}
-      <div className="flex flex-col bg-white rounded-lg">
+      <div className="flex flex-col bg-card rounded-lg">
         {displayBranches.map((branch, i) => {
           const isFirst = i === 0;
           const isLast = i === displayBranches.length - 1;
@@ -53,12 +54,14 @@ export function StackColumn({
             <button
               key={branch.name}
               onClick={() => onSelectBranch(branch)}
-              className={`text-left px-3 py-2.5 border-x border-t transition-colors
+              className={`text-left px-3 py-2.5 border-x border-t transition-all duration-200 animate-fade-in-up
                 ${isLast ? "border-b" : ""}
                 ${isFirst ? "rounded-t-lg" : ""}
                 ${isLast ? "rounded-b-lg" : ""}
-                ${isSelected ? "bg-accent ring-2 ring-ring z-10 relative" : "hover:bg-muted/50"}
+                ${isSelected ? "bg-accent ring-2 ring-ring z-10 relative shadow-[0_0_15px_var(--glow-color)]" : "hover:bg-muted/50 hover:scale-[1.02] hover:shadow-md hover:-translate-y-0.5"}
+                ${branch.isCurrent && !isSelected ? "animate-breathe-glow" : ""}
               `}
+              style={{ animationDelay: `${i * 50}ms` }}
             >
               <div className="flex items-center gap-2 min-w-0">
                 {branch.isCurrent && (
@@ -98,23 +101,11 @@ function CIStatusIcon({ status }: { status?: string }) {
 
   switch (status) {
     case "passing":
-      return (
-        <span className="text-green-600 text-xs" title="CI passing">
-          &#x2713;
-        </span>
-      );
+      return <AnimatedCheckmark />;
     case "failing":
-      return (
-        <span className="text-red-600 text-xs" title="CI failing">
-          &#x2717;
-        </span>
-      );
+      return <AnimatedX />;
     case "pending":
-      return (
-        <span className="text-amber-500 text-xs" title="CI pending">
-          &#x23F3;
-        </span>
-      );
+      return <PulsingDot />;
     default:
       return null;
   }

--- a/apps/web/src/components/stack-tree/branch-edge.tsx
+++ b/apps/web/src/components/stack-tree/branch-edge.tsx
@@ -21,9 +21,9 @@ export function BranchEdge({ x1, y1, x2, y2, needsRestack }: BranchEdgeProps) {
     <path
       d={path}
       fill="none"
-      className={needsRestack ? "stroke-amber-400" : "stroke-muted-foreground/40"}
+      className={`${needsRestack ? "stroke-amber-400 animate-edge-flow-fast" : "stroke-muted-foreground/40 animate-edge-flow"}`}
       strokeWidth={needsRestack ? 2 : 1.5}
-      strokeDasharray={needsRestack ? "4 3" : undefined}
+      strokeDasharray="10 10"
     />
   );
 }

--- a/apps/web/src/components/stack-tree/branch-node.tsx
+++ b/apps/web/src/components/stack-tree/branch-node.tsx
@@ -33,7 +33,21 @@ export function BranchNode({
       transform={`translate(${x - NODE_WIDTH / 2}, ${y - NODE_HEIGHT / 2})`}
       onClick={() => onClick(branch)}
       className="cursor-pointer"
+      style={{ transition: "transform 0.15s ease" }}
     >
+      {/* Glow behind selected node */}
+      {isSelected && (
+        <rect
+          width={NODE_WIDTH + 8}
+          height={NODE_HEIGHT + 8}
+          x={-4}
+          y={-4}
+          rx={12}
+          filter="url(#glow)"
+          className="fill-transparent stroke-transparent"
+          style={{ opacity: 0.6 }}
+        />
+      )}
       <rect
         width={NODE_WIDTH}
         height={NODE_HEIGHT}

--- a/apps/web/src/components/stack-tree/stack-tree.tsx
+++ b/apps/web/src/components/stack-tree/stack-tree.tsx
@@ -35,6 +35,17 @@ export function StackTree({
         className="mx-auto"
         style={{ minWidth: layout.width, minHeight: layout.height }}
       >
+        <defs>
+          <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="4" result="blur" />
+            <feFlood floodColor="var(--glow-color)" result="color" />
+            <feComposite in="color" in2="blur" operator="in" result="shadow" />
+            <feMerge>
+              <feMergeNode in="shadow" />
+              <feMergeNode in="SourceGraphic" />
+            </feMerge>
+          </filter>
+        </defs>
         {/* Edges first (below nodes) */}
         {layout.edges.map((edge) => (
           <BranchEdge

--- a/apps/web/src/components/status/status-badge.tsx
+++ b/apps/web/src/components/status/status-badge.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { Github } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import type { CIResponse, PRResponse } from "@/lib/api";
+import { usePrevious } from "@/hooks/use-previous";
+import { useConfetti } from "@/hooks/use-confetti";
 
 export function CIStatusBadge({ ci }: { ci?: CIResponse }) {
   if (!ci || ci.status === "none") return null;
@@ -46,6 +49,25 @@ export function ReviewBadge({ ci }: { ci?: CIResponse }) {
 }
 
 export function PRBadge({ pr }: { pr?: PRResponse }) {
+  const previousState = usePrevious(pr?.state);
+  const fireConfetti = useConfetti();
+  const hasFiredRef = useRef(false);
+
+  useEffect(() => {
+    if (
+      pr?.state === "MERGED" &&
+      previousState &&
+      previousState !== "MERGED" &&
+      !hasFiredRef.current
+    ) {
+      hasFiredRef.current = true;
+      fireConfetti();
+    }
+    if (pr?.state !== "MERGED") {
+      hasFiredRef.current = false;
+    }
+  }, [pr?.state, previousState, fireConfetti]);
+
   if (!pr) return null;
 
   const stateColors: Record<string, string> = {

--- a/apps/web/src/components/swimlane-label.tsx
+++ b/apps/web/src/components/swimlane-label.tsx
@@ -26,7 +26,8 @@ export function SwimlaneLabel({ label, lastActive, color }: SwimlaneLabelProps) 
 
 /**
  * Generate a soft pastel background color from a string.
- * Returns an HSL color with fixed saturation/lightness and a hue derived from the input.
+ * Returns a CSS `light-dark()` value that adapts to the color scheme.
+ * Light mode uses high lightness (95%), dark mode uses low lightness (18%).
  */
 export function swimlaneColor(name: string): string {
   let hash = 0;
@@ -34,7 +35,7 @@ export function swimlaneColor(name: string): string {
     hash = name.charCodeAt(i) + ((hash << 5) - hash);
   }
   const hue = ((hash % 360) + 360) % 360;
-  return `hsl(${hue} 30% 95%)`;
+  return `light-dark(hsl(${hue} 30% 95%), hsl(${hue} 20% 18%))`;
 }
 
 function TimeAgo({ date }: { date: Date }) {

--- a/apps/web/src/components/ui/animated-ci-icons.tsx
+++ b/apps/web/src/components/ui/animated-ci-icons.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+export function AnimatedCheckmark({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      className={`w-4 h-4 ${className}`}
+      aria-label="CI passing"
+    >
+      <path
+        d="M3 8.5 L6.5 12 L13 4"
+        fill="none"
+        className="stroke-green-600"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeDasharray={24}
+        strokeDashoffset={0}
+        style={{ animation: "checkmark-draw 0.4s ease-out" }}
+      />
+    </svg>
+  );
+}
+
+export function AnimatedX({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      className={`w-4 h-4 animate-shake ${className}`}
+      aria-label="CI failing"
+    >
+      <path
+        d="M4 4 L12 12 M12 4 L4 12"
+        fill="none"
+        className="stroke-red-600"
+        strokeWidth={2}
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export function PulsingDot({ className = "" }: { className?: string }) {
+  return (
+    <span
+      className={`inline-block w-2.5 h-2.5 rounded-full bg-amber-500 animate-pulse-dot ${className}`}
+      aria-label="CI pending"
+    />
+  );
+}

--- a/apps/web/src/components/ui/background-mesh.tsx
+++ b/apps/web/src/components/ui/background-mesh.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+export function BackgroundMesh() {
+  return (
+    <div
+      className="fixed inset-0 -z-10 overflow-hidden pointer-events-none"
+      aria-hidden="true"
+    >
+      <div
+        className="absolute -top-1/4 -left-1/4 w-[50vw] h-[50vw] rounded-full opacity-20 blur-[120px]"
+        style={{
+          background: "var(--gradient-start)",
+          animation: "mesh-float 20s ease-in-out infinite",
+        }}
+      />
+      <div
+        className="absolute top-1/3 -right-1/4 w-[40vw] h-[40vw] rounded-full opacity-15 blur-[120px]"
+        style={{
+          background: "var(--gradient-mid)",
+          animation: "mesh-float 25s ease-in-out infinite 5s",
+        }}
+      />
+      <div
+        className="absolute -bottom-1/4 left-1/3 w-[45vw] h-[45vw] rounded-full opacity-10 blur-[120px]"
+        style={{
+          background: "var(--gradient-end)",
+          animation: "mesh-float 22s ease-in-out infinite 10s",
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/skeleton-shimmer.tsx
+++ b/apps/web/src/components/ui/skeleton-shimmer.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+export function Skeleton({ className = "" }: { className?: string }) {
+  return (
+    <div
+      className={`relative overflow-hidden rounded bg-muted ${className}`}
+    >
+      <div className="absolute inset-0 animate-shimmer bg-gradient-to-r from-transparent via-foreground/5 to-transparent" />
+    </div>
+  );
+}
+
+export function SkeletonCard() {
+  return (
+    <div className="w-64 shrink-0">
+      {/* Header skeleton */}
+      <div className="px-1 pb-2 space-y-2">
+        <Skeleton className="h-5 w-24" />
+        <Skeleton className="h-3 w-32" />
+      </div>
+      {/* Card stack skeleton */}
+      <div className="flex flex-col rounded-lg border bg-card">
+        {[0, 1, 2].map((i) => (
+          <div
+            key={i}
+            className="px-3 py-2.5 border-b last:border-b-0 space-y-2"
+          >
+            <Skeleton className="h-4 w-40" />
+            <div className="flex gap-2">
+              <Skeleton className="h-3 w-12" />
+              <Skeleton className="h-3 w-8" />
+              <Skeleton className="h-3 w-16" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function SkeletonSwimlane() {
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <div className="flex flex-col items-end">
+        <div className="flex gap-4 items-end p-6 pb-4">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="animate-fade-in-up"
+              style={{ animationDelay: `${i * 100}ms` }}
+            >
+              <SkeletonCard />
+            </div>
+          ))}
+        </div>
+        {/* Trunk line skeleton */}
+        <div className="flex items-center gap-2 px-6 pb-6 w-full">
+          <Skeleton className="flex-1 h-0.5" />
+          <Skeleton className="h-3 w-10" />
+          <Skeleton className="flex-1 h-0.5" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/theme-toggle.tsx
+++ b/apps/web/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Sun, Moon, Monitor } from "lucide-react";
+import { useTheme } from "@/components/providers/theme-provider";
+
+const cycle = ["light", "dark", "system"] as const;
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  const next = () => {
+    const i = cycle.indexOf(theme);
+    setTheme(cycle[(i + 1) % cycle.length]);
+  };
+
+  const Icon = theme === "dark" ? Moon : theme === "light" ? Sun : Monitor;
+  const label =
+    theme === "dark" ? "Dark" : theme === "light" ? "Light" : "System";
+
+  return (
+    <button
+      onClick={next}
+      className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+      title={`Theme: ${label}. Click to cycle.`}
+    >
+      <Icon className="w-3.5 h-3.5" />
+      <span className="hidden sm:inline">{label}</span>
+    </button>
+  );
+}

--- a/apps/web/src/hooks/use-confetti.ts
+++ b/apps/web/src/hooks/use-confetti.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useCallback } from "react";
+import confetti from "canvas-confetti";
+
+export function useConfetti() {
+  return useCallback(() => {
+    confetti({
+      particleCount: 80,
+      spread: 70,
+      origin: { y: 0.6 },
+      disableForReducedMotion: true,
+    });
+  }, []);
+}

--- a/apps/web/src/hooks/use-previous.ts
+++ b/apps/web/src/hooks/use-previous.ts
@@ -1,0 +1,11 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T | undefined>(undefined);
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+}

--- a/mise.toml
+++ b/mise.toml
@@ -23,6 +23,9 @@ pnpm = "10"
 # Linting
 golangci-lint = "latest"
 
+# Development tools
+"aqua:watchexec/watchexec" = "latest" # File watcher for dev auto-reload
+
 # CLI utilities (recommended in AGENTS.md)
 "aqua:BurntSushi/ripgrep" = "latest"  # Fast text search (rg)
 "aqua:sharkdp/fd" = "latest"          # Fast file search
@@ -143,8 +146,8 @@ description = "Run the web app in development mode"
 run = "pnpm --filter @stackit/web dev"
 
 [tasks."api-dev"]
-description = "Run the API server in development mode"
-run = "go run ./apps/api --port 8080"
+description = "Run the API server in development mode (auto-reloads on file changes)"
+run = "watchexec -r -e go -w apps/api -w internal -w api -- go run ./apps/api --port 8080"
 
 [tasks.dev]
 description = "Run API + web dev servers using overmind and Procfile.dev"


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Polish web UI: animations, status footer, and worktree-aware API**

Improves the stackit web frontend with visual polish and a smarter API layer.

Key changes:
- **Visual flair** (PR #767): Adds entry animations, a dark mode toggle, and confetti on stack actions; introduces animated CI status icons (checkmark, X, pulsing dot) across branch cards
- **Stack status footer** (PR #768): Adds a color-coded footer below each stack column showing its overall state (shippable / needs restack / blocked / incomplete) with state-specific colors and subtle shadows
- **Worktree-aware API** (PR #769): Filters worktree anchor branches out of the API response so they never appear as real branches in the UI; adds a `hasWorktree` flag to `StackSummary` and renders a folder-git icon in the stack header when a worktree is attached

#### Stack


* **PR #767** 👈
  * **PR #768**
    * **PR #769**
      * **PR #770**
        * **PR #771**
          * **PR #772**
            * **PR #773**
              * **PR #774**
                * **PR #775**
                  * **PR #776**
                    * **PR #785**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #786 by jonnii*