### PR TITLE
fix(web): use oldest commit for branch card description

### DIFF
--- a/apps/web/src/components/swimlane/branch-card.tsx
+++ b/apps/web/src/components/swimlane/branch-card.tsx
@@ -38,7 +38,7 @@ export function BranchCard({
     >
       <div className="flex items-center gap-2 min-w-0">
         <span className="text-sm font-medium truncate" title={branch.name}>
-          {branch.commits?.[0]?.message || shortenBranchName(branch.name)}
+          {branch.commits?.at(-1)?.message || shortenBranchName(branch.name)}
         </span>
         {branch.isLocked && (
           <Tooltip>


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Improve branch card info and diff workspace commit display**

Improves the web UI with richer branch and commit information across the swimlane and diff workspace.

Key changes:
- **use-oldest-commit-for-branch-card-description**: Fix branch card to use the oldest (root) commit message as the display label, matching the stacking metaphor
- **show-commit-count-on-branch-card**: Add commit count badge to branch cards, and show individual commit messages with author/timestamp in the branch diff panel
- **show-commits-with-timestamps-and-conventional**: Show commits in the diff workspace with timestamps, conventional commit type badges (feat, fix, chore, etc.) with color coding, and improved visual hierarchy

#### Stack


* **PR #827** 👈
  * **PR #828**
    * **PR #829**
      * **PR #830**
        * **PR #831**
          * **PR #832**
            * **PR #833**
              * **PR #834**
                * **PR #835**
                  * **PR #836**
                    * **PR #837**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #838 by jonnii*