### PR TITLE
Merging 18 PRs

### DIFF
--- a/.claude/rules/stackit-workflow.md
+++ b/.claude/rules/stackit-workflow.md
@@ -9,7 +9,7 @@ This project uses stackit for stacked changes. **NEVER use raw git commands for 
 | `git commit -m "..."` | `command stackit create -m "..."` |
 | `git checkout -b` | `command stackit create -m "..."` |
 | `gh pr create` | `command stackit submit` |
-| `git rebase` | `command stackit restack` |
+| `git rebase` | `command stackit restack --upstack` (or `--all-stacks`) |
 
 **Exception:** `git commit` is allowed when adding commits to an existing stacked branch.
 
@@ -38,7 +38,7 @@ Use skills instead of manual commands:
 | `/stack-status` | Check stack health |
 | `/stack-fix` | Diagnose and fix issues |
 | `/stack-sync` | Sync with trunk, cleanup merged branches |
-| `/stack-restack` | Rebase all branches in stack |
+| `/stack-restack` | Rebase branches (scoped, multi-stack, or parallel) |
 | `/stack-tidy` | Clean up fixup/WIP commits across the stack |
 
 Run `/stackit` for the full guide.
@@ -51,7 +51,7 @@ Run `/stackit` for the full guide.
 | Empty branch created | You forgot to stage; delete branch and retry with staged changes |
 | Using `git commit` for new branch | Use `stackit create` - it creates branch + commit together |
 | Using `git checkout -b` | Use `stackit create` - branch name auto-generated from message |
-| Manual rebase broke stack | Use `stackit restack` to safely rebase all children |
+| Manual rebase broke stack | Use `stackit restack --upstack` to safely rebase children (or `--all-stacks` for all) |
 | Using `gh pr create` | Use `stackit submit` - it handles stacked PR dependencies |
 | Amending wrong commit | Use `stackit absorb` to auto-route changes to correct commits |
 | Stack out of sync after merge | Run `stackit sync` to cleanup merged branches and update trunk |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ command stackit submit
 command stackit checkout <branch>  # Go to branch with feedback
 # Make changes...
 command stackit modify             # Amend commit
-command stackit restack            # Update children
+command stackit restack --upstack   # Update children of this branch
 command stackit submit             # Update PRs
 ```
 
@@ -67,7 +67,7 @@ command stackit submit             # Update PRs
 | Forgetting to stage | Always `git add -A` before `create` |
 | Using `git commit` for new branch | Use `stackit create` instead |
 | Using `git checkout -b` | Use `stackit create` instead |
-| Manual rebase | Use `stackit restack` |
+| Manual rebase | Use `stackit restack --upstack` (or `--all-stacks`) |
 | Using `gh pr create` | Use `stackit submit` |
 
 **Use `/stack-plan` when starting from scratch** to plan the stack structure before writing code.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Stackit includes specialized commands designed for Claude Code, providing intell
 | `stack-create [branch-name]` | Create a new stacked branch with intelligent naming and commit messages | Adding a new feature branch to your stack |
 | `stack-submit [--stack \| --draft]` | Submit branches as PRs with auto-generated descriptions | Creating or updating pull requests |
 | `stack-sync` | Sync with trunk, cleanup merged branches, and restack | Keeping your stack up-to-date with main |
-| `stack-restack` | Rebase all branches to ensure proper ancestry | Fixing branch relationships after changes |
+| `stack-restack` | Rebase branches with scoped or multi-stack targeting | Fixing branch relationships after changes |
 | `stack-absorb` | Intelligently absorb working changes into correct commits | Applying fixes across multiple stack branches, with conflict resolution guidance |
 | `stack-fix` | Diagnose and fix common stack issues | Resolving compilation errors or structural problems |
 | `stack-describe` | Generate or update stack description from changes | Documenting your stack for PRs |
@@ -272,9 +272,9 @@ stack-submit --stack         # Creates/updates all PRs in the stack
 | Command | Description |
 |:---|:---|
 | `stackit flatten` | Move branches closer to trunk where possible |
-| `stackit restack` | Rebase all branches in the stack to ensure proper ancestry |
+| `stackit restack` | Rebase branches to ensure proper ancestry (`--branch X --upstack`, `--all-stacks`, `--stacks root1,root2`, `--parallel`) |
 | `stackit get [branch|PR]` | Sync a stack or specific PR from remote |
-| `stackit foreach` | Run a shell command on each branch in the stack (default: upstack) |
+| `stackit foreach` | Run a shell command on each branch (`--upstack`, `--all-stacks`, `--stacks`, `--parallel`) |
 | `stackit submit` | Push branches and create/update GitHub PRs (alias: `ss` for `--stack`) |
 | `stackit sync` | Pull trunk, delete merged branches, and restack |
 | `stackit merge` | Interactive merge wizard (use `merge next` or `merge ship` for non-interactive) |
@@ -323,7 +323,7 @@ These flags are available on all `stackit` commands:
 If you receive feedback on a branch in the middle of your stack:
 1. `stackit checkout <branch>` to move to that branch.
 2. Make your changes and run `stackit modify`.
-3. Run `stackit restack` to update all child branches.
+3. Run `stackit restack --upstack` to update child branches (or `--all-stacks` to cover every independent stack).
 4. Run `stackit submit` to update the PRs on GitHub.
 
 ### Using `stackit absorb`
@@ -535,7 +535,7 @@ stackit track
 
 ### Merge conflicts during restack
 
-When `stackit restack` encounters conflicts:
+When `stackit restack` encounters conflicts (use `--continue-on-conflict` to skip conflicted stacks and keep going):
 
 1. Resolve the conflicts in your editor
 2. Stage the resolved files: `git add .`

--- a/doc/src/cli/index.md
+++ b/doc/src/cli/index.md
@@ -59,7 +59,7 @@ Manage your entire stack.
 - $$stackit submit$$ - Create/update PRs
 - $$stackit sync$$ - Update from trunk
 - $$stackit merge$$ - Merge your stack
-- $$stackit restack$$ - Rebase all branches
+- $$stackit restack$$ - Rebase branches (scoped with `--upstack`, `--all-stacks`, `--parallel`)
 - $$stackit flatten$$ - Optimize stack structure
 
 ### Worktrees

--- a/doc/src/guide/concepts.md
+++ b/doc/src/guide/concepts.md
@@ -96,10 +96,12 @@ stackit untrack
 When you modify a branch in the middle of a stack, all child branches need to be rebased. This is called **restacking**.
 
 ```bash
-stackit restack
+stackit restack --upstack              # Restack current branch and descendants
+stackit restack --all-stacks           # Restack every independent stack
+stackit restack --all-stacks --parallel  # Same, but in parallel worktrees
 ```
 
-Stackit automatically rebases all affected branches to maintain the stack structure.
+Stackit rebases the affected branches to maintain the stack structure. Use `--branch <name>` to target a specific branch without checking it out first.
 
 ## Metadata
 

--- a/doc/src/start/submit.md
+++ b/doc/src/start/submit.md
@@ -83,7 +83,7 @@ After making changes to your stack:
 
 2. Restack child branches:
    ```bash
-   stackit restack
+   stackit restack --upstack
    ```
 
 3. Update the PRs:

--- a/doc/src/workflows/daily.md
+++ b/doc/src/workflows/daily.md
@@ -22,9 +22,9 @@ When you receive feedback on a branch in the middle of your stack:
    stackit modify
    ```
 
-3. Update all child branches:
+3. Update child branches:
    ```bash
-   stackit restack
+   stackit restack --upstack
    ```
 
 4. Update the PRs:

--- a/doc/src/workflows/index.md
+++ b/doc/src/workflows/index.md
@@ -40,7 +40,7 @@ Practical guides for using stackit effectively in your daily development.
 
 | Task | Command |
 |------|---------|
-| Update after code review | `stackit modify` then `stackit restack` |
+| Update after code review | `stackit modify` then `stackit restack --upstack` |
 | Absorb fixes into correct branches | `stackit absorb` |
 | Sync with main | `stackit sync` |
 | Split commits into branches | `stackit split` |

--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -61,6 +61,7 @@ type RestackProgress struct {
 	Reparented          bool                 // true if the branch was reparented
 	OldParent           string               // the old parent name if reparented
 	NewParent           string               // the new parent name if reparented
+	StackRoot           string               // independent stack root (set by multi-stack callers; empty for single-stack)
 }
 
 // RestackProgressCallback is called for each branch during restack with a

--- a/internal/actions/foreach/events.go
+++ b/internal/actions/foreach/events.go
@@ -49,6 +49,7 @@ func (CompletionEvent) foreachEvent() {}
 type BranchResult struct {
 	BranchName string
 	Status     BranchStatus
+	ExitCode   int
 	Output     string
 	Error      error
 }

