### PR TITLE
feat: add --message-file flag to create/modify/squash/split

### DIFF
--- a/.claude/rules/stackit-workflow.md
+++ b/.claude/rules/stackit-workflow.md
@@ -68,9 +68,10 @@ stackit create -m "feat: very specific message"
 
 # Prefer — command shape stays constant
 stackit create --message-file /tmp/.stackit-msg
+stackit create -F -      # also accepts stdin via "-"
 ```
 
-(Not all stackit commands support `--message-file` yet; use stdin or temp files where they do.)
+`create`, `modify`, `squash`, and `split --by-file` all accept `--message-file` (`-F`, except for `split` where `-F` is taken).
 
 ## Common Pitfalls
 

--- a/internal/cli/branch/create.go
+++ b/internal/cli/branch/create.go
@@ -13,14 +13,15 @@ import (
 // NewCreateCmd creates the create command
 func NewCreateCmd() *cobra.Command {
 	var (
-		all      bool
-		insert   bool
-		message  string
-		patch    bool
-		scope    string
-		update   bool
-		verbose  int
-		worktree bool
+		all         bool
+		insert      bool
+		message     string
+		messageFile string
+		patch       bool
+		scope       string
+		update      bool
+		verbose     int
+		worktree    bool
 	)
 
 	cmd := &cobra.Command{
@@ -40,6 +41,11 @@ If you have any unstaged changes, you will be asked whether you'd like to stage 
 					branchName = args[0]
 				}
 
+				resolvedMessage, err := common.ReadMessage(message, messageFile)
+				if err != nil {
+					return err
+				}
+
 				// Get config values
 				cfg, _ := config.LoadConfig(ctx.RepoRoot)
 				branchPattern := cfg.GetBranchPattern()
@@ -47,7 +53,7 @@ If you have any unstaged changes, you will be asked whether you'd like to stage 
 				// Prepare options
 				opts := create.Options{
 					BranchName:    branchName,
-					Message:       message,
+					Message:       resolvedMessage,
 					Scope:         scope,
 					All:           all,
 					Insert:        insert,
@@ -82,6 +88,7 @@ If you have any unstaged changes, you will be asked whether you'd like to stage 
 	cmd.Flags().BoolVarP(&all, "all", "a", false, "Stage all unstaged changes before creating the branch, including to untracked files")
 	cmd.Flags().BoolVarP(&insert, "insert", "i", false, "Insert this branch between the current branch and its child. If there are multiple children, prompts you to select which should be moved onto the new branch")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "Specify a commit message")
+	cmd.Flags().StringVarP(&messageFile, "message-file", "F", "", "Read commit message from a file (use \"-\" for stdin). Mutually exclusive with --message.")
 	cmd.Flags().BoolVarP(&patch, "patch", "p", false, "Pick hunks to stage before committing")
 	cmd.Flags().StringVar(&scope, "scope", "", "Set a scope (e.g., Jira ticket ID, Linear ID) for the new branch. If not provided, inherits from parent branch")
 	cmd.Flags().BoolVarP(&update, "update", "u", false, "Stage all updates to tracked files before creating the branch")

--- a/internal/cli/branch/modify.go
+++ b/internal/cli/branch/modify.go
@@ -17,6 +17,7 @@ func NewModifyCmd() *cobra.Command {
 		edit              bool
 		interactiveRebase bool
 		message           string
+		messageFile       string
 		noEdit            bool
 		patch             bool
 		resetAuthor       bool
@@ -41,13 +42,18 @@ Examples:
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
+				resolvedMessage, err := common.ReadMessage(message, messageFile)
+				if err != nil {
+					return err
+				}
+
 				// Determine noEdit flag:
 				// - If --no-edit is explicitly set, use it
 				// - If message is provided, don't open editor (noEdit = true)
 				// - If --edit is set, open editor (noEdit = false)
 				// - Default: open editor when amending without message (noEdit = false)
 				noEditFlag := noEdit
-				if message != "" && !edit {
+				if resolvedMessage != "" && !edit {
 					noEditFlag = true
 				}
 
@@ -57,7 +63,7 @@ Examples:
 					Update:            update,
 					Patch:             patch,
 					CreateCommit:      commit,
-					Message:           message,
+					Message:           resolvedMessage,
 					Edit:              edit,
 					NoEdit:            noEditFlag,
 					ResetAuthor:       resetAuthor,
@@ -74,6 +80,7 @@ Examples:
 	cmd.Flags().BoolVarP(&edit, "edit", "e", false, "If passed, open an editor to edit the commit message.")
 	cmd.Flags().BoolVar(&interactiveRebase, "interactive-rebase", false, "Ignore all other flags and start a git interactive rebase on the commits in this branch.")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "The message for the new or amended commit. If passed, no editor is opened.")
+	cmd.Flags().StringVarP(&messageFile, "message-file", "F", "", "Read commit message from a file (use \"-\" for stdin). Mutually exclusive with --message.")
 	cmd.Flags().BoolVarP(&noEdit, "no-edit", "n", false, "Don't modify the existing commit message. Takes precedence over --edit.")
 	cmd.Flags().BoolVarP(&patch, "patch", "p", false, "Pick hunks to stage before committing.")
 	cmd.Flags().BoolVar(&resetAuthor, "reset-author", false, "Set the author of the commit to the current user if amending.")

--- a/internal/cli/branch/split.go
+++ b/internal/cli/branch/split.go
@@ -24,6 +24,7 @@ func NewSplitCmd() *cobra.Command {
 		below             bool
 		name              string
 		message           string
+		messageFile       string
 		patchFile         string
 		dryRun            bool
 	)
@@ -74,6 +75,12 @@ Examples:
 		DisableFlagParsing: false,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
+				resolvedMessage, err := common.ReadMessage(message, messageFile)
+				if err != nil {
+					return err
+				}
+				message = resolvedMessage
+
 				// Determine split style - check all flag variants
 				var style split.Style
 				switch {
@@ -173,6 +180,7 @@ Examples:
 	cmd.Flags().BoolVar(&asSibling, "as-sibling", false, "Create split branches as siblings instead of a chain")
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Name for the new split branch (default: auto-generated)")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "Commit message for extraction (only with --by-file)")
+	cmd.Flags().StringVar(&messageFile, "message-file", "", "Read commit message from a file (use \"-\" for stdin). Mutually exclusive with --message.")
 
 	// Direction options (for hunk and file modes)
 	cmd.Flags().BoolVar(&above, "above", false, "Insert new branch above current (as child, upstack)")

--- a/internal/cli/branch/squash.go
+++ b/internal/cli/branch/squash.go
@@ -12,9 +12,10 @@ import (
 // NewSquashCmd creates the squash command
 func NewSquashCmd() *cobra.Command {
 	var (
-		message string
-		edit    bool
-		noEdit  bool
+		message     string
+		messageFile string
+		edit        bool
+		noEdit      bool
 	)
 
 	cmd := &cobra.Command{
@@ -27,6 +28,11 @@ all upstack branches (children) are automatically restacked.`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
+				resolvedMessage, err := common.ReadMessage(message, messageFile)
+				if err != nil {
+					return err
+				}
+
 				// Determine noEdit flag: noEdit = argv['no-edit'] || !argv.edit
 				// If --no-edit is set, noEdit = true
 				// If --edit is false, noEdit = true
