### PR TITLE
fix(merge): do not wait for CI when no checks are configured

### DIFF
--- a/internal/actions/merge/ci_waiter.go
+++ b/internal/actions/merge/ci_waiter.go
@@ -74,13 +74,19 @@ func (w *CIWaiter) WaitForChecks(ctx context.Context, branchName string, prNumbe
 	lastProgressReport := startTime
 	progressInterval := 1 * time.Second
 
-	// If we expect checks, give GitHub a moment to register them
-	if expectChecks {
+	// If no checks are expected, skip waiting entirely
+	if !expectChecks {
 		if w.output != nil {
-			w.output.Info("   Waiting for CI checks to register...")
+			w.output.Info("   No CI checks configured, skipping wait.")
 		}
-		time.Sleep(CIRegistrationDelay)
+		return &WaitResult{Passed: true}, nil
 	}
+
+	// Give GitHub a moment to register checks
+	if w.output != nil {
+		w.output.Info("   Waiting for CI checks to register...")
+	}
+	time.Sleep(CIRegistrationDelay)
 
 	if w.output != nil {
 		w.output.Info("   Waiting for CI checks (timeout: %v)...", w.timeout)

--- a/internal/actions/merge/ci_waiter_test.go
+++ b/internal/actions/merge/ci_waiter_test.go
@@ -1,0 +1,95 @@
+package merge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"stackit.dev/stackit/internal/github"
+)
+
+type mockGitHubClient struct {
+	github.Client
+	checkStatus *github.CheckStatus
+}
+
+func (m *mockGitHubClient) GetPRChecksStatus(_ context.Context, _ string) (*github.CheckStatus, error) {
+	return m.checkStatus, nil
+}
+
+func TestWaitForChecks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns immediately when no checks expected", func(t *testing.T) {
+		t.Parallel()
+
+		waiter := NewCIWaiter(CIWaiterOptions{
+			Client:       &mockGitHubClient{},
+			Timeout:      5 * time.Second,
+			PollInterval: 100 * time.Millisecond,
+		})
+
+		start := time.Now()
+		result, err := waiter.WaitForChecks(context.Background(), "branch", 1, false)
+		elapsed := time.Since(start)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.True(t, result.Passed)
+		// Should return almost immediately, not wait for any polling
+		require.Less(t, elapsed, 1*time.Second)
+	})
+
+	t.Run("returns when checks pass", func(t *testing.T) {
+		t.Parallel()
+
+		client := &mockGitHubClient{
+			checkStatus: &github.CheckStatus{
+				Passing: true,
+				Pending: false,
+				Checks: []github.CheckDetail{
+					{Name: "ci", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				},
+			},
+		}
+
+		waiter := NewCIWaiter(CIWaiterOptions{
+			Client:       client,
+			Timeout:      30 * time.Second, // Enough to cover CIRegistrationDelay + poll
+			PollInterval: 100 * time.Millisecond,
+		})
+
+		result, err := waiter.WaitForChecks(context.Background(), "branch", 1, true)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.True(t, result.Passed)
+	})
+
+	t.Run("returns error when checks fail", func(t *testing.T) {
+		t.Parallel()
+
+		client := &mockGitHubClient{
+			checkStatus: &github.CheckStatus{
+				Passing: false,
+				Pending: false,
+				Checks: []github.CheckDetail{
+					{Name: "ci", Status: "COMPLETED", Conclusion: "FAILURE"},
+				},
+			},
+		}
+
+		waiter := NewCIWaiter(CIWaiterOptions{
+			Client:       client,
+			Timeout:      30 * time.Second,
+			PollInterval: 100 * time.Millisecond,
+		})
+
+		result, err := waiter.WaitForChecks(context.Background(), "branch", 1, true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "CI checks failed")
+		require.NotNil(t, result)
+		require.False(t, result.Passed)
+	})
+}

--- a/internal/actions/merge/plan.go
+++ b/internal/actions/merge/plan.go
@@ -360,7 +360,10 @@ func CollectMergeBranches(ctx context.Context, eng mergePlanEngine, splog output
 						branchErrors[idx] = fmt.Sprintf("Branch %s PR #%d has failing CI checks", name, *prInfo.Number())
 					}
 				default:
-					checksStatus = ChecksPassing
+					if len(status.Checks) > 0 {
+						checksStatus = ChecksPassing
+					}
+					// else: no checks configured, keep ChecksNone
 				}
 			}
 		}


### PR DESCRIPTION


<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #842**
  * **PR #843** 👈
    * **PR #844**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->