### PR TITLE
feat(foreach): add foreach events and dry-run support

### DIFF
--- a/internal/actions/foreach/events.go
+++ b/internal/actions/foreach/events.go
@@ -49,6 +49,7 @@ func (CompletionEvent) foreachEvent() {}
 type BranchResult struct {
 	BranchName string
 	Status     BranchStatus
+	ExitCode   int
 	Output     string
 	Error      error
 }

--- a/internal/actions/foreach/foreach.go
+++ b/internal/actions/foreach/foreach.go
@@ -2,6 +2,7 @@ package foreach
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -135,6 +136,7 @@ func foreachSequential(ctx *app.Context, opts Options, branches []engine.Branch,
 
 		if err := eng.CheckoutBranch(ctx.Context, branch); err != nil {
 			result.Status = StatusError
+			result.ExitCode = -1
 			result.Error = err
 			handler.OnEvent(BranchProgressEvent{
 				BranchName: branchName,
@@ -169,6 +171,7 @@ func foreachSequential(ctx *app.Context, opts Options, branches []engine.Branch,
 
 		if err != nil {
 			result.Status = StatusError
+			result.ExitCode = exitCodeFromError(err)
 			result.Output = outputStr
 			result.Error = err
 			handler.OnEvent(BranchProgressEvent{
@@ -191,6 +194,7 @@ func foreachSequential(ctx *app.Context, opts Options, branches []engine.Branch,
 			}
 		} else {
 			result.Status = StatusDone
+			result.ExitCode = 0
 			result.Output = outputStr
 			handler.OnEvent(BranchProgressEvent{
 				BranchName: branchName,
@@ -251,6 +255,7 @@ func foreachParallel(ctx *app.Context, opts Options, branches []engine.Branch, h
 	type result struct {
 		branchName string
 		output     string
+		exitCode   int
 		err        error
 	}
 
@@ -307,6 +312,7 @@ func foreachParallel(ctx *app.Context, opts Options, branches []engine.Branch, h
 		results <- result{
 			branchName: res.branchName,
 			output:     res.output,
+			exitCode:   res.exitCode,
 			err:        res.err,
 		}
 	})
@@ -323,6 +329,7 @@ func foreachParallel(ctx *app.Context, opts Options, branches []engine.Branch, h
 		allResults = append(allResults, BranchResult{
 			BranchName: res.branchName,
 			Status:     status,
+			ExitCode:   res.exitCode,
 			Output:     res.output,
 			Error:      res.err,
 		})
@@ -370,11 +377,13 @@ func foreachParallel(ctx *app.Context, opts Options, branches []engine.Branch, h
 func executeCommandOnBranch(ctx context.Context, appCtx *app.Context, branch engine.Branch, fullCommand string, hooks []string) struct {
 	branchName string
 	output     string
+	exitCode   int
 	err        error
 } {
 	res := struct {
 		branchName string
 		output     string
+		exitCode   int
 		err        error
 	}{branchName: branch.GetName()}
 
@@ -382,6 +391,7 @@ func executeCommandOnBranch(ctx context.Context, appCtx *app.Context, branch eng
 	// Use SkipPrune variant since foreachParallel already pruned once before parallel execution.
 	worktreePath, cleanup, err := appCtx.Engine.CreateTemporaryWorktreeSkipPrune(ctx, branch.GetName(), "stackit-foreach-*")
 	if err != nil {
+		res.exitCode = -1
 		res.err = err
 		return res
 	}
@@ -399,8 +409,20 @@ func executeCommandOnBranch(ctx context.Context, appCtx *app.Context, branch eng
 	cmd.Env = append(cmd.Env, "STACKIT_BRANCH="+branch.GetName())
 
 	if err := cmd.Run(); err != nil {
+		res.exitCode = exitCodeFromError(err)
 		res.err = err
 	}
 	res.output = output.String()
 	return res
+}
+
+func exitCodeFromError(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if stderrors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
 }

--- a/internal/actions/foreach/json_handler.go
+++ b/internal/actions/foreach/json_handler.go
@@ -1,0 +1,107 @@
+package foreach
+
+import "sync"
+
+// JSONStatus represents the aggregate outcome of a foreach operation.
+type JSONStatus string
+
+const (
+	JSONStatusSuccess JSONStatus = "success"
+	JSONStatusFailure JSONStatus = "failure"
+	JSONStatusError   JSONStatus = "error"
+)
+
+// JSONResult represents the JSON output for foreach operations.
+type JSONResult struct {
+	Status       JSONStatus         `json:"status"`
+	Error        string             `json:"error,omitempty"`
+	Message      string             `json:"message,omitempty"`
+	Command      string             `json:"command,omitempty"`
+	Results      []JSONBranchResult `json:"results"`
+	TotalCount   int                `json:"total_count"`
+	SuccessCount int                `json:"success_count"`
+	FailureCount int                `json:"failure_count"`
+}
+
+// JSONBranchResult represents one branch result in foreach JSON output.
+type JSONBranchResult struct {
+	Branch   string       `json:"branch"`
+	Status   BranchStatus `json:"status"`
+	ExitCode int          `json:"exit_code"`
+	Output   string       `json:"output,omitempty"`
+	Error    string       `json:"error,omitempty"`
+}
+
+// JSONHandler collects foreach events for JSON output.
+type JSONHandler struct {
+	mu     sync.Mutex
+	Result *JSONResult
+}
+
+// NewJSONHandler creates a handler that collects foreach results as JSON data.
+func NewJSONHandler() *JSONHandler {
+	return &JSONHandler{
+		Result: &JSONResult{
+			Results: []JSONBranchResult{},
+		},
+	}
+}
+
+// OnEvent implements Handler.
+func (h *JSONHandler) OnEvent(e Event) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	switch ev := e.(type) {
+	case StackDisplayEvent:
+		h.Result.Command = ev.Command
+	case CompletionEvent:
+		h.Result.Message = ev.Message
+		h.Result.TotalCount = len(ev.Results)
+		h.Result.Results = make([]JSONBranchResult, 0, len(ev.Results))
+		h.Result.SuccessCount = 0
+		h.Result.FailureCount = 0
+
+		for _, result := range ev.Results {
+			branchResult := JSONBranchResult{
+				Branch:   result.BranchName,
+				Status:   result.Status,
+				ExitCode: result.ExitCode,
+				Output:   result.Output,
+			}
+			if result.Error != nil {
+				branchResult.Error = result.Error.Error()
+			}
+			h.Result.Results = append(h.Result.Results, branchResult)
+
+			if result.Status == StatusDone {
+				h.Result.SuccessCount++
+			} else {
+				h.Result.FailureCount++
+			}
+		}
+
+		if h.Result.FailureCount > 0 {
+			h.Result.Status = JSONStatusFailure
+		} else {
+			h.Result.Status = JSONStatusSuccess
+		}
+	}
+}
+
+// SetError records an action-level error in the JSON result.
+func (h *JSONHandler) SetError(err error) {
+	if err == nil {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.Result.Error = err.Error()
+	if h.Result.FailureCount > 0 {
+		h.Result.Status = JSONStatusFailure
+		return
+	}
+	h.Result.Status = JSONStatusError
+}

--- a/internal/cli/stack/foreach.go
+++ b/internal/cli/stack/foreach.go
@@ -1,6 +1,9 @@
 package stack
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"stackit.dev/stackit/internal/actions/foreach"
@@ -19,6 +22,7 @@ func NewForeachCmd() *cobra.Command {
 		noFailFast bool
 		parallel   bool
 		jobs       int
+		jsonOutput bool
 	)
 
 	cmd := &cobra.Command{
@@ -70,6 +74,21 @@ Examples:
 					}
 				}
 
+				if jsonOutput {
+					jsonHandler := foreach.NewJSONHandler()
+					err := foreach.Action(ctx, opts, jsonHandler)
+					if err != nil {
+						jsonHandler.SetError(err)
+					}
+
+					data, marshalErr := json.MarshalIndent(jsonHandler.Result, "", "  ")
+					if marshalErr != nil {
+						return fmt.Errorf("failed to marshal JSON: %w", marshalErr)
+					}
+					ctx.Output.Info("%s", string(data))
+					return err
+				}
+
 				// Create runner (manages terminal state) and handler (processes events)
 				runner, handler := NewForeachUI(ctx.Output, ctx.Logger, opts.Parallel)
 				defer runner.Cleanup()
@@ -85,6 +104,7 @@ Examples:
 	cmd.Flags().BoolVar(&noFailFast, "no-fail-fast", false, "Don't stop execution on the first failure")
 	cmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run commands in parallel using git worktrees")
 	cmd.Flags().IntVarP(&jobs, "jobs", "j", 0, "Number of parallel jobs (default: number of CPUs)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output results in JSON format.")
 
 	return cmd
 }

--- a/internal/cli/stack/foreach_test.go
+++ b/internal/cli/stack/foreach_test.go
@@ -1,10 +1,12 @@
 package stack_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"stackit.dev/stackit/internal/actions/foreach"
 	"stackit.dev/stackit/testhelpers"
 	"stackit.dev/stackit/testhelpers/scenario"
 )
@@ -162,5 +164,54 @@ All branches completed successfully (3 total)
 `), testhelpers.NormalizeOutput(output))
 
 		s.ExpectBranch("b3")
+	})
+
+	t.Run("json output reports branch results", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s.RunCli("init")
+		s.RunCli("create", "b1")
+		s.RunCli("create", "b2")
+		s.RunCli("checkout", "b1")
+
+		output, err := s.RunCliAndGetOutput("foreach", "--json", "echo", "$STACKIT_BRANCH")
+		require.NoError(t, err)
+
+		var result foreach.JSONResult
+		require.NoError(t, json.Unmarshal([]byte(output), &result))
+		require.Equal(t, foreach.JSONStatusSuccess, result.Status)
+		require.Equal(t, "echo $STACKIT_BRANCH", result.Command)
+		require.Equal(t, 2, result.TotalCount)
+		require.Equal(t, 2, result.SuccessCount)
+		require.Equal(t, 0, result.FailureCount)
+		require.Equal(t, []foreach.JSONBranchResult{
+			{Branch: "b1", Status: foreach.StatusDone, ExitCode: 0, Output: "b1\n"},
+			{Branch: "b2", Status: foreach.StatusDone, ExitCode: 0, Output: "b2\n"},
+		}, result.Results)
+	})
+
+	t.Run("json output reports command failures", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s.RunCli("init")
+		s.RunCli("create", "b1")
+		s.RunCli("create", "b2")
+		s.RunCli("checkout", "b1")
+
+		output, err := s.RunCliAndGetOutput("foreach", "--json", "--no-fail-fast", "false")
+		require.NoError(t, err)
+
+		var result foreach.JSONResult
+		require.NoError(t, json.Unmarshal([]byte(output), &result))
+		require.Equal(t, foreach.JSONStatusFailure, result.Status)
+		require.Equal(t, 2, result.TotalCount)
+		require.Equal(t, 0, result.SuccessCount)
+		require.Equal(t, 2, result.FailureCount)
+		require.Len(t, result.Results, 2)
+		for _, branchResult := range result.Results {
+			require.Equal(t, foreach.StatusError, branchResult.Status)
+			require.Equal(t, 1, branchResult.ExitCode)
+			require.Contains(t, branchResult.Error, "exit status 1")
+		}
 	})
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1776899834`.


* **PR #862**
  * **PR #863**
    * **PR #864** 👈
      * **PR #865**
        * **PR #866**
          * **PR #867**
            * **PR #868**
              * **PR #869**
                * **PR #870**
                  * **PR #871**
                    * **PR #872**
                      * **PR #873**
                        * **PR #874**
                          * **PR #875**
                            * **PR #876**
                              * **PR #877**
                                * **PR #878**
                                  * **PR #880**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->