### PR TITLE
refine(web): collapse recent commits when viewing a branch and restore preference on return

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -59,8 +59,9 @@ export default function Home() {
     [stackDetails, repo?.currentUser]
   );
 
-  const [showRecentCommits, setShowRecentCommits] = useState(true);
+  const [recentCommitsPreference, setRecentCommitsPreference] = useState(true);
   const hasSelection = selectedBranch || selectedStack;
+  const showRecentCommits = selectedBranch ? false : recentCommitsPreference;
   const branchOverlayMode = Boolean(selectedBranch && selectedBranchStack);
   const stacksAndHistoryContent =
     stackDetails.length > 0 ? (
@@ -101,12 +102,18 @@ export default function Home() {
         {/* Trunk line */}
         <div className="flex items-center gap-2 px-6 pb-2 shrink-0">
           <div className="flex-1 h-[2px] bg-gradient-to-r from-transparent via-muted-foreground/30 to-muted-foreground/30" />
-          <button
-            onClick={() => setShowRecentCommits((prev) => !prev)}
-            className="text-xs font-mono text-muted-foreground/70 px-2 hover:text-muted-foreground transition-colors cursor-pointer"
-          >
-            {repo?.trunk}
-          </button>
+          {selectedBranch ? (
+            <span className="text-xs font-mono text-muted-foreground/70 px-2">
+              {repo?.trunk}
+            </span>
+          ) : (
+            <button
+              onClick={() => setRecentCommitsPreference((prev) => !prev)}
+              className="text-xs font-mono text-muted-foreground/70 px-2 hover:text-muted-foreground transition-colors cursor-pointer"
+            >
+              {repo?.trunk}
+            </button>
+          )}
           <div className="flex-1 h-[2px] bg-gradient-to-l from-transparent via-muted-foreground/30 to-muted-foreground/30" />
         </div>
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Improve branch card info and diff workspace commit display**

Improves the web UI with richer branch and commit information across the swimlane and diff workspace.

Key changes:
- **use-oldest-commit-for-branch-card-description**: Fix branch card to use the oldest (root) commit message as the display label, matching the stacking metaphor
- **show-commit-count-on-branch-card**: Add commit count badge to branch cards, and show individual commit messages with author/timestamp in the branch diff panel
- **show-commits-with-timestamps-and-conventional**: Show commits in the diff workspace with timestamps, conventional commit type badges (feat, fix, chore, etc.) with color coding, and improved visual hierarchy

#### Stack


* **PR #827**
  * **PR #828**
    * **PR #829**
      * **PR #830**
        * **PR #831**
          * **PR #832**
            * **PR #833**
              * **PR #834**
                * **PR #835**
                  * **PR #836**
                    * **PR #837** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #838 by jonnii*