### PR TITLE
Merging 6 PRs

### DIFF
--- a/.claude/rules/stackit-workflow.md
+++ b/.claude/rules/stackit-workflow.md
@@ -68,9 +68,10 @@ stackit create -m "feat: very specific message"
 
 # Prefer — command shape stays constant
 stackit create --message-file /tmp/.stackit-msg
+stackit create -F -      # also accepts stdin via "-"
 ```
 
-(Not all stackit commands support `--message-file` yet; use stdin or temp files where they do.)
+`create`, `modify`, `squash`, and `split --by-file` all accept `--message-file` (`-F`, except for `split` where `-F` is taken).
 
 ## Common Pitfalls
 

--- a/.claude/rules/stackit-workflow.md
+++ b/.claude/rules/stackit-workflow.md
@@ -43,6 +43,35 @@ Use skills instead of manual commands:
 
 Run `/stackit` for the full guide.
 
+## Keeping Permission Rules Stable
+
+Claude's permission system matches Bash commands by prefix. Every literal piece of a command becomes part of the match string, so commands with a consistent shape across runs let a small number of rules cover everything. Inconsistent shapes blow up `.claude/settings.local.json` (one entry per literal commit message, redirection variant, etc.) and cause redundant approval prompts.
+
+**Run one command per Bash call.** Don't chain with `&&`. Each command should match its own rule (`Bash(git add:*)`, `Bash(stackit:*)`) rather than requiring a permission entry for the full compound string — which is what generates entries like `Bash(git add -A && stackit create -m "feat: very specific message" 2>&1)`.
+
+```bash
+# Avoid — compound command needs its own rule
+git add -A && stackit create -m "feat: foo"
+
+# Prefer — separate Bash calls, each matches its own rule
+git add -A
+stackit create -m "feat: foo"
+```
+
+**Don't append `2>&1`.** Claude's Bash tool already captures stderr. Appending the redirection extends the literal command string, breaks prefix matching, and creates one-off approval entries.
+
+**Prefer file paths or stdin for variable content.** When a command embeds long or unique text (commit messages, PR descriptions), reading from a file or stdin keeps the command line stable across runs so the same permission rule covers every message.
+
+```bash
+# Avoid — every new message text widens the permission surface
+stackit create -m "feat: very specific message"
+
+# Prefer — command shape stays constant
+stackit create --message-file /tmp/.stackit-msg
+```
+
+(Not all stackit commands support `--message-file` yet; use stdin or temp files where they do.)
+
 ## Common Pitfalls
 
 | Mistake | Fix |
@@ -55,3 +84,5 @@ Run `/stackit` for the full guide.
 | Using `gh pr create` | Use `stackit submit` - it handles stacked PR dependencies |
 | Amending wrong commit | Use `stackit absorb` to auto-route changes to correct commits |
 | Stack out of sync after merge | Run `stackit sync` to cleanup merged branches and update trunk |
+| Permission prompts every commit | Don't chain with `&&`; run `git add` and `stackit create` as separate commands |
+| `settings.local.json` ballooning with literal commit messages | Same root cause — split chained commands so `Bash(stackit:*)` covers the call |

--- a/.claude/rules/stackit-workflow.md
+++ b/.claude/rules/stackit-workflow.md
@@ -66,12 +66,15 @@ stackit create -m "feat: foo"
 # Avoid — every new message text widens the permission surface
 stackit create -m "feat: very specific message"
 
-# Prefer — command shape stays constant
-stackit create --message-file /tmp/.stackit-msg
-stackit create -F -      # also accepts stdin via "-"
+# Prefer — pipe via stdin; command shape stays constant across messages
+echo "feat: anything" | stackit create -F -
+
+# Or use a file path (per-invocation `mktemp` avoids collisions between
+# concurrent agents; a fixed path like /tmp/.stackit-msg is unsafe to share)
+msg=$(mktemp -t stackit-msg) && printf "feat: anything" > "$msg" && stackit create --message-file "$msg"
 ```
 
-`create`, `modify`, `squash`, and `split --by-file` all accept `--message-file` (`-F`, except for `split` where `-F` is taken).
+`create`, `modify`, `squash`, and `split --by-file` all accept `--message-file` (`-F`, except for `split` where `-F` is taken). The flag errors loudly on empty input, missing files, or being passed alongside `-m`, so silent fallthrough to other input paths can't mask a typo.
 
 ## Common Pitfalls
 

--- a/.claude/rules/stackit-workflow.md
+++ b/.claude/rules/stackit-workflow.md
@@ -6,10 +6,10 @@ This project uses stackit for stacked changes. **NEVER use raw git commands for 
 
 | Never Use | Use Instead |
 |-----------|-------------|
-| `git commit -m "..."` | `command stackit create -m "..."` |
-| `git checkout -b` | `command stackit create -m "..."` |
-| `gh pr create` | `command stackit submit` |
-| `git rebase` | `command stackit restack --upstack` (or `--all-stacks`) |
+| `git commit -m "..."` | `stackit create -m "..."` |
+| `git checkout -b` | `stackit create -m "..."` |
+| `gh pr create` | `stackit submit` |
+| `git rebase` | `stackit restack --upstack` (or `--all-stacks`) |
 
 **Exception:** `git commit` is allowed when adding commits to an existing stacked branch.
 
@@ -20,9 +20,9 @@ This project uses stackit for stacked changes. **NEVER use raw git commands for 
 # 2. Stage changes FIRST (required!)
 git add -A
 # 3. Create stacked branch with commit
-command stackit create -m "feat: description"
+stackit create -m "feat: description"
 # 4. Submit when ready
-command stackit submit
+stackit submit
 ```
 
 **Critical:** `stackit create` requires staged changes. Without staged changes, it creates an empty branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,8 @@ git add -A
 stackit create -m "feat: description"
 
 # Continue working, stage more changes, create more branches...
-git add -A && stackit create -m "feat: next phase"
+git add -A
+stackit create -m "feat: next phase"
 
 # Submit when ready
 stackit submit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,23 +41,23 @@ Go CLI for managing stacked changes in Git repositories.
 git add -A
 
 # Create stacked branch with commit
-command stackit create -m "feat: description"
+stackit create -m "feat: description"
 
 # Continue working, stage more changes, create more branches...
-git add -A && command stackit create -m "feat: next phase"
+git add -A && stackit create -m "feat: next phase"
 
 # Submit when ready
-command stackit submit
+stackit submit
 ```
 
 ### Handling PR Feedback
 
 ```bash
-command stackit checkout <branch>  # Go to branch with feedback
+stackit checkout <branch>  # Go to branch with feedback
 # Make changes...
-command stackit modify             # Amend commit
-command stackit restack --upstack   # Update children of this branch
-command stackit submit             # Update PRs
+stackit modify             # Amend commit
+stackit restack --upstack   # Update children of this branch
+stackit submit             # Update PRs
 ```
 
 ### Common Pitfalls

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,16 +40,22 @@ Go CLI for managing stacked changes in Git repositories.
 # Stage changes FIRST (required!)
 git add -A
 
-# Create stacked branch with commit
-stackit create -m "feat: description"
+# Create stacked branch with commit. For agent workflows, prefer piping the
+# message via `-F -` (or reading from a file with `-F <path>`) so the literal
+# message text stays out of the command line — see "Keeping Permission Rules
+# Stable" in .claude/rules/stackit-workflow.md.
+echo "feat: description" | stackit create -F -
 
 # Continue working, stage more changes, create more branches...
 git add -A
-stackit create -m "feat: next phase"
+echo "feat: next phase" | stackit create -F -
 
 # Submit when ready
 stackit submit
 ```
+
+`-m "literal message"` still works for one-off use; switch to `-F -` once a
+flow is repeated so permission rules cover every invocation.
 
 ### Handling PR Feedback
 

--- a/internal/cli/branch/create.go
+++ b/internal/cli/branch/create.go
@@ -13,14 +13,15 @@ import (
 // NewCreateCmd creates the create command
 func NewCreateCmd() *cobra.Command {
 	var (
-		all      bool
-		insert   bool
-		message  string
-		patch    bool
-		scope    string
-		update   bool
-		verbose  int
-		worktree bool
+		all         bool
+		insert      bool
+		message     string
+		messageFile string
+		patch       bool
+		scope       string
+		update      bool
+		verbose     int
+		worktree    bool
 	)
 
 	cmd := &cobra.Command{
@@ -40,6 +41,11 @@ If you have any unstaged changes, you will be asked whether you'd like to stage 
 					branchName = args[0]
 				}
 
+				resolvedMessage, err := common.ReadMessage(message, messageFile)
+				if err != nil {
+					return err
+				}
+
 				// Get config values
 				cfg, _ := config.LoadConfig(ctx.RepoRoot)
 				branchPattern := cfg.GetBranchPattern()
@@ -47,7 +53,7 @@ If you have any unstaged changes, you will be asked whether you'd like to stage 
 				// Prepare options
 				opts := create.Options{
 					BranchName:    branchName,
-					Message:       message,
+					Message:       resolvedMessage,
 					Scope:         scope,
 					All:           all,
 					Insert:        insert,
@@ -82,6 +88,7 @@ If you have any unstaged changes, you will be asked whether you'd like to stage 
 	cmd.Flags().BoolVarP(&all, "all", "a", false, "Stage all unstaged changes before creating the branch, including to untracked files")
 	cmd.Flags().BoolVarP(&insert, "insert", "i", false, "Insert this branch between the current branch and its child. If there are multiple children, prompts you to select which should be moved onto the new branch")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "Specify a commit message")
+	cmd.Flags().StringVarP(&messageFile, "message-file", "F", "", "Read commit message from a file (use \"-\" for stdin). Mutually exclusive with --message.")
 	cmd.Flags().BoolVarP(&patch, "patch", "p", false, "Pick hunks to stage before committing")
 	cmd.Flags().StringVar(&scope, "scope", "", "Set a scope (e.g., Jira ticket ID, Linear ID) for the new branch. If not provided, inherits from parent branch")
 	cmd.Flags().BoolVarP(&update, "update", "u", false, "Stage all updates to tracked files before creating the branch")

--- a/internal/cli/branch/create.go
+++ b/internal/cli/branch/create.go
@@ -31,7 +31,12 @@ func NewCreateCmd() *cobra.Command {
 
 If no branch name is specified, generate a branch name from the commit message.
 If your working directory contains no changes, an empty branch will be created.
-If you have any unstaged changes, you will be asked whether you'd like to stage them.`,
+If you have any unstaged changes, you will be asked whether you'd like to stage them.
+
+Examples:
+  stackit create -m "feat: add login"             # Inline message
+  stackit create feature -F /tmp/msg              # Read message from a file
+  printf "feat: add login" | stackit create -F -  # Read message from stdin`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {

--- a/internal/cli/branch/modify.go
+++ b/internal/cli/branch/modify.go
@@ -35,6 +35,7 @@ Automatically restacks descendants after the modification.
 
 Examples:
   stackit modify -a -m "Updated feature"  # Stage all and amend with message
+  stackit modify -a -F /tmp/msg           # Stage all and amend, reading message from a file
   stackit modify -a                       # Stage all and amend (opens editor)
   stackit modify -p                       # Interactive patch staging then amend
   stackit modify -c -a -m "New commit"    # Create new commit instead of amending

