### PR TITLE
fix: point agents-block link to repo instead of stackit.dev

### DIFF
--- a/internal/cli/integrations/agents/templates/agents-block.md
+++ b/internal/cli/integrations/agents/templates/agents-block.md
@@ -1,7 +1,7 @@
 <!-- stackit:start -->
 ## Git Workflow: Stacked PRs
 
-This project uses [stackit](https://stackit.dev) for stacked changes.
+This project uses [stackit](https://github.com/getstackit/stackit) for stacked changes.
 AI agents should proactively work in stacks.
 
 ### Why Stack?


### PR DESCRIPTION

stackit.dev currently redirects to STACKIT (an unrelated German cloud
company). Point the link in the AI agent workflow block to the GitHub
repo until a real docs domain is available.

Fixes #920

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #926** 👈
  * **PR #927**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->