### PR TITLE
perf: cache parent revision on BranchState; drop IsUpToDate re-read

### DIFF
--- a/docs/plans/perf/README.md
+++ b/docs/plans/perf/README.md
@@ -1,0 +1,42 @@
+# Performance Analysis
+
+Per-command analysis of where `stackit` spends time, with proposed wins. All claims are sourced from static reading of the code; **none of the numbers are measured**. Validate via instrumentation before committing to a refactor.
+
+## Start here
+
+- **[cross-cutting.md](cross-cutting.md)** — the wins that touch one place and benefit many commands. Read this first; it's the ROI ranking.
+
+## Per-command pages
+
+| Command | Tier | Page |
+|---|---|---|
+| `co` / `checkout` | deep | [co.md](co.md) |
+| `log` (+ `full`, `short`) | deep | [log.md](log.md) |
+| `create` | deep | [create.md](create.md) |
+| `modify` | deep | [modify.md](modify.md) |
+| `up`, `down`, `parent`, `children`, `top`, `bottom`, `trunk`, `main` | medium | [navigation.md](navigation.md) |
+| `info` / `i` | medium | [info.md](info.md) |
+| `absorb` | medium | [absorb.md](absorb.md) |
+| `restack` | medium | [restack.md](restack.md) |
+| `submit` / `ss` | medium | [submit.md](submit.md) |
+| `track`, `untrack` | medium | [track-untrack.md](track-untrack.md) |
+| `scope` | medium | [scope.md](scope.md) |
+| `describe` | medium | [describe.md](describe.md) |
+
+## Scope and caveats
+
+- **Skipped (per request):** `sync`, `ship`, `merge` — the complex shipping path. Patterns covered in other pages apply.
+- **Skipped (low frequency / trivial):** `init`, `doctor`, `debug`, `docs`, `shell`, `config get/set/show`, `passthrough` git commands, worktree subcommands, integration installers.
+- **Method:** static code reading. File-line references throughout. No measurements; validation suggestions at the bottom of each page.
+- **Tier:** "deep" pages walk the full call graph with citations; "medium" pages give the highlights and top wins.
+
+## Suggested attack order
+
+See [cross-cutting.md → Recommended attack order](cross-cutting.md#recommended-attack-order). TL;DR:
+
+1. Lite bootstrap path
+2. Kill pre-checkout `worktree.Status()`
+3. Conflict-impossible validation for restack
+4. Cached `IsUpToDate`
+5. Preload stack stats for `log`
+6. `RebuildBranches([]string)` for `untrack` + `absorb` cleanup

--- a/docs/plans/perf/absorb.md
+++ b/docs/plans/perf/absorb.md
@@ -1,0 +1,86 @@
+# `absorb` — Performance Analysis
+
+**Tier:** medium (less frequent than `modify`, but expensive when it runs — touches multiple commits and restacks).
+
+## Call graph
+
+```
+NewAbsorbCmd → common.Run                            (same bootstrap as co)
+  └─ absorb.Action                                   internal/actions/absorb/absorb.go:32
+       ├─ validation.AbsorbChain                     bunch of preflight checks
+       ├─ actions.TakeBestEffortSnapshot             see create.md #2
+       ├─ Engine.Graph(SortStrategyAlphabetical)     in-memory
+       │
+       ├─ eng.HasStagedChanges                       worktree.Status() — full tree walk
+       ├─ git.StageChanges (only if --all/--patch)
+       ├─ eng.HasStagedChanges                       worktree.Status() AGAIN
+       ├─ eng.ParseStagedHunks                       shells `git diff --cached`
+       │
+       ├─ graph.Range(current, {RecursiveParents})   in-memory walk
+       ├─ for each downstack branch:
+       │     branch.GetAllCommits(SHA)               commit range walk (per branch, in go-git)
+       │
+       ├─ for each hunk:
+       │     eng.FindTargetCommitForHunk             tries applying hunk to successive commits — most expensive part per-hunk
+       │
+       ├─ for each target:
+       │     eng.FindBranchForCommit                 lookup
+       │
+       ├─ if --dry-run: print + maybe JSON; return
+       │
+       ├─ eng.StashPush                              shells `git stash push`
+       ├─ for each modified branch (topo order):
+       │     eng.ApplyHunksToBranch                  checkout → amend → ...  ← N branches × git ops
+       ├─ eng.StashPop                               shells `git stash pop`
+       ├─ eng.Rebuild("")                            full rebuild after the rewrites
+       └─ RestackBranches(upstack)                   internal/actions/common.go:96
+              └─ ValidateRebases via per-spec worktrees   (same cost as modify.md #1)
+```
+
+## Where time goes
+
+1. **`ApplyHunksToBranch` loop** — for each modified branch, it checks out, amends, restacks. Each checkout pays the go-git `worktree.Status()` + `worktree.Checkout()` tax (`co.md` #1). For an absorb that touches 3 branches, that's 3 × full checkouts plus 3 amends.
+2. **`RestackBranches` → `ValidateRebases`** — worktree-per-spec (`modify.md` #1).
+3. **`FindTargetCommitForHunk`** — proportional to (hunks × downstack commits). For a heavy absorb (lots of staged hunks, deep stack), this dominates the pre-apply phase. Algorithm-bound; speedup needs algorithmic insight, not engine plumbing.
+4. **`worktree.Status()` × 2** (`HasStagedChanges` called before *and* after staging at `absorb.go:63` and `:78`). Same fix as `create.md` #1.
+5. **`eng.Rebuild("")`** after applying hunks — full rebuild of branch metadata cache because branch refs were rewritten. Necessary, but `Rebuild("")` does the full `GetAllBranchNames + batchReadMetadata + batchReadLocalMetadata` pass — could be scoped to "only refresh branches we touched plus their descendants".
+6. **`StashPush` / `StashPop`** — fixed ~10–30ms per side. Needed for safety.
+7. **`for each downstack branch: GetAllCommits`** — per-branch commit walk through go-git. Often cache-cold. A combined `git rev-list <oldest-ancestor>..<current> --boundary` would do it in one walk.
+
+## Proposed wins (ranked)
+
+### 1. Same checkout-path fix benefits every `ApplyHunksToBranch` iteration *(shared with co.md #1)*
+
+Each branch touched costs one full go-git Status+Checkout cycle. Eliminating `worktree.Status()` in `CheckoutBranch` saves N×(big number) here.
+
+### 2. Same worktree-validation fix benefits the post-absorb restack *(shared with modify.md #1)*
+
+`RestackBranches` here goes through the same `ValidateRebases` worktree-per-spec path. Trivially-safe rebases (very common after absorb — most hunks land in a single ancestor and don't change descendant-touched files) could skip validation entirely.
+
+### 3. Combine the two `HasStagedChanges` calls *(small, low risk)*
+
+`absorb.go:63` checks before staging, `:78` checks after. The first call is *only* used to decide whether to print "Nothing to absorb" — which the second call also catches. Drop the first one; the user-facing message arrives one staging op later but the behavior is the same.
+
+### 4. Scope `eng.Rebuild("")` to touched branches *(medium, medium risk)*
+
+After absorb, only the modified branches and their descendants have changed. A `RebuildBranches([]string)` that re-reads metadata + revisions for just that subset would skip O(N - touched) of the full rebuild. Useful here, in `restack`, in `modify`, in `sync`.
+
+### 5. Single downstack `git rev-list` instead of per-branch `GetAllCommits` *(small impact, simple)*
+
+`absorb.go:121–130` calls `GetAllCommits(SHA)` per branch and then walks. One `git rev-list --boundary <trunk>..<current>` returns all SHAs in one process. The per-branch attribution can be done from the parent-revision metadata already in the cache.
+
+### 6. `FindBranchForCommit` could come from a commit→branch map built during the SHA walk *(trivial)*
+
+While iterating `downstackBranches` to collect SHAs, also populate `commitSHA → branchName`. Then `FindBranchForCommit` becomes a map lookup. Today it's a separate function call per target hunk.
+
+## Validation
+
+```
+# Absorb that hits one branch (no restack work)
+STACKIT_NO_LOGGING=1 hyperfine 'stackit absorb --force --dry-run'
+
+# Absorb that crosses 3 branches with 5 descendants (worst case)
+STACKIT_NO_LOGGING=1 hyperfine 'stackit absorb --force'
+```
+
+Instrument: each `ApplyHunksToBranch` (esp. the inner Checkout call), the `RestackBranches` block, `FindTargetCommitForHunk`, and the `eng.Rebuild("")` call. Dry-run isolates the planning phase from the apply phase.

--- a/docs/plans/perf/co.md
+++ b/docs/plans/perf/co.md
@@ -1,0 +1,87 @@
+# `co` / `checkout` — Performance Analysis
+
+**Tier:** deep (hot path; runs many times per session).
+
+## Call graph
+
+```
+NewCheckoutCmd.RunE
+  └─ common.Run                              internal/cli/common/common.go:33
+       ├─ app.GetContextWithWriter           internal/app/context.go:377
+       │    ├─ git.NewRunner / DiscoverRepoRoot
+       │    ├─ config.LoadConfig
+       │    ├─ output.NewFileLogger
+       │    └─ engine.NewEngine              internal/engine/engine_impl.go:141
+       │         ├─ g.InitDefaultRepo()           (go-git open)
+       │         ├─ g.GetCurrentBranch()          (read HEAD)
+       │         ├─ rebuildInternal(false)        internal/engine/engine_internal.go:13
+       │         │    ├─ GetAllBranchNames()
+       │         │    ├─ batchReadMetadata(branches)
+       │         │    └─ batchReadLocalMetadata(branches)
+       │         └─ maybeAutoFetchRemoteMetadata()    fast path = 1 config read
+       └─ Engine.IsInManagedWorktree()       internal/cli/common/common.go:42
+  └─ common.Checkout → actions.CheckoutAction internal/actions/checkout.go:51
+       ├─ resolveBranchName                  internal/actions/checkout.go:264
+       │    └─ eng.AllBranches() (already cached, cheap)
+       ├─ getWorktreeSwitchInfo              internal/actions/checkout.go:200
+       │    ├─ Engine.GetStackRootForBranch
+       │    └─ Engine.GetWorktreeForStack    (metadata + fs.Stat)
+       ├─ Engine.CheckoutBranch              internal/engine/engine_writer.go:268
+       │    └─ git.runner.CheckoutBranch     internal/git/branches.go:45
+       │         ├─ worktree.Status()        ← O(working tree) go-git walk
+       │         └─ worktree.Checkout()      ← O(working tree) go-git checkout
+       └─ printBranchInfo                    internal/actions/checkout.go:151  (skipped if --quiet)
+            └─ up to 11 × IsBranchUpToDate
+                 └─ git.GetRevision + readMetadata   per branch, no batching
+```
+
+## Where time goes (largest → smallest, typical case)
+
+1. **`worktree.Status()` before checkout** (`internal/git/branches.go:58`). go-git walks the entire working tree to decide `Keep: !status.IsClean()`. On a large repo this is the single most expensive call. The check is purely to choose `Keep`.
+2. **`rebuildInternal` on every command** (`internal/engine/engine_internal.go:13`). Reads every branch's `refs/stackit/metadata/<branch>` and `refs/stackit/local-metadata/<branch>`. Parallelized but still O(N branches). For `co <exact-name>` none of this is needed.
+3. **`worktree.Checkout()` via go-git** (`internal/git/branches.go:62`). Pure-Go checkout is typically slower than shelling out to `git checkout`.
+4. **`printBranchInfo`** (`internal/actions/checkout.go:151`). Up to 11 round-trips through `IsUpToDate` (one for the target, ten ancestors). Each call does a fresh `git.GetRevision` + `readMetadata`; cached engine state is not consulted.
+5. **`IsInManagedWorktree()`** runs unconditionally in `common.Run` even when the user just wants to flip HEAD inside the main repo.
+
+## Proposed wins (ranked by expected impact ÷ risk)
+
+### 1. Eliminate the pre-checkout `Status()` walk *(high impact, low risk)*
+
+`internal/git/branches.go:45` — remove the `worktree.Status()` call and either:
+- always pass `Keep: true` and let go-git surface a clear conflict, or
+- shell out to `git checkout <branch>` and rely on git's own dirty-tree handling (still cheaper than a full status walk).
+
+Either change saves the dominant cost on large working trees.
+
+### 2. Lite bootstrap path that skips `rebuildInternal` *(high impact, medium risk)*
+
+Add an opt-in "no metadata" engine init that only resolves trunk + repo root. `co <exact-branch>` can use it because resolution only needs `GetAllBranchNames` (or even just a `git show-ref` for the one branch), not parsed metadata. Falls back to full rebuild on `--quiet=false` (so `printBranchInfo` still works) or on fuzzy/scope resolution.
+
+Every command benefits; `co` benefits most because the rest of its work is tiny.
+
+### 3. `IsUpToDate` should use in-memory state, not re-read metadata *(medium impact, low risk)*
+
+`internal/engine/engine_branch_status.go:148` calls `readMetadata` per branch even though `rebuildInternal` already loaded all metadata into `e.state.branchState`. Source the stored parent revision from `state.branchState` and batch the live parent-revision lookup via a single `git for-each-ref` over the parent set.
+
+### 4. `printBranchInfo` short-circuits *(small impact, free)*
+
+In `internal/actions/checkout.go:151`, the up-to-date check on the target branch and the ten downstack ancestors is informational. Wire it behind `--quiet` (already partially done) and a config flag. For users on deep stacks this removes 11 git calls per checkout.
+
+### 5. Skip `IsInManagedWorktree` when not needed *(small impact, free)*
+
+`common.Run` calls it for every command. Move the call into the commands that branch on worktree state (`co`, `worktree open`, `worktree attach`) instead of running it globally.
+
+### 6. Skip double `AllBranches` traversal *(trivial)*
+
+`resolveBranchName` builds a name slice and scans it linearly. With an exact name in hand, do one map lookup via `Engine.GetBranch` first and return immediately — only fall back to the slice scan for fuzzy/scope matching.
+
+## How to validate
+
+```
+STACKIT_NO_LOGGING=1 hyperfine \
+  'stackit co <branch> --quiet' \
+  'stackit co <branch>' \
+  'git checkout <branch>'
+```
+
+The delta between `co --quiet` and `git checkout` is the bootstrap cost; the delta between `co` and `co --quiet` is `printBranchInfo`. Instrument `rebuildInternal`, `worktree.Status`, `worktree.Checkout` with `time.Since(...)` log lines while iterating.

--- a/docs/plans/perf/create.md
+++ b/docs/plans/perf/create.md
@@ -1,0 +1,105 @@
+# `create` — Performance Analysis
+
+**Tier:** deep (the second most-run hot-path command after `co`).
+
+## Call graph
+
+```
+NewCreateCmd.RunE → common.Run                       (same bootstrap as co)
+  └─ create.Action                                   internal/actions/create/create.go:38
+       ├─ validation.MustBeOnBranch
+       ├─ actions.TakeBestEffortSnapshot
+       │     └─ engine.TakeSnapshot                  internal/engine/undo.go:108
+       │           ├─ for each branch: branch.GetRevision()        N revision lookups (not preloaded)
+       │           ├─ git.ListMetadata                              one go-git ref iter
+       │           ├─ json.MarshalIndent + os.WriteFile             snapshot file
+       │           └─ enforceMaxStackDepth                          os.ReadDir + sort + maybe os.Remove
+       │
+       ├─ eng.HasStagedChanges                       internal/git/staging.go:102
+       │     └─ worktree.Status()                    ← O(working tree)
+       ├─ if interactive + no staged:
+       │     eng.HasUnstagedChanges                  → another worktree.Status()
+       │
+       ├─ stage (optional, only if --all/--update/--patch):
+       │     git.StageChanges                        forks `git add ...`
+       │
+       ├─ getCommitMessageForBranch                  reads file/stdin/editor depending on flags
+       │
+       ├─ determineBranch
+       │     └─ pattern.GetBranchName                may shell to git config for user info
+       │
+       ├─ eng.AllBranches() + slices.ContainsFunc    O(N) duplicate check, cached
+       │
+       ├─ eng.CreateAndCheckoutBranch                internal/engine/engine_writer.go:296
+       │     └─ git.runner.CreateAndCheckoutBranch   internal/git/branches.go:91
+       │           ├─ worktree.Status()              ← O(working tree) again
+       │           └─ worktree.Checkout(Create:true) ← go-git checkout
+       │
+       ├─ if staged: eng.Commit                      internal/engine/engine_writer.go:709
+       │     └─ git.runner.Commit                    internal/git/commit.go:68
+       │           ├─ shells `git commit -m ...`     ← user hooks dominate
+       │           ├─ revisionCache.InvalidateAll
+       │           └─ ReloadRepository               ← closes + reopens go-git repo
+       │
+       ├─ eng.TrackBranch                            internal/engine/engine_writer.go:91
+       │     ├─ git.GetCurrentBranch                 cheap (HEAD)
+       │     ├─ optional GetAllBranchNames           usually a no-op (already cached)
+       │     └─ SetParent → metadata transaction     1 ref write
+       │
+       ├─ if --scope: eng.SetScope                   another metadata transaction
+       └─ if --insert: handleInsert + extra checkout back to original branch
+```
+
+## Where time goes (largest → smallest, typical interactive create)
+
+1. **`git commit` subprocess + user hooks** — the user's pre-commit hook usually dominates wall time when present. Stackit can't change that, but it can avoid duplicate work around it (see #4).
+2. **`ReloadRepository`** (`internal/git/runner.go:480`) after every commit. Closes the go-git `*Repository`, invalidates the entire revision cache, and re-opens. Re-opens of large repos cost real I/O; throwing away `revisionCache.AllBranchRevisions` is wasteful since only the freshly committed branch's SHA changed.
+3. **`worktree.Status()` × 2–3** — `HasStagedChanges` calls it once, `HasUnstagedChanges` calls it again in the interactive prompt path, and `CreateAndCheckoutBranch` calls it a third time to decide `Keep`. Each is a full working-tree walk; on a big repo this is the dominant non-hook cost.
+4. **`TakeSnapshot`** (`internal/engine/undo.go:108`). Iterates `e.state.branches` and calls `branch.GetRevision()` per branch, hitting `r.revisionCache` one entry at a time. Also calls `git.ListMetadata` (separate ref iter) and an `os.ReadDir` for stack-depth enforcement. On a 50-branch repo this is ~50 cached lookups + 1 metadata scan + snapshot write — usually 5–15ms but it runs on every mutation.
+5. **Bootstrap (`rebuildInternal`)** — same fixed cost as `co.md` describes.
+6. **`TrackBranch` re-fetches `GetCurrentBranch`** inside its critical section (`internal/engine/engine_writer.go:102`) even though we just created the branch. Small but pointless.
+7. **`getCommitMessageForBranch`** when no `-m` is provided opens an editor or reads from stdin — user-blocking, not stackit's fault.
+8. **`SetScope` does its own metadata transaction** instead of bundling with the parent-set in `TrackBranch`. Two ref writes where one would do.
+
+## Proposed wins (ranked)
+
+### 1. Coalesce all `worktree.Status()` calls *(high impact, low risk)*
+
+`HasStagedChanges`, `HasUnstagedChanges`, and the `Status()` inside `CreateAndCheckoutBranch` all walk the working tree. Add a single `RepoStatus` (`{HasStaged, HasUnstaged, HasUntracked}`) call early in `create.Action`, cache it on the engine for the duration of the request, and feed it to `CreateAndCheckoutBranch` so it can decide `Keep` without re-walking. Same fix benefits `modify`, `absorb`, and `submit`.
+
+For the `CreateAndCheckoutBranch` path, the cleanest fix is shared with `co`: always `Keep: true` or shell to `git checkout`. (See `co.md` win #1.)
+
+### 2. Snapshot should use batched revisions and skip on opt-out *(medium impact, low risk)*
+
+`TakeSnapshot` should call `BatchGetRevisions` (or use the revision cache after `LoadAllBranchRevisions`) instead of iterating per-branch. Also: snapshots are only consumed by `undo`. For users that never undo, the work and disk write are pure overhead. Add a config flag (`undo.enabled=false`) and short-circuit `TakeBestEffortSnapshot` when it's off.
+
+Also: `enforceMaxStackDepth` does `os.ReadDir + sort + os.Remove`. Cheap individually, but on every mutating command it adds up. Lazy enforcement (only when the directory size exceeds N × max-depth) is fine.
+
+### 3. Drop or scope `ReloadRepository` after commit *(medium impact, medium risk)*
+
+`ReloadRepository` throws away the entire go-git in-memory state to pick up a single new commit. Two cheaper options:
+- Just invalidate the affected branch in `revisionCache` (`revisionCache.Invalidate(branchName)`) and let go-git re-read its packed refs lazily.
+- Re-open only the refs subsystem, not the whole repo.
+
+Risk: go-git caches loose-object packs; if we don't reload we may miss the new commit object on subsequent lookups. Easiest first step is `revisionCache.Invalidate(branchName)` plus a targeted ref refresh.
+
+### 4. Bundle parent-set + scope into one metadata transaction *(small, low risk)*
+
+`TrackBranch` opens a transaction to write the parent ref. `SetScope` opens another. They could be one: extend `SetParent` to accept an optional scope, or expose a `TrackWithScope` helper that does both atomically. Saves one ref write + one git ref update.
+
+### 5. Skip `TrackBranch`'s "validate branches exist" re-fetch *(trivial)*
+
+`internal/engine/engine_writer.go:107–139` re-runs `GetAllBranchNames` if the just-created branch isn't in the cached list. After `CreateAndCheckoutBranch`, that cache is stale — but we know the answer (we just created it). Have `CreateAndCheckoutBranch` push the branch into `e.state.branches` (it already does, `engine_writer.go:307`), and have `TrackBranch` trust the cache.
+
+### 6. Defer `validation.MustBeOnBranch` `GetCurrentBranch` to use cached value *(trivial)*
+
+Bootstrap already populated `e.currentBranch`. The validator should consult `eng.CurrentBranch()` (cached) rather than re-shelling.
+
+## Validation
+
+```
+STACKIT_NO_LOGGING=1 hyperfine --warmup 1 \
+  'cd /tmp/scratch && git add . && stackit create -m "perf: noop"'
+```
+
+Run with a no-op pre-commit hook (or `--no-verify` if that flag is available) to isolate the stackit overhead from user hook cost. Instrument: each `worktree.Status()` call, `TakeSnapshot`, `ReloadRepository`, and `git commit`. The `Status` × 3 pattern is the easiest first measurement.

--- a/docs/plans/perf/cross-cutting.md
+++ b/docs/plans/perf/cross-cutting.md
@@ -1,0 +1,218 @@
+# Cross-Cutting Performance Wins
+
+This document collects the wins that appear across multiple per-command analyses. Each entry has a high impact-to-effort ratio because it benefits many commands at once.
+
+**How to read this:** the items are ordered by **how many of the analyzed commands benefit**, not by per-command magnitude. The "Affects" column lists which command pages discuss the same fix.
+
+---
+
+## Tier 1: Touch one place, every command gets faster
+
+### 1. Lite bootstrap path — skip full `rebuildInternal` for read-only / single-branch commands
+
+**Files:** `internal/app/context.go:306`, `internal/engine/engine_internal.go:13`
+
+Today every command pays the cost of `engine.NewEngine` → `rebuildInternal(false)` which lists every branch and reads every branch's `refs/stackit/metadata/*` ref. For most commands the data is wasted:
+
+- `parent`, `children`, `trunk` (default), `info`, `scope --show`, `describe --show` — only need the current branch and at most its parent/scope chain.
+- `co <exact-branch>`, `down`, `parent`, `up`, `top`, `bottom`, `main` — only need to validate the target branch exists.
+- `track --parent` — only needs the parent + child branch.
+
+**Proposal:** introduce an `engine.LoadMode` ({`Full`, `LazyByBranch`, `BranchListOnly`}) on `NewEngine`. In Lazy mode, `state.branchState` is populated on first access per branch; in `BranchListOnly` mode, only `GetAllBranchNames` runs. The `app.Context` factory picks the mode based on the command (or commands opt in via a `LoadMode` field on a request struct).
+
+This is the single biggest user-perceived win across the CLI. Especially for repos with hundreds of branches.
+
+**Affects:** co.md #2, navigation.md #1, info.md (indirect), scope.md #4, describe.md #4 — basically every page.
+
+---
+
+### 2. Stop calling `worktree.Status()` before every checkout / branch create
+
+**Files:** `internal/git/branches.go:45` (`CheckoutBranch`), `:91` (`CreateAndCheckoutBranch`)
+
+Both functions call go-git's `worktree.Status()` purely to decide the `Keep: !status.IsClean()` argument to `Checkout`. `Status()` walks the entire working tree — easily the slowest single operation in `co` on a large repo.
+
+**Proposal:** either (a) always pass `Keep: true` and let go-git's checkout surface a clear conflict, or (b) shell out to `git checkout <branch>` and let git handle dirty-tree behavior natively (typically faster than go-git's pure-Go checkout on large trees).
+
+**Affects:** co.md #1, create.md #1, modify.md #4, absorb.md #1, navigation.md #2, and every other command that ends in a branch switch.
+
+---
+
+### 3. `IsBranchUpToDate` / `IsUpToDate` should read in-memory state, not re-read metadata
+
+**Files:** `internal/engine/engine_branch_status.go:148`
+
+The current implementation re-reads metadata + does a fresh `git.GetRevision` per call, even though `rebuildInternal` already populated `state.branchState` with everything needed.
+
+**Proposal:** read the stored `ParentBranchRevision` from `state.branchState`, batch the parent SHA lookups (one `git for-each-ref` over the unique parent set), compare in-memory. Make per-branch lookups O(1) cache hits after bootstrap.
+
+**Affects:** co.md #3, log.md (indirectly through annotation builds), info.md #1, submit.md #1. Anywhere a stack is iterated checking up-to-date-ness.
+
+---
+
+### 4. Single batched git call for stats / diffs / revisions, never per-branch
+
+**Files:** `internal/engine/engine_branch_info.go:60` (`GetDiffStats`), `:159` (`GetAllCommits`), `internal/git/commit_info.go:150` (`LoadAllBranchRevisions`)
+
+Per-branch git invocations are the most pervasive N+1 pattern in the codebase. `log` and `submit` already preload revisions via `LoadAllBranchRevisions`. The same pattern needs to extend to:
+
+- **diff stats**: currently one `git diff --numstat` per branch in `log`. A single git invocation per stack (or per `(base, head)` pair) cached for the session.
+- **commit ranges**: `GetAllCommits` does a per-branch go-git walk; could do one `git rev-list --boundary` and partition by parent metadata.
+- **diff content** (for `--diff` / `--patch`): only on demand, but should also be cached.
+
+**Proposal:** introduce `eng.PreloadStackStats(branches)` that does one combined git pass and populates a per-branch cache. `log` calls it once; `info`, `submit`, etc., consult the same cache when set.
+
+**Affects:** log.md #1, info.md #3, absorb.md #5, modify.md #7.
+
+---
+
+### 5. Snapshot taking should batch revisions and be opt-out
+
+**Files:** `internal/engine/undo.go:108` (`TakeSnapshot`)
+
+Every mutating command (`create`, `modify`, `absorb`, `restack`) calls `TakeBestEffortSnapshot`, which iterates `state.branches` and calls `branch.GetRevision()` per branch. Two issues:
+
+- Per-branch loop instead of `BatchGetRevisions` (already exists).
+- The snapshot is only ever read by `stackit undo`; for users who never undo, it's pure overhead.
+
+**Proposal:**
+- Use `BatchGetRevisions` (or read from `revisionCache` after `LoadAllBranchRevisions`).
+- Add `undo.enabled` config flag (default `true`); when `false`, `TakeBestEffortSnapshot` is a no-op.
+- Move snapshot capture to *just before mutation*, not at the start of action — many actions short-circuit (e.g. `restack` when `!plan.HasWork()`) without ever needing one.
+
+**Affects:** create.md #2, restack.md #5 + #6, absorb (snapshot capture).
+
+---
+
+## Tier 2: Reusable plumbing for the expensive operations
+
+### 6. Coalesce `worktree.Status()` across the action's request
+
+**Files:** `internal/git/staging.go:102` (`HasStagedChanges`), `:115` (`HasUnstagedChanges`), `:128` (`HasUntrackedFiles`), all reused by multiple actions
+
+In `create`, `worktree.Status()` runs up to 3 times in a single command: once in `HasStagedChanges`, once in `HasUnstagedChanges` (if prompted), once in `CreateAndCheckoutBranch`. `absorb` does it twice (`absorb.go:63` and `:78`). `modify` does it after staging.
+
+**Proposal:** an action-scoped `RepoStatus` value (`{HasStaged, HasUnstaged, HasUntracked, modified files}`) computed once per request and cached on `app.Context`. Pass it through to git layer where needed. Fix #2 (skipping the pre-checkout Status) further reduces calls — combine the fixes.
+
+**Affects:** create.md #1, modify.md #5, absorb.md #3.
+
+---
+
+### 7. Conflict-impossible validation: skip per-spec worktrees when safe
+
+**Files:** `internal/engine/rebase_validator.go:72` (`ValidateRebases`)
+
+The single biggest cost on `modify` (mid-stack), `restack`, and `--restack`-mode `submit` is creating a worktree per descendant spec to dry-run the rebase.
+
+**Proposal:** before scheduling worktree validation, do a cheap file-overlap check per spec:
+- `git diff --name-only <old-parent>..<new-parent>` (the change being rebased *onto*)
+- `git diff --name-only <old-parent>..<branch>` (the change being rebased)
+- If the two file sets are disjoint, no conflict is possible — apply directly without a worktree.
+
+A typical post-amend restack touches one file in the parent; descendants usually touch other files. This collapses N worktrees → N cheap diffs (~ms each).
+
+Risk: rare false negatives (file-level granularity might miss hunk-level true non-conflicts that git would have rebased cleanly anyway — that's fine, fall back to worktree). False positives only happen if the diff sets *do* overlap; in that case we fall back to today's behavior. Safe.
+
+**Affects:** modify.md #1, restack.md #1, absorb.md #2, submit.md (#3 indirectly).
+
+---
+
+### 8. Reuse a single worktree per depth level for validation
+
+**Files:** `internal/engine/rebase_validator.go:184` (`ValidateRebasesParallel`)
+
+If #7 isn't enough (stack genuinely has overlapping changes), validation could still amortize worktree creation across siblings at the same depth: one worktree per concurrency lane, reset between specs via `git rebase --abort` + `git reset --hard`. Cost goes from O(specs) worktrees to O(levels × concurrency).
+
+**Affects:** modify.md #2, restack.md #3, absorb.md #2.
+
+---
+
+### 9. Scoped engine rebuild — `RebuildBranches([]string)`
+
+**Files:** `internal/engine/engine_internal.go:47` (`rebuild`), `internal/engine/engine_writer.go:148` (`UntrackBranch`)
+
+`engine.rebuild()` re-reads metadata for every branch in the repo even when only a handful changed. The worst offender is `UntrackBranch`, which calls `rebuild()` per branch in the loop — `untrack` of a 10-branch substack does 11 full rebuilds.
+
+**Proposal:** a `RebuildBranches([]string)` engine method that re-reads only the listed branches' metadata + revisions, then merges into `state.branchState`. Use from `untrack` (batched), `absorb` post-apply, `modify` post-commit, etc.
+
+**Affects:** absorb.md #4, track-untrack.md #1+#2.
+
+---
+
+### 10. Combine commit + metadata writes into single transactions
+
+**Files:** `internal/engine/transaction.go` (`MetadataTx`), all callers in `engine_writer.go`
+
+Commands that mutate both the parent ref and an adjacent metadata field (scope, lock, PR-update flag, description) issue two separate transactions today. Each transaction is a ref-update round trip. Combining them is straightforward via `withMetadataTx` once the engine exposes the right helpers.
+
+**Affects:** create.md #4 (parent + scope), scope.md #1, describe.md #2.
+
+---
+
+## Tier 3: Smaller universal hygiene
+
+### 11. Move `IsInManagedWorktree` out of the global `common.Run`
+
+**File:** `internal/cli/common/common.go:42`
+
+Runs unconditionally for every command. Only needed for `co`, `worktree open`, `worktree attach`, and similar.
+
+**Affects:** co.md #5, navigation.md (indirect), scope.md #3.
+
+---
+
+### 12. Stop calling `ReloadRepository` after every commit
+
+**File:** `internal/git/commit.go:57`, `:65`, `:82`
+
+Closes the entire go-git repo handle to pick up one new commit. Cheaper: invalidate just the affected branch in `revisionCache` and let go-git re-read the new packed ref lazily.
+
+**Affects:** create.md #3, modify.md #5, absorb.md (post-apply), anywhere a commit is created.
+
+---
+
+### 13. Replace per-call `config.LoadConfig` with `ctx.Config`
+
+**Files:** `internal/cli/navigation/trunk.go:71` + `:140`, others
+
+Bootstrap already loads config into `ctx.Config`. Several commands re-load it. Trivial to fix; affects perf only marginally but is a clean-up alongside the bigger items.
+
+**Affects:** navigation.md #4.
+
+---
+
+## Recommended attack order
+
+For maximum impact per engineering hour:
+
+1. **#1 (lite bootstrap)** — single biggest perceived speedup. Touches `app.Context` + engine. Affects every command. Multi-day, but every workday afterward saves time across the team.
+2. **#2 (kill pre-checkout Status)** — half-day change. Immediate huge win on large working trees for `co` / `create` / `modify` / `absorb` / navigation.
+3. **#7 (skip validation when conflict-impossible)** — biggest single win for `modify`, the second most-run hot-path mutating command.
+4. **#3 (`IsUpToDate` uses cached state)** — pre-req for cleaning up `log`, `submit`, `info` per-branch loops. Small standalone.
+5. **#4 (preload stack stats)** — turns `log` from O(N git processes) into O(1) on the diff-stats axis.
+6. **#9 (`RebuildBranches`)** — fixes the `untrack` N+1 quickly and unlocks better behavior in `absorb` / `modify`.
+7. The remaining items are mostly hygiene that compound once the above are in.
+
+## Order-of-magnitude estimates
+
+These are back-of-envelope guesses to size effort vs reward, not measured:
+
+| Win | Affected commands | Typical saving per affected run |
+|---|---|---|
+| #1 lite bootstrap | every command | bootstrap cost (50–500ms depending on branch count) |
+| #2 kill pre-checkout Status | co, create, modify, absorb, navigation | working-tree Status walk (100ms–1s on large repos) |
+| #7 skip safe validation | modify, restack, absorb | N × ~300ms worktree creation |
+| #3 cached IsUpToDate | log, submit, info | N × metadata read (~5ms each) |
+| #4 preload stack stats | log, info | N × ~5ms `git diff --numstat` processes |
+| #9 RebuildBranches | untrack, absorb, modify, sync | K × full rebuild on multi-branch operations |
+| #5 snapshot batching | every mutating command | 5–15ms |
+| #6 coalesce Status | create, modify, absorb | 2 × Status walks |
+| #10 combine txs | create, scope, describe | 1 ref write per command |
+| #11 gate IsInManagedWorktree | every command | tiny but free |
+| #12 scoped reload | create, modify, absorb | 1 go-git reopen |
+
+## What not to touch
+
+- **`git commit` itself and pre-commit hooks.** The user owns hook cost.
+- **GitHub API latency.** Batching is already in place; further wins are caching with TTL (`log.md` #4, `submit.md` #2) which is bounded by correctness.
+- **go-git's checkout itself when used.** Switching to shell-out is item #2's option (b); if we stay on go-git, the Status fix still applies. Don't rewrite go-git internals.

--- a/docs/plans/perf/describe.md
+++ b/docs/plans/perf/describe.md
@@ -1,0 +1,73 @@
+# `describe` — Performance Analysis
+
+**Tier:** medium (low frequency; one stack at a time; metadata push at the end).
+
+## Call graph
+
+```
+newDescribeCmd → common.Run → describe.Action          internal/actions/describe/describe.go:26
+  ├─ eng.IsTrunk + currentBranch.IsTracked            cache reads
+  ├─ eng.GetStackRootForBranch                        in-memory traversal
+  │
+  ├─ --show: print + return                           (no network)
+  ├─ --clear:
+  │    ├─ eng.ClearStackDescription                   metadata transaction
+  │    └─ markStackAndPushMetadata                    see below
+  ├─ -m / -d:
+  │    └─ applyStackDescription
+  │         ├─ eng.SetStackDescription                metadata transaction
+  │         └─ markStackAndPushMetadata
+  └─ interactive:
+       ├─ eng.GetStackDescription                     cache read
+       ├─ tui.OpenEditor                              user-blocking
+       └─ applyStackDescription
+
+markStackAndPushMetadata:
+  ├─ graph.CollectBranches(root)                      in-memory walk over stack
+  ├─ eng.BatchMarkNeedsPRBodyUpdate(branchNames)      ← writes ONE meta ref PER branch
+  └─ actions.PushMetadataOnly                         `git push refs/stackit/metadata/<root>`
+```
+
+## Where time goes
+
+1. **`actions.PushMetadataOnly`** — one network round trip. Same cost story as `scope.md` #1.
+2. **`BatchMarkNeedsPRBodyUpdate(branchNames)`** — currently writes one ref per branch. Let me verify what "Batch" means here in practice.
+
+Looking at `engine_writer.go:1062` (not pasted here), `BatchMarkNeedsPRBodyUpdate` should ideally write all the flags in a single `UpdateRefsBatch` call. The CLAUDE.md "Batch Operations" rule explicitly calls this out. If it does — good. If it just loops `MarkNeedsPRBodyUpdate` internally, that's an N+1.
+
+3. **`SetStackDescription` (or `ClearStackDescription`)** — one metadata transaction.
+4. **Bootstrap + open editor** — same fixed costs as everywhere else.
+
+For a stack with 10 branches, the metadata phase writes 1 description + 10 mark-flags + 1 push. The push dominates by an order of magnitude.
+
+## Wins (ranked)
+
+### 1. Ensure `BatchMarkNeedsPRBodyUpdate` is genuinely batched *(check first; high impact if it isn't)*
+
+This is one of the "use batch APIs" examples from `.claude/rules/code-style.md`. Confirm via `internal/engine/engine_writer.go:1062` that the implementation uses `UpdateRefsBatch` or `withMetadataTx` over the whole branch set. If it's a loop, the cost on a 20-branch stack is 20 × ref writes + 20 × tx overhead = ~50–200ms wasted. (The fact that it's called `Batch...` suggests it is — verify before optimizing.)
+
+### 2. Combine `SetStackDescription` + `BatchMarkNeedsPRBodyUpdate` in one tx *(shared with scope.md #1)*
+
+The description write and the mark-for-PR-update write touch overlapping metadata. One transaction over `{stackRoot, ...branches}` is enough.
+
+### 3. Defer the metadata push for `--show` — already done *(trivial confirmation)*
+
+`--show` short-circuits before any writes/pushes. Good.
+
+### 4. Bootstrap "lite" mode benefits `--show` *(shared with co.md #2)*
+
+`--show` only needs the current branch and its stack root. Doesn't need full metadata for every branch in the repo.
+
+### 5. Editor mode: don't re-fetch description after editor closes *(trivial)*
+
+`describe.go:96` reads `existingDesc` before opening the editor; `applyStackDescription` writes the new one. No redundant read on this path. Good.
+
+## Validation
+
+```
+STACKIT_NO_LOGGING=1 hyperfine \
+  'stackit describe --show' \
+  'stackit describe -m "Test"'
+```
+
+The delta isolates the metadata write + push from the bootstrap baseline. Instrument: each metadata transaction, `PushMetadataRefs`, and confirm `BatchMarkNeedsPRBodyUpdate` is a single ref-write batch (it should be — confirm via `git update-ref --stdin` or equivalent).

--- a/docs/plans/perf/info.md
+++ b/docs/plans/perf/info.md
@@ -1,0 +1,81 @@
+# `info` / `i` — Performance Analysis
+
+**Tier:** medium (frequent quick-status check; one branch at a time).
+
+## Call graph
+
+```
+newInfoCmd → common.Run                              (same bootstrap as co)
+  └─ actions.InfoAction                              internal/actions/info.go:61
+       ├─ if --stack: StackInfoAction                (separate stack-wide path)
+       ├─ ResolveBranchName                          cheap (cache lookup)
+       ├─ if untracked: FetchMetadataRefs + LoadRemoteMetadataCache + ApplyRemoteMetadataIfExists
+       │     ← network fetch — only on untracked-branch path
+       ├─ if --json: outputBranchInfoJSON            JSON path
+       │
+       ├─ branch.IsBranchUpToDate                    engine_branch_status.go:148 — fresh metadata read + GetRevision
+       ├─ eng.GetStackDescription
+       ├─ branch.GetCommitDate                       one git op
+       ├─ branch.GetPrInfo                           cache hit
+       ├─ graph.ChildBranches                        in-memory
+       │
+       └─ if --patch: branch.GetAllCommits + eng.ShowCommits(stat?)
+          if --diff:  branch.GetAllCommits + eng.GetParentCommitSHA + eng.ShowDiff(stat?)
+          else:        branch.GetAllCommits(Readable)
+```
+
+## Where time goes
+
+For the **default `stackit info` on the current branch** (no flags):
+1. **Bootstrap** dominates — info does ~5 git ops after bootstrap.
+2. `branch.IsBranchUpToDate` re-reads metadata + does a `GetRevision` even though bootstrap has all of this in `state.branchState`. Same N+1 pattern as `co.md` #3.
+3. `branch.GetCommitDate` shells out per call.
+4. `branch.GetAllCommits(Readable)` walks the commit range via go-git.
+
+For **`info --diff` / `info --patch`**:
+1. **`eng.ShowDiff` / `eng.ShowCommits`** dominates. These shell to `git show` / `git diff`. Cost scales with the diff size, not stackit overhead.
+2. `branch.GetAllCommits(SHA)` then `GetParentCommitSHA` adds an extra git op pair to find the base. For `--patch`, the base lookup uses the *oldest* commit's parent SHA — a separate `git rev-parse` is needed because `GetAllCommits` returns SHAs but not their parents.
+
+For **`info <untracked-branch>`** (`internal/actions/info.go:78–97`):
+- Triggers a real **`git fetch refs/stackit/metadata`** network call. Dominates everything — many seconds on slow networks. This is the only info path that does network I/O.
+
+## Proposed wins (ranked)
+
+### 1. Make `IsBranchUpToDate` use cached state *(shared with co.md #3)*
+
+`internal/engine/engine_branch_status.go:148` re-reads metadata per call. For `info`, this is one extra metadata read per invocation — small but free.
+
+### 2. Cache `FetchMetadataRefs` per session *(small impact, low risk)*
+
+`internal/actions/info.go:85` fetches every time an untracked branch is queried. Cache the result for the process lifetime — calling info on the same untracked branch twice should not re-fetch.
+
+### 3. Combine `GetAllCommits + GetParentCommitSHA` into one git call *(small impact, low risk)*
+
+For `--patch` mode, `internal/actions/info.go:197–201` does:
+- `GetAllCommits(SHA)` → walk commits
+- `GetParentCommitSHA(oldestSHA)` → another rev-parse
+
+A single `git rev-list --parents` over the range produces both. Or read `meta.GetParentBranchRevision()` directly — that *is* the base revision and is already in cache after bootstrap.
+
+### 4. `GetCommitDate` could come from the engine state cache *(trivial)*
+
+The branch SHA is cached after bootstrap. A `git log -1 --format=%ct <sha>` is needed once per HEAD — could be batched into a `branchState` field at rebuild time if `info`/`log` become hot enough to care.
+
+### 5. Skip the second `eng.GetBranch(branchName)` calls *(trivial)*
+
+`internal/actions/info.go:156` and `:170` re-resolve `branchObj` twice when the earlier `branch` is already correct. Map lookups are cheap but pointless.
+
+### 6. JSON mode does its own work (`outputBranchInfoJSON`)
+
+Not read here — likely shares the same per-branch cost. Should reuse the same cached state as the text path.
+
+## Validation
+
+```
+STACKIT_NO_LOGGING=1 hyperfine \
+  'stackit info' \
+  'stackit info --diff' \
+  'stackit info --diff --stat'
+```
+
+The delta to `stackit parent` is the post-bootstrap branch-info cost. The delta from `info` to `info --diff` is the diff render cost (usually git, not stackit).

--- a/docs/plans/perf/log.md
+++ b/docs/plans/perf/log.md
@@ -1,0 +1,83 @@
+# `log` (and `log full` / `log short`) — Performance Analysis
+
+**Tier:** deep (the dashboard view — run constantly, FULL hits GitHub).
+
+## Call graph (non-interactive, the common shell case)
+
+```
+executeLog → common.Run                          (same bootstrap as co — see co.md)
+  └─ actions.LogAction                            internal/actions/log.go:82
+       ├─ if --json:        logActionJSON         internal/actions/log.go:239
+       ├─ if interactive:   tui.NewLogModel + tea.Run      (separate TUI path)
+       │
+       ├─ if LogStyleFull:  Engine.PopulateRemoteShas      one shell `for-each-ref refs/remotes/...`
+       ├─ tui.GetWorktreeData(eng)                          one parse over engine state
+       ├─ Engine.PreloadBranchData                          internal/engine/engine_branch_info.go:135
+       │    ├─ git.LoadAllBranchRevisions                  one go-git ref iter → revision cache
+       │    └─ batchReadMetadata(branches)                  already done in rebuildInternal
+       │
+       ├─ if FULL: github.BatchGetPRChecksStatus(branchNames)   1 GraphQL call (latency-bound)
+       │
+       └─ utils.Run(allBranches, …)                         parallel worker pool, N branches
+              └─ tui.BuildFullAnnotation                    internal/tui/tree_renderer.go:288
+                    └─ GetBranchAnnotation                  internal/tui/tree_renderer.go:327
+                          ├─ branch.GetRevision()           cache hit (preloaded)
+                          ├─ branch.GetPrInfo()             cache hit (preloaded)
+                          ├─ branch.GetAllCommits(Readable) engine_branch_info.go:159 — go-git log range, per branch
+                          └─ branch.GetDiffStats()          engine_branch_info.go:60 — shells `git diff --numstat` per branch
+```
+
+## Where time goes (largest → smallest, typical FULL run)
+
+1. **`BatchGetPRChecksStatus`** (`internal/actions/log.go:143`). Single network round trip but it's GitHub GraphQL — typically 300–800ms. Dominates wall time for `log full`. Already batched; the only further wins are caching across runs (next-token / etag) or scoping to visible branches.
+2. **Per-branch `GetDiffStats`** (`internal/engine/engine_branch_info.go:60`). Each call spawns `git diff --numstat <base> <head>` (`internal/git/runner.go:873`). For N branches → N processes, ~3–8ms each plus IO. On a 20-branch stack this is 60–160ms of pure subprocess overhead. Parallelized via `utils.Run`, but still O(N) processes.
+3. **Per-branch `GetAllCommits(Readable)`** (`internal/engine/engine_branch_info.go:159`). Goes through `git.GetCommitRange`, which is in-process via go-git but still does a commit walk per branch. Mostly memory-bound but adds up with deep histories.
+4. **`PreloadBranchData`** (`internal/engine/engine_branch_info.go:135`). Already batched well. Branch revisions load in one ref iter; metadata reuses the cache populated during `rebuildInternal`. The metadata call here is essentially a no-op on the hot path — could be removed.
+5. **`rebuildInternal` in bootstrap** — see `co.md`. Same fixed cost on every invocation.
+6. **`PopulateRemoteShas` for FULL** (`internal/actions/log.go:104`). Single git invocation; small.
+7. **Summary loop** (`internal/actions/log.go:184`). Calls `ctx.Engine.GetBranch(name)` per annotation — map lookup, trivial.
+
+For `log short` and `log` (NORMAL): no GitHub round trip, no PR check, so the per-branch git work (diff stats, commit walk) dominates.
+
+For `log --json`: identical shape — same `PreloadBranchData`, same per-branch parallel fan-out via `utils.Run`, plus the same `BatchGetPRChecksStatus`. Same wins apply.
+
+## Proposed wins (ranked)
+
+### 1. Batch diff stats across all branches *(high impact, medium effort)*
+
+`GetDiffStats` is the worst N+1 in this command. Replace the per-branch `git diff --numstat <base> <head>` with a single `git diff --numstat --cc` walk or a per-stack-root invocation that emits one numstat block per branch, parsed once. Even a naive "build the (base,head) tuples and concurrent-launch up to maxConcurrency processes" caps overhead, but a single combined call is the real win. Cache the result keyed by `(base,head)` so subsequent log calls in the same session reuse it.
+
+Estimated saving on a 20-branch stack: 60–160ms → ~10–20ms.
+
+### 2. Defer `GetAllCommits` to when commit messages are actually displayed *(high impact, low risk)*
+
+`GetBranchAnnotation` (`internal/tui/tree_renderer.go:350`) calls `GetAllCommits` to populate `CommitMessages` for the detailed view. In NORMAL/FULL non-interactive renders only `CommitCount` is used in the tree. Split it: cheap-path returns count from a `git rev-list --count` (or use the existing `engine.state.branchState` if revisions match metadata), full message list only when the renderer asks for it. Also: `GetCommitRange` walks commits in-process — fine in isolation, but multiplied by N branches it's the second-biggest CPU cost.
+
+For `log short` (where `HideSummary` is set in `RenderOptions`), this whole call can be skipped entirely.
+
+### 3. Drop the redundant `batchReadMetadata` in `PreloadBranchData` *(small but free)*
+
+`internal/engine/engine_branch_info.go:148` calls `batchReadMetadata(branches)` again. By this point, `rebuildInternal` has already populated `e.state` from metadata and the cache layer (`metadataCache`) is hot. Either remove this call entirely or make it a cheap "ensure populated" check.
+
+### 4. Cache `BatchGetPRChecksStatus` between consecutive log invocations *(medium impact, low risk)*
+
+A TTL cache (say 30s) keyed on the sorted branch name list would make repeated `log full` invocations during a typing/review burst instant. Invalidate on `submit`. Optional: only fetch PR check status for branches that have a PR number in metadata — skips work for unsubmitted branches.
+
+### 5. Skip GraphQL entirely when no branch has a PR *(trivial, low impact)*
+
+`branchNames` in `internal/actions/log.go:136` includes branches with no PR. Pre-filter by checking `branch.GetPrInfo() != nil` from the already-loaded metadata before the network call.
+
+### 6. Worker pool bounded by repository fanout, not branch count *(small, future)*
+
+`utils.Run(allBranches, …)` spawns one goroutine per branch. For very large repos (hundreds of branches), bound it via `Engine.MaxConcurrency` — currently effectively unbounded for in-memory work but matters when each goroutine forks a git process (item #1).
+
+## Validation
+
+```
+STACKIT_NO_LOGGING=1 hyperfine \
+  'stackit log' \
+  'stackit log short' \
+  'stackit log full'
+```
+
+Instrument: `BatchGetPRChecksStatus`, the `utils.Run` block in `LogAction`, individual `GetDiffStats` calls (log a per-branch timing). The cross-section between FULL and short is the GitHub cost; the cross-section between log and log short is the per-branch annotation work.

--- a/docs/plans/perf/modify.md
+++ b/docs/plans/perf/modify.md
@@ -1,0 +1,102 @@
+# `modify` — Performance Analysis
+
+**Tier:** deep (the second hot-path mutating command after `create`; runs on every iteration).
+
+## Call graph
+
+```
+NewModifyCmd.RunE → common.Run                       (same bootstrap as co)
+  └─ actions.ModifyAction                            internal/actions/modify.go:34
+       ├─ validation.ModifyBranchChain               cheap ancestry checks
+       ├─ validation.MustNotHaveRebaseInProgress     fs check on .git/rebase-merge etc.
+       ├─ eng.IsBranchEmpty(currentBranch)           engine_branch_status.go:245 — git rev-list / metadata compare
+       ├─ git.StageChanges(opts)                     shells `git add ...` (only if --all/--update/--patch)
+       ├─ eng.HasStagedChanges                       worktree.Status() — full tree walk
+       │
+       ├─ eng.CommitWithOptions                      internal/engine/engine_writer.go:718
+       │     └─ git.runner.CommitWithOptions         internal/git/commit.go:20
+       │           ├─ shells `git commit --amend …`  user hooks dominate when present
+       │           ├─ revisionCache.InvalidateAll
+       │           └─ ReloadRepository               closes + reopens go-git repo
+       │
+       └─ if children exist:
+            RestackBranches                          internal/actions/common.go:96
+              └─ restackBranchesWithPlan             internal/actions/common.go:111
+                   ├─ validateBranchAncestry         per-branch ancestry probe
+                   ├─ Engine.PlanRestack             ~3 git ops per branch (sha + parent sha + check)
+                   └─ Engine.ValidateRebases         internal/engine/rebase_validator.go:72
+                        ├─ git.PruneWorktrees(ctx)   one-shot per call
+                        ├─ groupSpecsByDepth         in-memory
+                        └─ for each level, in parallel (up to MaxConcurrency):
+                             validateSingleSpec
+                               ├─ wt.CreateSession   ← `git worktree add` (slow, fs-bound)
+                               ├─ dryRunRebase       shells `git rebase --onto …`
+                               └─ wt.Cleanup        ← `git worktree remove`
+```
+
+## Where time goes (typical leaf-branch amend with N descendants)
+
+1. **`git worktree add` × N specs** inside `ValidateRebases`. Each worktree creation is hundreds of ms on large repos (file copy of the working tree contents). Branches at the same depth are parallelized — but every spec still gets its own worktree. For an amend with one descendant: one worktree. For five: five worktrees in parallel, capped at `MaxConcurrency`. This is the single biggest cost on a non-leaf modify.
+2. **User pre-commit hook** during the `git commit --amend`. Outside stackit's control but it runs every modify.
+3. **`ReloadRepository`** after the amend (`internal/git/commit.go:57`). Closes and re-opens the go-git repo, wiping the revision cache. Same cost as in `create.md` #3.
+4. **`PlanRestack`** — ~3 git ops per descendant. Currently bounded by descendant count, not particularly parallel. For a deep stack, this is meaningful.
+5. **`worktree.Status()`** in `HasStagedChanges` (`internal/git/staging.go:103`). Same full-tree walk pattern as in `create.md` #1.
+6. **`IsBranchEmpty`** — runs even when the user passed `-c` (already requested a new commit). Wasted work.
+7. **Bootstrap (`rebuildInternal`)** — fixed cost; see `co.md`.
+
+For a **leaf branch amend** (no children): the restack block is skipped entirely. The dominant non-hook cost is `worktree.Status()` (#5) + `ReloadRepository` (#3) + bootstrap. Big win there is shared with `create`.
+
+For a **mid-stack amend**: the worktree-validate dance dominates everything else.
+
+## Proposed wins (ranked)
+
+### 1. Skip `ValidateRebases` when the amend is conflict-free *(high impact, medium risk)*
+
+After an amend, every descendant's rebase is `rebase --onto <new-parent-sha> <old-parent-sha> <branch>`. If git can compute that as a fast-forward (the old parent is an ancestor of the new parent and no descendant commits touch the same files), there is no possibility of conflict. The validator could classify specs into:
+
+- **Trivially safe**: parent moved but descendant commits don't overlap with the diff between old/new parent — apply directly, no worktree.
+- **Needs validation**: otherwise.
+
+Cheap heuristic: compare `git diff --name-only old-parent..new-parent` with `git diff --name-only old-parent..branch` per spec. If the file sets are disjoint, no conflict is possible. The check is one `diff --name-only` per spec instead of one full worktree+rebase.
+
+For a typical amend that only touches one file in a leaf branch, this collapses N worktrees into N file-set comparisons (each ~1ms).
+
+### 2. Reuse a single validation worktree per depth level *(medium impact, medium risk)*
+
+`ValidateRebasesParallel` creates one worktree per spec. Within a depth level, branches are siblings — they all share the same upstream. A single reusable worktree per level (or per goroutine in a worker pool) could `git rebase --onto … && git rebase --abort` (or reset to a known state) between specs, paying worktree creation O(levels × concurrency) instead of O(specs).
+
+Risk: rerere state and partial-rebase state need careful reset between specs. The current per-spec isolation is the safe design — opt-in path for the validated-good case is safer.
+
+### 3. Drop `IsBranchEmpty` when `--commit` is set *(trivial)*
+
+`internal/actions/modify.go:57` checks emptiness even when the user already chose `-c`. Move the check inside the `if !opts.CreateCommit` branch.
+
+### 4. Same `worktree.Status()` coalescing as `create` *(low impact for modify, shared fix)*
+
+`HasStagedChanges` here calls `worktree.Status()`. `StageChanges` may have just finished a `git add` and knows what was staged. Returning a "staged any files?" flag from `StageChanges` would let us skip the second status walk. Same fix benefits `create`, `absorb`, `submit`.
+
+### 5. Same `ReloadRepository` scoping as `create` *(see create.md #3)*
+
+Invalidate just the affected branch's revision rather than dropping the whole go-git handle.
+
+### 6. Parallelize `PlanRestack`'s per-branch git ops *(small impact)*
+
+`PlanRestack` runs ~3 git ops per branch sequentially. Most are revision lookups that go through `revisionCache`. After `PreloadBranchData` (which modify doesn't currently call but easily could) most of these would be cache hits and the issue vanishes. Cheaper than building a fan-out.
+
+### 7. Pre-warm the revision cache before restack *(trivial)*
+
+Call `LoadAllBranchRevisions` (already exists, used by `log`) before `PlanRestack` so its per-branch SHA lookups are all cache hits. One go-git ref iter vs. N individual lookups.
+
+## Validation
+
+```
+# Leaf branch (isolates non-restack work)
+STACKIT_NO_LOGGING=1 hyperfine \
+  'echo // noop >> file.go; stackit modify -a --no-edit'
+
+# Mid-stack (5 descendants) — measures worktree validation cost
+STACKIT_NO_LOGGING=1 hyperfine \
+  'echo // noop >> file.go; stackit modify -a --no-edit'
+```
+
+Instrument: each `validateSingleSpec`, the worktree creation specifically, `ValidateRebases` total, `git commit`, `ReloadRepository`. The delta between leaf and mid-stack is essentially the worktree validation cost.

--- a/docs/plans/perf/navigation.md
+++ b/docs/plans/perf/navigation.md
@@ -1,0 +1,69 @@
+# Navigation commands — Performance Analysis
+
+Covers: `up`, `down`, `parent`, `children`, `top`, `bottom`, `trunk`, `main`. **Tier:** medium (high frequency, but the per-command logic is microseconds — bootstrap dominates).
+
+These commands are bundled because they share one performance story: **bootstrap is the entire cost**. The actual navigation logic is in-memory graph walks over data already loaded by `rebuildInternal`.
+
+## Per-command call summary
+
+| Command | After bootstrap | Ends with checkout? |
+|---|---|---|
+| `parent` (`internal/cli/navigation/parent.go`) | one `GetParent()` cache hit | no |
+| `children` (`children.go`) | one `graph.ChildBranches()` cache hit | no |
+| `down` (`down.go`) | walks parent chain in cache | yes (`common.Checkout`) |
+| `up` (`up.go`) | builds `graph`, walks children; with `--to` builds `Range(RecursiveChildren)` per child | yes |
+| `top` (`top.go`) → `actions/navigation.SwitchBranchAction` | walks children to leaf, may prompt | yes |
+| `bottom` (`bottom.go`) → same | walks parent chain to trunk-adjacent | yes |
+| `trunk` (default) (`trunk.go`) | walks parent chain + `config.LoadConfig` | no |
+| `trunk --add` | `GetAllBranchNames` + `LoadConfig` + `Save` | no |
+| `main` / `m` (`main.go`) | nothing | yes (`actions.CheckoutOptions{CheckoutTrunk: true}`) |
+
+## Where time goes
+
+1. **`common.Run` bootstrap** (~`rebuildInternal` + `IsInManagedWorktree`) — see `co.md`. For `parent`, `children`, `trunk` (default), this is **100% of runtime**. The graph walk afterwards is microseconds.
+2. **`worktree.Status()` + `worktree.Checkout()`** for the commands that end with a checkout. Same story as `co.md` items #1 + #3.
+3. **`up --to <branch>`** specifically: for each child of the current branch, calls `graph.Range(child, {RecursiveChildren: true})` (`internal/cli/navigation/up.go:79`), then `slices.Contains` over the result. If the current branch has K children and a total of N descendants, this is O(K × N). On a deep tree with many siblings, this is the only non-bootstrap cost worth noting. Cheap fix: do one downstack DFS rooted at the current branch, build a child-to-leaves map, and look up `toBranch` in O(1).
+4. **`trunk --add`** does a redundant `GetAllBranchNames` to verify the branch exists — engine state already has this list. Substitute `eng.GetBranch(trunkName).Exists()` or check membership in `e.state.branches`.
+5. **`findTrunkForBranch`** (`trunk.go:138`) calls `config.LoadConfig` from scratch even though `app.Context.Config` is already populated. Use `ctx.Config`.
+
+## Proposed wins (ranked)
+
+### 1. Lite bootstrap for read-only navigation *(high impact, medium risk)*
+
+`parent`, `children`, `trunk` (no flag), and the early "validate current branch" step of `up`/`down`/`top`/`bottom` only need:
+- current branch (one HEAD read)
+- the metadata ref for the current branch (to find its parent)
+- optionally the metadata refs for its direct children
+
+This is at most 3–10 metadata reads versus the N branch reads that `rebuildInternal` performs. A "lazy" engine mode where metadata is fetched per-branch on first access would make every navigation command (and `co <exact>`) essentially instant.
+
+This is the same win listed as #2 in `co.md` — they share the fix.
+
+### 2. Single checkout path optimization benefits all of `up`, `down`, `top`, `bottom`, `main` *(see co.md #1)*
+
+Fix `git.runner.CheckoutBranch` (skip `worktree.Status()`) → every navigate-and-checkout command gets faster proportionally to working-tree size.
+
+### 3. `up --to` should DFS once, not K × N *(small impact, low risk)*
+
+`internal/cli/navigation/up.go:75–88`: build `descendantsOf := map[branchName]bool` by walking from each child once. Then `descendantsOf[toBranch]` is O(1). Saves real work only on wide stacks with `--to`, but the current code is unnecessarily quadratic.
+
+### 4. `trunk` should reuse `ctx.Config` *(trivial)*
+
+`handleAddTrunk` (`trunk.go:71`) and `findTrunkForBranch` (`trunk.go:140`) both call `config.LoadConfig` again. Bootstrap already loaded it into `ctx.Config`. Substitute.
+
+### 5. `trunk --add` should skip `GetAllBranchNames` *(trivial)*
+
+`trunk.go:60`. The engine already has the branch list. `slices.Contains(eng.AllBranchNames(), name)` (or a `Engine.HasBranch` helper) avoids spawning a git command.
+
+## Validation
+
+```
+STACKIT_NO_LOGGING=1 hyperfine \
+  'stackit parent' \
+  'stackit children' \
+  'stackit trunk' \
+  'stackit down' \
+  'stackit main'
+```
+
+`parent`/`children`/`trunk` should be ~equal — they all just pay bootstrap. The delta to `down`/`main` is the checkout cost. The delta from `stackit parent` to a shell-level `pwd` is your bootstrap budget.

--- a/docs/plans/perf/restack.md
+++ b/docs/plans/perf/restack.md
@@ -1,0 +1,74 @@
+# `restack` — Performance Analysis
+
+**Tier:** medium (frequent after rebases, sync, or absorb; expensive when actual rebases run).
+
+## Call graph
+
+```
+NewRestackCmd → common.Run                           (same bootstrap as co)
+  └─ actions.PlanRestack                             internal/actions/restack.go:92
+       ├─ planRestackBranchGroups                    O(branches) graph walk
+       └─ for each group:
+            ├─ eng.SortBranchesTopologically
+            └─ eng.PlanRestack                       ~3 git ops per branch (sha + parent sha + check)
+  └─ if plan.HasBranches:
+       actions.RestackAction                         internal/actions/restack.go:121
+         ├─ TakeBestEffortSnapshot                   see create.md #2
+         ├─ rerere.EnsureEnabled                     one config read/write
+         │
+         └─ for each group (parallel if --parallel):
+              restackBranchesWithPlan                internal/actions/common.go:111
+                ├─ validateBranchAncestry            cheap
+                ├─ Engine.ValidateRebases            ← per-spec worktrees (see modify.md #1)
+                ├─ (apply or conflict workflow)
+                └─ engine state writes
+```
+
+## Where time goes
+
+1. **`Engine.ValidateRebases`** dominates — same per-spec worktree creation that hurts `modify` and `absorb`. Restack's worst case is "stack of 8 branches all touch the same file" → 8 worktrees, validated in dependency order with width-level parallelism.
+2. **`Engine.PlanRestack`** — ~3 git ops per branch, run twice if the CLI builds the plan AND the action rebuilds it (which today's code explicitly avoids by passing `enginePlan` through). Still O(branches) git ops once.
+3. **`TakeBestEffortSnapshot`** — same per-branch revision iteration as `create.md` #2.
+4. **`--parallel` with worktrees** — `restackGroupsParallel` (not read here) dispatches independent stack groups to separate worktrees. Each worktree creation is hundreds of ms; for the multi-stack case this is a feature (parallelism beats serial worktree-creates), but each group still individually pays per-spec validation.
+5. **Bootstrap** — same fixed cost as `co.md`.
+
+## Proposed wins (ranked)
+
+### 1. The big shared win: skip `ValidateRebases` when conflict-impossible *(shared with modify.md #1)*
+
+Per-spec diff-file overlap check turns most stack restacks into "0 worktrees needed". For typical post-amend restacks, the descendant commits don't touch the same files as the parent's amend diff. This collapses to a few `git diff --name-only` invocations.
+
+### 2. Pre-warm revision cache before `PlanRestack` *(small, free)*
+
+`engine.PlanRestack` does ~3 SHA lookups per branch. After `eng.LoadAllBranchRevisions()` (already exists, called from `log`), all lookups hit cache. Add the call before `PlanRestack` in `actions.PlanRestack` (`internal/actions/restack.go:92`). Same fix benefits `modify` indirectly through `RestackBranches`.
+
+### 3. Reuse validation worktree per depth level *(shared with modify.md #2)*
+
+Within a level (sibling branches), one worktree could validate all sibling specs back-to-back via `git rebase --onto … && git rebase --abort` between specs. Caps worktree creation at `levels × concurrency` instead of N.
+
+### 4. `--all-stacks` parallel mode should pre-build a worktree pool *(small impact, low risk)*
+
+`restackGroupsParallel` creates worktrees on demand. For large `--all-stacks` runs, a pre-allocated pool of `jobs` worktrees that gets reused across groups avoids redundant `git worktree add`/`git worktree remove` cycles. Particularly noticeable when many groups have few branches each.
+
+### 5. Snapshot scoping (shared with create.md #2)
+
+If `undo.enabled=false`, skip `TakeBestEffortSnapshot` entirely. For a no-op restack on an up-to-date stack (`!plan.HasWork()`), snapshot is pure overhead.
+
+### 6. Skip snapshot when `!plan.HasWork()` *(trivial)*
+
+Already short-circuits to the simple sync handler when nothing changes. The snapshot in `RestackAction` runs before that branch is taken. Move `TakeBestEffortSnapshot` after the no-work check, or only take a snapshot when we're about to mutate refs.
+
+## Validation
+
+```
+# Up-to-date stack (isolates fixed overhead)
+STACKIT_NO_LOGGING=1 hyperfine 'stackit restack'
+
+# Stack needing 5 conflict-free rebases (measures ValidateRebases cost)
+STACKIT_NO_LOGGING=1 hyperfine 'stackit restack --upstack'
+
+# Multi-stack parallel
+STACKIT_NO_LOGGING=1 hyperfine 'stackit restack --all-stacks --parallel'
+```
+
+Instrument: `ValidateRebases` total + per-spec, `PlanRestack`, `TakeBestEffortSnapshot`. The delta between up-to-date and needs-work is the validation cost.

--- a/docs/plans/perf/scope.md
+++ b/docs/plans/perf/scope.md
@@ -1,0 +1,66 @@
+# `scope` — Performance Analysis
+
+**Tier:** medium (low frequency; one branch at a time; network push at the end).
+
+## Call graph
+
+```
+newScopeCmd → common.Run → scope.Action               internal/actions/scope/action.go:22
+  ├─ --show: read explicit + resolved scope from cache; print            (no network)
+  ├─ --unset:
+  │    ├─ eng.SetScope(Empty)                        metadata transaction (1 ref)
+  │    ├─ eng.BatchMarkNeedsPRBodyUpdate              metadata transaction (1 ref)
+  │    └─ actions.PushMetadataOnly                    `git push refs/stackit/metadata/<branch>`
+  │
+  └─ set scope:
+       ├─ eng.SetScope(newScope)                     metadata transaction
+       ├─ if scope-in-branch-name and renamed:
+       │    handler.PromptConfirmRename
+       │    eng.RenameBranch                          ref rename + checkout
+       ├─ eng.BatchMarkNeedsPRBodyUpdate              another metadata transaction
+       └─ actions.PushMetadataOnly                    `git push`
+```
+
+## Where time goes
+
+1. **`actions.PushMetadataOnly`** — one `git push` (network round trip, 200–500ms typical). Dominates everything else when remote-sync is on.
+2. **`TestRemoteRefCompatibility`** on first run — another network round trip. Only runs once per repo (caches in `IsRemoteSyncEnabled`).
+3. **Two metadata transactions** per call: `SetScope` writes one ref, `BatchMarkNeedsPRBodyUpdate` writes another. Both go through the metadata tx machinery; each is ~2–5ms.
+4. **Bootstrap** — `rebuildInternal` as always.
+5. **`--show`** is pure cache reads after bootstrap. The fast path.
+
+`RenameBranch` is rare — only triggered when the user explicitly confirms — but it does a real branch checkout + ref rename and is more expensive than the rest combined when it runs.
+
+## Wins (ranked)
+
+### 1. Combine the two metadata writes into one transaction *(small impact, low risk)*
+
+`SetScope` then `BatchMarkNeedsPRBodyUpdate` are two separate transactions touching the same branch's metadata. The engine's `withMetadataTx` could absorb both writes into one ref update — saves one git ref write. Fix touches `scope/action.go:73` and `:118`. Same pattern affects `describe`, `lock`, anywhere a command both mutates metadata and marks the branch for PR sync.
+
+### 2. Make the metadata push async-friendly *(medium impact, medium risk)*
+
+For non-interactive `--unset` and `--set`, the user is blocked on `git push` of metadata before the command returns. Stackit's [`safety-invariants.md`](../../.claude/rules/safety-invariants.md) explicitly notes that GitHub writes should defer to `sync`, but the *metadata ref push* itself is the heavy bit here. Options:
+
+- Background the push (fork a `git push` in the background, return immediately, log failures). Risk: user runs `submit` before metadata sync — but `submit` would re-push anyway, so the failure mode is benign.
+- Batch metadata pushes across consecutive `scope`/`describe`/`lock` commands during a single shell session via a debounce. Complex; only worth it if these commands run in bursts.
+
+Default to keeping the sync push but document that it's the dominant cost.
+
+### 3. `--show` should skip remote-shas / IsInManagedWorktree *(small impact, free)*
+
+`common.Run` does `IsInManagedWorktree()` unconditionally (`internal/cli/common/common.go:42`). `scope --show` doesn't need that. Same fix listed in `co.md` #5 — gate per command.
+
+### 4. Bootstrap "lite" mode benefits `--show` *(shared with co.md #2)*
+
+`--show` only needs the current branch and its scope chain. Doesn't need a full `rebuildInternal`.
+
+## Validation
+
+```
+STACKIT_NO_LOGGING=1 hyperfine \
+  'stackit scope --show' \
+  'stackit scope ABC-123' \
+  'stackit scope --unset'
+```
+
+The `--show` baseline measures bootstrap-only cost. The delta to set/unset is dominated by the metadata push.

--- a/docs/plans/perf/submit.md
+++ b/docs/plans/perf/submit.md
@@ -1,0 +1,86 @@
+# `submit` (and `ss`) — Performance Analysis
+
+**Tier:** medium (frequent, but cost is dominated by remote API and `git push` latency, not local stackit work).
+
+## Call graph
+
+```
+NewSubmitCmd → executeSubmit → submit.Action         internal/actions/submit/submit.go:110
+  ├─ if untracked target: prompt + eng.TrackBranch
+  ├─ getBranchesToSubmit                              graph walk over the stack
+  ├─ pr.PopulateRemoteShas                            one `for-each-ref refs/remotes/...`
+  ├─ for each branch: branch.IsBranchUpToDate         N × GetRevision + readMetadata (see co.md #3)
+  ├─ tree.NewStackTree + normalizeDisplayTreeParents  in-memory
+  ├─ handler.OnEvent(StackDisplayEvent)               render
+  │
+  ├─ if --restack: actions.RestackBranches            ← per-spec worktree validation (see modify.md #1)
+  ├─ ValidateBranchesToSubmit                         per-branch checks
+  ├─ prepareBranchesForSubmit                         per-branch metadata + PR planning
+  │     ↳ may call GitHub for existing PR info
+  │
+  ├─ getGitHubClient                                  lazy init (one-time)
+  ├─ for each branch:
+  │     submitBranch                                  ← `git push` + GraphQL PR create/update
+  │       sequential for creates (PR number ordering)
+  │       parallel for updates (utils.Run)
+  │
+  ├─ if SubmitFooter: utils.Run(branches, UpdateBranchPRMetadata)   ← N × GraphQL update
+  └─ pushMetadataRefs(branches)                       one `git push refs/stackit/metadata/...`
+```
+
+## Where time goes
+
+For an **update-style submit** (PRs already exist, no restack needed):
+1. **`git push` per branch** — each is a network round trip. Parallelized. Dominates everything else; typical 200–500ms per push, bounded by `MaxConcurrency` and remote rate limits.
+2. **GitHub GraphQL "update PR" calls** — also network-bound, also parallelized.
+3. **`SubmitFooter` updates** — another N GraphQL round-trips after the pushes. Already parallel. Often the slowest single phase because it sets per-branch PR body footers that include the stack listing.
+4. **`pushMetadataRefs`** — one combined push for `refs/stackit/metadata/*`. Single round trip.
+5. **`PopulateRemoteShas`** — one shell git command.
+
+For a **new-stack submit** (creates):
+- Submission is **sequential** (`internal/actions/submit/submit.go:296`) to guarantee sequential PR numbers. This is by design but pays N × push-latency serially.
+
+For a **--restack submit**:
+- `RestackBranches` pays the per-spec worktree validation tax (`modify.md` #1).
+
+Local (non-network) overhead is small compared to remote calls. The dominant local cost is the same bootstrap and the same `IsBranchUpToDate` per branch (every branch in the stack iterates through a fresh `GetRevision + readMetadata`).
+
+## Proposed wins (ranked)
+
+### 1. Skip the per-branch `IsBranchUpToDate` re-reads *(shared with co.md #3)*
+
+`internal/actions/submit/submit.go:192` calls `branch.IsBranchUpToDate()` for every branch in the stack. Each goes through `engine_branch_status.go:148` and re-reads metadata. After bootstrap, the engine already knows whether each branch's stored `ParentBranchRevision` matches the current parent SHA. One batched comparison instead of N metadata reads.
+
+### 2. Cache PR check status reads (shared with log.md #4)
+
+`prepareBranchesForSubmit` reads existing PR info per branch. If `log full` ran recently or if the user invoked `submit` after a `status`/`log` view, a process-level TTL cache (~30s) on `BatchGetPRChecksStatus` and per-PR info reads would skip redundant GraphQL calls.
+
+### 3. Pre-build worktrees for parallel update path *(low impact today, useful for `--restack` path)*
+
+When `--restack` is on, the inner `RestackBranches` builds worktrees per spec. If submit ran restack frequently (or for `--all-stacks`), a reusable worktree pool would help. Same shape as `restack.md` #4.
+
+### 4. Combine the `SubmitFooter` update with the PR create/update call *(medium impact, low risk)*
+
+`internal/actions/submit/submit.go:325–337` runs a second pass of N GraphQL calls solely to write the footer. Each existing `submitBranch` call already issues a GraphQL update — extend it to include the rendered footer in the same call. Saves the entire second-pass round trip when `--submit-footer` is on (which is the default for many users).
+
+### 5. Push metadata refs in the same `git push` as branch refs *(medium impact, medium risk)*
+
+`pushMetadataRefs` is a separate `git push refs/stackit/metadata/*` at the end. For a stack of N branches the push pattern is "N branch pushes + 1 metadata push". A single `git push --atomic` listing both groups would save one round trip. Risk: atomic pushes fail-as-a-group; today's behavior tolerates a metadata-only push failure ("Run 'st sync' and try submitting again"). Keep the fallback.
+
+### 6. Sequential create path could parallelize after the first PR *(small impact, medium risk)*
+
+The reason creates are sequential is to get sequential PR numbers. After the first branch's PR is created (and its number known), subsequent creates only need *its number* — not the sequence. Could submit branches in batches: first one alone, then the rest in parallel referencing each other by number. Tricky because stacked PR descriptions reference each other; needs careful ordering.
+
+### 7. `getBranchesToSubmit` could skip the redundant `Graph` walk *(trivial)*
+
+If the action wants the stack containing the current branch, `eng.Graph` is built lazily; submit already builds one for `tree.NewStackTree`. Reuse the same graph rather than rebuilding inside `getBranchesToSubmit`.
+
+## Validation
+
+```
+STACKIT_NO_LOGGING=1 hyperfine \
+  'stackit submit --dry-run' \
+  'stackit submit'
+```
+
+The delta is the push + GraphQL cost — almost entirely network. Instrument: each `submitBranch`, `pushMetadataRefs`, the per-branch `IsBranchUpToDate` loop, and the `SubmitFooter` update phase. The `--dry-run` baseline isolates planning from network.

--- a/docs/plans/perf/track-untrack.md
+++ b/docs/plans/perf/track-untrack.md
@@ -1,0 +1,98 @@
+# `track` and `untrack` — Performance Analysis
+
+**Tier:** medium (less frequent than navigation/modify, but `untrack` has a real N+1 today).
+
+## `track`
+
+### Call graph
+
+```
+newTrackCmd → common.Run → track.Action               internal/actions/track/action.go:18
+  ├─ if --parent given:
+  │    ├─ eng.GetRevision(parent) + eng.GetRevision(branch)
+  │    ├─ eng.IsAncestor(parentRev, branchRev)        shells `git merge-base --is-ancestor`
+  │    └─ eng.TrackBranch                              metadata write (1 ref)
+  │
+  ├─ if --force:
+  │    ├─ eng.FindMostRecentTrackedAncestors          walks ref ancestry
+  │    └─ eng.TrackBranch
+  │
+  └─ interactive (no --parent):
+       trackBranchRecursively                          internal/actions/track/action.go:103
+         ├─ eng.FindMostRecentTrackedAncestors
+         ├─ handler.PromptSelectParent                 user-blocking
+         ├─ eng.TrackBranch
+         ├─ for each branch in AllBranches:           ← N branches
+         │     eng.GetMergeBase(candidate, branchName) ← `git merge-base` per branch (N calls)
+         │     eng.GetRevision(branchName)             cached on second iter
+         │     comparison
+         └─ recurse into untracked children
+```
+
+### Where time goes
+
+1. **Per-candidate `eng.GetMergeBase`** in the child-detection loop (`action.go:169`). For each branch in the repo, a separate `git merge-base <candidate> <branchName>` is called. On a 50-branch repo, that's 50 git merge-base processes. This is the dominant cost in interactive track.
+2. **`FindMostRecentTrackedAncestors`** — runs once (or twice — `:76` and `:114` in the same flow). Walks ancestry — bounded by parent-chain depth, not by N.
+3. **`eng.TrackBranch`** is cheap (one metadata ref write).
+4. **Bootstrap** — fixed cost; small relative to the merge-base loop above.
+
+### Wins
+
+#### 1. Replace per-candidate `GetMergeBase` with a single `rev-list` *(high impact, low risk)*
+
+`internal/actions/track/action.go:159–183` is the classic "find all descendants of a commit" question. One `git rev-list --children <branchName>..HEAD` (or `git for-each-ref --contains <branchName-sha>`) gives all branches that contain the branch's tip in one process. N+1 → 1.
+
+#### 2. Cache `GetRevision` in the candidate loop *(trivial)*
+
+`eng.GetRevision(eng.GetBranch(branchName))` is called inside the loop (`:174`) per candidate. Move it outside; it doesn't change.
+
+#### 3. Pre-warm with `LoadAllBranchRevisions` *(small impact, free)*
+
+Track does several `GetRevision` calls; if `LoadAllBranchRevisions` is called once at the start of `Action`, every subsequent revision lookup is a cache hit (one go-git ref iter vs many separate ones).
+
+## `untrack`
+
+### Call graph
+
+```
+newUntrackCmd → common.Run → untrack.Action            internal/actions/untrack/action.go:18
+  ├─ eng.Graph + graph.Range(RecursiveChildren)        in-memory
+  ├─ for each descendant:
+  │     eng.UntrackBranch(name)                        engine_writer.go:148
+  │       ├─ git.DeleteMetadata                        1 ref delete
+  │       └─ eng.rebuild()                             ← FULL REBUILD per descendant
+  └─ eng.UntrackBranch(branchName)                     another rebuild
+```
+
+### Where time goes
+
+1. **`eng.rebuild()` inside `UntrackBranch`** — see `internal/engine/engine_writer.go:155`. Each call does the full `GetAllBranchNames + batchReadMetadata + batchReadLocalMetadata` pass. Untracking a stack of K descendants triggers `K+1` full rebuilds. On a 30-branch repo untracking a 10-branch substack, that's 11 × (full branch enumeration + metadata read for every branch). The biggest performance bug in either command.
+2. Bootstrap — fixed cost.
+
+### Wins
+
+#### 1. Batch the metadata deletes and rebuild once *(high impact, low risk)*
+
+Replace the per-branch `eng.UntrackBranch(name)` loop with:
+- a single `git.DeleteRefsBatch(metadataRefNames)` (the engine already exposes `DeleteRefsBatch`),
+- one `eng.rebuild()` afterwards.
+
+For untracking 10 branches: 10 rebuilds → 1 rebuild, plus 10 → 1 ref deletes. The fix is one helper method on the engine: `BatchUntrackBranches([]string) error`.
+
+#### 2. Scope the rebuild to touched branches *(shared with absorb.md #4)*
+
+If the engine grew a `RebuildBranches([]string)`, even the single-branch untrack path would only re-read the affected metadata rather than the whole repo's worth.
+
+## Validation
+
+```
+# Track on a deep repo
+STACKIT_NO_LOGGING=1 hyperfine 'stackit track <branch> --parent <parent>'      # cheap path
+STACKIT_NO_LOGGING=1 hyperfine 'stackit track <branch> --force'               # ancestor walk
+STACKIT_NO_LOGGING=1 hyperfine 'stackit track <branch>'                       # interactive path — N×merge-base
+
+# Untrack a 10-branch substack
+STACKIT_NO_LOGGING=1 hyperfine 'stackit untrack <root> -f'
+```
+
+Instrument: the merge-base loop in `trackBranchRecursively`, every `eng.rebuild()` invocation, every `eng.UntrackBranch` call. The untrack rebuild count should be 1, not K+1, after the fix.


### PR DESCRIPTION

Add ParentBranchRevision to BranchState and populate it in
rebuildFromMetadata + updateBranchStateFromMeta. Rewrite IsUpToDate to read
the stored revision from cached state instead of re-reading metadata via
e.readMetadata(branchName). The metadata read was redundant — rebuild had
already loaded the field — and made IsUpToDate one of the known bypass paths
for the upcoming lazy-load chokepoint. Now it's a pure cache check + a single
revisionCache-backed parent SHA lookup.

This also fixes docs/perf/co.md win #3 independently.