### PR TITLE
feat(sync): add would_restack_stacks to dry-run JSON for restack planning

### DIFF
--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -18,10 +18,11 @@ import (
 
 // DryRunResult represents the JSON output for sync --dry-run
 type DryRunResult struct {
-	WouldPull     string   `json:"would_pull,omitempty"`     // Trunk branch that would be pulled
-	WouldClean    []string `json:"would_clean,omitempty"`    // Branches that would be deleted
-	WouldRestack  []string `json:"would_restack,omitempty"`  // Branches that would be restacked
-	SkippedStacks []string `json:"skipped_stacks,omitempty"` // Stacks skipped due to dirty worktrees
+	WouldPull          string   `json:"would_pull,omitempty"`           // Trunk branch that would be pulled
+	WouldClean         []string `json:"would_clean,omitempty"`          // Branches that would be deleted
+	WouldRestack       []string `json:"would_restack,omitempty"`        // Branches that would be restacked
+	WouldRestackStacks []string `json:"would_restack_stacks,omitempty"` // Deduped independent stack roots covering would_restack — pass to `restack --stacks <roots>`
+	SkippedStacks      []string `json:"skipped_stacks,omitempty"`       // Stacks skipped due to dirty worktrees
 }
 
 // Options contains options for the sync command

--- a/internal/cli/stack/sync.go
+++ b/internal/cli/stack/sync.go
@@ -4,6 +4,7 @@ package stack
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/spf13/cobra"
 
@@ -108,6 +109,7 @@ func syncDryRunJSON(ctx *app.Context, opts sync.Options) error {
 	// Collect candidate branches for deletion and restack checks
 	allBranches := eng.AllBranches()
 	var candidateNames []string
+	restackRootSet := make(map[string]struct{})
 	for _, branch := range allBranches {
 		if branch.IsTrunk() || !branch.IsTracked() {
 			continue
@@ -117,7 +119,20 @@ func syncDryRunJSON(ctx *app.Context, opts sync.Options) error {
 		// Check restack status while iterating
 		if opts.Restack && !branch.IsBranchUpToDate() {
 			result.WouldRestack = append(result.WouldRestack, branch.GetName())
+			if root := eng.GetStackRootForBranch(branch); root != "" {
+				restackRootSet[root] = struct{}{}
+			}
 		}
+	}
+
+	// Sort and dedupe restack roots so callers can pass them directly to `restack --stacks`.
+	if len(restackRootSet) > 0 {
+		roots := make([]string, 0, len(restackRootSet))
+		for root := range restackRootSet {
+			roots = append(roots, root)
+		}
+		sort.Strings(roots)
+		result.WouldRestackStacks = roots
 	}
 
 	// Batch-check deletion status for all candidates

--- a/internal/integration/json_output_test.go
+++ b/internal/integration/json_output_test.go
@@ -205,6 +205,43 @@ func TestJSONOutput(t *testing.T) {
 		// JSON was valid and parseable - verified by NoError above
 	})
 
+	t.Run("sync --dry-run --json --restack reports stack roots for would_restack branches", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t, WithRemote())
+
+		// Build two independent stacks rooted at trunk:
+		//   main -> alpha-root -> alpha-child
+		//   main -> beta-root
+		sh.Write("alpha_root", "alpha root").
+			Run("create alpha-root -m 'Add alpha root'").
+			Write("alpha_child", "alpha child").
+			Run("create alpha-child -m 'Add alpha child'").
+			Run("trunk").
+			Write("beta_root", "beta root").
+			Run("create beta-root -m 'Add beta root'")
+
+		// Force alpha-root to diverge from trunk by amending trunk's view via a new commit on trunk.
+		// We use a direct git call to shift trunk, then mark alpha-root as needing restack.
+		sh.Run("checkout alpha-root").
+			Git("commit --allow-empty -m 'force restack'")
+
+		// Checkout back to alpha-child so restack scope discovery sees the stack.
+		sh.Run("checkout alpha-child")
+
+		sh.Run("sync --dry-run --json --restack")
+		output := sh.Output()
+
+		var result sync.DryRunResult
+		err := json.Unmarshal([]byte(output), &result)
+		require.NoError(t, err, "sync --dry-run --json --restack should produce valid JSON")
+
+		// Every would_restack branch should map to a root; the deduped set should be
+		// sorted and contain only known stack roots (alpha-root, beta-root).
+		require.NotNil(t, result.WouldRestackStacks, "would_restack_stacks should be populated when branches need restack")
+		require.Equal(t, []string{"alpha-root"}, result.WouldRestackStacks,
+			"should deduplicate and sort restack roots; only alpha's stack has drift")
+	})
+
 	t.Run("log --json with no tracked branches outputs valid JSON", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #862**
  * **PR #863**
    * **PR #864**
      * **PR #865**
        * **PR #866**
          * **PR #867**
            * **PR #868**
              * **PR #869**
                * **PR #870**
                  * **PR #871**
                    * **PR #872**
                      * **PR #873** 👈
                        * **PR #874**
                          * **PR #875**
                            * **PR #876**
                              * **PR #877**
                                * **PR #878**
                                  * **PR #880**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #882 by jonnii*