### PR TITLE
Add interactive detail panels with navigation, warnings, and stats

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -5,6 +5,7 @@ import { useRepo } from "@/components/providers/repo-provider";
 import { OwnerSwimlane, getLastActiveDate } from "@/components/owner-swimlane";
 import { BranchDetail } from "@/components/branch-detail/branch-detail";
 import { StackDetailPanel } from "@/components/branch-detail/stack-detail";
+import { DetailEmptyState } from "@/components/branch-detail/detail-empty-state";
 import { EventFeed } from "@/components/event-feed";
 import { Separator } from "@/components/ui/separator";
 import { RecentlyMerged } from "@/components/recently-merged";
@@ -84,6 +85,26 @@ export default function Home() {
       return next;
     });
   }, []);
+
+  const handleNavigateToBranch = useCallback(
+    (name: string) => {
+      for (const stack of stackDetails) {
+        const found = stack.branches.find((b) => b.name === name);
+        if (found) {
+          handleSelectBranch(found);
+          return;
+        }
+      }
+    },
+    [stackDetails, handleSelectBranch]
+  );
+
+  const handleStackBranchSelect = useCallback(
+    (branch: BranchResponse) => {
+      handleSelectBranch(branch);
+    },
+    [handleSelectBranch]
+  );
 
   const currentUser = repo?.currentUser;
 