--- a/internal/actions/foreach/foreach.go
+++ b/internal/actions/foreach/foreach.go
@@ -24,6 +24,8 @@ type Options struct {
 	Args             []string
 	BranchName       string
 	Scope            engine.StackRange
+	AllStacks        bool     // Run across every independent stack rooted at trunk
+	StackRoots       []string // Run across the listed independent stack roots only
 	FailFast         bool
 	Parallel         bool
 	FindFirstFailure bool
@@ -34,24 +36,36 @@ type Options struct {
 func Action(ctx *app.Context, opts Options, handler Handler) error {
 	eng := ctx.Engine
 
+	multiStack := opts.AllStacks || len(opts.StackRoots) > 0
+
 	currentBranch := eng.CurrentBranch()
-	if currentBranch == nil && opts.BranchName == "" {
+	if !multiStack && currentBranch == nil && opts.BranchName == "" {
 		return errors.ErrNotOnBranch
 	}
 
-	targetBranch := engine.Branch{}
-	if opts.BranchName != "" {
-		targetBranch = eng.GetBranch(opts.BranchName)
-		if !targetBranch.IsTrunk() && !targetBranch.IsTracked() {
-			return fmt.Errorf("branch %s is not tracked by stackit", opts.BranchName)
+	// Build graph once — needed for scope range and for find-first-failure depth grouping.
+	graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
+
+	var branches []engine.Branch
+	if multiStack {
+		multiStackBranches, err := collectMultiStackBranches(eng, opts)
+		if err != nil {
+			return err
 		}
-	} else if currentBranch != nil {
-		targetBranch = *currentBranch
+		branches = multiStackBranches
+	} else {
+		targetBranch := engine.Branch{}
+		if opts.BranchName != "" {
+			targetBranch = eng.GetBranch(opts.BranchName)
+			if !targetBranch.IsTrunk() && !targetBranch.IsTracked() {
+				return fmt.Errorf("branch %s is not tracked by stackit", opts.BranchName)
+			}
+		} else if currentBranch != nil {
+			targetBranch = *currentBranch
+		}
+		branches = graph.Range(targetBranch, opts.Scope)
 	}
 
-	// Get branches based on scope
-	graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
-	branches := graph.Range(targetBranch, opts.Scope)
 	if len(branches) == 0 {
 		handler.OnEvent(CompletionEvent{Success: true, Message: "No branches to process"})
 		return nil
@@ -570,6 +584,38 @@ func executeCommandOnBranch(ctx context.Context, appCtx *app.Context, branch eng
 	}
 	res.output = output.String()
 	return res
+}
+
+// collectMultiStackBranches expands --all-stacks / --stacks into a flat branch list,
+// preserving independent-stack ordering and excluding trunk and untracked branches.
+func collectMultiStackBranches(eng engine.BranchReader, opts Options) ([]engine.Branch, error) {
+	stacks := engine.DiscoverIndependentStacks(eng)
+	if len(opts.StackRoots) > 0 {
+		stackByRoot := make(map[string]engine.IndependentStack, len(stacks))
+		for _, stack := range stacks {
+			stackByRoot[stack.RootBranch] = stack
+		}
+		filtered := make([]engine.IndependentStack, 0, len(opts.StackRoots))
+		for _, root := range opts.StackRoots {
+			stack, ok := stackByRoot[root]
+			if !ok {
+				return nil, fmt.Errorf("stack root %s not found", root)
+			}
+			filtered = append(filtered, stack)
+		}
+		stacks = filtered
+	}
+
+	branches := make([]engine.Branch, 0)
+	for _, stack := range stacks {
+		for _, branchName := range stack.Branches {
+			branch := eng.GetBranch(branchName)
+			if branch.IsTracked() && !branch.IsTrunk() {
+				branches = append(branches, branch)
+			}
+		}
+	}
+	return branches, nil
 }
 
 func exitCodeFromError(err error) int {

--- a/internal/actions/foreach/foreach.go
+++ b/internal/actions/foreach/foreach.go
@@ -19,12 +19,13 @@ import (
 
 // Options contains options for the foreach command
 type Options struct {
-	Command  string
-	Args     []string
-	Scope    engine.StackRange
-	FailFast bool
-	Parallel bool
-	Jobs     int
+	Command    string
+	Args       []string
+	BranchName string
+	Scope      engine.StackRange
+	FailFast   bool
+	Parallel   bool
+	Jobs       int
 }
 
 // Action executes a command on each branch in the stack with event handling
@@ -32,13 +33,23 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	eng := ctx.Engine
 
 	currentBranch := eng.CurrentBranch()
-	if currentBranch == nil {
+	if currentBranch == nil && opts.BranchName == "" {
 		return errors.ErrNotOnBranch
+	}
+
+	targetBranch := engine.Branch{}
+	if opts.BranchName != "" {
+		targetBranch = eng.GetBranch(opts.BranchName)
+		if !targetBranch.IsTrunk() && !targetBranch.IsTracked() {
+			return fmt.Errorf("branch %s is not tracked by stackit", opts.BranchName)
+		}
+	} else if currentBranch != nil {
+		targetBranch = *currentBranch
 	}
 
 	// Get branches based on scope
 	graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
-	branches := graph.Range(*currentBranch, opts.Scope)
+	branches := graph.Range(targetBranch, opts.Scope)
 	if len(branches) == 0 {
 		handler.OnEvent(CompletionEvent{Success: true, Message: "No branches to process"})
 		return nil
@@ -58,7 +69,10 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	// Build tree structure for display
-	currentBranchName := currentBranch.GetName()
+	currentBranchName := ""
+	if currentBranch != nil {
+		currentBranchName = currentBranch.GetName()
+	}
 	stackTree := tree.NewStackTree(nonTrunkBranches, currentBranchName, eng.Trunk().GetName())
 
 	// Display the stack

--- a/internal/actions/foreach/foreach.go
+++ b/internal/actions/foreach/foreach.go
@@ -2,6 +2,7 @@ package foreach
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -135,6 +136,7 @@ func foreachSequential(ctx *app.Context, opts Options, branches []engine.Branch,
 
 		if err := eng.CheckoutBranch(ctx.Context, branch); err != nil {
 			result.Status = StatusError
+			result.ExitCode = -1
 			result.Error = err
 			handler.OnEvent(BranchProgressEvent{
 				BranchName: branchName,
@@ -169,6 +171,7 @@ func foreachSequential(ctx *app.Context, opts Options, branches []engine.Branch,
 
 		if err != nil {
 			result.Status = StatusError
+			result.ExitCode = exitCodeFromError(err)
 			result.Output = outputStr
 			result.Error = err
 			handler.OnEvent(BranchProgressEvent{
@@ -191,6 +194,7 @@ func foreachSequential(ctx *app.Context, opts Options, branches []engine.Branch,
 			}
 		} else {
 			result.Status = StatusDone
+			result.ExitCode = 0
 			result.Output = outputStr
 			handler.OnEvent(BranchProgressEvent{
 				BranchName: branchName,
@@ -251,6 +255,7 @@ func foreachParallel(ctx *app.Context, opts Options, branches []engine.Branch, h
 	type result struct {
 		branchName string
 		output     string
+		exitCode   int
 		err        error
 	}
 
@@ -307,6 +312,7 @@ func foreachParallel(ctx *app.Context, opts Options, branches []engine.Branch, h
 		results <- result{
 			branchName: res.branchName,
 			output:     res.output,
+			exitCode:   res.exitCode,
 			err:        res.err,
 		}
 	})
@@ -323,6 +329,7 @@ func foreachParallel(ctx *app.Context, opts Options, branches []engine.Branch, h
 		allResults = append(allResults, BranchResult{
 			BranchName: res.branchName,
 			Status:     status,
+			ExitCode:   res.exitCode,
 			Output:     res.output,
 			Error:      res.err,
 		})
@@ -370,11 +377,13 @@ func foreachParallel(ctx *app.Context, opts Options, branches []engine.Branch, h
 func executeCommandOnBranch(ctx context.Context, appCtx *app.Context, branch engine.Branch, fullCommand string, hooks []string) struct {
 	branchName string
 	output     string
+	exitCode   int
 	err        error
 } {
 	res := struct {
 		branchName string
 		output     string
+		exitCode   int
 		err        error
 	}{branchName: branch.GetName()}
 
@@ -382,6 +391,7 @@ func executeCommandOnBranch(ctx context.Context, appCtx *app.Context, branch eng
 	// Use SkipPrune variant since foreachParallel already pruned once before parallel execution.
 	worktreePath, cleanup, err := appCtx.Engine.CreateTemporaryWorktreeSkipPrune(ctx, branch.GetName(), "stackit-foreach-*")
 	if err != nil {
+		res.exitCode = -1
 		res.err = err
 		return res
 	}
@@ -399,8 +409,20 @@ func executeCommandOnBranch(ctx context.Context, appCtx *app.Context, branch eng
 	cmd.Env = append(cmd.Env, "STACKIT_BRANCH="+branch.GetName())
 
 	if err := cmd.Run(); err != nil {
+		res.exitCode = exitCodeFromError(err)
 		res.err = err
 	}
 	res.output = output.String()
 	return res
+}
+
+func exitCodeFromError(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if stderrors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
 }

--- a/internal/actions/foreach/foreach.go
+++ b/internal/actions/foreach/foreach.go
@@ -20,13 +20,14 @@ import (
 
 // Options contains options for the foreach command
 type Options struct {
-	Command    string
-	Args       []string
-	BranchName string
-	Scope      engine.StackRange
-	FailFast   bool
-	Parallel   bool
-	Jobs       int
+	Command          string
+	Args             []string
+	BranchName       string
+	Scope            engine.StackRange
+	FailFast         bool
+	Parallel         bool
+	FindFirstFailure bool
+	Jobs             int
 }
 
 // Action executes a command on each branch in the stack with event handling
@@ -92,6 +93,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 	handler.OnEvent(ExecutionStartEvent{Branches: branchInfos})
 
+	if opts.FindFirstFailure {
+		return foreachFindFirstFailure(ctx, opts, nonTrunkBranches, graph, handler)
+	}
 	if opts.Parallel {
 		return foreachParallel(ctx, opts, nonTrunkBranches, handler)
 	}
@@ -372,6 +376,158 @@ func foreachParallel(ctx *app.Context, opts Options, branches []engine.Branch, h
 		Results: sortedResults,
 	})
 	return nil
+}
+
+func foreachFindFirstFailure(ctx *app.Context, opts Options, branches []engine.Branch, graph *engine.StackGraph, handler Handler) error {
+	numJobs := opts.Jobs
+	if numJobs <= 0 {
+		numJobs = stdruntime.NumCPU()
+	}
+
+	_ = ctx.Engine.PruneWorktrees(ctx.Context)
+
+	approvedHooks, err := worktree.ResolveApprovedHooks(ctx)
+	if err != nil {
+		ctx.Output.Warn("Failed to resolve worktree hooks: %v", err)
+	}
+
+	fullCommand := strings.Join(append([]string{opts.Command}, opts.Args...), " ")
+	branchesByDepth := groupBranchesByDepth(branches, graph)
+
+	allResults := make([]BranchResult, 0, len(branches))
+	depthOpts := opts
+	depthOpts.FailFast = false
+	for _, depthGroup := range branchesByDepth {
+		groupResults := runBranchesInWorktrees(ctx, depthOpts, depthGroup.branches, handler, fullCommand, approvedHooks, numJobs)
+		allResults = append(allResults, groupResults...)
+
+		if hasFailedResult(groupResults) {
+			handler.OnEvent(CompletionEvent{
+				Success: false,
+				Message: fmt.Sprintf("Command failed at stack depth %d", depthGroup.depth),
+				Results: allResults,
+			})
+			return fmt.Errorf("command failed at stack depth %d", depthGroup.depth)
+		}
+	}
+
+	handler.OnEvent(CompletionEvent{
+		Success: true,
+		Message: "Execution complete",
+		Results: allResults,
+	})
+	return nil
+}
+
+type branchDepthGroup struct {
+	depth    int
+	branches []engine.Branch
+}
+
+func groupBranchesByDepth(branches []engine.Branch, graph *engine.StackGraph) []branchDepthGroup {
+	groups := []branchDepthGroup{}
+	groupByDepth := make(map[int]int)
+	for _, branch := range branches {
+		depth := 0
+		if node := graph.GetNode(branch.GetName()); node != nil {
+			depth = node.Depth
+		}
+
+		idx, ok := groupByDepth[depth]
+		if !ok {
+			idx = len(groups)
+			groupByDepth[depth] = idx
+			groups = append(groups, branchDepthGroup{depth: depth})
+		}
+		groups[idx].branches = append(groups[idx].branches, branch)
+	}
+	return groups
+}
+
+func runBranchesInWorktrees(ctx *app.Context, opts Options, branches []engine.Branch, handler Handler, fullCommand string, hooks []string, numJobs int) []BranchResult {
+	type result struct {
+		branchName string
+		output     string
+		exitCode   int
+		err        error
+	}
+
+	results := make(chan result, len(branches))
+	runCtx, cancel := context.WithCancel(ctx.Context)
+	defer cancel()
+
+	utils.RunWithWorkers(branches, numJobs, func(branch engine.Branch) {
+		select {
+		case <-runCtx.Done():
+			return
+		default:
+		}
+
+		branchName := branch.GetName()
+		handler.OnEvent(BranchProgressEvent{
+			BranchName: branchName,
+			Status:     StatusRunning,
+		})
+
+		res := executeCommandOnBranch(runCtx, ctx, branch, fullCommand, hooks)
+		if res.err != nil {
+			if opts.FailFast {
+				cancel()
+			}
+			handler.OnEvent(BranchProgressEvent{
+				BranchName: branchName,
+				Status:     StatusError,
+				Output:     res.output,
+				Error:      res.err,
+			})
+		} else {
+			handler.OnEvent(BranchProgressEvent{
+				BranchName: branchName,
+				Status:     StatusDone,
+				Output:     res.output,
+			})
+		}
+
+		results <- result{
+			branchName: res.branchName,
+			output:     res.output,
+			exitCode:   res.exitCode,
+			err:        res.err,
+		}
+	})
+	close(results)
+
+	resultMap := make(map[string]BranchResult)
+	for res := range results {
+		status := StatusDone
+		if res.err != nil {
+			status = StatusError
+		}
+		resultMap[res.branchName] = BranchResult{
+			BranchName: res.branchName,
+			Status:     status,
+			ExitCode:   res.exitCode,
+			Output:     res.output,
+			Error:      res.err,
+		}
+	}
+
+	sortedResults := make([]BranchResult, 0, len(branches))
+	for _, branch := range branches {
+		if result, ok := resultMap[branch.GetName()]; ok {
+			sortedResults = append(sortedResults, result)
+		}
+	}
+	return sortedResults
+}
+
+func hasFailedResult(results []BranchResult) bool {
+	for _, result := range results {
+		if result.Status == StatusError {
+			return true
+		}
+	}
+	return false
 }
 
 func executeCommandOnBranch(ctx context.Context, appCtx *app.Context, branch engine.Branch, fullCommand string, hooks []string) struct {

--- a/internal/actions/foreach/foreach_test.go
+++ b/internal/actions/foreach/foreach_test.go
@@ -248,4 +248,86 @@ func TestForeachAction(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("branch option anchors traversal without changing original checkout", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"branch1": "main",
+				"branch2": "branch1",
+				"branch3": "branch2",
+			})
+
+		s.Checkout("branch3")
+
+		handler := &testHandler{}
+		opts := foreach.Options{
+			Command:    "true",
+			BranchName: "branch1",
+			Scope:      engine.StackRange{IncludeCurrent: true, RecursiveChildren: true},
+			FailFast:   true,
+		}
+
+		err := foreach.Action(s.Context, opts, handler)
+		require.NoError(t, err)
+
+		var executed []string
+		for _, e := range handler.Events() {
+			if bpe, ok := e.(foreach.BranchProgressEvent); ok && bpe.Status == foreach.StatusDone {
+				executed = append(executed, bpe.BranchName)
+			}
+		}
+		require.Equal(t, []string{"branch1", "branch2", "branch3"}, executed)
+		require.Equal(t, "branch3", s.Engine.CurrentBranch().GetName())
+	})
+
+	t.Run("branch option supports downstack traversal", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"branch1": "main",
+				"branch2": "branch1",
+				"branch3": "branch2",
+			})
+
+		s.Checkout("branch1")
+
+		handler := &testHandler{}
+		opts := foreach.Options{
+			Command:    "true",
+			BranchName: "branch3",
+			Scope:      engine.StackRange{IncludeCurrent: true, RecursiveParents: true},
+			FailFast:   true,
+		}
+
+		err := foreach.Action(s.Context, opts, handler)
+		require.NoError(t, err)
+
+		var executed []string
+		for _, e := range handler.Events() {
+			if bpe, ok := e.(foreach.BranchProgressEvent); ok && bpe.Status == foreach.StatusDone {
+				executed = append(executed, bpe.BranchName)
+			}
+		}
+		require.Equal(t, []string{"branch1", "branch2", "branch3"}, executed)
+		require.Equal(t, "branch1", s.Engine.CurrentBranch().GetName())
+	})
+
+	t.Run("branch option rejects untracked branch", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			CreateBranch("untracked").
+			Checkout("main")
+
+		handler := &testHandler{}
+		opts := foreach.Options{
+			Command:    "true",
+			BranchName: "untracked",
+			Scope:      engine.StackRange{IncludeCurrent: true},
+		}
+
+		err := foreach.Action(s.Context, opts, handler)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "branch untracked is not tracked by stackit")
+	})
 }

--- a/internal/actions/foreach/foreach_test.go
+++ b/internal/actions/foreach/foreach_test.go
@@ -330,4 +330,63 @@ func TestForeachAction(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "branch untracked is not tracked by stackit")
 	})
+
+	t.Run("find first failure stops after first failing depth", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"root":         "main",
+				"child-a":      "root",
+				"child-b":      "root",
+				"grandchild-a": "child-a",
+			})
+
+		s.Checkout("root")
+
+		handler := &testHandler{}
+		opts := foreach.Options{
+			Command:          "case \"$STACKIT_BRANCH\" in child-a|child-b) exit 1;; *) exit 0;; esac",
+			Scope:            engine.StackRange{IncludeCurrent: true, RecursiveChildren: true},
+			FindFirstFailure: true,
+			Jobs:             2,
+		}
+
+		err := foreach.Action(s.Context, opts, handler)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "command failed at stack depth 2")
+
+		var doneBranches []string
+		var failedBranches []string
+		for _, e := range handler.Events() {
+			if bpe, ok := e.(foreach.BranchProgressEvent); ok {
+				switch bpe.Status {
+				case foreach.StatusDone:
+					doneBranches = append(doneBranches, bpe.BranchName)
+				case foreach.StatusError:
+					failedBranches = append(failedBranches, bpe.BranchName)
+				}
+			}
+		}
+		require.Equal(t, []string{"root"}, doneBranches)
+		require.ElementsMatch(t, []string{"child-a", "child-b"}, failedBranches)
+		require.NotContains(t, append(doneBranches, failedBranches...), "grandchild-a")
+
+		var completion foreach.CompletionEvent
+		for _, e := range handler.Events() {
+			if ev, ok := e.(foreach.CompletionEvent); ok {
+				completion = ev
+			}
+		}
+		require.False(t, completion.Success)
+		require.Len(t, completion.Results, 3)
+		require.Equal(t, []string{"root", "child-a", "child-b"}, branchResultNames(completion.Results))
+	})
+}
+
+func branchResultNames(results []foreach.BranchResult) []string {
+	names := make([]string, len(results))
+	for i, result := range results {
+		names[i] = result.BranchName
+	}
+	return names
 }

--- a/internal/actions/foreach/json_handler.go
+++ b/internal/actions/foreach/json_handler.go
@@ -1,0 +1,107 @@
+package foreach
+
+import "sync"
+
+// JSONStatus represents the aggregate outcome of a foreach operation.
+type JSONStatus string
+
+const (
+	JSONStatusSuccess JSONStatus = "success"
+	JSONStatusFailure JSONStatus = "failure"
+	JSONStatusError   JSONStatus = "error"
+)
+
+// JSONResult represents the JSON output for foreach operations.
+type JSONResult struct {
+	Status       JSONStatus         `json:"status"`
+	Error        string             `json:"error,omitempty"`
+	Message      string             `json:"message,omitempty"`
+	Command      string             `json:"command,omitempty"`
+	Results      []JSONBranchResult `json:"results"`
+	TotalCount   int                `json:"total_count"`
+	SuccessCount int                `json:"success_count"`
+	FailureCount int                `json:"failure_count"`
+}
+
+// JSONBranchResult represents one branch result in foreach JSON output.
+type JSONBranchResult struct {
+	Branch   string       `json:"branch"`
+	Status   BranchStatus `json:"status"`
+	ExitCode int          `json:"exit_code"`
+	Output   string       `json:"output,omitempty"`
+	Error    string       `json:"error,omitempty"`
+}
+
+// JSONHandler collects foreach events for JSON output.
+type JSONHandler struct {
+	mu     sync.Mutex
+	Result *JSONResult
+}
+
+// NewJSONHandler creates a handler that collects foreach results as JSON data.
+func NewJSONHandler() *JSONHandler {
+	return &JSONHandler{
+		Result: &JSONResult{
+			Results: []JSONBranchResult{},
+		},
+	}
+}
+
+// OnEvent implements Handler.
+func (h *JSONHandler) OnEvent(e Event) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	switch ev := e.(type) {
+	case StackDisplayEvent:
+		h.Result.Command = ev.Command
+	case CompletionEvent:
+		h.Result.Message = ev.Message
+		h.Result.TotalCount = len(ev.Results)
+		h.Result.Results = make([]JSONBranchResult, 0, len(ev.Results))
+		h.Result.SuccessCount = 0
+		h.Result.FailureCount = 0
+
+		for _, result := range ev.Results {
+			branchResult := JSONBranchResult{
+				Branch:   result.BranchName,
+				Status:   result.Status,
+				ExitCode: result.ExitCode,
+				Output:   result.Output,
+			}
+			if result.Error != nil {
+				branchResult.Error = result.Error.Error()
+			}
+			h.Result.Results = append(h.Result.Results, branchResult)
+
+			if result.Status == StatusDone {
+				h.Result.SuccessCount++
+			} else {
+				h.Result.FailureCount++
+			}
+		}
+
+		if h.Result.FailureCount > 0 {
+			h.Result.Status = JSONStatusFailure
+		} else {
+			h.Result.Status = JSONStatusSuccess
+		}
+	}
+}
+
+// SetError records an action-level error in the JSON result.
+func (h *JSONHandler) SetError(err error) {
+	if err == nil {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.Result.Error = err.Error()
+	if h.Result.FailureCount > 0 {
+		h.Result.Status = JSONStatusFailure
+		return
+	}
+	h.Result.Status = JSONStatusError
+}

--- a/internal/actions/merge/multistack_discover.go
+++ b/internal/actions/merge/multistack_discover.go
@@ -29,42 +29,26 @@ func DiscoverStacks(eng engine.BranchReader) ([]MultiStackInfo, error) {
 // DiscoverStacksWithSort is like DiscoverStacks but allows specifying the sort strategy.
 // Use SortStrategySmart to match the ordering of `stackit log`.
 func DiscoverStacksWithSort(eng engine.BranchReader, strategy engine.SortStrategy) ([]MultiStackInfo, error) {
-	graph := engine.BuildStackGraph(eng, strategy, nil)
-	trunk := eng.Trunk()
+	independentStacks := engine.DiscoverIndependentStacksWithSort(eng, strategy)
 
-	// Get the trunk node to find its direct children (stack roots)
-	trunkNode := graph.GetNode(trunk.GetName())
-	if trunkNode == nil {
-		return nil, nil // No trunk found
-	}
-
-	stacks := make([]MultiStackInfo, 0, len(trunkNode.Children))
-	for _, rootName := range trunkNode.Children {
-		rootNode := graph.GetNode(rootName)
-		if rootNode == nil {
-			continue
+	stacks := make([]MultiStackInfo, 0, len(independentStacks))
+	for _, independentStack := range independentStacks {
+		branches := make([]engine.Branch, len(independentStack.Branches))
+		for i, branchName := range independentStack.Branches {
+			branches[i] = eng.GetBranch(branchName)
 		}
-
-		// Collect all branches in this stack using DFS
-		branches := graph.CollectBranches(rootNode.Branch)
-		branchNames := make([]string, len(branches))
-		for i, b := range branches {
-			branchNames[i] = b.GetName()
-		}
-
-		// Count PRs for this stack
-		prCount := countPRs(branches)
 
 		// Get scope from the root branch
 		scope := ""
-		if s := eng.GetScope(rootNode.Branch); !s.IsEmpty() {
+		root := eng.GetBranch(independentStack.RootBranch)
+		if s := eng.GetScope(root); !s.IsEmpty() {
 			scope = s.String()
 		}
 
 		stacks = append(stacks, MultiStackInfo{
-			RootBranch:  rootName,
-			AllBranches: branchNames,
-			PRCount:     prCount,
+			RootBranch:  independentStack.RootBranch,
+			AllBranches: independentStack.Branches,
+			PRCount:     countPRs(branches),
 			Scope:       scope,
 		})
 	}

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -95,11 +95,14 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 		return nil
 	}
 
-	progress := func(p RestackProgress) {
-		handleRestackProgress(eng, handler, p, &restacked, &skipped, &conflicts)
-	}
-
 	for _, group := range branchGroups {
+		// Wrap the progress callback to inject the stack root for this group.
+		groupRoot := group.rootBranch
+		progress := func(p RestackProgress) {
+			p.StackRoot = groupRoot
+			handleRestackProgress(eng, handler, p, &restacked, &skipped, &conflicts)
+		}
+
 		// Sort each independent stack topologically. Keeping groups separate lets
 		// --continue-on-conflict skip a conflicted stack while still restacking
 		// other independent stacks.
@@ -171,7 +174,9 @@ func restackGroupsParallel(
 		wtCtx.RepoRoot = wtPath
 
 		// Thread-safe progress callback that funnels into the shared counters + handler.
+		groupRoot := group.rootBranch
 		progress := func(p RestackProgress) {
+			p.StackRoot = groupRoot
 			mu.Lock()
 			defer mu.Unlock()
 			handleRestackProgress(eng, handler, p, &restacked, &skipped, &conflicts)
@@ -193,7 +198,8 @@ func restackGroupsParallel(
 }
 
 type restackBranchGroup struct {
-	branches []engine.Branch
+	rootBranch string // independent stack root name (direct child of trunk)
+	branches   []engine.Branch
 }
 
 func branchGroupsForIndependentStacks(eng engine.BranchReader, opts RestackOptions) ([]restackBranchGroup, error) {
@@ -226,7 +232,8 @@ func branchGroupsForIndependentStacks(eng engine.BranchReader, opts RestackOptio
 		}
 		if len(branches) > 0 {
 			groups = append(groups, restackBranchGroup{
-				branches: branches,
+				rootBranch: stack.RootBranch,
+				branches:   branches,
 			})
 		}
 	}
@@ -287,4 +294,12 @@ func handleRestackProgress(
 	}
 
 	handler.OnRestackBranch(p.Branch, res, p.NewRev, prNumber, p.LockReason, p.Frozen, p.IsCurrent, parentName, p.Reparented, p.OldParent, p.NewParent, p.RerereResolvedCount)
+
+	// Enrich JSON handler with stack root info (not part of the interface to avoid
+	// touching all implementors for a JSON-only concern).
+	if p.StackRoot != "" {
+		if jsonHandler, ok := handler.(*handlers.JSONRestackHandler); ok {
+			jsonHandler.SetLastBranchStackRoot(p.Branch, p.StackRoot)
+		}
+	}
 }

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"fmt"
+	"strings"
 
 	"stackit.dev/stackit/internal/app"
 	"stackit.dev/stackit/internal/engine"
@@ -12,8 +13,11 @@ import (
 
 // RestackOptions contains options for the restack command
 type RestackOptions struct {
-	BranchName string
-	Scope      engine.StackRange
+	BranchName         string
+	Scope              engine.StackRange
+	AllStacks          bool
+	StackRoots         []string
+	ContinueOnConflict bool
 }
 
 // RestackAction performs the restack operation
@@ -21,21 +25,36 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 	eng := ctx.Engine
 	out := ctx.Output
 
-	// Get branches to restack based on scope
-	branch := eng.GetBranch(opts.BranchName)
-	graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
-	branches := graph.Range(branch, opts.Scope)
+	var branchGroups []restackBranchGroup
+	if opts.AllStacks || len(opts.StackRoots) > 0 {
+		var err error
+		branchGroups, err = branchGroupsForIndependentStacks(eng, opts)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Get branches to restack based on scope
+		branch := eng.GetBranch(opts.BranchName)
+		graph := engine.BuildStackGraph(eng, engine.SortStrategyAlphabetical, nil)
+		branchGroups = []restackBranchGroup{{
+			branches: graph.Range(branch, opts.Scope),
+		}}
+	}
 
-	if len(branches) == 0 {
+	branchCount := countRestackBranches(branchGroups)
+	if branchCount == 0 {
 		out.Info("No branches to restack.")
 		return nil
 	}
 
-	ctx.Logger.Info("restack started branchCount=%v", len(branches))
+	ctx.Logger.Info("restack started branchCount=%v", branchCount)
 
 	// Take snapshot before modifying the repository
 	snapshotOpts := NewSnapshot("restack",
 		WithArg(opts.BranchName),
+		WithFlag(opts.AllStacks, "--all-stacks"),
+		WithFlagValue("--stacks", joinStrings(opts.StackRoots)),
+		WithFlag(opts.ContinueOnConflict, "--continue-on-conflict"),
 	)
 	if err := eng.TakeSnapshot(snapshotOpts); err != nil {
 		// Log but don't fail - snapshot is best effort
@@ -56,57 +75,126 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 		out.Warn("Failed to enable git rerere: %v", err)
 	}
 
-	// For standalone restack, we need to sort branches topologically for correct restack order
-	sortedBranches := eng.SortBranchesTopologically(branches)
-
 	// Use RestackHandler for consistent output
-	handler.OnRestackStart(len(sortedBranches))
+	handler.OnRestackStart(branchCount)
 
 	var restacked, skipped int
 	var conflicts []string
 
-	if err := RestackBranchesWithHandler(ctx, sortedBranches, func(p RestackProgress) {
-		res := handlers.RestackDone
-		switch p.Result {
-		case engine.RestackDone:
-			restacked++
-			res = handlers.RestackDone
-		case engine.RestackUnneeded:
-			res = handlers.RestackUnneeded
-		case engine.RestackConflict:
-			skipped++
-			conflicts = append(conflicts, p.Branch)
-			res = handlers.RestackConflict
-		}
+	progress := func(p RestackProgress) {
+		handleRestackProgress(eng, handler, p, &restacked, &skipped, &conflicts)
+	}
 
-		// Determine parent name for consistent output
-		parentName := ""
-		br := eng.GetBranch(p.Branch)
-		if br.GetName() != "" {
-			if parent := br.GetParent(); parent != nil {
-				parentName = parent.GetName()
-			} else {
-				parentName = eng.Trunk().GetName()
-			}
+	for _, group := range branchGroups {
+		// Sort each independent stack topologically. Keeping groups separate lets
+		// --continue-on-conflict skip a conflicted stack while still restacking
+		// other independent stacks.
+		sortedBranches := eng.SortBranchesTopologically(group.branches)
+		if err := RestackBranchesWithHandler(ctx, sortedBranches, progress, !opts.ContinueOnConflict); err != nil {
+			handler.OnRestackComplete(restacked, skipped, conflicts)
+			return fmt.Errorf("restack failed: %w", err)
 		}
-
-		// PR number is not always available without extra fetching, but we can try
-		var prNumber *int
-		if br.GetName() != "" {
-			if pr, err := eng.GetPrInfo(br); err == nil && pr != nil {
-				num := pr.Number()
-				prNumber = num
-			}
-		}
-
-		handler.OnRestackBranch(p.Branch, res, p.NewRev, prNumber, p.LockReason, p.Frozen, p.IsCurrent, parentName, p.Reparented, p.OldParent, p.NewParent, p.RerereResolvedCount)
-	}, true); err != nil {
-		handler.OnRestackComplete(restacked, skipped, conflicts)
-		return fmt.Errorf("restack failed: %w", err)
 	}
 
 	ctx.Logger.Info("restack completed restacked=%v skipped=%v conflicts=%v", restacked, skipped, len(conflicts))
 
 	handler.OnRestackComplete(restacked, skipped, conflicts)
 	return nil
+}
+
+type restackBranchGroup struct {
+	branches []engine.Branch
+}
+
+func branchGroupsForIndependentStacks(eng engine.BranchReader, opts RestackOptions) ([]restackBranchGroup, error) {
+	stacks := engine.DiscoverIndependentStacks(eng)
+	if len(opts.StackRoots) > 0 {
+		stackByRoot := make(map[string]engine.IndependentStack, len(stacks))
+		for _, stack := range stacks {
+			stackByRoot[stack.RootBranch] = stack
+		}
+
+		filtered := make([]engine.IndependentStack, 0, len(opts.StackRoots))
+		for _, root := range opts.StackRoots {
+			stack, ok := stackByRoot[root]
+			if !ok {
+				return nil, fmt.Errorf("stack root %s not found", root)
+			}
+			filtered = append(filtered, stack)
+		}
+		stacks = filtered
+	}
+
+	groups := make([]restackBranchGroup, 0, len(stacks))
+	for _, stack := range stacks {
+		branches := make([]engine.Branch, 0, len(stack.Branches))
+		for _, branchName := range stack.Branches {
+			branch := eng.GetBranch(branchName)
+			if branch.IsTracked() && !branch.IsTrunk() {
+				branches = append(branches, branch)
+			}
+		}
+		if len(branches) > 0 {
+			groups = append(groups, restackBranchGroup{
+				branches: branches,
+			})
+		}
+	}
+	return groups, nil
+}
+
+func joinStrings(values []string) string {
+	return strings.Join(values, ",")
+}
+
+func countRestackBranches(groups []restackBranchGroup) int {
+	count := 0
+	for _, group := range groups {
+		count += len(group.branches)
+	}
+	return count
+}
+
+func handleRestackProgress(
+	eng engine.BranchReader,
+	handler handlers.RestackHandler,
+	p RestackProgress,
+	restacked *int,
+	skipped *int,
+	conflicts *[]string,
+) {
+	res := handlers.RestackDone
+	switch p.Result {
+	case engine.RestackDone:
+		*restacked++
+		res = handlers.RestackDone
+	case engine.RestackUnneeded:
+		res = handlers.RestackUnneeded
+	case engine.RestackConflict:
+		*skipped++
+		*conflicts = append(*conflicts, p.Branch)
+		res = handlers.RestackConflict
+	}
+
+	// Determine parent name for consistent output
+	parentName := ""
+	br := eng.GetBranch(p.Branch)
+	if br.GetName() != "" {
+		if parent := br.GetParent(); parent != nil {
+			parentName = parent.GetName()
+		} else {
+			parentName = eng.Trunk().GetName()
+		}
+	}
+
+	// PR number is not always available without extra fetching, but we can try
+	var prNumber *int
+	if br.GetName() != "" {
+		if pr, err := eng.GetPrInfo(br); err == nil && pr != nil {
+			num := pr.Number()
+			prNumber = num
+		}
+	}
+
+	handler.OnRestackBranch(p.Branch, res, p.NewRev, prNumber, p.LockReason, p.Frozen, p.IsCurrent, parentName, p.Reparented, p.OldParent, p.NewParent, p.RerereResolvedCount)
 }

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -2,13 +2,16 @@ package actions
 
 import (
 	"fmt"
+	stdruntime "runtime"
 	"strings"
+	"sync"
 
 	"stackit.dev/stackit/internal/app"
 	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/internal/handlers"
 	"stackit.dev/stackit/internal/rerere"
 	"stackit.dev/stackit/internal/tui"
+	"stackit.dev/stackit/internal/utils"
 )
 
 // RestackOptions contains options for the restack command
@@ -18,6 +21,8 @@ type RestackOptions struct {
 	AllStacks          bool
 	StackRoots         []string
 	ContinueOnConflict bool
+	Parallel           bool // Run independent stack groups in parallel worktrees
+	Jobs               int  // Number of parallel workers (0 = NumCPU)
 }
 
 // RestackAction performs the restack operation
@@ -55,6 +60,7 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 		WithFlag(opts.AllStacks, "--all-stacks"),
 		WithFlagValue("--stacks", joinStrings(opts.StackRoots)),
 		WithFlag(opts.ContinueOnConflict, "--continue-on-conflict"),
+		WithFlag(opts.Parallel, "--parallel"),
 	)
 	if err := eng.TakeSnapshot(snapshotOpts); err != nil {
 		// Log but don't fail - snapshot is best effort
@@ -81,6 +87,14 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 	var restacked, skipped int
 	var conflicts []string
 
+	// Parallel mode: dispatch independent stack groups to separate worktrees.
+	if opts.Parallel && len(branchGroups) > 1 {
+		restacked, skipped, conflicts = restackGroupsParallel(ctx, opts, branchGroups, handler)
+		ctx.Logger.Info("restack completed (parallel) restacked=%v skipped=%v conflicts=%v", restacked, skipped, len(conflicts))
+		handler.OnRestackComplete(restacked, skipped, conflicts)
+		return nil
+	}
+
 	progress := func(p RestackProgress) {
 		handleRestackProgress(eng, handler, p, &restacked, &skipped, &conflicts)
 	}
@@ -100,6 +114,82 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 
 	handler.OnRestackComplete(restacked, skipped, conflicts)
 	return nil
+}
+
+// restackGroupsParallel runs each independent stack group in its own temporary
+// worktree. The groups have no shared branches, so rebases + ref updates are
+// safe to interleave. Progress callbacks and handler calls are serialized via
+// a mutex to prevent data races on shared counters.
+func restackGroupsParallel(
+	ctx *app.Context,
+	opts RestackOptions,
+	groups []restackBranchGroup,
+	handler handlers.RestackHandler,
+) (restacked, skipped int, conflicts []string) {
+	eng := ctx.Engine
+
+	numJobs := opts.Jobs
+	if numJobs <= 0 {
+		numJobs = stdruntime.NumCPU()
+	}
+	if numJobs > len(groups) {
+		numJobs = len(groups)
+	}
+
+	// Prune stale worktrees once before creating new ones.
+	_ = eng.PruneWorktrees(ctx.Context)
+
+	// Snapshot the parent engine state once — each worktree engine gets a copy.
+	snapshot := eng.SnapshotForWorktree()
+
+	// Shared result counters protected by a mutex.
+	var mu sync.Mutex
+
+	utils.RunWithWorkers(groups, numJobs, func(group restackBranchGroup) {
+		// Create a temporary worktree for this group. PruneSkip because we
+		// pruned once above and don't want N workers racing on prune.
+		wtPath, cleanup, err := eng.CreateTemporaryWorktreeSkipPrune(ctx.Context, eng.Trunk().GetName(), "stackit-restack-*")
+		if err != nil {
+			ctx.Logger.Warn("failed to create worktree for parallel restack: %v", err)
+			return
+		}
+		defer cleanup()
+
+		// Build a per-worktree engine from the snapshot.
+		wtEngine, err := engine.NewEngineForWorktree(engine.WorktreeEngineOptions{
+			WorktreePath: wtPath,
+			Snapshot:     snapshot,
+		})
+		if err != nil {
+			ctx.Logger.Warn("failed to create worktree engine: %v", err)
+			return
+		}
+
+		// Shallow-copy the app context, swapping in the worktree engine.
+		wtCtx := *ctx
+		wtCtx.Engine = wtEngine
+		wtCtx.RepoRoot = wtPath
+
+		// Thread-safe progress callback that funnels into the shared counters + handler.
+		progress := func(p RestackProgress) {
+			mu.Lock()
+			defer mu.Unlock()
+			handleRestackProgress(eng, handler, p, &restacked, &skipped, &conflicts)
+		}
+
+		sortedBranches := eng.SortBranchesTopologically(group.branches)
+		if err := RestackBranchesWithHandler(&wtCtx, sortedBranches, progress, !opts.ContinueOnConflict); err != nil {
+			ctx.Logger.Warn("parallel restack group failed: %v", err)
+		}
+	})
+
+	// Rebuild the main engine's cache so it sees the ref changes made by the
+	// worktree engines (they share the same .git directory).
+	if err := eng.Rebuild(eng.Trunk().GetName()); err != nil {
+		ctx.Logger.Warn("failed to rebuild engine after parallel restack: %v", err)
+	}
+
+	return restacked, skipped, conflicts
 }
 
 type restackBranchGroup struct {

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"errors"
 	"fmt"
 	stdruntime "runtime"
 	"strings"
@@ -13,6 +14,8 @@ import (
 	"stackit.dev/stackit/internal/tui"
 	"stackit.dev/stackit/internal/utils"
 )
+
+var newWorktreeEngine = engine.NewEngineForWorktree
 
 // RestackOptions contains options for the restack command
 type RestackOptions struct {
@@ -89,9 +92,13 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 
 	// Parallel mode: dispatch independent stack groups to separate worktrees.
 	if opts.Parallel && len(branchGroups) > 1 {
-		restacked, skipped, conflicts = restackGroupsParallel(ctx, opts, branchGroups, handler)
+		var err error
+		restacked, skipped, conflicts, err = restackGroupsParallel(ctx, opts, branchGroups, handler)
 		ctx.Logger.Info("restack completed (parallel) restacked=%v skipped=%v conflicts=%v", restacked, skipped, len(conflicts))
 		handler.OnRestackComplete(restacked, skipped, conflicts)
+		if err != nil {
+			return fmt.Errorf("restack failed: %w", err)
+		}
 		return nil
 	}
 
@@ -128,7 +135,7 @@ func restackGroupsParallel(
 	opts RestackOptions,
 	groups []restackBranchGroup,
 	handler handlers.RestackHandler,
-) (restacked, skipped int, conflicts []string) {
+) (restacked, skipped int, conflicts []string, err error) {
 	eng := ctx.Engine
 
 	numJobs := opts.Jobs
@@ -147,24 +154,33 @@ func restackGroupsParallel(
 
 	// Shared result counters protected by a mutex.
 	var mu sync.Mutex
+	var groupErrs []error
 
 	utils.RunWithWorkers(groups, numJobs, func(group restackBranchGroup) {
 		// Create a temporary worktree for this group. PruneSkip because we
 		// pruned once above and don't want N workers racing on prune.
 		wtPath, cleanup, err := eng.CreateTemporaryWorktreeSkipPrune(ctx.Context, eng.Trunk().GetName(), "stackit-restack-*")
 		if err != nil {
-			ctx.Logger.Warn("failed to create worktree for parallel restack: %v", err)
+			wrappedErr := fmt.Errorf("stack %s: create worktree: %w", group.rootBranch, err)
+			ctx.Logger.Warn("failed to create worktree for parallel restack: %v", wrappedErr)
+			mu.Lock()
+			groupErrs = append(groupErrs, wrappedErr)
+			mu.Unlock()
 			return
 		}
 		defer cleanup()
 
 		// Build a per-worktree engine from the snapshot.
-		wtEngine, err := engine.NewEngineForWorktree(engine.WorktreeEngineOptions{
+		wtEngine, err := newWorktreeEngine(engine.WorktreeEngineOptions{
 			WorktreePath: wtPath,
 			Snapshot:     snapshot,
 		})
 		if err != nil {
-			ctx.Logger.Warn("failed to create worktree engine: %v", err)
+			wrappedErr := fmt.Errorf("stack %s: create worktree engine: %w", group.rootBranch, err)
+			ctx.Logger.Warn("failed to create worktree engine: %v", wrappedErr)
+			mu.Lock()
+			groupErrs = append(groupErrs, wrappedErr)
+			mu.Unlock()
 			return
 		}
 
@@ -184,7 +200,11 @@ func restackGroupsParallel(
 
 		sortedBranches := eng.SortBranchesTopologically(group.branches)
 		if err := RestackBranchesWithHandler(&wtCtx, sortedBranches, progress, !opts.ContinueOnConflict); err != nil {
-			ctx.Logger.Warn("parallel restack group failed: %v", err)
+			wrappedErr := fmt.Errorf("stack %s: %w", group.rootBranch, err)
+			ctx.Logger.Warn("parallel restack group failed: %v", wrappedErr)
+			mu.Lock()
+			groupErrs = append(groupErrs, wrappedErr)
+			mu.Unlock()
 		}
 	})
 
@@ -194,7 +214,11 @@ func restackGroupsParallel(
 		ctx.Logger.Warn("failed to rebuild engine after parallel restack: %v", err)
 	}
 
-	return restacked, skipped, conflicts
+	if len(groupErrs) > 0 {
+		return restacked, skipped, conflicts, errors.Join(groupErrs...)
+	}
+
+	return restacked, skipped, conflicts, nil
 }
 
 type restackBranchGroup struct {

--- a/internal/actions/restack_test.go
+++ b/internal/actions/restack_test.go
@@ -1,0 +1,43 @@
+package actions
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/internal/handlers"
+	"stackit.dev/stackit/testhelpers"
+	"stackit.dev/stackit/testhelpers/scenario"
+)
+
+func TestRestackAction(t *testing.T) {
+	t.Run("parallel multi-stack restack returns worker errors", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"alpha-root":  "main",
+				"alpha-child": "alpha-root",
+				"beta-root":   "main",
+			})
+
+		originalNewWorktreeEngine := newWorktreeEngine
+		newWorktreeEngine = func(engine.WorktreeEngineOptions) (engine.Engine, error) {
+			return nil, errors.New("boom")
+		}
+		t.Cleanup(func() {
+			newWorktreeEngine = originalNewWorktreeEngine
+		})
+
+		err := RestackAction(s.Context, RestackOptions{
+			AllStacks: true,
+			Parallel:  true,
+			Jobs:      2,
+		}, handlers.NewJSONRestackHandler())
+		require.Error(t, err)
+		require.ErrorContains(t, err, "restack failed")
+		require.ErrorContains(t, err, "alpha-root")
+		require.ErrorContains(t, err, "beta-root")
+		require.ErrorContains(t, err, "create worktree engine")
+	})
+}

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -21,7 +21,7 @@ type DryRunResult struct {
 	WouldPull          string   `json:"would_pull,omitempty"`           // Trunk branch that would be pulled
 	WouldClean         []string `json:"would_clean,omitempty"`          // Branches that would be deleted
 	WouldRestack       []string `json:"would_restack,omitempty"`        // Branches that would be restacked
-	WouldRestackStacks []string `json:"would_restack_stacks,omitempty"` // Deduped independent stack roots covering would_restack — pass to `restack --stacks <roots>`
+	WouldRestackStacks []string `json:"would_restack_stacks,omitempty"` // Deduped independent stack roots covering the current dry-run's would_restack set; recompute after sync before passing to `restack --stacks <roots>` because cleanup/reparenting can change roots
 	SkippedStacks      []string `json:"skipped_stacks,omitempty"`       // Stacks skipped due to dirty worktrees
 }
 

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -18,10 +18,11 @@ import (
 
 // DryRunResult represents the JSON output for sync --dry-run
 type DryRunResult struct {
-	WouldPull     string   `json:"would_pull,omitempty"`     // Trunk branch that would be pulled
-	WouldClean    []string `json:"would_clean,omitempty"`    // Branches that would be deleted
-	WouldRestack  []string `json:"would_restack,omitempty"`  // Branches that would be restacked
-	SkippedStacks []string `json:"skipped_stacks,omitempty"` // Stacks skipped due to dirty worktrees
+	WouldPull          string   `json:"would_pull,omitempty"`           // Trunk branch that would be pulled
+	WouldClean         []string `json:"would_clean,omitempty"`          // Branches that would be deleted
+	WouldRestack       []string `json:"would_restack,omitempty"`        // Branches that would be restacked
+	WouldRestackStacks []string `json:"would_restack_stacks,omitempty"` // Deduped independent stack roots covering would_restack — pass to `restack --stacks <roots>`
+	SkippedStacks      []string `json:"skipped_stacks,omitempty"`       // Stacks skipped due to dirty worktrees
 }
 
 // Options contains options for the sync command

--- a/internal/cli/integrations/agents/templates/commands/stack-absorb.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-absorb.md
@@ -50,11 +50,10 @@ Save this information - you'll need it to find fixes.
      - "Let me specify" - I'll provide the command
 
 ```bash
-command stackit bottom --no-interactive
-command stackit foreach --upstack "<build-command>" 2>&1
+command stackit foreach --stack --json --find-first-failure --jobs 0 "<build-command>" 2>&1
 ```
 
-Parse output to find the FIRST failing branch. The failing branch is where to fix.
+Parse `.results` in the foreach JSON output and find entries whose `status` is not `"done"` or whose `exit_code` is non-zero. `--find-first-failure` stops before descendant depths, so the failed results are the earliest failing branches. The failing branch is where to fix.
 
 **If all branches pass**: Done! Absorb succeeded.
 
@@ -70,7 +69,7 @@ For each broken branch, identify what's missing by reading the error.
   # Edit the file to add the missing code from the unabsorbable hunk content
   git add <files>
   git commit -m "fix: add <missing-item> dependency"
-  command stackit restack --no-interactive
+  command stackit restack --branch <failing-branch> --upstack --no-interactive
   ```
 
 **Source 2: New files**
@@ -81,7 +80,7 @@ For each broken branch, identify what's missing by reading the error.
   # Copy the relevant code from the new file
   git add <files>
   git commit -m "fix: add <missing-item> from new file"
-  command stackit restack --no-interactive
+  command stackit restack --branch <failing-branch> --upstack --no-interactive
   ```
 
 **Source 3: Absorbed upstack (bring down)**
@@ -92,13 +91,13 @@ For each broken branch, identify what's missing by reading the error.
   # Apply the code from the absorbed hunk content
   git add <files>
   git commit -m "fix: bring down <missing-item> from upstack"
-  command stackit restack --no-interactive
+  command stackit restack --branch <failing-branch> --upstack --no-interactive
   ```
 
 ### Phase 4: Verify Fix
 
 ```bash
-command stackit foreach --stack "<build-command>" 2>&1
+command stackit foreach --branch <failing-branch> --upstack --json --find-first-failure --jobs 0 "<build-command>" 2>&1
 ```
 
 If another branch fails, repeat Phase 3 for that branch.
@@ -126,10 +125,11 @@ JSON shows:
 - absorbed: validateUser() call -> add-login branch
 - unabsorbable: hashPassword() definition (commutes_with_all)
 
-$ command stackit foreach --upstack "<build-command>"
+$ command stackit foreach --stack --json --find-first-failure --jobs 0 "<build-command>"
 
-add-auth: PASS
-add-login: FAIL - undefined: hashPassword
+JSON shows:
+- add-auth: PASS
+- add-login: FAIL - undefined: hashPassword
 
 Looking for hashPassword in unabsorbable hunks... Found!
 
@@ -137,9 +137,9 @@ $ command stackit checkout add-login --no-interactive
 # Edit utils/crypto.go to add hashPassword from unabsorbable content
 $ git add utils/crypto.go
 $ git commit -m "fix: add hashPassword dependency"
-$ command stackit restack --no-interactive
+$ command stackit restack --branch add-login --upstack --no-interactive
 
-$ command stackit foreach --stack "<build-command>"
+$ command stackit foreach --branch add-login --upstack --json --find-first-failure --jobs 0 "<build-command>"
 All branches pass!
 ```
 

--- a/internal/cli/integrations/agents/templates/commands/stack-fix.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-fix.md
@@ -29,7 +29,8 @@ Check the context and look for these indicators:
 - Restack only the affected independent stack:
   - If the affected branch is known, run `command stackit restack --branch <affected-branch> --upstack --no-interactive`.
   - If only the stack root is known, run `command stackit restack --branch <stack-root> --upstack --no-interactive`.
-  - If multiple independent stacks need restack, restack each stack root separately instead of running one broad restack.
+  - If several independent stack roots are known, run `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
+  - If every independent stack should be processed, run `command stackit restack --all-stacks --continue-on-conflict --no-interactive`.
 
 **Orphaned branches** (stackit log shows branch with no parent, or parent was merged):
 - Run `command stackit sync --no-interactive`
@@ -117,26 +118,35 @@ Optionally, verify the command works on current branch first:
 <check-command>
 ```
 
-#### Step 2: Go to bottom of stack and run checks upward
+#### Step 2: Run a depth-aware first-failure search
+Prefer JSON output so branch, status, exit code, and command output are machine-readable. Use `--find-first-failure` so independent branches at the same depth can run in parallel, and descendants after the first failing depth are skipped.
+
+For the current stack:
 ```bash
-command stackit bottom --no-interactive
-command stackit foreach --upstack "<check-command>" 2>&1
+command stackit foreach --stack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
 ```
 
-This starts at the bottom branch (closest to trunk) and walks toward leaves, stopping at the first failure. The failing branch is where the bug was introduced.
-
-**Example foreach output:**
-```
-Running on branch-1...
-✓ branch-1 (exit 0)
-Running on branch-2...
-✗ branch-2 (exit 1)
-  Error: undefined: someVariable
+For a known stack root or affected branch, avoid checking out first and anchor traversal explicitly:
+```bash
+command stackit foreach --branch <branch-or-root> --upstack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
 ```
 
-Parse the output to find the FIRST branch with `✗` or non-zero exit - that's where to fix.
+This starts at the selected root/branch and walks toward leaves. A failing branch at the earliest failing depth is where the bug was introduced. Multiple branches can fail at the same depth; inspect each failed result and fix the branch that matches the reported problem.
 
-**If all branches show `✓`**: Report success! Stack is healthy. Skip to "After Fixes".
+**Example JSON output:**
+```json
+{
+  "status": "failure",
+  "results": [
+    {"branch": "branch-1", "status": "done", "exit_code": 0},
+    {"branch": "branch-2", "status": "error", "exit_code": 1, "error": "exit status 1", "output": "undefined: someVariable"}
+  ]
+}
+```
+
+Parse `.results` and find entries whose `status` is not `"done"` or whose `exit_code` is non-zero. The first failing depth is already isolated by `--find-first-failure`.
+
+**If `.status` is `"success"`**: Report success! Stack is healthy. Skip to "After Fixes".
 
 #### Step 3: Checkout the failing branch
 ```bash
@@ -164,7 +174,7 @@ This rebases all child branches onto the fixed branch, propagating your fix.
 
 #### Step 6: Verify all branches now pass
 ```bash
-command stackit foreach --stack "<check-command>" 2>&1
+command stackit foreach --branch <failing-branch> --upstack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
 ```
 
 If it stops at another failure, repeat from Step 2 (there may be multiple independent issues).
@@ -192,9 +202,9 @@ The restack command automatically propagates your fix to all child branches.
 
 **Branching stack (multiple children)**: foreach handles this - all descendants are checked.
 
-**Multiple independent stacks**: Independent stack roots are direct children of trunk. Do not run an unscoped restack across unrelated stacks. If more than one independent stack needs restack, run `command stackit restack --branch <stack-root> --upstack --no-interactive` once per affected root.
+**Multiple independent stacks**: Independent stack roots are direct children of trunk. If more than one independent stack needs restack, prefer `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`. If all independent stacks need restack, use `command stackit restack --all-stacks --continue-on-conflict --no-interactive`.
 
-**Multiple independent failures**: After fixing one, re-run foreach to find next failure. For large error outputs with many distinct issues, consider spawning parallel haiku Task subagents to classify and prioritize errors before fixing.
+**Multiple independent failures**: After fixing one, re-run JSON `foreach --find-first-failure` to find the next failing depth. For multiple known independent stack roots, run one anchored `foreach --branch <root> --upstack --json --find-first-failure --jobs 0 "<check-command>"` per root and compare failed JSON results.
 
 **After amending a commit**: Always run `command stackit restack --branch <amended-branch> --upstack --no-interactive` because child branches reference the old commit SHA.
 

--- a/internal/cli/integrations/agents/templates/commands/stack-fold.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-fold.md
@@ -33,8 +33,8 @@ Fold (squash) granular branches into their parent branches.
 5. Before each fold, verify:
    - Branch has no children (fold leaf branches first)
    - Parent still not locked/frozen
-6. Execute: `command stackit checkout <branch> && command stackit fold --no-interactive`
-7. Run `command stackit restack --no-interactive` after folding
+6. Execute: `command stackit checkout <branch> --no-interactive && command stackit fold --no-interactive`
+7. After each fold, restack only the affected parent and descendants: `command stackit restack --branch <parent-branch> --upstack --no-interactive`
 8. Show final stack state
 
 ## Tool Trust
@@ -54,13 +54,13 @@ After successful fold, use `AskUserQuestion`:
 - Question: "Branches folded successfully. What would you like to do next?"
 - Options:
   - label: "Restack branches (Recommended)"
-    description: "Rebase all branches to ensure consistency after fold"
+    description: "Rebase affected descendants to ensure consistency after fold"
   - label: "Submit changes"
     description: "Push folded changes to update PRs"
   - label: "Done for now"
     description: "No follow-up action needed"
 
 Based on response:
-- **"Restack branches"**: Invoke `/stack-restack` skill using the `Skill` tool
+- **"Restack branches"**: Invoke `/stack-restack` skill using the `Skill` tool and pass the folded parent branch as the target
 - **"Submit changes"**: Invoke `/stack-submit` skill using the `Skill` tool
 - **"Done for now"**: End with summary of what was folded

--- a/internal/cli/integrations/agents/templates/commands/stack-restack.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-restack.md
@@ -16,18 +16,22 @@ allowed-tools: Bash(stackit:*), Bash(git:*), AskUserQuestion, Skill
 Rebase all branches in the stack to ensure proper parent-child ancestry.
 
 **Preconditions** (check context above):
-- Must be on a branch (not detached HEAD)
 - Must have clean working directory (no uncommitted changes)
+- Must be on a branch when using the current stack or `--branch`
+- `--all-stacks` and `--stacks` can be used when no current branch is relevant
 
 If preconditions fail, inform user and stop.
 
 Otherwise, choose the narrowest safe restack scope and show the result:
 - If a specific branch caused the issue or was just amended, run `command stackit restack --branch <branch> --upstack --no-interactive`.
 - If a whole independent stack needs restack, run `command stackit restack --branch <stack-root> --upstack --no-interactive`.
-- If multiple independent stacks need restack, run one scoped restack per affected stack root.
+- If several independent stack roots need restack, run `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
+- If every independent stack needs restack, run `command stackit restack --all-stacks --continue-on-conflict --no-interactive`.
 - Only run `command stackit restack --no-interactive` when the user explicitly wants the current stack restacked and no narrower branch/root is known.
 
-If conflicts occur, inform user they need to resolve conflicts and run `command stackit continue`.
+Conflict handling:
+- If a scoped restack enters conflict state, inform user they need to resolve conflicts and run `command stackit continue`.
+- If `--continue-on-conflict` reports skipped conflicts, no rebase is active for those skipped branches. To resolve one, run `command stackit restack --branch <conflicted-branch> --upstack --no-interactive`, then resolve conflicts and run `command stackit continue`.
 
 ## Follow-up
 

--- a/internal/cli/integrations/agents/templates/commands/stack-review.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-review.md
@@ -291,9 +291,13 @@ mutation {
 
 ### Step 7: Restack
 
+Restack only the reviewed branch and descendants so feedback changes propagate without rebasing unrelated stacks:
+
 ```bash
-command stackit restack --no-interactive
+command stackit restack --branch <reviewed-branch> --upstack --no-interactive
 ```
+
+If apply mode updated multiple independent PR branches, group their stack roots with `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
 
 ### Step 8: Report
 

--- a/internal/cli/integrations/agents/templates/commands/stack-status.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-status.md
@@ -45,7 +45,8 @@ Based on the stack state, provide actionable next steps:
 
 | Issue | Recommendation |
 |-------|----------------|
-| Branches need restack | `command stackit restack --no-interactive` |
+| One branch/stack needs restack | `command stackit restack --branch <branch-or-root> --upstack --no-interactive` |
+| Multiple independent stacks need restack | `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive` |
 | Branches have no PR | `command stackit submit --no-interactive` |
 | CI failing | Check CI logs and fix issues |
 | Branch ready to merge | `command stackit merge <branch> --no-interactive` |
@@ -73,7 +74,7 @@ Health:
   ✓  feature-api: CI passing, ready for review
 
 Recommendations:
-  1. Run `command stackit restack` to update feature-models
+  1. Run `command stackit restack --branch feature-models --upstack --no-interactive` to update feature-models and descendants
   2. Run `command stackit submit` to create PR for feature-api
 
 Summary: 2 branches, 1 needs attention

--- a/internal/cli/integrations/agents/templates/commands/stack-sync.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-sync.md
@@ -14,11 +14,17 @@ allowed-tools: Bash(stackit:*), Bash(git:*), AskUserQuestion, Skill
 
 Sync the stack with trunk: pull latest, cleanup merged branches, restack.
 
-1. Run `command stackit sync --dry-run --no-interactive` to preview
-2. If ALL branches would be deleted, confirm with user first using `AskUserQuestion`
-3. Run `command stackit sync --no-interactive`
-4. If branches remain, run `command stackit restack --no-interactive`
-5. Show final state with `command stackit log --no-interactive`
+1. Run `command stackit sync --dry-run --json --restack --no-interactive` to preview cleanup and restack work.
+2. Parse `would_clean`, `would_restack`, and `skipped_stacks` from the JSON preview.
+3. If ALL branches would be deleted, confirm with user first using `AskUserQuestion`.
+4. Run `command stackit sync --no-restack --no-interactive` so cleanup happens once and restack can use the narrowest safe scope.
+5. If branches remain and `would_restack` was non-empty, choose the restack scope:
+   - If one affected branch or stack root is known, run `command stackit restack --branch <branch-or-root> --upstack --no-interactive`.
+   - If several independent stack roots are known, run `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
+   - If all remaining independent stacks need restack or roots are unclear, run `command stackit restack --all-stacks --continue-on-conflict --no-interactive`.
+6. Show final state with `command stackit log --json --no-interactive`.
+
+If `--continue-on-conflict` reports skipped conflicts, no rebase is active for those skipped branches. To resolve one, run `command stackit restack --branch <conflicted-branch> --upstack --no-interactive`, then resolve conflicts and run `command stackit continue`.
 
 You can call multiple tools in a single response.
 

--- a/internal/cli/integrations/agents/templates/commands/stack-sync.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-sync.md
@@ -15,13 +15,13 @@ allowed-tools: Bash(stackit:*), Bash(git:*), AskUserQuestion, Skill
 Sync the stack with trunk: pull latest, cleanup merged branches, restack.
 
 1. Run `command stackit sync --dry-run --json --restack --no-interactive` to preview cleanup and restack work.
-2. Parse `would_clean`, `would_restack`, and `skipped_stacks` from the JSON preview.
+2. Parse `would_clean`, `would_restack`, `would_restack_stacks`, and `skipped_stacks` from the JSON preview.
 3. If ALL branches would be deleted, confirm with user first using `AskUserQuestion`.
 4. Run `command stackit sync --no-restack --no-interactive` so cleanup happens once and restack can use the narrowest safe scope.
 5. If branches remain and `would_restack` was non-empty, choose the restack scope:
-   - If one affected branch or stack root is known, run `command stackit restack --branch <branch-or-root> --upstack --no-interactive`.
-   - If several independent stack roots are known, run `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
-   - If all remaining independent stacks need restack or roots are unclear, run `command stackit restack --all-stacks --continue-on-conflict --no-interactive`.
+   - If `would_restack_stacks` has exactly one root, run `command stackit restack --branch <that-root> --upstack --no-interactive`.
+   - If `would_restack_stacks` lists several roots, run `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
+   - If every remaining independent stack needs restack or the root list is unavailable, run `command stackit restack --all-stacks --continue-on-conflict --no-interactive`.
 6. Show final state with `command stackit log --json --no-interactive`.
 
 If `--continue-on-conflict` reports skipped conflicts, no rebase is active for those skipped branches. To resolve one, run `command stackit restack --branch <conflicted-branch> --upstack --no-interactive`, then resolve conflicts and run `command stackit continue`.

--- a/internal/cli/integrations/agents/templates/commands/stack-sync.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-sync.md
@@ -16,13 +16,15 @@ Sync the stack with trunk: pull latest, cleanup merged branches, restack.
 
 1. Run `command stackit sync --dry-run --json --restack --no-interactive` to preview cleanup and restack work.
 2. Parse `would_clean`, `would_restack`, `would_restack_stacks`, and `skipped_stacks` from the JSON preview.
-3. If ALL branches would be deleted, confirm with user first using `AskUserQuestion`.
-4. Run `command stackit sync --no-restack --no-interactive` so cleanup happens once and restack can use the narrowest safe scope.
-5. If branches remain and `would_restack` was non-empty, choose the restack scope:
-   - If `would_restack_stacks` has exactly one root, run `command stackit restack --branch <that-root> --upstack --no-interactive`.
-   - If `would_restack_stacks` lists several roots, run `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
-   - If every remaining independent stack needs restack or the root list is unavailable, run `command stackit restack --all-stacks --continue-on-conflict --no-interactive`.
-6. Show final state with `command stackit log --json --no-interactive`.
+3. Treat `would_restack_stacks` as preview-only. Do not feed those roots directly into a post-sync `restack --stacks` decision, because cleanup, reparenting, or dirty-stack skipping can change the current roots.
+4. If ALL branches would be deleted, confirm with user first using `AskUserQuestion`.
+5. Run `command stackit sync --no-restack --no-interactive` so cleanup happens once and restack can use refreshed scope.
+6. Recompute current restack scope with a second `command stackit sync --dry-run --json --restack --no-interactive` and parse the refreshed `would_restack`, `would_restack_stacks`, and `skipped_stacks`.
+7. If branches remain and refreshed `would_restack` is non-empty, choose the restack scope from the refreshed JSON:
+   - If refreshed `would_restack_stacks` has exactly one root, run `command stackit restack --branch <that-root> --upstack --no-interactive`.
+   - If refreshed `would_restack_stacks` lists several roots, run `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
+   - If every remaining independent stack needs restack or the refreshed root list is unavailable, run `command stackit restack --all-stacks --continue-on-conflict --no-interactive`.
+8. Show final state with `command stackit log --json --no-interactive`.
 
 If `--continue-on-conflict` reports skipped conflicts, no rebase is active for those skipped branches. To resolve one, run `command stackit restack --branch <conflicted-branch> --upstack --no-interactive`, then resolve conflicts and run `command stackit continue`.
 

--- a/internal/cli/integrations/agents/templates/commands/stack-verify.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-verify.md
@@ -33,24 +33,20 @@ If provided in arguments, use that. Otherwise:
 
 ### 2. Run verification
 
-First, go to bottom of stack to ensure consistent ordering:
+**Quick mode (default)** - run branches at each depth in parallel and stop after the first failing depth:
 ```bash
-command stackit bottom --no-interactive
+command stackit foreach --stack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
 ```
 
-Then run checks:
-
-**Quick mode (default)** - stop at first failure:
+**Full diagnostic mode** - check all branches and collect every failure:
 ```bash
-command stackit foreach --upstack "<check-command>" 2>&1
+command stackit foreach --stack --json --parallel --jobs 0 --no-fail-fast "<check-command>" 2>&1
 ```
 
-**Full diagnostic mode** - check all branches:
+**Anchored mode** - if a branch or independent stack root is known, avoid checkout navigation and verify that upstack only:
 ```bash
-command stackit foreach --upstack --no-fail-fast "<check-command>" 2>&1
+command stackit foreach --branch <branch-or-root> --upstack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
 ```
-
-**Parallel mode** - For large stacks (5+ branches) with independent branches, consider spawning parallel Task subagents to verify sibling branches simultaneously. Only use this when branches don't have linear dependencies.
 
 If uncertain which mode to use, prompt with `AskUserQuestion`:
 - Header: "Verify mode"
@@ -61,18 +57,22 @@ If uncertain which mode to use, prompt with `AskUserQuestion`:
 
 ### 3. Parse foreach output
 
-Foreach output looks like:
-```
-Running on branch-1...
-✓ branch-1 (exit 0)
-Running on branch-2...
-✓ branch-2 (exit 0)
-Running on branch-3...
-✗ branch-3 (exit 1)
-  internal/foo.go:42: undefined: someVar
+Foreach JSON output looks like:
+```json
+{
+  "status": "failure",
+  "total_count": 3,
+  "success_count": 2,
+  "failure_count": 1,
+  "results": [
+    {"branch": "branch-1", "status": "done", "exit_code": 0},
+    {"branch": "branch-2", "status": "done", "exit_code": 0},
+    {"branch": "branch-3", "status": "error", "exit_code": 1, "output": "internal/foo.go:42: undefined: someVar"}
+  ]
+}
 ```
 
-Look for `✗` or non-zero exit codes to identify failures.
+Look for results whose `status` is not `"done"` or whose `exit_code` is non-zero. In quick mode, `--find-first-failure` already stopped before descendant depths, so the failed results are the earliest failing branches.
 
 ### 4. Present results clearly
 
@@ -84,8 +84,8 @@ Stack Verification Results
 ✓ branch-name-2 - passed
 ✗ branch-name-3 - FAILED
 
-Summary: 2 passed, 1 failed (stopped at first failure)
-First failure: branch-name-3
+Summary: 2 passed, 1 failed (stopped at first failing depth)
+First failing branch: branch-name-3
 ```
 
 **Full diagnostic format** (checks all):

--- a/internal/cli/integrations/agents/templates/skill/SKILL.md
+++ b/internal/cli/integrations/agents/templates/skill/SKILL.md
@@ -123,7 +123,7 @@ When to use multiple commits vs new branches:
 ### Syncing with Main
 
 1. Sync with trunk and cleanup: `command stackit sync --no-interactive`
-2. If branches were deleted or reparented: `command stackit restack --all-stacks --no-interactive` (covers every independent stack rooted at trunk). For a single stack, scope it: `command stackit restack --branch <root> --upstack --no-interactive`.
+2. If branches were deleted or reparented: `command stackit restack --all-stacks --continue-on-conflict --no-interactive` (covers every independent stack rooted at trunk while letting unaffected stacks proceed). For a single stack, scope it: `command stackit restack --branch <root> --upstack --no-interactive`.
 
 ### Fixing Issues
 

--- a/internal/cli/integrations/agents/templates/skill/SKILL.md
+++ b/internal/cli/integrations/agents/templates/skill/SKILL.md
@@ -123,7 +123,7 @@ When to use multiple commits vs new branches:
 ### Syncing with Main
 
 1. Sync with trunk and cleanup: `command stackit sync --no-interactive`
-2. If branches were deleted: `command stackit restack --no-interactive`
+2. If branches were deleted or reparented: `command stackit restack --all-stacks --no-interactive` (covers every independent stack rooted at trunk). For a single stack, scope it: `command stackit restack --branch <root> --upstack --no-interactive`.
 
 ### Fixing Issues
 
@@ -236,7 +236,7 @@ When working with stacks, NEVER use these git commands:
 | `git commit` (for new branches) | `command stackit create` |
 | `git checkout -b` | `command stackit create` |
 | `gh pr create` | `command stackit submit` |
-| `git rebase` | `command stackit restack` |
+| `git rebase` | `command stackit restack --branch <branch> --upstack` (or `--all-stacks`) |
 
 **Exception:** `git commit` is allowed ONLY when adding additional commits to an existing stacked branch.
 

--- a/internal/cli/integrations/agents/templates/skill/commands/recovery.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/recovery.md
@@ -60,7 +60,7 @@ Prefer the narrowest scope that covers the affected branches:
 command stackit restack --branch <branch> --upstack --no-interactive
 
 # Multiple independent stacks need attention (e.g. after sync reparented roots)
-command stackit restack --all-stacks --no-interactive
+command stackit restack --all-stacks --continue-on-conflict --no-interactive
 
 # Handle conflicts if they occur, then continue
 command stackit continue --no-interactive
@@ -77,7 +77,7 @@ command stackit sync --no-interactive
 # If restack is still needed, scope it — avoid broad restacks
 command stackit restack --branch <reparented-branch> --upstack --no-interactive
 # Or, if sync reparented roots across multiple stacks:
-command stackit restack --all-stacks --no-interactive
+command stackit restack --all-stacks --continue-on-conflict --no-interactive
 ```
 
 ### PR Base Mismatch

--- a/internal/cli/integrations/agents/templates/skill/commands/recovery.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/recovery.md
@@ -53,14 +53,20 @@ command stackit log --no-interactive
 
 ### Branch Needs Restack
 
-```bash
-# Rebase all branches to fix ancestry
-command stackit restack --no-interactive
+Prefer the narrowest scope that covers the affected branches:
 
-# Handle conflicts if they occur
-# Then continue
+```bash
+# Most common: restack the flagged branch and its descendants
+command stackit restack --branch <branch> --upstack --no-interactive
+
+# Multiple independent stacks need attention (e.g. after sync reparented roots)
+command stackit restack --all-stacks --no-interactive
+
+# Handle conflicts if they occur, then continue
 command stackit continue --no-interactive
 ```
+
+Use `--json` to see which branches were restacked vs skipped and avoid a redundant second pass.
 
 ### Orphaned Branch (Parent Merged)
 
@@ -68,8 +74,10 @@ command stackit continue --no-interactive
 # Sync will reparent automatically
 command stackit sync --no-interactive
 
-# Or manually restack
-command stackit restack --no-interactive
+# If restack is still needed, scope it — avoid broad restacks
+command stackit restack --branch <reparented-branch> --upstack --no-interactive
+# Or, if sync reparented roots across multiple stacks:
+command stackit restack --all-stacks --no-interactive
 ```
 
 ### PR Base Mismatch

--- a/internal/cli/integrations/agents/templates/skill/commands/stack.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/stack.md
@@ -8,7 +8,9 @@ Commands for managing the entire stack or multiple branches.
 
 | Command | Description |
 |---------|-------------|
-| `command stackit restack --no-interactive` | Rebase all branches to ensure proper ancestry |
+| `command stackit restack --branch <branch> --upstack --no-interactive` | Rebase a branch and its descendants (preferred — minimizes churn) |
+| `command stackit restack --all-stacks --no-interactive` | Rebase every independent stack rooted at trunk |
+| `command stackit restack --stacks <root1>,<root2> --no-interactive` | Rebase specific independent stack roots |
 | `command stackit sync --no-interactive` | Pull trunk, delete merged branches, restack |
 | `command stackit info --stack --json --no-interactive` | Export full stack metadata as JSON for analysis |
 | `command stackit merge` | Merge approved PRs and cleanup |
@@ -91,9 +93,23 @@ command stackit submit --no-interactive --stack
 ```bash
 git add .
 command stackit modify --no-interactive
-command stackit restack --no-interactive
+# Propagate the amend to descendants of this branch only
+command stackit restack --branch $(git branch --show-current) --upstack --no-interactive
 command stackit submit --no-interactive
 ```
+
+### Restack scope cheat sheet
+
+Prefer the narrowest scope that covers what actually changed:
+
+| Situation | Command |
+|-----------|---------|
+| Amended/modified one branch | `command stackit restack --branch <branch> --upstack --no-interactive` |
+| Uncertain which branches need restack (single stack) | `command stackit restack --branch <stack-root> --upstack --no-interactive` |
+| Multiple independent stacks need restack (post-sync, shared parent change) | `command stackit restack --all-stacks --no-interactive` |
+| Specific set of independent roots | `command stackit restack --stacks <root1>,<root2> --no-interactive` |
+
+Use `--json` for programmatic runs; it reports which branches were restacked, skipped, or conflicted so you can skip a redundant follow-up pass.
 
 ### Sync with main
 ```bash

--- a/internal/cli/integrations/agents/templates/skill/commands/stack.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/stack.md
@@ -9,8 +9,8 @@ Commands for managing the entire stack or multiple branches.
 | Command | Description |
 |---------|-------------|
 | `command stackit restack --branch <branch> --upstack --no-interactive` | Rebase a branch and its descendants (preferred — minimizes churn) |
-| `command stackit restack --all-stacks --no-interactive` | Rebase every independent stack rooted at trunk |
-| `command stackit restack --stacks <root1>,<root2> --no-interactive` | Rebase specific independent stack roots |
+| `command stackit restack --all-stacks --continue-on-conflict --no-interactive` | Rebase every independent stack rooted at trunk, skipping conflicted stacks so unrelated stacks still proceed |
+| `command stackit restack --stacks <root1>,<root2> --continue-on-conflict --no-interactive` | Rebase specific independent stack roots while letting unrelated selected roots continue past conflicts |
 | `command stackit sync --no-interactive` | Pull trunk, delete merged branches, restack |
 | `command stackit info --stack --json --no-interactive` | Export full stack metadata as JSON for analysis |
 | `command stackit merge` | Merge approved PRs and cleanup |
@@ -106,8 +106,8 @@ Prefer the narrowest scope that covers what actually changed:
 |-----------|---------|
 | Amended/modified one branch | `command stackit restack --branch <branch> --upstack --no-interactive` |
 | Uncertain which branches need restack (single stack) | `command stackit restack --branch <stack-root> --upstack --no-interactive` |
-| Multiple independent stacks need restack (post-sync, shared parent change) | `command stackit restack --all-stacks --no-interactive` |
-| Specific set of independent roots | `command stackit restack --stacks <root1>,<root2> --no-interactive` |
+| Multiple independent stacks need restack (post-sync, shared parent change) | `command stackit restack --all-stacks --continue-on-conflict --no-interactive` |
+| Specific set of independent roots | `command stackit restack --stacks <root1>,<root2> --continue-on-conflict --no-interactive` |
 
 Use `--json` for programmatic runs; it reports which branches were restacked, skipped, or conflicted so you can skip a redundant follow-up pass.
 

--- a/internal/cli/integrations/agents/templates/skill/reference.md
+++ b/internal/cli/integrations/agents/templates/skill/reference.md
@@ -66,8 +66,8 @@ bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
 | Command | Description |
 |---------|-------------|
 | `command stackit restack --branch <branch> --upstack --no-interactive` | Rebase a branch and its descendants (preferred) |
-| `command stackit restack --all-stacks --no-interactive` | Rebase every independent stack rooted at trunk |
-| `command stackit restack --stacks <root1>,<root2> --no-interactive` | Rebase specific independent stack roots |
+| `command stackit restack --all-stacks --continue-on-conflict --no-interactive` | Rebase every independent stack rooted at trunk while letting unaffected stacks continue |
+| `command stackit restack --stacks <root1>,<root2> --continue-on-conflict --no-interactive` | Rebase specific independent stack roots while letting unaffected selected roots continue |
 | `command stackit foreach` | Run command on each branch in stack |
 | `command stackit submit --no-interactive` | Push branches and create/update PRs |
 | `command stackit sync --no-interactive` | Pull trunk, delete merged branches, restack |

--- a/internal/cli/integrations/agents/templates/skill/reference.md
+++ b/internal/cli/integrations/agents/templates/skill/reference.md
@@ -65,7 +65,9 @@ bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
 
 | Command | Description |
 |---------|-------------|
-| `command stackit restack --no-interactive` | Rebase all branches to ensure proper ancestry |
+| `command stackit restack --branch <branch> --upstack --no-interactive` | Rebase a branch and its descendants (preferred) |
+| `command stackit restack --all-stacks --no-interactive` | Rebase every independent stack rooted at trunk |
+| `command stackit restack --stacks <root1>,<root2> --no-interactive` | Rebase specific independent stack roots |
 | `command stackit foreach` | Run command on each branch in stack |
 | `command stackit submit --no-interactive` | Push branches and create/update PRs |
 | `command stackit sync --no-interactive` | Pull trunk, delete merged branches, restack |
@@ -131,7 +133,8 @@ command stackit submit --no-interactive --stack
 ```bash
 git add .
 command stackit modify --no-interactive
-command stackit restack --no-interactive
+# Scope the restack to just this branch and its descendants
+command stackit restack --branch $(git branch --show-current) --upstack --no-interactive
 command stackit submit --no-interactive
 ```
 
@@ -151,7 +154,7 @@ For detailed troubleshooting workflows, see:
 
 | Issue | Solution |
 |-------|----------|
-| "Branch needs restack" | `command stackit restack --no-interactive` |
+| "Branch needs restack" | `command stackit restack --branch <branch> --upstack --no-interactive` (scope to the branch and its descendants) |
 | "Rebase conflict" | Resolve conflicts, `git add <files>`, `command stackit continue` |
 | "Orphaned branch" | `command stackit sync --no-interactive` to reparent |
 | "PR base mismatch" | `command stackit submit --no-interactive` to update PRs |

--- a/internal/cli/integrations/agents/templates/skill/workflows/absorb-conflict.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/absorb-conflict.md
@@ -103,9 +103,11 @@ git checkout <target-branch>
 git add path/to/file.go
 command stackit modify --no-interactive
 
-# 4. Restack to propagate
-command stackit restack --no-interactive
+# 4. Restack to propagate — scope to the amended branch and its descendants
+command stackit restack --branch <target-branch> --upstack --no-interactive
 ```
+
+Pass `--json` when you want a machine-readable report (which branches were restacked, skipped, or conflicted) instead of doing a second broad restack to "check".
 
 ### Strategy B: Split the Change
 

--- a/internal/cli/integrations/agents/templates/skill/workflows/conflict-resolution.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/conflict-resolution.md
@@ -346,7 +346,7 @@ command stackit modify --no-interactive
 command stackit restack --branch $(git branch --show-current) --upstack --no-interactive
 
 # If modifications affected multiple independent stacks, prefer:
-# command stackit restack --all-stacks --no-interactive
+# command stackit restack --all-stacks --continue-on-conflict --no-interactive
 ```
 
 Use `--json` to confirm which branches were touched and avoid running a second broad restack.

--- a/internal/cli/integrations/agents/templates/skill/workflows/conflict-resolution.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/conflict-resolution.md
@@ -341,10 +341,15 @@ command stackit sync --no-interactive --restack
 ### 3. Restack After Changes
 
 ```bash
-# After modifying a branch, restack children
+# After modifying a branch, restack only that branch's descendants
 command stackit modify --no-interactive
-command stackit restack --no-interactive
+command stackit restack --branch $(git branch --show-current) --upstack --no-interactive
+
+# If modifications affected multiple independent stacks, prefer:
+# command stackit restack --all-stacks --no-interactive
 ```
+
+Use `--json` to confirm which branches were touched and avoid running a second broad restack.
 
 ### 4. Use `command stackit foreach --no-interactive` to Check
 
@@ -420,8 +425,8 @@ command stackit continue --no-interactive
 **Scenario:** Restack causes conflict in `auth.go`
 
 ```bash
-# 1. Restack started
-command stackit restack --no-interactive
+# 1. Restack started (scoped to the affected branch and its descendants)
+command stackit restack --branch feature-x --upstack --no-interactive
 # → Conflict in auth.go
 
 # 2. Check status

--- a/internal/cli/integrations/agents/templates/skill/workflows/fix-absorb.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/fix-absorb.md
@@ -223,8 +223,9 @@ git cherry-pick abc123
 <build-command>
 # ✓ Build succeeded
 
-# 5. Restack children (they're now based on old version)
-command stackit restack --no-interactive
+# 5. Restack children (they're now based on old version) — scope to this subtree
+command stackit restack --branch add-validation --upstack --no-interactive
+# (use --all-stacks only if the fix affected multiple independent stacks)
 
 # 6. Verify entire stack
 command stackit foreach --no-interactive "<build-command>"

--- a/internal/cli/integrations/agents/templates/skill/workflows/stack-fold.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/stack-fold.md
@@ -49,10 +49,17 @@ command stackit fold --no-interactive
 ```
 
 ### 6. Post-Fold Cleanup
-After folding, ensure the stack is healthy:
+After folding, restack only the affected subtree. The parent branch now carries the folded commits, so descendants of the parent need their ancestry refreshed:
+
 ```bash
-command stackit restack --no-interactive
+# Scope restack to the parent and its descendants — avoid a broad restack
+command stackit restack --branch <parent-branch> --upstack --no-interactive
+
+# If you folded in multiple independent stacks in one session, prefer:
+# command stackit restack --all-stacks --no-interactive
 ```
+
+Use `--json` to verify only the expected branches were touched; skip a follow-up restack when output shows nothing pending.
 
 ## Safety Constraints
 - **Never fold into trunk** unless explicitly requested by the user.

--- a/internal/cli/integrations/agents/templates/skill/workflows/stack-fold.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/stack-fold.md
@@ -56,7 +56,7 @@ After folding, restack only the affected subtree. The parent branch now carries 
 command stackit restack --branch <parent-branch> --upstack --no-interactive
 
 # If you folded in multiple independent stacks in one session, prefer:
-# command stackit restack --all-stacks --no-interactive
+# command stackit restack --all-stacks --continue-on-conflict --no-interactive
 ```
 
 Use `--json` to verify only the expected branches were touched; skip a follow-up restack when output shows nothing pending.

--- a/internal/cli/stack/foreach.go
+++ b/internal/cli/stack/foreach.go
@@ -15,6 +15,7 @@ func NewForeachCmd() *cobra.Command {
 		upstack    bool
 		downstack  bool
 		stack      bool
+		branch     string
 		noFailFast bool
 		parallel   bool
 		jobs       int
@@ -38,11 +39,12 @@ Examples:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
 				opts := foreach.Options{
-					Command:  args[0],
-					Args:     args[1:],
-					FailFast: !noFailFast,
-					Parallel: parallel,
-					Jobs:     jobs,
+					Command:    args[0],
+					Args:       args[1:],
+					BranchName: branch,
+					FailFast:   !noFailFast,
+					Parallel:   parallel,
+					Jobs:       jobs,
 				}
 
 				// Define the traversal range
@@ -79,6 +81,7 @@ Examples:
 	cmd.Flags().BoolVar(&upstack, "upstack", true, "Run on current branch and descendants (default)")
 	cmd.Flags().BoolVar(&downstack, "downstack", false, "Run on current branch and ancestors")
 	cmd.Flags().BoolVar(&stack, "stack", false, "Run on the entire stack (ancestors and descendants)")
+	cmd.Flags().StringVar(&branch, "branch", "", "Which branch to run this command from. Defaults to the current branch.")
 	cmd.Flags().BoolVar(&noFailFast, "no-fail-fast", false, "Don't stop execution on the first failure")
 	cmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run commands in parallel using git worktrees")
 	cmd.Flags().IntVarP(&jobs, "jobs", "j", 0, "Number of parallel jobs (default: number of CPUs)")

--- a/internal/cli/stack/foreach.go
+++ b/internal/cli/stack/foreach.go
@@ -1,6 +1,9 @@
 package stack
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"stackit.dev/stackit/internal/actions/foreach"
@@ -19,6 +22,7 @@ func NewForeachCmd() *cobra.Command {
 		noFailFast bool
 		parallel   bool
 		jobs       int
+		jsonOutput bool
 	)
 
 	cmd := &cobra.Command{
@@ -70,6 +74,21 @@ Examples:
 					}
 				}
 
+				if jsonOutput {
+					jsonHandler := foreach.NewJSONHandler()
+					err := foreach.Action(ctx, opts, jsonHandler)
+					if err != nil {
+						jsonHandler.SetError(err)
+					}
+
+					data, marshalErr := json.MarshalIndent(jsonHandler.Result, "", "  ")
+					if marshalErr != nil {
+						return fmt.Errorf("failed to marshal JSON: %w", marshalErr)
+					}
+					ctx.Output.Info("%s", string(data))
+					return err
+				}
+
 				// Create runner (manages terminal state) and handler (processes events)
 				runner, handler := NewForeachUI(ctx.Output, ctx.Logger, opts.Parallel)
 				defer runner.Cleanup()
@@ -85,6 +104,7 @@ Examples:
 	cmd.Flags().BoolVar(&noFailFast, "no-fail-fast", false, "Don't stop execution on the first failure")
 	cmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run commands in parallel using git worktrees")
 	cmd.Flags().IntVarP(&jobs, "jobs", "j", 0, "Number of parallel jobs (default: number of CPUs)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output results in JSON format.")
 
 	return cmd
 }

--- a/internal/cli/stack/foreach.go
+++ b/internal/cli/stack/foreach.go
@@ -19,6 +19,8 @@ func NewForeachCmd() *cobra.Command {
 		downstack  bool
 		stack      bool
 		branch     string
+		allStacks  bool
+		stacks     []string
 		noFailFast bool
 		parallel   bool
 		firstFail  bool
@@ -38,41 +40,64 @@ Examples:
   st foreach mise run lint
   st foreach --stack 'go test ./... && go build'
   st foreach --downstack go test ./...
-  st foreach --parallel mise run test`,
+  st foreach --parallel mise run test
+  st foreach --all-stacks --parallel mise run test:fast
+  st foreach --stacks featA,featB --parallel mise run test:fast`,
 		Args:         cobra.MinimumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Validate multi-stack flags up-front so errors don't surface deep in the action.
+			multiStack := allStacks || len(stacks) > 0
+			if allStacks && len(stacks) > 0 {
+				return fmt.Errorf("only one of --all-stacks or --stacks can be specified")
+			}
+			if multiStack {
+				if branch != "" {
+					return fmt.Errorf("--branch cannot be used with --all-stacks or --stacks")
+				}
+				// --upstack defaults to true, so only reject when a scope flag was explicitly set.
+				if cmd.Flags().Changed("upstack") || cmd.Flags().Changed("downstack") || cmd.Flags().Changed("stack") {
+					return fmt.Errorf("--upstack, --downstack, and --stack cannot be used with --all-stacks or --stacks")
+				}
+			}
+
 			return common.Run(cmd, func(ctx *app.Context) error {
 				opts := foreach.Options{
 					Command:          args[0],
 					Args:             args[1:],
 					BranchName:       branch,
+					AllStacks:        allStacks,
+					StackRoots:       stacks,
 					FailFast:         !noFailFast,
 					Parallel:         parallel,
 					FindFirstFailure: firstFail,
 					Jobs:             jobs,
 				}
 
-				// Define the traversal range
-				// If parallel mode is enabled and no explicit scope flags are set, default to --stack
-				explicitScopeSet := cmd.Flags().Changed("stack") || cmd.Flags().Changed("downstack") || cmd.Flags().Changed("upstack")
-				if parallel && !explicitScopeSet {
-					// Parallel mode defaults to entire stack
-					opts.Scope = engine.StackRange{
-						IncludeCurrent:    true,
-						RecursiveParents:  true,
-						RecursiveChildren: true,
-					}
-				} else {
-					opts.Scope = engine.StackRange{IncludeCurrent: true}
-					switch {
-					case stack:
-						opts.Scope.RecursiveParents = true
-						opts.Scope.RecursiveChildren = true
-					case downstack:
-						opts.Scope.RecursiveParents = true
-					case upstack:
-						opts.Scope.RecursiveChildren = true
+				// Scope is ignored when running across independent stacks — every
+				// branch in each selected stack is included.
+				if !multiStack {
+					// Define the traversal range
+					// If parallel mode is enabled and no explicit scope flags are set, default to --stack
+					explicitScopeSet := cmd.Flags().Changed("stack") || cmd.Flags().Changed("downstack") || cmd.Flags().Changed("upstack")
+					if parallel && !explicitScopeSet {
+						// Parallel mode defaults to entire stack
+						opts.Scope = engine.StackRange{
+							IncludeCurrent:    true,
+							RecursiveParents:  true,
+							RecursiveChildren: true,
+						}
+					} else {
+						opts.Scope = engine.StackRange{IncludeCurrent: true}
+						switch {
+						case stack:
+							opts.Scope.RecursiveParents = true
+							opts.Scope.RecursiveChildren = true
+						case downstack:
+							opts.Scope.RecursiveParents = true
+						case upstack:
+							opts.Scope.RecursiveChildren = true
+						}
 					}
 				}
 
@@ -103,6 +128,8 @@ Examples:
 	cmd.Flags().BoolVar(&downstack, "downstack", false, "Run on current branch and ancestors")
 	cmd.Flags().BoolVar(&stack, "stack", false, "Run on the entire stack (ancestors and descendants)")
 	cmd.Flags().StringVar(&branch, "branch", "", "Which branch to run this command from. Defaults to the current branch.")
+	cmd.Flags().BoolVar(&allStacks, "all-stacks", false, "Run on every independent stack rooted at trunk.")
+	cmd.Flags().StringSliceVar(&stacks, "stacks", nil, "Run on specific independent stack roots (comma-separated).")
 	cmd.Flags().BoolVar(&noFailFast, "no-fail-fast", false, "Don't stop execution on the first failure")
 	cmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run commands in parallel using git worktrees")
 	cmd.Flags().BoolVar(&firstFail, "find-first-failure", false, "Run branches at each stack depth in parallel and stop after the first failing depth")

--- a/internal/cli/stack/foreach.go
+++ b/internal/cli/stack/foreach.go
@@ -21,6 +21,7 @@ func NewForeachCmd() *cobra.Command {
 		branch     string
 		noFailFast bool
 		parallel   bool
+		firstFail  bool
 		jobs       int
 		jsonOutput bool
 	)
@@ -43,12 +44,13 @@ Examples:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
 				opts := foreach.Options{
-					Command:    args[0],
-					Args:       args[1:],
-					BranchName: branch,
-					FailFast:   !noFailFast,
-					Parallel:   parallel,
-					Jobs:       jobs,
+					Command:          args[0],
+					Args:             args[1:],
+					BranchName:       branch,
+					FailFast:         !noFailFast,
+					Parallel:         parallel,
+					FindFirstFailure: firstFail,
+					Jobs:             jobs,
 				}
 
 				// Define the traversal range
@@ -86,7 +88,7 @@ Examples:
 						return fmt.Errorf("failed to marshal JSON: %w", marshalErr)
 					}
 					ctx.Output.Info("%s", string(data))
-					return err
+					return nil
 				}
 
 				// Create runner (manages terminal state) and handler (processes events)
@@ -103,6 +105,7 @@ Examples:
 	cmd.Flags().StringVar(&branch, "branch", "", "Which branch to run this command from. Defaults to the current branch.")
 	cmd.Flags().BoolVar(&noFailFast, "no-fail-fast", false, "Don't stop execution on the first failure")
 	cmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run commands in parallel using git worktrees")
+	cmd.Flags().BoolVar(&firstFail, "find-first-failure", false, "Run branches at each stack depth in parallel and stop after the first failing depth")
 	cmd.Flags().IntVarP(&jobs, "jobs", "j", 0, "Number of parallel jobs (default: number of CPUs)")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output results in JSON format.")
 

--- a/internal/cli/stack/foreach.go
+++ b/internal/cli/stack/foreach.go
@@ -102,6 +102,7 @@ Examples:
 				}
 
 				if jsonOutput {
+					cmd.SilenceErrors = true
 					jsonHandler := foreach.NewJSONHandler()
 					err := foreach.Action(ctx, opts, jsonHandler)
 					if err != nil {
@@ -113,7 +114,7 @@ Examples:
 						return fmt.Errorf("failed to marshal JSON: %w", marshalErr)
 					}
 					ctx.Output.Info("%s", string(data))
-					return nil
+					return err
 				}
 
 				// Create runner (manages terminal state) and handler (processes events)

--- a/internal/cli/stack/foreach_test.go
+++ b/internal/cli/stack/foreach_test.go
@@ -129,4 +129,38 @@ Summary:
 All branches completed successfully (1 total)
 `), testhelpers.NormalizeOutput(output))
 	})
+
+	t.Run("branch flag anchors traversal", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s.RunCli("init")
+		s.RunCli("create", "b1")
+		s.RunCli("create", "b2")
+		s.RunCli("create", "b3")
+		s.RunCli("checkout", "b3")
+
+		output, err := s.RunCliAndGetOutput("foreach", "--branch", "b1", "--upstack", "echo", "$STACKIT_BRANCH")
+		require.NoError(t, err)
+		require.Equal(t, testhelpers.NormalizeOutput(`
+Running on branch b1...
+b1
+✓ Command succeeded on branch b1
+Running on branch b2...
+b2
+✓ Command succeeded on branch b2
+Running on branch b3 (current)...
+b3
+✓ Command succeeded on branch b3 (current)
+Summary:
+  ✓ b1
+    b1
+  ✓ b2
+    b2
+  ✓ b3 (current)
+    b3
+All branches completed successfully (3 total)
+`), testhelpers.NormalizeOutput(output))
+
+		s.ExpectBranch("b3")
+	})
 }

--- a/internal/cli/stack/foreach_test.go
+++ b/internal/cli/stack/foreach_test.go
@@ -214,4 +214,37 @@ All branches completed successfully (3 total)
 			require.Contains(t, branchResult.Error, "exit status 1")
 		}
 	})
+
+	t.Run("find-first-failure json stops before descendants", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s.RunCli("init")
+		s.RunCli("create", "root")
+		s.RunCli("create", "child-a")
+		s.RunCli("checkout", "root")
+		s.RunCli("create", "child-b")
+		s.RunCli("checkout", "child-a")
+		s.RunCli("create", "grandchild-a")
+		s.RunCli("checkout", "root")
+
+		command := "case \"$STACKIT_BRANCH\" in child-a|child-b) exit 1;; *) echo $STACKIT_BRANCH;; esac"
+		output, err := s.RunCliAndGetOutput("foreach", "--json", "--find-first-failure", "--jobs", "2", command)
+		require.NoError(t, err)
+
+		var result foreach.JSONResult
+		require.NoError(t, json.Unmarshal([]byte(output), &result))
+		require.Equal(t, foreach.JSONStatusFailure, result.Status)
+		require.Equal(t, 3, result.TotalCount)
+		require.Equal(t, 1, result.SuccessCount)
+		require.Equal(t, 2, result.FailureCount)
+		require.Equal(t, []string{"root", "child-a", "child-b"}, jsonBranchNames(result.Results))
+	})
+}
+
+func jsonBranchNames(results []foreach.JSONBranchResult) []string {
+	names := make([]string, len(results))
+	for i, result := range results {
+		names[i] = result.Branch
+	}
+	return names
 }

--- a/internal/cli/stack/foreach_test.go
+++ b/internal/cli/stack/foreach_test.go
@@ -1,10 +1,12 @@
 package stack_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"stackit.dev/stackit/internal/actions/foreach"
 	"stackit.dev/stackit/testhelpers"
 	"stackit.dev/stackit/testhelpers/scenario"
 )
@@ -162,5 +164,54 @@ All branches completed successfully (3 total)
 `), testhelpers.NormalizeOutput(output))
 
 		s.ExpectBranch("b3")
+	})
+
+	t.Run("json output reports branch results", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s.RunCli("init")
+		s.RunCli("create", "b1")
+		s.RunCli("create", "b2")
+		s.RunCli("checkout", "b1")
+
+		output, err := s.RunCliAndGetOutput("foreach", "--json", "echo", "$STACKIT_BRANCH")
+		require.NoError(t, err)
+
+		var result foreach.JSONResult
+		require.NoError(t, json.Unmarshal([]byte(output), &result))
+		require.Equal(t, foreach.JSONStatusSuccess, result.Status)
+		require.Equal(t, "echo $STACKIT_BRANCH", result.Command)
+		require.Equal(t, 2, result.TotalCount)
+		require.Equal(t, 2, result.SuccessCount)
+		require.Equal(t, 0, result.FailureCount)
+		require.Equal(t, []foreach.JSONBranchResult{
+			{Branch: "b1", Status: foreach.StatusDone, ExitCode: 0, Output: "b1\n"},
+			{Branch: "b2", Status: foreach.StatusDone, ExitCode: 0, Output: "b2\n"},
+		}, result.Results)
+	})
+
+	t.Run("json output reports command failures", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s.RunCli("init")
+		s.RunCli("create", "b1")
+		s.RunCli("create", "b2")
+		s.RunCli("checkout", "b1")
+
+		output, err := s.RunCliAndGetOutput("foreach", "--json", "--no-fail-fast", "false")
+		require.NoError(t, err)
+
+		var result foreach.JSONResult
+		require.NoError(t, json.Unmarshal([]byte(output), &result))
+		require.Equal(t, foreach.JSONStatusFailure, result.Status)
+		require.Equal(t, 2, result.TotalCount)
+		require.Equal(t, 0, result.SuccessCount)
+		require.Equal(t, 2, result.FailureCount)
+		require.Len(t, result.Results, 2)
+		for _, branchResult := range result.Results {
+			require.Equal(t, foreach.StatusError, branchResult.Status)
+			require.Equal(t, 1, branchResult.ExitCode)
+			require.Contains(t, branchResult.Error, "exit status 1")
+		}
 	})
 }

--- a/internal/cli/stack/foreach_test.go
+++ b/internal/cli/stack/foreach_test.go
@@ -229,7 +229,7 @@ All branches completed successfully (3 total)
 
 		command := "case \"$STACKIT_BRANCH\" in child-a|child-b) exit 1;; *) echo $STACKIT_BRANCH;; esac"
 		output, err := s.RunCliAndGetOutput("foreach", "--json", "--find-first-failure", "--jobs", "2", command)
-		require.NoError(t, err)
+		require.Error(t, err)
 
 		var result foreach.JSONResult
 		require.NoError(t, json.Unmarshal([]byte(output), &result))

--- a/internal/cli/stack/foreach_test.go
+++ b/internal/cli/stack/foreach_test.go
@@ -239,6 +239,72 @@ All branches completed successfully (3 total)
 		require.Equal(t, 2, result.FailureCount)
 		require.Equal(t, []string{"root", "child-a", "child-b"}, jsonBranchNames(result.Results))
 	})
+
+	t.Run("all-stacks runs across every independent stack", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s.RunCli("init")
+
+		// Stack A: main -> alpha-root -> alpha-child
+		s.RunCli("create", "alpha-root", "-m", "alpha root")
+		s.RunCli("create", "alpha-child", "-m", "alpha child")
+
+		// Stack B: main -> beta-root (independent of alpha)
+		s.RunCli("checkout", "main")
+		s.RunCli("create", "beta-root", "-m", "beta root")
+
+		// Invoke from beta-root — with default upstack scope this would only see beta-root.
+		output, err := s.RunCliAndGetOutput("foreach", "--all-stacks", "--json", "echo", "$STACKIT_BRANCH")
+		require.NoError(t, err)
+
+		var result foreach.JSONResult
+		require.NoError(t, json.Unmarshal([]byte(output), &result))
+		require.Equal(t, foreach.JSONStatusSuccess, result.Status)
+		require.ElementsMatch(t, []string{"alpha-root", "alpha-child", "beta-root"}, jsonBranchNames(result.Results))
+	})
+
+	t.Run("stacks filters to the selected independent roots", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s.RunCli("init")
+
+		// Two independent stacks.
+		s.RunCli("create", "alpha-root", "-m", "alpha root")
+		s.RunCli("create", "alpha-child", "-m", "alpha child")
+		s.RunCli("checkout", "main")
+		s.RunCli("create", "beta-root", "-m", "beta root")
+
+		output, err := s.RunCliAndGetOutput("foreach", "--stacks", "alpha-root", "--json", "echo", "$STACKIT_BRANCH")
+		require.NoError(t, err)
+
+		var result foreach.JSONResult
+		require.NoError(t, json.Unmarshal([]byte(output), &result))
+		require.Equal(t, foreach.JSONStatusSuccess, result.Status)
+		require.ElementsMatch(t, []string{"alpha-root", "alpha-child"}, jsonBranchNames(result.Results))
+	})
+
+	t.Run("all-stacks rejects --stacks, --branch, and scope flags", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+		s.RunCli("init")
+		s.RunCli("create", "root", "-m", "r")
+
+		// --all-stacks and --stacks are mutually exclusive.
+		_, err := s.RunCliAndGetOutput("foreach", "--all-stacks", "--stacks", "root", "echo", "x")
+		require.Error(t, err)
+
+		// --branch can't be combined with multi-stack scopes.
+		_, err = s.RunCliAndGetOutput("foreach", "--all-stacks", "--branch", "root", "echo", "x")
+		require.Error(t, err)
+
+		// Explicit per-branch scope flag conflicts with --all-stacks.
+		_, err = s.RunCliAndGetOutput("foreach", "--all-stacks", "--stack", "echo", "x")
+		require.Error(t, err)
+
+		// Unknown stack root surfaces as an action-level error.
+		_, err = s.RunCliAndGetOutput("foreach", "--stacks", "does-not-exist", "echo", "x")
+		require.Error(t, err)
+	})
 }
 
 func jsonBranchNames(results []foreach.JSONBranchResult) []string {

--- a/internal/cli/stack/restack.go
+++ b/internal/cli/stack/restack.go
@@ -88,6 +88,7 @@ If conflicts are encountered, you will be prompted to resolve them via an intera
 
 				// JSON output mode
 				if jsonOutput {
+					cmd.SilenceErrors = true
 					jsonHandler := handlers.NewJSONRestackHandler()
 					err := actions.RestackAction(ctx, actions.RestackOptions{
 						BranchName:         targetBranch,

--- a/internal/cli/stack/restack.go
+++ b/internal/cli/stack/restack.go
@@ -17,11 +17,14 @@ import (
 // NewRestackCmd creates the restack command
 func NewRestackCmd() *cobra.Command {
 	var (
-		branch     string
-		downstack  bool
-		only       bool
-		upstack    bool
-		jsonOutput bool
+		branch             string
+		downstack          bool
+		only               bool
+		upstack            bool
+		allStacks          bool
+		stacks             []string
+		continueOnConflict bool
+		jsonOutput         bool
 	)
 
 	cmd := &cobra.Command{
@@ -46,10 +49,20 @@ If conflicts are encountered, you will be prompted to resolve them via an intera
 				if scopeFlags > 1 {
 					return fmt.Errorf("only one of --downstack, --only, or --upstack can be specified")
 				}
+				multiStack := allStacks || len(stacks) > 0
+				if allStacks && len(stacks) > 0 {
+					return fmt.Errorf("only one of --all-stacks or --stacks can be specified")
+				}
+				if multiStack && branch != "" {
+					return fmt.Errorf("--branch cannot be used with --all-stacks or --stacks")
+				}
+				if multiStack && scopeFlags > 0 {
+					return fmt.Errorf("--downstack, --only, and --upstack cannot be used with --all-stacks or --stacks")
+				}
 
 				// Determine target branch
 				targetBranch := branch
-				if targetBranch == "" {
+				if targetBranch == "" && !multiStack {
 					currentBranch := ctx.Engine.CurrentBranch()
 					if currentBranch == nil {
 						return fmt.Errorf("not on a branch and --branch not specified")
@@ -68,8 +81,11 @@ If conflicts are encountered, you will be prompted to resolve them via an intera
 				if jsonOutput {
 					jsonHandler := handlers.NewJSONRestackHandler()
 					err := actions.RestackAction(ctx, actions.RestackOptions{
-						BranchName: targetBranch,
-						Scope:      rng,
+						BranchName:         targetBranch,
+						Scope:              rng,
+						AllStacks:          allStacks,
+						StackRoots:         stacks,
+						ContinueOnConflict: continueOnConflict,
 					}, jsonHandler)
 
 					// Set error status if there was an error
@@ -94,8 +110,11 @@ If conflicts are encountered, you will be prompted to resolve them via an intera
 				defer runner.Cleanup()
 
 				return actions.RestackAction(ctx, actions.RestackOptions{
-					BranchName: targetBranch,
-					Scope:      rng,
+					BranchName:         targetBranch,
+					Scope:              rng,
+					AllStacks:          allStacks,
+					StackRoots:         stacks,
+					ContinueOnConflict: continueOnConflict,
 				}, handler)
 			})
 		},
@@ -105,6 +124,9 @@ If conflicts are encountered, you will be prompted to resolve them via an intera
 	cmd.Flags().BoolVar(&downstack, "downstack", false, "Only restack this branch and its ancestors.")
 	cmd.Flags().BoolVar(&only, "only", false, "Only restack this branch.")
 	cmd.Flags().BoolVar(&upstack, "upstack", false, "Only restack this branch and its descendants.")
+	cmd.Flags().BoolVar(&allStacks, "all-stacks", false, "Restack every independent stack rooted at trunk.")
+	cmd.Flags().StringSliceVar(&stacks, "stacks", nil, "Restack specific independent stack roots (comma-separated).")
+	cmd.Flags().BoolVar(&continueOnConflict, "continue-on-conflict", false, "Report restack conflicts without entering conflict resolution, continuing to independent stacks when possible.")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output results in JSON format.")
 
 	return cmd

--- a/internal/cli/stack/restack.go
+++ b/internal/cli/stack/restack.go
@@ -24,6 +24,8 @@ func NewRestackCmd() *cobra.Command {
 		allStacks          bool
 		stacks             []string
 		continueOnConflict bool
+		parallel           bool
+		jobs               int
 		jsonOutput         bool
 	)
 
@@ -59,6 +61,13 @@ If conflicts are encountered, you will be prompted to resolve them via an intera
 				if multiStack && scopeFlags > 0 {
 					return fmt.Errorf("--downstack, --only, and --upstack cannot be used with --all-stacks or --stacks")
 				}
+				// --jobs implies --parallel
+				if jobs > 0 {
+					parallel = true
+				}
+				if parallel && !multiStack {
+					return fmt.Errorf("--parallel requires --all-stacks or --stacks")
+				}
 
 				// Determine target branch
 				targetBranch := branch
@@ -86,6 +95,8 @@ If conflicts are encountered, you will be prompted to resolve them via an intera
 						AllStacks:          allStacks,
 						StackRoots:         stacks,
 						ContinueOnConflict: continueOnConflict,
+						Parallel:           parallel,
+						Jobs:               jobs,
 					}, jsonHandler)
 
 					// Set error status if there was an error
@@ -115,6 +126,8 @@ If conflicts are encountered, you will be prompted to resolve them via an intera
 					AllStacks:          allStacks,
 					StackRoots:         stacks,
 					ContinueOnConflict: continueOnConflict,
+					Parallel:           parallel,
+					Jobs:               jobs,
 				}, handler)
 			})
 		},
@@ -127,6 +140,8 @@ If conflicts are encountered, you will be prompted to resolve them via an intera
 	cmd.Flags().BoolVar(&allStacks, "all-stacks", false, "Restack every independent stack rooted at trunk.")
 	cmd.Flags().StringSliceVar(&stacks, "stacks", nil, "Restack specific independent stack roots (comma-separated).")
 	cmd.Flags().BoolVar(&continueOnConflict, "continue-on-conflict", false, "Report restack conflicts without entering conflict resolution, continuing to independent stacks when possible.")
+	cmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run independent stack groups in parallel worktrees (requires --all-stacks or --stacks).")
+	cmd.Flags().IntVarP(&jobs, "jobs", "j", 0, "Number of parallel jobs (default: number of CPUs). Implies --parallel.")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output results in JSON format.")
 
 	return cmd

--- a/internal/cli/stack/restack_test.go
+++ b/internal/cli/stack/restack_test.go
@@ -336,6 +336,176 @@ func TestRestackCommand(t *testing.T) {
 		require.Contains(t, normalized, "Summary: restacked 2")
 	})
 
+	t.Run("restack --all-stacks restacks every independent stack", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+			if err := s.Repo.CreateChangeAndCommit("initial", "init"); err != nil {
+				return err
+			}
+
+			if err := s.Repo.CreateChange("stackA change", "stackA", false); err != nil {
+				return err
+			}
+			createStackitBranch(t, binaryPath, s.Dir, "stackA", "stackA change")
+
+			if err := s.Repo.CreateChange("stackA-child change", "stackA-child", false); err != nil {
+				return err
+			}
+			createStackitBranch(t, binaryPath, s.Dir, "stackA-child", "stackA-child change")
+
+			if err := s.Repo.CheckoutBranch("main"); err != nil {
+				return err
+			}
+			if err := s.Repo.CreateChange("stackB change", "stackB", false); err != nil {
+				return err
+			}
+			createStackitBranch(t, binaryPath, s.Dir, "stackB", "stackB change")
+			return nil
+		})
+
+		stackABefore, err := scene.Repo.GetBranchSHA("stackA")
+		require.NoError(t, err)
+		stackAChildBefore, err := scene.Repo.GetBranchSHA("stackA-child")
+		require.NoError(t, err)
+		stackBBefore, err := scene.Repo.GetBranchSHA("stackB")
+		require.NoError(t, err)
+
+		err = scene.Repo.CheckoutBranch("main")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("main update", "main")
+		require.NoError(t, err)
+
+		cmd := exec.Command(binaryPath, "restack", "--all-stacks")
+		cmd.Dir = scene.Dir
+		output, err := cmd.CombinedOutput()
+
+		require.NoError(t, err, "restack command failed: %s", string(output))
+		normalized := testhelpers.NormalizeOutput(string(output))
+		require.Contains(t, normalized, "Restacked stackA on main")
+		require.Contains(t, normalized, "Restacked stackA-child on stackA")
+		require.Contains(t, normalized, "Restacked stackB on main")
+
+		stackAAfter, err := scene.Repo.GetBranchSHA("stackA")
+		require.NoError(t, err)
+		stackAChildAfter, err := scene.Repo.GetBranchSHA("stackA-child")
+		require.NoError(t, err)
+		stackBAfter, err := scene.Repo.GetBranchSHA("stackB")
+		require.NoError(t, err)
+		require.NotEqual(t, stackABefore, stackAAfter)
+		require.NotEqual(t, stackAChildBefore, stackAChildAfter)
+		require.NotEqual(t, stackBBefore, stackBAfter)
+	})
+
+	t.Run("restack --stacks only restacks selected independent stacks", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+			if err := s.Repo.CreateChangeAndCommit("initial", "init"); err != nil {
+				return err
+			}
+
+			if err := s.Repo.CreateChange("stackA change", "stackA", false); err != nil {
+				return err
+			}
+			createStackitBranch(t, binaryPath, s.Dir, "stackA", "stackA change")
+
+			if err := s.Repo.CreateChange("stackA-child change", "stackA-child", false); err != nil {
+				return err
+			}
+			createStackitBranch(t, binaryPath, s.Dir, "stackA-child", "stackA-child change")
+
+			if err := s.Repo.CheckoutBranch("main"); err != nil {
+				return err
+			}
+			if err := s.Repo.CreateChange("stackB change", "stackB", false); err != nil {
+				return err
+			}
+			createStackitBranch(t, binaryPath, s.Dir, "stackB", "stackB change")
+			return nil
+		})
+
+		stackABefore, err := scene.Repo.GetBranchSHA("stackA")
+		require.NoError(t, err)
+		stackAChildBefore, err := scene.Repo.GetBranchSHA("stackA-child")
+		require.NoError(t, err)
+		stackBBefore, err := scene.Repo.GetBranchSHA("stackB")
+		require.NoError(t, err)
+
+		err = scene.Repo.CheckoutBranch("main")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("main update", "main")
+		require.NoError(t, err)
+
+		cmd := exec.Command(binaryPath, "restack", "--stacks", "stackA")
+		cmd.Dir = scene.Dir
+		output, err := cmd.CombinedOutput()
+
+		require.NoError(t, err, "restack command failed: %s", string(output))
+		normalized := testhelpers.NormalizeOutput(string(output))
+		require.Contains(t, normalized, "Restacked stackA on main")
+		require.Contains(t, normalized, "Restacked stackA-child on stackA")
+		require.NotContains(t, normalized, "stackB")
+
+		stackAAfter, err := scene.Repo.GetBranchSHA("stackA")
+		require.NoError(t, err)
+		stackAChildAfter, err := scene.Repo.GetBranchSHA("stackA-child")
+		require.NoError(t, err)
+		stackBAfter, err := scene.Repo.GetBranchSHA("stackB")
+		require.NoError(t, err)
+		require.NotEqual(t, stackABefore, stackAAfter)
+		require.NotEqual(t, stackAChildBefore, stackAChildAfter)
+		require.Equal(t, stackBBefore, stackBAfter)
+	})
+
+	t.Run("restack --all-stacks --continue-on-conflict keeps processing independent stacks", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+			if err := s.Repo.CreateChangeAndCommit("initial", "conflict"); err != nil {
+				return err
+			}
+
+			if err := s.Repo.CreateChange("stackA conflicting change", "conflict", false); err != nil {
+				return err
+			}
+			createStackitBranch(t, binaryPath, s.Dir, "stackA", "stackA conflicting change")
+
+			if err := s.Repo.CheckoutBranch("main"); err != nil {
+				return err
+			}
+			if err := s.Repo.CreateChange("stackB change", "stackB", false); err != nil {
+				return err
+			}
+			createStackitBranch(t, binaryPath, s.Dir, "stackB", "stackB change")
+			return nil
+		})
+
+		stackABefore, err := scene.Repo.GetBranchSHA("stackA")
+		require.NoError(t, err)
+		stackBBefore, err := scene.Repo.GetBranchSHA("stackB")
+		require.NoError(t, err)
+
+		err = scene.Repo.CheckoutBranch("main")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("main conflicting change", "conflict")
+		require.NoError(t, err)
+
+		cmd := exec.Command(binaryPath, "restack", "--all-stacks", "--continue-on-conflict")
+		cmd.Dir = scene.Dir
+		output, err := cmd.CombinedOutput()
+
+		require.NoError(t, err, "restack command failed: %s", string(output))
+		normalized := testhelpers.NormalizeOutput(string(output))
+		require.Contains(t, normalized, "Skipped stackA (conflict)")
+		require.Contains(t, normalized, "Restacked stackB on main")
+		require.Contains(t, normalized, "Summary: restacked 1, skipped 1 (conflict)")
+
+		stackAAfter, err := scene.Repo.GetBranchSHA("stackA")
+		require.NoError(t, err)
+		stackBAfter, err := scene.Repo.GetBranchSHA("stackB")
+		require.NoError(t, err)
+		require.Equal(t, stackABefore, stackAAfter)
+		require.NotEqual(t, stackBBefore, stackBAfter)
+	})
+
 	t.Run("restack errors when multiple scope flags specified", func(t *testing.T) {
 		t.Parallel()
 		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
@@ -875,4 +1045,13 @@ func TestRestackCommand(t *testing.T) {
 			require.Contains(t, string(infoOutput), "parent", "%s should still have parent as its parent", child)
 		}
 	})
