### PR TITLE
fix: validate split flags before I/O and dogfood -F - in templates

### DIFF
--- a/.claude/rules/stackit-workflow.md
+++ b/.claude/rules/stackit-workflow.md
@@ -66,12 +66,15 @@ stackit create -m "feat: foo"
 # Avoid — every new message text widens the permission surface
 stackit create -m "feat: very specific message"
 
-# Prefer — command shape stays constant
-stackit create --message-file /tmp/.stackit-msg
-stackit create -F -      # also accepts stdin via "-"
+# Prefer — pipe via stdin; command shape stays constant across messages
+echo "feat: anything" | stackit create -F -
+
+# Or use a file path (per-invocation `mktemp` avoids collisions between
+# concurrent agents; a fixed path like /tmp/.stackit-msg is unsafe to share)
+msg=$(mktemp -t stackit-msg) && printf "feat: anything" > "$msg" && stackit create --message-file "$msg"
 ```
 
-`create`, `modify`, `squash`, and `split --by-file` all accept `--message-file` (`-F`, except for `split` where `-F` is taken).
+`create`, `modify`, `squash`, and `split --by-file` all accept `--message-file` (`-F`, except for `split` where `-F` is taken). The flag errors loudly on empty input, missing files, or being passed alongside `-m`, so silent fallthrough to other input paths can't mask a typo.
 
 ## Common Pitfalls
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,16 +40,22 @@ Go CLI for managing stacked changes in Git repositories.
 # Stage changes FIRST (required!)
 git add -A
 
-# Create stacked branch with commit
-stackit create -m "feat: description"
+# Create stacked branch with commit. For agent workflows, prefer piping the
+# message via `-F -` (or reading from a file with `-F <path>`) so the literal
+# message text stays out of the command line — see "Keeping Permission Rules
+# Stable" in .claude/rules/stackit-workflow.md.
+echo "feat: description" | stackit create -F -
 
 # Continue working, stage more changes, create more branches...
 git add -A
-stackit create -m "feat: next phase"
+echo "feat: next phase" | stackit create -F -
 
 # Submit when ready
 stackit submit
 ```
+
+`-m "literal message"` still works for one-off use; switch to `-F -` once a
+flow is repeated so permission rules cover every invocation.
 
 ### Handling PR Feedback
 

--- a/internal/cli/branch/split.go
+++ b/internal/cli/branch/split.go
@@ -76,15 +76,6 @@ Examples:
 		DisableFlagParsing: false,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
-				if messageFile == "-" && patchFile == "-" {
-					return fmt.Errorf("cannot read both --message-file and --patch from stdin")
-				}
-
-				resolvedMessage, err := common.ReadMessage(message, messageFile)
-				if err != nil {
-					return err
-				}
-
 				// Determine split style - check all flag variants
 				var style split.Style
 				switch {
@@ -116,25 +107,31 @@ Examples:
 				}
 				// If direction is empty, wizard will prompt (for hunk mode)
 
-				// Validate flag combinations
-				// --patch can only be used with --by-hunk
+				// Validate flag combinations BEFORE any I/O so an invalid
+				// invocation (e.g. --message-file - --by-commit) fails fast
+				// instead of draining stdin or opening a file first.
 				if patchFile != "" && style != split.StyleHunk {
 					return fmt.Errorf("--patch can only be used with --by-hunk")
 				}
-				// --name and --message require --by-file or --by-hunk with --patch
 				if name != "" && style != split.StyleFile && patchFile == "" {
 					return fmt.Errorf("--name can only be used with --by-file or --by-hunk --patch")
 				}