@@ -35,7 +41,7 @@ all upstack branches (children) are automatically restacked.`,
 
 				// Run squash action
 				return actions.SquashAction(ctx, actions.SquashOptions{
-					Message: message,
+					Message: resolvedMessage,
 					NoEdit:  noEditFlag,
 				})
 			})
@@ -43,6 +49,7 @@ all upstack branches (children) are automatically restacked.`,
 	}
 
 	cmd.Flags().StringVarP(&message, "message", "m", "", "The updated message for the commit.")
+	cmd.Flags().StringVarP(&messageFile, "message-file", "F", "", "Read commit message from a file (use \"-\" for stdin). Mutually exclusive with --message.")
 	cmd.Flags().BoolVar(&edit, "edit", true, "Modify the existing commit message.")
 	cmd.Flags().BoolVarP(&noEdit, "no-edit", "n", false, "Don't modify the existing commit message. Takes precedence over --edit")
 

--- a/internal/cli/common/messageinput.go
+++ b/internal/cli/common/messageinput.go
@@ -1,0 +1,42 @@
+package common
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// ReadMessage resolves a commit message from either an inline `-m` string or
+// a `--message-file` path. If messageFile is "-", the message is read from
+// stdin. Trailing whitespace is trimmed so `echo "msg" | stackit create -F -`
+// behaves the same as `stackit create -m "msg"`.
+//
+// Returns an error if both message and messageFile are non-empty.
+func ReadMessage(message, messageFile string) (string, error) {
+	if message != "" && messageFile != "" {
+		return "", fmt.Errorf("--message and --message-file are mutually exclusive")
+	}
+
+	if messageFile == "" {
+		return message, nil
+	}
+
+	return readMessageFrom(messageFile, os.Stdin)
+}
+
+func readMessageFrom(path string, stdin io.Reader) (string, error) {
+	var (
+		data []byte
+		err  error
+	)
+	if path == "-" {
+		data, err = io.ReadAll(stdin)
+	} else {
+		data, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return "", fmt.Errorf("read message file: %w", err)
+	}
+	return strings.TrimRight(string(data), "\n\r\t "), nil
+}

