### PR TITLE
refactor: consolidate branch diff to dedicated endpoint and lazy-load diff components

### DIFF
--- a/api/openapi/stackit.yaml
+++ b/api/openapi/stackit.yaml
@@ -92,29 +92,10 @@ paths:
                 $ref: "#/components/schemas/BranchResponse"
         "404":
           description: Branch not found.
-  /api/v1/branches/{branchName}/diff:
+  /api/v1/branch-diff:
     get:
       summary: Get raw patch diff for a tracked branch.
       operationId: getBranchDiff
-      parameters:
-        - in: path
-          name: branchName
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Branch diff details.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/BranchDiffResponse"
-        "404":
-          description: Branch not found.
-  /api/v1/branches/diff:
-    get:
-      summary: Get raw patch diff for a tracked branch by query parameter.
-      operationId: getBranchDiffByQuery
       parameters:
         - in: query
           name: branch

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
+import dynamic from "next/dynamic";
 import { useRepo } from "@/components/providers/repo-provider";
 import { OwnerSwimlane, getLastActiveDate } from "@/components/owner-swimlane";
 import { BranchDetail } from "@/components/branch-detail/branch-detail";
 import { StackDetailPanel } from "@/components/branch-detail/stack-detail";
-import { BranchDiffWorkspace } from "@/components/branch-detail/branch-diff-workspace";
 import { DetailEmptyState } from "@/components/branch-detail/detail-empty-state";
 import { EventFeed } from "@/components/event-feed";
 import { Separator } from "@/components/ui/separator";
@@ -15,6 +15,21 @@ import { SkeletonSwimlane } from "@/components/ui/skeleton-shimmer";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import type { BranchResponse, StackDetail } from "@/lib/api";
 import { formatTimeAgo } from "@/lib/time";
+
+const BranchDiffWorkspace = dynamic(
+  () =>
+    import("@/components/branch-detail/branch-diff-workspace").then(
+      (m) => m.BranchDiffWorkspace
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        Loading diff workspace...
+      </div>
+    ),
+  }
+);
 
 type Selection =
   | { type: "branch"; name: string }

