### PR TITLE
fix(restack): stop parallel worker from destroying conflict state and under-reporting failed groups

### DIFF
--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -156,6 +156,24 @@ func restackGroupsParallel(
 	var mu sync.Mutex
 	var groupErrs []error
 
+	// recordGroupFailure attributes every branch in a failed group to the handler
+	// as a conflict so the final summary reflects what the worker did not process.
+	// Without this a worktree/engine setup failure silently shows "skipped=0" while
+	// an entire stack failed to start. Caller must not already hold mu.
+	recordGroupFailure := func(group restackBranchGroup, wrappedErr error) {
+		mu.Lock()
+		defer mu.Unlock()
+		groupErrs = append(groupErrs, wrappedErr)
+		for _, b := range group.branches {
+			handleRestackProgress(eng, handler, RestackProgress{
+				Branch:    b.GetName(),
+				Result:    engine.RestackConflict,
+				Conflict:  true,
+				StackRoot: group.rootBranch,
+			}, &restacked, &skipped, &conflicts)
+		}
+	}
+
 	utils.RunWithWorkers(groups, numJobs, func(group restackBranchGroup) {
 		// Create a temporary worktree for this group. PruneSkip because we
 		// pruned once above and don't want N workers racing on prune.
@@ -163,9 +181,7 @@ func restackGroupsParallel(
 		if err != nil {
 			wrappedErr := fmt.Errorf("stack %s: create worktree: %w", group.rootBranch, err)
 			ctx.Logger.Warn("failed to create worktree for parallel restack: %v", wrappedErr)
-			mu.Lock()
-			groupErrs = append(groupErrs, wrappedErr)
-			mu.Unlock()
+			recordGroupFailure(group, wrappedErr)
 			return
 		}
 		defer cleanup()
@@ -178,9 +194,7 @@ func restackGroupsParallel(
 		if err != nil {
 			wrappedErr := fmt.Errorf("stack %s: create worktree engine: %w", group.rootBranch, err)
 			ctx.Logger.Warn("failed to create worktree engine: %v", wrappedErr)
-			mu.Lock()
-			groupErrs = append(groupErrs, wrappedErr)
-			mu.Unlock()
+			recordGroupFailure(group, wrappedErr)
 			return
 		}
 
@@ -198,8 +212,11 @@ func restackGroupsParallel(
 			handleRestackProgress(eng, handler, p, &restacked, &skipped, &conflicts)
 		}
 
+		// Parallel mode always reports conflicts via callback: the interactive conflict
+		// workflow writes rebase state into the worktree, which defer cleanup() tears
+		// down, so entering it would silently destroy what the user needs to resolve.
 		sortedBranches := eng.SortBranchesTopologically(group.branches)
-		if err := RestackBranchesWithHandler(&wtCtx, sortedBranches, progress, !opts.ContinueOnConflict); err != nil {
+		if err := RestackBranchesWithHandler(&wtCtx, sortedBranches, progress, false); err != nil {
 			wrappedErr := fmt.Errorf("stack %s: %w", group.rootBranch, err)
 			ctx.Logger.Warn("parallel restack group failed: %v", wrappedErr)
 			mu.Lock()

--- a/internal/actions/restack_test.go
+++ b/internal/actions/restack_test.go
@@ -29,15 +29,28 @@ func TestRestackAction(t *testing.T) {
 			newWorktreeEngine = originalNewWorktreeEngine
 		})
 
+		jsonHandler := handlers.NewJSONRestackHandler()
 		err := RestackAction(s.Context, RestackOptions{
 			AllStacks: true,
 			Parallel:  true,
 			Jobs:      2,
-		}, handlers.NewJSONRestackHandler())
+		}, jsonHandler)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "restack failed")
 		require.ErrorContains(t, err, "alpha-root")
 		require.ErrorContains(t, err, "beta-root")
 		require.ErrorContains(t, err, "create worktree engine")
+
+		// Every branch in a failed group must appear in the summary so users
+		// don't see "skipped=0" while entire stacks silently failed to start.
+		conflictBranches := make([]string, 0, len(jsonHandler.Result.Conflicts))
+		for _, c := range jsonHandler.Result.Conflicts {
+			conflictBranches = append(conflictBranches, c.Branch)
+		}
+		require.ElementsMatch(t,
+			[]string{"alpha-root", "alpha-child", "beta-root"},
+			conflictBranches,
+		)
+		require.Equal(t, len(conflictBranches), jsonHandler.Result.ConflictCount)
 	})
 }


### PR DESCRIPTION

When restack runs with --parallel, workers execute inside temporary worktrees
that are torn down by defer cleanup() once the worker returns. Previously:

1. If a rebase conflict occurred and --continue-on-conflict was not set,
   RestackBranchesWithHandler entered the interactive conflict workflow and
   wrote rebase state into the worktree — which cleanup() then deleted,
   leaving the user with nothing to resolve.

2. If worktree creation or engine initialization failed before any progress
   callback fired, the group's branches produced no counter updates. The
   final summary showed 'skipped=0' while an entire independent stack had
   failed to start.

Fix:

- Parallel workers now always run with shouldEnterConflictWorkflow=false, so
  conflicts are reported through the progress callback instead of written to
  the ephemeral worktree.
- Worker-side setup failures route every branch in the failed group through
  handleRestackProgress as a conflict, so handler.Conflicts reflects what was
  not processed and exit status remains non-zero via errors.Join.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #883** 👈
  * **PR #884**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->