### PR TITLE
refine(web): remove distracting re-trigger animations on navigation

### DIFF
--- a/apps/web/src/components/branch-detail/ci-checks.tsx
+++ b/apps/web/src/components/branch-detail/ci-checks.tsx
@@ -15,8 +15,7 @@ export function CIChecks({ ci }: { ci?: CIResponse }) {
         {ci.checks.map((check, i) => (
           <div
             key={check.name}
-            className="flex items-center gap-2 text-sm animate-fade-in-up"
-            style={{ animationDelay: `${i * 50}ms` }}
+            className="flex items-center gap-2 text-sm"
           >
             <CheckIcon conclusion={check.conclusion} status={check.status} />
             <span className="truncate">{check.name}</span>

--- a/apps/web/src/components/branch-detail/commit-list.tsx
+++ b/apps/web/src/components/branch-detail/commit-list.tsx
@@ -18,8 +18,7 @@ export function CommitList({ commits }: { commits?: CommitResponse[] }) {
         {commits.map((commit, i) => (
           <div
             key={commit.sha}
-            className="flex items-baseline gap-2 text-sm animate-fade-in-up"
-            style={{ animationDelay: `${i * 40}ms` }}
+            className="flex items-baseline gap-2 text-sm"
           >
             {repo ? (
               <a

--- a/apps/web/src/components/swimlane/owner-swimlane.tsx
+++ b/apps/web/src/components/swimlane/owner-swimlane.tsx
@@ -52,7 +52,6 @@ export function OwnerSwimlane({
             <motion.div
               key={stack.rootBranch}
               layout
-              initial={{ opacity: 0, y: 12 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, scale: 0.95 }}
               transition={{ duration: 0.2 }}

--- a/apps/web/src/components/swimlane/stack-column.tsx
+++ b/apps/web/src/components/swimlane/stack-column.tsx
@@ -59,10 +59,8 @@ export function StackColumn({
               isSelected={selectedBranch === branch.name}
               onClick={onSelectBranch}
               compact={compact}
-              className={`animate-fade-in-up
-                ${!isLast ? "border-b border-border/50" : ""}
-              `}
-              style={{ animationDelay: `${i * 50}ms`, opacity }}
+              className={!isLast ? "border-b border-border/50" : ""}
+              style={{ opacity }}
             />
           );
         })}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Improve branch card info and diff workspace commit display**

Improves the web UI with richer branch and commit information across the swimlane and diff workspace.

Key changes:
- **use-oldest-commit-for-branch-card-description**: Fix branch card to use the oldest (root) commit message as the display label, matching the stacking metaphor
- **show-commit-count-on-branch-card**: Add commit count badge to branch cards, and show individual commit messages with author/timestamp in the branch diff panel
- **show-commits-with-timestamps-and-conventional**: Show commits in the diff workspace with timestamps, conventional commit type badges (feat, fix, chore, etc.) with color coding, and improved visual hierarchy

#### Stack


* **PR #827**
  * **PR #828**
    * **PR #829**
      * **PR #830**
        * **PR #831**
          * **PR #832** 👈
            * **PR #833**
              * **PR #834**
                * **PR #835**
                  * **PR #836**
                    * **PR #837**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #838 by jonnii*