@@ -230,14 +251,28 @@ export default function Home() {
         {/* Right: detail + event feed panel (always visible) */}
         <div className="flex shrink-0">
           <Separator orientation="vertical" />
-          <div className="w-[400px] shrink-0 flex flex-col overflow-hidden">
-            {hasSelection && (
+          <div className="w-[480px] shrink-0 flex flex-col overflow-hidden">
+            {hasSelection ? (
               <div className="flex-1 overflow-auto p-4">
-                {selectedBranch && <BranchDetail branch={selectedBranch} />}
-                {selectedStack && <StackDetailPanel stack={selectedStack} />}
+                {selectedBranch && (
+                  <BranchDetail
+                    branch={selectedBranch}
+                    onNavigateToBranch={handleNavigateToBranch}
+                  />
+                )}
+                {selectedStack && (
+                  <StackDetailPanel
+                    stack={selectedStack}
+                    onSelectBranch={handleStackBranchSelect}
+                  />
+                )}
+              </div>
+            ) : (
+              <div className="flex-1">
+                <DetailEmptyState />
               </div>
             )}
-            {hasSelection && <Separator />}
+            <Separator />
             <div className="p-3 overflow-auto">
               <EventFeed />
             </div>

--- a/apps/web/src/components/branch-detail/branch-detail.tsx
+++ b/apps/web/src/components/branch-detail/branch-detail.tsx
@@ -1,9 +1,25 @@
 "use client";
 
 import { motion } from "motion/react";
+import {
+  ArrowUp,
+  ArrowDown,
+  AlertTriangle,
+  Lock,
+  Snowflake,
+  CloudOff,
+  GitPullRequest,
+  GitBranchPlus,
+  ArrowDownToLine,
+} from "lucide-react";
 import type { BranchResponse } from "@/lib/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
 import {
   PRBadge,
   CIStatusBadge,
@@ -15,9 +31,10 @@ import { CIChecks } from "./ci-checks";
 
 interface BranchDetailProps {
   branch: BranchResponse;
+  onNavigateToBranch?: (name: string) => void;
 }
 
-export function BranchDetail({ branch }: BranchDetailProps) {
+export function BranchDetail({ branch, onNavigateToBranch }: BranchDetailProps) {
   return (
     <motion.div
       key={branch.name}
@@ -25,31 +42,63 @@ export function BranchDetail({ branch }: BranchDetailProps) {
       animate={{ opacity: 1, x: 0 }}
       transition={{ duration: 0.2, ease: "easeOut" }}
     >
-    <Card>
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between gap-2">
-          <CardTitle className="text-base font-mono truncate min-w-0">{branch.name}</CardTitle>
+    <Card className="overflow-hidden">
+      <CardHeader className="pb-3 min-w-0">
+        <div className="flex items-center justify-between gap-2 min-w-0">
+          <CardTitle className="text-base truncate min-w-0" title={branch.pr ? branch.pr.title : branch.name}>
+            {branch.pr ? branch.pr.title : branch.name}
+          </CardTitle>
           <div className="flex items-center gap-2 shrink-0">
             <PRBadge pr={branch.pr} />
             <CIStatusBadge ci={branch.ci} />
             <ReviewBadge ci={branch.ci} />
           </div>
         </div>
-        {branch.pr && (
-          <p className="text-sm text-muted-foreground">{branch.pr.title}</p>
-        )}
+        <p className="text-xs font-mono text-muted-foreground truncate min-w-0" title={branch.name}>
+          {branch.name}
+        </p>
       </CardHeader>
 
       <CardContent className="space-y-4">
         {/* Metadata row */}
         <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
-          {branch.parent && <span>Parent: {branch.parent}</span>}
+          {branch.parent && (
+            <span className="flex items-center gap-1">
+              <ArrowUp className="w-3 h-3" />
+              {onNavigateToBranch ? (
+                <button
+                  onClick={() => onNavigateToBranch(branch.parent!)}
+                  className="hover:text-foreground hover:underline transition-colors"
+                >
+                  {branch.parent}
+                </button>
+              ) : (
+                branch.parent
+              )}
+            </span>
+          )}
           <span>
             {branch.commitCount} commit{branch.commitCount !== 1 && "s"}
           </span>
           <DiffStats added={branch.linesAdded} deleted={branch.linesDeleted} />
           {branch.commitAuthor && <span>{branch.commitAuthor}</span>}
         </div>
+
+        {/* Children */}
+        {branch.children && branch.children.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {branch.children.map((child) => (
+              <button
+                key={child}
+                onClick={() => onNavigateToBranch?.(child)}
+                className="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-mono bg-muted hover:bg-muted/80 hover:text-foreground text-muted-foreground transition-colors"
+              >
+                <ArrowDown className="w-3 h-3" />
+                {child}
+              </button>
+            ))}
+          </div>
+        )}
 
         {/* Warnings */}
         <Warnings branch={branch} />
@@ -67,28 +116,81 @@ export function BranchDetail({ branch }: BranchDetailProps) {
   );
 }
 
-function Warnings({ branch }: { branch: BranchResponse }) {
-  const warnings: string[] = [];
+interface WarningDef {
+  label: string;
+  hint: string;
+  icon: React.ComponentType<{ className?: string }>;
+}
 
-  if (branch.needsRestack) warnings.push("Needs restack");
-  if (branch.isLocked) warnings.push(`Locked (${branch.lockReason || "unknown"})`);
-  if (branch.isFrozen) warnings.push("Frozen");
-  if (branch.remoteStatus?.missingRemote) warnings.push("Not yet pushed");
-  if (branch.remoteStatus?.behind) warnings.push("Behind remote");
-  if (branch.remoteStatus?.diverged) warnings.push("Diverged from remote");
-  if (!branch.pr) warnings.push("No PR");
+function Warnings({ branch }: { branch: BranchResponse }) {
+  const warnings: WarningDef[] = [];
+
+  if (branch.needsRestack) {
+    warnings.push({
+      label: "Needs restack",
+      hint: "A parent branch has changed. Run stackit restack to update.",
+      icon: AlertTriangle,
+    });
+  }
+  if (branch.isLocked) {
+    warnings.push({
+      label: `Locked${branch.lockReason ? ` (${branch.lockReason})` : ""}`,
+      hint: "This branch is locked and cannot be modified until unlocked.",
+      icon: Lock,
+    });
+  }
+  if (branch.isFrozen) {
+    warnings.push({
+      label: "Frozen",
+      hint: "This branch is frozen and won't be included in restack operations.",
+      icon: Snowflake,
+    });
+  }
+  if (branch.remoteStatus?.missingRemote) {
+    warnings.push({
+      label: "Not yet pushed",
+      hint: "This branch hasn't been pushed to the remote. Run stackit submit to push.",
+      icon: CloudOff,
+    });
+  }
+  if (branch.remoteStatus?.behind) {
+    warnings.push({
+      label: "Behind remote",
+      hint: "The remote has changes that aren't in your local branch. Run stackit sync.",
+      icon: ArrowDownToLine,
+    });
+  }
+  if (branch.remoteStatus?.diverged) {
+    warnings.push({
+      label: "Diverged from remote",
+      hint: "Local and remote have different changes. Run stackit sync to reconcile.",
+      icon: GitBranchPlus,
+    });
+  }
+  if (!branch.pr) {
+    warnings.push({
+      label: "No PR",
+      hint: "No pull request exists yet. Run stackit submit to create one.",
+      icon: GitPullRequest,
+    });
+  }
 
   if (warnings.length === 0) return null;
 
   return (
     <div className="flex flex-wrap gap-1">
       {warnings.map((w) => (
-        <span
-          key={w}
-          className="inline-flex items-center rounded-md bg-amber-50 dark:bg-amber-950 px-2 py-0.5 text-xs text-amber-700 dark:text-amber-300 ring-1 ring-inset ring-amber-600/20"
-        >
-          {w}
-        </span>
+        <Tooltip key={w.label}>
+          <TooltipTrigger asChild>
+            <span className="inline-flex items-center gap-1 rounded-md bg-amber-50 dark:bg-amber-950 px-2 py-0.5 text-xs text-amber-700 dark:text-amber-300 ring-1 ring-inset ring-amber-600/20 cursor-default">
+              <w.icon className="w-3 h-3" />
+              {w.label}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {w.hint}
+          </TooltipContent>
+        </Tooltip>
       ))}
     </div>
   );

--- a/apps/web/src/components/branch-detail/commit-list.tsx
+++ b/apps/web/src/components/branch-detail/commit-list.tsx
@@ -1,9 +1,15 @@
 "use client";
 
 import type { CommitResponse } from "@/lib/api";
+import { useRepo } from "@/components/providers/repo-provider";
 
 export function CommitList({ commits }: { commits?: CommitResponse[] }) {
+  const { repo } = useRepo();
+
   if (!commits || commits.length === 0) return null;
+
+  const githubBase =
+    repo ? `https://github.com/${repo.owner}/${repo.repo}/commit/` : null;
 
   return (
     <div className="space-y-1">
@@ -17,9 +23,20 @@ export function CommitList({ commits }: { commits?: CommitResponse[] }) {
             className="flex items-baseline gap-2 text-sm animate-fade-in-up"
             style={{ animationDelay: `${i * 40}ms` }}
           >
-            <code className="text-xs text-muted-foreground font-mono shrink-0">
-              {commit.sha}
-            </code>
+            {githubBase ? (
+              <a
+                href={`${githubBase}${commit.sha}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-muted-foreground font-mono shrink-0 hover:text-foreground hover:underline"
+              >
+                {commit.sha}
+              </a>
+            ) : (
+              <code className="text-xs text-muted-foreground font-mono shrink-0">
+                {commit.sha}
+              </code>
+            )}
             <span className="truncate">{commit.message}</span>
           </div>
         ))}

--- a/apps/web/src/components/branch-detail/detail-empty-state.tsx
+++ b/apps/web/src/components/branch-detail/detail-empty-state.tsx
@@ -1,0 +1,12 @@
+import { GitBranch } from "lucide-react";
+
+export function DetailEmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-3 text-muted-foreground px-6">
+      <GitBranch className="w-8 h-8 opacity-40" />
+      <p className="text-sm text-center">
+        Select a branch or stack to view details
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/branch-detail/stack-detail.tsx
+++ b/apps/web/src/components/branch-detail/stack-detail.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { motion } from "motion/react";
-import type { StackDetail as StackDetailType, BranchResponse } from "@/lib/api";
+import type { StackDetail as StackDetailType, BranchResponse, SubmitResponse } from "@/lib/api";
 import { submitStack } from "@/lib/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
@@ -11,10 +11,13 @@ import {
   CIStatusBadge,
   DiffStats,
 } from "@/components/status/status-badge";
+import { StackDescription } from "@/components/stack-column";
 import { useRepo } from "@/components/providers/repo-provider";
+import { cn } from "@/lib/utils";
 
 interface StackDetailPanelProps {
   stack: StackDetailType;
+  onSelectBranch?: (branch: BranchResponse) => void;
 }
 
 const statusConfig: Record<string, { label: string; description: string; color: string }> = {
@@ -40,20 +43,41 @@ const statusConfig: Record<string, { label: string; description: string; color: 
   },
 };
 
-export function StackDetailPanel({ stack }: StackDetailPanelProps) {
+function computeStackStats(branches: BranchResponse[]) {
+  let prCount = 0;
+  let approvedCount = 0;
+  let ciPassingCount = 0;
+  let totalAdded = 0;
+  let totalDeleted = 0;
+
+  for (const b of branches) {
+    if (b.pr) prCount++;
+    if (b.ci?.reviewDecision === "APPROVED") approvedCount++;
+    if (b.ci?.status === "passing") ciPassingCount++;
+    totalAdded += b.linesAdded;
+    totalDeleted += b.linesDeleted;
+  }
+
+  return { prCount, approvedCount, ciPassingCount, totalAdded, totalDeleted, total: branches.length };
+}
+
+export function StackDetailPanel({ stack, onSelectBranch }: StackDetailPanelProps) {
   const status = statusConfig[stack.status] || statusConfig.incomplete;
   const issues = collectIssues(stack.branches);
+  const stats = computeStackStats(stack.branches);
   const { refresh } = useRepo();
 
+  const allHavePRs = stack.branches.every((b) => b.pr != null);
+
   const [submitting, setSubmitting] = useState(false);
-  const [submitResult, setSubmitResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [submitResult, setSubmitResult] = useState<SubmitResponse | null>(null);
 
   const handleSubmit = async () => {
     setSubmitting(true);
     setSubmitResult(null);
     try {
       const result = await submitStack(stack.rootBranch);
-      setSubmitResult({ success: result.success, message: result.message });
+      setSubmitResult(result);
       refresh();
     } catch (err) {
       setSubmitResult({
@@ -72,8 +96,8 @@ export function StackDetailPanel({ stack }: StackDetailPanelProps) {
       animate={{ opacity: 1, x: 0 }}
       transition={{ duration: 0.2, ease: "easeOut" }}
     >
-      <Card>
-        <CardHeader className="pb-3">
+      <Card className="overflow-hidden">
+        <CardHeader className="pb-3 min-w-0">
           <div className="flex items-center justify-between">
             <CardTitle className="text-base">Stack overview</CardTitle>
             <span className={`text-xs font-medium ${status.color}`}>
@@ -83,11 +107,22 @@ export function StackDetailPanel({ stack }: StackDetailPanelProps) {
           {stack.title && (
             <p className="text-sm text-muted-foreground">{stack.title}</p>
           )}
+          {stack.description && (
+            <StackDescription text={stack.description} />
+          )}
         </CardHeader>
 
         <CardContent className="space-y-4">
           {/* Status explanation */}
           <p className="text-sm text-muted-foreground">{status.description}</p>
+
+          {/* Aggregate stats */}
+          <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+            <span>{stats.prCount}/{stats.total} PRs</span>
+            <span>{stats.approvedCount}/{stats.total} approved</span>
+            <span>{stats.ciPassingCount}/{stats.total} CI passing</span>
+            <DiffStats added={stats.totalAdded} deleted={stats.totalDeleted} />
+          </div>
 
           {/* Issues */}
           {issues.length > 0 && (
@@ -122,32 +157,58 @@ export function StackDetailPanel({ stack }: StackDetailPanelProps) {
             </h4>
             <div className="flex flex-col gap-2">
               {[...stack.branches].reverse().map((branch) => (
-                <BranchRow key={branch.name} branch={branch} />
+                <BranchRow
+                  key={branch.name}
+                  branch={branch}
+                  onClick={onSelectBranch ? () => onSelectBranch(branch) : undefined}
+                />
               ))}
             </div>
           </div>
 
           <Separator />
 
-          {/* Submit button */}
-          <button
-            onClick={handleSubmit}
-            disabled={submitting || stack.status === "blocked"}
-            className="w-full rounded-md px-3 py-2 text-sm font-medium transition-colors bg-green-600 text-white hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-600 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {submitting ? "Submitting..." : "Submit stack"}
-          </button>
+          {/* Submit button — hidden when all branches already have PRs */}
+          {!allHavePRs && (
+            <button
+              onClick={handleSubmit}
+              disabled={submitting || stack.status === "blocked"}
+              className="w-full rounded-md px-3 py-2 text-sm font-medium transition-colors bg-green-600 text-white hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-600 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {submitting ? "Submitting..." : "Submit stack"}
+            </button>
+          )}
 
           {/* Submit result */}
           {submitResult && (
-            <div
-              className={`rounded-md px-3 py-2 text-sm ${
-                submitResult.success
-                  ? "bg-green-50 dark:bg-green-950 text-green-700 dark:text-green-300 ring-1 ring-inset ring-green-600/20"
-                  : "bg-red-50 dark:bg-red-950 text-red-700 dark:text-red-300 ring-1 ring-inset ring-red-600/20"
-              }`}
-            >
-              {submitResult.message}
+            <div className="space-y-2">
+              <div
+                className={`rounded-md px-3 py-2 text-sm ${
+                  submitResult.success
+                    ? "bg-green-50 dark:bg-green-950 text-green-700 dark:text-green-300 ring-1 ring-inset ring-green-600/20"
+                    : "bg-red-50 dark:bg-red-950 text-red-700 dark:text-red-300 ring-1 ring-inset ring-red-600/20"
+                }`}
+              >
+                {submitResult.message}
+              </div>
+              {submitResult.branches && submitResult.branches.length > 0 && (
+                <div className="flex flex-col gap-1">
+                  {submitResult.branches.map((b) => (
+                    <div
+                      key={b.name}
+                      className="flex items-center justify-between text-xs px-2 py-1 rounded-md bg-muted"
+                    >
+                      <span className="font-mono truncate">{b.name}</span>
+                      <span className={cn(
+                        "shrink-0 ml-2",
+                        b.error ? "text-red-600" : "text-green-600"
+                      )}>
+                        {b.error || b.status}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           )}
         </CardContent>
@@ -156,11 +217,24 @@ export function StackDetailPanel({ stack }: StackDetailPanelProps) {
   );
 }
 
-function BranchRow({ branch }: { branch: BranchResponse }) {
+function BranchRow({ branch, onClick }: { branch: BranchResponse; onClick?: () => void }) {
   return (
-    <div className="flex flex-col gap-1 rounded-md border px-3 py-2">
-      <div className="flex items-center justify-between gap-2">
-        <span className="text-sm font-mono truncate min-w-0">{branch.name}</span>
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex flex-col gap-1 rounded-md border px-3 py-2 text-left transition-colors w-full",
+        onClick && "cursor-pointer hover:bg-muted/50",
+        branch.isCurrent && "border-l-2 border-l-green-500"
+      )}
+    >
+      <div className="flex items-center justify-between gap-2 min-w-0">
+        <span className="flex items-center gap-1.5 text-sm font-mono truncate min-w-0" title={branch.name}>
+          {branch.isCurrent && (
+            <span className="inline-block w-2 h-2 rounded-full bg-green-500 shrink-0" />
+          )}
+          {branch.name}
+        </span>
         <div className="flex items-center gap-1.5 shrink-0">
           {branch.pr ? (
             <PRBadge pr={branch.pr} />
@@ -181,7 +255,7 @@ function BranchRow({ branch }: { branch: BranchResponse }) {
           </span>
         )}
       </div>
-    </div>
+    </button>
   );
 }
 

--- a/apps/web/src/components/recently-merged.tsx
+++ b/apps/web/src/components/recently-merged.tsx
@@ -264,7 +264,7 @@ export function RecentlyMerged() {
   }
 
   return (
-    <div className="px-6 pb-4 space-y-2">
+    <div className="px-6 pb-4 max-h-64 overflow-y-auto space-y-2">
       {groups.map((group) => (
         <div key={group.label}>
           <div className="text-[10px] font-medium text-muted-foreground/50 uppercase tracking-wider mb-0.5">


### PR DESCRIPTION
**Add interactive detail panels with navigation, warnings, and stats**

Improves the branch and stack detail panels (right sidebar) with richer information and interactivity using data already available in the frontend.

Key changes:
- **Empty state**: Shows a placeholder when nothing is selected instead of a blank panel; separator above EventFeed is now always visible
- **Branch navigation**: Parent branch is a clickable button (↑) that navigates to it; child branches shown as clickable pills (↓)
- **Warning pills**: Refactored with contextual lucide-react icons and Tooltip hints explaining what each warning means and how to fix it
- **Stack branch rows**: Converted to buttons — clicking navigates from stack view to branch detail; current branch gets a green dot and left border accent
- **Aggregate stats**: Stack overview shows a summary row (e.g. 2/4 PRs · 1/4 approved · 3/4 CI passing · +250/-80) between status description and issues
- **Stack description**: Reuses the collapsible markdown StackDescription component in the stack detail header when a description exists
- **Smart submit**: Submit button is hidden when all branches already have PRs; full SubmitResponse stored for per-branch feedback
- **Commit SHA links**: Each SHA links to the corresponding GitHub commit page
- **Sidebar width**: Widened from 400px to 480px for more breathing room
- **Truncation fix**: Long branch names and PR titles now correctly truncate with ellipsis; full text visible on hover via title attribute

This PR merges the following changes:

1. **#800** feat: improve detail panel with navigation, warnings, stats, and empty state
2. **#802** fix: fix branch name truncation in sidebar panels

### Stack

```
main
  └─ jonnii/20260302030719/improve-detail-panel-with-navigation-warnings (#800)
    └─ jonnii/20260302032011/fix-branch-name-truncation-in-sidebar-panels (#802)
```

Stackit-Stack-Size: 2
Stackit-PRs: 800,802
