### PR TITLE
Merging 5 PRs

### DIFF
--- a/api/openapi/stackit.yaml
+++ b/api/openapi/stackit.yaml
@@ -115,6 +115,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/StackDetail"
+        recentlyMerged:
+          type: array
+          items:
+            $ref: "#/components/schemas/TrunkCommitResponse"
     RepoResponse:
       type: object
       required: [owner, repo, trunk, currentBranch, remote]
@@ -254,4 +258,29 @@ components:
         status:
           type: string
         conclusion:
+          type: string
+    TrunkCommitResponse:
+      type: object
+      required: [sha, message, author, date, kind]
+      properties:
+        sha:
+          type: string
+        message:
+          type: string
+        author:
+          type: string
+        date:
+          type: string
+        kind:
+          type: string
+          enum: [regular, stack-merge]
+        prNumber:
+          type: integer
+        stackSize:
+          type: integer
+        stackPRs:
+          type: array
+          items:
+            type: integer
+        stackScope:
           type: string

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,15 +2,23 @@
 
 import { useMemo, useState } from "react";
 import { useRepo } from "@/components/providers/repo-provider";
-import { StackColumn } from "@/components/stack-column";
 import { OwnerSwimlane, getLastActiveDate } from "@/components/owner-swimlane";
 import { BranchDetail } from "@/components/branch-detail/branch-detail";
+import { RecentlyMerged } from "@/components/recently-merged";
 import { Separator } from "@/components/ui/separator";
 import type { BranchResponse, StackDetail } from "@/lib/api";
