### PR TITLE
fix: harden --message-file handling and broaden test coverage

### DIFF
--- a/internal/cli/branch/create.go
+++ b/internal/cli/branch/create.go
@@ -31,7 +31,12 @@ func NewCreateCmd() *cobra.Command {
 
 If no branch name is specified, generate a branch name from the commit message.
 If your working directory contains no changes, an empty branch will be created.
-If you have any unstaged changes, you will be asked whether you'd like to stage them.`,
+If you have any unstaged changes, you will be asked whether you'd like to stage them.
+
+Examples:
+  stackit create -m "feat: add login"             # Inline message
+  stackit create feature -F /tmp/msg              # Read message from a file
+  printf "feat: add login" | stackit create -F -  # Read message from stdin`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {

--- a/internal/cli/branch/modify.go
+++ b/internal/cli/branch/modify.go
@@ -35,6 +35,7 @@ Automatically restacks descendants after the modification.
 
 Examples:
   stackit modify -a -m "Updated feature"  # Stage all and amend with message
+  stackit modify -a -F /tmp/msg           # Stage all and amend, reading message from a file
   stackit modify -a                       # Stage all and amend (opens editor)
   stackit modify -p                       # Interactive patch staging then amend
   stackit modify -c -a -m "New commit"    # Create new commit instead of amending

--- a/internal/cli/branch/split.go
+++ b/internal/cli/branch/split.go
@@ -69,17 +69,21 @@ Examples:
   stackit split --by-file path/to/file.go --above     # Extract to child branch (above)
   stackit split --by-file path/to/file.go --as-sibling # Extract to sibling branch
   stackit split --by-file path/to/file.go --dry-run   # Preview the split
-  stackit split --by-commit --as-sibling              # Split commits as siblings`,
+  stackit split --by-commit --as-sibling              # Split commits as siblings
+  stackit split --by-file file.go --message-file msg.txt  # Read commit message from file (no -F shorthand on split; -F is --by-file-interactive)`,
 		SilenceUsage: true,
 		// Disable default help flag to allow -h for --by-hunk
 		DisableFlagParsing: false,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
+				if messageFile == "-" && patchFile == "-" {
+					return fmt.Errorf("cannot read both --message-file and --patch from stdin")
+				}
+
 				resolvedMessage, err := common.ReadMessage(message, messageFile)
 				if err != nil {
 					return err
 				}
-				message = resolvedMessage
 
 				// Determine split style - check all flag variants
 				var style split.Style
@@ -121,8 +125,8 @@ Examples:
 				if name != "" && style != split.StyleFile && patchFile == "" {
 					return fmt.Errorf("--name can only be used with --by-file or --by-hunk --patch")
 				}
-				if message != "" && style != split.StyleFile && patchFile == "" {
-					return fmt.Errorf("--message can only be used with --by-file or --by-hunk --patch")
+				if resolvedMessage != "" && style != split.StyleFile && patchFile == "" {
+					return fmt.Errorf("--message/--message-file can only be used with --by-file or --by-hunk --patch")
 				}
 				// --above/--below make sense with --by-hunk and --by-file
 				if (above || below) && style != "" && style != split.StyleHunk && style != split.StyleFile {
@@ -157,7 +161,7 @@ Examples:
 					BranchPattern: branchPattern,
 					AsSibling:     asSibling,
 					Name:          name,
-					Message:       message,
+					Message:       resolvedMessage,
 					UseWizard:     useWizard,
 					HunkSelector:  hunkSelector,
 					PatchFile:     patchFile,
@@ -180,7 +184,7 @@ Examples:
 	cmd.Flags().BoolVar(&asSibling, "as-sibling", false, "Create split branches as siblings instead of a chain")
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Name for the new split branch (default: auto-generated)")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "Commit message for extraction (only with --by-file)")
-	cmd.Flags().StringVar(&messageFile, "message-file", "", "Read commit message from a file (use \"-\" for stdin). Mutually exclusive with --message.")
+	cmd.Flags().StringVar(&messageFile, "message-file", "", "Read commit message from a file (use \"-\" for stdin) (only with --by-file or --by-hunk --patch). Mutually exclusive with --message. Note: split has no -F shorthand for this flag (taken by --by-file-interactive).")
 
 	// Direction options (for hunk and file modes)
 	cmd.Flags().BoolVar(&above, "above", false, "Insert new branch above current (as child, upstack)")

--- a/internal/cli/branch/squash.go
+++ b/internal/cli/branch/squash.go
@@ -24,7 +24,12 @@ func NewSquashCmd() *cobra.Command {
 		Long: `Squash all commits in the current branch into a single commit and restack upstack branches.
 
 This command combines all commits in the current branch into a single commit. After squashing,
-all upstack branches (children) are automatically restacked.`,
+all upstack branches (children) are automatically restacked.
+
+Examples:
+  stackit squash -m "feat: combined work"     # Squash with inline message
+  stackit squash -F /tmp/msg                  # Squash, reading message from a file
+  stackit squash --no-edit                    # Squash, keeping the current message`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {

--- a/internal/cli/common/messageinput.go
+++ b/internal/cli/common/messageinput.go
@@ -1,42 +1,64 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"strings"
 )
 
-// ReadMessage resolves a commit message from either an inline `-m` string or
-// a `--message-file` path. If messageFile is "-", the message is read from
-// stdin. Trailing whitespace is trimmed so `echo "msg" | stackit create -F -`
-// behaves the same as `stackit create -m "msg"`.
+// ReadMessage resolves a commit message from either an inline -m string or a
+// --message-file path. Used by create/modify/squash/split to keep variable
+// commit-message text out of the literal command line, which keeps Claude
+// permission rules stable across distinct messages and avoids shell-escaping
+// pitfalls for multi-line subject+body messages.
 //
-// Returns an error if both message and messageFile are non-empty.
+// If messageFile is "-", reads from stdin. If both flags are set, returns an
+// error. Trims surrounding whitespace; preserves internal newlines so
+// multi-line bodies survive intact. Errors when the resolved message is empty
+// (file is empty or stdin received nothing) — the caller passed --message-file
+// expecting a message, so silent fallthrough to other input paths would mask
+// the mistake.
 func ReadMessage(message, messageFile string) (string, error) {
 	if message != "" && messageFile != "" {
-		return "", fmt.Errorf("--message and --message-file are mutually exclusive")
+		return "", fmt.Errorf("cannot use --message and --message-file together; pass only one (use --message-file - to read from stdin)")
 	}
-
 	if messageFile == "" {
 		return message, nil
 	}
-
 	return readMessageFrom(messageFile, os.Stdin)
 }
 
-func readMessageFrom(path string, stdin io.Reader) (string, error) {
+func readMessageFrom(path string, stdin *os.File) (string, error) {
 	var (
 		data []byte
 		err  error
 	)
 	if path == "-" {
+		// Refuse to block on a terminal — the user almost certainly meant to
+		// pipe content and forgot.
+		if stat, statErr := stdin.Stat(); statErr == nil && stat.Mode()&os.ModeCharDevice != 0 {
+			return "", fmt.Errorf("--message-file - requires piped input; got terminal")
+		}
 		data, err = io.ReadAll(stdin)
 	} else {
 		data, err = os.ReadFile(path)
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("--message-file %q: file not found (use \"-\" to read from stdin)", path)
+		}
 	}
 	if err != nil {
-		return "", fmt.Errorf("read message file: %w", err)
+		return "", fmt.Errorf("read --message-file %q: %w", path, err)
 	}
-	return strings.TrimRight(string(data), "\n\r\t "), nil
+
+	msg := strings.TrimSpace(string(data))
+	if msg == "" {
+		if path == "-" {
+			return "", fmt.Errorf("--message-file - received empty input")
+		}
+		return "", fmt.Errorf("--message-file %q is empty", path)
+	}
+	return msg, nil
 }

--- a/internal/cli/common/messageinput_test.go
+++ b/internal/cli/common/messageinput_test.go
@@ -3,7 +3,6 @@ package common
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,29 +25,28 @@ func TestReadMessage(t *testing.T) {
 		require.Equal(t, "", got)
 	})
 
-	t.Run("errors when both given", func(t *testing.T) {
+	t.Run("errors when both given with actionable hint", func(t *testing.T) {
 		t.Parallel()
 		_, err := ReadMessage("feat: a", "/tmp/msg")
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "mutually exclusive")
+		require.Contains(t, err.Error(), "cannot use --message and --message-file together")
+		require.Contains(t, err.Error(), "use --message-file - to read from stdin")
 	})
 
 	t.Run("reads from file path", func(t *testing.T) {
 		t.Parallel()
-		dir := t.TempDir()
-		path := filepath.Join(dir, "msg")
-		require.NoError(t, writeFile(path, "feat: from file\n"))
+		path := filepath.Join(t.TempDir(), "msg")
+		require.NoError(t, os.WriteFile(path, []byte("feat: from file\n"), 0o600))
 
 		got, err := ReadMessage("", path)
 		require.NoError(t, err)
 		require.Equal(t, "feat: from file", got)
 	})
 
-	t.Run("trims trailing whitespace and newlines", func(t *testing.T) {
+	t.Run("trims surrounding whitespace", func(t *testing.T) {
 		t.Parallel()
-		dir := t.TempDir()
-		path := filepath.Join(dir, "msg")
-		require.NoError(t, writeFile(path, "feat: trim me\n\n  \t\n"))
+		path := filepath.Join(t.TempDir(), "msg")
+		require.NoError(t, os.WriteFile(path, []byte("\n\n  feat: trim me  \n\n"), 0o600))
 
 		got, err := ReadMessage("", path)
 		require.NoError(t, err)
@@ -57,30 +55,69 @@ func TestReadMessage(t *testing.T) {
 
 	t.Run("preserves internal newlines for multi-line messages", func(t *testing.T) {
 		t.Parallel()
-		dir := t.TempDir()
-		path := filepath.Join(dir, "msg")
-		require.NoError(t, writeFile(path, "feat: subject\n\nbody paragraph\n"))
+		path := filepath.Join(t.TempDir(), "msg")
+		require.NoError(t, os.WriteFile(path, []byte("feat: subject\n\nbody paragraph\n"), 0o600))
 
 		got, err := ReadMessage("", path)
 		require.NoError(t, err)
 		require.Equal(t, "feat: subject\n\nbody paragraph", got)
 	})
 
-	t.Run("returns error for missing file", func(t *testing.T) {
+	t.Run("errors with stdin hint when file does not exist", func(t *testing.T) {
 		t.Parallel()
 		_, err := ReadMessage("", "/nonexistent/path/to/msg")
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "read message file")
+		require.Contains(t, err.Error(), "--message-file")
+		require.Contains(t, err.Error(), "/nonexistent/path/to/msg")
+		require.Contains(t, err.Error(), "file not found")
+		require.Contains(t, err.Error(), `use "-" to read from stdin`)
+	})
+
+	t.Run("errors when file is empty", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "empty")
+		require.NoError(t, os.WriteFile(path, nil, 0o600))
+
+		_, err := ReadMessage("", path)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "is empty")
+	})
+
+	t.Run("errors when file is whitespace-only", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "ws")
+		require.NoError(t, os.WriteFile(path, []byte("\n\n  \t\n"), 0o600))
+
+		_, err := ReadMessage("", path)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "is empty")
 	})
 
 	t.Run("reads from stdin when path is dash", func(t *testing.T) {
 		t.Parallel()
-		got, err := readMessageFrom("-", strings.NewReader("feat: from stdin\n"))
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = r.Close() })
+
+		go func() {
+			_, _ = w.WriteString("feat: from stdin\n")
+			_ = w.Close()
+		}()
+
+		got, err := readMessageFrom("-", r)
 		require.NoError(t, err)
 		require.Equal(t, "feat: from stdin", got)
 	})
-}
 
