### PR TITLE
refactor(restack): typed ConflictMode and parallelResultCollector

### DIFF
--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -68,15 +68,30 @@ type RestackProgress struct {
 // RestackProgress describing the outcome.
 type RestackProgressCallback func(RestackProgress)
 
+// ConflictMode controls how RestackBranchesWithHandler responds to rebase conflicts.
+type ConflictMode int
+
+const (
+	// ConflictModeEnterWorkflow stops at the first conflict, writes rebase state
+	// to the working tree, and expects the user to resolve it with stackit continue.
+	// This is the standalone CLI default.
+	ConflictModeEnterWorkflow ConflictMode = iota
+
+	// ConflictModeContinue validates all branches first, restacks non-conflicting
+	// ones, and reports conflicts through the progress callback without writing
+	// rebase state. Use this in sync mode, parallel workers (rebase state would
+	// be torn down with the worktree), and --continue-on-conflict flows.
+	ConflictModeContinue
+)
+
 // RestackBranches restacks a list of branches using the engine's batch restack method
 func RestackBranches(ctx *app.Context, branches []engine.Branch) error {
-	return RestackBranchesWithHandler(ctx, branches, nil, true)
+	return RestackBranchesWithHandler(ctx, branches, nil, ConflictModeEnterWorkflow)
 }
 
-// RestackBranchesWithHandler restacks branches with optional progress callback
-// If shouldEnterConflictWorkflow is true, stops at first conflict and enters conflict workflow
-// If false, validates all branches first, restacks non-conflicting ones, and reports conflicts via callback
-func RestackBranchesWithHandler(ctx *app.Context, branches []engine.Branch, callback RestackProgressCallback, shouldEnterConflictWorkflow bool) error {
+// RestackBranchesWithHandler restacks branches with optional progress callback.
+// See ConflictMode for how mode controls conflict handling.
+func RestackBranchesWithHandler(ctx *app.Context, branches []engine.Branch, callback RestackProgressCallback, mode ConflictMode) error {
 	if len(branches) == 0 {
 		return nil
 	}
@@ -169,7 +184,7 @@ func RestackBranchesWithHandler(ctx *app.Context, branches []engine.Branch, call
 	}
 
 	// For standalone mode, enter conflict workflow on first conflict
-	if shouldEnterConflictWorkflow && len(conflictBranches) > 0 {
+	if mode == ConflictModeEnterWorkflow && len(conflictBranches) > 0 {
 		firstConflict := conflictBranches[0]
 
 		// Restack successfully up to the conflict
@@ -200,7 +215,7 @@ func RestackBranchesWithHandler(ctx *app.Context, branches []engine.Branch, call
 
 		// Sync mode should never leave the repo in a conflict workflow unless explicitly requested.
 		// If a runtime conflict occurred despite validation, clean it up and restore checkout state.
-		if !shouldEnterConflictWorkflow && ctx.Engine.Git().IsRebaseInProgress(ctx.Context) {
+		if mode == ConflictModeContinue && ctx.Engine.Git().IsRebaseInProgress(ctx.Context) {
 			conflictBranch := batchResult.ConflictBranch
 			if conflictBranch == "" {
 				conflictBranch = "unknown"
@@ -319,7 +334,7 @@ func RestackBranchesWithHandler(ctx *app.Context, branches []engine.Branch, call
 	}
 
 	// Report conflicts via callback for sync mode
-	if !shouldEnterConflictWorkflow && len(conflictBranches) > 0 {
+	if mode == ConflictModeContinue && len(conflictBranches) > 0 {
 		currentBranch := ctx.Engine.CurrentBranch()
 		currentBranchName := ""
 		if currentBranch != nil {

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -387,7 +387,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 					conflicts = append(conflicts, p.Branch)
 					handler.OnRestackBranch(p.Branch, handlers.RestackConflict, "", prNumber, p.LockReason, p.Frozen, p.IsCurrent, parentName, p.Reparented, p.OldParent, p.NewParent, p.RerereResolvedCount)
 				}
-			}, true); err != nil {
+			}, ConflictModeEnterWorkflow); err != nil {
 				handler.OnRestackComplete(restacked, skipped, conflicts)
 				return fmt.Errorf("restack failed: %w", err)
 			}

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -102,6 +102,11 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 		return nil
 	}
 
+	conflictMode := ConflictModeEnterWorkflow
+	if opts.ContinueOnConflict {
+		conflictMode = ConflictModeContinue
+	}
+
 	for _, group := range branchGroups {
 		// Wrap the progress callback to inject the stack root for this group.
 		groupRoot := group.rootBranch
@@ -114,7 +119,7 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 		// --continue-on-conflict skip a conflicted stack while still restacking
 		// other independent stacks.
 		sortedBranches := eng.SortBranchesTopologically(group.branches)
-		if err := RestackBranchesWithHandler(ctx, sortedBranches, progress, !opts.ContinueOnConflict); err != nil {
+		if err := RestackBranchesWithHandler(ctx, sortedBranches, progress, conflictMode); err != nil {
 			handler.OnRestackComplete(restacked, skipped, conflicts)
 			return fmt.Errorf("restack failed: %w", err)
 		}
@@ -126,10 +131,66 @@ func RestackAction(ctx *app.Context, opts RestackOptions, handler handlers.Resta
 	return nil
 }
 
+// parallelResultCollector serializes progress updates, error accumulation, and
+// counter bookkeeping across parallel restack workers. All methods take the
+// mutex internally; callers must not hold it.
+type parallelResultCollector struct {
+	mu        sync.Mutex
+	eng       engine.BranchReader
+	handler   handlers.RestackHandler
+	restacked int
+	skipped   int
+	conflicts []string
+	errs      []error
+}
+
+// recordProgress routes a progress event from a worker through handleRestackProgress.
+func (c *parallelResultCollector) recordProgress(p RestackProgress) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	handleRestackProgress(c.eng, c.handler, p, &c.restacked, &c.skipped, &c.conflicts)
+}
+
+// recordGroupFailure attributes every branch in a failed group to the handler
+// as a conflict so the final summary reflects what the worker did not process.
+// Without this a worktree/engine setup failure silently shows "skipped=0" while
+// an entire stack failed to start.
+func (c *parallelResultCollector) recordGroupFailure(group restackBranchGroup, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.errs = append(c.errs, err)
+	for _, b := range group.branches {
+		handleRestackProgress(c.eng, c.handler, RestackProgress{
+			Branch:    b.GetName(),
+			Result:    engine.RestackConflict,
+			Conflict:  true,
+			StackRoot: group.rootBranch,
+		}, &c.restacked, &c.skipped, &c.conflicts)
+	}
+}
+
+// recordRebaseError records an unexpected error returned from
+// RestackBranchesWithHandler. Per-branch outcomes were already routed through
+// recordProgress by the progress callback before the error surfaced, so only
+// the error itself needs to be captured.
+func (c *parallelResultCollector) recordRebaseError(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.errs = append(c.errs, err)
+}
+
+// joinedError returns the accumulated errors as a single joined error, or nil.
+func (c *parallelResultCollector) joinedError() error {
+	if len(c.errs) == 0 {
+		return nil
+	}
+	return errors.Join(c.errs...)
+}
+
 // restackGroupsParallel runs each independent stack group in its own temporary
 // worktree. The groups have no shared branches, so rebases + ref updates are
-// safe to interleave. Progress callbacks and handler calls are serialized via
-// a mutex to prevent data races on shared counters.
+// safe to interleave. Progress callbacks and handler calls are serialized
+// through parallelResultCollector to prevent data races on shared counters.
 func restackGroupsParallel(
 	ctx *app.Context,
 	opts RestackOptions,
@@ -152,27 +213,7 @@ func restackGroupsParallel(
 	// Snapshot the parent engine state once — each worktree engine gets a copy.
 	snapshot := eng.SnapshotForWorktree()
 
-	// Shared result counters protected by a mutex.
-	var mu sync.Mutex
-	var groupErrs []error
-
-	// recordGroupFailure attributes every branch in a failed group to the handler
-	// as a conflict so the final summary reflects what the worker did not process.
-	// Without this a worktree/engine setup failure silently shows "skipped=0" while
-	// an entire stack failed to start. Caller must not already hold mu.
-	recordGroupFailure := func(group restackBranchGroup, wrappedErr error) {
-		mu.Lock()
-		defer mu.Unlock()
-		groupErrs = append(groupErrs, wrappedErr)
-		for _, b := range group.branches {
-			handleRestackProgress(eng, handler, RestackProgress{
-				Branch:    b.GetName(),
-				Result:    engine.RestackConflict,
-				Conflict:  true,
-				StackRoot: group.rootBranch,
-			}, &restacked, &skipped, &conflicts)
-		}
-	}
+	collector := &parallelResultCollector{eng: eng, handler: handler}
 
 	utils.RunWithWorkers(groups, numJobs, func(group restackBranchGroup) {
 		// Create a temporary worktree for this group. PruneSkip because we
@@ -181,7 +222,7 @@ func restackGroupsParallel(
 		if err != nil {
 			wrappedErr := fmt.Errorf("stack %s: create worktree: %w", group.rootBranch, err)
 			ctx.Logger.Warn("failed to create worktree for parallel restack: %v", wrappedErr)
-			recordGroupFailure(group, wrappedErr)
+			collector.recordGroupFailure(group, wrappedErr)
 			return
 		}
 		defer cleanup()
@@ -194,7 +235,7 @@ func restackGroupsParallel(
 		if err != nil {
 			wrappedErr := fmt.Errorf("stack %s: create worktree engine: %w", group.rootBranch, err)
 			ctx.Logger.Warn("failed to create worktree engine: %v", wrappedErr)
-			recordGroupFailure(group, wrappedErr)
+			collector.recordGroupFailure(group, wrappedErr)
 			return
 		}
 
@@ -203,25 +244,20 @@ func restackGroupsParallel(
 		wtCtx.Engine = wtEngine
 		wtCtx.RepoRoot = wtPath
 
-		// Thread-safe progress callback that funnels into the shared counters + handler.
 		groupRoot := group.rootBranch
 		progress := func(p RestackProgress) {
 			p.StackRoot = groupRoot
-			mu.Lock()
-			defer mu.Unlock()
-			handleRestackProgress(eng, handler, p, &restacked, &skipped, &conflicts)
+			collector.recordProgress(p)
 		}
 
 		// Parallel mode always reports conflicts via callback: the interactive conflict
 		// workflow writes rebase state into the worktree, which defer cleanup() tears
 		// down, so entering it would silently destroy what the user needs to resolve.
 		sortedBranches := eng.SortBranchesTopologically(group.branches)
-		if err := RestackBranchesWithHandler(&wtCtx, sortedBranches, progress, false); err != nil {
+		if err := RestackBranchesWithHandler(&wtCtx, sortedBranches, progress, ConflictModeContinue); err != nil {
 			wrappedErr := fmt.Errorf("stack %s: %w", group.rootBranch, err)
 			ctx.Logger.Warn("parallel restack group failed: %v", wrappedErr)
-			mu.Lock()
-			groupErrs = append(groupErrs, wrappedErr)
-			mu.Unlock()
+			collector.recordRebaseError(wrappedErr)
 		}
 	})
 
@@ -231,11 +267,7 @@ func restackGroupsParallel(
 		ctx.Logger.Warn("failed to rebuild engine after parallel restack: %v", err)
 	}
 
-	if len(groupErrs) > 0 {
-		return restacked, skipped, conflicts, errors.Join(groupErrs...)
-	}
-
-	return restacked, skipped, conflicts, nil
+	return collector.restacked, collector.skipped, collector.conflicts, collector.joinedError()
 }
 
 type restackBranchGroup struct {

--- a/internal/actions/sync/restack.go
+++ b/internal/actions/sync/restack.go
@@ -123,7 +123,7 @@ func restackBranches(ctx *app.Context, branchesToRestack []string, restackScope 
 					Parent:     parentName,
 				})
 			}
-		}, false); err != nil {
+		}, actions.ConflictModeContinue); err != nil {
 			return fmt.Errorf("failed to restack branches: %w", err)
 		}
 		ctx.Logger.Info("restack branches completed durationMs=%d branchCount=%d", time.Since(restackStart).Milliseconds(), len(sortedBranches))


### PR DESCRIPTION

Two related cleanups around the parallel restack path:

1. Replace the bool 'shouldEnterConflictWorkflow' on RestackBranchesWithHandler
   with a typed ConflictMode enum (ConflictModeEnterWorkflow, ConflictModeContinue).
   The old form forced every call site to flip a bare bool — !ContinueOnConflict,
   just false, plain true — with no help from the type to catch mismatches.
   The enum makes intent obvious at the call site and lets the parallel-mode
   invariant (conflicts always routed via callback because the worktree gets
   torn down) document itself.

2. Extract parallelResultCollector to own the mutex, counters, and error
   accumulation that were previously three pieces of shared state wired
   through three closures. The worker body now reads top-to-bottom with all
   three error paths (worktree setup, engine init, rebase error) routed
   through named methods: recordGroupFailure / recordRebaseError /
   recordProgress. No behavior change.