### PR TITLE
feat(restack): add --parallel flag to run independent stacks in parallel worktrees

### DIFF
--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -2,13 +2,16 @@ package actions
 
 import (
 	"fmt"
+	stdruntime "runtime"
 	"strings"
+	"sync"
 
 	"stackit.dev/stackit/internal/app"
 	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/internal/handlers"
 	"stackit.dev/stackit/internal/rerere"
 	"stackit.dev/stackit/internal/tui"
+	"stackit.dev/stackit/internal/utils"
 )
 
 // RestackOptions contains options for the restack command
@@ -18,6 +21,8 @@ type RestackOptions struct {
 	AllStacks          bool
 	StackRoots         []string
 	ContinueOnConflict bool
+	Parallel           bool // Run independent stack groups in parallel worktrees
+	Jobs               int  // Number of parallel workers (0 = NumCPU)
 }
 
 // RestackAction performs the restack operation
@@ -55,6 +60,7 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 		WithFlag(opts.AllStacks, "--all-stacks"),
 		WithFlagValue("--stacks", joinStrings(opts.StackRoots)),
 		WithFlag(opts.ContinueOnConflict, "--continue-on-conflict"),
+		WithFlag(opts.Parallel, "--parallel"),
 	)
 	if err := eng.TakeSnapshot(snapshotOpts); err != nil {
 		// Log but don't fail - snapshot is best effort
@@ -81,6 +87,14 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 	var restacked, skipped int
 	var conflicts []string
 
+	// Parallel mode: dispatch independent stack groups to separate worktrees.
+	if opts.Parallel && len(branchGroups) > 1 {
+		restacked, skipped, conflicts = restackGroupsParallel(ctx, opts, branchGroups, handler)
+		ctx.Logger.Info("restack completed (parallel) restacked=%v skipped=%v conflicts=%v", restacked, skipped, len(conflicts))
+		handler.OnRestackComplete(restacked, skipped, conflicts)
+		return nil
+	}
+
 	progress := func(p RestackProgress) {
 		handleRestackProgress(eng, handler, p, &restacked, &skipped, &conflicts)
 	}
@@ -100,6 +114,82 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 
 	handler.OnRestackComplete(restacked, skipped, conflicts)
 	return nil
+}
+
+// restackGroupsParallel runs each independent stack group in its own temporary
+// worktree. The groups have no shared branches, so rebases + ref updates are
+// safe to interleave. Progress callbacks and handler calls are serialized via
+// a mutex to prevent data races on shared counters.
+func restackGroupsParallel(
+	ctx *app.Context,
+	opts RestackOptions,
+	groups []restackBranchGroup,
+	handler handlers.RestackHandler,
+) (restacked, skipped int, conflicts []string) {
+	eng := ctx.Engine
+
+	numJobs := opts.Jobs
+	if numJobs <= 0 {
+		numJobs = stdruntime.NumCPU()
+	}
+	if numJobs > len(groups) {
+		numJobs = len(groups)
+	}
+
+	// Prune stale worktrees once before creating new ones.
+	_ = eng.PruneWorktrees(ctx.Context)
+
+	// Snapshot the parent engine state once — each worktree engine gets a copy.
+	snapshot := eng.SnapshotForWorktree()
+
+	// Shared result counters protected by a mutex.
+	var mu sync.Mutex
+
+	utils.RunWithWorkers(groups, numJobs, func(group restackBranchGroup) {
+		// Create a temporary worktree for this group. PruneSkip because we
+		// pruned once above and don't want N workers racing on prune.
+		wtPath, cleanup, err := eng.CreateTemporaryWorktreeSkipPrune(ctx.Context, eng.Trunk().GetName(), "stackit-restack-*")
+		if err != nil {
+			ctx.Logger.Warn("failed to create worktree for parallel restack: %v", err)
+			return
+		}
+		defer cleanup()
+
+		// Build a per-worktree engine from the snapshot.
+		wtEngine, err := engine.NewEngineForWorktree(engine.WorktreeEngineOptions{
+			WorktreePath: wtPath,
+			Snapshot:     snapshot,
+		})
+		if err != nil {
+			ctx.Logger.Warn("failed to create worktree engine: %v", err)
+			return
+		}
+
+		// Shallow-copy the app context, swapping in the worktree engine.
+		wtCtx := *ctx
+		wtCtx.Engine = wtEngine
+		wtCtx.RepoRoot = wtPath
+
+		// Thread-safe progress callback that funnels into the shared counters + handler.
+		progress := func(p RestackProgress) {
+			mu.Lock()
+			defer mu.Unlock()
+			handleRestackProgress(eng, handler, p, &restacked, &skipped, &conflicts)
+		}
+
+		sortedBranches := eng.SortBranchesTopologically(group.branches)
+		if err := RestackBranchesWithHandler(&wtCtx, sortedBranches, progress, !opts.ContinueOnConflict); err != nil {
+			ctx.Logger.Warn("parallel restack group failed: %v", err)
+		}
+	})
+
+	// Rebuild the main engine's cache so it sees the ref changes made by the
+	// worktree engines (they share the same .git directory).
+	if err := eng.Rebuild(eng.Trunk().GetName()); err != nil {
+		ctx.Logger.Warn("failed to rebuild engine after parallel restack: %v", err)
+	}
+
+	return restacked, skipped, conflicts
 }
 
 type restackBranchGroup struct {

--- a/internal/cli/stack/restack.go
+++ b/internal/cli/stack/restack.go
@@ -24,6 +24,8 @@ func NewRestackCmd() *cobra.Command {
 		allStacks          bool
 		stacks             []string
 		continueOnConflict bool
+		parallel           bool
+		jobs               int
 		jsonOutput         bool
 	)
 
@@ -59,6 +61,13 @@ If conflicts are encountered, you will be prompted to resolve them via an intera
 				if multiStack && scopeFlags > 0 {
 					return fmt.Errorf("--downstack, --only, and --upstack cannot be used with --all-stacks or --stacks")
 				}
+				// --jobs implies --parallel
+				if jobs > 0 {
+					parallel = true
+				}
+				if parallel && !multiStack {
+					return fmt.Errorf("--parallel requires --all-stacks or --stacks")
+				}
 
 				// Determine target branch
 				targetBranch := branch
@@ -86,6 +95,8 @@ If conflicts are encountered, you will be prompted to resolve them via an intera
 						AllStacks:          allStacks,
 						StackRoots:         stacks,
 						ContinueOnConflict: continueOnConflict,
+						Parallel:           parallel,
+						Jobs:               jobs,
 					}, jsonHandler)
 
 					// Set error status if there was an error
