### PR TITLE
fix(restack): detach HEAD before conflict-workflow rebase

### DIFF
--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -429,6 +429,25 @@ func reportRestackResult(ctx *app.Context, branch engine.Branch, result engine.R
 // EnterConflictWorkflow performs the rebase to enter conflict state and persists continuation state.
 // This helper is shared between RestackBranchesWithHandler (standalone mode) and sync.RunSync (sync mode).
 func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches []engine.Branch) error {
+	// Detach HEAD before the real rebase. Validation already told us this rebase
+	// will conflict, so the worktree is about to be left in a long-lived rebase
+	// state. If the worktree is still "on a branch" (typically trunk, since
+	// `st sync` is usually run from main), a later `git rebase --abort` — by
+	// the user, by stackit's own error paths, or even by another `st sync` —
+	// can do `git reset --hard orig-head` and move that branch's ref to the
+	// failed rebase's target, corrupting the branch. Detaching first ensures
+	// abort can only touch HEAD, never a branch ref. `st continue` already
+	// re-attaches to the conflict branch on success.
+	if currentBranch := ctx.Engine.CurrentBranch(); currentBranch != nil {
+		currentRev, revErr := ctx.Engine.Git().GetCurrentRevision(ctx.Context)
+		if revErr != nil {
+			return fmt.Errorf("failed to read HEAD before conflict workflow: %w", revErr)
+		}
+		if detachErr := ctx.Engine.Git().CheckoutDetached(ctx.Context, currentRev); detachErr != nil {
+			return fmt.Errorf("failed to detach HEAD before conflict workflow: %w", detachErr)
+		}
+	}
+
 	// Perform rebase to enter conflict state
 	conflictBranch := ctx.Engine.GetBranch(firstConflict)
 	batchResult, err := ctx.Engine.RestackBranches(ctx.Context, []engine.Branch{conflictBranch})

--- a/internal/integration/conflict_test.go
+++ b/internal/integration/conflict_test.go
@@ -1,7 +1,10 @@
 package integration
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // =============================================================================
@@ -205,5 +208,50 @@ func TestConflictResolution(t *testing.T) {
 			OutputContains("Parent: main")
 
 		sh.Log("✓ Branching stack conflict resolution test complete!")
+	})
+
+	// Regression: entering the conflict workflow while the worktree is on
+	// trunk used to leave the worktree in a rebase state where the trunk's
+	// ref could be overwritten — by a manual `git rebase --abort`, by
+	// stackit's own error paths, or by a subsequent `st sync` — moving
+	// refs/heads/main to the failed rebase's target. EnterConflictWorkflow
+	// now detaches HEAD first so abort can only touch HEAD.
+	t.Run("entering conflict workflow from trunk preserves trunk ref", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Stack: main → feature, with conflicting changes on both sides.
+		sh.WriteFile("f.txt", "feature change").
+			Run("create feature -m 'feature change'").
+			OnBranch("feature")
+
+		sh.Checkout("main").
+			WriteFile("f.txt", "main change").
+			Git("commit -am 'main change'")
+
+		// Snapshot main's tip before the conflict workflow runs.
+		sh.Git("rev-parse main")
+		mainBefore := strings.TrimSpace(sh.Output())
+
+		// Trigger the conflict workflow from main. Restack hits the conflict
+		// during validation, then enters the real rebase (which fails),
+		// leaving the worktree in a rebase-in-progress state.
+		sh.RunExpectError("restack feature").
+			OutputContains("conflict").
+			OutputContains("feature")
+
+		sh.Git("status").OutputContains("currently rebasing")
+
+		// Main's ref must not move just because we entered conflict state.
+		sh.Git("rev-parse main")
+		require.Equal(t, mainBefore, strings.TrimSpace(sh.Output()),
+			"trunk ref must not change when entering conflict workflow")
+
+		// And `git rebase --abort` must not move it either — the worktree
+		// is detached, so abort can only touch HEAD.
+		sh.Git("rebase --abort")
+		sh.Git("rev-parse main")
+		require.Equal(t, mainBefore, strings.TrimSpace(sh.Output()),
+			"trunk ref must not change after aborting the conflict rebase")
 	})
 }


### PR DESCRIPTION

EnterConflictWorkflow runs the real rebase in the main worktree to
land the user in conflict state. If the worktree is on a branch
(typically trunk, since 'st sync' is usually run from main), a later
'git rebase --abort' — manual, from stackit's own error paths, or
from a follow-up sync — can do 'git reset --hard orig-head' and move
that branch's ref to the failed rebase's target, corrupting it.

Detach HEAD first so abort can only touch HEAD. 'st continue' already
re-attaches to the conflict branch on success.

Regression test confirms trunk's ref no longer moves on abort.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #953** 👈
  * **PR #954**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->