-				if resolvedMessage != "" && style != split.StyleFile && patchFile == "" {
+				if (message != "" || messageFile != "") && style != split.StyleFile && patchFile == "" {
 					return fmt.Errorf("--message/--message-file can only be used with --by-file or --by-hunk --patch")
 				}
-				// --above/--below make sense with --by-hunk and --by-file
 				if (above || below) && style != "" && style != split.StyleHunk && style != split.StyleFile {
 					return fmt.Errorf("--above/--below can only be used with --by-hunk or --by-file")
 				}
-				// --above with --by-file is incompatible with --as-sibling
 				if above && style == split.StyleFile && asSibling {
 					return fmt.Errorf("--above and --as-sibling cannot be used together")
+				}
+				if messageFile == "-" && patchFile == "-" {
+					return fmt.Errorf("cannot read both --message-file and --patch from stdin")
+				}
+
+				resolvedMessage, err := common.ReadMessage(message, messageFile)
+				if err != nil {
+					return err
 				}
 
 				// Load config for branch pattern and hunk selector

--- a/internal/cli/common/messageinput.go
+++ b/internal/cli/common/messageinput.go
@@ -46,7 +46,7 @@ func readMessageFrom(path string, stdin *os.File) (string, error) {
 	} else {
 		data, err = os.ReadFile(path)
 		if errors.Is(err, fs.ErrNotExist) {
-			return "", fmt.Errorf("--message-file %q: file not found (use \"-\" to read from stdin)", path)
+			return "", fmt.Errorf("--message-file %q: file not found (use \"-\" to read from stdin): %w", path, err)
 		}
 	}
 	if err != nil {

--- a/internal/cli/common/messageinput_test.go
+++ b/internal/cli/common/messageinput_test.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -71,6 +73,9 @@ func TestReadMessage(t *testing.T) {
 		require.Contains(t, err.Error(), "/nonexistent/path/to/msg")
 		require.Contains(t, err.Error(), "file not found")
 		require.Contains(t, err.Error(), `use "-" to read from stdin`)
+		// Caller should still be able to detect the underlying not-found
+		// condition via errors.Is — the wrapped error chain is preserved.
+		require.True(t, errors.Is(err, fs.ErrNotExist), "expected error chain to satisfy fs.ErrNotExist")
 	})
 
 	t.Run("errors when file is empty", func(t *testing.T) {

--- a/internal/cli/integrations/agents/templates/commands/stack-create.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-create.md
@@ -33,7 +33,7 @@ Create a new stacked branch with the current changes.
      - "Let me describe" → Wait for user to provide message
 4. If user provided `-m "message"`, use that message
 5. Otherwise, generate a commit message matching the project's style (see recent commits)
-6. Run: `echo "<message>" | stackit create [branch-name] [--scope <scope> if provided] --no-interactive`
+6. Run: `echo "<message>" | stackit create -F - [branch-name] [--scope <scope> if provided] --no-interactive`
 7. **If create fails due to missing scope** (error mentions scope required):
    - Use `AskUserQuestion`:
      - Header: "Scope"

--- a/internal/cli/integrations/agents/templates/commands/stack-plan.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-plan.md
@@ -270,7 +270,7 @@ git checkout <original-branch>
 Dry Run - Branch 1 of 3: <branch-name>
 ======================================
 git checkout "$BACKUP_COMMIT" -- file1.go file2.go
-echo "commit message" | stackit create <branch-name> --no-interactive
+echo "commit message" | stackit create -F - <branch-name> --no-interactive
 <check-command>
 
 [Continue for each branch...]
@@ -352,7 +352,7 @@ git checkout "$BACKUP_COMMIT" -- <file1> <file2> ...
 git diff --cached --stat
 
 # 3. Create the stacked branch
-echo "<commit-message>" | stackit create <branch-name> --no-interactive
+echo "<commit-message>" | stackit create -F - <branch-name> --no-interactive
 
 # 4. Verify the branch was created with commits (not empty)
 #    Check that we're on the new branch and it has the expected files

--- a/internal/cli/integrations/agents/templates/skill/SKILL.md
+++ b/internal/cli/integrations/agents/templates/skill/SKILL.md
@@ -89,13 +89,13 @@ bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
 3. **Create branch with commit** (branch name auto-generated from message, respects `branch.pattern` config):
    ```bash
    # Preferred: pipe format (handles multi-line messages and special characters)
-   echo "feat: add user authentication" | stackit create --no-interactive
+   echo "feat: add user authentication" | stackit create -F - --no-interactive
 
    # With explicit branch name
-   echo "feat: add user authentication" | stackit create my-branch --no-interactive
+   echo "feat: add user authentication" | stackit create -F - my-branch --no-interactive
 
    # Stage all changes and create in one command
-   echo "feat: add user authentication" | stackit create --all --no-interactive
+   echo "feat: add user authentication" | stackit create -F - --all --no-interactive
    ```
 4. If currently on trunk (e.g., main/master), warn and confirm or switch to a feature branch before creating.
 5. Show stack: `stackit log --no-interactive`
@@ -198,7 +198,7 @@ When generating commit messages:
 1. Check README.md and CONTRIBUTING.md for project guidelines
 2. Follow documented conventions if available
 3. If no conventions documented, write a clear, descriptive message
-4. **Use pipe format:** `echo "message" | stackit create --no-interactive`
+4. **Use pipe format:** `echo "message" | stackit create -F - --no-interactive`
 
 **Validation loop:**
 - Generate message

--- a/internal/cli/integrations/agents/templates/skill/commands/branch.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/branch.md
@@ -15,7 +15,7 @@ Commands for creating, modifying, and managing individual branches.
 **Required workflow for new stacked branches:**
 ```bash
 git add -A                                                # 1. Stage FIRST
-echo "message" | stackit create --no-interactive  # 2. Then create
+echo "message" | stackit create -F - --no-interactive  # 2. Then create
 ```
 
 ## Creating and Modifying
@@ -55,13 +55,13 @@ echo "message" | stackit create --no-interactive  # 2. Then create
 **Preferred usage (pipe format):**
 ```bash
 # Branch name auto-generated from commit message
-echo "feat: add user authentication" | stackit create --no-interactive
+echo "feat: add user authentication" | stackit create -F - --no-interactive
 
 # With explicit branch name
-echo "feat: add user authentication" | stackit create my-branch --no-interactive
+echo "feat: add user authentication" | stackit create -F - my-branch --no-interactive
 
 # Stage all and create
-echo "feat: add user authentication" | stackit create --all --no-interactive
+echo "feat: add user authentication" | stackit create -F - --all --no-interactive
 ```
 
 ### Multiple commits per branch

--- a/internal/cli/integrations/agents/templates/skill/commands/stack.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/stack.md
@@ -73,7 +73,7 @@ stackit foreach --no-interactive "git status --short"
 ### Start a feature stack
 ```bash
 git add .
-echo "feat: implement user authentication" | stackit create --no-interactive
+echo "feat: implement user authentication" | stackit create -F - --no-interactive
 
 # Add tests to the same branch (branches can have multiple commits)
 git add .
@@ -81,7 +81,7 @@ git commit -m "test: add auth tests"
 
 # Work on next part as a separate stacked branch
 git add .
-echo "feat: add JWT token validation" | stackit create --no-interactive
+echo "feat: add JWT token validation" | stackit create -F - --no-interactive
 ```
 
 ### Submit for review

--- a/internal/cli/integrations/agents/templates/skill/reference.md
+++ b/internal/cli/integrations/agents/templates/skill/reference.md
@@ -19,7 +19,7 @@ Quick reference for all stackit commands. For detailed documentation, see:
 **Required workflow for new stacked branches:**
 ```bash
 git add -A                                        # 1. Stage FIRST
-echo "message" | stackit create --no-interactive  # 2. Then create
+echo "message" | stackit create -F - --no-interactive  # 2. Then create
 ```
 
 ## Utility Scripts
@@ -108,13 +108,13 @@ bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
 ### Start a new feature
 ```bash
 git add .
-echo "feat: add new feature" | stackit create --no-interactive
+echo "feat: add new feature" | stackit create -F - --no-interactive
 ```
 
 ### Stack another change
 ```bash
 git add .
-echo "feat: extend feature" | stackit create --no-interactive
+echo "feat: extend feature" | stackit create -F - --no-interactive
 ```
 
 ### Add more commits to current branch

--- a/internal/cli/integrations/agents/templates/skill/scripts/analyze_stack.sh
+++ b/internal/cli/integrations/agents/templates/skill/scripts/analyze_stack.sh
@@ -44,7 +44,7 @@ echo -e "${BLUE}Health Checks:${NC}"
 if ! git diff-index --quiet HEAD -- 2>/dev/null; then
     echo -e "${YELLOW}⚠️  Uncommitted changes detected${NC}"
     echo "→ Run: git status"
-    echo "→ Consider: git add . && stackit modify"
+    echo "→ Consider: git add . (then) stackit modify"
     echo
 fi
 
@@ -154,7 +154,7 @@ if [ "$branches_no_pr" -gt 0 ]; then
 elif stackit log full 2>&1 | grep -qi "merged\|closed"; then
     echo "1. Sync with trunk: stackit sync --restack"
 elif ! git diff-index --quiet HEAD -- 2>/dev/null; then
-    echo "1. Commit changes: git add . && stackit modify"
+    echo "1. Commit changes: git add . (then) stackit modify"
 else
     echo -e "${GREEN}✓ Stack is healthy! Ready for development.${NC}"
 fi

--- a/internal/cli/integrations/agents/templates/skill/workflows/conflict-resolution.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/conflict-resolution.md
@@ -320,15 +320,15 @@ Smaller, focused branches = fewer conflicts. A branch can have multiple related 
 
 ```bash
 # Good: Small, focused changes (one branch per logical unit)
-echo "feat: add email validation" | stackit create --no-interactive
-echo "feat: add phone validation" | stackit create --no-interactive
+echo "feat: add email validation" | stackit create -F - --no-interactive
+echo "feat: add phone validation" | stackit create -F - --no-interactive
 
 # Also good: Multiple commits in one branch for related work
-echo "feat: add validation helpers" | stackit create --no-interactive
+echo "feat: add validation helpers" | stackit create -F - --no-interactive
 git add . && git commit -m "test: add validation tests"
 
 # Risky: Large, sweeping changes
-echo "feat: refactor entire validation system" | stackit create --no-interactive
+echo "feat: refactor entire validation system" | stackit create -F - --no-interactive
 ```
 
 ### 2. Sync Frequently

--- a/internal/integration/messagefile_test.go
+++ b/internal/integration/messagefile_test.go
@@ -125,6 +125,37 @@ func TestMessageFile(t *testing.T) {
 			RunExpectError("create feature -F " + msgPath).
 			OutputContains("is empty")
 	})
+
+	t.Run("split rejects --message-file - and --patch - together", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("file", "content").
+			Run("create feature -m 'init'").
+			RunExpectError("split --by-hunk --patch - --message-file -").
+			OutputContains("cannot read both --message-file and --patch from stdin")
+	})
+
+	t.Run("split rejects --message-file before reading any input", func(t *testing.T) {
+		// Regression: previously --by-commit --message-file - drained stdin
+		// (or read the file) before the mode-compat check fired. Now flag
+		// validation runs first.
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		msgPath := writeMessageFile(t, "feat: should not be read")
+		sh.Write("file", "content").
+			Run("create feature -m 'init'").
+			RunExpectError("split --by-commit --message-file " + msgPath).
+			OutputContains("--message/--message-file can only be used with --by-file")
+	})
+
+	t.Run("split errors when both --message and --message-file are given", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("file", "content").Run("create feature -m 'init'")
+		msgPath := writeMessageFile(t, "from file")
+		sh.RunExpectError("split --by-file file_test.txt --as-sibling -m 'inline' --message-file " + msgPath).
+			OutputContains("cannot use --message and --message-file together")
+	})
 }
 
 // writeMessageFile writes content to a temp file outside the repo working


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Closes the remaining items from the second round of review on the
--message-file stack:

