### PR TITLE
refine(web): replace loading diff text with skeleton UI

### DIFF
--- a/apps/web/src/components/branch-detail/branch-detail.tsx
+++ b/apps/web/src/components/branch-detail/branch-detail.tsx
@@ -29,14 +29,13 @@ import {
 } from "@/components/status/status-badge";
 import { CommitList } from "./commit-list";
 import { CIChecks } from "./ci-checks";
+import { DiffSkeleton } from "./diff-skeleton";
 
 const BranchDiff = dynamic(
   () => import("./branch-diff").then((m) => m.BranchDiff),
   {
     ssr: false,
-    loading: () => (
-      <p className="text-sm text-muted-foreground">Loading diff viewer...</p>
-    ),
+    loading: () => <DiffSkeleton />,
   }
 );
 

--- a/apps/web/src/components/branch-detail/branch-diff-workspace.tsx
+++ b/apps/web/src/components/branch-detail/branch-diff-workspace.tsx
@@ -2,14 +2,13 @@
 
 import dynamic from "next/dynamic";
 import type { BranchResponse } from "@/lib/api";
+import { DiffSkeleton } from "./diff-skeleton";
 
 const BranchDiff = dynamic(
   () => import("./branch-diff").then((m) => m.BranchDiff),
   {
     ssr: false,
-    loading: () => (
-      <p className="text-sm text-muted-foreground">Loading diff viewer...</p>
-    ),
+    loading: () => <DiffSkeleton />,
   }
 );
 

--- a/apps/web/src/components/branch-detail/branch-diff.tsx
+++ b/apps/web/src/components/branch-detail/branch-diff.tsx
@@ -424,7 +424,46 @@ export function BranchDiff({ branchName, revision, commits, onExit }: BranchDiff
       </div>
 
       {loading && (
-        <p className="text-sm text-muted-foreground">Loading diff…</p>
+        <div className={contentLayoutClass}>
+          <aside className={explorerClass}>
+            <div className="px-3 py-2 text-xs font-medium text-muted-foreground">
+              Files
+            </div>
+            <div className="p-2 space-y-1.5">
+              {[0, 1, 2, 3, 4].map((i) => (
+                <div key={i} className="flex items-center gap-2 px-1.5 py-1">
+                  <div className="h-3 w-3 shrink-0 rounded bg-muted animate-pulse" />
+                  <div
+                    className="h-3 rounded bg-muted animate-pulse"
+                    style={{ width: `${60 + (i * 17) % 30}%` }}
+                  />
+                </div>
+              ))}
+            </div>
+          </aside>
+          <div className={cn(diffPaneClass, "flex-1 space-y-3")}>
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="rounded-md border bg-card/60 overflow-hidden">
+                <div className="flex items-center gap-2 border-b px-3 py-2">
+                  <div className="h-3 w-3 rounded bg-muted animate-pulse" />
+                  <div
+                    className="h-3 rounded bg-muted animate-pulse"
+                    style={{ width: `${100 + (i * 37) % 80}px` }}
+                  />
+                </div>
+                <div className="p-3 space-y-2">
+                  {[0, 1, 2, 3].map((j) => (
+                    <div
+                      key={j}
+                      className="h-3 rounded bg-muted/60 animate-pulse"
+                      style={{ width: `${40 + ((i + j) * 23) % 55}%` }}
+                    />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
       )}
 
       {!loading && error && (

--- a/apps/web/src/components/branch-detail/diff-skeleton.tsx
+++ b/apps/web/src/components/branch-detail/diff-skeleton.tsx
@@ -1,0 +1,46 @@
+export function DiffSkeleton() {
+  return (
+    <div className="grid gap-3 lg:grid-cols-[18rem,minmax(0,1fr)] lg:items-start lg:gap-4">
+      {/* File explorer skeleton */}
+      <div className="rounded-md border bg-card/60">
+        <div className="px-3 py-2 text-xs font-medium text-muted-foreground">
+          Files
+        </div>
+        <div className="p-2 space-y-1.5">
+          {[0, 1, 2, 3, 4].map((i) => (
+            <div key={i} className="flex items-center gap-2 px-1.5 py-1">
+              <div className="h-3 w-3 shrink-0 rounded bg-muted animate-pulse" />
+              <div
+                className="h-3 rounded bg-muted animate-pulse"
+                style={{ width: `${60 + (i * 17) % 30}%` }}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+      {/* Diff pane skeleton */}
+      <div className="space-y-3">
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="rounded-md border bg-card/60 overflow-hidden">
+            <div className="flex items-center gap-2 border-b px-3 py-2">
+              <div className="h-3 w-3 rounded bg-muted animate-pulse" />
+              <div
+                className="h-3 rounded bg-muted animate-pulse"
+                style={{ width: `${100 + (i * 37) % 80}px` }}
+              />
+            </div>
+            <div className="p-3 space-y-2">
+              {[0, 1, 2, 3].map((j) => (
+                <div
+                  key={j}
+                  className="h-3 rounded bg-muted/60 animate-pulse"
+                  style={{ width: `${40 + ((i + j) * 23) % 55}%` }}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Improve branch card info and diff workspace commit display**

Improves the web UI with richer branch and commit information across the swimlane and diff workspace.

Key changes:
- **use-oldest-commit-for-branch-card-description**: Fix branch card to use the oldest (root) commit message as the display label, matching the stacking metaphor
- **show-commit-count-on-branch-card**: Add commit count badge to branch cards, and show individual commit messages with author/timestamp in the branch diff panel
- **show-commits-with-timestamps-and-conventional**: Show commits in the diff workspace with timestamps, conventional commit type badges (feat, fix, chore, etc.) with color coding, and improved visual hierarchy

#### Stack


* **PR #827**
  * **PR #828**
    * **PR #829**
      * **PR #830**
        * **PR #831**
          * **PR #832**
            * **PR #833** 👈
              * **PR #834**
                * **PR #835**
                  * **PR #836**
                    * **PR #837**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #838 by jonnii*