+}
+
+func createStackitBranch(t *testing.T, binaryPath, dir, branch, message string) {
+	t.Helper()
+
+	cmd := exec.Command(binaryPath, "create", branch, "-m", message)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "create command failed: %s", string(output))
 }

--- a/internal/cli/stack/restack_test.go
+++ b/internal/cli/stack/restack_test.go
@@ -506,6 +506,124 @@ func TestRestackCommand(t *testing.T) {
 		require.NotEqual(t, stackBBefore, stackBAfter)
 	})
 
+	t.Run("restack --all-stacks --parallel restacks every independent stack", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+			if err := s.Repo.CreateChangeAndCommit("initial", "init"); err != nil {
+				return err
+			}
+
+			if err := s.Repo.CreateChange("stackA change", "stackA", false); err != nil {
+				return err
+			}
+			createStackitBranch(t, binaryPath, s.Dir, "stackA", "stackA change")
+
+			if err := s.Repo.CreateChange("stackA-child change", "stackA-child", false); err != nil {
+				return err
+			}
+			createStackitBranch(t, binaryPath, s.Dir, "stackA-child", "stackA-child change")
+
+			if err := s.Repo.CheckoutBranch("main"); err != nil {
+				return err
+			}
+			if err := s.Repo.CreateChange("stackB change", "stackB", false); err != nil {
+				return err
+			}
+			createStackitBranch(t, binaryPath, s.Dir, "stackB", "stackB change")
+			return nil
+		})
+
+		stackABefore, err := scene.Repo.GetBranchSHA("stackA")
+		require.NoError(t, err)
+		stackAChildBefore, err := scene.Repo.GetBranchSHA("stackA-child")
+		require.NoError(t, err)
+		stackBBefore, err := scene.Repo.GetBranchSHA("stackB")
+		require.NoError(t, err)
+
+		err = scene.Repo.CheckoutBranch("main")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("main update", "main")
+		require.NoError(t, err)
+
+		cmd := exec.Command(binaryPath, "restack", "--all-stacks", "--parallel", "--jobs", "2")
+		cmd.Dir = scene.Dir
+		output, err := cmd.CombinedOutput()
+
+		require.NoError(t, err, "restack --all-stacks --parallel failed: %s", string(output))
+
+		// Verify all branches were actually restacked (SHAs changed)
+		stackAAfter, err := scene.Repo.GetBranchSHA("stackA")
+		require.NoError(t, err)
+		stackAChildAfter, err := scene.Repo.GetBranchSHA("stackA-child")
+		require.NoError(t, err)
+		stackBAfter, err := scene.Repo.GetBranchSHA("stackB")
+		require.NoError(t, err)
+		require.NotEqual(t, stackABefore, stackAAfter)
+		require.NotEqual(t, stackAChildBefore, stackAChildAfter)
+		require.NotEqual(t, stackBBefore, stackBAfter)
+	})
+
+	t.Run("restack --all-stacks --parallel --continue-on-conflict skips conflicted stacks", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+			if err := s.Repo.CreateChangeAndCommit("initial", "conflict"); err != nil {
+				return err
+			}
+
+			if err := s.Repo.CreateChange("stackA conflicting change", "conflict", false); err != nil {
+				return err
+			}
+			createStackitBranch(t, binaryPath, s.Dir, "stackA", "stackA conflicting change")
+
+			if err := s.Repo.CheckoutBranch("main"); err != nil {
+				return err
+			}
+			if err := s.Repo.CreateChange("stackB change", "stackB", false); err != nil {
+				return err
+			}
+			createStackitBranch(t, binaryPath, s.Dir, "stackB", "stackB change")
+			return nil
+		})
+
+		stackABefore, err := scene.Repo.GetBranchSHA("stackA")
+		require.NoError(t, err)
+		stackBBefore, err := scene.Repo.GetBranchSHA("stackB")
+		require.NoError(t, err)
+
+		err = scene.Repo.CheckoutBranch("main")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("main conflicting change", "conflict")
+		require.NoError(t, err)
+
+		cmd := exec.Command(binaryPath, "restack", "--all-stacks", "--parallel", "--jobs", "2", "--continue-on-conflict")
+		cmd.Dir = scene.Dir
+		output, err := cmd.CombinedOutput()
+
+		require.NoError(t, err, "restack command failed: %s", string(output))
+
+		// stackA should be untouched (conflict); stackB should be restacked
+		stackAAfter, err := scene.Repo.GetBranchSHA("stackA")
+		require.NoError(t, err)
+		stackBAfter, err := scene.Repo.GetBranchSHA("stackB")
+		require.NoError(t, err)
+		require.Equal(t, stackABefore, stackAAfter)
+		require.NotEqual(t, stackBBefore, stackBAfter)
+	})
+
+	t.Run("restack --parallel without --all-stacks errors", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+			return s.Repo.CreateChangeAndCommit("initial", "init")
+		})
+
+		cmd := exec.Command(binaryPath, "restack", "--parallel")
+		cmd.Dir = scene.Dir
+		output, err := cmd.CombinedOutput()
+
+		require.Error(t, err, "restack --parallel should require --all-stacks or --stacks")
+		require.Contains(t, string(output), "--parallel requires --all-stacks or --stacks")
+	})
+
 	t.Run("restack errors when multiple scope flags specified", func(t *testing.T) {
 		t.Parallel()
 		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {

--- a/internal/cli/stack/sync.go
+++ b/internal/cli/stack/sync.go
@@ -125,7 +125,9 @@ func syncDryRunJSON(ctx *app.Context, opts sync.Options) error {
 		}
 	}
 
-	// Sort and dedupe restack roots so callers can pass them directly to `restack --stacks`.
+	// Sort and dedupe restack roots for the current dry-run snapshot. Recompute after
+	// running sync before using these roots for a follow-up `restack --stacks`, since
+	// cleanup and reparenting can change which roots need work.
 	if len(restackRootSet) > 0 {
 		roots := make([]string, 0, len(restackRootSet))
 		for root := range restackRootSet {

--- a/internal/cli/stack/sync.go
+++ b/internal/cli/stack/sync.go
@@ -4,6 +4,7 @@ package stack
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/spf13/cobra"
 
@@ -108,6 +109,7 @@ func syncDryRunJSON(ctx *app.Context, opts sync.Options) error {
 	// Collect candidate branches for deletion and restack checks
 	allBranches := eng.AllBranches()
 	var candidateNames []string
+	restackRootSet := make(map[string]struct{})
 	for _, branch := range allBranches {
 		if branch.IsTrunk() || !branch.IsTracked() {
 			continue
@@ -117,7 +119,20 @@ func syncDryRunJSON(ctx *app.Context, opts sync.Options) error {
 		// Check restack status while iterating
 		if opts.Restack && !branch.IsBranchUpToDate() {
 			result.WouldRestack = append(result.WouldRestack, branch.GetName())
+			if root := eng.GetStackRootForBranch(branch); root != "" {
+				restackRootSet[root] = struct{}{}
+			}
 		}
+	}
+
+	// Sort and dedupe restack roots so callers can pass them directly to `restack --stacks`.
+	if len(restackRootSet) > 0 {
+		roots := make([]string, 0, len(restackRootSet))
+		for root := range restackRootSet {
+			roots = append(roots, root)
+		}
+		sort.Strings(roots)
+		result.WouldRestackStacks = roots
 	}
 
 	// Batch-check deletion status for all candidates

--- a/internal/engine/independent_stack.go
+++ b/internal/engine/independent_stack.go
@@ -1,0 +1,46 @@
+package engine
+
+// IndependentStack describes a standalone stack rooted at a direct child of trunk.
+type IndependentStack struct {
+	RootBranch string
+	Branches   []string
+}
+
+// DiscoverIndependentStacks returns all stacks rooted at direct children of trunk.
+//
+// Each stack includes its root branch first, followed by descendants in the graph's
+// depth-first order. Branches from separate stacks are independent of each other.
+func DiscoverIndependentStacks(eng BranchReader) []IndependentStack {
+	return DiscoverIndependentStacksWithSort(eng, SortStrategyAlphabetical)
+}
+
+// DiscoverIndependentStacksWithSort is like DiscoverIndependentStacks, but allows
+// callers to choose how sibling branches are ordered.
+func DiscoverIndependentStacksWithSort(eng BranchReader, strategy SortStrategy) []IndependentStack {
+	graph := BuildStackGraph(eng, strategy, nil)
+	trunkNode := graph.GetNode(eng.Trunk().GetName())
+	if trunkNode == nil {
+		return nil
+	}
+
+	stacks := make([]IndependentStack, 0, len(trunkNode.Children))
+	for _, rootName := range trunkNode.Children {
+		rootNode := graph.GetNode(rootName)
+		if rootNode == nil {
+			continue
+		}
+
+		branches := graph.CollectBranches(rootNode.Branch)
+		branchNames := make([]string, len(branches))
+		for i, branch := range branches {
+			branchNames[i] = branch.GetName()
+		}
+
+		stacks = append(stacks, IndependentStack{
+			RootBranch: rootName,
+			Branches:   branchNames,
+		})
+	}
+
+	return stacks
+}

--- a/internal/engine/independent_stack_test.go
+++ b/internal/engine/independent_stack_test.go
@@ -1,0 +1,71 @@
+package engine_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"stackit.dev/stackit/internal/engine"
+	"stackit.dev/stackit/testhelpers"
+	"stackit.dev/stackit/testhelpers/scenario"
+)
+
+func TestDiscoverIndependentStacks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns stacks rooted at direct trunk children", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"stack-a":       "main",
+				"stack-a-child": "stack-a",
+				"stack-a-leaf":  "stack-a-child",
+				"stack-b":       "main",
+				"stack-b-child": "stack-b",
+			})
+
+		stacks := engine.DiscoverIndependentStacks(s.Engine)
+
+		require.Equal(t, []engine.IndependentStack{
+			{
+				RootBranch: "stack-a",
+				Branches:   []string{"stack-a", "stack-a-child", "stack-a-leaf"},
+			},
+			{
+				RootBranch: "stack-b",
+				Branches:   []string{"stack-b", "stack-b-child"},
+			},
+		}, stacks)
+	})
+
+	t.Run("returns no stacks when trunk has no tracked children", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		stacks := engine.DiscoverIndependentStacks(s.Engine)
+
+		require.Empty(t, stacks)
+	})
+
+	t.Run("includes branching descendants under the same root", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"root":    "main",
+				"child-a": "root",
+				"child-b": "root",
+			})
+
+		stacks := engine.DiscoverIndependentStacks(s.Engine)
+
+		require.Equal(t, []engine.IndependentStack{
+			{
+				RootBranch: "root",
+				Branches:   []string{"root", "child-a", "child-b"},
+			},
+		}, stacks)
+	})
+}

