### PR TITLE
feat: hide worktree anchors from API response and add worktree indicator

### DIFF
--- a/api/openapi/stackit.yaml
+++ b/api/openapi/stackit.yaml
@@ -153,6 +153,8 @@ components:
           type: integer
         isCurrent:
           type: boolean
+        hasWorktree:
+          type: boolean
         description:
           type: string
         owner:

--- a/apps/web/src/components/stack-column.tsx
+++ b/apps/web/src/components/stack-column.tsx
@@ -3,6 +3,7 @@
 import type { BranchResponse, StackDetail } from "@/lib/api";
 import { PRBadge, DiffStats } from "@/components/status/status-badge";
 import { AnimatedCheckmark, AnimatedX, PulsingDot } from "@/components/ui/animated-ci-icons";
+import { FolderGit2 } from "lucide-react";
 
 interface StackColumnProps {
   stack: StackDetail;
@@ -23,11 +24,18 @@ export function StackColumn({
     <div className="flex flex-col w-64 shrink-0">
       {/* Stack header */}
       <div className="px-1 pb-2">
-        {stack.prCount > 0 && (
-          <span className="text-xs text-muted-foreground">
-            {stack.prCount} PR{stack.prCount !== 1 ? "s" : ""}
-          </span>
-        )}
+        <div className="flex items-center gap-2">
+          {stack.prCount > 0 && (
+            <span className="text-xs text-muted-foreground">
+              {stack.prCount} PR{stack.prCount !== 1 ? "s" : ""}
+            </span>
+          )}
+          {stack.hasWorktree && (
+            <span className="text-xs text-muted-foreground flex items-center gap-1" title="Worktree">
+              <FolderGit2 className="w-3 h-3" />
+            </span>
+          )}
+        </div>
         {stack.title && (
           <p className="text-xs text-muted-foreground mt-1 truncate" title={stack.title}>
             {stack.title}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -21,6 +21,7 @@ export interface StackSummary {
   branchCount: number;
   prCount: number;
   isCurrent: boolean;
+  hasWorktree?: boolean;
   description?: string;
   owner?: string;
 }

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -87,17 +87,39 @@ func MapStackSummary(eng engine.BranchReader, graph *engine.StackGraph, rootBran
 	currentBranch := eng.CurrentBranch().GetName()
 	isCurrent := slices.Contains(allBranches, currentBranch)
 
-	// Get title from root branch's PR or commit subject
-	title := rootBranch
+	// Detect worktree anchor and filter it from display branches
+	hasWorktree := false
+	displayBranches := allBranches
 	rootNode := graph.GetNode(rootBranch)
+	if rootNode != nil && rootNode.Branch.IsWorktreeAnchor() {
+		hasWorktree = true
+		displayBranches = make([]string, 0, len(allBranches)-1)
+		for _, name := range allBranches {
+			if name != rootBranch {
+				displayBranches = append(displayBranches, name)
+			}
+		}
+	}
+
+	// Get title from root branch's PR, or first child's PR for worktree anchors
+	title := rootBranch
 	if rootNode != nil {
-		if prInfo, err := rootNode.Branch.GetPrInfo(); err == nil && prInfo != nil && prInfo.Title() != "" {
+		if hasWorktree {
+			// Anchor has no PR — derive title from first child
+			if len(rootNode.Children) > 0 {
+				if childNode := graph.GetNode(rootNode.Children[0]); childNode != nil {
+					if prInfo, err := childNode.Branch.GetPrInfo(); err == nil && prInfo != nil && prInfo.Title() != "" {
+						title = prInfo.Title()
+					}
+				}
+			}
+		} else if prInfo, err := rootNode.Branch.GetPrInfo(); err == nil && prInfo != nil && prInfo.Title() != "" {
 			title = prInfo.Title()
 		}
 	}
 
-	// Compute stack status
-	status := computeStackStatus(graph, allBranches)
+	// Compute stack status using display branches (anchor excluded)
+	status := computeStackStatus(graph, displayBranches)
 
 	var description string
 	if rootNode != nil {
@@ -111,9 +133,10 @@ func MapStackSummary(eng engine.BranchReader, graph *engine.StackGraph, rootBran
 		Title:       title,
 		Status:      status,
 		Scope:       scope,
-		BranchCount: len(allBranches),
+		BranchCount: len(displayBranches),
 		PRCount:     prCount,
 		IsCurrent:   isCurrent,
+		HasWorktree: hasWorktree,
 		Description: description,
 		Owner:       owner,
 	}
@@ -131,8 +154,15 @@ func MapStackDetail(eng engine.BranchReader, graph *engine.StackGraph, rootBranc
 
 	summary := MapStackSummary(eng, graph, rootBranch, allBranches, prCount, scope, owner)
 
+	// Check if root is a worktree anchor to filter it from branches
+	isAnchor := summary.HasWorktree
+	anchorName := rootBranch
+
 	branches := make([]BranchResponse, 0, len(allBranches))
 	for _, name := range allBranches {
+		if isAnchor && name == anchorName {
+			continue
+		}
 		node := graph.GetNode(name)
 		if node == nil {
 			continue
@@ -141,7 +171,16 @@ func MapStackDetail(eng engine.BranchReader, graph *engine.StackGraph, rootBranc
 		if checksMap != nil {
 			checks = checksMap[name]
 		}
-		branches = append(branches, MapBranch(eng, node.Branch, node, checks))
+		br := MapBranch(eng, node.Branch, node, checks)
+		if isAnchor {
+			// Anchor's direct children become display roots
+			if br.Parent == anchorName {
+				br.Parent = ""
+			}
+			// All branches shift up one depth level
+			br.Depth--
+		}
+		branches = append(branches, br)
 	}
 
 	return StackDetail{

--- a/internal/contracts/http/responses.go
+++ b/internal/contracts/http/responses.go
@@ -54,6 +54,7 @@ type StackSummary struct {
 	BranchCount int    `json:"branchCount"`
 	PRCount     int    `json:"prCount"`
 	IsCurrent   bool   `json:"isCurrent"`
+	HasWorktree bool   `json:"hasWorktree,omitempty"`
 	Description string `json:"description,omitempty"`
 	Owner       string `json:"owner,omitempty"`
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Polish web UI: animations, status footer, and worktree-aware API**

Improves the stackit web frontend with visual polish and a smarter API layer.

Key changes:
- **Visual flair** (PR #767): Adds entry animations, a dark mode toggle, and confetti on stack actions; introduces animated CI status icons (checkmark, X, pulsing dot) across branch cards
- **Stack status footer** (PR #768): Adds a color-coded footer below each stack column showing its overall state (shippable / needs restack / blocked / incomplete) with state-specific colors and subtle shadows
- **Worktree-aware API** (PR #769): Filters worktree anchor branches out of the API response so they never appear as real branches in the UI; adds a `hasWorktree` flag to `StackSummary` and renders a folder-git icon in the stack header when a worktree is attached

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1772340662`.


* **PR #767**
  * **PR #768**
    * **PR #769** 👈
      * **PR #770**
        * **PR #771**
          * **PR #772**
            * **PR #773**
              * **PR #774**
                * **PR #775**
                  * **PR #776**
                    * **PR #785**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->