### PR TITLE
Merging 4 PRs

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -455,7 +455,7 @@ func reparentBranchIfNecessary(ctx context.Context, branch engine.Branch, plan *
 
 	// If parent changed, update it
 	if newParentName != parentName {
-		reparentOpts := buildReparentOptions(plan, parentName, eng, branchName, out)
+		reparentOpts := buildReparentOptions(plan, parentName)
 		if err := applyReparent(ctx, eng, branch, newParentName, reparentOpts); err != nil {
 			return "", fmt.Errorf("failed to set parent for %s: %w", branchName, err)
 		}
@@ -474,19 +474,12 @@ func reparentBranchIfNecessary(ctx context.Context, branch engine.Branch, plan *
 type reparentOptions struct {
 	// Preserve existing divergence point when changing parent.
 	preserveDivergence bool
-	// Existing divergence point to preserve when preserveDivergence is true.
-	oldDivergencePoint string
 }
 
-func buildReparentOptions(plan *deletionPlan, oldParentName string, eng engine.Engine, branchName string, out output.Output) reparentOptions {
-	opts := reparentOptions{}
-	if !shouldPreserveDivergenceOnReparent(plan, oldParentName) {
-		return opts
+func buildReparentOptions(plan *deletionPlan, oldParentName string) reparentOptions {
+	return reparentOptions{
+		preserveDivergence: shouldPreserveDivergenceOnReparent(plan, oldParentName),
 	}
-
-	opts.preserveDivergence = true
-	opts.oldDivergencePoint = readDivergencePoint(eng, branchName, out)
-	return opts
 }
 
 // Preserve divergence when old parent is being removed as merged/empty.
@@ -505,23 +498,10 @@ func shouldPreserveDivergenceOnReparent(plan *deletionPlan, oldParentName string
 	}
 }
 
-func readDivergencePoint(eng engine.Engine, branchName string, out output.Output) string {
-	meta, err := eng.Git().ReadMetadata(branchName)
-	if err != nil {
-		out.Debug("Failed to read metadata for %s while preserving divergence: %v", branchName, err)
-		return ""
-	}
-	if meta == nil || meta.GetParentBranchRevision() == nil {
-		return ""
-	}
-
-	return *meta.GetParentBranchRevision()
-}
-
 func applyReparent(ctx context.Context, eng engine.Engine, branch engine.Branch, newParentName string, opts reparentOptions) error {
 	newParent := eng.GetBranch(newParentName)
 	if opts.preserveDivergence {
-		return eng.SetParentPreservingDivergence(ctx, branch, newParent, opts.oldDivergencePoint)
+		return eng.ReparentBranch(ctx, branch, newParent)
 	}
 	return eng.SetParent(ctx, branch, newParent)
 }

--- a/internal/actions/delete/delete.go
+++ b/internal/actions/delete/delete.go
@@ -204,9 +204,8 @@ func preReparentChildrenWithPreservedDivergence(ctx *app.Context, toDelete []eng
 				continue
 			}
 
-			oldDivergencePoint, _ := eng.GetDivergencePoint(childName)
-			if err := eng.SetParentPreservingDivergence(gctx, child, eng.GetBranch(targetParentName), oldDivergencePoint); err != nil {
-				return nil, fmt.Errorf("failed to preserve divergence while reparenting %s to %s: %w", childName, targetParentName, err)
+			if err := eng.ReparentBranch(gctx, child, eng.GetBranch(targetParentName)); err != nil {
+				return nil, fmt.Errorf("failed to reparent %s to %s: %w", childName, targetParentName, err)
 			}
 			out.Debug("Pre-reparented %s to %s while preserving divergence", childName, targetParentName)
 			if !reparentedSet[childName] {

--- a/internal/actions/flatten/flatten.go
+++ b/internal/actions/flatten/flatten.go
@@ -189,12 +189,13 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Execute the flatten
 	handler.OnStep(StepFlattening, basehandler.StatusStarted, "Moving branches...")
 
-	// Build a map of branch -> oldUpstream from the rebase specs
-	// This is needed because SetParent may calculate a different value using merge-base,
-	// but we need to preserve the correct divergence point for proper rebasing
-	oldUpstreamMap := make(map[string]string)
+	// Build a map of branch -> divergence point from the rebase specs.
+	// SetParentPreservingDivergence needs this to set the correct divergence
+	// point, since the underlying SetParent would default to merge-base
+	// (which is too far back and would include parent branch commits).
+	divergencePoints := make(map[string]string)
 	for _, spec := range filteredPlan.RebaseSpecs {
-		oldUpstreamMap[spec.Branch] = spec.OldUpstream
+		divergencePoints[spec.Branch] = spec.OldUpstream
 	}
 
 	// Update parent pointers for all planned moves
@@ -202,21 +203,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		moveBranch := eng.GetBranch(move.Branch)
 		newParentBranch := eng.GetBranch(move.NewParent)
 
-		if err := eng.SetParent(gctx, moveBranch, newParentBranch); err != nil {
+		if err := eng.SetParentPreservingDivergence(gctx, moveBranch, newParentBranch, divergencePoints[move.Branch]); err != nil {
 			handler.OnStep(StepFlattening, basehandler.StatusFailed, err.Error())
 			return fmt.Errorf("failed to set parent for %s to %s: %w", move.Branch, move.NewParent, err)
-		}
-
-		// Update parent revision with the correct oldUpstream we calculated earlier.
-		// SetParent uses merge-base which may be incorrect when flattening branches
-		// that have diverged from their original parent. This correction is critical:
-		// without it, the restack will use merge-base as the divergence point, causing
-		// parent branch commits to be included in the flattened branch.
-		if oldUpstream, ok := oldUpstreamMap[move.Branch]; ok {
-			if err := eng.UpdateParentRevision(gctx, move.Branch, oldUpstream); err != nil {
-				handler.OnStep(StepFlattening, basehandler.StatusFailed, err.Error())
-				return fmt.Errorf("failed to update parent revision for %s: %w", move.Branch, err)
-			}
 		}
 
 		handler.OnBranchMoved(move.Branch, move.OldParent, move.NewParent)

--- a/internal/actions/flatten/flatten.go
+++ b/internal/actions/flatten/flatten.go
@@ -189,21 +189,12 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Execute the flatten
 	handler.OnStep(StepFlattening, basehandler.StatusStarted, "Moving branches...")
 
-	// Build a map of branch -> divergence point from the rebase specs.
-	// SetParentPreservingDivergence needs this to set the correct divergence
-	// point, since the underlying SetParent would default to merge-base
-	// (which is too far back and would include parent branch commits).
-	divergencePoints := make(map[string]string)
-	for _, spec := range filteredPlan.RebaseSpecs {
-		divergencePoints[spec.Branch] = spec.OldUpstream
-	}
-
 	// Update parent pointers for all planned moves
 	for _, move := range filteredPlan.Moves {
 		moveBranch := eng.GetBranch(move.Branch)
 		newParentBranch := eng.GetBranch(move.NewParent)
 
-		if err := eng.SetParentPreservingDivergence(gctx, moveBranch, newParentBranch, divergencePoints[move.Branch]); err != nil {
+		if err := eng.ReparentBranch(gctx, moveBranch, newParentBranch); err != nil {
 			handler.OnStep(StepFlattening, basehandler.StatusFailed, err.Error())
 			return fmt.Errorf("failed to set parent for %s to %s: %w", move.Branch, move.NewParent, err)
 		}

--- a/internal/actions/flatten/flatten.go
+++ b/internal/actions/flatten/flatten.go
@@ -209,10 +209,13 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 		// Update parent revision with the correct oldUpstream we calculated earlier.
 		// SetParent uses merge-base which may be incorrect when flattening branches
-		// that have diverged from their original parent.
+		// that have diverged from their original parent. This correction is critical:
+		// without it, the restack will use merge-base as the divergence point, causing
+		// parent branch commits to be included in the flattened branch.
 		if oldUpstream, ok := oldUpstreamMap[move.Branch]; ok {
 			if err := eng.UpdateParentRevision(gctx, move.Branch, oldUpstream); err != nil {
-				out.Debug("Failed to update parent revision for %s: %v", move.Branch, err)
+				handler.OnStep(StepFlattening, basehandler.StatusFailed, err.Error())
+				return fmt.Errorf("failed to update parent revision for %s: %w", move.Branch, err)
 			}
 		}
 

--- a/internal/actions/fold/fold_keep.go
+++ b/internal/actions/fold/fold_keep.go
@@ -51,9 +51,22 @@ func foldWithKeep(gctx context.Context, ctx *app.Context, currentBranch, parentB
 		return fmt.Errorf("failed to rebuild engine: %w", err)
 	}
 
-	// For each sibling, set parent to current branch and sync stack ID
+	// The current branch absorbed the parent via merge, so it needs a fresh
+	// merge-base calculation against the grandparent (now its parent).
+	// DeleteBranch preserved the old divergence point, which would cause
+	// restack to drop the merged commits. Using SetParent (not
+	// SetParentPreservingDivergence) is intentional here — we want the
+	// merge-base recalculation to include the absorbed commits.
+	refreshedCurrent := eng.GetBranch(currentBranch.GetName())
+	if grandparent := refreshedCurrent.GetParent(); grandparent != nil {
+		if err := eng.SetParent(gctx, refreshedCurrent, *grandparent); err != nil {
+			return fmt.Errorf("failed to reset divergence for %s: %w", currentBranch.GetName(), err)
+		}
+	}
+
+	// For each sibling, reparent to current branch (preserving divergence) and sync stack ID
 	for _, sibling := range siblings {
-		if err := eng.SetParent(gctx, sibling, currentBranch); err != nil {
+		if err := eng.ReparentBranch(gctx, sibling, refreshedCurrent); err != nil {
 			return fmt.Errorf("failed to reparent %s to %s: %w", sibling.GetName(), currentBranch.GetName(), err)
 		}
 		// Sync stack ID to match the new parent's stack

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -291,9 +291,10 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 					return fmt.Errorf("conflict during sync of %s. Resolve conflicts and try again: %w", branchName, err)
 				}
 			}
-			// Update parent if known
+			// Update parent if known, preserving the divergence point so that
+			// restacking doesn't carry commits from the old parent.
 			if parent, ok := parentMap[branchName]; ok {
-				if err := eng.SetParent(gctx, branch, eng.GetBranch(parent)); err != nil {
+				if err := eng.ReparentBranch(gctx, branch, eng.GetBranch(parent)); err != nil {
 					out.Debug("Failed to update parent for %s: %v", branchName, err)
 				}
 			}

--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -82,7 +82,7 @@ func Action(ctx *app.Context, opts Options, h Handler) error {
 
 	h.Start(plan.source, plan.oldParentName, plan.onto)
 
-	if err := eng.SetParentPreservingDivergence(gctx, plan.sourceBranch, plan.ontoBranch, plan.oldParentRev); err != nil {
+	if err := eng.ReparentBranch(gctx, plan.sourceBranch, plan.ontoBranch); err != nil {
 		return fmt.Errorf("failed to set parent: %w", err)
 	}
 

--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -182,23 +182,13 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Start the operation
 	handler.Start(source, oldParentName, onto)
 
-	// Build a map of child -> divergence point for preserving during reparent.
-	// Without this, SetParent writes merge-base which is too far back, causing
-	// children to carry the plucked branch's commits.
-	childDivergencePoints := make(map[string]string)
-	for _, spec := range rebaseSpecs {
-		if spec.Branch != source {
-			childDivergencePoints[spec.Branch] = spec.OldUpstream
-		}
-	}
-
 	// Step 1: Reparent children to grandparent
 	var reparentedChildren []string
 	if len(children) > 0 {
 		handler.OnStep(StepReparentingChild, basehandler.StatusStarted, "Reparenting children...")
 
 		for _, child := range children {
-			if err := eng.SetParentPreservingDivergence(gctx, child, grandparentBranch, childDivergencePoints[child.GetName()]); err != nil {
+			if err := eng.ReparentBranch(gctx, child, grandparentBranch); err != nil {
 				handler.OnStep(StepReparentingChild, basehandler.StatusFailed, err.Error())
 				return fmt.Errorf("failed to reparent %s to %s: %w", child.GetName(), grandparentBranch.GetName(), err)
 			}
@@ -215,9 +205,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		handler.OnStep(StepReparentingChild, basehandler.StatusSkipped, "No children to reparent")
 	}
 
-	// Step 2: Move source to new parent, preserving the divergence point
+	// Step 2: Move source to new parent
 	handler.OnStep(StepMovingSource, basehandler.StatusStarted, "Moving source branch...")
-	if err := eng.SetParentPreservingDivergence(gctx, sourceBranch, ontoBranch, sourceOldParentRev); err != nil {
+	if err := eng.ReparentBranch(gctx, sourceBranch, ontoBranch); err != nil {
 		handler.OnStep(StepMovingSource, basehandler.StatusFailed, err.Error())
 		return fmt.Errorf("failed to set parent: %w", err)
 	}

--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -182,13 +182,23 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Start the operation
 	handler.Start(source, oldParentName, onto)
 
+	// Build a map of child -> divergence point for preserving during reparent.
+	// Without this, SetParent writes merge-base which is too far back, causing
+	// children to carry the plucked branch's commits.
+	childDivergencePoints := make(map[string]string)
+	for _, spec := range rebaseSpecs {
+		if spec.Branch != source {
+			childDivergencePoints[spec.Branch] = spec.OldUpstream
+		}
+	}
+
 	// Step 1: Reparent children to grandparent
 	var reparentedChildren []string
 	if len(children) > 0 {
 		handler.OnStep(StepReparentingChild, basehandler.StatusStarted, "Reparenting children...")
 
 		for _, child := range children {
-			if err := eng.SetParent(gctx, child, grandparentBranch); err != nil {
+			if err := eng.SetParentPreservingDivergence(gctx, child, grandparentBranch, childDivergencePoints[child.GetName()]); err != nil {
 				handler.OnStep(StepReparentingChild, basehandler.StatusFailed, err.Error())
 				return fmt.Errorf("failed to reparent %s to %s: %w", child.GetName(), grandparentBranch.GetName(), err)
 			}

--- a/internal/actions/reorder.go
+++ b/internal/actions/reorder.go
@@ -252,36 +252,24 @@ func parseEditorContent(content string, originalBranches []string) ([]string, er
 func updateParentRelationships(ctx context.Context, eng reorderUpdateEngine, newOrder []string, out output.Output) error {
 	out.Debug("reorder: updateParentRelationships: processing %d branches", len(newOrder))
 
-	// Set parent of first branch to trunk
+	// Set parent of first branch to trunk, then chain each subsequent branch
 	trunk := eng.Trunk()
 	out.Debug("reorder: updateParentRelationships: trunk is %s", trunk.GetName())
 
-	if len(newOrder) > 0 {
-		firstBranch := eng.GetBranch(newOrder[0])
-		out.Debug("reorder: updateParentRelationships: setting parent of %s to trunk (%s)",
-			newOrder[0], trunk.GetName())
-		if err := eng.SetParent(ctx, firstBranch, trunk); err != nil {
-			out.Debug("reorder: updateParentRelationships: failed to set parent of %s: %v",
-				newOrder[0], err)
-			return fmt.Errorf("failed to set parent of %s to %s: %w", newOrder[0], trunk.GetName(), err)
+	for i, branchName := range newOrder {
+		branch := eng.GetBranch(branchName)
+		var parent engine.Branch
+		if i == 0 {
+			parent = trunk
+		} else {
+			parent = eng.GetBranch(newOrder[i-1])
 		}
-		out.Debug("reorder: updateParentRelationships: successfully set parent of %s to %s",
-			newOrder[0], trunk.GetName())
-	}
 
-	// Set parent of each subsequent branch to the branch before it
-	for i := 1; i < len(newOrder); i++ {
-		child := eng.GetBranch(newOrder[i])
-		parent := eng.GetBranch(newOrder[i-1])
 		out.Debug("reorder: updateParentRelationships: setting parent of %s to %s",
-			newOrder[i], newOrder[i-1])
-		if err := eng.SetParent(ctx, child, parent); err != nil {
-			out.Debug("reorder: updateParentRelationships: failed to set parent of %s: %v",
-				newOrder[i], err)
-			return fmt.Errorf("failed to set parent of %s to %s: %w", newOrder[i], newOrder[i-1], err)
+			branchName, parent.GetName())
+		if err := eng.ReparentBranch(ctx, branch, parent); err != nil {
+			return fmt.Errorf("failed to set parent of %s to %s: %w", branchName, parent.GetName(), err)
 		}
-		out.Debug("reorder: updateParentRelationships: successfully set parent of %s to %s",
-			newOrder[i], newOrder[i-1])
 	}
 
 	out.Debug("reorder: updateParentRelationships: all parent relationships updated")

--- a/internal/actions/split/split_file.go
+++ b/internal/actions/split/split_file.go
@@ -520,12 +520,10 @@ func splitByFileAbove(ctx context.Context, branchToSplit engine.Branch, newBranc
 	// Child branch is now fully set up, don't clean it up on subsequent errors
 	childBranchCreated = false
 
-	// Re-parent existing children to the new child branch
-	for _, existingChildName := range existingChildren {
-		existingChild := eng.GetBranch(existingChildName)
-		if err := eng.SetParent(ctx, existingChild, childBranch); err != nil {
-			return nil, fmt.Errorf("failed to reparent %s: %w", existingChildName, err)
-		}
+	// Re-parent existing children to the new child branch, preserving divergence
+	// points so children don't carry the split-out changes.
+	if err := eng.ReparentBranches(ctx, existingChildren, childBranch); err != nil {
+		return nil, fmt.Errorf("failed to reparent children: %w", err)
 	}
 
 	return &Result{

--- a/internal/actions/split/split_hunk.go
+++ b/internal/actions/split/split_hunk.go
@@ -812,12 +812,10 @@ func splitByHunkAbove(ctx *app.Context, branchToSplit engine.Branch, eng splitBy
 		handler.OnBranchCreated(childBranchName)
 	}
 
-	// Re-parent existing children to the new child branch
-	for _, existingChildName := range existingChildren {
-		existingChild := eng.GetBranch(existingChildName)
-		if err := eng.SetParent(gitCtx, existingChild, childBranch); err != nil {
-			return fmt.Errorf("failed to reparent %s: %w", existingChildName, err)
-		}
+	// Re-parent existing children to the new child branch, preserving divergence
+	// points so children don't carry the split-out changes.
+	if err := eng.ReparentBranches(gitCtx, existingChildren, childBranch); err != nil {
+		return fmt.Errorf("failed to reparent children: %w", err)
 	}
 
 	// Restack the children that were reparented

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -761,14 +761,9 @@ func DetachAction(ctx *app.Context, opts DetachOptions) error {
 
 		if len(childNames) > 0 {
 			trunk := ctx.Engine.Trunk()
-			// Reparent all children to trunk
-			for _, childName := range childNames {
-				childBranch := ctx.Engine.GetBranch(childName)
-				if err := ctx.Engine.SetParent(ctx.Context, childBranch, trunk); err != nil {
-					out.Warn("Failed to reparent %s to trunk: %v", childName, err)
-				} else {
-					out.Debug("Reparented %s to %s", childName, trunk.GetName())
-				}
+			// Reparent all children to trunk, preserving divergence points
+			if err := ctx.Engine.ReparentBranches(ctx.Context, childNames, trunk); err != nil {
+				out.Warn("Failed to reparent children to trunk: %v", err)
 			}
 		}
 

--- a/internal/cli/stack/reorder_test.go
+++ b/internal/cli/stack/reorder_test.go
@@ -1,9 +1,11 @@
 package stack_test
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -90,6 +92,92 @@ func TestReorderCommand(t *testing.T) {
 		output, err = cmd.CombinedOutput()
 		require.NoError(t, err, "parent command failed: %s", string(output))
 		require.Contains(t, string(output), "branch2", "branch1 should now have branch2 as parent")
+	})
+
+	t.Run("reorder preserves commit counts per branch", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+			// Create initial commit
+			if err := s.Repo.CreateChangeAndCommit("initial", "init"); err != nil {
+				return err
+			}
+			// Initialize stackit
+			cmd := exec.Command(binaryPath, "init")
+			cmd.Dir = s.Dir
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			// Create branch-a with 1 commit
+			if err := s.Repo.CreateChange("a change", "file-a", false); err != nil {
+				return err
+			}
+			cmd = exec.Command(binaryPath, "create", "branch-a", "-m", "branch-a change")
+			cmd.Dir = s.Dir
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			// Create branch-b with 1 commit on top of branch-a
+			if err := s.Repo.CreateChange("b change", "file-b", false); err != nil {
+				return err
+			}
+			cmd = exec.Command(binaryPath, "create", "branch-b", "-m", "branch-b change")
+			cmd.Dir = s.Dir
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			// Create branch-c with 1 commit on top of branch-b
+			if err := s.Repo.CreateChange("c change", "file-c", false); err != nil {
+				return err
+			}
+			cmd = exec.Command(binaryPath, "create", "branch-c", "-m", "branch-c change")
+			cmd.Dir = s.Dir
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			return nil
+		})
+
+		// Helper to get commit count between two refs
+		commitCount := func(t *testing.T, dir, from, to string) int {
+			t.Helper()
+			cmd := exec.Command("git", "rev-list", "--count", from+".."+to)
+			cmd.Dir = dir
+			out, err := cmd.CombinedOutput()
+			require.NoError(t, err, "rev-list failed: %s", string(out))
+			var count int
+			_, err = fmt.Sscanf(strings.TrimSpace(string(out)), "%d", &count)
+			require.NoError(t, err)
+			return count
+		}
+
+		// Verify initial commit counts: each branch has exactly 1 commit relative to parent
+		require.Equal(t, 1, commitCount(t, scene.Dir, "main", "branch-a"), "branch-a should have 1 commit above main")
+		require.Equal(t, 1, commitCount(t, scene.Dir, "branch-a", "branch-b"), "branch-b should have 1 commit above branch-a")
+		require.Equal(t, 1, commitCount(t, scene.Dir, "branch-b", "branch-c"), "branch-c should have 1 commit above branch-b")
+
+		// Reorder: branch-b, branch-a, branch-c (swap first two)
+		editorScript := createEditorScript(t, "branch-b\nbranch-a\nbranch-c\n")
+
+		cmd := exec.Command(binaryPath, "reorder")
+		cmd.Dir = scene.Dir
+		cmd.Env = append(os.Environ(), "EDITOR="+editorScript, "GIT_EDITOR="+editorScript)
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, err, "reorder command failed: %s", string(output))
+
+		// Run restack to rebase branches onto their new parents
+		cmd = exec.Command(binaryPath, "restack")
+		cmd.Dir = scene.Dir
+		output, err = cmd.CombinedOutput()
+		require.NoError(t, err, "restack command failed: %s", string(output))
+
+		// After reorder + restack: main -> branch-b -> branch-a -> branch-c
+		// Each branch should still have exactly 1 commit relative to its new parent
+		require.Equal(t, 1, commitCount(t, scene.Dir, "main", "branch-b"),
+			"branch-b should have 1 commit above main after reorder")
+		require.Equal(t, 1, commitCount(t, scene.Dir, "branch-b", "branch-a"),
+			"branch-a should have 1 commit above branch-b after reorder")
+		require.Equal(t, 1, commitCount(t, scene.Dir, "branch-a", "branch-c"),
+			"branch-c should have 1 commit above branch-a after reorder")
 	})
 
 	t.Run("reorder with descendants", func(t *testing.T) {

--- a/internal/engine/engine_split.go
+++ b/internal/engine/engine_split.go
@@ -126,10 +126,8 @@ func (e *engineImpl) ApplySplitToCommits(ctx context.Context, opts ApplySplitOpt
 	// branch, which is typically the original branch name if it was preserved).
 	if lastBranchName != opts.BranchToSplit {
 		lastBranch := e.GetBranch(lastBranchName)
-		for _, childBranchName := range children {
-			if err := e.SetParent(ctx, e.GetBranch(childBranchName), lastBranch); err != nil {
-				return fmt.Errorf("failed to update parent for %s: %w", childBranchName, err)
-			}
+		if err := e.ReparentBranches(ctx, children, lastBranch); err != nil {
+			return fmt.Errorf("failed to reparent children to %s: %w", lastBranchName, err)
 		}
 	}
 

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -302,7 +302,12 @@ func (e *engineImpl) restackBranch(
 		newParent := e.findNearestValidAncestor(ctx, branchName, metaMap)
 		e.mu.RUnlock()
 
-		// Reparent to the nearest valid ancestor
+		// Reparent to the nearest valid ancestor. Using SetParent (not
+		// SetParentPreservingDivergence) is intentional here: the old parent
+		// was merged/deleted, so SetParent's shouldUpdateRevision logic
+		// correctly preserves the existing divergence point when the old
+		// parent was merged into the new parent. The subsequent restack then
+		// rebases the branch's own commits onto the new parent.
 		if err := e.SetParent(ctx, e.GetBranch(branchName), e.GetBranch(newParent)); err != nil {
 			return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to reparent %s to %s: %w", branchName, newParent, err)
 		}
@@ -639,7 +644,7 @@ func (e *engineImpl) ContinueRebase(ctx context.Context, branchName string, reba
 
 	// Update metadata
 	if rebasedBranchBase != "" {
-		if err := e.UpdateParentRevision(ctx, branchName, rebasedBranchBase); err != nil {
+		if err := e.updateParentRevision(ctx, branchName, rebasedBranchBase); err != nil {
 			return ContinueRebaseResult{BranchName: branchName}, fmt.Errorf("failed to update metadata: %w", err)
 		}
 	}

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -372,24 +372,64 @@ func (e *engineImpl) SetParent(ctx context.Context, branch Branch, parentBranch 
 	})
 }
 
+// SetParentName updates only the parent branch name in metadata without
+// modifying ParentBranchRevision. Use this when the caller will set the
+// divergence point separately, or when the existing value should be preserved.
+func (e *engineImpl) SetParentName(ctx context.Context, branch Branch, parentBranch Branch) error {
+	branchName := branch.GetName()
+	parentBranchName := parentBranch.GetName()
+
+	if branchName == parentBranchName {
+		return fmt.Errorf("branch %s cannot be its own parent", branchName)
+	}
+
+	return e.WithRetry(ctx, func() error {
+		meta, err := e.readMetadata(branchName)
+		if err != nil {
+			return fmt.Errorf("failed to read metadata: %w", err)
+		}
+
+		meta = meta.WithParentBranchName(&parentBranchName)
+
+		tx := e.BeginTx(fmt.Sprintf("set parent name: %s -> %s", branchName, parentBranchName))
+		if err := tx.UpdateMeta(branchName, meta); err != nil {
+			return err
+		}
+		return tx.Commit(ctx)
+	})
+}
+
 // SetParentPreservingDivergence updates a branch's parent while preserving
 // the divergence point if it remains a valid ancestor. This is useful when
 // moving a branch to a new parent without changing which commits belong to it.
+//
+// Uses SetParentName (not SetParent) so the existing ParentBranchRevision is
+// never overwritten with an incorrect merge-base value. If oldDivergencePoint
+// is provided and valid, it is written as the new divergence point. If empty,
+// the existing divergence point is left untouched.
+//
+// Returns an error if oldDivergencePoint is provided but is not a valid ancestor
+// of the branch.
 func (e *engineImpl) SetParentPreservingDivergence(ctx context.Context, branch Branch, newParent Branch, oldDivergencePoint string) error {
-	if err := e.SetParent(ctx, branch, newParent); err != nil {
+	if err := e.SetParentName(ctx, branch, newParent); err != nil {
 		return err
 	}
 
-	// If we have an old divergence point and it's still a valid ancestor,
-	// restore it to preserve which commits belong to this branch
-	if oldDivergencePoint != "" {
-		isAncestor, err := e.git.IsAncestor(oldDivergencePoint, branch.GetName())
-		if err == nil && isAncestor {
-			return e.UpdateParentRevision(ctx, branch.GetName(), oldDivergencePoint)
-		}
+	if oldDivergencePoint == "" {
+		return nil
 	}
 
-	return nil
+	// Set the correct divergence point so restacking replays only this
+	// branch's commits, not commits from the old parent.
+	isAncestor, err := e.git.IsAncestor(oldDivergencePoint, branch.GetName())
+	if err != nil {
+		return fmt.Errorf("failed to check ancestry of divergence point %s for %s: %w", oldDivergencePoint, branch.GetName(), err)
+	}
+	if !isAncestor {
+		return fmt.Errorf("divergence point %s is not an ancestor of %s: cannot preserve divergence point", oldDivergencePoint, branch.GetName())
+	}
+
+	return e.UpdateParentRevision(ctx, branch.GetName(), oldDivergencePoint)
 }
 
 // UpdateParentRevision updates the parent revision in metadata using transaction API

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -205,14 +204,10 @@ func (e *engineImpl) DeleteBranch(ctx context.Context, branch Branch) error {
 		_, _ = fmt.Fprintf(e.writer, "Warning: failed to delete local metadata ref for %s: %v\n", branchName, err)
 	}
 
-	// Update children to point to parent (SetParent handles its own transactions)
+	// Reparent children to grandparent, preserving divergence points so
+	// children don't carry the deleted branch's commits after restacking.
 	parentBranch := e.GetBranch(parent)
-	var reparentErrs []error
-	for _, child := range children {
-		if err := e.SetParent(ctx, e.GetBranch(child), parentBranch); err != nil {
-			reparentErrs = append(reparentErrs, fmt.Errorf("%s -> %s: %w", child, parent, err))
-		}
-	}
+	reparentErr := e.ReparentBranches(ctx, children, parentBranch)
 
 	// Clean up in-memory cache for deleted branch
 	e.mu.Lock()
@@ -225,8 +220,8 @@ func (e *engineImpl) DeleteBranch(ctx context.Context, branch Branch) error {
 		e.state.setBranches(slices.Delete(e.state.branches, i, i+1))
 	}
 
-	if len(reparentErrs) > 0 {
-		return fmt.Errorf("deleted branch %s but failed to reparent %d child branch(es): %w", branchName, len(reparentErrs), errors.Join(reparentErrs...))
+	if reparentErr != nil {
+		return fmt.Errorf("deleted branch %s but failed to reparent child branch(es): %w", branchName, reparentErr)
 	}
 
 	return nil
@@ -372,10 +367,9 @@ func (e *engineImpl) SetParent(ctx context.Context, branch Branch, parentBranch 
 	})
 }
 
-// SetParentName updates only the parent branch name in metadata without
-// modifying ParentBranchRevision. Use this when the caller will set the
-// divergence point separately, or when the existing value should be preserved.
-func (e *engineImpl) SetParentName(ctx context.Context, branch Branch, parentBranch Branch) error {
+// setParentName updates only the parent branch name in metadata without
+// modifying ParentBranchRevision.
+func (e *engineImpl) setParentName(ctx context.Context, branch Branch, parentBranch Branch) error {
 	branchName := branch.GetName()
 	parentBranchName := parentBranch.GetName()
 
@@ -399,19 +393,12 @@ func (e *engineImpl) SetParentName(ctx context.Context, branch Branch, parentBra
 	})
 }
 
-// SetParentPreservingDivergence updates a branch's parent while preserving
-// the divergence point if it remains a valid ancestor. This is useful when
-// moving a branch to a new parent without changing which commits belong to it.
-//
-// Uses SetParentName (not SetParent) so the existing ParentBranchRevision is
-// never overwritten with an incorrect merge-base value. If oldDivergencePoint
-// is provided and valid, it is written as the new divergence point. If empty,
-// the existing divergence point is left untouched.
-//
-// Returns an error if oldDivergencePoint is provided but is not a valid ancestor
-// of the branch.
-func (e *engineImpl) SetParentPreservingDivergence(ctx context.Context, branch Branch, newParent Branch, oldDivergencePoint string) error {
-	if err := e.SetParentName(ctx, branch, newParent); err != nil {
+// setParentPreservingDivergence updates a branch's parent while preserving
+// the divergence point if it remains a valid ancestor. Uses setParentName
+// (not SetParent) so the existing ParentBranchRevision is never overwritten
+// with an incorrect merge-base value.
+func (e *engineImpl) setParentPreservingDivergence(ctx context.Context, branch Branch, newParent Branch, oldDivergencePoint string) error {
+	if err := e.setParentName(ctx, branch, newParent); err != nil {
 		return err
 	}
 
@@ -429,12 +416,40 @@ func (e *engineImpl) SetParentPreservingDivergence(ctx context.Context, branch B
 		return fmt.Errorf("divergence point %s is not an ancestor of %s: cannot preserve divergence point", oldDivergencePoint, branch.GetName())
 	}
 
-	return e.UpdateParentRevision(ctx, branch.GetName(), oldDivergencePoint)
+	return e.updateParentRevision(ctx, branch.GetName(), oldDivergencePoint)
 }
 
-// UpdateParentRevision updates the parent revision in metadata using transaction API
+// ReparentBranch changes a branch's parent while automatically preserving its
+// divergence point. This is the preferred way to reparent an existing branch
+// when the branch's own commits should not change.
+func (e *engineImpl) ReparentBranch(ctx context.Context, branch Branch, newParent Branch) error {
+	div, _ := e.GetDivergencePoint(branch.GetName())
+	return e.setParentPreservingDivergence(ctx, branch, newParent, div)
+}
+
+// ReparentBranches changes multiple branches to the same new parent while
+// preserving each branch's divergence point. Divergence points are captured
+// for all branches before any reparenting begins, ensuring correctness when
+// branches in the list are related to each other.
+func (e *engineImpl) ReparentBranches(ctx context.Context, branchNames []string, newParent Branch) error {
+	divPoints := make(map[string]string, len(branchNames))
+	for _, name := range branchNames {
+		if div, err := e.GetDivergencePoint(name); err == nil {
+			divPoints[name] = div
+		}
+	}
+
+	for _, name := range branchNames {
+		if err := e.setParentPreservingDivergence(ctx, e.GetBranch(name), newParent, divPoints[name]); err != nil {
+			return fmt.Errorf("failed to reparent %s to %s: %w", name, newParent.GetName(), err)
+		}
+	}
+	return nil
+}
+
+// updateParentRevision updates the parent revision in metadata using transaction API
 // with retry logic for concurrent modification resilience.
-func (e *engineImpl) UpdateParentRevision(ctx context.Context, branchName string, parentRev string) error {
+func (e *engineImpl) updateParentRevision(ctx context.Context, branchName string, parentRev string) error {
 	return e.WithRetry(ctx, func() error {
 		// Read existing metadata (outside lock for performance)
 		meta, err := e.readMetadata(branchName)

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -123,10 +123,15 @@ type BranchTracking interface {
 	TrackBranch(ctx context.Context, branchName string, parentBranchName string) error
 	UntrackBranch(branchName string) error
 	SetParent(ctx context.Context, branch Branch, parentBranch Branch) error
+	// SetParentName updates only the parent branch name in metadata without
+	// modifying ParentBranchRevision. Use this when the caller will set the
+	// correct divergence point separately, or when the existing divergence
+	// point should be preserved as-is.
+	SetParentName(ctx context.Context, branch Branch, parentBranch Branch) error
 	// SetParentPreservingDivergence updates a branch's parent while preserving
 	// the divergence point if it remains a valid ancestor. Use this when moving
 	// a branch to a new parent but the commits belonging to the branch haven't changed.
-	// If oldDivergencePoint is empty, behaves identically to SetParent.
+	// Returns an error if oldDivergencePoint is not empty and is not a valid ancestor.
 	SetParentPreservingDivergence(ctx context.Context, branch Branch, newParent Branch, oldDivergencePoint string) error
 	UpdateParentRevision(ctx context.Context, branchName string, parentRev string) error
 	SetScope(ctx context.Context, branch Branch, scope Scope) error

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -123,17 +123,13 @@ type BranchTracking interface {
 	TrackBranch(ctx context.Context, branchName string, parentBranchName string) error
 	UntrackBranch(branchName string) error
 	SetParent(ctx context.Context, branch Branch, parentBranch Branch) error
-	// SetParentName updates only the parent branch name in metadata without
-	// modifying ParentBranchRevision. Use this when the caller will set the
-	// correct divergence point separately, or when the existing divergence
-	// point should be preserved as-is.
-	SetParentName(ctx context.Context, branch Branch, parentBranch Branch) error
-	// SetParentPreservingDivergence updates a branch's parent while preserving
-	// the divergence point if it remains a valid ancestor. Use this when moving
-	// a branch to a new parent but the commits belonging to the branch haven't changed.
-	// Returns an error if oldDivergencePoint is not empty and is not a valid ancestor.
-	SetParentPreservingDivergence(ctx context.Context, branch Branch, newParent Branch, oldDivergencePoint string) error
-	UpdateParentRevision(ctx context.Context, branchName string, parentRev string) error
+	// ReparentBranch changes a branch's parent while automatically preserving
+	// its divergence point. Preferred over SetParent for existing branches.
+	ReparentBranch(ctx context.Context, branch Branch, newParent Branch) error
+	// ReparentBranches changes multiple branches to the same new parent while
+	// preserving divergence points. All divergence points are captured before
+	// any reparenting begins.
+	ReparentBranches(ctx context.Context, branchNames []string, newParent Branch) error
 	SetScope(ctx context.Context, branch Branch, scope Scope) error
 	SetBranchType(branch Branch, branchType git.BranchType) error
 	SetLocked(ctx context.Context, branches []Branch, reason LockReason) (BatchLockResult, error)

--- a/internal/integration/flatten_test.go
+++ b/internal/integration/flatten_test.go
@@ -253,6 +253,219 @@ func TestFlattenUndo(t *testing.T) {
 	})
 }
 
+func TestFlattenCommitIntegrity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("flattened branch only contains its own commits", func(t *testing.T) {
+		t.Parallel()
+
+		// Scenario: main -> A -> B -> C (independent changes)
+		// After flatten: main -> A, main -> B, main -> C
+		// Each branch should have exactly 1 commit relative to main
+
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("file-a", "content a").
+			Run("create branch-a -m 'Add file A'")
+
+		sh.Write("file-b", "content b").
+			Run("create branch-b -m 'Add file B'")
+
+		sh.Write("file-c", "content c").
+			Run("create branch-c -m 'Add file C'")
+
+		// Verify commit counts before flatten
+		sh.CommitCount("main", "branch-a", 1).
+			CommitCount("main", "branch-b", 2). // B has A's commit + B's commit
+			CommitCount("main", "branch-c", 3)  // C has A + B + C
+
+		sh.Run("flatten --yes")
+
+		// After flatten, each branch should have exactly 1 commit relative to main
+		sh.CommitCount("main", "branch-a", 1).
+			CommitCount("main", "branch-b", 1).
+			CommitCount("main", "branch-c", 1)
+	})
+
+	t.Run("flattened branch only contains its own commits when main has advanced", func(t *testing.T) {
+		t.Parallel()
+
+		// Scenario: User hasn't synced - main has new commits locally
+		// main -> A -> B (independent changes), then main gets a new commit
+		// After flatten: B should have exactly 1 commit relative to main
+
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("file-a", "content a").
+			Run("create branch-a -m 'Add file A'")
+
+		sh.Write("file-b", "content b").
+			Run("create branch-b -m 'Add file B'")
+
+		// Advance main (simulating a local pull or direct commit)
+		sh.Checkout("main").
+			Git("commit --allow-empty -m 'main: advance'")
+
+		// Go back to branch-b and flatten
+		sh.Checkout("branch-b").
+			Run("flatten --yes")
+
+		sh.ExpectStackStructure(map[string]string{
+			"branch-a": "main",
+			"branch-b": "main",
+		})
+
+		// Each branch should have exactly 1 commit relative to main
+		sh.CommitCount("main", "branch-a", 1).
+			CommitCount("main", "branch-b", 1)
+	})
+
+	t.Run("flattened branch excludes parent commits when parent has extra commits", func(t *testing.T) {
+		t.Parallel()
+
+		// Scenario: A has 2 commits, B has 1 commit on top
+		// B doesn't depend on A's content so can flatten to main
+		// After flatten: B should have exactly 1 commit relative to main
+
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("file-a1", "content a1").
+			Run("create branch-a -m 'Add file A1'")
+
+		// Add another commit to A
+		sh.Commit("file-a2", "Add file A2")
+
+		// Create B with independent changes
+		sh.Write("file-b", "content b").
+			Run("create branch-b -m 'Add file B'")
+
+		// Verify: A has 2 commits, B has 3 (2 from A + 1 own)
+		sh.CommitCount("main", "branch-a", 2).
+			CommitCount("main", "branch-b", 3)
+
+		sh.Run("flatten --yes")
+
+		sh.ExpectStackStructure(map[string]string{
+			"branch-a": "main",
+			"branch-b": "main",
+		})
+
+		// A should have 2 commits, B should have only 1
+		sh.CommitCount("main", "branch-a", 2).
+			CommitCount("main", "branch-b", 1)
+	})
+
+	t.Run("flatten after parent amended without restacking child", func(t *testing.T) {
+		t.Parallel()
+
+		// Scenario: A is created, B is created on top, then A is amended
+		// B is NOT restacked before flatten
+		// After flatten: B should only contain its own commit
+
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("file-a", "content a").
+			Run("create branch-a -m 'Add file A'")
+
+		sh.Write("file-b", "content b").
+			Run("create branch-b -m 'Add file B'")
+
+		// Go back to A and amend it (add more content)
+		sh.Checkout("branch-a").
+			Amend("file-a-extra", "extra content for A")
+
+		// Do NOT restack branch-b — it's now based on old A
+
+		// Go to B and flatten
+		sh.Checkout("branch-b").
+			Run("flatten --yes")
+
+		sh.ExpectStackStructure(map[string]string{
+			"branch-a": "main",
+			"branch-b": "main",
+		})
+
+		// B should have exactly 1 commit relative to main
+		sh.CommitCount("main", "branch-b", 1)
+	})
+
+	t.Run("flatten with main advanced and parent amended", func(t *testing.T) {
+		t.Parallel()
+
+		// Combined scenario: main advanced + parent amended + no restack
+		// This is the most likely scenario for the reported bug
+
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("file-a", "content a").
+			Run("create branch-a -m 'Add file A'")
+
+		sh.Write("file-b", "content b").
+			Run("create branch-b -m 'Add file B'")
+
+		// Advance main
+		sh.Checkout("main").
+			Git("commit --allow-empty -m 'main: advance'")
+
+		// Amend A (adds content, changes SHA)
+		sh.Checkout("branch-a").
+			Amend("file-a-extra", "extra content for A")
+
+		// Do NOT restack branch-b
+
+		// Flatten from B
+		sh.Checkout("branch-b").
+			Run("flatten --yes")
+
+		sh.ExpectStackStructure(map[string]string{
+			"branch-a": "main",
+			"branch-b": "main",
+		})
+
+		// B should have exactly 1 commit relative to main
+		sh.CommitCount("main", "branch-b", 1)
+	})
+
+	t.Run("flatten deep stack preserves correct commit counts", func(t *testing.T) {
+		t.Parallel()
+
+		// Scenario: main -> A -> B -> C -> D (all independent)
+		// After flatten: all on main, each with 1 commit
+
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("file-a", "content a").
+			Run("create branch-a -m 'Add file A'")
+
+		sh.Write("file-b", "content b").
+			Run("create branch-b -m 'Add file B'")
+
+		sh.Write("file-c", "content c").
+			Run("create branch-c -m 'Add file C'")
+
+		sh.Write("file-d", "content d").
+			Run("create branch-d -m 'Add file D'")
+
+		// Before flatten
+		sh.CommitCount("main", "branch-d", 4)
+
+		sh.Run("flatten --yes")
+
+		sh.ExpectStackStructure(map[string]string{
+			"branch-a": "main",
+			"branch-b": "main",
+			"branch-c": "main",
+			"branch-d": "main",
+		})
+
+		// Each should have exactly 1 commit
+		sh.CommitCount("main", "branch-a", 1).
+			CommitCount("main", "branch-b", 1).
+			CommitCount("main", "branch-c", 1).
+			CommitCount("main", "branch-d", 1)
+	})
+}
+
 func TestFlattenTreeStructure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/integration/move_noninteractive_test.go
+++ b/internal/integration/move_noninteractive_test.go
@@ -33,8 +33,9 @@ func TestMoveNonInteractive(t *testing.T) {
 			OutputContains("Moved b").
 			OutputContains("from a to main")
 
-		// Verify the move happened
-		sh.ExpectBranchParent("b", "main")
+		// Verify the move happened and b only has its own commit
+		sh.ExpectBranchParent("b", "main").
+			CommitCount("main", "b", 1)
 	})
 
 	t.Run("dry-run requires onto flag", func(t *testing.T) {

--- a/internal/integration/move_pr_update_test.go
+++ b/internal/integration/move_pr_update_test.go
@@ -21,6 +21,9 @@ func TestMoveMarksBranchesForPRBodyUpdate(t *testing.T) {
 		// Move B onto main (changing its parent from A to main)
 		sh.Run("move feature-b --onto main --yes")
 
+		// Verify B only has its own commit after move
+		sh.CommitCount("main", "feature-b", 1)
+
 		// The moved branch (B) should be marked for PR body update
 		sh.ExpectNeedsPRBodyUpdate("feature-b", true)
 
@@ -60,6 +63,9 @@ func TestMoveMarksBranchesForPRBodyUpdate(t *testing.T) {
 		// Move C onto A (changing its parent from B to A)
 		sh.Run("move feature-c --onto feature-a --yes")
 
+		// Verify C only has its own commit after move
+		sh.CommitCount("feature-a", "feature-c", 1)
+
 		// C should be marked (it moved)
 		sh.ExpectNeedsPRBodyUpdate("feature-c", true)
 
@@ -80,6 +86,9 @@ func TestMoveMarksBranchesForPRBodyUpdate(t *testing.T) {
 
 		// Move B onto main
 		sh.Run("move feature-b --onto main --yes")
+
+		// Verify B only has its own commit
+		sh.CommitCount("main", "feature-b", 1)
 
 		// Verify flags are set
 		sh.ExpectNeedsPRBodyUpdate("feature-b", true)

--- a/internal/integration/move_stack_id_test.go
+++ b/internal/integration/move_stack_id_test.go
@@ -24,6 +24,10 @@ func TestMoveStackID(t *testing.T) {
 		sh.Checkout("b")
 		sh.Run("move --onto main --no-interactive --yes")
 
+		// Verify b and c only contain their own commits
+		sh.CommitCount("main", "b", 1)
+		sh.CommitCount("b", "c", 1)
+
 		// After moving to trunk, b gets a new stack ID when a description is set
 		// Set description to trigger new stack ID creation for b's new stack
 		sh.Run("describe -m 'Second stack'")
@@ -80,6 +84,9 @@ func TestMoveStackID(t *testing.T) {
 		sh.Checkout("b")
 		sh.Run("move --onto x --no-interactive --yes")
 
+		// Verify b only contains its own commit
+		sh.CommitCount("x", "b", 1)
+
 		// Verify b now has the second stack's ID
 		sh.ExpectStackID("b", secondStackID)
 
@@ -123,6 +130,11 @@ func TestMoveStackID(t *testing.T) {
 		// Move b onto x (should also move c and d as descendants)
 		sh.Checkout("b")
 		sh.Run("move --onto x --no-interactive --yes")
+
+		// Verify each branch only contains its own commit
+		sh.CommitCount("x", "b", 1)
+		sh.CommitCount("b", "c", 1)
+		sh.CommitCount("c", "d", 1)
 
 		// Verify b, c, d all now have the second stack's ID
 		sh.ExpectStackID("b", secondStackID)
@@ -190,8 +202,11 @@ func TestMoveStackID(t *testing.T) {
 		sh.Checkout("c")
 		sh.Run("move --onto a --no-interactive --yes")
 
-		// Verify stack structure changed
-		sh.ExpectBranchParent("c", "a")
+		// Verify stack structure changed and each branch has correct commit count
+		sh.ExpectBranchParent("c", "a").
+			CommitCount("main", "a", 1).
+			CommitCount("a", "b", 1).
+			CommitCount("a", "c", 1)
 
 		// Verify all branches still have the same stack ID
 		sh.ExpectStackIDsMatch("a", "b", "c")

--- a/internal/integration/pluck_stack_id_test.go
+++ b/internal/integration/pluck_stack_id_test.go
@@ -43,8 +43,11 @@ func TestPluckStackID(t *testing.T) {
 		// Verify a still has the original stack ID
 		sh.ExpectStackID("a", originalStackID)
 
-		// Verify b is now on trunk (its own stack root)
-		sh.ExpectBranchParent("b", "main")
+		// Verify b is now on trunk with only its own commit
+		sh.ExpectBranchParent("b", "main").
+			CommitCount("main", "b", 1)
+		// Verify c (reparented to a) only has its own commit relative to a
+		sh.CommitCount("a", "c", 1)
 	})
 
 	t.Run("plucking branch to different stack inherits that stack ID", func(t *testing.T) {
@@ -90,8 +93,10 @@ func TestPluckStackID(t *testing.T) {
 		sh.ExpectStackID("a", firstStackID)
 		sh.ExpectStackID("c", firstStackID)
 
-		// Verify c was reparented to a (not moved with b)
-		sh.ExpectBranchParent("c", "a")
+		// Verify c was reparented to a (not moved with b) and each branch has correct commits
+		sh.ExpectBranchParent("c", "a").
+			CommitCount("x", "b", 1).
+			CommitCount("a", "c", 1)
 	})
 
 	t.Run("plucking within same stack does not change stack ID", func(t *testing.T) {
@@ -127,8 +132,10 @@ func TestPluckStackID(t *testing.T) {
 		// Verify c is now on a
 		sh.ExpectBranchParent("c", "a")
 
-		// Verify d was reparented to b
-		sh.ExpectBranchParent("d", "b")
+		// Verify d was reparented to b and each branch has correct commits
+		sh.ExpectBranchParent("d", "b").
+			CommitCount("a", "c", 1).
+			CommitCount("b", "d", 1)
 	})
 
 	t.Run("plucking leaf branch to trunk creates new stack", func(t *testing.T) {
@@ -165,7 +172,8 @@ func TestPluckStackID(t *testing.T) {
 		sh.ExpectStackID("a", originalStackID)
 		sh.ExpectStackID("b", originalStackID)
 
-		// Verify c is on trunk
-		sh.ExpectBranchParent("c", "main")
+		// Verify c is on trunk with only its own commit
+		sh.ExpectBranchParent("c", "main").
+			CommitCount("main", "c", 1)
 	})
 }

--- a/internal/integration/reparent_divergence_test.go
+++ b/internal/integration/reparent_divergence_test.go
@@ -1,0 +1,111 @@
+package integration
+
+import (
+	"testing"
+)
+
+// TestReparentDivergencePreservation tests that reparenting operations
+// preserve correct divergence points, so children don't carry commits
+// from their old parent after restacking.
+func TestReparentDivergencePreservation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("delete branch preserves child commit counts", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create stack: main -> a -> b -> c
+		// Each branch has exactly 1 commit relative to its parent
+		sh.CreateLinearStack3()
+
+		// Verify initial commit counts
+		sh.CommitCount("main", "a", 1)
+		sh.CommitCount("a", "b", 1)
+		sh.CommitCount("b", "c", 1)
+
+		// Delete b -- children (c) should be reparented to a
+		sh.Run("delete b --force")
+
+		// After restacking, c should have exactly 1 commit relative to a
+		// (not 2, which would happen if divergence point was set too far back)
+		sh.ExpectBranchParent("c", "a")
+		sh.Checkout("c")
+		sh.Run("restack")
+		sh.CommitCount("a", "c", 1)
+	})
+
+	t.Run("delete branch with multiple children preserves commit counts", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create branching stack:
+		//   main -> a -> b -> [c, d]
+		sh.Write("a.txt", "a content").
+			Run("create a -m 'Add a'")
+		sh.Write("b.txt", "b content").
+			Run("create b -m 'Add b'")
+		sh.Write("c.txt", "c content").
+			Run("create c -m 'Add c'")
+		sh.Checkout("b")
+		sh.Write("d.txt", "d content").
+			Run("create d -m 'Add d'")
+
+		// Verify initial state
+		sh.CommitCount("main", "a", 1)
+		sh.CommitCount("a", "b", 1)
+		sh.CommitCount("b", "c", 1)
+		sh.CommitCount("b", "d", 1)
+
+		// Delete b -- c and d should be reparented to a
+		sh.Run("delete b --force")
+
+		// After restacking, c and d should each have 1 commit relative to a
+		sh.ExpectBranchParent("c", "a")
+		sh.ExpectBranchParent("d", "a")
+		sh.Checkout("c")
+		sh.Run("restack")
+		sh.CommitCount("a", "c", 1)
+		sh.Checkout("d")
+		sh.Run("restack")
+		sh.CommitCount("a", "d", 1)
+	})
+
+	t.Run("fold keep reparents siblings with correct divergence", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Create diamond: main -> a -> [b, d]
+		// Then b -> c
+		//
+		//   main -> a -> b -> c
+		//             \-> d
+		sh.Write("a.txt", "a content").
+			Run("create a -m 'Add a'")
+		sh.Write("b.txt", "b content").
+			Run("create b -m 'Add b'")
+		sh.Write("c.txt", "c content").
+			Run("create c -m 'Add c'")
+		sh.Checkout("a")
+		sh.Write("d.txt", "d content").
+			Run("create d -m 'Add d'")
+
+		// Verify initial state
+		sh.CommitCount("main", "a", 1)
+		sh.CommitCount("a", "b", 1)
+		sh.CommitCount("b", "c", 1)
+		sh.CommitCount("a", "d", 1)
+
+		// Fold a into b (keep current=b) -- d (sibling) should be reparented to b
+		sh.Checkout("b")
+		sh.Run("fold --keep current")
+
+		// After fold+restack, d should have exactly 1 commit relative to b
+		// (not carry a's commit too)
+		sh.ExpectBranchParent("d", "b")
+		sh.CommitCount("b", "d", 1)
+
+		// c should still have exactly 1 commit relative to b
+		sh.ExpectBranchParent("c", "b")
+		sh.CommitCount("b", "c", 1)
+	})
+}

--- a/internal/integration/split_test.go
+++ b/internal/integration/split_test.go
@@ -1325,6 +1325,14 @@ func TestSplitByFileAbove(t *testing.T) {
 
 		// Verify new-child is a child of feature
 		sh.ExpectBranchParent("new-child", "feature")
+
+		// Restack so the git history reflects the new parent relationships
+		sh.Checkout("existing-child").
+			Run("restack")
+
+		// Verify existing-child has exactly 1 commit relative to new-child
+		// (not carrying the split-out changes from the parent)
+		sh.CommitCount("new-child", "existing-child", 1)
 	})
 
 	run("split --by-file --above incompatible with --as-sibling", func(_ *testing.T, sh *TestShell) {
@@ -1386,6 +1394,15 @@ func TestSplitByFileAbove(t *testing.T) {
 
 		// Verify new-child is a child of feature
 		sh.ExpectBranchParent("new-child", "feature")
+
+		// Restack so the git history reflects the new parent relationships
+		sh.Checkout("new-child").
+			Run("restack")
+
+		// Verify each child has exactly 1 commit relative to new-child
+		sh.CommitCount("new-child", "child1", 1).
+			CommitCount("new-child", "child2", 1).
+			CommitCount("new-child", "child3", 1)
 	})
 
 	run("split --by-file --above fails when all files selected", func(_ *testing.T, sh *TestShell) {

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 experimental = true
 
 [env]
-STACKIT_NO_LOGGING = "1"  # Used for tests
+STACKIT_NO_LOGGING = "1"                                    # Used for tests
 GOBIN = "{{ config_root }}/bin"
 PROJECT_ROOT = "{{ config_root }}"
 _.path = ["{{ config_root }}/bin", "{{ env.HOME }}/go/bin"]
@@ -24,16 +24,16 @@ pnpm = "10.32.1"
 golangci-lint = "latest"
 
 # Development tools
-"aqua:watchexec/watchexec" = "latest" # File watcher for dev auto-reload
+"aqua:watchexec/watchexec" = "latest"   # File watcher for dev auto-reload
 "aqua:goreleaser/goreleaser" = "latest" # Release automation
 
 # CLI utilities (recommended in AGENTS.md)
-"aqua:BurntSushi/ripgrep" = "latest"  # Fast text search (rg)
-"aqua:sharkdp/fd" = "latest"          # Fast file search
-"aqua:ast-grep/ast-grep" = "latest"   # AST-based code search
-"aqua:jqlang/jq" = "latest"           # JSON processing
-"aqua:mikefarah/yq" = "latest"        # YAML processing
-"cargo:tokei" = "latest"              # Code statistics
+"aqua:BurntSushi/ripgrep" = "latest" # Fast text search (rg)
+"aqua:sharkdp/fd" = "latest"         # Fast file search
+"aqua:ast-grep/ast-grep" = "latest"  # AST-based code search
+"aqua:jqlang/jq" = "latest"          # JSON processing
+"aqua:mikefarah/yq" = "latest"       # YAML processing
+"cargo:tokei" = "latest"             # Code statistics
 
 [tasks.compile]
 description = "Check compilation only (~2s)"


### PR DESCRIPTION
This PR merges the following changes:

1. **#851** test(flatten): add commit integrity tests to verify branches only contain their own commits after flatten
2. **#852** fix(flatten): propagate UpdateParentRevision error instead of silently swallowing it
3. **#853** refactor(engine): add SetParentName, fix SetParentPreservingDivergence, fix pluck child reparenting, add commit integrity tests
4. **#854** fix: preserve divergence points across delete, fold, reorder, split, get, and worktree reparenting

### Stack

```
main
  └─ jonnii/20260329180010/add-commit-integrity-tests-to-verify-branches (#851)
    └─ jonnii/20260329180201/propagate-UpdateParentRevision-error-instead-of (#852)
      └─ jonnii/20260329223419/add-SetParentName-fix-SetParentPreservingDivergen (#853)
        └─ jonnii/20260330013042/preserve-divergence-points-across-delete-fold (#854)
```

Stackit-Stack-Size: 4
Stackit-PRs: 851,852,853,854
