### PR TITLE
refactor: clean up merge API signatures

### DIFF
--- a/internal/actions/merge/consolidate.go
+++ b/internal/actions/merge/consolidate.go
@@ -109,7 +109,10 @@ func (c *ConsolidateMergeExecutor) Execute(ctx context.Context, opts ExecuteOpti
 		if err != nil {
 			return nil, fmt.Errorf("failed to get merge method: %w", err)
 		}
-		if err := github.EnableAutoMerge(ctx, c.engine.Git(), pr.NodeID, mergeMethod, c.buildTrailerMessage()); err != nil {
+		if err := github.EnableAutoMerge(ctx, c.engine.Git(), pr.NodeID, github.EnableAutoMergeOptions{
+			MergeMethod: mergeMethod,
+			CommitBody:  c.buildTrailerMessage(),
+		}); err != nil {
 			splog.Warn("Could not enable automerge: %v", err)
 			splog.Tip("Enable automerge manually on the PR: %s", pr.HTMLURL)
 		} else {

--- a/internal/actions/merge/pr_generator.go
+++ b/internal/actions/merge/pr_generator.go
@@ -32,7 +32,7 @@ func (g *PRContentGenerator) GenerateMultiStackPR(included []MultiStackInfo, exc
 	scopes := g.collectScopes(branches)
 
 	title := pr.FormatMergeTitle(scopes, len(branches))
-	body := g.generateBody(branches, g.convertExcluded(excluded))
+	body := g.generateBodyWithOptions(branches, g.convertExcluded(excluded), nil, firstNonEmpty(scopes))
 
 	return pr.Content{Title: title, Body: body}
 }
@@ -50,18 +50,13 @@ func (g *PRContentGenerator) GenerateConsolidationPR(branches []BranchMergeInfo)
 	}
 
 	title := pr.FormatMergeTitleWithDescription(stackDesc, scopes, len(mergeBranches))
-	body := g.generateBodyWithDescription(mergeBranches, nil, stackDesc)
+	body := g.generateBodyWithOptions(mergeBranches, nil, stackDesc, firstNonEmpty(scopes))
 
 	return pr.Content{Title: title, Body: body}
 }
 
-// generateBody creates the PR body with branches, exclusions, and stack tree.
-func (g *PRContentGenerator) generateBody(branches []pr.MergeBranch, excluded []pr.ExcludedBranch) string {
-	return g.generateBodyWithDescription(branches, excluded, nil)
-}
-
-// generateBodyWithDescription creates the PR body with branches, exclusions, stack tree, and optional description.
-func (g *PRContentGenerator) generateBodyWithDescription(branches []pr.MergeBranch, excluded []pr.ExcludedBranch, stackDesc *git.StackDescription) string {
+// generateBodyWithOptions creates the PR body with branches, exclusions, stack tree, optional description, and scope.
+func (g *PRContentGenerator) generateBodyWithOptions(branches []pr.MergeBranch, excluded []pr.ExcludedBranch, stackDesc *git.StackDescription, scope string) string {
 	// Build stack tree
 	treeBranches := make([]pr.StackTreeBranch, len(branches))
 	for i, branch := range branches {
@@ -84,6 +79,7 @@ func (g *PRContentGenerator) generateBodyWithDescription(branches []pr.MergeBran
 		Excluded:         excluded,
 		StackTree:        stackTree,
 		StackDescription: stackDesc,
+		Scope:            scope,
 	})
 }
 
@@ -153,6 +149,16 @@ func (g *PRContentGenerator) collectScopes(branches []pr.MergeBranch) []string {
 		scopes[i] = scope.String()
 	}
 	return scopes
+}
+
+// firstNonEmpty returns the first non-empty string from the slice, or "" if none.
+func firstNonEmpty(ss []string) string {
+	for _, s := range ss {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
 }
 
 // calculateDepth computes how deep a branch is in the stack.

--- a/internal/cli/stack/merge/orchestrate.go
+++ b/internal/cli/stack/merge/orchestrate.go
@@ -59,7 +59,7 @@ func (d *defaultPRMergeAPI) getMergeableState(ctx context.Context, runner git.Ru
 }
 
 func (d *defaultPRMergeAPI) enableAutoMerge(ctx context.Context, runner git.Runner, prNodeID string, method github.MergeMethod) error {
-	return github.EnableAutoMerge(ctx, runner, prNodeID, method, "")
+	return github.EnableAutoMerge(ctx, runner, prNodeID, github.EnableAutoMergeOptions{MergeMethod: method})
 }
 
 func (d *defaultPRMergeAPI) waitForPRMerge(ctx context.Context, runner git.Runner, prNodeID string, timeout, interval time.Duration) error {

--- a/internal/cli/stack/merge/ship.go
+++ b/internal/cli/stack/merge/ship.go
@@ -318,7 +318,7 @@ func runMultiStackShip(ctx *app.Context, opts shipMultiStackOptions) error {
 				out.Warn("Could not determine merge method: %v", methodErr)
 				out.Tip("Enable automerge manually on the PR: %s", result.PRURL)
 			} else {
-				if err := github.EnableAutoMerge(ctx.Context, ctx.Engine.Git(), prNodeID, mergeMethod, ""); err != nil {
+				if err := github.EnableAutoMerge(ctx.Context, ctx.Engine.Git(), prNodeID, github.EnableAutoMergeOptions{MergeMethod: mergeMethod}); err != nil {
 					out.Warn("Could not enable automerge: %v", err)
 					out.Tip("Enable automerge manually on the PR: %s", result.PRURL)
 				} else {

--- a/internal/github/pr_operations.go
+++ b/internal/github/pr_operations.go
@@ -389,13 +389,18 @@ type AutoMergeStatus struct {
 	MergeMethod string
 }
 
+// EnableAutoMergeOptions contains options for enabling auto-merge on a PR.
+type EnableAutoMergeOptions struct {
+	MergeMethod MergeMethod
+	CommitBody  string // optional — omit for default GitHub behavior
+}
+
 // EnableAutoMerge enables GitHub's auto-merge feature on a PR.
 // This requires the repository to have auto-merge enabled in settings.
-// If commitBody is non-empty, it is passed as the commitBody for squash/merge commits.
-func EnableAutoMerge(ctx context.Context, runner git.Runner, prNodeID string, mergeMethod MergeMethod, commitBody string) error {
+func EnableAutoMerge(ctx context.Context, runner git.Runner, prNodeID string, opts EnableAutoMergeOptions) error {
 	// Use a mutation that includes commitBody when provided
 	var mutation string
-	if commitBody != "" {
+	if opts.CommitBody != "" {
 		mutation = `mutation EnableAutoMerge($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!, $commitBody: String) {
 			enablePullRequestAutoMerge(input: {
 				pullRequestId: $pullRequestId
@@ -426,7 +431,7 @@ func EnableAutoMerge(ctx context.Context, runner git.Runner, prNodeID string, me
 
 	// Convert our MergeMethod to GitHub's GraphQL enum format
 	var graphqlMethod string
-	switch mergeMethod {
+	switch opts.MergeMethod {
 	case MergeMethodMerge:
 		graphqlMethod = "MERGE"
 	case MergeMethodSquash:
@@ -441,8 +446,8 @@ func EnableAutoMerge(ctx context.Context, runner git.Runner, prNodeID string, me
 		"pullRequestId": prNodeID,
 		"mergeMethod":   graphqlMethod,
 	}
-	if commitBody != "" {
-		variables["commitBody"] = commitBody
+	if opts.CommitBody != "" {
+		variables["commitBody"] = opts.CommitBody
 	}
 
 	_, err := executeGraphQLQuery(ctx, runner, mutation, variables)

--- a/internal/pr/merge.go
+++ b/internal/pr/merge.go
@@ -66,6 +66,10 @@ type MergeBodyParams struct {
 	// StackDescription is the description of the stack being merged.
 	// Optional - if present, it appears at the top of the body.
 	StackDescription *git.StackDescription
+
+	// Scope is the stack scope for trailers (e.g. "PROJ-123").
+	// Optional - if empty, no scope trailer is emitted.
+	Scope string
 }
 
 // MergeBranch represents a branch being merged.
@@ -128,12 +132,8 @@ func FormatMergeBody(params MergeBodyParams) string {
 	// Append stack trailers as a fallback for repos whose squash merge commit
 	// message setting uses "PR body". Trailers survive automatically in that case.
 	if len(params.Branches) > 0 {
-		scope := ""
-		if params.StackDescription != nil {
-			scope = params.StackDescription.Title
-		}
 		body.WriteString("\n")
-		body.WriteString(FormatStackTrailers(len(params.Branches), prNumbers, scope))
+		body.WriteString(FormatStackTrailers(len(params.Branches), prNumbers, params.Scope))
 	}
 
 	return body.String()

--- a/internal/pr/merge_test.go
+++ b/internal/pr/merge_test.go
@@ -236,6 +236,7 @@ Stackit-PRs: 1
 				Title:       "Add user authentication",
 				Description: "This stack implements JWT-based auth.",
 			},
+			Scope: "PROJ-123",
 		})
 
 		expected := `**Add user authentication**
@@ -255,7 +256,7 @@ main
 
 Stackit-Stack-Size: 1
 Stackit-PRs: 1
-Stackit-Scope: Add user authentication
+Stackit-Scope: PROJ-123
 `
 		assert.Equal(t, expected, result)
 	})
@@ -269,6 +270,7 @@ Stackit-Scope: Add user authentication
 			StackDescription: &git.StackDescription{
 				Title: "Add user authentication",
 			},
+			Scope: "PROJ-456",
 		})
 
 		expected := `**Add user authentication**
@@ -286,7 +288,7 @@ main
 
 Stackit-Stack-Size: 1
 Stackit-PRs: 1
-Stackit-Scope: Add user authentication
+Stackit-Scope: PROJ-456
 `
 		assert.Equal(t, expected, result)
 	})


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #777**
  * **PR #778** 👈
    * **PR #779**
      * **PR #780**
        * **PR #781**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #782 by jonnii*