@@ -115,6 +126,8 @@ If conflicts are encountered, you will be prompted to resolve them via an intera
 					AllStacks:          allStacks,
 					StackRoots:         stacks,
 					ContinueOnConflict: continueOnConflict,
+					Parallel:           parallel,
+					Jobs:               jobs,
 				}, handler)
 			})
 		},
@@ -127,6 +140,8 @@ If conflicts are encountered, you will be prompted to resolve them via an intera
 	cmd.Flags().BoolVar(&allStacks, "all-stacks", false, "Restack every independent stack rooted at trunk.")
 	cmd.Flags().StringSliceVar(&stacks, "stacks", nil, "Restack specific independent stack roots (comma-separated).")
 	cmd.Flags().BoolVar(&continueOnConflict, "continue-on-conflict", false, "Report restack conflicts without entering conflict resolution, continuing to independent stacks when possible.")
+	cmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run independent stack groups in parallel worktrees (requires --all-stacks or --stacks).")
+	cmd.Flags().IntVarP(&jobs, "jobs", "j", 0, "Number of parallel jobs (default: number of CPUs). Implies --parallel.")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output results in JSON format.")
 
 	return cmd

--- a/internal/cli/stack/restack_test.go
+++ b/internal/cli/stack/restack_test.go
@@ -506,6 +506,124 @@ func TestRestackCommand(t *testing.T) {
 		require.NotEqual(t, stackBBefore, stackBAfter)
 	})
 
