### PR TITLE
feat(foreach): add stack range filtering and parallel execution

### DIFF
--- a/internal/actions/foreach/foreach.go
+++ b/internal/actions/foreach/foreach.go
@@ -20,13 +20,14 @@ import (
 
 // Options contains options for the foreach command
 type Options struct {
-	Command    string
-	Args       []string
-	BranchName string
-	Scope      engine.StackRange
-	FailFast   bool
-	Parallel   bool
-	Jobs       int
+	Command          string
+	Args             []string
+	BranchName       string
+	Scope            engine.StackRange
+	FailFast         bool
+	Parallel         bool
+	FindFirstFailure bool
+	Jobs             int
 }
 
 // Action executes a command on each branch in the stack with event handling
@@ -92,6 +93,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 	handler.OnEvent(ExecutionStartEvent{Branches: branchInfos})
 
+	if opts.FindFirstFailure {
+		return foreachFindFirstFailure(ctx, opts, nonTrunkBranches, graph, handler)
+	}
 	if opts.Parallel {
 		return foreachParallel(ctx, opts, nonTrunkBranches, handler)
 	}
@@ -372,6 +376,158 @@ func foreachParallel(ctx *app.Context, opts Options, branches []engine.Branch, h
 		Results: sortedResults,
 	})
 	return nil
+}
+
+func foreachFindFirstFailure(ctx *app.Context, opts Options, branches []engine.Branch, graph *engine.StackGraph, handler Handler) error {
+	numJobs := opts.Jobs
+	if numJobs <= 0 {
+		numJobs = stdruntime.NumCPU()
+	}
+
+	_ = ctx.Engine.PruneWorktrees(ctx.Context)
+
+	approvedHooks, err := worktree.ResolveApprovedHooks(ctx)
+	if err != nil {
+		ctx.Output.Warn("Failed to resolve worktree hooks: %v", err)
+	}
+
+	fullCommand := strings.Join(append([]string{opts.Command}, opts.Args...), " ")
+	branchesByDepth := groupBranchesByDepth(branches, graph)
+
+	allResults := make([]BranchResult, 0, len(branches))
+	depthOpts := opts
+	depthOpts.FailFast = false
+	for _, depthGroup := range branchesByDepth {
+		groupResults := runBranchesInWorktrees(ctx, depthOpts, depthGroup.branches, handler, fullCommand, approvedHooks, numJobs)
+		allResults = append(allResults, groupResults...)
+
+		if hasFailedResult(groupResults) {
+			handler.OnEvent(CompletionEvent{
+				Success: false,
+				Message: fmt.Sprintf("Command failed at stack depth %d", depthGroup.depth),
+				Results: allResults,
+			})
+			return fmt.Errorf("command failed at stack depth %d", depthGroup.depth)
+		}
+	}
+
+	handler.OnEvent(CompletionEvent{
+		Success: true,
+		Message: "Execution complete",
+		Results: allResults,
+	})
+	return nil
+}
+
+type branchDepthGroup struct {
+	depth    int
+	branches []engine.Branch
+}
+
+func groupBranchesByDepth(branches []engine.Branch, graph *engine.StackGraph) []branchDepthGroup {
+	groups := []branchDepthGroup{}
+	groupByDepth := make(map[int]int)
+	for _, branch := range branches {
+		depth := 0
+		if node := graph.GetNode(branch.GetName()); node != nil {
+			depth = node.Depth
+		}
+
+		idx, ok := groupByDepth[depth]
+		if !ok {
+			idx = len(groups)
+			groupByDepth[depth] = idx
+			groups = append(groups, branchDepthGroup{depth: depth})
+		}
+		groups[idx].branches = append(groups[idx].branches, branch)
+	}
+	return groups
+}
+
+func runBranchesInWorktrees(ctx *app.Context, opts Options, branches []engine.Branch, handler Handler, fullCommand string, hooks []string, numJobs int) []BranchResult {
+	type result struct {
+		branchName string
+		output     string
+		exitCode   int
+		err        error
+	}
+
+	results := make(chan result, len(branches))
+	runCtx, cancel := context.WithCancel(ctx.Context)
+	defer cancel()
+
+	utils.RunWithWorkers(branches, numJobs, func(branch engine.Branch) {
+		select {
+		case <-runCtx.Done():
+			return
+		default:
+		}
+
+		branchName := branch.GetName()
+		handler.OnEvent(BranchProgressEvent{
+			BranchName: branchName,
+			Status:     StatusRunning,
+		})
+
+		res := executeCommandOnBranch(runCtx, ctx, branch, fullCommand, hooks)
+		if res.err != nil {
+			if opts.FailFast {
+				cancel()
+			}
+			handler.OnEvent(BranchProgressEvent{
+				BranchName: branchName,
+				Status:     StatusError,
+				Output:     res.output,
+				Error:      res.err,
+			})
+		} else {
+			handler.OnEvent(BranchProgressEvent{
+				BranchName: branchName,
+				Status:     StatusDone,
+				Output:     res.output,
+			})
+		}
+
+		results <- result{
+			branchName: res.branchName,
+			output:     res.output,
+			exitCode:   res.exitCode,
+			err:        res.err,
+		}
+	})
+	close(results)
+
+	resultMap := make(map[string]BranchResult)
+	for res := range results {
+		status := StatusDone
+		if res.err != nil {
+			status = StatusError
+		}
+		resultMap[res.branchName] = BranchResult{
+			BranchName: res.branchName,
+			Status:     status,
+			ExitCode:   res.exitCode,
+			Output:     res.output,
+			Error:      res.err,
+		}
+	}
+
+	sortedResults := make([]BranchResult, 0, len(branches))
+	for _, branch := range branches {
+		if result, ok := resultMap[branch.GetName()]; ok {
+			sortedResults = append(sortedResults, result)
+		}
+	}
+	return sortedResults
+}
+
+func hasFailedResult(results []BranchResult) bool {
+	for _, result := range results {
+		if result.Status == StatusError {
+			return true
+		}
+	}
+	return false
 }
 
 func executeCommandOnBranch(ctx context.Context, appCtx *app.Context, branch engine.Branch, fullCommand string, hooks []string) struct {

--- a/internal/actions/foreach/foreach_test.go
+++ b/internal/actions/foreach/foreach_test.go
@@ -330,4 +330,63 @@ func TestForeachAction(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "branch untracked is not tracked by stackit")
 	})
