### PR TITLE
perf: instrument metadata cache hits/misses and batch-loads

### DIFF
--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -594,6 +594,10 @@ func (d *demoGitRunner) RenameMetadata(_, _ string) error {
 
 func (d *demoGitRunner) ClearMetadataCache() {}
 
+func (d *demoGitRunner) MetadataCacheStats() git.MetadataCacheSummary {
+	return git.MetadataCacheSummary{}
+}
+
 func (d *demoGitRunner) ReadLocalMetadata(_ string) (*git.LocalMeta, error) {
 	return &git.LocalMeta{}, nil
 }

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -257,6 +257,10 @@ type MetadataOperations interface {
 
 	// Cache management
 	ClearMetadataCache()
+
+	// MetadataCacheStats returns cumulative cache hit/miss counts since process start.
+	// Used by tests and instrumentation to verify lazy-load behavior.
+	MetadataCacheStats() MetadataCacheSummary
 }
 
 // StackMetadataOperations handles stack-level metadata persistence.

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -131,6 +131,9 @@ func (r *runner) BatchReadMetadata(branchNames []string) (map[string]*Meta, map[
 		return results, errs
 	}
 
+	start := time.Now()
+	missesBefore := r.metadataCache.misses.Load()
+
 	utils.Run(branchNames, func(name string) {
 		meta, err := r.ReadMetadata(name)
 		if err != nil {
@@ -143,6 +146,10 @@ func (r *runner) BatchReadMetadata(branchNames []string) (map[string]*Meta, map[
 		results[name] = meta
 		resultsMu.Unlock()
 	})
+
+	missed := r.metadataCache.misses.Load() - missesBefore
+	r.infoLog("metadata batch-load kind=shared branches=%d cache_misses=%d elapsed_ms=%d",
+		len(branchNames), missed, time.Since(start).Milliseconds())
 
 	return results, errs
 }
@@ -158,6 +165,8 @@ func (r *runner) BatchReadLocalMetadata(branchNames []string) map[string]*LocalM
 		return results
 	}
 
+	start := time.Now()
+
 	utils.Run(branchNames, func(name string) {
 		meta, err := r.ReadLocalMetadata(name)
 		if err != nil {
@@ -168,6 +177,9 @@ func (r *runner) BatchReadLocalMetadata(branchNames []string) map[string]*LocalM
 		results[name] = meta
 		resultsMu.Unlock()
 	})
+
+	r.infoLog("metadata batch-load kind=local branches=%d elapsed_ms=%d",
+		len(branchNames), time.Since(start).Milliseconds())
 
 	return results
 }
@@ -241,6 +253,19 @@ func (r *runner) DeleteMetadata(branchName string) error {
 // from external changes (e.g., branches created in another terminal) are not retained.
 func (r *runner) ClearMetadataCache() {
 	r.metadataCache.Clear()
+}
+
+// MetadataCacheStats returns cumulative hit/miss counts for the metadata cache
+// since process start. Counts are read with atomics and are safe to call
+// concurrently. Reset via ResetMetadataCacheStats (test-only).
+func (r *runner) MetadataCacheStats() MetadataCacheSummary {
+	return r.metadataCache.Summary()
+}
+
+// ResetMetadataCacheStats zeroes the metadata cache counters. Intended for
+// tests that need to assert behavior of a single operation in isolation.
+func (r *runner) ResetMetadataCacheStats() {
+	r.metadataCache.ResetStats()
 }
 
 func (r *runner) RenameMetadata(oldName, newName string) error {

--- a/internal/git/metadata_cache.go
+++ b/internal/git/metadata_cache.go
@@ -3,6 +3,7 @@ package git
 import (
 	"strings"
 	"sync"
+	"sync/atomic"
 )
 
 // metadataCache provides thread-safe caching of branch metadata.
@@ -10,16 +11,45 @@ import (
 // without deep copying.
 type metadataCache struct {
 	entries sync.Map // map[string]*Meta
+
+	// Instrumentation counters. Updated with atomics to stay lock-free on the
+	// hot Get path. Exposed via Summary() for logging and tests.
+	hits   atomic.Uint64
+	misses atomic.Uint64
+}
+
+// MetadataCacheSummary captures cumulative metadata-cache activity since
+// process start. Used by tests and by the runner to log periodic stats.
+type MetadataCacheSummary struct {
+	Hits   uint64
+	Misses uint64
 }
 
 // Get returns the cached metadata for the given branch, or nil if not cached.
 func (c *metadataCache) Get(branchName string) *Meta {
 	value, ok := c.entries.Load(branchName)
 	if !ok {
+		c.misses.Add(1)
 		return nil
 	}
+	c.hits.Add(1)
 	meta, _ := value.(*Meta)
 	return meta
+}
+
+// Summary returns the current cumulative hit/miss counts.
+func (c *metadataCache) Summary() MetadataCacheSummary {
+	return MetadataCacheSummary{
+		Hits:   c.hits.Load(),
+		Misses: c.misses.Load(),
+	}
+}
+
+// ResetStats zeroes the instrumentation counters. Intended for tests that
+// want to assert behavior of a single operation in isolation.
+func (c *metadataCache) ResetStats() {
+	c.hits.Store(0)
+	c.misses.Store(0)
 }
 
 // Put stores the metadata in the cache.

--- a/internal/git/metadata_cache_test.go
+++ b/internal/git/metadata_cache_test.go
@@ -122,3 +122,63 @@ func TestMetadataCache_Concurrent(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestMetadataCache_HitMissCounters(t *testing.T) {
+	t.Parallel()
+
+	var c metadataCache
+
+	// Initial state: zero hits, zero misses.
+	require.Equal(t, MetadataCacheSummary{}, c.Summary())
+
+	// A miss bumps misses but not hits.
+	require.Nil(t, c.Get("missing"))
+	require.Equal(t, MetadataCacheSummary{Hits: 0, Misses: 1}, c.Summary())
+
+	// Populate, then a hit bumps hits but not misses.
+	c.Put("present", NewMeta())
+	require.NotNil(t, c.Get("present"))
+	require.Equal(t, MetadataCacheSummary{Hits: 1, Misses: 1}, c.Summary())
+
+	// Multiple hits accumulate.
+	for range 4 {
+		require.NotNil(t, c.Get("present"))
+	}
+	require.Equal(t, MetadataCacheSummary{Hits: 5, Misses: 1}, c.Summary())
+
+	// ResetStats zeroes counters without disturbing entries.
+	c.ResetStats()
+	require.Equal(t, MetadataCacheSummary{}, c.Summary())
+	require.NotNil(t, c.Get("present"))
+	require.Equal(t, MetadataCacheSummary{Hits: 1, Misses: 0}, c.Summary())
+}
+
+func TestMetadataCache_CountersConcurrent(t *testing.T) {
+	t.Parallel()
+
+	var c metadataCache
+	c.Put("present", NewMeta())
+
+	var wg sync.WaitGroup
+	const goroutines = 32
+	const itersPerG = 100
+
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+			for j := range itersPerG {
+				if (i+j)%2 == 0 {
+					c.Get("present") // hit
+				} else {
+					c.Get("missing") // miss
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	got := c.Summary()
+	require.Equal(t, uint64(goroutines*itersPerG), got.Hits+got.Misses,
+		"every Get must increment exactly one counter; race-free atomics")
+}

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -23,9 +23,13 @@ import (
 	"github.com/getstackit/stackit/internal/utils"
 )
 
-// DebugLogger is an interface for logging debug messages
+// DebugLogger is an interface for logging messages from the git layer.
+// Despite its name, it carries both debug and informational events; the latter
+// is used for instrumentation lines (cache stats, batch-load timings) that
+// should be visible at the default log level.
 type DebugLogger interface {
 	Debug(msg string, args ...any)
+	Info(msg string, args ...any)
 }
 
 // DefaultCommandTimeout is the default timeout for git commands
@@ -445,6 +449,18 @@ func (r *runner) debugLog(format string, args ...any) {
 	r.loggerMu.RUnlock()
 	if logger != nil {
 		logger.Debug(format, args...)
+	}
+}
+
+// infoLog emits an informational log entry through the attached logger.
+// Used for low-volume instrumentation events (e.g. metadata batch-load timings)
+// that should be visible at the default log level.
+func (r *runner) infoLog(format string, args ...any) {
+	r.loggerMu.RLock()
+	logger := r.logger
+	r.loggerMu.RUnlock()
+	if logger != nil {
+		logger.Info(format, args...)
 	}
 }
 

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -1085,6 +1085,10 @@ func (t *tracingRunner) ClearMetadataCache() {
 	t.inner.ClearMetadataCache()
 }
 
+func (t *tracingRunner) MetadataCacheStats() MetadataCacheSummary {
+	return t.inner.MetadataCacheStats()
+}
+
 func (t *tracingRunner) RenameMetadata(oldName, newName string) error {
 	start := time.Now()
 	err := t.inner.RenameMetadata(oldName, newName)


### PR DESCRIPTION

Add atomic hit/miss counters to metadataCache with a Summary() accessor and
matching Runner.MetadataCacheStats() method. Emit Info-level log lines from
BatchReadMetadata and BatchReadLocalMetadata with branch count, miss count,
and elapsed time. This is the measurement baseline for the lite bootstrap
work — lets us verify before/after metadata I/O without env-var-gated tracing.

Expands the internal DebugLogger interface to include Info(); both FileLogger
and NullLogger already implement it.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #956** 👈
  * **PR #957**
    * **PR #958**
      * **PR #959**
        * **PR #960**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->