### PR TITLE
refactor: replace BranchRow list in stack detail with reusable StackColumn

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -295,6 +295,7 @@ export default function Home() {
                 <StackDetailPanel
                   stack={selectedBranchStack}
                   onSelectBranch={handleStackBranchSelect}
+                  selectedBranchName={selectedBranch?.name ?? null}
                 />
               </div>
             ) : hasSelection ? (
@@ -309,6 +310,7 @@ export default function Home() {
                   <StackDetailPanel
                     stack={selectedStack}
                     onSelectBranch={handleStackBranchSelect}
+                    selectedBranchName={null}
                   />
                 )}
               </div>

--- a/apps/web/src/components/branch-detail/stack-detail.tsx
+++ b/apps/web/src/components/branch-detail/stack-detail.tsx
@@ -7,17 +7,16 @@ import { submitStack } from "@/lib/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import {
-  PRBadge,
-  CIStatusBadge,
   DiffStats,
 } from "@/components/status/status-badge";
-import { StackDescription } from "@/components/stack-column";
+import { StackDescription, StackColumn } from "@/components/stack-column";
 import { useRepo } from "@/components/providers/repo-provider";
 import { cn } from "@/lib/utils";
 
 interface StackDetailPanelProps {
   stack: StackDetailType;
   onSelectBranch?: (branch: BranchResponse) => void;
+  selectedBranchName?: string | null;
 }
 
 const statusConfig: Record<string, { label: string; description: string; color: string }> = {
@@ -61,7 +60,11 @@ function computeStackStats(branches: BranchResponse[]) {
   return { prCount, approvedCount, ciPassingCount, totalAdded, totalDeleted, total: branches.length };
 }
 
-export function StackDetailPanel({ stack, onSelectBranch }: StackDetailPanelProps) {
+export function StackDetailPanel({
+  stack,
+  onSelectBranch,
+  selectedBranchName = null,
+}: StackDetailPanelProps) {
   const status = statusConfig[stack.status] || statusConfig.incomplete;
   const issues = collectIssues(stack.branches);
   const stats = computeStackStats(stack.branches);
@@ -155,15 +158,16 @@ export function StackDetailPanel({ stack, onSelectBranch }: StackDetailPanelProp
             <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
               Branches ({stack.branches.length})
             </h4>
-            <div className="flex flex-col gap-2">
-              {[...stack.branches].reverse().map((branch) => (
-                <BranchRow
-                  key={branch.name}
-                  branch={branch}
-                  onClick={onSelectBranch ? () => onSelectBranch(branch) : undefined}
-                />
-              ))}
-            </div>
+            <StackColumn
+              stack={stack}
+              selectedBranch={selectedBranchName}
+              selectedStack={null}
+              onSelectBranch={(branch) => onSelectBranch?.(branch)}
+              onSelectStack={() => {}}
+              showHeader={false}
+              showFooter={false}
+              fillWidth
+            />
           </div>
 
           <Separator />
@@ -214,48 +218,6 @@ export function StackDetailPanel({ stack, onSelectBranch }: StackDetailPanelProp
         </CardContent>
       </Card>
     </motion.div>
-  );
-}
-
-function BranchRow({ branch, onClick }: { branch: BranchResponse; onClick?: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "flex flex-col gap-1 rounded-md border px-3 py-2 text-left transition-colors w-full",
-        onClick && "cursor-pointer hover:bg-muted/50",
-        branch.isCurrent && "border-l-2 border-l-green-500"
-      )}
-    >
-      <div className="flex items-center justify-between gap-2 min-w-0">
-        <span className="flex items-center gap-1.5 text-sm font-mono truncate min-w-0" title={branch.name}>
-          {branch.isCurrent && (
-            <span className="inline-block w-2 h-2 rounded-full bg-green-500 shrink-0" />
-          )}
-          {branch.name}
-        </span>
-        <div className="flex items-center gap-1.5 shrink-0">
-          {branch.pr ? (
-            <PRBadge pr={branch.pr} />
-          ) : (
-            <span className="text-xs text-muted-foreground">no PR</span>
-          )}
-          <CIStatusBadge ci={branch.ci} />
-        </div>
-      </div>
-      <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
-        <DiffStats added={branch.linesAdded} deleted={branch.linesDeleted} />
-        {branch.needsRestack && (
-          <span className="text-amber-600 dark:text-amber-400">needs restack</span>
-        )}
-        {branch.isLocked && (
-          <span className="text-red-600 dark:text-red-400">
-            locked{branch.lockReason ? ` (${branch.lockReason})` : ""}
-          </span>
-        )}
-      </div>
-    </button>
   );
 }
 

--- a/apps/web/src/components/stack-column.tsx
+++ b/apps/web/src/components/stack-column.tsx
@@ -15,6 +15,9 @@ interface StackColumnProps {
   onSelectBranch: (branch: BranchResponse) => void;
   onSelectStack: (stack: StackDetail) => void;
   compact?: boolean;
+  showHeader?: boolean;
+  showFooter?: boolean;
+  fillWidth?: boolean;
 }
 
 export function StackColumn({
@@ -24,31 +27,36 @@ export function StackColumn({
   onSelectBranch,
   onSelectStack,
   compact = false,
+  showHeader = true,
+  showFooter = true,
+  fillWidth = false,
 }: StackColumnProps) {
   // Order branches root→leaf, then reverse so leaf is at top (stacking metaphor)
   const orderedBranches = orderBranches(stack.branches);
   const displayBranches = [...orderedBranches].reverse();
 
   return (
-    <div className="flex flex-col w-64 shrink-0">
+    <div className={`flex flex-col ${fillWidth ? "w-full" : "w-64 shrink-0"}`}>
       {/* Stack header */}
-      <div className={`px-1 ${compact ? "pb-1" : "pb-2"}`}>
-        {stack.hasWorktree && (
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-muted-foreground flex items-center gap-1" title="Worktree">
-              <FolderGit2 className="w-3 h-3" />
-            </span>
-          </div>
-        )}
-        {stack.title && (
-          <p className={`font-medium text-muted-foreground truncate ${compact ? "text-[11px] mt-0.5" : "text-xs mt-1"}`} title={stack.title}>
-            {stack.title}
-          </p>
-        )}
-        {stack.description && (
-          <StackDescription text={stack.description} compact={compact} />
-        )}
-      </div>
+      {showHeader && (
+        <div className={`px-1 ${compact ? "pb-1" : "pb-2"}`}>
+          {stack.hasWorktree && (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-muted-foreground flex items-center gap-1" title="Worktree">
+                <FolderGit2 className="w-3 h-3" />
+              </span>
+            </div>
+          )}
+          {stack.title && (
+            <p className={`font-medium text-muted-foreground truncate ${compact ? "text-[11px] mt-0.5" : "text-xs mt-1"}`} title={stack.title}>
+              {stack.title}
+            </p>
+          )}
+          {stack.description && (
+            <StackDescription text={stack.description} compact={compact} />
+          )}
+        </div>
+      )}
 
       {/* Stacked branch cards */}
       <div className="flex flex-col bg-card rounded-t-lg">
@@ -74,12 +82,14 @@ export function StackColumn({
       </div>
 
       {/* Status footer */}
-      <StackStatusFooter
-        status={stack.status}
-        selected={selectedStack === stack.rootBranch}
-        compact={compact}
-        onClick={() => onSelectStack(stack)}
-      />
+      {showFooter && (
+        <StackStatusFooter
+          status={stack.status}
+          selected={selectedStack === stack.rootBranch}
+          compact={compact}
+          onClick={() => onSelectStack(stack)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/stack-tree-column.tsx
+++ b/apps/web/src/components/stack-tree-column.tsx
@@ -12,6 +12,8 @@ interface StackTreeColumnProps {
   onSelectBranch: (branch: BranchResponse) => void;
   onSelectStack: (stack: StackDetail) => void;
   compact?: boolean;
+  showHeader?: boolean;
+  showFooter?: boolean;
 }
 
 export function StackTreeColumn({
@@ -21,27 +23,31 @@ export function StackTreeColumn({
   onSelectBranch,
   onSelectStack,
   compact = false,
+  showHeader = true,
+  showFooter = true,
 }: StackTreeColumnProps) {
   return (
     <div className="flex flex-col min-w-64 shrink-0">
       {/* Stack header */}
-      <div className={`px-1 ${compact ? "pb-1" : "pb-2"}`}>
-        {stack.hasWorktree && (
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-muted-foreground flex items-center gap-1" title="Worktree">
-              <FolderGit2 className="w-3 h-3" />
-            </span>
-          </div>
-        )}
-        {stack.title && (
-          <p className={`font-medium text-muted-foreground truncate ${compact ? "text-[11px] mt-0.5" : "text-xs mt-1"}`} title={stack.title}>
-            {stack.title}
-          </p>
-        )}
-        {stack.description && (
-          <StackDescription text={stack.description} compact={compact} />
-        )}
-      </div>
+      {showHeader && (
+        <div className={`px-1 ${compact ? "pb-1" : "pb-2"}`}>
+          {stack.hasWorktree && (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-muted-foreground flex items-center gap-1" title="Worktree">
+                <FolderGit2 className="w-3 h-3" />
+              </span>
+            </div>
+          )}
+          {stack.title && (
+            <p className={`font-medium text-muted-foreground truncate ${compact ? "text-[11px] mt-0.5" : "text-xs mt-1"}`} title={stack.title}>
+              {stack.title}
+            </p>
+          )}
+          {stack.description && (
+            <StackDescription text={stack.description} compact={compact} />
+          )}
+        </div>
+      )}
 
       {/* Tree visualization: linear card stacks with connectors at branch points */}
       <SegmentTree
@@ -49,14 +55,14 @@ export function StackTreeColumn({
         selectedBranch={selectedBranch}
         onSelectBranch={onSelectBranch}
         compact={compact}
-        footer={
+        footer={showFooter ? (
           <StackStatusFooter
             status={stack.status}
             selected={selectedStack === stack.rootBranch}
             compact={compact}
             onClick={() => onSelectStack(stack)}
           />
-        }
+        ) : undefined}
       />
     </div>
   );


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Add branch diff view with file tree sidebar and component refactoring**

Adds an inline diff view to the web UI that shows a branch's changes relative to its divergence point, with a file tree sidebar for navigation. The stack also includes significant web component reorganization to support the new architecture.

Key changes:
- **#812 add-branch-diff-view**: New `GET /api/branches/<name>/diff` endpoint returns a unified patch between the branch's divergence point and HEAD; `BranchDiff` and `BranchDiffWorkspace` components render it using `@pierre/diffs` with split-view, word-level highlighting
- **#813 overlay-layout**: Refactors the main layout from a full-screen takeover to an overlay mode — the diff workspace occupies the upper portion while the stacks/history strip remains visible below
- **#814 simplify-workspace**: Strips the redundant header card from `BranchDiffWorkspace` (title, PR link, stats) since that info already appears in the side panel; leaves only the "Back" button and the diff
- **#815 compact-mode**: Threads a `compact` prop through `OwnerSwimlane` → `StackColumn` → `BranchCard` / `SegmentTree` / `ForkConnector` for a denser layout in the bottom overlay strip (tighter padding, 11px text, shorter fork connectors)
- **#816 stack-detail-reuse**: Replaces the one-off `BranchRow` list in `StackDetailPanel` with the shared `StackColumn`, adding `showHeader`, `showFooter`, and `fillWidth` props; propagates `selectedBranchName` so the active branch is highlighted in the side panel
- **#817 dedicated-diff-endpoint**: Consolidates branch diff fetching to a dedicated `useBranchDiff` hook and lazy-loads diff components to avoid bundling the heavy diff renderer on initial page load
- **#818 component-reorganization**: Reorganizes web app components by feature area and extracts shared utilities into dedicated modules, reducing duplication across diff/stack views
- **#819 layout-status-modules**: Consolidates web components into `layout/` and `status/` subdirectories, grouping related components for better discoverability and maintainability
- **#820 file-tree-sidebar**: Adds a collapsible file tree sidebar to the branch diff view, allowing users to jump directly to changed files; supports expand/collapse state and highlights the active file

#### Stack


* **PR #812**
  * **PR #813**
    * **PR #814**
      * **PR #815**
        * **PR #816** 👈
          * **PR #817**
            * **PR #818**
              * **PR #819**
                * **PR #820**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #821 by jonnii*