### PR TITLE
fix: fix branch name truncation in sidebar panels

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -251,7 +251,7 @@ export default function Home() {
         {/* Right: detail + event feed panel (always visible) */}
         <div className="flex shrink-0">
           <Separator orientation="vertical" />
-          <div className="w-[400px] shrink-0 flex flex-col overflow-hidden">
+          <div className="w-[480px] shrink-0 flex flex-col overflow-hidden">
             {hasSelection ? (
               <div className="flex-1 overflow-auto p-4">
                 {selectedBranch && (

--- a/apps/web/src/components/branch-detail/branch-detail.tsx
+++ b/apps/web/src/components/branch-detail/branch-detail.tsx
@@ -42,19 +42,21 @@ export function BranchDetail({ branch, onNavigateToBranch }: BranchDetailProps) 
       animate={{ opacity: 1, x: 0 }}
       transition={{ duration: 0.2, ease: "easeOut" }}
     >
-    <Card>
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between gap-2">
-          <CardTitle className="text-base font-mono truncate min-w-0">{branch.name}</CardTitle>
+    <Card className="overflow-hidden">
+      <CardHeader className="pb-3 min-w-0">
+        <div className="flex items-center justify-between gap-2 min-w-0">
+          <CardTitle className="text-base truncate min-w-0" title={branch.pr ? branch.pr.title : branch.name}>
+            {branch.pr ? branch.pr.title : branch.name}
+          </CardTitle>
           <div className="flex items-center gap-2 shrink-0">
             <PRBadge pr={branch.pr} />
             <CIStatusBadge ci={branch.ci} />
             <ReviewBadge ci={branch.ci} />
           </div>
         </div>
-        {branch.pr && (
-          <p className="text-sm text-muted-foreground">{branch.pr.title}</p>
-        )}
+        <p className="text-xs font-mono text-muted-foreground truncate min-w-0" title={branch.name}>
+          {branch.name}
+        </p>
       </CardHeader>
 
       <CardContent className="space-y-4">

--- a/apps/web/src/components/branch-detail/stack-detail.tsx
+++ b/apps/web/src/components/branch-detail/stack-detail.tsx
@@ -96,8 +96,8 @@ export function StackDetailPanel({ stack, onSelectBranch }: StackDetailPanelProp
       animate={{ opacity: 1, x: 0 }}
       transition={{ duration: 0.2, ease: "easeOut" }}
     >
-      <Card>
-        <CardHeader className="pb-3">
+      <Card className="overflow-hidden">
+        <CardHeader className="pb-3 min-w-0">
           <div className="flex items-center justify-between">
             <CardTitle className="text-base">Stack overview</CardTitle>
             <span className={`text-xs font-medium ${status.color}`}>
@@ -228,8 +228,8 @@ function BranchRow({ branch, onClick }: { branch: BranchResponse; onClick?: () =
         branch.isCurrent && "border-l-2 border-l-green-500"
       )}
     >
-      <div className="flex items-center justify-between gap-2">
-        <span className="flex items-center gap-1.5 text-sm font-mono truncate min-w-0">
+      <div className="flex items-center justify-between gap-2 min-w-0">
+        <span className="flex items-center gap-1.5 text-sm font-mono truncate min-w-0" title={branch.name}>
           {branch.isCurrent && (
             <span className="inline-block w-2 h-2 rounded-full bg-green-500 shrink-0" />
           )}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Add interactive detail panels with navigation, warnings, and stats**

Improves the branch and stack detail panels (right sidebar) with richer information and interactivity using data already available in the frontend.

Key changes:
- **Empty state**: Shows a placeholder when nothing is selected instead of a blank panel; separator above EventFeed is now always visible
- **Branch navigation**: Parent branch is a clickable button (↑) that navigates to it; child branches shown as clickable pills (↓)
- **Warning pills**: Refactored with contextual lucide-react icons and Tooltip hints explaining what each warning means and how to fix it
- **Stack branch rows**: Converted to buttons — clicking navigates from stack view to branch detail; current branch gets a green dot and left border accent
- **Aggregate stats**: Stack overview shows a summary row (e.g. 2/4 PRs · 1/4 approved · 3/4 CI passing · +250/-80) between status description and issues
- **Stack description**: Reuses the collapsible markdown StackDescription component in the stack detail header when a description exists
- **Smart submit**: Submit button is hidden when all branches already have PRs; full SubmitResponse stored for per-branch feedback
- **Commit SHA links**: Each SHA links to the corresponding GitHub commit page
- **Sidebar width**: Widened from 400px to 480px for more breathing room
- **Truncation fix**: Long branch names and PR titles now correctly truncate with ellipsis; full text visible on hover via title attribute

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1772421833`.


* **PR #800**
  * **PR #802** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->