### PR TITLE
fix: omit scope trailer on mixed-scope merges and fix duplicate trailer key parsing

### DIFF
--- a/internal/actions/merge/consolidate.go
+++ b/internal/actions/merge/consolidate.go
@@ -164,7 +164,7 @@ func (c *ConsolidateMergeExecutor) createMergeBranch(ctx context.Context) (strin
 	splog := c.ctx.Output
 	// Generate unique branch name
 	timestamp := time.Now().Unix()
-	scope := c.getStackScope()
+	scope := c.getStackScopeOrDefault()
 	branchName := fmt.Sprintf("stack-merge-%s-%d", scope, timestamp)
 
 	splog.Info("📋 Creating merge branch: %s", branchName)
@@ -201,7 +201,7 @@ func (c *ConsolidateMergeExecutor) createMergeBranch(ctx context.Context) (strin
 
 	// Append stack trailers for history tracking
 	prNumbers := c.collectPRNumbers()
-	trailers := pr.FormatStackTrailers(len(branches), prNumbers, scope)
+	trailers := pr.FormatStackTrailers(len(branches), prNumbers, c.getTrailerScope())
 	commitMsg += "\n\n" + trailers
 
 	splog.Info("  Merging %d branches via octopus merge...", len(branches))
@@ -335,7 +335,7 @@ func (c *ConsolidateMergeExecutor) lockAndNotifyIndividualPRs(_ context.Context,
 
 // Helper methods
 
-func (c *ConsolidateMergeExecutor) getStackScope() string {
+func (c *ConsolidateMergeExecutor) getStackScopeOrDefault() string {
 	// Get scope from the first branch in the stack
 	if len(c.plan.BranchesToMerge) > 0 {
 		branch := c.engine.GetBranch(c.plan.BranchesToMerge[0].BranchName)
@@ -364,13 +364,27 @@ func (c *ConsolidateMergeExecutor) collectPRNumbers() []int {
 
 // buildTrailerMessage returns the trailer block for the consolidation merge commit.
 func (c *ConsolidateMergeExecutor) buildTrailerMessage() string {
-	scope := c.getStackScope()
+	scope := c.getTrailerScope()
 	prNumbers := c.collectPRNumbers()
 	branches := make([]string, len(c.plan.BranchesToMerge))
 	for i, b := range c.plan.BranchesToMerge {
 		branches[i] = b.BranchName
 	}
 	return pr.FormatStackTrailers(len(branches), prNumbers, scope)
+}
+
+// getTrailerScope returns a scope only when all non-empty branch scopes match.
+func (c *ConsolidateMergeExecutor) getTrailerScope() string {
+	scopes := make([]string, 0, len(c.plan.BranchesToMerge))
+	for _, b := range c.plan.BranchesToMerge {
+		branch := c.engine.GetBranch(b.BranchName)
+		scope := c.engine.GetScope(branch)
+		if scope.IsEmpty() {
+			continue
+		}
+		scopes = append(scopes, scope.String())
+	}
+	return trailerScope(scopes)
 }
 
 // resolveMergeMethod returns the merge method to use, preferring the override if set.

--- a/internal/actions/merge/pr_generator.go
+++ b/internal/actions/merge/pr_generator.go
@@ -32,7 +32,7 @@ func (g *PRContentGenerator) GenerateMultiStackPR(included []MultiStackInfo, exc
 	scopes := g.collectScopes(branches)
 
 	title := pr.FormatMergeTitle(scopes, len(branches))
-	body := g.generateBodyWithOptions(branches, g.convertExcluded(excluded), nil, firstNonEmpty(scopes))
+	body := g.generateBodyWithOptions(branches, g.convertExcluded(excluded), nil, trailerScope(scopes))
 
 	return pr.Content{Title: title, Body: body}
 }
@@ -50,7 +50,7 @@ func (g *PRContentGenerator) GenerateConsolidationPR(branches []BranchMergeInfo)
 	}
 
 	title := pr.FormatMergeTitleWithDescription(stackDesc, scopes, len(mergeBranches))
-	body := g.generateBodyWithOptions(mergeBranches, nil, stackDesc, firstNonEmpty(scopes))
+	body := g.generateBodyWithOptions(mergeBranches, nil, stackDesc, trailerScope(scopes))
 
 	return pr.Content{Title: title, Body: body}
 }
@@ -151,14 +151,23 @@ func (g *PRContentGenerator) collectScopes(branches []pr.MergeBranch) []string {
 	return scopes
 }
 
-// firstNonEmpty returns the first non-empty string from the slice, or "" if none.
-func firstNonEmpty(ss []string) string {
-	for _, s := range ss {
-		if s != "" {
-			return s
+// trailerScope returns a scope only when all non-empty scopes match.
+// This avoids mislabeling mixed-scope merges.
+func trailerScope(scopes []string) string {
+	var selected string
+	for _, scope := range scopes {
+		if scope == "" {
+			continue
+		}
+		if selected == "" {
+			selected = scope
+			continue
+		}
+		if scope != selected {
+			return ""
 		}
 	}
-	return ""
+	return selected
 }
 
 // calculateDepth computes how deep a branch is in the stack.

--- a/internal/actions/merge/pr_generator_test.go
+++ b/internal/actions/merge/pr_generator_test.go
@@ -161,4 +161,43 @@ func TestPRContentGenerator_GenerateMultiStackPR(t *testing.T) {
 		assert.Contains(t, content.Body, "feature-b")
 		assert.Contains(t, content.Body, "conflict")
 	})
+
+	t.Run("mixed_scopes_omits_scope_trailer", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithStack(map[string]string{
+			"feature-a": "main",
+			"feature-b": "main",
+		})
+
+		err := s.Engine.SetScope(context.Background(), s.Engine.GetBranch("feature-a"), engine.NewScope("PROJ-1"))
+		assert.NoError(t, err)
+		err = s.Engine.SetScope(context.Background(), s.Engine.GetBranch("feature-b"), engine.NewScope("PROJ-2"))
+		assert.NoError(t, err)
+
+		gen := NewPRContentGenerator(s.Engine)
+		content := gen.GenerateMultiStackPR(
+			[]MultiStackInfo{
+				{RootBranch: "feature-a", AllBranches: []string{"feature-a"}},
+				{RootBranch: "feature-b", AllBranches: []string{"feature-b"}},
+			},
+			nil,
+		)
+
+		assert.Equal(t, "Merging PROJ-1, PROJ-2", content.Title)
+		assert.NotContains(t, content.Body, "Stackit-Scope:")
+	})
+}
+
+func TestTrailerScope(t *testing.T) {
+	t.Run("returns empty when all scopes are empty", func(t *testing.T) {
+		assert.Equal(t, "", trailerScope([]string{"", ""}))
+	})
+
+	t.Run("returns the shared scope", func(t *testing.T) {
+		assert.Equal(t, "PROJ-1", trailerScope([]string{"", "PROJ-1", "PROJ-1"}))
+	})
+
+	t.Run("returns empty when scopes differ", func(t *testing.T) {
+		assert.Equal(t, "", trailerScope([]string{"PROJ-1", "PROJ-2"}))
+	})
 }

--- a/internal/git/recent_commits.go
+++ b/internal/git/recent_commits.go
@@ -2,10 +2,13 @@ package git
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 )
+
+const trailerValueSeparator = "\x1e"
 
 // RecentCommit represents a commit from the git log with optional stack trailer metadata.
 type RecentCommit struct {
@@ -14,7 +17,7 @@ type RecentCommit struct {
 	Author     string
 	Date       time.Time
 	StackSize  int    // from Stackit-Stack-Size trailer (0 if absent)
-	StackPRs   string // from Stackit-PRs trailer (raw comma-separated, empty if absent)
+	StackPRs   string // from Stackit-PRs trailer (comma-separated, empty if absent)
 	StackScope string // from Stackit-Scope trailer (empty if absent)
 }
 
@@ -22,7 +25,8 @@ type RecentCommit struct {
 // Uses git log with a custom format string that includes trailer values.
 func (r *runner) GetRecentCommits(branchName string, count int) ([]RecentCommit, error) {
 	// Format: SHA\x1fsubject\x1fauthor\x1fdate\x1fstack-size\x1fprs\x1fscope
-	format := "%H\x1f%s\x1f%an\x1f%aI\x1f%(trailers:key=Stackit-Stack-Size,valueonly,separator=)\x1f%(trailers:key=Stackit-PRs,valueonly,separator=)\x1f%(trailers:key=Stackit-Scope,valueonly,separator=)"
+	// Use a non-empty trailer separator so duplicate keys remain parseable.
+	format := "%H\x1f%s\x1f%an\x1f%aI\x1f%(trailers:key=Stackit-Stack-Size,valueonly,separator=%x1e)\x1f%(trailers:key=Stackit-PRs,valueonly,separator=%x1e)\x1f%(trailers:key=Stackit-Scope,valueonly,separator=%x1e)"
 
 	output, err := r.runGitCommandInternal("log", fmt.Sprintf("-%d", count), "--format="+format, branchName)
 	if err != nil {
@@ -56,22 +60,69 @@ func (r *runner) GetRecentCommits(branchName string, count int) ([]RecentCommit,
 		}
 
 		if len(fields) > 4 {
-			val := strings.TrimSpace(fields[4])
-			if n, parseErr := strconv.Atoi(val); parseErr == nil {
-				commit.StackSize = n
-			}
+			commit.StackSize = parseStackSizeTrailer(fields[4])
 		}
 
 		if len(fields) > 5 {
-			commit.StackPRs = strings.TrimSpace(fields[5])
+			commit.StackPRs = parseStackPRsTrailer(fields[5])
 		}
 
 		if len(fields) > 6 {
-			commit.StackScope = strings.TrimSpace(fields[6])
+			commit.StackScope = parseStackScopeTrailer(fields[6])
 		}
 
 		commits = append(commits, commit)
 	}
 
 	return commits, nil
+}
+
+func parseStackSizeTrailer(raw string) int {
+	for value := range strings.SplitSeq(raw, trailerValueSeparator) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if n, err := strconv.Atoi(value); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+func parseStackPRsTrailer(raw string) string {
+	var prNumbers []int
+	for value := range strings.SplitSeq(raw, trailerValueSeparator) {
+		for part := range strings.SplitSeq(value, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			n, err := strconv.Atoi(part)
+			if err != nil || slices.Contains(prNumbers, n) {
+				continue
+			}
+			prNumbers = append(prNumbers, n)
+		}
+	}
+
+	if len(prNumbers) == 0 {
+		return ""
+	}
+
+	values := make([]string, len(prNumbers))
+	for i, n := range prNumbers {
+		values[i] = strconv.Itoa(n)
+	}
+	return strings.Join(values, ",")
+}
+
+func parseStackScopeTrailer(raw string) string {
+	for value := range strings.SplitSeq(raw, trailerValueSeparator) {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/internal/git/recent_commits_test.go
+++ b/internal/git/recent_commits_test.go
@@ -1,0 +1,36 @@
+package git_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"stackit.dev/stackit/internal/git"
+	"stackit.dev/stackit/testhelpers"
+)
+
+func TestGetRecentCommits_DuplicateTrailers(t *testing.T) {
+	scene := testhelpers.NewScene(t, func(s *testhelpers.Scene) error {
+		return s.Repo.CreateChangeAndCommit("initial", "init")
+	})
+
+	err := scene.Repo.CreateChange("change", "dup", false)
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand("add", ".")
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand(
+		"commit",
+		"-m", "Consolidate stack [PROJ-123]",
+		"-m", "Stackit-Stack-Size: 2\nStackit-Stack-Size: 2\nStackit-PRs: 1,2\nStackit-PRs: 1,2\nStackit-Scope: PROJ-123\nStackit-Scope: PROJ-123",
+	)
+	require.NoError(t, err)
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	commits, err := runner.GetRecentCommits("main", 1)
+	require.NoError(t, err)
+	require.Len(t, commits, 1)
+
+	require.Equal(t, 2, commits[0].StackSize)
+	require.Equal(t, "1,2", commits[0].StackPRs)
+	require.Equal(t, "PROJ-123", commits[0].StackScope)
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1772336454`.


* **PR #777**
  * **PR #778**
    * **PR #779** 👈
      * **PR #780**
        * **PR #781**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->