### PR TITLE
refine(web): polish swimlane UI with accent borders, depth opacity, and StackHeader component

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -66,7 +66,7 @@ export default function Home() {
       <div className="flex flex-col justify-end min-h-full">
         {/* Swimlanes: only this area scrolls horizontally */}
         <div className="overflow-x-auto">
-          <div className="flex items-end gap-8 p-6 pb-4 min-w-max">
+          <div className="flex items-end gap-6 p-6 pb-4 min-w-max">
             {/* Your stacks */}
             {yourStacks.length > 0 && (
               <OwnerSwimlane
@@ -99,9 +99,9 @@ export default function Home() {
 
         {/* Trunk line */}
         <div className="flex items-center gap-2 px-6 pb-2 shrink-0">
-          <div className="flex-1 border-t-2 border-dashed border-muted-foreground/30" />
-          <span className="text-xs font-mono text-muted-foreground">{repo?.trunk}</span>
-          <div className="flex-1 border-t-2 border-dashed border-muted-foreground/30" />
+          <div className="flex-1 h-[2px] bg-gradient-to-r from-transparent via-muted-foreground/30 to-muted-foreground/30" />
+          <span className="text-xs font-mono text-muted-foreground/70 px-2">{repo?.trunk}</span>
+          <div className="flex-1 h-[2px] bg-gradient-to-l from-transparent via-muted-foreground/30 to-muted-foreground/30" />
         </div>
 
         {/* Recent trunk commits */}

--- a/apps/web/src/components/status/status-badge.tsx
+++ b/apps/web/src/components/status/status-badge.tsx
@@ -81,9 +81,9 @@ export function PRBadge({ pr }: { pr?: PRResponse }) {
       href={pr.url}
       target="_blank"
       rel="noopener noreferrer"
-      className={`inline-flex items-center gap-1 text-xs font-mono hover:underline ${stateColors[pr.state] || ""}`}
+      className={`inline-flex items-center gap-1 text-xs font-mono font-semibold hover:underline ${stateColors[pr.state] || ""}`}
     >
-      <Github className="w-3 h-3" />
+      <Github className="w-3.5 h-3.5" />
       #{pr.number}
       {pr.isDraft && " (draft)"}
     </a>

--- a/apps/web/src/components/swimlane/branch-card.tsx
+++ b/apps/web/src/components/swimlane/branch-card.tsx
@@ -29,8 +29,8 @@ export function BranchCard({
       onClick={() => onClick(branch)}
       className={`text-left bg-card transition-all duration-200
         ${compact ? "px-2.5 py-1.5" : "px-3 py-2.5"}
-        ${isSelected ? "!bg-accent z-10 relative" : "hover:!bg-muted hover:scale-[1.02] hover:shadow-md hover:-translate-y-0.5"}
-        ${branch.isCurrent ? "border-l-[3px] border-l-[var(--glow-color-current)]" : ""}
+        ${isSelected ? "!bg-accent z-10 relative" : "hover:!bg-muted/80 hover:shadow-sm"}
+        ${branch.isCurrent ? "border-l-[3px] border-l-[var(--glow-color-current)] bg-accent/30" : ""}
         ${branch.isLocked ? "opacity-60" : ""}
         ${className}
       `}

--- a/apps/web/src/components/swimlane/owner-swimlane.tsx
+++ b/apps/web/src/components/swimlane/owner-swimlane.tsx
@@ -5,7 +5,7 @@ import { motion, AnimatePresence } from "motion/react";
 import type { BranchResponse, StackDetail } from "@/lib/api";
 import { StackColumn, hasBranching } from "@/components/swimlane/stack-column";
 import { StackTreeColumn } from "@/components/swimlane/stack-tree-column";
-import { SwimlaneLabel, swimlaneColor } from "@/components/swimlane/swimlane-label";
+import { SwimlaneLabel, swimlaneColor, swimlaneAccent } from "@/components/swimlane/swimlane-label";
 
 const COLLAPSED_LIMIT = 3;
 
@@ -39,11 +39,13 @@ export function OwnerSwimlane({
     : stacks;
   const hiddenCount = stacks.length - COLLAPSED_LIMIT;
 
+  const accentColor = swimlaneAccent(label);
+
   return (
     <div className="flex flex-col shrink-0">
       <div
-        className={`flex items-end ${compact ? "gap-3 px-2 py-2" : "gap-4 px-3 pt-3"}`}
-        style={{ backgroundColor: color }}
+        className={`flex items-end ${compact ? "gap-3 px-2 py-2" : "gap-4 px-3 pt-3"} rounded-t-xl border-t-2`}
+        style={{ backgroundColor: color, borderColor: accentColor }}
       >
         <AnimatePresence mode="popLayout">
           {visibleStacks.map((stack) => (

--- a/apps/web/src/components/swimlane/stack-column.tsx
+++ b/apps/web/src/components/swimlane/stack-column.tsx
@@ -38,32 +38,19 @@ export function StackColumn({
 
   return (
     <div className={`flex flex-col ${fillWidth ? "w-full" : "w-64 shrink-0"}`}>
-      {/* Stack header */}
       {showHeader && (
-        <div className={`px-1 ${compact ? "pb-1" : "pb-2"}`}>
-          {stack.hasWorktree && (
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-muted-foreground flex items-center gap-1" title="Worktree">
-                <FolderGit2 className="w-3 h-3" />
-              </span>
-            </div>
-          )}
-          {stack.title && (
-            <p className={`font-medium text-muted-foreground truncate ${compact ? "text-[11px] mt-0.5" : "text-xs mt-1"}`} title={stack.title}>
-              {stack.title}
-            </p>
-          )}
-          {stack.description && (
-            <StackDescription text={stack.description} compact={compact} />
-          )}
-        </div>
+        <StackHeader stack={stack} compact={compact} />
       )}
 
       {/* Stacked branch cards */}
-      <div className="flex flex-col bg-card rounded-t-lg">
+      <div className="flex flex-col rounded-t-lg overflow-hidden border-x border-t shadow-sm">
         {displayBranches.map((branch, i) => {
-          const isFirst = i === 0;
           const isLast = i === displayBranches.length - 1;
+          // Subtle depth gradient: top card (leaf) is brightest, bottom card (root) is slightly dimmer
+          const depth = displayBranches.length > 1
+            ? i / (displayBranches.length - 1)
+            : 0;
+          const opacity = 1 - depth * 0.06;
 
           return (
             <BranchCard
@@ -72,11 +59,10 @@ export function StackColumn({
               isSelected={selectedBranch === branch.name}
               onClick={onSelectBranch}
               compact={compact}
-              className={`animate-fade-in-up border-x border-t
-                ${isLast ? "border-b rounded-b-lg relative z-[1] shadow-[0_4px_6px_-2px_rgba(0,0,0,0.15)]" : ""}
-                ${isFirst ? "rounded-t-lg" : ""}
+              className={`animate-fade-in-up
+                ${!isLast ? "border-b border-border/50" : ""}
               `}
-              style={{ animationDelay: `${i * 50}ms` }}
+              style={{ animationDelay: `${i * 50}ms`, opacity }}
             />
           );
         })}
@@ -111,7 +97,7 @@ export function StackStatusFooter({
   return (
     <button
       onClick={onClick}
-      className={`flex items-center justify-center px-3 rounded-b-lg border-x border-b font-medium cursor-pointer transition-all duration-200 ${compact ? "-mt-1.5 pt-2.5 py-1 text-[11px]" : "-mt-2 pt-3.5 py-1.5 text-xs"} ${c.text} ${selected ? `${c.selectedBg} font-semibold` : `${c.bg} ${c.shadow} hover:brightness-95 dark:hover:brightness-110`}`}
+      className={`flex items-center justify-center px-3 rounded-b-lg border-x border-b font-medium cursor-pointer transition-all duration-200 ${compact ? "py-1 text-[11px]" : "py-1.5 text-xs"} ${c.text} ${selected ? `${c.selectedBg} font-semibold` : `${c.bg} ${c.shadow} hover:brightness-95 dark:hover:brightness-110`}`}
     >
       {c.label}
     </button>
@@ -139,6 +125,34 @@ function orderBranches(branches: BranchResponse[]): BranchResponse[] {
   }
 
   return ordered;
+}
+
+export function StackHeader({
+  stack,
+  compact = false,
+}: {
+  stack: StackDetail;
+  compact?: boolean;
+}) {
+  const hasContent = stack.hasWorktree || stack.title;
+  if (!hasContent) return null;
+
+  return (
+    <div className={`px-1 ${compact ? "pb-1" : "pb-2"}`}>
+      {stack.hasWorktree && (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground flex items-center gap-1" title="Worktree">
+            <FolderGit2 className="w-3 h-3" />
+          </span>
+        </div>
+      )}
+      {stack.title && (
+        <p className={`font-medium text-muted-foreground truncate ${compact ? "text-[11px] mt-0.5" : "text-xs mt-1"}`} title={stack.title}>
+          {stack.title}
+        </p>
+      )}
+    </div>
+  );
 }
 
 const DESCRIPTION_COLLAPSE_LENGTH = 80;

--- a/apps/web/src/components/swimlane/stack-tree-column.tsx
+++ b/apps/web/src/components/swimlane/stack-tree-column.tsx
@@ -2,8 +2,7 @@
 
 import type { BranchResponse, StackDetail } from "@/lib/api";
 import { SegmentTree } from "@/components/stack-tree/segment-tree";
-import { StackStatusFooter, StackDescription } from "@/components/swimlane/stack-column";
-import { FolderGit2 } from "lucide-react";
+import { StackStatusFooter, StackHeader } from "@/components/swimlane/stack-column";
 
 interface StackTreeColumnProps {
   stack: StackDetail;
@@ -28,25 +27,8 @@ export function StackTreeColumn({
 }: StackTreeColumnProps) {
   return (
     <div className="flex flex-col min-w-64 shrink-0">
-      {/* Stack header */}
       {showHeader && (
-        <div className={`px-1 ${compact ? "pb-1" : "pb-2"}`}>
-          {stack.hasWorktree && (
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-muted-foreground flex items-center gap-1" title="Worktree">
-                <FolderGit2 className="w-3 h-3" />
-              </span>
-            </div>
-          )}
-          {stack.title && (
-            <p className={`font-medium text-muted-foreground truncate ${compact ? "text-[11px] mt-0.5" : "text-xs mt-1"}`} title={stack.title}>
-              {stack.title}
-            </p>
-          )}
-          {stack.description && (
-            <StackDescription text={stack.description} compact={compact} />
-          )}
-        </div>
+        <StackHeader stack={stack} compact={compact} />
       )}
 
       {/* Tree visualization: linear card stacks with connectors at branch points */}

--- a/apps/web/src/components/swimlane/swimlane-label.tsx
+++ b/apps/web/src/components/swimlane/swimlane-label.tsx
@@ -15,14 +15,14 @@ export function SwimlaneLabel({
 }: SwimlaneLabelProps) {
   return (
     <div
-      className={`flex items-center justify-center w-full rounded-b-md ${compact ? "gap-1.5 px-2 py-0.5" : "gap-2 px-3 py-1"}`}
+      className={`flex items-center justify-center w-full rounded-b-xl ${compact ? "gap-1.5 px-2 py-0.5" : "gap-2 px-3 py-1"}`}
       style={{ backgroundColor: color }}
     >
       <span className={`${compact ? "text-[11px]" : "text-xs"} font-semibold text-foreground/80`}>
         {label}
       </span>
       {lastActive && (
-        <span className={`${compact ? "text-[9px]" : "text-[10px]"} text-foreground/40`}>
+        <span className={`${compact ? "text-[9px]" : "text-[10px]"} text-foreground/60`}>
           active {formatLastActive(lastActive)}
         </span>
       )}
@@ -30,18 +30,27 @@ export function SwimlaneLabel({
   );
 }
 
-/**
- * Generate a soft pastel background color from a string.
- * Returns a CSS `light-dark()` value that adapts to the color scheme.
- * Light mode uses high lightness (95%), dark mode uses low lightness (18%).
- */
-export function swimlaneColor(name: string): string {
+function swimlaneHue(name: string): number {
   let hash = 0;
   for (let i = 0; i < name.length; i++) {
     hash = name.charCodeAt(i) + ((hash << 5) - hash);
   }
-  const hue = ((hash % 360) + 360) % 360;
+  return ((hash % 360) + 360) % 360;
+}
+
+/**
+ * Generate a soft pastel background color from a string.
+ * Returns a CSS `light-dark()` value that adapts to the color scheme.
+ */
+export function swimlaneColor(name: string): string {
+  const hue = swimlaneHue(name);
   return `light-dark(hsl(${hue} 30% 95%), hsl(${hue} 20% 18%))`;
+}
+
+/** Saturated accent color for borders/highlights derived from the swimlane hue. */
+export function swimlaneAccent(name: string): string {
+  const hue = swimlaneHue(name);
+  return `light-dark(hsl(${hue} 50% 65%), hsl(${hue} 40% 45%))`;
 }
 
 function formatLastActive(date: Date): string {

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -102,29 +102,15 @@ func MapStackSummary(eng engine.BranchReader, graph *engine.StackGraph, rootBran
 		}
 	}
 
-	// Get title from root branch's PR, or first child's PR for worktree anchors
-	title := rootBranch
-	if rootNode != nil {
-		if hasWorktree {
-			// Anchor has no PR — derive title from first child
-			if len(rootNode.Children) > 0 {
-				if childNode := graph.GetNode(rootNode.Children[0]); childNode != nil {
-					if prInfo, err := childNode.Branch.GetPrInfo(); err == nil && prInfo != nil && prInfo.Title() != "" {
-						title = prInfo.Title()
-					}
-				}
-			}
-		} else if prInfo, err := rootNode.Branch.GetPrInfo(); err == nil && prInfo != nil && prInfo.Title() != "" {
-			title = prInfo.Title()
-		}
-	}
-
 	// Compute stack status using display branches (anchor excluded)
 	status := computeStackStatus(graph, displayBranches)
 
-	var description string
+	// Title and description come exclusively from explicit stack descriptions
+	// set via `stackit describe`. No fallback to PR titles or branch names.
+	var title, description string
 	if rootNode != nil {
 		if stackDesc := eng.GetStackDescription(rootNode.Branch); stackDesc != nil && !stackDesc.IsEmpty() {
+			title = stackDesc.Title
 			description = stackDesc.Description
 		}
 	}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Improve branch card info and diff workspace commit display**

Improves the web UI with richer branch and commit information across the swimlane and diff workspace.

Key changes:
- **use-oldest-commit-for-branch-card-description**: Fix branch card to use the oldest (root) commit message as the display label, matching the stacking metaphor
- **show-commit-count-on-branch-card**: Add commit count badge to branch cards, and show individual commit messages with author/timestamp in the branch diff panel
- **show-commits-with-timestamps-and-conventional**: Show commits in the diff workspace with timestamps, conventional commit type badges (feat, fix, chore, etc.) with color coding, and improved visual hierarchy

#### Stack


* **PR #827**
  * **PR #828**
    * **PR #829**
      * **PR #830** 👈
        * **PR #831**
          * **PR #832**
            * **PR #833**
              * **PR #834**
                * **PR #835**
                  * **PR #836**
                    * **PR #837**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #838 by jonnii*