--- a/internal/handlers/restack.go
+++ b/internal/handlers/restack.go
@@ -2,6 +2,7 @@
 package handlers
 
 import (
+	"slices"
 	"sync"
 
 	"stackit.dev/stackit/internal/engine"
@@ -61,6 +62,7 @@ type RestackJSONResult struct {
 	Restacked     []RestackBranchInfo   `json:"restacked,omitempty"`
 	Skipped       []string              `json:"skipped,omitempty"`
 	Conflicts     []RestackConflictInfo `json:"conflicts,omitempty"`
+	StackRoots    []string              `json:"stack_roots,omitempty"` // Deduped independent stack roots that were processed
 	TotalCount    int                   `json:"total_count"`
 	RestackCount  int                   `json:"restack_count"`
 	ConflictCount int                   `json:"conflict_count"`
@@ -70,6 +72,7 @@ type RestackJSONResult struct {
 type RestackBranchInfo struct {
 	Name                string `json:"name"`
 	Parent              string `json:"parent"`
+	StackRoot           string `json:"stack_root,omitempty"` // Independent stack root this branch belongs to
 	NewRev              string `json:"new_rev,omitempty"`
 	PRNumber            *int   `json:"pr_number,omitempty"`
 	RerereResolvedCount int    `json:"rerere_resolved_count,omitempty"`
@@ -77,8 +80,9 @@ type RestackBranchInfo struct {
 
 // RestackConflictInfo represents a conflict during restack
 type RestackConflictInfo struct {
-	Branch string `json:"branch"`
-	Parent string `json:"parent"`
+	Branch    string `json:"branch"`
+	Parent    string `json:"parent"`
+	StackRoot string `json:"stack_root,omitempty"` // Independent stack root this branch belongs to
 }
 
 // JSONRestackHandler collects restack results for JSON output.
@@ -140,6 +144,35 @@ func (h *JSONRestackHandler) OnRestackComplete(restacked, _ int, _ []string) {
 		h.Result.Status = RestackJSONStatusConflict
 	} else {
 		h.Result.Status = RestackJSONStatusSuccess
+	}
+}
+
+// SetLastBranchStackRoot annotates the most recently added restacked or conflict
+// entry for the given branch with its independent stack root. It also maintains
+// the deduped top-level StackRoots list. Called outside the handler interface so
+// only JSON output is enriched without touching all implementors.
+func (h *JSONRestackHandler) SetLastBranchStackRoot(branch, stackRoot string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	// Annotate the matching restacked entry (search from end — just appended).
+	for i := len(h.Result.Restacked) - 1; i >= 0; i-- {
+		if h.Result.Restacked[i].Name == branch {
+			h.Result.Restacked[i].StackRoot = stackRoot
+			break
+		}
+	}
+	// Annotate the matching conflict entry.
+	for i := len(h.Result.Conflicts) - 1; i >= 0; i-- {
+		if h.Result.Conflicts[i].Branch == branch {
+			h.Result.Conflicts[i].StackRoot = stackRoot
+			break
+		}
+	}
+
+	// Maintain deduped StackRoots.
+	if !slices.Contains(h.Result.StackRoots, stackRoot) {
+		h.Result.StackRoots = append(h.Result.StackRoots, stackRoot)
 	}
 }
 

--- a/internal/handlers/restack.go
+++ b/internal/handlers/restack.go
@@ -2,6 +2,8 @@
 package handlers
 
 import (
+	"sync"
+
 	"stackit.dev/stackit/internal/engine"
 )
 
@@ -79,8 +81,10 @@ type RestackConflictInfo struct {
 	Parent string `json:"parent"`
 }
 
-// JSONRestackHandler collects restack results for JSON output
+// JSONRestackHandler collects restack results for JSON output.
+// All methods are mutex-protected so concurrent callers (parallel restack) are safe.
 type JSONRestackHandler struct {
+	mu     sync.Mutex
 	Result *RestackJSONResult
 }
 
@@ -97,11 +101,15 @@ func NewJSONRestackHandler() *JSONRestackHandler {
 
 // OnRestackStart implements RestackHandler.
 func (h *JSONRestackHandler) OnRestackStart(branchCount int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	h.Result.TotalCount = branchCount
 }
 
 // OnRestackBranch implements RestackHandler.
 func (h *JSONRestackHandler) OnRestackBranch(branch string, result RestackResult, newRev string, prNumber *int, _ engine.LockReason, _ bool, _ bool, parent string, _ bool, _, _ string, rerereResolvedCount int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	switch result {
 	case RestackDone:
 		h.Result.Restacked = append(h.Result.Restacked, RestackBranchInfo{
@@ -123,6 +131,8 @@ func (h *JSONRestackHandler) OnRestackBranch(branch string, result RestackResult
 
 // OnRestackComplete implements RestackHandler.
 func (h *JSONRestackHandler) OnRestackComplete(restacked, _ int, _ []string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	h.Result.RestackCount = restacked
 	h.Result.ConflictCount = len(h.Result.Conflicts)
 
@@ -137,6 +147,8 @@ func (h *JSONRestackHandler) OnRestackComplete(restacked, _ int, _ []string) {
 // Call this when the restack action returns an error.
 func (h *JSONRestackHandler) SetError(err error) {
 	if err != nil {
+		h.mu.Lock()
+		defer h.mu.Unlock()
 		// If we already observed restack conflicts, keep status as "conflict"
 		// and attach the error details for debugging/context.
 		if len(h.Result.Conflicts) > 0 {

--- a/internal/handlers/restack_test.go
+++ b/internal/handlers/restack_test.go
@@ -103,6 +103,32 @@ func TestJSONRestackHandler(t *testing.T) {
 		require.Len(t, handler.Result.Conflicts, 1)
 	})
 
+	t.Run("SetLastBranchStackRoot annotates branches and dedupes roots", func(t *testing.T) {
+		t.Parallel()
+
+		handler := NewJSONRestackHandler()
+		handler.OnRestackStart(3)
+
+		handler.OnRestackBranch("alpha", RestackDone, "aaa", nil, engine.LockReasonNone, false, false, "main", false, "", "", 0)
+		handler.SetLastBranchStackRoot("alpha", "alpha")
+
+		handler.OnRestackBranch("alpha-child", RestackDone, "bbb", nil, engine.LockReasonNone, false, false, "alpha", false, "", "", 0)
+		handler.SetLastBranchStackRoot("alpha-child", "alpha")
+
+		handler.OnRestackBranch("beta", RestackConflict, "", nil, engine.LockReasonNone, false, false, "main", false, "", "", 0)
+		handler.SetLastBranchStackRoot("beta", "beta")
+
+		handler.OnRestackComplete(2, 0, []string{"beta"})
+
+		// Per-branch annotation
+		require.Equal(t, "alpha", handler.Result.Restacked[0].StackRoot)
+		require.Equal(t, "alpha", handler.Result.Restacked[1].StackRoot)
+		require.Equal(t, "beta", handler.Result.Conflicts[0].StackRoot)
+
+		// Deduped top-level roots
+		require.Equal(t, []string{"alpha", "beta"}, handler.Result.StackRoots)
+	})
+
 	t.Run("SetError does nothing for nil error", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/integration/json_output_test.go
+++ b/internal/integration/json_output_test.go
@@ -205,6 +205,43 @@ func TestJSONOutput(t *testing.T) {
 		// JSON was valid and parseable - verified by NoError above
 	})
 
+	t.Run("sync --dry-run --json --restack reports stack roots for would_restack branches", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t, WithRemote())
+
+		// Build two independent stacks rooted at trunk:
+		//   main -> alpha-root -> alpha-child
+		//   main -> beta-root
+		sh.Write("alpha_root", "alpha root").
+			Run("create alpha-root -m 'Add alpha root'").
+			Write("alpha_child", "alpha child").
+			Run("create alpha-child -m 'Add alpha child'").
+			Run("trunk").
+			Write("beta_root", "beta root").
+			Run("create beta-root -m 'Add beta root'")
+
+		// Force alpha-root to diverge from trunk by amending trunk's view via a new commit on trunk.
+		// We use a direct git call to shift trunk, then mark alpha-root as needing restack.
+		sh.Run("checkout alpha-root").
+			Git("commit --allow-empty -m 'force restack'")
+
+		// Checkout back to alpha-child so restack scope discovery sees the stack.
+		sh.Run("checkout alpha-child")
+
+		sh.Run("sync --dry-run --json --restack")
+		output := sh.Output()
+
+		var result sync.DryRunResult
+		err := json.Unmarshal([]byte(output), &result)
+		require.NoError(t, err, "sync --dry-run --json --restack should produce valid JSON")
+
+		// Every would_restack branch should map to a root; the deduped set should be
+		// sorted and contain only known stack roots (alpha-root, beta-root).
+		require.NotNil(t, result.WouldRestackStacks, "would_restack_stacks should be populated when branches need restack")
+		require.Equal(t, []string{"alpha-root"}, result.WouldRestackStacks,
+			"should deduplicate and sort restack roots; only alpha's stack has drift")
+	})
+
 	t.Run("log --json with no tracked branches outputs valid JSON", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)


### PR DESCRIPTION
This PR merges the following changes:

1. **#862** refactor(merge): simplify multistack discovery logic
2. **#863** feat(foreach): improve foreach action and add tests
3. **#864** feat(foreach): add foreach events and dry-run support
4. **#865** feat(foreach): add stack range filtering and parallel execution
5. **#866** feat(restack): improve restack with better CLI flags and add tests
6. **#867** docs(cli): update stack-fix agent template
7. **#868** docs(cli): update stack-verify agent template
8. **#869** docs(cli): update stack-absorb agent template
9. **#870** docs(cli): update stack-sync agent template
10. **#871** docs(cli): update stack-status agent template
11. **#872** docs(cli): update skill templates to use scoped restack commands
12. **#873** feat(sync): add would_restack_stacks to dry-run JSON for restack planning
13. **#874** feat(foreach): add --all-stacks and --stacks multi-stack scope flags
14. **#875** feat(restack): add --parallel flag to run independent stacks in parallel worktrees
15. **#876** feat(restack): annotate JSON output with stack_root per branch for multi-stack grouping
16. **#877** docs: update restack examples to use scoped flags across user-facing docs
17. **#878** fix: harden stack automation error handling
18. **#880** docs: clarify would_restack_stacks must be recomputed after sync before restack

### Stack

```
main
  └─ jonnii/20260415014309/simplify-multistack-discovery-logic (#862)
    └─ jonnii/20260415014644/improve-foreach-action-and-add-tests (#863)
      └─ jonnii/20260415015107/add-foreach-events-and-dry-run-support (#864)
        └─ jonnii/20260415015552/add-stack-range-filtering-and-parallel-execution (#865)
          └─ jonnii/20260415020529/improve-restack-with-better-CLI-flags-and-add (#866)
            └─ jonnii/20260415021035/update-stack-fix-agent-template (#867)
              └─ jonnii/20260415022132/update-stack-verify-agent-template (#868)
                └─ jonnii/20260415022435/update-stack-absorb-agent-template (#869)
                  └─ jonnii/20260415022653/update-stack-sync-agent-template (#870)
                    └─ jonnii/20260415022842/update-stack-status-agent-template (#871)
                      └─ jonnii/20260415023903/update-skill-templates-to-use-scoped-restack (#872)
                        └─ jonnii/20260415024545/add-would_restack_stacks-to-dry-run-JSON-for (#873)
                          └─ jonnii/20260415025350/add-all-stacks-and-stacks-multi-stack-scope (#874)
                            └─ jonnii/20260421200717/add-parallel-flag-to-run-independent-stacks-in (#875)
                              └─ jonnii/20260421201736/annotate-JSON-output-with-stack_root-per-branch (#876)
                                └─ jonnii/20260421202331/update-restack-examples-to-use-scoped-flags (#877)
                                  └─ jonnii/20260421204210/harden-stack-automation-error-handling (#878)
                                    └─ jonnii/20260422221327/clarify-would_restack_stacks-must-be-recomputed (#880)
```

Stackit-Stack-Size: 18
Stackit-PRs: 862,863,864,865,866,867,868,869,870,871,872,873,874,875,876,877,878,880
