### PR TITLE
refactor(engine): add SetParentName, fix SetParentPreservingDivergence, fix pluck child reparenting, add commit integrity tests

### DIFF
--- a/internal/actions/flatten/flatten.go
+++ b/internal/actions/flatten/flatten.go
@@ -189,12 +189,13 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Execute the flatten
 	handler.OnStep(StepFlattening, basehandler.StatusStarted, "Moving branches...")
 
-	// Build a map of branch -> oldUpstream from the rebase specs
-	// This is needed because SetParent may calculate a different value using merge-base,
-	// but we need to preserve the correct divergence point for proper rebasing
-	oldUpstreamMap := make(map[string]string)
+	// Build a map of branch -> divergence point from the rebase specs.
+	// SetParentPreservingDivergence needs this to set the correct divergence
+	// point, since the underlying SetParent would default to merge-base
+	// (which is too far back and would include parent branch commits).
+	divergencePoints := make(map[string]string)
 	for _, spec := range filteredPlan.RebaseSpecs {
-		oldUpstreamMap[spec.Branch] = spec.OldUpstream
+		divergencePoints[spec.Branch] = spec.OldUpstream
 	}
 
 	// Update parent pointers for all planned moves
@@ -202,21 +203,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		moveBranch := eng.GetBranch(move.Branch)
 		newParentBranch := eng.GetBranch(move.NewParent)
 
