### PR TITLE
refactor(merge): simplify multistack discovery logic

### DIFF
--- a/internal/actions/merge/multistack_discover.go
+++ b/internal/actions/merge/multistack_discover.go
@@ -29,42 +29,26 @@ func DiscoverStacks(eng engine.BranchReader) ([]MultiStackInfo, error) {
 // DiscoverStacksWithSort is like DiscoverStacks but allows specifying the sort strategy.
 // Use SortStrategySmart to match the ordering of `stackit log`.
 func DiscoverStacksWithSort(eng engine.BranchReader, strategy engine.SortStrategy) ([]MultiStackInfo, error) {
-	graph := engine.BuildStackGraph(eng, strategy, nil)
-	trunk := eng.Trunk()
+	independentStacks := engine.DiscoverIndependentStacksWithSort(eng, strategy)
 
-	// Get the trunk node to find its direct children (stack roots)
-	trunkNode := graph.GetNode(trunk.GetName())
-	if trunkNode == nil {
-		return nil, nil // No trunk found
-	}
-
-	stacks := make([]MultiStackInfo, 0, len(trunkNode.Children))
-	for _, rootName := range trunkNode.Children {
-		rootNode := graph.GetNode(rootName)
-		if rootNode == nil {
-			continue
+	stacks := make([]MultiStackInfo, 0, len(independentStacks))
+	for _, independentStack := range independentStacks {
+		branches := make([]engine.Branch, len(independentStack.Branches))
+		for i, branchName := range independentStack.Branches {
+			branches[i] = eng.GetBranch(branchName)
 		}
-
-		// Collect all branches in this stack using DFS
-		branches := graph.CollectBranches(rootNode.Branch)
-		branchNames := make([]string, len(branches))
-		for i, b := range branches {
-			branchNames[i] = b.GetName()
-		}
-
-		// Count PRs for this stack
-		prCount := countPRs(branches)
 
 		// Get scope from the root branch
 		scope := ""
-		if s := eng.GetScope(rootNode.Branch); !s.IsEmpty() {
+		root := eng.GetBranch(independentStack.RootBranch)
+		if s := eng.GetScope(root); !s.IsEmpty() {
 			scope = s.String()
 		}
 
 		stacks = append(stacks, MultiStackInfo{
-			RootBranch:  rootName,
-			AllBranches: branchNames,
-			PRCount:     prCount,
+			RootBranch:  independentStack.RootBranch,
+			AllBranches: independentStack.Branches,
+			PRCount:     countPRs(branches),
 			Scope:       scope,
 		})
 	}

--- a/internal/engine/independent_stack.go
+++ b/internal/engine/independent_stack.go
@@ -1,0 +1,46 @@
+package engine
+
+// IndependentStack describes a standalone stack rooted at a direct child of trunk.
+type IndependentStack struct {
+	RootBranch string
+	Branches   []string
+}
+
+// DiscoverIndependentStacks returns all stacks rooted at direct children of trunk.
+//
+// Each stack includes its root branch first, followed by descendants in the graph's
+// depth-first order. Branches from separate stacks are independent of each other.
+func DiscoverIndependentStacks(eng BranchReader) []IndependentStack {
+	return DiscoverIndependentStacksWithSort(eng, SortStrategyAlphabetical)
+}
+
+// DiscoverIndependentStacksWithSort is like DiscoverIndependentStacks, but allows
+// callers to choose how sibling branches are ordered.
+func DiscoverIndependentStacksWithSort(eng BranchReader, strategy SortStrategy) []IndependentStack {
+	graph := BuildStackGraph(eng, strategy, nil)
+	trunkNode := graph.GetNode(eng.Trunk().GetName())
+	if trunkNode == nil {
+		return nil
+	}
+
+	stacks := make([]IndependentStack, 0, len(trunkNode.Children))
+	for _, rootName := range trunkNode.Children {
+		rootNode := graph.GetNode(rootName)
+		if rootNode == nil {
+			continue
+		}
+
+		branches := graph.CollectBranches(rootNode.Branch)
+		branchNames := make([]string, len(branches))
+		for i, branch := range branches {
+			branchNames[i] = branch.GetName()
+		}
+
+		stacks = append(stacks, IndependentStack{
+			RootBranch: rootName,
+			Branches:   branchNames,
+		})
+	}
+
+	return stacks
+}

--- a/internal/engine/independent_stack_test.go
+++ b/internal/engine/independent_stack_test.go
@@ -1,0 +1,71 @@
+package engine_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/testhelpers"
+	"stackit.dev/stackit/testhelpers/scenario"
+)
+
+func TestDiscoverIndependentStacks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns stacks rooted at direct trunk children", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"stack-a":       "main",
+				"stack-a-child": "stack-a",
+				"stack-a-leaf":  "stack-a-child",
+				"stack-b":       "main",
+				"stack-b-child": "stack-b",
+			})
+
+		stacks := engine.DiscoverIndependentStacks(s.Engine)
+
+		require.Equal(t, []engine.IndependentStack{
+			{
+				RootBranch: "stack-a",
+				Branches:   []string{"stack-a", "stack-a-child", "stack-a-leaf"},
+			},
+			{
+				RootBranch: "stack-b",
+				Branches:   []string{"stack-b", "stack-b-child"},
+			},
+		}, stacks)
+	})
+
+	t.Run("returns no stacks when trunk has no tracked children", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		stacks := engine.DiscoverIndependentStacks(s.Engine)
+
+		require.Empty(t, stacks)
+	})
+
+	t.Run("includes branching descendants under the same root", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"root":    "main",
+				"child-a": "root",
+				"child-b": "root",
+			})
+
+		stacks := engine.DiscoverIndependentStacks(s.Engine)
+
+		require.Equal(t, []engine.IndependentStack{
+			{
+				RootBranch: "root",
+				Branches:   []string{"root", "child-a", "child-b"},
+			},
+		}, stacks)
+	})
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1776899834`.


* **PR #862** 👈
  * **PR #863**
    * **PR #864**
      * **PR #865**
        * **PR #866**
          * **PR #867**
            * **PR #868**
              * **PR #869**
                * **PR #870**
                  * **PR #871**
                    * **PR #872**
                      * **PR #873**
                        * **PR #874**
                          * **PR #875**
                            * **PR #876**
                              * **PR #877**
                                * **PR #878**
                                  * **PR #880**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->