### PR TITLE
feat: add branch diff view with patch parsing

### DIFF
--- a/api/openapi/stackit.yaml
+++ b/api/openapi/stackit.yaml
@@ -92,6 +92,46 @@ paths:
                 $ref: "#/components/schemas/BranchResponse"
         "404":
           description: Branch not found.
+  /api/v1/branches/{branchName}/diff:
+    get:
+      summary: Get raw patch diff for a tracked branch.
+      operationId: getBranchDiff
+      parameters:
+        - in: path
+          name: branchName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Branch diff details.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BranchDiffResponse"
+        "404":
+          description: Branch not found.
+  /api/v1/branches/diff:
+    get:
+      summary: Get raw patch diff for a tracked branch by query parameter.
+      operationId: getBranchDiffByQuery
+      parameters:
+        - in: query
+          name: branch
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Branch diff details.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BranchDiffResponse"
+        "400":
+          description: Missing branch query parameter.
+        "404":
+          description: Branch not found.
   /api/v1/events:
     get:
       summary: Server-sent event stream for repository refresh events.
@@ -215,6 +255,18 @@ components:
           $ref: "#/components/schemas/PRResponse"
         ci:
           $ref: "#/components/schemas/CIResponse"
+    BranchDiffResponse:
+      type: object
+      required: [branch, baseRevision, headRevision, patch]
+      properties:
+        branch:
+          type: string
+        baseRevision:
+          type: string
+        headRevision:
+          type: string
+        patch:
+          type: string
     CommitResponse:
       type: object
       required: [sha, message]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@pierre/diffs": "^1.0.10",
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -5,6 +5,7 @@ import { useRepo } from "@/components/providers/repo-provider";
 import { OwnerSwimlane, getLastActiveDate } from "@/components/owner-swimlane";
 import { BranchDetail } from "@/components/branch-detail/branch-detail";
 import { StackDetailPanel } from "@/components/branch-detail/stack-detail";
+import { BranchDiffWorkspace } from "@/components/branch-detail/branch-diff-workspace";
 import { DetailEmptyState } from "@/components/branch-detail/detail-empty-state";
 import { EventFeed } from "@/components/event-feed";
 import { Separator } from "@/components/ui/separator";
@@ -23,7 +24,6 @@ export default function Home() {
   const {
     repo,
     stackDetails,
-    recentlyMerged,
     loading,
     error,
     lastUpdated,
@@ -53,6 +53,15 @@ export default function Home() {
     return stackDetails.find((s) => s.rootBranch === selection.rootBranch) ?? null;
   }, [selection, stackDetails]);
 
+  const selectedBranchStack = useMemo(() => {
+    if (!selectedBranch) return null;
+    return (
+      stackDetails.find((s) =>
+        s.branches.some((b) => b.name === selectedBranch.name)
+      ) ?? null
+    );
+  }, [selectedBranch, stackDetails]);
+
   const handleSelectBranch = useCallback((branch: BranchResponse | null) => {
     const url = new URL(window.location.href);
     url.searchParams.delete("stack");
@@ -63,6 +72,14 @@ export default function Home() {
       setSelection(null);
       url.searchParams.delete("branch");
     }
+    window.history.replaceState({}, "", url.toString());
+  }, []);
+
+  const handleClearSelection = useCallback(() => {
+    setSelection(null);
+    const url = new URL(window.location.href);
+    url.searchParams.delete("branch");
+    url.searchParams.delete("stack");
     window.history.replaceState({}, "", url.toString());
   }, []);
 
@@ -130,6 +147,7 @@ export default function Home() {
   }, [stackDetails, currentUser]);
 
   const hasSelection = selectedBranch || selectedStack;