-func writeFile(path, content string) error {
-	return os.WriteFile(path, []byte(content), 0o600)
+	t.Run("errors when stdin pipe is empty", func(t *testing.T) {
+		t.Parallel()
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = r.Close() })
+		require.NoError(t, w.Close())
+
+		_, err = readMessageFrom("-", r)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "--message-file - received empty input")
+	})
 }

--- a/internal/integration/messagefile_test.go
+++ b/internal/integration/messagefile_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestMessageFile verifies the --message-file flag wires through to create,
-// modify, and squash by reading the commit message from a file rather than
-// embedding it as a literal -m argument.
+// TestMessageFile verifies the --message-file (-F) flag wires through to
+// create, modify, squash, and split — keeping commit-message text out of the
+// literal command line for permission-rule stability.
 func TestMessageFile(t *testing.T) {
 	t.Parallel()
 
@@ -18,8 +18,7 @@ func TestMessageFile(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)
 
-		msgPath := filepath.Join(sh.Dir(), ".commit-msg")
-		require.NoError(t, os.WriteFile(msgPath, []byte("feat: from file\n"), 0o600))
+		msgPath := writeMessageFile(t, "feat: from file\n")
 
 		sh.Write("feature", "content").
 			Run("create feature -F " + msgPath).
@@ -28,30 +27,123 @@ func TestMessageFile(t *testing.T) {
 			OutputContains("feat: from file")
 	})
 
