### PR TITLE
fix(flatten): propagate UpdateParentRevision error instead of silently swallowing it

### DIFF
--- a/internal/actions/flatten/flatten.go
+++ b/internal/actions/flatten/flatten.go
@@ -209,10 +209,13 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 		// Update parent revision with the correct oldUpstream we calculated earlier.
 		// SetParent uses merge-base which may be incorrect when flattening branches
-		// that have diverged from their original parent.
+		// that have diverged from their original parent. This correction is critical:
+		// without it, the restack will use merge-base as the divergence point, causing
+		// parent branch commits to be included in the flattened branch.
 		if oldUpstream, ok := oldUpstreamMap[move.Branch]; ok {
 			if err := eng.UpdateParentRevision(gctx, move.Branch, oldUpstream); err != nil {
-				out.Debug("Failed to update parent revision for %s: %v", move.Branch, err)
+				handler.OnStep(StepFlattening, basehandler.StatusFailed, err.Error())
+				return fmt.Errorf("failed to update parent revision for %s: %w", move.Branch, err)
 			}
 		}
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #851**
  * **PR #852** 👈
    * **PR #853**
      * **PR #854**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #855 by jonnii*