+
+	t.Run("find first failure stops after first failing depth", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"root":         "main",
+				"child-a":      "root",
+				"child-b":      "root",
+				"grandchild-a": "child-a",
+			})
+
+		s.Checkout("root")
+
+		handler := &testHandler{}
+		opts := foreach.Options{
+			Command:          "case \"$STACKIT_BRANCH\" in child-a|child-b) exit 1;; *) exit 0;; esac",
+			Scope:            engine.StackRange{IncludeCurrent: true, RecursiveChildren: true},
+			FindFirstFailure: true,
+			Jobs:             2,
+		}
+
+		err := foreach.Action(s.Context, opts, handler)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "command failed at stack depth 2")
+
+		var doneBranches []string
+		var failedBranches []string
+		for _, e := range handler.Events() {
+			if bpe, ok := e.(foreach.BranchProgressEvent); ok {
+				switch bpe.Status {
+				case foreach.StatusDone:
+					doneBranches = append(doneBranches, bpe.BranchName)
+				case foreach.StatusError:
+					failedBranches = append(failedBranches, bpe.BranchName)
+				}
+			}
+		}
+		require.Equal(t, []string{"root"}, doneBranches)
+		require.ElementsMatch(t, []string{"child-a", "child-b"}, failedBranches)
+		require.NotContains(t, append(doneBranches, failedBranches...), "grandchild-a")
+
+		var completion foreach.CompletionEvent
+		for _, e := range handler.Events() {
+			if ev, ok := e.(foreach.CompletionEvent); ok {
+				completion = ev
+			}
+		}
+		require.False(t, completion.Success)
+		require.Len(t, completion.Results, 3)
+		require.Equal(t, []string{"root", "child-a", "child-b"}, branchResultNames(completion.Results))
+	})
+}
+
+func branchResultNames(results []foreach.BranchResult) []string {
+	names := make([]string, len(results))
+	for i, result := range results {
+		names[i] = result.BranchName
+	}
+	return names
 }