split.go:
- Reorder RunE so style determination and flag-combination validation
  run before any I/O. Previously `stackit split --by-commit
  --message-file -` would drain stdin via ReadMessage and then error
  on an unrelated mode-compat check; now invalid combinations fail
  fast without opening a file or reading from stdin.
- The stdin-clash guard (`-F - --patch -`) moves into the same
  upfront validation block.

messageinput.go:
- The not-found error path now wraps with %w so callers can use
  `errors.Is(err, fs.ErrNotExist)` for programmatic handling. The
  human-readable prefix is unchanged.

Templates and AGENTS.md:
- Bulk-replace `echo "..." | stackit create` with
  `echo "..." | stackit create -F -` across 20 sites in
  internal/cli/integrations/agents/templates/. The implicit pipe path
  via utils.ReadFromStdin still works, but the explicit -F - form is
  what the new permission-stability rule recommends and is what the
  hardening (TTY guard, empty-input error) protects.
- AGENTS.md workflow examples now use `echo "msg" | stackit
  create -F -` instead of `-m "literal message"`. Adds a one-line
  pointer to the stackit-workflow rule explaining when to switch from
  -m to -F.
- analyze_stack.sh: drop two `git add . && stackit modify` chained
  commands. The new permission-stability rule recommends running them
  separately so a single `Bash(stackit:*)` covers the call.
- stackit-workflow.md: the "Prefer file paths or stdin" example
  no longer hard-codes /tmp/.stackit-msg. Two parallel agents writing
  the same fixed path could clobber each other's message; the rule
  now leads with stdin (`-F -`) and shows the file form via
  `mktemp` for unique-per-invocation paths.

Tests:
- Integration: split rejects --message-file before reading any input
  (regression for the reordered validation).
- Integration: split rejects --message-file - --patch - (covers the
  new stdin-clash guard).
- Integration: split mutex error (-m + -F together) — was create-only
  and modify/squash, now split too.
- Unit: errors.Is(err, fs.ErrNotExist) holds for the wrapped
  not-found error.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #898**
  * **PR #899**
    * **PR #900**
      * **PR #901**
        * **PR #902**
          * **PR #903** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #904 by jonnii*