### PR TITLE
fix: harden stack automation error handling

### DIFF
--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"errors"
 	"fmt"
 	stdruntime "runtime"
 	"strings"
@@ -13,6 +14,8 @@ import (
 	"stackit.dev/stackit/internal/tui"
 	"stackit.dev/stackit/internal/utils"
 )
+
+var newWorktreeEngine = engine.NewEngineForWorktree
 
 // RestackOptions contains options for the restack command
 type RestackOptions struct {
@@ -89,9 +92,13 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 
 	// Parallel mode: dispatch independent stack groups to separate worktrees.
 	if opts.Parallel && len(branchGroups) > 1 {
-		restacked, skipped, conflicts = restackGroupsParallel(ctx, opts, branchGroups, handler)
+		var err error
+		restacked, skipped, conflicts, err = restackGroupsParallel(ctx, opts, branchGroups, handler)
 		ctx.Logger.Info("restack completed (parallel) restacked=%v skipped=%v conflicts=%v", restacked, skipped, len(conflicts))
 		handler.OnRestackComplete(restacked, skipped, conflicts)
+		if err != nil {
+			return fmt.Errorf("restack failed: %w", err)
+		}
 		return nil
 	}
 
@@ -128,7 +135,7 @@ func restackGroupsParallel(
 	opts RestackOptions,
 	groups []restackBranchGroup,
 	handler handlers.RestackHandler,
-) (restacked, skipped int, conflicts []string) {
+) (restacked, skipped int, conflicts []string, err error) {
 	eng := ctx.Engine
 
 	numJobs := opts.Jobs
@@ -147,24 +154,33 @@ func restackGroupsParallel(
 
 	// Shared result counters protected by a mutex.
 	var mu sync.Mutex
+	var groupErrs []error
 
 	utils.RunWithWorkers(groups, numJobs, func(group restackBranchGroup) {
 		// Create a temporary worktree for this group. PruneSkip because we
 		// pruned once above and don't want N workers racing on prune.
 		wtPath, cleanup, err := eng.CreateTemporaryWorktreeSkipPrune(ctx.Context, eng.Trunk().GetName(), "stackit-restack-*")
 		if err != nil {
-			ctx.Logger.Warn("failed to create worktree for parallel restack: %v", err)
+			wrappedErr := fmt.Errorf("stack %s: create worktree: %w", group.rootBranch, err)
+			ctx.Logger.Warn("failed to create worktree for parallel restack: %v", wrappedErr)
+			mu.Lock()
+			groupErrs = append(groupErrs, wrappedErr)
+			mu.Unlock()
 			return
 		}
 		defer cleanup()
 
 		// Build a per-worktree engine from the snapshot.
-		wtEngine, err := engine.NewEngineForWorktree(engine.WorktreeEngineOptions{
+		wtEngine, err := newWorktreeEngine(engine.WorktreeEngineOptions{
 			WorktreePath: wtPath,
 			Snapshot:     snapshot,
 		})
 		if err != nil {
-			ctx.Logger.Warn("failed to create worktree engine: %v", err)
+			wrappedErr := fmt.Errorf("stack %s: create worktree engine: %w", group.rootBranch, err)
+			ctx.Logger.Warn("failed to create worktree engine: %v", wrappedErr)
+			mu.Lock()
+			groupErrs = append(groupErrs, wrappedErr)
+			mu.Unlock()
 			return
 		}
 
@@ -184,7 +200,11 @@ func restackGroupsParallel(
 
 		sortedBranches := eng.SortBranchesTopologically(group.branches)
 		if err := RestackBranchesWithHandler(&wtCtx, sortedBranches, progress, !opts.ContinueOnConflict); err != nil {
-			ctx.Logger.Warn("parallel restack group failed: %v", err)
+			wrappedErr := fmt.Errorf("stack %s: %w", group.rootBranch, err)
+			ctx.Logger.Warn("parallel restack group failed: %v", wrappedErr)
+			mu.Lock()
+			groupErrs = append(groupErrs, wrappedErr)
+			mu.Unlock()
 		}
 	})
 
@@ -194,7 +214,11 @@ func restackGroupsParallel(
 		ctx.Logger.Warn("failed to rebuild engine after parallel restack: %v", err)
 	}
 
-	return restacked, skipped, conflicts
+	if len(groupErrs) > 0 {
+		return restacked, skipped, conflicts, errors.Join(groupErrs...)
+	}
+
+	return restacked, skipped, conflicts, nil
 }
 
 type restackBranchGroup struct {

--- a/internal/actions/restack_test.go
+++ b/internal/actions/restack_test.go
@@ -1,0 +1,43 @@
+package actions
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/handlers"
+	"stackit.dev/stackit/testhelpers"
+	"stackit.dev/stackit/testhelpers/scenario"
+)
+
+func TestRestackAction(t *testing.T) {
+	t.Run("parallel multi-stack restack returns worker errors", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"alpha-root":  "main",
+				"alpha-child": "alpha-root",
+				"beta-root":   "main",
+			})
+
+		originalNewWorktreeEngine := newWorktreeEngine
+		newWorktreeEngine = func(engine.WorktreeEngineOptions) (engine.Engine, error) {
+			return nil, errors.New("boom")
+		}
+		t.Cleanup(func() {
+			newWorktreeEngine = originalNewWorktreeEngine
+		})
+
+		err := RestackAction(s.Context, RestackOptions{
+			AllStacks: true,
+			Parallel:  true,
+			Jobs:      2,
+		}, handlers.NewJSONRestackHandler())
+		require.Error(t, err)
+		require.ErrorContains(t, err, "restack failed")
+		require.ErrorContains(t, err, "alpha-root")
+		require.ErrorContains(t, err, "beta-root")
+		require.ErrorContains(t, err, "create worktree engine")
+	})
+}

--- a/internal/cli/integrations/agents/templates/commands/stack-sync.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-sync.md
@@ -15,13 +15,13 @@ allowed-tools: Bash(stackit:*), Bash(git:*), AskUserQuestion, Skill
 Sync the stack with trunk: pull latest, cleanup merged branches, restack.
 
 1. Run `command stackit sync --dry-run --json --restack --no-interactive` to preview cleanup and restack work.
-2. Parse `would_clean`, `would_restack`, and `skipped_stacks` from the JSON preview.
+2. Parse `would_clean`, `would_restack`, `would_restack_stacks`, and `skipped_stacks` from the JSON preview.
 3. If ALL branches would be deleted, confirm with user first using `AskUserQuestion`.
 4. Run `command stackit sync --no-restack --no-interactive` so cleanup happens once and restack can use the narrowest safe scope.
 5. If branches remain and `would_restack` was non-empty, choose the restack scope:
-   - If one affected branch or stack root is known, run `command stackit restack --branch <branch-or-root> --upstack --no-interactive`.
-   - If several independent stack roots are known, run `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
-   - If all remaining independent stacks need restack or roots are unclear, run `command stackit restack --all-stacks --continue-on-conflict --no-interactive`.
+   - If `would_restack_stacks` has exactly one root, run `command stackit restack --branch <that-root> --upstack --no-interactive`.
+   - If `would_restack_stacks` lists several roots, run `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
+   - If every remaining independent stack needs restack or the root list is unavailable, run `command stackit restack --all-stacks --continue-on-conflict --no-interactive`.
 6. Show final state with `command stackit log --json --no-interactive`.
 
 If `--continue-on-conflict` reports skipped conflicts, no rebase is active for those skipped branches. To resolve one, run `command stackit restack --branch <conflicted-branch> --upstack --no-interactive`, then resolve conflicts and run `command stackit continue`.

--- a/internal/cli/integrations/agents/templates/skill/SKILL.md
+++ b/internal/cli/integrations/agents/templates/skill/SKILL.md
@@ -123,7 +123,7 @@ When to use multiple commits vs new branches:
 ### Syncing with Main
 
 1. Sync with trunk and cleanup: `command stackit sync --no-interactive`
-2. If branches were deleted or reparented: `command stackit restack --all-stacks --no-interactive` (covers every independent stack rooted at trunk). For a single stack, scope it: `command stackit restack --branch <root> --upstack --no-interactive`.
+2. If branches were deleted or reparented: `command stackit restack --all-stacks --continue-on-conflict --no-interactive` (covers every independent stack rooted at trunk while letting unaffected stacks proceed). For a single stack, scope it: `command stackit restack --branch <root> --upstack --no-interactive`.
 
 ### Fixing Issues
 

--- a/internal/cli/integrations/agents/templates/skill/commands/recovery.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/recovery.md
@@ -60,7 +60,7 @@ Prefer the narrowest scope that covers the affected branches:
 command stackit restack --branch <branch> --upstack --no-interactive
 
 # Multiple independent stacks need attention (e.g. after sync reparented roots)
-command stackit restack --all-stacks --no-interactive
+command stackit restack --all-stacks --continue-on-conflict --no-interactive
 
 # Handle conflicts if they occur, then continue
 command stackit continue --no-interactive
@@ -77,7 +77,7 @@ command stackit sync --no-interactive
 # If restack is still needed, scope it — avoid broad restacks
 command stackit restack --branch <reparented-branch> --upstack --no-interactive
 # Or, if sync reparented roots across multiple stacks:
-command stackit restack --all-stacks --no-interactive
+command stackit restack --all-stacks --continue-on-conflict --no-interactive
 ```
 
 ### PR Base Mismatch

--- a/internal/cli/integrations/agents/templates/skill/commands/stack.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/stack.md
@@ -9,8 +9,8 @@ Commands for managing the entire stack or multiple branches.
 | Command | Description |
 |---------|-------------|
 | `command stackit restack --branch <branch> --upstack --no-interactive` | Rebase a branch and its descendants (preferred — minimizes churn) |
-| `command stackit restack --all-stacks --no-interactive` | Rebase every independent stack rooted at trunk |
-| `command stackit restack --stacks <root1>,<root2> --no-interactive` | Rebase specific independent stack roots |
+| `command stackit restack --all-stacks --continue-on-conflict --no-interactive` | Rebase every independent stack rooted at trunk, skipping conflicted stacks so unrelated stacks still proceed |
+| `command stackit restack --stacks <root1>,<root2> --continue-on-conflict --no-interactive` | Rebase specific independent stack roots while letting unrelated selected roots continue past conflicts |
 | `command stackit sync --no-interactive` | Pull trunk, delete merged branches, restack |
 | `command stackit info --stack --json --no-interactive` | Export full stack metadata as JSON for analysis |
 | `command stackit merge` | Merge approved PRs and cleanup |
@@ -106,8 +106,8 @@ Prefer the narrowest scope that covers what actually changed:
 |-----------|---------|
 | Amended/modified one branch | `command stackit restack --branch <branch> --upstack --no-interactive` |
 | Uncertain which branches need restack (single stack) | `command stackit restack --branch <stack-root> --upstack --no-interactive` |
-| Multiple independent stacks need restack (post-sync, shared parent change) | `command stackit restack --all-stacks --no-interactive` |
-| Specific set of independent roots | `command stackit restack --stacks <root1>,<root2> --no-interactive` |
+| Multiple independent stacks need restack (post-sync, shared parent change) | `command stackit restack --all-stacks --continue-on-conflict --no-interactive` |
+| Specific set of independent roots | `command stackit restack --stacks <root1>,<root2> --continue-on-conflict --no-interactive` |
 
 Use `--json` for programmatic runs; it reports which branches were restacked, skipped, or conflicted so you can skip a redundant follow-up pass.
 

--- a/internal/cli/integrations/agents/templates/skill/reference.md
+++ b/internal/cli/integrations/agents/templates/skill/reference.md
@@ -66,8 +66,8 @@ bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
 | Command | Description |
 |---------|-------------|
 | `command stackit restack --branch <branch> --upstack --no-interactive` | Rebase a branch and its descendants (preferred) |
-| `command stackit restack --all-stacks --no-interactive` | Rebase every independent stack rooted at trunk |
-| `command stackit restack --stacks <root1>,<root2> --no-interactive` | Rebase specific independent stack roots |
+| `command stackit restack --all-stacks --continue-on-conflict --no-interactive` | Rebase every independent stack rooted at trunk while letting unaffected stacks continue |
+| `command stackit restack --stacks <root1>,<root2> --continue-on-conflict --no-interactive` | Rebase specific independent stack roots while letting unaffected selected roots continue |
 | `command stackit foreach` | Run command on each branch in stack |
 | `command stackit submit --no-interactive` | Push branches and create/update PRs |
 | `command stackit sync --no-interactive` | Pull trunk, delete merged branches, restack |

--- a/internal/cli/integrations/agents/templates/skill/workflows/conflict-resolution.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/conflict-resolution.md
@@ -346,7 +346,7 @@ command stackit modify --no-interactive
 command stackit restack --branch $(git branch --show-current) --upstack --no-interactive
 
 # If modifications affected multiple independent stacks, prefer:
-# command stackit restack --all-stacks --no-interactive
+# command stackit restack --all-stacks --continue-on-conflict --no-interactive
 ```
 
 Use `--json` to confirm which branches were touched and avoid running a second broad restack.

--- a/internal/cli/integrations/agents/templates/skill/workflows/stack-fold.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/stack-fold.md
@@ -56,7 +56,7 @@ After folding, restack only the affected subtree. The parent branch now carries 
 command stackit restack --branch <parent-branch> --upstack --no-interactive
 
 # If you folded in multiple independent stacks in one session, prefer:
-# command stackit restack --all-stacks --no-interactive
+# command stackit restack --all-stacks --continue-on-conflict --no-interactive
 ```
 
 Use `--json` to verify only the expected branches were touched; skip a follow-up restack when output shows nothing pending.

--- a/internal/cli/stack/foreach.go
+++ b/internal/cli/stack/foreach.go
@@ -102,6 +102,7 @@ Examples:
 				}
 
 				if jsonOutput {
+					cmd.SilenceErrors = true
 					jsonHandler := foreach.NewJSONHandler()
 					err := foreach.Action(ctx, opts, jsonHandler)
 					if err != nil {
@@ -113,7 +114,7 @@ Examples:
 						return fmt.Errorf("failed to marshal JSON: %w", marshalErr)
 					}
 					ctx.Output.Info("%s", string(data))
-					return nil
+					return err
 				}
 
 				// Create runner (manages terminal state) and handler (processes events)

--- a/internal/cli/stack/foreach_test.go
+++ b/internal/cli/stack/foreach_test.go
@@ -229,7 +229,7 @@ All branches completed successfully (3 total)
 
 		command := "case \"$STACKIT_BRANCH\" in child-a|child-b) exit 1;; *) echo $STACKIT_BRANCH;; esac"
 		output, err := s.RunCliAndGetOutput("foreach", "--json", "--find-first-failure", "--jobs", "2", command)
-		require.NoError(t, err)
+		require.Error(t, err)
 
 		var result foreach.JSONResult
 		require.NoError(t, json.Unmarshal([]byte(output), &result))

--- a/internal/cli/stack/restack.go
+++ b/internal/cli/stack/restack.go
@@ -88,6 +88,7 @@ If conflicts are encountered, you will be prompted to resolve them via an intera
 
 				// JSON output mode
 				if jsonOutput {
+					cmd.SilenceErrors = true
 					jsonHandler := handlers.NewJSONRestackHandler()
 					err := actions.RestackAction(ctx, actions.RestackOptions{
 						BranchName:         targetBranch,


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #862**
  * **PR #863**
    * **PR #864**
      * **PR #865**
        * **PR #866**
          * **PR #867**
            * **PR #868**
              * **PR #869**
                * **PR #870**
                  * **PR #871**
                    * **PR #872**
                      * **PR #873**
                        * **PR #874**
                          * **PR #875**
                            * **PR #876**
                              * **PR #877**
                                * **PR #878** 👈
                                  * **PR #880**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #882 by jonnii*