### PR TITLE
fix(web): sync diff viewer theme with app theme toggle

### DIFF
--- a/apps/web/src/components/branch-detail/branch-diff.tsx
+++ b/apps/web/src/components/branch-detail/branch-diff.tsx
@@ -9,6 +9,7 @@ import { ChevronDown, ChevronRight, FileText, Folder, GitCommitHorizontal, X } f
 import { useEffect, useMemo, useRef, useState } from "react";
 import { fetchBranchDiff, type BranchDiffResponse, type CommitResponse } from "@/lib/api";
 import { useRepo } from "@/components/providers/repo-provider";
+import { useTheme } from "@/components/providers/theme-provider";
 import { commitUrl } from "@/lib/github";
 import { cn } from "@/lib/utils";
 
@@ -19,12 +20,11 @@ interface BranchDiffProps {
   onExit?: () => void;
 }
 
-const DIFF_OPTIONS = {
+const BASE_DIFF_OPTIONS = {
   diffStyle: "split",
   lineDiffType: "word",
   hunkSeparators: "metadata",
   overflow: "scroll",
-  themeType: "system",
 } as const;
 
 function getFileKey(file: FileDiffMetadata, index: number): string {
@@ -371,6 +371,12 @@ export function BranchDiff({ branchName, revision, commits, onExit }: BranchDiff
   }, [parsed.files]);
 
   const { repo } = useRepo();
+  const { resolvedTheme } = useTheme();
+
+  const diffOptions = useMemo(
+    () => ({ ...BASE_DIFF_OPTIONS, themeType: resolvedTheme } as const),
+    [resolvedTheme]
+  );
 
   const fileCountLabel = `${parsed.files.length} file${parsed.files.length !== 1 ? "s" : ""}`;
   const showFileCount = !loading && !error && !parsed.parseError;
@@ -656,7 +662,7 @@ export function BranchDiff({ branchName, revision, commits, onExit }: BranchDiff
                             Collapse
                           </button>
                         )}
-                        <FileDiff fileDiff={file} options={DIFF_OPTIONS} className="block" />
+                        <FileDiff fileDiff={file} options={diffOptions} className="block" />
                       </>
                     )}
                   </div>

--- a/apps/web/src/components/providers/theme-provider.tsx
+++ b/apps/web/src/components/providers/theme-provider.tsx
@@ -9,14 +9,17 @@ import {
 } from "react";
 
 type Theme = "light" | "dark" | "system";
+type ResolvedTheme = "light" | "dark";
 
 interface ThemeContextValue {
   theme: Theme;
+  resolvedTheme: ResolvedTheme;
   setTheme: (theme: Theme) => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue>({
   theme: "system",
+  resolvedTheme: "light",
   setTheme: () => {},
 });
 
@@ -40,8 +43,13 @@ function applyTheme(theme: Theme) {
   document.documentElement.style.colorScheme = resolved;
 }
 
+function resolveTheme(theme: Theme): ResolvedTheme {
+  return theme === "system" ? getSystemPreference() : theme;
+}
+
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setThemeState] = useState<Theme>("system");
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("light");
 
   // Initialize from localStorage on mount
   useEffect(() => {
@@ -50,6 +58,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       ? stored
       : "system";
     setThemeState(initial);
+    setResolvedTheme(resolveTheme(initial));
     applyTheme(initial);
   }, []);
 
@@ -57,7 +66,10 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
     const handler = () => {
-      if (theme === "system") applyTheme("system");
+      if (theme === "system") {
+        setResolvedTheme(getSystemPreference());
+        applyTheme("system");
+      }
     };
     mq.addEventListener("change", handler);
     return () => mq.removeEventListener("change", handler);
@@ -65,12 +77,13 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   const setTheme = useCallback((next: Theme) => {
     setThemeState(next);
+    setResolvedTheme(resolveTheme(next));
     localStorage.setItem(STORAGE_KEY, next);
     applyTheme(next);
   }, []);
 
   return (
-    <ThemeContext.Provider value={{ theme, setTheme }}>
+    <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme }}>
       {children}
     </ThemeContext.Provider>
   );


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Improve branch card info and diff workspace commit display**

Improves the web UI with richer branch and commit information across the swimlane and diff workspace.

Key changes:
- **use-oldest-commit-for-branch-card-description**: Fix branch card to use the oldest (root) commit message as the display label, matching the stacking metaphor
- **show-commit-count-on-branch-card**: Add commit count badge to branch cards, and show individual commit messages with author/timestamp in the branch diff panel
- **show-commits-with-timestamps-and-conventional**: Show commits in the diff workspace with timestamps, conventional commit type badges (feat, fix, chore, etc.) with color coding, and improved visual hierarchy

#### Stack


* **PR #827**
  * **PR #828**
    * **PR #829**
      * **PR #830**
        * **PR #831**
          * **PR #832**
            * **PR #833**
              * **PR #834**
                * **PR #835** 👈
                  * **PR #836**
                    * **PR #837**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #838 by jonnii*