### PR TITLE
feat: add always-visible event feed sidebar with real-time activity detection

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,17 +1,21 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
-import { AnimatePresence, motion } from "motion/react";
 import { useRepo } from "@/components/providers/repo-provider";
 import { OwnerSwimlane, getLastActiveDate } from "@/components/owner-swimlane";
 import { BranchDetail } from "@/components/branch-detail/branch-detail";
 import { RecentlyMerged } from "@/components/recently-merged";
+import { EventFeed } from "@/components/event-feed";
 import { Separator } from "@/components/ui/separator";
 import { BackgroundMesh } from "@/components/ui/background-mesh";
 import { SkeletonSwimlane } from "@/components/ui/skeleton-shimmer";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import type { BranchResponse, StackDetail } from "@/lib/api";
 import { formatTimeAgo } from "@/lib/time";
+
+type Selection =
+  | { type: "branch"; name: string }
+  | { type: "stack"; rootBranch: string };
 
 export default function Home() {
   const {
@@ -23,31 +27,61 @@ export default function Home() {
     lastUpdated,
     refresh,
   } = useRepo();
-  const [selectedBranchName, setSelectedBranchName] = useState<string | null>(
-    () => {
-      if (typeof window === "undefined") return null;
-      return new URLSearchParams(window.location.search).get("branch");
-    }
-  );
+  const [selection, setSelection] = useState<Selection | null>(() => {
+    if (typeof window === "undefined") return null;
+    const params = new URLSearchParams(window.location.search);
+    const branch = params.get("branch");
+    if (branch) return { type: "branch", name: branch };
+    const stack = params.get("stack");
+    if (stack) return { type: "stack", rootBranch: stack };
+    return null;
+  });
 
   const selectedBranch = useMemo(() => {
-    if (!selectedBranchName) return null;
+    if (!selection || selection.type !== "branch") return null;
     for (const stack of stackDetails) {
-      const found = stack.branches.find((b) => b.name === selectedBranchName);
+      const found = stack.branches.find((b) => b.name === selection.name);
       if (found) return found;
     }
     return null;
-  }, [selectedBranchName, stackDetails]);
+  }, [selection, stackDetails]);
+
+  const selectedStack = useMemo(() => {
+    if (!selection || selection.type !== "stack") return null;
+    return stackDetails.find((s) => s.rootBranch === selection.rootBranch) ?? null;
+  }, [selection, stackDetails]);
 
   const handleSelectBranch = useCallback((branch: BranchResponse | null) => {
-    setSelectedBranchName(branch?.name ?? null);
     const url = new URL(window.location.href);
+    url.searchParams.delete("stack");
     if (branch) {
+      setSelection({ type: "branch", name: branch.name });
       url.searchParams.set("branch", branch.name);
     } else {
+      setSelection(null);
       url.searchParams.delete("branch");
     }
     window.history.replaceState({}, "", url.toString());
+  }, []);
+
+  const handleSelectStack = useCallback((stack: StackDetail) => {
+    setSelection((prev) => {
+      const deselecting = prev?.type === "stack" && prev.rootBranch === stack.rootBranch;
+      const next = deselecting ? null : { type: "stack" as const, rootBranch: stack.rootBranch };
+
+      queueMicrotask(() => {
+        const url = new URL(window.location.href);
+        url.searchParams.delete("branch");
+        if (next) {
+          url.searchParams.set("stack", stack.rootBranch);
+        } else {
+          url.searchParams.delete("stack");
+        }
+        window.history.replaceState({}, "", url.toString());
+      });
+
+      return next;
+    });
   }, []);
 
   const currentUser = repo?.currentUser;
@@ -72,6 +106,8 @@ export default function Home() {
     );
     return { yourStacks: yours, otherOwners: sortedOthers };
   }, [stackDetails, currentUser]);