-	t.Run("create errors when both --message and --message-file are given", func(t *testing.T) {
+	t.Run("create preserves multi-line subject and body", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)
 
-		msgPath := filepath.Join(sh.Dir(), ".commit-msg")
-		require.NoError(t, os.WriteFile(msgPath, []byte("from file"), 0o600))
+		msgPath := writeMessageFile(t, "feat: subject line\n\nbody paragraph one\n\nbody paragraph two\n")
 
 		sh.Write("feature", "content").
-			RunExpectError("create feature -m 'inline' -F " + msgPath).
-			OutputContains("mutually exclusive")
+			Run("create feature -F " + msgPath).
+			Git("log -1 --format=%B").
+			OutputContains("feat: subject line").
+			OutputContains("body paragraph one").
+			OutputContains("body paragraph two")
 	})
 
-	t.Run("modify updates message from file", func(t *testing.T) {
+	t.Run("modify updates commit message from file", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)
 
 		sh.Write("feature", "content").
 			Run("create feature -m 'Original'")
 
-		msgPath := filepath.Join(sh.Dir(), ".commit-msg")
-		require.NoError(t, os.WriteFile(msgPath, []byte("feat: updated from file\n"), 0o600))
-
+		msgPath := writeMessageFile(t, "feat: updated from file\n")
 		sh.Run("modify -F " + msgPath).
 			Git("log -1 --format=%s").
 			OutputContains("feat: updated from file")
 	})
