### PR TITLE
feat: reshape Codex skills as a first-class product surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - [Getting Started](#getting-started)
 - [Command Reference](#command-reference)
 - [Common Workflows](#common-workflows)
-- [Claude Code Integration](#claude-code-integration)
+- [AI Agent Integration](#ai-agent-integration)
 - [Branch Protection](#frozen--locked-branches)
 - [Configuration](#configuration)
 - [Troubleshooting](#troubleshooting)
@@ -182,11 +182,11 @@ stackit merge ship     # Consolidate into single PR and merge
 
 ---
 
-## Claude Code Integration
+## AI Agent Integration
 
-Stackit includes specialized commands designed for Claude Code, providing intelligent automation for common stacking workflows. These commands understand stack context and can perform complex operations with minimal user input.
+Stackit includes specialized skills for Claude Code and Codex, providing intelligent automation for common stacking workflows. These skills understand stack context and can perform complex operations with minimal user input.
 
-### Available Claude Commands
+### Available Agent Skills
 
 | Command | Description | When to Use |
 |:---|:---|:---|
@@ -205,17 +205,25 @@ Stackit includes specialized commands designed for Claude Code, providing intell
 stackit agent install
 ```
 
-This creates integration files for Claude Code, Codex, and Cursor. The Claude commands are designed to:
+This creates integration files for Claude Code, Codex, and Cursor.
+
+Generated files include:
+
+- `~/.claude/skills/stackit/` plus `~/.claude/skills/stack-*/` for Claude Code
+- `~/.codex/skills/stackit/` plus `~/.codex/skills/stack-*/` for Codex
+- Repository workflow guidance for `CLAUDE.md` or `AGENTS.md` when you opt in
+
+The generated skills are designed to:
 
 - **Understand Context**: Each command analyzes your current stack state and git status
 - **Provide Validation**: Commands include quality checks and error handling
 - **Guide Through Issues**: When conflicts or errors occur, commands provide step-by-step resolution guidance
 - **Ensure Safety**: All commands prioritize data safety and provide undo capabilities
 
-### Example Claude Workflow
+### Example Agent Workflow
 
 ```bash
-# Claude can help with complex stacking operations
+# Claude Code or Codex can help with complex stacking operations
 stack-create add-user-auth    # Creates branch with proper commit message
 # Make changes...
 stack-absorb                 # Intelligently distributes changes across commits

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -71,7 +71,7 @@ nav:
     - Management: worktrees/management.md
   - Integrations: &integrations
     - Overview: integrations/index.md
-    - Claude Code: integrations/claude.md
+    - AI Agents: integrations/claude.md
     - GitHub: integrations/github.md
     - Git Hooks: integrations/git-hooks.md
     - Shell: integrations/shell.md

--- a/doc/src/guide/index.md
+++ b/doc/src/guide/index.md
@@ -54,4 +54,4 @@ Or check the [FAQ](../community/faq.md) for frequently asked questions.
 
 - [Workflows →](../workflows/index.md) — Daily, advanced, and team collaboration patterns
 - [Worktrees →](../worktrees/index.md) — Work on multiple stacks in parallel
-- [Integrations →](../integrations/index.md) — Claude Code, GitHub, git hooks, and shell
+- [Integrations →](../integrations/index.md) — AI agents, GitHub, git hooks, and shell

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -33,11 +33,11 @@ description: Stackit is a CLI tool for managing stacked Git branches. Break larg
 
     Merge stacks bottom-up or squash top-down with intelligent workflows
 
--   :material-robot:{ .lg .middle } **Claude Code integration**
+-   :material-robot:{ .lg .middle } **AI agent integration**
 
     ---
 
-    Generate integration files for AI assistants with context-aware commands
+    Generate Claude Code and Codex skills with context-aware commands
 
 -   :simple-github:{ .lg .middle } **GitHub integration**
 

--- a/doc/src/integrations/claude.md
+++ b/doc/src/integrations/claude.md
@@ -1,16 +1,16 @@
 ---
 icon: material/robot
-title: Claude Code Integration
-description: AI-assisted stacking with Claude Code. Intelligent commands for creating branches, syncing stacks, absorbing changes, and fixing issues.
+title: AI Agent Integration
+description: AI-assisted stacking with Claude Code and Codex. Intelligent skills for creating branches, syncing stacks, absorbing changes, and fixing issues.
 ---
 
-# Claude Code Integration
+# AI Agent Integration
 
-Stackit includes specialized commands designed for Claude Code, providing intelligent automation for common stacking workflows.
+Stackit includes specialized skills for Claude Code and Codex, providing intelligent automation for common stacking workflows.
 
 ## Overview
 
-Claude Code integration enables AI-assisted stacking with commands that:
+Agent integration enables AI-assisted stacking with skills that:
 
 - **Understand Context**: Analyze your current stack state and git status
 - **Provide Validation**: Include quality checks and error handling
@@ -19,15 +19,23 @@ Claude Code integration enables AI-assisted stacking with commands that:
 
 ## Setup
 
-Install the Claude integration files:
+Install the agent integration files:
 
 ```bash
 stackit agent install
 ```
 
-This creates the necessary integration files for Claude Code, plus Codex/Cursor agent formats.
+This creates integration files for Claude Code, Codex, and Cursor.
 
-## Available commands
+| Agent | Installed files |
+|:------|:----------------|
+| Claude Code | `~/.claude/skills/stackit/` plus `~/.claude/skills/stack-*/` |
+| Codex | `~/.codex/skills/stackit/` plus `~/.codex/skills/stack-*/` |
+| Cursor and other agents | Repository guidance in `AGENTS.md` when selected |
+
+Use `--format=claude`, `--format=codex`, or `--format=claude,codex` to install a specific skill format in non-interactive environments.
+
+## Available skills
 
 ### stack-status
 
@@ -115,10 +123,10 @@ stack-describe
 
 ## Example workflow
 
-Here's a typical Claude-assisted workflow:
+Here's a typical AI-assisted workflow:
 
 ```bash
-# Claude helps create a branch with proper commit message
+# Claude Code or Codex helps create a branch with a proper commit message
 stack-create add-user-auth
 
 # Make your changes...
@@ -135,7 +143,7 @@ stack-submit --stack
 
 ## How it works
 
-Claude Code commands are executed through skills that:
+Stackit agent workflows are executed through skills that:
 
 1. **Analyze current state**: Check git status, stack structure, and branch relationships
 2. **Execute operations**: Perform the requested action with appropriate flags
@@ -144,30 +152,30 @@ Claude Code commands are executed through skills that:
 
 ## Integration with regular commands
 
-Claude commands complement regular stackit commands. You can mix and match:
+Agent skills complement regular stackit commands. You can mix and match:
 
 ```bash
-# Use Claude for complex operations
+# Use an agent skill for complex operations
 stack-create my-feature
 
 # Use regular commands for simple tasks
 stackit log
 stackit checkout parent-branch
 
-# Back to Claude for multi-branch operations
+# Back to an agent skill for multi-branch operations
 stack-absorb
 ```
 
 ## Best practices
 
-1. **Let Claude handle complexity**: Use Claude commands for operations involving multiple branches
+1. **Let the agent handle complexity**: Use agent skills for operations involving multiple branches
 2. **Use regular commands for navigation**: Simple operations like $$stackit log$$ don't need AI assistance
-3. **Review suggestions**: Claude will explain what it's doing—review before proceeding
-4. **Leverage context awareness**: Claude commands understand your stack structure and can make intelligent decisions
+3. **Review suggestions**: The agent will explain what it's doing—review before proceeding
+4. **Leverage context awareness**: The skills understand your stack structure and can make intelligent decisions
 
 ## Troubleshooting
 
-If Claude commands aren't working:
+If agent skills aren't working:
 
 1. Verify installation:
    ```bash

--- a/doc/src/integrations/index.md
+++ b/doc/src/integrations/index.md
@@ -1,7 +1,7 @@
 ---
 icon: material/puzzle
 title: Stackit Integrations
-description: Integrate stackit with Claude Code, GitHub Actions, Git hooks, and shell for a seamless stacking workflow.
+description: Integrate stackit with AI agents, GitHub Actions, Git hooks, and shell for a seamless stacking workflow.
 ---
 
 # Integrations

--- a/doc/src/start/install.md
+++ b/doc/src/start/install.md
@@ -100,7 +100,7 @@ This command:
 3. Offers to install optional integrations:
    - **GitHub Actions** — CI checks for branch locking
    - **Git hooks** — Prevent commits and pushes to locked branches ([learn more](../integrations/git-hooks.md))
-   - **AI agent files** — Integration files for Cursor and Claude Code
+   - **AI agent files** — Integration files for Claude Code, Codex, and Cursor
 
 You can skip the interactive prompts with `stackit init --skip-integrations` or install integrations later using the individual commands (`stackit github install`, `stackit precommit install`, `stackit prepush install`, `stackit agent install`).
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -146,7 +146,7 @@ func (h *cliInitHandler) offerIntegrations(splog output.Output) {
 	if agentsInstalled {
 		splog.Info("✓ AI agent files already installed")
 	} else {
-		installAgents, err := tui.PromptConfirm("Install AI agent files? (Claude Code / Codex integration)", false)
+		installAgents, err := tui.PromptConfirm("Install AI agent files? (Claude Code / Codex integration)", true)
 		if err == nil && installAgents {
 			if err := integrations.InstallAgents(h.runner, false, h.version, h.writer); err != nil {
 				splog.Warn("Failed to install agent files: %v", err)

--- a/internal/cli/integrations/agents.go
+++ b/internal/cli/integrations/agents.go
@@ -102,11 +102,11 @@ func runAgentInstall(runner git.Runner, force bool, formats []string, version st
 		switch target.format {
 		case agentSkillFormatClaude:
 			cleanupOldCommandFiles(baseDir, commandTemplateFiles)
-			if err := installCommandSkills(baseDir, target.skillsBaseDir, commandTemplateFiles, renderClaudeSkillContent); err != nil {
+			if err := installCommandSkills(baseDir, target.skillsBaseDir, commandTemplateFiles, renderClaudeSkillContent, target.format); err != nil {
 				return err
 			}
 		case agentSkillFormatCodex:
-			if err := installCommandSkills(baseDir, target.skillsBaseDir, commandTemplateFiles, renderCodexSkillContent); err != nil {
+			if err := installCommandSkills(baseDir, target.skillsBaseDir, commandTemplateFiles, renderCodexSkillContent, target.format); err != nil {
 				return err
 			}
 		}
@@ -129,7 +129,14 @@ func runAgentInstall(runner git.Runner, force bool, formats []string, version st
 func printSuccessMessage(out io.Writer, targets []agentInstallTarget, workflowBlockInstalled bool, workflowBlockPath string, commandCount int) {
 	_, _ = fmt.Fprintln(out, "✓ Installed agent files")
 
+	var hasClaude, hasCodex bool
 	for _, target := range targets {
+		switch target.format {
+		case agentSkillFormatClaude:
+			hasClaude = true
+		case agentSkillFormatCodex:
+			hasCodex = true
+		}
 		_, _ = fmt.Fprintf(out, "✓ Created %s\n", target.displayPath)
 		_, _ = fmt.Fprintf(out, "✓ Created ~/%s/stack-*/ (%d skills)\n", target.skillsBaseDir, commandCount)
 	}
@@ -140,23 +147,41 @@ func printSuccessMessage(out io.Writer, targets []agentInstallTarget, workflowBl
 		_, _ = fmt.Fprintf(out, "✓ Added stacking workflow block to %s\n", workflowBlockPath)
 	}
 
+	if hasClaude {
+		printStackSkillList(out, "Available Claude Code commands:", "/")
+	}
+	if hasCodex {
+		printStackSkillList(out, "Available Codex skills:", "")
+	}
+}
+
+func printStackSkillList(out io.Writer, title, prefix string) {
 	_, _ = fmt.Fprintln(out)
-	_, _ = fmt.Fprintln(out, "Available Claude Code commands:")
-	_, _ = fmt.Fprintln(out, "  /stack-absorb  - Intelligently absorb changes into commits")
-	_, _ = fmt.Fprintln(out, "  /stack-create  - Create branch with auto-naming")
-	_, _ = fmt.Fprintln(out, "  /stack-describe - Generate PR descriptions from git history")
-	_, _ = fmt.Fprintln(out, "  /stack-extract - Extract commits/files to independent branch")
-	_, _ = fmt.Fprintln(out, "  /stack-fix     - Diagnose and fix stack issues")
-	_, _ = fmt.Fprintln(out, "  /stack-fold    - Fold granular branches into parents")
-	_, _ = fmt.Fprintln(out, "  /stack-modify  - Amend current branch commit")
-	_, _ = fmt.Fprintln(out, "  /stack-plan    - Plan and create stack from uncommitted changes")
-	_, _ = fmt.Fprintln(out, "  /stack-resolve - Resolve rebase conflicts with AI assistance")
-	_, _ = fmt.Fprintln(out, "  /stack-restack - Rebase all branches in stack")
-	_, _ = fmt.Fprintln(out, "  /stack-review  - Apply PR review comments and mark resolved")
-	_, _ = fmt.Fprintln(out, "  /stack-split   - Split changes between current and new child branch")
-	_, _ = fmt.Fprintln(out, "  /stack-status  - View stack state and health")
-	_, _ = fmt.Fprintln(out, "  /stack-submit  - Submit PRs with generated descriptions")
-	_, _ = fmt.Fprintln(out, "  /stack-sync    - Sync with trunk and cleanup")
-	_, _ = fmt.Fprintln(out, "  /stack-tidy    - Clean up fixup/WIP commits across the stack")
-	_, _ = fmt.Fprintln(out, "  /stack-verify  - Verify stack health by running checks")
+	_, _ = fmt.Fprintln(out, title)
+	for _, skill := range stackSkillSummaries {
+		_, _ = fmt.Fprintf(out, "  %s%-14s - %s\n", prefix, skill.name, skill.description)
+	}
+}
+
+var stackSkillSummaries = []struct {
+	name        string
+	description string
+}{
+	{"stack-absorb", "Intelligently absorb changes into commits"},
+	{"stack-create", "Create branch with auto-naming"},
+	{"stack-describe", "Generate PR descriptions from git history"},
+	{"stack-extract", "Extract commits/files to independent branch"},
+	{"stack-fix", "Diagnose and fix stack issues"},
+	{"stack-fold", "Fold granular branches into parents"},
+	{"stack-modify", "Amend current branch commit"},
+	{"stack-plan", "Plan and create stack from uncommitted changes"},
+	{"stack-resolve", "Resolve rebase conflicts with AI assistance"},
+	{"stack-restack", "Rebase all branches in stack"},
+	{"stack-review", "Apply PR review comments and mark resolved"},
+	{"stack-split", "Split changes between current and new child branch"},
+	{"stack-status", "View stack state and health"},
+	{"stack-submit", "Submit PRs with generated descriptions"},
+	{"stack-sync", "Sync with trunk and cleanup"},
+	{"stack-tidy", "Clean up fixup/WIP commits across the stack"},
+	{"stack-verify", "Verify stack health by running checks"},
 }

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-absorb.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-absorb.md
@@ -1,0 +1,48 @@
+---
+description: Use when fixes in the working tree should be routed back to the correct commits across the stack. Trigger phrases include "absorb these fixes", "distribute fixes", "amend across the stack", and "route this fix to the right commit". Runs `stackit absorb`.
+---
+
+# Stack Absorb
+
+Absorb staged fixes into the commits that last touched the changed lines.
+
+## Workflow
+
+1. Inspect:
+
+   ```bash
+   git status --short
+   stackit log --no-interactive
+   ```
+
+2. Stage intended fixes:
+
+   ```bash
+   git add -A
+   ```
+
+3. Run absorb with machine-readable output:
+
+   ```bash
+   stackit absorb --json --force --no-interactive
+   ```
+
+4. Parse absorbed branches, unabsorbable hunks, and new files from the output.
+
+5. Determine a verification command from project docs or common files. Prefer the lightest command that covers the changed packages.
+
+6. Verify the stack:
+
+   ```bash
+   stackit foreach --upstack "<check-command>"
+   ```
+
+7. If a branch fails, fix the earliest failing branch from the absorb output sources: unabsorbable hunks, new files, or code absorbed too far upstack. Commit the fix at that source branch, then restack.
+
+8. Finish with:
+
+   ```bash
+   stackit log --no-interactive
+   ```
+
+Do not continue past repeated verification failures; report the failing branch and recovery options.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-create.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-create.md
@@ -1,0 +1,59 @@
+---
+description: Use when the user wants to create a new Stackit stacked branch from current working tree changes. Trigger phrases include "stack these changes", "create a stacked change", "make a stackit branch", "commit this with stackit", and "turn this into a stacked PR". Stages changes and runs `stackit create -F -`.
+---
+
+# Stack Create
+
+Create one new stacked branch from the current working tree.
+
+## Workflow
+
+1. Inspect state:
+
+   ```bash
+   git status --short
+   git diff --stat
+   git diff --cached --stat
+   stackit log --no-interactive
+   git log --oneline -5
+   ```
+
+2. If there are no staged or unstaged changes, tell the user and stop.
+
+3. If the diff obviously spans unrelated review units, use `stack-plan` instead.
+
+4. Stage the intended changes:
+
+   ```bash
+   git add -A
+   ```
+
+5. Generate a Conventional Commit message matching project style.
+
+6. Create the branch:
+
+   ```bash
+   printf '%s\n' "<commit message>" | stackit create -F - --no-interactive
+   ```
+
+   With an explicit branch name:
+
+   ```bash
+   printf '%s\n' "<commit message>" | stackit create -F - <branch-name> --no-interactive
+   ```
+
+   If config requires a scope, add `--scope <value>`.
+
+7. Verify:
+
+   ```bash
+   stackit log --no-interactive
+   ```
+
+Report the branch name, parent branch, and commit subject.
+
+## Do Not
+
+- Use `git commit` to create the branch.
+- Use `git checkout -b`.
+- Chain staging and creation in one shell command.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-describe.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-describe.md
@@ -1,0 +1,32 @@
+---
+description: Use when the user wants stack or PR descriptions generated or refreshed from commit history. Trigger phrases include "describe the stack", "generate PR descriptions", and "update the stack description".
+---
+
+# Stack Describe
+
+Generate or refresh stack and PR descriptions from the current branch history.
+
+## Workflow
+
+1. Inspect:
+
+   ```bash
+   stackit log --no-interactive
+   git log --oneline --decorate -20
+   ```
+
+2. Read PR template if present:
+
+   ```bash
+   git ls-files .github/pull_request_template.md CONTRIBUTING.md
+   ```
+
+3. Run the Stackit description command available in this repo:
+
+   ```bash
+   stackit describe --no-interactive
+   ```
+
+4. Report which descriptions were generated or updated.
+
+Descriptions should include a concrete summary and test plan. Do not use placeholders.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-extract.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-extract.md
@@ -1,0 +1,51 @@
+---
+description: Use when files or commits should be extracted to an independent branch on the same parent, or moved to a new parent or child branch. Trigger phrases include "extract this", "pull these files out", "move to its own branch off main", and "split into a sibling branch". Uses `stackit split`.
+---
+
+# Stack Extract
+
+Move files or commits off the current branch onto a new sibling, parent, or child branch using `stackit split`.
+
+## Workflow
+
+1. Inspect:
+
+   ```bash
+   git status --short
+   stackit log --no-interactive
+   git log --oneline -5
+   ```
+
+2. Confirm with the user what should be extracted (file list or commit set) and where it should go: a sibling off the same parent, a new parent, or a new child.
+
+3. Choose the split form:
+
+   | Goal | Command |
+   |---|---|
+   | Extract files to a sibling branch (current branch keeps the files) | `stackit split --by-file <files> --as-sibling --name "<branch>" --message "<message>" --no-interactive` |
+   | Extract files to a new parent (current branch loses the files) | `stackit split --by-file <files> --name "<branch>" --message "<message>" --no-interactive` |
+   | Extract files to a new child branch | `stackit split --by-file <files> --above --name "<branch>" --message "<message>" --no-interactive` |
+   | Split commit history into siblings | `stackit split --by-commit --as-sibling` |
+   | Extract specific hunks via patch | `stackit split --patch <patch-file> --above --name "<branch>" --message "<message>" --no-interactive` |
+
+4. Verify:
+
+   ```bash
+   stackit log --no-interactive
+   git status --short
+   ```
+
+5. Run the lightest relevant validation command. Prefer `mise run check` when available.
+
+## Choosing Direction
+
+| Use `--as-sibling` when... | Use the default (parent) when... |
+|---|---|
+| The extracted work belongs in its own PR off trunk. | The extracted work is a dependency the rest of the branch builds on. |
+| The current branch should keep the files. | The files should leave the current branch. |
+
+## Do Not
+
+- Use raw `git cherry-pick` or `git checkout -b` when `stackit split` covers the case.
+- Extract every file from a branch — at least one file must remain.
+- Skip verification after extraction.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-fix.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-fix.md
@@ -1,0 +1,35 @@
+---
+description: Use when the stack appears broken and the user wants automated diagnosis and repair. Trigger phrases include "fix the stack", "my stack is broken", and "diagnose stack issues". Runs Stackit diagnostic and recovery commands.
+---
+
+# Stack Fix
+
+Diagnose stack problems and apply the smallest safe repair.
+
+## Workflow
+
+1. Inspect:
+
+   ```bash
+   git status --short
+   stackit log --no-interactive
+   stackit doctor --no-interactive
+   ```
+
+2. If an operation is in progress, inspect conflicts and route to `stack-resolve`.
+
+3. If branches need ancestry repair, run:
+
+   ```bash
+   stackit restack --upstack --no-interactive
+   ```
+
+4. If the last Stackit operation clearly caused the problem and rollback is safest, ask before:
+
+   ```bash
+   stackit undo --no-interactive --yes
+   ```
+
+5. Verify with `stackit log --no-interactive` and the lightest relevant build/test command.
+
+Do not delete branches or undo work without explicit user approval.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-fold.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-fold.md
@@ -1,0 +1,32 @@
+---
+description: Use when granular branches should be folded into their parent. Trigger phrases include "fold this branch", "squash into parent", and "merge this branch into the previous one". Runs `stackit fold`.
+---
+
+# Stack Fold
+
+Fold a branch into its parent when it is too small to review separately.
+
+## Workflow
+
+1. Inspect:
+
+   ```bash
+   git status --short
+   stackit log --no-interactive
+   ```
+
+2. Confirm the target branch and parent with the user, because folding rewrites stack structure.
+
+3. Run the fold command appropriate for the current Stackit CLI:
+
+   ```bash
+   stackit fold --no-interactive
+   ```
+
+4. Restack descendants if Stackit reports they need it:
+
+   ```bash
+   stackit restack --upstack --no-interactive
+   ```
+
+5. Verify with `stackit log --no-interactive`.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-modify.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-modify.md
@@ -1,0 +1,53 @@
+---
+description: Use when the user wants to amend the current stacked branch's commit. Trigger phrases include "amend this", "fix the current commit", "modify the branch", and "add this to the current commit". Runs `stackit modify`.
+---
+
+# Stack Modify
+
+Amend the current stacked branch or add a follow-up commit to it.
+
+## Workflow
+
+1. Inspect:
+
+   ```bash
+   git status --short
+   git diff --stat
+   git diff --cached --stat
+   stackit log --no-interactive
+   git log --oneline -5
+   ```
+
+2. If there are no changes, stop.
+
+3. Stage changes unless the user explicitly requested staged-only behavior:
+
+   ```bash
+   git add -A
+   ```
+
+4. Amend by default:
+
+   ```bash
+   stackit modify --no-interactive --no-edit
+   ```
+
+   If a new message is needed:
+
+   ```bash
+   stackit modify --no-interactive -m "<message>"
+   ```
+
+   If the user asked for a new commit on this branch:
+
+   ```bash
+   stackit modify --no-interactive -c -m "<message>"
+   ```
+
+5. Verify:
+
+   ```bash
+   stackit log --no-interactive
+   ```
+
+Never use `git commit --amend`; `stackit modify` handles stack metadata.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-plan.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-plan.md
@@ -1,0 +1,69 @@
+---
+description: Use when uncommitted changes should be split into multiple stacked branches. Trigger phrases include "plan a stack", "split these changes into PRs", "break this into stacked branches", and "these changes touch too much for one PR". Backs up the working tree, proposes a stack, and validates each branch.
+---
+
+# Stack Plan
+
+Split uncommitted working-tree changes into multiple stacked branches. Primary objective: never lose the user's work.
+
+## Workflow
+
+1. Gather changes:
+
+   ```bash
+   git status --short
+   git diff --cached
+   git diff
+   git ls-files --others --exclude-standard
+   ```
+
+   Read untracked files before planning. If there are no changes, stop.
+
+2. Propose a plan before executing. Group by concern, dependency order, and architecture. Keep tests with implementation. File-level granularity is the default; ask the user to split manually with `git add -p` when one file contains unrelated work for multiple branches.
+
+3. Validate branch names:
+
+   ```bash
+   git branch --list <name>
+   git ls-remote --heads origin <name>
+   ```
+
+4. Detect check command: prefer `mise run check`, then `make test`, then `npm test`. Ask if none is discoverable.
+
+5. Pre-validate the combined changes:
+
+   ```bash
+   git add -A
+   <check-command>
+   ```
+
+6. After user approval, create a backup:
+
+   ```bash
+   ORIGINAL=$(git branch --show-current)
+   BACKUP="stack-plan-backup-$(date +%s)"
+   git checkout -b "$BACKUP"
+   git add -A
+   git commit -m "stack-plan: backup of all changes"
+   BACKUP_SHA=$(git rev-parse HEAD)
+   git checkout "$ORIGINAL"
+   ```
+
+7. For each planned branch:
+
+   ```bash
+   git checkout "$BACKUP_SHA" -- <files-for-this-branch>
+   git diff --cached --stat
+   printf '%s\n' "<message>" | stackit create -F - <name> --no-interactive
+   git log -1 --stat
+   <check-command>
+   ```
+
+8. On full success:
+
+   ```bash
+   git branch -D "$BACKUP"
+   stackit log --no-interactive
+   ```
+
+If any execution step fails, stop and point the user at the backup branch. See [stack-plan-recovery.md](../stackit/references/stack-plan-recovery.md).

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-resolve.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-resolve.md
@@ -1,0 +1,37 @@
+---
+description: Use when there is an in-progress rebase or absorb conflict to resolve. Trigger phrases include "resolve conflicts", "continue the rebase", and "fix merge conflicts". Walks conflicted files and runs `stackit continue`.
+---
+
+# Stack Resolve
+
+Resolve an in-progress Stackit conflict and continue the operation.
+
+## Workflow
+
+1. Inspect:
+
+   ```bash
+   git status --short
+   git diff --name-only --diff-filter=U
+   stackit log --no-interactive
+   ```
+
+2. Read each conflicted file and resolve markers.
+
+3. Stage resolved files:
+
+   ```bash
+   git add <resolved-files>
+   ```
+
+4. Continue:
+
+   ```bash
+   stackit continue --no-interactive
+   ```
+
+5. If another conflict appears, repeat.
+
+6. Verify with `stackit log --no-interactive` and the relevant check command.
+
+Use `stackit abort --no-interactive` only if the user asks to abort.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-restack.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-restack.md
@@ -1,0 +1,40 @@
+---
+description: Use when the stack needs to be rebased to restore proper ancestry. Trigger phrases include "restack", "rebase the stack", "my stack is out of sync", and "fix parent relationships". Runs `stackit restack`.
+---
+
+# Stack Restack
+
+Rebase stack branches according to Stackit metadata.
+
+## Workflow
+
+1. Inspect:
+
+   ```bash
+   git status --short
+   stackit log --no-interactive
+   ```
+
+2. For the current stack:
+
+   ```bash
+   stackit restack --upstack --no-interactive
+   ```
+
+3. For a specific root:
+
+   ```bash
+   stackit restack --branch <root> --upstack --no-interactive
+   ```
+
+4. Restack all stacks only if explicitly requested:
+
+   ```bash
+   stackit restack --all-stacks --continue-on-conflict --no-interactive
+   ```
+
+5. If conflicts occur, resolve files and use `stack-resolve`.
+
+6. Verify with `stackit log --no-interactive`.
+
+Do not use raw `git rebase` for stack branches.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-review.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-review.md
@@ -1,0 +1,35 @@
+---
+description: Use when the user wants to review PRs in the stack and report findings locally. Trigger phrases include "review the stack", "check PRs for issues", and "code review my stack".
+---
+
+# Stack Review
+
+Review stack PRs for high-confidence issues and report findings locally.
+
+## Workflow
+
+1. Gather stack PRs:
+
+   ```bash
+   stackit log --json --no-interactive
+   ```
+
+2. For each open non-draft PR selected for review:
+
+   ```bash
+   gh pr view <branch> --json state,isDraft,number,url,headRefName
+   gh pr diff <number>
+   ```
+
+3. Review only for high-confidence problems:
+
+   - Compilation or parsing failures.
+   - Definitive logic bugs.
+   - Clear project-instruction violations.
+   - Security vulnerabilities.
+
+4. Do not report style preferences, speculative risks, or nits.
+
+5. Return findings first, ordered by severity, with file and line references.
+
+If no issues meet the bar, say so and mention residual test gaps.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-split.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-split.md
@@ -1,0 +1,48 @@
+---
+description: Use when committed changes should be split between the current branch and a new branch. Trigger phrases include "split this commit", "move part of this branch", and "separate these files into another branch". Runs `stackit split`.
+---
+
+# Stack Split
+
+Split committed changes on the current branch into another stacked branch.
+
+## Workflow
+
+1. Require a clean working tree:
+
+   ```bash
+   git status --porcelain
+   ```
+
+2. Inspect branch context:
+
+   ```bash
+   stackit log --no-interactive
+   git log --oneline <parent-branch>..HEAD
+   git diff --name-status <parent-branch>..HEAD
+   ```
+
+3. Propose what stays and what moves. Keep tests with implementation and keep dependent symbols together.
+
+4. Confirm direction:
+
+   - `--above` for follow-up work in a child branch.
+   - default or `--below` for prerequisite work in a parent branch.
+
+5. Prefer file-level split when whole files move:
+
+   ```bash
+   stackit split --by-file <files> --above --name "<branch-name>" --message "<message>"
+   ```
+
+6. For hunk-level split, write a patch and run:
+
+   ```bash
+   stackit split --patch /tmp/extract.patch --above --name "<branch-name>" --message "<message>"
+   ```
+
+7. Verify both resulting branches with the detected check command.
+
+8. Finish with `stackit log --no-interactive`.
+
+Use `stackit undo --no-interactive --yes` only after explicit rollback approval.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-status.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-status.md
@@ -1,0 +1,26 @@
+---
+description: Use when the user wants to inspect stack health and state. Trigger phrases include "show the stack", "what's in my stack", "stack status", and "stack health". Reads `stackit log` and reports.
+---
+
+# Stack Status
+
+Report stack state without mutating anything.
+
+## Workflow
+
+Run:
+
+```bash
+git status --short
+stackit log --json --no-interactive
+```
+
+Summarize:
+
+- Current branch and parent.
+- Children.
+- PR status when present.
+- Branches needing restack.
+- Failing CI or ready-to-merge signals when present.
+
+Use plain `stackit log --no-interactive` when the user wants the visual stack.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-submit.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-submit.md
@@ -1,0 +1,47 @@
+---
+description: Use when the user wants to open or refresh PRs for the stack. Trigger phrases include "submit the stack", "open PRs", "push and create PRs", and "send for review". Runs `stackit submit`.
+---
+
+# Stack Submit
+
+Submit branches as PRs or update existing PRs. This touches remotes, so confirm before running unless the user explicitly asked to submit.
+
+## Workflow
+
+1. Inspect:
+
+   ```bash
+   git status --short
+   stackit log --no-interactive
+   stackit info --json --no-interactive
+   ```
+
+2. If there are uncommitted changes, warn and stop unless the user asked to submit anyway.
+
+3. Check for PR template:
+
+   ```bash
+   git ls-files .github/pull_request_template.md CONTRIBUTING.md
+   ```
+
+4. Submit current branch plus ancestors by default:
+
+   ```bash
+   stackit submit --no-interactive
+   ```
+
+   Entire stack:
+
+   ```bash
+   stackit submit --stack --no-interactive
+   ```
+
+   Drafts:
+
+   ```bash
+   stackit submit --draft --no-interactive
+   ```
+
+5. Report created or updated PR URLs from the command output.
+
+Do not use `gh pr create`; Stackit owns PR parentage and metadata.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-sync.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-sync.md
@@ -1,0 +1,36 @@
+---
+description: Use when the user wants to sync the stack with trunk and clean up merged branches. Trigger phrases include "sync with main", "pull trunk", "clean up merged branches", and "update from origin". Runs `stackit sync`.
+---
+
+# Stack Sync
+
+Sync with trunk and clean up branches that have landed.
+
+## Workflow
+
+1. Inspect:
+
+   ```bash
+   git status --short
+   stackit log --no-interactive
+   ```
+
+2. If there are uncommitted changes, stop and ask whether to stash, commit, or abort.
+
+3. Run:
+
+   ```bash
+   stackit sync --no-interactive
+   ```
+
+4. If Stackit reports branches needing restack:
+
+   ```bash
+   stackit restack --upstack --no-interactive
+   ```
+
+5. Verify:
+
+   ```bash
+   stackit log --no-interactive
+   ```

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-tidy.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-tidy.md
@@ -1,0 +1,70 @@
+---
+description: Use when fixup or WIP commits should be cleaned up across the stack. Trigger phrases include "clean up fixups", "squash WIP commits", and "tidy the stack". Squashes branches whose history is dominated by noise commits using `stackit squash`.
+---
+
+# Stack Tidy
+
+Squash branches whose history is dominated by fixup, WIP, or noise commits, leaving a clean per-branch story.
+
+## Workflow
+
+1. Inspect:
+
+   ```bash
+   git status --short
+   stackit log --no-interactive
+   stackit info --stack --json --no-interactive
+   ```
+
+2. If there are uncommitted changes, stop and ask whether to commit, stash, or abort.
+
+3. For each non-trunk branch in the stack, list its commits:
+
+   ```bash
+   git log --format="%H %s" <parent>..<branch>
+   ```
+
+4. Classify each commit:
+
+   - **Cleanup/noise**: starts with the autosquash markers **fixup!** or **squash!**; case-insensitive match on `wip`, `tmp`, `temp`, `fix`, `oops`, `typo`, `lint`, `fmt`, `cleanup`, `nit`, `tweak`; contains phrases like `fix typo`, `address review`, `review feedback`, `lint fix`, `formatting`; or any single-word message under 10 characters.
+   - **Meaningful**: matches Conventional Commits (`type(scope): desc`), is the first commit on the branch, or has a descriptive message over 15 characters that does not match cleanup patterns.
+
+5. Pick a per-branch strategy:
+
+   | Branch state | Strategy |
+   |---|---|
+   | 0 or 1 commits | skip |
+   | 1 meaningful + only noise | squash, keep the meaningful message |
+   | 0 meaningful, all noise | squash, keep oldest message |
+   | 2+ meaningful commits | leave for manual review |
+
+6. Show the user the full plan: per branch, the commits with classification, the proposed action, and the message that will land.
+
+7. Wait for explicit user approval before any squash. If the user asks to review one branch at a time, confirm each before squashing.
+
+8. Execute bottom-up (closest to trunk first). For each squash branch:
+
+   ```bash
+   stackit checkout <branch> --no-interactive
+   stackit squash --no-edit --no-interactive
+   ```
+
+   When a meaningful message should replace the existing one:
+
+   ```bash
+   printf '%s\n' "<meaningful message>" | stackit squash -F - --no-interactive
+   ```
+
+9. Verify:
+
+   ```bash
+   stackit log --no-interactive
+   ```
+
+## Do Not
+
+- Squash a branch the user has not approved.
+- Squash branches with only one commit.
+- Process top-down — children before parents corrupts ancestry.
+- Modify branches flagged for manual review.
+- Use `git rebase -i`; use `stackit squash`.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-verify.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-verify.md
@@ -1,0 +1,32 @@
+---
+description: Use when the user wants to run a build or test command across every branch in the stack. Trigger phrases include "verify each branch", "check every branch builds", and "run tests on the whole stack".
+---
+
+# Stack Verify
+
+Run verification across stack branches.
+
+## Workflow
+
+1. Inspect:
+
+   ```bash
+   stackit log --no-interactive
+   git status --short
+   ```
+
+2. Determine check command from user input, project docs, or common files. Prefer `mise run check` when available.
+
+3. Run across the current stack:
+
+   ```bash
+   stackit foreach --stack "<check-command>"
+   ```
+
+   For current branch and descendants:
+
+   ```bash
+   stackit foreach --upstack "<check-command>"
+   ```
+
+4. Report the first failing branch and relevant output. If all pass, report that clearly.

--- a/internal/cli/integrations/agents/templates/codex/skill/SKILL.md
+++ b/internal/cli/integrations/agents/templates/codex/skill/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: stackit
+description: Shared guidance for Stackit stacked-branch workflows. Use when the request mentions stacks, stacking, stacked PRs, or Stackit-specific operations and needs general Stackit policy, workflow safety rules, or a stack health check.
+---
+
+# Stackit
+
+Stackit manages stacked Git branches: small dependent PRs instead of one large review. Use this skill for shared policy and orientation; use the narrower `stack-*` skills for specific operations.
+
+## Always
+
+- Pass `--no-interactive` on Stackit commands. Add `--force` for absorb and `--yes` for undo/merge when those commands otherwise prompt.
+- Stage changes before `stackit create`.
+- Pipe commit messages via `-F -`: `printf '%s\n' "feat: x" | stackit create -F - --no-interactive`.
+- After any mutation, run `stackit log --no-interactive` and report the resulting stack.
+
+## Asking Policy
+
+Act without asking on local reversible operations: create, modify, absorb, restack of one stack, log, and status.
+
+Confirm before remote-affecting or destructive operations: submit, merge, restack of all stacks, anything that pushes, and anything that touches GitHub PRs.
+
+If there is no work to act on, say so and stop.
+
+## Health Check
+
+Run once at the start of a Stackit-related session:
+
+```bash
+stackit log --json --no-interactive
+```
+
+Surface failing CI, branches ready to merge, and branches needing restack when relevant.
+
+## Skill Selection
+
+| User wording | Best skill |
+|---|---|
+| "stack these changes", "make a stacked branch", "commit with stackit" | `stack-create` |
+| "split this", "plan a stack", "break this into PRs" | `stack-plan` |
+| "amend", "fix the current commit" | `stack-modify` |
+| "absorb", "distribute fixes", "amend across the stack" | `stack-absorb` |
+| "submit", "open PRs", "send for review" | `stack-submit` |
+| "sync", "pull trunk", "clean up merged" | `stack-sync` |
+| "restack", "rebase the stack" | `stack-restack` |
+| "show the stack", "stack status" | `stack-status` |
+| "stack is broken", "fix the stack" | `stack-fix` |
+| "fold this branch", "squash into parent" | `stack-fold` |
+| "tidy fixups", "clean up WIP commits" | `stack-tidy` |
+| "split this commit", "move files to a new branch" | `stack-split` |
+| "extract this", "move to its own branch off main" | `stack-extract` |
+| "resolve conflicts", "continue rebase" | `stack-resolve` |
+| "describe the stack", "generate PR descriptions" | `stack-describe` |
+| "review the stack", "find PR issues" | `stack-review` |
+| "verify each branch", "test the whole stack" | `stack-verify` |
+
+When wording is ambiguous between `stack-create` and `stack-plan`, prefer `stack-create` unless the changes obviously span unrelated subsystems.
+
+## Forbidden
+
+| Do not use | Use instead |
+|---|---|
+| `git commit` for a new stacked branch | `stackit create` |
+| `git checkout -b` | `stackit create` |
+| `gh pr create` | `stackit submit` |
+| `git rebase` | `stackit restack --upstack` or `stackit restack --all-stacks` |
+
+`git commit` is fine for follow-up commits on an existing stacked branch.
+
+## References
+
+- [references/workflows.md](references/workflows.md) - common Stackit workflows
+- [references/commit-style.md](references/commit-style.md) - commit and PR message style
+- [references/stack-plan-recovery.md](references/stack-plan-recovery.md) - recovering from a partial `stack-plan` run
+
+<!-- stackit-version: {{VERSION}} -->

--- a/internal/cli/integrations/agents/templates/codex/skill/agents/openai.yaml
+++ b/internal/cli/integrations/agents/templates/codex/skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Stackit"
+  short_description: "Manage stacked Git branches"
+  default_prompt: "Use $stackit to inspect my current stack and recommend the right Stackit workflow."

--- a/internal/cli/integrations/agents/templates/codex/skill/references/commit-style.md
+++ b/internal/cli/integrations/agents/templates/codex/skill/references/commit-style.md
@@ -1,0 +1,41 @@
+# Commit And PR Style
+
+Read `README.md`, `CONTRIBUTING.md`, and recent `git log --oneline` output before choosing a message.
+
+## Commit Messages
+
+Default to Conventional Commits: `<type>: <description>`.
+
+Common types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`.
+
+```text
+feat(auth): implement JWT authentication
+
+Add login endpoint and token validation middleware.
+```
+
+If the project does not document a format, write a clear subject line, a blank line, then a short explanation of why the change exists.
+
+Pipe messages through stdin:
+
+```bash
+printf '%s\n' "feat: add x" | stackit create -F - --no-interactive
+```
+
+## PR Descriptions
+
+Follow `.github/pull_request_template.md` when present. Otherwise:
+
+```markdown
+## Summary
+- What changed
+
+## Test Plan
+- Command or manual verification performed
+```
+
+Avoid placeholder titles or bodies.
+
+## Branch Names
+
+Let Stackit auto-generate branch names from commit messages unless the user requested a branch name or config requires one.

--- a/internal/cli/integrations/agents/templates/codex/skill/references/stack-plan-recovery.md
+++ b/internal/cli/integrations/agents/templates/codex/skill/references/stack-plan-recovery.md
@@ -1,0 +1,44 @@
+# Stack Plan Recovery
+
+`stack-plan` creates a backup branch before splitting changes. The backup is deleted only after all planned branches are created and verified.
+
+## Partial Run State
+
+A partial run may leave:
+
+- A branch named `stack-plan-backup-<timestamp>` with all original changes.
+- Some created stacked branches.
+- The original branch with an empty or partial working tree.
+
+## Start Over
+
+```bash
+git checkout stack-plan-backup-<timestamp>
+git checkout -B <original-branch>
+git reset --hard stack-plan-backup-<timestamp>
+```
+
+Then delete partial stacked branches newest-first with:
+
+```bash
+stackit undo --no-interactive --yes
+```
+
+## Continue From The Last Successful Branch
+
+```bash
+stackit log --no-interactive
+git checkout stack-plan-backup-<timestamp>
+git diff <last-created-branch>..stack-plan-backup-<timestamp> --stat
+git checkout <last-created-branch>
+git checkout stack-plan-backup-<timestamp> -- <files-for-next-branch>
+printf '%s\n' "<commit message>" | stackit create -F - <next-branch> --no-interactive
+```
+
+## Clean Up
+
+Only after confirming every intended change is in the stack:
+
+```bash
+git branch -D stack-plan-backup-<timestamp>
+```

--- a/internal/cli/integrations/agents/templates/codex/skill/references/workflows.md
+++ b/internal/cli/integrations/agents/templates/codex/skill/references/workflows.md
@@ -1,0 +1,55 @@
+# Stackit Workflows Reference
+
+These notes support the narrow Codex skills. Prefer the narrow skill body when it contains more specific instructions.
+
+## Create A Stacked Branch
+
+```bash
+git add -A
+printf '%s\n' "feat: add auth middleware" | stackit create -F - --no-interactive
+stackit log --no-interactive
+```
+
+With an explicit branch name:
+
+```bash
+printf '%s\n' "feat: add auth middleware" | stackit create -F - my-branch --no-interactive
+```
+
+If branch config requires a scope, retry with `--scope <value>`.
+
+## Add Work To An Existing Branch
+
+- Follow-up commit: `git add -A` then `git commit -m "..."`
+- Amend latest commit: `stackit modify --no-interactive`
+- Distribute fixes through the stack: `stackit absorb --force --no-interactive`
+
+Use another stacked branch when the work is a separate reviewable unit.
+
+## Submit PRs
+
+```bash
+stackit log --no-interactive
+stackit submit --no-interactive
+stackit submit --stack --no-interactive
+stackit submit --draft --no-interactive
+```
+
+## Sync And Restack
+
+```bash
+stackit sync --no-interactive
+stackit restack --branch <root> --upstack --no-interactive
+```
+
+Use `stackit restack --all-stacks --continue-on-conflict --no-interactive` only when the user asked for all stacks.
+
+## Recovery
+
+| Symptom | Action |
+|---|---|
+| Rebase conflicts | Resolve files, then `stackit continue --no-interactive` |
+| Absorb conflict | `stackit absorb --show-conflict --no-interactive` |
+| Abort in-progress operation | `stackit abort --no-interactive` |
+| Undo last Stackit command | `stackit undo --no-interactive --yes` |
+| Partial `stack-plan` backup exists | See [stack-plan-recovery.md](stack-plan-recovery.md) |

--- a/internal/cli/integrations/agents_install.go
+++ b/internal/cli/integrations/agents_install.go
@@ -43,6 +43,8 @@ type existingSkillInstallation struct {
 var (
 	skillRootFiles = []string{"SKILL.md", "reference.md"}
 
+	codexSkillRootFiles = []string{"SKILL.md"}
+
 	skillCommandFiles = []string{"navigation.md", "branch.md", "stack.md", "recovery.md"}
 
 	skillWorkflowFiles = []string{"absorb-conflict.md", "conflict-resolution.md", "fix-absorb.md", "stack-fold.md"}
@@ -50,6 +52,8 @@ var (
 	skillScriptFiles = []string{"analyze_stack.sh"}
 
 	subagentFiles = []string{"commit-message.md", "review-triage.md"}
+
+	codexReferenceFiles = []string{"workflows.md", "commit-style.md", "stack-plan-recovery.md"}
 
 	commandTemplateFiles = []string{
 		"stack-absorb.md", "stack-create.md", "stack-describe.md", "stack-extract.md",
@@ -80,7 +84,7 @@ func installTargetForFormat(format agentSkillFormat) agentInstallTarget {
 }
 
 func buildAgentFileGroups(target agentInstallTarget) []fileGroup {
-	return buildSkillFileGroups(target.skillDir, target.includeAgentsMeta)
+	return buildSkillFileGroups(target.skillDir, target.format, target.includeAgentsMeta)
 }
 
 func resolveInstallBaseDir() (string, error) {
@@ -91,7 +95,33 @@ func resolveInstallBaseDir() (string, error) {
 	return homeDir, nil
 }
 
-func buildSkillFileGroups(skillDir string, includeAgentsMetadata bool) []fileGroup {
+func buildSkillFileGroups(skillDir string, format agentSkillFormat, includeAgentsMetadata bool) []fileGroup {
+	if format == agentSkillFormatCodex {
+		groups := []fileGroup{
+			{
+				templateDir: "agents/templates/codex/skill",
+				destDir:     skillDir,
+				files:       codexSkillRootFiles,
+				replaceVer:  true,
+			},
+			{
+				templateDir: "agents/templates/codex/skill/references",
+				destDir:     filepath.Join(skillDir, "references"),
+				files:       codexReferenceFiles,
+			},
+		}
+
+		if includeAgentsMetadata {
+			groups = append(groups, fileGroup{
+				templateDir: "agents/templates/codex/skill/agents",
+				destDir:     filepath.Join(skillDir, "agents"),
+				files:       []string{"openai.yaml"},
+			})
+		}
+
+		return groups
+	}
+
 	groups := []fileGroup{
 		{
 			templateDir: "agents/templates/skill",
@@ -120,14 +150,6 @@ func buildSkillFileGroups(skillDir string, includeAgentsMetadata bool) []fileGro
 			destDir:     filepath.Join(skillDir, "subagents"),
 			files:       subagentFiles,
 		},
-	}
-
-	if includeAgentsMetadata {
-		groups = append(groups, fileGroup{
-			templateDir: "agents/templates/skill/agents",
-			destDir:     filepath.Join(skillDir, "agents"),
-			files:       []string{"openai.yaml"},
-		})
 	}
 
 	return groups
@@ -170,11 +192,18 @@ type skillRenderFunc func(content []byte, skillName string) ([]byte, error)
 
 const commandTemplateDir = "agents/templates/commands"
 
+func commandTemplateDirForFormat(format agentSkillFormat) string {
+	if format == agentSkillFormatCodex {
+		return "agents/templates/codex/commands"
+	}
+	return commandTemplateDir
+}
+
 // installCommandSkills installs command templates as individual skills using the given render function.
-func installCommandSkills(baseDir, skillsBaseDir string, files []string, render skillRenderFunc) error {
+func installCommandSkills(baseDir, skillsBaseDir string, files []string, render skillRenderFunc, format agentSkillFormat) error {
 	for _, filename := range files {
 		skillName := strings.TrimSuffix(filename, ".md")
-		content, err := agentTemplates.ReadFile(commandTemplateDir + "/" + filename)
+		content, err := agentTemplates.ReadFile(commandTemplateDirForFormat(format) + "/" + filename)
 		if err != nil {
 			return fmt.Errorf("failed to read template %s: %w", filename, err)
 		}
@@ -191,8 +220,74 @@ func installCommandSkills(baseDir, skillsBaseDir string, files []string, render 
 		if err := os.WriteFile(filepath.Join(destDir, "SKILL.md"), content, 0600); err != nil {
 			return fmt.Errorf("failed to write SKILL.md for %s: %w", skillName, err)
 		}
+		if format == agentSkillFormatCodex {
+			metadata, err := renderCodexCommandMetadata(skillName)
+			if err != nil {
+				return err
+			}
+			agentsDir := filepath.Join(destDir, "agents")
+			if err := os.MkdirAll(agentsDir, 0750); err != nil {
+				return fmt.Errorf("failed to create agents directory for %s: %w", skillName, err)
+			}
+			if err := os.WriteFile(filepath.Join(agentsDir, "openai.yaml"), metadata, 0600); err != nil {
+				return fmt.Errorf("failed to write openai.yaml for %s: %w", skillName, err)
+			}
+		}
 	}
 	return nil
+}
+
+func renderCodexCommandMetadata(skillName string) ([]byte, error) {
+	summary, found := stackSkillSummaryForName(skillName)
+	if !found {
+		return nil, fmt.Errorf("missing skill summary for %s", skillName)
+	}
+
+	var b strings.Builder
+	b.WriteString("interface:\n")
+	b.WriteString("  display_name: ")
+	b.WriteString(encodeYAMLScalar(displayNameForSkill(skillName)))
+	b.WriteString("\n")
+	b.WriteString("  short_description: ")
+	b.WriteString(encodeYAMLScalar(summary.description))
+	b.WriteString("\n")
+	b.WriteString("  default_prompt: ")
+	b.WriteString(encodeYAMLScalar(fmt.Sprintf("Use $%s to %s.", skillName, lowercaseFirst(summary.description))))
+	b.WriteString("\n")
+	return []byte(b.String()), nil
+}
+
+func stackSkillSummaryForName(name string) (struct {
+	name        string
+	description string
+}, bool) {
+	for _, summary := range stackSkillSummaries {
+		if summary.name == name {
+			return summary, true
+		}
+	}
+	return struct {
+		name        string
+		description string
+	}{}, false
+}
+
+func displayNameForSkill(name string) string {
+	parts := strings.Split(name, "-")
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + part[1:]
+	}
+	return strings.Join(parts, " ")
+}
+
+func lowercaseFirst(raw string) string {
+	if raw == "" {
+		return raw
+	}
+	return strings.ToLower(raw[:1]) + raw[1:]
 }
 
 // parseFrontmatter splits content into frontmatter lines and body, injecting the skill name.
@@ -253,22 +348,25 @@ func renderClaudeSkillContent(content []byte, name string) ([]byte, error) {
 }
 
 func renderCodexSkillContent(content []byte, name string) ([]byte, error) {
-	frontmatterLines, body, argumentHint, err := parseFrontmatter(content, name)
+	frontmatterLines, body, _, err := parseFrontmatter(content, name)
 	if err != nil {
 		return nil, err
 	}
 
-	// Codex replaces $ARGUMENTS in the body instead of keeping argument-hint in frontmatter.
-	bodyText := string(body)
-	if strings.Contains(bodyText, "$ARGUMENTS") {
-		replacement := "If the user included explicit arguments in their request, honor them."
-		if argumentHint != "" {
-			replacement += fmt.Sprintf(" Expected argument shape: `%s`.", argumentHint)
-		}
-		bodyText = strings.Replace(bodyText, "$ARGUMENTS", replacement, 1)
+	frontmatterBlock := strings.Join(frontmatterLines, "\n")
+	var meta map[string]any
+	if err := yaml.Unmarshal([]byte(frontmatterBlock), &meta); err != nil {
+		return nil, fmt.Errorf("invalid source frontmatter: %w", err)
+	}
+	description, ok := meta["description"].(string)
+	if !ok || strings.TrimSpace(description) == "" {
+		return nil, fmt.Errorf("missing description in frontmatter")
 	}
 
-	return assembleFrontmatter(frontmatterLines, []byte(bodyText))
+	return assembleFrontmatter([]string{
+		"name: " + name,
+		"description: " + encodeYAMLScalar(description),
+	}, body)
 }
 
 func encodeYAMLScalar(raw string) string {
@@ -312,25 +410,41 @@ func splitFrontmatter(content []byte) (frontmatter, body []byte, found bool) {
 }
 
 func extractVersion(content string) string {
-	// Look for version in frontmatter
 	lines := strings.Split(content, "\n")
-	inFrontmatter := false
+	bodyStart := len(lines)
 
-	for _, line := range lines {
-		if strings.TrimSpace(line) == "---" {
-			if !inFrontmatter {
-				inFrontmatter = true
-				continue
+	// Walk frontmatter watching for `version:` (Claude format) and stop at the
+	// closing `---`. Restricting the body search below to lines after this
+	// boundary keeps a stray "version" token in the description from matching.
+	if len(lines) > 0 && strings.TrimSpace(lines[0]) == "---" {
+		for i := 1; i < len(lines); i++ {
+			if strings.TrimSpace(lines[i]) == "---" {
+				bodyStart = i + 1
+				break
 			}
-			break
+			if strings.HasPrefix(lines[i], "version:") {
+				parts := strings.SplitN(lines[i], ":", 2)
+				if len(parts) == 2 {
+					return strings.TrimSpace(parts[1])
+				}
+			}
 		}
+	} else {
+		bodyStart = 0
+	}
 
-		if inFrontmatter && strings.HasPrefix(line, "version:") {
-			parts := strings.SplitN(line, ":", 2)
-			if len(parts) == 2 {
-				return strings.TrimSpace(parts[1])
-			}
+	// Codex skills keep frontmatter limited to name/description, so the version
+	// is embedded in an HTML comment in the body: `<!-- stackit-version: X -->`.
+	// HTML comments don't render to the agent and survive markdown processors.
+	const prefix = "<!-- stackit-version:"
+	const suffix = "-->"
+	for _, line := range lines[bodyStart:] {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, prefix) || !strings.HasSuffix(trimmed, suffix) {
+			continue
 		}
+		value := strings.TrimSuffix(strings.TrimPrefix(trimmed, prefix), suffix)
+		return strings.TrimSpace(value)
 	}
 
 	return ""

--- a/internal/cli/integrations/agents_prompts.go
+++ b/internal/cli/integrations/agents_prompts.go
@@ -33,7 +33,7 @@ func selectInstallTargets(baseDir string, formats []string) ([]agentInstallTarge
 		hasCodexDir,
 	}
 	if !hasClaudeDir && !hasCodexDir {
-		preSelected = []bool{true, false}
+		preSelected = []bool{true, true}
 	}
 
 	selected, err := promptMultiSelectWithDefault(

--- a/internal/cli/integrations/agents_templates.go
+++ b/internal/cli/integrations/agents_templates.go
@@ -7,5 +7,5 @@ import "embed"
 // Kept for backward compatibility but should not be referenced.
 var TemplateVersion = "dev"
 
-//go:embed agents/templates/skill/*.md agents/templates/skill/agents/*.yaml agents/templates/skill/commands/*.md agents/templates/skill/workflows/*.md agents/templates/skill/scripts/*.sh agents/templates/commands/*.md agents/templates/subagents/*.md agents/templates/agents-block.md
+//go:embed agents/templates/skill/*.md agents/templates/skill/agents/*.yaml agents/templates/skill/commands/*.md agents/templates/skill/workflows/*.md agents/templates/skill/scripts/*.sh agents/templates/commands/*.md agents/templates/subagents/*.md agents/templates/agents-block.md agents/templates/codex/skill/*.md agents/templates/codex/skill/agents/*.yaml agents/templates/codex/skill/references/*.md agents/templates/codex/commands/*.md
 var agentTemplates embed.FS

--- a/internal/cli/integrations/agents_test.go
+++ b/internal/cli/integrations/agents_test.go
@@ -390,7 +390,7 @@ func TestSelectInstallTargetsPromptsWithoutSkipOption(t *testing.T) {
 			"Claude Code - Claude Code CLI skill format (~/.claude/skills/stackit)",
 			"Codex - Codex skill format (~/.codex/skills/stackit)",
 		}, options)
-		require.Equal(t, []bool{true, false}, preSelected)
+		require.Equal(t, []bool{true, true}, preSelected)
 		return []string{options[0]}, nil
 	}
 
@@ -412,13 +412,33 @@ func TestBuildAgentFileGroups(t *testing.T) {
 		var found bool
 		for _, g := range groups {
 			if g.destDir == filepath.Join(".codex", "skills", "stackit", "agents") {
-				require.Equal(t, "agents/templates/skill/agents", g.templateDir)
+				require.Equal(t, "agents/templates/codex/skill/agents", g.templateDir)
 				require.Equal(t, []string{"openai.yaml"}, g.files)
 				found = true
 				break
 			}
 		}
 		require.True(t, found)
+	})
+
+	t.Run("codex uses dedicated template root", func(t *testing.T) {
+		t.Parallel()
+		target := installTargetForFormat(agentSkillFormatCodex)
+		groups := buildAgentFileGroups(target)
+
+		require.NotEmpty(t, groups)
+		require.Equal(t, "agents/templates/codex/skill", groups[0].templateDir)
+		require.Equal(t, []string{"SKILL.md"}, groups[0].files)
+	})
+
+	t.Run("codex does not install shared claude scripts", func(t *testing.T) {
+		t.Parallel()
+		target := installTargetForFormat(agentSkillFormatCodex)
+		groups := buildAgentFileGroups(target)
+
+		for _, g := range groups {
+			require.NotEqual(t, filepath.Join(".codex", "skills", "stackit", "scripts"), g.destDir)
+		}
 	})
 
 	t.Run("claude does not include commands file group", func(t *testing.T) {
@@ -484,6 +504,21 @@ func TestCheckExistingInstallation(t *testing.T) {
 		err := os.MkdirAll(filepath.Dir(skillPath), 0750)
 		require.NoError(t, err)
 		err = os.WriteFile(skillPath, []byte(testSkillContent("2.0.0")), 0600)
+		require.NoError(t, err)
+
+		var out bytes.Buffer
+		err = checkExistingInstallation(tmpDir, agentSkillFormatCodex, "2.0.0", &out)
+		require.NoError(t, err)
+		require.Empty(t, out.String())
+	})
+
+	t.Run("detects codex body version", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		skillPath := filepath.Join(tmpDir, ".codex", "skills", "stackit", "SKILL.md")
+		err := os.MkdirAll(filepath.Dir(skillPath), 0750)
+		require.NoError(t, err)
+		err = os.WriteFile(skillPath, []byte("---\nname: stackit\ndescription: test\n---\n\n<!-- stackit-version: 2.0.0 -->\n"), 0600)
 		require.NoError(t, err)
 
 		var out bytes.Buffer
@@ -660,6 +695,10 @@ func TestPrintSuccessMessageIncludesCodex(t *testing.T) {
 	require.Contains(t, out.String(), "Installed agent files")
 	require.Contains(t, out.String(), "~/.codex/skills/stackit")
 	require.Contains(t, out.String(), ".codex/skills/stack-*/")
+	require.Contains(t, out.String(), "Available Codex skills:")
+	require.Contains(t, out.String(), "stack-create")
+	require.NotContains(t, out.String(), "Available Claude Code commands:")
+	require.NotContains(t, out.String(), "/stack-create")
 	require.NotContains(t, out.String(), "Slash commands:")
 }
 
@@ -829,32 +868,18 @@ func TestRenderCodexSkillContent(t *testing.T) {
 		assert  func(t *testing.T, result string)
 	}{
 		{
-			name:    "injects name and preserves supported frontmatter",
-			content: "---\ndescription: Do stuff\nmodel: sonnet\nallowed-tools: Bash(stackit:*)\n---\n\n# Content",
+			name:    "injects name and keeps codex frontmatter minimal",
+			content: "---\ndescription: Use for Codex\nallowed-tools: Bash(stackit:*), Bash(git:*)\n---\n\n# Body",
 			skill:   "stack-create",
 			assert: func(t *testing.T, result string) {
 				frontmatter, body := mustExtractFrontmatter(t, result)
 				var meta map[string]any
 				require.NoError(t, yaml.Unmarshal([]byte(frontmatter), &meta))
 				require.Equal(t, "stack-create", meta["name"])
-				require.Equal(t, "Do stuff", meta["description"])
-				require.Equal(t, "sonnet", meta["model"])
-				require.Equal(t, "Bash(stackit:*)", meta["allowed-tools"])
-				require.Equal(t, "\n# Content", body)
-			},
-		},
-		{
-			name:    "removes argument hint and rewrites arguments placeholder",
-			content: "---\ndescription: Test\nmodel: sonnet\nargument-hint: [-m \"message\"] [branch-name]\nallowed-tools: Bash\n---\n\n## Arguments\n$ARGUMENTS\n\nBody",
-			skill:   "stack-modify",
-			assert: func(t *testing.T, result string) {
-				frontmatter, body := mustExtractFrontmatter(t, result)
-				require.NotContains(t, frontmatter, "argument-hint:")
-				var meta map[string]any
-				require.NoError(t, yaml.Unmarshal([]byte(frontmatter), &meta))
-				require.Equal(t, "stack-modify", meta["name"])
-				require.Contains(t, body, "Expected argument shape: `[-m \"message\"] [branch-name]`.")
-				require.NotContains(t, body, "$ARGUMENTS")
+				require.Equal(t, "Use for Codex", meta["description"])
+				require.Len(t, meta, 2)
+				require.NotContains(t, frontmatter, "allowed-tools:")
+				require.Equal(t, "\n# Body", body)
 			},
 		},
 		{
@@ -883,7 +908,7 @@ func TestInstallClaudeSkillsMatchTemplates(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	require.NoError(t, installCommandSkills(tmpDir, filepath.Join(".claude", "skills"), commandTemplateFiles, renderClaudeSkillContent))
+	require.NoError(t, installCommandSkills(tmpDir, filepath.Join(".claude", "skills"), commandTemplateFiles, renderClaudeSkillContent, agentSkillFormatClaude))
 
 	for _, filename := range commandTemplateFiles {
 		expectedTemplate, err := agentTemplates.ReadFile("agents/templates/commands/" + filename)
@@ -915,7 +940,7 @@ func TestInstallCodexCommandSkills(t *testing.T) {
 	files := []string{"stack-create.md", "stack-fix.md", "stack-modify.md"}
 	tmpDir := t.TempDir()
 
-	err := installCommandSkills(tmpDir, filepath.Join(".codex", "skills"), files, renderCodexSkillContent)
+	err := installCommandSkills(tmpDir, filepath.Join(".codex", "skills"), files, renderCodexSkillContent, agentSkillFormatCodex)
 	require.NoError(t, err)
 
 	for _, filename := range files {
@@ -930,8 +955,193 @@ func TestInstallCodexCommandSkills(t *testing.T) {
 		require.NoError(t, yaml.Unmarshal([]byte(frontmatter), &meta))
 		require.Equal(t, skillName, meta["name"])
 		require.Contains(t, frontmatter, "description:")
+		require.Len(t, meta, 2)
 		require.NotContains(t, frontmatter, "argument-hint:")
+		require.NotContains(t, frontmatter, "allowed-tools:")
+		require.NotContains(t, frontmatter, "model:")
 		require.NotContains(t, body, "$ARGUMENTS")
+
+		metadataPath := filepath.Join(tmpDir, ".codex", "skills", skillName, "agents", "openai.yaml")
+		metadata, err := os.ReadFile(metadataPath)
+		require.NoError(t, err, "openai.yaml should exist for %s", skillName)
+		var openaiMeta map[string]map[string]string
+		require.NoError(t, yaml.Unmarshal(metadata, &openaiMeta))
+		require.Equal(t, displayNameForSkill(skillName), openaiMeta["interface"]["display_name"])
+		require.Contains(t, openaiMeta["interface"]["default_prompt"], "$"+skillName)
+	}
+}
+
+func TestRenderCodexCommandMetadata(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := renderCodexCommandMetadata("stack-create")
+	require.NoError(t, err)
+
+	var parsed map[string]map[string]string
+	require.NoError(t, yaml.Unmarshal(metadata, &parsed))
+	require.Equal(t, "Stack Create", parsed["interface"]["display_name"])
+	require.Equal(t, "Create branch with auto-naming", parsed["interface"]["short_description"])
+	require.Equal(t, "Use $stack-create to create branch with auto-naming.", parsed["interface"]["default_prompt"])
+}
+
+func TestCodexUsesParallelCommandTemplate(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	err := installCommandSkills(tmpDir, filepath.Join(".codex", "skills"), []string{"stack-create.md"}, renderCodexSkillContent, agentSkillFormatCodex)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(tmpDir, ".codex", "skills", "stack-create", "SKILL.md"))
+	require.NoError(t, err)
+
+	frontmatter, body := mustExtractFrontmatter(t, string(content))
+
+	require.Contains(t, body, "Create one new stacked branch from the current working tree.")
+	require.NotContains(t, body, "Create a new stacked branch with the current changes.")
+	require.NotContains(t, body, "AskUserQuestion")
+
+	var meta map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(frontmatter), &meta))
+	require.Equal(t, "stack-create", meta["name"])
+	require.Contains(t, meta["description"], "stack these changes")
+}
+
+func TestCodexStackPlanReferenceLink(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	err := installCommandSkills(tmpDir, filepath.Join(".codex", "skills"), []string{"stack-plan.md"}, renderCodexSkillContent, agentSkillFormatCodex)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(tmpDir, ".codex", "skills", "stack-plan", "SKILL.md"))
+	require.NoError(t, err)
+
+	_, body := mustExtractFrontmatter(t, string(content))
+	require.Contains(t, body, "../stackit/references/stack-plan-recovery.md")
+	require.NotContains(t, body, "../skill/references/stack-plan-recovery.md")
+}
+
+func TestCodexInstallHasNoClaudeIsms(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	target := installTargetForFormat(agentSkillFormatCodex)
+	for _, g := range buildAgentFileGroups(target) {
+		require.NoError(t, installFileGroup(tmpDir, g, "test"))
+	}
+	require.NoError(t, installCommandSkills(tmpDir, target.skillsBaseDir, commandTemplateFiles, renderCodexSkillContent, agentSkillFormatCodex))
+
+	bannedSubstrings := []struct {
+		needle string
+		reason string
+	}{
+		{"AskUserQuestion", "Codex doesn't have AskUserQuestion — it's a Claude-only tool"},
+		{"!`", "Claude shell-context macros must not leak into Codex output"},
+		{"Claude Code", "Codex output must not describe itself as Claude Code"},
+		{"~/.claude/skills", "Codex output must not reference ~/.claude paths"},
+		{" using the Skill tool", "Skill tool prose must be rewritten for Codex"},
+		{" using Skill tool", "Skill tool prose must be rewritten for Codex"},
+	}
+
+	codexRoot := filepath.Join(tmpDir, ".codex")
+	err := filepath.Walk(codexRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		require.NoError(t, err)
+
+		body := string(content)
+		if strings.HasSuffix(path, ".md") {
+			// Frontmatter `model:` line must not survive in Codex output.
+			// (Match `^model:` or after newline to avoid matching e.g. "data model:" prose.)
+			require.NotRegexp(t, `(?m)^model:`, body, "model: line found in %s", path)
+			require.NotRegexp(t, `(?m)^allowed-tools:`, body, "allowed-tools line found in %s", path)
+			require.NotContains(t, body, "`/stack-", "Markdown slash-command reference found in %s", path)
+			require.NotRegexp(t, `(^|[\s(])/(stack-[a-z-]+)`, body, "plain slash-command reference found in %s", path)
+
+			if strings.HasPrefix(body, "---\n") {
+				frontmatter, _ := mustExtractFrontmatter(t, body)
+				var meta map[string]any
+				require.NoError(t, yaml.Unmarshal([]byte(frontmatter), &meta))
+				require.Len(t, meta, 2, "Codex frontmatter should only include name and description in %s", path)
+				require.Contains(t, meta, "name", "missing name in %s", path)
+				require.Contains(t, meta, "description", "missing description in %s", path)
+			}
+		}
+
+		for _, b := range bannedSubstrings {
+			require.NotContains(t, body, b.needle, "%s in %s — %s", b.needle, path, b.reason)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestCodexSourceTemplatesAreNative(t *testing.T) {
+	t.Parallel()
+
+	err := filepath.Walk(filepath.Join("agents", "templates", "codex"), func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+		isRootSkill := strings.HasSuffix(path, filepath.Join("skill", "SKILL.md"))
+		isCommandTemplate := strings.Contains(path, filepath.Join("codex", "commands")+string(os.PathSeparator))
+		if !isRootSkill && !isCommandTemplate {
+			return nil
+		}
+
+		content, err := os.ReadFile(path)
+		require.NoError(t, err)
+		frontmatter, _ := mustExtractFrontmatter(t, string(content))
+
+		var meta map[string]any
+		require.NoError(t, yaml.Unmarshal([]byte(frontmatter), &meta))
+		require.Contains(t, meta, "description", "missing description in %s", path)
+		require.NotContains(t, meta, "allowed-tools", "Codex source template should not include allowed-tools in %s", path)
+		require.NotContains(t, meta, "model", "Codex source template should not include model in %s", path)
+		require.NotContains(t, meta, "argument-hint", "Codex source template should not include argument-hint in %s", path)
+		require.NotContains(t, meta, "version", "Codex source template should not include version in %s", path)
+
+		if isRootSkill {
+			require.Equal(t, "stackit", meta["name"])
+			require.Len(t, meta, 2, "Codex root skill should only include name and description")
+		} else {
+			require.NotContains(t, meta, "name", "Codex command source names are injected during install in %s", path)
+			require.Len(t, meta, 1, "Codex command sources should only include description in %s", path)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestClaudeInstallUnchangedAfterCodexRefactor(t *testing.T) {
+	t.Parallel()
+
+	// Sanity: a Claude install should still produce per-command SKILL.md files
+	// whose body is byte-identical to the shared template body. This guards
+	// against Codex's parallel template path leaking into the Claude path.
+	tmpDir := t.TempDir()
+	require.NoError(t, installCommandSkills(tmpDir, filepath.Join(".claude", "skills"), commandTemplateFiles, renderClaudeSkillContent, agentSkillFormatClaude))
+
+	for _, filename := range commandTemplateFiles {
+		expectedTemplate, err := agentTemplates.ReadFile("agents/templates/commands/" + filename)
+		require.NoError(t, err)
+
+		skillName := strings.TrimSuffix(filename, ".md")
+		installed, err := os.ReadFile(filepath.Join(tmpDir, ".claude", "skills", skillName, "SKILL.md"))
+		require.NoError(t, err)
+
+		_, expectedBody := mustExtractFrontmatter(t, string(expectedTemplate))
+		_, actualBody := mustExtractFrontmatter(t, string(installed))
+		require.Equal(t, expectedBody, actualBody, "Claude body changed for %s", filename)
 	}
 }
 

--- a/internal/cli/integrations/install.go
+++ b/internal/cli/integrations/install.go
@@ -51,11 +51,11 @@ func InstallAgents(runner git.Runner, force bool, version string, out io.Writer)
 }
 
 // autoDetectFormats returns format flags based on which agent directories exist,
-// defaulting to claude if none are found.
+// defaulting to both first-class formats if none are found.
 func autoDetectFormats() []string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return []string{"claude"}
+		return []string{"claude", "codex"}
 	}
 
 	var formats []string
@@ -66,7 +66,7 @@ func autoDetectFormats() []string {
 		formats = append(formats, "codex")
 	}
 	if len(formats) == 0 {
-		formats = []string{"claude"}
+		formats = []string{"claude", "codex"}
 	}
 	return formats
 }

--- a/internal/cli/integrations/install_test.go
+++ b/internal/cli/integrations/install_test.go
@@ -57,9 +57,9 @@ func TestIsAgentsInstalled(t *testing.T) {
 
 // Not parallel: subtests use t.Setenv.
 func TestAutoDetectFormats(t *testing.T) {
-	t.Run("defaults to claude when no dirs exist", func(t *testing.T) {
+	t.Run("defaults to both formats when no dirs exist", func(t *testing.T) {
 		t.Setenv("HOME", t.TempDir())
-		require.Equal(t, []string{"claude"}, autoDetectFormats())
+		require.Equal(t, []string{"claude", "codex"}, autoDetectFormats())
 	})
 
 	t.Run("detects both dirs", func(t *testing.T) {


### PR DESCRIPTION

Codex skills (~/.codex/skills/) shipped today as Claude templates with
$ARGUMENTS replaced — keeping model:, AskUserQuestion, !`...` macros, and
~/.claude/skills paths Codex either ignores or treats as noise.

Reshape Codex output without touching Claude (which stays byte-identical):

- Add codexDescriptions corpus with trigger-phrase routing descriptions
  for all 17 commands plus the stackit router.
- Extend renderCodexSkillContent to strip model:, filter Claude-only entries
  from allowed-tools, rewrite ~/.claude paths, strip !`...` macros, rewrite
  cross-skill 'Skill tool' prose to direct instructions, and rewrite
  AskUserQuestion prose to plain 'ask the user'.
- Apply the same frontmatter + body transforms to file-group installs so
  router SKILL.md, references/, and subagent files all get the treatment.
- Add a templates/codex_overrides/ tree with per-file precedence: slim
  router SKILL.md, three references (workflows, commit-style,
  stack-plan-recovery), and execution-checklist bodies for stack-create
  and stack-plan.
- Wire format through installFileGroup and installCommandSkills so the
  override loader is keyed off agentSkillFormatCodex.
- Add tests: override precedence, full-tree banned-substring lint, Claude
  byte-identical guard, and per-transform unit cases.