### PR TITLE
chore: rename module to github.com/getstackit/stackit

### DIFF
--- a/apps/cli/main.go
+++ b/apps/cli/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"runtime/debug"
 
-	"stackit.dev/stackit/internal/cli"
-	"stackit.dev/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/cli"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 var (

--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -14,8 +14,8 @@ import (
 	"syscall"
 	"time"
 
-	"stackit.dev/stackit/internal/api"
-	"stackit.dev/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/api"
+	"github.com/getstackit/stackit/internal/app"
 )
 
 // all: is required because Next static exports use underscore-prefixed paths like _next/.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module stackit.dev/stackit
+module github.com/getstackit/stackit
 
 go 1.26.0
 

--- a/internal/actions/abort/action.go
+++ b/internal/actions/abort/action.go
@@ -3,8 +3,8 @@ package abort
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
 )
 
 // Options contains options for the abort command

--- a/internal/actions/abort/handler.go
+++ b/internal/actions/abort/handler.go
@@ -1,7 +1,7 @@
 // Package abort implements the stackit abort command for canceling in-progress operations.
 package abort
 
-import "stackit.dev/stackit/internal/actions/handler"
+import "github.com/getstackit/stackit/internal/actions/handler"
 
 // Handler receives events from abort action
 type Handler interface {

--- a/internal/actions/abort_test.go
+++ b/internal/actions/abort_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/abort"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/abort"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 // testAbortHandler is a test handler for abort operations

--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -6,12 +6,12 @@ import (
 	"maps"
 	"strings"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/actions/validation"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/actions/validation"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 const (

--- a/internal/actions/absorb/absorb_test.go
+++ b/internal/actions/absorb/absorb_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestAbsorbScopeBoundaries(t *testing.T) {

--- a/internal/actions/absorb/conflict.go
+++ b/internal/actions/absorb/conflict.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // IsAbsorbInProgress checks if there's a failed absorb operation that needs cleanup.

--- a/internal/actions/absorb/handler.go
+++ b/internal/actions/absorb/handler.go
@@ -1,8 +1,8 @@
 package absorb
 
 import (
-	"stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // Step represents a step in the absorb process

--- a/internal/actions/absorb/output.go
+++ b/internal/actions/absorb/output.go
@@ -1,10 +1,10 @@
 package absorb
 
 import (
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // printDryRunOutput prints what would be absorbed in dry-run mode

--- a/internal/actions/absorb/plan.go
+++ b/internal/actions/absorb/plan.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // PlanJSON is the machine-readable absorb plan for LLM consumption

--- a/internal/actions/absorb/plan_test.go
+++ b/internal/actions/absorb/plan_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestGeneratePlanJSON(t *testing.T) {

--- a/internal/actions/branch_traversal_test.go
+++ b/internal/actions/branch_traversal_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/navigation"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/navigation"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 // testNavigationHandler is a test handler for navigation operations

--- a/internal/actions/checkout.go
+++ b/internal/actions/checkout.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/sahilm/fuzzy"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // CheckoutOptions contains options for the checkout command

--- a/internal/actions/checkout_test.go
+++ b/internal/actions/checkout_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestCheckoutActionWorktreeSwitchIncludesTargetBranch(t *testing.T) {

--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -7,11 +7,11 @@ import (
 	"sort"
 	"strings"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // CleanBranchesOptions contains options for cleaning branches

--- a/internal/actions/clean_branches_test.go
+++ b/internal/actions/clean_branches_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestCleanBranches(t *testing.T) {

--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/gertd/go-pluralize"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 var pluralizeClient = pluralize.NewClient()

--- a/internal/actions/config.go
+++ b/internal/actions/config.go
@@ -5,9 +5,9 @@ import (
 	"io"
 	"strings"
 
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 const valueNotSet = "(not set)"

--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -3,12 +3,12 @@ package actions
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // ContinueOptions contains options for the continue command

--- a/internal/actions/create/create.go
+++ b/internal/actions/create/create.go
@@ -6,15 +6,15 @@ import (
 	"path/filepath"
 	"slices"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/actions/validation"
-	"stackit.dev/stackit/internal/actions/worktree"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/actions/validation"
+	"github.com/getstackit/stackit/internal/actions/worktree"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // Options contains options for the create command

--- a/internal/actions/create/create_test.go
+++ b/internal/actions/create/create_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestCreateAction_Stdin(t *testing.T) {

--- a/internal/actions/create/handler.go
+++ b/internal/actions/create/handler.go
@@ -1,6 +1,6 @@
 package create
 
-import "stackit.dev/stackit/internal/actions/handler"
+import "github.com/getstackit/stackit/internal/actions/handler"
 
 // Step represents a step in the create process
 type Step string

--- a/internal/actions/create/insert.go
+++ b/internal/actions/create/insert.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 func handleInsert(ctx context.Context, newBranch, currentBranch string, runtimeCtx *app.Context, opts *Options) error {

--- a/internal/actions/create/message.go
+++ b/internal/actions/create/message.go
@@ -3,9 +3,9 @@ package create
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 func getCommitMessage(ctx *app.Context) (string, error) {

--- a/internal/actions/debug.go
+++ b/internal/actions/debug.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"time"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // DebugOptions contains options for the debug command

--- a/internal/actions/delete/delete.go
+++ b/internal/actions/delete/delete.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"os"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/actions/validation"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/actions/validation"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Options contains options for deleting branches

--- a/internal/actions/delete/delete_test.go
+++ b/internal/actions/delete/delete_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestDelete(t *testing.T) {

--- a/internal/actions/delete/handler.go
+++ b/internal/actions/delete/handler.go
@@ -1,6 +1,6 @@
 package delete
 
-import "stackit.dev/stackit/internal/actions/handler"
+import "github.com/getstackit/stackit/internal/actions/handler"
 
 // Result contains the result of the delete action.
 type Result struct {

--- a/internal/actions/describe/describe.go
+++ b/internal/actions/describe/describe.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"strings"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/style"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // Options contains options for the describe command

--- a/internal/actions/describe/describe_test.go
+++ b/internal/actions/describe/describe_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/describe"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/describe"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 // testDescribeHandler is a test handler for describe operations

--- a/internal/actions/describe/handler.go
+++ b/internal/actions/describe/handler.go
@@ -1,7 +1,7 @@
 // Package describe implements the stackit describe command for managing stack descriptions.
 package describe
 
-import "stackit.dev/stackit/internal/actions/handler"
+import "github.com/getstackit/stackit/internal/actions/handler"
 
 // Handler receives events from describe action
 type Handler interface {

--- a/internal/actions/doctor/doctor.go
+++ b/internal/actions/doctor/doctor.go
@@ -4,7 +4,7 @@ package doctor
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/app"
 )
 
 // Options contains options for the doctor command

--- a/internal/actions/doctor/environment.go
+++ b/internal/actions/doctor/environment.go
@@ -6,8 +6,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/github"
 )
 
 // checkEnvironment performs environment-related checks

--- a/internal/actions/doctor/github.go
+++ b/internal/actions/doctor/github.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // getGitHubToken gets the GitHub token (similar to internal/github/pr_info.go)

--- a/internal/actions/doctor/handler.go
+++ b/internal/actions/doctor/handler.go
@@ -1,6 +1,6 @@
 package doctor
 
-import "stackit.dev/stackit/internal/actions/handler"
+import "github.com/getstackit/stackit/internal/actions/handler"
 
 // CheckStatus represents the result of a diagnostic check
 type CheckStatus string

--- a/internal/actions/doctor/repository.go
+++ b/internal/actions/doctor/repository.go
@@ -3,8 +3,8 @@ package doctor
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/github"
 )
 
 // checkRepository performs repository-related checks

--- a/internal/actions/doctor/stack_state.go
+++ b/internal/actions/doctor/stack_state.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"stackit.dev/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // checkStackState performs stack state and metadata integrity checks

--- a/internal/actions/flatten/flatten.go
+++ b/internal/actions/flatten/flatten.go
@@ -4,11 +4,11 @@ package flatten
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions"
-	basehandler "stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	basehandler "github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Options contains options for the flatten command

--- a/internal/actions/flatten/flatten_test.go
+++ b/internal/actions/flatten/flatten_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/flatten"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/flatten"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func writeFile(t *testing.T, s *scenario.Scenario, name, content string) {

--- a/internal/actions/flatten/handler.go
+++ b/internal/actions/flatten/handler.go
@@ -1,6 +1,6 @@
 package flatten
 
-import basehandler "stackit.dev/stackit/internal/actions/handler"
+import basehandler "github.com/getstackit/stackit/internal/actions/handler"
 
 // Step represents a step in the flatten process
 type Step string

--- a/internal/actions/fold/fold.go
+++ b/internal/actions/fold/fold.go
@@ -4,11 +4,11 @@ package fold
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/actions/validation"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/actions/validation"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Options contains options for the fold command

--- a/internal/actions/fold/fold_keep.go
+++ b/internal/actions/fold/fold_keep.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 func foldWithKeep(gctx context.Context, ctx *app.Context, currentBranch, parentBranch engine.Branch, eng engine.Engine, splog output.Output, _ Options) error {

--- a/internal/actions/fold/fold_normal.go
+++ b/internal/actions/fold/fold_normal.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 func foldNormal(gctx context.Context, ctx *app.Context, currentBranch, parentBranch engine.Branch, eng engine.Engine, splog output.Output, _ Options) error {

--- a/internal/actions/fold/fold_test.go
+++ b/internal/actions/fold/fold_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestFoldAction(t *testing.T) {

--- a/internal/actions/fold/handler.go
+++ b/internal/actions/fold/handler.go
@@ -1,6 +1,6 @@
 package fold
 
-import "stackit.dev/stackit/internal/actions/handler"
+import "github.com/getstackit/stackit/internal/actions/handler"
 
 // Step represents a step in the fold process
 type Step string

--- a/internal/actions/foreach/events.go
+++ b/internal/actions/foreach/events.go
@@ -1,7 +1,7 @@
 package foreach
 
 import (
-	"stackit.dev/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
 )
 
 // Event represents a feedback event from the foreach action.

--- a/internal/actions/foreach/foreach.go
+++ b/internal/actions/foreach/foreach.go
@@ -9,12 +9,12 @@ import (
 	stdruntime "runtime"
 	"strings"
 
-	"stackit.dev/stackit/internal/actions/worktree"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/tui/components/tree"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions/worktree"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // Options contains options for the foreach command

--- a/internal/actions/foreach/foreach_test.go
+++ b/internal/actions/foreach/foreach_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/foreach"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/foreach"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 type testHandler struct {

--- a/internal/actions/freeze.go
+++ b/internal/actions/freeze.go
@@ -3,9 +3,9 @@ package actions
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // FreezeAction freezes the specified branch and all branches downstack of it (recursive parents)

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -6,11 +6,11 @@ import (
 	"strconv"
 	"sync"
 
-	"stackit.dev/stackit/internal/actions/validation"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/handlers"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions/validation"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/handlers"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // GetPhase represents the current phase of the get operation

--- a/internal/actions/get_test.go
+++ b/internal/actions/get_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/google/go-github/v62/github"
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestGetAction(t *testing.T) {

--- a/internal/actions/info.go
+++ b/internal/actions/info.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // SingleBranchInfo represents JSON-serializable info for a single branch (used by info --json)

--- a/internal/actions/init/init.go
+++ b/internal/actions/init/init.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"slices"
 
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // Options contains options for the init action

--- a/internal/actions/integrations/precommit.go
+++ b/internal/actions/integrations/precommit.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 const precommitHookTemplate = `#!/bin/bash

--- a/internal/actions/integrations/prepush.go
+++ b/internal/actions/integrations/prepush.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 const prepushHookTemplate = `#!/bin/bash

--- a/internal/actions/lock/handler.go
+++ b/internal/actions/lock/handler.go
@@ -1,8 +1,8 @@
 package lock
 
 import (
-	"stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/actions/submit"
+	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/actions/submit"
 )
 
 // Handler receives events from lock/unlock actions

--- a/internal/actions/lock/lock.go
+++ b/internal/actions/lock/lock.go
@@ -4,11 +4,11 @@ package lock
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/actions/submit"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/actions/submit"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Action locks the specified branch and all branches downstack of it

--- a/internal/actions/lock/lock_test.go
+++ b/internal/actions/lock/lock_test.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/lock"
-	"stackit.dev/stackit/internal/actions/submit"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/lock"
+	"github.com/getstackit/stackit/internal/actions/submit"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 // testLockHandler is a test handler for lock operations

--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -9,13 +9,13 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/components/tree"
-	"stackit.dev/stackit/internal/tui/style"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // LogStyle defines the output style for the log command

--- a/internal/actions/merge/ci_waiter.go
+++ b/internal/actions/merge/ci_waiter.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // CIWaiter handles waiting for CI checks to pass on GitHub PRs.

--- a/internal/actions/merge/ci_waiter_test.go
+++ b/internal/actions/merge/ci_waiter_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/github"
 )
 
 type mockGitHubClient struct {

--- a/internal/actions/merge/cleanup.go
+++ b/internal/actions/merge/cleanup.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
 )
 
 // prCleanupEngine is the minimal interface needed for PR cleanup

--- a/internal/actions/merge/consolidate.go
+++ b/internal/actions/merge/consolidate.go
@@ -6,12 +6,12 @@ import (
 	"strings"
 	"time"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/pr"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/pr"
 )
 
 // ConsolidationResult contains information about a completed consolidation

--- a/internal/actions/merge/consolidate_test.go
+++ b/internal/actions/merge/consolidate_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/merge"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestConsolidateMergeExecutor(t *testing.T) {

--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 const (

--- a/internal/actions/merge/execute_steps.go
+++ b/internal/actions/merge/execute_steps.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
 )
 
 // validateStepPreconditions validates that a step can be executed

--- a/internal/actions/merge/handler.go
+++ b/internal/actions/merge/handler.go
@@ -3,7 +3,7 @@ package merge
 import (
 	"time"
 
-	"stackit.dev/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/github"
 )
 
 // Phase represents a phase in the merge process

--- a/internal/actions/merge/helpers.go
+++ b/internal/actions/merge/helpers.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 type pauseResumer interface {

--- a/internal/actions/merge/interactive.go
+++ b/internal/actions/merge/interactive.go
@@ -1,7 +1,7 @@
 package merge
 
 import (
-	"stackit.dev/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // MergeType represents what the user wants to merge

--- a/internal/actions/merge/interactive_test.go
+++ b/internal/actions/merge/interactive_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestDetermineRecommendedStrategy(t *testing.T) {

--- a/internal/actions/merge/merge.go
+++ b/internal/actions/merge/merge.go
@@ -2,8 +2,8 @@
 package merge
 
 import (
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/github"
 )
 
 // Options contains options for the merge command

--- a/internal/actions/merge/merge_test.go
+++ b/internal/actions/merge/merge_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/merge"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestAction(t *testing.T) {

--- a/internal/actions/merge/multistack.go
+++ b/internal/actions/merge/multistack.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // ExecuteMultiStack performs the multi-stack merge operation.

--- a/internal/actions/merge/multistack_ci.go
+++ b/internal/actions/merge/multistack_ci.go
@@ -6,9 +6,9 @@ import (
 	"os/exec"
 	"time"
 
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // LocalCIValidator runs local CI validation on merged code

--- a/internal/actions/merge/multistack_discover.go
+++ b/internal/actions/merge/multistack_discover.go
@@ -3,7 +3,7 @@ package merge
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // FormatStackLabel creates a display label for a stack

--- a/internal/actions/merge/multistack_pr.go
+++ b/internal/actions/merge/multistack_pr.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"time"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/pr"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/pr"
 )
 
 // MultiStackPRCreator handles creating the multi-stack PR

--- a/internal/actions/merge/multistack_validation_test.go
+++ b/internal/actions/merge/multistack_validation_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestValidateBranchesMatchRemote(t *testing.T) {

--- a/internal/actions/merge/multistack_worktree.go
+++ b/internal/actions/merge/multistack_worktree.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/worktree"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/worktree"
 )
 
 // MultiStackWorktreeResult contains the result of merging stacks in a worktree

--- a/internal/actions/merge/multistack_worktree_test.go
+++ b/internal/actions/merge/multistack_worktree_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestMultiStackWorktreeExecutor_ConflictingStackResetsState(t *testing.T) {

--- a/internal/actions/merge/plan.go
+++ b/internal/actions/merge/plan.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 	"time"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // Strategy defines how PRs in the stack should be merged

--- a/internal/actions/merge/plan_test.go
+++ b/internal/actions/merge/plan_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/merge"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestCreateMergePlan(t *testing.T) {

--- a/internal/actions/merge/pr_generator.go
+++ b/internal/actions/merge/pr_generator.go
@@ -1,9 +1,9 @@
 package merge
 
 import (
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/pr"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/pr"
 )
 
 // PRContentGenerator handles PR title and body generation for merge PRs.

--- a/internal/actions/merge/pr_generator_test.go
+++ b/internal/actions/merge/pr_generator_test.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/pr"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/pr"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestPRContentGenerator_GenerateConsolidationPR(t *testing.T) {

--- a/internal/actions/merge/wizard.go
+++ b/internal/actions/merge/wizard.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"strings"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	sterrors "stackit.dev/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	sterrors "github.com/getstackit/stackit/internal/errors"
 )
 
 // WizardOptions configures the interactive merge wizard

--- a/internal/actions/merge/worktree.go
+++ b/internal/actions/merge/worktree.go
@@ -3,8 +3,8 @@ package merge
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // ExecuteInWorktree executes the merge plan in a temporary worktree

--- a/internal/actions/merge/worktree_merge_test.go
+++ b/internal/actions/merge/worktree_merge_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/merge"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestExecuteInWorktree(t *testing.T) {

--- a/internal/actions/metadata.go
+++ b/internal/actions/metadata.go
@@ -1,8 +1,8 @@
 package actions
 
 import (
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // MetadataPushEngine defines the engine capabilities needed for pushing metadata.

--- a/internal/actions/modify.go
+++ b/internal/actions/modify.go
@@ -3,12 +3,12 @@ package actions
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions/validation"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/tui/style"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions/validation"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // ModifyOptions contains options for the modify command

--- a/internal/actions/modify_test.go
+++ b/internal/actions/modify_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestModifyAction_Stdin(t *testing.T) {

--- a/internal/actions/move/handler.go
+++ b/internal/actions/move/handler.go
@@ -3,9 +3,9 @@ package move
 import (
 	"errors"
 
-	"stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // Step represents a step in the move process

--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"strings"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/actions/validation"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/actions/validation"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Options contains options for the move command

--- a/internal/actions/move/move_test.go
+++ b/internal/actions/move/move_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestMoveAction(t *testing.T) {

--- a/internal/actions/move/selection.go
+++ b/internal/actions/move/selection.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // Selection contains precomputed data for validating potential move targets.

--- a/internal/actions/move/selection_interactive.go
+++ b/internal/actions/move/selection_interactive.go
@@ -3,9 +3,9 @@ package move
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // SelectOntoInteractive shows an interactive branch selector for choosing the "onto" branch

--- a/internal/actions/navigation/action.go
+++ b/internal/actions/navigation/action.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
 )
 
 // Direction represents the traversal direction

--- a/internal/actions/navigation/action_test.go
+++ b/internal/actions/navigation/action_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestTraverseUpwardSkipsWorktreeAnchors(t *testing.T) {

--- a/internal/actions/navigation/handler.go
+++ b/internal/actions/navigation/handler.go
@@ -1,7 +1,7 @@
 // Package navigation implements the stackit top/bottom commands for navigating stacked branches.
 package navigation
 
-import "stackit.dev/stackit/internal/actions/handler"
+import "github.com/getstackit/stackit/internal/actions/handler"
 
 // Handler receives events from navigation action
 type Handler interface {

--- a/internal/actions/pluck/handler.go
+++ b/internal/actions/pluck/handler.go
@@ -1,6 +1,6 @@
 package pluck
 
-import basehandler "stackit.dev/stackit/internal/actions/handler"
+import basehandler "github.com/getstackit/stackit/internal/actions/handler"
 
 // Step represents a step in the pluck process
 type Step string

--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -4,12 +4,12 @@ package pluck
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions"
-	basehandler "stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/actions/validation"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	basehandler "github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/actions/validation"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Options contains options for the pluck command

--- a/internal/actions/pluck/pluck_test.go
+++ b/internal/actions/pluck/pluck_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestPluckAction(t *testing.T) {

--- a/internal/actions/pop.go
+++ b/internal/actions/pop.go
@@ -3,9 +3,9 @@ package actions
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions/validation"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions/validation"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // PopOptions contains options for the pop command

--- a/internal/actions/pop_test.go
+++ b/internal/actions/pop_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestPopAction(t *testing.T) {

--- a/internal/actions/pr_updates.go
+++ b/internal/actions/pr_updates.go
@@ -1,11 +1,11 @@
 package actions
 
 import (
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/pr"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/pr"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // UpdateStackPRMetadata updates PR titles and body footers for a list of branches

--- a/internal/actions/rename.go
+++ b/internal/actions/rename.go
@@ -3,11 +3,11 @@ package actions
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions/validation"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/style"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions/validation"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // RenameOptions contains options for the rename command

--- a/internal/actions/reorder.go
+++ b/internal/actions/reorder.go
@@ -6,11 +6,11 @@ import (
 	"slices"
 	"strings"
 
-	"stackit.dev/stackit/internal/actions/validation"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/actions/validation"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // ReorderAction performs the reorder operation

--- a/internal/actions/resolve.go
+++ b/internal/actions/resolve.go
@@ -1,8 +1,8 @@
 package actions
 
 import (
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
 )
 
 // ResolveBranchName resolves a branch name, defaulting to current branch if empty.

--- a/internal/actions/resolve_test.go
+++ b/internal/actions/resolve_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestResolveBranchName(t *testing.T) {

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 	"sync"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/handlers"
-	"stackit.dev/stackit/internal/rerere"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/handlers"
+	"github.com/getstackit/stackit/internal/rerere"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 var newWorktreeEngine = engine.NewEngineForWorktree

--- a/internal/actions/restack_test.go
+++ b/internal/actions/restack_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/handlers"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/handlers"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestRestackAction(t *testing.T) {

--- a/internal/actions/scope/action.go
+++ b/internal/actions/scope/action.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Options contains options for the scope command

--- a/internal/actions/scope/handler.go
+++ b/internal/actions/scope/handler.go
@@ -1,7 +1,7 @@
 // Package scope implements the stackit scope command for managing branch scopes.
 package scope
 
-import "stackit.dev/stackit/internal/actions/handler"
+import "github.com/getstackit/stackit/internal/actions/handler"
 
 // Handler receives events from scope action
 type Handler interface {

--- a/internal/actions/scope/scope_test.go
+++ b/internal/actions/scope/scope_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/scope"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/scope"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 // testScopeHandler is a test handler for scope operations

--- a/internal/actions/split/handler.go
+++ b/internal/actions/split/handler.go
@@ -1,6 +1,6 @@
 package split
 
-import "stackit.dev/stackit/internal/actions/handler"
+import "github.com/getstackit/stackit/internal/actions/handler"
 
 // Step represents a step in the split process
 type Step string

--- a/internal/actions/split/interactive.go
+++ b/internal/actions/split/interactive.go
@@ -1,8 +1,8 @@
 package split
 
 import (
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // DirectionContext provides context for the direction selection prompt

--- a/internal/actions/split/split.go
+++ b/internal/actions/split/split.go
@@ -4,11 +4,11 @@ package split
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
 )
 
 // Style specifies the split mode

--- a/internal/actions/split/split_commit.go
+++ b/internal/actions/split/split_commit.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"slices"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/style"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // splitByCommitEngine is a minimal interface needed for splitting by commit

--- a/internal/actions/split/split_file.go
+++ b/internal/actions/split/split_file.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 	"time"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/style"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // splitByFileEngine is a minimal interface needed for splitting by file

--- a/internal/actions/split/split_hunk.go
+++ b/internal/actions/split/split_hunk.go
@@ -8,14 +8,14 @@ import (
 	"strings"
 	"time"
 
-	"stackit.dev/stackit/internal/actions"
-	handlerBase "stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	sterrors "stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	handlerBase "github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	sterrors "github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // hunkOptions contains options for hunk-based splitting

--- a/internal/actions/split/split_prompts.go
+++ b/internal/actions/split/split_prompts.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"slices"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 func promptBranchName(existingNames []string, originalBranchName string, branchNum int, eng engine.BranchReader) (string, error) {

--- a/internal/actions/split/wizard.go
+++ b/internal/actions/split/wizard.go
@@ -3,12 +3,12 @@ package split
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions"
-	handlerBase "stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/actions"
+	handlerBase "github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
 )
 
 // WizardOptions configures the interactive split wizard

--- a/internal/actions/squash.go
+++ b/internal/actions/squash.go
@@ -3,10 +3,10 @@ package actions
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // SquashOptions contains options for the squash command

--- a/internal/actions/stack_info.go
+++ b/internal/actions/stack_info.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"strings"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/tui/components/tree"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // StackBranchInfo represents JSON-serializable info for a single branch in a stack

--- a/internal/actions/stack_info_test.go
+++ b/internal/actions/stack_info_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestStackInfoAction(t *testing.T) {

--- a/internal/actions/submit/events.go
+++ b/internal/actions/submit/events.go
@@ -1,7 +1,7 @@
 package submit
 
 import (
-	"stackit.dev/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
 )
 
 // Event represents a feedback event from the submit action.

--- a/internal/actions/submit/parent_resolution.go
+++ b/internal/actions/submit/parent_resolution.go
@@ -1,6 +1,6 @@
 package submit
 
-import "stackit.dev/stackit/internal/engine"
+import "github.com/getstackit/stackit/internal/engine"
 
 // resolveSubmitParentName returns the nearest non-worktree-anchor ancestor.
 // If no tracked non-anchor parent exists, trunk is returned.

--- a/internal/actions/submit/parent_resolution_test.go
+++ b/internal/actions/submit/parent_resolution_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestResolveSubmitParentNameSkipsWorktreeAnchors(t *testing.T) {

--- a/internal/actions/submit/planning.go
+++ b/internal/actions/submit/planning.go
@@ -3,9 +3,9 @@ package submit
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
 )
 
 // prepareBranchesForSubmit prepares submission info for each branch, emitting events via handler

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"sync"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/tui/components/tree"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // PR submission action constants

--- a/internal/actions/submit/submit_metadata.go
+++ b/internal/actions/submit/submit_metadata.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"strings"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/pr"
-	"stackit.dev/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/pr"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // GetPRTitle gets the PR title, prompting if needed

--- a/internal/actions/submit/submit_metadata_fetch_test.go
+++ b/internal/actions/submit/submit_metadata_fetch_test.go
@@ -7,9 +7,9 @@ import (
 	gh "github.com/google/go-github/v62/github"
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/submit"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/submit"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestPreparePRMetadata_FetchFromGitHub(t *testing.T) {

--- a/internal/actions/submit/submit_metadata_test.go
+++ b/internal/actions/submit/submit_metadata_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/submit"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/submit"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 const (

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/submit"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/submit"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 // noopHandler is a test handler that ignores all events

--- a/internal/actions/submit/submit_validation.go
+++ b/internal/actions/submit/submit_validation.go
@@ -5,11 +5,11 @@ import (
 	"context"
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // ValidateBranchesToSubmit validates that branches are ready to submit

--- a/internal/actions/sync/branch_cleaning.go
+++ b/internal/actions/sync/branch_cleaning.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // cleanBranches handles cleaning merged/closed branches

--- a/internal/actions/sync/branch_cleaning_test.go
+++ b/internal/actions/sync/branch_cleaning_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestCleanBranchesNonInteractiveRespectsDirtyStackFilter(t *testing.T) {

--- a/internal/actions/sync/branch_sync.go
+++ b/internal/actions/sync/branch_sync.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // syncStackBranches pulls stack branches that are behind their remote counterparts.

--- a/internal/actions/sync/github_sync.go
+++ b/internal/actions/sync/github_sync.go
@@ -5,12 +5,12 @@ import (
 	"sync"
 	"time"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/tui/style"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // GitHubSyncResult holds the results from GitHub PR info sync (network operation)

--- a/internal/actions/sync/metadata_cleanup_test.go
+++ b/internal/actions/sync/metadata_cleanup_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestMetadataCleanup(t *testing.T) {

--- a/internal/actions/sync/metadata_sync.go
+++ b/internal/actions/sync/metadata_sync.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"time"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // syncRemoteMetadata fetches and processes remote metadata.

--- a/internal/actions/sync/restack.go
+++ b/internal/actions/sync/restack.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // restackBranches handles restacking branches after sync operations.

--- a/internal/actions/sync/stack_metadata_gc.go
+++ b/internal/actions/sync/stack_metadata_gc.go
@@ -1,7 +1,7 @@
 package sync
 
 import (
-	"stackit.dev/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/app"
 )
 
 // StackMetadataGCResult contains the results of stack metadata garbage collection.

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -6,12 +6,12 @@ import (
 	"strings"
 	"time"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/handlers"
-	"stackit.dev/stackit/internal/rerere"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/handlers"
+	"github.com/getstackit/stackit/internal/rerere"
 
 	"golang.org/x/sync/errgroup"
 )

--- a/internal/actions/sync/sync_diamond_test.go
+++ b/internal/actions/sync/sync_diamond_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/google/go-github/v62/github"
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	stackitgithub "stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	stackitgithub "github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 const (

--- a/internal/actions/sync/sync_test.go
+++ b/internal/actions/sync/sync_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestSyncAction(t *testing.T) {

--- a/internal/actions/sync/trunk_sync.go
+++ b/internal/actions/sync/trunk_sync.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // syncTrunk handles pulling the trunk and resolving any conflicts

--- a/internal/actions/sync/worktree_cleanup.go
+++ b/internal/actions/sync/worktree_cleanup.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"time"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
 )
 
 // WorktreeCleanupResult contains the results of worktree cleanup

--- a/internal/actions/sync/worktree_cleanup_test.go
+++ b/internal/actions/sync/worktree_cleanup_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/sync"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/sync"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestSyncCleansOrphanedWorktrees(t *testing.T) {

--- a/internal/actions/track/action.go
+++ b/internal/actions/track/action.go
@@ -3,8 +3,8 @@ package track
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Options contains options for the track command

--- a/internal/actions/track/handler.go
+++ b/internal/actions/track/handler.go
@@ -4,10 +4,10 @@ package track
 import (
 	"context"
 
-	"stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // Handler receives events from track action

--- a/internal/actions/track/track_test.go
+++ b/internal/actions/track/track_test.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/track"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/track"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 // testTrackHandler is a test handler for track operations

--- a/internal/actions/undo/handler.go
+++ b/internal/actions/undo/handler.go
@@ -1,8 +1,8 @@
 package undo
 
 import (
-	"stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // Handler receives events from undo action

--- a/internal/actions/undo/undo.go
+++ b/internal/actions/undo/undo.go
@@ -4,10 +4,10 @@ package undo
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/timeutil"
+	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/timeutil"
 )
 
 // Options contains options for the undo command

--- a/internal/actions/undo/undo_test.go
+++ b/internal/actions/undo/undo_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestUndoAction(t *testing.T) {

--- a/internal/actions/unfreeze.go
+++ b/internal/actions/unfreeze.go
@@ -3,9 +3,9 @@ package actions
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // UnfreezeAction unfreezes the specified branch and all branches upstack of it (recursive children)

--- a/internal/actions/untrack/action.go
+++ b/internal/actions/untrack/action.go
@@ -3,9 +3,9 @@ package untrack
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Options contains options for the untrack command

--- a/internal/actions/untrack/handler.go
+++ b/internal/actions/untrack/handler.go
@@ -1,7 +1,7 @@
 // Package untrack implements the stackit untrack command for stopping branch tracking.
 package untrack
 
-import "stackit.dev/stackit/internal/actions/handler"
+import "github.com/getstackit/stackit/internal/actions/handler"
 
 // Handler receives events from untrack action
 type Handler interface {

--- a/internal/actions/untrack/untrack_test.go
+++ b/internal/actions/untrack/untrack_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/untrack"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/untrack"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 // testUntrackHandler is a test handler for untrack operations

--- a/internal/actions/validation/chains.go
+++ b/internal/actions/validation/chains.go
@@ -3,7 +3,7 @@ package validation
 import (
 	"context"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // ModifyBranchChain validates for simple branch modifications (rename, scope).

--- a/internal/actions/validation/chains_test.go
+++ b/internal/actions/validation/chains_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/validation"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/validation"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestModifyBranchChain(t *testing.T) {

--- a/internal/actions/validation/validators.go
+++ b/internal/actions/validation/validators.go
@@ -13,9 +13,9 @@ import (
 	"context"
 	"fmt"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // Validator validates a single precondition.

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -8,12 +8,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // ListOptions contains options for the list action

--- a/internal/actions/worktree/actions_test.go
+++ b/internal/actions/worktree/actions_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/worktree"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/worktree"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestListAction(t *testing.T) {

--- a/internal/actions/worktree/hooks.go
+++ b/internal/actions/worktree/hooks.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // HookTimeout is the maximum duration a hook can run before being killed

--- a/internal/api/handlers/branch_diff.go
+++ b/internal/api/handlers/branch_diff.go
@@ -3,8 +3,8 @@ package handlers
 import (
 	"net/http"
 
-	httpcontract "stackit.dev/stackit/internal/contracts/http"
-	"stackit.dev/stackit/internal/engine"
+	httpcontract "github.com/getstackit/stackit/internal/contracts/http"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // BranchDiffHandler serves raw branch patch diffs.

--- a/internal/api/handlers/branches.go
+++ b/internal/api/handlers/branches.go
@@ -3,9 +3,9 @@ package handlers
 import (
 	"net/http"
 
-	httpcontract "stackit.dev/stackit/internal/contracts/http"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/github"
+	httpcontract "github.com/getstackit/stackit/internal/contracts/http"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
 )
 
 // BranchesHandler serves branch data.

--- a/internal/api/handlers/branches_test.go
+++ b/internal/api/handlers/branches_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	httpcontract "stackit.dev/stackit/internal/contracts/http"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	httpcontract "github.com/getstackit/stackit/internal/contracts/http"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestBranchesHandler_AllowsBranchNamedDiff(t *testing.T) {

--- a/internal/api/handlers/repo.go
+++ b/internal/api/handlers/repo.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"net/http"
 
-	httpcontract "stackit.dev/stackit/internal/contracts/http"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/github"
+	httpcontract "github.com/getstackit/stackit/internal/contracts/http"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
 )
 
 // RepoHandler serves repository metadata.

--- a/internal/api/handlers/stacks.go
+++ b/internal/api/handlers/stacks.go
@@ -5,10 +5,10 @@ import (
 	"net/url"
 	"strings"
 
-	"stackit.dev/stackit/internal/actions/merge"
-	httpcontract "stackit.dev/stackit/internal/contracts/http"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/actions/merge"
+	httpcontract "github.com/getstackit/stackit/internal/contracts/http"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
 )
 
 // StacksHandler serves stack data.

--- a/internal/api/handlers/submit.go
+++ b/internal/api/handlers/submit.go
@@ -5,11 +5,11 @@ import (
 	"io"
 	"net/http"
 
-	"stackit.dev/stackit/internal/actions/submit"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/actions/submit"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // SubmitHandler handles POST requests to submit a stack.

--- a/internal/api/handlers/view.go
+++ b/internal/api/handlers/view.go
@@ -3,8 +3,8 @@ package handlers
 import (
 	"net/http"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
 )
 
 // ViewHandler serves the combined view payload for the frontend.

--- a/internal/api/handlers/view_assembler.go
+++ b/internal/api/handlers/view_assembler.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions/merge"
-	httpcontract "stackit.dev/stackit/internal/contracts/http"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/actions/merge"
+	httpcontract "github.com/getstackit/stackit/internal/contracts/http"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/github"
 )
 
 // ViewAssembler builds the combined /view payload.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -13,10 +13,10 @@ import (
 	"sync"
 	"time"
 
-	"stackit.dev/stackit/internal/api/handlers"
-	"stackit.dev/stackit/internal/api/watcher"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/api/handlers"
+	"github.com/getstackit/stackit/internal/api/watcher"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
 )
 
 // ServerConfig holds configuration for the API server.

--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -12,12 +12,12 @@ import (
 	"os"
 	"sync"
 
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // Context provides access to engine and output for commands

--- a/internal/app/context_test.go
+++ b/internal/app/context_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/github"
 )
 
 func TestGitHubLazyClientIsSharedAcrossContextCopies(t *testing.T) {

--- a/internal/cli/abort.go
+++ b/internal/cli/abort.go
@@ -3,12 +3,12 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/abort"
-	"stackit.dev/stackit/internal/actions/absorb"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/cli/stack"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions/abort"
+	"github.com/getstackit/stackit/internal/actions/absorb"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/cli/stack"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // newAbortCmd creates the abort command

--- a/internal/cli/branch/absorb.go
+++ b/internal/cli/branch/absorb.go
@@ -4,9 +4,9 @@ package branch
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/absorb"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/actions/absorb"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // NewAbsorbCmd creates the absorb command

--- a/internal/cli/branch/absorb_handlers.go
+++ b/internal/cli/branch/absorb_handlers.go
@@ -1,12 +1,12 @@
 package branch
 
 import (
-	"stackit.dev/stackit/internal/actions/absorb"
-	"stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/actions/absorb"
+	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // NewAbsorbUI creates a runner and handler pair for absorb operations.

--- a/internal/cli/branch/absorb_test.go
+++ b/internal/cli/branch/absorb_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestAbsorbCommand(t *testing.T) {

--- a/internal/cli/branch/create.go
+++ b/internal/cli/branch/create.go
@@ -4,10 +4,10 @@ package branch
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/create"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/actions/create"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/config"
 )
 
 // NewCreateCmd creates the create command

--- a/internal/cli/branch/create_handlers.go
+++ b/internal/cli/branch/create_handlers.go
@@ -3,13 +3,13 @@ package branch
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions/create"
-	"stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/style"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions/create"
+	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // NewCreateUI creates a runner and handler pair for create operations.

--- a/internal/cli/branch/create_test.go
+++ b/internal/cli/branch/create_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestCreateCommand(t *testing.T) {

--- a/internal/cli/branch/delete.go
+++ b/internal/cli/branch/delete.go
@@ -4,9 +4,9 @@ package branch
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/delete"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/actions/delete"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // NewDeleteCmd creates the delete command

--- a/internal/cli/branch/delete_handlers.go
+++ b/internal/cli/branch/delete_handlers.go
@@ -1,11 +1,11 @@
 package branch
 
 import (
-	"stackit.dev/stackit/internal/actions/delete"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions/delete"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // NewDeleteUI creates a runner and handler pair for delete operations.

--- a/internal/cli/branch/fold.go
+++ b/internal/cli/branch/fold.go
@@ -4,10 +4,10 @@ package branch
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/fold"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	_ "stackit.dev/stackit/internal/demo" // Register demo engine factory
+	"github.com/getstackit/stackit/internal/actions/fold"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	_ "github.com/getstackit/stackit/internal/demo" // Register demo engine factory
 )
 
 // NewFoldCmd creates the fold command

--- a/internal/cli/branch/fold_handlers.go
+++ b/internal/cli/branch/fold_handlers.go
@@ -1,12 +1,12 @@
 package branch
 
 import (
-	"stackit.dev/stackit/internal/actions/fold"
-	"stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions/fold"
+	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // NewFoldUI creates a runner and handler pair for fold operations.

--- a/internal/cli/branch/freeze.go
+++ b/internal/cli/branch/freeze.go
@@ -3,10 +3,10 @@ package branch
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/errors"
 )
 
 // NewFreezeCmd creates the freeze command

--- a/internal/cli/branch/get.go
+++ b/internal/cli/branch/get.go
@@ -3,9 +3,9 @@ package branch
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // NewGetCmd creates the get command

--- a/internal/cli/branch/get_handlers.go
+++ b/internal/cli/branch/get_handlers.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"strings"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/handlers"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/handlers"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // NewGetUI creates a runner and handler pair for get operations.

--- a/internal/cli/branch/get_test.go
+++ b/internal/cli/branch/get_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestGetCommand(t *testing.T) {

--- a/internal/cli/branch/lock.go
+++ b/internal/cli/branch/lock.go
@@ -3,11 +3,11 @@ package branch
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/lock"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions/lock"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // NewLockCmd creates the lock command

--- a/internal/cli/branch/lock_handlers.go
+++ b/internal/cli/branch/lock_handlers.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"strings"
 
-	"stackit.dev/stackit/internal/actions/lock"
-	"stackit.dev/stackit/internal/actions/submit"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions/lock"
+	"github.com/getstackit/stackit/internal/actions/submit"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // NewLockUI creates a handler for lock/unlock operations.

--- a/internal/cli/branch/modify.go
+++ b/internal/cli/branch/modify.go
@@ -4,9 +4,9 @@ package branch
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // NewModifyCmd creates the modify command

--- a/internal/cli/branch/modify_test.go
+++ b/internal/cli/branch/modify_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestModifyCommand(t *testing.T) {

--- a/internal/cli/branch/pop.go
+++ b/internal/cli/branch/pop.go
@@ -4,10 +4,10 @@ package branch
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	_ "stackit.dev/stackit/internal/demo" // Register demo engine factory
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	_ "github.com/getstackit/stackit/internal/demo" // Register demo engine factory
 )
 
 // NewPopCmd creates the pop command

--- a/internal/cli/branch/rename.go
+++ b/internal/cli/branch/rename.go
@@ -3,9 +3,9 @@ package branch
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // NewRenameCmd creates the rename command

--- a/internal/cli/branch/split.go
+++ b/internal/cli/branch/split.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/split"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/actions/split"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/config"
 )
 
 // NewSplitCmd creates the split command

--- a/internal/cli/branch/split_handlers.go
+++ b/internal/cli/branch/split_handlers.go
@@ -8,17 +8,17 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/actions/split"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
-	splitcomp "stackit.dev/stackit/internal/tui/components/split"
-	"stackit.dev/stackit/internal/tui/style"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/actions/split"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+	splitcomp "github.com/getstackit/stackit/internal/tui/components/split"
+	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // NewSplitUI creates a runner and handler pair for split operations.

--- a/internal/cli/branch/split_test.go
+++ b/internal/cli/branch/split_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestSplitCommand(t *testing.T) {

--- a/internal/cli/branch/squash.go
+++ b/internal/cli/branch/squash.go
@@ -4,9 +4,9 @@ package branch
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // NewSquashCmd creates the squash command

--- a/internal/cli/branch/squash_test.go
+++ b/internal/cli/branch/squash_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestSquashCommand(t *testing.T) {

--- a/internal/cli/branch/unfreeze.go
+++ b/internal/cli/branch/unfreeze.go
@@ -3,10 +3,10 @@ package branch
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/errors"
 )
 
 // NewUnfreezeCmd creates the unfreeze command

--- a/internal/cli/cli_test_main_test.go
+++ b/internal/cli/cli_test_main_test.go
@@ -3,9 +3,9 @@ package cli_test
 import (
 	"testing"
 
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/inprocess"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/inprocess"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestMain(m *testing.M) {

--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // GetGlobalOptions returns runtime.GlobalOptions populated from a cobra.Command's flags

--- a/internal/cli/common/directives.go
+++ b/internal/cli/common/directives.go
@@ -3,9 +3,9 @@ package common
 import (
 	"os"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // HasShellIntegration checks if stackit shell integration is installed.

--- a/internal/cli/common/format.go
+++ b/internal/cli/common/format.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Restack reason constants used by sync and get handlers.

--- a/internal/cli/common/handler.go
+++ b/internal/cli/common/handler.go
@@ -3,7 +3,7 @@ package common
 import (
 	"sync"
 
-	"stackit.dev/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // BaseHandler provides common functionality for CLI handlers.

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -10,13 +10,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
-	configtui "stackit.dev/stackit/internal/tui/config"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+	configtui "github.com/getstackit/stackit/internal/tui/config"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Config key constants for CLI commands

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestConfigCommand(t *testing.T) {

--- a/internal/cli/continue.go
+++ b/internal/cli/continue.go
@@ -3,9 +3,9 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // newContinueCmd creates the continue command

--- a/internal/cli/continue_test.go
+++ b/internal/cli/continue_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestContinueCommand(t *testing.T) {

--- a/internal/cli/dashboard/shippable.go
+++ b/internal/cli/dashboard/shippable.go
@@ -7,9 +7,9 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // RunShippable starts the shippable work dashboard.

--- a/internal/cli/dashboard/shippable_model.go
+++ b/internal/cli/dashboard/shippable_model.go
@@ -10,15 +10,15 @@ import (
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/shippable"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/components/tree"
-	"stackit.dev/stackit/internal/tui/core"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/shippable"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/tui/core"
 )
 
 const (

--- a/internal/cli/dashboard/shippable_update.go
+++ b/internal/cli/dashboard/shippable_update.go
@@ -8,10 +8,10 @@ import (
 	"charm.land/bubbles/v2/progress"
 	tea "charm.land/bubbletea/v2"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/actions/submit"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/shippable"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/actions/submit"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/shippable"
 )
 
 // Update handles all messages and updates the model.

--- a/internal/cli/dashboard/shippable_view.go
+++ b/internal/cli/dashboard/shippable_view.go
@@ -8,10 +8,10 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"stackit.dev/stackit/internal/shippable"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/components/tree"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/shippable"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // View renders the dashboard.

--- a/internal/cli/dashboard/styles.go
+++ b/internal/cli/dashboard/styles.go
@@ -3,7 +3,7 @@ package dashboard
 import (
 	"sync"
 
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // All dashboard styles are defined in style.DefaultDashboardStyles() so that

--- a/internal/cli/debug.go
+++ b/internal/cli/debug.go
@@ -3,9 +3,9 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // newDebugCmd creates the debug command

--- a/internal/cli/describe.go
+++ b/internal/cli/describe.go
@@ -3,10 +3,10 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/describe"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions/describe"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // newDescribeCmd creates the describe command

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/config"
 )
 
 // newDocsCmd creates the docs command for generating documentation.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -3,10 +3,10 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/doctor"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/actions/doctor"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/config"
 )
 
 // newDoctorCmd creates the doctor command

--- a/internal/cli/doctor_handlers.go
+++ b/internal/cli/doctor_handlers.go
@@ -1,10 +1,10 @@
 package cli
 
 import (
-	"stackit.dev/stackit/internal/actions/doctor"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/actions/doctor"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // NewDoctorUI creates a runner and handler pair for doctor operations.

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -3,9 +3,9 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // newInfoCmd creates the info command

--- a/internal/cli/info_test.go
+++ b/internal/cli/info_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestInfoCommand(t *testing.T) {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -7,14 +7,14 @@ import (
 
 	"github.com/spf13/cobra"
 
-	initaction "stackit.dev/stackit/internal/actions/init"
-	"stackit.dev/stackit/internal/cli/integrations"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/rerere"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/style"
+	initaction "github.com/getstackit/stackit/internal/actions/init"
+	"github.com/getstackit/stackit/internal/cli/integrations"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/rerere"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // cliInitHandler implements initaction.Handler for the CLI

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestInitCommand(t *testing.T) {

--- a/internal/cli/integrations/agents.go
+++ b/internal/cli/integrations/agents.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	stackiterrors "stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/git"
+	stackiterrors "github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // NewAgentsCmd creates the agent command

--- a/internal/cli/integrations/agents_prompts.go
+++ b/internal/cli/integrations/agents_prompts.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	stackiterrors "stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/tui"
+	stackiterrors "github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 var (

--- a/internal/cli/integrations/agents_test.go
+++ b/internal/cli/integrations/agents_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
-	stackiterrors "stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/tui"
+	stackiterrors "github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 func TestReplaceWorkflowBlock(t *testing.T) {

--- a/internal/cli/integrations/github.go
+++ b/internal/cli/integrations/github.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 //go:embed github/templates/*.yml

--- a/internal/cli/integrations/install.go
+++ b/internal/cli/integrations/install.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"stackit.dev/stackit/internal/actions/integrations"
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/actions/integrations"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // InstallGitHub installs GitHub Actions workflow for stackit CI checks.

--- a/internal/cli/integrations/install_test.go
+++ b/internal/cli/integrations/install_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // Not parallel: subtests use t.Setenv.

--- a/internal/cli/integrations/precommit.go
+++ b/internal/cli/integrations/precommit.go
@@ -3,8 +3,8 @@ package integrations
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/integrations"
-	"stackit.dev/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/actions/integrations"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // NewPrecommitCmd creates the precommit command

--- a/internal/cli/integrations/prepush.go
+++ b/internal/cli/integrations/prepush.go
@@ -3,8 +3,8 @@ package integrations
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/integrations"
-	"stackit.dev/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/actions/integrations"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // NewPrepushCmd creates the prepush command

--- a/internal/cli/navigation/bottom.go
+++ b/internal/cli/navigation/bottom.go
@@ -3,12 +3,12 @@ package navigation
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/actions/navigation"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/cli/stack"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/actions/navigation"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/cli/stack"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // NewBottomCmd creates the bottom command

--- a/internal/cli/navigation/checkout.go
+++ b/internal/cli/navigation/checkout.go
@@ -3,9 +3,9 @@ package navigation
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // NewCheckoutCmd creates the checkout command

--- a/internal/cli/navigation/checkout_handlers.go
+++ b/internal/cli/navigation/checkout_handlers.go
@@ -1,11 +1,11 @@
 package navigation
 
 import (
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // NewCheckoutUI creates a runner and handler pair for checkout operations.

--- a/internal/cli/navigation/checkout_test.go
+++ b/internal/cli/navigation/checkout_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestCheckoutCommand(t *testing.T) {

--- a/internal/cli/navigation/children.go
+++ b/internal/cli/navigation/children.go
@@ -3,11 +3,11 @@ package navigation
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // NewChildrenCmd creates the children command

--- a/internal/cli/navigation/down.go
+++ b/internal/cli/navigation/down.go
@@ -3,11 +3,11 @@ package navigation
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // NewDownCmd creates the down command

--- a/internal/cli/navigation/log.go
+++ b/internal/cli/navigation/log.go
@@ -4,10 +4,10 @@ package navigation
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/errors"
 )
 
 // NewLogCmd creates the log command

--- a/internal/cli/navigation/log_test.go
+++ b/internal/cli/navigation/log_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestLogCommand(t *testing.T) {

--- a/internal/cli/navigation/main.go
+++ b/internal/cli/navigation/main.go
@@ -3,9 +3,9 @@ package navigation
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // NewMainCmd creates the main command

--- a/internal/cli/navigation/navigation_test.go
+++ b/internal/cli/navigation/navigation_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestNavigationCommands(t *testing.T) {

--- a/internal/cli/navigation/parent.go
+++ b/internal/cli/navigation/parent.go
@@ -3,10 +3,10 @@ package navigation
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // NewParentCmd creates the parent command

--- a/internal/cli/navigation/top.go
+++ b/internal/cli/navigation/top.go
@@ -3,12 +3,12 @@ package navigation
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/actions/navigation"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/cli/stack"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/actions/navigation"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/cli/stack"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // NewTopCmd creates the top command

--- a/internal/cli/navigation/trunk.go
+++ b/internal/cli/navigation/trunk.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // NewTrunkCmd creates the trunk command

--- a/internal/cli/navigation/up.go
+++ b/internal/cli/navigation/up.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/style"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // NewUpCmd creates the up command

--- a/internal/cli/passthrough.go
+++ b/internal/cli/passthrough.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 var gitCommandAllowlist = []string{

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,12 +5,12 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/cli/branch"
-	"stackit.dev/stackit/internal/cli/integrations"
-	"stackit.dev/stackit/internal/cli/navigation"
-	"stackit.dev/stackit/internal/cli/shell"
-	"stackit.dev/stackit/internal/cli/stack"
-	"stackit.dev/stackit/internal/cli/worktree"
+	"github.com/getstackit/stackit/internal/cli/branch"
+	"github.com/getstackit/stackit/internal/cli/integrations"
+	"github.com/getstackit/stackit/internal/cli/navigation"
+	"github.com/getstackit/stackit/internal/cli/shell"
+	"github.com/getstackit/stackit/internal/cli/stack"
+	"github.com/getstackit/stackit/internal/cli/worktree"
 )
 
 // NewRootCmd creates the root cobra command

--- a/internal/cli/scope.go
+++ b/internal/cli/scope.go
@@ -3,11 +3,11 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/scope"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/cli/stack"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions/scope"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/cli/stack"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // newScopeCmd creates the scope command

--- a/internal/cli/scope_test.go
+++ b/internal/cli/scope_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestScopeCommand(t *testing.T) {

--- a/internal/cli/stack/abort_handlers.go
+++ b/internal/cli/stack/abort_handlers.go
@@ -1,10 +1,10 @@
 package stack
 
 import (
-	"stackit.dev/stackit/internal/actions/abort"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/actions/abort"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // NewAbortUI creates a handler for abort operations.

--- a/internal/cli/stack/flatten.go
+++ b/internal/cli/stack/flatten.go
@@ -3,9 +3,9 @@ package stack
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/flatten"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/actions/flatten"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // NewFlattenCmd creates the flatten command

--- a/internal/cli/stack/flatten_handlers.go
+++ b/internal/cli/stack/flatten_handlers.go
@@ -3,12 +3,12 @@ package stack
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions/flatten"
-	"stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
-	flattenComponent "stackit.dev/stackit/internal/tui/components/flatten"
+	"github.com/getstackit/stackit/internal/actions/flatten"
+	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+	flattenComponent "github.com/getstackit/stackit/internal/tui/components/flatten"
 )
 
 // NewFlattenUI creates a runner and handler pair for flatten operations.

--- a/internal/cli/stack/foreach.go
+++ b/internal/cli/stack/foreach.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/foreach"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/actions/foreach"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // NewForeachCmd creates the foreach command

--- a/internal/cli/stack/foreach_handlers.go
+++ b/internal/cli/stack/foreach_handlers.go
@@ -3,14 +3,14 @@ package stack
 import (
 	"strings"
 
-	"stackit.dev/stackit/internal/actions/foreach"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
-	foreachComponent "stackit.dev/stackit/internal/tui/components/foreach"
-	"stackit.dev/stackit/internal/tui/components/tree"
-	"stackit.dev/stackit/internal/tui/core"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions/foreach"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+	foreachComponent "github.com/getstackit/stackit/internal/tui/components/foreach"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/tui/core"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // NewForeachUI creates a runner and handler pair for foreach operations.

--- a/internal/cli/stack/foreach_handlers_test.go
+++ b/internal/cli/stack/foreach_handlers_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/foreach"
-	"stackit.dev/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/actions/foreach"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 func TestNewForeachUI_ParallelUsesSimpleHandler(t *testing.T) {

--- a/internal/cli/stack/foreach_test.go
+++ b/internal/cli/stack/foreach_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/foreach"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/foreach"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestForeachCommand(t *testing.T) {

--- a/internal/cli/stack/merge.go
+++ b/internal/cli/stack/merge.go
@@ -4,13 +4,13 @@ package stack
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	mergeAction "stackit.dev/stackit/internal/actions/merge"
-	"stackit.dev/stackit/internal/actions/sync"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	mergeCmd "stackit.dev/stackit/internal/cli/stack/merge"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	mergeAction "github.com/getstackit/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/actions/sync"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	mergeCmd "github.com/getstackit/stackit/internal/cli/stack/merge"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // NewMergeCmd creates the merge command

--- a/internal/cli/stack/merge/drain.go
+++ b/internal/cli/stack/merge/drain.go
@@ -7,14 +7,14 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	mergeAction "stackit.dev/stackit/internal/actions/merge"
-	"stackit.dev/stackit/internal/actions/sync"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/actions"
+	mergeAction "github.com/getstackit/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/actions/sync"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // NewDrainCmd creates the merge drain subcommand.

--- a/internal/cli/stack/merge/handlers.go
+++ b/internal/cli/stack/merge/handlers.go
@@ -7,13 +7,13 @@ import (
 	"sync"
 	"time"
 
-	mergeAction "stackit.dev/stackit/internal/actions/merge"
-	sterrors "stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/shippable"
-	"stackit.dev/stackit/internal/tui"
-	mergeComponent "stackit.dev/stackit/internal/tui/components/merge"
-	"stackit.dev/stackit/internal/tui/style"
+	mergeAction "github.com/getstackit/stackit/internal/actions/merge"
+	sterrors "github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/shippable"
+	"github.com/getstackit/stackit/internal/tui"
+	mergeComponent "github.com/getstackit/stackit/internal/tui/components/merge"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // NewMergeUI creates a runner and handler pair for merge operations.

--- a/internal/cli/stack/merge/merge.go
+++ b/internal/cli/stack/merge/merge.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	mergeAction "stackit.dev/stackit/internal/actions/merge"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
+	mergeAction "github.com/getstackit/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // PostMergeHandler handles post-merge actions like syncing trunk.

--- a/internal/cli/stack/merge/merge_test.go
+++ b/internal/cli/stack/merge/merge_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	mergeAction "stackit.dev/stackit/internal/actions/merge"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	mergeAction "github.com/getstackit/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestNewMergeCmd(t *testing.T) {

--- a/internal/cli/stack/merge/next.go
+++ b/internal/cli/stack/merge/next.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	mergeAction "stackit.dev/stackit/internal/actions/merge"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/tui"
+	mergeAction "github.com/getstackit/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // NewNextCmd creates the merge next subcommand.

--- a/internal/cli/stack/merge/orchestrate.go
+++ b/internal/cli/stack/merge/orchestrate.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 const (

--- a/internal/cli/stack/merge/orchestrate_test.go
+++ b/internal/cli/stack/merge/orchestrate_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // mockPRMergeAPI is a test double for prMergeAPI that records calls and returns configured responses.

--- a/internal/cli/stack/merge/ship.go
+++ b/internal/cli/stack/merge/ship.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	mergeAction "stackit.dev/stackit/internal/actions/merge"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/tui"
+	mergeAction "github.com/getstackit/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // NewShipCmd creates the merge ship subcommand.

--- a/internal/cli/stack/merge/status.go
+++ b/internal/cli/stack/merge/status.go
@@ -4,9 +4,9 @@ package merge
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/shippable"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/shippable"
 )
 
 // NewStatusCmd creates the merge status subcommand.

--- a/internal/cli/stack/move.go
+++ b/internal/cli/stack/move.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/move"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/actions/move"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // NewMoveCmd creates the move command

--- a/internal/cli/stack/move_handlers.go
+++ b/internal/cli/stack/move_handlers.go
@@ -3,14 +3,14 @@ package stack
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/actions/move"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/actions/move"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // NewMoveUI creates a runner and handler pair for move operations.

--- a/internal/cli/stack/move_test.go
+++ b/internal/cli/stack/move_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestMoveCommand(t *testing.T) {

--- a/internal/cli/stack/navigation_handlers.go
+++ b/internal/cli/stack/navigation_handlers.go
@@ -1,10 +1,10 @@
 package stack
 
 import (
-	"stackit.dev/stackit/internal/actions/navigation"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/actions/navigation"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // NewNavigationUI creates a handler for navigation operations.

--- a/internal/cli/stack/pluck.go
+++ b/internal/cli/stack/pluck.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/pluck"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/actions/pluck"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // NewPluckCmd creates the pluck command

--- a/internal/cli/stack/pluck_handlers.go
+++ b/internal/cli/stack/pluck_handlers.go
@@ -1,12 +1,12 @@
 package stack
 
 import (
-	"stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/actions/pluck"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/actions/pluck"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // NewPluckUI creates a runner and handler pair for pluck operations.

--- a/internal/cli/stack/reorder.go
+++ b/internal/cli/stack/reorder.go
@@ -4,8 +4,8 @@ package stack
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // NewReorderCmd creates the reorder command

--- a/internal/cli/stack/reorder_test.go
+++ b/internal/cli/stack/reorder_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestReorderCommand(t *testing.T) {

--- a/internal/cli/stack/restack.go
+++ b/internal/cli/stack/restack.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/handlers"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/handlers"
 )
 
 // NewRestackCmd creates the restack command

--- a/internal/cli/stack/restack_test.go
+++ b/internal/cli/stack/restack_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestRestackCommand(t *testing.T) {

--- a/internal/cli/stack/scope_handlers.go
+++ b/internal/cli/stack/scope_handlers.go
@@ -3,10 +3,10 @@ package stack
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions/scope"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/actions/scope"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // NewScopeUI creates a handler for scope operations.

--- a/internal/cli/stack/submit.go
+++ b/internal/cli/stack/submit.go
@@ -8,17 +8,17 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/submit"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/config"
-	_ "stackit.dev/stackit/internal/demo" // Register demo engine factory
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
-	submitComponent "stackit.dev/stackit/internal/tui/components/submit"
-	"stackit.dev/stackit/internal/tui/components/tree"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions/submit"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/config"
+	_ "github.com/getstackit/stackit/internal/demo" // Register demo engine factory
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+	submitComponent "github.com/getstackit/stackit/internal/tui/components/submit"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 type submitFlags struct {

--- a/internal/cli/stack/submit_test.go
+++ b/internal/cli/stack/submit_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestSubmitCommand(t *testing.T) {

--- a/internal/cli/stack/sync.go
+++ b/internal/cli/stack/sync.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/sync"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/actions/sync"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // NewSyncCmd creates the sync command

--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -5,14 +5,14 @@ import (
 	"strings"
 	stdsync "sync"
 
-	"stackit.dev/stackit/internal/actions"
-	syncAction "stackit.dev/stackit/internal/actions/sync"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
-	syncComponent "stackit.dev/stackit/internal/tui/components/sync"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions"
+	syncAction "github.com/getstackit/stackit/internal/actions/sync"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+	syncComponent "github.com/getstackit/stackit/internal/tui/components/sync"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // NewSyncUI creates a runner and handler pair for sync operations.

--- a/internal/cli/stack/sync_handlers_test.go
+++ b/internal/cli/stack/sync_handlers_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	syncAction "stackit.dev/stackit/internal/actions/sync"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
-	syncComponent "stackit.dev/stackit/internal/tui/components/sync"
+	syncAction "github.com/getstackit/stackit/internal/actions/sync"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+	syncComponent "github.com/getstackit/stackit/internal/tui/components/sync"
 )
 
 func TestInteractiveSyncHandler_Start(t *testing.T) {

--- a/internal/cli/stack/sync_test.go
+++ b/internal/cli/stack/sync_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestSyncCommand(t *testing.T) {

--- a/internal/cli/stack/track_handlers.go
+++ b/internal/cli/stack/track_handlers.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions/track"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions/track"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // NewTrackUI creates a handler for track operations.

--- a/internal/cli/stack/untrack_handlers.go
+++ b/internal/cli/stack/untrack_handlers.go
@@ -3,11 +3,11 @@ package stack
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions/untrack"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions/untrack"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // NewUntrackUI creates a handler for untrack operations.

--- a/internal/cli/track.go
+++ b/internal/cli/track.go
@@ -3,12 +3,12 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/track"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/cli/stack"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions/track"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/cli/stack"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // newTrackCmd creates the track command

--- a/internal/cli/track_test.go
+++ b/internal/cli/track_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestTrackCommand(t *testing.T) {

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -3,9 +3,9 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/cli/dashboard"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/cli/dashboard"
 )
 
 // newUICmd creates the ui command

--- a/internal/cli/undo.go
+++ b/internal/cli/undo.go
@@ -3,9 +3,9 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/undo"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/actions/undo"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
 )
 
 // newUndoCmd creates the undo command

--- a/internal/cli/undo_handlers.go
+++ b/internal/cli/undo_handlers.go
@@ -1,12 +1,12 @@
 package cli
 
 import (
-	"stackit.dev/stackit/internal/actions/handler"
-	"stackit.dev/stackit/internal/actions/undo"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/actions/undo"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // NewUndoUI creates a runner and handler pair for undo operations.

--- a/internal/cli/untrack.go
+++ b/internal/cli/untrack.go
@@ -3,12 +3,12 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/untrack"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/cli/stack"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/actions/untrack"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/cli/stack"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // newUntrackCmd creates the untrack command

--- a/internal/cli/untrack_test.go
+++ b/internal/cli/untrack_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestUntrackCommand(t *testing.T) {

--- a/internal/cli/worktree/worktree.go
+++ b/internal/cli/worktree/worktree.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"stackit.dev/stackit/internal/actions/worktree"
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/cli/common"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/actions/worktree"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // NewWorktreeCmd creates the worktree command group

--- a/internal/config/branch_pattern.go
+++ b/internal/config/branch_pattern.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"strings"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // BranchPattern represents a branch name pattern with validation

--- a/internal/config/config_git.go
+++ b/internal/config/config_git.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // GitConfig provides typed access to stackit configuration stored in git config.

--- a/internal/config/config_git_test.go
+++ b/internal/config/config_git_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 // removeDefaultConfig removes the default JSON config file created by test setup

--- a/internal/config/continuation.go
+++ b/internal/config/continuation.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // ContinuationState represents the state of a command that was interrupted by a rebase conflict

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 const (

--- a/internal/config/repo_config.go
+++ b/internal/config/repo_config.go
@@ -7,7 +7,7 @@
 package config
 
 import (
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // resolveGitDir returns the path to the shared .git directory.

--- a/internal/config/repo_config_test.go
+++ b/internal/config/repo_config_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestConfigSubmitFooter(t *testing.T) {

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"time"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/github"
 )
 
 // MapBranch converts an engine Branch and its StackNode into an API BranchResponse.

--- a/internal/contracts/http/mappers_test.go
+++ b/internal/contracts/http/mappers_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 func TestMapTrunkCommits(t *testing.T) {

--- a/internal/demo/demo_data.go
+++ b/internal/demo/demo_data.go
@@ -2,7 +2,7 @@
 // without requiring a real git repository.
 package demo
 
-import "stackit.dev/stackit/internal/engine"
+import "github.com/getstackit/stackit/internal/engine"
 
 // Branch represents a simulated branch with PR info
 type Branch struct {

--- a/internal/demo/demo_engine.go
+++ b/internal/demo/demo_engine.go
@@ -3,8 +3,8 @@ package demo
 import (
 	"time"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // Delay constants for simulating real operations

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // demoGitRunner implements git.Runner with simulated data for demo mode.

--- a/internal/demo/demo_github_client.go
+++ b/internal/demo/demo_github_client.go
@@ -7,9 +7,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // prCounter is used to generate unique PR numbers

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"io"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // PRManager provides operations for managing pull request information

--- a/internal/engine/engine_absorb.go
+++ b/internal/engine/engine_absorb.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // ApplyHunksToBranch applies multiple hunks to commits in a branch by recreating them.

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // GetCommitDate returns the commit date for a branch

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // IsTrunk checks if a branch is the trunk

--- a/internal/engine/engine_frozen_sync_test.go
+++ b/internal/engine/engine_frozen_sync_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestRestackFrozenBranch(t *testing.T) {

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // GetPendingChanges returns the status of pending changes in the working directory

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -9,7 +9,7 @@ import (
 	"slices"
 	"sync"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // engineImpl is a minimal implementation of the Engine interface

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestTrackBranch(t *testing.T) {

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"slices"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // rebuildInternal is the internal rebuild logic without locking

--- a/internal/engine/engine_merged_history_test.go
+++ b/internal/engine/engine_merged_history_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 const prStateMerged = "MERGED"

--- a/internal/engine/engine_pr.go
+++ b/internal/engine/engine_pr.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // GetPrInfo returns PR information for a branch

--- a/internal/engine/engine_reader.go
+++ b/internal/engine/engine_reader.go
@@ -6,7 +6,7 @@ import (
 	"iter"
 	"slices"
 
-	"stackit.dev/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/errors"
 )
 
 // AllBranches returns all branches

--- a/internal/engine/engine_split.go
+++ b/internal/engine/engine_split.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"slices"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // ApplySplitToCommits creates branches at specified commit points

--- a/internal/engine/engine_split_test.go
+++ b/internal/engine/engine_split_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestApplySplitToCommits(t *testing.T) {

--- a/internal/engine/engine_squash.go
+++ b/internal/engine/engine_squash.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // SquashCurrentBranch squashes all commits in the current branch into a single commit

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // PullTrunk pulls the trunk branch from remote

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // timeNow is a variable for time.Now to allow mocking in tests

--- a/internal/engine/independent_stack_test.go
+++ b/internal/engine/independent_stack_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestDiscoverIndependentStacks(t *testing.T) {

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -5,7 +5,7 @@ import (
 	"iter"
 	"time"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // StackNavigator handles stack relationship queries

--- a/internal/engine/metadata_store.go
+++ b/internal/engine/metadata_store.go
@@ -3,7 +3,7 @@ package engine
 import (
 	"context"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // readMetadata loads branch metadata from the configured metadata store.

--- a/internal/engine/persistence_locked_test.go
+++ b/internal/engine/persistence_locked_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestPrInfoLockedPersistence(t *testing.T) {

--- a/internal/engine/persistence_test.go
+++ b/internal/engine/persistence_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 func TestMetaSerialization(t *testing.T) {

--- a/internal/engine/pr_body_update_test.go
+++ b/internal/engine/pr_body_update_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestPRBodyUpdateTracking(t *testing.T) {

--- a/internal/engine/rebase_validator.go
+++ b/internal/engine/rebase_validator.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"sync"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // ValidationErrorType distinguishes between conflict errors and system errors

--- a/internal/engine/rebase_validator_bench_test.go
+++ b/internal/engine/rebase_validator_bench_test.go
@@ -7,10 +7,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 const mainBranch = "main"

--- a/internal/engine/rebase_validator_test.go
+++ b/internal/engine/rebase_validator_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestValidateRebases(t *testing.T) {

--- a/internal/engine/remote_sync.go
+++ b/internal/engine/remote_sync.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // RemoteMetadataView provides read-only access to the remote metadata cache.

--- a/internal/engine/stack_description_test.go
+++ b/internal/engine/stack_description_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestGetStackDescription(t *testing.T) {

--- a/internal/engine/stack_graph_test.go
+++ b/internal/engine/stack_graph_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestStackGraphRangeAncestorsExcludeTrunk(t *testing.T) {

--- a/internal/engine/stack_id_test.go
+++ b/internal/engine/stack_id_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestGenerateStackID(t *testing.T) {

--- a/internal/engine/stack_range_test.go
+++ b/internal/engine/stack_range_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestStackRangeUpstack(t *testing.T) {

--- a/internal/engine/state_core.go
+++ b/internal/engine/state_core.go
@@ -3,7 +3,7 @@ package engine
 import (
 	"slices"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // BranchState holds the cached metadata state for a single branch.

--- a/internal/engine/transaction.go
+++ b/internal/engine/transaction.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // Transaction retry configuration

--- a/internal/engine/transaction_test.go
+++ b/internal/engine/transaction_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestSetLocked_SingleBranch(t *testing.T) {

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // SortStrategy specifies how branches should be sorted in displays

--- a/internal/engine/undo.go
+++ b/internal/engine/undo.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 const (

--- a/internal/engine/undo_test.go
+++ b/internal/engine/undo_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 // snapshotOpts is a helper to create SnapshotOptions for tests

--- a/internal/engine/worktree_test.go
+++ b/internal/engine/worktree_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestIsInManagedWorktree_MainRepo(t *testing.T) {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // Standard library error functions wrapped for convenience

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -3,7 +3,7 @@ package git
 import (
 	"context"
 
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // CommitOptions contains options for creating a commit

--- a/internal/git/commit_info.go
+++ b/internal/git/commit_info.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 func (r *runner) getCommitDate(repo *Repository, branchName string) (time.Time, error) {

--- a/internal/git/config_test.go
+++ b/internal/git/config_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestConfigStore_GetSet(t *testing.T) {

--- a/internal/git/debug_staging_test.go
+++ b/internal/git/debug_staging_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestDebugHasUnstagedChanges(t *testing.T) {

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestIsDiffEmpty(t *testing.T) {

--- a/internal/git/merge_base_test.go
+++ b/internal/git/merge_base_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestIsAncestor(t *testing.T) {

--- a/internal/git/merge_detection_test.go
+++ b/internal/git/merge_detection_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestIsMerged(t *testing.T) {

--- a/internal/git/meta_accessors_test.go
+++ b/internal/git/meta_accessors_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 const (

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // LockReason is an enum for the reason why a branch is locked

--- a/internal/git/pull_test.go
+++ b/internal/git/pull_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestPullBranch_Reproduction(t *testing.T) {

--- a/internal/git/push_test.go
+++ b/internal/git/push_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestPushBranchWithExplicitForceWithLease(t *testing.T) {

--- a/internal/git/rebase_test.go
+++ b/internal/git/rebase_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestRebase(t *testing.T) {

--- a/internal/git/recent_commits_test.go
+++ b/internal/git/recent_commits_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestGetRecentCommits_DuplicateTrailers(t *testing.T) {

--- a/internal/git/refs_batch_test.go
+++ b/internal/git/refs_batch_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestUpdateRefsBatch(t *testing.T) {

--- a/internal/git/remote_metadata_test.go
+++ b/internal/git/remote_metadata_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestBatchDeleteRemoteMetadataRefs(t *testing.T) {

--- a/internal/git/remote_test.go
+++ b/internal/git/remote_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestFetchRemoteShas(t *testing.T) {

--- a/internal/git/repo_test.go
+++ b/internal/git/repo_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestGetRepoInfo(t *testing.T) {

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -18,7 +18,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // DebugLogger is an interface for logging debug messages

--- a/internal/git/stack_metadata_test.go
+++ b/internal/git/stack_metadata_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestStackMetaOperations(t *testing.T) {

--- a/internal/git/staging_test.go
+++ b/internal/git/staging_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestStageAll(t *testing.T) {

--- a/internal/git/worktree_ref_test.go
+++ b/internal/git/worktree_ref_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestResolveRefInWorktree(t *testing.T) {

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestWorktree(t *testing.T) {

--- a/internal/github/client_real.go
+++ b/internal/github/client_real.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/go-github/v62/github"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // StackitGitHubClient implements Client using the real GitHub API

--- a/internal/github/pr_info.go
+++ b/internal/github/pr_info.go
@@ -11,8 +11,8 @@ import (
 	"github.com/google/go-github/v62/github"
 	"golang.org/x/oauth2"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // SyncPrInfo syncs PR information for branches from GitHub

--- a/internal/github/pr_info_test.go
+++ b/internal/github/pr_info_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	githubpkg "stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	githubpkg "github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestParseGitHubRemoteURL(t *testing.T) {

--- a/internal/github/pr_operations.go
+++ b/internal/github/pr_operations.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/go-github/v62/github"
 	"golang.org/x/oauth2"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 var (

--- a/internal/github/pr_operations_test.go
+++ b/internal/github/pr_operations_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	githubpkg "stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	githubpkg "github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestCreatePullRequest(t *testing.T) {

--- a/internal/github/pr_titles.go
+++ b/internal/github/pr_titles.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // BatchGetPRTitlesGraphQL fetches PR titles for multiple PR numbers using a single GraphQL query.

--- a/internal/github/status.go
+++ b/internal/github/status.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // Status check constants

--- a/internal/github/status_test.go
+++ b/internal/github/status_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"stackit.dev/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/github"
 )
 
 func TestCheckStatus_IsApproved(t *testing.T) {

--- a/internal/handlers/restack.go
+++ b/internal/handlers/restack.go
@@ -5,7 +5,7 @@ import (
 	"slices"
 	"sync"
 
-	"stackit.dev/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // RestackResult represents the outcome of a restack operation for a single branch

--- a/internal/handlers/restack_test.go
+++ b/internal/handlers/restack_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 func TestJSONRestackHandler(t *testing.T) {

--- a/internal/integration/config_init_test.go
+++ b/internal/integration/config_init_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/inprocess"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/inprocess"
 )
 
 func TestConfigInit(t *testing.T) {

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/utils"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/inprocess"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/utils"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/inprocess"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 // =============================================================================

--- a/internal/integration/init_test.go
+++ b/internal/integration/init_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/inprocess"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/inprocess"
 )
 
 func TestInitIntegration(t *testing.T) {

--- a/internal/integration/json_output_test.go
+++ b/internal/integration/json_output_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions"
-	"stackit.dev/stackit/internal/actions/sync"
-	"stackit.dev/stackit/internal/handlers"
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/actions/sync"
+	"github.com/getstackit/stackit/internal/handlers"
 )
 
 // =============================================================================

--- a/internal/integration/merged_history_test.go
+++ b/internal/integration/merged_history_test.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/components/tree"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestMergedDownstackHistory(t *testing.T) {

--- a/internal/integration/remote_metadata_sync_test.go
+++ b/internal/integration/remote_metadata_sync_test.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestRemoteMetadataSync(t *testing.T) {

--- a/internal/integration/scope_integration_test.go
+++ b/internal/integration/scope_integration_test.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/submit"
-	"stackit.dev/stackit/internal/actions/sync"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/submit"
+	"github.com/getstackit/stackit/internal/actions/sync"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 // noopHandler is a test handler that ignores all events

--- a/internal/integration/sync_test.go
+++ b/internal/integration/sync_test.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/actions/sync"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/actions/sync"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 const prStateMerged = "MERGED"

--- a/internal/integration/sync_ui_test.go
+++ b/internal/integration/sync_ui_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestSyncUIReporting(t *testing.T) {

--- a/internal/operations/submit.go
+++ b/internal/operations/submit.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"sync"
 
-	submitAction "stackit.dev/stackit/internal/actions/submit"
-	"stackit.dev/stackit/internal/app"
+	submitAction "github.com/getstackit/stackit/internal/actions/submit"
+	"github.com/getstackit/stackit/internal/app"
 )
 
 // SubmitOperation wraps the submit action as an async Operation.

--- a/internal/operations/sync.go
+++ b/internal/operations/sync.go
@@ -3,8 +3,8 @@ package operations
 import (
 	"context"
 
-	syncAction "stackit.dev/stackit/internal/actions/sync"
-	"stackit.dev/stackit/internal/app"
+	syncAction "github.com/getstackit/stackit/internal/actions/sync"
+	"github.com/getstackit/stackit/internal/app"
 )
 
 // SyncOperation wraps the sync action as an async Operation.

--- a/internal/pr/body.go
+++ b/internal/pr/body.go
@@ -1,7 +1,7 @@
 package pr
 
 import (
-	"stackit.dev/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // GenerateBody creates a PR body from branch commits.

--- a/internal/pr/merge.go
+++ b/internal/pr/merge.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // FormatMergeTitleWithDescription formats a merge PR title, using the stack description if present.

--- a/internal/pr/merge_test.go
+++ b/internal/pr/merge_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 func TestFormatMergeTitleWithDescription(t *testing.T) {

--- a/internal/pr/sections.go
+++ b/internal/pr/sections.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // formatStackDescription formats a stack description for display in PR body.

--- a/internal/pr/sections_test.go
+++ b/internal/pr/sections_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 const testPRBody = "## Description\nThis is my PR."

--- a/internal/pr/title.go
+++ b/internal/pr/title.go
@@ -1,7 +1,7 @@
 package pr
 
 import (
-	"stackit.dev/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // GenerateTitle creates a PR title from branch commits.

--- a/internal/rerere/rerere.go
+++ b/internal/rerere/rerere.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"strings"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 const declinedKey = "stackit.rerere.declined"

--- a/internal/rerere/rerere_test.go
+++ b/internal/rerere/rerere_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestEnsureEnabled(t *testing.T) {

--- a/internal/shippable/analyzer.go
+++ b/internal/shippable/analyzer.go
@@ -3,9 +3,9 @@ package shippable
 import (
 	"context"
 
-	"stackit.dev/stackit/internal/actions/merge"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
 )
 
 // Analyzer analyzes stacks for shippability.

--- a/internal/shippable/combiner.go
+++ b/internal/shippable/combiner.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions/merge"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/worktree"
+	"github.com/getstackit/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/worktree"
 )
 
 // Combiner analyzes whether multiple stacks can be merged together.

--- a/internal/shippable/combiner_test.go
+++ b/internal/shippable/combiner_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"stackit.dev/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/actions/merge"
 )
 
 func TestCombinationResult_IncludedCount(t *testing.T) {

--- a/internal/shippable/ship.go
+++ b/internal/shippable/ship.go
@@ -3,8 +3,8 @@ package shippable
 import (
 	"fmt"
 
-	"stackit.dev/stackit/internal/actions/merge"
-	"stackit.dev/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/app"
 )
 
 // ShipOptions configures the ship operation.

--- a/internal/shippable/ship_test.go
+++ b/internal/shippable/ship_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"stackit.dev/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/actions/merge"
 )
 
 func TestShipResult_Fields(t *testing.T) {

--- a/internal/shippable/types.go
+++ b/internal/shippable/types.go
@@ -4,7 +4,7 @@
 package shippable
 
 import (
-	"stackit.dev/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/actions/merge"
 )
 
 // Status represents the overall shippability state of a stack.

--- a/internal/shippable/types_test.go
+++ b/internal/shippable/types_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"stackit.dev/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/actions/merge"
 )
 
 func TestStatus_Constants(t *testing.T) {

--- a/internal/tui/base_model.go
+++ b/internal/tui/base_model.go
@@ -2,7 +2,7 @@
 package tui
 
 import (
-	"stackit.dev/stackit/internal/tui/core"
+	"github.com/getstackit/stackit/internal/tui/core"
 )
 
 // BaseModel is an alias to core.BaseModel for backwards compatibility.

--- a/internal/tui/components/flatten/model.go
+++ b/internal/tui/components/flatten/model.go
@@ -9,8 +9,8 @@ import (
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
 
-	"stackit.dev/stackit/internal/tui/core"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/tui/core"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Phase represents a flatten phase

--- a/internal/tui/components/foreach/foreach.go
+++ b/internal/tui/components/foreach/foreach.go
@@ -4,8 +4,8 @@ package foreach
 import (
 	"charm.land/lipgloss/v2"
 
-	"stackit.dev/stackit/internal/tui/core"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/tui/core"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Item represents a branch being processed

--- a/internal/tui/components/foreach/model.go
+++ b/internal/tui/components/foreach/model.go
@@ -8,8 +8,8 @@ import (
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
 
-	"stackit.dev/stackit/internal/tui/components/tree"
-	"stackit.dev/stackit/internal/tui/core"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/tui/core"
 )
 
 // Model is the bubbletea model for foreach progress.

--- a/internal/tui/components/merge/model.go
+++ b/internal/tui/components/merge/model.go
@@ -10,9 +10,9 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/tui/core"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/tui/core"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Group represents a group of steps that should be displayed as a single line

--- a/internal/tui/components/split/commit_editor.go
+++ b/internal/tui/components/split/commit_editor.go
@@ -11,8 +11,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"stackit.dev/stackit/internal/tui/style"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // CommitEditorConfig configures the commit message editor

--- a/internal/tui/components/split/keys.go
+++ b/internal/tui/components/split/keys.go
@@ -3,7 +3,7 @@ package split
 import (
 	"charm.land/bubbles/v2/key"
 
-	"stackit.dev/stackit/internal/tui/core"
+	"github.com/getstackit/stackit/internal/tui/core"
 )
 
 // KeyMap defines unified key bindings for the split wizard

--- a/internal/tui/components/split/messages.go
+++ b/internal/tui/components/split/messages.go
@@ -2,7 +2,7 @@
 package split
 
 import (
-	"stackit.dev/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // TypeSelectedMsg indicates user selected a split type

--- a/internal/tui/components/split/model.go
+++ b/internal/tui/components/split/model.go
@@ -10,12 +10,12 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/components/tree"
-	"stackit.dev/stackit/internal/tui/core"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/tui/core"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // State represents the main state of the split wizard

--- a/internal/tui/components/split/styles.go
+++ b/internal/tui/components/split/styles.go
@@ -1,7 +1,7 @@
 package split
 
 import (
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Styles contains styling for the split component using shared style types

--- a/internal/tui/components/split/types.go
+++ b/internal/tui/components/split/types.go
@@ -1,6 +1,6 @@
 package split
 
-import "stackit.dev/stackit/internal/engine"
+import "github.com/getstackit/stackit/internal/engine"
 
 // Style specifies the split mode
 // Note: This mirrors split.Style from actions/split to avoid import cycles.

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -8,8 +8,8 @@ import (
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
 
-	"stackit.dev/stackit/internal/tui/components/tree"
-	"stackit.dev/stackit/internal/tui/core"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/tui/core"
 )
 
 // Model is the bubbletea model for submit progress.

--- a/internal/tui/components/submit/submit.go
+++ b/internal/tui/components/submit/submit.go
@@ -4,7 +4,7 @@ package submit
 import (
 	"charm.land/lipgloss/v2"
 
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Item represents a branch being submitted

--- a/internal/tui/components/sync/model.go
+++ b/internal/tui/components/sync/model.go
@@ -10,8 +10,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"stackit.dev/stackit/internal/tui/core"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/tui/core"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Phase represents a sync phase

--- a/internal/tui/components/sync/model_test.go
+++ b/internal/tui/components/sync/model_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // viewString extracts the string content from a tea.View for test assertions.

--- a/internal/tui/components/tree/stack_tree.go
+++ b/internal/tui/components/tree/stack_tree.go
@@ -1,6 +1,6 @@
 package tree
 
-import "stackit.dev/stackit/internal/engine"
+import "github.com/getstackit/stackit/internal/engine"
 
 // StackTree represents the structure of a branch stack for rendering.
 // It encapsulates parent/child relationships and metadata needed to visualize stacks.

--- a/internal/tui/components/tree/tree.go
+++ b/internal/tui/components/tree/tree.go
@@ -8,7 +8,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 const (

--- a/internal/tui/components/tree/tree_test.go
+++ b/internal/tui/components/tree/tree_test.go
@@ -6,7 +6,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 func TestStackTreeRenderer_RenderStack_LinearStack(t *testing.T) {

--- a/internal/tui/config/config.go
+++ b/internal/tui/config/config.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"strings"
 
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // TUIAction provides an interactive TUI for editing configuration

--- a/internal/tui/direction_select.go
+++ b/internal/tui/direction_select.go
@@ -10,10 +10,10 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/tui/components/tree"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Direction represents where to place a new branch

--- a/internal/tui/flatten_preview.go
+++ b/internal/tui/flatten_preview.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // FlattenPlannedMove represents a single branch move in the flatten plan.

--- a/internal/tui/hunk_selector.go
+++ b/internal/tui/hunk_selector.go
@@ -11,10 +11,10 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/tui/core"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/tui/core"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // defaultPreviewLines is the number of diff lines to show in the collapsed preview

--- a/internal/tui/large_tree_stories.go
+++ b/internal/tui/large_tree_stories.go
@@ -5,7 +5,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"stackit.dev/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
 )
 
 func registerLargeTreeStories() {

--- a/internal/tui/log_ui.go
+++ b/internal/tui/log_ui.go
@@ -11,14 +11,14 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui/components/tree"
-	"stackit.dev/stackit/internal/tui/keys"
-	"stackit.dev/stackit/internal/tui/style"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/tui/keys"
+	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 const (

--- a/internal/tui/move_model.go
+++ b/internal/tui/move_model.go
@@ -8,10 +8,10 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/tui/components/tree"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 const (

--- a/internal/tui/move_preview.go
+++ b/internal/tui/move_preview.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // MovePreviewData contains the data needed to render a move preview.

--- a/internal/tui/prompts.go
+++ b/internal/tui/prompts.go
@@ -12,11 +12,11 @@ import (
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/tui/components/tree"
-	"stackit.dev/stackit/internal/tui/style"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 type promptKeyMap struct {

--- a/internal/tui/reorder_ui.go
+++ b/internal/tui/reorder_ui.go
@@ -9,8 +9,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"stackit.dev/stackit/internal/tui/keys"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/tui/keys"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Tree symbols for rendering

--- a/internal/tui/runner.go
+++ b/internal/tui/runner.go
@@ -14,8 +14,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui/core"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui/core"
 )
 
 // Runner manages async bubbletea program lifecycle with panic recovery.

--- a/internal/tui/shippable_stories.go
+++ b/internal/tui/shippable_stories.go
@@ -9,8 +9,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"stackit.dev/stackit/internal/tui/core"
-	"stackit.dev/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/tui/core"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // storyStack represents a simulated stack for the storyboard.

--- a/internal/tui/status.go
+++ b/internal/tui/status.go
@@ -2,7 +2,7 @@
 package tui
 
 import (
-	"stackit.dev/stackit/internal/tui/core"
+	"github.com/getstackit/stackit/internal/tui/core"
 )
 
 // Status is an alias to core.Status for backwards compatibility.

--- a/internal/tui/stories.go
+++ b/internal/tui/stories.go
@@ -7,8 +7,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"stackit.dev/stackit/internal/tui/components/submit"
-	"stackit.dev/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/tui/components/submit"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
 )
 
 // Story represents a specific state of a TUI component

--- a/internal/tui/style/formatter.go
+++ b/internal/tui/style/formatter.go
@@ -8,7 +8,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"stackit.dev/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/errors"
 )
 
 // GetLogShortColor returns a styled string with the color from StackitColors

--- a/internal/tui/tree_renderer.go
+++ b/internal/tui/tree_renderer.go
@@ -1,9 +1,9 @@
 package tui
 
 import (
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
 )
 
 // NewStackTreeRenderer creates a tree renderer configured for the current engine state

--- a/internal/tui/tree_renderer_worktree_anchor_test.go
+++ b/internal/tui/tree_renderer_worktree_anchor_test.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/git"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/internal/tui/components/tree"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestNewStackTreeRendererHidesWorktreeAnchorKeepsDescendants(t *testing.T) {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -15,11 +15,11 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/internal/tui/components/submit"
-	"stackit.dev/stackit/internal/tui/core"
-	"stackit.dev/stackit/internal/tui/style"
-	"stackit.dev/stackit/internal/utils"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui/components/submit"
+	"github.com/getstackit/stackit/internal/tui/core"
+	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // Key constants re-exported from core for backwards compatibility.

--- a/internal/worktree/executor.go
+++ b/internal/worktree/executor.go
@@ -4,9 +4,9 @@ package worktree
 import (
 	"context"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/errors"
-	"stackit.dev/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // Session represents an active worktree session that can be used to execute operations.

--- a/internal/worktree/executor_test.go
+++ b/internal/worktree/executor_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/output"
-	"stackit.dev/stackit/testhelpers"
-	"stackit.dev/stackit/testhelpers/scenario"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestExecutor_CreateSession(t *testing.T) {

--- a/testhelpers/README.md
+++ b/testhelpers/README.md
@@ -18,7 +18,7 @@ The scene system creates isolated test environments with temporary Git repositor
 ```go
 import (
     "testing"
-    "stackit.dev/stackit/testhelpers"
+    "github.com/getstackit/stackit/testhelpers"
 )
 
 func TestMyFeature(t *testing.T) {
@@ -152,10 +152,10 @@ The `NewMockGitHubServer` and `NewMockGitHubClient` functions create a mock GitH
 ```go
 import (
     "testing"
-    "stackit.dev/stackit/testhelpers"
-    "stackit.dev/stackit/internal/actions"
-    "stackit.dev/stackit/internal/engine"
-    "stackit.dev/stackit/internal/output"
+    "github.com/getstackit/stackit/testhelpers"
+    "github.com/getstackit/stackit/internal/actions"
+    "github.com/getstackit/stackit/internal/engine"
+    "github.com/getstackit/stackit/internal/output"
 )
 
 func TestSubmitWithMockedGitHub(t *testing.T) {

--- a/testhelpers/example_test.go
+++ b/testhelpers/example_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 // TestExampleUsage demonstrates how to use the testhelpers package.

--- a/testhelpers/github_mock_client.go
+++ b/testhelpers/github_mock_client.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/google/go-github/v62/github"
 
-	githubpkg "stackit.dev/stackit/internal/github"
-	"stackit.dev/stackit/internal/utils"
+	githubpkg "github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // MockGitHubClient implements githubpkg.Client using the mock server

--- a/testhelpers/inprocess/inprocess.go
+++ b/testhelpers/inprocess/inprocess.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"strings"
 
-	"stackit.dev/stackit/internal/cli"
+	"github.com/getstackit/stackit/internal/cli"
 )
 
 // CLI provides in-process CLI execution for faster tests.

--- a/testhelpers/pr_info.go
+++ b/testhelpers/pr_info.go
@@ -1,7 +1,7 @@
 package testhelpers
 
 import (
-	"stackit.dev/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // NewTestPrInfo creates a PrInfo for testing with common defaults

--- a/testhelpers/scenario/scenario.go
+++ b/testhelpers/scenario/scenario.go
@@ -14,11 +14,11 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/internal/app"
-	"stackit.dev/stackit/internal/config"
-	"stackit.dev/stackit/internal/engine"
-	"stackit.dev/stackit/internal/tui"
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 // InProcessRunner is a function that executes a stackit command in-process.
@@ -321,7 +321,7 @@ func (s *Scenario) RunCli(args ...string) *Scenario {
 	if s.InProcess {
 		runner := GetGlobalInProcessRunner()
 		if runner == nil {
-			s.T.Fatal("GlobalInProcessRunner not set. Import stackit.dev/stackit/internal/integration/setup in your test.")
+			s.T.Fatal("GlobalInProcessRunner not set. Import github.com/getstackit/stackit/internal/integration/setup in your test.")
 		}
 		// Use in-process runner if enabled
 		_, err := runner(s.Scene.Dir, args...)

--- a/testhelpers/scene_test.go
+++ b/testhelpers/scene_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"stackit.dev/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers"
 )
 
 func TestInitialCommitSceneSetupTemplate(t *testing.T) {


### PR DESCRIPTION

The Go module path was stackit.dev/stackit, but stackit.dev currently
redirects to STACKIT (an unrelated German cloud company). Switch to the
standard github.com/owner/repo form so the path matches the canonical
source and is resolvable.

Mechanical find-replace across 451 files; no behavior changes.