### PR TITLE
feat(web): add language-specific file icons using react-icons

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-icons": "^5.6.0",
     "react-markdown": "^10.1.0",
     "tailwind-merge": "^3.5.0"
   },

--- a/apps/web/src/components/branch-detail/branch-diff.tsx
+++ b/apps/web/src/components/branch-detail/branch-diff.tsx
@@ -5,12 +5,13 @@ import {
   type FileDiffMetadata,
 } from "@pierre/diffs";
 import { FileDiff } from "@pierre/diffs/react";
-import { ChevronDown, ChevronRight, FileText, Folder, GitCommitHorizontal, X } from "lucide-react";
+import { ChevronDown, ChevronRight, Folder, GitCommitHorizontal, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { fetchBranchDiff, type BranchDiffResponse, type CommitResponse } from "@/lib/api";
 import { useRepo } from "@/components/providers/repo-provider";
 import { useTheme } from "@/components/providers/theme-provider";
 import { commitUrl } from "@/lib/github";
+import { getFileIcon } from "@/lib/file-icons";
 import { cn } from "@/lib/utils";
 
 interface BranchDiffProps {
@@ -573,7 +574,7 @@ export function BranchDiff({ branchName, revision, commits, onExit }: BranchDiff
                         className="flex items-center gap-1.5 rounded px-2 py-1 text-xs text-muted-foreground"
                         style={{ paddingLeft: `${row.depth * 14 + 8}px` }}
                       >
-                        <Folder className="h-3.5 w-3.5 shrink-0" />
+                        <Folder className="h-3.5 w-3.5 shrink-0 text-blue-400" />
                         <span className="truncate">{row.name}</span>
                       </div>
                     ) : (
@@ -594,7 +595,7 @@ export function BranchDiff({ branchName, revision, commits, onExit }: BranchDiff
                         style={{ paddingLeft: `${row.depth * 14 + 8}px` }}
                         title={row.title}
                       >
-                        <FileText className="h-3.5 w-3.5 shrink-0" />
+                        {getFileIcon(row.name)}
                         <span className="truncate">{row.name}</span>
                       </button>
                     )}

--- a/apps/web/src/lib/file-icons.tsx
+++ b/apps/web/src/lib/file-icons.tsx
@@ -1,0 +1,127 @@
+import type { ReactNode } from "react";
+
+// Language / framework brand icons (Simple Icons via react-icons)
+import {
+  SiGo,
+  SiTypescript,
+  SiJavascript,
+  SiReact,
+  SiCss,
+  SiSass,
+  SiHtml5,
+  SiJson,
+  SiYaml,
+  SiToml,
+  SiMarkdown,
+  SiGnubash,
+  SiPython,
+  SiRust,
+  SiRuby,
+  SiDocker,
+  SiSvg,
+  SiEslint,
+  SiGit,
+} from "react-icons/si";
+import {
+  VscFile,
+  VscFileMedia,
+  VscGear,
+  VscLock,
+  VscDatabase,
+} from "react-icons/vsc";
+
+const iconClass = "h-3.5 w-3.5 shrink-0";
+
+const extensionMap: Record<string, ReactNode> = {
+  // Go
+  ".go": <SiGo className={`${iconClass} text-cyan-500`} />,
+
+  // TypeScript / JavaScript
+  ".ts": <SiTypescript className={`${iconClass} text-blue-500`} />,
+  ".tsx": <SiReact className={`${iconClass} text-blue-400`} />,
+  ".js": <SiJavascript className={`${iconClass} text-yellow-500`} />,
+  ".jsx": <SiReact className={`${iconClass} text-blue-400`} />,
+  ".mjs": <SiJavascript className={`${iconClass} text-yellow-500`} />,
+  ".cjs": <SiJavascript className={`${iconClass} text-yellow-500`} />,
+  ".d.ts": <SiTypescript className={`${iconClass} text-blue-600 dark:text-blue-400`} />,
+
+  // Web
+  ".css": <SiCss className={`${iconClass} text-blue-500`} />,
+  ".scss": <SiSass className={`${iconClass} text-pink-500`} />,
+  ".html": <SiHtml5 className={`${iconClass} text-orange-500`} />,
+  ".svg": <SiSvg className={`${iconClass} text-orange-400`} />,
+
+  // Data / Config
+  ".json": <SiJson className={`${iconClass} text-yellow-600 dark:text-yellow-400`} />,
+  ".yaml": <SiYaml className={`${iconClass} text-red-400`} />,
+  ".yml": <SiYaml className={`${iconClass} text-red-400`} />,
+  ".toml": <SiToml className={`${iconClass} text-gray-500 dark:text-gray-400`} />,
+  ".env": <VscGear className={`${iconClass} text-yellow-600 dark:text-yellow-400`} />,
+
+  // Documentation
+  ".md": <SiMarkdown className={`${iconClass} text-blue-400 dark:text-blue-300`} />,
+  ".mdx": <SiMarkdown className={`${iconClass} text-blue-400 dark:text-blue-300`} />,
+  ".txt": <VscFile className={`${iconClass} text-gray-400`} />,
+
+  // Shell / Scripts
+  ".sh": <SiGnubash className={`${iconClass} text-green-500`} />,
+  ".bash": <SiGnubash className={`${iconClass} text-green-500`} />,
+  ".zsh": <SiGnubash className={`${iconClass} text-green-500`} />,
+
+  // Images
+  ".png": <VscFileMedia className={`${iconClass} text-green-400`} />,
+  ".jpg": <VscFileMedia className={`${iconClass} text-green-400`} />,
+  ".jpeg": <VscFileMedia className={`${iconClass} text-green-400`} />,
+  ".gif": <VscFileMedia className={`${iconClass} text-green-400`} />,
+  ".webp": <VscFileMedia className={`${iconClass} text-green-400`} />,
+  ".ico": <VscFileMedia className={`${iconClass} text-green-400`} />,
+
+  // Languages
+  ".rs": <SiRust className={`${iconClass} text-orange-600 dark:text-orange-400`} />,
+  ".py": <SiPython className={`${iconClass} text-yellow-500`} />,
+  ".rb": <SiRuby className={`${iconClass} text-red-500`} />,
+
+  // Database
+  ".sql": <VscDatabase className={`${iconClass} text-blue-300`} />,
+};
+
+const filenameMap: Record<string, ReactNode> = {
+  "Dockerfile": <SiDocker className={`${iconClass} text-blue-500`} />,
+  "Makefile": <VscGear className={`${iconClass} text-orange-500`} />,
+  ".gitignore": <SiGit className={`${iconClass} text-orange-500`} />,
+  ".eslintrc": <SiEslint className={`${iconClass} text-purple-500`} />,
+  ".eslintrc.json": <SiEslint className={`${iconClass} text-purple-500`} />,
+  "eslint.config.js": <SiEslint className={`${iconClass} text-purple-500`} />,
+  "eslint.config.mjs": <SiEslint className={`${iconClass} text-purple-500`} />,
+  "package.json": <SiJson className={`${iconClass} text-green-500`} />,
+  "tsconfig.json": <SiTypescript className={`${iconClass} text-blue-500`} />,
+  "go.mod": <SiGo className={`${iconClass} text-cyan-500`} />,
+  "go.sum": <VscLock className={`${iconClass} text-cyan-400`} />,
+  "pnpm-lock.yaml": <VscLock className={`${iconClass} text-orange-400`} />,
+  "package-lock.json": <VscLock className={`${iconClass} text-orange-400`} />,
+  "yarn.lock": <VscLock className={`${iconClass} text-blue-400`} />,
+};
+
+const defaultIcon = <VscFile className={`${iconClass} text-muted-foreground`} />;
+
+export function getFileIcon(filename: string): ReactNode {
+  // Check full filename first (e.g., Dockerfile, go.mod)
+  const match = filenameMap[filename];
+  if (match) return match;
+
+  // Check compound extensions (e.g., .d.ts)
+  const lowerName = filename.toLowerCase();
+  if (lowerName.endsWith(".d.ts")) {
+    return extensionMap[".d.ts"];
+  }
+
+  // Check simple extension
+  const dotIndex = lowerName.lastIndexOf(".");
+  if (dotIndex !== -1) {
+    const ext = lowerName.slice(dotIndex);
+    const extMatch = extensionMap[ext];
+    if (extMatch) return extMatch;
+  }
+
+  return defaultIcon;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      react-icons:
+        specifier: ^5.6.0
+        version: 5.6.0(react@19.2.3)
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.3)
@@ -3959,6 +3962,11 @@ packages:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
       react: ^19.2.3
+
+  react-icons@5.6.0:
+    resolution: {integrity: sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==}
+    peerDependencies:
+      react: '*'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -8892,6 +8900,10 @@ snapshots:
     dependencies:
       react: 19.2.3
       scheduler: 0.27.0
+
+  react-icons@5.6.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   react-is@16.13.1: {}
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Improve branch card info and diff workspace commit display**

Improves the web UI with richer branch and commit information across the swimlane and diff workspace.

Key changes:
- **use-oldest-commit-for-branch-card-description**: Fix branch card to use the oldest (root) commit message as the display label, matching the stacking metaphor
- **show-commit-count-on-branch-card**: Add commit count badge to branch cards, and show individual commit messages with author/timestamp in the branch diff panel
- **show-commits-with-timestamps-and-conventional**: Show commits in the diff workspace with timestamps, conventional commit type badges (feat, fix, chore, etc.) with color coding, and improved visual hierarchy

#### Stack


* **PR #827**
  * **PR #828**
    * **PR #829**
      * **PR #830**
        * **PR #831**
          * **PR #832**
            * **PR #833**
              * **PR #834**
                * **PR #835**
                  * **PR #836** 👈
                    * **PR #837**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #838 by jonnii*