--- a/apps/web/src/components/branch-detail/branch-detail.tsx
+++ b/apps/web/src/components/branch-detail/branch-detail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion } from "motion/react";
+import dynamic from "next/dynamic";
 import {
   ArrowUp,
   ArrowDown,
@@ -28,7 +29,16 @@ import {
 } from "@/components/status/status-badge";
 import { CommitList } from "./commit-list";
 import { CIChecks } from "./ci-checks";
-import { BranchDiff } from "./branch-diff";
+
+const BranchDiff = dynamic(
+  () => import("./branch-diff").then((m) => m.BranchDiff),
+  {
+    ssr: false,
+    loading: () => (
+      <p className="text-sm text-muted-foreground">Loading diff viewer...</p>
+    ),
+  }
+);
 
 interface BranchDetailProps {
   branch: BranchResponse;

--- a/apps/web/src/components/branch-detail/branch-diff-workspace.tsx
+++ b/apps/web/src/components/branch-detail/branch-diff-workspace.tsx
@@ -1,7 +1,17 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import type { BranchResponse } from "@/lib/api";
-import { BranchDiff } from "./branch-diff";
+
+const BranchDiff = dynamic(
+  () => import("./branch-diff").then((m) => m.BranchDiff),
+  {
+    ssr: false,
+    loading: () => (
+      <p className="text-sm text-muted-foreground">Loading diff viewer...</p>
+    ),
+  }
+);
 
 interface BranchDiffWorkspaceProps {
   branch: BranchResponse;

--- a/apps/web/src/components/branch-detail/branch-diff.tsx
+++ b/apps/web/src/components/branch-detail/branch-diff.tsx
@@ -25,6 +25,9 @@ export function BranchDiff({ branchName, revision }: BranchDiffProps) {
 
   useEffect(() => {
     let active = true;
+    setLoading(true);
+    setError(null);
+    setDiff(null);
 
     fetchBranchDiff(branchName)
       .then((result) => {

--- a/apps/web/src/lib/__tests__/api.test.ts
+++ b/apps/web/src/lib/__tests__/api.test.ts
@@ -88,7 +88,7 @@ describe("fetchBranchDiff", () => {
 
     await fetchBranchDiff("feat/bar");
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/branches/diff?branch=feat%2Fbar"
+      "http://localhost:8080/api/branch-diff?branch=feat%2Fbar"
     );
   });
 });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -152,7 +152,7 @@ export function fetchBranch(name: string): Promise<BranchResponse> {
 
 export function fetchBranchDiff(name: string): Promise<BranchDiffResponse> {
   return fetchAPI<BranchDiffResponse>(
-    `/api/branches/diff?branch=${encodeURIComponent(name)}`
+    `/api/branch-diff?branch=${encodeURIComponent(name)}`
   );
 }
 

--- a/internal/api/handlers/branch_diff.go
+++ b/internal/api/handlers/branch_diff.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"net/http"
+
+	httpcontract "stackit.dev/stackit/internal/contracts/http"
+	"stackit.dev/stackit/internal/engine"
+)
+
+// BranchDiffHandler serves raw branch patch diffs.
+type BranchDiffHandler struct {
+	eng engine.BranchReader
+}
+
+// NewBranchDiffHandler creates a handler for /api/branch-diff and /api/v1/branch-diff.
+func NewBranchDiffHandler(eng engine.BranchReader) *BranchDiffHandler {
+	return &BranchDiffHandler{eng: eng}
+}
+
+// ServeHTTP handles GET branch diff endpoint.
+func (h *BranchDiffHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	branchName := r.URL.Query().Get("branch")
+	if branchName == "" {
+		http.Error(w, "missing branch query parameter", http.StatusBadRequest)
+		return
+	}
+
+	branch := h.eng.GetBranch(branchName)
+	if !branch.IsTracked() {
+		http.Error(w, "branch not found or not tracked", http.StatusNotFound)
+		return
+	}
+
+	baseRevision, err := h.eng.GetDivergencePoint(branchName)
+	if err != nil {
+		http.Error(w, "failed to resolve branch base: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	headRevision, err := branch.GetRevision()
+	if err != nil {
+		http.Error(w, "failed to resolve branch revision: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	patch, err := h.eng.GetDiffBetween(r.Context(), baseRevision, headRevision)
+	if err != nil {
+		http.Error(w, "failed to compute branch diff: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, httpcontract.BranchDiffResponse{
+		Branch:       branchName,
+		BaseRevision: baseRevision,
+		HeadRevision: headRevision,
+		Patch:        patch,
+	})
+}

--- a/internal/api/handlers/branches.go
+++ b/internal/api/handlers/branches.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"net/http"
-	"strings"
 
 	httpcontract "stackit.dev/stackit/internal/contracts/http"
 	"stackit.dev/stackit/internal/engine"
@@ -33,19 +32,9 @@ func (h *BranchesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	switch {
-	case branchName == "diff":
-		queryBranch := r.URL.Query().Get("branch")
-		if queryBranch == "" {
-			http.Error(w, "missing branch query parameter", http.StatusBadRequest)
-			return
-		}
-		h.getBranchDiff(w, r, queryBranch)
-	case branchName == "":
+	if branchName == "" {
 		h.listBranches(w, r)
-	case strings.HasSuffix(branchName, "/diff"):
-		h.getBranchDiff(w, r, strings.TrimSuffix(branchName, "/diff"))
-	default:
+	} else {
 		h.getBranch(w, r, branchName)
 	}
 }
@@ -112,42 +101,4 @@ func (h *BranchesHandler) getBranch(w http.ResponseWriter, r *http.Request, bran
 
 	resp := httpcontract.MapBranch(h.eng, branch, node, checks)
 	writeJSON(w, resp)
-}
-
-func (h *BranchesHandler) getBranchDiff(w http.ResponseWriter, r *http.Request, branchName string) {
-	if branchName == "" {
-		http.Error(w, "branch not found or not tracked", http.StatusNotFound)
-		return
-	}
-
-	branch := h.eng.GetBranch(branchName)
-	if !branch.IsTracked() {
-		http.Error(w, "branch not found or not tracked", http.StatusNotFound)
-		return
-	}
-
-	baseRevision, err := h.eng.GetDivergencePoint(branchName)
-	if err != nil {
-		http.Error(w, "failed to resolve branch base: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	headRevision, err := branch.GetRevision()
-	if err != nil {
-		http.Error(w, "failed to resolve branch revision: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	patch, err := h.eng.GetDiffBetween(r.Context(), baseRevision, headRevision)
-	if err != nil {
-		http.Error(w, "failed to compute branch diff: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	writeJSON(w, httpcontract.BranchDiffResponse{
-		Branch:       branchName,
-		BaseRevision: baseRevision,
-		HeadRevision: headRevision,
-		Patch:        patch,
-	})
 }

--- a/internal/api/handlers/branches_test.go
+++ b/internal/api/handlers/branches_test.go
@@ -1,0 +1,117 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	httpcontract "stackit.dev/stackit/internal/contracts/http"
+	"stackit.dev/stackit/testhelpers"
+	"stackit.dev/stackit/testhelpers/scenario"
+)
+
+func TestBranchesHandler_AllowsBranchNamedDiff(t *testing.T) {
+	t.Parallel()
+
+	s := setupTrackedBranchScenario(t, "diff")
+	handler := NewBranchesHandler(s.Engine, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/branches/diff", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp httpcontract.BranchResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Equal(t, "diff", resp.Name)
+}
+
+func TestBranchesHandler_AllowsBranchEndingInDiffSuffix(t *testing.T) {
+	t.Parallel()
+
+	branchName := "team/feature/diff"
+	s := setupTrackedBranchScenario(t, branchName)
+	handler := NewBranchesHandler(s.Engine, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/branches/"+url.PathEscape(branchName), nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp httpcontract.BranchResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Equal(t, branchName, resp.Name)
+}
+
+func TestBranchDiffHandler_ReturnsDiff(t *testing.T) {
+	t.Parallel()
+
+	branchName := "feature"
+	s := setupTrackedBranchScenario(t, branchName)
+	handler := NewBranchDiffHandler(s.Engine)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/branch-diff?branch="+url.QueryEscape(branchName), nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp httpcontract.BranchDiffResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Equal(t, branchName, resp.Branch)
+	require.NotEmpty(t, resp.BaseRevision)
+	require.NotEmpty(t, resp.HeadRevision)
+	require.Contains(t, resp.Patch, "diff --git")
+}
+
+func TestBranchDiffHandler_RequiresBranchQuery(t *testing.T) {
+	t.Parallel()
+
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	handler := NewBranchDiffHandler(s.Engine)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/branch-diff", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "missing branch query parameter")
+}
+
+func TestBranchDiffHandler_RejectsUntrackedBranch(t *testing.T) {
+	t.Parallel()
+
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	handler := NewBranchDiffHandler(s.Engine)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/branch-diff?branch=main", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	require.Contains(t, rr.Body.String(), "branch not found or not tracked")
+}
+
+func setupTrackedBranchScenario(t *testing.T, branchName string) *scenario.Scenario {
+	t.Helper()
+
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	filePrefix := "change-" + strings.ReplaceAll(branchName, "/", "-")
+
+	s.CreateBranch(branchName).
+		CommitChange(filePrefix, "change on "+branchName).
+		Checkout("main").
+		TrackBranch(branchName, "main").
+		Rebuild()
+
+	return s
+}

--- a/internal/api/handlers/path_test.go
+++ b/internal/api/handlers/path_test.go
@@ -46,7 +46,7 @@ func TestParseResourcePath(t *testing.T) {
 			wantOK:    true,
 		},
 		{
-			name:      "versioned branch diff path with encoded branch name",
+			name:      "versioned branches path with encoded branch ending in diff",
 			path:      "/api/v1/branches/jonnii%2F20260228%2Ffeature/diff",
 			resource:  "branches",
 			wantValue: "jonnii/20260228/feature/diff",

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -63,6 +63,7 @@ func (s *Server) Start() error {
 	repoHandler := handlers.NewRepoHandler(s.eng, s.gh, s.config.Remote)
 	stacksHandler := handlers.NewStacksHandler(s.eng, s.gh)
 	branchesHandler := handlers.NewBranchesHandler(s.eng, s.gh)
+	branchDiffHandler := handlers.NewBranchDiffHandler(s.eng)
 	eventsHandler := handlers.NewEventsHandler(s.broadcaster)
 
 	for _, prefix := range prefixes {
@@ -72,6 +73,7 @@ func (s *Server) Start() error {
 		apiMux.Handle(path.Join(prefix, "stacks")+"/", stacksHandler)
 		apiMux.Handle(path.Join(prefix, "branches"), branchesHandler)
 		apiMux.Handle(path.Join(prefix, "branches")+"/", branchesHandler)
+		apiMux.Handle(path.Join(prefix, "branch-diff"), branchDiffHandler)
 		apiMux.Handle(path.Join(prefix, "events"), eventsHandler)
 	}
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Add branch diff view with file tree sidebar and component refactoring**

Adds an inline diff view to the web UI that shows a branch's changes relative to its divergence point, with a file tree sidebar for navigation. The stack also includes significant web component reorganization to support the new architecture.

Key changes:
- **#812 add-branch-diff-view**: New `GET /api/branches/<name>/diff` endpoint returns a unified patch between the branch's divergence point and HEAD; `BranchDiff` and `BranchDiffWorkspace` components render it using `@pierre/diffs` with split-view, word-level highlighting
- **#813 overlay-layout**: Refactors the main layout from a full-screen takeover to an overlay mode — the diff workspace occupies the upper portion while the stacks/history strip remains visible below
- **#814 simplify-workspace**: Strips the redundant header card from `BranchDiffWorkspace` (title, PR link, stats) since that info already appears in the side panel; leaves only the "Back" button and the diff
- **#815 compact-mode**: Threads a `compact` prop through `OwnerSwimlane` → `StackColumn` → `BranchCard` / `SegmentTree` / `ForkConnector` for a denser layout in the bottom overlay strip (tighter padding, 11px text, shorter fork connectors)
- **#816 stack-detail-reuse**: Replaces the one-off `BranchRow` list in `StackDetailPanel` with the shared `StackColumn`, adding `showHeader`, `showFooter`, and `fillWidth` props; propagates `selectedBranchName` so the active branch is highlighted in the side panel
- **#817 dedicated-diff-endpoint**: Consolidates branch diff fetching to a dedicated `useBranchDiff` hook and lazy-loads diff components to avoid bundling the heavy diff renderer on initial page load
- **#818 component-reorganization**: Reorganizes web app components by feature area and extracts shared utilities into dedicated modules, reducing duplication across diff/stack views
- **#819 layout-status-modules**: Consolidates web components into `layout/` and `status/` subdirectories, grouping related components for better discoverability and maintainability
- **#820 file-tree-sidebar**: Adds a collapsible file tree sidebar to the branch diff view, allowing users to jump directly to changed files; supports expand/collapse state and highlights the active file

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1772684709`.


* **PR #812**
  * **PR #813**
    * **PR #814**
      * **PR #815**
        * **PR #816**
          * **PR #817** 👈
            * **PR #818**
              * **PR #819**
                * **PR #820**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->