### PR TITLE
feat(actions): show conflict marker line ranges

### DIFF
--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -16,6 +16,9 @@ package actions
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/gertd/go-pluralize"
 
@@ -595,7 +598,10 @@ func WithFlagValue(flag string, value string) SnapshotOption {
 	}
 }
 
-// PrintConflictStatus displays conflict information and instructions to the user
+// PrintConflictStatus displays conflict information and instructions to the user.
+// Assumes a rebase is in progress: HEAD-side markers reflect the parent/base and
+// the ">>>>>>>" side reflects the branch being replayed. Both call sites
+// (EnterConflictWorkflow and ContinueAction) operate during rebase.
 func PrintConflictStatus(ctx *app.Context, branchName string) error {
 	reader := ctx.Reader()
 	out := ctx.Output
@@ -607,9 +613,20 @@ func PrintConflictStatus(ctx *app.Context, branchName string) error {
 	// Get unmerged files
 	unmergedFiles, err := reader.GetUnmergedFiles(ctx.Context)
 	if err == nil && len(unmergedFiles) > 0 {
-		out.Info("%s", style.ColorYellow("Unmerged files:"))
+		out.Info("%s", style.ColorYellow("Conflicted files:"))
 		for _, file := range unmergedFiles {
-			out.Info("%s", style.ColorRed(file))
+			sections, sectionErr := conflictMarkerSectionsForFile(ctx.RepoRoot, file)
+			if sectionErr != nil || len(sections) == 0 {
+				out.Info("  %s", style.ColorRed(file))
+				continue
+			}
+			for _, section := range sections {
+				out.Info("  %s (lines %d-%d)",
+					style.ColorRed(file),
+					section.StartLine,
+					section.EndLine,
+				)
+			}
 		}
 		out.Newline()
 	}
@@ -627,11 +644,70 @@ func PrintConflictStatus(ctx *app.Context, branchName string) error {
 		out.Newline()
 	}
 
-	out.Info("%s", style.ColorYellow("To fix and continue your previous Stackit command:"))
-	out.Info("(1) resolve the listed merge conflicts")
-	out.Info("(2) mark them as resolved with %s", style.ColorCyan("stackit add ."))
-	out.Info("(3) run %s to continue executing your previous Stackit command", style.ColorCyan("stackit continue"))
-	out.Info("It's safe to cancel the ongoing rebase with %s.", style.ColorCyan("git rebase --abort"))
+	parentBranch := "the current base"
+	if branch := ctx.Engine.GetBranch(branchName); branch.GetName() != "" {
+		parentBranch = branch.GetParentOrTrunk()
+	}
+
+	out.Info("%s", style.ColorYellow("To resolve:"))
+	out.Info("  1. Open each conflicted file and remove conflict markers:")
+	out.Info("     %s  (incoming changes from %s)", style.ColorCyan("<<<<<<< HEAD"), parentBranch)
+	out.Info("     %s", style.ColorCyan("======="))
+	out.Info("     %s  (changes from %s)", style.ColorCyan(">>>>>>>"), branchName)
+	out.Info("  2. Stage resolved files: %s", style.ColorCyan("stackit add <file>"))
+	out.Info("  3. Continue the previous Stackit command: %s", style.ColorCyan("stackit continue"))
+	out.Info("  4. Abort and restore the pre-command snapshot: %s", style.ColorCyan("stackit abort"))
+	out.Info("Tip: %s stages all resolved files before continuing.", style.ColorCyan("stackit continue --all"))
 
 	return nil
+}
+
+type conflictMarkerSection struct {
+	StartLine int
+	EndLine   int
+}
+
+func conflictMarkerSectionsForFile(repoRoot, file string) ([]conflictMarkerSection, error) {
+	path := file
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(repoRoot, file)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return findConflictMarkerSections(string(content)), nil
+}
+
+// findConflictMarkerSections scans for git conflict regions delimited by
+// <<<<<<<, =======, and >>>>>>> markers. Diff3-style ||||||| ancestor markers
+// between <<<<<<< and ======= are tolerated (ignored). A new <<<<<<< before a
+// section is closed restarts tracking, so unterminated sections do not block
+// detection of subsequent complete sections.
+func findConflictMarkerSections(content string) []conflictMarkerSection {
+	lines := strings.Split(content, "\n")
+	sections := make([]conflictMarkerSection, 0)
+	startLine := 0
+	seenSeparator := false
+
+	for i, line := range lines {
+		lineNo := i + 1
+		switch {
+		case strings.HasPrefix(line, "<<<<<<<"):
+			startLine = lineNo
+			seenSeparator = false
+		case startLine > 0 && strings.HasPrefix(line, "======="):
+			seenSeparator = true
+		case startLine > 0 && seenSeparator && strings.HasPrefix(line, ">>>>>>>"):
+			sections = append(sections, conflictMarkerSection{
+				StartLine: startLine,
+				EndLine:   lineNo,
+			})
+			startLine = 0
+			seenSeparator = false
+		}
+	}
+
+	return sections
 }

--- a/internal/actions/common_test.go
+++ b/internal/actions/common_test.go
@@ -1,0 +1,152 @@
+package actions
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindConflictMarkerSections(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		content  string
+		expected []conflictMarkerSection
+	}{
+		{
+			name: "single section",
+			content: strings.Join([]string{
+				"before",
+				"<<<<<<< HEAD",
+				"base",
+				"=======",
+				"branch",
+				">>>>>>> feature",
+				"after",
+			}, "\n"),
+			expected: []conflictMarkerSection{{StartLine: 2, EndLine: 6}},
+		},
+		{
+			name: "multiple sections",
+			content: strings.Join([]string{
+				"<<<<<<< HEAD",
+				"a",
+				"=======",
+				"b",
+				">>>>>>> branch-a",
+				"middle",
+				"<<<<<<< HEAD",
+				"c",
+				"=======",
+				"d",
+				">>>>>>> branch-b",
+			}, "\n"),
+			expected: []conflictMarkerSection{
+				{StartLine: 1, EndLine: 5},
+				{StartLine: 7, EndLine: 11},
+			},
+		},
+		{
+			name: "no complete section",
+			content: strings.Join([]string{
+				"<<<<<<< HEAD",
+				"base",
+				"=======",
+				"branch",
+			}, "\n"),
+			expected: []conflictMarkerSection{},
+		},
+		{
+			name: "diff3 style with ancestor marker",
+			content: strings.Join([]string{
+				"<<<<<<< HEAD",
+				"ours",
+				"||||||| common ancestor",
+				"base",
+				"=======",
+				"theirs",
+				">>>>>>> branch",
+			}, "\n"),
+			expected: []conflictMarkerSection{{StartLine: 1, EndLine: 7}},
+		},
+		{
+			name: "unterminated section then complete section",
+			content: strings.Join([]string{
+				"<<<<<<< HEAD",
+				"unterminated",
+				"<<<<<<< HEAD",
+				"a",
+				"=======",
+				"b",
+				">>>>>>> branch",
+			}, "\n"),
+			expected: []conflictMarkerSection{{StartLine: 3, EndLine: 7}},
+		},
+		{
+			name: "separator before any start marker is ignored",
+			content: strings.Join([]string{
+				"heading",
+				"=======",
+				"more text",
+				"<<<<<<< HEAD",
+				"a",
+				"=======",
+				"b",
+				">>>>>>> branch",
+			}, "\n"),
+			expected: []conflictMarkerSection{{StartLine: 4, EndLine: 8}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expected, findConflictMarkerSections(tt.content))
+		})
+	}
+}
+
+func TestConflictMarkerSectionsForFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reads file via relative path joined to repo root", func(t *testing.T) {
+		t.Parallel()
+		repoRoot := t.TempDir()
+		rel := filepath.Join("sub", "file.txt")
+		require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, "sub"), 0o755))
+		content := strings.Join([]string{
+			"<<<<<<< HEAD",
+			"a",
+			"=======",
+			"b",
+			">>>>>>> branch",
+		}, "\n")
+		require.NoError(t, os.WriteFile(filepath.Join(repoRoot, rel), []byte(content), 0o644))
+
+		sections, err := conflictMarkerSectionsForFile(repoRoot, rel)
+		require.NoError(t, err)
+		require.Equal(t, []conflictMarkerSection{{StartLine: 1, EndLine: 5}}, sections)
+	})
+
+	t.Run("absolute path is used as-is", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		abs := filepath.Join(dir, "file.txt")
+		require.NoError(t, os.WriteFile(abs, []byte("no markers here"), 0o644))
+
+		sections, err := conflictMarkerSectionsForFile("/unrelated/root", abs)
+		require.NoError(t, err)
+		require.Empty(t, sections)
+	})
+
+	t.Run("missing file returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := conflictMarkerSectionsForFile(t.TempDir(), "does-not-exist.txt")
+		require.Error(t, err)
+	})
+}