+
+  const hasSelection = selectedBranch || selectedStack;
 
   if (loading) {
     return (
@@ -149,8 +185,10 @@ export default function Home() {
                   <OwnerSwimlane
                     label="You"
                     stacks={yourStacks}
-                    selectedBranch={selectedBranch?.name ?? null}
+                    selectedBranch={selection?.type === "branch" ? selection.name : null}
+                    selectedStack={selection?.type === "stack" ? selection.rootBranch : null}
                     onSelectBranch={handleSelectBranch}
+                    onSelectStack={handleSelectStack}
                   />
                 )}
 
@@ -161,8 +199,10 @@ export default function Home() {
                     label={`@${owner}`}
                     lastActive={getLastActiveDate(stacks)}
                     stacks={stacks}
-                    selectedBranch={selectedBranch?.name ?? null}
+                    selectedBranch={selection?.type === "branch" ? selection.name : null}
+                    selectedStack={selection?.type === "stack" ? selection.rootBranch : null}
                     onSelectBranch={handleSelectBranch}
+                    onSelectStack={handleSelectStack}
                   />
                 ))}
               </div>
@@ -188,24 +228,21 @@ export default function Home() {
           )}
         </div>
 
-        {/* Right: branch detail */}
-        <AnimatePresence>
-          {selectedBranch && (
-            <motion.div
-              key="detail-panel"
-              className="flex shrink-0"
-              initial={{ width: 0, opacity: 0 }}
-              animate={{ width: 400, opacity: 1 }}
-              exit={{ width: 0, opacity: 0 }}
-              transition={{ duration: 0.2, ease: "easeInOut" }}
-            >
-              <Separator orientation="vertical" />
-              <div className="w-[400px] shrink-0 overflow-auto p-4">
-                <BranchDetail branch={selectedBranch} />
+        {/* Right: detail + event feed panel (always visible) */}
+        <div className="flex shrink-0">
+          <Separator orientation="vertical" />
+          <div className="w-[400px] shrink-0 flex flex-col overflow-hidden">
+            {hasSelection && (
+              <div className="flex-1 overflow-auto p-4">
+                {selectedBranch && <BranchDetail branch={selectedBranch} />}
               </div>
-            </motion.div>
-          )}
-        </AnimatePresence>
+            )}
+            {hasSelection && <Separator />}
+            <div className="p-3 overflow-auto">
+              <EventFeed />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/event-feed.tsx
+++ b/apps/web/src/components/event-feed.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState } from "react";
+import {
+  GitBranch,
+  Trash2,
+  ArrowRightLeft,
+  GitPullRequest,
+  GitMerge,
+  XCircle,
+  CircleDot,
+  AlertTriangle,
+  CheckCircle2,
+  Layers,
+  RefreshCw,
+  ChevronDown,
+  ChevronRight,
+  X,
+} from "lucide-react";
+import { useRepo } from "@/components/providers/repo-provider";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type { EventKind } from "@/lib/api";
+
+const EVENT_CONFIG: Record<
+  EventKind,
+  { icon: typeof GitBranch; label: string; color: string }
+> = {
+  branch_created: {
+    icon: GitBranch,
+    label: "Branch created",
+    color: "text-green-500",
+  },
+  branch_deleted: {
+    icon: Trash2,
+    label: "Branch deleted",
+    color: "text-red-500",
+  },
+  branch_switched: {
+    icon: ArrowRightLeft,
+    label: "Switched to",
+    color: "text-blue-500",
+  },
+  pr_opened: {
+    icon: GitPullRequest,
+    label: "PR opened",
+    color: "text-green-500",
+  },
+  pr_merged: {
+    icon: GitMerge,
+    label: "PR merged",
+    color: "text-purple-500",
+  },
+  pr_closed: {
+    icon: XCircle,
+    label: "PR closed",
+    color: "text-red-500",
+  },
+  ci_changed: {
+    icon: CircleDot,
+    label: "CI status",
+    color: "text-yellow-500",
+  },
+  needs_restack: {
+    icon: AlertTriangle,
+    label: "Needs restack",
+    color: "text-orange-500",
+  },
+  restack_resolved: {
+    icon: CheckCircle2,
+    label: "Restack resolved",
+    color: "text-green-500",
+  },
+  stack_created: {
+    icon: Layers,
+    label: "Stack created",
+    color: "text-green-500",
+  },
+  stack_deleted: {
+    icon: Layers,
+    label: "Stack deleted",
+    color: "text-red-500",
+  },
+  revision_updated: {
+    icon: RefreshCw,
+    label: "Updated",
+    color: "text-blue-500",
+  },
+};
+
+function formatRelativeTime(timestamp: string): string {
+  const seconds = Math.floor(
+    (Date.now() - new Date(timestamp).getTime()) / 1000
+  );
+  if (seconds < 5) return "just now";
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function EventFeed() {
+  const { events, clearEvents } = useRepo();
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div className="flex flex-col">
+      {/* Header */}
+      <button
+        onClick={() => setCollapsed(!collapsed)}
+        className="flex items-center justify-between px-1 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <span className="flex items-center gap-1">
+          {collapsed ? (
+            <ChevronRight className="h-3 w-3" />
+          ) : (
+            <ChevronDown className="h-3 w-3" />
+          )}
+          Activity
+          {events.length > 0 && (
+            <span className="ml-1 text-[10px] bg-muted rounded-full px-1.5 py-0.5 tabular-nums">
+              {events.length}
+            </span>
+          )}
+        </span>
+        {events.length > 0 && !collapsed && (
+          <span
+            onClick={(e) => {
+              e.stopPropagation();
+              clearEvents();
+            }}
+            className="flex items-center gap-0.5 text-[10px] text-muted-foreground hover:text-foreground cursor-pointer"
+          >
+            <X className="h-2.5 w-2.5" />
+            Clear
+          </span>
+        )}
+      </button>
+
+      {/* Event list */}
+      {!collapsed && (
+        <ScrollArea className="max-h-[300px]">
+          {events.length === 0 ? (
+            <p className="text-xs text-muted-foreground/60 py-4 text-center">
+              No recent activity
+            </p>
+          ) : (
+            <div className="flex flex-col gap-0.5">
+              {events.map((event, i) => {
+                const config = EVENT_CONFIG[event.kind];
+                const Icon = config.icon;
+                return (
+                  <div
+                    key={`${event.timestamp}-${event.kind}-${event.branch}-${i}`}
+                    className="flex items-start gap-2 px-1 py-1 rounded-sm hover:bg-muted/50 transition-colors"
+                  >
+                    <Icon
+                      className={`h-3.5 w-3.5 mt-0.5 shrink-0 ${config.color}`}
+                    />
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-baseline gap-1 text-xs">
+                        <span className="text-muted-foreground">
+                          {config.label}
+                        </span>
+                        {event.branch && (
+                          <span className="font-mono text-foreground truncate">
+                            {event.branch}
+                          </span>
+                        )}
+                      </div>
+                      {event.detail && (
+                        <span className="text-[10px] text-muted-foreground/70">
+                          {event.detail}
+                        </span>
+                      )}
+                    </div>
+                    <span className="text-[10px] text-muted-foreground/50 shrink-0 tabular-nums">
+                      {formatRelativeTime(event.timestamp)}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </ScrollArea>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/owner-swimlane.tsx
+++ b/apps/web/src/components/owner-swimlane.tsx
@@ -13,7 +13,9 @@ interface OwnerSwimlaneProps {
   lastActive?: Date;
   stacks: StackDetail[];
   selectedBranch: string | null;
+  selectedStack: string | null;
   onSelectBranch: (branch: BranchResponse) => void;
+  onSelectStack: (stack: StackDetail) => void;
 }
 
 export function OwnerSwimlane({
@@ -21,7 +23,9 @@ export function OwnerSwimlane({
   lastActive,
   stacks,
   selectedBranch,
+  selectedStack,
   onSelectBranch,
+  onSelectStack,
 }: OwnerSwimlaneProps) {
   const [expanded, setExpanded] = useState(false);
   const color = swimlaneColor(label);
@@ -51,7 +55,9 @@ export function OwnerSwimlane({
               <StackColumn
                 stack={stack}
                 selectedBranch={selectedBranch}
+                selectedStack={selectedStack}
                 onSelectBranch={onSelectBranch}
+                onSelectStack={onSelectStack}
               />
             </motion.div>
           ))}

--- a/apps/web/src/components/providers/repo-provider.tsx
+++ b/apps/web/src/components/providers/repo-provider.tsx
@@ -6,6 +6,7 @@ import {
   useEffect,
   useState,
   useCallback,
+  useRef,
   type ReactNode,
 } from "react";
 import {
@@ -13,8 +14,13 @@ import {
   type RepoResponse,
   type StackDetail,
   type TrunkCommitResponse,
+  type ViewResponse,
+  type FeedEvent,
 } from "@/lib/api";
 import { useSSE } from "@/lib/use-sse";
+import { diffViews } from "@/lib/diff-views";
+
+const MAX_EVENTS = 100;
 
 interface RepoState {
   repo: RepoResponse | null;
@@ -23,7 +29,9 @@ interface RepoState {
   loading: boolean;
   error: string | null;
   lastUpdated: Date | null;
+  events: FeedEvent[];
   refresh: () => void;
+  clearEvents: () => void;
 }
 
 const RepoContext = createContext<RepoState | null>(null);
@@ -43,6 +51,22 @@ export function RepoProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [events, setEvents] = useState<FeedEvent[]>([]);
+
+  const prevViewRef = useRef<ViewResponse | null>(null);
+
+  const addEvents = useCallback((newEvents: FeedEvent[]) => {
+    if (newEvents.length === 0) return;
+    setEvents((prev) => [...newEvents, ...prev].slice(0, MAX_EVENTS));
+  }, []);
+
+  const addEvent = useCallback((event: FeedEvent) => {
+    setEvents((prev) => [event, ...prev].slice(0, MAX_EVENTS));
+  }, []);
+
+  const clearEvents = useCallback(() => {
+    setEvents([]);
+  }, []);
 
   const loadData = useCallback(async () => {
     try {
@@ -142,9 +166,20 @@ export function RepoProvider({ children }: { children: ReactNode }) {
         },
       ];
 
-      setStackDetails([...view.stacks, ...sampleStacks]);
+      const augmentedView: ViewResponse = {
+        repo: view.repo,
+        stacks: [...view.stacks, ...sampleStacks],
+      };
       setRecentlyMerged(view.recentlyMerged ?? []);
 
+      // Diff against previous view to detect changes
+      if (prevViewRef.current) {
+        const detected = diffViews(prevViewRef.current, augmentedView);
+        addEvents(detected);
+      }
+      prevViewRef.current = augmentedView;
+
+      setStackDetails(augmentedView.stacks);
       setError(null);
       setLastUpdated(new Date());
     } catch (err) {
@@ -152,15 +187,15 @@ export function RepoProvider({ children }: { children: ReactNode }) {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [addEvents]);
 
   // Initial load
   useEffect(() => {
     loadData();
   }, [loadData]);
 
-  // SSE updates trigger refresh
-  useSSE(loadData);
+  // SSE updates trigger refresh; server events get added directly
+  useSSE(loadData, addEvent);
 
   return (
     <RepoContext.Provider
@@ -171,7 +206,9 @@ export function RepoProvider({ children }: { children: ReactNode }) {
         loading,
         error,
         lastUpdated,
+        events,
         refresh: loadData,
+        clearEvents,
       }}
     >
       {children}

--- a/apps/web/src/components/stack-column.tsx
+++ b/apps/web/src/components/stack-column.tsx
@@ -10,13 +10,17 @@ import Markdown from "react-markdown";
 interface StackColumnProps {
   stack: StackDetail;
   selectedBranch: string | null;
+  selectedStack: string | null;
   onSelectBranch: (branch: BranchResponse) => void;
+  onSelectStack: (stack: StackDetail) => void;
 }
 
 export function StackColumn({
   stack,
   selectedBranch,
+  selectedStack,
   onSelectBranch,
+  onSelectStack,
 }: StackColumnProps) {
   // Order branches root→leaf, then reverse so leaf is at top (stacking metaphor)
   const orderedBranches = orderBranches(stack.branches);
@@ -93,7 +97,11 @@ export function StackColumn({
       </div>
 
       {/* Status footer */}
-      <StackStatusFooter status={stack.status} />
+      <StackStatusFooter
+        status={stack.status}
+        selected={selectedStack === stack.rootBranch}
+        onClick={() => onSelectStack(stack)}
+      />
     </div>
   );
 }
@@ -125,15 +133,16 @@ const statusConfig: Record<string, { label: string; bg: string; text: string; sh
   },
 };
 
-function StackStatusFooter({ status }: { status: string }) {
+function StackStatusFooter({ status, selected, onClick }: { status: string; selected: boolean; onClick: () => void }) {
   const c = statusConfig[status] || statusConfig.incomplete;
 
   return (
-    <div
-      className={`flex items-center justify-center px-3 py-1.5 -mt-2 pt-3.5 rounded-b-lg border-x border-b text-xs font-medium ${c.bg} ${c.text} ${c.shadow}`}
+    <button
+      onClick={onClick}
+      className={`flex items-center justify-center px-3 py-1.5 -mt-2 pt-3.5 rounded-b-lg border-x border-b text-xs font-medium cursor-pointer transition-all duration-200 ${c.bg} ${c.text} ${c.shadow} ${selected ? "ring-2 ring-ring" : "hover:brightness-95 dark:hover:brightness-110"}`}
     >
       {c.label}
-    </div>
+    </button>
   );
 }
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -141,3 +141,53 @@ export function fetchBranch(name: string): Promise<BranchResponse> {
     `/api/branches/${encodeURIComponent(name)}`
   );
 }
+
+// --- Event Feed Types ---
+
+export type EventKind =
+  | "branch_created"
+  | "branch_deleted"
+  | "branch_switched"
+  | "pr_opened"
+  | "pr_merged"
+  | "pr_closed"
+  | "ci_changed"
+  | "needs_restack"
+  | "restack_resolved"
+  | "stack_created"
+  | "stack_deleted"
+  | "revision_updated";
+
+export interface FeedEvent {
+  kind: EventKind;
+  timestamp: string;
+  branch?: string;
+  detail?: string;
+}
+
+// --- Mutation Types ---
+
+export interface SubmitResponse {
+  success: boolean;
+  message: string;
+  branches?: {
+    name: string;
+    status: string;
+    url?: string;
+    error?: string;
+  }[];
+}
+
+// --- Mutation Functions ---
+
+export async function submitStack(rootBranch: string): Promise<SubmitResponse> {
+  const res = await fetch(
+    `${API_BASE}/api/submit/${encodeURIComponent(rootBranch)}`,
+    { method: "POST" }
+  );
+  const data: SubmitResponse = await res.json();
+  if (!res.ok && !data.message) {
+    throw new Error(`API error: ${res.status} ${res.statusText}`);
+  }
+  return data;
+}

--- a/apps/web/src/lib/diff-views.ts
+++ b/apps/web/src/lib/diff-views.ts
@@ -1,0 +1,150 @@
+import type { ViewResponse, FeedEvent, BranchResponse } from "@/lib/api";
+
+/**
+ * Compares two ViewResponse snapshots and returns detected changes as FeedEvents.
+ * Pure function — no side effects.
+ */
+export function diffViews(
+  prev: ViewResponse,
+  next: ViewResponse
+): FeedEvent[] {
+  const events: FeedEvent[] = [];
+  const now = new Date().toISOString();
+
+  // Build branch maps
+  const prevBranches = new Map<string, BranchResponse>();
+  const nextBranches = new Map<string, BranchResponse>();
+
+  for (const stack of prev.stacks) {
+    for (const b of stack.branches) {
+      prevBranches.set(b.name, b);
+    }
+  }
+  for (const stack of next.stacks) {
+    for (const b of stack.branches) {
+      nextBranches.set(b.name, b);
+    }
+  }
+
+  // Branches created / deleted
+  for (const name of nextBranches.keys()) {
+    if (!prevBranches.has(name)) {
+      events.push({ kind: "branch_created", timestamp: now, branch: name });
+    }
+  }
+  for (const name of prevBranches.keys()) {
+    if (!nextBranches.has(name)) {
+      events.push({ kind: "branch_deleted", timestamp: now, branch: name });
+    }
+  }
+
+  // Per-branch changes (PR state, CI, restack, revision)
+  for (const [name, nextB] of nextBranches) {
+    const prevB = prevBranches.get(name);
+    if (!prevB) continue;
+
+    // PR state changes
+    const prevPR = prevB.pr;
+    const nextPR = nextB.pr;
+    if (!prevPR && nextPR) {
+      events.push({
+        kind: "pr_opened",
+        timestamp: now,
+        branch: name,
+        detail: `#${nextPR.number}`,
+      });
+    } else if (prevPR && nextPR && prevPR.state !== nextPR.state) {
+      switch (nextPR.state) {
+        case "MERGED":
+          events.push({
+            kind: "pr_merged",
+            timestamp: now,
+            branch: name,
+            detail: `#${nextPR.number}`,
+          });
+          break;
+        case "CLOSED":
+          events.push({
+            kind: "pr_closed",
+            timestamp: now,
+            branch: name,
+            detail: `#${nextPR.number}`,
+          });
+          break;
+        case "OPEN":
+          events.push({
+            kind: "pr_opened",
+            timestamp: now,
+            branch: name,
+            detail: `#${nextPR.number} reopened`,
+          });
+          break;
+      }
+    }
+
+    // CI status changes
+    if (prevB.ci?.status !== nextB.ci?.status && nextB.ci) {
+      events.push({
+        kind: "ci_changed",
+        timestamp: now,
+        branch: name,
+        detail: nextB.ci.status,
+      });
+    }
+
+    // Restack status changes
+    if (!prevB.needsRestack && nextB.needsRestack) {
+      events.push({ kind: "needs_restack", timestamp: now, branch: name });
+    } else if (prevB.needsRestack && !nextB.needsRestack) {
+      events.push({ kind: "restack_resolved", timestamp: now, branch: name });
+    }
+
+    // Revision changes
+    if (prevB.revision !== nextB.revision) {
+      events.push({
+        kind: "revision_updated",
+        timestamp: now,
+        branch: name,
+        detail: nextB.revision.slice(0, 7),
+      });
+    }
+  }
+
+  // Stack-level changes
+  const prevStacks = new Set(prev.stacks.map((s) => s.rootBranch));
+  const nextStacks = new Set(next.stacks.map((s) => s.rootBranch));
+
+  for (const root of nextStacks) {
+    if (!prevStacks.has(root)) {
+      events.push({
+        kind: "stack_created",
+        timestamp: now,
+        branch: root,
+      });
+    }
+  }
+  for (const root of prevStacks) {
+    if (!nextStacks.has(root)) {
+      events.push({
+        kind: "stack_deleted",
+        timestamp: now,
+        branch: root,
+      });
+    }
+  }
+
+  // Current branch changed (client-side detection)
+  if (
+    prev.repo.currentBranch !== next.repo.currentBranch &&
+    next.repo.currentBranch
+  ) {
+    events.push({
+      kind: "branch_switched",
+      timestamp: now,
+      branch: next.repo.currentBranch,
+      detail: `from ${prev.repo.currentBranch}`,
+    });
+  }
+
+  return events;
+}

--- a/apps/web/src/lib/use-sse.ts
+++ b/apps/web/src/lib/use-sse.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useCallback } from "react";
+import type { FeedEvent } from "@/lib/api";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 
@@ -9,10 +10,17 @@ type SSECallback = () => void;
 /**
  * Hook that connects to the SSE event stream and calls onUpdate
  * whenever stack refresh events are received.
+ * Optionally calls onEvent for server-sourced feed events.
  */
-export function useSSE(onUpdate: SSECallback) {
+export function useSSE(
+  onUpdate: SSECallback,
+  onEvent?: (event: FeedEvent) => void
+) {
   const callbackRef = useRef(onUpdate);
   callbackRef.current = onUpdate;
+
+  const eventCallbackRef = useRef(onEvent);
+  eventCallbackRef.current = onEvent;
 
   const stableCallback = useCallback(() => {
     callbackRef.current();
@@ -30,6 +38,23 @@ export function useSSE(onUpdate: SSECallback) {
     });
 
     eventSource.addEventListener("refresh", () => {
+      stableCallback();
+    });
+
+    eventSource.addEventListener("branch_switched", (e) => {
+      if (eventCallbackRef.current) {
+        try {
+          const data = JSON.parse(e.data);
+          eventCallbackRef.current({
+            kind: "branch_switched",
+            timestamp: data.timestamp || new Date().toISOString(),
+            branch: data.to,
+            detail: `from ${data.from}`,
+          });
+        } catch {
+          // Ignore malformed events
+        }
+      }
       stableCallback();
     });
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -3,6 +3,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"log"
@@ -29,12 +30,13 @@ type ServerConfig struct {
 
 // Server is the stackit-web HTTP server.
 type Server struct {
-	config      ServerConfig
-	eng         engine.Engine
-	gh          github.Client
-	broadcaster *handlers.EventBroadcaster
-	httpServer  *http.Server
-	refWatcher  *watcher.RefWatcher
+	config            ServerConfig
+	eng               engine.Engine
+	gh                github.Client
+	broadcaster       *handlers.EventBroadcaster
+	httpServer        *http.Server
+	refWatcher        *watcher.RefWatcher
+	lastCurrentBranch string
 }
 
 // NewServer creates a new API server.
@@ -95,11 +97,28 @@ func (s *Server) Start() error {
 	// Start watching git refs for changes so the engine stays current
 	if s.config.RepoRoot != "" {
 		trunkName := s.eng.Trunk().GetName()
+		if cb := s.eng.CurrentBranch(); cb != nil {
+			s.lastCurrentBranch = cb.GetName()
+		}
 		s.refWatcher = watcher.NewRefWatcher(s.config.RepoRoot, 200*time.Millisecond, func() {
 			if err := s.eng.Rebuild(trunkName); err != nil {
 				log.Printf("engine rebuild failed: %v", err)
 				return
 			}
+
+			if cb := s.eng.CurrentBranch(); cb != nil {
+				newBranch := cb.GetName()
+				if s.lastCurrentBranch != "" && newBranch != s.lastCurrentBranch {
+					data, _ := json.Marshal(map[string]string{
+						"from":      s.lastCurrentBranch,
+						"to":        newBranch,
+						"timestamp": time.Now().Format(time.RFC3339),
+					})
+					s.broadcaster.Broadcast("branch_switched", string(data))
+				}
+				s.lastCurrentBranch = newBranch
+			}
+
 			s.broadcaster.Broadcast("refresh", "{}")
 		})
 		go func() {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Adds a persistent right-panel event feed showing real-time repository activity.

## What's new

- **Always-visible panel**: Right panel (400px) is permanently visible — no longer hides when nothing is selected
- **EventFeed component**: Collapsible "Activity (N)" header, Lucide icons per event type, relative timestamps, and a Clear button
- **Client-side diffing** via `diffViews()`: Compares consecutive `ViewResponse` snapshots to detect branch created/deleted, PR opened/merged/closed, CI status changes, restack needed/resolved, revision updates, stack created/deleted, current branch switched
- **Server `branch_switched` event**: Server broadcasts SSE `branch_switched` event when HEAD changes between watcher ticks
- **`FeedEvent` / `EventKind` types** added to `api.ts` (12 event kinds)
- **`useSSE` hook** extended with optional `onEvent` callback for server-sourced events
- **Event accumulation** in `RepoProvider`: events capped at 100, exposed via context

## Test plan

- [ ] Start `stackit web`, open the UI — right panel visible with empty "No recent activity" message
- [ ] Create/delete branches — "Branch created" / "Branch deleted" events appear in the feed
- [ ] Switch branches via `git checkout` — "Switched to" event fires (both server SSE and client diffing)
- [ ] Click a branch/stack — detail renders above the feed with a separator
- [ ] Click away (deselect) — panel stays open showing only the feed
- [ ] Click "Clear" — feed empties
- [ ] Collapse/expand the Activity header toggles the event list

<hr/>

<!-- STACKIT-SECTION-START -->
**Polish web UI: animations, status footer, and worktree-aware API**

Improves the stackit web frontend with visual polish and a smarter API layer.

Key changes:
- **Visual flair** (PR #767): Adds entry animations, a dark mode toggle, and confetti on stack actions; introduces animated CI status icons (checkmark, X, pulsing dot) across branch cards
- **Stack status footer** (PR #768): Adds a color-coded footer below each stack column showing its overall state (shippable / needs restack / blocked / incomplete) with state-specific colors and subtle shadows
- **Worktree-aware API** (PR #769): Filters worktree anchor branches out of the API response so they never appear as real branches in the UI; adds a `hasWorktree` flag to `StackSummary` and renders a folder-git icon in the stack header when a worktree is attached

#### Stack


* **PR #767**
  * **PR #768**
    * **PR #769**
      * **PR #770**
        * **PR #771** 👈
          * **PR #772**
            * **PR #773**
              * **PR #774**
                * **PR #775**
                  * **PR #776**
                    * **PR #785**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #786 by jonnii*