### PR TITLE
fix(restack): classify branches by validation result, not spec position

### DIFF
--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -162,61 +162,7 @@ func restackBranchesWithPlan(ctx *app.Context, branches []engine.Branch, prePlan
 		}
 	}
 
-	// Split branches into successful and conflicting
-	var successBranches []engine.Branch
-	var conflictBranches []string
-
-	if validation.Success {
-		// All branches succeeded - add them all to success list
-		for _, branch := range branches {
-			if _, exists := plan.ApplyMap[branch.GetName()]; exists {
-				successBranches = append(successBranches, branch)
-			}
-		}
-	} else {
-		// Build a position map for fast lookups
-		positionMap := make(map[string]int)
-		for i, spec := range specs {
-			positionMap[spec.Branch] = i
-		}
-		branchIndex := make(map[string]int, len(branches))
-		for i, branch := range branches {
-			branchIndex[branch.GetName()] = i
-		}
-
-		// Find position of failed branch
-		failedPos, failedExists := positionMap[validation.FailedBranch]
-		if !failedExists {
-			// This shouldn't happen, but handle gracefully
-			ctx.Logger.Warn("failed branch not found in specs branch=%v", validation.FailedBranch)
-			failedPos = len(specs) // Treat as if it failed at the end
-		}
-
-		// Classify branches based on their position relative to the conflict
-		for _, branch := range branches {
-			branchName := branch.GetName()
-			if _, exists := plan.ApplyMap[branchName]; !exists {
-				continue
-			}
-
-			pos, ok := positionMap[branchName]
-			if !ok {
-				if branchIndex[branchName] < branchIndex[validation.FailedBranch] {
-					successBranches = append(successBranches, branch)
-				}
-				continue
-			}
-
-			if pos < failedPos {
-				// Branch comes before conflict - will succeed
-				successBranches = append(successBranches, branch)
-			} else if pos == failedPos {
-				// This is the conflicted branch
-				conflictBranches = append(conflictBranches, branchName)
-			}
-			// Branches after conflict (pos > failedPos) are not processed
-		}
-	}
+	successBranches, conflictBranches := classifyValidatedBranches(branches, plan, validation)
 
 	// For standalone mode, enter conflict workflow on first conflict
 	if mode == ConflictModeEnterWorkflow && len(conflictBranches) > 0 {
@@ -305,6 +251,48 @@ func restackBranchesWithPlan(ctx *app.Context, branches []engine.Branch, prePlan
 	}
 
 	return nil
+}
+
+// classifyValidatedBranches splits the planned branches into ones safe to
+// apply now and ones to surface as conflicts, using the validation result as
+// the source of truth instead of position-in-specs arithmetic. The earlier
+// position-based split was racy: when multiple sibling specs at the same
+// depth validate in parallel and one fails, validation.FailedBranch is
+// whichever failure arrives first on the results channel — non-deterministic.
+// Alphabetically-earlier canceled siblings would then satisfy `pos < failedPos`
+// and end up in successBranches without a matching entry in NewSHAs, and the
+// engine would error with "missing validated SHA for X". Here we apply a
+// branch only if its action proves it's safe: Frozen/Anchor branches don't
+// touch a rebase worktree at all, and Validated branches need a confirmed SHA.
+func classifyValidatedBranches(branches []engine.Branch, plan *engine.RestackPlan, validation *engine.RebaseValidation) (success []engine.Branch, conflicts []string) {
+	if plan == nil || validation == nil {
+		return nil, nil
+	}
+	for _, branch := range branches {
+		branchName := branch.GetName()
+		if _, exists := plan.ApplyMap[branchName]; !exists {
+			continue
+		}
+		item, ok := plan.Items[branchName]
+		if !ok {
+			continue
+		}
+
+		switch item.Action {
+		case engine.RestackPlanApplyFrozen, engine.RestackPlanApplyAnchor:
+			success = append(success, branch)
+		case engine.RestackPlanApplyValidated:
+			if _, hasSHA := validation.NewSHAs[branchName]; hasSHA {
+				success = append(success, branch)
+			} else if branchName == validation.FailedBranch {
+				conflicts = append(conflicts, branchName)
+			}
+			// Otherwise the branch was canceled — a sibling at the same depth
+			// failed first, or validation never reached this depth. Leave it
+			// for the next restack pass.
+		}
+	}
+	return success, conflicts
 }
 
 func getCurrentBranchName(eng engine.BranchReader) string {

--- a/internal/actions/common_test.go
+++ b/internal/actions/common_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 func TestFindConflictMarkerSections(t *testing.T) {
@@ -148,5 +150,120 @@ func TestConflictMarkerSectionsForFile(t *testing.T) {
 		t.Parallel()
 		_, err := conflictMarkerSectionsForFile(t.TempDir(), "does-not-exist.txt")
 		require.Error(t, err)
+	})
+}
+
+func TestClassifyValidatedBranches(t *testing.T) {
+	t.Parallel()
+
+	mkBranch := func(name string) engine.Branch {
+		return engine.NewBranch(name, nil)
+	}
+	mkPlan := func(items map[string]engine.RestackPlanAction) *engine.RestackPlan {
+		plan := &engine.RestackPlan{
+			Items:    map[string]engine.RestackPlanItem{},
+			ApplyMap: map[string]bool{},
+		}
+		for name, action := range items {
+			plan.Items[name] = engine.RestackPlanItem{Branch: name, Action: action}
+			plan.ApplyMap[name] = true
+		}
+		return plan
+	}
+
+	t.Run("all validated branches succeed when each has a NewSHA", func(t *testing.T) {
+		t.Parallel()
+		plan := mkPlan(map[string]engine.RestackPlanAction{
+			"a": engine.RestackPlanApplyValidated,
+			"b": engine.RestackPlanApplyValidated,
+		})
+		validation := &engine.RebaseValidation{
+			Success: true,
+			NewSHAs: map[string]string{"a": "sha-a", "b": "sha-b"},
+		}
+
+		success, conflicts := classifyValidatedBranches(
+			[]engine.Branch{mkBranch("a"), mkBranch("b")},
+			plan,
+			validation,
+		)
+
+		require.Empty(t, conflicts)
+		require.Len(t, success, 2)
+		require.Equal(t, "a", success[0].GetName())
+		require.Equal(t, "b", success[1].GetName())
+	})
+
+	t.Run("frozen and anchor branches succeed without a NewSHA", func(t *testing.T) {
+		t.Parallel()
+		plan := mkPlan(map[string]engine.RestackPlanAction{
+			"frozen": engine.RestackPlanApplyFrozen,
+			"anchor": engine.RestackPlanApplyAnchor,
+		})
+		validation := &engine.RebaseValidation{
+			Success: true,
+			NewSHAs: map[string]string{},
+		}
+
+		success, conflicts := classifyValidatedBranches(
+			[]engine.Branch{mkBranch("frozen"), mkBranch("anchor")},
+			plan,
+			validation,
+		)
+
+		require.Empty(t, conflicts)
+		require.Len(t, success, 2)
+	})
+
+	// Regression: when sibling validations race in parallel and one fails,
+	// canceled siblings have no NewSHA. The previous position-based logic
+	// would put an alphabetically-earlier canceled sibling into success
+	// (its position in specs was < the failed branch's position) and the
+	// engine then errored with "missing validated SHA for X". The fix
+	// classifies by capability: only branches with a confirmed NewSHA
+	// (or a no-validation action) are eligible.
+	t.Run("canceled sibling at same depth is dropped, not added to success", func(t *testing.T) {
+		t.Parallel()
+		plan := mkPlan(map[string]engine.RestackPlanAction{
+			"alpha-canceled": engine.RestackPlanApplyValidated,
+			"beta-conflict":  engine.RestackPlanApplyValidated,
+			"gamma-ok":       engine.RestackPlanApplyValidated,
+		})
+		validation := &engine.RebaseValidation{
+			Success:      false,
+			FailedBranch: "beta-conflict",
+			NewSHAs:      map[string]string{"gamma-ok": "sha-gamma"},
+		}
+
+		success, conflicts := classifyValidatedBranches(
+			[]engine.Branch{mkBranch("alpha-canceled"), mkBranch("beta-conflict"), mkBranch("gamma-ok")},
+			plan,
+			validation,
+		)
+
+		require.Equal(t, []string{"beta-conflict"}, conflicts)
+		require.Len(t, success, 1, "only gamma-ok (with confirmed NewSHA) should succeed")
+		require.Equal(t, "gamma-ok", success[0].GetName())
+	})
+
+	t.Run("branches not in the plan are ignored", func(t *testing.T) {
+		t.Parallel()
+		plan := mkPlan(map[string]engine.RestackPlanAction{
+			"a": engine.RestackPlanApplyValidated,
+		})
+		validation := &engine.RebaseValidation{
+			Success: true,
+			NewSHAs: map[string]string{"a": "sha-a"},
+		}
+
+		success, conflicts := classifyValidatedBranches(
+			[]engine.Branch{mkBranch("a"), mkBranch("not-in-plan")},
+			plan,
+			validation,
+		)
+
+		require.Empty(t, conflicts)
+		require.Len(t, success, 1)
+		require.Equal(t, "a", success[0].GetName())
 	})
 }


### PR DESCRIPTION

When validation runs sibling specs at the same depth in parallel, the
recorded validation.FailedBranch is whichever failure arrives first on
the results channel — non-deterministic. The old position-based split
(pos < failedPos => success) would put an alphabetically-earlier
canceled sibling into successBranches even though its result never
reached NewSHAs, and the engine then errored with
"missing validated SHA for X".

Replace position arithmetic with capability classification:
Frozen/Anchor branches don't need a SHA (they're applied by ref
update), Validated branches need a confirmed NewSHA, and the failed
branch becomes the conflict. Canceled siblings are left for the next
restack pass.

Factors the logic out as classifyValidatedBranches() with unit tests.