### PR TITLE
fix: harden worktree removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,9 +268,9 @@ stack-submit --stack         # Creates/updates all PRs in the stack
 ### Worktree Management
 | Command | Description |
 |:---|:---|
-| `stackit worktree create <name>` | Create a new worktree (use `--open` to auto-cd) |
+| `stackit worktree create <name>` | Create a new worktree (auto-cd with shell integration; use `--no-open` to skip) |
 | `stackit worktree list` | List all managed worktrees |
-| `stackit worktree remove <stack>` | Remove a worktree and unregister it |
+| `stackit worktree remove <stack>` | Remove a worktree and unregister it (use `--force` to discard dirty changes) |
 | `stackit worktree open <stack>` | Open a worktree (auto-cd with shell integration, or print path for `cd $(...)`) |
 | `stackit worktree attach <branch>` | Attach an existing stack to a worktree |
 | `stackit worktree detach <name>` | Detach a stack from a worktree |

--- a/docs/worktree.md
+++ b/docs/worktree.md
@@ -10,7 +10,7 @@ Worktrees allow you to work on multiple stacks in parallel, each in its own dire
 | `stackit worktree attach <branch>` | Create a worktree for an existing stack |
 | `stackit worktree list` | List all managed worktrees |
 | `stackit worktree open <name>` | Open/cd to a worktree |
-| `stackit worktree remove <name>` | Remove worktree and delete branches |
+| `stackit worktree remove <name>` | Remove worktree and delete the registered root if empty |
 | `stackit worktree detach <name>` | Remove worktree but keep branches |
 | `stackit worktree prune` | Clean up empty/stale worktrees |
 
@@ -98,19 +98,19 @@ stackit worktree open my-feature
 
 With shell integration enabled, this changes your directory to the worktree. Without shell integration, it prints the path for use with `cd $(...)`.
 
-### `worktree remove` - Delete worktree and branches
+### `worktree remove` - Delete a worktree
 
-Removes the worktree directory and deletes the anchor branch (if it has no children).
+Removes the worktree directory and deletes the registered root or anchor branch if it has no children.
 
 ```bash
 stackit worktree remove my-feature
 ```
 
 **Options:**
-- `--force`: Remove even with uncommitted changes
+- `--force`: Remove and discard uncommitted changes
 - `--keep-branch`: Keep the anchor branch instead of deleting it
 