--- a/internal/cli/branch/modify.go
+++ b/internal/cli/branch/modify.go
@@ -17,6 +17,7 @@ func NewModifyCmd() *cobra.Command {
 		edit              bool
 		interactiveRebase bool
 		message           string
+		messageFile       string
 		noEdit            bool
 		patch             bool
 		resetAuthor       bool
@@ -41,13 +42,18 @@ Examples:
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
+				resolvedMessage, err := common.ReadMessage(message, messageFile)
+				if err != nil {
+					return err
+				}
+
 				// Determine noEdit flag:
 				// - If --no-edit is explicitly set, use it
 				// - If message is provided, don't open editor (noEdit = true)
 				// - If --edit is set, open editor (noEdit = false)
 				// - Default: open editor when amending without message (noEdit = false)
 				noEditFlag := noEdit
-				if message != "" && !edit {
+				if resolvedMessage != "" && !edit {
 					noEditFlag = true
 				}
 
@@ -57,7 +63,7 @@ Examples:
 					Update:            update,
 					Patch:             patch,
 					CreateCommit:      commit,
-					Message:           message,
+					Message:           resolvedMessage,
 					Edit:              edit,
 					NoEdit:            noEditFlag,
 					ResetAuthor:       resetAuthor,
@@ -74,6 +80,7 @@ Examples:
 	cmd.Flags().BoolVarP(&edit, "edit", "e", false, "If passed, open an editor to edit the commit message.")
 	cmd.Flags().BoolVar(&interactiveRebase, "interactive-rebase", false, "Ignore all other flags and start a git interactive rebase on the commits in this branch.")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "The message for the new or amended commit. If passed, no editor is opened.")
+	cmd.Flags().StringVarP(&messageFile, "message-file", "F", "", "Read commit message from a file (use \"-\" for stdin). Mutually exclusive with --message.")
 	cmd.Flags().BoolVarP(&noEdit, "no-edit", "n", false, "Don't modify the existing commit message. Takes precedence over --edit.")
 	cmd.Flags().BoolVarP(&patch, "patch", "p", false, "Pick hunks to stage before committing.")
 	cmd.Flags().BoolVar(&resetAuthor, "reset-author", false, "Set the author of the commit to the current user if amending.")

--- a/internal/cli/branch/split.go
+++ b/internal/cli/branch/split.go
@@ -76,15 +76,6 @@ Examples:
 		DisableFlagParsing: false,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
-				if messageFile == "-" && patchFile == "-" {
-					return fmt.Errorf("cannot read both --message-file and --patch from stdin")
-				}
-
-				resolvedMessage, err := common.ReadMessage(message, messageFile)
-				if err != nil {
-					return err
-				}
-
 				// Determine split style - check all flag variants
 				var style split.Style
 				switch {
@@ -116,25 +107,31 @@ Examples:
 				}
 				// If direction is empty, wizard will prompt (for hunk mode)
 
-				// Validate flag combinations
-				// --patch can only be used with --by-hunk
+				// Validate flag combinations BEFORE any I/O so an invalid
+				// invocation (e.g. --message-file - --by-commit) fails fast
+				// instead of draining stdin or opening a file first.
 				if patchFile != "" && style != split.StyleHunk {
 					return fmt.Errorf("--patch can only be used with --by-hunk")
 				}
-				// --name and --message require --by-file or --by-hunk with --patch
 				if name != "" && style != split.StyleFile && patchFile == "" {
 					return fmt.Errorf("--name can only be used with --by-file or --by-hunk --patch")
 				}
-				if resolvedMessage != "" && style != split.StyleFile && patchFile == "" {
+				if (message != "" || messageFile != "") && style != split.StyleFile && patchFile == "" {
 					return fmt.Errorf("--message/--message-file can only be used with --by-file or --by-hunk --patch")
 				}
-				// --above/--below make sense with --by-hunk and --by-file
 				if (above || below) && style != "" && style != split.StyleHunk && style != split.StyleFile {
 					return fmt.Errorf("--above/--below can only be used with --by-hunk or --by-file")
 				}
-				// --above with --by-file is incompatible with --as-sibling
 				if above && style == split.StyleFile && asSibling {
 					return fmt.Errorf("--above and --as-sibling cannot be used together")
+				}
+				if messageFile == "-" && patchFile == "-" {
+					return fmt.Errorf("cannot read both --message-file and --patch from stdin")
+				}
+
+				resolvedMessage, err := common.ReadMessage(message, messageFile)
+				if err != nil {
+					return err
 				}
 
 				// Load config for branch pattern and hunk selector

--- a/internal/cli/branch/split.go
+++ b/internal/cli/branch/split.go
@@ -69,17 +69,21 @@ Examples:
   stackit split --by-file path/to/file.go --above     # Extract to child branch (above)
   stackit split --by-file path/to/file.go --as-sibling # Extract to sibling branch
   stackit split --by-file path/to/file.go --dry-run   # Preview the split
-  stackit split --by-commit --as-sibling              # Split commits as siblings`,
+  stackit split --by-commit --as-sibling              # Split commits as siblings
+  stackit split --by-file file.go --message-file msg.txt  # Read commit message from file (no -F shorthand on split; -F is --by-file-interactive)`,
 		SilenceUsage: true,
 		// Disable default help flag to allow -h for --by-hunk
 		DisableFlagParsing: false,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
+				if messageFile == "-" && patchFile == "-" {
+					return fmt.Errorf("cannot read both --message-file and --patch from stdin")
+				}
+
 				resolvedMessage, err := common.ReadMessage(message, messageFile)
 				if err != nil {
 					return err
 				}
-				message = resolvedMessage
 
 				// Determine split style - check all flag variants
 				var style split.Style
@@ -121,8 +125,8 @@ Examples:
 				if name != "" && style != split.StyleFile && patchFile == "" {
 					return fmt.Errorf("--name can only be used with --by-file or --by-hunk --patch")
 				}
-				if message != "" && style != split.StyleFile && patchFile == "" {
-					return fmt.Errorf("--message can only be used with --by-file or --by-hunk --patch")
+				if resolvedMessage != "" && style != split.StyleFile && patchFile == "" {
+					return fmt.Errorf("--message/--message-file can only be used with --by-file or --by-hunk --patch")
 				}
 				// --above/--below make sense with --by-hunk and --by-file
 				if (above || below) && style != "" && style != split.StyleHunk && style != split.StyleFile {
@@ -157,7 +161,7 @@ Examples:
 					BranchPattern: branchPattern,
 					AsSibling:     asSibling,
 					Name:          name,
-					Message:       message,
+					Message:       resolvedMessage,
 					UseWizard:     useWizard,
 					HunkSelector:  hunkSelector,
 					PatchFile:     patchFile,
@@ -180,7 +184,7 @@ Examples:
 	cmd.Flags().BoolVar(&asSibling, "as-sibling", false, "Create split branches as siblings instead of a chain")
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Name for the new split branch (default: auto-generated)")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "Commit message for extraction (only with --by-file)")
-	cmd.Flags().StringVar(&messageFile, "message-file", "", "Read commit message from a file (use \"-\" for stdin). Mutually exclusive with --message.")
+	cmd.Flags().StringVar(&messageFile, "message-file", "", "Read commit message from a file (use \"-\" for stdin) (only with --by-file or --by-hunk --patch). Mutually exclusive with --message. Note: split has no -F shorthand for this flag (taken by --by-file-interactive).")
 
 	// Direction options (for hunk and file modes)
 	cmd.Flags().BoolVar(&above, "above", false, "Insert new branch above current (as child, upstack)")

--- a/internal/cli/branch/split.go
+++ b/internal/cli/branch/split.go
@@ -24,6 +24,7 @@ func NewSplitCmd() *cobra.Command {
 		below             bool
 		name              string
 		message           string
+		messageFile       string
 		patchFile         string
 		dryRun            bool
 	)
@@ -74,6 +75,12 @@ Examples:
 		DisableFlagParsing: false,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
+				resolvedMessage, err := common.ReadMessage(message, messageFile)
+				if err != nil {
+					return err
+				}
+				message = resolvedMessage
+
 				// Determine split style - check all flag variants
 				var style split.Style
 				switch {
@@ -173,6 +180,7 @@ Examples:
 	cmd.Flags().BoolVar(&asSibling, "as-sibling", false, "Create split branches as siblings instead of a chain")
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Name for the new split branch (default: auto-generated)")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "Commit message for extraction (only with --by-file)")
+	cmd.Flags().StringVar(&messageFile, "message-file", "", "Read commit message from a file (use \"-\" for stdin). Mutually exclusive with --message.")
 
 	// Direction options (for hunk and file modes)
 	cmd.Flags().BoolVar(&above, "above", false, "Insert new branch above current (as child, upstack)")

--- a/internal/cli/branch/squash.go
+++ b/internal/cli/branch/squash.go
@@ -24,7 +24,12 @@ func NewSquashCmd() *cobra.Command {
 		Long: `Squash all commits in the current branch into a single commit and restack upstack branches.
 
 This command combines all commits in the current branch into a single commit. After squashing,
-all upstack branches (children) are automatically restacked.`,
+all upstack branches (children) are automatically restacked.
+
+Examples:
+  stackit squash -m "feat: combined work"     # Squash with inline message
+  stackit squash -F /tmp/msg                  # Squash, reading message from a file
+  stackit squash --no-edit                    # Squash, keeping the current message`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {

--- a/internal/cli/branch/squash.go
+++ b/internal/cli/branch/squash.go
@@ -12,9 +12,10 @@ import (
 // NewSquashCmd creates the squash command
 func NewSquashCmd() *cobra.Command {
 	var (
-		message string
-		edit    bool
-		noEdit  bool
+		message     string
+		messageFile string
+		edit        bool
+		noEdit      bool
 	)
 
 	cmd := &cobra.Command{
@@ -27,6 +28,11 @@ all upstack branches (children) are automatically restacked.`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
+				resolvedMessage, err := common.ReadMessage(message, messageFile)
+				if err != nil {
+					return err
+				}
+
 				// Determine noEdit flag: noEdit = argv['no-edit'] || !argv.edit
 				// If --no-edit is set, noEdit = true
 				// If --edit is false, noEdit = true
@@ -35,7 +41,7 @@ all upstack branches (children) are automatically restacked.`,
 
 				// Run squash action
 				return actions.SquashAction(ctx, actions.SquashOptions{
-					Message: message,
+					Message: resolvedMessage,
 					NoEdit:  noEditFlag,
 				})
 			})
@@ -43,6 +49,7 @@ all upstack branches (children) are automatically restacked.`,
 	}
 
 	cmd.Flags().StringVarP(&message, "message", "m", "", "The updated message for the commit.")
+	cmd.Flags().StringVarP(&messageFile, "message-file", "F", "", "Read commit message from a file (use \"-\" for stdin). Mutually exclusive with --message.")
 	cmd.Flags().BoolVar(&edit, "edit", true, "Modify the existing commit message.")
 	cmd.Flags().BoolVarP(&noEdit, "no-edit", "n", false, "Don't modify the existing commit message. Takes precedence over --edit")
 

--- a/internal/cli/common/messageinput.go
+++ b/internal/cli/common/messageinput.go
@@ -1,42 +1,64 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"strings"
 )
 
-// ReadMessage resolves a commit message from either an inline `-m` string or
-// a `--message-file` path. If messageFile is "-", the message is read from
-// stdin. Trailing whitespace is trimmed so `echo "msg" | stackit create -F -`
-// behaves the same as `stackit create -m "msg"`.
+// ReadMessage resolves a commit message from either an inline -m string or a
+// --message-file path. Used by create/modify/squash/split to keep variable
+// commit-message text out of the literal command line, which keeps Claude
+// permission rules stable across distinct messages and avoids shell-escaping
+// pitfalls for multi-line subject+body messages.
 //
-// Returns an error if both message and messageFile are non-empty.
+// If messageFile is "-", reads from stdin. If both flags are set, returns an
+// error. Trims surrounding whitespace; preserves internal newlines so
+// multi-line bodies survive intact. Errors when the resolved message is empty
+// (file is empty or stdin received nothing) — the caller passed --message-file
+// expecting a message, so silent fallthrough to other input paths would mask
+// the mistake.
 func ReadMessage(message, messageFile string) (string, error) {
 	if message != "" && messageFile != "" {
-		return "", fmt.Errorf("--message and --message-file are mutually exclusive")
+		return "", fmt.Errorf("cannot use --message and --message-file together; pass only one (use --message-file - to read from stdin)")
 	}
-
 	if messageFile == "" {
 		return message, nil
 	}
-
 	return readMessageFrom(messageFile, os.Stdin)
 }
 
-func readMessageFrom(path string, stdin io.Reader) (string, error) {
+func readMessageFrom(path string, stdin *os.File) (string, error) {
 	var (
 		data []byte
 		err  error
 	)
 	if path == "-" {
+		// Refuse to block on a terminal — the user almost certainly meant to
+		// pipe content and forgot.
+		if stat, statErr := stdin.Stat(); statErr == nil && stat.Mode()&os.ModeCharDevice != 0 {
+			return "", fmt.Errorf("--message-file - requires piped input; got terminal")
+		}
 		data, err = io.ReadAll(stdin)
 	} else {
 		data, err = os.ReadFile(path)
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("--message-file %q: file not found (use \"-\" to read from stdin)", path)
+		}
 	}
 	if err != nil {
-		return "", fmt.Errorf("read message file: %w", err)
+		return "", fmt.Errorf("read --message-file %q: %w", path, err)
 	}
-	return strings.TrimRight(string(data), "\n\r\t "), nil
+
+	msg := strings.TrimSpace(string(data))
+	if msg == "" {
+		if path == "-" {
+			return "", fmt.Errorf("--message-file - received empty input")
+		}
+		return "", fmt.Errorf("--message-file %q is empty", path)
+	}
+	return msg, nil
 }

--- a/internal/cli/common/messageinput.go
+++ b/internal/cli/common/messageinput.go
@@ -46,7 +46,7 @@ func readMessageFrom(path string, stdin *os.File) (string, error) {
 	} else {
 		data, err = os.ReadFile(path)
 		if errors.Is(err, fs.ErrNotExist) {
-			return "", fmt.Errorf("--message-file %q: file not found (use \"-\" to read from stdin)", path)
+			return "", fmt.Errorf("--message-file %q: file not found (use \"-\" to read from stdin): %w", path, err)
 		}
 	}
 	if err != nil {

--- a/internal/cli/common/messageinput.go
+++ b/internal/cli/common/messageinput.go
@@ -1,0 +1,42 @@
+package common
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// ReadMessage resolves a commit message from either an inline `-m` string or
+// a `--message-file` path. If messageFile is "-", the message is read from
+// stdin. Trailing whitespace is trimmed so `echo "msg" | stackit create -F -`
+// behaves the same as `stackit create -m "msg"`.
+//
+// Returns an error if both message and messageFile are non-empty.
+func ReadMessage(message, messageFile string) (string, error) {
+	if message != "" && messageFile != "" {
+		return "", fmt.Errorf("--message and --message-file are mutually exclusive")
+	}
+
+	if messageFile == "" {
+		return message, nil
+	}
+
+	return readMessageFrom(messageFile, os.Stdin)
+}
+
+func readMessageFrom(path string, stdin io.Reader) (string, error) {
+	var (
+		data []byte
+		err  error
+	)
+	if path == "-" {
+		data, err = io.ReadAll(stdin)
+	} else {
+		data, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return "", fmt.Errorf("read message file: %w", err)
+	}
+	return strings.TrimRight(string(data), "\n\r\t "), nil
+}

--- a/internal/cli/common/messageinput_test.go
+++ b/internal/cli/common/messageinput_test.go
@@ -1,0 +1,86 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadMessage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns inline message when no file given", func(t *testing.T) {
+		t.Parallel()
+		got, err := ReadMessage("feat: inline", "")
+		require.NoError(t, err)
+		require.Equal(t, "feat: inline", got)
+	})
+
+	t.Run("returns empty when neither given", func(t *testing.T) {
+		t.Parallel()
+		got, err := ReadMessage("", "")
+		require.NoError(t, err)
+		require.Equal(t, "", got)
+	})
+
+	t.Run("errors when both given", func(t *testing.T) {
+		t.Parallel()
+		_, err := ReadMessage("feat: a", "/tmp/msg")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "mutually exclusive")
+	})
+
+	t.Run("reads from file path", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "msg")
+		require.NoError(t, writeFile(path, "feat: from file\n"))
+
+		got, err := ReadMessage("", path)
+		require.NoError(t, err)
+		require.Equal(t, "feat: from file", got)
+	})
+
+	t.Run("trims trailing whitespace and newlines", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "msg")
+		require.NoError(t, writeFile(path, "feat: trim me\n\n  \t\n"))
+
+		got, err := ReadMessage("", path)
+		require.NoError(t, err)
+		require.Equal(t, "feat: trim me", got)
+	})
+
+	t.Run("preserves internal newlines for multi-line messages", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "msg")
+		require.NoError(t, writeFile(path, "feat: subject\n\nbody paragraph\n"))
+
+		got, err := ReadMessage("", path)
+		require.NoError(t, err)
+		require.Equal(t, "feat: subject\n\nbody paragraph", got)
+	})
+
+	t.Run("returns error for missing file", func(t *testing.T) {
+		t.Parallel()
+		_, err := ReadMessage("", "/nonexistent/path/to/msg")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "read message file")
+	})
+
+	t.Run("reads from stdin when path is dash", func(t *testing.T) {
+		t.Parallel()
+		got, err := readMessageFrom("-", strings.NewReader("feat: from stdin\n"))
+		require.NoError(t, err)
+		require.Equal(t, "feat: from stdin", got)
+	})
+}
+
+func writeFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o600)
+}

--- a/internal/cli/common/messageinput_test.go
+++ b/internal/cli/common/messageinput_test.go
@@ -3,7 +3,6 @@ package common
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,29 +25,28 @@ func TestReadMessage(t *testing.T) {
 		require.Equal(t, "", got)
 	})
 
-	t.Run("errors when both given", func(t *testing.T) {
+	t.Run("errors when both given with actionable hint", func(t *testing.T) {
 		t.Parallel()
 		_, err := ReadMessage("feat: a", "/tmp/msg")
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "mutually exclusive")
+		require.Contains(t, err.Error(), "cannot use --message and --message-file together")
+		require.Contains(t, err.Error(), "use --message-file - to read from stdin")
 	})
 
 	t.Run("reads from file path", func(t *testing.T) {
 		t.Parallel()
-		dir := t.TempDir()
-		path := filepath.Join(dir, "msg")
-		require.NoError(t, writeFile(path, "feat: from file\n"))
+		path := filepath.Join(t.TempDir(), "msg")
+		require.NoError(t, os.WriteFile(path, []byte("feat: from file\n"), 0o600))
 
 		got, err := ReadMessage("", path)
 		require.NoError(t, err)
 		require.Equal(t, "feat: from file", got)
 	})
 
-	t.Run("trims trailing whitespace and newlines", func(t *testing.T) {
+	t.Run("trims surrounding whitespace", func(t *testing.T) {
 		t.Parallel()
-		dir := t.TempDir()
-		path := filepath.Join(dir, "msg")
-		require.NoError(t, writeFile(path, "feat: trim me\n\n  \t\n"))
+		path := filepath.Join(t.TempDir(), "msg")
+		require.NoError(t, os.WriteFile(path, []byte("\n\n  feat: trim me  \n\n"), 0o600))
 
 		got, err := ReadMessage("", path)
 		require.NoError(t, err)
@@ -57,30 +55,69 @@ func TestReadMessage(t *testing.T) {
 
 	t.Run("preserves internal newlines for multi-line messages", func(t *testing.T) {
 		t.Parallel()
-		dir := t.TempDir()
-		path := filepath.Join(dir, "msg")
-		require.NoError(t, writeFile(path, "feat: subject\n\nbody paragraph\n"))
+		path := filepath.Join(t.TempDir(), "msg")
+		require.NoError(t, os.WriteFile(path, []byte("feat: subject\n\nbody paragraph\n"), 0o600))
 
 		got, err := ReadMessage("", path)
 		require.NoError(t, err)
 		require.Equal(t, "feat: subject\n\nbody paragraph", got)
 	})
 
-	t.Run("returns error for missing file", func(t *testing.T) {
+	t.Run("errors with stdin hint when file does not exist", func(t *testing.T) {
 		t.Parallel()
 		_, err := ReadMessage("", "/nonexistent/path/to/msg")
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "read message file")
+		require.Contains(t, err.Error(), "--message-file")
+		require.Contains(t, err.Error(), "/nonexistent/path/to/msg")
+		require.Contains(t, err.Error(), "file not found")
+		require.Contains(t, err.Error(), `use "-" to read from stdin`)
+	})
+
+	t.Run("errors when file is empty", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "empty")
+		require.NoError(t, os.WriteFile(path, nil, 0o600))
+
+		_, err := ReadMessage("", path)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "is empty")
+	})
+
+	t.Run("errors when file is whitespace-only", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "ws")
+		require.NoError(t, os.WriteFile(path, []byte("\n\n  \t\n"), 0o600))
+
+		_, err := ReadMessage("", path)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "is empty")
 	})
 
 	t.Run("reads from stdin when path is dash", func(t *testing.T) {
 		t.Parallel()
-		got, err := readMessageFrom("-", strings.NewReader("feat: from stdin\n"))
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = r.Close() })
+
+		go func() {
+			_, _ = w.WriteString("feat: from stdin\n")
+			_ = w.Close()
+		}()
+
+		got, err := readMessageFrom("-", r)
 		require.NoError(t, err)
 		require.Equal(t, "feat: from stdin", got)
 	})
-}
 
-func writeFile(path, content string) error {
-	return os.WriteFile(path, []byte(content), 0o600)
+	t.Run("errors when stdin pipe is empty", func(t *testing.T) {
+		t.Parallel()
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = r.Close() })
+		require.NoError(t, w.Close())
+
+		_, err = readMessageFrom("-", r)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "--message-file - received empty input")
+	})
 }

--- a/internal/cli/common/messageinput_test.go
+++ b/internal/cli/common/messageinput_test.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -71,6 +73,9 @@ func TestReadMessage(t *testing.T) {
 		require.Contains(t, err.Error(), "/nonexistent/path/to/msg")
 		require.Contains(t, err.Error(), "file not found")
 		require.Contains(t, err.Error(), `use "-" to read from stdin`)
+		// Caller should still be able to detect the underlying not-found
+		// condition via errors.Is — the wrapped error chain is preserved.
+		require.True(t, errors.Is(err, fs.ErrNotExist), "expected error chain to satisfy fs.ErrNotExist")
 	})
 
 	t.Run("errors when file is empty", func(t *testing.T) {

--- a/internal/cli/integrations/agents/templates/commands/stack-absorb.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-absorb.md
@@ -11,7 +11,7 @@ Absorb staged changes into the correct commits, then intelligently fix any broke
 ## Context
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Stack state: !`command stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive 2>&1`
 
 ## How Absorb Works
 
@@ -26,7 +26,7 @@ Absorb assigns each change to the commit that last modified those lines. This ma
 ### Phase 1: Absorb with JSON Output
 
 ```bash
-command stackit absorb --json --force --no-interactive 2>&1
+stackit absorb --json --force --no-interactive 2>&1
 ```
 
 Parse the JSON output to understand:
@@ -50,7 +50,7 @@ Save this information - you'll need it to find fixes.
      - "Let me specify" - I'll provide the command
 
 ```bash
-command stackit foreach --stack --json --find-first-failure --jobs 0 "<build-command>" 2>&1
+stackit foreach --stack --json --find-first-failure --jobs 0 "<build-command>" 2>&1
 ```
 
 Parse `.results` in the foreach JSON output and find entries whose `status` is not `"done"` or whose `exit_code` is non-zero. `--find-first-failure` stops before descendant depths, so the failed results are the earliest failing branches. The failing branch is where to fix.
@@ -65,39 +65,39 @@ For each broken branch, identify what's missing by reading the error.
 - Check the JSON's `unabsorbable` array for the missing code
 - If found, apply it to the failing branch:
   ```bash
-  command stackit checkout <failing-branch> --no-interactive
+  stackit checkout <failing-branch> --no-interactive
   # Edit the file to add the missing code from the unabsorbable hunk content
   git add <files>
   git commit -m "fix: add <missing-item> dependency"
-  command stackit restack --branch <failing-branch> --upstack --no-interactive
+  stackit restack --branch <failing-branch> --upstack --no-interactive
   ```
 
 **Source 2: New files**
 - Check the JSON's `new_files` array
 - If the missing code is in a new file, copy relevant parts:
   ```bash
-  command stackit checkout <failing-branch> --no-interactive
+  stackit checkout <failing-branch> --no-interactive
   # Copy the relevant code from the new file
   git add <files>
   git commit -m "fix: add <missing-item> from new file"
-  command stackit restack --branch <failing-branch> --upstack --no-interactive
+  stackit restack --branch <failing-branch> --upstack --no-interactive
   ```
 
 **Source 3: Absorbed upstack (bring down)**
 - Check the JSON's `absorbed` array for hunks that went to child branches
 - If the missing code was absorbed to a child, it needs to come DOWN:
   ```bash
-  command stackit checkout <failing-branch> --no-interactive
+  stackit checkout <failing-branch> --no-interactive
   # Apply the code from the absorbed hunk content
   git add <files>
   git commit -m "fix: bring down <missing-item> from upstack"
-  command stackit restack --branch <failing-branch> --upstack --no-interactive
+  stackit restack --branch <failing-branch> --upstack --no-interactive
   ```
 
 ### Phase 4: Verify Fix
 
 ```bash
-command stackit foreach --branch <failing-branch> --upstack --json --find-first-failure --jobs 0 "<build-command>" 2>&1
+stackit foreach --branch <failing-branch> --upstack --json --find-first-failure --jobs 0 "<build-command>" 2>&1
 ```
 
 If another branch fails, repeat Phase 3 for that branch.
@@ -119,13 +119,13 @@ When branch X fails with "undefined: foo":
 ## Example
 
 ```
-$ command stackit absorb --json --force --no-interactive
+$ stackit absorb --json --force --no-interactive
 
 JSON shows:
 - absorbed: validateUser() call -> add-login branch
 - unabsorbable: hashPassword() definition (commutes_with_all)
 
-$ command stackit foreach --stack --json --find-first-failure --jobs 0 "<build-command>"
+$ stackit foreach --stack --json --find-first-failure --jobs 0 "<build-command>"
 
 JSON shows:
 - add-auth: PASS
@@ -133,13 +133,13 @@ JSON shows:
 
 Looking for hashPassword in unabsorbable hunks... Found!
 
-$ command stackit checkout add-login --no-interactive
+$ stackit checkout add-login --no-interactive
 # Edit utils/crypto.go to add hashPassword from unabsorbable content
 $ git add utils/crypto.go
 $ git commit -m "fix: add hashPassword dependency"
-$ command stackit restack --branch add-login --upstack --no-interactive
+$ stackit restack --branch add-login --upstack --no-interactive
 
-$ command stackit foreach --branch add-login --upstack --json --find-first-failure --jobs 0 "<build-command>"
+$ stackit foreach --branch add-login --upstack --json --find-first-failure --jobs 0 "<build-command>"
 All branches pass!
 ```
 
@@ -163,7 +163,7 @@ If max attempts (2) are reached for a branch, use `AskUserQuestion`:
 - Header: "Fix attempts"
 - Question: "Unable to fix after 2 attempts on this branch. How should I proceed?"
 - Options:
-  - "Undo absorb" - Run `command stackit undo` to rollback
+  - "Undo absorb" - Run `stackit undo` to rollback
   - "Stop here" - Keep state, I'll fix manually
   - "Skip this branch" - Continue fixing other branches
 

--- a/internal/cli/integrations/agents/templates/commands/stack-create.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-create.md
@@ -33,7 +33,7 @@ Create a new stacked branch with the current changes.
      - "Let me describe" → Wait for user to provide message
 4. If user provided `-m "message"`, use that message
 5. Otherwise, generate a commit message matching the project's style (see recent commits)
-6. Run: `echo "<message>" | command stackit create [branch-name] [--scope <scope> if provided] --no-interactive`
+6. Run: `echo "<message>" | stackit create [branch-name] [--scope <scope> if provided] --no-interactive`
 7. **If create fails due to missing scope** (error mentions scope required):
    - Use `AskUserQuestion`:
      - Header: "Scope"

--- a/internal/cli/integrations/agents/templates/commands/stack-create.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-create.md
@@ -33,7 +33,7 @@ Create a new stacked branch with the current changes.
      - "Let me describe" → Wait for user to provide message
 4. If user provided `-m "message"`, use that message
 5. Otherwise, generate a commit message matching the project's style (see recent commits)
-6. Run: `echo "<message>" | stackit create [branch-name] [--scope <scope> if provided] --no-interactive`
+6. Run: `echo "<message>" | stackit create -F - [branch-name] [--scope <scope> if provided] --no-interactive`
 7. **If create fails due to missing scope** (error mentions scope required):
    - Use `AskUserQuestion`:
      - Header: "Scope"

--- a/internal/cli/integrations/agents/templates/commands/stack-describe.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-describe.md
@@ -10,9 +10,9 @@ Generate a comprehensive description for the current stack based on all changes.
 
 ## Context
 - Current branch: !`git branch --show-current`
-- Stack state: !`command stackit log --no-interactive 2>&1`
-- Stack info: !`command stackit info --stack --json --no-interactive 2>&1`
-- Current description: !`command stackit describe --show --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive 2>&1`
+- Stack info: !`stackit info --stack --json --no-interactive 2>&1`
+- Current description: !`stackit describe --show --no-interactive 2>&1`
 
 ## Instructions
 
@@ -54,7 +54,7 @@ Format the description as markdown with:
 Run the describe command:
 
 ```bash
-command stackit describe -m "<title>" -d "<description>" --no-interactive
+stackit describe -m "<title>" -d "<description>" --no-interactive
 ```
 
 Note: The description argument supports multiline text.
@@ -64,7 +64,7 @@ Note: The description argument supports multiline text.
 Show the user what was set:
 
 ```bash
-command stackit describe --show --no-interactive
+stackit describe --show --no-interactive
 ```
 
 ## Example Output

--- a/internal/cli/integrations/agents/templates/commands/stack-extract.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-extract.md
@@ -11,7 +11,7 @@ Extract commits or file changes from the current branch to a new independent bra
 ## Context
 - Current branch: !`git branch --show-current`
 - Recent commits: !`git log --oneline -5`
-- Stack state: !`command stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive 2>&1`
 
 ## Instructions
 
@@ -20,7 +20,7 @@ Extract commits or file changes from the current branch to a new independent bra
 If the user wants to extract specific file(s) to an independent branch:
 
 ```bash
-command stackit split --by-file <file-path> --as-sibling --name "<branch-name>"
+stackit split --by-file <file-path> --as-sibling --name "<branch-name>"
 ```
 
 This creates a new branch on the same parent (usually main) with just those file changes.
@@ -29,7 +29,7 @@ The current branch is unchanged - files are NOT removed.
 **Example:**
 ```bash
 # Extract docs changes to a sibling branch
-command stackit split --by-file docs/README.md --as-sibling --name "docs-update"
+stackit split --by-file docs/README.md --as-sibling --name "docs-update"
 ```
 
 ### Use Case 2: Extract to parent branch (Default split behavior)
@@ -37,7 +37,7 @@ command stackit split --by-file docs/README.md --as-sibling --name "docs-update"
 If the extracted files should logically come before the current changes (dependency extraction):
 
 ```bash
-command stackit split --by-file <file-path>
+stackit split --by-file <file-path>
 ```
 
 This creates the split branch as a NEW PARENT of the current branch.
@@ -48,7 +48,7 @@ The files ARE removed from the current branch.
 If you need to split a branch with multiple commits into sibling branches:
 
 ```bash
-command stackit split --by-commit --as-sibling
+stackit split --by-commit --as-sibling
 ```
 
 This interactively lets you select split points. All resulting branches will be
@@ -58,7 +58,7 @@ siblings on the same parent instead of a linear chain.
 
 After extraction, verify:
 ```bash
-command stackit log  # Both branches should be siblings on the same parent
+stackit log  # Both branches should be siblings on the same parent
 <build-command>      # All checks should pass (check README.md for project's build command)
 ```
 

--- a/internal/cli/integrations/agents/templates/commands/stack-fix.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-fix.md
@@ -11,7 +11,7 @@ Diagnose and fix stack problems, including build/lint/test failures.
 ## Context
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Stack state: !`command stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive 2>&1`
 
 ## Instructions
 
@@ -27,13 +27,13 @@ Check the context and look for these indicators:
 
 **Branches need restack** (stackit log shows "needs restack" or branches are out of sync):
 - Restack only the affected independent stack:
-  - If the affected branch is known, run `command stackit restack --branch <affected-branch> --upstack --no-interactive`.
-  - If only the stack root is known, run `command stackit restack --branch <stack-root> --upstack --no-interactive`.
-  - If several independent stack roots are known, run `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
-  - If every independent stack should be processed, run `command stackit restack --all-stacks --continue-on-conflict --no-interactive`.
+  - If the affected branch is known, run `stackit restack --branch <affected-branch> --upstack --no-interactive`.
+  - If only the stack root is known, run `stackit restack --branch <stack-root> --upstack --no-interactive`.
+  - If several independent stack roots are known, run `stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
+  - If every independent stack should be processed, run `stackit restack --all-stacks --continue-on-conflict --no-interactive`.
 
 **Orphaned branches** (stackit log shows branch with no parent, or parent was merged):
-- Run `command stackit sync --no-interactive`
+- Run `stackit sync --no-interactive`
 
 **Uncommitted changes** (git status shows modified/untracked files):
 - Use `AskUserQuestion`:
@@ -72,8 +72,8 @@ Fix any lint errors, unused variables, or build failures NOW. This prevents havi
 
 #### Step 4: Stage and continue
 ```bash
-command stackit add .
-command stackit continue
+stackit add .
+stackit continue
 ```
 
 #### Step 5: If you amended a commit, restack children
@@ -81,14 +81,14 @@ If you made additional fixes and amended them into a commit:
 ```bash
 git add -A
 git commit --amend --no-edit
-command stackit restack --branch <amended-branch> --upstack --no-interactive
+stackit restack --branch <amended-branch> --upstack --no-interactive
 ```
 
 Child branches need restacking after an amend because the commit SHA changed.
 
 #### Step 6: Verify
 ```bash
-command stackit log  # Should show clean tree, no "needs restack"
+stackit log  # Should show clean tree, no "needs restack"
 <build-command>      # All checks should pass
 ```
 
@@ -123,12 +123,12 @@ Prefer JSON output so branch, status, exit code, and command output are machine-
 
 For the current stack:
 ```bash
-command stackit foreach --stack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
+stackit foreach --stack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
 ```
 
 For a known stack root or affected branch, avoid checking out first and anchor traversal explicitly:
 ```bash
-command stackit foreach --branch <branch-or-root> --upstack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
+stackit foreach --branch <branch-or-root> --upstack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
 ```
 
 This starts at the selected root/branch and walks toward leaves. A failing branch at the earliest failing depth is where the bug was introduced. Multiple branches can fail at the same depth; inspect each failed result and fix the branch that matches the reported problem.
@@ -150,7 +150,7 @@ Parse `.results` and find entries whose `status` is not `"done"` or whose `exit_
 
 #### Step 3: Checkout the failing branch
 ```bash
-command stackit checkout <failing-branch> --no-interactive
+stackit checkout <failing-branch> --no-interactive
 ```
 
 #### Step 4: Fix the issue
@@ -164,7 +164,7 @@ command stackit checkout <failing-branch> --no-interactive
 
 #### Step 5: Propagate the fix via restack
 ```bash
-command stackit restack --branch <failing-branch> --upstack --no-interactive
+stackit restack --branch <failing-branch> --upstack --no-interactive
 ```
 
 This rebases all child branches onto the fixed branch, propagating your fix.
@@ -174,7 +174,7 @@ This rebases all child branches onto the fixed branch, propagating your fix.
 
 #### Step 6: Verify all branches now pass
 ```bash
-command stackit foreach --branch <failing-branch> --upstack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
+stackit foreach --branch <failing-branch> --upstack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
 ```
 
 If it stops at another failure, repeat from Step 2 (there may be multiple independent issues).
@@ -182,7 +182,7 @@ If it stops at another failure, repeat from Step 2 (there may be multiple indepe
 ### 4. After Fixes
 
 Verify stack is healthy:
-- `command stackit log` shows clean tree
+- `stackit log` shows clean tree
 - All branches pass checks
 
 ## Key Insight
@@ -202,11 +202,11 @@ The restack command automatically propagates your fix to all child branches.
 
 **Branching stack (multiple children)**: foreach handles this - all descendants are checked.
 
-**Multiple independent stacks**: Independent stack roots are direct children of trunk. If more than one independent stack needs restack, prefer `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`. If all independent stacks need restack, use `command stackit restack --all-stacks --continue-on-conflict --no-interactive`.
+**Multiple independent stacks**: Independent stack roots are direct children of trunk. If more than one independent stack needs restack, prefer `stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`. If all independent stacks need restack, use `stackit restack --all-stacks --continue-on-conflict --no-interactive`.
 
 **Multiple independent failures**: After fixing one, re-run JSON `foreach --find-first-failure` to find the next failing depth. For multiple known independent stack roots, run one anchored `foreach --branch <root> --upstack --json --find-first-failure --jobs 0 "<check-command>"` per root and compare failed JSON results.
 
-**After amending a commit**: Always run `command stackit restack --branch <amended-branch> --upstack --no-interactive` because child branches reference the old commit SHA.
+**After amending a commit**: Always run `stackit restack --branch <amended-branch> --upstack --no-interactive` because child branches reference the old commit SHA.
 
 ## Tool Trust
 
@@ -218,9 +218,9 @@ Only apply fixes you're 90%+ confident about. If unsure whether a fix is correct
 
 ## Do NOT
 - Fix the same bug on multiple branches manually
-- Use `git checkout` directly - use `command stackit checkout` instead
-- Use `git rebase --continue` - use `command stackit continue` instead (it handles metadata properly)
-- Use `git rebase --abort` - use `command stackit abort` instead
+- Use `git checkout` directly - use `stackit checkout` instead
+- Use `git rebase --continue` - use `stackit continue` instead (it handles metadata properly)
+- Use `git rebase --abort` - use `stackit abort` instead
 - Make destructive changes without user confirmation
 - Loop indefinitely on fixes (max 2 attempts per issue type)
 - Skip asking what check command to use if unclear

--- a/internal/cli/integrations/agents/templates/commands/stack-fold.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-fold.md
@@ -10,8 +10,8 @@ Fold (squash) granular branches into their parent branches.
 
 ## Context
 - Current branch: !`git branch --show-current`
-- Stack state: !`command stackit log --no-interactive 2>&1`
-- Stack info: !`command stackit info --stack --json --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive 2>&1`
+- Stack info: !`stackit info --stack --json --no-interactive 2>&1`
 
 ## Instructions
 
@@ -22,7 +22,7 @@ Fold (squash) granular branches into their parent branches.
    - Parent must not be locked or frozen
    - Must match parent's scope
 2. Propose a fold plan to user with reasoning
-3. Run `command stackit fold --dry-run --no-interactive` to preview
+3. Run `stackit fold --dry-run --no-interactive` to preview
 4. Use `AskUserQuestion` to confirm fold plan:
    - Header: "Fold plan"
    - Question: "Ready to fold these branches into their parents?"
@@ -33,8 +33,8 @@ Fold (squash) granular branches into their parent branches.
 5. Before each fold, verify:
    - Branch has no children (fold leaf branches first)
    - Parent still not locked/frozen
-6. Execute: `command stackit checkout <branch> --no-interactive && command stackit fold --no-interactive`
-7. After each fold, restack only the affected parent and descendants: `command stackit restack --branch <parent-branch> --upstack --no-interactive`
+6. Execute: `stackit checkout <branch> --no-interactive && stackit fold --no-interactive`
+7. After each fold, restack only the affected parent and descendants: `stackit restack --branch <parent-branch> --upstack --no-interactive`
 8. Show final stack state
 
 ## Tool Trust

--- a/internal/cli/integrations/agents/templates/commands/stack-modify.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-modify.md
@@ -12,7 +12,7 @@ argument-hint: [-m "message"] [-a] [-c] [--no-edit]
 - Unstaged changes: !`git diff --stat 2>&1 | head -20`
 - Staged changes: !`git diff --cached --stat 2>&1 | head -20`
 - Recent commits on branch: !`git log --oneline -5 2>&1`
-- Stack state: !`command stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive 2>&1`
 
 ## Arguments
 $ARGUMENTS
@@ -41,23 +41,23 @@ Modify the current branch by amending its commit or creating a new commit. Autom
 3. **Run the command:**
    ```bash
    # Amend (default) with message
-   command stackit modify -m "<message>"
+   stackit modify -m "<message>"
 
    # Amend keeping existing message
-   command stackit modify --no-edit
+   stackit modify --no-edit
 
    # New commit
-   command stackit modify -c -m "<message>"
+   stackit modify -c -m "<message>"
 
    # Stage all + amend
-   command stackit modify -a -m "<message>"
+   stackit modify -a -m "<message>"
    ```
 
 4. **Handle results:**
    - On success, report what was modified and that descendants were restacked
    - On failure, report the error clearly
 
-**Never use:** `git commit --amend` — always use `command stackit modify` so descendants are restacked.
+**Never use:** `git commit --amend` — always use `stackit modify` so descendants are restacked.
 
 ## Follow-up
 

--- a/internal/cli/integrations/agents/templates/commands/stack-plan.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-plan.md
@@ -14,7 +14,7 @@ Analyze uncommitted working tree changes, suggest a logical stacking structure, 
 ## Context
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Stack state: !`command stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive 2>&1`
 
 ## Arguments
 $ARGUMENTS
@@ -270,7 +270,7 @@ git checkout <original-branch>
 Dry Run - Branch 1 of 3: <branch-name>
 ======================================
 git checkout "$BACKUP_COMMIT" -- file1.go file2.go
-echo "commit message" | command stackit create <branch-name> --no-interactive
+echo "commit message" | stackit create <branch-name> --no-interactive
 <check-command>
 
 [Continue for each branch...]
@@ -352,7 +352,7 @@ git checkout "$BACKUP_COMMIT" -- <file1> <file2> ...
 git diff --cached --stat
 
 # 3. Create the stacked branch
-echo "<commit-message>" | command stackit create <branch-name> --no-interactive
+echo "<commit-message>" | stackit create <branch-name> --no-interactive
 
 # 4. Verify the branch was created with commits (not empty)
 #    Check that we're on the new branch and it has the expected files
@@ -405,15 +405,15 @@ Then use `AskUserQuestion`:
 - Question: "The build failed on branch <branch-name>. How would you like to proceed?"
 - Options:
   - "Continue" - I've fixed the issue, resume from next branch
-  - "Undo last" - Rollback <branch-name> with `command stackit undo`
+  - "Undo last" - Rollback <branch-name> with `stackit undo`
   - "Rollback all" - Undo all created branches and restore from backup
   - "Stop here" - Keep created branches, I'll handle it manually
 
 **If user selects "Rollback all"**:
 ```bash
 # Undo each created branch in reverse order
-command stackit undo --yes  # Undo branch X
-command stackit undo --yes  # Undo branch X-1
+stackit undo --yes  # Undo branch X
+stackit undo --yes  # Undo branch X-1
 # ... repeat for all created branches
 
 # Restore all changes from backup
@@ -443,7 +443,7 @@ After all branches are created successfully:
 git branch -D "$BACKUP_BRANCH"
 
 # Show the final stack
-command stackit log --no-interactive
+stackit log --no-interactive
 ```
 
 Present a summary:
@@ -499,7 +499,7 @@ Trust all tools work without error. Don't run exploratory commands to verify too
 - Continue past a build failure
 - Continue if a branch is created empty (verify each branch has commits)
 - Put the same file in multiple branches
-- Use `git commit` directly - always use `command stackit create`
+- Use `git commit` directly - always use `stackit create`
 - Make up branch names without showing the user first
 - Skip build verification (unless user explicitly says to)
 - Delete the backup branch until ALL branches are successfully created and verified

--- a/internal/cli/integrations/agents/templates/commands/stack-plan.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-plan.md
@@ -270,7 +270,7 @@ git checkout <original-branch>
 Dry Run - Branch 1 of 3: <branch-name>
 ======================================
 git checkout "$BACKUP_COMMIT" -- file1.go file2.go
-echo "commit message" | stackit create <branch-name> --no-interactive
+echo "commit message" | stackit create -F - <branch-name> --no-interactive
 <check-command>
 
 [Continue for each branch...]
@@ -352,7 +352,7 @@ git checkout "$BACKUP_COMMIT" -- <file1> <file2> ...
 git diff --cached --stat
 
 # 3. Create the stacked branch
-echo "<commit-message>" | stackit create <branch-name> --no-interactive
+echo "<commit-message>" | stackit create -F - <branch-name> --no-interactive
 
 # 4. Verify the branch was created with commits (not empty)
 #    Check that we're on the new branch and it has the expected files

--- a/internal/cli/integrations/agents/templates/commands/stack-resolve.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-resolve.md
@@ -1,7 +1,7 @@
 ---
 description: Resolve rebase conflicts with AI assistance
 model: claude-sonnet-4-20250514
-allowed-tools: Read, Edit, AskUserQuestion, Bash(git show *), Bash(git diff *), Bash(git add *), Bash(git rebase --continue), Bash(grep *), Bash(command stackit *), Bash(make *), Bash(npm *), Bash(yarn *), Bash(pnpm *), Bash(go *), Bash(cargo *), Bash(mise run *)
+allowed-tools: Read, Edit, AskUserQuestion, Bash(git show *), Bash(git diff *), Bash(git add *), Bash(git rebase --continue), Bash(grep *), Bash(stackit *), Bash(make *), Bash(npm *), Bash(yarn *), Bash(pnpm *), Bash(go *), Bash(cargo *), Bash(mise run *)
 ---
 
 # Conflict Resolution
@@ -124,13 +124,13 @@ After rebase continues successfully:
 
 2. **If clean:**
    ```bash
-   command stackit log --no-interactive
+   stackit log --no-interactive
    ```
    Show the updated stack state.
 
 3. **If the rebase is fully complete:**
    - Inform the user
-   - Suggest `command stackit submit` if PRs need updating
+   - Suggest `stackit submit` if PRs need updating
 
 ## Communication Style
 

--- a/internal/cli/integrations/agents/templates/commands/stack-restack.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-restack.md
@@ -9,7 +9,7 @@ allowed-tools: Bash(stackit:*), Bash(git:*), AskUserQuestion, Skill
 ## Context
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Stack state: !`command stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive 2>&1`
 
 ## Task
 
@@ -23,15 +23,15 @@ Rebase all branches in the stack to ensure proper parent-child ancestry.
 If preconditions fail, inform user and stop.
 
 Otherwise, choose the narrowest safe restack scope and show the result:
-- If a specific branch caused the issue or was just amended, run `command stackit restack --branch <branch> --upstack --no-interactive`.
-- If a whole independent stack needs restack, run `command stackit restack --branch <stack-root> --upstack --no-interactive`.
-- If several independent stack roots need restack, run `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
-- If every independent stack needs restack, run `command stackit restack --all-stacks --continue-on-conflict --no-interactive`.
-- Only run `command stackit restack --no-interactive` when the user explicitly wants the current stack restacked and no narrower branch/root is known.
+- If a specific branch caused the issue or was just amended, run `stackit restack --branch <branch> --upstack --no-interactive`.
+- If a whole independent stack needs restack, run `stackit restack --branch <stack-root> --upstack --no-interactive`.
+- If several independent stack roots need restack, run `stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
+- If every independent stack needs restack, run `stackit restack --all-stacks --continue-on-conflict --no-interactive`.
+- Only run `stackit restack --no-interactive` when the user explicitly wants the current stack restacked and no narrower branch/root is known.
 
 Conflict handling:
-- If a scoped restack enters conflict state, inform user they need to resolve conflicts and run `command stackit continue`.
-- If `--continue-on-conflict` reports skipped conflicts, no rebase is active for those skipped branches. To resolve one, run `command stackit restack --branch <conflicted-branch> --upstack --no-interactive`, then resolve conflicts and run `command stackit continue`.
+- If a scoped restack enters conflict state, inform user they need to resolve conflicts and run `stackit continue`.
+- If `--continue-on-conflict` reports skipped conflicts, no rebase is active for those skipped branches. To resolve one, run `stackit restack --branch <conflicted-branch> --upstack --no-interactive`, then resolve conflicts and run `stackit continue`.
 
 ## Follow-up
 

--- a/internal/cli/integrations/agents/templates/commands/stack-review.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-review.md
@@ -16,7 +16,7 @@ Perform code reviews on PRs in the stack. Finds bugs, checks CLAUDE.md complianc
 ## Context
 - Current branch: !`git branch --show-current`
 - Repo: !`gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null`
-- Stack state: !`command stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive 2>&1`
 
 ## Arguments
 $ARGUMENTS
@@ -51,7 +51,7 @@ Perform code reviews on stack PRs in parallel, reporting high-confidence issues 
 Get all branches in the stack that have open PRs:
 
 ```bash
-command stackit log --json --no-interactive 2>&1
+stackit log --json --no-interactive 2>&1
 ```
 
 Parse the JSON to identify branches with PRs. For each branch, check if the PR is reviewable:
@@ -294,10 +294,10 @@ mutation {
 Restack only the reviewed branch and descendants so feedback changes propagate without rebasing unrelated stacks:
 
 ```bash
-command stackit restack --branch <reviewed-branch> --upstack --no-interactive
+stackit restack --branch <reviewed-branch> --upstack --no-interactive
 ```
 
-If apply mode updated multiple independent PR branches, group their stack roots with `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
+If apply mode updated multiple independent PR branches, group their stack roots with `stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
 
 ### Step 8: Report
 

--- a/internal/cli/integrations/agents/templates/commands/stack-split.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-split.md
@@ -31,7 +31,7 @@ Split the committed changes on the current branch between this branch and a new 
 ## Context
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Stack state: !`command stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive 2>&1`
 
 ## Arguments
 $ARGUMENTS
@@ -46,9 +46,9 @@ This workflow uses **stackit's undo system** to ensure commits are never lost:
 
 1. **Before execution**: Stackit automatically takes a snapshot of the current state
 2. **During execution**: The split command handles all git operations safely
-3. **On failure**: Use `command stackit undo` to restore the previous state
+3. **On failure**: Use `stackit undo` to restore the previous state
 
-Recovery is always: `command stackit undo`
+Recovery is always: `stackit undo`
 
 ## Instructions
 
@@ -84,7 +84,7 @@ Get the commits on the current branch that will be analyzed for splitting:
 
 ```bash
 # Get parent branch from stackit metadata
-command stackit log --no-interactive
+stackit log --no-interactive
 
 # Get the diff between parent and current branch HEAD
 # This shows all changes that could be split
@@ -316,14 +316,14 @@ Use `AskUserQuestion` to get approval:
 
 For file-level splits:
 ```bash
-command stackit split --by-file <files-to-extract> --above --dry-run \
+stackit split --by-file <files-to-extract> --above --dry-run \
     --name "<new-branch-name>" \
     --message "<commit-message>"
 ```
 
 For hunk-level splits (write patch first, then):
 ```bash
-command stackit split --patch /tmp/extract.patch --above --dry-run \
+stackit split --patch /tmp/extract.patch --above --dry-run \
     --name "<new-branch-name>" \
     --message "<commit-message>"
 ```
@@ -350,12 +350,12 @@ Use `--by-file` when extracting complete files (not individual hunks within file
 
 ```bash
 # Extract files to a child branch (upstack):
-command stackit split --by-file path/to/file1.go path/to/file2.go --above \
+stackit split --by-file path/to/file1.go path/to/file2.go --above \
     --name "<child-branch-name>" \
     --message "<commit-message>"
 
 # Extract files to a parent branch (downstack, default):
-command stackit split --by-file path/to/file1.go path/to/file2.go \
+stackit split --by-file path/to/file1.go path/to/file2.go \
     --name "<parent-branch-name>" \
     --message "<commit-message>"
 ```
@@ -402,12 +402,12 @@ Write the patch to `/tmp/extract.patch` using the Write tool.
 
 ```bash
 # For --above (extract to child branch):
-command stackit split --patch /tmp/extract.patch --above \
+stackit split --patch /tmp/extract.patch --above \
     --name "<child-branch-name>" \
     --message "<commit-message>"
 
 # For --below (extract to parent branch, default):
-command stackit split --patch /tmp/extract.patch \
+stackit split --patch /tmp/extract.patch \
     --name "<parent-branch-name>" \
     --message "<commit-message>"
 ```
@@ -444,7 +444,7 @@ After both branches are verified successfully:
 
 ```bash
 # Show the final stack
-command stackit log --no-interactive
+stackit log --no-interactive
 ```
 
 Present a summary:
@@ -463,7 +463,7 @@ Child branch [<child-branch>]:
 Stack structure:
 <stackit log output>
 
-Recovery: If anything is wrong, run `command stackit undo` to restore.
+Recovery: If anything is wrong, run `stackit undo` to restore.
 
 Next steps:
 - Run /stack-submit to create/update PRs
@@ -479,7 +479,7 @@ Next steps:
 | Phase 1.5 | Dependency conflict detected | Ask user: keep together / extract both / proceed |
 | Phase 2 | All hunks same category | Inform user - splitting not needed |
 | Phase 4 | User cancels | Exit - no changes made |
-| Phase 5 | Split command fails | `command stackit undo` |
+| Phase 5 | Split command fails | `stackit undo` |
 | Phase 5 | Build fails | Offer: Continue/Rollback |
 
 **On any execution failure**, use `AskUserQuestion`:
@@ -492,7 +492,7 @@ Next steps:
 
 **If user selects "Rollback"**:
 ```bash
-command stackit undo
+stackit undo
 ```
 
 Then report: "Rolled back to original state. Your commits are restored."
@@ -560,16 +560,16 @@ new file mode 100644
 **Examples:**
 ```bash
 # Extract files to child branch (upstack)
-command stackit split --by-file internal/utils.go --above -n "refactor-utils" -m "Extract utilities"
+stackit split --by-file internal/utils.go --above -n "refactor-utils" -m "Extract utilities"
 
 # Extract files to parent branch (downstack, default)
-command stackit split --by-file internal/config.go -n "config-changes" -m "Extract config"
+stackit split --by-file internal/config.go -n "config-changes" -m "Extract config"
 
 # Preview a file-level split without executing
-command stackit split --by-file internal/utils.go --above --dry-run -n "refactor-utils"
+stackit split --by-file internal/utils.go --above --dry-run -n "refactor-utils"
 
 # Hunk-level split using a patch file
-command stackit split --patch /tmp/extract.patch --above -n "feature-part-2" -m "Part 2"
+stackit split --patch /tmp/extract.patch --above -n "feature-part-2" -m "Part 2"
 ```
 
 **Note:** `--by-file` extracts entire files to the new branch, not just the changes to those files. Use `--patch` or `--by-hunk` for hunk-level splitting within files.
@@ -587,7 +587,7 @@ Only classify hunks you're 90%+ confident about. For ambiguous hunks, ask the us
 - Create branches without user approval of the plan
 - Continue past a build failure without user consent
 - Put the same hunk in both patches
-- Use `git commit` directly for the child branch - use `command stackit create`
+- Use `git commit` directly for the child branch - use `stackit create`
 - Skip build verification (unless user explicitly says to)
 - Propose child branch names that already exist
 - Split hunks that are interdependent (function + its usages) without asking

--- a/internal/cli/integrations/agents/templates/commands/stack-status.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-status.md
@@ -10,9 +10,9 @@ Show the current stack state, identify issues, and provide actionable recommenda
 ## Context
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Stack state (text): !`command stackit log --no-interactive 2>&1`
-- Stack state (json): !`command stackit log --json --no-interactive 2>&1`
-- Branch info: !`command stackit info --json --no-interactive 2>&1`
+- Stack state (text): !`stackit log --no-interactive 2>&1`
+- Stack state (json): !`stackit log --json --no-interactive 2>&1`
+- Branch info: !`stackit info --json --no-interactive 2>&1`
 
 ## Task
 
@@ -45,12 +45,12 @@ Based on the stack state, provide actionable next steps:
 
 | Issue | Recommendation |
 |-------|----------------|
-| One branch/stack needs restack | `command stackit restack --branch <branch-or-root> --upstack --no-interactive` |
-| Multiple independent stacks need restack | `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive` |
-| Branches have no PR | `command stackit submit --no-interactive` |
+| One branch/stack needs restack | `stackit restack --branch <branch-or-root> --upstack --no-interactive` |
+| Multiple independent stacks need restack | `stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive` |
+| Branches have no PR | `stackit submit --no-interactive` |
 | CI failing | Check CI logs and fix issues |
-| Branch ready to merge | `command stackit merge <branch> --no-interactive` |
-| Branches need trunk updates | `command stackit sync --no-interactive` |
+| Branch ready to merge | `stackit merge <branch> --no-interactive` |
+| Branches need trunk updates | `stackit sync --no-interactive` |
 
 ### Step 4: Summary
 
@@ -74,8 +74,8 @@ Health:
   ✓  feature-api: CI passing, ready for review
 
 Recommendations:
-  1. Run `command stackit restack --branch feature-models --upstack --no-interactive` to update feature-models and descendants
-  2. Run `command stackit submit` to create PR for feature-api
+  1. Run `stackit restack --branch feature-models --upstack --no-interactive` to update feature-models and descendants
+  2. Run `stackit submit` to create PR for feature-api
 
 Summary: 2 branches, 1 needs attention
 ```

--- a/internal/cli/integrations/agents/templates/commands/stack-submit.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-submit.md
@@ -11,8 +11,8 @@ Submit branches to GitHub and create/update PRs.
 
 ## Context
 - Current branch: !`git branch --show-current`
-- Stack state: !`command stackit log --no-interactive 2>&1`
-- Branch info: !`command stackit info --json --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive 2>&1`
+- Branch info: !`stackit info --json --no-interactive 2>&1`
 
 ## Arguments
 $ARGUMENTS
@@ -22,7 +22,7 @@ $ARGUMENTS
 ### Step 1: Pre-flight Checks
 
 Check the branch info JSON:
-- If parent branch doesn't exist or was deleted, run `command stackit sync --no-interactive` first
+- If parent branch doesn't exist or was deleted, run `stackit sync --no-interactive` first
 - If there are uncommitted changes, warn the user
 
 ### Step 2: Identify Branches Needing PRs
@@ -37,12 +37,12 @@ Run submit command:
 
 **Current branch only:**
 ```bash
-command stackit submit --no-interactive
+stackit submit --no-interactive
 ```
 
 **Entire stack:**
 ```bash
-command stackit submit --stack --no-interactive
+stackit submit --stack --no-interactive
 ```
 
 **As drafts:** add `--draft`
@@ -76,5 +76,5 @@ After successful submit, use `AskUserQuestion`:
 
 Based on response:
 - **"Sync with trunk"**: Invoke `/stack-sync` skill using the `Skill` tool
-- **"Check PR status"**: Run `command stackit log full --no-interactive`
+- **"Check PR status"**: Run `stackit log full --no-interactive`
 - **"Done for now"**: End with summary including PR URLs from the submit output

--- a/internal/cli/integrations/agents/templates/commands/stack-sync.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-sync.md
@@ -8,25 +8,25 @@ allowed-tools: Bash(stackit:*), Bash(git:*), AskUserQuestion, Skill
 
 ## Context
 - Current branch: !`git branch --show-current`
-- Stack state: !`command stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive 2>&1`
 
 ## Task
 
 Sync the stack with trunk: pull latest, cleanup merged branches, restack.
 
-1. Run `command stackit sync --dry-run --json --restack --no-interactive` to preview cleanup and restack work.
+1. Run `stackit sync --dry-run --json --restack --no-interactive` to preview cleanup and restack work.
 2. Parse `would_clean`, `would_restack`, `would_restack_stacks`, and `skipped_stacks` from the JSON preview.
 3. Treat `would_restack_stacks` as preview-only. Do not feed those roots directly into a post-sync `restack --stacks` decision, because cleanup, reparenting, or dirty-stack skipping can change the current roots.
 4. If ALL branches would be deleted, confirm with user first using `AskUserQuestion`.
-5. Run `command stackit sync --no-restack --no-interactive` so cleanup happens once and restack can use refreshed scope.
-6. Recompute current restack scope with a second `command stackit sync --dry-run --json --restack --no-interactive` and parse the refreshed `would_restack`, `would_restack_stacks`, and `skipped_stacks`.
+5. Run `stackit sync --no-restack --no-interactive` so cleanup happens once and restack can use refreshed scope.
+6. Recompute current restack scope with a second `stackit sync --dry-run --json --restack --no-interactive` and parse the refreshed `would_restack`, `would_restack_stacks`, and `skipped_stacks`.
 7. If branches remain and refreshed `would_restack` is non-empty, choose the restack scope from the refreshed JSON:
-   - If refreshed `would_restack_stacks` has exactly one root, run `command stackit restack --branch <that-root> --upstack --no-interactive`.
-   - If refreshed `would_restack_stacks` lists several roots, run `command stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
-   - If every remaining independent stack needs restack or the refreshed root list is unavailable, run `command stackit restack --all-stacks --continue-on-conflict --no-interactive`.
-8. Show final state with `command stackit log --json --no-interactive`.
+   - If refreshed `would_restack_stacks` has exactly one root, run `stackit restack --branch <that-root> --upstack --no-interactive`.
+   - If refreshed `would_restack_stacks` lists several roots, run `stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
+   - If every remaining independent stack needs restack or the refreshed root list is unavailable, run `stackit restack --all-stacks --continue-on-conflict --no-interactive`.
+8. Show final state with `stackit log --json --no-interactive`.
 
-If `--continue-on-conflict` reports skipped conflicts, no rebase is active for those skipped branches. To resolve one, run `command stackit restack --branch <conflicted-branch> --upstack --no-interactive`, then resolve conflicts and run `command stackit continue`.
+If `--continue-on-conflict` reports skipped conflicts, no rebase is active for those skipped branches. To resolve one, run `stackit restack --branch <conflicted-branch> --upstack --no-interactive`, then resolve conflicts and run `stackit continue`.
 
 You can call multiple tools in a single response.
 

--- a/internal/cli/integrations/agents/templates/commands/stack-tidy.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-tidy.md
@@ -10,8 +10,8 @@ Clean up commits across the stack by squashing fixup/WIP commits into meaningful
 
 ## Context
 - Current branch: !`git branch --show-current`
-- Stack state: !`command stackit log --no-interactive 2>&1`
-- Stack info: !`command stackit info --stack --json --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive 2>&1`
+- Stack info: !`stackit info --stack --json --no-interactive 2>&1`
 
 ## Task
 
@@ -43,8 +43,8 @@ For each commit, classify as **cleanup** or **meaningful**:
 | Condition | Strategy | Action |
 |-----------|----------|--------|
 | 0 or 1 commits | **SKIP** | Nothing to tidy |
-| 1 meaningful + rest noise | **SQUASH** | `command stackit squash -m "<meaningful msg>" --no-edit --no-interactive` |
-| 0 meaningful (all noise) | **SQUASH** | `command stackit squash --no-edit --no-interactive` (keeps oldest msg) |
+| 1 meaningful + rest noise | **SQUASH** | `stackit squash -m "<meaningful msg>" --no-edit --no-interactive` |
+| 0 meaningful (all noise) | **SQUASH** | `stackit squash --no-edit --no-interactive` (keeps oldest msg) |
 | 2+ meaningful commits | **REVIEW** | Show commits, suggest manual action |
 
 ### Step 4: Present Plan
@@ -72,7 +72,7 @@ Use `AskUserQuestion`:
 
 Process branches **closest to trunk first** (bottom-up). For each SQUASH branch:
 
-1. `command stackit checkout <branch> --no-interactive`
+1. `stackit checkout <branch> --no-interactive`
 2. Run the squash command from Step 3
 3. Show result
 
@@ -80,7 +80,7 @@ Skip REVIEW and SKIP branches.
 
 ### Step 7: Show Results
 
-Show final stack state with `command stackit log --no-interactive`.
+Show final stack state with `stackit log --no-interactive`.
 
 ## Tool Trust
 
@@ -91,7 +91,7 @@ Trust all tools work without error. Don't run exploratory commands to verify too
 - Squash branches with only 1 commit
 - Process branches top-down (children before parents) — always bottom-up
 - Modify REVIEW branches without explicit user instruction
-- Use `git rebase -i` — use `command stackit squash` instead
+- Use `git rebase -i` — use `stackit squash` instead
 
 ## Follow-up
 
@@ -108,5 +108,5 @@ After successful tidy, use `AskUserQuestion`:
 
 Based on response:
 - **"Submit changes"**: Invoke `/stack-submit` skill using the `Skill` tool
-- **"View final stack"**: Run `command stackit log --no-interactive` and display
+- **"View final stack"**: Run `stackit log --no-interactive` and display
 - **"Done for now"**: End with summary of what was tidied

--- a/internal/cli/integrations/agents/templates/commands/stack-verify.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-verify.md
@@ -12,7 +12,7 @@ Run verification checks on all branches in the stack and report results.
 ## Context
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Stack state: !`command stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive 2>&1`
 
 ## Arguments
 $ARGUMENTS
@@ -35,17 +35,17 @@ If provided in arguments, use that. Otherwise:
 
 **Quick mode (default)** - run branches at each depth in parallel and stop after the first failing depth:
 ```bash
-command stackit foreach --stack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
+stackit foreach --stack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
 ```
 
 **Full diagnostic mode** - check all branches and collect every failure:
 ```bash
-command stackit foreach --stack --json --parallel --jobs 0 --no-fail-fast "<check-command>" 2>&1
+stackit foreach --stack --json --parallel --jobs 0 --no-fail-fast "<check-command>" 2>&1
 ```
 
 **Anchored mode** - if a branch or independent stack root is known, avoid checkout navigation and verify that upstack only:
 ```bash
-command stackit foreach --branch <branch-or-root> --upstack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
+stackit foreach --branch <branch-or-root> --upstack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
 ```
 
 If uncertain which mode to use, prompt with `AskUserQuestion`:
@@ -155,5 +155,5 @@ After verification completes, use `AskUserQuestion` based on results:
 Based on response:
 - **"Submit PRs"**: Invoke `/stack-submit` skill using the `Skill` tool
 - **"Fix issues"**: Invoke `/stack-fix` skill using the `Skill` tool
-- **"View stack"** / **"View details"**: Run `command stackit log --no-interactive`
+- **"View stack"** / **"View details"**: Run `stackit log --no-interactive`
 - **"Done for now"**: End with summary of verification results

--- a/internal/cli/integrations/agents/templates/skill/SKILL.md
+++ b/internal/cli/integrations/agents/templates/skill/SKILL.md
@@ -89,13 +89,13 @@ bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
 3. **Create branch with commit** (branch name auto-generated from message, respects `branch.pattern` config):
    ```bash
    # Preferred: pipe format (handles multi-line messages and special characters)
-   echo "feat: add user authentication" | stackit create --no-interactive
+   echo "feat: add user authentication" | stackit create -F - --no-interactive
 
    # With explicit branch name
-   echo "feat: add user authentication" | stackit create my-branch --no-interactive
+   echo "feat: add user authentication" | stackit create -F - my-branch --no-interactive
 
    # Stage all changes and create in one command
-   echo "feat: add user authentication" | stackit create --all --no-interactive
+   echo "feat: add user authentication" | stackit create -F - --all --no-interactive
    ```
 4. If currently on trunk (e.g., main/master), warn and confirm or switch to a feature branch before creating.
 5. Show stack: `stackit log --no-interactive`
@@ -198,7 +198,7 @@ When generating commit messages:
 1. Check README.md and CONTRIBUTING.md for project guidelines
 2. Follow documented conventions if available
 3. If no conventions documented, write a clear, descriptive message
-4. **Use pipe format:** `echo "message" | stackit create --no-interactive`
+4. **Use pipe format:** `echo "message" | stackit create -F - --no-interactive`
 
 **Validation loop:**
 - Generate message

--- a/internal/cli/integrations/agents/templates/skill/SKILL.md
+++ b/internal/cli/integrations/agents/templates/skill/SKILL.md
@@ -37,13 +37,13 @@ You are an expert at using Stackit to manage stacked Git branches. Stackit helps
 
 ## Before Any Operation
 
-**Always run `command stackit log --no-interactive` first** to understand:
+**Always run `stackit log --no-interactive` first** to understand:
 - Current branch position in the stack
 - Parent/child relationships
 - Which branches need attention
 
 **CRITICAL: Non-Interactive Mode**
-When calling `command stackit` commands, **ALWAYS** include the `--no-interactive` flag. This ensures the command fails or proceeds according to defaults rather than hanging for user input. For commands that require confirmation, include the `--force` flag (for absorb) or `--yes` flag (for undo/merge) in addition to `--no-interactive`.
+When calling `stackit` commands, **ALWAYS** include the `--no-interactive` flag. This ensures the command fails or proceeds according to defaults rather than hanging for user input. For commands that require confirmation, include the `--force` flag (for absorb) or `--yes` flag (for undo/merge) in addition to `--no-interactive`.
 
 **Check for project conventions:**
 - Read `README.md` and `CONTRIBUTING.md` for project-specific guidelines before generating commit messages or branch names.
@@ -54,7 +54,7 @@ When calling `command stackit` commands, **ALWAYS** include the `--no-interactiv
 
 **Run at session start** to proactively identify issues:
 ```bash
-command stackit log --json --no-interactive
+stackit log --json --no-interactive
 ```
 
 This returns a JSON report with:
@@ -76,7 +76,7 @@ Would you like me to help address any of these?
 bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
 ```
 
-> **Note:** All stackit commands below should be called with `command stackit ... --no-interactive`.
+> **Note:** All stackit commands below should be called with `stackit ... --no-interactive`.
 
 ## Core Workflows
 
@@ -89,48 +89,48 @@ bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
 3. **Create branch with commit** (branch name auto-generated from message, respects `branch.pattern` config):
    ```bash
    # Preferred: pipe format (handles multi-line messages and special characters)
-   echo "feat: add user authentication" | command stackit create --no-interactive
+   echo "feat: add user authentication" | stackit create --no-interactive
 
    # With explicit branch name
-   echo "feat: add user authentication" | command stackit create my-branch --no-interactive
+   echo "feat: add user authentication" | stackit create my-branch --no-interactive
 
    # Stage all changes and create in one command
-   echo "feat: add user authentication" | command stackit create --all --no-interactive
+   echo "feat: add user authentication" | stackit create --all --no-interactive
    ```
 4. If currently on trunk (e.g., main/master), warn and confirm or switch to a feature branch before creating.
-5. Show stack: `command stackit log --no-interactive`
+5. Show stack: `stackit log --no-interactive`
 
 ### Adding More Commits to a Branch
 
 **A stacked branch can have multiple commits.** You don't need to create a new branch for every commit:
 
 - **Add another commit:** Make changes, stage them, then use `git commit` as normal
-- **Amend the current commit:** `command stackit modify` (like `git commit --amend`)
-- **Absorb changes into the right commits:** Stage fixes across multiple commits, then `command stackit absorb` automatically amends each change to the correct commit
+- **Amend the current commit:** `stackit modify` (like `git commit --amend`)
+- **Absorb changes into the right commits:** Stage fixes across multiple commits, then `stackit absorb` automatically amends each change to the correct commit
 
 When to use multiple commits vs new branches:
 - **Same logical change:** Multiple commits in one branch (e.g., implementation + tests)
-- **Separate reviewable units:** Create a new stacked branch with `command stackit create`
+- **Separate reviewable units:** Create a new stacked branch with `stackit create`
 
 ### Submitting PRs
 
-1. Check stack state: `command stackit log --no-interactive`
+1. Check stack state: `stackit log --no-interactive`
 2. Submit options:
-   - Current + ancestors: `command stackit submit --no-interactive`
-   - Entire stack: `command stackit submit --stack --no-interactive`
-   - As drafts: `command stackit submit --draft --no-interactive`
+   - Current + ancestors: `stackit submit --no-interactive`
+   - Entire stack: `stackit submit --stack --no-interactive`
+   - As drafts: `stackit submit --draft --no-interactive`
 
 ### Syncing with Main
 
-1. Sync with trunk and cleanup: `command stackit sync --no-interactive`
-2. If branches were deleted or reparented: `command stackit restack --all-stacks --continue-on-conflict --no-interactive` (covers every independent stack rooted at trunk while letting unaffected stacks proceed). For a single stack, scope it: `command stackit restack --branch <root> --upstack --no-interactive`.
+1. Sync with trunk and cleanup: `stackit sync --no-interactive`
+2. If branches were deleted or reparented: `stackit restack --all-stacks --continue-on-conflict --no-interactive` (covers every independent stack rooted at trunk while letting unaffected stacks proceed). For a single stack, scope it: `stackit restack --branch <root> --upstack --no-interactive`.
 
 ### Fixing Issues
 
-- **Rebase conflicts:** Resolve files, then `command stackit continue --no-interactive`
-- **Absorb conflicts:** See [workflows/absorb-conflict.md](workflows/absorb-conflict.md) or use `command stackit absorb --show-conflict --no-interactive`
-- **Abort operation:** `command stackit abort --no-interactive`
-- **Undo last command:** `command stackit undo --no-interactive --yes`
+- **Rebase conflicts:** Resolve files, then `stackit continue --no-interactive`
+- **Absorb conflicts:** See [workflows/absorb-conflict.md](workflows/absorb-conflict.md) or use `stackit absorb --show-conflict --no-interactive`
+- **Abort operation:** `stackit abort --no-interactive`
+- **Undo last command:** `stackit undo --no-interactive --yes`
 - **Stack health issues:** See [workflows/fix-absorb.md](workflows/fix-absorb.md) or run `/stack-fix`
 - **Intelligent folding:** See [workflows/stack-fold.md](workflows/stack-fold.md) or run `/stack-fold`
 
@@ -198,7 +198,7 @@ When generating commit messages:
 1. Check README.md and CONTRIBUTING.md for project guidelines
 2. Follow documented conventions if available
 3. If no conventions documented, write a clear, descriptive message
-4. **Use pipe format:** `echo "message" | command stackit create --no-interactive`
+4. **Use pipe format:** `echo "message" | stackit create --no-interactive`
 
 **Validation loop:**
 - Generate message
@@ -233,18 +233,18 @@ When working with stacks, NEVER use these git commands:
 
 | FORBIDDEN | USE INSTEAD |
 |-----------|-------------|
-| `git commit` (for new branches) | `command stackit create` |
-| `git checkout -b` | `command stackit create` |
-| `gh pr create` | `command stackit submit` |
-| `git rebase` | `command stackit restack --branch <branch> --upstack` (or `--all-stacks`) |
+| `git commit` (for new branches) | `stackit create` |
+| `git checkout -b` | `stackit create` |
+| `gh pr create` | `stackit submit` |
+| `git rebase` | `stackit restack --branch <branch> --upstack` (or `--all-stacks`) |
 
 **Exception:** `git commit` is allowed ONLY when adding additional commits to an existing stacked branch.
 
 ## Important Rules
 
-1. **NEVER use `git commit` to create new stacked branches** - always use `command stackit create`
-2. **Stage changes BEFORE running `command stackit create`** - it requires staged changes to work correctly
-3. **Check state before destructive operations** - run `command stackit log` first
+1. **NEVER use `git commit` to create new stacked branches** - always use `stackit create`
+2. **Stage changes BEFORE running `stackit create`** - it requires staged changes to work correctly
+3. **Check state before destructive operations** - run `stackit log` first
 4. **Always validate after absorb** - absorb can cause compilation errors, see fix-absorb workflow
 5. **Handle conflicts gracefully** - guide user through resolution, see conflict-resolution workflow
 6. **Keep PRs small and focused** - suggest splitting if too large

--- a/internal/cli/integrations/agents/templates/skill/commands/branch.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/branch.md
@@ -2,52 +2,52 @@
 
 Commands for creating, modifying, and managing individual branches.
 
-> **CRITICAL:** Always run these commands with `command stackit ... --no-interactive`. For commands that require confirmation, include `--force` (for absorb) or `--yes` (for undo/merge).
+> **CRITICAL:** Always run these commands with `stackit ... --no-interactive`. For commands that require confirmation, include `--force` (for absorb) or `--yes` (for undo/merge).
 
 ## FORBIDDEN Commands
 
 | FORBIDDEN | USE INSTEAD |
 |-----------|-------------|
-| `git commit` (new branches) | `command stackit create` |
-| `git checkout -b` | `command stackit create` |
-| `gh pr create` | `command stackit submit` |
+| `git commit` (new branches) | `stackit create` |
+| `git checkout -b` | `stackit create` |
+| `gh pr create` | `stackit submit` |
 
 **Required workflow for new stacked branches:**
 ```bash
 git add -A                                                # 1. Stage FIRST
-echo "message" | command stackit create --no-interactive  # 2. Then create
+echo "message" | stackit create --no-interactive  # 2. Then create
 ```
 
 ## Creating and Modifying
 
 | Command | Description |
 |---------|-------------|
-| `command stackit create [name]` | Create a new stacked branch (name optional, auto-generated) |
-| `command stackit modify` | Amend current commit (like git commit --amend) |
-| `command stackit absorb` | Auto-amend changes to correct commits in stack |
+| `stackit create [name]` | Create a new stacked branch (name optional, auto-generated) |
+| `stackit modify` | Amend current commit (like git commit --amend) |
+| `stackit absorb` | Auto-amend changes to correct commits in stack |
 
 ## Branch Lifecycle
 
 | Command | Description |
 |---------|-------------|
-| `command stackit split` | Split current branch into multiple branches |
-| `command stackit squash` | Squash all commits on current branch |
-| `command stackit fold` | Merge current branch into its parent |
-| `command stackit pop` | Delete branch but keep changes in working tree |
-| `command stackit delete` | Delete current branch and metadata |
-| `command stackit rename [name]` | Rename current branch |
+| `stackit split` | Split current branch into multiple branches |
+| `stackit squash` | Squash all commits on current branch |
+| `stackit fold` | Merge current branch into its parent |
+| `stackit pop` | Delete branch but keep changes in working tree |
+| `stackit delete` | Delete current branch and metadata |
+| `stackit rename [name]` | Rename current branch |
 
 ## Metadata
 
 | Command | Description |
 |---------|-------------|
-| `command stackit scope [name]` | Manage logical scope (Jira/Linear ID) |
-| `command stackit track` | Start tracking a branch |
-| `command stackit untrack` | Stop tracking a branch |
+| `stackit scope [name]` | Manage logical scope (Jira/Linear ID) |
+| `stackit track` | Start tracking a branch |
+| `stackit untrack` | Stop tracking a branch |
 
 ## Common Flag Patterns
 
-### command stackit create
+### stackit create
 - `--all` - Stage all changes first
 - `--insert` - Insert between current and child
 - `-w` - Create with a dedicated worktree
@@ -55,26 +55,26 @@ echo "message" | command stackit create --no-interactive  # 2. Then create
 **Preferred usage (pipe format):**
 ```bash
 # Branch name auto-generated from commit message
-echo "feat: add user authentication" | command stackit create --no-interactive
+echo "feat: add user authentication" | stackit create --no-interactive
 
 # With explicit branch name
-echo "feat: add user authentication" | command stackit create my-branch --no-interactive
+echo "feat: add user authentication" | stackit create my-branch --no-interactive
 
 # Stage all and create
-echo "feat: add user authentication" | command stackit create --all --no-interactive
+echo "feat: add user authentication" | stackit create --all --no-interactive
 ```
 
 ### Multiple commits per branch
 **A stacked branch can have multiple commits.** You don't need a new branch for every commit:
 - Add another commit: `git add . && git commit -m "message"`
-- Amend current commit: `command stackit modify --no-interactive`
-- Absorb fixes to correct commits: `command stackit absorb --no-interactive`
+- Amend current commit: `stackit modify --no-interactive`
+- Absorb fixes to correct commits: `stackit absorb --no-interactive`
 
-### command stackit modify
+### stackit modify
 - Similar to `git commit --amend` but updates stack metadata
 - Auto-restacks children if needed
 
-### command stackit absorb
+### stackit absorb
 - Automatically determines which commit each change belongs to
 - **Warning:** May cause compilation errors if dependencies split across commits
 - Always validate with build/test after absorb

--- a/internal/cli/integrations/agents/templates/skill/commands/branch.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/branch.md
@@ -15,7 +15,7 @@ Commands for creating, modifying, and managing individual branches.
 **Required workflow for new stacked branches:**
 ```bash
 git add -A                                                # 1. Stage FIRST
-echo "message" | stackit create --no-interactive  # 2. Then create
+echo "message" | stackit create -F - --no-interactive  # 2. Then create
 ```
 
 ## Creating and Modifying
@@ -55,13 +55,13 @@ echo "message" | stackit create --no-interactive  # 2. Then create
 **Preferred usage (pipe format):**
 ```bash
 # Branch name auto-generated from commit message
-echo "feat: add user authentication" | stackit create --no-interactive
+echo "feat: add user authentication" | stackit create -F - --no-interactive
 
 # With explicit branch name
-echo "feat: add user authentication" | stackit create my-branch --no-interactive
+echo "feat: add user authentication" | stackit create -F - my-branch --no-interactive
 
 # Stage all and create
-echo "feat: add user authentication" | stackit create --all --no-interactive
+echo "feat: add user authentication" | stackit create -F - --all --no-interactive
 ```
 
 ### Multiple commits per branch

--- a/internal/cli/integrations/agents/templates/skill/commands/navigation.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/navigation.md
@@ -2,36 +2,36 @@
 
 Commands for moving through your stack and viewing stack state.
 
-> **CRITICAL:** Always run these commands with `command stackit ... --no-interactive`.
+> **CRITICAL:** Always run these commands with `stackit ... --no-interactive`.
 
 ## Core Navigation
 
 | Command | Description |
 |---------|-------------|
-| `command stackit log --no-interactive` | Display the branch tree visualization |
-| `command stackit log full --no-interactive` | Show tree with GitHub PR status and CI checks |
-| `command stackit checkout [branch] --no-interactive` | Switch to a specific branch |
+| `stackit log --no-interactive` | Display the branch tree visualization |
+| `stackit log full --no-interactive` | Show tree with GitHub PR status and CI checks |
+| `stackit checkout [branch] --no-interactive` | Switch to a specific branch |
 
 ## Movement Commands
 
 | Command | Description |
 |---------|-------------|
-| `command stackit up --no-interactive` | Move to the child branch |
-| `command stackit down --no-interactive` | Move to the parent branch |
-| `command stackit top --no-interactive` | Move to the top of the stack |
-| `command stackit bottom --no-interactive` | Move to the bottom of the stack |
-| `command stackit trunk --no-interactive` | Return to the main/trunk branch |
+| `stackit up --no-interactive` | Move to the child branch |
+| `stackit down --no-interactive` | Move to the parent branch |
+| `stackit top --no-interactive` | Move to the top of the stack |
+| `stackit bottom --no-interactive` | Move to the bottom of the stack |
+| `stackit trunk --no-interactive` | Return to the main/trunk branch |
 
 ## Information Commands
 
 | Command | Description |
 |---------|-------------|
-| `command stackit children` | Show children of current branch |
-| `command stackit parent` | Show parent of current branch |
-| `command stackit info --no-interactive` | Show detailed branch info |
+| `stackit children` | Show children of current branch |
+| `stackit parent` | Show parent of current branch |
+| `stackit info --no-interactive` | Show detailed branch info |
 
 ## Quick Tips
 
-- Always run `command stackit log --no-interactive` first to understand your position
-- Use `command stackit checkout <branch> --no-interactive` to switch to a specific branch
-- `command stackit log full --no-interactive` shows PR status - useful before submitting
+- Always run `stackit log --no-interactive` first to understand your position
+- Use `stackit checkout <branch> --no-interactive` to switch to a specific branch
+- `stackit log full --no-interactive` shows PR status - useful before submitting

--- a/internal/cli/integrations/agents/templates/skill/commands/recovery.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/recovery.md
@@ -2,23 +2,23 @@
 
 Commands for troubleshooting, recovery, and diagnostics.
 
-> **CRITICAL:** Always run these commands with `command stackit ... --no-interactive`. For commands that require confirmation, include `--force` (for absorb) or `--yes` (for undo/merge).
+> **CRITICAL:** Always run these commands with `stackit ... --no-interactive`. For commands that require confirmation, include `--force` (for absorb) or `--yes` (for undo/merge).
 
 ## Recovery Commands
 
 | Command | Description |
 |---------|-------------|
-| `command stackit undo --no-interactive --yes` | Restore repo to state before a command |
-| `command stackit continue --no-interactive` | Continue interrupted operation |
-| `command stackit abort --no-interactive` | Abort interrupted operation |
+| `stackit undo --no-interactive --yes` | Restore repo to state before a command |
+| `stackit continue --no-interactive` | Continue interrupted operation |
+| `stackit abort --no-interactive` | Abort interrupted operation |
 
 ## Diagnostic Commands
 
 | Command | Description |
 |---------|-------------|
-| `command stackit doctor --no-interactive` | Diagnose and fix setup issues |
-| `command stackit info --no-interactive` | Show detailed branch info |
-| `command stackit debug --no-interactive` | Dump debugging info |
+| `stackit doctor --no-interactive` | Diagnose and fix setup issues |
+| `stackit info --no-interactive` | Show detailed branch info |
+| `stackit debug --no-interactive` | Dump debugging info |
 
 ## Recovery Workflows
 
@@ -35,20 +35,20 @@ git status
 git add <resolved-files>
 
 # 3. Continue
-command stackit continue --no-interactive
+stackit continue --no-interactive
 
 # Or abort if needed
-command stackit abort --no-interactive
+stackit abort --no-interactive
 ```
 
 ### Undo Last Operation
 
 ```bash
 # Restore to previous state
-command stackit undo --no-interactive --yes
+stackit undo --no-interactive --yes
 
 # Check if it worked
-command stackit log --no-interactive
+stackit log --no-interactive
 ```
 
 ### Branch Needs Restack
@@ -57,13 +57,13 @@ Prefer the narrowest scope that covers the affected branches:
 
 ```bash
 # Most common: restack the flagged branch and its descendants
-command stackit restack --branch <branch> --upstack --no-interactive
+stackit restack --branch <branch> --upstack --no-interactive
 
 # Multiple independent stacks need attention (e.g. after sync reparented roots)
-command stackit restack --all-stacks --continue-on-conflict --no-interactive
+stackit restack --all-stacks --continue-on-conflict --no-interactive
 
 # Handle conflicts if they occur, then continue
-command stackit continue --no-interactive
+stackit continue --no-interactive
 ```
 
 Use `--json` to see which branches were restacked vs skipped and avoid a redundant second pass.
@@ -72,19 +72,19 @@ Use `--json` to see which branches were restacked vs skipped and avoid a redunda
 
 ```bash
 # Sync will reparent automatically
-command stackit sync --no-interactive
+stackit sync --no-interactive
 
 # If restack is still needed, scope it — avoid broad restacks
-command stackit restack --branch <reparented-branch> --upstack --no-interactive
+stackit restack --branch <reparented-branch> --upstack --no-interactive
 # Or, if sync reparented roots across multiple stacks:
-command stackit restack --all-stacks --continue-on-conflict --no-interactive
+stackit restack --all-stacks --continue-on-conflict --no-interactive
 ```
 
 ### PR Base Mismatch
 
 ```bash
 # Submit will update PR base branches
-command stackit submit --no-interactive
+stackit submit --no-interactive
 ```
 
 ### Uncommitted Changes Blocking Operation
@@ -92,7 +92,7 @@ command stackit submit --no-interactive
 ```bash
 # Option 1: Commit them
 git add .
-command stackit modify --no-interactive
+stackit modify --no-interactive
 
 # Option 2: Stash them
 git stash
@@ -107,20 +107,20 @@ git stash pop
 
 ```bash
 # View structure
-command stackit log --no-interactive
+stackit log --no-interactive
 
 # Get detailed info
-command stackit info --no-interactive
+stackit info --no-interactive
 
 # Check for issues
-command stackit doctor --no-interactive
+stackit doctor --no-interactive
 ```
 
 ### Debug Issues
 
 ```bash
 # Dump all diagnostic info
-command stackit debug --no-interactive
+stackit debug --no-interactive
 
 # This shows:
 # - Git refs
@@ -132,8 +132,8 @@ command stackit debug --no-interactive
 ## Troubleshooting Checklist
 
 When things go wrong:
-1. Check status: `git status` and `command stackit log --no-interactive`
+1. Check status: `git status` and `stackit log --no-interactive`
 2. Look for interrupted operations (rebase, merge)
-3. Try `command stackit doctor --no-interactive` for automatic fixes
-4. If stuck, `command stackit abort --no-interactive` then `command stackit undo --no-interactive --yes`
-5. For persistent issues, check `command stackit debug --no-interactive` output
+3. Try `stackit doctor --no-interactive` for automatic fixes
+4. If stuck, `stackit abort --no-interactive` then `stackit undo --no-interactive --yes`
+5. For persistent issues, check `stackit debug --no-interactive` output

--- a/internal/cli/integrations/agents/templates/skill/commands/stack.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/stack.md
@@ -2,32 +2,32 @@
 
 Commands for managing the entire stack or multiple branches.
 
-> **CRITICAL:** Always run these commands with `command stackit ... --no-interactive`.
+> **CRITICAL:** Always run these commands with `stackit ... --no-interactive`.
 
 ## Stack Maintenance
 
 | Command | Description |
 |---------|-------------|
-| `command stackit restack --branch <branch> --upstack --no-interactive` | Rebase a branch and its descendants (preferred — minimizes churn) |
-| `command stackit restack --all-stacks --continue-on-conflict --no-interactive` | Rebase every independent stack rooted at trunk, skipping conflicted stacks so unrelated stacks still proceed |
-| `command stackit restack --stacks <root1>,<root2> --continue-on-conflict --no-interactive` | Rebase specific independent stack roots while letting unrelated selected roots continue past conflicts |
-| `command stackit sync --no-interactive` | Pull trunk, delete merged branches, restack |
-| `command stackit info --stack --json --no-interactive` | Export full stack metadata as JSON for analysis |
-| `command stackit merge` | Merge approved PRs and cleanup |
-| `command stackit fold --no-interactive` | Fold current branch into its parent |
+| `stackit restack --branch <branch> --upstack --no-interactive` | Rebase a branch and its descendants (preferred — minimizes churn) |
+| `stackit restack --all-stacks --continue-on-conflict --no-interactive` | Rebase every independent stack rooted at trunk, skipping conflicted stacks so unrelated stacks still proceed |
+| `stackit restack --stacks <root1>,<root2> --continue-on-conflict --no-interactive` | Rebase specific independent stack roots while letting unrelated selected roots continue past conflicts |
+| `stackit sync --no-interactive` | Pull trunk, delete merged branches, restack |
+| `stackit info --stack --json --no-interactive` | Export full stack metadata as JSON for analysis |
+| `stackit merge` | Merge approved PRs and cleanup |
+| `stackit fold --no-interactive` | Fold current branch into its parent |
 
 ## Bulk Operations
 
 | Command | Description |
 |---------|-------------|
-| `command stackit foreach --no-interactive` | Run command on each branch in stack |
-| `command stackit submit --no-interactive` | Push branches and create/update PRs |
-| `command stackit reorder` | Interactively reorder branches |
-| `command stackit move` | Rebase branch onto new parent |
+| `stackit foreach --no-interactive` | Run command on each branch in stack |
+| `stackit submit --no-interactive` | Push branches and create/update PRs |
+| `stackit reorder` | Interactively reorder branches |
+| `stackit move` | Rebase branch onto new parent |
 
 ## Common Flag Patterns
 
-### command stackit submit --no-interactive
+### stackit submit --no-interactive
 - `--stack` - Submit entire stack (alias: `ss`)
 - `--draft` - Create as draft PRs
 - `--edit` - Edit PR metadata interactively
@@ -35,16 +35,16 @@ Commands for managing the entire stack or multiple branches.
 **Examples:**
 ```bash
 # Submit current branch and ancestors
-command stackit submit --no-interactive
+stackit submit --no-interactive
 
 # Submit entire stack
-command stackit submit --no-interactive --stack
+stackit submit --no-interactive --stack
 
 # Submit as drafts
-command stackit submit --no-interactive --draft --stack
+stackit submit --no-interactive --draft --stack
 ```
 
-### command stackit sync --no-interactive
+### stackit sync --no-interactive
 - `--restack` - Auto-restack after cleanup
 
 **What it does:**
@@ -53,19 +53,19 @@ command stackit submit --no-interactive --draft --stack
 3. Deletes branches whose PRs were closed
 4. Optionally restacks remaining branches
 
-### command stackit foreach --no-interactive
-**Usage:** `command stackit foreach --no-interactive "command to run"`
+### stackit foreach --no-interactive
+**Usage:** `stackit foreach --no-interactive "command to run"`
 
 **Examples:**
 ```bash
 # Build all branches (use project's build command from README.md)
-command stackit foreach --no-interactive "<build-command>"
+stackit foreach --no-interactive "<build-command>"
 
 # Test all branches (use project's test command from README.md)
-command stackit foreach --no-interactive "<test-command>"
+stackit foreach --no-interactive "<test-command>"
 
 # Show status on each
-command stackit foreach --no-interactive "git status --short"
+stackit foreach --no-interactive "git status --short"
 ```
 
 ## Workflow Examples
@@ -73,7 +73,7 @@ command stackit foreach --no-interactive "git status --short"
 ### Start a feature stack
 ```bash
 git add .
-echo "feat: implement user authentication" | command stackit create --no-interactive
+echo "feat: implement user authentication" | stackit create --no-interactive
 
 # Add tests to the same branch (branches can have multiple commits)
 git add .
@@ -81,21 +81,21 @@ git commit -m "test: add auth tests"
 
 # Work on next part as a separate stacked branch
 git add .
-echo "feat: add JWT token validation" | command stackit create --no-interactive
+echo "feat: add JWT token validation" | stackit create --no-interactive
 ```
 
 ### Submit for review
 ```bash
-command stackit submit --no-interactive --stack
+stackit submit --no-interactive --stack
 ```
 
 ### After code review changes
 ```bash
 git add .
-command stackit modify --no-interactive
+stackit modify --no-interactive
 # Propagate the amend to descendants of this branch only
-command stackit restack --branch $(git branch --show-current) --upstack --no-interactive
-command stackit submit --no-interactive
+stackit restack --branch $(git branch --show-current) --upstack --no-interactive
+stackit submit --no-interactive
 ```
 
 ### Restack scope cheat sheet
@@ -104,14 +104,14 @@ Prefer the narrowest scope that covers what actually changed:
 
 | Situation | Command |
 |-----------|---------|
-| Amended/modified one branch | `command stackit restack --branch <branch> --upstack --no-interactive` |
-| Uncertain which branches need restack (single stack) | `command stackit restack --branch <stack-root> --upstack --no-interactive` |
-| Multiple independent stacks need restack (post-sync, shared parent change) | `command stackit restack --all-stacks --continue-on-conflict --no-interactive` |
-| Specific set of independent roots | `command stackit restack --stacks <root1>,<root2> --continue-on-conflict --no-interactive` |
+| Amended/modified one branch | `stackit restack --branch <branch> --upstack --no-interactive` |
+| Uncertain which branches need restack (single stack) | `stackit restack --branch <stack-root> --upstack --no-interactive` |
+| Multiple independent stacks need restack (post-sync, shared parent change) | `stackit restack --all-stacks --continue-on-conflict --no-interactive` |
+| Specific set of independent roots | `stackit restack --stacks <root1>,<root2> --continue-on-conflict --no-interactive` |
 
 Use `--json` for programmatic runs; it reports which branches were restacked, skipped, or conflicted so you can skip a redundant follow-up pass.
 
 ### Sync with main
 ```bash
-command stackit sync --no-interactive --restack
+stackit sync --no-interactive --restack
 ```

--- a/internal/cli/integrations/agents/templates/skill/commands/stack.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/stack.md
@@ -73,7 +73,7 @@ stackit foreach --no-interactive "git status --short"
 ### Start a feature stack
 ```bash
 git add .
-echo "feat: implement user authentication" | stackit create --no-interactive
+echo "feat: implement user authentication" | stackit create -F - --no-interactive
 
 # Add tests to the same branch (branches can have multiple commits)
 git add .
@@ -81,7 +81,7 @@ git commit -m "test: add auth tests"
 
 # Work on next part as a separate stacked branch
 git add .
-echo "feat: add JWT token validation" | stackit create --no-interactive
+echo "feat: add JWT token validation" | stackit create -F - --no-interactive
 ```
 
 ### Submit for review

--- a/internal/cli/integrations/agents/templates/skill/reference.md
+++ b/internal/cli/integrations/agents/templates/skill/reference.md
@@ -19,7 +19,7 @@ Quick reference for all stackit commands. For detailed documentation, see:
 **Required workflow for new stacked branches:**
 ```bash
 git add -A                                        # 1. Stage FIRST
-echo "message" | stackit create --no-interactive  # 2. Then create
+echo "message" | stackit create -F - --no-interactive  # 2. Then create
 ```
 
 ## Utility Scripts
@@ -108,13 +108,13 @@ bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
 ### Start a new feature
 ```bash
 git add .
-echo "feat: add new feature" | stackit create --no-interactive
+echo "feat: add new feature" | stackit create -F - --no-interactive
 ```
 
 ### Stack another change
 ```bash
 git add .
-echo "feat: extend feature" | stackit create --no-interactive
+echo "feat: extend feature" | stackit create -F - --no-interactive
 ```
 
 ### Add more commits to current branch

--- a/internal/cli/integrations/agents/templates/skill/reference.md
+++ b/internal/cli/integrations/agents/templates/skill/reference.md
@@ -6,20 +6,20 @@ Quick reference for all stackit commands. For detailed documentation, see:
 - **Stack operation details:** [commands/stack.md](commands/stack.md)
 - **Recovery details:** [commands/recovery.md](commands/recovery.md)
 
-> **CRITICAL:** Always run stackit with `command stackit ... --no-interactive`. For commands that require confirmation, include `--force` (for absorb) or `--yes` (for undo/merge).
+> **CRITICAL:** Always run stackit with `stackit ... --no-interactive`. For commands that require confirmation, include `--force` (for absorb) or `--yes` (for undo/merge).
 
 ## FORBIDDEN Commands
 
 | FORBIDDEN | USE INSTEAD |
 |-----------|-------------|
-| `git commit` (new branches) | `command stackit create` |
-| `git checkout -b` | `command stackit create` |
-| `gh pr create` | `command stackit submit` |
+| `git commit` (new branches) | `stackit create` |
+| `git checkout -b` | `stackit create` |
+| `gh pr create` | `stackit submit` |
 
 **Required workflow for new stacked branches:**
 ```bash
 git add -A                                        # 1. Stage FIRST
-echo "message" | command stackit create --no-interactive  # 2. Then create
+echo "message" | stackit create --no-interactive  # 2. Then create
 ```
 
 ## Utility Scripts
@@ -35,72 +35,72 @@ bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
 
 | Command | Description |
 |---------|-------------|
-| `command stackit log` | Display the branch tree visualization |
-| `command stackit log full` | Show tree with GitHub PR status and CI checks |
-| `command stackit checkout [branch]` | Switch to a specific branch |
-| `command stackit up` | Move to the child branch |
-| `command stackit down` | Move to the parent branch |
-| `command stackit top` | Move to the top of the stack |
-| `command stackit bottom` | Move to the bottom of the stack |
-| `command stackit trunk` | Return to the main/trunk branch |
-| `command stackit children` | Show children of current branch |
-| `command stackit parent` | Show parent of current branch |
+| `stackit log` | Display the branch tree visualization |
+| `stackit log full` | Show tree with GitHub PR status and CI checks |
+| `stackit checkout [branch]` | Switch to a specific branch |
+| `stackit up` | Move to the child branch |
+| `stackit down` | Move to the parent branch |
+| `stackit top` | Move to the top of the stack |
+| `stackit bottom` | Move to the bottom of the stack |
+| `stackit trunk` | Return to the main/trunk branch |
+| `stackit children` | Show children of current branch |
+| `stackit parent` | Show parent of current branch |
 
 ## Branch Management
 
 | Command | Description |
 |---------|-------------|
-| `command stackit create --no-interactive [name]` | Create a new stacked branch |
-| `command stackit modify --no-interactive` | Amend current commit (like git commit --amend) |
-| `command stackit absorb` | Auto-amend changes to correct commits in stack |
-| `command stackit split` | Split current branch into multiple branches |
-| `command stackit squash` | Squash all commits on current branch |
-| `command stackit fold` | Merge current branch into its parent |
-| `command stackit pop` | Delete branch but keep changes in working tree |
-| `command stackit delete` | Delete current branch and metadata |
-| `command stackit rename [name]` | Rename current branch |
-| `command stackit scope [name]` | Manage logical scope (Jira/Linear ID) |
+| `stackit create --no-interactive [name]` | Create a new stacked branch |
+| `stackit modify --no-interactive` | Amend current commit (like git commit --amend) |
+| `stackit absorb` | Auto-amend changes to correct commits in stack |
+| `stackit split` | Split current branch into multiple branches |
+| `stackit squash` | Squash all commits on current branch |
+| `stackit fold` | Merge current branch into its parent |
+| `stackit pop` | Delete branch but keep changes in working tree |
+| `stackit delete` | Delete current branch and metadata |
+| `stackit rename [name]` | Rename current branch |
+| `stackit scope [name]` | Manage logical scope (Jira/Linear ID) |
 
 ## Stack Operations
 
 | Command | Description |
 |---------|-------------|
-| `command stackit restack --branch <branch> --upstack --no-interactive` | Rebase a branch and its descendants (preferred) |
-| `command stackit restack --all-stacks --continue-on-conflict --no-interactive` | Rebase every independent stack rooted at trunk while letting unaffected stacks continue |
-| `command stackit restack --stacks <root1>,<root2> --continue-on-conflict --no-interactive` | Rebase specific independent stack roots while letting unaffected selected roots continue |
-| `command stackit foreach` | Run command on each branch in stack |
-| `command stackit submit --no-interactive` | Push branches and create/update PRs |
-| `command stackit sync --no-interactive` | Pull trunk, delete merged branches, restack |
-| `command stackit merge` | Merge approved PRs and cleanup |
-| `command stackit reorder` | Interactively reorder branches |
-| `command stackit move` | Rebase branch onto new parent |
+| `stackit restack --branch <branch> --upstack --no-interactive` | Rebase a branch and its descendants (preferred) |
+| `stackit restack --all-stacks --continue-on-conflict --no-interactive` | Rebase every independent stack rooted at trunk while letting unaffected stacks continue |
+| `stackit restack --stacks <root1>,<root2> --continue-on-conflict --no-interactive` | Rebase specific independent stack roots while letting unaffected selected roots continue |
+| `stackit foreach` | Run command on each branch in stack |
+| `stackit submit --no-interactive` | Push branches and create/update PRs |
+| `stackit sync --no-interactive` | Pull trunk, delete merged branches, restack |
+| `stackit merge` | Merge approved PRs and cleanup |
+| `stackit reorder` | Interactively reorder branches |
+| `stackit move` | Rebase branch onto new parent |
 
 ## Recovery & Utilities
 
 | Command | Description |
 |---------|-------------|
-| `command stackit undo` | Restore repo to state before a command |
-| `command stackit continue` | Continue interrupted operation |
-| `command stackit abort` | Abort interrupted operation |
-| `command stackit doctor` | Diagnose and fix setup issues |
-| `command stackit info` | Show detailed branch info |
-| `command stackit track` | Start tracking a branch |
-| `command stackit untrack` | Stop tracking a branch |
-| `command stackit debug` | Dump debugging info |
+| `stackit undo` | Restore repo to state before a command |
+| `stackit continue` | Continue interrupted operation |
+| `stackit abort` | Abort interrupted operation |
+| `stackit doctor` | Diagnose and fix setup issues |
+| `stackit info` | Show detailed branch info |
+| `stackit track` | Start tracking a branch |
+| `stackit untrack` | Stop tracking a branch |
+| `stackit debug` | Dump debugging info |
 
 ## Common Flag Patterns
 
-### command stackit create --no-interactive
+### stackit create --no-interactive
 - `-m "message"` - Commit message
 - `--all` - Stage all changes first
 - `--insert` - Insert between current and child
 
-### command stackit submit --no-interactive
+### stackit submit --no-interactive
 - `--stack` - Submit entire stack (alias: `ss`)
 - `--draft` - Create as draft PRs
 - `--edit` - Edit PR metadata interactively
 
-### command stackit sync --no-interactive
+### stackit sync --no-interactive
 - `--restack` - Auto-restack after cleanup
 
 ## Workflow Examples
@@ -108,13 +108,13 @@ bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
 ### Start a new feature
 ```bash
 git add .
-echo "feat: add new feature" | command stackit create --no-interactive
+echo "feat: add new feature" | stackit create --no-interactive
 ```
 
 ### Stack another change
 ```bash
 git add .
-echo "feat: extend feature" | command stackit create --no-interactive
+echo "feat: extend feature" | stackit create --no-interactive
 ```
 
 ### Add more commits to current branch
@@ -126,21 +126,21 @@ git commit -m "test: add tests for feature"
 
 ### Submit for review
 ```bash
-command stackit submit --no-interactive --stack
+stackit submit --no-interactive --stack
 ```
 
 ### After code review changes
 ```bash
 git add .
-command stackit modify --no-interactive
+stackit modify --no-interactive
 # Scope the restack to just this branch and its descendants
-command stackit restack --branch $(git branch --show-current) --upstack --no-interactive
-command stackit submit --no-interactive
+stackit restack --branch $(git branch --show-current) --upstack --no-interactive
+stackit submit --no-interactive
 ```
 
 ### Sync with main
 ```bash
-command stackit sync --no-interactive --restack
+stackit sync --no-interactive --restack
 ```
 
 ## Troubleshooting
@@ -154,8 +154,8 @@ For detailed troubleshooting workflows, see:
 
 | Issue | Solution |
 |-------|----------|
-| "Branch needs restack" | `command stackit restack --branch <branch> --upstack --no-interactive` (scope to the branch and its descendants) |
-| "Rebase conflict" | Resolve conflicts, `git add <files>`, `command stackit continue` |
-| "Orphaned branch" | `command stackit sync --no-interactive` to reparent |
-| "PR base mismatch" | `command stackit submit --no-interactive` to update PRs |
+| "Branch needs restack" | `stackit restack --branch <branch> --upstack --no-interactive` (scope to the branch and its descendants) |
+| "Rebase conflict" | Resolve conflicts, `git add <files>`, `stackit continue` |
+| "Orphaned branch" | `stackit sync --no-interactive` to reparent |
+| "PR base mismatch" | `stackit submit --no-interactive` to update PRs |
 | Build breaks after absorb | See [workflows/fix-absorb.md](workflows/fix-absorb.md) |

--- a/internal/cli/integrations/agents/templates/skill/scripts/analyze_stack.sh
+++ b/internal/cli/integrations/agents/templates/skill/scripts/analyze_stack.sh
@@ -44,7 +44,7 @@ echo -e "${BLUE}Health Checks:${NC}"
 if ! git diff-index --quiet HEAD -- 2>/dev/null; then
     echo -e "${YELLOW}⚠️  Uncommitted changes detected${NC}"
     echo "→ Run: git status"
-    echo "→ Consider: git add . && stackit modify"
+    echo "→ Consider: git add . (then) stackit modify"
     echo
 fi
 
@@ -154,7 +154,7 @@ if [ "$branches_no_pr" -gt 0 ]; then
 elif stackit log full 2>&1 | grep -qi "merged\|closed"; then
     echo "1. Sync with trunk: stackit sync --restack"
 elif ! git diff-index --quiet HEAD -- 2>/dev/null; then
-    echo "1. Commit changes: git add . && stackit modify"
+    echo "1. Commit changes: git add . (then) stackit modify"
 else
     echo -e "${GREEN}✓ Stack is healthy! Ready for development.${NC}"
 fi

--- a/internal/cli/integrations/agents/templates/skill/workflows/absorb-conflict.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/absorb-conflict.md
@@ -2,7 +2,7 @@
 
 Guide for resolving conflicts during `stackit absorb --no-interactive --force` operations. Unlike regular git conflicts, absorb conflicts occur when staged changes cannot be cleanly applied to their target commits in the stack.
 
-> **CRITICAL:** Always run stackit commands with `command stackit ... --no-interactive`. For commands that require confirmation, also include the `--yes` or `-y` flag.
+> **CRITICAL:** Always run stackit commands with `stackit ... --no-interactive`. For commands that require confirmation, also include the `--yes` or `-y` flag.
 
 ## Understanding Absorb Conflicts
 
@@ -47,10 +47,10 @@ When absorb fails with a conflict, identify where the change should go:
 
 ```bash
 # Show absorb plan (dry run)
-command stackit absorb --dry-run --no-interactive
+stackit absorb --dry-run --no-interactive
 
 # View commits in current branch's stack
-command stackit log --no-interactive
+stackit log --no-interactive
 
 # See what each commit changed
 git log --oneline --stat HEAD~5..HEAD
@@ -101,10 +101,10 @@ git checkout <target-branch>
 
 # 3. Amend the commit
 git add path/to/file.go
-command stackit modify --no-interactive
+stackit modify --no-interactive
 
 # 4. Restack to propagate — scope to the amended branch and its descendants
-command stackit restack --branch <target-branch> --upstack --no-interactive
+stackit restack --branch <target-branch> --upstack --no-interactive
 ```
 
 Pass `--json` when you want a machine-readable report (which branches were restacked, skipped, or conflicted) instead of doing a second broad restack to "check".
@@ -121,13 +121,13 @@ git reset HEAD
 git add -p  # Use patch mode to select hunks
 
 # 3. Absorb the first part
-command stackit absorb --no-interactive --force
+stackit absorb --no-interactive --force
 
 # 4. Stage the remaining part
 git add -p
 
 # 5. Absorb (will go to different commit)
-command stackit absorb --no-interactive --force
+stackit absorb --no-interactive --force
 ```
 
 ### Strategy C: Create New Commit
@@ -137,7 +137,7 @@ If the change doesn't belong in any existing commit:
 ```bash
 # 1. Keep the staged changes
 # 2. Create a new commit on top
-command stackit create --no-interactive "description of change"
+stackit create --no-interactive "description of change"
 ```
 
 ### Strategy D: Interactive Resolution
@@ -146,10 +146,10 @@ For complex cases, use the absorb conflict workflow:
 
 ```bash
 # 1. Show what absorb wants to do
-command stackit absorb --dry-run --no-interactive
+stackit absorb --dry-run --no-interactive
 
 # 2. If conflict occurs, check state
-command stackit absorb --show-conflict --no-interactive
+stackit absorb --show-conflict --no-interactive
 
 # 3. Resolve the conflict manually
 # Edit the file, removing conflict markers
@@ -158,10 +158,10 @@ command stackit absorb --show-conflict --no-interactive
 git add path/to/file.go
 
 # 5. Re-run absorb after resolution
-command stackit absorb --no-interactive --force
+stackit absorb --no-interactive --force
 
 # Or abort and try a different approach
-command stackit abort --no-interactive
+stackit abort --no-interactive
 ```
 
 ## Step 5: Verify and Complete
@@ -170,11 +170,11 @@ After resolution:
 
 ```bash
 # 1. Verify the stack structure
-command stackit log --no-interactive
+stackit log --no-interactive
 
 # 2. Build/test each affected branch (use project's commands from README.md)
-command stackit foreach --no-interactive "<build-command>"
-command stackit foreach --no-interactive "<test-command>"
+stackit foreach --no-interactive "<build-command>"
+stackit foreach --no-interactive "<test-command>"
 
 # 3. Check for any remaining issues
 git status
@@ -279,7 +279,7 @@ Three-way merge couldn't auto-resolve. Manually resolve or use Claude assistance
 
 ### Left in detached HEAD state
 
-Absorb failed midway. Run `command stackit abort --no-interactive` to recover.
+Absorb failed midway. Run `stackit abort --no-interactive` to recover.
 
 ### Changes lost after conflict
 
@@ -297,4 +297,4 @@ Check `git stash list` - absorb stashes changes before starting. Use `git stash 
 - All staged changes applied to appropriate commits
 - No conflict markers in any files
 - Stack builds and tests pass
-- `command stackit log --no-interactive` shows clean structure
+- `stackit log --no-interactive` shows clean structure

--- a/internal/cli/integrations/agents/templates/skill/workflows/conflict-resolution.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/conflict-resolution.md
@@ -320,15 +320,15 @@ Smaller, focused branches = fewer conflicts. A branch can have multiple related 
 
 ```bash
 # Good: Small, focused changes (one branch per logical unit)
-echo "feat: add email validation" | stackit create --no-interactive
-echo "feat: add phone validation" | stackit create --no-interactive
+echo "feat: add email validation" | stackit create -F - --no-interactive
+echo "feat: add phone validation" | stackit create -F - --no-interactive
 
 # Also good: Multiple commits in one branch for related work
-echo "feat: add validation helpers" | stackit create --no-interactive
+echo "feat: add validation helpers" | stackit create -F - --no-interactive
 git add . && git commit -m "test: add validation tests"
 
 # Risky: Large, sweeping changes
-echo "feat: refactor entire validation system" | stackit create --no-interactive
+echo "feat: refactor entire validation system" | stackit create -F - --no-interactive
 ```
 
 ### 2. Sync Frequently

--- a/internal/cli/integrations/agents/templates/skill/workflows/conflict-resolution.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/conflict-resolution.md
@@ -2,7 +2,7 @@
 
 Guide for resolving conflicts during stackit operations (restack, sync, merge, etc.).
 
-> **CRITICAL:** Always run stackit commands with `command stackit ... --no-interactive`. For commands that require confirmation, also include the `--yes` or `-y` flag.
+> **CRITICAL:** Always run stackit commands with `stackit ... --no-interactive`. For commands that require confirmation, also include the `--yes` or `-y` flag.
 
 ## Understanding Conflicts
 
@@ -194,7 +194,7 @@ Once all conflicts are resolved and verified:
 git add .
 
 # Continue the operation
-command stackit continue --no-interactive
+stackit continue --no-interactive
 
 # Or if using git directly
 git rebase --continue
@@ -303,13 +303,13 @@ If resolution is too complex or you want to reconsider:
 
 ```bash
 # Abort the operation
-command stackit abort --no-interactive
+stackit abort --no-interactive
 
 # Or with git
 git rebase --abort
 
 # Then undo stackit command
-command stackit undo --no-interactive --yes
+stackit undo --no-interactive --yes
 ```
 
 ## Prevention Strategies
@@ -320,42 +320,42 @@ Smaller, focused branches = fewer conflicts. A branch can have multiple related 
 
 ```bash
 # Good: Small, focused changes (one branch per logical unit)
-echo "feat: add email validation" | command stackit create --no-interactive
-echo "feat: add phone validation" | command stackit create --no-interactive
+echo "feat: add email validation" | stackit create --no-interactive
+echo "feat: add phone validation" | stackit create --no-interactive
 
 # Also good: Multiple commits in one branch for related work
-echo "feat: add validation helpers" | command stackit create --no-interactive
+echo "feat: add validation helpers" | stackit create --no-interactive
 git add . && git commit -m "test: add validation tests"
 
 # Risky: Large, sweeping changes
-echo "feat: refactor entire validation system" | command stackit create --no-interactive
+echo "feat: refactor entire validation system" | stackit create --no-interactive
 ```
 
 ### 2. Sync Frequently
 
 ```bash
 # Sync often to stay current with main
-command stackit sync --no-interactive --restack
+stackit sync --no-interactive --restack
 ```
 
 ### 3. Restack After Changes
 
 ```bash
 # After modifying a branch, restack only that branch's descendants
-command stackit modify --no-interactive
-command stackit restack --branch $(git branch --show-current) --upstack --no-interactive
+stackit modify --no-interactive
+stackit restack --branch $(git branch --show-current) --upstack --no-interactive
 
 # If modifications affected multiple independent stacks, prefer:
-# command stackit restack --all-stacks --continue-on-conflict --no-interactive
+# stackit restack --all-stacks --continue-on-conflict --no-interactive
 ```
 
 Use `--json` to confirm which branches were touched and avoid running a second broad restack.
 
-### 4. Use `command stackit foreach --no-interactive` to Check
+### 4. Use `stackit foreach --no-interactive` to Check
 
 ```bash
 # Verify entire stack builds before operations (use project's build command from README.md)
-command stackit foreach --no-interactive "<build-command>"
+stackit foreach --no-interactive "<build-command>"
 ```
 
 ## Advanced: Complex Multi-Branch Conflicts
@@ -369,22 +369,22 @@ When restacking affects multiple branches:
 
 ```bash
 # Example workflow
-command stackit log --no-interactive  # Note branch order
+stackit log --no-interactive  # Note branch order
 
 # Resolve first conflict
 git status  # See conflicted files
 # ... resolve conflicts ...
 git add .
-command stackit continue --no-interactive
+stackit continue --no-interactive
 
 # Before moving to next conflict, verify
 <build-command>
-command stackit log --no-interactive  # Confirm structure still correct
+stackit log --no-interactive  # Confirm structure still correct
 
 # Continue to next conflict
 # ... resolve conflicts ...
 git add .
-command stackit continue --no-interactive
+stackit continue --no-interactive
 
 # Repeat until complete
 ```
@@ -396,28 +396,28 @@ command stackit continue --no-interactive
 ```bash
 # Stage all resolved files
 git add .
-command stackit continue --no-interactive
+stackit continue --no-interactive
 ```
 
 ### "No rebase in progress"
 
 ```bash
 # Operation already completed or aborted
-command stackit log --no-interactive  # Check current state
+stackit log --no-interactive  # Check current state
 ```
 
 ### "Conflict resolution broke the build"
 
 ```bash
 # Abort and try again
-command stackit abort --no-interactive
-command stackit undo --no-interactive --yes
+stackit abort --no-interactive
+stackit undo --no-interactive --yes
 
 # Or fix the build issue
 <build-command>  # See error (check README.md for project's build command)
 # Fix the issue
 git add .
-command stackit continue --no-interactive
+stackit continue --no-interactive
 ```
 
 ## Example Walkthrough
@@ -426,7 +426,7 @@ command stackit continue --no-interactive
 
 ```bash
 # 1. Restack started (scoped to the affected branch and its descendants)
-command stackit restack --branch feature-x --upstack --no-interactive
+stackit restack --branch feature-x --upstack --no-interactive
 # → Conflict in auth.go
 
 # 2. Check status
@@ -451,11 +451,11 @@ vim auth.go
 
 # 7. Continue
 git add auth.go
-command stackit continue --no-interactive
+stackit continue --no-interactive
 # → Restack completes
 
 # 8. Verify final state
-command stackit log --no-interactive
+stackit log --no-interactive
 # → Stack structure correct
 ```
 
@@ -465,4 +465,4 @@ command stackit log --no-interactive
 - ✓ Project builds successfully
 - ✓ Tests pass
 - ✓ Operation completed (not still in progress)
-- ✓ Stack structure is correct (`command stackit log --no-interactive`)
+- ✓ Stack structure is correct (`stackit log --no-interactive`)

--- a/internal/cli/integrations/agents/templates/skill/workflows/fix-absorb.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/fix-absorb.md
@@ -2,7 +2,7 @@
 
 After `stackit absorb`, compilation errors may occur when absorbed changes depend on files/changes that didn't get cleanly absorbed into the same commit.
 
-> **CRITICAL:** Always run stackit commands with `command stackit ... --no-interactive`. For commands that require confirmation, also include the `--yes` or `-y` flag.
+> **CRITICAL:** Always run stackit commands with `stackit ... --no-interactive`. For commands that require confirmation, also include the `--yes` or `-y` flag.
 
 ## Why This Happens
 
@@ -48,7 +48,7 @@ Starting from the **bottom** of the stack (earliest branch), build and test each
 
 ```bash
 # Get list of branches in stack order
-command stackit log --no-interactive
+stackit log --no-interactive
 
 # For each branch (bottom to top):
 git checkout <branch-name>
@@ -86,7 +86,7 @@ For each missing item, search upstack branches for where it's defined:
 
 ```bash
 # Get child branch name
-command stackit children --no-interactive
+stackit children --no-interactive
 
 # Check what changes exist in child that aren't in current
 git diff <current-branch>..<child-branch>
@@ -130,7 +130,7 @@ git show <child-branch>:path/to/file.go > path/to/file.go
 
 # 3. Commit the fix
 git add path/to/file.go
-command stackit modify --no-interactive  # Amends current branch's commit
+stackit modify --no-interactive  # Amends current branch's commit
 ```
 
 ### Option C: Interactive rebase (advanced)
@@ -153,10 +153,10 @@ After fixing all branches, verify the entire stack builds:
 
 ```bash
 # Build all branches in order
-command stackit foreach --no-interactive "<build-command>"
+stackit foreach --no-interactive "<build-command>"
 
 # Test all branches
-command stackit foreach --no-interactive "<test-command>"
+stackit foreach --no-interactive "<test-command>"
 ```
 
 **Expected output:**
@@ -197,7 +197,7 @@ To avoid this in the future:
 1. **Keep changes focused**: Absorb works best when changes are closely related
 2. **Absorb frequently**: Smaller sets of changes = fewer dependency issues
 3. **Check as you go**: Run build after absorb to catch issues early
-4. **Use modify for small fixes**: `command stackit modify --no-interactive` is safer for targeted changes
+4. **Use modify for small fixes**: `stackit modify --no-interactive` is safer for targeted changes
 
 ## Example Walkthrough
 
@@ -224,11 +224,11 @@ git cherry-pick abc123
 # ✓ Build succeeded
 
 # 5. Restack children (they're now based on old version) — scope to this subtree
-command stackit restack --branch add-validation --upstack --no-interactive
+stackit restack --branch add-validation --upstack --no-interactive
 # (use --all-stacks only if the fix affected multiple independent stacks)
 
 # 6. Verify entire stack
-command stackit foreach --no-interactive "<build-command>"
+stackit foreach --no-interactive "<build-command>"
 # ✓ All branches succeed
 ```
 
@@ -236,5 +236,5 @@ command stackit foreach --no-interactive "<build-command>"
 
 - ✓ All branches build without errors
 - ✓ All branches pass tests
-- ✓ Stack structure is clean (`command stackit log --no-interactive` shows proper tree)
+- ✓ Stack structure is clean (`stackit log --no-interactive` shows proper tree)
 - ✓ No git conflicts or issues

--- a/internal/cli/integrations/agents/templates/skill/workflows/stack-fold.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/stack-fold.md
@@ -12,7 +12,7 @@ This workflow guides the LLM through analyzing a branch stack and recommending b
 ### 1. Gather Context
 Fetch the complete metadata for the current stack:
 ```bash
-command stackit info --stack --json --no-interactive
+stackit info --stack --json --no-interactive
 ```
 
 ### 2. Identify Candidates
@@ -30,7 +30,7 @@ Analyze the JSON output to find folding candidates.
 ### 3. Detailed Analysis (Optional but Recommended)
 For high-confidence candidates, verify the actual changes to ensure they are safe to merge into the parent:
 ```bash
-command stackit info <branch-name> --diff --no-interactive
+stackit info <branch-name> --diff --no-interactive
 ```
 
 ### 4. Propose a Fold Plan
@@ -44,8 +44,8 @@ Present your findings to the user. For each recommendation, include:
 Wait for user confirmation. If confirmed, perform the fold:
 ```bash
 # Fold branch into parent (keeps parent name)
-command stackit checkout <branch-to-fold> --no-interactive
-command stackit fold --no-interactive
+stackit checkout <branch-to-fold> --no-interactive
+stackit fold --no-interactive
 ```
 
 ### 6. Post-Fold Cleanup
@@ -53,10 +53,10 @@ After folding, restack only the affected subtree. The parent branch now carries 
 
 ```bash
 # Scope restack to the parent and its descendants — avoid a broad restack
-command stackit restack --branch <parent-branch> --upstack --no-interactive
+stackit restack --branch <parent-branch> --upstack --no-interactive
 
 # If you folded in multiple independent stacks in one session, prefer:
-# command stackit restack --all-stacks --continue-on-conflict --no-interactive
+# stackit restack --all-stacks --continue-on-conflict --no-interactive
 ```
 
 Use `--json` to verify only the expected branches were touched; skip a follow-up restack when output shows nothing pending.

--- a/internal/integration/messagefile_test.go
+++ b/internal/integration/messagefile_test.go
@@ -1,0 +1,57 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMessageFile verifies the --message-file flag wires through to create,
+// modify, and squash by reading the commit message from a file rather than
+// embedding it as a literal -m argument.
+func TestMessageFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("create reads commit message from file", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		msgPath := filepath.Join(sh.Dir(), ".commit-msg")
+		require.NoError(t, os.WriteFile(msgPath, []byte("feat: from file\n"), 0o600))
+
+		sh.Write("feature", "content").
+			Run("create feature -F " + msgPath).
+			OnBranch("feature").
+			Git("log -1 --format=%s").
+			OutputContains("feat: from file")
+	})
+
+	t.Run("create errors when both --message and --message-file are given", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		msgPath := filepath.Join(sh.Dir(), ".commit-msg")
+		require.NoError(t, os.WriteFile(msgPath, []byte("from file"), 0o600))
+
+		sh.Write("feature", "content").
+			RunExpectError("create feature -m 'inline' -F " + msgPath).
+			OutputContains("mutually exclusive")
+	})
+
+	t.Run("modify updates message from file", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("feature", "content").
+			Run("create feature -m 'Original'")
+
+		msgPath := filepath.Join(sh.Dir(), ".commit-msg")
+		require.NoError(t, os.WriteFile(msgPath, []byte("feat: updated from file\n"), 0o600))
+
+		sh.Run("modify -F " + msgPath).
+			Git("log -1 --format=%s").
+			OutputContains("feat: updated from file")
+	})
+}

--- a/internal/integration/messagefile_test.go
+++ b/internal/integration/messagefile_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestMessageFile verifies the --message-file flag wires through to create,
-// modify, and squash by reading the commit message from a file rather than
-// embedding it as a literal -m argument.
+// TestMessageFile verifies the --message-file (-F) flag wires through to
+// create, modify, squash, and split — keeping commit-message text out of the
+// literal command line for permission-rule stability.
 func TestMessageFile(t *testing.T) {
 	t.Parallel()
 
@@ -18,8 +18,7 @@ func TestMessageFile(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)
 
-		msgPath := filepath.Join(sh.Dir(), ".commit-msg")
-		require.NoError(t, os.WriteFile(msgPath, []byte("feat: from file\n"), 0o600))
+		msgPath := writeMessageFile(t, "feat: from file\n")
 
 		sh.Write("feature", "content").
 			Run("create feature -F " + msgPath).
@@ -28,30 +27,123 @@ func TestMessageFile(t *testing.T) {
 			OutputContains("feat: from file")
 	})
 
-	t.Run("create errors when both --message and --message-file are given", func(t *testing.T) {
+	t.Run("create preserves multi-line subject and body", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)
 
-		msgPath := filepath.Join(sh.Dir(), ".commit-msg")
-		require.NoError(t, os.WriteFile(msgPath, []byte("from file"), 0o600))
+		msgPath := writeMessageFile(t, "feat: subject line\n\nbody paragraph one\n\nbody paragraph two\n")
 
 		sh.Write("feature", "content").
-			RunExpectError("create feature -m 'inline' -F " + msgPath).
-			OutputContains("mutually exclusive")
+			Run("create feature -F " + msgPath).
+			Git("log -1 --format=%B").
+			OutputContains("feat: subject line").
+			OutputContains("body paragraph one").
+			OutputContains("body paragraph two")
 	})
 
-	t.Run("modify updates message from file", func(t *testing.T) {
+	t.Run("modify updates commit message from file", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)
 
 		sh.Write("feature", "content").
 			Run("create feature -m 'Original'")
 
-		msgPath := filepath.Join(sh.Dir(), ".commit-msg")
-		require.NoError(t, os.WriteFile(msgPath, []byte("feat: updated from file\n"), 0o600))
-
+		msgPath := writeMessageFile(t, "feat: updated from file\n")
 		sh.Run("modify -F " + msgPath).
 			Git("log -1 --format=%s").
 			OutputContains("feat: updated from file")
 	})
+
+	t.Run("squash reads commit message from file", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("a1", "a1").
+			Run("create feature -m 'feat: first'")
+		sh.Write("a2", "a2").
+			Run("modify -c -m 'feat: second'")
+
+		msgPath := writeMessageFile(t, "feat: squashed from file\n")
+		sh.Run("squash -F " + msgPath).
+			Git("log -1 --format=%s").
+			OutputContains("feat: squashed from file")
+	})
+
+	t.Run("split reads commit message from file", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// sh.Write("file", ...) creates a file named "file_test.txt"
+		// (helper concatenates "_test.txt"); --by-file references that path.
+		sh.Write("file", "content").
+			Run("create feature -m 'Add feature'")
+
+		msgPath := writeMessageFile(t, "feat: extracted from file\n")
+		sh.Run("split --by-file file_test.txt --as-sibling --message-file " + msgPath).
+			Checkout("feature_split").
+			Git("log -1 --format=%s").
+			OutputContains("feat: extracted from file")
+	})
+
+	t.Run("create errors when both --message and --message-file are given", func(t *testing.T) {
+		t.Parallel()
+		runMutexTest(t, "create feature -m 'inline' -F ")
+	})
+
+	t.Run("modify errors when both --message and --message-file are given", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("feature", "content").Run("create feature -m 'Original'")
+		msgPath := writeMessageFile(t, "from file")
+		sh.RunExpectError("modify -m 'inline' -F " + msgPath).
+			OutputContains("cannot use --message and --message-file together")
+	})
+
+	t.Run("squash errors when both --message and --message-file are given", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("feature", "content").Run("create feature -m 'Original'")
+		msgPath := writeMessageFile(t, "from file")
+		sh.RunExpectError("squash -m 'inline' -F " + msgPath).
+			OutputContains("cannot use --message and --message-file together")
+	})
+
+	t.Run("create errors when message file does not exist", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("feature", "content").
+			RunExpectError("create feature -F /tmp/stackit-nonexistent-msg").
+			OutputContains("file not found").
+			OutputContains(`use "-" to read from stdin`)
+	})
+
+	t.Run("create errors when message file is empty", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		msgPath := writeMessageFile(t, "")
+		sh.Write("feature", "content").
+			RunExpectError("create feature -F " + msgPath).
+			OutputContains("is empty")
+	})
+}
+
+// writeMessageFile writes content to a temp file outside the repo working
+// tree (so it doesn't leak into staged changes) and returns the path.
+func writeMessageFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "msg")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+// runMutexTest covers the --message + --message-file mutex error for the
+// create command. modify/squash variants need their own setup so they live
+// inline above.
+func runMutexTest(t *testing.T, cmd string) {
+	t.Helper()
+	sh := NewTestShellInProcess(t)
+	msgPath := writeMessageFile(t, "from file")
+	sh.Write("feature", "content").
+		RunExpectError(cmd + msgPath).
+		OutputContains("cannot use --message and --message-file together")
 }

