### PR TITLE
docs: update restack examples to use scoped flags across user-facing docs

### DIFF
--- a/.claude/rules/stackit-workflow.md
+++ b/.claude/rules/stackit-workflow.md
@@ -9,7 +9,7 @@ This project uses stackit for stacked changes. **NEVER use raw git commands for 
 | `git commit -m "..."` | `command stackit create -m "..."` |
 | `git checkout -b` | `command stackit create -m "..."` |
 | `gh pr create` | `command stackit submit` |
-| `git rebase` | `command stackit restack` |
+| `git rebase` | `command stackit restack --upstack` (or `--all-stacks`) |
 
 **Exception:** `git commit` is allowed when adding commits to an existing stacked branch.
 
@@ -38,7 +38,7 @@ Use skills instead of manual commands:
 | `/stack-status` | Check stack health |
 | `/stack-fix` | Diagnose and fix issues |
 | `/stack-sync` | Sync with trunk, cleanup merged branches |
-| `/stack-restack` | Rebase all branches in stack |
+| `/stack-restack` | Rebase branches (scoped, multi-stack, or parallel) |
 | `/stack-tidy` | Clean up fixup/WIP commits across the stack |
 
 Run `/stackit` for the full guide.
@@ -51,7 +51,7 @@ Run `/stackit` for the full guide.
 | Empty branch created | You forgot to stage; delete branch and retry with staged changes |
 | Using `git commit` for new branch | Use `stackit create` - it creates branch + commit together |
 | Using `git checkout -b` | Use `stackit create` - branch name auto-generated from message |
-| Manual rebase broke stack | Use `stackit restack` to safely rebase all children |
+| Manual rebase broke stack | Use `stackit restack --upstack` to safely rebase children (or `--all-stacks` for all) |
 | Using `gh pr create` | Use `stackit submit` - it handles stacked PR dependencies |
 | Amending wrong commit | Use `stackit absorb` to auto-route changes to correct commits |
 | Stack out of sync after merge | Run `stackit sync` to cleanup merged branches and update trunk |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ command stackit submit
 command stackit checkout <branch>  # Go to branch with feedback
 # Make changes...
 command stackit modify             # Amend commit
