### PR TITLE
feat(git): auto-continue rerere-resolved rebases

### DIFF
--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -27,24 +27,42 @@ import (
 
 var pluralizeClient = pluralize.NewClient()
 
+// FormatRerereResolved renders the standard message describing how many
+// rebase conflicts git rerere auto-resolved during an operation.
+func FormatRerereResolved(count int) string {
+	return fmt.Sprintf("Resolved %d %s using git rerere.", count, Pluralize("conflict", count))
+}
+
+func printRerereResolved(ctx *app.Context, count int) {
+	ctx.Output.Info("%s", FormatRerereResolved(count))
+}
+
 // Restacker is a minimal interface needed for restacking branches
 type Restacker interface {
 	engine.BranchReader
 	engine.SyncManager
 }
 
-// RestackProgressCallback is called for each branch during restack
-// branchName: the branch being processed
-// result: the restack result (Done, Unneeded, Conflict)
-// newRev: the new revision if restacked (empty if not applicable)
-// conflict: true if this is a conflict
-// lockReason: why the branch is locked (empty if not locked)
-// frozen: true if the branch is frozen
-// isCurrent: true if this is the current branch
-// reparented: true if the branch was reparented
-// oldParent: the old parent name if reparented
-// newParent: the new parent name if reparented
-type RestackProgressCallback func(branchName string, result engine.RestackResult, newRev string, conflict bool, lockReason engine.LockReason, frozen bool, isCurrent bool, reparented bool, oldParent, newParent string)
+// RestackProgress describes the outcome of restacking a single branch. It is
+// passed to RestackProgressCallback so callers can report progress without
+// juggling a long positional parameter list.
+type RestackProgress struct {
+	Branch              string               // the branch being processed
+	Result              engine.RestackResult // Done, Unneeded, or Conflict
+	NewRev              string               // new revision if restacked (empty otherwise)
+	RerereResolvedCount int                  // number of rebase continuations handled by git rerere
+	Conflict            bool                 // true if this is a conflict
+	LockReason          engine.LockReason    // why the branch is locked (empty if not locked)
+	Frozen              bool                 // true if the branch is frozen
+	IsCurrent           bool                 // true if this is the current branch
+	Reparented          bool                 // true if the branch was reparented
+	OldParent           string               // the old parent name if reparented
+	NewParent           string               // the new parent name if reparented
+}
+
+// RestackProgressCallback is called for each branch during restack with a
+// RestackProgress describing the outcome.
+type RestackProgressCallback func(RestackProgress)
 
 // RestackBranches restacks a list of branches using the engine's batch restack method
 func RestackBranches(ctx *app.Context, branches []engine.Branch) error {
@@ -244,7 +262,18 @@ func RestackBranchesWithHandler(ctx *app.Context, branches []engine.Branch, call
 
 			// Report via callback if provided
 			if callback != nil {
-				callback(branchName, result.Result, newRev, false, result.LockReason, result.Frozen, branchName == currentBranchName, result.Reparented, result.OldParent, result.NewParent)
+				callback(RestackProgress{
+					Branch:              branchName,
+					Result:              result.Result,
+					NewRev:              newRev,
+					RerereResolvedCount: result.RerereResolvedCount,
+					LockReason:          result.LockReason,
+					Frozen:              result.Frozen,
+					IsCurrent:           branchName == currentBranchName,
+					Reparented:          result.Reparented,
+					OldParent:           result.OldParent,
+					NewParent:           result.NewParent,
+				})
 				continue
 			}
 
@@ -264,6 +293,9 @@ func RestackBranchesWithHandler(ctx *app.Context, branches []engine.Branch, call
 				ctx.Output.Info("Restacked %s on %s.",
 					style.ColorBranchName(branchName, isCurrent),
 					style.ColorBranchName(parentName, false))
+				if result.RerereResolvedCount > 0 {
+					printRerereResolved(ctx, result.RerereResolvedCount)
+				}
 			case engine.RestackUnneeded:
 				switch {
 				case !branch.CanModify():
@@ -292,7 +324,12 @@ func RestackBranchesWithHandler(ctx *app.Context, branches []engine.Branch, call
 
 		for _, branchName := range conflictBranches {
 			if callback != nil {
-				callback(branchName, engine.RestackConflict, "", true, engine.LockReasonNone, false, branchName == currentBranchName, false, "", "")
+				callback(RestackProgress{
+					Branch:    branchName,
+					Result:    engine.RestackConflict,
+					Conflict:  true,
+					IsCurrent: branchName == currentBranchName,
+				})
 			}
 		}
 	}

--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -81,6 +81,9 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 			}
 			branchName = currentBranch.GetName()
 		}
+		if result.RerereResolvedCount > 0 {
+			printRerereResolved(ctx, result.RerereResolvedCount)
+		}
 		if err := PrintConflictStatus(ctx, branchName); err != nil {
 			return fmt.Errorf("failed to print conflict status: %w", err)
 		}
@@ -93,6 +96,9 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 	}
 
 	out.Info("Resolved rebase conflict for %s.", style.ColorBranchName(result.BranchName, true))
+	if result.RerereResolvedCount > 0 {
+		printRerereResolved(ctx, result.RerereResolvedCount)
+	}
 
 	// Continue with remaining branches to restack
 	if len(continuation.BranchesToRestack) > 0 {

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -90,7 +90,7 @@ func (h *GetNullHandler) Complete(_ GetSummary) {}
 func (h *GetNullHandler) OnRestackStart(_ int) {}
 
 // OnRestackBranch implements RestackHandler.
-func (h *GetNullHandler) OnRestackBranch(_ string, _ handlers.RestackResult, _ string, _ *int, _ engine.LockReason, _ bool, _ bool, _ string, _ bool, _, _ string) {
+func (h *GetNullHandler) OnRestackBranch(_ string, _ handlers.RestackResult, _ string, _ *int, _ engine.LockReason, _ bool, _ bool, _ string, _ bool, _, _ string, _ int) {
 }
 
 // OnRestackComplete implements RestackHandler.
@@ -363,29 +363,29 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 			// Use RestackHandler for consistent output
 			handler.OnRestackStart(len(sorted))
 
-			if err := RestackBranchesWithHandler(ctx, sorted, func(branchName string, result engine.RestackResult, newRev string, _ bool, lockReason engine.LockReason, frozen bool, isCurrent bool, reparented bool, oldParent, newParent string) {
-				prNumber := getPRNumber(eng, branchName)
+			if err := RestackBranchesWithHandler(ctx, sorted, func(p RestackProgress) {
+				prNumber := getPRNumber(eng, p.Branch)
 
 				parentName := ""
-				br := eng.GetBranch(branchName)
+				br := eng.GetBranch(p.Branch)
 				if br.GetName() != "" {
-					if p := br.GetParent(); p != nil {
-						parentName = p.GetName()
+					if parent := br.GetParent(); parent != nil {
+						parentName = parent.GetName()
 					} else {
 						parentName = eng.Trunk().GetName()
 					}
 				}
 
-				switch result {
+				switch p.Result {
 				case engine.RestackDone:
 					restacked++
-					handler.OnRestackBranch(branchName, handlers.RestackDone, newRev, prNumber, lockReason, frozen, isCurrent, parentName, reparented, oldParent, newParent)
+					handler.OnRestackBranch(p.Branch, handlers.RestackDone, p.NewRev, prNumber, p.LockReason, p.Frozen, p.IsCurrent, parentName, p.Reparented, p.OldParent, p.NewParent, p.RerereResolvedCount)
 				case engine.RestackUnneeded:
-					handler.OnRestackBranch(branchName, handlers.RestackUnneeded, "", prNumber, lockReason, frozen, isCurrent, parentName, reparented, oldParent, newParent)
+					handler.OnRestackBranch(p.Branch, handlers.RestackUnneeded, "", prNumber, p.LockReason, p.Frozen, p.IsCurrent, parentName, p.Reparented, p.OldParent, p.NewParent, p.RerereResolvedCount)
 				case engine.RestackConflict:
 					skipped++
-					conflicts = append(conflicts, branchName)
-					handler.OnRestackBranch(branchName, handlers.RestackConflict, "", prNumber, lockReason, frozen, isCurrent, parentName, reparented, oldParent, newParent)
+					conflicts = append(conflicts, p.Branch)
+					handler.OnRestackBranch(p.Branch, handlers.RestackConflict, "", prNumber, p.LockReason, p.Frozen, p.IsCurrent, parentName, p.Reparented, p.OldParent, p.NewParent, p.RerereResolvedCount)
 				}
 			}, true); err != nil {
 				handler.OnRestackComplete(restacked, skipped, conflicts)

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -6,6 +6,8 @@ import (
 	"stackit.dev/stackit/internal/app"
 	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/internal/handlers"
+	"stackit.dev/stackit/internal/rerere"
+	"stackit.dev/stackit/internal/tui"
 )
 
 // RestackOptions contains options for the restack command
@@ -45,6 +47,15 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 		handler = &handlers.NullRestackHandler{}
 	}
 
+	interactiveRererePrompt := ctx.Interactive && !ctx.Quiet && tui.IsTTY()
+	if _, jsonOutput := handler.(*handlers.JSONRestackHandler); jsonOutput {
+		interactiveRererePrompt = false
+	}
+	pauser, _ := handler.(rerere.Pauser)
+	if _, err := rerere.EnsureEnabled(ctx.Context, ctx.Git(), interactiveRererePrompt, pauser); err != nil {
+		out.Warn("Failed to enable git rerere: %v", err)
+	}
+
 	// For standalone restack, we need to sort branches topologically for correct restack order
 	sortedBranches := eng.SortBranchesTopologically(branches)
 
@@ -54,9 +65,9 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 	var restacked, skipped int
 	var conflicts []string
 
-	if err := RestackBranchesWithHandler(ctx, sortedBranches, func(branchName string, result engine.RestackResult, newRev string, _ bool, lockReason engine.LockReason, frozen bool, isCurrent bool, reparented bool, oldParent, newParent string) {
+	if err := RestackBranchesWithHandler(ctx, sortedBranches, func(p RestackProgress) {
 		res := handlers.RestackDone
-		switch result {
+		switch p.Result {
 		case engine.RestackDone:
 			restacked++
 			res = handlers.RestackDone
@@ -64,16 +75,16 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 			res = handlers.RestackUnneeded
 		case engine.RestackConflict:
 			skipped++
-			conflicts = append(conflicts, branchName)
+			conflicts = append(conflicts, p.Branch)
 			res = handlers.RestackConflict
 		}
 
 		// Determine parent name for consistent output
 		parentName := ""
-		br := eng.GetBranch(branchName)
+		br := eng.GetBranch(p.Branch)
 		if br.GetName() != "" {
-			if p := br.GetParent(); p != nil {
-				parentName = p.GetName()
+			if parent := br.GetParent(); parent != nil {
+				parentName = parent.GetName()
 			} else {
 				parentName = eng.Trunk().GetName()
 			}
@@ -88,7 +99,7 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 			}
 		}
 
-		handler.OnRestackBranch(branchName, res, newRev, prNumber, lockReason, frozen, isCurrent, parentName, reparented, oldParent, newParent)
+		handler.OnRestackBranch(p.Branch, res, p.NewRev, prNumber, p.LockReason, p.Frozen, p.IsCurrent, parentName, p.Reparented, p.OldParent, p.NewParent, p.RerereResolvedCount)
 	}, true); err != nil {
 		handler.OnRestackComplete(restacked, skipped, conflicts)
 		return fmt.Errorf("restack failed: %w", err)

--- a/internal/actions/sync/restack.go
+++ b/internal/actions/sync/restack.go
@@ -69,56 +69,57 @@ func restackBranches(ctx *app.Context, branchesToRestack []string, restackScope 
 	// Restack branches with handler for progress
 	if len(sortedBranches) > 0 {
 		restackStart := time.Now()
-		if err := actions.RestackBranchesWithHandler(ctx, sortedBranches, func(branchName string, result engine.RestackResult, newRev string, _ bool, lockReason engine.LockReason, frozen bool, isCurrent bool, _ bool, _, _ string) {
-			prNumber := getPRNumber(ctx.Status(), branchName)
+		if err := actions.RestackBranchesWithHandler(ctx, sortedBranches, func(p actions.RestackProgress) {
+			prNumber := getPRNumber(ctx.Status(), p.Branch)
 
 			parentName := ""
-			br := nav.GetBranch(branchName)
+			br := nav.GetBranch(p.Branch)
 			if br.GetName() != "" {
-				if p := br.GetParent(); p != nil {
-					parentName = p.GetName()
+				if parent := br.GetParent(); parent != nil {
+					parentName = parent.GetName()
 				} else {
 					parentName = ctx.Engine.Trunk().GetName()
 				}
 			}
 
-			switch result {
+			switch p.Result {
 			case engine.RestackDone:
 				summary.BranchesRestacked++
 				handler.EmitEvent(Event{
-					Phase:       PhaseRestack,
-					Type:        EventCompleted,
-					Branch:      branchName,
-					PRNumber:    prNumber,
-					NewRevision: newRev,
-					LockReason:  lockReason,
-					Frozen:      frozen,
-					IsCurrent:   isCurrent,
-					Parent:      parentName,
+					Phase:               PhaseRestack,
+					Type:                EventCompleted,
+					Branch:              p.Branch,
+					PRNumber:            prNumber,
+					NewRevision:         p.NewRev,
+					LockReason:          p.LockReason,
+					Frozen:              p.Frozen,
+					IsCurrent:           p.IsCurrent,
+					Parent:              parentName,
+					RerereResolvedCount: p.RerereResolvedCount,
 				})
 			case engine.RestackUnneeded:
 				handler.EmitEvent(Event{
 					Phase:      PhaseRestack,
 					Type:       EventCompleted,
-					Branch:     branchName,
+					Branch:     p.Branch,
 					PRNumber:   prNumber,
-					LockReason: lockReason,
-					Frozen:     frozen,
-					IsCurrent:  isCurrent,
+					LockReason: p.LockReason,
+					Frozen:     p.Frozen,
+					IsCurrent:  p.IsCurrent,
 					Parent:     parentName,
 				})
 			case engine.RestackConflict:
 				summary.BranchesSkipped++
-				summary.ConflictBranches = append(summary.ConflictBranches, branchName)
+				summary.ConflictBranches = append(summary.ConflictBranches, p.Branch)
 				handler.EmitEvent(Event{
 					Phase:      PhaseRestack,
 					Type:       EventSkipped,
-					Branch:     branchName,
+					Branch:     p.Branch,
 					PRNumber:   prNumber,
 					Conflict:   true,
-					LockReason: lockReason,
-					Frozen:     frozen,
-					IsCurrent:  isCurrent,
+					LockReason: p.LockReason,
+					Frozen:     p.Frozen,
+					IsCurrent:  p.IsCurrent,
 					Parent:     parentName,
 				})
 			}

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -11,6 +11,7 @@ import (
 	"stackit.dev/stackit/internal/app"
 	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/internal/handlers"
+	"stackit.dev/stackit/internal/rerere"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -244,6 +245,11 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return nil
 	}
 
+	pauser, _ := handler.(rerere.Pauser)
+	if _, err := rerere.EnsureEnabled(gctx, ctx.Git(), ctx.Interactive && !ctx.Quiet && handler.IsInteractive(), pauser); err != nil {
+		out.Warn("Failed to enable git rerere: %v", err)
+	}
+
 	handler.EmitEvent(Event{Phase: PhaseRestack, Type: EventStarted})
 
 	if err := restackBranches(ctx, branchesToRestack, opts.RestackScope, expandScope, dirtyAnchors, handler, summary); err != nil {
@@ -318,19 +324,20 @@ const (
 
 // Event represents a progress update during sync
 type Event struct {
-	Phase       Phase             // Current phase
-	Type        EventType         // Event type
-	Branch      string            // Branch name (if applicable)
-	PRNumber    *int              // PR number (if applicable)
-	Message     string            // Human-readable description
-	OldRevision string            // For position changes
-	NewRevision string            // For position changes
-	Conflict    bool              // Is this a conflict?
-	LockReason  engine.LockReason // Why the branch is locked (empty if not locked)
-	Frozen      bool              // Is the branch frozen?
-	IsCurrent   bool              // Is this the current branch?
-	Parent      string            // Parent branch name (if applicable)
-	Error       error             // If non-nil, this step had an error
+	Phase               Phase             // Current phase
+	Type                EventType         // Event type
+	Branch              string            // Branch name (if applicable)
+	PRNumber            *int              // PR number (if applicable)
+	Message             string            // Human-readable description
+	OldRevision         string            // For position changes
+	NewRevision         string            // For position changes
+	Conflict            bool              // Is this a conflict?
+	LockReason          engine.LockReason // Why the branch is locked (empty if not locked)
+	Frozen              bool              // Is the branch frozen?
+	IsCurrent           bool              // Is this the current branch?
+	Parent              string            // Parent branch name (if applicable)
+	RerereResolvedCount int               // Number of rebase continuations handled by git rerere
+	Error               error             // If non-nil, this step had an error
 }
 
 // IsLocked returns true if the event associated branch is locked
@@ -424,7 +431,7 @@ func (h *NullHandler) Complete(Summary) {}
 func (h *NullHandler) OnRestackStart(int) {}
 
 // OnRestackBranch implements RestackHandler.
-func (h *NullHandler) OnRestackBranch(string, RestackResult, string, *int, engine.LockReason, bool, bool, string, bool, string, string) {
+func (h *NullHandler) OnRestackBranch(string, RestackResult, string, *int, engine.LockReason, bool, bool, string, bool, string, string, int) {
 }
 
 // OnRestackComplete implements RestackHandler.

--- a/internal/actions/sync/sync_test.go
+++ b/internal/actions/sync/sync_test.go
@@ -215,12 +215,12 @@ type runtimeConflictRunner struct {
 	injected         bool
 }
 
-func (r *runtimeConflictRunner) Rebase(ctx context.Context, branchName, upstream, oldUpstream string) (git.RebaseResult, error) {
+func (r *runtimeConflictRunner) Rebase(ctx context.Context, branchName, upstream, oldUpstream string) (git.RebaseOutcome, error) {
 	if branchName == r.conflictBranch && !r.injected {
 		r.injected = true
 		r.rebaseInProgress = true
 		_ = r.CheckoutDetached(ctx, branchName)
-		return git.RebaseConflict, nil
+		return git.RebaseOutcome{Result: git.RebaseConflict}, nil
 	}
 	return r.Runner.Rebase(ctx, branchName, upstream, oldUpstream)
 }

--- a/internal/cli/branch/get_handlers.go
+++ b/internal/cli/branch/get_handlers.go
@@ -169,7 +169,7 @@ func (h *SimpleGetHandler) OnRestackStart(_ int) {
 }
 
 // OnRestackBranch implements RestackHandler for restack phase
-func (h *SimpleGetHandler) OnRestackBranch(branch string, result handlers.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, reparented bool, oldParent, newParent string) {
+func (h *SimpleGetHandler) OnRestackBranch(branch string, result handlers.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, reparented bool, oldParent, newParent string, rerereResolvedCount int) {
 	h.Lock()
 	defer h.Unlock()
 
@@ -190,6 +190,9 @@ func (h *SimpleGetHandler) OnRestackBranch(branch string, result handlers.Restac
 		}
 		msg += fmt.Sprintf(" -> %s", style.ColorDim(newRev))
 		h.Output.Info("  %s", msg)
+		if rerereResolvedCount > 0 {
+			h.Output.Info("%s", actions.FormatRerereResolved(rerereResolvedCount))
+		}
 	case handlers.RestackUnneeded:
 		reason := common.ReasonNoRestackNeeded
 		if lockReason.IsLocked() {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -12,6 +12,7 @@ import (
 	"stackit.dev/stackit/internal/config"
 	"stackit.dev/stackit/internal/git"
 	"stackit.dev/stackit/internal/output"
+	"stackit.dev/stackit/internal/rerere"
 	"stackit.dev/stackit/internal/tui"
 	"stackit.dev/stackit/internal/tui/style"
 )
@@ -79,6 +80,12 @@ func (h *cliInitHandler) OnSuccess(trunkName string, wasInitialized bool, isRese
 	splog.Info("  - undo.depth:     %s", style.ColorDim("10"))
 	splog.Newline()
 	splog.Info("Run '%s' to change these settings.", style.ColorCyan("stackit config"))
+
+	if !h.noInteractive && tui.IsTTY() {
+		if _, err := rerere.EnsureEnabled(context.Background(), h.runner, true, nil); err != nil {
+			splog.Warn("Failed to enable git rerere: %v", err)
+		}
+	}
 
 	// Offer interactive integration installation
 	if !h.noInteractive && tui.IsTTY() {
@@ -196,9 +203,11 @@ func newInitCmd(version string) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to get repo root: %w", err)
 			}
+			interactive, _ := cmd.Flags().GetBool("interactive")
+			quiet, _ := cmd.Flags().GetBool("quiet")
 
 			handler := &cliInitHandler{
-				noInteractive: noInteractive,
+				noInteractive: noInteractive || !interactive || quiet,
 				writer:        cmd.OutOrStdout(),
 				version:       version,
 				runner:        runner,

--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	stdsync "sync"
 
+	"stackit.dev/stackit/internal/actions"
 	syncAction "stackit.dev/stackit/internal/actions/sync"
 	"stackit.dev/stackit/internal/cli/common"
 	"stackit.dev/stackit/internal/engine"
@@ -242,6 +243,9 @@ func (h *SimpleSyncHandler) printRestackEvent(event syncAction.Event) {
 			}
 			msg += fmt.Sprintf(" -> %s", style.ColorDim(event.NewRevision))
 			h.Output.Info("  %s", msg)
+			if event.RerereResolvedCount > 0 {
+				h.Output.Info("%s", actions.FormatRerereResolved(event.RerereResolvedCount))
+			}
 		} else {
 			reason := common.ReasonNoRestackNeeded
 			if event.IsLocked() {
@@ -291,7 +295,7 @@ func (h *SimpleSyncHandler) OnRestackStart(_ int) {
 }
 
 // OnRestackBranch implements RestackHandler for standalone restack operations
-func (h *SimpleSyncHandler) OnRestackBranch(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, reparented bool, oldParent, newParent string) {
+func (h *SimpleSyncHandler) OnRestackBranch(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, reparented bool, oldParent, newParent string, rerereResolvedCount int) {
 	// Log reparenting info if applicable
 	if reparented {
 		h.Output.Info("Reparented %s from %s to %s (parent was merged/deleted).",
@@ -302,14 +306,15 @@ func (h *SimpleSyncHandler) OnRestackBranch(branch string, result syncAction.Res
 
 	// Convert to Event and use existing printRestackEvent
 	event := syncAction.Event{
-		Phase:       syncAction.PhaseRestack,
-		Branch:      branch,
-		PRNumber:    prNumber,
-		NewRevision: newRev,
-		LockReason:  lockReason,
-		Frozen:      frozen,
-		IsCurrent:   isCurrent,
-		Parent:      parent,
+		Phase:               syncAction.PhaseRestack,
+		Branch:              branch,
+		PRNumber:            prNumber,
+		NewRevision:         newRev,
+		LockReason:          lockReason,
+		Frozen:              frozen,
+		IsCurrent:           isCurrent,
+		Parent:              parent,
+		RerereResolvedCount: rerereResolvedCount,
 	}
 
 	switch result {
@@ -565,12 +570,12 @@ func (h *InteractiveSyncHandler) OnRestackStart(branchCount int) {
 }
 
 // OnRestackBranch implements RestackHandler for standalone restack operations
-func (h *InteractiveSyncHandler) OnRestackBranch(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, reparented bool, oldParent, newParent string) {
+func (h *InteractiveSyncHandler) OnRestackBranch(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, reparented bool, oldParent, newParent string, rerereResolvedCount int) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	// Build detail message
-	detail := h.formatRestackDetail(branch, result, newRev, prNumber, lockReason, frozen, isCurrent, parent)
+	detail := h.formatRestackDetail(branch, result, newRev, prNumber, lockReason, frozen, isCurrent, parent, rerereResolvedCount)
 	if detail != "" {
 		if reparented {
 			detail = fmt.Sprintf("Reparented %s -> %s. %s", oldParent, newParent, detail)
@@ -590,7 +595,7 @@ func (h *InteractiveSyncHandler) OnRestackBranch(branch string, result syncActio
 }
 
 // formatRestackDetail formats a restack event into a detail string
-func (h *InteractiveSyncHandler) formatRestackDetail(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string) string {
+func (h *InteractiveSyncHandler) formatRestackDetail(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, rerereResolvedCount int) string {
 	prInfo := ""
 	if prNumber != nil {
 		prInfo = fmt.Sprintf(" (PR #%d)", *prNumber)
@@ -605,6 +610,9 @@ func (h *InteractiveSyncHandler) formatRestackDetail(branch string, result syncA
 			msg += fmt.Sprintf(" on %s", parent)
 		}
 		msg += fmt.Sprintf(" -> %s", newRev)
+		if rerereResolvedCount > 0 {
+			msg += " " + actions.FormatRerereResolved(rerereResolvedCount)
+		}
 		return msg
 	case syncAction.RestackUnneeded:
 		reason := common.ReasonNoRestackNeeded
@@ -641,6 +649,13 @@ func (h *InteractiveSyncHandler) Cleanup() {}
 
 // IsInteractive implements Handler. Returns true for TTY handler.
 func (h *InteractiveSyncHandler) IsInteractive() bool { return true }
+
+// Pause releases the terminal so external prompts can run without contending
+// with the active Bubble Tea program. Implements rerere.Pauser.
+func (h *InteractiveSyncHandler) Pause() { h.runner.Pause() }
+
+// Resume restores the TUI after Pause. Implements rerere.Pauser.
+func (h *InteractiveSyncHandler) Resume() { h.runner.Resume() }
 
 // PromptMetadataConflict implements Handler. Pauses TUI, displays conflict, prompts user.
 func (h *InteractiveSyncHandler) PromptMetadataConflict(diff *engine.MetadataDiff) (bool, error) {

--- a/internal/cli/stack/sync_handlers_test.go
+++ b/internal/cli/stack/sync_handlers_test.go
@@ -155,6 +155,7 @@ func TestInteractiveSyncHandler_OnRestackBranch(t *testing.T) {
 		"main",
 		false, // reparented
 		"", "",
+		0,
 	)
 
 	// Should send PhaseDetailMsg and ProgressTickMsg

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -212,12 +212,12 @@ func (d *demoGitRunner) PushBranch(_ context.Context, _, _ string, _ git.PushOpt
 	return nil
 }
 
-func (d *demoGitRunner) Rebase(_ context.Context, _, _, _ string) (git.RebaseResult, error) {
-	return git.RebaseDone, nil
+func (d *demoGitRunner) Rebase(_ context.Context, _, _, _ string) (git.RebaseOutcome, error) {
+	return git.RebaseOutcome{Result: git.RebaseDone}, nil
 }
 
-func (d *demoGitRunner) RebaseContinue(_ context.Context) (git.RebaseResult, error) {
-	return git.RebaseDone, nil
+func (d *demoGitRunner) RebaseContinue(_ context.Context) (git.RebaseOutcome, error) {
+	return git.RebaseOutcome{Result: git.RebaseDone}, nil
 }
 
 func (d *demoGitRunner) RebaseAbort(_ context.Context) error {
@@ -501,8 +501,8 @@ func (d *demoGitRunner) CommitAmendNoEdit(_ context.Context) error {
 	return nil
 }
 
-func (d *demoGitRunner) RebaseContinueNoEdit(_ context.Context) (git.RebaseResult, error) {
-	return git.RebaseDone, nil
+func (d *demoGitRunner) RebaseContinueNoEdit(_ context.Context) (git.RebaseOutcome, error) {
+	return git.RebaseOutcome{Result: git.RebaseDone}, nil
 }
 
 func (d *demoGitRunner) StagePatch(_ context.Context) error {

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -384,21 +384,23 @@ func (e *engineImpl) restackBranch(
 	gitResult, err := e.git.Rebase(ctx, branchName, parent, oldParentRev)
 	if err != nil {
 		return RestackBranchResult{
-			Result:            RestackConflict,
-			RebasedBranchBase: parentRev,
-			Reparented:        reparented,
-			OldParent:         oldParent,
-			NewParent:         parent,
+			Result:              RestackConflict,
+			RebasedBranchBase:   parentRev,
+			Reparented:          reparented,
+			OldParent:           oldParent,
+			NewParent:           parent,
+			RerereResolvedCount: gitResult.RerereResolvedCount,
 		}, fmt.Errorf("rebase failed for %s onto %s (old base %s): %w", branchName, parent, oldParentRev, err)
 	}
 
-	if gitResult == git.RebaseConflict {
+	if gitResult.Result == git.RebaseConflict {
 		return RestackBranchResult{
-			Result:            RestackConflict,
-			RebasedBranchBase: parentRev,
-			Reparented:        reparented,
-			OldParent:         oldParent,
-			NewParent:         parent,
+			Result:              RestackConflict,
+			RebasedBranchBase:   parentRev,
+			Reparented:          reparented,
+			OldParent:           oldParent,
+			NewParent:           parent,
+			RerereResolvedCount: gitResult.RerereResolvedCount,
 		}, nil
 	}
 
@@ -483,11 +485,12 @@ func (e *engineImpl) restackBranch(
 	}
 
 	return RestackBranchResult{
-		Result:            RestackDone,
-		RebasedBranchBase: parentRev,
-		Reparented:        reparented,
-		OldParent:         oldParent,
-		NewParent:         parent,
+		Result:              RestackDone,
+		RebasedBranchBase:   parentRev,
+		Reparented:          reparented,
+		OldParent:           oldParent,
+		NewParent:           parent,
+		RerereResolvedCount: gitResult.RerereResolvedCount,
 	}, nil
 }
 
@@ -623,11 +626,11 @@ func (e *engineImpl) ContinueRebase(ctx context.Context, branchName string, reba
 	// Call git rebase --continue
 	result, err := e.git.RebaseContinue(ctx)
 	if err != nil {
-		return ContinueRebaseResult{Result: int(git.RebaseConflict), BranchName: branchName}, err
+		return ContinueRebaseResult{Result: int(git.RebaseConflict), BranchName: branchName, RerereResolvedCount: result.RerereResolvedCount}, err
 	}
 
-	if result == git.RebaseConflict {
-		return ContinueRebaseResult{Result: int(git.RebaseConflict), BranchName: branchName}, nil
+	if result.Result == git.RebaseConflict {
+		return ContinueRebaseResult{Result: int(git.RebaseConflict), BranchName: branchName, RerereResolvedCount: result.RerereResolvedCount}, nil
 	}
 
 	// Get the new rebased SHA
@@ -655,8 +658,9 @@ func (e *engineImpl) ContinueRebase(ctx context.Context, branchName string, reba
 	}
 
 	return ContinueRebaseResult{
-		Result:     int(git.RebaseDone),
-		BranchName: branchName,
+		Result:              int(git.RebaseDone),
+		BranchName:          branchName,
+		RerereResolvedCount: result.RerereResolvedCount,
 	}, nil
 }
 
@@ -667,7 +671,7 @@ func (e *engineImpl) Rebase(ctx context.Context, branchName, upstream, oldUpstre
 		return RestackConflict, err
 	}
 
-	if gitResult == git.RebaseConflict {
+	if gitResult.Result == git.RebaseConflict {
 		return RestackConflict, nil
 	}
 

--- a/internal/engine/rebase_validator.go
+++ b/internal/engine/rebase_validator.go
@@ -75,7 +75,9 @@ func (e *engineImpl) ValidateRebases(ctx context.Context, specs []RebaseSpec) (*
 // dryRunRebase performs a rebase without updating branch refs.
 // This allows testing if a rebase would succeed without modifying the repository.
 // Returns the rebase result, the new SHA (if successful), conflicting files (if any), and any error.
-func dryRunRebase(ctx context.Context, g git.Runner, branchName, upstream, oldUpstream string) (git.RebaseResult, string, []string, error) {
+func dryRunRebase(ctx context.Context, g git.Runner, branchName, upstream, oldUpstream string) (git.RebaseOutcome, string, []string, error) {
+	outcome := git.RebaseOutcome{Result: git.RebaseDone}
+
 	// Perform rebase in detached HEAD mode using branchName~0.
 	// The ~0 suffix resolves to the same commit as branchName but tells git to check out
 	// the commit directly (detached HEAD) rather than the branch ref. This means the rebase
@@ -84,25 +86,28 @@ func dryRunRebase(ctx context.Context, g git.Runner, branchName, upstream, oldUp
 	_, err := g.RunGitCommandWithContext(ctx, "rebase", "--onto", upstream, oldUpstream, branchName+"~0")
 	if err != nil {
 		if g.IsRebaseInProgress(ctx) {
-			// Get conflicting files before aborting
-			conflictFiles, _ := g.GetUnmergedFiles(ctx)
-			return git.RebaseConflict, "", conflictFiles, nil
+			autoOutcome, conflictFiles, autoErr := git.AutoContinueRerereRebase(ctx, g, err)
+			if autoErr != nil || autoOutcome.Result == git.RebaseConflict {
+				return autoOutcome, "", conflictFiles, autoErr
+			}
+			outcome = autoOutcome
+		} else {
+			// Abort rebase if it failed for other reasons
+			_, _ = g.RunGitCommandWithContext(ctx, "rebase", "--abort")
+			return git.RebaseOutcome{Result: git.RebaseConflict}, "", nil, err
 		}
-		// Abort rebase if it failed for other reasons
-		_, _ = g.RunGitCommandWithContext(ctx, "rebase", "--abort")
-		return git.RebaseConflict, "", nil, err
 	}
 
 	// Get the resulting SHA from the detached HEAD
 	newSHA, err := g.GetCurrentRevision(ctx)
 	if err != nil {
-		return git.RebaseConflict, "", nil, fmt.Errorf("failed to get revision after rebase: %w", err)
+		return git.RebaseOutcome{Result: git.RebaseConflict, RerereResolvedCount: outcome.RerereResolvedCount}, "", nil, fmt.Errorf("failed to get revision after rebase: %w", err)
 	}
 
 	// DO NOT update the branch ref - this is the key difference from normal Rebase
 	// The branch ref stays unchanged, keeping the main repo unmodified
 
-	return git.RebaseDone, newSHA, nil, nil
+	return outcome, newSHA, nil, nil
 }
 
 // validationLevel represents a group of specs that can be validated in parallel
@@ -368,7 +373,7 @@ func (e *engineImpl) validateSingleSpec(
 
 	// Perform dry-run rebase
 	rebaseResult, newSHA, conflictFiles, err := dryRunRebase(ctx, wtGit, spec.Branch, newParent, spec.OldUpstream)
-	if err != nil || rebaseResult == git.RebaseConflict {
+	if err != nil || rebaseResult.Result == git.RebaseConflict {
 		// Build helpful error message with branch name
 		errorMsg := fmt.Sprintf("conflict rebasing %s onto %s", spec.Branch, spec.NewParent)
 		errorType := ValidationErrorConflict

--- a/internal/engine/rebase_validator_test.go
+++ b/internal/engine/rebase_validator_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/git"
 	"stackit.dev/stackit/testhelpers"
 	"stackit.dev/stackit/testhelpers/scenario"
 )
@@ -345,6 +346,94 @@ func TestValidateRebases(t *testing.T) {
 		require.True(t, result.Success)
 		require.Equal(t, engine.ValidationErrorNone, result.ErrorType, "should set ValidationErrorNone for successful validation")
 	})
+}
+
+func TestValidateRebasesUsesRerereResolvedConflicts(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	g := s.Engine.Git()
+	require.NoError(t, g.SetConfig("rerere.enabled", "true"))
+	require.NoError(t, g.SetConfig("rerere.autoupdate", "true"))
+
+	s.Checkout("main").
+		CommitChange("conflicting-file.txt", "original version")
+
+	oldBase, err := s.Engine.GetRevision(s.Engine.Trunk())
+	require.NoError(t, err)
+
+	s.CreateBranch("branch1").
+		CommitChange("conflicting-file.txt", "branch version")
+
+	s.Checkout("main").
+		CommitChange("conflicting-file.txt", "main version")
+
+	result, err := g.Rebase(context.Background(), "branch1", "main", oldBase)
+	require.NoError(t, err)
+	require.Equal(t, git.RebaseConflict, result.Result)
+	require.True(t, g.IsRebaseInProgress(context.Background()))
+
+	require.NoError(t, s.Scene.Repo.ResolveMergeConflicts())
+	require.NoError(t, s.Scene.Repo.MarkMergeConflictsAsResolved())
+	result, err = g.RebaseContinue(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, git.RebaseDone, result.Result)
+
+	require.NoError(t, s.Scene.Repo.CheckoutBranch("main"))
+	require.NoError(t, s.Scene.Repo.RunGitCommand("checkout", "-b", "branch2", oldBase))
+	require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("branch version", "conflicting-file.txt"))
+
+	validation, err := s.Engine.ValidateRebases(context.Background(), []engine.RebaseSpec{
+		{
+			Branch:      "branch2",
+			NewParent:   "main",
+			OldUpstream: oldBase,
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, validation.Success)
+	require.NotEmpty(t, validation.NewSHAs["branch2"])
+}
+
+func TestRestackBranchesPropagatesRerereResolvedCount(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	g := s.Engine.Git()
+	require.NoError(t, g.SetConfig("rerere.enabled", "true"))
+	require.NoError(t, g.SetConfig("rerere.autoupdate", "true"))
+
+	s.Checkout("main").
+		CommitChange("conflicting-file.txt", "original version")
+
+	oldBase, err := s.Engine.GetRevision(s.Engine.Trunk())
+	require.NoError(t, err)
+
+	s.CreateBranch("branch2").
+		CommitChange("conflicting-file.txt", "branch version").
+		TrackBranch("branch2", "main")
+
+	s.Checkout("main").
+		CommitChange("conflicting-file.txt", "main version")
+
+	// Record a rerere resolution for this exact conflict using a throwaway
+	// branch created off oldBase with the same content as branch2.
+	require.NoError(t, s.Scene.Repo.RunGitCommand("checkout", "-b", "branch1", oldBase))
+	require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("branch version", "conflicting-file.txt"))
+	rebaseResult, err := g.Rebase(context.Background(), "branch1", "main", oldBase)
+	require.NoError(t, err)
+	require.Equal(t, git.RebaseConflict, rebaseResult.Result)
+	require.NoError(t, s.Scene.Repo.ResolveMergeConflicts())
+	require.NoError(t, s.Scene.Repo.MarkMergeConflictsAsResolved())
+	rebaseResult, err = g.RebaseContinue(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, git.RebaseDone, rebaseResult.Result)
+
+	// Now restack branch2 through the engine. The same conflict should be
+	// auto-resolved by rerere and the count should propagate through
+	// RestackBranchResult.
+	branch2 := s.Engine.GetBranch("branch2")
+	require.NotNil(t, branch2)
+	batchResult, err := s.Engine.RestackBranches(context.Background(), []engine.Branch{branch2})
+	require.NoError(t, err)
+	require.Equal(t, engine.RestackDone, batchResult.Results["branch2"].Result)
+	require.Greater(t, batchResult.Results["branch2"].RerereResolvedCount, 0)
 }
 
 func TestValidateRebasesParallel(t *testing.T) {

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -765,13 +765,14 @@ const (
 
 // RestackBranchResult represents the result of restacking a branch, including the rebased branch base
 type RestackBranchResult struct {
-	Result            RestackResult
-	RebasedBranchBase string     // The new parent revision after successful rebase (only set if Result is RestackDone or RestackConflict)
-	Reparented        bool       // True if the branch was reparented due to merged/deleted parent
-	OldParent         string     // The old parent branch name (only set if Reparented is true)
-	NewParent         string     // The new parent branch name (only set if Reparented is true)
-	LockReason        LockReason // Reason why the branch is locked
-	Frozen            bool       // True if the branch is frozen
+	Result              RestackResult
+	RebasedBranchBase   string     // The new parent revision after successful rebase (only set if Result is RestackDone or RestackConflict)
+	Reparented          bool       // True if the branch was reparented due to merged/deleted parent
+	OldParent           string     // The old parent branch name (only set if Reparented is true)
+	NewParent           string     // The new parent branch name (only set if Reparented is true)
+	LockReason          LockReason // Reason why the branch is locked
+	Frozen              bool       // True if the branch is frozen
+	RerereResolvedCount int        // Number of rebase continuations handled by git rerere
 }
 
 // IsLocked returns true if the branch is locked
@@ -789,8 +790,9 @@ type RestackBatchResult struct {
 
 // ContinueRebaseResult represents the result of continuing a rebase
 type ContinueRebaseResult struct {
-	Result     int    // git.RebaseResult value (0 = RebaseDone, 1 = RebaseConflict)
-	BranchName string // Only set if Result is RebaseDone
+	Result              int    // git.RebaseResult value (0 = RebaseDone, 1 = RebaseConflict)
+	BranchName          string // Only set if Result is RebaseDone
+	RerereResolvedCount int    // Number of rebase continuations handled by git rerere
 }
 
 // PRSubmissionStatus represents the submission status of a branch

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -134,9 +134,9 @@ type CommitWriter interface {
 
 // RebaseOperations handles rebase operations.
 type RebaseOperations interface {
-	Rebase(ctx context.Context, branchName, upstream, oldUpstream string) (RebaseResult, error)
-	RebaseContinue(ctx context.Context) (RebaseResult, error)
-	RebaseContinueNoEdit(ctx context.Context) (RebaseResult, error)
+	Rebase(ctx context.Context, branchName, upstream, oldUpstream string) (RebaseOutcome, error)
+	RebaseContinue(ctx context.Context) (RebaseOutcome, error)
+	RebaseContinueNoEdit(ctx context.Context) (RebaseOutcome, error)
 	RebaseAbort(ctx context.Context) error
 	InteractiveRebase(ctx context.Context, onto string) error
 	IsRebaseInProgress(ctx context.Context) bool

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -18,19 +18,33 @@ const (
 	RebaseConflict
 )
 
-func (r *runner) Rebase(ctx context.Context, branchName, upstream, oldUpstream string) (RebaseResult, error) {
+// RebaseOutcome represents the result of a rebase operation, including any
+// conflicts that git rerere resolved automatically.
+type RebaseOutcome struct {
+	Result              RebaseResult
+	RerereResolvedCount int
+}
+
+func (r *runner) Rebase(ctx context.Context, branchName, upstream, oldUpstream string) (RebaseOutcome, error) {
+	outcome := RebaseOutcome{Result: RebaseDone}
+
 	// Use detached HEAD to avoid "already used by worktree" errors
 	// We use branchName~0 to force a detached checkout of the branch tip
 	_, err := r.RunGitCommandWithContext(ctx, "rebase", "--onto", upstream, oldUpstream, branchName+"~0")
 	if err != nil {
 		r.revisionCache.InvalidateAll()
 		if r.IsRebaseInProgress(ctx) {
-			return RebaseConflict, nil
-		}
-		// Abort rebase if it failed for other reasons
-		_, _ = r.RunGitCommandWithContext(ctx, "rebase", "--abort")
+			autoOutcome, autoErr := r.continueRerereResolvedRebase(ctx, err)
+			if autoErr != nil || autoOutcome.Result == RebaseConflict {
+				return autoOutcome, autoErr
+			}
+			outcome = autoOutcome
+		} else {
+			// Abort rebase if it failed for other reasons
+			_, _ = r.RunGitCommandWithContext(ctx, "rebase", "--abort")
 
-		return RebaseConflict, err
+			return RebaseOutcome{Result: RebaseConflict}, err
+		}
 	}
 
 	r.revisionCache.InvalidateAll()
@@ -38,39 +52,88 @@ func (r *runner) Rebase(ctx context.Context, branchName, upstream, oldUpstream s
 	// Since we rebased in detached HEAD, we must manually update the branch ref
 	newRev, err := r.GetCurrentRevision(ctx)
 	if err != nil {
-		return RebaseConflict, fmt.Errorf("failed to get revision after rebase: %w", err)
+		return RebaseOutcome{Result: RebaseConflict, RerereResolvedCount: outcome.RerereResolvedCount}, fmt.Errorf("failed to get revision after rebase: %w", err)
 	}
 
 	if err := r.UpdateBranchRef(ctx, branchName, newRev); err != nil {
-		return RebaseConflict, fmt.Errorf("failed to update branch ref %s: %w", branchName, err)
+		return RebaseOutcome{Result: RebaseConflict, RerereResolvedCount: outcome.RerereResolvedCount}, fmt.Errorf("failed to update branch ref %s: %w", branchName, err)
 	}
 
-	return RebaseDone, nil
+	return outcome, nil
 }
 
-func (r *runner) RebaseContinueNoEdit(ctx context.Context) (RebaseResult, error) {
+func (r *runner) rebaseContinueOnce(ctx context.Context) error {
 	_, err := r.RunGitCommandWithEnv(ctx, []string{"GIT_EDITOR=true"}, "rebase", "--continue")
 	r.revisionCache.InvalidateAll()
-	if err != nil {
-		if r.IsRebaseInProgress(ctx) {
-			return RebaseConflict, nil
-		}
-		return RebaseConflict, err
-	}
-	return RebaseDone, nil
+	return err
 }
 
-func (r *runner) RebaseContinue(ctx context.Context) (RebaseResult, error) {
-	_, err := r.RunGitCommandWithEnv(ctx, []string{"GIT_EDITOR=true"}, "rebase", "--continue")
-	r.revisionCache.InvalidateAll()
-	if err != nil {
-		if r.IsRebaseInProgress(ctx) {
-			return RebaseConflict, nil
+// MaxRerereContinueIterations caps the auto-continue loop so a pathological
+// rebase cannot spin forever. Real rebases finish in far fewer iterations.
+const MaxRerereContinueIterations = 1000
+
+// AutoContinueRerereRebase drives `git rebase --continue` while rerere keeps
+// all conflicts resolved (no unmerged files remain). It returns:
+//   - RebaseOutcome with Result=RebaseDone and the count of rerere-resolved
+//     commits when the rebase completes.
+//   - RebaseOutcome with Result=RebaseConflict and the list of unmerged files
+//     when rerere cannot resolve a conflict.
+//   - a non-nil error if `rebase --continue` fails unexpectedly or the
+//     iteration cap is hit. The originalErr is wrapped into these errors so
+//     callers keep the context that triggered auto-continue.
+func AutoContinueRerereRebase(ctx context.Context, r Runner, originalErr error) (RebaseOutcome, []string, error) {
+	outcome := RebaseOutcome{Result: RebaseConflict}
+
+	for range MaxRerereContinueIterations {
+		if !r.IsRebaseInProgress(ctx) {
+			outcome.Result = RebaseDone
+			return outcome, nil, nil
 		}
-		return RebaseConflict, fmt.Errorf("rebase continue failed: %w", err)
+
+		unmergedFiles, err := r.GetUnmergedFiles(ctx)
+		if err != nil {
+			return outcome, nil, originalErr
+		}
+		if len(unmergedFiles) > 0 {
+			return outcome, unmergedFiles, nil
+		}
+
+		if _, err := r.RunGitCommandWithEnv(ctx, []string{"GIT_EDITOR=true"}, "rebase", "--continue"); err != nil {
+			return outcome, nil, fmt.Errorf("rebase --continue failed after rerere replay: %w", err)
+		}
+		outcome.RerereResolvedCount++
 	}
 
-	return RebaseDone, nil
+	return outcome, nil, fmt.Errorf("rerere auto-continue exceeded %d iterations: %w", MaxRerereContinueIterations, originalErr)
+}
+
+func (r *runner) continueRerereResolvedRebase(ctx context.Context, originalErr error) (RebaseOutcome, error) {
+	outcome, _, err := AutoContinueRerereRebase(ctx, r, originalErr)
+	r.revisionCache.InvalidateAll()
+	return outcome, err
+}
+
+func (r *runner) RebaseContinueNoEdit(ctx context.Context) (RebaseOutcome, error) {
+	err := r.rebaseContinueOnce(ctx)
+	if err != nil {
+		if r.IsRebaseInProgress(ctx) {
+			return r.continueRerereResolvedRebase(ctx, err)
+		}
+		return RebaseOutcome{Result: RebaseConflict}, err
+	}
+	return RebaseOutcome{Result: RebaseDone}, nil
+}
+
+func (r *runner) RebaseContinue(ctx context.Context) (RebaseOutcome, error) {
+	err := r.rebaseContinueOnce(ctx)
+	if err != nil {
+		if r.IsRebaseInProgress(ctx) {
+			return r.continueRerereResolvedRebase(ctx, err)
+		}
+		return RebaseOutcome{Result: RebaseConflict}, fmt.Errorf("rebase continue failed: %w", err)
+	}
+
+	return RebaseOutcome{Result: RebaseDone}, nil
 }
 
 func (r *runner) RebaseAbort(ctx context.Context) error {

--- a/internal/git/rebase_test.go
+++ b/internal/git/rebase_test.go
@@ -42,7 +42,7 @@ func TestRebase(t *testing.T) {
 		runner := git.NewRunner(nil)
 		result, err := runner.Rebase(context.Background(), "branch1", "main", branch1Rev)
 		require.NoError(t, err)
-		require.Equal(t, git.RebaseDone, result)
+		require.Equal(t, git.RebaseDone, result.Result)
 
 		// Verify branch1 is now based on new main
 		err = scene.Repo.CheckoutBranch("branch1")
@@ -83,9 +83,99 @@ func TestRebase(t *testing.T) {
 		runner := git.NewRunner(nil)
 		result, err := runner.Rebase(context.Background(), "branch1", "main", forkPoint)
 		require.NoError(t, err)
-		require.Equal(t, git.RebaseConflict, result)
+		require.Equal(t, git.RebaseConflict, result.Result)
 
 		// Verify rebase is in progress
+		require.True(t, runner.IsRebaseInProgress(context.Background()))
+	})
+
+	t.Run("auto-continues when rerere resolved conflict", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, func(s *testhelpers.Scene) error {
+			return s.Repo.CreateChangeAndCommit("initial content", "conflict")
+		})
+		runner := git.NewRunner(nil)
+		require.NoError(t, runner.SetConfig("rerere.enabled", "true"))
+		require.NoError(t, runner.SetConfig("rerere.autoupdate", "true"))
+
+		forkPoint, err := scene.Repo.GetRef("main")
+		require.NoError(t, err)
+
+		require.NoError(t, scene.Repo.CreateAndCheckoutBranch("branch1"))
+		require.NoError(t, scene.Repo.CreateChange("branch modification", "conflict", false))
+		require.NoError(t, scene.Repo.RunGitCommand("commit", "-m", "branch change"))
+
+		require.NoError(t, scene.Repo.CheckoutBranch("main"))
+		require.NoError(t, scene.Repo.CreateChange("main modification", "conflict", false))
+		require.NoError(t, scene.Repo.RunGitCommand("commit", "-m", "main change"))
+
+		result, err := runner.Rebase(context.Background(), "branch1", "main", forkPoint)
+		require.NoError(t, err)
+		require.Equal(t, git.RebaseConflict, result.Result)
+		require.True(t, runner.IsRebaseInProgress(context.Background()))
+
+		require.NoError(t, scene.Repo.ResolveMergeConflicts())
+		require.NoError(t, scene.Repo.MarkMergeConflictsAsResolved())
+		result, err = runner.RebaseContinue(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, git.RebaseDone, result.Result)
+		require.False(t, runner.IsRebaseInProgress(context.Background()))
+
+		require.NoError(t, scene.Repo.CheckoutBranch("main"))
+		require.NoError(t, scene.Repo.RunGitCommand("checkout", "-b", "branch2", forkPoint))
+		require.NoError(t, scene.Repo.CreateChange("branch modification", "conflict", false))
+		require.NoError(t, scene.Repo.RunGitCommand("commit", "-m", "branch change again"))
+
+		result, err = runner.Rebase(context.Background(), "branch2", "main", forkPoint)
+		require.NoError(t, err)
+		require.Equal(t, git.RebaseDone, result.Result)
+		require.Greater(t, result.RerereResolvedCount, 0)
+		require.False(t, runner.IsRebaseInProgress(context.Background()))
+	})
+
+	// Without rerere.autoupdate, rerere applies resolutions to the working
+	// tree but does not stage them, so GetUnmergedFiles still reports the
+	// file as unmerged and auto-continue must bail out. rerere.EnsureEnabled
+	// is responsible for ensuring autoupdate is set whenever rerere is on.
+	t.Run("does not auto-continue when autoupdate is disabled", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, func(s *testhelpers.Scene) error {
+			return s.Repo.CreateChangeAndCommit("initial content", "conflict")
+		})
+		runner := git.NewRunner(nil)
+		require.NoError(t, runner.SetConfig("rerere.enabled", "true"))
+		require.NoError(t, runner.SetConfig("rerere.autoupdate", "false"))
+
+		forkPoint, err := scene.Repo.GetRef("main")
+		require.NoError(t, err)
+
+		require.NoError(t, scene.Repo.CreateAndCheckoutBranch("branch1"))
+		require.NoError(t, scene.Repo.CreateChange("branch modification", "conflict", false))
+		require.NoError(t, scene.Repo.RunGitCommand("commit", "-m", "branch change"))
+
+		require.NoError(t, scene.Repo.CheckoutBranch("main"))
+		require.NoError(t, scene.Repo.CreateChange("main modification", "conflict", false))
+		require.NoError(t, scene.Repo.RunGitCommand("commit", "-m", "main change"))
+
+		// Resolve once so rerere records the resolution.
+		result, err := runner.Rebase(context.Background(), "branch1", "main", forkPoint)
+		require.NoError(t, err)
+		require.Equal(t, git.RebaseConflict, result.Result)
+		require.NoError(t, scene.Repo.ResolveMergeConflicts())
+		require.NoError(t, scene.Repo.MarkMergeConflictsAsResolved())
+		result, err = runner.RebaseContinue(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, git.RebaseDone, result.Result)
+
+		// Replay on a fresh branch. rerere will replay the resolution into
+		// the working tree but won't stage it, so we still surface conflict.
+		require.NoError(t, scene.Repo.CheckoutBranch("main"))
+		require.NoError(t, scene.Repo.RunGitCommand("checkout", "-b", "branch2", forkPoint))
+		require.NoError(t, scene.Repo.CreateChange("branch modification", "conflict", false))
+		require.NoError(t, scene.Repo.RunGitCommand("commit", "-m", "branch change again"))
+
+		result, err = runner.Rebase(context.Background(), "branch2", "main", forkPoint)
+		require.NoError(t, err)
+		require.Equal(t, git.RebaseConflict, result.Result)
+		require.Equal(t, 0, result.RerereResolvedCount)
 		require.True(t, runner.IsRebaseInProgress(context.Background()))
 	})
 }
@@ -176,11 +266,75 @@ func TestRebaseContinue(t *testing.T) {
 		// Continue rebase
 		result, err := runner.RebaseContinue(context.Background())
 		require.NoError(t, err)
-		require.Equal(t, git.RebaseDone, result)
+		require.Equal(t, git.RebaseDone, result.Result)
 
 		// Rebase should be complete
 		require.False(t, runner.IsRebaseInProgress(context.Background()))
 	})
+}
+
+// RebaseContinue delegates to AutoContinueRerereRebase whenever a manual
+// `rebase --continue` leaves the rebase in progress with no unmerged files,
+// which happens when rerere has already resolved and staged the next commit's
+// conflict. The test pre-seeds rerere for the second commit's conflict, stops
+// the rebase on the first commit's conflict, resolves it by hand, and then
+// relies on RebaseContinue to drive the rebase to completion through the
+// rerere-resolved second commit.
+func TestRebaseContinueAutoContinuesThroughRerereResolvedCommit(t *testing.T) {
+	scene := testhelpers.NewScene(t, func(s *testhelpers.Scene) error {
+		return s.Repo.CreateChangeAndCommit("v0", "fileA.txt")
+	})
+	runner := git.NewRunner(nil)
+	require.NoError(t, runner.SetConfig("rerere.enabled", "true"))
+	require.NoError(t, runner.SetConfig("rerere.autoupdate", "true"))
+
+	fork0, err := scene.Repo.GetRef("main")
+	require.NoError(t, err)
+
+	// Main commit M1 conflicts with branch1's first commit (fileA). Main
+	// commit M2 conflicts with branch1's second commit (fileB).
+	require.NoError(t, scene.Repo.CreateChange("mA", "fileA.txt", false))
+	require.NoError(t, scene.Repo.RunGitCommand("commit", "-am", "main A"))
+	mainAfterM1, err := scene.Repo.GetRef("main")
+	require.NoError(t, err)
+	require.NoError(t, scene.Repo.CreateChangeAndCommit("mB", "fileB.txt"))
+
+	// Pre-seed rerere with a resolution for the fileB conflict by running
+	// the same conflict through a throwaway branch and resolving by hand.
+	require.NoError(t, scene.Repo.RunGitCommand("checkout", "-b", "seed", mainAfterM1))
+	require.NoError(t, scene.Repo.CreateChangeAndCommit("branchB", "fileB.txt"))
+	seedResult, err := runner.Rebase(context.Background(), "seed", "main", mainAfterM1)
+	require.NoError(t, err)
+	require.Equal(t, git.RebaseConflict, seedResult.Result)
+	require.NoError(t, scene.Repo.ResolveMergeConflicts())
+	require.NoError(t, scene.Repo.MarkMergeConflictsAsResolved())
+	seedResult, err = runner.RebaseContinue(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, git.RebaseDone, seedResult.Result)
+
+	// Build branch1 off the original fork point with two commits. B1 clashes
+	// with M1 (needs manual resolution), B2 clashes with M2 but reuses the
+	// resolution rerere recorded above.
+	require.NoError(t, scene.Repo.CheckoutBranch("main"))
+	require.NoError(t, scene.Repo.RunGitCommand("checkout", "-b", "branch1", fork0))
+	require.NoError(t, scene.Repo.CreateChangeAndCommit("bA", "fileA.txt"))
+	require.NoError(t, scene.Repo.CreateChangeAndCommit("branchB", "fileB.txt"))
+
+	result, err := runner.Rebase(context.Background(), "branch1", "main", fork0)
+	require.NoError(t, err)
+	require.Equal(t, git.RebaseConflict, result.Result)
+	require.True(t, runner.IsRebaseInProgress(context.Background()))
+
+	// User resolves the B1/fileA conflict manually.
+	require.NoError(t, scene.Repo.ResolveMergeConflicts())
+	require.NoError(t, scene.Repo.MarkMergeConflictsAsResolved())
+
+	// RebaseContinue should drive the remaining B2 cherry-pick through
+	// rerere and finish the rebase cleanly.
+	contResult, err := runner.RebaseContinue(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, git.RebaseDone, contResult.Result)
+	require.False(t, runner.IsRebaseInProgress(context.Background()))
 }
 
 func TestGetRebaseHead(t *testing.T) {

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -637,21 +637,21 @@ func (t *tracingRunner) CommitAmendNoEdit(ctx context.Context) error {
 
 // RebaseOperations methods
 
-func (t *tracingRunner) Rebase(ctx context.Context, branchName, upstream, oldUpstream string) (RebaseResult, error) {
+func (t *tracingRunner) Rebase(ctx context.Context, branchName, upstream, oldUpstream string) (RebaseOutcome, error) {
 	start := time.Now()
 	result, err := t.inner.Rebase(ctx, branchName, upstream, oldUpstream)
 	t.trace("Rebase", time.Since(start), err == nil, err, slog.String("branch", branchName), slog.String("upstream", upstream))
 	return result, err
 }
 
-func (t *tracingRunner) RebaseContinue(ctx context.Context) (RebaseResult, error) {
+func (t *tracingRunner) RebaseContinue(ctx context.Context) (RebaseOutcome, error) {
 	start := time.Now()
 	result, err := t.inner.RebaseContinue(ctx)
 	t.trace("RebaseContinue", time.Since(start), err == nil, err)
 	return result, err
 }
 
-func (t *tracingRunner) RebaseContinueNoEdit(ctx context.Context) (RebaseResult, error) {
+func (t *tracingRunner) RebaseContinueNoEdit(ctx context.Context) (RebaseOutcome, error) {
 	start := time.Now()
 	result, err := t.inner.RebaseContinueNoEdit(ctx)
 	t.trace("RebaseContinueNoEdit", time.Since(start), err == nil, err)

--- a/internal/handlers/restack.go
+++ b/internal/handlers/restack.go
@@ -24,7 +24,7 @@ type RestackHandler interface {
 	OnRestackStart(branchCount int)
 
 	// OnRestackBranch is called for each branch during restack
-	OnRestackBranch(branch string, result RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, reparented bool, oldParent, newParent string)
+	OnRestackBranch(branch string, result RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, reparented bool, oldParent, newParent string, rerereResolvedCount int)
 
 	// OnRestackComplete is called when restack finishes
 	OnRestackComplete(restacked, skipped int, conflicts []string)
@@ -37,7 +37,7 @@ type NullRestackHandler struct{}
 func (h *NullRestackHandler) OnRestackStart(_ int) {}
 
 // OnRestackBranch implements RestackHandler.
-func (h *NullRestackHandler) OnRestackBranch(_ string, _ RestackResult, _ string, _ *int, _ engine.LockReason, _ bool, _ bool, _ string, _ bool, _, _ string) {
+func (h *NullRestackHandler) OnRestackBranch(_ string, _ RestackResult, _ string, _ *int, _ engine.LockReason, _ bool, _ bool, _ string, _ bool, _, _ string, _ int) {
 }
 
 // OnRestackComplete implements RestackHandler.
@@ -66,10 +66,11 @@ type RestackJSONResult struct {
 
 // RestackBranchInfo represents info about a restacked branch
 type RestackBranchInfo struct {
-	Name     string `json:"name"`
-	Parent   string `json:"parent"`
-	NewRev   string `json:"new_rev,omitempty"`
-	PRNumber *int   `json:"pr_number,omitempty"`
+	Name                string `json:"name"`
+	Parent              string `json:"parent"`
+	NewRev              string `json:"new_rev,omitempty"`
+	PRNumber            *int   `json:"pr_number,omitempty"`
+	RerereResolvedCount int    `json:"rerere_resolved_count,omitempty"`
 }
 
 // RestackConflictInfo represents a conflict during restack
@@ -100,14 +101,15 @@ func (h *JSONRestackHandler) OnRestackStart(branchCount int) {
 }
 
 // OnRestackBranch implements RestackHandler.
-func (h *JSONRestackHandler) OnRestackBranch(branch string, result RestackResult, newRev string, prNumber *int, _ engine.LockReason, _ bool, _ bool, parent string, _ bool, _, _ string) {
+func (h *JSONRestackHandler) OnRestackBranch(branch string, result RestackResult, newRev string, prNumber *int, _ engine.LockReason, _ bool, _ bool, parent string, _ bool, _, _ string, rerereResolvedCount int) {
 	switch result {
 	case RestackDone:
 		h.Result.Restacked = append(h.Result.Restacked, RestackBranchInfo{
-			Name:     branch,
-			Parent:   parent,
-			NewRev:   newRev,
-			PRNumber: prNumber,
+			Name:                branch,
+			Parent:              parent,
+			NewRev:              newRev,
+			PRNumber:            prNumber,
+			RerereResolvedCount: rerereResolvedCount,
 		})
 	case RestackUnneeded:
 		h.Result.Skipped = append(h.Result.Skipped, branch)

--- a/internal/handlers/restack_test.go
+++ b/internal/handlers/restack_test.go
@@ -20,8 +20,8 @@ func TestJSONRestackHandler(t *testing.T) {
 
 		// Simulate branch restacking
 		prNum := 123
-		handler.OnRestackBranch("branch-a", RestackDone, "abc123", &prNum, engine.LockReasonNone, false, false, "main", false, "", "")
-		handler.OnRestackBranch("branch-b", RestackDone, "def456", nil, engine.LockReasonNone, false, false, "branch-a", false, "", "")
+		handler.OnRestackBranch("branch-a", RestackDone, "abc123", &prNum, engine.LockReasonNone, false, false, "main", false, "", "", 2)
+		handler.OnRestackBranch("branch-b", RestackDone, "def456", nil, engine.LockReasonNone, false, false, "branch-a", false, "", "", 0)
 
 		handler.OnRestackComplete(2, 0, nil)
 
@@ -31,6 +31,7 @@ func TestJSONRestackHandler(t *testing.T) {
 		require.Equal(t, "main", handler.Result.Restacked[0].Parent)
 		require.Equal(t, "abc123", handler.Result.Restacked[0].NewRev)
 		require.Equal(t, 123, *handler.Result.Restacked[0].PRNumber)
+		require.Equal(t, 2, handler.Result.Restacked[0].RerereResolvedCount)
 		require.Equal(t, 3, handler.Result.TotalCount)
 		require.Equal(t, 2, handler.Result.RestackCount)
 	})
@@ -42,8 +43,8 @@ func TestJSONRestackHandler(t *testing.T) {
 		handler.OnRestackStart(2)
 
 		// Simulate branches that don't need restacking
-		handler.OnRestackBranch("branch-a", RestackUnneeded, "", nil, engine.LockReasonNone, false, false, "main", false, "", "")
-		handler.OnRestackBranch("branch-b", RestackUnneeded, "", nil, engine.LockReasonNone, false, false, "branch-a", false, "", "")
+		handler.OnRestackBranch("branch-a", RestackUnneeded, "", nil, engine.LockReasonNone, false, false, "main", false, "", "", 0)
+		handler.OnRestackBranch("branch-b", RestackUnneeded, "", nil, engine.LockReasonNone, false, false, "branch-a", false, "", "", 0)
 
 		handler.OnRestackComplete(0, 2, nil)
 
@@ -61,8 +62,8 @@ func TestJSONRestackHandler(t *testing.T) {
 		handler.OnRestackStart(2)
 
 		// Simulate a conflict
-		handler.OnRestackBranch("branch-a", RestackDone, "abc123", nil, engine.LockReasonNone, false, false, "main", false, "", "")
-		handler.OnRestackBranch("branch-b", RestackConflict, "", nil, engine.LockReasonNone, false, false, "branch-a", false, "", "")
+		handler.OnRestackBranch("branch-a", RestackDone, "abc123", nil, engine.LockReasonNone, false, false, "main", false, "", "", 0)
+		handler.OnRestackBranch("branch-b", RestackConflict, "", nil, engine.LockReasonNone, false, false, "branch-a", false, "", "", 0)
 
 		handler.OnRestackComplete(1, 0, []string{"branch-b"})
 
@@ -92,7 +93,7 @@ func TestJSONRestackHandler(t *testing.T) {
 
 		handler := NewJSONRestackHandler()
 		handler.OnRestackStart(1)
-		handler.OnRestackBranch("branch-a", RestackConflict, "", nil, engine.LockReasonNone, false, false, "main", false, "", "")
+		handler.OnRestackBranch("branch-a", RestackConflict, "", nil, engine.LockReasonNone, false, false, "main", false, "", "", 0)
 		handler.OnRestackComplete(0, 0, []string{"branch-a"})
 
 		handler.SetError(errors.New("restack stopped due to conflict on branch-a"))

--- a/internal/rerere/rerere.go
+++ b/internal/rerere/rerere.go
@@ -1,0 +1,84 @@
+package rerere
+
+import (
+	"context"
+	"strings"
+
+	"stackit.dev/stackit/internal/git"
+	"stackit.dev/stackit/internal/tui"
+)
+
+const declinedKey = "stackit.rerere.declined"
+
+// ConfirmFunc prompts the user for a yes/no answer. Matches the signature
+// of tui.PromptConfirm.
+type ConfirmFunc func(prompt string, defaultValue bool) (bool, error)
+
+// Pauser releases and restores an active TUI so a prompt can read the
+// terminal without contending with a running Bubble Tea program.
+type Pauser interface {
+	Pause()
+	Resume()
+}
+
+// EnsureEnabled offers to enable git rerere for this repository. It never
+// prompts when interactive is false or the user previously declined.
+//
+// When rerere.enabled is already true, it still ensures rerere.autoupdate
+// is true — stackit's auto-continue loop (see internal/git/rebase.go) relies
+// on rerere staging resolutions itself, and silently no-ops when autoupdate
+// is off.
+//
+// If pauser is non-nil, it is paused around the confirmation prompt so a
+// surrounding TUI does not contend for stdin/stdout.
+func EnsureEnabled(ctx context.Context, runner git.Runner, interactive bool, pauser Pauser) (bool, error) {
+	return ensureEnabled(ctx, runner, interactive, pauser, tui.PromptConfirm)
+}
+
+func ensureEnabled(_ context.Context, runner git.Runner, interactive bool, pauser Pauser, confirm ConfirmFunc) (bool, error) {
+	if configBool(runner, "rerere.enabled") {
+		if !configBool(runner, "rerere.autoupdate") {
+			if err := runner.SetConfig("rerere.autoupdate", "true"); err != nil {
+				return false, err
+			}
+		}
+		return false, nil
+	}
+
+	if configBool(runner, declinedKey) || !interactive {
+		return false, nil
+	}
+
+	ok, err := promptWithPause(pauser, confirm, "Enable git rerere to remember conflict resolutions?", true)
+	if err != nil {
+		return false, nil //nolint:nilerr // prompt cancel (Ctrl+C) should not error — treat as decline without persisting
+	}
+	if !ok {
+		_ = runner.SetConfig(declinedKey, "true")
+		return false, nil
+	}
+
+	if err := runner.SetConfig("rerere.enabled", "true"); err != nil {
+		return false, err
+	}
+	if err := runner.SetConfig("rerere.autoupdate", "true"); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func promptWithPause(pauser Pauser, confirm ConfirmFunc, prompt string, defaultValue bool) (bool, error) {
+	if pauser != nil {
+		pauser.Pause()
+		defer pauser.Resume()
+	}
+	return confirm(prompt, defaultValue)
+}
+
+func configBool(runner git.Runner, key string) bool {
+	value, err := runner.GetConfig(key)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(value), "true")
+}

--- a/internal/rerere/rerere_test.go
+++ b/internal/rerere/rerere_test.go
@@ -1,0 +1,157 @@
+package rerere
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"stackit.dev/stackit/internal/git"
+	"stackit.dev/stackit/testhelpers"
+)
+
+func TestEnsureEnabled(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-interactive skips prompt", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		runner := git.NewRunnerWithPath(scene.Dir, nil)
+
+		prompted := false
+		confirm := func(string, bool) (bool, error) {
+			prompted = true
+			return true, nil
+		}
+
+		enabled, err := ensureEnabled(context.Background(), runner, false, nil, confirm)
+		require.NoError(t, err)
+		require.False(t, enabled)
+		require.False(t, prompted)
+	})
+
+	t.Run("accepted prompt enables rerere", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		runner := git.NewRunnerWithPath(scene.Dir, nil)
+
+		confirm := func(prompt string, defaultYes bool) (bool, error) {
+			require.Equal(t, "Enable git rerere to remember conflict resolutions?", prompt)
+			require.True(t, defaultYes)
+			return true, nil
+		}
+
+		enabled, err := ensureEnabled(context.Background(), runner, true, nil, confirm)
+		require.NoError(t, err)
+		require.True(t, enabled)
+
+		rerereEnabled, err := runner.GetConfig("rerere.enabled")
+		require.NoError(t, err)
+		require.Equal(t, "true", rerereEnabled)
+
+		rerereAutoupdate, err := runner.GetConfig("rerere.autoupdate")
+		require.NoError(t, err)
+		require.Equal(t, "true", rerereAutoupdate)
+	})
+
+	t.Run("declined prompt is remembered", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		runner := git.NewRunnerWithPath(scene.Dir, nil)
+
+		confirm := func(string, bool) (bool, error) {
+			return false, nil
+		}
+
+		enabled, err := ensureEnabled(context.Background(), runner, true, nil, confirm)
+		require.NoError(t, err)
+		require.False(t, enabled)
+
+		declined, err := runner.GetConfig(declinedKey)
+		require.NoError(t, err)
+		require.Equal(t, "true", declined)
+
+		promptedAgain := false
+		confirm = func(string, bool) (bool, error) {
+			promptedAgain = true
+			return true, nil
+		}
+
+		enabled, err = ensureEnabled(context.Background(), runner, true, nil, confirm)
+		require.NoError(t, err)
+		require.False(t, enabled)
+		require.False(t, promptedAgain)
+	})
+
+	t.Run("already enabled skips prompt and sets autoupdate", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		runner := git.NewRunnerWithPath(scene.Dir, nil)
+		require.NoError(t, runner.SetConfig("rerere.enabled", "true"))
+
+		prompted := false
+		confirm := func(string, bool) (bool, error) {
+			prompted = true
+			return true, nil
+		}
+
+		enabled, err := ensureEnabled(context.Background(), runner, true, nil, confirm)
+		require.NoError(t, err)
+		require.False(t, enabled)
+		require.False(t, prompted)
+
+		// rerere.autoupdate must be set — the auto-continue loop in
+		// internal/git/rebase.go bails out when rerere applies a resolution
+		// without staging it.
+		autoupdate, err := runner.GetConfig("rerere.autoupdate")
+		require.NoError(t, err)
+		require.Equal(t, "true", autoupdate)
+	})
+
+	t.Run("already enabled with autoupdate=false is upgraded", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		runner := git.NewRunnerWithPath(scene.Dir, nil)
+		require.NoError(t, runner.SetConfig("rerere.enabled", "true"))
+		require.NoError(t, runner.SetConfig("rerere.autoupdate", "false"))
+
+		confirm := func(string, bool) (bool, error) {
+			t.Fatalf("prompt should not fire when rerere is already enabled")
+			return false, nil
+		}
+
+		enabled, err := ensureEnabled(context.Background(), runner, true, nil, confirm)
+		require.NoError(t, err)
+		require.False(t, enabled)
+
+		autoupdate, err := runner.GetConfig("rerere.autoupdate")
+		require.NoError(t, err)
+		require.Equal(t, "true", autoupdate)
+	})
+
+	t.Run("pauser wraps prompt", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+		runner := git.NewRunnerWithPath(scene.Dir, nil)
+
+		p := &recordingPauser{}
+		confirm := func(string, bool) (bool, error) {
+			require.Equal(t, 1, p.pauseCount, "Pause must run before prompt")
+			require.Equal(t, 0, p.resumeCount, "Resume must run after prompt")
+			return false, nil
+		}
+
+		_, err := ensureEnabled(context.Background(), runner, true, p, confirm)
+		require.NoError(t, err)
+		require.Equal(t, 1, p.pauseCount)
+		require.Equal(t, 1, p.resumeCount)
+	})
+}
+
+type recordingPauser struct {
+	pauseCount  int
+	resumeCount int
+}
+
+func (p *recordingPauser) Pause()  { p.pauseCount++ }
+func (p *recordingPauser) Resume() { p.resumeCount++ }


### PR DESCRIPTION

Prompt once to enable git rerere, continue rebases when recorded resolutions leave no unmerged files, and surface brief rerere resolution counts through restack output.