--- a/internal/cli/common/messageinput_test.go
+++ b/internal/cli/common/messageinput_test.go
@@ -1,0 +1,86 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadMessage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns inline message when no file given", func(t *testing.T) {
+		t.Parallel()
+		got, err := ReadMessage("feat: inline", "")
+		require.NoError(t, err)
+		require.Equal(t, "feat: inline", got)
+	})
+
+	t.Run("returns empty when neither given", func(t *testing.T) {
+		t.Parallel()
+		got, err := ReadMessage("", "")
+		require.NoError(t, err)
+		require.Equal(t, "", got)
+	})
+
+	t.Run("errors when both given", func(t *testing.T) {
+		t.Parallel()
+		_, err := ReadMessage("feat: a", "/tmp/msg")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "mutually exclusive")
+	})
+
+	t.Run("reads from file path", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "msg")
+		require.NoError(t, writeFile(path, "feat: from file\n"))
+
+		got, err := ReadMessage("", path)
+		require.NoError(t, err)
+		require.Equal(t, "feat: from file", got)
+	})
+
+	t.Run("trims trailing whitespace and newlines", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "msg")
+		require.NoError(t, writeFile(path, "feat: trim me\n\n  \t\n"))
+
+		got, err := ReadMessage("", path)
+		require.NoError(t, err)
+		require.Equal(t, "feat: trim me", got)
+	})
+
+	t.Run("preserves internal newlines for multi-line messages", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "msg")
+		require.NoError(t, writeFile(path, "feat: subject\n\nbody paragraph\n"))
+
+		got, err := ReadMessage("", path)
+		require.NoError(t, err)
+		require.Equal(t, "feat: subject\n\nbody paragraph", got)
+	})
+
+	t.Run("returns error for missing file", func(t *testing.T) {
+		t.Parallel()
+		_, err := ReadMessage("", "/nonexistent/path/to/msg")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "read message file")
+	})
+
+	t.Run("reads from stdin when path is dash", func(t *testing.T) {
+		t.Parallel()
+		got, err := readMessageFrom("-", strings.NewReader("feat: from stdin\n"))
+		require.NoError(t, err)
+		require.Equal(t, "feat: from stdin", got)
+	})
+}
+
+func writeFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o600)
+}

--- a/internal/integration/messagefile_test.go
+++ b/internal/integration/messagefile_test.go
@@ -1,0 +1,57 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMessageFile verifies the --message-file flag wires through to create,
+// modify, and squash by reading the commit message from a file rather than
+// embedding it as a literal -m argument.
+func TestMessageFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("create reads commit message from file", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		msgPath := filepath.Join(sh.Dir(), ".commit-msg")
+		require.NoError(t, os.WriteFile(msgPath, []byte("feat: from file\n"), 0o600))
+
+		sh.Write("feature", "content").
+			Run("create feature -F " + msgPath).
+			OnBranch("feature").
+			Git("log -1 --format=%s").
+			OutputContains("feat: from file")
+	})
+
+	t.Run("create errors when both --message and --message-file are given", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		msgPath := filepath.Join(sh.Dir(), ".commit-msg")
+		require.NoError(t, os.WriteFile(msgPath, []byte("from file"), 0o600))
+
+		sh.Write("feature", "content").
+			RunExpectError("create feature -m 'inline' -F " + msgPath).
+			OutputContains("mutually exclusive")
+	})
+
+	t.Run("modify updates message from file", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("feature", "content").
+			Run("create feature -m 'Original'")
+
+		msgPath := filepath.Join(sh.Dir(), ".commit-msg")
+		require.NoError(t, os.WriteFile(msgPath, []byte("feat: updated from file\n"), 0o600))
+
+		sh.Run("modify -F " + msgPath).
+			Git("log -1 --format=%s").
+			OutputContains("feat: updated from file")
+	})
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Adds a `--message-file` (`-F`) flag to commands that accept commit
messages, mirroring git's `commit -F`. Use a file path or `-` for
stdin.

Motivation: when Claude (or any harness with a permission allowlist)
runs `stackit create -m "feat: literal text"`, the literal message
becomes part of the Bash command line and the permission rule must
match it. Distinct messages either trigger fresh approval prompts or
bloat the allowlist with one entry per commit. Reading the message
from a file keeps the command line stable across runs so a single
`Bash(stackit:*)` rule covers every call.

Implementation:
- New helper `internal/cli/common/ReadMessage(message, messageFile)`
  resolves the message, errors if both flags are set, and supports
  `-` for stdin. Trailing whitespace is trimmed so piped echoes
  behave naturally.
- Wired into create, modify, squash, and split. `split` already uses
  `-F` for `--by-file-interactive` so it gets the long form only.
- `create` and `modify` already had implicit stdin support via
  `utils.ReadFromStdin`; `-F -` is now an explicit alternate. squash
  gains both file and stdin support for the first time.

Updates the permission-stability guidance in stackit-workflow.md to
drop the "not yet implemented" caveat now that all four commands
support the flag.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #898**
  * **PR #899**
    * **PR #900**
      * **PR #901** 👈
        * **PR #902**
          * **PR #903**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #904 by jonnii*