--- a/internal/integration/messagefile_test.go
+++ b/internal/integration/messagefile_test.go
@@ -125,6 +125,37 @@ func TestMessageFile(t *testing.T) {
 			RunExpectError("create feature -F " + msgPath).
 			OutputContains("is empty")
 	})
+
+	t.Run("split rejects --message-file - and --patch - together", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("file", "content").
+			Run("create feature -m 'init'").
+			RunExpectError("split --by-hunk --patch - --message-file -").
+			OutputContains("cannot read both --message-file and --patch from stdin")
+	})
+
+	t.Run("split rejects --message-file before reading any input", func(t *testing.T) {
+		// Regression: previously --by-commit --message-file - drained stdin
+		// (or read the file) before the mode-compat check fired. Now flag
+		// validation runs first.
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		msgPath := writeMessageFile(t, "feat: should not be read")
+		sh.Write("file", "content").
+			Run("create feature -m 'init'").
+			RunExpectError("split --by-commit --message-file " + msgPath).
+			OutputContains("--message/--message-file can only be used with --by-file")
+	})
+
+	t.Run("split errors when both --message and --message-file are given", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("file", "content").Run("create feature -m 'init'")
+		msgPath := writeMessageFile(t, "from file")
+		sh.RunExpectError("split --by-file file_test.txt --as-sibling -m 'inline' --message-file " + msgPath).
+			OutputContains("cannot use --message and --message-file together")
+	})
 }
 
 // writeMessageFile writes content to a temp file outside the repo working

