### PR TITLE
feat: render branching stacks as linear segments with fork connectors

### DIFF
--- a/apps/web/src/components/__tests__/owner-swimlane.test.tsx
+++ b/apps/web/src/components/__tests__/owner-swimlane.test.tsx
@@ -68,7 +68,7 @@ describe("OwnerSwimlane", () => {
     expect(screen.getAllByRole("button").length).toBeGreaterThan(0);
   });
 
-  it("renders branching stack with tree edges SVG", () => {
+  it("renders branching stack with fork connector", () => {
     const stack = makeStack({
       rootBranch: "main",
       branches: [
@@ -89,8 +89,8 @@ describe("OwnerSwimlane", () => {
       />
     );
 
-    // Branching stacks render StackTree which uses an SVG for edges
-    expect(container.querySelector('[data-testid="stack-tree-edges"]')).not.toBeNull();
+    // Branching stacks render SegmentTree which uses fork connectors at branch points
+    expect(container.querySelector('[data-testid="fork-connector"]')).not.toBeNull();
   });
 
   it("renders mixed stacks with correct visualization for each", () => {
@@ -122,9 +122,9 @@ describe("OwnerSwimlane", () => {
       />
     );
 
-    // Exactly one tree edges SVG (from the branching stack)
-    const treeSvgs = container.querySelectorAll('[data-testid="stack-tree-edges"]');
-    expect(treeSvgs.length).toBe(1);
+    // Exactly one fork connector SVG (from the branching stack)
+    const forkConnectors = container.querySelectorAll('[data-testid="fork-connector"]');
+    expect(forkConnectors.length).toBe(1);
   });
 
   it("renders branch cards with same content in both views", () => {

--- a/apps/web/src/components/stack-tree-column.tsx
+++ b/apps/web/src/components/stack-tree-column.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { BranchResponse, StackDetail } from "@/lib/api";
-import { StackTree } from "@/components/stack-tree/stack-tree";
+import { SegmentTree } from "@/components/stack-tree/segment-tree";
 import { StackStatusFooter, StackDescription } from "@/components/stack-column";
 import { FolderGit2 } from "lucide-react";
 
@@ -41,8 +41,8 @@ export function StackTreeColumn({
         )}
       </div>
 
-      {/* Tree visualization with status footer attached to root node */}
-      <StackTree
+      {/* Tree visualization: linear card stacks with connectors at branch points */}
+      <SegmentTree
         branches={stack.branches}
         selectedBranch={selectedBranch}
         onSelectBranch={onSelectBranch}

--- a/apps/web/src/components/stack-tree/__tests__/tree-layout.test.ts
+++ b/apps/web/src/components/stack-tree/__tests__/tree-layout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeTreeLayout } from "../tree-layout";
+import { computeTreeLayout, decomposeTree, NODE_W, COLUMN_GAP } from "../tree-layout";
 import type { BranchResponse } from "@/lib/api";
 
 function makeBranch(overrides: Partial<BranchResponse> & { name: string }): BranchResponse {
@@ -108,5 +108,127 @@ describe("computeTreeLayout", () => {
 
     const layout = computeTreeLayout(branches);
     expect(layout.edges[0].needsRestack).toBe(false);
+  });
+});
+
+describe("decomposeTree", () => {
+  it("returns empty segment for no branches", () => {
+    const segment = decomposeTree([]);
+    expect(segment.branches).toEqual([]);
+    expect(segment.forks).toBeUndefined();
+    expect(segment.width).toBe(NODE_W);
+  });
+
+  it("returns a single linear segment for a chain", () => {
+    const branches = [
+      makeBranch({ name: "main" }),
+      makeBranch({ name: "a", parent: "main", depth: 1 }),
+      makeBranch({ name: "b", parent: "a", depth: 2 }),
+    ];
+
+    const segment = decomposeTree(branches);
+    expect(segment.branches.map((b) => b.name)).toEqual(["main", "a", "b"]);
+    expect(segment.forks).toBeUndefined();
+    expect(segment.width).toBe(NODE_W);
+  });
+
+  it("splits at fork point", () => {
+    const branches = [
+      makeBranch({ name: "main" }),
+      makeBranch({ name: "left", parent: "main", depth: 1 }),
+      makeBranch({ name: "right", parent: "main", depth: 1 }),
+    ];
+
+    const segment = decomposeTree(branches);
+    expect(segment.branches.map((b) => b.name)).toEqual(["main"]);
+    expect(segment.forks).toHaveLength(2);
+    expect(segment.forks![0].branches.map((b) => b.name)).toEqual(["left"]);
+    expect(segment.forks![1].branches.map((b) => b.name)).toEqual(["right"]);
+  });
+
+  it("computes width for two-way fork", () => {
+    const branches = [
+      makeBranch({ name: "main" }),
+      makeBranch({ name: "left", parent: "main", depth: 1 }),
+      makeBranch({ name: "right", parent: "main", depth: 1 }),
+    ];
+
+    const segment = decomposeTree(branches);
+    expect(segment.width).toBe(NODE_W * 2 + COLUMN_GAP);
+  });
+
+  it("handles linear chain above fork", () => {
+    const branches = [
+      makeBranch({ name: "main" }),
+      makeBranch({ name: "a", parent: "main", depth: 1 }),
+      makeBranch({ name: "left", parent: "a", depth: 2 }),
+      makeBranch({ name: "right", parent: "a", depth: 2 }),
+    ];
+
+    const segment = decomposeTree(branches);
+    // trunk chain includes main and a (the fork point)
+    expect(segment.branches.map((b) => b.name)).toEqual(["main", "a"]);
+    expect(segment.forks).toHaveLength(2);
+  });
+
+  it("handles nested forks", () => {
+    const branches = [
+      makeBranch({ name: "main" }),
+      makeBranch({ name: "a", parent: "main", depth: 1 }),
+      makeBranch({ name: "b", parent: "a", depth: 2 }),
+      makeBranch({ name: "b1", parent: "b", depth: 3 }),
+      makeBranch({ name: "b2", parent: "b", depth: 3 }),
+      makeBranch({ name: "c", parent: "a", depth: 2 }),
+    ];
+
+    const segment = decomposeTree(branches);
+    expect(segment.branches.map((b) => b.name)).toEqual(["main", "a"]);
+    expect(segment.forks).toHaveLength(2);
+
+    // First fork: b with nested forks b1, b2
+    const bFork = segment.forks![0];
+    expect(bFork.branches.map((b) => b.name)).toEqual(["b"]);
+    expect(bFork.forks).toHaveLength(2);
+    expect(bFork.forks![0].branches[0].name).toBe("b1");
+    expect(bFork.forks![1].branches[0].name).toBe("b2");
+
+    // Second fork: c (linear)
+    expect(segment.forks![1].branches.map((b) => b.name)).toEqual(["c"]);
+    expect(segment.forks![1].forks).toBeUndefined();
+  });
+
+  it("handles linear chain after fork", () => {
+    const branches = [
+      makeBranch({ name: "main" }),
+      makeBranch({ name: "left", parent: "main", depth: 1 }),
+      makeBranch({ name: "left-child", parent: "left", depth: 2 }),
+      makeBranch({ name: "right", parent: "main", depth: 1 }),
+    ];
+
+    const segment = decomposeTree(branches);
+    expect(segment.forks).toHaveLength(2);
+    // Left fork includes the chain left → left-child
+    expect(segment.forks![0].branches.map((b) => b.name)).toEqual([
+      "left",
+      "left-child",
+    ]);
+    expect(segment.forks![1].branches.map((b) => b.name)).toEqual(["right"]);
+  });
+
+  it("nested fork width accounts for grandchildren", () => {
+    const branches = [
+      makeBranch({ name: "root" }),
+      makeBranch({ name: "a", parent: "root", depth: 1 }),
+      makeBranch({ name: "a1", parent: "a", depth: 2 }),
+      makeBranch({ name: "a2", parent: "a", depth: 2 }),
+      makeBranch({ name: "b", parent: "root", depth: 1 }),
+    ];
+
+    const segment = decomposeTree(branches);
+    // Fork a: width = 2*NODE_W + COLUMN_GAP (for a1 and a2)
+    // Fork b: width = NODE_W
+    // Total: (2*NODE_W + COLUMN_GAP) + COLUMN_GAP + NODE_W
+    const expectedWidth = 3 * NODE_W + 2 * COLUMN_GAP;
+    expect(segment.width).toBe(expectedWidth);
   });
 });

--- a/apps/web/src/components/stack-tree/segment-tree.tsx
+++ b/apps/web/src/components/stack-tree/segment-tree.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useMemo } from "react";
+import type { BranchResponse } from "@/lib/api";
+import { BranchCard } from "@/components/branch-card";
+import { decomposeTree, type TreeSegment, NODE_W, COLUMN_GAP } from "./tree-layout";
+
+interface SegmentTreeProps {
+  branches: BranchResponse[];
+  selectedBranch: string | null;
+  onSelectBranch: (branch: BranchResponse) => void;
+  footer?: React.ReactNode;
+}
+
+export function SegmentTree({
+  branches,
+  selectedBranch,
+  onSelectBranch,
+  footer,
+}: SegmentTreeProps) {
+  const segment = useMemo(() => decomposeTree(branches), [branches]);
+
+  if (segment.branches.length === 0 && !segment.forks?.length) {
+    return (
+      <div className="flex items-center justify-center h-full text-muted-foreground">
+        No branches in this stack
+      </div>
+    );
+  }
+
+  return (
+    <SegmentNode
+      segment={segment}
+      selectedBranch={selectedBranch}
+      onSelectBranch={onSelectBranch}
+      footer={footer}
+    />
+  );
+}
+
+interface SegmentNodeProps {
+  segment: TreeSegment;
+  selectedBranch: string | null;
+  onSelectBranch: (branch: BranchResponse) => void;
+  footer?: React.ReactNode;
+}
+
+function SegmentNode({
+  segment,
+  selectedBranch,
+  onSelectBranch,
+  footer,
+}: SegmentNodeProps) {
+  const hasForks = segment.forks && segment.forks.length > 0;
+  // Display order: leaf at top (reverse of root-to-leaf)
+  const displayBranches = [...segment.branches].reverse();
+
+  return (
+    <div
+      className="flex flex-col items-center"
+      style={{ width: segment.width }}
+    >
+      {/* Fork children above */}
+      {hasForks && (
+        <>
+          <div
+            className="flex items-end"
+            style={{ gap: COLUMN_GAP }}
+          >
+            {segment.forks!.map((fork, i) => (
+              <SegmentNode
+                key={fork.branches[0]?.name ?? i}
+                segment={fork}
+                selectedBranch={selectedBranch}
+                onSelectBranch={onSelectBranch}
+              />
+            ))}
+          </div>
+          <ForkConnector segment={segment} />
+        </>
+      )}
+
+      {/* Linear trunk segment */}
+      {displayBranches.length > 0 && (
+        <div style={{ width: NODE_W }}>
+          <div className="flex flex-col bg-card rounded-t-lg">
+            {displayBranches.map((branch, i) => {
+              const isFirst = i === 0;
+              const isLast = i === displayBranches.length - 1;
+
+              return (
+                <BranchCard
+                  key={branch.name}
+                  branch={branch}
+                  isSelected={selectedBranch === branch.name}
+                  onClick={onSelectBranch}
+                  className={`border-x border-t
+                    ${isLast ? "border-b rounded-b-lg relative z-[1] shadow-[0_4px_6px_-2px_rgba(0,0,0,0.15)]" : ""}
+                    ${isFirst ? "rounded-t-lg" : ""}
+                  `}
+                />
+              );
+            })}
+          </div>
+          {footer}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const CONNECTOR_H = 28;
+const CURVE_R = 6;
+
+function ForkConnector({ segment }: { segment: TreeSegment }) {
+  if (!segment.forks || segment.forks.length < 2) return null;
+
+  const totalWidth = segment.width;
+  const forks = segment.forks;
+
+  const forksWidth =
+    forks.reduce((sum, f) => sum + f.width, 0) +
+    COLUMN_GAP * (forks.length - 1);
+
+  // Center the forks area within the total width
+  const startX = (totalWidth - forksWidth) / 2;
+
+  // Compute center X of each fork column
+  const centers: number[] = [];
+  let x = startX;
+  for (const fork of forks) {
+    centers.push(x + fork.width / 2);
+    x += fork.width + COLUMN_GAP;
+  }
+
+  // Trunk center (where all forks converge)
+  const trunkX = totalWidth / 2;
+  const midY = CONNECTOR_H / 2;
+  const leftX = Math.min(...centers);
+  const rightX = Math.max(...centers);
+
+  return (
+    <svg
+      width={totalWidth}
+      height={CONNECTOR_H}
+      className="shrink-0"
+      data-testid="fork-connector"
+    >
+      {/* Vertical stubs from each fork column down to the horizontal line */}
+      {centers.map((cx, i) => (
+        <line
+          key={`v-${i}`}
+          x1={cx}
+          y1={0}
+          x2={cx}
+          y2={midY}
+          className={
+            forks[i].branches[0]?.needsRestack
+              ? "stroke-amber-400"
+              : "stroke-muted-foreground/40"
+          }
+          strokeWidth={forks[i].branches[0]?.needsRestack ? 2 : 1.5}
+        />
+      ))}
+      {/* Horizontal line connecting all fork columns */}
+      <line
+        x1={leftX}
+        y1={midY}
+        x2={rightX}
+        y2={midY}
+        className="stroke-muted-foreground/40"
+        strokeWidth={1.5}
+      />
+      {/* Vertical line from center down to trunk */}
+      <line
+        x1={trunkX}
+        y1={midY}
+        x2={trunkX}
+        y2={CONNECTOR_H}
+        className="stroke-muted-foreground/40"
+        strokeWidth={1.5}
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/components/stack-tree/tree-layout.ts
+++ b/apps/web/src/components/stack-tree/tree-layout.ts
@@ -5,6 +5,7 @@ export const V_GAP = 88; // vertical gap between levels
 export const NODE_W = 256;
 export const NODE_H = 64;
 export const TREE_PADDING = 20;
+export const COLUMN_GAP = 12; // gap between fork columns
 
 export interface LayoutNode {
   branch: BranchResponse;
@@ -149,4 +150,93 @@ export function computeTreeLayout(branches: BranchResponse[]): TreeLayout {
   const height = Math.max(...allY) + NODE_H + PADDING * 2;
 
   return { nodes, edges, width, height };
+}
+
+/**
+ * A segment of a stack tree: a linear chain of branches that may fork
+ * at the top into multiple child segments.
+ */
+export interface TreeSegment {
+  /** Branches forming a linear chain, ordered root-to-leaf (bottom to top in display). */
+  branches: BranchResponse[];
+  /** Child segments if the topmost branch has multiple children. */
+  forks?: TreeSegment[];
+  /** Computed width in pixels for layout. */
+  width: number;
+}
+
+/**
+ * Decomposes a flat branch list into a tree of linear segments.
+ * Each segment is a chain of single-child branches. When a branch has
+ * multiple children, the segment records them as `forks`.
+ */
+export function decomposeTree(branches: BranchResponse[]): TreeSegment {
+  if (branches.length === 0) {
+    return { branches: [], width: NODE_W };
+  }
+
+  const byName = new Map<string, BranchResponse>();
+  const childrenOf = new Map<string, string[]>();
+
+  for (const b of branches) {
+    byName.set(b.name, b);
+  }
+
+  // Build children map preserving DFS order from the branch list
+  for (const b of branches) {
+    if (b.parent && byName.has(b.parent)) {
+      const existing = childrenOf.get(b.parent) || [];
+      existing.push(b.name);
+      childrenOf.set(b.parent, existing);
+    }
+  }
+
+  const roots = branches.filter(
+    (b) => !b.parent || !byName.has(b.parent)
+  );
+
+  function buildSegment(startName: string): TreeSegment {
+    const chain: BranchResponse[] = [];
+    let current = startName;
+
+    for (;;) {
+      const branch = byName.get(current);
+      if (!branch) break;
+      chain.push(branch);
+
+      const children = childrenOf.get(current) || [];
+      if (children.length === 1) {
+        current = children[0];
+      } else if (children.length > 1) {
+        const forks = children.map((child) => buildSegment(child));
+        const forksWidth =
+          forks.reduce((sum, f) => sum + f.width, 0) +
+          COLUMN_GAP * (forks.length - 1);
+        return {
+          branches: chain,
+          forks,
+          width: Math.max(NODE_W, forksWidth),
+        };
+      } else {
+        break;
+      }
+    }
+
+    return { branches: chain, width: NODE_W };
+  }
+
+  if (roots.length === 1) {
+    return buildSegment(roots[0].name);
+  }
+
+  // Multiple roots: treat as parallel forks
+  const forks = roots.map((r) => buildSegment(r.name));
+  const forksWidth =
+    forks.reduce((sum, f) => sum + f.width, 0) +
+    COLUMN_GAP * (forks.length - 1);
+  return {
+    branches: [],
+    forks,
+    width: Math.max(NODE_W, forksWidth),
+  };
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #790**
  * **PR #794**
    * **PR #795**
      * **PR #796** 👈
        * **PR #797**
          * **PR #798**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #799 by jonnii*