+
+	t.Run("squash reads commit message from file", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("a1", "a1").
+			Run("create feature -m 'feat: first'")
+		sh.Write("a2", "a2").
+			Run("modify -c -m 'feat: second'")
+
+		msgPath := writeMessageFile(t, "feat: squashed from file\n")
+		sh.Run("squash -F " + msgPath).
+			Git("log -1 --format=%s").
+			OutputContains("feat: squashed from file")
+	})
+
+	t.Run("split reads commit message from file", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// sh.Write("file", ...) creates a file named "file_test.txt"
+		// (helper concatenates "_test.txt"); --by-file references that path.
+		sh.Write("file", "content").
+			Run("create feature -m 'Add feature'")
+
+		msgPath := writeMessageFile(t, "feat: extracted from file\n")
+		sh.Run("split --by-file file_test.txt --as-sibling --message-file " + msgPath).
+			Checkout("feature_split").
+			Git("log -1 --format=%s").
+			OutputContains("feat: extracted from file")
+	})
+
+	t.Run("create errors when both --message and --message-file are given", func(t *testing.T) {
+		t.Parallel()
+		runMutexTest(t, "create feature -m 'inline' -F ")
+	})
+
+	t.Run("modify errors when both --message and --message-file are given", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("feature", "content").Run("create feature -m 'Original'")
+		msgPath := writeMessageFile(t, "from file")
+		sh.RunExpectError("modify -m 'inline' -F " + msgPath).
+			OutputContains("cannot use --message and --message-file together")
+	})
+
+	t.Run("squash errors when both --message and --message-file are given", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("feature", "content").Run("create feature -m 'Original'")
+		msgPath := writeMessageFile(t, "from file")
+		sh.RunExpectError("squash -m 'inline' -F " + msgPath).
+			OutputContains("cannot use --message and --message-file together")
+	})
+
+	t.Run("create errors when message file does not exist", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("feature", "content").
+			RunExpectError("create feature -F /tmp/stackit-nonexistent-msg").
+			OutputContains("file not found").
+			OutputContains(`use "-" to read from stdin`)
+	})
+
+	t.Run("create errors when message file is empty", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		msgPath := writeMessageFile(t, "")
+		sh.Write("feature", "content").
+			RunExpectError("create feature -F " + msgPath).
+			OutputContains("is empty")
+	})
+}
+
+// writeMessageFile writes content to a temp file outside the repo working
+// tree (so it doesn't leak into staged changes) and returns the path.
+func writeMessageFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "msg")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+// runMutexTest covers the --message + --message-file mutex error for the
+// create command. modify/squash variants need their own setup so they live
+// inline above.
+func runMutexTest(t *testing.T, cmd string) {
+	t.Helper()
+	sh := NewTestShellInProcess(t)
+	msgPath := writeMessageFile(t, "from file")
+	sh.Write("feature", "content").
+		RunExpectError(cmd + msgPath).
+		OutputContains("cannot use --message and --message-file together")
 }

