### PR TITLE
fix(move): let interactive users resolve conflicts and continue

### DIFF
--- a/internal/actions/move/handler.go
+++ b/internal/actions/move/handler.go
@@ -65,6 +65,8 @@ type Handler interface {
 
 	// PromptConfirmMove displays a preview of the move and asks for confirmation.
 	// Returns true to proceed with the move, false to cancel.
+	// If the preview reports conflicts, returning true means the user has opted
+	// to proceed and resolve conflicts manually via `stackit continue`.
 	// In non-interactive mode, returns true (auto-confirm).
 	PromptConfirmMove(preview Preview) (bool, error)
 

--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -72,8 +72,12 @@ func Action(ctx *app.Context, opts Options, h Handler) error {
 		return dryRun(ctx, plan.source, plan.oldParentName, plan.onto, plan.sourceBranch, plan.descendants, plan.rebaseSpecs)
 	}
 
-	if err := validateForExecution(ctx, h, plan, opts.SkipConfirm); err != nil {
+	proceed, err := validateForExecution(ctx, h, plan, opts.SkipConfirm)
+	if err != nil {
 		return err
+	}
+	if !proceed {
+		return nil
 	}
 
 	renamed, source, sourceBranch := maybeRename(ctx, h, opts, plan)
@@ -180,14 +184,18 @@ func buildMovePlan(eng engine.Engine, out output.Output, source, onto string, re
 	}, nil
 }
 
-func validateForExecution(ctx *app.Context, h Handler, plan *movePlan, skipConfirm bool) error {
+// validateForExecution validates the planned move (in interactive mode it also
+// confirms with the user). It returns (proceed, error): proceed=false with a
+// nil error means the user canceled and the caller should stop without
+// surfacing an error.
+func validateForExecution(ctx *app.Context, h Handler, plan *movePlan, skipConfirm bool) (bool, error) {
 	if h.IsInteractive() && !skipConfirm {
 		return confirmInteractive(ctx, h, plan)
 	}
 	return validateNonInteractive(ctx, h, plan)
 }
 
-func confirmInteractive(ctx *app.Context, h Handler, plan *movePlan) error {
+func confirmInteractive(ctx *app.Context, h Handler, plan *movePlan) (bool, error) {
 	eng := ctx.Engine
 	out := ctx.Output
 
@@ -198,35 +206,37 @@ func confirmInteractive(ctx *app.Context, h Handler, plan *movePlan) error {
 
 	confirmed, err := h.PromptConfirmMove(preview)
 	if err != nil {
-		return fmt.Errorf("failed to prompt for confirmation: %w", err)
+		return false, fmt.Errorf("failed to prompt for confirmation: %w", err)
 	}
 	if !confirmed {
 		out.Info("Move canceled.")
-		return nil
+		return false, nil
 	}
 
+	// System errors (worktree setup, etc.) can't be resolved by the user,
+	// so abort instead of dropping into the conflict workflow.
 	if validationErr != nil {
-		return fmt.Errorf("failed to validate rebases: %w", validationErr)
+		return false, fmt.Errorf("failed to validate rebases: %w", validationErr)
 	}
-	if preview.HasConflicts {
-		return fmt.Errorf("move would cause conflicts: %s on branch %s", preview.ConflictError, preview.ConflictBranch)
-	}
-	return nil
+
+	// Conflicts are fine to proceed with — the restack call below will enter
+	// the conflict workflow so the user can resolve and `stackit continue`.
+	return true, nil
 }
 
-func validateNonInteractive(ctx *app.Context, h Handler, plan *movePlan) error {
+func validateNonInteractive(ctx *app.Context, h Handler, plan *movePlan) (bool, error) {
 	h.OnStep(StepValidating, handler.StatusStarted, "Validating rebases...")
 	validation, err := ctx.Engine.ValidateRebases(ctx.Context, plan.rebaseSpecs)
 	if err != nil {
 		h.OnStep(StepValidating, handler.StatusFailed, err.Error())
-		return fmt.Errorf("failed to validate rebases: %w", err)
+		return false, fmt.Errorf("failed to validate rebases: %w", err)
 	}
 	if !validation.Success {
 		h.OnStep(StepValidating, handler.StatusFailed, validation.ErrorMessage)
-		return fmt.Errorf("move would cause conflicts: %s on branch %s", validation.ErrorMessage, validation.FailedBranch)
+		return false, fmt.Errorf("move would cause conflicts: %s on branch %s", validation.ErrorMessage, validation.FailedBranch)
 	}
 	h.OnStep(StepValidating, handler.StatusCompleted, "Validation passed")
-	return nil
+	return true, nil
 }
 
 func buildPreview(plan *movePlan, commits []string, validation *engine.RebaseValidation, validationErr error) Preview {

--- a/internal/actions/move/move_test.go
+++ b/internal/actions/move/move_test.go
@@ -2,15 +2,47 @@ package move
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
+
+// interactiveTestHandler simulates an interactive user for move tests. It
+// records whether the prompt was issued and lets the test choose to proceed or
+// cancel. It is *not* the production InteractiveMoveHandler — we want a
+// minimal stub so action-layer tests do not depend on the cli package.
+type interactiveTestHandler struct {
+	NullHandler
+	proceed bool
+	prompts int
+	preview Preview
+}
+
+func (h *interactiveTestHandler) IsInteractive() bool { return true }
+
+func (h *interactiveTestHandler) PromptConfirmMove(p Preview) (bool, error) {
+	h.prompts++
+	h.preview = p
+	return h.proceed, nil
+}
+
+// writeAndCommit writes content to a file at the repo root and commits it with
+// the given message. Used to seed conflicting commits across branches.
+func writeAndCommit(t *testing.T, s *scenario.Scenario, file, content, message string) {
+	t.Helper()
+	path := filepath.Join(s.Scene.Dir, file)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	s.RunGit("add", file).RunGit("commit", "-m", message).Rebuild()
+}
 
 func TestMoveAction(t *testing.T) {
 	t.Run("moves branch downstack and restacks descendants", func(t *testing.T) {
@@ -476,5 +508,82 @@ func TestMoveAction(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(branchCCommits), "branchC should have 1 commit")
 		require.Equal(t, "commit C", branchCCommits[0])
+	})
+
+	t.Run("interactive cancel does not move", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"branch1": "main",
+				"branch2": "branch1",
+			})
+
+		h := &interactiveTestHandler{proceed: false}
+		err := Action(s.Context, Options{
+			Source: "branch2",
+			Onto:   "main",
+		}, h)
+		require.NoError(t, err)
+		require.Equal(t, 1, h.prompts, "user should have been prompted")
+
+		// Branch should still be parented to branch1 — the move was canceled.
+		parent := s.Engine.GetBranch("branch2").GetParent()
+		require.NotNil(t, parent)
+		require.Equal(t, "branch1", parent.GetName())
+	})
+
+	t.Run("interactive proceed on conflict enters conflict workflow", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).WithInitialCommit()
+
+		// Restack invokes git commit without stripping global config, so any
+		// signing requirement from the host env (e.g. a sandbox key) breaks
+		// the rebase mid-test. Local config wins so this is safe in CI too.
+		s.RunGit("config", "commit.gpgsign", "false")
+		s.RunGit("config", "tag.gpgsign", "false")
+
+		// branch1: change conflict.txt
+		s.Checkout("main").
+			CreateBranch("branch1")
+		writeAndCommit(t, s, "conflict.txt", "branch1 content\n", "branch1 change")
+		s.TrackBranch("branch1", "main")
+
+		// branch2 forks from main with a conflicting change to the same file
+		s.Checkout("main").
+			CreateBranch("branch2")
+		writeAndCommit(t, s, "conflict.txt", "branch2 content\n", "branch2 change")
+		s.TrackBranch("branch2", "main")
+
+		// Attempt to move branch2 onto branch1 — this will conflict on conflict.txt.
+		// The interactive handler opts to proceed and resolve manually.
+		h := &interactiveTestHandler{proceed: true}
+		err := Action(s.Context, Options{
+			Source: "branch2",
+			Onto:   "branch1",
+		}, h)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "conflict")
+		require.True(t, h.preview.HasConflicts, "preview should report a conflict")
+
+		// Rebase must be in progress so the user can resolve.
+		require.True(t, s.Engine.Git().IsRebaseInProgress(s.Context.Context),
+			"rebase should be in progress after entering conflict workflow")
+
+		// Continuation state should be persisted for `stackit continue` to pick up.
+		cont, contErr := config.GetContinuationState(s.Scene.Dir)
+		require.NoError(t, contErr)
+		require.NotNil(t, cont)
+		require.Equal(t, "branch2", cont.CurrentBranchOverride)
+
+		// Parent metadata is updated even though the rebase is incomplete.
+		parent := s.Engine.GetBranch("branch2").GetParent()
+		require.NotNil(t, parent)
+		require.Equal(t, "branch1", parent.GetName())
+
+		// Resolve the conflict (take incoming) and continue.
+		require.NoError(t, s.Scene.Repo.ResolveMergeConflicts())
+		require.NoError(t, s.Scene.Repo.MarkMergeConflictsAsResolved())
+
+		require.NoError(t, actions.ContinueAction(s.Context, actions.ContinueOptions{}))
+		require.False(t, s.Engine.Git().IsRebaseInProgress(s.Context.Context),
+			"rebase should be complete after stackit continue")
 	})
 }

