### PR TITLE
feat: add lock indicator to branch cards

### DIFF
--- a/apps/web/src/components/branch-card.tsx
+++ b/apps/web/src/components/branch-card.tsx
@@ -4,6 +4,7 @@ import type { BranchResponse, CIResponse } from "@/lib/api";
 import { PRBadge, DiffStats } from "@/components/status/status-badge";
 import { AnimatedCheckmark, AnimatedX, PulsingDot } from "@/components/ui/animated-ci-icons";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { Lock } from "lucide-react";
 
 interface BranchCardProps {
   branch: BranchResponse;
@@ -26,6 +27,7 @@ export function BranchCard({
       className={`text-left px-3 py-2.5 bg-card transition-all duration-200
         ${isSelected ? "!bg-accent z-10 relative" : "hover:!bg-muted hover:scale-[1.02] hover:shadow-md hover:-translate-y-0.5"}
         ${branch.isCurrent ? "border-l-[3px] border-l-[var(--glow-color-current)]" : ""}
+        ${branch.isLocked ? "opacity-60" : ""}
         ${className}
       `}
       style={style}
@@ -34,6 +36,16 @@ export function BranchCard({
         <span className="text-sm font-medium truncate" title={branch.name}>
           {branch.commits?.[0]?.message || shortenBranchName(branch.name)}
         </span>
+        {branch.isLocked && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Lock className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {branch.lockReason ? `Locked: ${branch.lockReason}` : "Locked"}
+            </TooltipContent>
+          </Tooltip>
+        )}
         {branch.needsRestack && (
           <span className="text-amber-500 shrink-0" title="Needs restack">
             &#x21BB;


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #790**
  * **PR #794**
    * **PR #795**
      * **PR #796**
        * **PR #797**
          * **PR #798** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #799 by jonnii*