### PR TITLE
refactor: extract stack metadata types and enrich RecentCommit fields

### DIFF
--- a/api/openapi/stackit.yaml
+++ b/api/openapi/stackit.yaml
@@ -261,7 +261,7 @@ components:
           type: string
     TrunkCommitResponse:
       type: object
-      required: [sha, message, author, date]
+      required: [sha, message, author, date, kind]
       properties:
         sha:
           type: string
@@ -271,6 +271,9 @@ components:
           type: string
         date:
           type: string
+        kind:
+          type: string
+          enum: [regular, stack-merge]
         prNumber:
           type: integer
         stackSize:

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,12 +2,12 @@
 
 import { useMemo, useState } from "react";
 import { useRepo } from "@/components/providers/repo-provider";
-import { StackColumn } from "@/components/stack-column";
 import { OwnerSwimlane, getLastActiveDate } from "@/components/owner-swimlane";
 import { BranchDetail } from "@/components/branch-detail/branch-detail";
 import { RecentlyMerged } from "@/components/recently-merged";
 import { Separator } from "@/components/ui/separator";
 import type { BranchResponse, StackDetail } from "@/lib/api";
+import { formatTimeAgo } from "@/lib/time";
 
 export default function Home() {
   const {
@@ -163,16 +163,4 @@ export default function Home() {
       </div>
     </div>
   );
-}
-
-function formatTimeAgo(date: Date): string {
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
-  if (seconds < 5) return "just now";
-  if (seconds < 60) return `${seconds}s ago`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
 }

--- a/apps/web/src/components/recently-merged.tsx
+++ b/apps/web/src/components/recently-merged.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { TrunkCommitResponse } from "@/lib/api";
+import { formatTimeAgo } from "@/lib/time";
 
 interface RecentlyMergedProps {
   commits: TrunkCommitResponse[];
@@ -14,7 +15,7 @@ export function RecentlyMerged({ commits, owner, repo }: RecentlyMergedProps) {
   return (
     <div className="px-6 pb-6 space-y-1">
       {commits.map((commit) =>
-        commit.stackSize && commit.stackSize > 0 ? (
+        commit.kind === "stack-merge" ? (
           <StackMergeEntry
             key={commit.sha}
             commit={commit}
@@ -131,17 +132,4 @@ function PRLink({
 
 function stripPRSuffix(message: string): string {
   return message.replace(/\s*\(#\d+\)\s*$/, "");
-}
-
-function formatTimeAgo(dateStr: string): string {
-  const date = new Date(dateStr);
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
-  if (seconds < 5) return "just now";
-  if (seconds < 60) return `${seconds}s ago`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -90,6 +90,7 @@ export interface TrunkCommitResponse {
   message: string;
   author: string;
   date: string;
+  kind: "regular" | "stack-merge";
   prNumber?: number;
   stackSize?: number;
   stackPRs?: number[];

--- a/apps/web/src/lib/time.ts
+++ b/apps/web/src/lib/time.ts
@@ -1,0 +1,16 @@
+export function formatTimeAgo(input: Date | string): string {
+  const date = typeof input === "string" ? new Date(input) : input;
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+
+  if (seconds < 5) return "just now";
+  if (seconds < 60) return `${seconds}s ago`;
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/internal/actions/merge/consolidate.go
+++ b/internal/actions/merge/consolidate.go
@@ -109,9 +109,10 @@ func (c *ConsolidateMergeExecutor) Execute(ctx context.Context, opts ExecuteOpti
 		if err != nil {
 			return nil, fmt.Errorf("failed to get merge method: %w", err)
 		}
+		metadata := c.buildStackMetadata()
 		if err := github.EnableAutoMerge(ctx, c.engine.Git(), pr.NodeID, github.EnableAutoMergeOptions{
 			MergeMethod: mergeMethod,
-			CommitBody:  c.buildTrailerMessage(),
+			CommitBody:  metadata.ToTrailers(),
 		}); err != nil {
 			splog.Warn("Could not enable automerge: %v", err)
 			splog.Tip("Enable automerge manually on the PR: %s", pr.HTMLURL)
@@ -200,9 +201,8 @@ func (c *ConsolidateMergeExecutor) createMergeBranch(ctx context.Context) (strin
 	}
 
 	// Append stack trailers for history tracking
-	prNumbers := c.collectPRNumbers()
-	trailers := pr.FormatStackTrailers(len(branches), prNumbers, c.getTrailerScope())
-	commitMsg += "\n\n" + trailers
+	metadata := c.buildStackMetadata()
+	commitMsg += "\n\n" + metadata.ToTrailers()
 
 	splog.Info("  Merging %d branches via octopus merge...", len(branches))
 	splog.Debug("Consolidation merge: merging branches %v", branches)
@@ -260,9 +260,10 @@ func (c *ConsolidateMergeExecutor) waitForConsolidationMerge(ctx context.Context
 	})
 	waiter.SetProgressHandler(c.handler, c.stepIndex)
 
+	metadata := c.buildStackMetadata()
 	mergeOpts := github.MergePROptions{
-		Method:        mergeMethod,
-		CommitMessage: c.buildTrailerMessage(),
+		Method:     mergeMethod,
+		CommitBody: metadata.ToTrailers(),
 	}
 	return waiter.WaitAndMerge(ctx, branchName, pr, expectChecks, mergeOpts)
 }
@@ -351,22 +352,16 @@ func (c *ConsolidateMergeExecutor) getOwnerRepo() (owner, repo string) {
 	return c.ctx.GitHub().GetOwnerRepo()
 }
 
-// collectPRNumbers returns PR numbers from all branches in the merge plan.
-func (c *ConsolidateMergeExecutor) collectPRNumbers() []int {
-	var nums []int
+// buildStackMetadata builds stack metadata for consolidation merge commits.
+func (c *ConsolidateMergeExecutor) buildStackMetadata() pr.StackMetadata {
+	scope := c.getTrailerScope()
+	prNumbers := make([]int, 0, len(c.plan.BranchesToMerge))
 	for _, b := range c.plan.BranchesToMerge {
 		if b.PRNumber > 0 {
-			nums = append(nums, b.PRNumber)
+			prNumbers = append(prNumbers, b.PRNumber)
 		}
 	}
-	return nums
-}
-
-// buildTrailerMessage returns the trailer block for the consolidation merge commit.
-func (c *ConsolidateMergeExecutor) buildTrailerMessage() string {
-	scope := c.getTrailerScope()
-	prNumbers := c.collectPRNumbers()
-	return pr.FormatStackTrailers(len(c.plan.BranchesToMerge), prNumbers, scope)
+	return pr.NewStackMetadata(len(c.plan.BranchesToMerge), prNumbers, scope)
 }
 
 // getTrailerScope returns a scope only when all non-empty branch scopes match.
@@ -380,7 +375,7 @@ func (c *ConsolidateMergeExecutor) getTrailerScope() string {
 		}
 		scopes = append(scopes, scope.String())
 	}
-	return trailerScope(scopes)
+	return pr.ResolveUnifiedScope(scopes)
 }
 
 // resolveMergeMethod returns the merge method to use, preferring the override if set.

--- a/internal/actions/merge/pr_generator.go
+++ b/internal/actions/merge/pr_generator.go
@@ -32,7 +32,7 @@ func (g *PRContentGenerator) GenerateMultiStackPR(included []MultiStackInfo, exc
 	scopes := g.collectScopes(branches)
 
 	title := pr.FormatMergeTitle(scopes, len(branches))
-	body := g.generateBodyWithOptions(branches, g.convertExcluded(excluded), nil, trailerScope(scopes))
+	body := g.generateBodyWithOptions(branches, g.convertExcluded(excluded), nil, pr.ResolveUnifiedScope(scopes))
 
 	return pr.Content{Title: title, Body: body}
 }
@@ -50,7 +50,7 @@ func (g *PRContentGenerator) GenerateConsolidationPR(branches []BranchMergeInfo)
 	}
 
 	title := pr.FormatMergeTitleWithDescription(stackDesc, scopes, len(mergeBranches))
-	body := g.generateBodyWithOptions(mergeBranches, nil, stackDesc, trailerScope(scopes))
+	body := g.generateBodyWithOptions(mergeBranches, nil, stackDesc, pr.ResolveUnifiedScope(scopes))
 
 	return pr.Content{Title: title, Body: body}
 }
@@ -79,7 +79,7 @@ func (g *PRContentGenerator) generateBodyWithOptions(branches []pr.MergeBranch, 
 		Excluded:         excluded,
 		StackTree:        stackTree,
 		StackDescription: stackDesc,
-		Scope:            scope,
+		Metadata:         pr.BuildStackMetadata(branches, scope),
 	})
 }
 
@@ -149,25 +149,6 @@ func (g *PRContentGenerator) collectScopes(branches []pr.MergeBranch) []string {
 		scopes[i] = scope.String()
 	}
 	return scopes
-}
-
-// trailerScope returns a scope only when all non-empty scopes match.
-// This avoids mislabeling mixed-scope merges.
-func trailerScope(scopes []string) string {
-	var selected string
-	for _, scope := range scopes {
-		if scope == "" {
-			continue
-		}
-		if selected == "" {
-			selected = scope
-			continue
-		}
-		if scope != selected {
-			return ""
-		}
-	}
-	return selected
 }
 
 // calculateDepth computes how deep a branch is in the stack.

--- a/internal/actions/merge/pr_generator_test.go
+++ b/internal/actions/merge/pr_generator_test.go
@@ -8,6 +8,7 @@ import (
 
 	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/internal/git"
+	"stackit.dev/stackit/internal/pr"
 	"stackit.dev/stackit/testhelpers"
 	"stackit.dev/stackit/testhelpers/scenario"
 )
@@ -188,21 +189,21 @@ func TestPRContentGenerator_GenerateMultiStackPR(t *testing.T) {
 	})
 }
 
-func TestTrailerScope(t *testing.T) {
+func TestResolveUnifiedScope(t *testing.T) {
 	t.Parallel()
 
 	t.Run("returns empty when all scopes are empty", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, "", trailerScope([]string{"", ""}))
+		assert.Equal(t, "", pr.ResolveUnifiedScope([]string{"", ""}))
 	})
 
 	t.Run("returns the shared scope", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, "PROJ-1", trailerScope([]string{"", "PROJ-1", "PROJ-1"}))
+		assert.Equal(t, "PROJ-1", pr.ResolveUnifiedScope([]string{"", "PROJ-1", "PROJ-1"}))
 	})
 
 	t.Run("returns empty when scopes differ", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, "", trailerScope([]string{"PROJ-1", "PROJ-2"}))
+		assert.Equal(t, "", pr.ResolveUnifiedScope([]string{"PROJ-1", "PROJ-2"}))
 	})
 }

--- a/internal/api/handlers/view.go
+++ b/internal/api/handlers/view.go
@@ -3,22 +3,21 @@ package handlers
 import (
 	"net/http"
 
-	"stackit.dev/stackit/internal/actions/merge"
-	httpcontract "stackit.dev/stackit/internal/contracts/http"
 	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/internal/github"
 )
 
 // ViewHandler serves the combined view payload for the frontend.
 type ViewHandler struct {
-	eng    engine.BranchReader
-	gh     github.Client
-	remote string
+	assembler *ViewAssembler
 }
 
 // NewViewHandler creates a handler for /api/view and /api/v1/view.
+// Assembly logic lives in ViewAssembler to keep this handler transport-focused.
 func NewViewHandler(eng engine.BranchReader, gh github.Client, remote string) *ViewHandler {
-	return &ViewHandler{eng: eng, gh: gh, remote: remote}
+	return &ViewHandler{
+		assembler: NewViewAssembler(eng, gh, remote),
+	}
 }
 
 // ServeHTTP handles GET view endpoints.
@@ -28,58 +27,11 @@ func (h *ViewHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build repo info
-	owner, repo := "", ""
-	var currentUser string
-	if h.gh != nil {
-		owner, repo = h.gh.GetOwnerRepo()
-		currentUser, _ = h.gh.GetCurrentUser(r.Context())
-	}
-	repoResp := httpcontract.RepoResponse{
-		Owner:         owner,
-		Repo:          repo,
-		Trunk:         h.eng.Trunk().GetName(),
-		CurrentBranch: h.eng.CurrentBranch().GetName(),
-		Remote:        h.remote,
-		CurrentUser:   currentUser,
-	}
-
-	// Discover all stacks
-	stacks, err := merge.DiscoverStacksWithSort(h.eng, engine.SortStrategySmart)
+	view, err := h.assembler.Build(r.Context())
 	if err != nil {
-		http.Error(w, "failed to discover stacks: "+err.Error(), http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	graph := engine.BuildStackGraph(h.eng, engine.SortStrategySmart, nil)
-
-	// Collect all branch names across all stacks for a single batched CI check
-	var allBranches []string
-	for _, stack := range stacks {
-		allBranches = append(allBranches, stack.AllBranches...)
-	}
-
-	var checksMap map[string]*github.CheckStatus
-	if h.gh != nil && len(allBranches) > 0 {
-		checksMap, _ = h.gh.BatchGetPRChecksStatus(r.Context(), allBranches)
-	}
-
-	// Map all stack details using the shared checks map
-	details := make([]httpcontract.StackDetail, 0, len(stacks))
-	for _, stack := range stacks {
-		detail := httpcontract.MapStackDetail(h.eng, graph, stack.RootBranch, stack.AllBranches, stack.PRCount, stack.Scope, checksMap)
-		details = append(details, detail)
-	}
-
-	// Fetch recently merged trunk commits with stack metadata
-	var recentlyMerged []httpcontract.TrunkCommitResponse
-	if recentCommits, err := h.eng.GetRecentTrunkCommits(10); err == nil && len(recentCommits) > 0 {
-		recentlyMerged = httpcontract.MapTrunkCommits(recentCommits)
-	}
-
-	writeJSON(w, httpcontract.ViewResponse{
-		Repo:           repoResp,
-		Stacks:         details,
-		RecentlyMerged: recentlyMerged,
-	})
+	writeJSON(w, view)
 }

--- a/internal/api/handlers/view_assembler.go
+++ b/internal/api/handlers/view_assembler.go
@@ -1,0 +1,101 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"stackit.dev/stackit/internal/actions/merge"
+	httpcontract "stackit.dev/stackit/internal/contracts/http"
+	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/github"
+)
+
+// ViewAssembler builds the combined /view payload.
+type ViewAssembler struct {
+	eng    engine.BranchReader
+	gh     github.Client
+	remote string
+}
+
+func NewViewAssembler(eng engine.BranchReader, gh github.Client, remote string) *ViewAssembler {
+	return &ViewAssembler{
+		eng:    eng,
+		gh:     gh,
+		remote: remote,
+	}
+}
+
+func (a *ViewAssembler) Build(ctx context.Context) (httpcontract.ViewResponse, error) {
+	stacks, err := merge.DiscoverStacksWithSort(a.eng, engine.SortStrategySmart)
+	if err != nil {
+		return httpcontract.ViewResponse{}, fmt.Errorf("failed to discover stacks: %w", err)
+	}
+
+	graph := engine.BuildStackGraph(a.eng, engine.SortStrategySmart, nil)
+	checksMap := a.fetchChecks(ctx, stacks)
+	details := a.mapStackDetails(graph, stacks, checksMap)
+
+	recentlyMerged := a.fetchRecentlyMerged()
+
+	return httpcontract.ViewResponse{
+		Repo:           a.buildRepo(ctx),
+		Stacks:         details,
+		RecentlyMerged: recentlyMerged,
+	}, nil
+}
+
+func (a *ViewAssembler) buildRepo(ctx context.Context) httpcontract.RepoResponse {
+	owner, repo := "", ""
+	var currentUser string
+	if a.gh != nil {
+		owner, repo = a.gh.GetOwnerRepo()
+		currentUser, _ = a.gh.GetCurrentUser(ctx)
+	}
+
+	return httpcontract.RepoResponse{
+		Owner:         owner,
+		Repo:          repo,
+		Trunk:         a.eng.Trunk().GetName(),
+		CurrentBranch: a.eng.CurrentBranch().GetName(),
+		Remote:        a.remote,
+		CurrentUser:   currentUser,
+	}
+}
+
+func (a *ViewAssembler) fetchChecks(ctx context.Context, stacks []merge.MultiStackInfo) map[string]*github.CheckStatus {
+	if a.gh == nil {
+		return nil
+	}
+
+	var allBranches []string
+	for _, stack := range stacks {
+		allBranches = append(allBranches, stack.AllBranches...)
+	}
+	if len(allBranches) == 0 {
+		return nil
+	}
+
+	checksMap, _ := a.gh.BatchGetPRChecksStatus(ctx, allBranches)
+	return checksMap
+}
+
+func (a *ViewAssembler) mapStackDetails(
+	graph *engine.StackGraph,
+	stacks []merge.MultiStackInfo,
+	checksMap map[string]*github.CheckStatus,
+) []httpcontract.StackDetail {
+	details := make([]httpcontract.StackDetail, 0, len(stacks))
+	for _, stack := range stacks {
+		detail := httpcontract.MapStackDetail(a.eng, graph, stack.RootBranch, stack.AllBranches, stack.PRCount, stack.Scope, checksMap)
+		details = append(details, detail)
+	}
+	return details
+}
+
+func (a *ViewAssembler) fetchRecentlyMerged() []httpcontract.TrunkCommitResponse {
+	recentCommits, err := a.eng.GetRecentTrunkCommits(10)
+	if err != nil || len(recentCommits) == 0 {
+		return nil
+	}
+	return httpcontract.MapTrunkCommits(recentCommits)
+}

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -1,10 +1,7 @@
 package httpcontract
 
 import (
-	"regexp"
 	"slices"
-	"strconv"
-	"strings"
 	"time"
 
 	"stackit.dev/stackit/internal/engine"
@@ -260,12 +257,8 @@ func computeStackStatus(graph *engine.StackGraph, branchNames []string) string {
 	}
 }
 
-// prNumberRe matches PR number suffixes like "(#123)" in commit subjects.
-var prNumberRe = regexp.MustCompile(`\(#(\d+)\)\s*$`)
-
 // MapTrunkCommits converts git RecentCommit values to API TrunkCommitResponse values.
-// It parses PR numbers from the "(#N)" suffix in commit subjects and passes through
-// stack trailer fields.
+// Parsing/normalization is done in the git layer; this function maps fields.
 func MapTrunkCommits(commits []git.RecentCommit) []TrunkCommitResponse {
 	result := make([]TrunkCommitResponse, 0, len(commits))
 	for _, c := range commits {
@@ -274,24 +267,17 @@ func MapTrunkCommits(commits []git.RecentCommit) []TrunkCommitResponse {
 			Message:    c.Subject,
 			Author:     c.Author,
 			Date:       c.Date.Format(time.RFC3339),
+			PRNumber:   c.PRNumber,
+			Kind:       string(c.Kind),
 			StackSize:  c.StackSize,
+			StackPRs:   append([]int(nil), c.StackPRNumbers...),
 			StackScope: c.StackScope,
 		}
 
-		// Parse PR number from commit subject "(#123)"
-		if matches := prNumberRe.FindStringSubmatch(c.Subject); len(matches) > 1 {
-			if n, err := strconv.Atoi(matches[1]); err == nil {
-				resp.PRNumber = n
-			}
-		}
-
-		// Parse stack PR numbers from trailer value
-		if c.StackPRs != "" {
-			for part := range strings.SplitSeq(c.StackPRs, ",") {
-				part = strings.TrimSpace(part)
-				if n, err := strconv.Atoi(part); err == nil {
-					resp.StackPRs = append(resp.StackPRs, n)
-				}
+		if resp.Kind == "" {
+			resp.Kind = TrunkCommitKindRegular
+			if c.StackSize > 0 {
+				resp.Kind = TrunkCommitKindStackMerge
 			}
 		}
 

--- a/internal/contracts/http/mappers_test.go
+++ b/internal/contracts/http/mappers_test.go
@@ -1,0 +1,72 @@
+package httpcontract
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"stackit.dev/stackit/internal/git"
+)
+
+func TestMapTrunkCommits(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	commits := []git.RecentCommit{
+		{
+			SHA:            "1234567890abcdef",
+			Subject:        "Consolidate auth stack",
+			Author:         "alice",
+			Date:           now,
+			PRNumber:       123,
+			Kind:           git.RecentCommitKindStackMerge,
+			StackSize:      2,
+			StackPRNumbers: []int{45, 46},
+			StackScope:     "PROJ-1",
+		},
+		{
+			SHA:     "abcdef1234567890",
+			Subject: "Fix typo",
+			Author:  "bob",
+			Date:    now,
+			Kind:    git.RecentCommitKindRegular,
+		},
+	}
+
+	got := MapTrunkCommits(commits)
+	require.Len(t, got, 2)
+
+	require.Equal(t, "1234567", got[0].SHA)
+	require.Equal(t, "Consolidate auth stack", got[0].Message)
+	require.Equal(t, "alice", got[0].Author)
+	require.Equal(t, now.Format(time.RFC3339), got[0].Date)
+	require.Equal(t, 123, got[0].PRNumber)
+	require.Equal(t, TrunkCommitKindStackMerge, got[0].Kind)
+	require.Equal(t, 2, got[0].StackSize)
+	require.Equal(t, []int{45, 46}, got[0].StackPRs)
+	require.Equal(t, "PROJ-1", got[0].StackScope)
+
+	require.Equal(t, "abcdef1", got[1].SHA)
+	require.Equal(t, TrunkCommitKindRegular, got[1].Kind)
+	require.Equal(t, 0, got[1].PRNumber)
+	require.Empty(t, got[1].StackPRs)
+}
+
+func TestMapTrunkCommits_DefaultKindFallback(t *testing.T) {
+	t.Parallel()
+
+	commits := []git.RecentCommit{
+		{
+			SHA:       "1234567890abcdef",
+			Subject:   "Consolidate stack",
+			Author:    "alice",
+			Date:      time.Now().UTC(),
+			StackSize: 3,
+		},
+	}
+
+	got := MapTrunkCommits(commits)
+	require.Len(t, got, 1)
+	require.Equal(t, TrunkCommitKindStackMerge, got[0].Kind)
+}

--- a/internal/contracts/http/responses.go
+++ b/internal/contracts/http/responses.go
@@ -14,6 +14,13 @@ type ViewResponse struct {
 	RecentlyMerged []TrunkCommitResponse `json:"recentlyMerged,omitempty"`
 }
 
+const (
+	// TrunkCommitKindRegular is a normal non-stack merge trunk commit.
+	TrunkCommitKindRegular = "regular"
+	// TrunkCommitKindStackMerge is a stack consolidation merge commit.
+	TrunkCommitKindStackMerge = "stack-merge"
+)
+
 // TrunkCommitResponse represents a commit on the trunk branch,
 // optionally enriched with stack metadata from git trailers.
 type TrunkCommitResponse struct {
@@ -21,6 +28,7 @@ type TrunkCommitResponse struct {
 	Message    string `json:"message"`
 	Author     string `json:"author"`
 	Date       string `json:"date"`
+	Kind       string `json:"kind"`
 	PRNumber   int    `json:"prNumber,omitempty"`
 	StackSize  int    `json:"stackSize,omitempty"`
 	StackPRs   []int  `json:"stackPRs,omitempty"`

--- a/internal/git/recent_commits.go
+++ b/internal/git/recent_commits.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"fmt"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -10,15 +11,27 @@ import (
 
 const trailerValueSeparator = "\x1e"
 
+var prNumberSuffixRe = regexp.MustCompile(`\(#(\d+)\)\s*$`)
+
+// RecentCommitKind describes the presentation type of a trunk commit.
+type RecentCommitKind string
+
+const (
+	RecentCommitKindRegular    RecentCommitKind = "regular"
+	RecentCommitKindStackMerge RecentCommitKind = "stack-merge"
+)
+
 // RecentCommit represents a commit from the git log with optional stack trailer metadata.
 type RecentCommit struct {
-	SHA        string
-	Subject    string
-	Author     string
-	Date       time.Time
-	StackSize  int    // from Stackit-Stack-Size trailer (0 if absent)
-	StackPRs   string // from Stackit-PRs trailer (comma-separated, empty if absent)
-	StackScope string // from Stackit-Scope trailer (empty if absent)
+	SHA            string
+	Subject        string
+	Author         string
+	Date           time.Time
+	PRNumber       int              // parsed from subject suffix "(#123)" if present
+	Kind           RecentCommitKind // derived from trailer metadata
+	StackSize      int              // from Stackit-Stack-Size trailer (0 if absent)
+	StackPRNumbers []int            // from Stackit-PRs trailer
+	StackScope     string           // from Stackit-Scope trailer (empty if absent)
 }
 
 // GetRecentCommits returns the most recent commits from a branch, including stack trailer metadata.
@@ -64,12 +77,15 @@ func (r *runner) GetRecentCommits(branchName string, count int) ([]RecentCommit,
 		}
 
 		if len(fields) > 5 {
-			commit.StackPRs = parseStackPRsTrailer(fields[5])
+			commit.StackPRNumbers = parseStackPRsTrailer(fields[5])
 		}
 
 		if len(fields) > 6 {
 			commit.StackScope = parseStackScopeTrailer(fields[6])
 		}
+
+		commit.PRNumber = parsePRNumberFromSubject(commit.Subject)
+		commit.Kind = deriveRecentCommitKind(commit)
 
 		commits = append(commits, commit)
 	}
@@ -90,7 +106,7 @@ func parseStackSizeTrailer(raw string) int {
 	return 0
 }
 
-func parseStackPRsTrailer(raw string) string {
+func parseStackPRsTrailer(raw string) []int {
 	var prNumbers []int
 	for value := range strings.SplitSeq(raw, trailerValueSeparator) {
 		for part := range strings.SplitSeq(value, ",") {
@@ -105,16 +121,7 @@ func parseStackPRsTrailer(raw string) string {
 			prNumbers = append(prNumbers, n)
 		}
 	}
-
-	if len(prNumbers) == 0 {
-		return ""
-	}
-
-	values := make([]string, len(prNumbers))
-	for i, n := range prNumbers {
-		values[i] = strconv.Itoa(n)
-	}
-	return strings.Join(values, ",")
+	return prNumbers
 }
 
 func parseStackScopeTrailer(raw string) string {
@@ -125,4 +132,23 @@ func parseStackScopeTrailer(raw string) string {
 		}
 	}
 	return ""
+}
+
+func parsePRNumberFromSubject(subject string) int {
+	matches := prNumberSuffixRe.FindStringSubmatch(subject)
+	if len(matches) < 2 {
+		return 0
+	}
+	n, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func deriveRecentCommitKind(commit RecentCommit) RecentCommitKind {
+	if commit.StackSize > 0 {
+		return RecentCommitKindStackMerge
+	}
+	return RecentCommitKindRegular
 }

--- a/internal/git/recent_commits_test.go
+++ b/internal/git/recent_commits_test.go
@@ -32,8 +32,9 @@ func TestGetRecentCommits_DuplicateTrailers(t *testing.T) {
 	require.Len(t, commits, 1)
 
 	require.Equal(t, 2, commits[0].StackSize)
-	require.Equal(t, "1,2", commits[0].StackPRs)
+	require.Equal(t, []int{1, 2}, commits[0].StackPRNumbers)
 	require.Equal(t, "PROJ-123", commits[0].StackScope)
+	require.Equal(t, git.RecentCommitKindStackMerge, commits[0].Kind)
 }
 
 func TestGetRecentCommits_WithoutTrailers(t *testing.T) {
@@ -56,8 +57,9 @@ func TestGetRecentCommits_WithoutTrailers(t *testing.T) {
 
 	require.Equal(t, "Regular commit without trailers", commits[0].Subject)
 	require.Equal(t, 0, commits[0].StackSize)
-	require.Equal(t, "", commits[0].StackPRs)
+	require.Empty(t, commits[0].StackPRNumbers)
 	require.Equal(t, "", commits[0].StackScope)
+	require.Equal(t, git.RecentCommitKindRegular, commits[0].Kind)
 }
 
 func TestGetRecentCommits_MultipleCommits(t *testing.T) {
@@ -94,14 +96,37 @@ func TestGetRecentCommits_MultipleCommits(t *testing.T) {
 	// Most recent first (commit with trailers)
 	require.Equal(t, "Consolidate stack", commits[0].Subject)
 	require.Equal(t, 3, commits[0].StackSize)
-	require.Equal(t, "10,20,30", commits[0].StackPRs)
+	require.Equal(t, []int{10, 20, 30}, commits[0].StackPRNumbers)
 	require.Equal(t, "FEAT-1", commits[0].StackScope)
+	require.Equal(t, git.RecentCommitKindStackMerge, commits[0].Kind)
 
 	// Second commit (no trailers)
 	require.Equal(t, "First commit", commits[1].Subject)
 	require.Equal(t, 0, commits[1].StackSize)
-	require.Equal(t, "", commits[1].StackPRs)
+	require.Empty(t, commits[1].StackPRNumbers)
+	require.Equal(t, git.RecentCommitKindRegular, commits[1].Kind)
 
 	// Initial commit
 	require.Equal(t, "initial", commits[2].Subject)
+}
+
+func TestGetRecentCommits_ParsesPRNumberSuffix(t *testing.T) {
+	t.Parallel()
+	scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+		return s.Repo.CreateChangeAndCommit("initial", "init")
+	})
+
+	err := scene.Repo.CreateChange("file1", "content1", false)
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand("add", ".")
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand("commit", "-m", "Add status badge (#123)")
+	require.NoError(t, err)
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	commits, err := runner.GetRecentCommits("main", 1)
+	require.NoError(t, err)
+	require.Len(t, commits, 1)
+	require.Equal(t, 123, commits[0].PRNumber)
+	require.Equal(t, git.RecentCommitKindRegular, commits[0].Kind)
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -72,8 +72,8 @@ type MergeMethodSettings struct {
 
 // MergePROptions configures how a pull request should be merged.
 type MergePROptions struct {
-	Method        MergeMethod
-	CommitMessage string // Optional: appended to/replaces auto-generated commit body
+	Method     MergeMethod
+	CommitBody string // Optional commit body for merge/squash commit message.
 }
 
 // Client is an interface for GitHub API interactions

--- a/internal/github/pr_operations.go
+++ b/internal/github/pr_operations.go
@@ -276,7 +276,8 @@ func ParseReviewers(reviewersStr string) ([]string, []string) {
 }
 
 // MergePullRequest merges a pull request using the GitHub API.
-// If opts.CommitMessage is set, it is used as the commit message body for squash/merge commits.
+// If opts.CommitBody is set, it is used as an additional commit message body
+// for merge/squash strategies.
 func MergePullRequest(ctx context.Context, client *github.Client, owner, repo, branchName string, opts MergePROptions) error {
 	// First, get the PR for this branch
 	pr, err := GetPullRequestByBranch(ctx, client, owner, repo, branchName)
@@ -291,7 +292,7 @@ func MergePullRequest(ctx context.Context, client *github.Client, owner, repo, b
 	mergeRequest := &github.PullRequestOptions{
 		MergeMethod: string(opts.Method),
 	}
-	_, _, err = client.PullRequests.Merge(ctx, owner, repo, *pr.Number, opts.CommitMessage, mergeRequest)
+	_, _, err = client.PullRequests.Merge(ctx, owner, repo, *pr.Number, opts.CommitBody, mergeRequest)
 	if err != nil {
 		return fmt.Errorf("failed to merge PR #%d for branch %s using %s: %w", *pr.Number, branchName, opts.Method, err)
 	}

--- a/internal/pr/merge.go
+++ b/internal/pr/merge.go
@@ -67,9 +67,9 @@ type MergeBodyParams struct {
 	// Optional - if present, it appears at the top of the body.
 	StackDescription *git.StackDescription
 
-	// Scope is the stack scope for trailers (e.g. "PROJ-123").
-	// Optional - if empty, no scope trailer is emitted.
-	Scope string
+	// Metadata is stack metadata for trailers.
+	// Optional - if StackSize is zero, metadata is derived from Branches.
+	Metadata StackMetadata
 }
 
 // MergeBranch represents a branch being merged.
@@ -103,11 +103,9 @@ func FormatMergeBody(params MergeBodyParams) string {
 	body.WriteString("This PR merges the following changes:\n\n")
 
 	// Branch list with PR info
-	prNumbers := make([]int, 0, len(params.Branches))
 	for i, branch := range params.Branches {
 		if branch.PRNumber > 0 {
 			fmt.Fprintf(&body, "%d. **#%d** %s\n", i+1, branch.PRNumber, branch.PRTitle)
-			prNumbers = append(prNumbers, branch.PRNumber)
 		} else {
 			fmt.Fprintf(&body, "%d. %s\n", i+1, branch.Name)
 		}
@@ -132,8 +130,12 @@ func FormatMergeBody(params MergeBodyParams) string {
 	// Append stack trailers as a fallback for repos whose squash merge commit
 	// message setting uses "PR body". Trailers survive automatically in that case.
 	if len(params.Branches) > 0 {
+		metadata := params.Metadata
+		if metadata.StackSize == 0 {
+			metadata = BuildStackMetadata(params.Branches, metadata.Scope)
+		}
 		body.WriteString("\n")
-		body.WriteString(FormatStackTrailers(len(params.Branches), prNumbers, params.Scope))
+		body.WriteString(metadata.ToTrailers())
 	}
 
 	return body.String()

--- a/internal/pr/merge_test.go
+++ b/internal/pr/merge_test.go
@@ -236,7 +236,7 @@ Stackit-PRs: 1
 				Title:       "Add user authentication",
 				Description: "This stack implements JWT-based auth.",
 			},
-			Scope: "PROJ-123",
+			Metadata: StackMetadata{Scope: "PROJ-123"},
 		})
 
 		expected := `**Add user authentication**
@@ -270,7 +270,7 @@ Stackit-Scope: PROJ-123
 			StackDescription: &git.StackDescription{
 				Title: "Add user authentication",
 			},
-			Scope: "PROJ-456",
+			Metadata: StackMetadata{Scope: "PROJ-456"},
 		})
 
 		expected := `**Add user authentication**

--- a/internal/pr/scope.go
+++ b/internal/pr/scope.go
@@ -1,0 +1,20 @@
+package pr
+
+// ResolveUnifiedScope returns a scope only when all non-empty scopes match.
+// This avoids mislabeling mixed-scope merge metadata.
+func ResolveUnifiedScope(scopes []string) string {
+	var selected string
+	for _, scope := range scopes {
+		if scope == "" {
+			continue
+		}
+		if selected == "" {
+			selected = scope
+			continue
+		}
+		if scope != selected {
+			return ""
+		}
+	}
+	return selected
+}

--- a/internal/pr/scope_test.go
+++ b/internal/pr/scope_test.go
@@ -1,0 +1,46 @@
+package pr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveUnifiedScope(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		scopes []string
+		want   string
+	}{
+		{
+			name:   "all empty",
+			scopes: []string{"", ""},
+			want:   "",
+		},
+		{
+			name:   "single non-empty scope",
+			scopes: []string{"", "PROJ-1", ""},
+			want:   "PROJ-1",
+		},
+		{
+			name:   "matching non-empty scopes",
+			scopes: []string{"PROJ-1", "PROJ-1"},
+			want:   "PROJ-1",
+		},
+		{
+			name:   "mixed scopes",
+			scopes: []string{"PROJ-1", "PROJ-2"},
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ResolveUnifiedScope(tt.scopes)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/pr/trailers.go
+++ b/internal/pr/trailers.go
@@ -13,40 +13,69 @@ const (
 	TrailerScope     = "Stackit-Scope"
 )
 
-// StackTrailerInfo contains parsed stack metadata from git trailers.
-type StackTrailerInfo struct {
+// StackMetadata contains stack metadata embedded in git trailers.
+type StackMetadata struct {
 	StackSize int
 	PRNumbers []int
 	Scope     string
 }
 
-// FormatStackTrailers builds a git trailer block for a consolidation merge commit.
+// StackTrailerInfo is an alias kept for backwards compatibility.
+type StackTrailerInfo = StackMetadata
+
+// NewStackMetadata constructs stack metadata from explicit fields.
+func NewStackMetadata(stackSize int, prNumbers []int, scope string) StackMetadata {
+	return StackMetadata{
+		StackSize: stackSize,
+		PRNumbers: slicesClone(prNumbers),
+		Scope:     scope,
+	}
+}
+
+// BuildStackMetadata derives stack metadata from merge branches.
+func BuildStackMetadata(branches []MergeBranch, scope string) StackMetadata {
+	prNumbers := make([]int, 0, len(branches))
+	for _, branch := range branches {
+		if branch.PRNumber > 0 {
+			prNumbers = append(prNumbers, branch.PRNumber)
+		}
+	}
+
+	return NewStackMetadata(len(branches), prNumbers, scope)
+}
+
+// ToTrailers builds a git trailer block for this metadata.
 // The trailers follow the standard git trailer format (key: value) and can be
 // parsed by git log's %(trailers) format specifier.
-func FormatStackTrailers(stackSize int, prNumbers []int, scope string) string {
+func (m StackMetadata) ToTrailers() string {
 	var b strings.Builder
 
-	fmt.Fprintf(&b, "%s: %d\n", TrailerStackSize, stackSize)
+	fmt.Fprintf(&b, "%s: %d\n", TrailerStackSize, m.StackSize)
 
-	if len(prNumbers) > 0 {
-		prStrs := make([]string, len(prNumbers))
-		for i, n := range prNumbers {
+	if len(m.PRNumbers) > 0 {
+		prStrs := make([]string, len(m.PRNumbers))
+		for i, n := range m.PRNumbers {
 			prStrs[i] = strconv.Itoa(n)
 		}
 		fmt.Fprintf(&b, "%s: %s\n", TrailerPRs, strings.Join(prStrs, ","))
 	}
 
-	if scope != "" {
-		fmt.Fprintf(&b, "%s: %s\n", TrailerScope, scope)
+	if m.Scope != "" {
+		fmt.Fprintf(&b, "%s: %s\n", TrailerScope, m.Scope)
 	}
 
 	return b.String()
 }
 
-// ParseStackTrailers extracts stack trailer values from a commit message body.
+// FormatStackTrailers is a compatibility wrapper around StackMetadata.ToTrailers.
+func FormatStackTrailers(stackSize int, prNumbers []int, scope string) string {
+	return NewStackMetadata(stackSize, prNumbers, scope).ToTrailers()
+}
+
+// ParseStackMetadataTrailers extracts stack trailer values from a commit message body.
 // Returns nil if no stack trailers are found.
-func ParseStackTrailers(body string) *StackTrailerInfo {
-	info := &StackTrailerInfo{}
+func ParseStackMetadataTrailers(body string) *StackMetadata {
+	info := &StackMetadata{}
 	found := false
 
 	for line := range strings.SplitSeq(body, "\n") {
@@ -78,6 +107,11 @@ func ParseStackTrailers(body string) *StackTrailerInfo {
 	return info
 }
 
+// ParseStackTrailers is a compatibility wrapper around ParseStackMetadataTrailers.
+func ParseStackTrailers(body string) *StackTrailerInfo {
+	return ParseStackMetadataTrailers(body)
+}
+
 // parseTrailer checks if a line matches "Key: value" and returns the value.
 func parseTrailer(line, key string) (string, bool) {
 	prefix := key + ":"
@@ -97,4 +131,13 @@ func parsePRNumbers(s string) []int {
 		}
 	}
 	return nums
+}
+
+func slicesClone(in []int) []int {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]int, len(in))
+	copy(out, in)
+	return out
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1772336454`.


* **PR #777**
  * **PR #778**
    * **PR #779**
      * **PR #780**
        * **PR #781** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->