### PR TITLE
feat: add stack status footer below branch cards with state-based styling

### DIFF
--- a/apps/web/src/components/stack-column.tsx
+++ b/apps/web/src/components/stack-column.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { BranchResponse, StackDetail } from "@/lib/api";
-import { PRBadge, DiffStats, StackStatusBadge } from "@/components/status/status-badge";
+import { PRBadge, DiffStats } from "@/components/status/status-badge";
 import { AnimatedCheckmark, AnimatedX, PulsingDot } from "@/components/ui/animated-ci-icons";
 
 interface StackColumnProps {
@@ -23,14 +23,11 @@ export function StackColumn({
     <div className="flex flex-col w-64 shrink-0">
       {/* Stack header */}
       <div className="px-1 pb-2">
-        <div className="flex items-center gap-2">
-          <StackStatusBadge status={stack.status} />
-          {stack.prCount > 0 && (
-            <span className="text-xs text-muted-foreground">
-              {stack.prCount} PR{stack.prCount !== 1 ? "s" : ""}
-            </span>
-          )}
-        </div>
+        {stack.prCount > 0 && (
+          <span className="text-xs text-muted-foreground">
+            {stack.prCount} PR{stack.prCount !== 1 ? "s" : ""}
+          </span>
+        )}
         {stack.title && (
           <p className="text-xs text-muted-foreground mt-1 truncate" title={stack.title}>
             {stack.title}
@@ -44,7 +41,7 @@ export function StackColumn({
       </div>
 
       {/* Stacked branch cards */}
-      <div className="flex flex-col bg-card rounded-lg">
+      <div className="flex flex-col bg-card rounded-t-lg">
         {displayBranches.map((branch, i) => {
           const isFirst = i === 0;
           const isLast = i === displayBranches.length - 1;
@@ -57,7 +54,6 @@ export function StackColumn({
               className={`text-left px-3 py-2.5 border-x border-t transition-all duration-200 animate-fade-in-up
                 ${isLast ? "border-b" : ""}
                 ${isFirst ? "rounded-t-lg" : ""}
-                ${isLast ? "rounded-b-lg" : ""}
                 ${isSelected ? "bg-accent ring-2 ring-ring z-10 relative shadow-[0_0_15px_var(--glow-color)]" : "hover:bg-muted/50 hover:scale-[1.02] hover:shadow-md hover:-translate-y-0.5"}
                 ${branch.isCurrent && !isSelected ? "animate-breathe-glow" : ""}
               `}
@@ -92,6 +88,48 @@ export function StackColumn({
           );
         })}
       </div>
+
+      {/* Status footer */}
+      <StackStatusFooter status={stack.status} />
+    </div>
+  );
+}
+
+const statusConfig: Record<string, { label: string; bg: string; text: string; shadow: string }> = {
+  shippable: {
+    label: "Ready to ship",
+    bg: "bg-green-100 dark:bg-green-950/60",
+    text: "text-green-700 dark:text-green-400",
+    shadow: "shadow-[0_2px_8px_rgba(34,197,94,0.2)] dark:shadow-[0_2px_8px_rgba(34,197,94,0.15)]",
+  },
+  pending: {
+    label: "Needs restack",
+    bg: "bg-amber-100 dark:bg-amber-950/60",
+    text: "text-amber-700 dark:text-amber-400",
+    shadow: "shadow-[0_2px_8px_rgba(245,158,11,0.2)] dark:shadow-[0_2px_8px_rgba(245,158,11,0.15)]",
+  },
+  blocked: {
+    label: "Blocked",
+    bg: "bg-red-100 dark:bg-red-950/60",
+    text: "text-red-700 dark:text-red-400",
+    shadow: "shadow-[0_2px_8px_rgba(239,68,68,0.2)] dark:shadow-[0_2px_8px_rgba(239,68,68,0.15)]",
+  },
+  incomplete: {
+    label: "Incomplete",
+    bg: "bg-muted",
+    text: "text-muted-foreground",
+    shadow: "shadow-[0_2px_8px_rgba(0,0,0,0.05)] dark:shadow-[0_2px_8px_rgba(0,0,0,0.15)]",
+  },
+};
+
+function StackStatusFooter({ status }: { status: string }) {
+  const c = statusConfig[status] || statusConfig.incomplete;
+
+  return (
+    <div
+      className={`flex items-center justify-center px-3 py-1.5 rounded-b-lg border-x border-b text-xs font-medium ${c.bg} ${c.text} ${c.shadow}`}
+    >
+      {c.label}
     </div>
   );
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Polish web UI: animations, status footer, and worktree-aware API**

Improves the stackit web frontend with visual polish and a smarter API layer.

Key changes:
- **Visual flair** (PR #767): Adds entry animations, a dark mode toggle, and confetti on stack actions; introduces animated CI status icons (checkmark, X, pulsing dot) across branch cards
- **Stack status footer** (PR #768): Adds a color-coded footer below each stack column showing its overall state (shippable / needs restack / blocked / incomplete) with state-specific colors and subtle shadows
- **Worktree-aware API** (PR #769): Filters worktree anchor branches out of the API response so they never appear as real branches in the UI; adds a `hasWorktree` flag to `StackSummary` and renders a folder-git icon in the stack header when a worktree is attached

#### Stack


* **PR #767**
  * **PR #768** 👈
    * **PR #769**
      * **PR #770**
        * **PR #771**
          * **PR #772**
            * **PR #773**
              * **PR #774**
                * **PR #775**
                  * **PR #776**
                    * **PR #785**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #786 by jonnii*