### PR TITLE
feat: add compact mode to swimlane and stack components for overlay panel

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -163,6 +163,7 @@ export default function Home() {
                 selectedStack={selection?.type === "stack" ? selection.rootBranch : null}
                 onSelectBranch={handleSelectBranch}
                 onSelectStack={handleSelectStack}
+                compact={branchOverlayMode}
               />
             )}
 
@@ -177,6 +178,7 @@ export default function Home() {
                 selectedStack={selection?.type === "stack" ? selection.rootBranch : null}
                 onSelectBranch={handleSelectBranch}
                 onSelectStack={handleSelectStack}
+                compact={branchOverlayMode}
               />
             ))}
           </div>
@@ -190,7 +192,7 @@ export default function Home() {
         </div>
 
         {/* Recent trunk commits */}
-        <RecentlyMerged />
+        <RecentlyMerged compact={branchOverlayMode} />
       </div>
     ) : (
       <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
@@ -273,7 +275,7 @@ export default function Home() {
                   onExit={handleClearSelection}
                 />
               </div>
-              <div className="h-[36vh] min-h-[240px] max-h-[460px] overflow-y-auto overflow-x-hidden bg-background/70">
+              <div className="h-[30vh] min-h-[180px] max-h-[340px] overflow-y-auto overflow-x-hidden bg-background/70">
                 {stacksAndHistoryContent}
               </div>
             </>

--- a/apps/web/src/components/branch-card.tsx
+++ b/apps/web/src/components/branch-card.tsx
@@ -10,6 +10,7 @@ interface BranchCardProps {
   branch: BranchResponse;
   isSelected: boolean;
   onClick: (branch: BranchResponse) => void;
+  compact?: boolean;
   className?: string;
   style?: React.CSSProperties;
 }
@@ -18,13 +19,15 @@ export function BranchCard({
   branch,
   isSelected,
   onClick,
+  compact = false,
   className = "",
   style,
 }: BranchCardProps) {
   return (
     <button
       onClick={() => onClick(branch)}
-      className={`text-left px-3 py-2.5 bg-card transition-all duration-200
+      className={`text-left bg-card transition-all duration-200
+        ${compact ? "px-2.5 py-1.5" : "px-3 py-2.5"}
         ${isSelected ? "!bg-accent z-10 relative" : "hover:!bg-muted hover:scale-[1.02] hover:shadow-md hover:-translate-y-0.5"}
         ${branch.isCurrent ? "border-l-[3px] border-l-[var(--glow-color-current)]" : ""}
         ${branch.isLocked ? "opacity-60" : ""}
@@ -52,15 +55,17 @@ export function BranchCard({
           </span>
         )}
       </div>
-      <div className="flex items-center gap-2 mt-1">
-        {branch.pr ? (
-          <PRBadge pr={branch.pr} />
-        ) : (
-          <span className="text-xs text-muted-foreground">no PR</span>
-        )}
-        <CIStatusWithTooltip ci={branch.ci} />
-        <DiffStats added={branch.linesAdded} deleted={branch.linesDeleted} />
-      </div>
+      {!compact && (
+        <div className="flex items-center gap-2 mt-1">
+          {branch.pr ? (
+            <PRBadge pr={branch.pr} />
+          ) : (
+            <span className="text-xs text-muted-foreground">no PR</span>
+          )}
+          <CIStatusWithTooltip ci={branch.ci} />
+          <DiffStats added={branch.linesAdded} deleted={branch.linesDeleted} />
+        </div>
+      )}
     </button>
   );
 }

--- a/apps/web/src/components/owner-swimlane.tsx
+++ b/apps/web/src/components/owner-swimlane.tsx
@@ -17,6 +17,7 @@ interface OwnerSwimlaneProps {
   selectedStack: string | null;
   onSelectBranch: (branch: BranchResponse) => void;
   onSelectStack: (stack: StackDetail) => void;
+  compact?: boolean;
 }
 
 export function OwnerSwimlane({
@@ -27,6 +28,7 @@ export function OwnerSwimlane({
   selectedStack,
   onSelectBranch,
   onSelectStack,
+  compact = false,
 }: OwnerSwimlaneProps) {
   const [expanded, setExpanded] = useState(false);
   const color = swimlaneColor(label);
@@ -40,7 +42,7 @@ export function OwnerSwimlane({
   return (
     <div className="flex flex-col shrink-0">
       <div
-        className="flex gap-4 items-end px-3 pt-3"
+        className={`flex items-end ${compact ? "gap-3 px-2 py-2" : "gap-4 px-3 pt-3"}`}
         style={{ backgroundColor: color }}
       >
         <AnimatePresence mode="popLayout">
@@ -60,6 +62,7 @@ export function OwnerSwimlane({
                   selectedStack={selectedStack}
                   onSelectBranch={onSelectBranch}
                   onSelectStack={onSelectStack}
+                  compact={compact}
                 />
               ) : (
                 <StackColumn
@@ -68,6 +71,7 @@ export function OwnerSwimlane({
                   selectedStack={selectedStack}
                   onSelectBranch={onSelectBranch}
                   onSelectStack={onSelectStack}
+                  compact={compact}
                 />
               )}
             </motion.div>
@@ -77,7 +81,7 @@ export function OwnerSwimlane({
           <motion.button
             layout
             onClick={() => setExpanded(!expanded)}
-            className="flex items-center justify-center w-8 shrink-0 self-stretch rounded border border-dashed border-muted-foreground/30 text-xs text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground transition-colors"
+            className={`flex items-center justify-center w-8 shrink-0 self-stretch rounded border border-dashed border-muted-foreground/30 text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground transition-colors ${compact ? "text-[11px]" : "text-xs"}`}
           >
             <span className="-rotate-90 whitespace-nowrap">
               {expanded ? "Show less" : `+${hiddenCount} more`}
@@ -85,7 +89,7 @@ export function OwnerSwimlane({
           </motion.button>
         )}
       </div>
-      <SwimlaneLabel label={label} lastActive={lastActive} color={color} />
+      <SwimlaneLabel label={label} lastActive={lastActive} color={color} compact={compact} />
     </div>
   );
 }

--- a/apps/web/src/components/recently-merged.tsx
+++ b/apps/web/src/components/recently-merged.tsx
@@ -251,7 +251,7 @@ function CommitItem({
   );
 }
 
-export function RecentlyMerged() {
+export function RecentlyMerged({ compact = false }: { compact?: boolean }) {
   const { recentlyMerged, repo } = useRepo();
 
   const groups = useMemo(
@@ -264,10 +264,12 @@ export function RecentlyMerged() {
   }
 
   return (
-    <div className="px-6 pb-4 max-h-64 overflow-y-auto space-y-2">
+    <div
+      className={`${compact ? "px-4 pb-2 max-h-36 space-y-1.5" : "px-6 pb-4 max-h-64 space-y-2"} overflow-y-auto`}
+    >
       {groups.map((group) => (
         <div key={group.label}>
-          <div className="text-[10px] font-medium text-muted-foreground/50 uppercase tracking-wider mb-0.5">
+          <div className={`${compact ? "text-[9px]" : "text-[10px]"} font-medium text-muted-foreground/50 uppercase tracking-wider mb-0.5`}>
             {group.label}
           </div>
           <div>

--- a/apps/web/src/components/stack-column.tsx
+++ b/apps/web/src/components/stack-column.tsx
@@ -14,6 +14,7 @@ interface StackColumnProps {
   selectedStack: string | null;
   onSelectBranch: (branch: BranchResponse) => void;
   onSelectStack: (stack: StackDetail) => void;
+  compact?: boolean;
 }
 
 export function StackColumn({
@@ -22,6 +23,7 @@ export function StackColumn({
   selectedStack,
   onSelectBranch,
   onSelectStack,
+  compact = false,
 }: StackColumnProps) {
   // Order branches root→leaf, then reverse so leaf is at top (stacking metaphor)
   const orderedBranches = orderBranches(stack.branches);
@@ -30,7 +32,7 @@ export function StackColumn({
   return (
     <div className="flex flex-col w-64 shrink-0">
       {/* Stack header */}
-      <div className="px-1 pb-2">
+      <div className={`px-1 ${compact ? "pb-1" : "pb-2"}`}>
         {stack.hasWorktree && (
           <div className="flex items-center gap-2">
             <span className="text-xs text-muted-foreground flex items-center gap-1" title="Worktree">
@@ -39,12 +41,12 @@ export function StackColumn({
           </div>
         )}
         {stack.title && (
-          <p className="text-xs font-medium text-muted-foreground mt-1 truncate" title={stack.title}>
+          <p className={`font-medium text-muted-foreground truncate ${compact ? "text-[11px] mt-0.5" : "text-xs mt-1"}`} title={stack.title}>
             {stack.title}
           </p>
         )}
         {stack.description && (
-          <StackDescription text={stack.description} />
+          <StackDescription text={stack.description} compact={compact} />
         )}
       </div>
 
@@ -60,6 +62,7 @@ export function StackColumn({
               branch={branch}
               isSelected={selectedBranch === branch.name}
               onClick={onSelectBranch}
+              compact={compact}
               className={`animate-fade-in-up border-x border-t
                 ${isLast ? "border-b rounded-b-lg relative z-[1] shadow-[0_4px_6px_-2px_rgba(0,0,0,0.15)]" : ""}
                 ${isFirst ? "rounded-t-lg" : ""}
@@ -74,6 +77,7 @@ export function StackColumn({
       <StackStatusFooter
         status={stack.status}
         selected={selectedStack === stack.rootBranch}
+        compact={compact}
         onClick={() => onSelectStack(stack)}
       />
     </div>
@@ -111,13 +115,23 @@ const statusConfig: Record<string, { label: string; bg: string; selectedBg: stri
   },
 };
 
-export function StackStatusFooter({ status, selected, onClick }: { status: string; selected: boolean; onClick: () => void }) {
+export function StackStatusFooter({
+  status,
+  selected,
+  onClick,
+  compact = false,
+}: {
+  status: string;
+  selected: boolean;
+  onClick: () => void;
+  compact?: boolean;
+}) {
   const c = statusConfig[status] || statusConfig.incomplete;
 
   return (
     <button
       onClick={onClick}
-      className={`flex items-center justify-center px-3 py-1.5 -mt-2 pt-3.5 rounded-b-lg border-x border-b text-xs font-medium cursor-pointer transition-all duration-200 ${c.text} ${selected ? `${c.selectedBg} font-semibold` : `${c.bg} ${c.shadow} hover:brightness-95 dark:hover:brightness-110`}`}
+      className={`flex items-center justify-center px-3 rounded-b-lg border-x border-b font-medium cursor-pointer transition-all duration-200 ${compact ? "-mt-1.5 pt-2.5 py-1 text-[11px]" : "-mt-2 pt-3.5 py-1.5 text-xs"} ${c.text} ${selected ? `${c.selectedBg} font-semibold` : `${c.bg} ${c.shadow} hover:brightness-95 dark:hover:brightness-110`}`}
     >
       {c.label}
     </button>
@@ -149,16 +163,22 @@ function orderBranches(branches: BranchResponse[]): BranchResponse[] {
 
 const DESCRIPTION_COLLAPSE_LENGTH = 80;
 
-export function StackDescription({ text }: { text: string }) {
+export function StackDescription({
+  text,
+  compact = false,
+}: {
+  text: string;
+  compact?: boolean;
+}) {
   const canCollapse = text.length > DESCRIPTION_COLLAPSE_LENGTH;
   const [collapsed, setCollapsed] = useState(canCollapse);
 
   return (
     <div
       onClick={canCollapse ? () => setCollapsed(!collapsed) : undefined}
-      className={`text-xs text-muted-foreground mt-1 flex items-start gap-1 ${canCollapse ? "cursor-pointer hover:text-foreground/70" : ""}`}
+      className={`${compact ? "text-[11px] mt-0.5" : "text-xs mt-1"} text-muted-foreground flex items-start gap-1 ${canCollapse ? "cursor-pointer hover:text-foreground/70" : ""}`}
     >
-      <div className={`prose prose-xs dark:prose-invert max-w-none [&>*]:text-xs [&>*]:text-muted-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_ul]:my-0.5 [&_ol]:my-0.5 [&_li]:my-0 [&_p]:my-0.5 ${collapsed ? "line-clamp-2" : ""}`}>
+      <div className={`prose prose-xs dark:prose-invert max-w-none [&>*]:text-muted-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_ul]:my-0.5 [&_ol]:my-0.5 [&_li]:my-0 [&_p]:my-0.5 ${compact ? "[&>*]:text-[11px]" : "[&>*]:text-xs"} ${collapsed ? "line-clamp-2" : ""}`}>
         <Markdown>{text}</Markdown>
       </div>
       {canCollapse && (

--- a/apps/web/src/components/stack-tree-column.tsx
+++ b/apps/web/src/components/stack-tree-column.tsx
@@ -11,6 +11,7 @@ interface StackTreeColumnProps {
   selectedStack: string | null;
   onSelectBranch: (branch: BranchResponse) => void;
   onSelectStack: (stack: StackDetail) => void;
+  compact?: boolean;
 }
 
 export function StackTreeColumn({
@@ -19,11 +20,12 @@ export function StackTreeColumn({
   selectedStack,
   onSelectBranch,
   onSelectStack,
+  compact = false,
 }: StackTreeColumnProps) {
   return (
     <div className="flex flex-col min-w-64 shrink-0">
       {/* Stack header */}
-      <div className="px-1 pb-2">
+      <div className={`px-1 ${compact ? "pb-1" : "pb-2"}`}>
         {stack.hasWorktree && (
           <div className="flex items-center gap-2">
             <span className="text-xs text-muted-foreground flex items-center gap-1" title="Worktree">
@@ -32,12 +34,12 @@ export function StackTreeColumn({
           </div>
         )}
         {stack.title && (
-          <p className="text-xs font-medium text-muted-foreground mt-1 truncate" title={stack.title}>
+          <p className={`font-medium text-muted-foreground truncate ${compact ? "text-[11px] mt-0.5" : "text-xs mt-1"}`} title={stack.title}>
             {stack.title}
           </p>
         )}
         {stack.description && (
-          <StackDescription text={stack.description} />
+          <StackDescription text={stack.description} compact={compact} />
         )}
       </div>
 
@@ -46,10 +48,12 @@ export function StackTreeColumn({
         branches={stack.branches}
         selectedBranch={selectedBranch}
         onSelectBranch={onSelectBranch}
+        compact={compact}
         footer={
           <StackStatusFooter
             status={stack.status}
             selected={selectedStack === stack.rootBranch}
+            compact={compact}
             onClick={() => onSelectStack(stack)}
           />
         }

--- a/apps/web/src/components/stack-tree/segment-tree.tsx
+++ b/apps/web/src/components/stack-tree/segment-tree.tsx
@@ -9,6 +9,7 @@ interface SegmentTreeProps {
   branches: BranchResponse[];
   selectedBranch: string | null;
   onSelectBranch: (branch: BranchResponse) => void;
+  compact?: boolean;
   footer?: React.ReactNode;
 }
 
@@ -16,6 +17,7 @@ export function SegmentTree({
   branches,
   selectedBranch,
   onSelectBranch,
+  compact = false,
   footer,
 }: SegmentTreeProps) {
   const segment = useMemo(() => decomposeTree(branches), [branches]);
@@ -33,6 +35,7 @@ export function SegmentTree({
       segment={segment}
       selectedBranch={selectedBranch}
       onSelectBranch={onSelectBranch}
+      compact={compact}
       footer={footer}
     />
   );
@@ -42,6 +45,7 @@ interface SegmentNodeProps {
   segment: TreeSegment;
   selectedBranch: string | null;
   onSelectBranch: (branch: BranchResponse) => void;
+  compact: boolean;
   footer?: React.ReactNode;
 }
 
@@ -49,6 +53,7 @@ function SegmentNode({
   segment,
   selectedBranch,
   onSelectBranch,
+  compact,
   footer,
 }: SegmentNodeProps) {
   const hasForks = segment.forks && segment.forks.length > 0;
@@ -73,10 +78,11 @@ function SegmentNode({
                 segment={fork}
                 selectedBranch={selectedBranch}
                 onSelectBranch={onSelectBranch}
+                compact={compact}
               />
             ))}
           </div>
-          <ForkConnector segment={segment} />
+          <ForkConnector segment={segment} compact={compact} />
         </>
       )}
 
@@ -94,6 +100,7 @@ function SegmentNode({
                   branch={branch}
                   isSelected={selectedBranch === branch.name}
                   onClick={onSelectBranch}
+                  compact={compact}
                   className={`border-x border-t
                     ${isLast ? "border-b rounded-b-lg relative z-[1] shadow-[0_4px_6px_-2px_rgba(0,0,0,0.15)]" : ""}
                     ${isFirst ? "rounded-t-lg" : ""}
@@ -110,11 +117,18 @@ function SegmentNode({
 }
 
 const CONNECTOR_H = 28;
-const CURVE_R = 6;
+const CONNECTOR_H_COMPACT = 18;
 
-function ForkConnector({ segment }: { segment: TreeSegment }) {
+function ForkConnector({
+  segment,
+  compact,
+}: {
+  segment: TreeSegment;
+  compact: boolean;
+}) {
   if (!segment.forks || segment.forks.length < 2) return null;
 
+  const connectorHeight = compact ? CONNECTOR_H_COMPACT : CONNECTOR_H;
   const totalWidth = segment.width;
   const forks = segment.forks;
 
@@ -135,14 +149,14 @@ function ForkConnector({ segment }: { segment: TreeSegment }) {
 
   // Trunk center (where all forks converge)
   const trunkX = totalWidth / 2;
-  const midY = CONNECTOR_H / 2;
+  const midY = connectorHeight / 2;
   const leftX = Math.min(...centers);
   const rightX = Math.max(...centers);
 
   return (
     <svg
       width={totalWidth}
-      height={CONNECTOR_H}
+      height={connectorHeight}
       className="shrink-0"
       data-testid="fork-connector"
     >
@@ -176,7 +190,7 @@ function ForkConnector({ segment }: { segment: TreeSegment }) {
         x1={trunkX}
         y1={midY}
         x2={trunkX}
-        y2={CONNECTOR_H}
+        y2={connectorHeight}
         className="stroke-muted-foreground/40"
         strokeWidth={1.5}
       />

--- a/apps/web/src/components/swimlane-label.tsx
+++ b/apps/web/src/components/swimlane-label.tsx
@@ -4,20 +4,26 @@ interface SwimlaneLabelProps {
   label: string;
   lastActive?: Date;
   color: string;
+  compact?: boolean;
 }
 
-export function SwimlaneLabel({ label, lastActive, color }: SwimlaneLabelProps) {
+export function SwimlaneLabel({
+  label,
+  lastActive,
+  color,
+  compact = false,
+}: SwimlaneLabelProps) {
   return (
     <div
-      className="flex items-center justify-center gap-2 px-3 py-1 w-full rounded-b-md"
+      className={`flex items-center justify-center w-full rounded-b-md ${compact ? "gap-1.5 px-2 py-0.5" : "gap-2 px-3 py-1"}`}
       style={{ backgroundColor: color }}
     >
-      <span className="text-xs font-semibold text-foreground/80">
+      <span className={`${compact ? "text-[11px]" : "text-xs"} font-semibold text-foreground/80`}>
         {label}
       </span>
       {lastActive && (
-        <span className="text-[10px] text-foreground/40">
-          active <TimeAgo date={lastActive} />
+        <span className={`${compact ? "text-[9px]" : "text-[10px]"} text-foreground/40`}>
+          active {formatLastActive(lastActive)}
         </span>
       )}
     </div>
@@ -38,14 +44,9 @@ export function swimlaneColor(name: string): string {
   return `light-dark(hsl(${hue} 30% 95%), hsl(${hue} 20% 18%))`;
 }
 
-function TimeAgo({ date }: { date: Date }) {
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
-  if (seconds < 5) return <>just now</>;
-  if (seconds < 60) return <>{seconds}s ago</>;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return <>{minutes}m ago</>;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return <>{hours}h ago</>;
-  const days = Math.floor(hours / 24);
-  return <>{days}d ago</>;
+function formatLastActive(date: Date): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  }).format(date);
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Add branch diff view with file tree sidebar and component refactoring**

Adds an inline diff view to the web UI that shows a branch's changes relative to its divergence point, with a file tree sidebar for navigation. The stack also includes significant web component reorganization to support the new architecture.

Key changes:
- **#812 add-branch-diff-view**: New `GET /api/branches/<name>/diff` endpoint returns a unified patch between the branch's divergence point and HEAD; `BranchDiff` and `BranchDiffWorkspace` components render it using `@pierre/diffs` with split-view, word-level highlighting
- **#813 overlay-layout**: Refactors the main layout from a full-screen takeover to an overlay mode — the diff workspace occupies the upper portion while the stacks/history strip remains visible below
- **#814 simplify-workspace**: Strips the redundant header card from `BranchDiffWorkspace` (title, PR link, stats) since that info already appears in the side panel; leaves only the "Back" button and the diff
- **#815 compact-mode**: Threads a `compact` prop through `OwnerSwimlane` → `StackColumn` → `BranchCard` / `SegmentTree` / `ForkConnector` for a denser layout in the bottom overlay strip (tighter padding, 11px text, shorter fork connectors)
- **#816 stack-detail-reuse**: Replaces the one-off `BranchRow` list in `StackDetailPanel` with the shared `StackColumn`, adding `showHeader`, `showFooter`, and `fillWidth` props; propagates `selectedBranchName` so the active branch is highlighted in the side panel
- **#817 dedicated-diff-endpoint**: Consolidates branch diff fetching to a dedicated `useBranchDiff` hook and lazy-loads diff components to avoid bundling the heavy diff renderer on initial page load
- **#818 component-reorganization**: Reorganizes web app components by feature area and extracts shared utilities into dedicated modules, reducing duplication across diff/stack views
- **#819 layout-status-modules**: Consolidates web components into `layout/` and `status/` subdirectories, grouping related components for better discoverability and maintainability
- **#820 file-tree-sidebar**: Adds a collapsible file tree sidebar to the branch diff view, allowing users to jump directly to changed files; supports expand/collapse state and highlights the active file

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1772684709`.


* **PR #812**
  * **PR #813**
    * **PR #814**
      * **PR #815** 👈
        * **PR #816**
          * **PR #817**
            * **PR #818**
              * **PR #819**
                * **PR #820**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->