-**Use when:** The stack is fully merged or you want to discard all the work.
+**Use when:** The stack is fully merged, or you intentionally want to discard the workspace.
 
 ### `worktree detach` - Remove worktree, keep branches
 

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -144,12 +144,22 @@ func RemoveAction(ctx *app.Context, opts RemoveOptions) error {
 
 	// Check if path exists before trying to remove
 	if _, statErr := os.Stat(wtInfo.Path); statErr == nil {
-		// Try to remove the git worktree
-		if removeErr := ctx.Engine.RemoveWorktree(ctx.Context, wtInfo.Path); removeErr != nil {
-			if !opts.Force {
-				return fmt.Errorf("failed to remove worktree at %s: %w (use --force to override)", wtInfo.Path, removeErr)
+		if !opts.Force {
+			isDirty, dirtyErr := ctx.Git().WorktreeHasUncommittedChanges(ctx.Context, wtInfo.Path)
+			if dirtyErr != nil {
+				return fmt.Errorf("failed to check worktree status at %s: %w", wtInfo.Path, dirtyErr)
 			}
-			out.Warn("Failed to remove worktree directory, continuing with unregistration: %v", removeErr)
+			if isDirty {
+				return fmt.Errorf("worktree has uncommitted changes; use --force to discard them")
+			}
+		}
+
+		// Try to remove the git worktree
+		if removeErr := removeWorktreePath(ctx, wtInfo.Path, opts.Force); removeErr != nil {
+			if opts.Force {
+				return fmt.Errorf("failed to force remove worktree at %s: %w", wtInfo.Path, removeErr)
+			}
+			return fmt.Errorf("failed to remove worktree at %s: %w (use --force to discard uncommitted changes)", wtInfo.Path, removeErr)
 		}
 	} else {
 		out.Debug("Worktree path %s does not exist, skipping removal", wtInfo.Path)
@@ -666,20 +676,6 @@ func AttachAction(ctx *app.Context, opts AttachOptions) (*AttachResult, error) {
 		return nil, fmt.Errorf("failed to register worktree: %w", err)
 	}
 
-	// If we weren't already on trunk, checkout trunk now (stack now "belongs" to worktree)
-	if !needsCheckout {
-		if err := eng.CheckoutBranch(ctx.Context, trunk); err != nil {
-			// Clean up on failure
-			_ = eng.UnregisterWorktree(stackRootName)
-			_ = eng.RemoveWorktree(ctx.Context, worktreePath)
-			// Try to restore original branch
-			if currentBranch != nil {
-				_ = eng.CheckoutBranch(ctx.Context, *currentBranch)
-			}
-			return nil, fmt.Errorf("failed to checkout trunk: %w", err)
-		}
-	}
-
 	out.Success("Attached stack %s to worktree", style.ColorBranchName(stackRootName, false))
 	out.Info("  Name: %s", style.ColorBranchName(name, false))
 	out.Info("  Path: %s", style.ColorDim(worktreePath))
@@ -734,11 +730,11 @@ func DetachAction(ctx *app.Context, opts DetachOptions) error {
 
 	// Remove the git worktree directory
 	if _, statErr := os.Stat(wtInfo.Path); statErr == nil {
-		if removeErr := ctx.Engine.RemoveWorktree(ctx.Context, wtInfo.Path); removeErr != nil {
-			if !opts.Force {
-				return fmt.Errorf("failed to remove worktree at %s: %w (use --force to override)", wtInfo.Path, removeErr)
+		if removeErr := removeWorktreePath(ctx, wtInfo.Path, opts.Force); removeErr != nil {
+			if opts.Force {
+				return fmt.Errorf("failed to force remove worktree at %s: %w", wtInfo.Path, removeErr)
 			}
-			out.Warn("Failed to remove worktree directory, continuing with unregistration: %v", removeErr)
+			return fmt.Errorf("failed to remove worktree at %s: %w (use --force to discard uncommitted changes)", wtInfo.Path, removeErr)
 		}
 	} else {
 		out.Debug("Worktree path %s does not exist, skipping removal", wtInfo.Path)
@@ -782,4 +778,11 @@ func DetachAction(ctx *app.Context, opts DetachOptions) error {
 	}
 
 	return nil
+}
+
+func removeWorktreePath(ctx *app.Context, path string, force bool) error {
+	if force {
+		return ctx.Engine.ForceRemoveWorktree(ctx.Context, path)
+	}
+	return ctx.Engine.RemoveWorktree(ctx.Context, path)
 }

--- a/internal/cli/worktree/worktree.go
+++ b/internal/cli/worktree/worktree.go
@@ -219,7 +219,7 @@ func newPruneCmd() *cobra.Command {
 		Long: `Remove all worktrees that have no stacked branches.
 
 Empty worktrees are those with only the anchor branch and no work in progress.
-Worktrees with uncommitted changes are skipped unless --force is used.`,
+Worktrees with uncommitted changes are skipped.`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -449,6 +449,10 @@ func (d *demoGitRunner) RemoveWorktree(_ context.Context, _ string) error {
 	return nil
 }
 
+func (d *demoGitRunner) ForceRemoveWorktree(_ context.Context, _ string) error {
+	return nil
+}
+
 func (d *demoGitRunner) ListWorktrees(_ context.Context) ([]string, error) {
 	return []string{}, nil
 }

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -759,6 +759,11 @@ func (e *engineImpl) RemoveWorktree(ctx context.Context, path string) error {
 	return e.git.RemoveWorktree(ctx, path)
 }
 
+// ForceRemoveWorktree removes a worktree even if it contains uncommitted changes.
+func (e *engineImpl) ForceRemoveWorktree(ctx context.Context, path string) error {
+	return e.git.ForceRemoveWorktree(ctx, path)
+}
+
 // PruneWorktrees removes stale worktree entries from .git/worktrees.
 // This cleans up worktree information for worktrees whose working directory
 // has been deleted or is otherwise unavailable.

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -207,6 +207,7 @@ type CommitOperations interface {
 type WorktreeOperations interface {
 	AddWorktree(ctx context.Context, path string, branch string, detach bool) error
 	RemoveWorktree(ctx context.Context, path string) error
+	ForceRemoveWorktree(ctx context.Context, path string) error
 	CreateTemporaryWorktree(ctx context.Context, branch string, prefix string) (path string, cleanup func(), err error)
 	// CreateTemporaryWorktreeSkipPrune is like CreateTemporaryWorktree but skips the automatic
 	// PruneWorktrees() call. Use this when creating multiple worktrees in parallel after

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -193,6 +193,7 @@ type WorktreeOperations interface {
 	AddWorktree(ctx context.Context, path string, branch string, detach bool) error
 	AddWorktreeWithOptions(ctx context.Context, path string, branch string, detach bool, noCheckout bool) error
 	RemoveWorktree(ctx context.Context, path string) error
+	ForceRemoveWorktree(ctx context.Context, path string) error
 	ListWorktrees(ctx context.Context) ([]string, error)
 	PruneWorktrees(ctx context.Context) error
 	GetWorktreePathForBranch(ctx context.Context, branchName string) (string, error)

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -866,6 +866,13 @@ func (t *tracingRunner) RemoveWorktree(ctx context.Context, path string) error {
 	return err
 }
 
+func (t *tracingRunner) ForceRemoveWorktree(ctx context.Context, path string) error {
+	start := time.Now()
+	err := t.inner.ForceRemoveWorktree(ctx, path)
+	t.trace("ForceRemoveWorktree", time.Since(start), err == nil, err)
+	return err
+}
+
 func (t *tracingRunner) ListWorktrees(ctx context.Context) ([]string, error) {
 	start := time.Now()
 	result, err := t.inner.ListWorktrees(ctx)

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -46,6 +46,14 @@ func (r *runner) AddWorktreeWithOptions(ctx context.Context, path string, branch
 }
 
 func (r *runner) RemoveWorktree(ctx context.Context, path string) error {
+	_, err := r.RunGitCommandWithContext(ctx, "worktree", "remove", path)
+	if err != nil {
+		return fmt.Errorf("failed to remove worktree at %s: %w", path, err)
+	}
+	return nil
+}
+
+func (r *runner) ForceRemoveWorktree(ctx context.Context, path string) error {
 	_, err := r.RunGitCommandWithContext(ctx, "worktree", "remove", "--force", path)
 	if err != nil {
 		return fmt.Errorf("failed to remove worktree at %s: %w", path, err)

--- a/internal/integration/worktree_attach_detach_test.go
+++ b/internal/integration/worktree_attach_detach_test.go
@@ -100,6 +100,20 @@ func TestWorktreeAttach(t *testing.T) {
 		sh.HasBranches("main", "stack-root", "child")
 	})
 
+	run("attach preserves unrelated current branch", func(_ *testing.T, sh *TestShell) {
+		sh.WriteFile("a.txt", "a").
+			Run("create stack-a -m 'stack a'")
+		sh.Checkout("main")
+		sh.WriteFile("b.txt", "b").
+			Run("create stack-b -m 'stack b'")
+
+		sh.Run("worktree attach stack-a")
+
+		sh.OnBranch("stack-b")
+		sh.Run("worktree list").
+			OutputContains("stack-a")
+	})
+
 	run("attach fails for untracked branch", func(_ *testing.T, sh *TestShell) {
 		// Create a regular git branch (not tracked by stackit)
 		sh.Git("checkout -b untracked-branch")

--- a/internal/integration/worktree_comprehensive_test.go
+++ b/internal/integration/worktree_comprehensive_test.go
@@ -93,6 +93,43 @@ func TestWorktreeBasicOperations(t *testing.T) {
 			t.Errorf("Worktree directory should be removed at %s", worktreePath)
 		}
 	})
+
+	run("worktree remove refuses dirty worktree without force", func(t *testing.T, sh *TestShell) {
+		sh.WriteFile("dirty-stack.txt", "dirty-stack").
+			Run("create dirty-stack -w -m 'dirty stack branch'")
+
+		worktreePath := sh.GetWorktreePath("dirty-stack")
+		uncommittedFile := worktreePath + "/uncommitted.txt"
+		if err := os.WriteFile(uncommittedFile, []byte("uncommitted"), 0644); err != nil {
+			t.Fatalf("Failed to write file: %v", err)
+		}
+
+		sh.RunExpectError("worktree remove dirty-stack")
+
+		if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
+			t.Errorf("Dirty worktree should still exist")
+		}
+
+		sh.Run("worktree list").
+			OutputContains("dirty-stack")
+	})
+
+	run("worktree remove force discards dirty worktree", func(t *testing.T, sh *TestShell) {
+		sh.WriteFile("force-stack.txt", "force-stack").
+			Run("create force-stack -w -m 'force stack branch'")
+
+		worktreePath := sh.GetWorktreePath("force-stack")
+		uncommittedFile := worktreePath + "/uncommitted.txt"
+		if err := os.WriteFile(uncommittedFile, []byte("uncommitted"), 0644); err != nil {
+			t.Fatalf("Failed to write file: %v", err)
+		}
+
+		sh.Run("worktree remove force-stack --force")
+
+		if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
+			t.Errorf("Worktree directory should be removed at %s", worktreePath)
+		}
+	})
 }
 
 // =============================================================================


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #948** 👈
  * **PR #949**
    * **PR #950**
      * **PR #951**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #955*