### PR TITLE
feat: show stacks below diff workspace in branch overlay mode

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -147,7 +147,56 @@ export default function Home() {
   }, [stackDetails, currentUser]);
 
   const hasSelection = selectedBranch || selectedStack;
-  const singleStackMode = Boolean(selectedBranch && selectedBranchStack);
+  const branchOverlayMode = Boolean(selectedBranch && selectedBranchStack);
+  const stacksAndHistoryContent =
+    stackDetails.length > 0 ? (
+      <div className="flex flex-col justify-end min-h-full">
+        {/* Swimlanes: only this area scrolls horizontally */}
+        <div className="overflow-x-auto">
+          <div className="flex items-end gap-8 p-6 pb-4 min-w-max">
+            {/* Your stacks */}
+            {yourStacks.length > 0 && (
+              <OwnerSwimlane
+                label="You"
+                stacks={yourStacks}
+                selectedBranch={selection?.type === "branch" ? selection.name : null}
+                selectedStack={selection?.type === "stack" ? selection.rootBranch : null}
+                onSelectBranch={handleSelectBranch}
+                onSelectStack={handleSelectStack}
+              />
+            )}
+
+            {/* Teammate swimlanes */}
+            {otherOwners.map(([owner, stacks]) => (
+              <OwnerSwimlane
+                key={owner}
+                label={`@${owner}`}
+                lastActive={getLastActiveDate(stacks)}
+                stacks={stacks}
+                selectedBranch={selection?.type === "branch" ? selection.name : null}
+                selectedStack={selection?.type === "stack" ? selection.rootBranch : null}
+                onSelectBranch={handleSelectBranch}
+                onSelectStack={handleSelectStack}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Trunk line */}
+        <div className="flex items-center gap-2 px-6 pb-2 shrink-0">
+          <div className="flex-1 border-t-2 border-dashed border-muted-foreground/30" />
+          <span className="text-xs font-mono text-muted-foreground">{repo?.trunk}</span>
+          <div className="flex-1 border-t-2 border-dashed border-muted-foreground/30" />
+        </div>
+
+        {/* Recent trunk commits */}
+        <RecentlyMerged />
+      </div>
+    ) : (
+      <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+        No stacks found
+      </div>
+    );
 
   if (loading) {
     return (
@@ -215,59 +264,23 @@ export default function Home() {
 
       {/* Main content: stacks area + detail panel */}
       <div className="flex flex-1 overflow-hidden">
-        <div className="flex-1 overflow-y-auto overflow-x-hidden">
-          {singleStackMode && selectedBranch && selectedBranchStack ? (
-            <BranchDiffWorkspace
-              branch={selectedBranch}
-              stack={selectedBranchStack}
-              onExit={handleClearSelection}
-            />
-          ) : stackDetails.length > 0 ? (
-            <div className="flex flex-col justify-end min-h-full">
-              {/* Swimlanes: only this area scrolls horizontally */}
-              <div className="overflow-x-auto">
-                <div className="flex items-end gap-8 p-6 pb-4 min-w-max">
-                  {/* Your stacks */}
-                  {yourStacks.length > 0 && (
-                    <OwnerSwimlane
-                      label="You"
-                      stacks={yourStacks}
-                      selectedBranch={selection?.type === "branch" ? selection.name : null}
-                      selectedStack={selection?.type === "stack" ? selection.rootBranch : null}
-                      onSelectBranch={handleSelectBranch}
-                      onSelectStack={handleSelectStack}
-                    />
-                  )}
-
-                  {/* Teammate swimlanes */}
-                  {otherOwners.map(([owner, stacks]) => (
-                    <OwnerSwimlane
-                      key={owner}
-                      label={`@${owner}`}
-                      lastActive={getLastActiveDate(stacks)}
-                      stacks={stacks}
-                      selectedBranch={selection?.type === "branch" ? selection.name : null}
-                      selectedStack={selection?.type === "stack" ? selection.rootBranch : null}
-                      onSelectBranch={handleSelectBranch}
-                      onSelectStack={handleSelectStack}
-                    />
-                  ))}
-                </div>
+        <div className="flex flex-1 flex-col overflow-hidden">
+          {branchOverlayMode && selectedBranch && selectedBranchStack ? (
+            <>
+              <div className="min-h-0 flex-1 overflow-hidden border-b">
+                <BranchDiffWorkspace
+                  branch={selectedBranch}
+                  stack={selectedBranchStack}
+                  onExit={handleClearSelection}
+                />
               </div>
-
-              {/* Trunk line */}
-              <div className="flex items-center gap-2 px-6 pb-2 shrink-0">
-                <div className="flex-1 border-t-2 border-dashed border-muted-foreground/30" />
-                <span className="text-xs font-mono text-muted-foreground">{repo?.trunk}</span>
-                <div className="flex-1 border-t-2 border-dashed border-muted-foreground/30" />
+              <div className="h-[36vh] min-h-[240px] max-h-[460px] overflow-y-auto overflow-x-hidden bg-background/70">
+                {stacksAndHistoryContent}
               </div>
-
-              {/* Recent trunk commits */}
-              <RecentlyMerged />
-            </div>
+            </>
           ) : (
-            <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
-              No stacks found
+            <div className="flex-1 overflow-y-auto overflow-x-hidden">
+              {stacksAndHistoryContent}
             </div>
           )}
         </div>
@@ -276,7 +289,7 @@ export default function Home() {
         <div className="flex shrink-0">
           <Separator orientation="vertical" />
           <div className="w-[480px] shrink-0 flex flex-col overflow-hidden">
-            {singleStackMode && selectedBranchStack ? (
+            {branchOverlayMode && selectedBranchStack ? (
               <div className="flex-1 overflow-auto p-4">
                 <StackDetailPanel
                   stack={selectedBranchStack}
@@ -303,7 +316,7 @@ export default function Home() {
                 <DetailEmptyState />
               </div>
             )}
-            {!singleStackMode && (
+            {!branchOverlayMode && (
               <>
                 <Separator />
                 <div className="p-3 overflow-auto">

--- a/apps/web/src/components/branch-detail/branch-diff-workspace.tsx
+++ b/apps/web/src/components/branch-detail/branch-diff-workspace.tsx
@@ -23,7 +23,7 @@ export function BranchDiffWorkspace({
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0">
             <p className="text-xs uppercase tracking-wider text-muted-foreground">
-              Single Stack View
+              Branch Layer
             </p>
             <h2 className="text-lg font-semibold truncate" title={title}>
               {title}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Add branch diff view with file tree sidebar and component refactoring**

Adds an inline diff view to the web UI that shows a branch's changes relative to its divergence point, with a file tree sidebar for navigation. The stack also includes significant web component reorganization to support the new architecture.

Key changes:
- **#812 add-branch-diff-view**: New `GET /api/branches/<name>/diff` endpoint returns a unified patch between the branch's divergence point and HEAD; `BranchDiff` and `BranchDiffWorkspace` components render it using `@pierre/diffs` with split-view, word-level highlighting
- **#813 overlay-layout**: Refactors the main layout from a full-screen takeover to an overlay mode — the diff workspace occupies the upper portion while the stacks/history strip remains visible below
- **#814 simplify-workspace**: Strips the redundant header card from `BranchDiffWorkspace` (title, PR link, stats) since that info already appears in the side panel; leaves only the "Back" button and the diff
- **#815 compact-mode**: Threads a `compact` prop through `OwnerSwimlane` → `StackColumn` → `BranchCard` / `SegmentTree` / `ForkConnector` for a denser layout in the bottom overlay strip (tighter padding, 11px text, shorter fork connectors)
- **#816 stack-detail-reuse**: Replaces the one-off `BranchRow` list in `StackDetailPanel` with the shared `StackColumn`, adding `showHeader`, `showFooter`, and `fillWidth` props; propagates `selectedBranchName` so the active branch is highlighted in the side panel
- **#817 dedicated-diff-endpoint**: Consolidates branch diff fetching to a dedicated `useBranchDiff` hook and lazy-loads diff components to avoid bundling the heavy diff renderer on initial page load
- **#818 component-reorganization**: Reorganizes web app components by feature area and extracts shared utilities into dedicated modules, reducing duplication across diff/stack views
- **#819 layout-status-modules**: Consolidates web components into `layout/` and `status/` subdirectories, grouping related components for better discoverability and maintainability
- **#820 file-tree-sidebar**: Adds a collapsible file tree sidebar to the branch diff view, allowing users to jump directly to changed files; supports expand/collapse state and highlights the active file

#### Stack


* **PR #812**
  * **PR #813** 👈
    * **PR #814**
      * **PR #815**
        * **PR #816**
          * **PR #817**
            * **PR #818**
              * **PR #819**
                * **PR #820**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #821 by jonnii*