### PR TITLE
fix: respect caller context in ResetTrunkToRemote fallback fetch

### DIFF
--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -53,7 +53,7 @@ func (e *engineImpl) ResetTrunkToRemote(ctx context.Context) error {
 	remoteSha, err := e.git.GetRemoteSha(remote, trunk)
 	if err != nil {
 		// Fallback: try to get it from ls-remote if the tracking branch is missing
-		remoteShas, fetchErr := e.git.FetchRemoteShas(context.Background(), remote)
+		remoteShas, fetchErr := e.git.FetchRemoteShas(ctx, remote)
 		if fetchErr == nil {
 			if sha, ok := remoteShas[trunk]; ok {
 				remoteSha = sha

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -682,12 +682,10 @@ func (e *engineImpl) RenameBranch(ctx context.Context, oldBranch, newBranch Bran
 	oldLocalRef := fmt.Sprintf("%s%s", git.LocalMetadataRefPrefix, oldName)
 	newLocalRef := fmt.Sprintf("%s%s", git.LocalMetadataRefPrefix, newName)
 	if sha, err := e.git.GetRef(oldLocalRef); err == nil {
-		if err := e.git.UpdateRef(newLocalRef, sha); err == nil {
-			if err := e.git.DeleteRef(oldLocalRef); err != nil {
-				_, _ = fmt.Fprintf(e.writer, "Warning: failed to delete old local metadata ref: %v\n", err)
-			}
-		} else {
+		if err := e.git.UpdateRef(newLocalRef, sha); err != nil {
 			_, _ = fmt.Fprintf(e.writer, "Warning: failed to update new local metadata ref: %v\n", err)
+		} else if err := e.git.DeleteRef(oldLocalRef); err != nil {
+			_, _ = fmt.Fprintf(e.writer, "Warning: failed to delete old local metadata ref: %v\n", err)
 		}
 	}
 


### PR DESCRIPTION
The fallback FetchRemoteShas call in ResetTrunkToRemote used
context.Background() instead of the passed ctx, making it
impossible to cancel via the caller's context (e.g. Ctrl+C).

Also refactor nested if-err==nil pattern in RenameBranch's local
metadata ref rename to use early returns per code style guidelines.

https://claude.ai/code/session_01DKBBKgHTqhL4QKhdM64Bx1