### PR TITLE
refactor: simplify branch diff workspace by removing redundant header

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -270,7 +270,6 @@ export default function Home() {
               <div className="min-h-0 flex-1 overflow-hidden border-b">
                 <BranchDiffWorkspace
                   branch={selectedBranch}
-                  stack={selectedBranchStack}
                   onExit={handleClearSelection}
                 />
               </div>

--- a/apps/web/src/components/branch-detail/branch-diff-workspace.tsx
+++ b/apps/web/src/components/branch-detail/branch-diff-workspace.tsx
@@ -1,71 +1,26 @@
 "use client";
 
-import type { BranchResponse, StackDetail } from "@/lib/api";
-import { DiffStats } from "@/components/status/status-badge";
+import type { BranchResponse } from "@/lib/api";
 import { BranchDiff } from "./branch-diff";
 
 interface BranchDiffWorkspaceProps {
   branch: BranchResponse;
-  stack: StackDetail;
   onExit: () => void;
 }
 
 export function BranchDiffWorkspace({
   branch,
-  stack,
   onExit,
 }: BranchDiffWorkspaceProps) {
-  const title = branch.pr?.title || branch.name;
-
   return (
-    <div className="h-full flex flex-col p-6 gap-4">
-      <div className="rounded-xl border bg-card p-4">
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0">
-            <p className="text-xs uppercase tracking-wider text-muted-foreground">
-              Branch Layer
-            </p>
-            <h2 className="text-lg font-semibold truncate" title={title}>
-              {title}
-            </h2>
-            <p
-              className="text-xs font-mono text-muted-foreground truncate mt-1"
-              title={branch.name}
-            >
-              {branch.name}
-            </p>
-            <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground mt-2">
-              <span>{stack.title || stack.rootBranch}</span>
-              <span>{stack.branches.length} branches</span>
-              <span>
-                {branch.commitCount} commit{branch.commitCount !== 1 && "s"}
-              </span>
-              <DiffStats
-                added={branch.linesAdded}
-                deleted={branch.linesDeleted}
-              />
-            </div>
-          </div>
-
-          <div className="flex items-center gap-2 shrink-0">
-            {branch.pr?.url && (
-              <a
-                href={branch.pr.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="rounded-md border px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-              >
-                Open PR
-              </a>
-            )}
-            <button
-              onClick={onExit}
-              className="rounded-md border px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-            >
-              Back to all stacks
-            </button>
-          </div>
-        </div>
+    <div className="h-full flex flex-col p-4 gap-3">
+      <div className="flex justify-end">
+        <button
+          onClick={onExit}
+          className="rounded-md border px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+        >
+          Back to all stacks
+        </button>
       </div>
 
       <div className="min-h-0 flex-1 overflow-auto rounded-xl border bg-card p-4">


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Add branch diff view with file tree sidebar and component refactoring**

Adds an inline diff view to the web UI that shows a branch's changes relative to its divergence point, with a file tree sidebar for navigation. The stack also includes significant web component reorganization to support the new architecture.

Key changes:
- **#812 add-branch-diff-view**: New `GET /api/branches/<name>/diff` endpoint returns a unified patch between the branch's divergence point and HEAD; `BranchDiff` and `BranchDiffWorkspace` components render it using `@pierre/diffs` with split-view, word-level highlighting
- **#813 overlay-layout**: Refactors the main layout from a full-screen takeover to an overlay mode — the diff workspace occupies the upper portion while the stacks/history strip remains visible below
- **#814 simplify-workspace**: Strips the redundant header card from `BranchDiffWorkspace` (title, PR link, stats) since that info already appears in the side panel; leaves only the "Back" button and the diff
- **#815 compact-mode**: Threads a `compact` prop through `OwnerSwimlane` → `StackColumn` → `BranchCard` / `SegmentTree` / `ForkConnector` for a denser layout in the bottom overlay strip (tighter padding, 11px text, shorter fork connectors)
- **#816 stack-detail-reuse**: Replaces the one-off `BranchRow` list in `StackDetailPanel` with the shared `StackColumn`, adding `showHeader`, `showFooter`, and `fillWidth` props; propagates `selectedBranchName` so the active branch is highlighted in the side panel
- **#817 dedicated-diff-endpoint**: Consolidates branch diff fetching to a dedicated `useBranchDiff` hook and lazy-loads diff components to avoid bundling the heavy diff renderer on initial page load
- **#818 component-reorganization**: Reorganizes web app components by feature area and extracts shared utilities into dedicated modules, reducing duplication across diff/stack views
- **#819 layout-status-modules**: Consolidates web components into `layout/` and `status/` subdirectories, grouping related components for better discoverability and maintainability
- **#820 file-tree-sidebar**: Adds a collapsible file tree sidebar to the branch diff view, allowing users to jump directly to changed files; supports expand/collapse state and highlights the active file

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1772684709`.


* **PR #812**
  * **PR #813**
    * **PR #814** 👈
      * **PR #815**
        * **PR #816**
          * **PR #817**
            * **PR #818**
              * **PR #819**
                * **PR #820**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->