-		if err := eng.SetParent(gctx, moveBranch, newParentBranch); err != nil {
+		if err := eng.SetParentPreservingDivergence(gctx, moveBranch, newParentBranch, divergencePoints[move.Branch]); err != nil {
 			handler.OnStep(StepFlattening, basehandler.StatusFailed, err.Error())
 			return fmt.Errorf("failed to set parent for %s to %s: %w", move.Branch, move.NewParent, err)
-		}
-
-		// Update parent revision with the correct oldUpstream we calculated earlier.
-		// SetParent uses merge-base which may be incorrect when flattening branches
-		// that have diverged from their original parent. This correction is critical:
-		// without it, the restack will use merge-base as the divergence point, causing
-		// parent branch commits to be included in the flattened branch.
-		if oldUpstream, ok := oldUpstreamMap[move.Branch]; ok {
-			if err := eng.UpdateParentRevision(gctx, move.Branch, oldUpstream); err != nil {
-				handler.OnStep(StepFlattening, basehandler.StatusFailed, err.Error())
-				return fmt.Errorf("failed to update parent revision for %s: %w", move.Branch, err)
-			}
 		}
 
 		handler.OnBranchMoved(move.Branch, move.OldParent, move.NewParent)

--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -182,13 +182,23 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Start the operation
 	handler.Start(source, oldParentName, onto)
 
+	// Build a map of child -> divergence point for preserving during reparent.
+	// Without this, SetParent writes merge-base which is too far back, causing
+	// children to carry the plucked branch's commits.
+	childDivergencePoints := make(map[string]string)
+	for _, spec := range rebaseSpecs {
+		if spec.Branch != source {
+			childDivergencePoints[spec.Branch] = spec.OldUpstream
+		}
+	}
+
 	// Step 1: Reparent children to grandparent
 	var reparentedChildren []string
 	if len(children) > 0 {
 		handler.OnStep(StepReparentingChild, basehandler.StatusStarted, "Reparenting children...")
 
 		for _, child := range children {
-			if err := eng.SetParent(gctx, child, grandparentBranch); err != nil {
+			if err := eng.SetParentPreservingDivergence(gctx, child, grandparentBranch, childDivergencePoints[child.GetName()]); err != nil {
 				handler.OnStep(StepReparentingChild, basehandler.StatusFailed, err.Error())
 				return fmt.Errorf("failed to reparent %s to %s: %w", child.GetName(), grandparentBranch.GetName(), err)
 			}

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -372,24 +372,64 @@ func (e *engineImpl) SetParent(ctx context.Context, branch Branch, parentBranch 
 	})
 }
 
+// SetParentName updates only the parent branch name in metadata without
+// modifying ParentBranchRevision. Use this when the caller will set the
+// divergence point separately, or when the existing value should be preserved.
+func (e *engineImpl) SetParentName(ctx context.Context, branch Branch, parentBranch Branch) error {
+	branchName := branch.GetName()
+	parentBranchName := parentBranch.GetName()
+
+	if branchName == parentBranchName {
+		return fmt.Errorf("branch %s cannot be its own parent", branchName)
+	}
+
+	return e.WithRetry(ctx, func() error {
+		meta, err := e.readMetadata(branchName)
+		if err != nil {
+			return fmt.Errorf("failed to read metadata: %w", err)
+		}
+
+		meta = meta.WithParentBranchName(&parentBranchName)
+
+		tx := e.BeginTx(fmt.Sprintf("set parent name: %s -> %s", branchName, parentBranchName))
+		if err := tx.UpdateMeta(branchName, meta); err != nil {
+			return err
+		}
+		return tx.Commit(ctx)
+	})
+}
+
 // SetParentPreservingDivergence updates a branch's parent while preserving
 // the divergence point if it remains a valid ancestor. This is useful when
 // moving a branch to a new parent without changing which commits belong to it.
+//
+// Uses SetParentName (not SetParent) so the existing ParentBranchRevision is
+// never overwritten with an incorrect merge-base value. If oldDivergencePoint
+// is provided and valid, it is written as the new divergence point. If empty,
+// the existing divergence point is left untouched.
+//
+// Returns an error if oldDivergencePoint is provided but is not a valid ancestor
+// of the branch.
 func (e *engineImpl) SetParentPreservingDivergence(ctx context.Context, branch Branch, newParent Branch, oldDivergencePoint string) error {
-	if err := e.SetParent(ctx, branch, newParent); err != nil {
+	if err := e.SetParentName(ctx, branch, newParent); err != nil {
 		return err
 	}
 
-	// If we have an old divergence point and it's still a valid ancestor,
-	// restore it to preserve which commits belong to this branch
-	if oldDivergencePoint != "" {
-		isAncestor, err := e.git.IsAncestor(oldDivergencePoint, branch.GetName())
-		if err == nil && isAncestor {
-			return e.UpdateParentRevision(ctx, branch.GetName(), oldDivergencePoint)
-		}
+	if oldDivergencePoint == "" {
+		return nil
 	}
 
-	return nil
+	// Set the correct divergence point so restacking replays only this
+	// branch's commits, not commits from the old parent.
+	isAncestor, err := e.git.IsAncestor(oldDivergencePoint, branch.GetName())
+	if err != nil {
+		return fmt.Errorf("failed to check ancestry of divergence point %s for %s: %w", oldDivergencePoint, branch.GetName(), err)
+	}
+	if !isAncestor {
+		return fmt.Errorf("divergence point %s is not an ancestor of %s: cannot preserve divergence point", oldDivergencePoint, branch.GetName())
+	}
+
+	return e.UpdateParentRevision(ctx, branch.GetName(), oldDivergencePoint)
 }
 
 // UpdateParentRevision updates the parent revision in metadata using transaction API

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -123,10 +123,15 @@ type BranchTracking interface {
 	TrackBranch(ctx context.Context, branchName string, parentBranchName string) error
 	UntrackBranch(branchName string) error
 	SetParent(ctx context.Context, branch Branch, parentBranch Branch) error
+	// SetParentName updates only the parent branch name in metadata without
+	// modifying ParentBranchRevision. Use this when the caller will set the
+	// correct divergence point separately, or when the existing divergence
+	// point should be preserved as-is.
+	SetParentName(ctx context.Context, branch Branch, parentBranch Branch) error
 	// SetParentPreservingDivergence updates a branch's parent while preserving
 	// the divergence point if it remains a valid ancestor. Use this when moving
 	// a branch to a new parent but the commits belonging to the branch haven't changed.
-	// If oldDivergencePoint is empty, behaves identically to SetParent.
+	// Returns an error if oldDivergencePoint is not empty and is not a valid ancestor.
 	SetParentPreservingDivergence(ctx context.Context, branch Branch, newParent Branch, oldDivergencePoint string) error
 	UpdateParentRevision(ctx context.Context, branchName string, parentRev string) error
 	SetScope(ctx context.Context, branch Branch, scope Scope) error

--- a/internal/integration/move_noninteractive_test.go
+++ b/internal/integration/move_noninteractive_test.go
@@ -33,8 +33,9 @@ func TestMoveNonInteractive(t *testing.T) {
 			OutputContains("Moved b").
 			OutputContains("from a to main")
 
-		// Verify the move happened
-		sh.ExpectBranchParent("b", "main")
+		// Verify the move happened and b only has its own commit
+		sh.ExpectBranchParent("b", "main").
+			CommitCount("main", "b", 1)
 	})
 
 	t.Run("dry-run requires onto flag", func(t *testing.T) {

--- a/internal/integration/move_pr_update_test.go
+++ b/internal/integration/move_pr_update_test.go
@@ -21,6 +21,9 @@ func TestMoveMarksBranchesForPRBodyUpdate(t *testing.T) {
 		// Move B onto main (changing its parent from A to main)
 		sh.Run("move feature-b --onto main --yes")
 
+		// Verify B only has its own commit after move
+		sh.CommitCount("main", "feature-b", 1)
+
 		// The moved branch (B) should be marked for PR body update
 		sh.ExpectNeedsPRBodyUpdate("feature-b", true)
 
@@ -60,6 +63,9 @@ func TestMoveMarksBranchesForPRBodyUpdate(t *testing.T) {
 		// Move C onto A (changing its parent from B to A)
 		sh.Run("move feature-c --onto feature-a --yes")
 
+		// Verify C only has its own commit after move
+		sh.CommitCount("feature-a", "feature-c", 1)
+
 		// C should be marked (it moved)
 		sh.ExpectNeedsPRBodyUpdate("feature-c", true)
 
@@ -80,6 +86,9 @@ func TestMoveMarksBranchesForPRBodyUpdate(t *testing.T) {
 
 		// Move B onto main
 		sh.Run("move feature-b --onto main --yes")
+
+		// Verify B only has its own commit
+		sh.CommitCount("main", "feature-b", 1)
 
 		// Verify flags are set
 		sh.ExpectNeedsPRBodyUpdate("feature-b", true)

--- a/internal/integration/move_stack_id_test.go
+++ b/internal/integration/move_stack_id_test.go
@@ -24,6 +24,10 @@ func TestMoveStackID(t *testing.T) {
 		sh.Checkout("b")
 		sh.Run("move --onto main --no-interactive --yes")
 
+		// Verify b and c only contain their own commits
+		sh.CommitCount("main", "b", 1)
+		sh.CommitCount("b", "c", 1)
+
 		// After moving to trunk, b gets a new stack ID when a description is set
 		// Set description to trigger new stack ID creation for b's new stack
 		sh.Run("describe -m 'Second stack'")
@@ -80,6 +84,9 @@ func TestMoveStackID(t *testing.T) {
 		sh.Checkout("b")
 		sh.Run("move --onto x --no-interactive --yes")
 
+		// Verify b only contains its own commit
+		sh.CommitCount("x", "b", 1)
+
 		// Verify b now has the second stack's ID
 		sh.ExpectStackID("b", secondStackID)
 
@@ -123,6 +130,11 @@ func TestMoveStackID(t *testing.T) {
 		// Move b onto x (should also move c and d as descendants)
 		sh.Checkout("b")
 		sh.Run("move --onto x --no-interactive --yes")
+
+		// Verify each branch only contains its own commit
+		sh.CommitCount("x", "b", 1)
+		sh.CommitCount("b", "c", 1)
+		sh.CommitCount("c", "d", 1)
 
 		// Verify b, c, d all now have the second stack's ID
 		sh.ExpectStackID("b", secondStackID)
@@ -190,8 +202,11 @@ func TestMoveStackID(t *testing.T) {
 		sh.Checkout("c")
 		sh.Run("move --onto a --no-interactive --yes")
 
-		// Verify stack structure changed
-		sh.ExpectBranchParent("c", "a")
+		// Verify stack structure changed and each branch has correct commit count
+		sh.ExpectBranchParent("c", "a").
+			CommitCount("main", "a", 1).
+			CommitCount("a", "b", 1).
+			CommitCount("a", "c", 1)
 
 		// Verify all branches still have the same stack ID
 		sh.ExpectStackIDsMatch("a", "b", "c")

--- a/internal/integration/pluck_stack_id_test.go
+++ b/internal/integration/pluck_stack_id_test.go
@@ -43,8 +43,11 @@ func TestPluckStackID(t *testing.T) {
 		// Verify a still has the original stack ID
 		sh.ExpectStackID("a", originalStackID)
 
-		// Verify b is now on trunk (its own stack root)
-		sh.ExpectBranchParent("b", "main")
+		// Verify b is now on trunk with only its own commit
+		sh.ExpectBranchParent("b", "main").
+			CommitCount("main", "b", 1)
+		// Verify c (reparented to a) only has its own commit relative to a
+		sh.CommitCount("a", "c", 1)
 	})
 
 	t.Run("plucking branch to different stack inherits that stack ID", func(t *testing.T) {
@@ -90,8 +93,10 @@ func TestPluckStackID(t *testing.T) {
 		sh.ExpectStackID("a", firstStackID)
 		sh.ExpectStackID("c", firstStackID)
 
-		// Verify c was reparented to a (not moved with b)
-		sh.ExpectBranchParent("c", "a")
+		// Verify c was reparented to a (not moved with b) and each branch has correct commits
+		sh.ExpectBranchParent("c", "a").
+			CommitCount("x", "b", 1).
+			CommitCount("a", "c", 1)
 	})
 
 	t.Run("plucking within same stack does not change stack ID", func(t *testing.T) {
@@ -127,8 +132,10 @@ func TestPluckStackID(t *testing.T) {
 		// Verify c is now on a
 		sh.ExpectBranchParent("c", "a")
 
-		// Verify d was reparented to b
-		sh.ExpectBranchParent("d", "b")
+		// Verify d was reparented to b and each branch has correct commits
+		sh.ExpectBranchParent("d", "b").
+			CommitCount("a", "c", 1).
+			CommitCount("b", "d", 1)
 	})
 
 	t.Run("plucking leaf branch to trunk creates new stack", func(t *testing.T) {
@@ -165,7 +172,8 @@ func TestPluckStackID(t *testing.T) {
 		sh.ExpectStackID("a", originalStackID)
 		sh.ExpectStackID("b", originalStackID)
 
-		// Verify c is on trunk
-		sh.ExpectBranchParent("c", "main")
+		// Verify c is on trunk with only its own commit
+		sh.ExpectBranchParent("c", "main").
+			CommitCount("main", "c", 1)
 	})
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #851**
  * **PR #852**
    * **PR #853** 👈
      * **PR #854**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #855 by jonnii*