### PR TITLE
feat(web): style unpushed branches with diagonal stripes

### DIFF
--- a/apps/web/src/components/stack-tree/branch-node.tsx
+++ b/apps/web/src/components/stack-tree/branch-node.tsx
@@ -22,6 +22,7 @@ export function BranchNode({
   onClick,
 }: BranchNodeProps) {
   const ciIcon = getCIIcon(branch);
+  const notPushed = branch.remoteStatus?.missingRemote;
   const borderClass = isSelected
     ? "stroke-blue-500/50 stroke-1"
     : "stroke-border stroke-1";
@@ -33,12 +34,33 @@ export function BranchNode({
       className="cursor-pointer"
       style={{ transition: "transform 0.15s ease" }}
     >
+      {notPushed && (
+        <defs>
+          <pattern
+            id={`stripes-${branch.name}`}
+            width={12}
+            height={12}
+            patternUnits="userSpaceOnUse"
+            patternTransform="rotate(-45)"
+          >
+            <rect width={4} height={12} fill="oklch(0.65 0.05 250 / 0.12)" />
+          </pattern>
+        </defs>
+      )}
       <rect
         width={NODE_WIDTH}
         height={NODE_HEIGHT}
         rx={8}
         className={`fill-card ${borderClass}`}
       />
+      {notPushed && (
+        <rect
+          width={NODE_WIDTH}
+          height={NODE_HEIGHT}
+          rx={8}
+          fill={`url(#stripes-${branch.name})`}
+        />
+      )}
       {/* Left accent bar for current (checked out) branch */}
       {branch.isCurrent && (
         <rect

--- a/apps/web/src/components/swimlane/branch-card.tsx
+++ b/apps/web/src/components/swimlane/branch-card.tsx
@@ -34,7 +34,12 @@ export function BranchCard({
         ${branch.isLocked ? "opacity-60" : ""}
         ${className}
       `}
-      style={style}
+      style={{
+        ...style,
+        ...(branch.remoteStatus?.missingRemote ? {
+          backgroundImage: "repeating-linear-gradient(-45deg, transparent, transparent 8px, oklch(0.65 0.05 250 / 0.12) 8px, oklch(0.65 0.05 250 / 0.12) 12px)",
+        } : undefined),
+      }}
     >
       <div className="flex items-center gap-2 min-w-0">
         <span className="text-sm font-medium truncate" title={branch.name}>


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Improve branch card info and diff workspace commit display**

Improves the web UI with richer branch and commit information across the swimlane and diff workspace.

Key changes:
- **use-oldest-commit-for-branch-card-description**: Fix branch card to use the oldest (root) commit message as the display label, matching the stacking metaphor
- **show-commit-count-on-branch-card**: Add commit count badge to branch cards, and show individual commit messages with author/timestamp in the branch diff panel
- **show-commits-with-timestamps-and-conventional**: Show commits in the diff workspace with timestamps, conventional commit type badges (feat, fix, chore, etc.) with color coding, and improved visual hierarchy

#### Stack


* **PR #827**
  * **PR #828**
    * **PR #829**
      * **PR #830**
        * **PR #831**
          * **PR #832**
            * **PR #833**
              * **PR #834** 👈
                * **PR #835**
                  * **PR #836**
                    * **PR #837**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #838 by jonnii*