+	t.Run("restack --all-stacks --parallel restacks every independent stack", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+			if err := s.Repo.CreateChangeAndCommit("initial", "init"); err != nil {
+				return err
+			}
+
+			if err := s.Repo.CreateChange("stackA change", "stackA", false); err != nil {
+				return err
+			}
+			createStackitBranch(t, binaryPath, s.Dir, "stackA", "stackA change")
+
+			if err := s.Repo.CreateChange("stackA-child change", "stackA-child", false); err != nil {
+				return err
+			}
+			createStackitBranch(t, binaryPath, s.Dir, "stackA-child", "stackA-child change")
+
+			if err := s.Repo.CheckoutBranch("main"); err != nil {
+				return err
+			}
+			if err := s.Repo.CreateChange("stackB change", "stackB", false); err != nil {
+				return err
+			}
+			createStackitBranch(t, binaryPath, s.Dir, "stackB", "stackB change")
+			return nil
+		})
+
+		stackABefore, err := scene.Repo.GetBranchSHA("stackA")
+		require.NoError(t, err)
+		stackAChildBefore, err := scene.Repo.GetBranchSHA("stackA-child")
+		require.NoError(t, err)
+		stackBBefore, err := scene.Repo.GetBranchSHA("stackB")
+		require.NoError(t, err)
+
+		err = scene.Repo.CheckoutBranch("main")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("main update", "main")
+		require.NoError(t, err)
+
+		cmd := exec.Command(binaryPath, "restack", "--all-stacks", "--parallel", "--jobs", "2")
+		cmd.Dir = scene.Dir
+		output, err := cmd.CombinedOutput()
+
+		require.NoError(t, err, "restack --all-stacks --parallel failed: %s", string(output))
+
+		// Verify all branches were actually restacked (SHAs changed)
+		stackAAfter, err := scene.Repo.GetBranchSHA("stackA")
+		require.NoError(t, err)
+		stackAChildAfter, err := scene.Repo.GetBranchSHA("stackA-child")
+		require.NoError(t, err)
+		stackBAfter, err := scene.Repo.GetBranchSHA("stackB")
+		require.NoError(t, err)
+		require.NotEqual(t, stackABefore, stackAAfter)
+		require.NotEqual(t, stackAChildBefore, stackAChildAfter)
+		require.NotEqual(t, stackBBefore, stackBAfter)
+	})
+
+	t.Run("restack --all-stacks --parallel --continue-on-conflict skips conflicted stacks", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+			if err := s.Repo.CreateChangeAndCommit("initial", "conflict"); err != nil {
+				return err
+			}
+
+			if err := s.Repo.CreateChange("stackA conflicting change", "conflict", false); err != nil {
+				return err
+			}
+			createStackitBranch(t, binaryPath, s.Dir, "stackA", "stackA conflicting change")
+
+			if err := s.Repo.CheckoutBranch("main"); err != nil {
+				return err
+			}
+			if err := s.Repo.CreateChange("stackB change", "stackB", false); err != nil {
+				return err
+			}
+			createStackitBranch(t, binaryPath, s.Dir, "stackB", "stackB change")
+			return nil
+		})
+
+		stackABefore, err := scene.Repo.GetBranchSHA("stackA")
+		require.NoError(t, err)
+		stackBBefore, err := scene.Repo.GetBranchSHA("stackB")
+		require.NoError(t, err)
+
+		err = scene.Repo.CheckoutBranch("main")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("main conflicting change", "conflict")
+		require.NoError(t, err)
+
+		cmd := exec.Command(binaryPath, "restack", "--all-stacks", "--parallel", "--jobs", "2", "--continue-on-conflict")
+		cmd.Dir = scene.Dir
+		output, err := cmd.CombinedOutput()
+
+		require.NoError(t, err, "restack command failed: %s", string(output))
+
+		// stackA should be untouched (conflict); stackB should be restacked
+		stackAAfter, err := scene.Repo.GetBranchSHA("stackA")
+		require.NoError(t, err)
+		stackBAfter, err := scene.Repo.GetBranchSHA("stackB")
+		require.NoError(t, err)
+		require.Equal(t, stackABefore, stackAAfter)
+		require.NotEqual(t, stackBBefore, stackBAfter)
+	})
+
+	t.Run("restack --parallel without --all-stacks errors", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+			return s.Repo.CreateChangeAndCommit("initial", "init")
+		})
+
+		cmd := exec.Command(binaryPath, "restack", "--parallel")
+		cmd.Dir = scene.Dir
+		output, err := cmd.CombinedOutput()
+
+		require.Error(t, err, "restack --parallel should require --all-stacks or --stacks")
+		require.Contains(t, string(output), "--parallel requires --all-stacks or --stacks")
+	})
+
 	t.Run("restack errors when multiple scope flags specified", func(t *testing.T) {
 		t.Parallel()
 		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {

--- a/internal/handlers/restack.go
+++ b/internal/handlers/restack.go
@@ -2,6 +2,8 @@
 package handlers
 
 import (
+	"sync"
+
 	"stackit.dev/stackit/internal/engine"
 )
 
@@ -79,8 +81,10 @@ type RestackConflictInfo struct {
 	Parent string `json:"parent"`
 }
 
-// JSONRestackHandler collects restack results for JSON output
+// JSONRestackHandler collects restack results for JSON output.
+// All methods are mutex-protected so concurrent callers (parallel restack) are safe.
 type JSONRestackHandler struct {
+	mu     sync.Mutex
 	Result *RestackJSONResult
 }
 
@@ -97,11 +101,15 @@ func NewJSONRestackHandler() *JSONRestackHandler {
 
 // OnRestackStart implements RestackHandler.
 func (h *JSONRestackHandler) OnRestackStart(branchCount int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	h.Result.TotalCount = branchCount
 }
 
 // OnRestackBranch implements RestackHandler.
 func (h *JSONRestackHandler) OnRestackBranch(branch string, result RestackResult, newRev string, prNumber *int, _ engine.LockReason, _ bool, _ bool, parent string, _ bool, _, _ string, rerereResolvedCount int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	switch result {
 	case RestackDone:
 		h.Result.Restacked = append(h.Result.Restacked, RestackBranchInfo{
@@ -123,6 +131,8 @@ func (h *JSONRestackHandler) OnRestackBranch(branch string, result RestackResult
 
 // OnRestackComplete implements RestackHandler.
 func (h *JSONRestackHandler) OnRestackComplete(restacked, _ int, _ []string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	h.Result.RestackCount = restacked
 	h.Result.ConflictCount = len(h.Result.Conflicts)
 
@@ -137,6 +147,8 @@ func (h *JSONRestackHandler) OnRestackComplete(restacked, _ int, _ []string) {
 // Call this when the restack action returns an error.
 func (h *JSONRestackHandler) SetError(err error) {
 	if err != nil {
+		h.mu.Lock()
+		defer h.mu.Unlock()
 		// If we already observed restack conflicts, keep status as "conflict"
 		// and attach the error details for debugging/context.
 		if len(h.Result.Conflicts) > 0 {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #862**
  * **PR #863**
    * **PR #864**
      * **PR #865**
        * **PR #866**
          * **PR #867**
            * **PR #868**
              * **PR #869**
                * **PR #870**
                  * **PR #871**
                    * **PR #872**
                      * **PR #873**
                        * **PR #874**
                          * **PR #875** 👈
                            * **PR #876**
                              * **PR #877**
                                * **PR #878**
                                  * **PR #880**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #882 by jonnii*