### PR TITLE
Merging 6 PRs

### DIFF
--- a/api/openapi/stackit.yaml
+++ b/api/openapi/stackit.yaml
@@ -284,5 +284,9 @@ components:
           type: array
           items:
             type: integer
+        stackPRTitles:
+          type: object
+          additionalProperties:
+            type: string
         stackScope:
           type: string

--- a/apps/web/src/components/__tests__/owner-swimlane.test.tsx
+++ b/apps/web/src/components/__tests__/owner-swimlane.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { OwnerSwimlane } from "../owner-swimlane";
+import type { BranchResponse, StackDetail } from "@/lib/api";
+
+// Mock motion/react to avoid animation issues in tests
+vi.mock("motion/react", () => ({
+  motion: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => <div {...props}>{children}</div>,
+    button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => <button {...props}>{children}</button>,
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+
+function makeBranch(overrides: Partial<BranchResponse> & { name: string }): BranchResponse {
+  return {
+    depth: 0,
+    isCurrent: false,
+    needsRestack: false,
+    isLocked: false,
+    isFrozen: false,
+    revision: "abc123",
+    commitDate: "2025-01-01",
+    commitAuthor: "test",
+    commitCount: 1,
+    linesAdded: 0,
+    linesDeleted: 0,
+    ...overrides,
+  };
+}
+
+function makeStack(overrides: Partial<StackDetail> & { rootBranch: string; branches: BranchResponse[] }): StackDetail {
+  return {
+    title: "",
+    status: "shippable",
+    branchCount: overrides.branches.length,
+    prCount: 0,
+    isCurrent: false,
+    ...overrides,
+  };
+}
+
+const noop = () => {};
+
+describe("OwnerSwimlane", () => {
+  it("renders linear stack without tree edges SVG", () => {
+    const stack = makeStack({
+      rootBranch: "main",
+      branches: [
+        makeBranch({ name: "main", children: ["feat"] }),
+        makeBranch({ name: "feat", parent: "main" }),
+      ],
+    });
+
+    const { container } = render(
+      <OwnerSwimlane
+        label="me"
+        stacks={[stack]}
+        selectedBranch={null}
+        selectedStack={null}
+        onSelectBranch={noop}
+        onSelectStack={noop}
+      />
+    );
+
+    // Linear stacks render StackColumn, not StackTree
+    expect(container.querySelector('[data-testid="stack-tree-edges"]')).toBeNull();
+    expect(screen.getAllByRole("button").length).toBeGreaterThan(0);
+  });
+
+  it("renders branching stack with fork connector", () => {
+    const stack = makeStack({
+      rootBranch: "main",
+      branches: [
+        makeBranch({ name: "main", children: ["left", "right"] }),
+        makeBranch({ name: "left", parent: "main" }),
+        makeBranch({ name: "right", parent: "main" }),
+      ],
+    });
+
+    const { container } = render(
+      <OwnerSwimlane
+        label="me"
+        stacks={[stack]}
+        selectedBranch={null}
+        selectedStack={null}
+        onSelectBranch={noop}
+        onSelectStack={noop}
+      />
+    );
+
+    // Branching stacks render SegmentTree which uses fork connectors at branch points
+    expect(container.querySelector('[data-testid="fork-connector"]')).not.toBeNull();
+  });
+
+  it("renders mixed stacks with correct visualization for each", () => {
+    const linearStack = makeStack({
+      rootBranch: "linear-root",
+      branches: [
+        makeBranch({ name: "linear-root", children: ["child"] }),
+        makeBranch({ name: "child", parent: "linear-root" }),
+      ],
+    });
+
+    const branchingStack = makeStack({
+      rootBranch: "branching-root",
+      branches: [
+        makeBranch({ name: "branching-root", children: ["left", "right"] }),
+        makeBranch({ name: "left", parent: "branching-root" }),
+        makeBranch({ name: "right", parent: "branching-root" }),
+      ],
+    });
+
+    const { container } = render(
+      <OwnerSwimlane
+        label="me"
+        stacks={[linearStack, branchingStack]}
+        selectedBranch={null}
+        selectedStack={null}
+        onSelectBranch={noop}
+        onSelectStack={noop}
+      />
+    );
+
+    // Exactly one fork connector SVG (from the branching stack)
+    const forkConnectors = container.querySelectorAll('[data-testid="fork-connector"]');
+    expect(forkConnectors.length).toBe(1);
+  });
+
+  it("renders branch cards with same content in both views", () => {
+    const linearStack = makeStack({
+      rootBranch: "lin",
+      branches: [
+        makeBranch({ name: "lin", children: ["lin-child"] }),
+        makeBranch({ name: "lin-child", parent: "lin" }),
+      ],
+    });
+
+    const branchingStack = makeStack({
+      rootBranch: "br",
+      branches: [
+        makeBranch({ name: "br", children: ["br-left", "br-right"] }),
+        makeBranch({ name: "br-left", parent: "br" }),
+        makeBranch({ name: "br-right", parent: "br" }),
+      ],
+    });
+
+    render(
+      <OwnerSwimlane
+        label="me"
+        stacks={[linearStack, branchingStack]}
+        selectedBranch={null}
+        selectedStack={null}
+        onSelectBranch={noop}
+        onSelectStack={noop}
+      />
+    );
+
+    // Both views show "no PR" text for branches without PRs (shared BranchCard)
+    const noPrLabels = screen.getAllByText("no PR");
+    // 5 branches total across both stacks
+    expect(noPrLabels.length).toBe(5);
+  });
+});

--- a/apps/web/src/components/__tests__/stack-column.test.ts
+++ b/apps/web/src/components/__tests__/stack-column.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { hasBranching, shortenBranchName } from "../stack-column";
+import type { BranchResponse } from "@/lib/api";
+
+function makeBranch(overrides: Partial<BranchResponse> & { name: string }): BranchResponse {
+  return {
+    depth: 0,
+    isCurrent: false,
+    needsRestack: false,
+    isLocked: false,
+    isFrozen: false,
+    revision: "abc123",
+    commitDate: "2025-01-01",
+    commitAuthor: "test",
+    commitCount: 1,
+    linesAdded: 0,
+    linesDeleted: 0,
+    ...overrides,
+  };
+}
+
+describe("hasBranching", () => {
+  it("returns false for empty branches", () => {
+    expect(hasBranching([])).toBe(false);
+  });
+
+  it("returns false for a single branch with no children", () => {
+    expect(hasBranching([makeBranch({ name: "main" })])).toBe(false);
+  });
+
+  it("returns false for a linear stack", () => {
+    const branches = [
+      makeBranch({ name: "main", children: ["feat-a"] }),
+      makeBranch({ name: "feat-a", parent: "main", children: ["feat-b"] }),
+      makeBranch({ name: "feat-b", parent: "feat-a" }),
+    ];
+    expect(hasBranching(branches)).toBe(false);
+  });
+
+  it("returns true when a branch has two children", () => {
+    const branches = [
+      makeBranch({ name: "main", children: ["feat-a", "feat-b"] }),
+      makeBranch({ name: "feat-a", parent: "main" }),
+      makeBranch({ name: "feat-b", parent: "main" }),
+    ];
+    expect(hasBranching(branches)).toBe(true);
+  });
+
+  it("returns true when a non-root branch has multiple children", () => {
+    const branches = [
+      makeBranch({ name: "main", children: ["middle"] }),
+      makeBranch({ name: "middle", parent: "main", children: ["left", "right"] }),
+      makeBranch({ name: "left", parent: "middle" }),
+      makeBranch({ name: "right", parent: "middle" }),
+    ];
+    expect(hasBranching(branches)).toBe(true);
+  });
+
+  it("returns false when children is undefined", () => {
+    const branches = [
+      makeBranch({ name: "main" }),
+      makeBranch({ name: "feat", parent: "main" }),
+    ];
+    expect(hasBranching(branches)).toBe(false);
+  });
+
+  it("returns false when children is an empty array", () => {
+    const branches = [
+      makeBranch({ name: "main", children: [] }),
+    ];
+    expect(hasBranching(branches)).toBe(false);
+  });
+});
+
+describe("shortenBranchName", () => {
+  it("returns description part from user/timestamp/description pattern", () => {
+    expect(shortenBranchName("jonnii/20260301202047/show-PR-titles")).toBe("show-PR-titles");
+  });
+
+  it("returns full name when no timestamp pattern", () => {
+    expect(shortenBranchName("feature/my-branch")).toBe("feature/my-branch");
+  });
+
+  it("returns full name for simple branch names", () => {
+    expect(shortenBranchName("main")).toBe("main");
+  });
+
+  it("handles description with slashes", () => {
+    expect(shortenBranchName("user/20260301202047/feat/nested")).toBe("feat/nested");
+  });
+});

--- a/apps/web/src/components/branch-card.tsx
+++ b/apps/web/src/components/branch-card.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import type { BranchResponse, CIResponse } from "@/lib/api";
+import { PRBadge, DiffStats } from "@/components/status/status-badge";
+import { AnimatedCheckmark, AnimatedX, PulsingDot } from "@/components/ui/animated-ci-icons";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { Lock } from "lucide-react";
+
+interface BranchCardProps {
+  branch: BranchResponse;
+  isSelected: boolean;
+  onClick: (branch: BranchResponse) => void;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export function BranchCard({
+  branch,
+  isSelected,
+  onClick,
+  className = "",
+  style,
+}: BranchCardProps) {
+  return (
+    <button
+      onClick={() => onClick(branch)}
+      className={`text-left px-3 py-2.5 bg-card transition-all duration-200
+        ${isSelected ? "!bg-accent z-10 relative" : "hover:!bg-muted hover:scale-[1.02] hover:shadow-md hover:-translate-y-0.5"}
+        ${branch.isCurrent ? "border-l-[3px] border-l-[var(--glow-color-current)]" : ""}
+        ${branch.isLocked ? "opacity-60" : ""}
+        ${className}
+      `}
+      style={style}
+    >
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="text-sm font-medium truncate" title={branch.name}>
+          {branch.commits?.[0]?.message || shortenBranchName(branch.name)}
+        </span>
+        {branch.isLocked && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Lock className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {branch.lockReason ? `Locked: ${branch.lockReason}` : "Locked"}
+            </TooltipContent>
+          </Tooltip>
+        )}
+        {branch.needsRestack && (
+          <span className="text-amber-500 shrink-0" title="Needs restack">
+            &#x21BB;
+          </span>
+        )}
+      </div>
+      <div className="flex items-center gap-2 mt-1">
+        {branch.pr ? (
+          <PRBadge pr={branch.pr} />
+        ) : (
+          <span className="text-xs text-muted-foreground">no PR</span>
+        )}
+        <CIStatusWithTooltip ci={branch.ci} />
+        <DiffStats added={branch.linesAdded} deleted={branch.linesDeleted} />
+      </div>
+    </button>
+  );
+}
+
+/** Strip common prefixes like "user/timestamp/" to show a shorter name. */
+export function shortenBranchName(name: string): string {
+  const match = name.match(/^[^/]+\/\d{14}\/(.+)$/);
+  return match ? match[1] : name;
+}
+
+function CIStatusIcon({ status }: { status?: string }) {
+  if (!status || status === "none") return null;
+
+  switch (status) {
+    case "passing":
+      return <AnimatedCheckmark />;
+    case "failing":
+      return <AnimatedX />;
+    case "pending":
+      return <PulsingDot />;
+    default:
+      return null;
+  }
+}
+
+function CheckIcon({ conclusion, status }: { conclusion: string; status: string }) {
+  if (status !== "COMPLETED") {
+    return <PulsingDot />;
+  }
+  switch (conclusion) {
+    case "SUCCESS":
+      return <AnimatedCheckmark />;
+    case "FAILURE":
+      return <AnimatedX />;
+    case "NEUTRAL":
+      return <span className="inline-block w-2.5 h-2.5 rounded-full bg-muted-foreground/40" />;
+    default:
+      return <PulsingDot />;
+  }
+}
+
+function CIStatusWithTooltip({ ci }: { ci?: CIResponse }) {
+  if (!ci || ci.status === "none") return null;
+
+  const checks = ci.checks ?? [];
+  const passingCount = checks.filter(
+    (c) => c.status === "COMPLETED" && c.conclusion === "SUCCESS"
+  ).length;
+  const total = checks.length;
+
+  const statusColorClass =
+    ci.status === "passing"
+      ? "text-green-600"
+      : ci.status === "failing"
+        ? "text-red-600"
+        : "text-amber-500";
+
+  if (total === 0) {
+    return <CIStatusIcon status={ci.status} />;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className={`inline-flex items-center gap-1 shrink-0 ${statusColorClass}`}>
+          <CIStatusIcon status={ci.status} />
+          <span className="text-[10px] font-medium leading-none">
+            {passingCount}/{total}
+          </span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-64">
+        <div className="space-y-1 py-0.5">
+          {checks.map((check) => (
+            <div key={check.name} className="flex items-center gap-2 text-xs">
+              <CheckIcon conclusion={check.conclusion} status={check.status} />
+              <span className="truncate">{check.name}</span>
+            </div>
+          ))}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/components/branch-detail/branch-detail.tsx
+++ b/apps/web/src/components/branch-detail/branch-detail.tsx
@@ -27,9 +27,9 @@ export function BranchDetail({ branch }: BranchDetailProps) {
     >
     <Card>
       <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-base font-mono">{branch.name}</CardTitle>
-          <div className="flex items-center gap-2">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base font-mono truncate min-w-0">{branch.name}</CardTitle>
+          <div className="flex items-center gap-2 shrink-0">
             <PRBadge pr={branch.pr} />
             <CIStatusBadge ci={branch.ci} />
             <ReviewBadge ci={branch.ci} />

--- a/apps/web/src/components/branch-detail/stack-detail.tsx
+++ b/apps/web/src/components/branch-detail/stack-detail.tsx
@@ -159,8 +159,8 @@ export function StackDetailPanel({ stack }: StackDetailPanelProps) {
 function BranchRow({ branch }: { branch: BranchResponse }) {
   return (
     <div className="flex flex-col gap-1 rounded-md border px-3 py-2">
-      <div className="flex items-center justify-between gap-2 min-w-0">
-        <span className="text-sm font-mono truncate">{branch.name}</span>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-mono truncate min-w-0">{branch.name}</span>
         <div className="flex items-center gap-1.5 shrink-0">
           {branch.pr ? (
             <PRBadge pr={branch.pr} />

--- a/apps/web/src/components/owner-swimlane.tsx
+++ b/apps/web/src/components/owner-swimlane.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import type { BranchResponse, StackDetail } from "@/lib/api";
-import { StackColumn } from "@/components/stack-column";
+import { StackColumn, hasBranching } from "@/components/stack-column";
+import { StackTreeColumn } from "@/components/stack-tree-column";
 import { SwimlaneLabel, swimlaneColor } from "@/components/swimlane-label";
 
 const COLLAPSED_LIMIT = 3;
@@ -52,13 +53,23 @@ export function OwnerSwimlane({
               exit={{ opacity: 0, scale: 0.95 }}
               transition={{ duration: 0.2 }}
             >
-              <StackColumn
-                stack={stack}
-                selectedBranch={selectedBranch}
-                selectedStack={selectedStack}
-                onSelectBranch={onSelectBranch}
-                onSelectStack={onSelectStack}
-              />
+              {hasBranching(stack.branches) ? (
+                <StackTreeColumn
+                  stack={stack}
+                  selectedBranch={selectedBranch}
+                  selectedStack={selectedStack}
+                  onSelectBranch={onSelectBranch}
+                  onSelectStack={onSelectStack}
+                />
+              ) : (
+                <StackColumn
+                  stack={stack}
+                  selectedBranch={selectedBranch}
+                  selectedStack={selectedStack}
+                  onSelectBranch={onSelectBranch}
+                  onSelectStack={onSelectStack}
+                />
+              )}
             </motion.div>
           ))}
         </AnimatePresence>

--- a/apps/web/src/components/recently-merged.tsx
+++ b/apps/web/src/components/recently-merged.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { GitMerge } from "lucide-react";
 import { useRepo } from "@/components/providers/repo-provider";
 import {
@@ -138,6 +138,8 @@ function RegularCommitItem({
   );
 }
 
+const STACK_PR_COLLAPSE_THRESHOLD = 3;
+
 function StackMergeItem({
   commit,
   owner,
@@ -149,6 +151,14 @@ function StackMergeItem({
 }) {
   const displayMessage = stripPRSuffix(commit.message);
   const stackPRs = commit.stackPRs ?? [];
+  const titles = commit.stackPRTitles;
+  const hasTitles = titles && Object.keys(titles).length > 0;
+  const [expanded, setExpanded] = useState(false);
+
+  const visiblePRs = expanded || stackPRs.length <= STACK_PR_COLLAPSE_THRESHOLD
+    ? stackPRs
+    : stackPRs.slice(0, STACK_PR_COLLAPSE_THRESHOLD);
+  const hiddenCount = stackPRs.length - visiblePRs.length;
 
   return (
     <div className="border-l-2 border-purple-400/50 dark:border-purple-500/40 pl-3 py-1.5 my-0.5 rounded-r">
@@ -168,30 +178,71 @@ function StackMergeItem({
           {displayMessage}
         </span>
         <div className="flex items-center gap-1.5 shrink-0">
-          <span className="text-[10px] font-medium text-purple-600/70 dark:text-purple-400/60">
-            {commit.stackSize} PRs
-          </span>
+          {commit.prNumber && owner && repoName ? (
+            <a
+              href={prUrl(owner, repoName, commit.prNumber)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[10px] font-mono font-medium text-purple-500/60 dark:text-purple-400/50 hover:text-purple-600 dark:hover:text-purple-300 transition-colors"
+            >
+              #{commit.prNumber}
+            </a>
+          ) : (
+            <span className="text-[10px] font-medium text-purple-600/70 dark:text-purple-400/60">
+              {commit.stackSize} PRs
+            </span>
+          )}
           <span className="text-[10px] text-muted-foreground/40 tabular-nums w-12 text-right">
             {formatTimeAgo(commit.date)}
           </span>
         </div>
       </div>
 
-      {/* Constituent PR links */}
+      {/* Constituent PRs with titles */}
       {stackPRs.length > 0 && owner && repoName && (
-        <div className="flex items-center gap-1 mt-1.5 ml-7">
-          {stackPRs.map((pr) => (
-            <a
-              key={pr}
-              href={prUrl(owner, repoName, pr)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[10px] font-mono text-purple-500/60 dark:text-purple-400/50 hover:text-purple-600 dark:hover:text-purple-300 bg-purple-500/5 hover:bg-purple-500/10 rounded px-1.5 py-0.5 transition-colors"
-            >
-              #{pr}
-            </a>
-          ))}
-        </div>
+        hasTitles ? (
+          <div className="mt-1.5 ml-7 space-y-0.5">
+            {visiblePRs.map((pr) => (
+              <div key={pr} className="flex items-center gap-1.5 min-w-0">
+                <a
+                  href={prUrl(owner, repoName, pr)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[10px] font-mono text-purple-500/60 dark:text-purple-400/50 hover:text-purple-600 dark:hover:text-purple-300 shrink-0 transition-colors"
+                >
+                  #{pr}
+                </a>
+                {titles[pr] && (
+                  <span className="text-[10px] text-muted-foreground/70 truncate">
+                    {titles[pr]}
+                  </span>
+                )}
+              </div>
+            ))}
+            {hiddenCount > 0 && (
+              <button
+                onClick={() => setExpanded(true)}
+                className="text-[10px] text-purple-500/50 hover:text-purple-500 dark:text-purple-400/40 dark:hover:text-purple-400 transition-colors"
+              >
+                +{hiddenCount} more
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="flex items-center gap-1 mt-1.5 ml-7">
+            {stackPRs.map((pr) => (
+              <a
+                key={pr}
+                href={prUrl(owner, repoName, pr)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[10px] font-mono text-purple-500/60 dark:text-purple-400/50 hover:text-purple-600 dark:hover:text-purple-300 bg-purple-500/5 hover:bg-purple-500/10 rounded px-1.5 py-0.5 transition-colors"
+              >
+                #{pr}
+              </a>
+            ))}
+          </div>
+        )
       )}
     </div>
   );

--- a/apps/web/src/components/stack-column.tsx
+++ b/apps/web/src/components/stack-column.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import type { BranchResponse, CIResponse, StackDetail } from "@/lib/api";
-import { PRBadge, DiffStats } from "@/components/status/status-badge";
-import { AnimatedCheckmark, AnimatedX, PulsingDot } from "@/components/ui/animated-ci-icons";
-import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import type { BranchResponse, StackDetail } from "@/lib/api";
+import { BranchCard } from "@/components/branch-card";
 import { FolderGit2, ChevronDown } from "lucide-react";
 import Markdown from "react-markdown";
+
+export { shortenBranchName } from "@/components/branch-card";
 
 interface StackColumnProps {
   stack: StackDetail;
@@ -53,43 +53,19 @@ export function StackColumn({
         {displayBranches.map((branch, i) => {
           const isFirst = i === 0;
           const isLast = i === displayBranches.length - 1;
-          const isSelected = selectedBranch === branch.name;
 
           return (
-            <button
+            <BranchCard
               key={branch.name}
-              onClick={() => onSelectBranch(branch)}
-              className={`text-left px-3 py-2.5 border-x border-t transition-all duration-200 animate-fade-in-up bg-card
+              branch={branch}
+              isSelected={selectedBranch === branch.name}
+              onClick={onSelectBranch}
+              className={`animate-fade-in-up border-x border-t
                 ${isLast ? "border-b rounded-b-lg relative z-[1] shadow-[0_4px_6px_-2px_rgba(0,0,0,0.15)]" : ""}
                 ${isFirst ? "rounded-t-lg" : ""}
-                ${isSelected ? "!bg-accent z-10 relative" : "hover:!bg-muted hover:scale-[1.02] hover:shadow-md hover:-translate-y-0.5"}
-                ${branch.isCurrent ? "border-l-[3px] border-l-[var(--glow-color-current)]" : ""}
               `}
               style={{ animationDelay: `${i * 50}ms` }}
-            >
-              <div className="flex items-center gap-2 min-w-0">
-                <span
-                  className="text-sm font-medium truncate"
-                  title={branch.name}
-                >
-                  {branch.commits?.[0]?.message || shortenBranchName(branch.name)}
-                </span>
-                {branch.needsRestack && (
-                  <span className="text-amber-500 shrink-0" title="Needs restack">
-                    &#x21BB;
-                  </span>
-                )}
-              </div>
-              <div className="flex items-center gap-2 mt-1">
-                {branch.pr ? (
-                  <PRBadge pr={branch.pr} />
-                ) : (
-                  <span className="text-xs text-muted-foreground">no PR</span>
-                )}
-                <CIStatusWithTooltip ci={branch.ci} />
-                <DiffStats added={branch.linesAdded} deleted={branch.linesDeleted} />
-              </div>
-            </button>
+            />
           );
         })}
       </div>
@@ -135,7 +111,7 @@ const statusConfig: Record<string, { label: string; bg: string; selectedBg: stri
   },
 };
 
-function StackStatusFooter({ status, selected, onClick }: { status: string; selected: boolean; onClick: () => void }) {
+export function StackStatusFooter({ status, selected, onClick }: { status: string; selected: boolean; onClick: () => void }) {
   const c = statusConfig[status] || statusConfig.incomplete;
 
   return (
@@ -145,81 +121,6 @@ function StackStatusFooter({ status, selected, onClick }: { status: string; sele
     >
       {c.label}
     </button>
-  );
-}
-
-function CIStatusIcon({ status }: { status?: string }) {
-  if (!status || status === "none") return null;
-
-  switch (status) {
-    case "passing":
-      return <AnimatedCheckmark />;
-    case "failing":
-      return <AnimatedX />;
-    case "pending":
-      return <PulsingDot />;
-    default:
-      return null;
-  }
-}
-
-function CheckIcon({ conclusion, status }: { conclusion: string; status: string }) {
-  if (status !== "COMPLETED") {
-    return <PulsingDot />;
-  }
-  switch (conclusion) {
-    case "SUCCESS":
-      return <AnimatedCheckmark />;
-    case "FAILURE":
-      return <AnimatedX />;
-    case "NEUTRAL":
-      return <span className="inline-block w-2.5 h-2.5 rounded-full bg-muted-foreground/40" />;
-    default:
-      return <PulsingDot />;
-  }
-}
-
-function CIStatusWithTooltip({ ci }: { ci?: CIResponse }) {
-  if (!ci || ci.status === "none") return null;
-
-  const checks = ci.checks ?? [];
-  const passingCount = checks.filter(
-    (c) => c.status === "COMPLETED" && c.conclusion === "SUCCESS"
-  ).length;
-  const total = checks.length;
-
-  const statusColorClass =
-    ci.status === "passing"
-      ? "text-green-600"
-      : ci.status === "failing"
-        ? "text-red-600"
-        : "text-amber-500";
-
-  if (total === 0) {
-    return <CIStatusIcon status={ci.status} />;
-  }
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span className={`inline-flex items-center gap-1 shrink-0 ${statusColorClass}`}>
-          <CIStatusIcon status={ci.status} />
-          <span className="text-[10px] font-medium leading-none">
-            {passingCount}/{total}
-          </span>
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="top" className="max-w-64">
-        <div className="space-y-1 py-0.5">
-          {checks.map((check) => (
-            <div key={check.name} className="flex items-center gap-2 text-xs">
-              <CheckIcon conclusion={check.conclusion} status={check.status} />
-              <span className="truncate">{check.name}</span>
-            </div>
-          ))}
-        </div>
-      </TooltipContent>
-    </Tooltip>
   );
 }
 
@@ -248,7 +149,7 @@ function orderBranches(branches: BranchResponse[]): BranchResponse[] {
 
 const DESCRIPTION_COLLAPSE_LENGTH = 80;
 
-function StackDescription({ text }: { text: string }) {
+export function StackDescription({ text }: { text: string }) {
   const canCollapse = text.length > DESCRIPTION_COLLAPSE_LENGTH;
   const [collapsed, setCollapsed] = useState(canCollapse);
 
@@ -269,9 +170,7 @@ function StackDescription({ text }: { text: string }) {
   );
 }
 
-/** Strip common prefixes like "user/timestamp/" to show a shorter name. */
-function shortenBranchName(name: string): string {
-  // Match patterns like "user/timestamp/description" and return the description part
-  const match = name.match(/^[^/]+\/\d{14}\/(.+)$/);
-  return match ? match[1] : name;
+/** Returns true if any branch in the list has more than one child (i.e. the stack forks). */
+export function hasBranching(branches: BranchResponse[]): boolean {
+  return branches.some((b) => (b.children?.length ?? 0) > 1);
 }

--- a/apps/web/src/components/stack-tree-column.tsx
+++ b/apps/web/src/components/stack-tree-column.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import type { BranchResponse, StackDetail } from "@/lib/api";
+import { SegmentTree } from "@/components/stack-tree/segment-tree";
+import { StackStatusFooter, StackDescription } from "@/components/stack-column";
+import { FolderGit2 } from "lucide-react";
+
+interface StackTreeColumnProps {
+  stack: StackDetail;
+  selectedBranch: string | null;
+  selectedStack: string | null;
+  onSelectBranch: (branch: BranchResponse) => void;
+  onSelectStack: (stack: StackDetail) => void;
+}
+
+export function StackTreeColumn({
+  stack,
+  selectedBranch,
+  selectedStack,
+  onSelectBranch,
+  onSelectStack,
+}: StackTreeColumnProps) {
+  return (
+    <div className="flex flex-col min-w-64 shrink-0">
+      {/* Stack header */}
+      <div className="px-1 pb-2">
+        {stack.hasWorktree && (
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground flex items-center gap-1" title="Worktree">
+              <FolderGit2 className="w-3 h-3" />
+            </span>
+          </div>
+        )}
+        {stack.title && (
+          <p className="text-xs font-medium text-muted-foreground mt-1 truncate" title={stack.title}>
+            {stack.title}
+          </p>
+        )}
+        {stack.description && (
+          <StackDescription text={stack.description} />
+        )}
+      </div>
+
+      {/* Tree visualization: linear card stacks with connectors at branch points */}
+      <SegmentTree
+        branches={stack.branches}
+        selectedBranch={selectedBranch}
+        onSelectBranch={onSelectBranch}
+        footer={
+          <StackStatusFooter
+            status={stack.status}
+            selected={selectedStack === stack.rootBranch}
+            onClick={() => onSelectStack(stack)}
+          />
+        }
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/stack-tree/__tests__/tree-layout.test.ts
+++ b/apps/web/src/components/stack-tree/__tests__/tree-layout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeTreeLayout } from "../tree-layout";
+import { computeTreeLayout, decomposeTree, NODE_W, COLUMN_GAP } from "../tree-layout";
 import type { BranchResponse } from "@/lib/api";
 
 function makeBranch(overrides: Partial<BranchResponse> & { name: string }): BranchResponse {
@@ -50,7 +50,7 @@ describe("computeTreeLayout", () => {
     expect(layout.edges[0].childName).toBe("feature");
   });
 
-  it("positions child below parent", () => {
+  it("positions child above parent (branches upward)", () => {
     const branches = [
       makeBranch({ name: "main" }),
       makeBranch({ name: "feature", parent: "main", depth: 1 }),
@@ -59,7 +59,7 @@ describe("computeTreeLayout", () => {
     const layout = computeTreeLayout(branches);
     const mainNode = layout.nodes.find((n) => n.branch.name === "main")!;
     const featureNode = layout.nodes.find((n) => n.branch.name === "feature")!;
-    expect(featureNode.y).toBeGreaterThan(mainNode.y);
+    expect(featureNode.y).toBeLessThan(mainNode.y);
   });
 
   it("positions siblings side by side", () => {
@@ -108,5 +108,127 @@ describe("computeTreeLayout", () => {
 
     const layout = computeTreeLayout(branches);
     expect(layout.edges[0].needsRestack).toBe(false);
+  });
+});
+
+describe("decomposeTree", () => {
+  it("returns empty segment for no branches", () => {
+    const segment = decomposeTree([]);
+    expect(segment.branches).toEqual([]);
+    expect(segment.forks).toBeUndefined();
+    expect(segment.width).toBe(NODE_W);
+  });
+
+  it("returns a single linear segment for a chain", () => {
+    const branches = [
+      makeBranch({ name: "main" }),
+      makeBranch({ name: "a", parent: "main", depth: 1 }),
+      makeBranch({ name: "b", parent: "a", depth: 2 }),
+    ];
+
+    const segment = decomposeTree(branches);
+    expect(segment.branches.map((b) => b.name)).toEqual(["main", "a", "b"]);
+    expect(segment.forks).toBeUndefined();
+    expect(segment.width).toBe(NODE_W);
+  });
+
+  it("splits at fork point", () => {
+    const branches = [
+      makeBranch({ name: "main" }),
+      makeBranch({ name: "left", parent: "main", depth: 1 }),
+      makeBranch({ name: "right", parent: "main", depth: 1 }),
+    ];
+
+    const segment = decomposeTree(branches);
+    expect(segment.branches.map((b) => b.name)).toEqual(["main"]);
+    expect(segment.forks).toHaveLength(2);
+    expect(segment.forks![0].branches.map((b) => b.name)).toEqual(["left"]);
+    expect(segment.forks![1].branches.map((b) => b.name)).toEqual(["right"]);
+  });
+
+  it("computes width for two-way fork", () => {
+    const branches = [
+      makeBranch({ name: "main" }),
+      makeBranch({ name: "left", parent: "main", depth: 1 }),
+      makeBranch({ name: "right", parent: "main", depth: 1 }),
+    ];
+
+    const segment = decomposeTree(branches);
+    expect(segment.width).toBe(NODE_W * 2 + COLUMN_GAP);
+  });
+
+  it("handles linear chain above fork", () => {
+    const branches = [
+      makeBranch({ name: "main" }),
+      makeBranch({ name: "a", parent: "main", depth: 1 }),
+      makeBranch({ name: "left", parent: "a", depth: 2 }),
+      makeBranch({ name: "right", parent: "a", depth: 2 }),
+    ];
+
+    const segment = decomposeTree(branches);
+    // trunk chain includes main and a (the fork point)
+    expect(segment.branches.map((b) => b.name)).toEqual(["main", "a"]);
+    expect(segment.forks).toHaveLength(2);
+  });
+
+  it("handles nested forks", () => {
+    const branches = [
+      makeBranch({ name: "main" }),
+      makeBranch({ name: "a", parent: "main", depth: 1 }),
+      makeBranch({ name: "b", parent: "a", depth: 2 }),
+      makeBranch({ name: "b1", parent: "b", depth: 3 }),
+      makeBranch({ name: "b2", parent: "b", depth: 3 }),
+      makeBranch({ name: "c", parent: "a", depth: 2 }),
+    ];
+
+    const segment = decomposeTree(branches);
+    expect(segment.branches.map((b) => b.name)).toEqual(["main", "a"]);
+    expect(segment.forks).toHaveLength(2);
+
+    // First fork: b with nested forks b1, b2
+    const bFork = segment.forks![0];
+    expect(bFork.branches.map((b) => b.name)).toEqual(["b"]);
+    expect(bFork.forks).toHaveLength(2);
+    expect(bFork.forks![0].branches[0].name).toBe("b1");
+    expect(bFork.forks![1].branches[0].name).toBe("b2");
+
+    // Second fork: c (linear)
+    expect(segment.forks![1].branches.map((b) => b.name)).toEqual(["c"]);
+    expect(segment.forks![1].forks).toBeUndefined();
+  });
+
+  it("handles linear chain after fork", () => {
+    const branches = [
+      makeBranch({ name: "main" }),
+      makeBranch({ name: "left", parent: "main", depth: 1 }),
+      makeBranch({ name: "left-child", parent: "left", depth: 2 }),
+      makeBranch({ name: "right", parent: "main", depth: 1 }),
+    ];
+
+    const segment = decomposeTree(branches);
+    expect(segment.forks).toHaveLength(2);
+    // Left fork includes the chain left → left-child
+    expect(segment.forks![0].branches.map((b) => b.name)).toEqual([
+      "left",
+      "left-child",
+    ]);
+    expect(segment.forks![1].branches.map((b) => b.name)).toEqual(["right"]);
+  });
+
+  it("nested fork width accounts for grandchildren", () => {
+    const branches = [
+      makeBranch({ name: "root" }),
+      makeBranch({ name: "a", parent: "root", depth: 1 }),
+      makeBranch({ name: "a1", parent: "a", depth: 2 }),
+      makeBranch({ name: "a2", parent: "a", depth: 2 }),
+      makeBranch({ name: "b", parent: "root", depth: 1 }),
+    ];
+
+    const segment = decomposeTree(branches);
+    // Fork a: width = 2*NODE_W + COLUMN_GAP (for a1 and a2)
+    // Fork b: width = NODE_W
+    // Total: (2*NODE_W + COLUMN_GAP) + COLUMN_GAP + NODE_W
+    const expectedWidth = 3 * NODE_W + 2 * COLUMN_GAP;
+    expect(segment.width).toBe(expectedWidth);
   });
 });

--- a/apps/web/src/components/stack-tree/branch-edge.tsx
+++ b/apps/web/src/components/stack-tree/branch-edge.tsx
@@ -9,21 +9,22 @@ interface BranchEdgeProps {
 }
 
 export function BranchEdge({ x1, y1, x2, y2, needsRestack }: BranchEdgeProps) {
-  // Vertical path with a slight curve at the bend
+  // Vertical path with a slight curve at the bend (works for both up and down directions)
   const midY = y1 + (y2 - y1) / 2;
+  const dy = Math.sign(y2 - y1) || 1;
+  const r = dy * 10;
 
   const path =
     x1 === x2
       ? `M ${x1} ${y1} L ${x2} ${y2}`
-      : `M ${x1} ${y1} L ${x1} ${midY} Q ${x1} ${midY + 10} ${x1 + (x2 - x1) * 0.2} ${midY + 10} L ${x2 - (x2 - x1) * 0.2} ${midY + 10} Q ${x2} ${midY + 10} ${x2} ${midY + 20} L ${x2} ${y2}`;
+      : `M ${x1} ${y1} L ${x1} ${midY} Q ${x1} ${midY + r} ${x1 + (x2 - x1) * 0.2} ${midY + r} L ${x2 - (x2 - x1) * 0.2} ${midY + r} Q ${x2} ${midY + r} ${x2} ${midY + r * 2} L ${x2} ${y2}`;
 
   return (
     <path
       d={path}
       fill="none"
-      className={`${needsRestack ? "stroke-amber-400 animate-edge-flow-fast" : "stroke-muted-foreground/40 animate-edge-flow"}`}
+      className={needsRestack ? "stroke-amber-400" : "stroke-muted-foreground/40"}
       strokeWidth={needsRestack ? 2 : 1.5}
-      strokeDasharray="10 10"
     />
   );
 }

--- a/apps/web/src/components/stack-tree/segment-tree.tsx
+++ b/apps/web/src/components/stack-tree/segment-tree.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useMemo } from "react";
+import type { BranchResponse } from "@/lib/api";
+import { BranchCard } from "@/components/branch-card";
+import { decomposeTree, type TreeSegment, NODE_W, COLUMN_GAP } from "./tree-layout";
+
+interface SegmentTreeProps {
+  branches: BranchResponse[];
+  selectedBranch: string | null;
+  onSelectBranch: (branch: BranchResponse) => void;
+  footer?: React.ReactNode;
+}
+
+export function SegmentTree({
+  branches,
+  selectedBranch,
+  onSelectBranch,
+  footer,
+}: SegmentTreeProps) {
+  const segment = useMemo(() => decomposeTree(branches), [branches]);
+
+  if (segment.branches.length === 0 && !segment.forks?.length) {
+    return (
+      <div className="flex items-center justify-center h-full text-muted-foreground">
+        No branches in this stack
+      </div>
+    );
+  }
+
+  return (
+    <SegmentNode
+      segment={segment}
+      selectedBranch={selectedBranch}
+      onSelectBranch={onSelectBranch}
+      footer={footer}
+    />
+  );
+}
+
+interface SegmentNodeProps {
+  segment: TreeSegment;
+  selectedBranch: string | null;
+  onSelectBranch: (branch: BranchResponse) => void;
+  footer?: React.ReactNode;
+}
+
+function SegmentNode({
+  segment,
+  selectedBranch,
+  onSelectBranch,
+  footer,
+}: SegmentNodeProps) {
+  const hasForks = segment.forks && segment.forks.length > 0;
+  // Display order: leaf at top (reverse of root-to-leaf)
+  const displayBranches = [...segment.branches].reverse();
+
+  return (
+    <div
+      className="flex flex-col items-center"
+      style={{ width: segment.width }}
+    >
+      {/* Fork children above */}
+      {hasForks && (
+        <>
+          <div
+            className="flex items-end"
+            style={{ gap: COLUMN_GAP }}
+          >
+            {segment.forks!.map((fork, i) => (
+              <SegmentNode
+                key={fork.branches[0]?.name ?? i}
+                segment={fork}
+                selectedBranch={selectedBranch}
+                onSelectBranch={onSelectBranch}
+              />
+            ))}
+          </div>
+          <ForkConnector segment={segment} />
+        </>
+      )}
+
+      {/* Linear trunk segment */}
+      {displayBranches.length > 0 && (
+        <div className="flex flex-col" style={{ width: NODE_W }}>
+          <div className="flex flex-col bg-card rounded-lg">
+            {displayBranches.map((branch, i) => {
+              const isFirst = i === 0;
+              const isLast = i === displayBranches.length - 1;
+
+              return (
+                <BranchCard
+                  key={branch.name}
+                  branch={branch}
+                  isSelected={selectedBranch === branch.name}
+                  onClick={onSelectBranch}
+                  className={`border-x border-t
+                    ${isLast ? "border-b rounded-b-lg relative z-[1] shadow-[0_4px_6px_-2px_rgba(0,0,0,0.15)]" : ""}
+                    ${isFirst ? "rounded-t-lg" : ""}
+                  `}
+                />
+              );
+            })}
+          </div>
+          {footer}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const CONNECTOR_H = 28;
+const CURVE_R = 6;
+
+function ForkConnector({ segment }: { segment: TreeSegment }) {
+  if (!segment.forks || segment.forks.length < 2) return null;
+
+  const totalWidth = segment.width;
+  const forks = segment.forks;
+
+  const forksWidth =
+    forks.reduce((sum, f) => sum + f.width, 0) +
+    COLUMN_GAP * (forks.length - 1);
+
+  // Center the forks area within the total width
+  const startX = (totalWidth - forksWidth) / 2;
+
+  // Compute center X of each fork column
+  const centers: number[] = [];
+  let x = startX;
+  for (const fork of forks) {
+    centers.push(x + fork.width / 2);
+    x += fork.width + COLUMN_GAP;
+  }
+
+  // Trunk center (where all forks converge)
+  const trunkX = totalWidth / 2;
+  const midY = CONNECTOR_H / 2;
+  const leftX = Math.min(...centers);
+  const rightX = Math.max(...centers);
+
+  return (
+    <svg
+      width={totalWidth}
+      height={CONNECTOR_H}
+      className="shrink-0"
+      data-testid="fork-connector"
+    >
+      {/* Vertical stubs from each fork column down to the horizontal line */}
+      {centers.map((cx, i) => (
+        <line
+          key={`v-${i}`}
+          x1={cx}
+          y1={0}
+          x2={cx}
+          y2={midY}
+          className={
+            forks[i].branches[0]?.needsRestack
+              ? "stroke-amber-400"
+              : "stroke-muted-foreground/40"
+          }
+          strokeWidth={forks[i].branches[0]?.needsRestack ? 2 : 1.5}
+        />
+      ))}
+      {/* Horizontal line connecting all fork columns */}
+      <line
+        x1={leftX}
+        y1={midY}
+        x2={rightX}
+        y2={midY}
+        className="stroke-muted-foreground/40"
+        strokeWidth={1.5}
+      />
+      {/* Vertical line from center down to trunk */}
+      <line
+        x1={trunkX}
+        y1={midY}
+        x2={trunkX}
+        y2={CONNECTOR_H}
+        className="stroke-muted-foreground/40"
+        strokeWidth={1.5}
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/components/stack-tree/stack-tree.tsx
+++ b/apps/web/src/components/stack-tree/stack-tree.tsx
@@ -2,20 +2,24 @@
 
 import { useMemo } from "react";
 import type { BranchResponse } from "@/lib/api";
-import { BranchNode, NODE_HEIGHT } from "./branch-node";
+import { BranchCard } from "@/components/branch-card";
 import { BranchEdge } from "./branch-edge";
-import { computeTreeLayout } from "./tree-layout";
+import { computeTreeLayout, NODE_W, NODE_H, TREE_PADDING } from "./tree-layout";
+
+const FOOTER_H = 28;
 
 interface StackTreeProps {
   branches: BranchResponse[];
   selectedBranch: string | null;
   onSelectBranch: (branch: BranchResponse) => void;
+  footer?: React.ReactNode;
 }
 
 export function StackTree({
   branches,
   selectedBranch,
   onSelectBranch,
+  footer,
 }: StackTreeProps) {
   const layout = useMemo(() => computeTreeLayout(branches), [branches]);
 
@@ -27,39 +31,67 @@ export function StackTree({
     );
   }
 
+  // Root node is at the bottom (highest Y after flip)
+  const rootNode = layout.nodes.reduce((a, b) => (a.y > b.y ? a : b));
+
+  // When footer is present, remove bottom padding so footer sits flush at the bottom
+  const totalHeight = footer
+    ? layout.height - TREE_PADDING + FOOTER_H
+    : layout.height;
+
   return (
     <div className="overflow-auto flex-1">
-      <svg
-        width={layout.width}
-        height={layout.height}
-        className="mx-auto"
-        style={{ minWidth: layout.width, minHeight: layout.height }}
+      <div
+        className="relative mx-auto"
+        style={{ width: layout.width, height: totalHeight }}
       >
-        <defs />
-        {/* Edges first (below nodes) */}
-        {layout.edges.map((edge) => (
-          <BranchEdge
-            key={`${edge.parentName}-${edge.childName}`}
-            x1={edge.x1}
-            y1={edge.y1}
-            x2={edge.x2}
-            y2={edge.y2}
-            needsRestack={edge.needsRestack}
-          />
-        ))}
+        {/* SVG edges layer (behind cards) */}
+        <svg
+          className="absolute inset-0 pointer-events-none"
+          width={layout.width}
+          height={totalHeight}
+          data-testid="stack-tree-edges"
+        >
+          {layout.edges.map((edge) => (
+            <BranchEdge
+              key={`${edge.parentName}-${edge.childName}`}
+              x1={edge.x1}
+              y1={edge.y1}
+              x2={edge.x2}
+              y2={edge.y2}
+              needsRestack={edge.needsRestack}
+            />
+          ))}
+        </svg>
 
-        {/* Nodes */}
-        {layout.nodes.map((node) => (
-          <BranchNode
-            key={node.branch.name}
-            branch={node.branch}
-            x={node.x}
-            y={node.y}
-            isSelected={node.branch.name === selectedBranch}
-            onClick={onSelectBranch}
-          />
-        ))}
-      </svg>
+        {/* HTML branch cards layer */}
+        {layout.nodes.map((node) => {
+          const isRoot = node === rootNode;
+          return (
+            <div
+              key={node.branch.name}
+              className="absolute flex flex-col"
+              style={{
+                left: node.x - NODE_W / 2,
+                top: node.y - NODE_H / 2,
+                width: NODE_W,
+              }}
+            >
+              <BranchCard
+                branch={node.branch}
+                isSelected={node.branch.name === selectedBranch}
+                onClick={onSelectBranch}
+                className={
+                  isRoot && footer
+                    ? "rounded-t-lg border-x border-t shadow-sm w-full"
+                    : "rounded-lg border shadow-sm w-full"
+                }
+              />
+              {isRoot && footer}
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/stack-tree/tree-layout.ts
+++ b/apps/web/src/components/stack-tree/tree-layout.ts
@@ -1,8 +1,11 @@
 import type { BranchResponse } from "@/lib/api";
 
-const H_GAP = 40; // horizontal gap between siblings
-const V_GAP = 80; // vertical gap between levels
-const NODE_W = 160;
+export const H_GAP = 24; // horizontal gap between siblings
+export const V_GAP = 88; // vertical gap between levels
+export const NODE_W = 256;
+export const NODE_H = 64;
+export const TREE_PADDING = 20;
+export const COLUMN_GAP = 12; // gap between fork columns
 
 export interface LayoutNode {
   branch: BranchResponse;
@@ -28,8 +31,8 @@ export interface TreeLayout {
 }
 
 /**
- * Computes a top-down tree layout from a flat list of branches.
- * Returns positioned nodes and edges for SVG rendering.
+ * Computes a bottom-up tree layout from a flat list of branches.
+ * Root is at the bottom, leaves branch upward (matching the stacking metaphor).
  */
 export function computeTreeLayout(branches: BranchResponse[]): TreeLayout {
   if (branches.length === 0) {
@@ -88,6 +91,12 @@ export function computeTreeLayout(branches: BranchResponse[]): TreeLayout {
     layout(root.name, 0);
   }
 
+  // Flip Y so root is at the bottom and leaves branch upward
+  const maxY = Math.max(...Array.from(positions.values()).map((p) => p.y));
+  for (const [name, pos] of positions) {
+    positions.set(name, { x: pos.x, y: maxY - pos.y });
+  }
+
   // Build layout nodes
   const nodes: LayoutNode[] = [];
   const edges: LayoutEdge[] = [];
@@ -98,8 +107,7 @@ export function computeTreeLayout(branches: BranchResponse[]): TreeLayout {
     nodes.push({ branch: b, x: pos.x, y: pos.y });
   }
 
-  // Build edges
-  const nodeHeight = 56;
+  // Build edges (parent is below child after flip)
   for (const b of branches) {
     if (!b.parent || !byName.has(b.parent)) continue;
     const parentPos = positions.get(b.parent);
@@ -110,22 +118,22 @@ export function computeTreeLayout(branches: BranchResponse[]): TreeLayout {
       parentName: b.parent,
       childName: b.name,
       x1: parentPos.x,
-      y1: parentPos.y + nodeHeight / 2,
+      y1: parentPos.y - NODE_H / 2,
       x2: childPos.x,
-      y2: childPos.y - nodeHeight / 2,
+      y2: childPos.y + NODE_H / 2,
       needsRestack: b.needsRestack,
     });
   }
 
   // Compute bounds and normalize positions.
-  // Node coordinates are center-based (BranchNode translates by -NODE_W/2, -nodeHeight/2),
-  // so offsets must account for half the node dimensions to keep nodes within the SVG viewport.
-  const PADDING = 20;
+  // Node coordinates are center-based, so offsets must account for
+  // half the node dimensions to keep nodes within the viewport.
+  const PADDING = TREE_PADDING;
   const allX = nodes.map((n) => n.x);
   const allY = nodes.map((n) => n.y);
   const minX = Math.min(...allX);
   const offsetX = -minX + NODE_W / 2 + PADDING;
-  const offsetY = nodeHeight / 2 + PADDING;
+  const offsetY = NODE_H / 2 + PADDING;
 
   for (const node of nodes) {
     node.x += offsetX;
@@ -139,7 +147,96 @@ export function computeTreeLayout(branches: BranchResponse[]): TreeLayout {
   }
 
   const width = (Math.max(...allX) - minX) + NODE_W + PADDING * 2;
-  const height = Math.max(...allY) + nodeHeight + PADDING * 2;
+  const height = Math.max(...allY) + NODE_H + PADDING * 2;
 
   return { nodes, edges, width, height };
+}
+
+/**
+ * A segment of a stack tree: a linear chain of branches that may fork
+ * at the top into multiple child segments.
+ */
+export interface TreeSegment {
+  /** Branches forming a linear chain, ordered root-to-leaf (bottom to top in display). */
+  branches: BranchResponse[];
+  /** Child segments if the topmost branch has multiple children. */
+  forks?: TreeSegment[];
+  /** Computed width in pixels for layout. */
+  width: number;
+}
+
+/**
+ * Decomposes a flat branch list into a tree of linear segments.
+ * Each segment is a chain of single-child branches. When a branch has
+ * multiple children, the segment records them as `forks`.
+ */
+export function decomposeTree(branches: BranchResponse[]): TreeSegment {
+  if (branches.length === 0) {
+    return { branches: [], width: NODE_W };
+  }
+
+  const byName = new Map<string, BranchResponse>();
+  const childrenOf = new Map<string, string[]>();
+
+  for (const b of branches) {
+    byName.set(b.name, b);
+  }
+
+  // Build children map preserving DFS order from the branch list
+  for (const b of branches) {
+    if (b.parent && byName.has(b.parent)) {
+      const existing = childrenOf.get(b.parent) || [];
+      existing.push(b.name);
+      childrenOf.set(b.parent, existing);
+    }
+  }
+
+  const roots = branches.filter(
+    (b) => !b.parent || !byName.has(b.parent)
+  );
+
+  function buildSegment(startName: string): TreeSegment {
+    const chain: BranchResponse[] = [];
+    let current = startName;
+
+    for (;;) {
+      const branch = byName.get(current);
+      if (!branch) break;
+      chain.push(branch);
+
+      const children = childrenOf.get(current) || [];
+      if (children.length === 1) {
+        current = children[0];
+      } else if (children.length > 1) {
+        const forks = children.map((child) => buildSegment(child));
+        const forksWidth =
+          forks.reduce((sum, f) => sum + f.width, 0) +
+          COLUMN_GAP * (forks.length - 1);
+        return {
+          branches: chain,
+          forks,
+          width: Math.max(NODE_W, forksWidth),
+        };
+      } else {
+        break;
+      }
+    }
+
+    return { branches: chain, width: NODE_W };
+  }
+
+  if (roots.length === 1) {
+    return buildSegment(roots[0].name);
+  }
+
+  // Multiple roots: treat as parallel forks
+  const forks = roots.map((r) => buildSegment(r.name));
+  const forksWidth =
+    forks.reduce((sum, f) => sum + f.width, 0) +
+    COLUMN_GAP * (forks.length - 1);
+  return {
+    branches: [],
+    forks,
+    width: Math.max(NODE_W, forksWidth),
+  };
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -95,6 +95,7 @@ export interface TrunkCommitResponse {
   prNumber?: number;
   stackSize?: number;
   stackPRs?: number[];
+  stackPRTitles?: Record<number, string>;
   stackScope?: string;
 }
 

--- a/internal/api/handlers/view_assembler.go
+++ b/internal/api/handlers/view_assembler.go
@@ -7,6 +7,7 @@ import (
 	"stackit.dev/stackit/internal/actions/merge"
 	httpcontract "stackit.dev/stackit/internal/contracts/http"
 	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/git"
 	"stackit.dev/stackit/internal/github"
 )
 
@@ -35,7 +36,7 @@ func (a *ViewAssembler) Build(ctx context.Context) (httpcontract.ViewResponse, e
 	checksMap := a.fetchChecks(ctx, stacks)
 	details := a.mapStackDetails(graph, stacks, checksMap)
 
-	recentlyMerged := a.fetchRecentlyMerged()
+	recentlyMerged := a.fetchRecentlyMerged(ctx)
 
 	return httpcontract.ViewResponse{
 		Repo:           a.buildRepo(ctx),
@@ -92,10 +93,44 @@ func (a *ViewAssembler) mapStackDetails(
 	return details
 }
 
-func (a *ViewAssembler) fetchRecentlyMerged() []httpcontract.TrunkCommitResponse {
+func (a *ViewAssembler) fetchRecentlyMerged(ctx context.Context) []httpcontract.TrunkCommitResponse {
 	recentCommits, err := a.eng.GetRecentTrunkCommits(10)
 	if err != nil || len(recentCommits) == 0 {
 		return nil
 	}
-	return httpcontract.MapTrunkCommits(recentCommits)
+
+	prTitles := a.fetchPRTitles(ctx, recentCommits)
+	return httpcontract.MapTrunkCommits(recentCommits, prTitles)
+}
+
+// fetchPRTitles collects all unique PR numbers from stack-merge commits and
+// batch-fetches their titles from GitHub. Returns nil on error or if no GitHub client.
+func (a *ViewAssembler) fetchPRTitles(ctx context.Context, commits []git.RecentCommit) map[int]string {
+	if a.gh == nil {
+		return nil
+	}
+
+	seen := make(map[int]struct{})
+	var prNumbers []int
+	for _, c := range commits {
+		if c.StackSize == 0 {
+			continue
+		}
+		for _, pr := range c.StackPRNumbers {
+			if _, ok := seen[pr]; !ok {
+				seen[pr] = struct{}{}
+				prNumbers = append(prNumbers, pr)
+			}
+		}
+	}
+	if len(prNumbers) == 0 {
+		return nil
+	}
+
+	owner, repo := a.gh.GetOwnerRepo()
+	titles, err := a.gh.BatchGetPRTitles(ctx, owner, repo, prNumbers)
+	if err != nil {
+		return nil
+	}
+	return titles
 }

--- a/internal/app/context_test.go
+++ b/internal/app/context_test.go
@@ -91,6 +91,10 @@ func (f *fakeGitHubClient) BatchGetPRChecksStatus(_ context.Context, _ []string)
 	return nil, nil
 }
 
+func (f *fakeGitHubClient) BatchGetPRTitles(_ context.Context, _, _ string, _ []int) (map[int]string, error) {
+	return nil, nil
+}
+
 func (f *fakeGitHubClient) GetOwnerRepo() (string, string) {
 	return "", ""
 }

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -299,7 +299,8 @@ func computeStackStatus(graph *engine.StackGraph, branchNames []string) string {
 // MapTrunkCommits converts git RecentCommit values to API TrunkCommitResponse values.
 // Commits whose PR number is already represented by a stack-merge's StackPRs are
 // filtered out so that consolidated stacks don't show duplicate entries.
-func MapTrunkCommits(commits []git.RecentCommit) []TrunkCommitResponse {
+// prTitles is an optional map of PR number to title; pass nil if unavailable.
+func MapTrunkCommits(commits []git.RecentCommit, prTitles map[int]string) []TrunkCommitResponse {
 	// Collect all PR numbers that are covered by stack-merge consolidation commits.
 	coveredPRs := make(map[int]struct{})
 	for _, c := range commits {
@@ -329,6 +330,19 @@ func MapTrunkCommits(commits []git.RecentCommit) []TrunkCommitResponse {
 			StackSize:  c.StackSize,
 			StackPRs:   append([]int(nil), c.StackPRNumbers...),
 			StackScope: c.StackScope,
+		}
+
+		// Populate PR titles for stack-merge commits when available
+		if c.StackSize > 0 && len(prTitles) > 0 {
+			titles := make(map[int]string)
+			for _, pr := range c.StackPRNumbers {
+				if title, ok := prTitles[pr]; ok {
+					titles[pr] = title
+				}
+			}
+			if len(titles) > 0 {
+				resp.StackPRTitles = titles
+			}
 		}
 
 		if resp.Kind == "" {

--- a/internal/contracts/http/mappers_test.go
+++ b/internal/contracts/http/mappers_test.go
@@ -34,7 +34,7 @@ func TestMapTrunkCommits(t *testing.T) {
 		},
 	}
 
-	got := MapTrunkCommits(commits)
+	got := MapTrunkCommits(commits, nil)
 	require.Len(t, got, 2)
 
 	require.Equal(t, "1234567", got[0].SHA)
@@ -94,7 +94,7 @@ func TestMapTrunkCommits_FiltersCoveredPRs(t *testing.T) {
 		},
 	}
 
-	got := MapTrunkCommits(commits)
+	got := MapTrunkCommits(commits, nil)
 	require.Len(t, got, 2, "commits covered by stack-merge should be filtered out")
 
 	require.Equal(t, "aaaa000", got[0].SHA)
@@ -117,7 +117,58 @@ func TestMapTrunkCommits_DefaultKindFallback(t *testing.T) {
 		},
 	}
 
-	got := MapTrunkCommits(commits)
+	got := MapTrunkCommits(commits, nil)
 	require.Len(t, got, 1)
 	require.Equal(t, TrunkCommitKindStackMerge, got[0].Kind)
+}
+
+func TestMapTrunkCommits_WithPRTitles(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	commits := []git.RecentCommit{
+		{
+			SHA:            "1234567890abcdef",
+			Subject:        "Consolidate auth stack",
+			Author:         "alice",
+			Date:           now,
+			Kind:           git.RecentCommitKindStackMerge,
+			StackSize:      3,
+			StackPRNumbers: []int{45, 46, 47},
+		},
+	}
+
+	titles := map[int]string{
+		45: "feat: add auth",
+		46: "feat: add middleware",
+		// 47 intentionally missing to test partial titles
+	}
+
+	got := MapTrunkCommits(commits, titles)
+	require.Len(t, got, 1)
+	require.Equal(t, map[int]string{
+		45: "feat: add auth",
+		46: "feat: add middleware",
+	}, got[0].StackPRTitles)
+}
+
+func TestMapTrunkCommits_NilTitlesNoStackPRTitles(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	commits := []git.RecentCommit{
+		{
+			SHA:            "1234567890abcdef",
+			Subject:        "Consolidate auth stack",
+			Author:         "alice",
+			Date:           now,
+			Kind:           git.RecentCommitKindStackMerge,
+			StackSize:      2,
+			StackPRNumbers: []int{45, 46},
+		},
+	}
+
+	got := MapTrunkCommits(commits, nil)
+	require.Len(t, got, 1)
+	require.Nil(t, got[0].StackPRTitles)
 }

--- a/internal/contracts/http/responses.go
+++ b/internal/contracts/http/responses.go
@@ -24,15 +24,16 @@ const (
 // TrunkCommitResponse represents a commit on the trunk branch,
 // optionally enriched with stack metadata from git trailers.
 type TrunkCommitResponse struct {
-	SHA        string `json:"sha"`
-	Message    string `json:"message"`
-	Author     string `json:"author"`
-	Date       string `json:"date"`
-	Kind       string `json:"kind"`
-	PRNumber   int    `json:"prNumber,omitempty"`
-	StackSize  int    `json:"stackSize,omitempty"`
-	StackPRs   []int  `json:"stackPRs,omitempty"`
-	StackScope string `json:"stackScope,omitempty"`
+	SHA           string         `json:"sha"`
+	Message       string         `json:"message"`
+	Author        string         `json:"author"`
+	Date          string         `json:"date"`
+	Kind          string         `json:"kind"`
+	PRNumber      int            `json:"prNumber,omitempty"`
+	StackSize     int            `json:"stackSize,omitempty"`
+	StackPRs      []int          `json:"stackPRs,omitempty"`
+	StackPRTitles map[int]string `json:"stackPRTitles,omitempty"`
+	StackScope    string         `json:"stackScope,omitempty"`
 }
 
 // RepoResponse contains repository metadata.

--- a/internal/demo/demo_github_client.go
+++ b/internal/demo/demo_github_client.go
@@ -177,6 +177,28 @@ func (c *GitHubClient) BatchGetPRChecksStatus(ctx context.Context, branchNames [
 	return results, nil
 }
 
+// BatchGetPRTitles returns plausible fake titles for demo mode
+func (c *GitHubClient) BatchGetPRTitles(_ context.Context, _, _ string, prNumbers []int) (map[int]string, error) {
+	simulateDelay(delayShort)
+
+	titles := []string{
+		"feat: add user authentication",
+		"feat: add database migrations",
+		"fix: resolve race condition in worker",
+		"refactor: extract service layer",
+		"feat: add rate limiting middleware",
+		"feat: implement webhook handlers",
+		"fix: correct timezone handling",
+		"feat: add CSV export support",
+	}
+
+	results := make(map[int]string, len(prNumbers))
+	for i, num := range prNumbers {
+		results[num] = titles[i%len(titles)]
+	}
+	return results, nil
+}
+
 // ClosePullRequest simulates closing a pull request
 func (c *GitHubClient) ClosePullRequest(_ context.Context, _, _ string, prNumber int) error {
 	simulateDelay(delayShort)

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -103,6 +103,9 @@ type Client interface {
 	// BatchGetPRChecksStatus returns the check status for multiple branches
 	BatchGetPRChecksStatus(ctx context.Context, branchNames []string) (map[string]*CheckStatus, error)
 
+	// BatchGetPRTitles returns titles for multiple PRs by number
+	BatchGetPRTitles(ctx context.Context, owner, repo string, prNumbers []int) (map[int]string, error)
+
 	// GetOwnerRepo returns the repository owner and name
 	GetOwnerRepo() (owner, repo string)
 

--- a/internal/github/client_real.go
+++ b/internal/github/client_real.go
@@ -170,6 +170,11 @@ func (c *StackitGitHubClient) BatchGetPRChecksStatus(ctx context.Context, branch
 	return BatchGetPRChecksStatusGraphQL(ctx, c.runner, c.owner, c.repo, branchNames)
 }
 
+// BatchGetPRTitles returns titles for multiple PRs by number
+func (c *StackitGitHubClient) BatchGetPRTitles(ctx context.Context, owner, repo string, prNumbers []int) (map[int]string, error) {
+	return BatchGetPRTitlesGraphQL(ctx, c.runner, owner, repo, prNumbers)
+}
+
 // ClosePullRequest closes a pull request
 func (c *StackitGitHubClient) ClosePullRequest(ctx context.Context, owner, repo string, prNumber int) error {
 	state := "closed"

--- a/internal/github/pr_titles.go
+++ b/internal/github/pr_titles.go
@@ -1,0 +1,86 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"stackit.dev/stackit/internal/git"
+)
+
+// BatchGetPRTitlesGraphQL fetches PR titles for multiple PR numbers using a single GraphQL query.
+func BatchGetPRTitlesGraphQL(ctx context.Context, runner git.Runner, owner, repo string, prNumbers []int) (map[int]string, error) {
+	if len(prNumbers) == 0 {
+		return make(map[int]string), nil
+	}
+
+	// Deduplicate PR numbers
+	seen := make(map[int]struct{}, len(prNumbers))
+	unique := make([]int, 0, len(prNumbers))
+	for _, n := range prNumbers {
+		if _, ok := seen[n]; !ok {
+			seen[n] = struct{}{}
+			unique = append(unique, n)
+		}
+	}
+
+	query := buildPRTitlesQuery(unique)
+	variables := map[string]any{
+		"owner": owner,
+		"repo":  repo,
+	}
+
+	body, err := executeGraphQLQuery(ctx, runner, query, variables)
+	if err != nil {
+		return nil, err
+	}
+
+	return parsePRTitlesResponse(body, unique)
+}
+
+// buildPRTitlesQuery builds a GraphQL query to fetch titles for multiple PRs by number.
+func buildPRTitlesQuery(prNumbers []int) string {
+	var b strings.Builder
+	b.WriteString("query($owner: String!, $repo: String!) {\n")
+	b.WriteString("  repository(owner: $owner, name: $repo) {\n")
+	for _, n := range prNumbers {
+		fmt.Fprintf(&b, "    pr_%d: pullRequest(number: %d) { title }\n", n, n)
+	}
+	b.WriteString("  }\n")
+	b.WriteString("}\n")
+	return b.String()
+}
+
+// parsePRTitlesResponse parses the GraphQL response for PR title queries.
+func parsePRTitlesResponse(body []byte, prNumbers []int) (map[int]string, error) {
+	var graphqlResponse struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(body, &graphqlResponse); err != nil {
+		return nil, fmt.Errorf("failed to parse GraphQL response: %w", err)
+	}
+
+	repository, ok := graphqlResponse.Data["repository"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("invalid GraphQL response format: missing repository")
+	}
+
+	results := make(map[int]string, len(prNumbers))
+	for _, n := range prNumbers {
+		alias := fmt.Sprintf("pr_%d", n)
+		data, ok := repository[alias]
+		if !ok || data == nil {
+			continue
+		}
+		prData, ok := data.(map[string]any)
+		if !ok {
+			continue
+		}
+		if title, ok := prData["title"].(string); ok {
+			results[n] = title
+		}
+	}
+
+	return results, nil
+}

--- a/internal/github/pr_titles_test.go
+++ b/internal/github/pr_titles_test.go
@@ -1,0 +1,93 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPRTitlesQuery(t *testing.T) {
+	t.Parallel()
+
+	query := buildPRTitlesQuery([]int{42, 99})
+
+	require.Contains(t, query, "pr_42: pullRequest(number: 42) { title }")
+	require.Contains(t, query, "pr_99: pullRequest(number: 99) { title }")
+	require.Contains(t, query, "repository(owner: $owner, name: $repo)")
+}
+
+func TestBuildPRTitlesQuery_Empty(t *testing.T) {
+	t.Parallel()
+
+	query := buildPRTitlesQuery(nil)
+
+	require.Contains(t, query, "repository(owner: $owner, name: $repo)")
+	require.NotContains(t, query, "pullRequest")
+}
+
+func TestParsePRTitlesResponse(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"data": {
+			"repository": {
+				"pr_42": {"title": "feat: add auth"},
+				"pr_99": {"title": "fix: resolve race condition"}
+			}
+		}
+	}`)
+
+	titles, err := parsePRTitlesResponse(body, []int{42, 99})
+	require.NoError(t, err)
+	require.Equal(t, map[int]string{
+		42: "feat: add auth",
+		99: "fix: resolve race condition",
+	}, titles)
+}
+
+func TestParsePRTitlesResponse_NullEntry(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"data": {
+			"repository": {
+				"pr_42": {"title": "feat: add auth"},
+				"pr_99": null
+			}
+		}
+	}`)
+
+	titles, err := parsePRTitlesResponse(body, []int{42, 99})
+	require.NoError(t, err)
+	require.Equal(t, map[int]string{42: "feat: add auth"}, titles)
+}
+
+func TestParsePRTitlesResponse_Empty(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"data": {
+			"repository": {}
+		}
+	}`)
+
+	titles, err := parsePRTitlesResponse(body, []int{42})
+	require.NoError(t, err)
+	require.Empty(t, titles)
+}
+
+func TestParsePRTitlesResponse_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	_, err := parsePRTitlesResponse([]byte(`{invalid`), []int{42})
+	require.Error(t, err)
+}
+
+func TestParsePRTitlesResponse_MissingRepository(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"data": {}}`)
+	_, err := parsePRTitlesResponse(body, []int{42})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing repository")
+}

--- a/testhelpers/github_mock_client.go
+++ b/testhelpers/github_mock_client.go
@@ -2,6 +2,7 @@ package testhelpers
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/google/go-github/v62/github"
@@ -154,6 +155,15 @@ func (c *MockGitHubClient) BatchGetPRChecksStatus(ctx context.Context, branchNam
 		mu.Unlock()
 	})
 
+	return results, nil
+}
+
+// BatchGetPRTitles returns synthetic titles for testing
+func (c *MockGitHubClient) BatchGetPRTitles(_ context.Context, _, _ string, prNumbers []int) (map[int]string, error) {
+	results := make(map[int]string, len(prNumbers))
+	for _, num := range prNumbers {
+		results[num] = fmt.Sprintf("PR #%d title", num)
+	}
 	return results, nil
 }
 


### PR DESCRIPTION
This PR merges the following changes:

1. **#790** feat: show PR titles in recently merged view
2. **#794** feat: show tree visualization for branching stacks
3. **#795** feat: improve branching stack tree rendering and alignment
4. **#796** feat: render branching stacks as linear segments with fork connectors
5. **#797** fix: round bottom corners and fix status footer width in fork columns
6. **#798** feat: add lock indicator to branch cards

### Stack

```
main
  └─ jonnii/20260301202047/show-PR-titles-in-recently-merged-view (#790)
    └─ jonnii/20260302013935/show-tree-visualization-for-branching-stacks (#794)
      └─ jonnii/20260302015757/improve-branching-stack-tree-rendering-and (#795)
        └─ jonnii/20260302021847/render-branching-stacks-as-linear-segments-with (#796)
          └─ jonnii/20260302022116/round-bottom-corners-and-fix-status-footer-width (#797)
            └─ jonnii/20260302022802/add-lock-indicator-to-branch-cards (#798)
```

Stackit-Stack-Size: 6
Stackit-PRs: 790,794,795,796,797,798
