### PR TITLE
feat: improve recently merged commit history display

### DIFF
--- a/apps/web/src/components/recently-merged.tsx
+++ b/apps/web/src/components/recently-merged.tsx
@@ -1,7 +1,13 @@
 "use client";
 
-import { GitCommitHorizontal } from "lucide-react";
+import { useMemo } from "react";
+import { GitMerge } from "lucide-react";
 import { useRepo } from "@/components/providers/repo-provider";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 import type { TrunkCommitResponse } from "@/lib/api";
 
 function formatTimeAgo(dateStr: string): string {
@@ -21,7 +27,86 @@ function stripPRSuffix(message: string): string {
   return message.replace(/\s*\(#\d+\)\s*$/, "");
 }
 
-function TrunkCommitItem({
+function prUrl(owner: string, repo: string, pr: number): string {
+  return `https://github.com/${owner}/${repo}/pull/${pr}`;
+}
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length >= 2) return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  return name.slice(0, 2).toUpperCase();
+}
+
+type TimeGroup = "Today" | "Yesterday" | "This week" | "Earlier";
+
+function timeGroup(dateStr: string): TimeGroup {
+  const now = new Date();
+  const date = new Date(dateStr);
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const startOfYesterday = new Date(startOfToday.getTime() - 86_400_000);
+  const startOfWeek = new Date(startOfToday.getTime() - startOfToday.getDay() * 86_400_000);
+
+  if (date >= startOfToday) return "Today";
+  if (date >= startOfYesterday) return "Yesterday";
+  if (date >= startOfWeek) return "This week";
+  return "Earlier";
+}
+
+function groupCommits(
+  commits: TrunkCommitResponse[]
+): { label: TimeGroup; commits: TrunkCommitResponse[] }[] {
+  const order: TimeGroup[] = ["Today", "Yesterday", "This week", "Earlier"];
+  const map = new Map<TimeGroup, TrunkCommitResponse[]>();
+  for (const c of commits) {
+    const g = timeGroup(c.date);
+    const list = map.get(g);
+    if (list) {
+      list.push(c);
+    } else {
+      map.set(g, [c]);
+    }
+  }
+  return order.filter((l) => map.has(l)).map((l) => ({ label: l, commits: map.get(l)! }));
+}
+
+function AuthorAvatar({ name, sha }: { name: string; sha: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="flex items-center justify-center w-5 h-5 rounded-full bg-muted text-[9px] font-semibold text-muted-foreground shrink-0 select-none">
+          {initials(name)}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="left">
+        <span>{name}</span>
+        <span className="ml-2 font-mono text-muted-foreground">{sha}</span>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function PRLink({
+  pr,
+  owner,
+  repoName,
+}: {
+  pr: number;
+  owner: string;
+  repoName: string;
+}) {
+  return (
+    <a
+      href={prUrl(owner, repoName, pr)}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center text-[11px] font-mono font-medium text-muted-foreground hover:text-foreground bg-muted hover:bg-accent rounded px-1.5 py-0.5 transition-colors"
+    >
+      #{pr}
+    </a>
+  );
+}
+
+function RegularCommitItem({
   commit,
   owner,
   repoName,
@@ -33,26 +118,19 @@ function TrunkCommitItem({
   const displayMessage = stripPRSuffix(commit.message);
 
   return (
-    <div className="flex items-start gap-2 py-1.5 text-muted-foreground/70">
-      <GitCommitHorizontal className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-      <div className="flex-1 min-w-0 flex items-baseline gap-1.5">
-        <code className="text-[11px] font-mono shrink-0">{commit.sha}</code>
-        <span className="text-xs truncate" title={commit.message}>
-          {displayMessage}
-        </span>
-      </div>
+    <div className="flex items-center gap-2 py-1.5 group">
+      <AuthorAvatar name={commit.author} sha={commit.sha} />
+      <span
+        className="flex-1 min-w-0 text-xs text-foreground/80 truncate"
+        title={commit.message}
+      >
+        {displayMessage}
+      </span>
       <div className="flex items-center gap-1.5 shrink-0">
         {commit.prNumber && owner && repoName ? (
-          <a
-            href={`https://github.com/${owner}/${repoName}/pull/${commit.prNumber}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-[11px] font-mono text-muted-foreground/50 hover:text-foreground transition-colors"
-          >
-            #{commit.prNumber}
-          </a>
+          <PRLink pr={commit.prNumber} owner={owner} repoName={repoName} />
         ) : null}
-        <span className="text-[11px] text-muted-foreground/40">
+        <span className="text-[10px] text-muted-foreground/40 tabular-nums w-12 text-right">
           {formatTimeAgo(commit.date)}
         </span>
       </div>
@@ -60,25 +138,115 @@ function TrunkCommitItem({
   );
 }
 
+function StackMergeItem({
+  commit,
+  owner,
+  repoName,
+}: {
+  commit: TrunkCommitResponse;
+  owner?: string;
+  repoName?: string;
+}) {
+  const displayMessage = stripPRSuffix(commit.message);
+  const stackPRs = commit.stackPRs ?? [];
+
+  return (
+    <div className="border-l-2 border-purple-400/50 dark:border-purple-500/40 pl-3 py-1.5 my-0.5 rounded-r">
+      {/* Main commit line */}
+      <div className="flex items-center gap-2">
+        <AuthorAvatar name={commit.author} sha={commit.sha} />
+        <GitMerge className="h-3 w-3 shrink-0 text-purple-500 dark:text-purple-400" />
+        {commit.stackScope && (
+          <span className="text-[10px] font-mono text-purple-500/70 dark:text-purple-400/70 shrink-0">
+            {commit.stackScope}
+          </span>
+        )}
+        <span
+          className="flex-1 min-w-0 text-xs text-foreground/80 truncate"
+          title={commit.message}
+        >
+          {displayMessage}
+        </span>
+        <div className="flex items-center gap-1.5 shrink-0">
+          <span className="text-[10px] font-medium text-purple-600/70 dark:text-purple-400/60">
+            {commit.stackSize} PRs
+          </span>
+          <span className="text-[10px] text-muted-foreground/40 tabular-nums w-12 text-right">
+            {formatTimeAgo(commit.date)}
+          </span>
+        </div>
+      </div>
+
+      {/* Constituent PR links */}
+      {stackPRs.length > 0 && owner && repoName && (
+        <div className="flex items-center gap-1 mt-1.5 ml-7">
+          {stackPRs.map((pr) => (
+            <a
+              key={pr}
+              href={prUrl(owner, repoName, pr)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[10px] font-mono text-purple-500/60 dark:text-purple-400/50 hover:text-purple-600 dark:hover:text-purple-300 bg-purple-500/5 hover:bg-purple-500/10 rounded px-1.5 py-0.5 transition-colors"
+            >
+              #{pr}
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CommitItem({
+  commit,
+  owner,
+  repoName,
+}: {
+  commit: TrunkCommitResponse;
+  owner?: string;
+  repoName?: string;
+}) {
+  if (commit.kind === "stack-merge") {
+    return (
+      <StackMergeItem commit={commit} owner={owner} repoName={repoName} />
+    );
+  }
+  return (
+    <RegularCommitItem commit={commit} owner={owner} repoName={repoName} />
+  );
+}
+
 export function RecentlyMerged() {
   const { recentlyMerged, repo } = useRepo();
 
-  if (!recentlyMerged || recentlyMerged.length === 0) {
+  const groups = useMemo(
+    () => groupCommits(recentlyMerged ?? []),
+    [recentlyMerged]
+  );
+
+  if (groups.length === 0) {
     return null;
   }
 
   return (
-    <div className="px-6 pb-4">
-      <div className="space-y-0">
-        {recentlyMerged.map((commit) => (
-          <TrunkCommitItem
-            key={commit.sha}
-            commit={commit}
-            owner={repo?.owner}
-            repoName={repo?.repo}
-          />
-        ))}
-      </div>
+    <div className="px-6 pb-4 space-y-2">
+      {groups.map((group) => (
+        <div key={group.label}>
+          <div className="text-[10px] font-medium text-muted-foreground/50 uppercase tracking-wider mb-0.5">
+            {group.label}
+          </div>
+          <div>
+            {group.commits.map((commit) => (
+              <CommitItem
+                key={commit.sha}
+                commit={commit}
+                owner={repo?.owner}
+                repoName={repo?.repo}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -297,10 +297,28 @@ func computeStackStatus(graph *engine.StackGraph, branchNames []string) string {
 }
 
 // MapTrunkCommits converts git RecentCommit values to API TrunkCommitResponse values.
-// Parsing/normalization is done in the git layer; this function maps fields.
+// Commits whose PR number is already represented by a stack-merge's StackPRs are
+// filtered out so that consolidated stacks don't show duplicate entries.
 func MapTrunkCommits(commits []git.RecentCommit) []TrunkCommitResponse {
+	// Collect all PR numbers that are covered by stack-merge consolidation commits.
+	coveredPRs := make(map[int]struct{})
+	for _, c := range commits {
+		if c.StackSize > 0 {
+			for _, pr := range c.StackPRNumbers {
+				coveredPRs[pr] = struct{}{}
+			}
+		}
+	}
+
 	result := make([]TrunkCommitResponse, 0, len(commits))
 	for _, c := range commits {
+		// Skip commits whose PR is already represented by a stack-merge.
+		if c.PRNumber != 0 && c.StackSize == 0 {
+			if _, covered := coveredPRs[c.PRNumber]; covered {
+				continue
+			}
+		}
+
 		resp := TrunkCommitResponse{
 			SHA:        shortSHA(c.SHA),
 			Message:    c.Subject,

--- a/internal/contracts/http/mappers_test.go
+++ b/internal/contracts/http/mappers_test.go
@@ -53,6 +53,57 @@ func TestMapTrunkCommits(t *testing.T) {
 	require.Empty(t, got[1].StackPRs)
 }
 
+func TestMapTrunkCommits_FiltersCoveredPRs(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	commits := []git.RecentCommit{
+		{
+			SHA:            "aaaa000000000000",
+			Subject:        "Consolidate stack (#99)",
+			Author:         "alice",
+			Date:           now,
+			PRNumber:       99,
+			Kind:           git.RecentCommitKindStackMerge,
+			StackSize:      3,
+			StackPRNumbers: []int{45, 46, 47},
+		},
+		{
+			SHA:      "bbbb000000000000",
+			Subject:  "feat: add auth (#45)",
+			Author:   "alice",
+			Date:     now,
+			PRNumber: 45,
+			Kind:     git.RecentCommitKindRegular,
+		},
+		{
+			SHA:      "cccc000000000000",
+			Subject:  "feat: add middleware (#46)",
+			Author:   "alice",
+			Date:     now,
+			PRNumber: 46,
+			Kind:     git.RecentCommitKindRegular,
+		},
+		{
+			SHA:      "dddd000000000000",
+			Subject:  "unrelated fix (#50)",
+			Author:   "bob",
+			Date:     now,
+			PRNumber: 50,
+			Kind:     git.RecentCommitKindRegular,
+		},
+	}
+
+	got := MapTrunkCommits(commits)
+	require.Len(t, got, 2, "commits covered by stack-merge should be filtered out")
+
+	require.Equal(t, "aaaa000", got[0].SHA)
+	require.Equal(t, TrunkCommitKindStackMerge, got[0].Kind)
+
+	require.Equal(t, "dddd000", got[1].SHA)
+	require.Equal(t, "unrelated fix (#50)", got[1].Message)
+}
+
 func TestMapTrunkCommits_DefaultKindFallback(t *testing.T) {
 	t.Parallel()
 

--- a/internal/git/recent_commits.go
+++ b/internal/git/recent_commits.go
@@ -12,6 +12,7 @@ import (
 const trailerValueSeparator = "\x1e"
 
 var prNumberSuffixRe = regexp.MustCompile(`\(#(\d+)\)\s*$`)
+var mergeSubjectRe = regexp.MustCompile(`^Merge pull request #(\d+) from `)
 
 // RecentCommitKind describes the presentation type of a trunk commit.
 type RecentCommitKind string
@@ -36,12 +37,14 @@ type RecentCommit struct {
 
 // GetRecentCommits returns the most recent commits from a branch, including stack trailer metadata.
 // Uses git log with a custom format string that includes trailer values.
+// For merge commits ("Merge pull request #N from ..."), the subject is replaced with the
+// first line of the body, which contains the actual PR title.
 func (r *runner) GetRecentCommits(branchName string, count int) ([]RecentCommit, error) {
-	// Format: SHA\x1fsubject\x1fauthor\x1fdate\x1fstack-size\x1fprs\x1fscope
-	// Use a non-empty trailer separator so duplicate keys remain parseable.
-	format := "%H\x1f%s\x1f%an\x1f%aI\x1f%(trailers:key=Stackit-Stack-Size,valueonly,separator=%x1e)\x1f%(trailers:key=Stackit-PRs,valueonly,separator=%x1e)\x1f%(trailers:key=Stackit-Scope,valueonly,separator=%x1e)"
+	// Format: SHA\x1fsubject\x1fauthor\x1fdate\x1fbody\x1fstack-size\x1fprs\x1fscope\x00
+	// Records are separated by null bytes so multi-line bodies don't break parsing.
+	format := "%H\x1f%s\x1f%an\x1f%aI\x1f%b\x1f%(trailers:key=Stackit-Stack-Size,valueonly,separator=%x1e)\x1f%(trailers:key=Stackit-PRs,valueonly,separator=%x1e)\x1f%(trailers:key=Stackit-Scope,valueonly,separator=%x1e)%x00"
 
-	output, err := r.runGitCommandInternal("log", fmt.Sprintf("-%d", count), "--format="+format, branchName)
+	output, err := r.runGitCommandInternal("log", "--first-parent", fmt.Sprintf("-%d", count), "--format="+format, branchName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get recent commits for %s: %w", branchName, err)
 	}
@@ -52,19 +55,30 @@ func (r *runner) GetRecentCommits(branchName string, count int) ([]RecentCommit,
 	}
 
 	var commits []RecentCommit
-	for line := range strings.SplitSeq(output, "\n") {
-		if line == "" {
+	for record := range strings.SplitSeq(output, "\x00") {
+		record = strings.TrimSpace(record)
+		if record == "" {
 			continue
 		}
 
-		fields := strings.SplitN(line, "\x1f", 7)
+		fields := strings.SplitN(record, "\x1f", 8)
 		if len(fields) < 4 {
 			continue
 		}
 
+		subject := fields[1]
+		body := ""
+		if len(fields) > 4 {
+			body = fields[4]
+		}
+
+		// For GitHub merge commits, the subject is "Merge pull request #N from ...".
+		// The actual PR title is the first line of the body.
+		subject = resolveSubject(subject, body)
+
 		commit := RecentCommit{
 			SHA:     fields[0],
-			Subject: fields[1],
+			Subject: subject,
 			Author:  fields[2],
 		}
 
@@ -72,25 +86,65 @@ func (r *runner) GetRecentCommits(branchName string, count int) ([]RecentCommit,
 			commit.Date = date
 		}
 
-		if len(fields) > 4 {
-			commit.StackSize = parseStackSizeTrailer(fields[4])
-		}
-
 		if len(fields) > 5 {
-			commit.StackPRNumbers = parseStackPRsTrailer(fields[5])
+			commit.StackSize = parseStackSizeTrailer(fields[5])
 		}
 
 		if len(fields) > 6 {
-			commit.StackScope = parseStackScopeTrailer(fields[6])
+			commit.StackPRNumbers = parseStackPRsTrailer(fields[6])
+		}
+
+		if len(fields) > 7 {
+			commit.StackScope = parseStackScopeTrailer(fields[7])
 		}
 
 		commit.PRNumber = parsePRNumberFromSubject(commit.Subject)
+		if commit.PRNumber == 0 {
+			commit.PRNumber = parseMergePRNumber(fields[1])
+		}
 		commit.Kind = deriveRecentCommitKind(commit)
 
 		commits = append(commits, commit)
 	}
 
 	return commits, nil
+}
+
+// resolveSubject returns a human-readable subject for a commit.
+// For GitHub merge commits ("Merge pull request #N from ..."), it extracts the
+// actual PR title from the first line of the body.
+func resolveSubject(subject, body string) string {
+	if !mergeSubjectRe.MatchString(subject) {
+		return subject
+	}
+	firstLine := firstNonEmptyLine(body)
+	if firstLine != "" {
+		return firstLine
+	}
+	return subject
+}
+
+// parseMergePRNumber extracts the PR number from a "Merge pull request #N from ..." subject.
+func parseMergePRNumber(subject string) int {
+	matches := mergeSubjectRe.FindStringSubmatch(subject)
+	if len(matches) < 2 {
+		return 0
+	}
+	n, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func firstNonEmptyLine(s string) string {
+	for line := range strings.SplitSeq(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return ""
 }
 
 func parseStackSizeTrailer(raw string) int {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Polish web UI: animations, status footer, and worktree-aware API**

Improves the stackit web frontend with visual polish and a smarter API layer.

Key changes:
- **Visual flair** (PR #767): Adds entry animations, a dark mode toggle, and confetti on stack actions; introduces animated CI status icons (checkmark, X, pulsing dot) across branch cards
- **Stack status footer** (PR #768): Adds a color-coded footer below each stack column showing its overall state (shippable / needs restack / blocked / incomplete) with state-specific colors and subtle shadows
- **Worktree-aware API** (PR #769): Filters worktree anchor branches out of the API response so they never appear as real branches in the UI; adds a `hasWorktree` flag to `StackSummary` and renders a folder-git icon in the stack header when a worktree is attached

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1772340662`.


* **PR #767**
  * **PR #768**
    * **PR #769**
      * **PR #770**
        * **PR #771**
          * **PR #772**
            * **PR #773**
              * **PR #774**
                * **PR #775**
                  * **PR #776**
                    * **PR #785** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->