--- a/internal/integration/conflict_test.go
+++ b/internal/integration/conflict_test.go
@@ -44,7 +44,10 @@ func TestConflictResolution(t *testing.T) {
 		sh.Checkout("branch-a").
 			RunExpectError("restack --upstack").
 			OutputContains("conflict").
-			OutputContains("branch-a")
+			OutputContains("branch-a").
+			OutputContains("Conflicted files:").
+			OutputContains("common.txt (lines 1-").
+			OutputContains("stackit continue")
 
 		// 4. Verify: restack stops at branch-a with conflict
 		sh.Log("Verifying conflict on branch-a...")
@@ -55,7 +58,10 @@ func TestConflictResolution(t *testing.T) {
 		sh.WriteFile("common.txt", "main content\nbranch a content").
 			RunExpectError("continue").
 			OutputContains("conflict").
-			OutputContains("branch-b")
+			OutputContains("branch-b").
+			OutputContains("Conflicted files:").
+			OutputContains("common.txt (lines 1-").
+			OutputContains("stackit continue")
 
 		// 6. Verify: restack continues, stops at branch-b with conflict
 		sh.Log("Verifying conflict on branch-b...")


### PR DESCRIPTION

Report conflicted files with marker line ranges and clearer stackit continue/abort guidance when restack pauses for conflicts.