+import { formatTimeAgo } from "@/lib/time";
 
 export default function Home() {
-  const { repo, stackDetails, loading, error, lastUpdated, refresh } =
-    useRepo();
+  const {
+    repo,
+    stackDetails,
+    recentlyMerged,
+    loading,
+    error,
+    lastUpdated,
+    refresh,
+  } = useRepo();
   const [selectedBranch, setSelectedBranch] = useState<BranchResponse | null>(
     null
   );
@@ -123,11 +131,18 @@ export default function Home() {
               </div>
 
               {/* Trunk line */}
-              <div className="flex items-center gap-2 px-6 pb-6">
+              <div className="flex items-center gap-2 px-6 pb-2">
                 <div className="flex-1 border-t-2 border-dashed border-muted-foreground/30" />
                 <span className="text-xs font-mono text-muted-foreground">{repo?.trunk}</span>
                 <div className="flex-1 border-t-2 border-dashed border-muted-foreground/30" />
               </div>
+
+              {/* Recently merged history */}
+              <RecentlyMerged
+                commits={recentlyMerged}
+                owner={repo?.owner}
+                repo={repo?.repo}
+              />
             </div>
           ) : (
             <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
@@ -148,16 +163,4 @@ export default function Home() {
       </div>
     </div>
   );
-}
-
-function formatTimeAgo(date: Date): string {
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
-  if (seconds < 5) return "just now";
-  if (seconds < 60) return `${seconds}s ago`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
 }

--- a/apps/web/src/components/providers/repo-provider.tsx
+++ b/apps/web/src/components/providers/repo-provider.tsx
@@ -12,12 +12,14 @@ import {
   fetchView,
   type RepoResponse,
   type StackDetail,
+  type TrunkCommitResponse,
 } from "@/lib/api";
 import { useSSE } from "@/lib/use-sse";
 
 interface RepoState {
   repo: RepoResponse | null;
   stackDetails: StackDetail[];
+  recentlyMerged: TrunkCommitResponse[];
   loading: boolean;
   error: string | null;
   lastUpdated: Date | null;
@@ -35,6 +37,9 @@ export function useRepo() {
 export function RepoProvider({ children }: { children: ReactNode }) {
   const [repo, setRepo] = useState<RepoResponse | null>(null);
   const [stackDetails, setStackDetails] = useState<StackDetail[]>([]);
+  const [recentlyMerged, setRecentlyMerged] = useState<TrunkCommitResponse[]>(
+    []
+  );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
@@ -138,6 +143,7 @@ export function RepoProvider({ children }: { children: ReactNode }) {
       ];
 
       setStackDetails([...view.stacks, ...sampleStacks]);
+      setRecentlyMerged(view.recentlyMerged ?? []);
 
       setError(null);
       setLastUpdated(new Date());
@@ -161,6 +167,7 @@ export function RepoProvider({ children }: { children: ReactNode }) {
       value={{
         repo,
         stackDetails,
+        recentlyMerged,
         loading,
         error,
         lastUpdated,

--- a/apps/web/src/components/recently-merged.tsx
+++ b/apps/web/src/components/recently-merged.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import type { TrunkCommitResponse } from "@/lib/api";
+import { formatTimeAgo } from "@/lib/time";
+
+interface RecentlyMergedProps {
+  commits: TrunkCommitResponse[];
+  owner?: string;
+  repo?: string;
+}
+
+export function RecentlyMerged({ commits, owner, repo }: RecentlyMergedProps) {
+  if (commits.length === 0) return null;
+
+  return (
+    <div className="px-6 pb-6 space-y-1">
+      {commits.map((commit) =>
+        commit.kind === "stack-merge" ? (
+          <StackMergeEntry
+            key={commit.sha}
+            commit={commit}
+            owner={owner}
+            repo={repo}
+          />
+        ) : (
+          <RegularCommitEntry
+            key={commit.sha}
+            commit={commit}
+            owner={owner}
+            repo={repo}
+          />
+        )
+      )}
+    </div>
+  );
+}
+
+function StackMergeEntry({
+  commit,
+  owner,
+  repo,
+}: {
+  commit: TrunkCommitResponse;
+  owner?: string;
+  repo?: string;
+}) {
+  const prCount = commit.stackPRs?.length ?? commit.stackSize ?? 0;
+
+  return (
+    <div className="rounded-lg border border-muted p-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          {commit.stackScope && (
+            <span className="text-xs font-mono bg-muted px-1.5 py-0.5 rounded">
+              {commit.stackScope}
+            </span>
+          )}
+          <span className="text-sm text-foreground">
+            {prCount} PR{prCount !== 1 ? "s" : ""} merged
+          </span>
+        </div>
+        <span className="text-xs text-muted-foreground">
+          {formatTimeAgo(commit.date)}
+        </span>
+      </div>
+      {commit.stackPRs && commit.stackPRs.length > 0 && (
+        <div className="flex items-center gap-1.5 mt-1.5">
+          {commit.stackPRs.map((prNum) => (
+            <PRLink
+              key={prNum}
+              prNumber={prNum}
+              owner={owner}
+              repo={repo}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RegularCommitEntry({
+  commit,
+  owner,
+  repo,
+}: {
+  commit: TrunkCommitResponse;
+  owner?: string;
+  repo?: string;
+}) {
+  return (
+    <div className="flex items-center gap-2 py-1 px-1 text-sm text-muted-foreground">
+      <span className="font-mono text-xs">{commit.sha}</span>
+      <span className="truncate flex-1">
+        {commit.prNumber ? (
+          <>
+            {stripPRSuffix(commit.message)}{" "}
+            <PRLink prNumber={commit.prNumber} owner={owner} repo={repo} />
+          </>
+        ) : (
+          commit.message
+        )}
+      </span>
+      <span className="text-xs shrink-0">{formatTimeAgo(commit.date)}</span>
+    </div>
+  );
+}
+
+function PRLink({
+  prNumber,
+  owner,
+  repo,
+}: {
+  prNumber: number;
+  owner?: string;
+  repo?: string;
+}) {
+  if (owner && repo) {
+    return (
+      <a
+        href={`https://github.com/${owner}/${repo}/pull/${prNumber}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-xs font-mono text-blue-500 hover:underline"
+      >
+        #{prNumber}
+      </a>
+    );
+  }
+  return <span className="text-xs font-mono text-blue-500">#{prNumber}</span>;
+}
+
+function stripPRSuffix(message: string): string {
+  return message.replace(/\s*\(#\d+\)\s*$/, "");
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -85,11 +85,24 @@ export interface RemoteStatus {
   missingRemote: boolean;
 }
 
+export interface TrunkCommitResponse {
+  sha: string;
+  message: string;
+  author: string;
+  date: string;
+  kind: "regular" | "stack-merge";
+  prNumber?: number;
+  stackSize?: number;
+  stackPRs?: number[];
+  stackScope?: string;
+}
+
 // --- Combined View Response ---
 
 export interface ViewResponse {
   repo: RepoResponse;
   stacks: StackDetail[];
+  recentlyMerged?: TrunkCommitResponse[];
 }
 
 // --- Fetch Functions ---

--- a/apps/web/src/lib/time.ts
+++ b/apps/web/src/lib/time.ts
@@ -1,0 +1,16 @@
+export function formatTimeAgo(input: Date | string): string {
+  const date = typeof input === "string" ? new Date(input) : input;
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+
+  if (seconds < 5) return "just now";
+  if (seconds < 60) return `${seconds}s ago`;
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/internal/actions/merge/ci_waiter.go
+++ b/internal/actions/merge/ci_waiter.go
@@ -156,7 +156,7 @@ func (w *CIWaiter) WaitForChecks(ctx context.Context, branchName string, prNumbe
 
 // WaitAndMerge waits for CI checks to pass and then merges the PR.
 // This is used for consolidation PRs that should be auto-merged.
-func (w *CIWaiter) WaitAndMerge(ctx context.Context, branchName string, pr *github.PullRequestInfo, expectChecks bool, mergeMethod github.MergeMethod) error {
+func (w *CIWaiter) WaitAndMerge(ctx context.Context, branchName string, pr *github.PullRequestInfo, expectChecks bool, mergeOpts github.MergePROptions) error {
 	if w.output != nil {
 		w.output.Info("Consolidation PR:")
 		w.output.Info("  ◉ %s PR #%d ⏳", branchName, pr.Number)
@@ -175,7 +175,7 @@ func (w *CIWaiter) WaitAndMerge(ctx context.Context, branchName string, pr *gith
 		w.output.Info("     Auto-merging...")
 	}
 
-	if err := w.client.MergePullRequest(ctx, branchName, mergeMethod); err != nil {
+	if err := w.client.MergePullRequest(ctx, branchName, mergeOpts); err != nil {
 		return fmt.Errorf("failed to auto-merge consolidation PR #%d: %w", pr.Number, err)
 	}
 

--- a/internal/actions/merge/consolidate.go
+++ b/internal/actions/merge/consolidate.go
@@ -11,6 +11,7 @@ import (
 	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/internal/git"
 	"stackit.dev/stackit/internal/github"
+	"stackit.dev/stackit/internal/pr"
 )
 
 // ConsolidationResult contains information about a completed consolidation
@@ -108,7 +109,11 @@ func (c *ConsolidateMergeExecutor) Execute(ctx context.Context, opts ExecuteOpti
 		if err != nil {
 			return nil, fmt.Errorf("failed to get merge method: %w", err)
 		}
-		if err := github.EnableAutoMerge(ctx, c.engine.Git(), pr.NodeID, mergeMethod); err != nil {
+		metadata := c.buildStackMetadata()
+		if err := github.EnableAutoMerge(ctx, c.engine.Git(), pr.NodeID, github.EnableAutoMergeOptions{
+			MergeMethod: mergeMethod,
+			CommitBody:  metadata.ToTrailers(),
+		}); err != nil {
 			splog.Warn("Could not enable automerge: %v", err)
 			splog.Tip("Enable automerge manually on the PR: %s", pr.HTMLURL)
 		} else {
@@ -160,7 +165,7 @@ func (c *ConsolidateMergeExecutor) createMergeBranch(ctx context.Context) (strin
 	splog := c.ctx.Output
 	// Generate unique branch name
 	timestamp := time.Now().Unix()
-	scope := c.getStackScope()
+	scope := c.getStackScopeOrDefault()
 	branchName := fmt.Sprintf("stack-merge-%s-%d", scope, timestamp)
 
 	splog.Info("📋 Creating merge branch: %s", branchName)
@@ -194,6 +199,10 @@ func (c *ConsolidateMergeExecutor) createMergeBranch(ctx context.Context) (strin
 	} else {
 		commitMsg += fmt.Sprintf(" (%d branches)", len(branches))
 	}
+
+	// Append stack trailers for history tracking
+	metadata := c.buildStackMetadata()
+	commitMsg += "\n\n" + metadata.ToTrailers()
 
 	splog.Info("  Merging %d branches via octopus merge...", len(branches))
 	splog.Debug("Consolidation merge: merging branches %v", branches)
@@ -251,7 +260,12 @@ func (c *ConsolidateMergeExecutor) waitForConsolidationMerge(ctx context.Context
 	})
 	waiter.SetProgressHandler(c.handler, c.stepIndex)
 
-	return waiter.WaitAndMerge(ctx, branchName, pr, expectChecks, mergeMethod)
+	metadata := c.buildStackMetadata()
+	mergeOpts := github.MergePROptions{
+		Method:     mergeMethod,
+		CommitBody: metadata.ToTrailers(),
+	}
+	return waiter.WaitAndMerge(ctx, branchName, pr, expectChecks, mergeOpts)
 }
 
 func (c *ConsolidateMergeExecutor) postMergeCleanup(_ context.Context) {
@@ -322,7 +336,7 @@ func (c *ConsolidateMergeExecutor) lockAndNotifyIndividualPRs(_ context.Context,
 
 // Helper methods
 
-func (c *ConsolidateMergeExecutor) getStackScope() string {
+func (c *ConsolidateMergeExecutor) getStackScopeOrDefault() string {
 	// Get scope from the first branch in the stack
 	if len(c.plan.BranchesToMerge) > 0 {
 		branch := c.engine.GetBranch(c.plan.BranchesToMerge[0].BranchName)
@@ -336,6 +350,32 @@ func (c *ConsolidateMergeExecutor) getStackScope() string {
 
 func (c *ConsolidateMergeExecutor) getOwnerRepo() (owner, repo string) {
 	return c.ctx.GitHub().GetOwnerRepo()
+}
+
+// buildStackMetadata builds stack metadata for consolidation merge commits.
+func (c *ConsolidateMergeExecutor) buildStackMetadata() pr.StackMetadata {
+	scope := c.getTrailerScope()
+	prNumbers := make([]int, 0, len(c.plan.BranchesToMerge))
+	for _, b := range c.plan.BranchesToMerge {
+		if b.PRNumber > 0 {
+			prNumbers = append(prNumbers, b.PRNumber)
+		}
+	}
+	return pr.NewStackMetadata(len(c.plan.BranchesToMerge), prNumbers, scope)
+}
+
+// getTrailerScope returns a scope only when all non-empty branch scopes match.
+func (c *ConsolidateMergeExecutor) getTrailerScope() string {
+	scopes := make([]string, 0, len(c.plan.BranchesToMerge))
+	for _, b := range c.plan.BranchesToMerge {
+		branch := c.engine.GetBranch(b.BranchName)
+		scope := c.engine.GetScope(branch)
+		if scope.IsEmpty() {
+			continue
+		}
+		scopes = append(scopes, scope.String())
+	}
+	return pr.ResolveUnifiedScope(scopes)
 }
 
 // resolveMergeMethod returns the merge method to use, preferring the override if set.

--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -280,7 +280,7 @@ func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecut
 			}
 		}
 
-		if err := githubClient.MergePullRequest(ctx.Context, step.BranchName, mergeMethod); err != nil {
+		if err := githubClient.MergePullRequest(ctx.Context, step.BranchName, github.MergePROptions{Method: mergeMethod}); err != nil {
 			out.Debug("StepMergePR for branch %s failed: %v", step.BranchName, err)
 			return fmt.Errorf("failed to merge PR: %w", err)
 		}

--- a/internal/actions/merge/multistack_pr.go
+++ b/internal/actions/merge/multistack_pr.go
@@ -116,5 +116,5 @@ func (p *MultiStackPRCreator) WaitAndMerge(ctx context.Context, branchName strin
 		Output: p.ctx.Output,
 	})
 
-	return waiter.WaitAndMerge(ctx, branchName, pr, true, mergeMethod)
+	return waiter.WaitAndMerge(ctx, branchName, pr, true, github.MergePROptions{Method: mergeMethod})
 }

--- a/internal/actions/merge/pr_generator.go
+++ b/internal/actions/merge/pr_generator.go
@@ -32,7 +32,7 @@ func (g *PRContentGenerator) GenerateMultiStackPR(included []MultiStackInfo, exc
 	scopes := g.collectScopes(branches)
 
 	title := pr.FormatMergeTitle(scopes, len(branches))
-	body := g.generateBody(branches, g.convertExcluded(excluded))
+	body := g.generateBodyWithOptions(branches, g.convertExcluded(excluded), nil, pr.ResolveUnifiedScope(scopes))
 
 	return pr.Content{Title: title, Body: body}
 }
@@ -50,18 +50,13 @@ func (g *PRContentGenerator) GenerateConsolidationPR(branches []BranchMergeInfo)
 	}
 
 	title := pr.FormatMergeTitleWithDescription(stackDesc, scopes, len(mergeBranches))
-	body := g.generateBodyWithDescription(mergeBranches, nil, stackDesc)
+	body := g.generateBodyWithOptions(mergeBranches, nil, stackDesc, pr.ResolveUnifiedScope(scopes))
 
 	return pr.Content{Title: title, Body: body}
 }
 
-// generateBody creates the PR body with branches, exclusions, and stack tree.
-func (g *PRContentGenerator) generateBody(branches []pr.MergeBranch, excluded []pr.ExcludedBranch) string {
-	return g.generateBodyWithDescription(branches, excluded, nil)
-}
-
-// generateBodyWithDescription creates the PR body with branches, exclusions, stack tree, and optional description.
-func (g *PRContentGenerator) generateBodyWithDescription(branches []pr.MergeBranch, excluded []pr.ExcludedBranch, stackDesc *git.StackDescription) string {
+// generateBodyWithOptions creates the PR body with branches, exclusions, stack tree, optional description, and scope.
+func (g *PRContentGenerator) generateBodyWithOptions(branches []pr.MergeBranch, excluded []pr.ExcludedBranch, stackDesc *git.StackDescription, scope string) string {
 	// Build stack tree
 	treeBranches := make([]pr.StackTreeBranch, len(branches))
 	for i, branch := range branches {
@@ -84,6 +79,7 @@ func (g *PRContentGenerator) generateBodyWithDescription(branches []pr.MergeBran
 		Excluded:         excluded,
 		StackTree:        stackTree,
 		StackDescription: stackDesc,
+		Metadata:         pr.BuildStackMetadata(branches, scope),
 	})
 }
 

--- a/internal/actions/merge/pr_generator_test.go
+++ b/internal/actions/merge/pr_generator_test.go
@@ -8,6 +8,7 @@ import (
 
 	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/internal/git"
+	"stackit.dev/stackit/internal/pr"
 	"stackit.dev/stackit/testhelpers"
 	"stackit.dev/stackit/testhelpers/scenario"
 )
@@ -160,5 +161,49 @@ func TestPRContentGenerator_GenerateMultiStackPR(t *testing.T) {
 		assert.Contains(t, content.Body, "### Excluded")
 		assert.Contains(t, content.Body, "feature-b")
 		assert.Contains(t, content.Body, "conflict")
+	})
+
+	t.Run("mixed_scopes_omits_scope_trailer", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithStack(map[string]string{
+			"feature-a": "main",
+			"feature-b": "main",
+		})
+
+		err := s.Engine.SetScope(context.Background(), s.Engine.GetBranch("feature-a"), engine.NewScope("PROJ-1"))
+		assert.NoError(t, err)
+		err = s.Engine.SetScope(context.Background(), s.Engine.GetBranch("feature-b"), engine.NewScope("PROJ-2"))
+		assert.NoError(t, err)
+
+		gen := NewPRContentGenerator(s.Engine)
+		content := gen.GenerateMultiStackPR(
+			[]MultiStackInfo{
+				{RootBranch: "feature-a", AllBranches: []string{"feature-a"}},
+				{RootBranch: "feature-b", AllBranches: []string{"feature-b"}},
+			},
+			nil,
+		)
+
+		assert.Equal(t, "Merging PROJ-1, PROJ-2", content.Title)
+		assert.NotContains(t, content.Body, "Stackit-Scope:")
+	})
+}
+
+func TestResolveUnifiedScope(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns empty when all scopes are empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "", pr.ResolveUnifiedScope([]string{"", ""}))
+	})
+
+	t.Run("returns the shared scope", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "PROJ-1", pr.ResolveUnifiedScope([]string{"", "PROJ-1", "PROJ-1"}))
+	})
+
+	t.Run("returns empty when scopes differ", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "", pr.ResolveUnifiedScope([]string{"PROJ-1", "PROJ-2"}))
 	})
 }

--- a/internal/api/handlers/view.go
+++ b/internal/api/handlers/view.go
@@ -3,22 +3,21 @@ package handlers
 import (
 	"net/http"
 
-	"stackit.dev/stackit/internal/actions/merge"
-	httpcontract "stackit.dev/stackit/internal/contracts/http"
 	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/internal/github"
 )
 
 // ViewHandler serves the combined view payload for the frontend.
 type ViewHandler struct {
-	eng    engine.BranchReader
-	gh     github.Client
-	remote string
+	assembler *ViewAssembler
 }
 
 // NewViewHandler creates a handler for /api/view and /api/v1/view.
+// Assembly logic lives in ViewAssembler to keep this handler transport-focused.
 func NewViewHandler(eng engine.BranchReader, gh github.Client, remote string) *ViewHandler {
-	return &ViewHandler{eng: eng, gh: gh, remote: remote}
+	return &ViewHandler{
+		assembler: NewViewAssembler(eng, gh, remote),
+	}
 }
 
 // ServeHTTP handles GET view endpoints.
@@ -28,51 +27,11 @@ func (h *ViewHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build repo info
-	owner, repo := "", ""
-	var currentUser string
-	if h.gh != nil {
-		owner, repo = h.gh.GetOwnerRepo()
-		currentUser, _ = h.gh.GetCurrentUser(r.Context())
-	}
-	repoResp := httpcontract.RepoResponse{
-		Owner:         owner,
-		Repo:          repo,
-		Trunk:         h.eng.Trunk().GetName(),
-		CurrentBranch: h.eng.CurrentBranch().GetName(),
-		Remote:        h.remote,
-		CurrentUser:   currentUser,
-	}
-
-	// Discover all stacks
-	stacks, err := merge.DiscoverStacksWithSort(h.eng, engine.SortStrategySmart)
+	view, err := h.assembler.Build(r.Context())
 	if err != nil {
-		http.Error(w, "failed to discover stacks: "+err.Error(), http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	graph := engine.BuildStackGraph(h.eng, engine.SortStrategySmart, nil)
-
-	// Collect all branch names across all stacks for a single batched CI check
-	var allBranches []string
-	for _, stack := range stacks {
-		allBranches = append(allBranches, stack.AllBranches...)
-	}
-
-	var checksMap map[string]*github.CheckStatus
-	if h.gh != nil && len(allBranches) > 0 {
-		checksMap, _ = h.gh.BatchGetPRChecksStatus(r.Context(), allBranches)
-	}
-
-	// Map all stack details using the shared checks map
-	details := make([]httpcontract.StackDetail, 0, len(stacks))
-	for _, stack := range stacks {
-		detail := httpcontract.MapStackDetail(h.eng, graph, stack.RootBranch, stack.AllBranches, stack.PRCount, stack.Scope, checksMap)
-		details = append(details, detail)
-	}
-
-	writeJSON(w, httpcontract.ViewResponse{
-		Repo:   repoResp,
-		Stacks: details,
-	})
+	writeJSON(w, view)
 }

--- a/internal/api/handlers/view_assembler.go
+++ b/internal/api/handlers/view_assembler.go
@@ -1,0 +1,101 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"stackit.dev/stackit/internal/actions/merge"
+	httpcontract "stackit.dev/stackit/internal/contracts/http"
+	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/github"
+)
+
+// ViewAssembler builds the combined /view payload.
+type ViewAssembler struct {
+	eng    engine.BranchReader
+	gh     github.Client
+	remote string
+}
+
+func NewViewAssembler(eng engine.BranchReader, gh github.Client, remote string) *ViewAssembler {
+	return &ViewAssembler{
+		eng:    eng,
+		gh:     gh,
+		remote: remote,
+	}
+}
+
+func (a *ViewAssembler) Build(ctx context.Context) (httpcontract.ViewResponse, error) {
+	stacks, err := merge.DiscoverStacksWithSort(a.eng, engine.SortStrategySmart)
+	if err != nil {
+		return httpcontract.ViewResponse{}, fmt.Errorf("failed to discover stacks: %w", err)
+	}
+
+	graph := engine.BuildStackGraph(a.eng, engine.SortStrategySmart, nil)
+	checksMap := a.fetchChecks(ctx, stacks)
+	details := a.mapStackDetails(graph, stacks, checksMap)
+
+	recentlyMerged := a.fetchRecentlyMerged()
+
+	return httpcontract.ViewResponse{
+		Repo:           a.buildRepo(ctx),
+		Stacks:         details,
+		RecentlyMerged: recentlyMerged,
+	}, nil
+}
+
+func (a *ViewAssembler) buildRepo(ctx context.Context) httpcontract.RepoResponse {
+	owner, repo := "", ""
+	var currentUser string
+	if a.gh != nil {
+		owner, repo = a.gh.GetOwnerRepo()
+		currentUser, _ = a.gh.GetCurrentUser(ctx)
+	}
+
+	return httpcontract.RepoResponse{
+		Owner:         owner,
+		Repo:          repo,
+		Trunk:         a.eng.Trunk().GetName(),
+		CurrentBranch: a.eng.CurrentBranch().GetName(),
+		Remote:        a.remote,
+		CurrentUser:   currentUser,
+	}
+}
+
+func (a *ViewAssembler) fetchChecks(ctx context.Context, stacks []merge.MultiStackInfo) map[string]*github.CheckStatus {
+	if a.gh == nil {
+		return nil
+	}
+
+	var allBranches []string
+	for _, stack := range stacks {
+		allBranches = append(allBranches, stack.AllBranches...)
+	}
+	if len(allBranches) == 0 {
+		return nil
+	}
+
+	checksMap, _ := a.gh.BatchGetPRChecksStatus(ctx, allBranches)
+	return checksMap
+}
+
+func (a *ViewAssembler) mapStackDetails(
+	graph *engine.StackGraph,
+	stacks []merge.MultiStackInfo,
+	checksMap map[string]*github.CheckStatus,
+) []httpcontract.StackDetail {
+	details := make([]httpcontract.StackDetail, 0, len(stacks))
+	for _, stack := range stacks {
+		detail := httpcontract.MapStackDetail(a.eng, graph, stack.RootBranch, stack.AllBranches, stack.PRCount, stack.Scope, checksMap)
+		details = append(details, detail)
+	}
+	return details
+}
+
+func (a *ViewAssembler) fetchRecentlyMerged() []httpcontract.TrunkCommitResponse {
+	recentCommits, err := a.eng.GetRecentTrunkCommits(10)
+	if err != nil || len(recentCommits) == 0 {
+		return nil
+	}
+	return httpcontract.MapTrunkCommits(recentCommits)
+}

--- a/internal/app/context_test.go
+++ b/internal/app/context_test.go
@@ -75,7 +75,7 @@ func (f *fakeGitHubClient) GetPullRequest(_ context.Context, _, _ string, _ int)
 	return nil, nil
 }
 
-func (f *fakeGitHubClient) MergePullRequest(_ context.Context, _ string, _ github.MergeMethod) error {
+func (f *fakeGitHubClient) MergePullRequest(_ context.Context, _ string, _ github.MergePROptions) error {
 	return nil
 }
 

--- a/internal/cli/stack/merge/orchestrate.go
+++ b/internal/cli/stack/merge/orchestrate.go
@@ -59,7 +59,7 @@ func (d *defaultPRMergeAPI) getMergeableState(ctx context.Context, runner git.Ru
 }
 
 func (d *defaultPRMergeAPI) enableAutoMerge(ctx context.Context, runner git.Runner, prNodeID string, method github.MergeMethod) error {
-	return github.EnableAutoMerge(ctx, runner, prNodeID, method)
+	return github.EnableAutoMerge(ctx, runner, prNodeID, github.EnableAutoMergeOptions{MergeMethod: method})
 }
 
 func (d *defaultPRMergeAPI) waitForPRMerge(ctx context.Context, runner git.Runner, prNodeID string, timeout, interval time.Duration) error {
@@ -71,7 +71,7 @@ func (d *defaultPRMergeAPI) waitForMergeable(ctx context.Context, runner git.Run
 }
 
 func (d *defaultPRMergeAPI) mergePR(ctx context.Context, branchName string, method github.MergeMethod) error {
-	return d.client.MergePullRequest(ctx, branchName, method)
+	return d.client.MergePullRequest(ctx, branchName, github.MergePROptions{Method: method})
 }
 
 // orchestrateMerge implements a 3-tier merge strategy:

--- a/internal/cli/stack/merge/ship.go
+++ b/internal/cli/stack/merge/ship.go
@@ -318,7 +318,7 @@ func runMultiStackShip(ctx *app.Context, opts shipMultiStackOptions) error {
 				out.Warn("Could not determine merge method: %v", methodErr)
 				out.Tip("Enable automerge manually on the PR: %s", result.PRURL)
 			} else {
-				if err := github.EnableAutoMerge(ctx.Context, ctx.Engine.Git(), prNodeID, mergeMethod); err != nil {
+				if err := github.EnableAutoMerge(ctx.Context, ctx.Engine.Git(), prNodeID, github.EnableAutoMergeOptions{MergeMethod: mergeMethod}); err != nil {
 					out.Warn("Could not enable automerge: %v", err)
 					out.Tip("Enable automerge manually on the PR: %s", result.PRURL)
 				} else {

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/git"
 	"stackit.dev/stackit/internal/github"
 )
 
@@ -254,4 +255,33 @@ func computeStackStatus(graph *engine.StackGraph, branchNames []string) string {
 	default:
 		return "shippable"
 	}
+}
+
+// MapTrunkCommits converts git RecentCommit values to API TrunkCommitResponse values.
+// Parsing/normalization is done in the git layer; this function maps fields.
+func MapTrunkCommits(commits []git.RecentCommit) []TrunkCommitResponse {
+	result := make([]TrunkCommitResponse, 0, len(commits))
+	for _, c := range commits {
+		resp := TrunkCommitResponse{
+			SHA:        shortSHA(c.SHA),
+			Message:    c.Subject,
+			Author:     c.Author,
+			Date:       c.Date.Format(time.RFC3339),
+			PRNumber:   c.PRNumber,
+			Kind:       string(c.Kind),
+			StackSize:  c.StackSize,
+			StackPRs:   append([]int(nil), c.StackPRNumbers...),
+			StackScope: c.StackScope,
+		}
+
+		if resp.Kind == "" {
+			resp.Kind = TrunkCommitKindRegular
+			if c.StackSize > 0 {
+				resp.Kind = TrunkCommitKindStackMerge
+			}
+		}
+
+		result = append(result, resp)
+	}
+	return result
 }

--- a/internal/contracts/http/mappers_test.go
+++ b/internal/contracts/http/mappers_test.go
@@ -1,0 +1,72 @@
+package httpcontract
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"stackit.dev/stackit/internal/git"
+)
+
+func TestMapTrunkCommits(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	commits := []git.RecentCommit{
+		{
+			SHA:            "1234567890abcdef",
+			Subject:        "Consolidate auth stack",
+			Author:         "alice",
+			Date:           now,
+			PRNumber:       123,
+			Kind:           git.RecentCommitKindStackMerge,
+			StackSize:      2,
+			StackPRNumbers: []int{45, 46},
+			StackScope:     "PROJ-1",
+		},
+		{
+			SHA:     "abcdef1234567890",
+			Subject: "Fix typo",
+			Author:  "bob",
+			Date:    now,
+			Kind:    git.RecentCommitKindRegular,
+		},
+	}
+
+	got := MapTrunkCommits(commits)
+	require.Len(t, got, 2)
+
+	require.Equal(t, "1234567", got[0].SHA)
+	require.Equal(t, "Consolidate auth stack", got[0].Message)
+	require.Equal(t, "alice", got[0].Author)
+	require.Equal(t, now.Format(time.RFC3339), got[0].Date)
+	require.Equal(t, 123, got[0].PRNumber)
+	require.Equal(t, TrunkCommitKindStackMerge, got[0].Kind)
+	require.Equal(t, 2, got[0].StackSize)
+	require.Equal(t, []int{45, 46}, got[0].StackPRs)
+	require.Equal(t, "PROJ-1", got[0].StackScope)
+
+	require.Equal(t, "abcdef1", got[1].SHA)
+	require.Equal(t, TrunkCommitKindRegular, got[1].Kind)
+	require.Equal(t, 0, got[1].PRNumber)
+	require.Empty(t, got[1].StackPRs)
+}
+
+func TestMapTrunkCommits_DefaultKindFallback(t *testing.T) {
+	t.Parallel()
+
+	commits := []git.RecentCommit{
+		{
+			SHA:       "1234567890abcdef",
+			Subject:   "Consolidate stack",
+			Author:    "alice",
+			Date:      time.Now().UTC(),
+			StackSize: 3,
+		},
+	}
+
+	got := MapTrunkCommits(commits)
+	require.Len(t, got, 1)
+	require.Equal(t, TrunkCommitKindStackMerge, got[0].Kind)
+}

--- a/internal/contracts/http/responses.go
+++ b/internal/contracts/http/responses.go
@@ -9,8 +9,30 @@ package httpcontract
 // It bundles repo metadata and all stack details into a single payload
 // to avoid N+1 API calls.
 type ViewResponse struct {
-	Repo   RepoResponse  `json:"repo"`
-	Stacks []StackDetail `json:"stacks"`
+	Repo           RepoResponse          `json:"repo"`
+	Stacks         []StackDetail         `json:"stacks"`
+	RecentlyMerged []TrunkCommitResponse `json:"recentlyMerged,omitempty"`
+}
+
+const (
+	// TrunkCommitKindRegular is a normal non-stack merge trunk commit.
+	TrunkCommitKindRegular = "regular"
+	// TrunkCommitKindStackMerge is a stack consolidation merge commit.
+	TrunkCommitKindStackMerge = "stack-merge"
+)
+
+// TrunkCommitResponse represents a commit on the trunk branch,
+// optionally enriched with stack metadata from git trailers.
+type TrunkCommitResponse struct {
+	SHA        string `json:"sha"`
+	Message    string `json:"message"`
+	Author     string `json:"author"`
+	Date       string `json:"date"`
+	Kind       string `json:"kind"`
+	PRNumber   int    `json:"prNumber,omitempty"`
+	StackSize  int    `json:"stackSize,omitempty"`
+	StackPRs   []int  `json:"stackPRs,omitempty"`
+	StackScope string `json:"stackScope,omitempty"`
 }
 
 // RepoResponse contains repository metadata.

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -425,6 +425,10 @@ func (d *demoGitRunner) GetCommitLog(_, _ string) (string, error) {
 	return "demo commit", nil
 }
 
+func (d *demoGitRunner) GetRecentCommits(_ string, _ int) ([]git.RecentCommit, error) {
+	return nil, nil
+}
+
 func (d *demoGitRunner) GetStatusPorcelain(_ context.Context) (string, error) {
 	return "M  test.txt", nil
 }

--- a/internal/demo/demo_github_client.go
+++ b/internal/demo/demo_github_client.go
@@ -114,7 +114,7 @@ func (c *GitHubClient) GetPullRequest(_ context.Context, _, _ string, prNumber i
 }
 
 // MergePullRequest simulates merging a pull request using the specified merge method
-func (c *GitHubClient) MergePullRequest(_ context.Context, branchName string, _ github.MergeMethod) error {
+func (c *GitHubClient) MergePullRequest(_ context.Context, branchName string, _ github.MergePROptions) error {
 	simulateDelay(delayMedium)
 
 	if pr, ok := c.prs[branchName]; ok {

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"stackit.dev/stackit/internal/git"
 )
 
 // GetCommitDate returns the commit date for a branch
@@ -163,6 +165,12 @@ func (e *engineImpl) PreloadBranchData() {
 	if len(branches) > 0 {
 		e.batchReadMetadata(branches)
 	}
+}
+
+// GetRecentTrunkCommits returns the most recent commits on the trunk branch,
+// including any stack trailer metadata embedded in consolidation merge commits.
+func (e *engineImpl) GetRecentTrunkCommits(count int) ([]git.RecentCommit, error) {
+	return e.git.GetRecentCommits(e.trunk, count)
 }
 
 // GetAllCommits returns commits for a branch in various formats

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -65,6 +65,7 @@ type BranchInfo interface {
 	GetRevisionForName(branchName string) (string, error)
 	BatchGetRevisions(branchNames []string) (map[string]string, []error)
 	GetCurrentRevision(ctx context.Context) (string, error)
+	GetRecentTrunkCommits(count int) ([]git.RecentCommit, error)
 	GetReflog(ctx context.Context, count int, format string) (string, error)
 	// GetDivergencePoint returns the divergence point of a branch from its parent.
 	// Returns the ParentBranchRevision from metadata if valid, otherwise the parent's current revision.

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -85,6 +85,7 @@ type CommitReader interface {
 	GetCommitHistorySHAs(branchName string) ([]string, error)
 	GetCommitSHA(branchName string, offset int) (string, error)
 	GetCommitLog(sha, format string) (string, error)
+	GetRecentCommits(branchName string, count int) ([]RecentCommit, error)
 	GetCommitTemplate(ctx context.Context) (string, error)
 	GetParentCommitSHA(commitSHA string) (string, error)
 }

--- a/internal/git/recent_commits.go
+++ b/internal/git/recent_commits.go
@@ -1,0 +1,154 @@
+package git
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const trailerValueSeparator = "\x1e"
+
+var prNumberSuffixRe = regexp.MustCompile(`\(#(\d+)\)\s*$`)
+
+// RecentCommitKind describes the presentation type of a trunk commit.
+type RecentCommitKind string
+
+const (
+	RecentCommitKindRegular    RecentCommitKind = "regular"
+	RecentCommitKindStackMerge RecentCommitKind = "stack-merge"
+)
+
+// RecentCommit represents a commit from the git log with optional stack trailer metadata.
+type RecentCommit struct {
+	SHA            string
+	Subject        string
+	Author         string
+	Date           time.Time
+	PRNumber       int              // parsed from subject suffix "(#123)" if present
+	Kind           RecentCommitKind // derived from trailer metadata
+	StackSize      int              // from Stackit-Stack-Size trailer (0 if absent)
+	StackPRNumbers []int            // from Stackit-PRs trailer
+	StackScope     string           // from Stackit-Scope trailer (empty if absent)
+}
+
+// GetRecentCommits returns the most recent commits from a branch, including stack trailer metadata.
+// Uses git log with a custom format string that includes trailer values.
+func (r *runner) GetRecentCommits(branchName string, count int) ([]RecentCommit, error) {
+	// Format: SHA\x1fsubject\x1fauthor\x1fdate\x1fstack-size\x1fprs\x1fscope
+	// Use a non-empty trailer separator so duplicate keys remain parseable.
+	format := "%H\x1f%s\x1f%an\x1f%aI\x1f%(trailers:key=Stackit-Stack-Size,valueonly,separator=%x1e)\x1f%(trailers:key=Stackit-PRs,valueonly,separator=%x1e)\x1f%(trailers:key=Stackit-Scope,valueonly,separator=%x1e)"
+
+	output, err := r.runGitCommandInternal("log", fmt.Sprintf("-%d", count), "--format="+format, branchName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recent commits for %s: %w", branchName, err)
+	}
+
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return nil, nil
+	}
+
+	var commits []RecentCommit
+	for line := range strings.SplitSeq(output, "\n") {
+		if line == "" {
+			continue
+		}
+
+		fields := strings.SplitN(line, "\x1f", 7)
+		if len(fields) < 4 {
+			continue
+		}
+
+		commit := RecentCommit{
+			SHA:     fields[0],
+			Subject: fields[1],
+			Author:  fields[2],
+		}
+
+		if date, parseErr := time.Parse(time.RFC3339, fields[3]); parseErr == nil {
+			commit.Date = date
+		}
+
+		if len(fields) > 4 {
+			commit.StackSize = parseStackSizeTrailer(fields[4])
+		}
+
+		if len(fields) > 5 {
+			commit.StackPRNumbers = parseStackPRsTrailer(fields[5])
+		}
+
+		if len(fields) > 6 {
+			commit.StackScope = parseStackScopeTrailer(fields[6])
+		}
+
+		commit.PRNumber = parsePRNumberFromSubject(commit.Subject)
+		commit.Kind = deriveRecentCommitKind(commit)
+
+		commits = append(commits, commit)
+	}
+
+	return commits, nil
+}
+
+func parseStackSizeTrailer(raw string) int {
+	for value := range strings.SplitSeq(raw, trailerValueSeparator) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if n, err := strconv.Atoi(value); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+func parseStackPRsTrailer(raw string) []int {
+	var prNumbers []int
+	for value := range strings.SplitSeq(raw, trailerValueSeparator) {
+		for part := range strings.SplitSeq(value, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			n, err := strconv.Atoi(part)
+			if err != nil || slices.Contains(prNumbers, n) {
+				continue
+			}
+			prNumbers = append(prNumbers, n)
+		}
+	}
+	return prNumbers
+}
+
+func parseStackScopeTrailer(raw string) string {
+	for value := range strings.SplitSeq(raw, trailerValueSeparator) {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func parsePRNumberFromSubject(subject string) int {
+	matches := prNumberSuffixRe.FindStringSubmatch(subject)
+	if len(matches) < 2 {
+		return 0
+	}
+	n, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func deriveRecentCommitKind(commit RecentCommit) RecentCommitKind {
+	if commit.StackSize > 0 {
+		return RecentCommitKindStackMerge
+	}
+	return RecentCommitKindRegular
+}

--- a/internal/git/recent_commits_test.go
+++ b/internal/git/recent_commits_test.go
@@ -1,0 +1,132 @@
+package git_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"stackit.dev/stackit/internal/git"
+	"stackit.dev/stackit/testhelpers"
+)
+
+func TestGetRecentCommits_DuplicateTrailers(t *testing.T) {
+	t.Parallel()
+	scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+		return s.Repo.CreateChangeAndCommit("initial", "init")
+	})
+
+	err := scene.Repo.CreateChange("change", "dup", false)
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand("add", ".")
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand(
+		"commit",
+		"-m", "Consolidate stack [PROJ-123]",
+		"-m", "Stackit-Stack-Size: 2\nStackit-Stack-Size: 2\nStackit-PRs: 1,2\nStackit-PRs: 1,2\nStackit-Scope: PROJ-123\nStackit-Scope: PROJ-123",
+	)
+	require.NoError(t, err)
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	commits, err := runner.GetRecentCommits("main", 1)
+	require.NoError(t, err)
+	require.Len(t, commits, 1)
+
+	require.Equal(t, 2, commits[0].StackSize)
+	require.Equal(t, []int{1, 2}, commits[0].StackPRNumbers)
+	require.Equal(t, "PROJ-123", commits[0].StackScope)
+	require.Equal(t, git.RecentCommitKindStackMerge, commits[0].Kind)
+}
+
+func TestGetRecentCommits_WithoutTrailers(t *testing.T) {
+	t.Parallel()
+	scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+		return s.Repo.CreateChangeAndCommit("initial", "init")
+	})
+
+	err := scene.Repo.CreateChange("file1", "content1", false)
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand("add", ".")
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand("commit", "-m", "Regular commit without trailers")
+	require.NoError(t, err)
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	commits, err := runner.GetRecentCommits("main", 1)
+	require.NoError(t, err)
+	require.Len(t, commits, 1)
+
+	require.Equal(t, "Regular commit without trailers", commits[0].Subject)
+	require.Equal(t, 0, commits[0].StackSize)
+	require.Empty(t, commits[0].StackPRNumbers)
+	require.Equal(t, "", commits[0].StackScope)
+	require.Equal(t, git.RecentCommitKindRegular, commits[0].Kind)
+}
+
+func TestGetRecentCommits_MultipleCommits(t *testing.T) {
+	t.Parallel()
+	scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+		return s.Repo.CreateChangeAndCommit("initial", "init")
+	})
+
+	// Create a regular commit
+	err := scene.Repo.CreateChange("file1", "content1", false)
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand("add", ".")
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand("commit", "-m", "First commit")
+	require.NoError(t, err)
+
+	// Create a commit with trailers
+	err = scene.Repo.CreateChange("file2", "content2", false)
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand("add", ".")
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand(
+		"commit",
+		"-m", "Consolidate stack",
+		"-m", "Stackit-Stack-Size: 3\nStackit-PRs: 10,20,30\nStackit-Scope: FEAT-1",
+	)
+	require.NoError(t, err)
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	commits, err := runner.GetRecentCommits("main", 3)
+	require.NoError(t, err)
+	require.Len(t, commits, 3)
+
+	// Most recent first (commit with trailers)
+	require.Equal(t, "Consolidate stack", commits[0].Subject)
+	require.Equal(t, 3, commits[0].StackSize)
+	require.Equal(t, []int{10, 20, 30}, commits[0].StackPRNumbers)
+	require.Equal(t, "FEAT-1", commits[0].StackScope)
+	require.Equal(t, git.RecentCommitKindStackMerge, commits[0].Kind)
+
+	// Second commit (no trailers)
+	require.Equal(t, "First commit", commits[1].Subject)
+	require.Equal(t, 0, commits[1].StackSize)
+	require.Empty(t, commits[1].StackPRNumbers)
+	require.Equal(t, git.RecentCommitKindRegular, commits[1].Kind)
+
+	// Initial commit
+	require.Equal(t, "initial", commits[2].Subject)
+}
+
+func TestGetRecentCommits_ParsesPRNumberSuffix(t *testing.T) {
+	t.Parallel()
+	scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+		return s.Repo.CreateChangeAndCommit("initial", "init")
+	})
+
+	err := scene.Repo.CreateChange("file1", "content1", false)
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand("add", ".")
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand("commit", "-m", "Add status badge (#123)")
+	require.NoError(t, err)
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	commits, err := runner.GetRecentCommits("main", 1)
+	require.NoError(t, err)
+	require.Len(t, commits, 1)
+	require.Equal(t, 123, commits[0].PRNumber)
+	require.Equal(t, git.RecentCommitKindRegular, commits[0].Kind)
+}

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -416,6 +416,13 @@ func (t *tracingRunner) GetCommitLog(sha, format string) (string, error) {
 	return result, err
 }
 
+func (t *tracingRunner) GetRecentCommits(branchName string, count int) ([]RecentCommit, error) {
+	start := time.Now()
+	result, err := t.inner.GetRecentCommits(branchName, count)
+	t.trace("GetRecentCommits", time.Since(start), err == nil, err, slog.String("branch", branchName), slog.Int("count", count))
+	return result, err
+}
+
 func (t *tracingRunner) GetCommitTemplate(ctx context.Context) (string, error) {
 	start := time.Now()
 	result, err := t.inner.GetCommitTemplate(ctx)

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -70,6 +70,12 @@ type MergeMethodSettings struct {
 	AllowRebaseMerge bool
 }
 
+// MergePROptions configures how a pull request should be merged.
+type MergePROptions struct {
+	Method     MergeMethod
+	CommitBody string // Optional commit body for merge/squash commit message.
+}
+
 // Client is an interface for GitHub API interactions
 type Client interface {
 	// CreatePullRequest creates a new pull request
@@ -86,7 +92,7 @@ type Client interface {
 	GetPullRequest(ctx context.Context, owner, repo string, prNumber int) (*PullRequestInfo, error)
 
 	// MergePullRequest merges a pull request using the specified merge method
-	MergePullRequest(ctx context.Context, branchName string, method MergeMethod) error
+	MergePullRequest(ctx context.Context, branchName string, opts MergePROptions) error
 
 	// GetAllowedMergeMethods returns the allowed merge methods for the repository
 	GetAllowedMergeMethods(ctx context.Context) (*MergeMethodSettings, error)

--- a/internal/github/client_real.go
+++ b/internal/github/client_real.go
@@ -137,8 +137,8 @@ func (c *StackitGitHubClient) GetPullRequest(ctx context.Context, owner, repo st
 }
 
 // MergePullRequest merges a pull request using the specified merge method
-func (c *StackitGitHubClient) MergePullRequest(ctx context.Context, branchName string, method MergeMethod) error {
-	return MergePullRequest(ctx, c.client, c.owner, c.repo, branchName, method)
+func (c *StackitGitHubClient) MergePullRequest(ctx context.Context, branchName string, opts MergePROptions) error {
+	return MergePullRequest(ctx, c.client, c.owner, c.repo, branchName, opts)
 }
 
 // GetAllowedMergeMethods returns the allowed merge methods for the repository

--- a/internal/github/pr_operations.go
+++ b/internal/github/pr_operations.go
@@ -275,8 +275,10 @@ func ParseReviewers(reviewersStr string) ([]string, []string) {
 	return reviewers, teamReviewers
 }
 
-// MergePullRequest merges a pull request using the GitHub API
-func MergePullRequest(ctx context.Context, client *github.Client, owner, repo, branchName string, method MergeMethod) error {
+// MergePullRequest merges a pull request using the GitHub API.
+// If opts.CommitBody is set, it is used as an additional commit message body
+// for merge/squash strategies.
+func MergePullRequest(ctx context.Context, client *github.Client, owner, repo, branchName string, opts MergePROptions) error {
 	// First, get the PR for this branch
 	pr, err := GetPullRequestByBranch(ctx, client, owner, repo, branchName)
 	if err != nil {
@@ -288,11 +290,11 @@ func MergePullRequest(ctx context.Context, client *github.Client, owner, repo, b
 
 	// Merge the PR using the specified method
 	mergeRequest := &github.PullRequestOptions{
-		MergeMethod: string(method),
+		MergeMethod: string(opts.Method),
 	}
-	_, _, err = client.PullRequests.Merge(ctx, owner, repo, *pr.Number, "", mergeRequest)
+	_, _, err = client.PullRequests.Merge(ctx, owner, repo, *pr.Number, opts.CommitBody, mergeRequest)
 	if err != nil {
-		return fmt.Errorf("failed to merge PR #%d for branch %s using %s: %w", *pr.Number, branchName, method, err)
+		return fmt.Errorf("failed to merge PR #%d for branch %s using %s: %w", *pr.Number, branchName, opts.Method, err)
 	}
 	return nil
 }
@@ -388,25 +390,52 @@ type AutoMergeStatus struct {
 	MergeMethod string
 }
 
+// EnableAutoMergeOptions contains options for enabling auto-merge on a PR.
+type EnableAutoMergeOptions struct {
+	MergeMethod MergeMethod
+	CommitBody  string // optional — omit for default GitHub behavior
+}
+
 // EnableAutoMerge enables GitHub's auto-merge feature on a PR.
 // This requires the repository to have auto-merge enabled in settings.
-func EnableAutoMerge(ctx context.Context, runner git.Runner, prNodeID string, mergeMethod MergeMethod) error {
-	mutation := `mutation EnableAutoMerge($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
-		enablePullRequestAutoMerge(input: {
-			pullRequestId: $pullRequestId
-			mergeMethod: $mergeMethod
-		}) {
-			pullRequest {
-				autoMergeRequest {
-					enabledAt
+func EnableAutoMerge(ctx context.Context, runner git.Runner, prNodeID string, opts EnableAutoMergeOptions) error {
+	// We use two separate mutations because GitHub's GraphQL API treats
+	// `commitBody: null` differently from omitting commitBody entirely.
+	// When omitted, GitHub uses its default commit message (e.g., PR body).
+	// When explicitly set to null, it may override that default to empty.
+	var mutation string
+	if opts.CommitBody != "" {
+		mutation = `mutation EnableAutoMerge($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!, $commitBody: String) {
+			enablePullRequestAutoMerge(input: {
+				pullRequestId: $pullRequestId
+				mergeMethod: $mergeMethod
+				commitBody: $commitBody
+			}) {
+				pullRequest {
+					autoMergeRequest {
+						enabledAt
+					}
 				}
 			}
-		}
-	}`
+		}`
+	} else {
+		mutation = `mutation EnableAutoMerge($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+			enablePullRequestAutoMerge(input: {
+				pullRequestId: $pullRequestId
+				mergeMethod: $mergeMethod
+			}) {
+				pullRequest {
+					autoMergeRequest {
+						enabledAt
+					}
+				}
+			}
+		}`
+	}
 
 	// Convert our MergeMethod to GitHub's GraphQL enum format
 	var graphqlMethod string
-	switch mergeMethod {
+	switch opts.MergeMethod {
 	case MergeMethodMerge:
 		graphqlMethod = "MERGE"
 	case MergeMethodSquash:
@@ -420,6 +449,9 @@ func EnableAutoMerge(ctx context.Context, runner git.Runner, prNodeID string, me
 	variables := map[string]any{
 		"pullRequestId": prNodeID,
 		"mergeMethod":   graphqlMethod,
+	}
+	if opts.CommitBody != "" {
+		variables["commitBody"] = opts.CommitBody
 	}
 
 	_, err := executeGraphQLQuery(ctx, runner, mutation, variables)

--- a/internal/pr/merge.go
+++ b/internal/pr/merge.go
@@ -66,6 +66,10 @@ type MergeBodyParams struct {
 	// StackDescription is the description of the stack being merged.
 	// Optional - if present, it appears at the top of the body.
 	StackDescription *git.StackDescription
+
+	// Metadata is stack metadata for trailers.
+	// Optional - if StackSize is zero, metadata is derived from Branches.
+	Metadata StackMetadata
 }
 
 // MergeBranch represents a branch being merged.
@@ -121,6 +125,17 @@ func FormatMergeBody(params MergeBodyParams) string {
 		body.WriteString("```\n")
 		body.WriteString(params.StackTree)
 		body.WriteString("```\n")
+	}
+
+	// Append stack trailers as a fallback for repos whose squash merge commit
+	// message setting uses "PR body". Trailers survive automatically in that case.
+	if len(params.Branches) > 0 {
+		metadata := params.Metadata
+		if metadata.StackSize == 0 {
+			metadata = BuildStackMetadata(params.Branches, metadata.Scope)
+		}
+		body.WriteString("\n")
+		body.WriteString(metadata.ToTrailers())
 	}
 
 	return body.String()

--- a/internal/pr/merge_test.go
+++ b/internal/pr/merge_test.go
@@ -116,6 +116,9 @@ func TestFormatMergeBody(t *testing.T) {
 main
   └─ feature-a (#123)
 ` + "```" + `
+
+Stackit-Stack-Size: 1
+Stackit-PRs: 123
 `
 		assert.Equal(t, expected, result)
 	})
@@ -141,6 +144,9 @@ main
   └─ feature-a (#1)
     └─ feature-a-1 (#2)
 ` + "```" + `
+
+Stackit-Stack-Size: 2
+Stackit-PRs: 1,2
 `
 		assert.Equal(t, expected, result)
 	})
@@ -163,6 +169,8 @@ main
 main
   └─ feature-a
 ` + "```" + `
+
+Stackit-Stack-Size: 1
 `
 		assert.Equal(t, expected, result)
 	})
@@ -194,6 +202,9 @@ main
 main
   └─ feature-a (#1)
 ` + "```" + `
+
+Stackit-Stack-Size: 1
+Stackit-PRs: 1
 `
 		assert.Equal(t, expected, result)
 	})
@@ -208,6 +219,9 @@ main
 		expected := `This PR merges the following changes:
 
 1. **#1** Add feature A
+
+Stackit-Stack-Size: 1
+Stackit-PRs: 1
 `
 		assert.Equal(t, expected, result)
 	})
@@ -222,6 +236,7 @@ main
 				Title:       "Add user authentication",
 				Description: "This stack implements JWT-based auth.",
 			},
+			Metadata: StackMetadata{Scope: "PROJ-123"},
 		})
 
 		expected := `**Add user authentication**
@@ -238,6 +253,10 @@ This PR merges the following changes:
 main
   └─ feature-a (#1)
 ` + "```" + `
+
+Stackit-Stack-Size: 1
+Stackit-PRs: 1
+Stackit-Scope: PROJ-123
 `
 		assert.Equal(t, expected, result)
 	})
@@ -251,6 +270,7 @@ main
 			StackDescription: &git.StackDescription{
 				Title: "Add user authentication",
 			},
+			Metadata: StackMetadata{Scope: "PROJ-456"},
 		})
 
 		expected := `**Add user authentication**
@@ -265,6 +285,10 @@ This PR merges the following changes:
 main
   └─ feature-a (#1)
 ` + "```" + `
+
+Stackit-Stack-Size: 1
+Stackit-PRs: 1
+Stackit-Scope: PROJ-456
 `
 		assert.Equal(t, expected, result)
 	})
@@ -289,6 +313,9 @@ main
 main
   └─ feature-a (#1)
 ` + "```" + `
+
+Stackit-Stack-Size: 1
+Stackit-PRs: 1
 `
 		assert.Equal(t, expected, result)
 	})

--- a/internal/pr/scope.go
+++ b/internal/pr/scope.go
@@ -1,0 +1,20 @@
+package pr
+
+// ResolveUnifiedScope returns a scope only when all non-empty scopes match.
+// This avoids mislabeling mixed-scope merge metadata.
+func ResolveUnifiedScope(scopes []string) string {
+	var selected string
+	for _, scope := range scopes {
+		if scope == "" {
+			continue
+		}
+		if selected == "" {
+			selected = scope
+			continue
+		}
+		if scope != selected {
+			return ""
+		}
+	}
+	return selected
+}

--- a/internal/pr/scope_test.go
+++ b/internal/pr/scope_test.go
@@ -1,0 +1,46 @@
+package pr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveUnifiedScope(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		scopes []string
+		want   string
+	}{
+		{
+			name:   "all empty",
+			scopes: []string{"", ""},
+			want:   "",
+		},
+		{
+			name:   "single non-empty scope",
+			scopes: []string{"", "PROJ-1", ""},
+			want:   "PROJ-1",
+		},
+		{
+			name:   "matching non-empty scopes",
+			scopes: []string{"PROJ-1", "PROJ-1"},
+			want:   "PROJ-1",
+		},
+		{
+			name:   "mixed scopes",
+			scopes: []string{"PROJ-1", "PROJ-2"},
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ResolveUnifiedScope(tt.scopes)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/pr/trailers.go
+++ b/internal/pr/trailers.go
@@ -1,0 +1,143 @@
+package pr
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Trailer key constants for stack metadata embedded in merge commits.
+const (
+	TrailerStackSize = "Stackit-Stack-Size"
+	TrailerPRs       = "Stackit-PRs"
+	TrailerScope     = "Stackit-Scope"
+)
+
+// StackMetadata contains stack metadata embedded in git trailers.
+type StackMetadata struct {
+	StackSize int
+	PRNumbers []int
+	Scope     string
+}
+
+// StackTrailerInfo is an alias kept for backwards compatibility.
+type StackTrailerInfo = StackMetadata
+
+// NewStackMetadata constructs stack metadata from explicit fields.
+func NewStackMetadata(stackSize int, prNumbers []int, scope string) StackMetadata {
+	return StackMetadata{
+		StackSize: stackSize,
+		PRNumbers: slicesClone(prNumbers),
+		Scope:     scope,
+	}
+}
+
+// BuildStackMetadata derives stack metadata from merge branches.
+func BuildStackMetadata(branches []MergeBranch, scope string) StackMetadata {
+	prNumbers := make([]int, 0, len(branches))
+	for _, branch := range branches {
+		if branch.PRNumber > 0 {
+			prNumbers = append(prNumbers, branch.PRNumber)
+		}
+	}
+
+	return NewStackMetadata(len(branches), prNumbers, scope)
+}
+
+// ToTrailers builds a git trailer block for this metadata.
+// The trailers follow the standard git trailer format (key: value) and can be
+// parsed by git log's %(trailers) format specifier.
+func (m StackMetadata) ToTrailers() string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "%s: %d\n", TrailerStackSize, m.StackSize)
+
+	if len(m.PRNumbers) > 0 {
+		prStrs := make([]string, len(m.PRNumbers))
+		for i, n := range m.PRNumbers {
+			prStrs[i] = strconv.Itoa(n)
+		}
+		fmt.Fprintf(&b, "%s: %s\n", TrailerPRs, strings.Join(prStrs, ","))
+	}
+
+	if m.Scope != "" {
+		fmt.Fprintf(&b, "%s: %s\n", TrailerScope, m.Scope)
+	}
+
+	return b.String()
+}
+
+// FormatStackTrailers is a compatibility wrapper around StackMetadata.ToTrailers.
+func FormatStackTrailers(stackSize int, prNumbers []int, scope string) string {
+	return NewStackMetadata(stackSize, prNumbers, scope).ToTrailers()
+}
+
+// ParseStackMetadataTrailers extracts stack trailer values from a commit message body.
+// Returns nil if no stack trailers are found.
+func ParseStackMetadataTrailers(body string) *StackMetadata {
+	info := &StackMetadata{}
+	found := false
+
+	for line := range strings.SplitSeq(body, "\n") {
+		line = strings.TrimSpace(line)
+
+		if val, ok := parseTrailer(line, TrailerStackSize); ok {
+			if n, err := strconv.Atoi(val); err == nil {
+				info.StackSize = n
+				found = true
+			}
+		}
+
+		if val, ok := parseTrailer(line, TrailerPRs); ok {
+			info.PRNumbers = parsePRNumbers(val)
+			if len(info.PRNumbers) > 0 {
+				found = true
+			}
+		}
+
+		if val, ok := parseTrailer(line, TrailerScope); ok {
+			info.Scope = val
+			found = true
+		}
+	}
+
+	if !found {
+		return nil
+	}
+	return info
+}
+
+// ParseStackTrailers is a compatibility wrapper around ParseStackMetadataTrailers.
+func ParseStackTrailers(body string) *StackTrailerInfo {
+	return ParseStackMetadataTrailers(body)
+}
+
+// parseTrailer checks if a line matches "Key: value" and returns the value.
+func parseTrailer(line, key string) (string, bool) {
+	prefix := key + ":"
+	if !strings.HasPrefix(line, prefix) {
+		return "", false
+	}
+	return strings.TrimSpace(line[len(prefix):]), true
+}
+
+// parsePRNumbers parses a comma-separated list of PR numbers.
+func parsePRNumbers(s string) []int {
+	var nums []int
+	for part := range strings.SplitSeq(s, ",") {
+		part = strings.TrimSpace(part)
+		if n, err := strconv.Atoi(part); err == nil {
+			nums = append(nums, n)
+		}
+	}
+	return nums
+}
+
+func slicesClone(in []int) []int {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]int, len(in))
+	copy(out, in)
+	return out
+}

--- a/internal/pr/trailers_test.go
+++ b/internal/pr/trailers_test.go
@@ -1,0 +1,109 @@
+package pr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatAndParseStackTrailers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		stackSize int
+		prNumbers []int
+		scope     string
+		wantSize  int
+		wantPRs   []int
+		wantScope string
+	}{
+		{
+			name:      "full trailers",
+			stackSize: 3,
+			prNumbers: []int{45, 46, 47},
+			scope:     "PROJ-123",
+			wantSize:  3,
+			wantPRs:   []int{45, 46, 47},
+			wantScope: "PROJ-123",
+		},
+		{
+			name:      "no scope",
+			stackSize: 2,
+			prNumbers: []int{10, 11},
+			scope:     "",
+			wantSize:  2,
+			wantPRs:   []int{10, 11},
+			wantScope: "",
+		},
+		{
+			name:      "no PR numbers",
+			stackSize: 1,
+			prNumbers: nil,
+			scope:     "FIX",
+			wantSize:  1,
+			wantPRs:   nil,
+			wantScope: "FIX",
+		},
+		{
+			name:      "single PR",
+			stackSize: 1,
+			prNumbers: []int{99},
+			scope:     "",
+			wantSize:  1,
+			wantPRs:   []int{99},
+			wantScope: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			formatted := FormatStackTrailers(tt.stackSize, tt.prNumbers, tt.scope)
+			info := ParseStackTrailers(formatted)
+
+			require.NotNil(t, info)
+			require.Equal(t, tt.wantSize, info.StackSize)
+			require.Equal(t, tt.wantPRs, info.PRNumbers)
+			require.Equal(t, tt.wantScope, info.Scope)
+		})
+	}
+}
+
+func TestParseStackTrailers_noTrailers(t *testing.T) {
+	t.Parallel()
+
+	info := ParseStackTrailers("Just a regular commit message\n\nWith some body text.")
+	require.Nil(t, info)
+}
+
+func TestParseStackTrailers_embeddedInCommitBody(t *testing.T) {
+	t.Parallel()
+
+	body := `Consolidate stack [PROJ-123]: feat-a, feat-b, feat-c
+
+This merges the following changes:
+1. feat-a (#45)
+2. feat-b (#46)
+3. feat-c (#47)
+
+Stackit-Stack-Size: 3
+Stackit-PRs: 45,46,47
+Stackit-Scope: PROJ-123`
+
+	info := ParseStackTrailers(body)
+	require.NotNil(t, info)
+	require.Equal(t, 3, info.StackSize)
+	require.Equal(t, []int{45, 46, 47}, info.PRNumbers)
+	require.Equal(t, "PROJ-123", info.Scope)
+}
+
+func TestFormatStackTrailers_format(t *testing.T) {
+	t.Parallel()
+
+	result := FormatStackTrailers(3, []int{1, 2, 3}, "SCOPE")
+	require.Contains(t, result, "Stackit-Stack-Size: 3")
+	require.Contains(t, result, "Stackit-PRs: 1,2,3")
+	require.Contains(t, result, "Stackit-Scope: SCOPE")
+}

--- a/testhelpers/github_mock_client.go
+++ b/testhelpers/github_mock_client.go
@@ -106,7 +106,7 @@ func (c *MockGitHubClient) GetPullRequest(ctx context.Context, owner, repo strin
 }
 
 // MergePullRequest merges a pull request using the specified merge method
-func (c *MockGitHubClient) MergePullRequest(_ context.Context, _ string, _ githubpkg.MergeMethod) error {
+func (c *MockGitHubClient) MergePullRequest(_ context.Context, _ string, _ githubpkg.MergePROptions) error {
 	// In tests, just return nil
 	return nil
 }


### PR DESCRIPTION
This PR merges the following changes:

1. **#777** feat: embed stack trailers in consolidation commits and add history view
2. **#778** refactor: clean up merge API signatures
3. **#779** fix: omit scope trailer on mixed-scope merges and fix duplicate trailer key parsing
4. **#780** fix: address code review feedback on stack trailers
5. **#781** refactor: extract stack metadata types and enrich RecentCommit fields

### Stack

```
main
  └─ jonnii/20260301023411/embed-stack-trailers-in-consolidation-commits-and (#777)
    └─ jonnii/20260301024335/clean-up-merge-API-signatures (#778)
      └─ jonnii/20260301030051/omit-scope-trailer-on-mixed-scope-merges-and-fix (#779)
        └─ jonnii/20260301031253/address-code-review-feedback-on-stack-trailers (#780)
          └─ jonnii/20260301032822/extract-stack-metadata-types-and-enrich (#781)
```

Stackit-Stack-Size: 5
Stackit-PRs: 777,778,779,780,781