--- a/internal/cli/stack/foreach.go
+++ b/internal/cli/stack/foreach.go
@@ -21,6 +21,7 @@ func NewForeachCmd() *cobra.Command {
 		branch     string
 		noFailFast bool
 		parallel   bool
+		firstFail  bool
 		jobs       int
 		jsonOutput bool
 	)
@@ -43,12 +44,13 @@ Examples:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
 				opts := foreach.Options{
-					Command:    args[0],
-					Args:       args[1:],
-					BranchName: branch,
-					FailFast:   !noFailFast,
-					Parallel:   parallel,
-					Jobs:       jobs,
+					Command:          args[0],
+					Args:             args[1:],
+					BranchName:       branch,
+					FailFast:         !noFailFast,
+					Parallel:         parallel,
+					FindFirstFailure: firstFail,
+					Jobs:             jobs,
 				}
 
 				// Define the traversal range
@@ -86,7 +88,7 @@ Examples:
 						return fmt.Errorf("failed to marshal JSON: %w", marshalErr)
 					}
 					ctx.Output.Info("%s", string(data))
-					return err
+					return nil
 				}
 
 				// Create runner (manages terminal state) and handler (processes events)
@@ -103,6 +105,7 @@ Examples:
 	cmd.Flags().StringVar(&branch, "branch", "", "Which branch to run this command from. Defaults to the current branch.")
 	cmd.Flags().BoolVar(&noFailFast, "no-fail-fast", false, "Don't stop execution on the first failure")
 	cmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run commands in parallel using git worktrees")
+	cmd.Flags().BoolVar(&firstFail, "find-first-failure", false, "Run branches at each stack depth in parallel and stop after the first failing depth")
 	cmd.Flags().IntVarP(&jobs, "jobs", "j", 0, "Number of parallel jobs (default: number of CPUs)")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output results in JSON format.")
 

--- a/internal/cli/stack/foreach_test.go
+++ b/internal/cli/stack/foreach_test.go
@@ -214,4 +214,37 @@ All branches completed successfully (3 total)
 			require.Contains(t, branchResult.Error, "exit status 1")
 		}
 	})
+
+	t.Run("find-first-failure json stops before descendants", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s.RunCli("init")
+		s.RunCli("create", "root")
+		s.RunCli("create", "child-a")
+		s.RunCli("checkout", "root")
+		s.RunCli("create", "child-b")
+		s.RunCli("checkout", "child-a")
+		s.RunCli("create", "grandchild-a")
+		s.RunCli("checkout", "root")
+
+		command := "case \"$STACKIT_BRANCH\" in child-a|child-b) exit 1;; *) echo $STACKIT_BRANCH;; esac"
+		output, err := s.RunCliAndGetOutput("foreach", "--json", "--find-first-failure", "--jobs", "2", command)
+		require.NoError(t, err)
+
+		var result foreach.JSONResult
+		require.NoError(t, json.Unmarshal([]byte(output), &result))
+		require.Equal(t, foreach.JSONStatusFailure, result.Status)
+		require.Equal(t, 3, result.TotalCount)
+		require.Equal(t, 1, result.SuccessCount)
+		require.Equal(t, 2, result.FailureCount)
+		require.Equal(t, []string{"root", "child-a", "child-b"}, jsonBranchNames(result.Results))
+	})
+}
+
+func jsonBranchNames(results []foreach.JSONBranchResult) []string {
+	names := make([]string, len(results))
+	for i, result := range results {
+		names[i] = result.Branch
+	}
+	return names
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #862**
  * **PR #863**
    * **PR #864**
      * **PR #865** 👈
        * **PR #866**
          * **PR #867**
            * **PR #868**
              * **PR #869**
                * **PR #870**
                  * **PR #871**
                    * **PR #872**
                      * **PR #873**
                        * **PR #874**
                          * **PR #875**
                            * **PR #876**
                              * **PR #877**
                                * **PR #878**
                                  * **PR #880**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #882 by jonnii*