--- a/internal/integration/split_test.go
+++ b/internal/integration/split_test.go
@@ -294,7 +294,7 @@ func TestSplitAsSibling(t *testing.T) {
 
 		// Should error because --message only works with --by-file
 		sh.RunExpectError("split --by-commit --message 'bad message'").
-			OutputContains("--message can only be used with --by-file")
+			OutputContains("--message/--message-file can only be used with --by-file")
 	})
 
 	// Scenario:
@@ -339,7 +339,7 @@ func TestSplitAsSibling(t *testing.T) {
 
 		// Should error because --message requires explicit --by-file
 		sh.RunExpectError("split --message 'bad message'").
-			OutputContains("--message can only be used with --by-file")
+			OutputContains("--message/--message-file can only be used with --by-file")
 	})
 
 	run("split --by-file --as-sibling rejects duplicate custom branch name", func(_ *testing.T, sh *TestShell) {


### PR DESCRIPTION
This PR merges the following changes:

1. **#898** refactor: drop `command` prefix from agent templates
2. **#899** refactor: drop `command` prefix from project rules and AGENTS.md
3. **#900** docs: add permission-stability guidance for stackit workflow
4. **#901** feat: add --message-file flag to create/modify/squash/split
5. **#902** fix: harden --message-file handling and broaden test coverage
6. **#903** fix: validate split flags before I/O and dogfood -F - in templates

### Stack

```
main
  └─ jonnii/20260502010935/drop-command-prefix-from-agent-templates (#898)
    └─ jonnii/20260502011424/drop-command-prefix-from-project-rules-and (#899)
      └─ jonnii/20260502011802/add-permission-stability-guidance-for-stackit (#900)
        └─ jonnii/20260502013457/add-message-file-flag-to (#901)
          └─ jonnii/20260502015519/harden-message-file-handling-and-broaden-test (#902)
            └─ jonnii/20260502021005/validate-split-flags-before-I/O-and-dogfood-F (#903)
```

Stackit-Stack-Size: 6
Stackit-PRs: 898,899,900,901,902,903
