### PR TITLE
refactor: drop `command` prefix from project rules and AGENTS.md

### DIFF
--- a/.claude/rules/stackit-workflow.md
+++ b/.claude/rules/stackit-workflow.md
@@ -6,10 +6,10 @@ This project uses stackit for stacked changes. **NEVER use raw git commands for 
 
 | Never Use | Use Instead |
 |-----------|-------------|
-| `git commit -m "..."` | `command stackit create -m "..."` |
-| `git checkout -b` | `command stackit create -m "..."` |
-| `gh pr create` | `command stackit submit` |
-| `git rebase` | `command stackit restack --upstack` (or `--all-stacks`) |
+| `git commit -m "..."` | `stackit create -m "..."` |
+| `git checkout -b` | `stackit create -m "..."` |
+| `gh pr create` | `stackit submit` |
+| `git rebase` | `stackit restack --upstack` (or `--all-stacks`) |
 
 **Exception:** `git commit` is allowed when adding commits to an existing stacked branch.
 
@@ -20,9 +20,9 @@ This project uses stackit for stacked changes. **NEVER use raw git commands for 
 # 2. Stage changes FIRST (required!)
 git add -A
 # 3. Create stacked branch with commit
-command stackit create -m "feat: description"
+stackit create -m "feat: description"
 # 4. Submit when ready
-command stackit submit
+stackit submit
 ```
 
 **Critical:** `stackit create` requires staged changes. Without staged changes, it creates an empty branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,23 +41,23 @@ Go CLI for managing stacked changes in Git repositories.
 git add -A
 
 # Create stacked branch with commit
-command stackit create -m "feat: description"
+stackit create -m "feat: description"
 
 # Continue working, stage more changes, create more branches...
-git add -A && command stackit create -m "feat: next phase"
+git add -A && stackit create -m "feat: next phase"
 
 # Submit when ready
-command stackit submit
+stackit submit
 ```
 
 ### Handling PR Feedback
 
 ```bash
-command stackit checkout <branch>  # Go to branch with feedback
+stackit checkout <branch>  # Go to branch with feedback
 # Make changes...
-command stackit modify             # Amend commit
-command stackit restack --upstack   # Update children of this branch
-command stackit submit             # Update PRs
+stackit modify             # Amend commit
+stackit restack --upstack   # Update children of this branch
+stackit submit             # Update PRs
 ```
 
 ### Common Pitfalls


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Mirrors the template change so that humans (and Claude) reading the
in-repo rules see the same form being recommended in the installed
agent skills. `stackit` works fine inside Claude's non-interactive
Bash sandbox; the `command` builtin only mattered for bypassing user
shell aliases, which aren't loaded there.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #898**
  * **PR #899** 👈
    * **PR #900**
      * **PR #901**
        * **PR #902**
          * **PR #903**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #904 by jonnii*