### PR TITLE
perf: batch metadata ref deletion in Reset

### DIFF
--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -232,9 +232,13 @@ func (e *engineImpl) Reset(newTrunkName string) error {
 		return fmt.Errorf("failed to get metadata refs: %w", err)
 	}
 
-	for branchName := range metadataRefs {
-		if err := e.git.DeleteMetadata(branchName); err != nil {
-			continue
+	if len(metadataRefs) > 0 {
+		refNames := make([]string, 0, len(metadataRefs))
+		for branchName := range metadataRefs {
+			refNames = append(refNames, git.MetadataRefName(branchName))
+		}
+		if err := e.git.DeleteRefsBatch(context.Background(), refNames); err != nil {
+			return fmt.Errorf("failed to delete metadata refs: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Reset called DeleteMetadata once per ref, spawning a separate git process
for each metadata ref. Replace with DeleteRefsBatch, which atomically
deletes all refs in a single git update-ref --stdin invocation.

Also surfaces failures instead of silently swallowing them: the previous
loop continued on error, leaving stale metadata refs without any signal.