### PR TITLE
refactor(info): split branch query from cli rendering

### DIFF
--- a/internal/actions/info.go
+++ b/internal/actions/info.go
@@ -1,188 +1,180 @@
 package actions
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
-	"strings"
 	"time"
 
-	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
-	"github.com/getstackit/stackit/internal/output"
 )
 
-// SingleBranchInfo represents JSON-serializable info for a single branch (used by info --json)
-type SingleBranchInfo struct {
-	Name             string              `json:"name"`
-	IsCurrent        bool                `json:"is_current"`
-	IsTrunk          bool                `json:"is_trunk"`
-	IsLocked         bool                `json:"is_locked"`
-	IsFrozen         bool                `json:"is_frozen"`
-	NeedsRestack     bool                `json:"needs_restack"`
-	Scope            string              `json:"scope"`
-	CommitDate       string              `json:"commit_date,omitempty"`
-	Parent           string              `json:"parent,omitempty"`
-	Children         []string            `json:"children,omitempty"`
-	PR               *SingleBranchPRInfo `json:"pr,omitempty"`
-	CommitMessages   []string            `json:"commit_messages"`
-	DiffStats        SingleBranchStats   `json:"diff_stats"`
-	StackTitle       string              `json:"stack_title,omitempty"`
-	StackDescription string              `json:"stack_description,omitempty"`
+// BranchInfoPR represents pull request information for a branch.
+type BranchInfoPR struct {
+	Number  *int
+	Title   string
+	State   git.PRState
+	IsDraft bool
+	URL     string
+	Body    string
 }
 
-// SingleBranchPRInfo represents PR information for JSON output
-type SingleBranchPRInfo struct {
-	Number  int         `json:"number"`
-	Title   string      `json:"title"`
-	State   git.PRState `json:"state"`
-	IsDraft bool        `json:"is_draft"`
-	URL     string      `json:"url"`
+// BranchDiffStats represents summary diff information for a branch. It is pure
+// data; the JSON shape lives in the CLI adapter that renders it.
+type BranchDiffStats struct {
+	FilesChanged int
+	Additions    int
+	Deletions    int
 }
 
-// SingleBranchStats represents diff statistics for a branch
-type SingleBranchStats struct {
-	FilesChanged int `json:"files_changed"`
-	Additions    int `json:"additions"`
-	Deletions    int `json:"deletions"`
+// BranchInfoResult contains structured data for `stackit info` on a single branch.
+type BranchInfoResult struct {
+	Name             string
+	IsCurrent        bool
+	IsTrunk          bool
+	IsLocked         bool
+	IsFrozen         bool
+	NeedsRestack     bool
+	Scope            string
+	CommitDate       string
+	Parent           string
+	Children         []string
+	PR               *BranchInfoPR
+	CommitMessages   []string
+	DiffStats        BranchDiffStats
+	StackTitle       string
+	StackDescription string
+	PatchOutput      string
+	DiffOutput       string
 }
 
-// InfoOptions contains options for the info command
-type InfoOptions struct {
+// BranchInfoQueryOptions contains options for querying single-branch info.
+type BranchInfoQueryOptions struct {
 	BranchName string
-	Body       bool
 	Diff       bool
 	Patch      bool
 	Stat       bool
-	Stack      bool
-	JSON       bool
 }
 
-// InfoAction displays information about a branch or the entire stack
-func InfoAction(ctx *app.Context, opts InfoOptions) error {
-	if opts.Stack {
-		return StackInfoAction(ctx, StackInfoOptions{
-			JSON: opts.JSON,
-		})
-	}
+type branchInfoDebugLogger interface {
+	Debug(format string, args ...any)
+}
 
-	eng := ctx.Engine
-	out := ctx.Output
-
+// QueryBranchInfo gathers structured information for `stackit info`.
+func QueryBranchInfo(ctx context.Context, eng engine.Engine, opts BranchInfoQueryOptions, debug branchInfoDebugLogger) (BranchInfoResult, error) {
 	branchName, err := ResolveBranchName(eng, opts.BranchName)
 	if err != nil {
-		return err
+		return BranchInfoResult{}, err
 	}
 
 	branch := eng.GetBranch(branchName)
-
 	if !branch.IsTracked() && !branch.IsTrunk() {
-		_, err := eng.GetRevision(branch)
-		if err != nil {
-			return fmt.Errorf("branch %s does not exist", branchName)
+		if _, err := eng.GetRevision(branch); err != nil {
+			return BranchInfoResult{}, fmt.Errorf("branch %s does not exist", branchName)
 		}
-
-		// For remote branches, fetch metadata to show the latest info
-		remoteCtx, cancelRemote := ctx.RemoteOperationContext()
-		defer cancelRemote()
-		if err := eng.FetchRemoteMetadata(remoteCtx); err != nil {
-			out.Debug("Failed to fetch remote metadata: %v", err)
-		} else if err := eng.ApplyRemoteMetadataForBranches(remoteCtx, []string{branchName}); err != nil {
-			out.Debug("Failed to apply remote metadata for %s: %v", branchName, err)
-		}
+		refreshRemoteMetadataForBranchInfo(ctx, eng, branchName, debug)
 	}
 
-	// Handle JSON output for single branch
-	if opts.JSON {
-		return outputBranchInfoJSON(ctx, branch)
+	return buildBranchInfoResult(ctx, eng, branchName, branch, opts)
+}
+
+func refreshRemoteMetadataForBranchInfo(ctx context.Context, eng engine.Engine, branchName string, debug branchInfoDebugLogger) {
+	if err := eng.FetchRemoteMetadata(ctx); err != nil {
+		debugBranchInfof(debug, "Failed to fetch remote metadata: %v", err)
+		return
 	}
 
-	// If stat is set without diff or patch, it implies diff
-	effectiveDiff := opts.Diff || (opts.Stat && !opts.Patch)
-	effectivePatch := opts.Patch && !opts.Diff
+	if err := eng.LoadRemoteMetadataCache(); err != nil {
+		debugBranchInfof(debug, "Failed to load remote metadata cache: %v", err)
+		return
+	}
 
-	var outputLines []string
+	if err := eng.ApplyRemoteMetadataIfExists(branchName); err != nil {
+		debugBranchInfof(debug, "Failed to apply remote metadata for %s: %v", branchName, err)
+	}
+}
 
+func buildBranchInfoResult(ctx context.Context, eng engine.Engine, branchName string, branch engine.Branch, opts BranchInfoQueryOptions) (BranchInfoResult, error) {
 	currentBranch := eng.CurrentBranch()
-	isCurrent := branchName == currentBranch.GetName()
+	isCurrent := currentBranch != nil && branchName == currentBranch.GetName()
 	isTrunk := branch.IsTrunk()
 
-	coloredBranchName := output.BranchWithTrunk(branchName, isCurrent, isTrunk)
-
-	if branch.IsLocked() {
-		coloredBranchName += " " + output.IconLocked() + " " + output.Dim("(locked)")
-	}
-	if branch.IsFrozen() {
-		coloredBranchName += " " + output.IconFrozen() + " " + output.Dim("(frozen)")
-	}
-
-	if !isTrunk && !branch.IsBranchUpToDate() {
-		coloredBranchName += " " + output.NeedsRestack("(needs restack)")
-	}
-
-	if scope := branch.GetScope(); !scope.IsNone() {
-		coloredBranchName += " " + output.Scope(scope.String())
-	}
-
-	outputLines = append(outputLines, coloredBranchName)
-
-	// Show stack description if present
-	stackDesc := eng.GetStackDescription(branch)
-	if stackDesc != nil && !stackDesc.IsEmpty() {
-		outputLines = append(outputLines, "")
-		// Render title and description together through glamour for consistent formatting
-		var markdown string
-		if stackDesc.Description != "" {
-			markdown = "# " + stackDesc.Title + "\n\n" + stackDesc.Description
-		} else {
-			markdown = "# " + stackDesc.Title
-		}
-		rendered := output.RenderMarkdown(markdown)
-		outputLines = append(outputLines, rendered)
+	result := BranchInfoResult{
+		Name:           branchName,
+		IsCurrent:      isCurrent,
+		IsTrunk:        isTrunk,
+		IsLocked:       branch.IsLocked(),
+		IsFrozen:       branch.IsFrozen(),
+		NeedsRestack:   !isTrunk && !branch.IsBranchUpToDate(),
+		Scope:          branch.GetScope().String(),
+		CommitMessages: []string{},
+		Children:       []string{},
 	}
 
 	commitDate, err := branch.GetCommitDate()
 	if err == nil {
-		dateStr := commitDate.Format(time.RFC3339)
-		outputLines = append(outputLines, output.Dim(dateStr))
+		result.CommitDate = commitDate.Format(time.RFC3339)
 	}
 
-	var prInfo *engine.PrInfo
-	if !isTrunk {
-		prInfo, _ = branch.GetPrInfo()
-		if prInfo != nil && prInfo.Number() != nil {
-			prTitleLine := getPRTitleLine(prInfo)
-			if prTitleLine != "" {
-				outputLines = append(outputLines, "")
-				outputLines = append(outputLines, prTitleLine)
-			}
-			if prInfo.URL() != "" {
-				outputLines = append(outputLines, output.Magenta(prInfo.URL()))
-			}
-		}
-	}
-
-	parentBranch := branch.GetParent()
-	if parentBranch != nil {
-		outputLines = append(outputLines, "")
-		outputLines = append(outputLines, fmt.Sprintf("%s: %s", output.Cyan("Parent"), output.BranchNameWithTrunk(parentBranch.GetName(), parentBranch.IsTrunk())))
+	if parent := branch.GetParent(); parent != nil {
+		result.Parent = parent.GetName()
 	}
 
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
-	children := graph.ChildBranches(branch)
-	if len(children) > 0 {
-		outputLines = append(outputLines, fmt.Sprintf("%s:", output.Cyan("Children")))
-		for _, child := range children {
-			outputLines = append(outputLines, fmt.Sprintf("▸ %s", output.BranchNameWithTrunk(child.GetName(), child.IsTrunk())))
+	for _, child := range graph.ChildBranches(branch) {
+		result.Children = append(result.Children, child.GetName())
+	}
+
+	if !isTrunk {
+		prInfo, _ := branch.GetPrInfo()
+		if prInfo != nil {
+			result.PR = &BranchInfoPR{
+				Number:  prInfo.Number(),
+				Title:   prInfo.Title(),
+				State:   prInfo.State(),
+				IsDraft: prInfo.IsDraft(),
+				URL:     prInfo.URL(),
+				Body:    prInfo.Body(),
+			}
 		}
 	}
 
-	if opts.Body && prInfo != nil && prInfo.Body() != "" {
-		outputLines = append(outputLines, "")
-		outputLines = append(outputLines, prInfo.Body())
+	commits, err := branch.GetAllCommits(engine.CommitFormatReadable)
+	if err == nil {
+		result.CommitMessages = commits
 	}
 
-	outputLines = append(outputLines, "")
+	// Diff stats — resolved via the batched reader over a single-branch set,
+	// rather than a per-branch accessor.
+	diff := eng.BatchDiffStats(engine.BranchesOf(branch))[branchName]
+	result.DiffStats.Additions = diff.Added
+	result.DiffStats.Deletions = diff.Deleted
+
+	// Files changed — measured against the branch's divergence point, the same
+	// base BatchDiffStats uses above, so the file count stays consistent with the
+	// additions/deletions when the parent has advanced since the branch diverged.
+	if !isTrunk {
+		base, err := eng.GetDivergencePoint(branchName)
+		if err == nil && base != "" {
+			branchRev, err := branch.GetRevision()
+			if err == nil {
+				files, err := eng.GetChangedFiles(ctx, git.RevRange{Base: base, Head: branchRev})
+				if err == nil {
+					result.DiffStats.FilesChanged = len(files)
+				}
+			}
+		}
+	}
+
+	stackDesc := eng.GetStackDescription(branch)
+	if stackDesc != nil && !stackDesc.IsEmpty() {
+		result.StackTitle = stackDesc.Title
+		result.StackDescription = stackDesc.Description
+	}
+
+	effectiveDiff := opts.Diff || (opts.Stat && !opts.Patch)
+	effectivePatch := opts.Patch && !opts.Diff
+
 	if effectivePatch {
 		baseRevision := ""
 		if isTrunk {
@@ -196,30 +188,22 @@ func InfoAction(ctx *app.Context, opts InfoOptions) error {
 		}
 		branchRevision, err := branch.GetRevision()
 		if err == nil {
-			commitsOutput, err := eng.ShowCommits(ctx.Context, git.RevRange{Base: baseRevision, Head: branchRevision}, true, opts.Stat)
-			if err == nil && commitsOutput != "" {
-				outputLines = append(outputLines, commitsOutput)
-			}
-		}
-	} else {
-		commits, err := branch.GetAllCommits(engine.CommitFormatReadable)
-		if err == nil {
-			for _, commit := range commits {
-				outputLines = append(outputLines, output.Dim(commit))
+			patchOutput, err := eng.ShowCommits(ctx, git.RevRange{Base: baseRevision, Head: branchRevision}, true, opts.Stat)
+			if err == nil {
+				result.PatchOutput = patchOutput
 			}
 		}
 	}
 
 	if effectiveDiff {
-		outputLines = append(outputLines, "")
 		if isTrunk {
 			headRevision, err := branch.GetRevision()
 			if err == nil {
 				parentSHA, err := eng.GetCommitSHA(branchName, 1)
 				if err == nil {
-					diffOutput, err := eng.ShowDiff(ctx.Context, parentSHA, headRevision, opts.Stat)
-					if err == nil && diffOutput != "" {
-						outputLines = append(outputLines, diffOutput)
+					diffOutput, err := eng.ShowDiff(ctx, parentSHA, headRevision, opts.Stat)
+					if err == nil {
+						result.DiffOutput = diffOutput
 					}
 				}
 			}
@@ -230,141 +214,21 @@ func InfoAction(ctx *app.Context, opts InfoOptions) error {
 				parentSHA, _ := eng.GetParentCommitSHA(oldestSHA)
 				branchRevision, err := branch.GetRevision()
 				if err == nil {
-					diffOutput, err := eng.ShowDiff(ctx.Context, parentSHA, branchRevision, opts.Stat)
-					if err == nil && diffOutput != "" {
-						outputLines = append(outputLines, diffOutput)
+					diffOutput, err := eng.ShowDiff(ctx, parentSHA, branchRevision, opts.Stat)
+					if err == nil {
+						result.DiffOutput = diffOutput
 					}
 				}
 			}
 		}
 	}
 
-	// Apply dimming for merged/closed PRs
-	if prInfo != nil && (prInfo.State() == git.PRStateMerged || prInfo.State() == git.PRStateClosed) {
-		for i := range outputLines {
-			outputLines[i] = output.Dim(outputLines[i])
-		}
-	}
-
-	out.Print(strings.Join(outputLines, "\n"))
-	out.Newline()
-
-	return nil
+	return result, nil
 }
 
-func getPRTitleLine(prInfo *engine.PrInfo) string {
-	if prInfo == nil || prInfo.Number() == nil || prInfo.Title() == "" {
-		return ""
+func debugBranchInfof(debug branchInfoDebugLogger, format string, args ...any) {
+	if debug == nil {
+		return
 	}
-
-	state := prInfo.State()
-
-	prNumber := output.PRNumber(*prInfo.Number())
-
-	switch state {
-	case git.PRStateMerged:
-		return fmt.Sprintf("%s (Merged) %s", prNumber, prInfo.Title())
-	case git.PRStateClosed:
-		return fmt.Sprintf("%s (Abandoned) %s", prNumber, output.Dim(prInfo.Title()))
-	default:
-		prState := ""
-		if prInfo.IsDraft() {
-			prState = output.Dim("(Draft)")
-		}
-		return fmt.Sprintf("%s %s %s", prNumber, prState, prInfo.Title())
-	}
-}
-
-// outputBranchInfoJSON outputs branch information as JSON
-func outputBranchInfoJSON(ctx *app.Context, branch engine.Branch) error {
-	eng := ctx.Engine
-	branchName := branch.GetName()
-	currentBranch := eng.CurrentBranch()
-	isCurrent := currentBranch != nil && branchName == currentBranch.GetName()
-	isTrunk := branch.IsTrunk()
-
-	info := SingleBranchInfo{
-		Name:           branchName,
-		IsCurrent:      isCurrent,
-		IsTrunk:        isTrunk,
-		IsLocked:       branch.IsLocked(),
-		IsFrozen:       branch.IsFrozen(),
-		NeedsRestack:   !isTrunk && !branch.IsBranchUpToDate(),
-		Scope:          branch.GetScope().String(),
-		CommitMessages: []string{},
-		Children:       []string{},
-	}
-
-	// Commit date
-	commitDate, err := branch.GetCommitDate()
-	if err == nil {
-		info.CommitDate = commitDate.Format(time.RFC3339)
-	}
-
-	// Parent
-	if parent := branch.GetParent(); parent != nil {
-		info.Parent = parent.GetName()
-	}
-
-	// Children
-	graph := eng.Graph(engine.SortStrategyAlphabetical)
-	for _, child := range graph.ChildBranches(branch) {
-		info.Children = append(info.Children, child.GetName())
-	}
-
-	// PR info
-	if !isTrunk {
-		prInfo, _ := branch.GetPrInfo()
-		if prInfo != nil && prInfo.Number() != nil {
-			info.PR = &SingleBranchPRInfo{
-				Number:  *prInfo.Number(),
-				Title:   prInfo.Title(),
-				State:   prInfo.State(),
-				IsDraft: prInfo.IsDraft(),
-				URL:     prInfo.URL(),
-			}
-		}
-	}
-
-	// Commit messages
-	commits, err := branch.GetAllCommits(engine.CommitFormatReadable)
-	if err == nil {
-		info.CommitMessages = commits
-	}
-
-	// Diff stats — resolved via the batched reader over a single-branch set,
-	// rather than a per-branch accessor.
-	diff := eng.BatchDiffStats(engine.BranchesOf(branch))[branchName]
-	info.DiffStats.Additions = diff.Added
-	info.DiffStats.Deletions = diff.Deleted
-
-	// Files changed — measured against the branch's divergence point, the same
-	// base GetDiffStats uses above, so the file count stays consistent with the
-	// additions/deletions when the parent has advanced since the branch diverged.
-	if !isTrunk {
-		base, err := eng.GetDivergencePoint(branchName)
-		if err == nil && base != "" {
-			branchRev, err := branch.GetRevision()
-			if err == nil {
-				files, err := eng.GetChangedFiles(ctx.Context, git.RevRange{Base: base, Head: branchRev})
-				if err == nil {
-					info.DiffStats.FilesChanged = len(files)
-				}
-			}
-		}
-	}
-
-	// Stack description
-	stackDesc := eng.GetStackDescription(branch)
-	if stackDesc != nil && !stackDesc.IsEmpty() {
-		info.StackTitle = stackDesc.Title
-		info.StackDescription = stackDesc.Description
-	}
-
-	data, err := json.MarshalIndent(info, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal branch info to JSON: %w", err)
-	}
-	ctx.Output.Info("%s", string(data))
-	return nil
+	debug.Debug(format, args...)
 }

--- a/internal/actions/info_test.go
+++ b/internal/actions/info_test.go
@@ -1,11 +1,13 @@
 package actions
 
 import (
-	"encoding/json"
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
@@ -33,10 +35,74 @@ func TestSingleBranchInfoFilesChangedUsesDivergenceBase(t *testing.T) {
 
 func singleBranchFilesChanged(t *testing.T, s *scenario.Scenario, name string) int {
 	t.Helper()
-	s.Output.Reset()
-	require.NoError(t, outputBranchInfoJSON(s.Context, s.Engine.GetBranch(name)))
-
-	var info SingleBranchInfo
-	require.NoError(t, json.Unmarshal(s.Output.Bytes(), &info))
+	info, err := QueryBranchInfo(context.Background(), s.Engine, BranchInfoQueryOptions{
+		BranchName: name,
+	}, nil)
+	require.NoError(t, err)
 	return info.DiffStats.FilesChanged
+}
+
+func TestQueryBranchInfo(t *testing.T) {
+	t.Run("returns structured branch info for a tracked branch", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.InitialCommitSceneSetup)
+
+		require.NoError(t, s.Scene.Repo.CreateAndCheckoutBranch("feature"))
+		require.NoError(t, s.Scene.Repo.CreateChange("feature change", "feature.txt", false))
+		require.NoError(t, s.Scene.Repo.RunGitCommand("add", "."))
+		require.NoError(t, s.Scene.Repo.RunGitCommand("commit", "-m", "feature change"))
+		require.NoError(t, s.Scene.Repo.CreateAndCheckoutBranch("child"))
+		require.NoError(t, s.Scene.Repo.CreateChange("child change", "child.txt", false))
+		require.NoError(t, s.Scene.Repo.RunGitCommand("add", "."))
+		require.NoError(t, s.Scene.Repo.RunGitCommand("commit", "-m", "child change"))
+		s.Rebuild()
+
+		require.NoError(t, s.Engine.TrackBranch(context.Background(), "feature", "main"))
+		require.NoError(t, s.Engine.TrackBranch(context.Background(), "child", "feature"))
+		require.NoError(t, s.Engine.SetScope(context.Background(), s.Engine.GetBranch("feature"), engine.NewScope("PROJ-123")))
+		s.Checkout("feature")
+
+		info, err := QueryBranchInfo(context.Background(), s.Engine, BranchInfoQueryOptions{
+			BranchName: "feature",
+		}, nil)
+		require.NoError(t, err)
+
+		require.Equal(t, "feature", info.Name)
+		require.True(t, info.IsCurrent)
+		require.False(t, info.IsTrunk)
+		require.Equal(t, "PROJ-123", info.Scope)
+		require.Equal(t, "main", info.Parent)
+		require.Contains(t, info.Children, "child")
+		require.Contains(t, strings.Join(info.CommitMessages, "\n"), "feature change")
+		require.GreaterOrEqual(t, info.DiffStats.FilesChanged, 1)
+		require.NotEmpty(t, info.CommitDate)
+	})
+
+	t.Run("includes diff and patch output when requested", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.InitialCommitSceneSetup)
+
+		require.NoError(t, s.Scene.Repo.CreateAndCheckoutBranch("feature"))
+		require.NoError(t, s.Scene.Repo.CreateChange("feature change", "feature.txt", false))
+		require.NoError(t, s.Scene.Repo.RunGitCommand("add", "."))
+		require.NoError(t, s.Scene.Repo.RunGitCommand("commit", "-m", "feature change"))
+		s.Rebuild()
+		require.NoError(t, s.Engine.TrackBranch(context.Background(), "feature", "main"))
+
+		info, err := QueryBranchInfo(context.Background(), s.Engine, BranchInfoQueryOptions{
+			BranchName: "feature",
+			Patch:      true,
+		}, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, info.PatchOutput)
+		require.Empty(t, info.DiffOutput)
+	})
+
+	t.Run("errors for a missing branch", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.InitialCommitSceneSetup)
+
+		_, err := QueryBranchInfo(context.Background(), s.Engine, BranchInfoQueryOptions{
+			BranchName: "missing",
+		}, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not exist")
+	})
 }

--- a/internal/actions/stack_info.go
+++ b/internal/actions/stack_info.go
@@ -1,93 +1,92 @@
 package actions
 
 import (
-	"encoding/json"
-	"fmt"
-	"strings"
+	"context"
 
-	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/errors"
-	"github.com/getstackit/stackit/internal/output"
-	"github.com/getstackit/stackit/internal/tui/components/tree"
 )
 
-// StackBranchInfo represents JSON-serializable info for a single branch in a stack
-type StackBranchInfo struct {
-	Name           string    `json:"name"`
-	Parent         string    `json:"parent"`
-	IsLocked       bool      `json:"is_locked"`
-	IsFrozen       bool      `json:"is_frozen"`
-	Scope          string    `json:"scope"`
-	PRNumber       *int      `json:"pr_number,omitempty"`
-	PRURL          string    `json:"pr_url,omitempty"`
-	CommitMessages []string  `json:"commit_messages"`
-	DiffStats      DiffStats `json:"diff_stats"`
+// StackInfoBranch is structured info for one non-trunk branch in a stack.
+type StackInfoBranch struct {
+	Name           string
+	Parent         string
+	IsLocked       bool
+	IsFrozen       bool
+	Scope          string
+	PRNumber       *int
+	PRURL          string
+	CommitMessages []string
+	DiffStats      BranchDiffStats
 }
 
-// DiffStats represents summary diff information
-type DiffStats struct {
-	FilesChanged int `json:"files_changed"`
-	Additions    int `json:"additions"`
-	Deletions    int `json:"deletions"`
+// StackInfoResult contains structured data for `stackit info --stack`. It carries
+// both the per-branch annotations (Branches) and the stack shape needed to draw
+// the tree (Order/Parents/UpToDate), all as plain data — the CLI adapter turns it
+// into a tree widget or JSON.
+type StackInfoResult struct {
+	StackTitle       string
+	StackDescription string
+	Current          string
+	Trunk            string
+	Branches         []StackInfoBranch // non-trunk branches, in stack order
+	Order            []string          // every branch name (incl trunk), in stack order
+	Parents          map[string]string // branch -> parent (incl trunk)
+	UpToDate         map[string]bool   // branch -> up to date with parent (incl trunk)
 }
 
-// StackInfoOutput represents JSON-serializable output for the stack info command
-type StackInfoOutput struct {
-	StackTitle       string            `json:"stack_title,omitempty"`
-	StackDescription string            `json:"stack_description,omitempty"`
-	Branches         []StackBranchInfo `json:"branches"`
-}
-
-// StackInfoOptions contains options for the stack info logic
-type StackInfoOptions struct {
-	JSON bool
-}
-
-// StackInfoAction retrieves information about branches in the current stack
-func StackInfoAction(ctx *app.Context, opts StackInfoOptions) error {
-	eng := ctx.Engine
-
-	currentBranch := eng.CurrentBranch()
-	if currentBranch == nil {
-		return errors.ErrNotOnBranch
+// QueryStackInfo gathers structured information about the current stack.
+func QueryStackInfo(ctx context.Context, eng engine.Engine) (StackInfoResult, error) {
+	current := eng.CurrentBranch()
+	if current == nil {
+		return StackInfoResult{}, errors.ErrNotOnBranch
 	}
 
-	// Build StackGraph for efficient traversals
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
-	stackBranches := graph.Range(*currentBranch, engine.StackRange{
+	stackBranches := graph.Range(*current, engine.StackRange{
 		RecursiveParents:  true,
 		IncludeCurrent:    true,
 		RecursiveChildren: true,
 	})
-	result := make([]StackBranchInfo, 0, len(stackBranches))
 
-	// Read each per-branch concern the loop needs as its own batched value map —
-	// commits, diff stats, changed-file counts, and PR submission status — instead
-	// of warming an engine-global cache. The loop is a projection over these maps.
+	// Read each per-branch concern the projection needs as its own batched value
+	// map — commits, diff stats, changed-file counts, PR status, and restack
+	// status — instead of warming an engine-global cache.
 	commits := eng.BatchCommits(stackBranches, engine.CommitFormatReadable)
 	diffs := eng.BatchDiffStats(stackBranches)
-	fileCounts := eng.BatchChangedFileCounts(ctx.Context, stackBranches)
+	fileCounts := eng.BatchChangedFileCounts(ctx, stackBranches)
+	prStatuses, _ := eng.BatchGetPRSubmissionStatus(ctx, stackBranches)
+	statuses := eng.ReadBranchStatuses(stackBranches)
 
-	remoteCtx, cancelRemote := ctx.RemoteOperationContext()
-	defer cancelRemote()
-	prStatuses, _ := eng.BatchGetPRSubmissionStatus(remoteCtx, stackBranches)
+	trunk := eng.Trunk().GetName()
+	result := StackInfoResult{
+		Current:  current.GetName(),
+		Trunk:    trunk,
+		Order:    make([]string, 0, len(stackBranches)),
+		Parents:  make(map[string]string, len(stackBranches)),
+		UpToDate: make(map[string]bool, len(stackBranches)),
+		Branches: make([]StackInfoBranch, 0, len(stackBranches)),
+	}
 
 	for _, branch := range stackBranches {
+		name := branch.GetName()
+		result.Order = append(result.Order, name)
+		result.Parents[name] = branch.GetParentOrTrunk()
+		result.UpToDate[name] = statuses.IsUpToDate(branch)
+
 		if branch.IsTrunk() {
 			continue
 		}
-		name := branch.GetName()
 
 		diff := diffs[name]
-		info := StackBranchInfo{
+		info := StackInfoBranch{
 			Name:           name,
 			Parent:         branch.GetParentOrTrunk(),
 			IsLocked:       branch.IsLocked(),
 			IsFrozen:       branch.IsFrozen(),
 			Scope:          branch.GetScope().String(),
 			CommitMessages: commits[name],
-			DiffStats: DiffStats{
+			DiffStats: BranchDiffStats{
 				Additions:    diff.Added,
 				Deletions:    diff.Deleted,
 				FilesChanged: fileCounts[name],
@@ -97,91 +96,23 @@ func StackInfoAction(ctx *app.Context, opts StackInfoOptions) error {
 			info.CommitMessages = []string{}
 		}
 
-		// PR info
-		prStatus := prStatuses[name]
-		if prStatus.PRNumber != nil {
+		if prStatus := prStatuses[name]; prStatus.PRNumber != nil {
 			info.PRNumber = prStatus.PRNumber
 			if prStatus.PRInfo != nil {
 				info.PRURL = prStatus.PRInfo.URL()
 			}
 		}
 
-		result = append(result, info)
+		result.Branches = append(result.Branches, info)
 	}
 
-	if opts.JSON {
-		output := StackInfoOutput{
-			Branches: result,
-		}
-		stackDesc := eng.GetStackDescription(*currentBranch)
-		if stackDesc != nil && !stackDesc.IsEmpty() {
-			output.StackTitle = stackDesc.Title
-			output.StackDescription = stackDesc.Description
-		}
-		data, err := json.MarshalIndent(output, "", "  ")
-		if err != nil {
-			return fmt.Errorf("failed to marshal stack info to JSON: %w", err)
-		}
-		ctx.Output.Info("%s", string(data))
-	} else {
-		// Show stack description if present
-		stackDesc := eng.GetStackDescription(*currentBranch)
-		if stackDesc != nil && !stackDesc.IsEmpty() {
-			// Render title and description together through glamour for consistent formatting
-			var markdown string
-			if stackDesc.Description != "" {
-				markdown = "# " + stackDesc.Title + "\n\n" + stackDesc.Description
-			} else {
-				markdown = "# " + stackDesc.Title
-			}
-			rendered := output.RenderMarkdown(markdown)
-			ctx.Output.Info("%s", rendered)
-			ctx.Output.Info("")
-			ctx.Output.Info(strings.Repeat("─", 40))
-			ctx.Output.Info("")
-		}
+	// Trunk never needs a restack; mirror the tree renderer's own invariant.
+	result.UpToDate[trunk] = true
 
-		// Build tree data structure for rendering
-		trunkName := eng.Trunk().GetName()
-		stackTree := tree.NewStackTree(stackBranches, currentBranch.GetName(), trunkName)
-		stackTree.FixedMap = make(map[string]bool)
-		// Resolve restack status for the whole stack in one batched parent-revision
-		// read instead of a per-branch NeedsRestack() (each of which would shell a
-		// separate `git rev-parse` for the parent).
-		statuses := eng.ReadBranchStatuses(stackBranches)
-		for _, branch := range stackBranches {
-			// IsFixed means it does NOT need restack
-			stackTree.FixedMap[branch.GetName()] = statuses.IsUpToDate(branch)
-		}
-		stackTree.FixedMap[trunkName] = true
-
-		renderer := tree.NewRenderer(stackTree)
-
-		// Build annotations with commit messages and PR info
-		annotations := make(map[string]tree.BranchAnnotation)
-		for _, info := range result {
-			annotations[info.Name] = tree.BranchAnnotation{
-				CommitMessages: info.CommitMessages,
-				LinesAdded:     info.DiffStats.Additions,
-				LinesDeleted:   info.DiffStats.Deletions,
-				Scope:          info.Scope,
-				IsLocked:       info.IsLocked,
-				IsFrozen:       info.IsFrozen,
-				PRNumber:       info.PRNumber,
-				PRURL:          info.PRURL,
-			}
-		}
-		renderer.SetAnnotations(annotations)
-
-		// Render the tree with commit messages
-		lines := renderer.RenderStack(currentBranch.GetName(), tree.RenderOptions{
-			ShowCommitMessages:  true,
-			HideSummary:         true,
-			SkipSelectionPrefix: true,
-		})
-
-		ctx.Output.Info("%s", strings.Join(lines, "\n"))
+	if stackDesc := eng.GetStackDescription(*current); stackDesc != nil && !stackDesc.IsEmpty() {
+		result.StackTitle = stackDesc.Title
+		result.StackDescription = stackDesc.Description
 	}
 
-	return nil
+	return result, nil
 }

--- a/internal/actions/stack_info_test.go
+++ b/internal/actions/stack_info_test.go
@@ -2,7 +2,6 @@ package actions
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,9 +11,9 @@ import (
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
-func TestStackInfoAction(t *testing.T) {
+func TestQueryStackInfo(t *testing.T) {
 	t.Parallel()
-	t.Run("returns JSON info for the current stack", func(t *testing.T) {
+	t.Run("returns structured info for the current stack", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
@@ -28,25 +27,14 @@ func TestStackInfoAction(t *testing.T) {
 		s.Checkout("branch2")
 		s.Scene.Repo.CreateChangeAndCommit("c2", "f2.txt")
 
-		err := StackInfoAction(s.Context, StackInfoOptions{JSON: true})
-		output := s.Output.String()
-
+		result, err := QueryStackInfo(context.Background(), s.Engine)
 		require.NoError(t, err)
-		require.NotEmpty(t, output)
+		require.Len(t, result.Branches, 2)
 
-		var info StackInfoOutput
-		err = json.Unmarshal([]byte(output), &info)
-		require.NoError(t, err)
-
-		// Check branches
-		require.Len(t, info.Branches, 2)
-
-		// Map by name for easier checking
-		branchMap := make(map[string]StackBranchInfo)
-		for _, b := range info.Branches {
+		branchMap := make(map[string]StackInfoBranch)
+		for _, b := range result.Branches {
 			branchMap[b.Name] = b
 		}
-
 		require.Contains(t, branchMap, "branch1")
 		require.Contains(t, branchMap, "branch2")
 
@@ -59,37 +47,23 @@ func TestStackInfoAction(t *testing.T) {
 		require.Equal(t, "branch1", b2.Parent)
 		require.NotEmpty(t, b2.CommitMessages)
 		require.GreaterOrEqual(t, b2.DiffStats.FilesChanged, 1)
+
+		// Tree structure: Order holds the stacked (non-trunk) branches; trunk is
+		// referenced via Trunk/Parents and is always fixed.
+		require.Equal(t, []string{"branch1", "branch2"}, result.Order)
+		require.Equal(t, "main", result.Trunk)
+		require.Equal(t, "main", result.Parents["branch1"])
+		require.True(t, result.UpToDate["main"])
 	})
 
 	t.Run("fails when not on a branch", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
-		// Detach HEAD
 		s.RunGit("checkout", "--detach", "main")
 
-		err := StackInfoAction(s.Context, StackInfoOptions{JSON: true})
+		_, err := QueryStackInfo(context.Background(), s.Engine)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not on a branch")
-	})
-
-	t.Run("returns tree view with commit messages when JSON flag is false", func(t *testing.T) {
-		t.Parallel()
-		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
-			WithStack(map[string]string{
-				"branch1": "main",
-			})
-		s.Checkout("branch1")
-
-		err := StackInfoAction(s.Context, StackInfoOptions{JSON: false})
-		output := s.Output.String()
-
-		require.NoError(t, err)
-		// Tree format includes branch name with symbol
-		require.Contains(t, output, "branch1")
-		// Tree format shows trunk at bottom
-		require.Contains(t, output, "main")
-		// Tree format shows commit messages
-		require.Contains(t, output, "change on branch1")
 	})
 
 	t.Run("includes lock and frozen state", func(t *testing.T) {
@@ -106,16 +80,10 @@ func TestStackInfoAction(t *testing.T) {
 		_, err = s.Engine.SetFrozen(context.Background(), engine.BranchesOf(branch1), true)
 		require.NoError(t, err)
 
-		err = StackInfoAction(s.Context, StackInfoOptions{JSON: true})
-		output := s.Output.String()
-
+		result, err := QueryStackInfo(context.Background(), s.Engine)
 		require.NoError(t, err)
-
-		var info StackInfoOutput
-		err = json.Unmarshal([]byte(output), &info)
-		require.NoError(t, err)
-		require.Len(t, info.Branches, 1)
-		require.True(t, info.Branches[0].IsLocked)
-		require.True(t, info.Branches[0].IsFrozen)
+		require.Len(t, result.Branches, 1)
+		require.True(t, result.Branches[0].IsLocked)
+		require.True(t, result.Branches[0].IsFrozen)
 	})
 }

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -33,20 +33,56 @@ If no branch is specified and --stack is not provided, displays information abou
 		SilenceUsage:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
-				branchName := ""
-				if len(args) > 0 {
-					branchName = args[0]
+				if stack {
+					remoteCtx, cancel := ctx.RemoteOperationContext()
+					defer cancel()
+
+					result, err := actions.QueryStackInfo(remoteCtx, ctx.Engine)
+					if err != nil {
+						return err
+					}
+
+					if json {
+						data, err := renderStackInfoJSON(result)
+						if err != nil {
+							return err
+						}
+						ctx.Output.Info("%s", string(data))
+						return nil
+					}
+
+					ctx.Output.Info("%s", renderStackInfoText(result))
+					return nil
 				}
 
-				return actions.InfoAction(ctx, actions.InfoOptions{
-					BranchName: branchName,
-					Body:       body,
-					Diff:       diff,
-					Patch:      patch,
-					Stat:       stat,
-					Stack:      stack,
-					JSON:       json,
-				})
+				opts := actions.BranchInfoQueryOptions{
+					Diff:  diff,
+					Patch: patch,
+					Stat:  stat,
+				}
+				if len(args) > 0 {
+					opts.BranchName = args[0]
+				}
+
+				info, err := actions.QueryBranchInfo(ctx.Context, ctx.Engine, opts, ctx.Output)
+				if err != nil {
+					return err
+				}
+
+				if json {
+					data, err := renderBranchInfoJSON(info)
+					if err != nil {
+						return err
+					}
+					ctx.Output.Info("%s", string(data))
+					return nil
+				}
+
+				ctx.Output.Print(renderBranchInfoText(info, branchInfoRenderOptions{
+					Body: body,
+				}))
+				ctx.Output.Newline()
+				return nil
 			})
 		},
 	}

--- a/internal/cli/info_render.go
+++ b/internal/cli/info_render.go
@@ -1,0 +1,289 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/tui/components/tree"
+	"github.com/getstackit/stackit/internal/tui/style"
+)
+
+// diffStatsJSON is the CLI-owned JSON shape for branch diff stats. The actions
+// layer returns actions.BranchDiffStats (pure data); the json tags live here.
+type diffStatsJSON struct {
+	FilesChanged int `json:"files_changed"`
+	Additions    int `json:"additions"`
+	Deletions    int `json:"deletions"`
+}
+
+func toDiffStatsJSON(s actions.BranchDiffStats) diffStatsJSON {
+	return diffStatsJSON{FilesChanged: s.FilesChanged, Additions: s.Additions, Deletions: s.Deletions}
+}
+
+type singleBranchInfoJSON struct {
+	Name             string              `json:"name"`
+	IsCurrent        bool                `json:"is_current"`
+	IsTrunk          bool                `json:"is_trunk"`
+	IsLocked         bool                `json:"is_locked"`
+	IsFrozen         bool                `json:"is_frozen"`
+	NeedsRestack     bool                `json:"needs_restack"`
+	Scope            string              `json:"scope"`
+	CommitDate       string              `json:"commit_date,omitempty"`
+	Parent           string              `json:"parent,omitempty"`
+	Children         []string            `json:"children,omitempty"`
+	PR               *singleBranchPRJSON `json:"pr,omitempty"`
+	CommitMessages   []string            `json:"commit_messages"`
+	DiffStats        diffStatsJSON       `json:"diff_stats"`
+	StackTitle       string              `json:"stack_title,omitempty"`
+	StackDescription string              `json:"stack_description,omitempty"`
+}
+
+type singleBranchPRJSON struct {
+	Number  int    `json:"number"`
+	Title   string `json:"title"`
+	State   string `json:"state"`
+	IsDraft bool   `json:"is_draft"`
+	URL     string `json:"url"`
+}
+
+type branchInfoRenderOptions struct {
+	Body bool
+}
+
+func renderBranchInfoText(info actions.BranchInfoResult, opts branchInfoRenderOptions) string {
+	var outputLines []string
+
+	coloredBranchName := style.ColorBranchNameWithTrunk(info.Name, info.IsCurrent, info.IsTrunk)
+	if info.IsLocked {
+		coloredBranchName += " " + style.IconLocked() + " " + style.ColorDim("(locked)")
+	}
+	if info.IsFrozen {
+		coloredBranchName += " " + style.IconFrozen() + " " + style.ColorDim("(frozen)")
+	}
+	if info.NeedsRestack {
+		coloredBranchName += " " + style.ColorNeedsRestack("(needs restack)")
+	}
+	if info.Scope != "" {
+		coloredBranchName += " " + style.ColorScope(info.Scope)
+	}
+	outputLines = append(outputLines, coloredBranchName)
+
+	if info.StackTitle != "" {
+		outputLines = append(outputLines, "")
+		outputLines = append(outputLines, style.RenderMarkdown(renderStackDescriptionMarkdown(info.StackTitle, info.StackDescription)))
+	}
+
+	if info.CommitDate != "" {
+		outputLines = append(outputLines, style.ColorDim(info.CommitDate))
+	}
+
+	if prTitleLine := renderPRTitleLine(info.PR); prTitleLine != "" {
+		outputLines = append(outputLines, "")
+		outputLines = append(outputLines, prTitleLine)
+		if info.PR != nil && info.PR.URL != "" {
+			outputLines = append(outputLines, style.ColorMagenta(info.PR.URL))
+		}
+	}
+
+	if info.Parent != "" {
+		outputLines = append(outputLines, "")
+		outputLines = append(outputLines, fmt.Sprintf("%s: %s", style.ColorCyan("Parent"), style.ColorBranchNameWithTrunk(info.Parent, false, false)))
+	}
+
+	if len(info.Children) > 0 {
+		outputLines = append(outputLines, fmt.Sprintf("%s:", style.ColorCyan("Children")))
+		for _, child := range info.Children {
+			outputLines = append(outputLines, fmt.Sprintf("▸ %s", style.ColorBranchNameWithTrunk(child, false, false)))
+		}
+	}
+
+	if opts.Body && info.PR != nil && info.PR.Body != "" {
+		outputLines = append(outputLines, "")
+		outputLines = append(outputLines, info.PR.Body)
+	}
+
+	outputLines = append(outputLines, "")
+	if info.PatchOutput != "" {
+		outputLines = append(outputLines, info.PatchOutput)
+	} else {
+		for _, commit := range info.CommitMessages {
+			outputLines = append(outputLines, style.ColorDim(commit))
+		}
+	}
+
+	if info.DiffOutput != "" {
+		outputLines = append(outputLines, "")
+		outputLines = append(outputLines, info.DiffOutput)
+	}
+
+	if shouldDimBranchInfo(info.PR) {
+		for i := range outputLines {
+			outputLines[i] = style.ColorDim(outputLines[i])
+		}
+	}
+
+	return strings.Join(outputLines, "\n")
+}
+
+func renderBranchInfoJSON(info actions.BranchInfoResult) ([]byte, error) {
+	output := singleBranchInfoJSON{
+		Name:             info.Name,
+		IsCurrent:        info.IsCurrent,
+		IsTrunk:          info.IsTrunk,
+		IsLocked:         info.IsLocked,
+		IsFrozen:         info.IsFrozen,
+		NeedsRestack:     info.NeedsRestack,
+		Scope:            info.Scope,
+		CommitDate:       info.CommitDate,
+		Parent:           info.Parent,
+		Children:         info.Children,
+		CommitMessages:   info.CommitMessages,
+		DiffStats:        toDiffStatsJSON(info.DiffStats),
+		StackTitle:       info.StackTitle,
+		StackDescription: info.StackDescription,
+	}
+
+	if info.PR != nil && info.PR.Number != nil {
+		output.PR = &singleBranchPRJSON{
+			Number:  *info.PR.Number,
+			Title:   info.PR.Title,
+			State:   string(info.PR.State),
+			IsDraft: info.PR.IsDraft,
+			URL:     info.PR.URL,
+		}
+	}
+
+	return json.MarshalIndent(output, "", "  ")
+}
+
+func renderPRTitleLine(prInfo *actions.BranchInfoPR) string {
+	if prInfo == nil || prInfo.Number == nil || prInfo.Title == "" {
+		return ""
+	}
+
+	prNumber := style.ColorPRNumber(*prInfo.Number)
+	switch prInfo.State {
+	case git.PRStateMerged:
+		return fmt.Sprintf("%s (Merged) %s", prNumber, prInfo.Title)
+	case git.PRStateClosed:
+		return fmt.Sprintf("%s (Abandoned) %s", prNumber, style.ColorDim(prInfo.Title))
+	default:
+		prState := ""
+		if prInfo.IsDraft {
+			prState = style.ColorDim("(Draft)")
+		}
+		return fmt.Sprintf("%s %s %s", prNumber, prState, prInfo.Title)
+	}
+}
+
+func renderStackDescriptionMarkdown(title, description string) string {
+	if description != "" {
+		return "# " + title + "\n\n" + description
+	}
+	return "# " + title
+}
+
+func shouldDimBranchInfo(prInfo *actions.BranchInfoPR) bool {
+	if prInfo == nil {
+		return false
+	}
+	return prInfo.State == git.PRStateMerged || prInfo.State == git.PRStateClosed
+}
+
+type stackInfoJSON struct {
+	StackTitle       string            `json:"stack_title,omitempty"`
+	StackDescription string            `json:"stack_description,omitempty"`
+	Branches         []stackBranchJSON `json:"branches"`
+}
+
+type stackBranchJSON struct {
+	Name           string        `json:"name"`
+	Parent         string        `json:"parent"`
+	IsLocked       bool          `json:"is_locked"`
+	IsFrozen       bool          `json:"is_frozen"`
+	Scope          string        `json:"scope"`
+	PRNumber       *int          `json:"pr_number,omitempty"`
+	PRURL          string        `json:"pr_url,omitempty"`
+	CommitMessages []string      `json:"commit_messages"`
+	DiffStats      diffStatsJSON `json:"diff_stats"`
+}
+
+func renderStackInfoJSON(result actions.StackInfoResult) ([]byte, error) {
+	output := stackInfoJSON{
+		StackTitle:       result.StackTitle,
+		StackDescription: result.StackDescription,
+		Branches:         make([]stackBranchJSON, 0, len(result.Branches)),
+	}
+	for _, b := range result.Branches {
+		output.Branches = append(output.Branches, stackBranchJSON{
+			Name:           b.Name,
+			Parent:         b.Parent,
+			IsLocked:       b.IsLocked,
+			IsFrozen:       b.IsFrozen,
+			Scope:          b.Scope,
+			PRNumber:       b.PRNumber,
+			PRURL:          b.PRURL,
+			CommitMessages: b.CommitMessages,
+			DiffStats:      toDiffStatsJSON(b.DiffStats),
+		})
+	}
+	return json.MarshalIndent(output, "", "  ")
+}
+
+func renderStackInfoText(result actions.StackInfoResult) string {
+	var sections []string
+
+	if result.StackTitle != "" {
+		markdown := renderStackDescriptionMarkdown(result.StackTitle, result.StackDescription)
+		sections = append(sections, style.RenderMarkdown(markdown), "", strings.Repeat("─", 40), "")
+	}
+
+	stackTree := &tree.StackTree{
+		Branches:       result.Order,
+		CurrentBranchV: result.Current,
+		TrunkBranch:    result.Trunk,
+		ParentMap:      result.Parents,
+		ChildrenMap:    childrenFromParents(result.Order, result.Parents),
+		FixedMap:       result.UpToDate,
+	}
+
+	annotations := make(map[string]tree.BranchAnnotation, len(result.Branches))
+	for _, b := range result.Branches {
+		annotations[b.Name] = tree.BranchAnnotation{
+			CommitMessages: b.CommitMessages,
+			LinesAdded:     b.DiffStats.Additions,
+			LinesDeleted:   b.DiffStats.Deletions,
+			Scope:          b.Scope,
+			IsLocked:       b.IsLocked,
+			IsFrozen:       b.IsFrozen,
+			PRNumber:       b.PRNumber,
+			PRURL:          b.PRURL,
+		}
+	}
+
+	renderer := tree.NewRenderer(stackTree)
+	renderer.SetAnnotations(annotations)
+	lines := renderer.RenderStack(result.Current, tree.RenderOptions{
+		ShowCommitMessages:  true,
+		HideSummary:         true,
+		SkipSelectionPrefix: true,
+	})
+
+	sections = append(sections, strings.Join(lines, "\n"))
+	return strings.Join(sections, "\n")
+}
+
+// childrenFromParents builds the inverse of a branch->parent map, preserving the
+// order branches appear in, matching tree.NewStackTree's own construction.
+func childrenFromParents(order []string, parents map[string]string) map[string][]string {
+	children := make(map[string][]string)
+	for _, name := range order {
+		if parent := parents[name]; parent != "" {
+			children[parent] = append(children[parent], name)
+		}
+	}
+	return children
+}

--- a/internal/cli/info_test.go
+++ b/internal/cli/info_test.go
@@ -146,6 +146,24 @@ func TestInfoCommand(t *testing.T) {
 			"should contain patch output, got: %s", output)
 	})
 
+	t.Run("info with --json returns structured branch data", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.InitialCommitSceneSetup).WithInProcess(true)
+
+		if err := s.Scene.Repo.CreateChange("feature change", "test", false); err != nil {
+			t.Fatal(err)
+		}
+		s.RunCli("create", "feature", "-m", "feature change")
+
+		output, err := s.RunCliAndGetOutput("info", "--json")
+
+		require.NoError(t, err, "info command failed: %s", output)
+		require.Contains(t, output, `"name": "feature"`)
+		require.Contains(t, output, `"is_current": true`)
+		require.Contains(t, output, `"commit_messages": [`)
+		require.Contains(t, output, `"diff_stats": {`)
+	})
+
 	t.Run("info with --stat flag shows diffstat", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.InitialCommitSceneSetup).WithInProcess(true)
@@ -262,6 +280,28 @@ func TestInfoCommand(t *testing.T) {
 
 		require.Error(t, err, "info should fail when stackit not initialized")
 		require.Contains(t, output, "not initialized", "should mention not initialized")
+	})
+
+	t.Run("info with --stack shows tree with commit messages", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.InitialCommitSceneSetup).WithInProcess(true)
+
+		if err := s.Scene.Repo.CreateChange("a change", "a", false); err != nil {
+			t.Fatal(err)
+		}
+		s.RunCli("create", "a", "-m", "a change")
+		if err := s.Scene.Repo.CreateChange("b change", "b", false); err != nil {
+			t.Fatal(err)
+		}
+		s.RunCli("create", "b", "-m", "b change")
+
+		output, err := s.RunCliAndGetOutput("info", "--stack")
+
+		require.NoError(t, err, "info command failed: %s", output)
+		require.Contains(t, output, "a", "tree should show branch a")
+		require.Contains(t, output, "b", "tree should show branch b")
+		require.Contains(t, output, "main", "tree should show trunk")
+		require.Contains(t, output, "a change", "tree should show commit messages")
 	})
 
 	t.Run("info with --stack --json shows JSON output", func(t *testing.T) {


### PR DESCRIPTION
- fix: restack worktree-anchored branch onto trunk, not stale anchor
- feat: show submit progress in the TUI
- feat: consolidate restack conflict reporting into one actionable block
- refactor: drop the submit progress bar
- feat: make restack output terse and outcome-focused
- refactor(info): split branch query from cli rendering