+  const singleStackMode = Boolean(selectedBranch && selectedBranchStack);
 
   if (loading) {
     return (
@@ -198,7 +216,13 @@ export default function Home() {
       {/* Main content: stacks area + detail panel */}
       <div className="flex flex-1 overflow-hidden">
         <div className="flex-1 overflow-y-auto overflow-x-hidden">
-          {stackDetails.length > 0 ? (
+          {singleStackMode && selectedBranch && selectedBranchStack ? (
+            <BranchDiffWorkspace
+              branch={selectedBranch}
+              stack={selectedBranchStack}
+              onExit={handleClearSelection}
+            />
+          ) : stackDetails.length > 0 ? (
             <div className="flex flex-col justify-end min-h-full">
               {/* Swimlanes: only this area scrolls horizontally */}
               <div className="overflow-x-auto">
@@ -252,7 +276,14 @@ export default function Home() {
         <div className="flex shrink-0">
           <Separator orientation="vertical" />
           <div className="w-[480px] shrink-0 flex flex-col overflow-hidden">
-            {hasSelection ? (
+            {singleStackMode && selectedBranchStack ? (
+              <div className="flex-1 overflow-auto p-4">
+                <StackDetailPanel
+                  stack={selectedBranchStack}
+                  onSelectBranch={handleStackBranchSelect}
+                />
+              </div>
+            ) : hasSelection ? (
               <div className="flex-1 overflow-auto p-4">
                 {selectedBranch && (
                   <BranchDetail
@@ -272,10 +303,14 @@ export default function Home() {
                 <DetailEmptyState />
               </div>
             )}
-            <Separator />
-            <div className="p-3 overflow-auto">
-              <EventFeed />
-            </div>
+            {!singleStackMode && (
+              <>
+                <Separator />
+                <div className="p-3 overflow-auto">
+                  <EventFeed />
+                </div>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/apps/web/src/components/branch-detail/branch-detail.tsx
+++ b/apps/web/src/components/branch-detail/branch-detail.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/components/status/status-badge";
 import { CommitList } from "./commit-list";
 import { CIChecks } from "./ci-checks";
+import { BranchDiff } from "./branch-diff";
 
 interface BranchDetailProps {
   branch: BranchResponse;
@@ -107,6 +108,9 @@ export function BranchDetail({ branch, onNavigateToBranch }: BranchDetailProps) 
 
         {/* Commits */}
         <CommitList commits={branch.commits} />
+
+        {/* Branch diff */}
+        <BranchDiff branchName={branch.name} revision={branch.revision} />
 
         {/* CI Checks */}
         <CIChecks ci={branch.ci} />

--- a/apps/web/src/components/branch-detail/branch-diff-workspace.tsx
+++ b/apps/web/src/components/branch-detail/branch-diff-workspace.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import type { BranchResponse, StackDetail } from "@/lib/api";
+import { DiffStats } from "@/components/status/status-badge";
+import { BranchDiff } from "./branch-diff";
+
+interface BranchDiffWorkspaceProps {
+  branch: BranchResponse;
+  stack: StackDetail;
+  onExit: () => void;
+}
+
+export function BranchDiffWorkspace({
+  branch,
+  stack,
+  onExit,
+}: BranchDiffWorkspaceProps) {
+  const title = branch.pr?.title || branch.name;
+
+  return (
+    <div className="h-full flex flex-col p-6 gap-4">
+      <div className="rounded-xl border bg-card p-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <p className="text-xs uppercase tracking-wider text-muted-foreground">
+              Single Stack View
+            </p>
+            <h2 className="text-lg font-semibold truncate" title={title}>
+              {title}
+            </h2>
+            <p
+              className="text-xs font-mono text-muted-foreground truncate mt-1"
+              title={branch.name}
+            >
+              {branch.name}
+            </p>
+            <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground mt-2">
+              <span>{stack.title || stack.rootBranch}</span>
+              <span>{stack.branches.length} branches</span>
+              <span>
+                {branch.commitCount} commit{branch.commitCount !== 1 && "s"}
+              </span>
+              <DiffStats
+                added={branch.linesAdded}
+                deleted={branch.linesDeleted}
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 shrink-0">
+            {branch.pr?.url && (
+              <a
+                href={branch.pr.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-md border px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+              >
+                Open PR
+              </a>
+            )}
+            <button
+              onClick={onExit}
+              className="rounded-md border px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+            >
+              Back to all stacks
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto rounded-xl border bg-card p-4">
+        <BranchDiff
+          key={`${branch.name}:${branch.revision}`}
+          branchName={branch.name}
+          revision={branch.revision}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/branch-detail/branch-diff.tsx
+++ b/apps/web/src/components/branch-detail/branch-diff.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { parsePatchFiles, type FileDiffMetadata } from "@pierre/diffs";
+import { FileDiff } from "@pierre/diffs/react";
+import { useEffect, useMemo, useState } from "react";
+import { fetchBranchDiff, type BranchDiffResponse } from "@/lib/api";
+
+interface BranchDiffProps {
+  branchName: string;
+  revision: string;
+}
+
+const DIFF_OPTIONS = {
+  diffStyle: "split",
+  lineDiffType: "word",
+  hunkSeparators: "metadata",
+  overflow: "scroll",
+  themeType: "system",
+} as const;
+
+export function BranchDiff({ branchName, revision }: BranchDiffProps) {
+  const [diff, setDiff] = useState<BranchDiffResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    fetchBranchDiff(branchName)
+      .then((result) => {
+        if (!active) return;
+        setDiff(result);
+      })
+      .catch((err) => {
+        if (!active) return;
+        setError(err instanceof Error ? err.message : "Failed to load branch diff");
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [branchName, revision]);
+
+  const parsed = useMemo(() => {
+    if (!diff?.patch.trim()) {
+      return { files: [] as FileDiffMetadata[], parseError: null as string | null };
+    }
+
+    try {
+      const files = parsePatchFiles(diff.patch).flatMap((group) => group.files);
+      return { files, parseError: null as string | null };
+    } catch (err) {
+      return {
+        files: [] as FileDiffMetadata[],
+        parseError: err instanceof Error ? err.message : "Failed to parse patch",
+      };
+    }
+  }, [diff]);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+          Diff
+        </h4>
+        {!loading && !error && parsed.files.length > 0 && (
+          <span className="text-xs text-muted-foreground">
+            {parsed.files.length} file{parsed.files.length !== 1 && "s"}
+          </span>
+        )}
+      </div>
+
+      {loading && (
+        <p className="text-sm text-muted-foreground">Loading diff…</p>
+      )}
+
+      {!loading && error && (
+        <p className="text-sm text-destructive">{error}</p>
+      )}
+
+      {!loading && !error && diff && !diff.patch.trim() && (
+        <p className="text-sm text-muted-foreground">
+          No changes relative to base commit {diff.baseRevision.slice(0, 7)}.
+        </p>
+      )}
+
+      {!loading && !error && parsed.parseError && diff?.patch && (
+        <div className="space-y-2">
+          <p className="text-sm text-destructive">
+            Could not parse diff. Showing raw patch.
+          </p>
+          <pre className="max-h-80 overflow-auto rounded-md border bg-muted/30 p-3 text-xs">
+            {diff.patch}
+          </pre>
+        </div>
+      )}
+
+      {!loading && !error && !parsed.parseError && parsed.files.length > 0 && (
+        <div className="space-y-3">
+          {parsed.files.map((file, i) => (
+            <div key={`${file.prevName ?? file.name}:${file.name}:${i}`} className="rounded-md border bg-background">
+              <FileDiff fileDiff={file} options={DIFF_OPTIONS} className="block" />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/__tests__/api.test.ts
+++ b/apps/web/src/lib/__tests__/api.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { fetchView, fetchRepo, fetchStacks, fetchStack, fetchBranch } from "../api";
+import {
+  fetchView,
+  fetchRepo,
+  fetchStacks,
+  fetchStack,
+  fetchBranch,
+  fetchBranchDiff,
+} from "../api";
 
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
@@ -71,6 +78,17 @@ describe("fetchBranch", () => {
     await fetchBranch("feat/bar");
     expect(mockFetch).toHaveBeenCalledWith(
       "http://localhost:8080/api/branches/feat%2Fbar"
+    );
+  });
+});
+
+describe("fetchBranchDiff", () => {
+  it("sends encoded branch name in query string", async () => {
+    mockOk({ branch: "feat/bar", baseRevision: "abc", headRevision: "def", patch: "" });
+
+    await fetchBranchDiff("feat/bar");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/api/branches/diff?branch=feat%2Fbar"
     );
   });
 });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -53,6 +53,13 @@ export interface BranchResponse {
   remoteStatus?: RemoteStatus;
 }
 
+export interface BranchDiffResponse {
+  branch: string;
+  baseRevision: string;
+  headRevision: string;
+  patch: string;
+}
+
 export interface PRResponse {
   number: number;
   title: string;
@@ -140,6 +147,12 @@ export function fetchBranches(): Promise<BranchResponse[]> {
 export function fetchBranch(name: string): Promise<BranchResponse> {
   return fetchAPI<BranchResponse>(
     `/api/branches/${encodeURIComponent(name)}`
+  );
+}
+
+export function fetchBranchDiff(name: string): Promise<BranchDiffResponse> {
+  return fetchAPI<BranchDiffResponse>(
+    `/api/branches/diff?branch=${encodeURIComponent(name)}`
   );
 }
 

--- a/internal/api/handlers/branches.go
+++ b/internal/api/handlers/branches.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"strings"
 
 	httpcontract "stackit.dev/stackit/internal/contracts/http"
 	"stackit.dev/stackit/internal/engine"
@@ -32,9 +33,19 @@ func (h *BranchesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if branchName == "" {
+	switch {
+	case branchName == "diff":
+		queryBranch := r.URL.Query().Get("branch")
+		if queryBranch == "" {
+			http.Error(w, "missing branch query parameter", http.StatusBadRequest)
+			return
+		}
+		h.getBranchDiff(w, r, queryBranch)
+	case branchName == "":
 		h.listBranches(w, r)
-	} else {
+	case strings.HasSuffix(branchName, "/diff"):
+		h.getBranchDiff(w, r, strings.TrimSuffix(branchName, "/diff"))
+	default:
 		h.getBranch(w, r, branchName)
 	}
 }
@@ -101,4 +112,42 @@ func (h *BranchesHandler) getBranch(w http.ResponseWriter, r *http.Request, bran
 
 	resp := httpcontract.MapBranch(h.eng, branch, node, checks)
 	writeJSON(w, resp)
+}
+
+func (h *BranchesHandler) getBranchDiff(w http.ResponseWriter, r *http.Request, branchName string) {
+	if branchName == "" {
+		http.Error(w, "branch not found or not tracked", http.StatusNotFound)
+		return
+	}
+
+	branch := h.eng.GetBranch(branchName)
+	if !branch.IsTracked() {
+		http.Error(w, "branch not found or not tracked", http.StatusNotFound)
+		return
+	}
+
+	baseRevision, err := h.eng.GetDivergencePoint(branchName)
+	if err != nil {
+		http.Error(w, "failed to resolve branch base: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	headRevision, err := branch.GetRevision()
+	if err != nil {
+		http.Error(w, "failed to resolve branch revision: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	patch, err := h.eng.GetDiffBetween(r.Context(), baseRevision, headRevision)
+	if err != nil {
+		http.Error(w, "failed to compute branch diff: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, httpcontract.BranchDiffResponse{
+		Branch:       branchName,
+		BaseRevision: baseRevision,
+		HeadRevision: headRevision,
+		Patch:        patch,
+	})
 }

--- a/internal/api/handlers/path_test.go
+++ b/internal/api/handlers/path_test.go
@@ -39,6 +39,27 @@ func TestParseResourcePath(t *testing.T) {
 			wantOK:    true,
 		},
 		{
+			name:      "versioned branches with encoded branch path",
+			path:      "/api/v1/branches/jonnii%2F20260228%2Ffeature",
+			resource:  "branches",
+			wantValue: "jonnii/20260228/feature",
+			wantOK:    true,
+		},
+		{
+			name:      "versioned branch diff path with encoded branch name",
+			path:      "/api/v1/branches/jonnii%2F20260228%2Ffeature/diff",
+			resource:  "branches",
+			wantValue: "jonnii/20260228/feature/diff",
+			wantOK:    true,
+		},
+		{
+			name:      "versioned stack with encoded root branch",
+			path:      "/api/v1/stacks/jonnii%2F20260228%2Ffeature",
+			resource:  "stacks",
+			wantValue: "jonnii/20260228/feature",
+			wantOK:    true,
+		},
+		{
 			name:      "resource not found",
 			path:      "/api/v1/view",
 			resource:  "stacks",

--- a/internal/api/handlers/stacks.go
+++ b/internal/api/handlers/stacks.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 
 	"stackit.dev/stackit/internal/actions/merge"
@@ -99,5 +100,10 @@ func parseResourcePath(requestPath, resource string) (string, bool) {
 	}
 
 	suffix := strings.TrimPrefix(after, "/")
-	return suffix, true
+	decoded, err := url.PathUnescape(suffix)
+	if err != nil {
+		// Keep previous behavior for malformed escape sequences.
+		return suffix, true
+	}
+	return decoded, true
 }

--- a/internal/contracts/http/responses.go
+++ b/internal/contracts/http/responses.go
@@ -90,6 +90,14 @@ type BranchResponse struct {
 	RemoteStatus *RemoteStatus    `json:"remoteStatus,omitempty"`
 }
 
+// BranchDiffResponse contains raw patch data for a branch relative to its divergence point.
+type BranchDiffResponse struct {
+	Branch       string `json:"branch"`
+	BaseRevision string `json:"baseRevision"`
+	HeadRevision string `json:"headRevision"`
+	Patch        string `json:"patch"`
+}
+
 // PRResponse contains pull request metadata.
 type PRResponse struct {
 	Number  int    `json:"number"`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@pierre/diffs':
+        specifier: ^1.0.10
+        version: 1.0.11(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       canvas-confetti:
         specifier: ^1.9.4
         version: 1.9.4
@@ -839,6 +842,12 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@pierre/diffs@1.0.11':
+    resolution: {integrity: sha512-j6zIEoyImQy1HfcJqbrDwP0O5I7V2VNXAaw53FqQ+SykRfaNwABeZHs9uibXO4supaXPmTx6LEH9Lffr03e1Tw==}
+    peerDependencies:
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
+
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
 
@@ -1659,6 +1668,30 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@shikijs/core@3.23.0':
+    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
+
+  '@shikijs/engine-javascript@3.23.0':
+    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
+
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
+  '@shikijs/transformers@3.23.0':
+    resolution: {integrity: sha512-F9msZVxdF+krQNSdQ4V+Ja5QemeAoTQ2jxt7nJCwhDsdF1JWS3KxIQXA3lQbyKwS3J61oHRUSv4jYWv3CkaKTQ==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
@@ -2962,6 +2995,9 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -2987,6 +3023,9 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -3427,6 +3466,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru_map@0.4.1:
+    resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
+
   lucide-react@0.574.0:
     resolution: {integrity: sha512-dJ8xb5juiZVIbdSn3HTyHsjjIwUwZ4FNwV0RtYDScOyySOeie1oXZTymST6YPJ4Qwt3Po8g4quhYl4OxtACiuQ==}
     peerDependencies:
@@ -3735,6 +3777,12 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  oniguruma-parser@0.12.1:
+    resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
+
+  oniguruma-to-es@4.3.4:
+    resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==}
+
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
@@ -3970,6 +4018,15 @@ packages:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
 
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
@@ -4101,6 +4158,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shiki@3.23.0:
+    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -5363,6 +5423,18 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@pierre/diffs@1.0.11(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/engine-javascript': 3.23.0
+      '@shikijs/transformers': 3.23.0
+      diff: 8.0.3
+      hast-util-to-html: 9.0.5
+      lru_map: 0.4.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      shiki: 3.23.0
+
   '@radix-ui/number@1.1.1': {}
 
   '@radix-ui/primitive@1.1.3': {}
@@ -6188,6 +6260,44 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@shikijs/core@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.4
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/transformers@3.23.0':
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
@@ -7648,6 +7758,20 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -7689,6 +7813,8 @@ snapshots:
       - '@noble/hashes'
 
   html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -8085,6 +8211,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru_map@0.4.1: {}
 
   lucide-react@0.574.0(react@19.2.3):
     dependencies:
@@ -8520,6 +8648,14 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  oniguruma-parser@0.12.1: {}
+
+  oniguruma-to-es@4.3.4:
+    dependencies:
+      oniguruma-parser: 0.12.1
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   open@11.0.0:
     dependencies:
       default-browser: 5.5.0
@@ -8832,6 +8968,16 @@ snapshots:
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
 
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
   regexp.prototype.flags@1.5.4:
     dependencies:
       call-bind: 1.0.8
@@ -9098,6 +9244,17 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shiki@3.23.0:
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/engine-javascript': 3.23.0
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   side-channel-list@1.0.0:
     dependencies:


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Add branch diff view with file tree sidebar and component refactoring**

Adds an inline diff view to the web UI that shows a branch's changes relative to its divergence point, with a file tree sidebar for navigation. The stack also includes significant web component reorganization to support the new architecture.

Key changes:
- **#812 add-branch-diff-view**: New `GET /api/branches/<name>/diff` endpoint returns a unified patch between the branch's divergence point and HEAD; `BranchDiff` and `BranchDiffWorkspace` components render it using `@pierre/diffs` with split-view, word-level highlighting
- **#813 overlay-layout**: Refactors the main layout from a full-screen takeover to an overlay mode — the diff workspace occupies the upper portion while the stacks/history strip remains visible below
- **#814 simplify-workspace**: Strips the redundant header card from `BranchDiffWorkspace` (title, PR link, stats) since that info already appears in the side panel; leaves only the "Back" button and the diff
- **#815 compact-mode**: Threads a `compact` prop through `OwnerSwimlane` → `StackColumn` → `BranchCard` / `SegmentTree` / `ForkConnector` for a denser layout in the bottom overlay strip (tighter padding, 11px text, shorter fork connectors)
- **#816 stack-detail-reuse**: Replaces the one-off `BranchRow` list in `StackDetailPanel` with the shared `StackColumn`, adding `showHeader`, `showFooter`, and `fillWidth` props; propagates `selectedBranchName` so the active branch is highlighted in the side panel
- **#817 dedicated-diff-endpoint**: Consolidates branch diff fetching to a dedicated `useBranchDiff` hook and lazy-loads diff components to avoid bundling the heavy diff renderer on initial page load
- **#818 component-reorganization**: Reorganizes web app components by feature area and extracts shared utilities into dedicated modules, reducing duplication across diff/stack views
- **#819 layout-status-modules**: Consolidates web components into `layout/` and `status/` subdirectories, grouping related components for better discoverability and maintainability
- **#820 file-tree-sidebar**: Adds a collapsible file tree sidebar to the branch diff view, allowing users to jump directly to changed files; supports expand/collapse state and highlights the active file

#### Stack


* **PR #812** 👈
  * **PR #813**
    * **PR #814**
      * **PR #815**
        * **PR #816**
          * **PR #817**
            * **PR #818**
              * **PR #819**
                * **PR #820**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #821 by jonnii*