--- a/internal/integration/split_test.go
+++ b/internal/integration/split_test.go
@@ -294,7 +294,7 @@ func TestSplitAsSibling(t *testing.T) {
 
 		// Should error because --message only works with --by-file
 		sh.RunExpectError("split --by-commit --message 'bad message'").
-			OutputContains("--message can only be used with --by-file")
+			OutputContains("--message/--message-file can only be used with --by-file")
 	})
 
 	// Scenario:
@@ -339,7 +339,7 @@ func TestSplitAsSibling(t *testing.T) {
 
 		// Should error because --message requires explicit --by-file
 		sh.RunExpectError("split --message 'bad message'").
-			OutputContains("--message can only be used with --by-file")
+			OutputContains("--message/--message-file can only be used with --by-file")
 	})
 
 	run("split --by-file --as-sibling rejects duplicate custom branch name", func(_ *testing.T, sh *TestShell) {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Addresses review feedback on the --message-file flag from review:

Bugs / correctness:
- ReadMessage now errors when the resolved message is empty (file is
  empty/whitespace-only or stdin pipe yielded nothing). Previously
  returned an empty string and silently fell through to the action
  layer's implicit utils.ReadFromStdin, which could mask user mistakes
  or accidentally consume piped content meant for a different purpose.
- TTY guard on '-': reading stdin from a terminal now returns a clear
  error instead of blocking indefinitely.
- split now rejects '--message-file - --patch -' upfront, since both
  paths would race for os.Stdin and the second to read would silently
  see EOF.
- ReadMessage uses strings.TrimSpace (matching utils.ReadFromStdin)
  instead of TrimRight, so leading whitespace before the subject is
  consistently stripped across both stdin paths.

Error message UX:
- Mutex error now says 'cannot use --message and --message-file
  together; pass only one (use --message-file - to read from stdin)'
  instead of the bare 'are mutually exclusive'.
- Missing-file error names the flag and points to '-' for stdin:
  '--message-file "path": file not found (use "-" to read from
  stdin)'.
- split's mutex error now mentions both '--message/--message-file'
  rather than just '--message'.

Code style:
- split: drop the 'message = resolvedMessage' reassignment of the
  closure-captured flag variable; use resolvedMessage directly in
  subsequent validation and the action options. Matches the pattern
  used by create/modify/squash.

Help / docs:
- Added Examples blocks to create and squash Long descriptions
  (project doc rule requires concrete examples).
- Added -F examples to modify's existing Examples block.
- split's Examples now include a --message-file invocation that
  documents the lack of a -F shorthand on this command (since -F is
  taken by --by-file-interactive).
- split's --message-file help text now states the '(only with
  --by-file or --by-hunk --patch)' constraint, mirroring its
  --message partner.
- ReadMessage doc comment now leads with the why (Claude permission
  rule stability, multi-line message handling) instead of just
  describing what the function does.

Test coverage:
- Unit tests cover empty file, whitespace-only file, missing-file
  error wording, mutex error wording, and empty-stdin via os.Pipe.
- Integration tests now cover squash -F and split --message-file
  end-to-end (previously only create and modify were exercised).
- Multi-line subject+body preservation, missing-file error, and
  empty-file error all have integration coverage.
- Mutex error has integration coverage on modify and squash (was
  create-only).
- Updated split_test.go assertions to match the new
  '--message/--message-file' phrasing.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1777859803`.


* **PR #898**
  * **PR #899**
    * **PR #900**
      * **PR #901**
        * **PR #902** 👈
          * **PR #903**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->