--- a/internal/cli/stack/move_handlers.go
+++ b/internal/cli/stack/move_handlers.go
@@ -126,10 +126,12 @@ func (h *InteractiveMoveHandler) PromptConfirmMove(preview move.Preview) (bool, 
 
 	h.Output.Newline()
 
-	// If there are conflicts, warn user more prominently
+	// If there are conflicts, offer to enter the conflict-resolution workflow.
 	if preview.HasConflicts {
-		h.Output.Info("The move cannot proceed due to conflicts.")
-		return tui.PromptConfirm("View the conflict details above and cancel?", false)
+		h.Output.Info("The move will hit conflicts that need to be resolved manually.")
+		h.Output.Info("Proceeding will pause the rebase so you can fix the files, then run %s.",
+			style.ColorCyan("stackit continue"))
+		return tui.PromptConfirm("Proceed and resolve conflicts manually?", false)
 	}
 
 	return tui.PromptConfirm("Proceed with move?", true)


### PR DESCRIPTION
Previously, when `stackit move` detected conflicts during interactive
validation, the only option offered was to cancel — and even the cancel
path was buggy (saying "no" to the prompt printed "Move canceled" but
then proceeded with the move anyway).

Now:

- The conflict prompt offers to proceed and resolve manually. Choosing
  to proceed reparents the branch, then lets the restack step enter the
  standard conflict workflow (rebase paused, continuation state
  persisted) so the user can fix files and run `stackit continue`.
- Cancel actually cancels: `validateForExecution` returns a proceed
  flag so the action stops without surfacing an error when the user
  declines.
- Non-interactive (`--yes`) keeps its strict behavior: conflicts still
  abort with an error, which is what scripted callers expect.

Adds action-level tests covering both cancel and proceed-on-conflict
flows, including the `stackit continue` step that completes the move.