### PR TITLE
docs: clarify would_restack_stacks must be recomputed after sync before restack

### DIFF
--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -21,7 +21,7 @@ type DryRunResult struct {
 	WouldPull          string   `json:"would_pull,omitempty"`           // Trunk branch that would be pulled
 	WouldClean         []string `json:"would_clean,omitempty"`          // Branches that would be deleted
 	WouldRestack       []string `json:"would_restack,omitempty"`        // Branches that would be restacked
-	WouldRestackStacks []string `json:"would_restack_stacks,omitempty"` // Deduped independent stack roots covering would_restack — pass to `restack --stacks <roots>`
+	WouldRestackStacks []string `json:"would_restack_stacks,omitempty"` // Deduped independent stack roots covering the current dry-run's would_restack set; recompute after sync before passing to `restack --stacks <roots>` because cleanup/reparenting can change roots
 	SkippedStacks      []string `json:"skipped_stacks,omitempty"`       // Stacks skipped due to dirty worktrees
 }
 

--- a/internal/cli/integrations/agents/templates/commands/stack-sync.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-sync.md
@@ -16,13 +16,15 @@ Sync the stack with trunk: pull latest, cleanup merged branches, restack.
 
 1. Run `command stackit sync --dry-run --json --restack --no-interactive` to preview cleanup and restack work.
 2. Parse `would_clean`, `would_restack`, `would_restack_stacks`, and `skipped_stacks` from the JSON preview.
-3. If ALL branches would be deleted, confirm with user first using `AskUserQuestion`.
-4. Run `command stackit sync --no-restack --no-interactive` so cleanup happens once and restack can use the narrowest safe scope.
-5. If branches remain and `would_restack` was non-empty, choose the restack scope:
-   - If `would_restack_stacks` has exactly one root, run `command stackit restack --branch <that-root> --upstack --no-interactive`.
-   - If `would_restack_stacks` lists several roots, run `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
-   - If every remaining independent stack needs restack or the root list is unavailable, run `command stackit restack --all-stacks --continue-on-conflict --no-interactive`.
-6. Show final state with `command stackit log --json --no-interactive`.
+3. Treat `would_restack_stacks` as preview-only. Do not feed those roots directly into a post-sync `restack --stacks` decision, because cleanup, reparenting, or dirty-stack skipping can change the current roots.
+4. If ALL branches would be deleted, confirm with user first using `AskUserQuestion`.
+5. Run `command stackit sync --no-restack --no-interactive` so cleanup happens once and restack can use refreshed scope.
+6. Recompute current restack scope with a second `command stackit sync --dry-run --json --restack --no-interactive` and parse the refreshed `would_restack`, `would_restack_stacks`, and `skipped_stacks`.
+7. If branches remain and refreshed `would_restack` is non-empty, choose the restack scope from the refreshed JSON:
+   - If refreshed `would_restack_stacks` has exactly one root, run `command stackit restack --branch <that-root> --upstack --no-interactive`.
+   - If refreshed `would_restack_stacks` lists several roots, run `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
+   - If every remaining independent stack needs restack or the refreshed root list is unavailable, run `command stackit restack --all-stacks --continue-on-conflict --no-interactive`.
+8. Show final state with `command stackit log --json --no-interactive`.
 
 If `--continue-on-conflict` reports skipped conflicts, no rebase is active for those skipped branches. To resolve one, run `command stackit restack --branch <conflicted-branch> --upstack --no-interactive`, then resolve conflicts and run `command stackit continue`.
 

--- a/internal/cli/stack/sync.go
+++ b/internal/cli/stack/sync.go
@@ -125,7 +125,9 @@ func syncDryRunJSON(ctx *app.Context, opts sync.Options) error {
 		}
 	}
 
-	// Sort and dedupe restack roots so callers can pass them directly to `restack --stacks`.
+	// Sort and dedupe restack roots for the current dry-run snapshot. Recompute after
+	// running sync before using these roots for a follow-up `restack --stacks`, since
+	// cleanup and reparenting can change which roots need work.
 	if len(restackRootSet) > 0 {
 		roots := make([]string, 0, len(restackRootSet))
 		for root := range restackRootSet {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1776899834`.


* **PR #862**
  * **PR #863**
    * **PR #864**
      * **PR #865**
        * **PR #866**
          * **PR #867**
            * **PR #868**
              * **PR #869**
                * **PR #870**
                  * **PR #871**
                    * **PR #872**
                      * **PR #873**
                        * **PR #874**
                          * **PR #875**
                            * **PR #876**
                              * **PR #877**
                                * **PR #878**
                                  * **PR #880** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->