-command stackit restack            # Update children
+command stackit restack --upstack   # Update children of this branch
 command stackit submit             # Update PRs
 ```
 
@@ -67,7 +67,7 @@ command stackit submit             # Update PRs
 | Forgetting to stage | Always `git add -A` before `create` |
 | Using `git commit` for new branch | Use `stackit create` instead |
 | Using `git checkout -b` | Use `stackit create` instead |
-| Manual rebase | Use `stackit restack` |
+| Manual rebase | Use `stackit restack --upstack` (or `--all-stacks`) |
 | Using `gh pr create` | Use `stackit submit` |
 
 **Use `/stack-plan` when starting from scratch** to plan the stack structure before writing code.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Stackit includes specialized commands designed for Claude Code, providing intell
 | `stack-create [branch-name]` | Create a new stacked branch with intelligent naming and commit messages | Adding a new feature branch to your stack |
 | `stack-submit [--stack \| --draft]` | Submit branches as PRs with auto-generated descriptions | Creating or updating pull requests |
 | `stack-sync` | Sync with trunk, cleanup merged branches, and restack | Keeping your stack up-to-date with main |
-| `stack-restack` | Rebase all branches to ensure proper ancestry | Fixing branch relationships after changes |
+| `stack-restack` | Rebase branches with scoped or multi-stack targeting | Fixing branch relationships after changes |
 | `stack-absorb` | Intelligently absorb working changes into correct commits | Applying fixes across multiple stack branches, with conflict resolution guidance |
 | `stack-fix` | Diagnose and fix common stack issues | Resolving compilation errors or structural problems |
 | `stack-describe` | Generate or update stack description from changes | Documenting your stack for PRs |
@@ -272,9 +272,9 @@ stack-submit --stack         # Creates/updates all PRs in the stack
 | Command | Description |
 |:---|:---|
 | `stackit flatten` | Move branches closer to trunk where possible |
-| `stackit restack` | Rebase all branches in the stack to ensure proper ancestry |
+| `stackit restack` | Rebase branches to ensure proper ancestry (`--branch X --upstack`, `--all-stacks`, `--stacks root1,root2`, `--parallel`) |
 | `stackit get [branch|PR]` | Sync a stack or specific PR from remote |
-| `stackit foreach` | Run a shell command on each branch in the stack (default: upstack) |
+| `stackit foreach` | Run a shell command on each branch (`--upstack`, `--all-stacks`, `--stacks`, `--parallel`) |
 | `stackit submit` | Push branches and create/update GitHub PRs (alias: `ss` for `--stack`) |
 | `stackit sync` | Pull trunk, delete merged branches, and restack |
 | `stackit merge` | Interactive merge wizard (use `merge next` or `merge ship` for non-interactive) |
@@ -323,7 +323,7 @@ These flags are available on all `stackit` commands:
 If you receive feedback on a branch in the middle of your stack:
 1. `stackit checkout <branch>` to move to that branch.
 2. Make your changes and run `stackit modify`.
-3. Run `stackit restack` to update all child branches.
+3. Run `stackit restack --upstack` to update child branches (or `--all-stacks` to cover every independent stack).
 4. Run `stackit submit` to update the PRs on GitHub.
 
 ### Using `stackit absorb`
@@ -535,7 +535,7 @@ stackit track
 
 ### Merge conflicts during restack
 
-When `stackit restack` encounters conflicts:
+When `stackit restack` encounters conflicts (use `--continue-on-conflict` to skip conflicted stacks and keep going):
 
 1. Resolve the conflicts in your editor
 2. Stage the resolved files: `git add .`

--- a/doc/src/cli/index.md
+++ b/doc/src/cli/index.md
@@ -59,7 +59,7 @@ Manage your entire stack.
 - $$stackit submit$$ - Create/update PRs
 - $$stackit sync$$ - Update from trunk
 - $$stackit merge$$ - Merge your stack
-- $$stackit restack$$ - Rebase all branches
+- $$stackit restack$$ - Rebase branches (scoped with `--upstack`, `--all-stacks`, `--parallel`)
 - $$stackit flatten$$ - Optimize stack structure
 
 ### Worktrees

--- a/doc/src/guide/concepts.md
+++ b/doc/src/guide/concepts.md
@@ -96,10 +96,12 @@ stackit untrack
 When you modify a branch in the middle of a stack, all child branches need to be rebased. This is called **restacking**.
 
 ```bash
-stackit restack
+stackit restack --upstack              # Restack current branch and descendants
+stackit restack --all-stacks           # Restack every independent stack
+stackit restack --all-stacks --parallel  # Same, but in parallel worktrees
 ```
 
-Stackit automatically rebases all affected branches to maintain the stack structure.
+Stackit rebases the affected branches to maintain the stack structure. Use `--branch <name>` to target a specific branch without checking it out first.
 
 ## Metadata
 

--- a/doc/src/start/submit.md
+++ b/doc/src/start/submit.md
@@ -83,7 +83,7 @@ After making changes to your stack:
 
 2. Restack child branches:
    ```bash
-   stackit restack
+   stackit restack --upstack
    ```
 
 3. Update the PRs:

--- a/doc/src/workflows/daily.md
+++ b/doc/src/workflows/daily.md
@@ -22,9 +22,9 @@ When you receive feedback on a branch in the middle of your stack:
    stackit modify
    ```
 
-3. Update all child branches:
+3. Update child branches:
    ```bash
-   stackit restack
+   stackit restack --upstack
    ```
 
 4. Update the PRs:

--- a/doc/src/workflows/index.md
+++ b/doc/src/workflows/index.md
@@ -40,7 +40,7 @@ Practical guides for using stackit effectively in your daily development.
 
 | Task | Command |
 |------|---------|
-| Update after code review | `stackit modify` then `stackit restack` |
+| Update after code review | `stackit modify` then `stackit restack --upstack` |
 | Absorb fixes into correct branches | `stackit absorb` |
 | Sync with main | `stackit sync` |
 | Split commits into branches | `stackit split` |


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1776899834`.


* **PR #862**
  * **PR #863**
    * **PR #864**
      * **PR #865**
        * **PR #866**
          * **PR #867**
            * **PR #868**
              * **PR #869**
                * **PR #870**
                  * **PR #871**
                    * **PR #872**
                      * **PR #873**
                        * **PR #874**
                          * **PR #875**
                            * **PR #876**
                              * **PR #877** 👈
                                * **PR #878**
                                  * **PR #880**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->