### PR TITLE
feat(web): show commit count on branch card

### DIFF
--- a/apps/web/src/components/branch-detail/branch-diff-workspace.tsx
+++ b/apps/web/src/components/branch-detail/branch-diff-workspace.tsx
@@ -29,6 +29,7 @@ export function BranchDiffWorkspace({
           key={`${branch.name}:${branch.revision}`}
           branchName={branch.name}
           revision={branch.revision}
+          commits={branch.commits}
           onExit={onExit}
         />
       </div>

--- a/apps/web/src/components/branch-detail/branch-diff.tsx
+++ b/apps/web/src/components/branch-detail/branch-diff.tsx
@@ -5,14 +5,17 @@ import {
   type FileDiffMetadata,
 } from "@pierre/diffs";
 import { FileDiff } from "@pierre/diffs/react";
-import { ChevronDown, ChevronRight, FileText, Folder, X } from "lucide-react";
+import { ChevronDown, ChevronRight, FileText, Folder, GitCommitHorizontal, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { fetchBranchDiff, type BranchDiffResponse } from "@/lib/api";
+import { fetchBranchDiff, type BranchDiffResponse, type CommitResponse } from "@/lib/api";
+import { useRepo } from "@/components/providers/repo-provider";
+import { commitUrl } from "@/lib/github";
 import { cn } from "@/lib/utils";
 
 interface BranchDiffProps {
   branchName: string;
   revision: string;
+  commits?: CommitResponse[];
   onExit?: () => void;
 }
 
@@ -193,7 +196,7 @@ function buildExplorerRows(entries: ExplorerFileEntry[]): ExplorerRow[] {
   return rows;
 }
 
-export function BranchDiff({ branchName, revision, onExit }: BranchDiffProps) {
+export function BranchDiff({ branchName, revision, commits, onExit }: BranchDiffProps) {
   const [diff, setDiff] = useState<BranchDiffResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -313,6 +316,8 @@ export function BranchDiff({ branchName, revision, onExit }: BranchDiffProps) {
     };
   }, [parsed.files]);
 
+  const { repo } = useRepo();
+
   const fileCountLabel = `${parsed.files.length} file${parsed.files.length !== 1 ? "s" : ""}`;
   const showFileCount = !loading && !error && !parsed.parseError;
   const workspaceMode = Boolean(onExit);
@@ -392,6 +397,41 @@ export function BranchDiff({ branchName, revision, onExit }: BranchDiffProps) {
       {!loading && !error && !parsed.parseError && parsed.files.length > 0 && (
         <div className={contentLayoutClass}>
           <aside className={explorerClass}>
+            {commits && commits.length > 0 && (
+              <div className="border-b">
+                <div className="px-3 py-2 text-xs font-medium text-muted-foreground">
+                  Commits
+                </div>
+                <div className="px-2 pb-2 space-y-0.5">
+                  {commits.map((commit) => (
+                    <div
+                      key={commit.sha}
+                      className="flex items-center gap-1.5 rounded px-1.5 py-1 text-xs group"
+                    >
+                      <GitCommitHorizontal className="h-3 w-3 shrink-0 text-muted-foreground" />
+                      {repo ? (
+                        <a
+                          href={commitUrl(repo.owner, repo.repo, commit.sha)}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="truncate text-muted-foreground hover:text-foreground transition-colors"
+                          title={`${commit.sha} — ${commit.message}`}
+                        >
+                          {commit.message}
+                        </a>
+                      ) : (
+                        <span
+                          className="truncate text-muted-foreground"
+                          title={`${commit.sha} — ${commit.message}`}
+                        >
+                          {commit.message}
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
             <div className="border-b px-3 py-2 text-xs font-medium text-muted-foreground">
               Files
             </div>

--- a/apps/web/src/components/swimlane/__tests__/owner-swimlane.test.tsx
+++ b/apps/web/src/components/swimlane/__tests__/owner-swimlane.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { OwnerSwimlane } from "../owner-swimlane";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import type { BranchResponse, StackDetail } from "@/lib/api";
 
 // Mock motion/react to avoid animation issues in tests
@@ -53,14 +54,16 @@ describe("OwnerSwimlane", () => {
     });
 
     const { container } = render(
-      <OwnerSwimlane
-        label="me"
-        stacks={[stack]}
-        selectedBranch={null}
-        selectedStack={null}
-        onSelectBranch={noop}
-        onSelectStack={noop}
-      />
+      <TooltipProvider>
+        <OwnerSwimlane
+          label="me"
+          stacks={[stack]}
+          selectedBranch={null}
+          selectedStack={null}
+          onSelectBranch={noop}
+          onSelectStack={noop}
+        />
+      </TooltipProvider>
     );
 
     // Linear stacks render StackColumn, not StackTree
@@ -79,14 +82,16 @@ describe("OwnerSwimlane", () => {
     });
 
     const { container } = render(
-      <OwnerSwimlane
-        label="me"
-        stacks={[stack]}
-        selectedBranch={null}
-        selectedStack={null}
-        onSelectBranch={noop}
-        onSelectStack={noop}
-      />
+      <TooltipProvider>
+        <OwnerSwimlane
+          label="me"
+          stacks={[stack]}
+          selectedBranch={null}
+          selectedStack={null}
+          onSelectBranch={noop}
+          onSelectStack={noop}
+        />
+      </TooltipProvider>
     );
 
     // Branching stacks render SegmentTree which uses fork connectors at branch points
@@ -112,14 +117,16 @@ describe("OwnerSwimlane", () => {
     });
 
     const { container } = render(
-      <OwnerSwimlane
-        label="me"
-        stacks={[linearStack, branchingStack]}
-        selectedBranch={null}
-        selectedStack={null}
-        onSelectBranch={noop}
-        onSelectStack={noop}
-      />
+      <TooltipProvider>
+        <OwnerSwimlane
+          label="me"
+          stacks={[linearStack, branchingStack]}
+          selectedBranch={null}
+          selectedStack={null}
+          onSelectBranch={noop}
+          onSelectStack={noop}
+        />
+      </TooltipProvider>
     );
 
     // Exactly one fork connector SVG (from the branching stack)
@@ -145,20 +152,22 @@ describe("OwnerSwimlane", () => {
       ],
     });
 
-    render(
-      <OwnerSwimlane
-        label="me"
-        stacks={[linearStack, branchingStack]}
-        selectedBranch={null}
-        selectedStack={null}
-        onSelectBranch={noop}
-        onSelectStack={noop}
-      />
+    const { container } = render(
+      <TooltipProvider>
+        <OwnerSwimlane
+          label="me"
+          stacks={[linearStack, branchingStack]}
+          selectedBranch={null}
+          selectedStack={null}
+          onSelectBranch={noop}
+          onSelectStack={noop}
+        />
+      </TooltipProvider>
     );
 
-    // Both views show "no PR" text for branches without PRs (shared BranchCard)
-    const noPrLabels = screen.getAllByText("no PR");
-    // 5 branches total across both stacks
-    expect(noPrLabels.length).toBe(5);
+    // Both views show "No PR" tooltip icon for branches without PRs (shared BranchCard)
+    // 5 branches total across both stacks, each renders a GitPullRequestDraft icon
+    const noPrIcons = container.querySelectorAll("svg.lucide-git-pull-request-draft");
+    expect(noPrIcons.length).toBe(5);
   });
 });

--- a/apps/web/src/components/swimlane/branch-card.tsx
+++ b/apps/web/src/components/swimlane/branch-card.tsx
@@ -4,7 +4,7 @@ import type { BranchResponse } from "@/lib/api";
 import { PRBadge, DiffStats } from "@/components/status/status-badge";
 import { CIStatusWithTooltip } from "@/components/status/ci-status";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
-import { Lock } from "lucide-react";
+import { GitCommitVertical, GitPullRequestDraft, Lock } from "lucide-react";
 import { shortenBranchName } from "@/lib/branch-utils";
 
 interface BranchCardProps {
@@ -61,10 +61,21 @@ export function BranchCard({
           {branch.pr ? (
             <PRBadge pr={branch.pr} />
           ) : (
-            <span className="text-xs text-muted-foreground">no PR</span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <GitPullRequestDraft className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+              </TooltipTrigger>
+              <TooltipContent side="top">No PR</TooltipContent>
+            </Tooltip>
           )}
           <CIStatusWithTooltip ci={branch.ci} />
           <DiffStats added={branch.linesAdded} deleted={branch.linesDeleted} />
+          {branch.commitCount > 0 && (
+            <span className="flex items-center gap-0.5 text-xs text-muted-foreground" title={`${branch.commitCount} commit${branch.commitCount !== 1 ? "s" : ""}`}>
+              <GitCommitVertical className="w-3 h-3" />
+              {branch.commitCount}
+            </span>
+          )}
         </div>
       )}
     </button>


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Improve branch card info and diff workspace commit display**

Improves the web UI with richer branch and commit information across the swimlane and diff workspace.

Key changes:
- **use-oldest-commit-for-branch-card-description**: Fix branch card to use the oldest (root) commit message as the display label, matching the stacking metaphor
- **show-commit-count-on-branch-card**: Add commit count badge to branch cards, and show individual commit messages with author/timestamp in the branch diff panel
- **show-commits-with-timestamps-and-conventional**: Show commits in the diff workspace with timestamps, conventional commit type badges (feat, fix, chore, etc.) with color coding, and improved visual hierarchy

#### Stack


* **PR #827**
  * **PR #828** 👈
    * **PR #829**
      * **PR #830**
        * **PR #831**
          * **PR #832**
            * **PR #833**
              * **PR #834**
                * **PR #835**
                  * **PR #836**
                    * **PR #837**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #838 by jonnii*