### PR TITLE
Improve branch card info and diff workspace commit display

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-icons": "^5.6.0",
     "react-markdown": "^10.1.0",
     "tailwind-merge": "^3.5.0"
   },

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import dynamic from "next/dynamic";
 import { useRepo } from "@/components/providers/repo-provider";
 import { OwnerSwimlane } from "@/components/swimlane/owner-swimlane";
@@ -59,14 +59,16 @@ export default function Home() {
     [stackDetails, repo?.currentUser]
   );
 
+  const [recentCommitsPreference, setRecentCommitsPreference] = useState(true);
   const hasSelection = selectedBranch || selectedStack;
+  const showRecentCommits = selectedBranch ? false : recentCommitsPreference;
   const branchOverlayMode = Boolean(selectedBranch && selectedBranchStack);
   const stacksAndHistoryContent =
     stackDetails.length > 0 ? (
       <div className="flex flex-col justify-end min-h-full">
         {/* Swimlanes: only this area scrolls horizontally */}
         <div className="overflow-x-auto">
-          <div className="flex items-end gap-8 p-6 pb-4 min-w-max">
+          <div className="flex items-end gap-6 p-6 pb-4 min-w-max">
             {/* Your stacks */}
             {yourStacks.length > 0 && (
               <OwnerSwimlane
@@ -99,13 +101,34 @@ export default function Home() {
 
         {/* Trunk line */}
         <div className="flex items-center gap-2 px-6 pb-2 shrink-0">
-          <div className="flex-1 border-t-2 border-dashed border-muted-foreground/30" />
-          <span className="text-xs font-mono text-muted-foreground">{repo?.trunk}</span>
-          <div className="flex-1 border-t-2 border-dashed border-muted-foreground/30" />
+          <div className="flex-1 h-[2px] bg-gradient-to-r from-transparent via-muted-foreground/30 to-muted-foreground/30" />
+          {selectedBranch ? (
+            <span className="text-xs font-mono text-muted-foreground/70 px-2">
+              {repo?.trunk}
+            </span>
+          ) : (
+            <button
+              onClick={() => setRecentCommitsPreference((prev) => !prev)}
+              className="text-xs font-mono text-muted-foreground/70 px-2 hover:text-muted-foreground transition-colors cursor-pointer"
+            >
+              {repo?.trunk}
+            </button>
+          )}
+          <div className="flex-1 h-[2px] bg-gradient-to-l from-transparent via-muted-foreground/30 to-muted-foreground/30" />
         </div>
 
         {/* Recent trunk commits */}
-        <RecentlyMerged compact={branchOverlayMode} />
+        <div
+          className="grid transition-[grid-template-rows,opacity] duration-300 ease-in-out"
+          style={{
+            gridTemplateRows: showRecentCommits ? "1fr" : "0fr",
+            opacity: showRecentCommits ? 1 : 0,
+          }}
+        >
+          <div className="overflow-hidden">
+            <RecentlyMerged compact={branchOverlayMode} />
+          </div>
+        </div>
       </div>
     ) : (
       <div className="flex items-center justify-center h-full text-muted-foreground text-sm">

--- a/apps/web/src/components/branch-detail/branch-detail.tsx
+++ b/apps/web/src/components/branch-detail/branch-detail.tsx
@@ -29,14 +29,13 @@ import {
 } from "@/components/status/status-badge";
 import { CommitList } from "./commit-list";
 import { CIChecks } from "./ci-checks";
+import { DiffSkeleton } from "./diff-skeleton";
 
 const BranchDiff = dynamic(
   () => import("./branch-diff").then((m) => m.BranchDiff),
   {
     ssr: false,
-    loading: () => (
-      <p className="text-sm text-muted-foreground">Loading diff viewer...</p>
-    ),
+    loading: () => <DiffSkeleton />,
   }
 );
 

--- a/apps/web/src/components/branch-detail/branch-diff-workspace.tsx
+++ b/apps/web/src/components/branch-detail/branch-diff-workspace.tsx
@@ -2,14 +2,13 @@
 
 import dynamic from "next/dynamic";
 import type { BranchResponse } from "@/lib/api";
+import { DiffSkeleton } from "./diff-skeleton";
 
 const BranchDiff = dynamic(
   () => import("./branch-diff").then((m) => m.BranchDiff),
   {
     ssr: false,
-    loading: () => (
-      <p className="text-sm text-muted-foreground">Loading diff viewer...</p>
-    ),
+    loading: () => <DiffSkeleton />,
   }
 );
 
@@ -29,6 +28,7 @@ export function BranchDiffWorkspace({
           key={`${branch.name}:${branch.revision}`}
           branchName={branch.name}
           revision={branch.revision}
+          commits={branch.commits}
           onExit={onExit}
         />
       </div>

--- a/apps/web/src/components/branch-detail/branch-diff.tsx
+++ b/apps/web/src/components/branch-detail/branch-diff.tsx
@@ -5,23 +5,27 @@ import {
   type FileDiffMetadata,
 } from "@pierre/diffs";
 import { FileDiff } from "@pierre/diffs/react";
-import { ChevronDown, ChevronRight, FileText, Folder, X } from "lucide-react";
+import { ChevronDown, ChevronRight, Folder, GitCommitHorizontal, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { fetchBranchDiff, type BranchDiffResponse } from "@/lib/api";
+import { fetchBranchDiff, type BranchDiffResponse, type CommitResponse } from "@/lib/api";
+import { useRepo } from "@/components/providers/repo-provider";
+import { useTheme } from "@/components/providers/theme-provider";
+import { commitUrl } from "@/lib/github";
+import { getFileIcon } from "@/lib/file-icons";
 import { cn } from "@/lib/utils";
 
 interface BranchDiffProps {
   branchName: string;
   revision: string;
+  commits?: CommitResponse[];
   onExit?: () => void;
 }
 
-const DIFF_OPTIONS = {
+const BASE_DIFF_OPTIONS = {
   diffStyle: "split",
   lineDiffType: "word",
   hunkSeparators: "metadata",
   overflow: "scroll",
-  themeType: "system",
 } as const;
 
 function getFileKey(file: FileDiffMetadata, index: number): string {
@@ -193,7 +197,61 @@ function buildExplorerRows(entries: ExplorerFileEntry[]): ExplorerRow[] {
   return rows;
 }
 
-export function BranchDiff({ branchName, revision, onExit }: BranchDiffProps) {
+function relativeTime(iso: string): string {
+  const seconds = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
+  if (seconds < 60) return "now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo`;
+  return `${Math.floor(months / 12)}y`;
+}
+
+const CONVENTIONAL_COMMIT_RE = /^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/;
+
+const COMMIT_TYPE_COLORS: Record<string, string> = {
+  feat:     "text-green-600 dark:text-green-400",
+  fix:      "text-red-600 dark:text-red-400",
+  docs:     "text-blue-600 dark:text-blue-400",
+  style:    "text-purple-600 dark:text-purple-400",
+  refactor: "text-amber-600 dark:text-amber-400",
+  perf:     "text-orange-600 dark:text-orange-400",
+  test:     "text-cyan-600 dark:text-cyan-400",
+  chore:    "text-gray-500 dark:text-gray-400",
+  ci:       "text-gray-500 dark:text-gray-400",
+  build:    "text-gray-500 dark:text-gray-400",
+};
+
+interface ConventionalCommit {
+  type: string;
+  scope: string | null;
+  isBreaking: boolean;
+  description: string;
+  color: string;
+}
+
+function parseConventionalCommit(message: string): ConventionalCommit | null {
+  const match = message.match(CONVENTIONAL_COMMIT_RE);
+  if (!match) return null;
+
+  const type = match[1];
+  const color = COMMIT_TYPE_COLORS[type];
+  if (!color) return null;
+
+  return {
+    type,
+    scope: match[2] ?? null,
+    isBreaking: match[3] === "!",
+    description: match[4],
+    color,
+  };
+}
+
+export function BranchDiff({ branchName, revision, commits, onExit }: BranchDiffProps) {
   const [diff, setDiff] = useState<BranchDiffResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -313,6 +371,14 @@ export function BranchDiff({ branchName, revision, onExit }: BranchDiffProps) {
     };
   }, [parsed.files]);
 
+  const { repo } = useRepo();
+  const { resolvedTheme } = useTheme();
+
+  const diffOptions = useMemo(
+    () => ({ ...BASE_DIFF_OPTIONS, themeType: resolvedTheme } as const),
+    [resolvedTheme]
+  );
+
   const fileCountLabel = `${parsed.files.length} file${parsed.files.length !== 1 ? "s" : ""}`;
   const showFileCount = !loading && !error && !parsed.parseError;
   const workspaceMode = Boolean(onExit);
@@ -365,7 +431,46 @@ export function BranchDiff({ branchName, revision, onExit }: BranchDiffProps) {
       </div>
 
       {loading && (
-        <p className="text-sm text-muted-foreground">Loading diff…</p>
+        <div className={contentLayoutClass}>
+          <aside className={explorerClass}>
+            <div className="px-3 py-2 text-xs font-medium text-muted-foreground">
+              Files
+            </div>
+            <div className="p-2 space-y-1.5">
+              {[0, 1, 2, 3, 4].map((i) => (
+                <div key={i} className="flex items-center gap-2 px-1.5 py-1">
+                  <div className="h-3 w-3 shrink-0 rounded bg-muted animate-pulse" />
+                  <div
+                    className="h-3 rounded bg-muted animate-pulse"
+                    style={{ width: `${60 + (i * 17) % 30}%` }}
+                  />
+                </div>
+              ))}
+            </div>
+          </aside>
+          <div className={cn(diffPaneClass, "flex-1 space-y-3")}>
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="rounded-md border bg-card/60 overflow-hidden">
+                <div className="flex items-center gap-2 border-b px-3 py-2">
+                  <div className="h-3 w-3 rounded bg-muted animate-pulse" />
+                  <div
+                    className="h-3 rounded bg-muted animate-pulse"
+                    style={{ width: `${100 + (i * 37) % 80}px` }}
+                  />
+                </div>
+                <div className="p-3 space-y-2">
+                  {[0, 1, 2, 3].map((j) => (
+                    <div
+                      key={j}
+                      className="h-3 rounded bg-muted/60 animate-pulse"
+                      style={{ width: `${40 + ((i + j) * 23) % 55}%` }}
+                    />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
       )}
 
       {!loading && error && (
@@ -392,6 +497,71 @@ export function BranchDiff({ branchName, revision, onExit }: BranchDiffProps) {
       {!loading && !error && !parsed.parseError && parsed.files.length > 0 && (
         <div className={contentLayoutClass}>
           <aside className={explorerClass}>
+            {commits && commits.length > 0 && (
+              <div className="border-b">
+                <div className="px-3 py-2 text-xs font-medium text-muted-foreground">
+                  Commits
+                </div>
+                <div className="px-2 pb-2 space-y-0.5">
+                  {commits.map((commit) => {
+                    const cc = parseConventionalCommit(commit.message);
+                    const tooltip = `${commit.sha} — ${commit.message}`;
+
+                    return (
+                      <div
+                        key={commit.sha}
+                        className="flex items-center gap-1.5 rounded px-1.5 py-1 text-xs"
+                      >
+                        <GitCommitHorizontal className="h-3 w-3 shrink-0 text-muted-foreground" />
+                        {cc ? (
+                          <span className="flex items-baseline gap-1 min-w-0">
+                            <span className={cn("shrink-0 font-medium", cc.color)}>
+                              {cc.type}
+                              {cc.scope ? `(${cc.scope})` : ""}
+                              {cc.isBreaking ? "!" : ""}:
+                            </span>
+                            {repo ? (
+                              <a
+                                href={commitUrl(repo.owner, repo.repo, commit.sha)}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="truncate text-muted-foreground hover:text-foreground transition-colors"
+                                title={tooltip}
+                              >
+                                {cc.description}
+                              </a>
+                            ) : (
+                              <span className="truncate text-muted-foreground" title={tooltip}>
+                                {cc.description}
+                              </span>
+                            )}
+                          </span>
+                        ) : repo ? (
+                          <a
+                            href={commitUrl(repo.owner, repo.repo, commit.sha)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="truncate text-muted-foreground hover:text-foreground transition-colors"
+                            title={tooltip}
+                          >
+                            {commit.message}
+                          </a>
+                        ) : (
+                          <span className="truncate text-muted-foreground" title={tooltip}>
+                            {commit.message}
+                          </span>
+                        )}
+                        {commit.date && (
+                          <span className="ml-auto shrink-0 text-muted-foreground/60 tabular-nums">
+                            {relativeTime(commit.date)}
+                          </span>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
             <div className="border-b px-3 py-2 text-xs font-medium text-muted-foreground">
               Files
             </div>
@@ -404,7 +574,7 @@ export function BranchDiff({ branchName, revision, onExit }: BranchDiffProps) {
                         className="flex items-center gap-1.5 rounded px-2 py-1 text-xs text-muted-foreground"
                         style={{ paddingLeft: `${row.depth * 14 + 8}px` }}
                       >
-                        <Folder className="h-3.5 w-3.5 shrink-0" />
+                        <Folder className="h-3.5 w-3.5 shrink-0 text-blue-400" />
                         <span className="truncate">{row.name}</span>
                       </div>
                     ) : (
@@ -425,7 +595,7 @@ export function BranchDiff({ branchName, revision, onExit }: BranchDiffProps) {
                         style={{ paddingLeft: `${row.depth * 14 + 8}px` }}
                         title={row.title}
                       >
-                        <FileText className="h-3.5 w-3.5 shrink-0" />
+                        {getFileIcon(row.name)}
                         <span className="truncate">{row.name}</span>
                       </button>
                     )}
@@ -493,7 +663,7 @@ export function BranchDiff({ branchName, revision, onExit }: BranchDiffProps) {
                             Collapse
                           </button>
                         )}
-                        <FileDiff fileDiff={file} options={DIFF_OPTIONS} className="block" />
+                        <FileDiff fileDiff={file} options={diffOptions} className="block" />
                       </>
                     )}
                   </div>

--- a/apps/web/src/components/branch-detail/ci-checks.tsx
+++ b/apps/web/src/components/branch-detail/ci-checks.tsx
@@ -15,8 +15,7 @@ export function CIChecks({ ci }: { ci?: CIResponse }) {
         {ci.checks.map((check, i) => (
           <div
             key={check.name}
-            className="flex items-center gap-2 text-sm animate-fade-in-up"
-            style={{ animationDelay: `${i * 50}ms` }}
+            className="flex items-center gap-2 text-sm"
           >
             <CheckIcon conclusion={check.conclusion} status={check.status} />
             <span className="truncate">{check.name}</span>

--- a/apps/web/src/components/branch-detail/commit-list.tsx
+++ b/apps/web/src/components/branch-detail/commit-list.tsx
@@ -18,8 +18,7 @@ export function CommitList({ commits }: { commits?: CommitResponse[] }) {
         {commits.map((commit, i) => (
           <div
             key={commit.sha}
-            className="flex items-baseline gap-2 text-sm animate-fade-in-up"
-            style={{ animationDelay: `${i * 40}ms` }}
+            className="flex items-baseline gap-2 text-sm"
           >
             {repo ? (
               <a

--- a/apps/web/src/components/branch-detail/diff-skeleton.tsx
+++ b/apps/web/src/components/branch-detail/diff-skeleton.tsx
@@ -1,0 +1,46 @@
+export function DiffSkeleton() {
+  return (
+    <div className="grid gap-3 lg:grid-cols-[18rem,minmax(0,1fr)] lg:items-start lg:gap-4">
+      {/* File explorer skeleton */}
+      <div className="rounded-md border bg-card/60">
+        <div className="px-3 py-2 text-xs font-medium text-muted-foreground">
+          Files
+        </div>
+        <div className="p-2 space-y-1.5">
+          {[0, 1, 2, 3, 4].map((i) => (
+            <div key={i} className="flex items-center gap-2 px-1.5 py-1">
+              <div className="h-3 w-3 shrink-0 rounded bg-muted animate-pulse" />
+              <div
+                className="h-3 rounded bg-muted animate-pulse"
+                style={{ width: `${60 + (i * 17) % 30}%` }}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+      {/* Diff pane skeleton */}
+      <div className="space-y-3">
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="rounded-md border bg-card/60 overflow-hidden">
+            <div className="flex items-center gap-2 border-b px-3 py-2">
+              <div className="h-3 w-3 rounded bg-muted animate-pulse" />
+              <div
+                className="h-3 rounded bg-muted animate-pulse"
+                style={{ width: `${100 + (i * 37) % 80}px` }}
+              />
+            </div>
+            <div className="p-3 space-y-2">
+              {[0, 1, 2, 3].map((j) => (
+                <div
+                  key={j}
+                  className="h-3 rounded bg-muted/60 animate-pulse"
+                  style={{ width: `${40 + ((i + j) * 23) % 55}%` }}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/providers/theme-provider.tsx
+++ b/apps/web/src/components/providers/theme-provider.tsx
@@ -9,14 +9,17 @@ import {
 } from "react";
 
 type Theme = "light" | "dark" | "system";
+type ResolvedTheme = "light" | "dark";
 
 interface ThemeContextValue {
   theme: Theme;
+  resolvedTheme: ResolvedTheme;
   setTheme: (theme: Theme) => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue>({
   theme: "system",
+  resolvedTheme: "light",
   setTheme: () => {},
 });
 
@@ -40,8 +43,13 @@ function applyTheme(theme: Theme) {
   document.documentElement.style.colorScheme = resolved;
 }
 
+function resolveTheme(theme: Theme): ResolvedTheme {
+  return theme === "system" ? getSystemPreference() : theme;
+}
+
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setThemeState] = useState<Theme>("system");
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("light");
 
   // Initialize from localStorage on mount
   useEffect(() => {
@@ -50,6 +58,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       ? stored
       : "system";
     setThemeState(initial);
+    setResolvedTheme(resolveTheme(initial));
     applyTheme(initial);
   }, []);
 
@@ -57,7 +66,10 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
     const handler = () => {
-      if (theme === "system") applyTheme("system");
+      if (theme === "system") {
+        setResolvedTheme(getSystemPreference());
+        applyTheme("system");
+      }
     };
     mq.addEventListener("change", handler);
     return () => mq.removeEventListener("change", handler);
@@ -65,12 +77,13 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   const setTheme = useCallback((next: Theme) => {
     setThemeState(next);
+    setResolvedTheme(resolveTheme(next));
     localStorage.setItem(STORAGE_KEY, next);
     applyTheme(next);
   }, []);
 
   return (
-    <ThemeContext.Provider value={{ theme, setTheme }}>
+    <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/apps/web/src/components/stack-tree/branch-node.tsx
+++ b/apps/web/src/components/stack-tree/branch-node.tsx
@@ -22,6 +22,7 @@ export function BranchNode({
   onClick,
 }: BranchNodeProps) {
   const ciIcon = getCIIcon(branch);
+  const notPushed = branch.remoteStatus?.missingRemote;
   const borderClass = isSelected
     ? "stroke-blue-500/50 stroke-1"
     : "stroke-border stroke-1";
@@ -33,12 +34,33 @@ export function BranchNode({
       className="cursor-pointer"
       style={{ transition: "transform 0.15s ease" }}
     >
+      {notPushed && (
+        <defs>
+          <pattern
+            id={`stripes-${branch.name}`}
+            width={12}
+            height={12}
+            patternUnits="userSpaceOnUse"
+            patternTransform="rotate(-45)"
+          >
+            <rect width={4} height={12} fill="oklch(0.65 0.05 250 / 0.12)" />
+          </pattern>
+        </defs>
+      )}
       <rect
         width={NODE_WIDTH}
         height={NODE_HEIGHT}
         rx={8}
         className={`fill-card ${borderClass}`}
       />
+      {notPushed && (
+        <rect
+          width={NODE_WIDTH}
+          height={NODE_HEIGHT}
+          rx={8}
+          fill={`url(#stripes-${branch.name})`}
+        />
+      )}
       {/* Left accent bar for current (checked out) branch */}
       {branch.isCurrent && (
         <rect

--- a/apps/web/src/components/status/status-badge.tsx
+++ b/apps/web/src/components/status/status-badge.tsx
@@ -81,9 +81,9 @@ export function PRBadge({ pr }: { pr?: PRResponse }) {
       href={pr.url}
       target="_blank"
       rel="noopener noreferrer"
-      className={`inline-flex items-center gap-1 text-xs font-mono hover:underline ${stateColors[pr.state] || ""}`}
+      className={`inline-flex items-center gap-1 text-xs font-mono font-semibold hover:underline ${stateColors[pr.state] || ""}`}
     >
-      <Github className="w-3 h-3" />
+      <Github className="w-3.5 h-3.5" />
       #{pr.number}
       {pr.isDraft && " (draft)"}
     </a>

--- a/apps/web/src/components/swimlane/__tests__/owner-swimlane.test.tsx
+++ b/apps/web/src/components/swimlane/__tests__/owner-swimlane.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { OwnerSwimlane } from "../owner-swimlane";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import type { BranchResponse, StackDetail } from "@/lib/api";
 
 // Mock motion/react to avoid animation issues in tests
@@ -53,14 +54,16 @@ describe("OwnerSwimlane", () => {
     });
 
     const { container } = render(
-      <OwnerSwimlane
-        label="me"
-        stacks={[stack]}
-        selectedBranch={null}
-        selectedStack={null}
-        onSelectBranch={noop}
-        onSelectStack={noop}
-      />
+      <TooltipProvider>
+        <OwnerSwimlane
+          label="me"
+          stacks={[stack]}
+          selectedBranch={null}
+          selectedStack={null}
+          onSelectBranch={noop}
+          onSelectStack={noop}
+        />
+      </TooltipProvider>
     );
 
     // Linear stacks render StackColumn, not StackTree
@@ -79,14 +82,16 @@ describe("OwnerSwimlane", () => {
     });
 
     const { container } = render(
-      <OwnerSwimlane
-        label="me"
-        stacks={[stack]}
-        selectedBranch={null}
-        selectedStack={null}
-        onSelectBranch={noop}
-        onSelectStack={noop}
-      />
+      <TooltipProvider>
+        <OwnerSwimlane
+          label="me"
+          stacks={[stack]}
+          selectedBranch={null}
+          selectedStack={null}
+          onSelectBranch={noop}
+          onSelectStack={noop}
+        />
+      </TooltipProvider>
     );
 
     // Branching stacks render SegmentTree which uses fork connectors at branch points
@@ -112,14 +117,16 @@ describe("OwnerSwimlane", () => {
     });
 
     const { container } = render(
-      <OwnerSwimlane
-        label="me"
-        stacks={[linearStack, branchingStack]}
-        selectedBranch={null}
-        selectedStack={null}
-        onSelectBranch={noop}
-        onSelectStack={noop}
-      />
+      <TooltipProvider>
+        <OwnerSwimlane
+          label="me"
+          stacks={[linearStack, branchingStack]}
+          selectedBranch={null}
+          selectedStack={null}
+          onSelectBranch={noop}
+          onSelectStack={noop}
+        />
+      </TooltipProvider>
     );
 
     // Exactly one fork connector SVG (from the branching stack)
@@ -145,20 +152,22 @@ describe("OwnerSwimlane", () => {
       ],
     });
 
-    render(
-      <OwnerSwimlane
-        label="me"
-        stacks={[linearStack, branchingStack]}
-        selectedBranch={null}
-        selectedStack={null}
-        onSelectBranch={noop}
-        onSelectStack={noop}
-      />
+    const { container } = render(
+      <TooltipProvider>
+        <OwnerSwimlane
+          label="me"
+          stacks={[linearStack, branchingStack]}
+          selectedBranch={null}
+          selectedStack={null}
+          onSelectBranch={noop}
+          onSelectStack={noop}
+        />
+      </TooltipProvider>
     );
 
-    // Both views show "no PR" text for branches without PRs (shared BranchCard)
-    const noPrLabels = screen.getAllByText("no PR");
-    // 5 branches total across both stacks
-    expect(noPrLabels.length).toBe(5);
+    // Both views show "No PR" tooltip icon for branches without PRs (shared BranchCard)
+    // 5 branches total across both stacks, each renders a GitPullRequestDraft icon
+    const noPrIcons = container.querySelectorAll("svg.lucide-git-pull-request-draft");
+    expect(noPrIcons.length).toBe(5);
   });
 });

--- a/apps/web/src/components/swimlane/branch-card.tsx
+++ b/apps/web/src/components/swimlane/branch-card.tsx
@@ -4,7 +4,7 @@ import type { BranchResponse } from "@/lib/api";
 import { PRBadge, DiffStats } from "@/components/status/status-badge";
 import { CIStatusWithTooltip } from "@/components/status/ci-status";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
-import { Lock } from "lucide-react";
+import { GitCommitVertical, GitPullRequestDraft, Lock } from "lucide-react";
 import { shortenBranchName } from "@/lib/branch-utils";
 
 interface BranchCardProps {
@@ -29,16 +29,21 @@ export function BranchCard({
       onClick={() => onClick(branch)}
       className={`text-left bg-card transition-all duration-200
         ${compact ? "px-2.5 py-1.5" : "px-3 py-2.5"}
-        ${isSelected ? "!bg-accent z-10 relative" : "hover:!bg-muted hover:scale-[1.02] hover:shadow-md hover:-translate-y-0.5"}
-        ${branch.isCurrent ? "border-l-[3px] border-l-[var(--glow-color-current)]" : ""}
+        ${isSelected ? "!bg-accent z-10 relative" : "hover:!bg-muted/80 hover:shadow-sm"}
+        ${branch.isCurrent ? "border-l-[3px] border-l-[var(--glow-color-current)] bg-accent/30" : ""}
         ${branch.isLocked ? "opacity-60" : ""}
         ${className}
       `}
-      style={style}
+      style={{
+        ...style,
+        ...(branch.remoteStatus?.missingRemote ? {
+          backgroundImage: "repeating-linear-gradient(-45deg, transparent, transparent 8px, oklch(0.65 0.05 250 / 0.12) 8px, oklch(0.65 0.05 250 / 0.12) 12px)",
+        } : undefined),
+      }}
     >
       <div className="flex items-center gap-2 min-w-0">
         <span className="text-sm font-medium truncate" title={branch.name}>
-          {branch.commits?.[0]?.message || shortenBranchName(branch.name)}
+          {branch.commits?.at(-1)?.message || shortenBranchName(branch.name)}
         </span>
         {branch.isLocked && (
           <Tooltip>
@@ -61,10 +66,21 @@ export function BranchCard({
           {branch.pr ? (
             <PRBadge pr={branch.pr} />
           ) : (
-            <span className="text-xs text-muted-foreground">no PR</span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <GitPullRequestDraft className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+              </TooltipTrigger>
+              <TooltipContent side="top">No PR</TooltipContent>
+            </Tooltip>
           )}
           <CIStatusWithTooltip ci={branch.ci} />
           <DiffStats added={branch.linesAdded} deleted={branch.linesDeleted} />
+          {branch.commitCount > 0 && (
+            <span className="flex items-center gap-0.5 text-xs text-muted-foreground" title={`${branch.commitCount} commit${branch.commitCount !== 1 ? "s" : ""}`}>
+              <GitCommitVertical className="w-3 h-3" />
+              {branch.commitCount}
+            </span>
+          )}
         </div>
       )}
     </button>

--- a/apps/web/src/components/swimlane/owner-swimlane.tsx
+++ b/apps/web/src/components/swimlane/owner-swimlane.tsx
@@ -5,7 +5,7 @@ import { motion, AnimatePresence } from "motion/react";
 import type { BranchResponse, StackDetail } from "@/lib/api";
 import { StackColumn, hasBranching } from "@/components/swimlane/stack-column";
 import { StackTreeColumn } from "@/components/swimlane/stack-tree-column";
-import { SwimlaneLabel, swimlaneColor } from "@/components/swimlane/swimlane-label";
+import { SwimlaneLabel, swimlaneColor, swimlaneAccent } from "@/components/swimlane/swimlane-label";
 
 const COLLAPSED_LIMIT = 3;
 
@@ -39,18 +39,19 @@ export function OwnerSwimlane({
     : stacks;
   const hiddenCount = stacks.length - COLLAPSED_LIMIT;
 
+  const accentColor = swimlaneAccent(label);
+
   return (
     <div className="flex flex-col shrink-0">
       <div
-        className={`flex items-end ${compact ? "gap-3 px-2 py-2" : "gap-4 px-3 pt-3"}`}
-        style={{ backgroundColor: color }}
+        className={`flex items-end ${compact ? "gap-3 px-2 py-2" : "gap-4 px-3 pt-3"} rounded-t-xl border-t-2`}
+        style={{ backgroundColor: color, borderColor: accentColor }}
       >
         <AnimatePresence mode="popLayout">
           {visibleStacks.map((stack) => (
             <motion.div
               key={stack.rootBranch}
               layout
-              initial={{ opacity: 0, y: 12 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, scale: 0.95 }}
               transition={{ duration: 0.2 }}

--- a/apps/web/src/components/swimlane/stack-column.tsx
+++ b/apps/web/src/components/swimlane/stack-column.tsx
@@ -38,32 +38,19 @@ export function StackColumn({
 
   return (
     <div className={`flex flex-col ${fillWidth ? "w-full" : "w-64 shrink-0"}`}>
-      {/* Stack header */}
       {showHeader && (
-        <div className={`px-1 ${compact ? "pb-1" : "pb-2"}`}>
-          {stack.hasWorktree && (
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-muted-foreground flex items-center gap-1" title="Worktree">
-                <FolderGit2 className="w-3 h-3" />
-              </span>
-            </div>
-          )}
-          {stack.title && (
-            <p className={`font-medium text-muted-foreground truncate ${compact ? "text-[11px] mt-0.5" : "text-xs mt-1"}`} title={stack.title}>
-              {stack.title}
-            </p>
-          )}
-          {stack.description && (
-            <StackDescription text={stack.description} compact={compact} />
-          )}
-        </div>
+        <StackHeader stack={stack} compact={compact} />
       )}
 
       {/* Stacked branch cards */}
-      <div className="flex flex-col bg-card rounded-t-lg">
+      <div className="flex flex-col rounded-t-lg overflow-hidden border-x border-t shadow-sm">
         {displayBranches.map((branch, i) => {
-          const isFirst = i === 0;
           const isLast = i === displayBranches.length - 1;
+          // Subtle depth gradient: top card (leaf) is brightest, bottom card (root) is slightly dimmer
+          const depth = displayBranches.length > 1
+            ? i / (displayBranches.length - 1)
+            : 0;
+          const opacity = 1 - depth * 0.06;
 
           return (
             <BranchCard
@@ -72,11 +59,8 @@ export function StackColumn({
               isSelected={selectedBranch === branch.name}
               onClick={onSelectBranch}
               compact={compact}
-              className={`animate-fade-in-up border-x border-t
-                ${isLast ? "border-b rounded-b-lg relative z-[1] shadow-[0_4px_6px_-2px_rgba(0,0,0,0.15)]" : ""}
-                ${isFirst ? "rounded-t-lg" : ""}
-              `}
-              style={{ animationDelay: `${i * 50}ms` }}
+              className={!isLast ? "border-b border-border/50" : ""}
+              style={{ opacity }}
             />
           );
         })}
@@ -111,7 +95,7 @@ export function StackStatusFooter({
   return (
     <button
       onClick={onClick}
-      className={`flex items-center justify-center px-3 rounded-b-lg border-x border-b font-medium cursor-pointer transition-all duration-200 ${compact ? "-mt-1.5 pt-2.5 py-1 text-[11px]" : "-mt-2 pt-3.5 py-1.5 text-xs"} ${c.text} ${selected ? `${c.selectedBg} font-semibold` : `${c.bg} ${c.shadow} hover:brightness-95 dark:hover:brightness-110`}`}
+      className={`flex items-center justify-center px-3 rounded-b-lg border-x border-b font-medium cursor-pointer transition-all duration-200 ${compact ? "py-1 text-[11px]" : "py-1.5 text-xs"} ${c.text} ${selected ? `${c.selectedBg} font-semibold` : `${c.bg} ${c.shadow} hover:brightness-95 dark:hover:brightness-110`}`}
     >
       {c.label}
     </button>
@@ -139,6 +123,34 @@ function orderBranches(branches: BranchResponse[]): BranchResponse[] {
   }
 
   return ordered;
+}
+
+export function StackHeader({
+  stack,
+  compact = false,
+}: {
+  stack: StackDetail;
+  compact?: boolean;
+}) {
+  const hasContent = stack.hasWorktree || stack.title;
+  if (!hasContent) return null;
+
+  return (
+    <div className={`px-1 ${compact ? "pb-1" : "pb-2"}`}>
+      {stack.hasWorktree && (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground flex items-center gap-1" title="Worktree">
+            <FolderGit2 className="w-3 h-3" />
+          </span>
+        </div>
+      )}
+      {stack.title && (
+        <p className={`font-medium text-muted-foreground truncate ${compact ? "text-[11px] mt-0.5" : "text-xs mt-1"}`} title={stack.title}>
+          {stack.title}
+        </p>
+      )}
+    </div>
+  );
 }
 
 const DESCRIPTION_COLLAPSE_LENGTH = 80;

--- a/apps/web/src/components/swimlane/stack-tree-column.tsx
+++ b/apps/web/src/components/swimlane/stack-tree-column.tsx
@@ -2,8 +2,7 @@
 
 import type { BranchResponse, StackDetail } from "@/lib/api";
 import { SegmentTree } from "@/components/stack-tree/segment-tree";
-import { StackStatusFooter, StackDescription } from "@/components/swimlane/stack-column";
-import { FolderGit2 } from "lucide-react";
+import { StackStatusFooter, StackHeader } from "@/components/swimlane/stack-column";
 
 interface StackTreeColumnProps {
   stack: StackDetail;
@@ -28,25 +27,8 @@ export function StackTreeColumn({
 }: StackTreeColumnProps) {
   return (
     <div className="flex flex-col min-w-64 shrink-0">
-      {/* Stack header */}
       {showHeader && (
-        <div className={`px-1 ${compact ? "pb-1" : "pb-2"}`}>
-          {stack.hasWorktree && (
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-muted-foreground flex items-center gap-1" title="Worktree">
-                <FolderGit2 className="w-3 h-3" />
-              </span>
-            </div>
-          )}
-          {stack.title && (
-            <p className={`font-medium text-muted-foreground truncate ${compact ? "text-[11px] mt-0.5" : "text-xs mt-1"}`} title={stack.title}>
-              {stack.title}
-            </p>
-          )}
-          {stack.description && (
-            <StackDescription text={stack.description} compact={compact} />
-          )}
-        </div>
+        <StackHeader stack={stack} compact={compact} />
       )}
 
       {/* Tree visualization: linear card stacks with connectors at branch points */}

--- a/apps/web/src/components/swimlane/swimlane-label.tsx
+++ b/apps/web/src/components/swimlane/swimlane-label.tsx
@@ -15,14 +15,14 @@ export function SwimlaneLabel({
 }: SwimlaneLabelProps) {
   return (
     <div
-      className={`flex items-center justify-center w-full rounded-b-md ${compact ? "gap-1.5 px-2 py-0.5" : "gap-2 px-3 py-1"}`}
+      className={`flex items-center justify-center w-full rounded-b-xl ${compact ? "gap-1.5 px-2 py-0.5" : "gap-2 px-3 py-1"}`}
       style={{ backgroundColor: color }}
     >
       <span className={`${compact ? "text-[11px]" : "text-xs"} font-semibold text-foreground/80`}>
         {label}
       </span>
       {lastActive && (
-        <span className={`${compact ? "text-[9px]" : "text-[10px]"} text-foreground/40`}>
+        <span className={`${compact ? "text-[9px]" : "text-[10px]"} text-foreground/60`}>
           active {formatLastActive(lastActive)}
         </span>
       )}
@@ -30,18 +30,27 @@ export function SwimlaneLabel({
   );
 }
 
-/**
- * Generate a soft pastel background color from a string.
- * Returns a CSS `light-dark()` value that adapts to the color scheme.
- * Light mode uses high lightness (95%), dark mode uses low lightness (18%).
- */
-export function swimlaneColor(name: string): string {
+function swimlaneHue(name: string): number {
   let hash = 0;
   for (let i = 0; i < name.length; i++) {
     hash = name.charCodeAt(i) + ((hash << 5) - hash);
   }
-  const hue = ((hash % 360) + 360) % 360;
+  return ((hash % 360) + 360) % 360;
+}
+
+/**
+ * Generate a soft pastel background color from a string.
+ * Returns a CSS `light-dark()` value that adapts to the color scheme.
+ */
+export function swimlaneColor(name: string): string {
+  const hue = swimlaneHue(name);
   return `light-dark(hsl(${hue} 30% 95%), hsl(${hue} 20% 18%))`;
+}
+
+/** Saturated accent color for borders/highlights derived from the swimlane hue. */
+export function swimlaneAccent(name: string): string {
+  const hue = swimlaneHue(name);
+  return `light-dark(hsl(${hue} 50% 65%), hsl(${hue} 40% 45%))`;
 }
 
 function formatLastActive(date: Date): string {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -84,6 +84,7 @@ export interface CheckDetailResponse {
 export interface CommitResponse {
   sha: string;
   message: string;
+  date?: string;
 }
 
 export interface RemoteStatus {

--- a/apps/web/src/lib/file-icons.tsx
+++ b/apps/web/src/lib/file-icons.tsx
@@ -1,0 +1,127 @@
+import type { ReactNode } from "react";
+
+// Language / framework brand icons (Simple Icons via react-icons)
+import {
+  SiGo,
+  SiTypescript,
+  SiJavascript,
+  SiReact,
+  SiCss,
+  SiSass,
+  SiHtml5,
+  SiJson,
+  SiYaml,
+  SiToml,
+  SiMarkdown,
+  SiGnubash,
+  SiPython,
+  SiRust,
+  SiRuby,
+  SiDocker,
+  SiSvg,
+  SiEslint,
+  SiGit,
+} from "react-icons/si";
+import {
+  VscFile,
+  VscFileMedia,
+  VscGear,
+  VscLock,
+  VscDatabase,
+} from "react-icons/vsc";
+
+const iconClass = "h-3.5 w-3.5 shrink-0";
+
+const extensionMap: Record<string, ReactNode> = {
+  // Go
+  ".go": <SiGo className={`${iconClass} text-cyan-500`} />,
+
+  // TypeScript / JavaScript
+  ".ts": <SiTypescript className={`${iconClass} text-blue-500`} />,
+  ".tsx": <SiReact className={`${iconClass} text-blue-400`} />,
+  ".js": <SiJavascript className={`${iconClass} text-yellow-500`} />,
+  ".jsx": <SiReact className={`${iconClass} text-blue-400`} />,
+  ".mjs": <SiJavascript className={`${iconClass} text-yellow-500`} />,
+  ".cjs": <SiJavascript className={`${iconClass} text-yellow-500`} />,
+  ".d.ts": <SiTypescript className={`${iconClass} text-blue-600 dark:text-blue-400`} />,
+
+  // Web
+  ".css": <SiCss className={`${iconClass} text-blue-500`} />,
+  ".scss": <SiSass className={`${iconClass} text-pink-500`} />,
+  ".html": <SiHtml5 className={`${iconClass} text-orange-500`} />,
+  ".svg": <SiSvg className={`${iconClass} text-orange-400`} />,
+
+  // Data / Config
+  ".json": <SiJson className={`${iconClass} text-yellow-600 dark:text-yellow-400`} />,
+  ".yaml": <SiYaml className={`${iconClass} text-red-400`} />,
+  ".yml": <SiYaml className={`${iconClass} text-red-400`} />,
+  ".toml": <SiToml className={`${iconClass} text-gray-500 dark:text-gray-400`} />,
+  ".env": <VscGear className={`${iconClass} text-yellow-600 dark:text-yellow-400`} />,
+
+  // Documentation
+  ".md": <SiMarkdown className={`${iconClass} text-blue-400 dark:text-blue-300`} />,
+  ".mdx": <SiMarkdown className={`${iconClass} text-blue-400 dark:text-blue-300`} />,
+  ".txt": <VscFile className={`${iconClass} text-gray-400`} />,
+
+  // Shell / Scripts
+  ".sh": <SiGnubash className={`${iconClass} text-green-500`} />,
+  ".bash": <SiGnubash className={`${iconClass} text-green-500`} />,
+  ".zsh": <SiGnubash className={`${iconClass} text-green-500`} />,
+
+  // Images
+  ".png": <VscFileMedia className={`${iconClass} text-green-400`} />,
+  ".jpg": <VscFileMedia className={`${iconClass} text-green-400`} />,
+  ".jpeg": <VscFileMedia className={`${iconClass} text-green-400`} />,
+  ".gif": <VscFileMedia className={`${iconClass} text-green-400`} />,
+  ".webp": <VscFileMedia className={`${iconClass} text-green-400`} />,
+  ".ico": <VscFileMedia className={`${iconClass} text-green-400`} />,
+
+  // Languages
+  ".rs": <SiRust className={`${iconClass} text-orange-600 dark:text-orange-400`} />,
+  ".py": <SiPython className={`${iconClass} text-yellow-500`} />,
+  ".rb": <SiRuby className={`${iconClass} text-red-500`} />,
+
+  // Database
+  ".sql": <VscDatabase className={`${iconClass} text-blue-300`} />,
+};
+
+const filenameMap: Record<string, ReactNode> = {
+  "Dockerfile": <SiDocker className={`${iconClass} text-blue-500`} />,
+  "Makefile": <VscGear className={`${iconClass} text-orange-500`} />,
+  ".gitignore": <SiGit className={`${iconClass} text-orange-500`} />,
+  ".eslintrc": <SiEslint className={`${iconClass} text-purple-500`} />,
+  ".eslintrc.json": <SiEslint className={`${iconClass} text-purple-500`} />,
+  "eslint.config.js": <SiEslint className={`${iconClass} text-purple-500`} />,
+  "eslint.config.mjs": <SiEslint className={`${iconClass} text-purple-500`} />,
+  "package.json": <SiJson className={`${iconClass} text-green-500`} />,
+  "tsconfig.json": <SiTypescript className={`${iconClass} text-blue-500`} />,
+  "go.mod": <SiGo className={`${iconClass} text-cyan-500`} />,
+  "go.sum": <VscLock className={`${iconClass} text-cyan-400`} />,
+  "pnpm-lock.yaml": <VscLock className={`${iconClass} text-orange-400`} />,
+  "package-lock.json": <VscLock className={`${iconClass} text-orange-400`} />,
+  "yarn.lock": <VscLock className={`${iconClass} text-blue-400`} />,
+};
+
+const defaultIcon = <VscFile className={`${iconClass} text-muted-foreground`} />;
+
+export function getFileIcon(filename: string): ReactNode {
+  // Check full filename first (e.g., Dockerfile, go.mod)
+  const match = filenameMap[filename];
+  if (match) return match;
+
+  // Check compound extensions (e.g., .d.ts)
+  const lowerName = filename.toLowerCase();
+  if (lowerName.endsWith(".d.ts")) {
+    return extensionMap[".d.ts"];
+  }
+
+  // Check simple extension
+  const dotIndex = lowerName.lastIndexOf(".");
+  if (dotIndex !== -1) {
+    const ext = lowerName.slice(dotIndex);
+    const extMatch = extensionMap[ext];
+    if (extMatch) return extMatch;
+  }
+
+  return defaultIcon;
+}

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -2,6 +2,7 @@ package httpcontract
 
 import (
 	"slices"
+	"strings"
 	"time"
 
 	"stackit.dev/stackit/internal/engine"
@@ -55,8 +56,8 @@ func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.Stack
 	}
 
 	// Map commits
-	if commits, err := eng.GetAllCommits(branch, engine.CommitFormatReadable); err == nil {
-		resp.Commits = mapCommits(commits)
+	if commits, err := eng.GetAllCommits(branch, engine.CommitFormatReadableWithDate); err == nil {
+		resp.Commits = mapCommitsWithDate(commits)
 	}
 
 	// Map PR info
@@ -101,29 +102,15 @@ func MapStackSummary(eng engine.BranchReader, graph *engine.StackGraph, rootBran
 		}
 	}
 
-	// Get title from root branch's PR, or first child's PR for worktree anchors
-	title := rootBranch
-	if rootNode != nil {
-		if hasWorktree {
-			// Anchor has no PR — derive title from first child
-			if len(rootNode.Children) > 0 {
-				if childNode := graph.GetNode(rootNode.Children[0]); childNode != nil {
-					if prInfo, err := childNode.Branch.GetPrInfo(); err == nil && prInfo != nil && prInfo.Title() != "" {
-						title = prInfo.Title()
-					}
-				}
-			}
-		} else if prInfo, err := rootNode.Branch.GetPrInfo(); err == nil && prInfo != nil && prInfo.Title() != "" {
-			title = prInfo.Title()
-		}
-	}
-
 	// Compute stack status using display branches (anchor excluded)
 	status := computeStackStatus(graph, displayBranches)
 
-	var description string
+	// Title and description come exclusively from explicit stack descriptions
+	// set via `stackit describe`. No fallback to PR titles or branch names.
+	var title, description string
 	if rootNode != nil {
 		if stackDesc := eng.GetStackDescription(rootNode.Branch); stackDesc != nil && !stackDesc.IsEmpty() {
+			title = stackDesc.Title
 			description = stackDesc.Description
 		}
 	}
@@ -231,21 +218,18 @@ func mapCI(checks *github.CheckStatus) *CIResponse {
 	return ci
 }
 
-func mapCommits(readable []string) []CommitResponse {
-	commits := make([]CommitResponse, 0, len(readable))
-	for _, line := range readable {
-		if len(line) < 8 {
+func mapCommitsWithDate(lines []string) []CommitResponse {
+	commits := make([]CommitResponse, 0, len(lines))
+	for _, line := range lines {
+		// Tab-separated format: "abc1234\t2024-01-15T10:30:00Z\tCommit message"
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) < 3 {
 			continue
 		}
-		// Readable format is "abc1234 Commit message"
-		sha := line[:7]
-		msg := ""
-		if len(line) > 8 {
-			msg = line[8:]
-		}
 		commits = append(commits, CommitResponse{
-			SHA:     sha,
-			Message: msg,
+			SHA:     parts[0],
+			Message: parts[2],
+			Date:    parts[1],
 		})
 	}
 	return commits

--- a/internal/contracts/http/responses.go
+++ b/internal/contracts/http/responses.go
@@ -126,6 +126,7 @@ type CheckDetailResponse struct {
 type CommitResponse struct {
 	SHA     string `json:"sha"`
 	Message string `json:"message"`
+	Date    string `json:"date,omitempty"`
 }
 
 // RemoteStatus describes how a branch relates to its remote tracking branch.

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -50,6 +50,8 @@ const (
 	CommitFormatSHA CommitFormat = "SHA" // Full SHA
 	// CommitFormatReadable is a readable one-line format
 	CommitFormatReadable CommitFormat = "READABLE" // Oneline format: "abc123 Commit message"
+	// CommitFormatReadableWithDate includes an ISO date: "abc123\t2024-01-15T10:30:00Z\tCommit message"
+	CommitFormatReadableWithDate CommitFormat = "READABLE_WITH_DATE"
 	// CommitFormatMessage is the full commit message
 	CommitFormatMessage CommitFormat = "MESSAGE" // Full commit message
 	// CommitFormatSubject is the first line of the commit message

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -781,6 +781,11 @@ func formatCommits(commits []*object.Commit, format string) ([]string, error) {
 			shortHash := commit.Hash.String()[:7]
 			subject := strings.Split(strings.TrimSpace(commit.Message), "\n")[0]
 			formatted = fmt.Sprintf("%s %s", shortHash, subject)
+		case "READABLE_WITH_DATE":
+			// Tab-separated: short SHA, ISO date, subject
+			shortHash := commit.Hash.String()[:7]
+			subject := strings.Split(strings.TrimSpace(commit.Message), "\n")[0]
+			formatted = fmt.Sprintf("%s\t%s\t%s", shortHash, commit.Author.When.UTC().Format(time.RFC3339), subject)
 		case "MESSAGE":
 			formatted = strings.TrimSpace(commit.Message)
 		case "SUBJECT":
@@ -817,6 +822,9 @@ func (r *runner) getCommitRangeWithFallback(base, head, format string) ([]string
 		case "READABLE":
 			// Oneline format: short SHA + subject
 			formatted, err = r.GetCommitLog(sha, "%h %s")
+		case "READABLE_WITH_DATE":
+			// Tab-separated: short SHA, ISO date, subject
+			formatted, err = r.GetCommitLog(sha, "%h\t%aI\t%s")
 		case "MESSAGE":
 			formatted, err = r.GetCommitLog(sha, "%B")
 		case "SUBJECT":

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      react-icons:
+        specifier: ^5.6.0
+        version: 5.6.0(react@19.2.3)
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.3)
@@ -3959,6 +3962,11 @@ packages:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
       react: ^19.2.3
+
+  react-icons@5.6.0:
+    resolution: {integrity: sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==}
+    peerDependencies:
+      react: '*'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -8892,6 +8900,10 @@ snapshots:
     dependencies:
       react: 19.2.3
       scheduler: 0.27.0
+
+  react-icons@5.6.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   react-is@16.13.1: {}
 


### PR DESCRIPTION
**Improve branch card info and diff workspace commit display**

Improves the web UI with richer branch and commit information across the swimlane and diff workspace.

Key changes:
- **use-oldest-commit-for-branch-card-description**: Fix branch card to use the oldest (root) commit message as the display label, matching the stacking metaphor
- **show-commit-count-on-branch-card**: Add commit count badge to branch cards, and show individual commit messages with author/timestamp in the branch diff panel
- **show-commits-with-timestamps-and-conventional**: Show commits in the diff workspace with timestamps, conventional commit type badges (feat, fix, chore, etc.) with color coding, and improved visual hierarchy

This PR merges the following changes:

1. **#827** fix(web): use oldest commit for branch card description
2. **#828** feat(web): show commit count on branch card
3. **#829** feat(web): show commits with timestamps and conventional commit colors in diff workspace
4. **#830** refine(web): polish swimlane UI with accent borders, depth opacity, and StackHeader component
5. **#831** feat(web): animate recently merged commits collapse with grid-rows transition
6. **#832** refine(web): remove distracting re-trigger animations on navigation
7. **#833** refine(web): replace loading diff text with skeleton UI
8. **#834** feat(web): style unpushed branches with diagonal stripes
9. **#835** fix(web): sync diff viewer theme with app theme toggle
10. **#836** feat(web): add language-specific file icons using react-icons
11. **#837** refine(web): collapse recent commits when viewing a branch and restore preference on return

### Stack

```
main
  └─ jonnii/20260306024746/use-oldest-commit-for-branch-card-description (#827)
    └─ jonnii/20260306025749/show-commit-count-on-branch-card (#828)
      └─ jonnii/20260306030539/show-commits-with-timestamps-and-conventional (#829)
        └─ jonnii/20260306033259/refine-web-polish-swimlane-UI-with-accent (#830)
          └─ jonnii/20260306033510/animate-recently-merged-commits-collapse-with (#831)
            └─ jonnii/20260306034017/refine-web-remove-distracting-re-trigger (#832)
              └─ jonnii/20260306034336/refine-web-replace-loading-diff-text-with (#833)
                └─ jonnii/20260306034850/style-unpushed-branches-with-diagonal-stripes (#834)
                  └─ jonnii/20260306035154/sync-diff-viewer-theme-with-app-theme-toggle (#835)
                    └─ jonnii/20260306040016/add-language-specific-file-icons-using-react-icons (#836)
                      └─ jonnii/20260306040438/refine-web-collapse-recent-commits-when-viewing (#837)
```

Stackit-Stack-Size: 11
Stackit-PRs: 827,828,829,830,831,832,833,834,835,836,837
