### PR TITLE
perf: batch and parallelize remote metadata + PR base updates

### DIFF
--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -597,11 +597,13 @@ func pushMetadataRefs(ctx *app.Context, branches []engine.Branch) error {
 
 	rm := ctx.RemoteMetadata()
 
-	// Update LastModifiedBy for each branch
-	for _, branch := range branches {
-		if err := rm.SetLastModifiedBy(branch.GetName()); err != nil {
-			return fmt.Errorf("failed to update metadata for %s: %w", branch.GetName(), err)
-		}
+	branchNames := make([]string, len(branches))
+	for i, branch := range branches {
+		branchNames[i] = branch.GetName()
+	}
+
+	if err := rm.BatchSetLastModifiedBy(branchNames); err != nil {
+		return fmt.Errorf("failed to update metadata: %w", err)
 	}
 
 	// Check if remote sync is enabled; if not, run compatibility test first
@@ -614,12 +616,6 @@ func pushMetadataRefs(ctx *app.Context, branches []engine.Branch) error {
 		if err := ctx.Git().EnsureMetadataRefspecConfigured(); err != nil {
 			ctx.Output.Debug("Failed to configure metadata refspec: %v", err)
 		}
-	}
-
-	// Extract branch names for PushMetadataRefs
-	branchNames := make([]string, len(branches))
-	for i, branch := range branches {
-		branchNames[i] = branch.GetName()
 	}
 
 	// Push metadata refs

--- a/internal/actions/sync/github_sync.go
+++ b/internal/actions/sync/github_sync.go
@@ -10,6 +10,7 @@ import (
 	"stackit.dev/stackit/internal/engine"
 	"stackit.dev/stackit/internal/github"
 	"stackit.dev/stackit/internal/tui/style"
+	"stackit.dev/stackit/internal/utils"
 )
 
 // GitHubSyncResult holds the results from GitHub PR info sync (network operation)
@@ -163,8 +164,15 @@ func PushParentsToGitHub(ctx *app.Context, result *GitHubSyncResult, dirtyAnchor
 	githubClient := ctx.GitHub()
 
 	allBranches := eng.AllBranches()
-	updated := []string{}
 
+	type baseUpdate struct {
+		branchName      string
+		prNumber        int
+		oldBase         string
+		localParentName string
+	}
+
+	var pending []baseUpdate
 	for _, branch := range allBranches {
 		if branch.IsTrunk() {
 			continue
@@ -182,8 +190,6 @@ func PushParentsToGitHub(ctx *app.Context, result *GitHubSyncResult, dirtyAnchor
 			continue
 		}
 
-		githubBase := prInfo.Base
-
 		// Get local parent
 		currentParent := branch.GetParent()
 		localParentName := ""
@@ -193,28 +199,44 @@ func PushParentsToGitHub(ctx *app.Context, result *GitHubSyncResult, dirtyAnchor
 			localParentName = currentParent.GetName()
 		}
 
-		// If local parent differs from GitHub base, update GitHub to match local
-		if githubBase != localParentName {
-			out.Debug("PR for %s has base %s, but local parent is %s. Updating GitHub PR base...",
-				branch.GetName(), githubBase, localParentName)
-
-			updateOpts := github.UpdatePROptions{
-				Base: &localParentName,
-			}
-
-			if _, err := githubClient.UpdatePullRequest(gctx, result.RepoOwner, result.RepoName, prInfo.Number, updateOpts); err != nil {
-				out.Debug("Failed to update PR base for %s: %v", branch.GetName(), err)
-				continue
-			}
-
-			out.Info("Updated PR base for %s: %s → %s",
-				style.ColorBranchName(branch.GetName(), false),
-				style.ColorDim(githubBase),
-				style.ColorBranchName(localParentName, false))
-
-			updated = append(updated, branch.GetName())
+		if prInfo.Base == localParentName {
+			continue
 		}
+
+		pending = append(pending, baseUpdate{
+			branchName:      branch.GetName(),
+			prNumber:        prInfo.Number,
+			oldBase:         prInfo.Base,
+			localParentName: localParentName,
+		})
 	}
+
+	var (
+		mu      sync.Mutex
+		updated []string
+	)
+	utils.Run(pending, func(u baseUpdate) {
+		out.Debug("PR for %s has base %s, but local parent is %s. Updating GitHub PR base...",
+			u.branchName, u.oldBase, u.localParentName)
+
+		updateOpts := github.UpdatePROptions{
+			Base: &u.localParentName,
+		}
+
+		if _, err := githubClient.UpdatePullRequest(gctx, result.RepoOwner, result.RepoName, u.prNumber, updateOpts); err != nil {
+			out.Debug("Failed to update PR base for %s: %v", u.branchName, err)
+			return
+		}
+
+		out.Info("Updated PR base for %s: %s → %s",
+			style.ColorBranchName(u.branchName, false),
+			style.ColorDim(u.oldBase),
+			style.ColorBranchName(u.localParentName, false))
+
+		mu.Lock()
+		updated = append(updated, u.branchName)
+		mu.Unlock()
+	})
 
 	return &ParentsToGitHubResult{
 		BranchesUpdated: updated,


### PR DESCRIPTION
Two N+1 fixes on the submit/sync hot paths:

- pushMetadataRefs (submit): replace the per-branch SetLastModifiedBy
  loop with the existing BatchSetLastModifiedBy, which fetches user.name
  and user.email once and updates metadata refs in parallel.

- PushParentsToGitHub (sync): collect PR base updates first, then run
  githubClient.UpdatePullRequest calls in parallel via utils.Run instead
  of issuing them sequentially.

For an N-branch stack this turns N sequential calls into one (git
config) plus a parallel fan-out, matching the pattern already used in
UpdateStackPRMetadata and BatchSetLastModifiedBy elsewhere.