### PR TITLE
chore(create-release): bump goreleaser wait timeout to 1200s

### DIFF
--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -31,7 +31,7 @@ The deterministic steps live in `.claude/skills/create-release/scripts/`. Use th
 | `gather-commits.sh <tag>` | Sanity-check commit list since `<tag>` (catches direct pushes) |
 | `bump-version.sh <current> <patch\|minor\|major>` | Compute next semver tag |
 | `tag-and-push.sh <tag>` | Create annotated tag + push to origin |
-| `wait-for-release.sh <tag> [timeout]` | Poll until goreleaser materializes the release |
+| `wait-for-release.sh <tag> [timeout]` | Poll until goreleaser materializes the release (default 1200s; goreleaser typically takes 9-11 minutes) |
 | `apply-notes.sh <tag> <file>` | Overwrite release body with notes file, print URL |
 | `append-github-footer.sh <new> <prev> <file>` | Append GitHub's auto-generated "What's Changed" footer |
 

--- a/.claude/skills/create-release/scripts/wait-for-release.sh
+++ b/.claude/skills/create-release/scripts/wait-for-release.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 # Poll until the GitHub release for the given tag exists. Goreleaser
-# typically materializes the release entry 2-4 minutes after tag push.
+# typically materializes the release entry 9-11 minutes after tag push
+# (the workflow has to build CLI + server binaries for 3 OSes × 2 arches,
+# run upx compression, and publish to the Homebrew tap). 1200s gives
+# comfortable headroom over the historical 9-11 minute runtime.
 # Usage: wait-for-release.sh <tag> [timeout-seconds]
 set -euo pipefail
 
 tag="${1:?missing tag}"
-timeout="${2:-600}"
+timeout="${2:-1200}"
 interval=20
 elapsed=0
 


### PR DESCRIPTION

The release workflow takes 9-11 minutes (v0.17.10 hit 10m44s,
v0.17.14 hit 10m35s), so the previous 600s default timed out
before goreleaser could materialize the release. Bump to 1200s
to leave comfortable headroom.