### PR TITLE
refactor: route engine state reads through engineImpl.readState chokepoint

### DIFF
--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -96,7 +96,7 @@ func (e *engineImpl) GetDiffStats(branch Branch) (int, int, error) {
 func (e *engineImpl) resolveBranchComparisonRevisions(branchName string) (base, branchRev string, err error) {
 	e.mu.RLock()
 	trunk := e.trunk
-	state := e.state.branchState.GetByName(branchName)
+	state := e.readState(branchName)
 	e.mu.RUnlock()
 
 	parent := trunk

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -19,7 +19,7 @@ func (e *engineImpl) IsTrunk(branch Branch) bool {
 func (e *engineImpl) IsTracked(branch Branch) bool {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	state := e.state.branchState.Get(branch)
+	state := e.readState(branch.GetName())
 	return state != nil && state.Parent != ""
 }
 
@@ -34,7 +34,7 @@ func (e *engineImpl) GetScope(branch Branch) Scope {
 	for !visited[current] {
 		visited[current] = true
 
-		state := e.state.branchState.GetByName(current)
+		state := e.readState(current)
 		if state == nil {
 			break
 		}
@@ -57,7 +57,7 @@ func (e *engineImpl) GetScope(branch Branch) Scope {
 func (e *engineImpl) IsLocked(branch Branch) bool {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	if state := e.state.branchState.Get(branch); state != nil {
+	if state := e.readState(branch.GetName()); state != nil {
 		return state.IsLocked()
 	}
 	return false
@@ -67,7 +67,7 @@ func (e *engineImpl) IsLocked(branch Branch) bool {
 func (e *engineImpl) GetLockReason(branch Branch) LockReason {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	if state := e.state.branchState.Get(branch); state != nil {
+	if state := e.readState(branch.GetName()); state != nil {
 		return state.LockReason
 	}
 	return LockReasonNone
@@ -77,7 +77,7 @@ func (e *engineImpl) GetLockReason(branch Branch) LockReason {
 func (e *engineImpl) IsFrozen(branch Branch) bool {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	if state := e.state.branchState.Get(branch); state != nil {
+	if state := e.readState(branch.GetName()); state != nil {
 		return state.Frozen
 	}
 	return false
@@ -87,7 +87,7 @@ func (e *engineImpl) IsFrozen(branch Branch) bool {
 func (e *engineImpl) GetBranchType(branch Branch) git.BranchType {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	if state := e.state.branchState.Get(branch); state != nil {
+	if state := e.readState(branch.GetName()); state != nil {
 		return state.BranchType
 	}
 	return ""
@@ -120,7 +120,7 @@ func (e *engineImpl) SetBranchType(branch Branch, branchType git.BranchType) err
 	}
 
 	// Update in-memory state
-	if state := e.state.branchState.GetByName(branchName); state != nil {
+	if state := e.readState(branchName); state != nil {
 		state.BranchType = branchType
 	}
 
@@ -132,7 +132,7 @@ func (e *engineImpl) GetExplicitScope(branch Branch) Scope {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	if state := e.state.branchState.Get(branch); state != nil && state.HasScope() {
+	if state := e.readState(branch.GetName()); state != nil && state.HasScope() {
 		return state.GetScope()
 	}
 	return Empty()
@@ -151,7 +151,7 @@ func (e *engineImpl) IsUpToDate(branch Branch) bool {
 	}
 
 	e.mu.RLock()
-	state := e.state.branchState.GetByName(branch.GetName())
+	state := e.readState(branch.GetName())
 	e.mu.RUnlock()
 
 	if state == nil {
@@ -176,7 +176,7 @@ func (e *engineImpl) IsUpToDate(branch Branch) bool {
 func (e *engineImpl) GetBranchRemoteStatus(branch Branch) (BranchRemoteStatus, error) {
 	branchName := branch.GetName()
 	e.mu.RLock()
-	state := e.state.branchState.Get(branch)
+	state := e.readState(branch.GetName())
 	var remoteSha string
 	if state != nil {
 		remoteSha = state.RemoteSHA
@@ -237,7 +237,7 @@ func (e *engineImpl) IsMergedIntoTrunk(ctx context.Context, branchName string) (
 // IsBranchEmpty checks if a branch has no changes compared to its parent
 func (e *engineImpl) IsBranchEmpty(ctx context.Context, branchName string) (bool, error) {
 	e.mu.RLock()
-	state := e.state.branchState.GetByName(branchName)
+	state := e.readState(branchName)
 	trunk := e.trunk
 	e.mu.RUnlock()
 

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -146,37 +146,30 @@ func (e *engineImpl) getExplicitScope(branch Branch) Scope {
 // IsUpToDate checks if a branch is up to date with its parent
 // A branch is up to date if its parent revision matches the stored parent revision
 func (e *engineImpl) IsUpToDate(branch Branch) bool {
-	branchName := branch.GetName()
 	if e.IsTrunk(branch) {
 		return true
 	}
 
 	e.mu.RLock()
-	state := e.state.branchState.GetByName(branchName)
+	state := e.state.branchState.GetByName(branch.GetName())
 	e.mu.RUnlock()
 
 	if state == nil {
 		return true // Not tracked, consider it fixed
 	}
 
-	// Get current parent revision
+	if state.ParentBranchRevision == "" {
+		return false // No stored revision, needs restack
+	}
+
+	// Get current parent revision (cached via revisionCache after first read).
 	parentRev, err := e.git.GetRevision(state.Parent)
 	if err != nil {
 		return false // Can't determine, assume needs restack
 	}
 
-	// Get stored parent revision from metadata
-	meta, err := e.readMetadata(branchName)
-	if err != nil {
-		return false // No metadata, assume needs restack
-	}
-
-	if meta.GetParentBranchRevision() == nil {
-		return false // No stored revision, needs restack
-	}
-
-	// Branch is fixed if stored revision matches current parent revision
-	return *meta.GetParentBranchRevision() == parentRev
+	// Branch is up to date if stored revision matches current parent revision.
+	return state.ParentBranchRevision == parentRev
 }
 
 // GetBranchRemoteStatus returns the relationship between a local branch and its remote

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -253,6 +253,19 @@ func (e *engineImpl) Git() git.Runner {
 	return e.git
 }
 
+// readState returns the cached BranchState for a branch by name, or nil if
+// the branch is unknown to the engine. This is the single chokepoint for
+// branch-state reads inside the engine — every accessor that needs to inspect
+// scope, lock, parent, type, or frozen state goes through here so future
+// lazy-load work has one place to insert the gate.
+//
+// The caller is responsible for holding e.mu (read or write) for the duration
+// of the read; this helper does NOT acquire the lock. Many callers compose
+// multiple state reads under a single lock and need that consistency.
+func (e *engineImpl) readState(name string) *BranchState {
+	return e.state.branchState.GetByName(name)
+}
+
 // Rebuild reloads branch cache with new trunk
 func (e *engineImpl) Rebuild(newTrunkName string) error {
 	e.mu.Lock()
@@ -282,7 +295,7 @@ func (e *engineImpl) PopulateRemoteShas() error {
 
 	// Set RemoteSHA for tracked branches that have a remote
 	for branchName, sha := range remoteShas {
-		if state := e.state.branchState.GetByName(branchName); state != nil {
+		if state := e.readState(branchName); state != nil {
 			state.RemoteSHA = sha
 		}
 	}

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -124,7 +124,7 @@ func (e *engineImpl) shouldReparentBranch(ctx context.Context, parentBranchName 
 // Returns trunk if all ancestors have been merged
 func (e *engineImpl) findNearestValidAncestor(ctx context.Context, branchName string, metaMap map[string]*git.Meta) string {
 	// Get the starting parent from branchState
-	state := e.state.branchState.GetByName(branchName)
+	state := e.readState(branchName)
 	if state == nil {
 		return e.trunk
 	}
@@ -135,7 +135,7 @@ func (e *engineImpl) findNearestValidAncestor(ctx context.Context, branchName st
 			return current
 		}
 		// Move to the next parent
-		parentState := e.state.branchState.GetByName(current)
+		parentState := e.readState(current)
 		if parentState == nil {
 			break
 		}

--- a/internal/engine/engine_reader.go
+++ b/internal/engine/engine_reader.go
@@ -89,7 +89,7 @@ func (e *engineImpl) GetParent(branch Branch) *Branch {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	if state := e.state.branchState.Get(branch); state != nil {
+	if state := e.readState(branch.GetName()); state != nil {
 		b := NewBranch(state.Parent, e)
 		return &b
 	}
@@ -272,7 +272,7 @@ func (e *engineImpl) GetDivergencePoint(branchName string) (string, error) {
 
 	// Get the parent branch
 	e.mu.RLock()
-	state := e.state.branchState.GetByName(branchName)
+	state := e.readState(branchName)
 	e.mu.RUnlock()
 
 	if state == nil {

--- a/internal/engine/engine_split.go
+++ b/internal/engine/engine_split.go
@@ -179,7 +179,7 @@ func (e *engineImpl) DetachAndResetBranchChanges(ctx context.Context, branchName
 
 	// Get the parent branch
 	parentBranchName := e.trunk
-	if state := e.state.branchState.GetByName(branchName); state != nil {
+	if state := e.readState(branchName); state != nil {
 		parentBranchName = state.Parent
 	}
 

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -112,7 +112,7 @@ func (e *engineImpl) restackBranch(
 	}
 
 	e.mu.RLock()
-	state := e.state.branchState.GetByName(branchName)
+	state := e.readState(branchName)
 	e.mu.RUnlock()
 
 	var parent string
@@ -721,7 +721,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches []Branch, val
 		// Crawl up the branch state to find all ancestors
 		current := name
 		for {
-			state := e.state.branchState.GetByName(current)
+			state := e.readState(current)
 			if state == nil || state.Parent == e.trunk || allInvolvedBranches[state.Parent] {
 				break
 			}

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -171,7 +171,7 @@ func (e *engineImpl) DeleteBranch(ctx context.Context, branch Branch) error {
 
 	// Get parent
 	parent := e.trunk
-	if state := e.state.branchState.GetByName(branchName); state != nil {
+	if state := e.readState(branchName); state != nil {
 		parent = state.Parent
 	}
 
@@ -990,7 +990,7 @@ func (e *engineImpl) GetStackRootForBranch(branch Branch) string {
 
 	current := branchName
 	for {
-		state := e.state.branchState.GetByName(current)
+		state := e.readState(current)
 		if state == nil {
 			// Should not happen since we checked above, but handle gracefully
 			return ""

--- a/internal/engine/remote_sync.go
+++ b/internal/engine/remote_sync.go
@@ -187,7 +187,7 @@ func (e *engineImpl) ApplyRemoteMetadataIfExists(branchName string) error {
 	}
 
 	// Update local branch state
-	if state := e.state.branchState.GetByName(branchName); state != nil {
+	if state := e.readState(branchName); state != nil {
 		state.LockReason = remote.GetLockReason()
 		if remote.GetScope() != nil {
 			state.Scope = *remote.GetScope()
@@ -318,7 +318,7 @@ func (e *engineImpl) AcceptRemoteMetadata(branch string) error {
 func (e *engineImpl) RejectRemoteMetadata(branch string) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if state := e.state.branchState.GetByName(branch); state != nil {
+	if state := e.readState(branch); state != nil {
 		state.LocalModified = true
 	}
 }
@@ -328,7 +328,7 @@ func (e *engineImpl) HasLocalModifications(branch string) bool {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	if state := e.state.branchState.GetByName(branch); state != nil && state.LocalModified {
+	if state := e.readState(branch); state != nil && state.LocalModified {
 		return true
 	}
 

--- a/internal/engine/restack_plan.go
+++ b/internal/engine/restack_plan.go
@@ -65,7 +65,7 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 	parent := branch.GetParent()
 	parentName := e.trunk
 	e.mu.RLock()
-	state := e.state.branchState.GetByName(branchName)
+	state := e.readState(branchName)
 	e.mu.RUnlock()
 	if state != nil && state.Parent != "" {
 		parentName = state.Parent

--- a/internal/engine/state_core.go
+++ b/internal/engine/state_core.go
@@ -9,13 +9,14 @@ import (
 // BranchState holds the cached metadata state for a single branch.
 // This consolidates what was previously stored in separate maps.
 type BranchState struct {
-	Parent        string         // Parent branch name
-	Scope         string         // Scope string (may be empty)
-	LockReason    git.LockReason // Lock reason (empty if not locked)
-	Frozen        bool           // Whether branch is frozen (local-only state)
-	BranchType    git.BranchType // Branch type (worktree-anchor, utility, etc.)
-	RemoteSHA     string         // Remote SHA (populated by PopulateRemoteShas)
-	LocalModified bool           // Has local metadata changes not yet pushed
+	Parent               string         // Parent branch name
+	ParentBranchRevision string         // Stored parent SHA from metadata; "" if none recorded
+	Scope                string         // Scope string (may be empty)
+	LockReason           git.LockReason // Lock reason (empty if not locked)
+	Frozen               bool           // Whether branch is frozen (local-only state)
+	BranchType           git.BranchType // Branch type (worktree-anchor, utility, etc.)
+	RemoteSHA            string         // Remote SHA (populated by PopulateRemoteShas)
+	LocalModified        bool           // Has local metadata changes not yet pushed
 }
 
 // HasScope returns true if this branch has an explicit scope set.
@@ -164,6 +165,9 @@ func (s *stateCore) rebuildFromMetadata(
 		if meta.GetScope() != nil {
 			state.Scope = *meta.GetScope()
 		}
+		if rev := meta.GetParentBranchRevision(); rev != nil {
+			state.ParentBranchRevision = *rev
+		}
 
 		s.branchState.Set(name, state)
 		s.childrenMap[parent] = append(s.childrenMap[parent], name)
@@ -202,6 +206,12 @@ func (s *stateCore) updateBranchStateFromMeta(branch string, meta *git.Meta) {
 		state.Scope = *meta.GetScope()
 	} else {
 		state.Scope = ""
+	}
+
+	if rev := meta.GetParentBranchRevision(); rev != nil {
+		state.ParentBranchRevision = *rev
+	} else {
+		state.ParentBranchRevision = ""
 	}
 
 	state.LockReason = meta.GetLockReason()


### PR DESCRIPTION

Mechanical no-op refactor: every direct e.state.branchState.Get/GetByName
call inside the engine now goes through e.readState(name). The wrapper is a
pure passthrough today — caller continues to hold e.mu as before — but
establishes a single seam where the upcoming lazy-load gate can plug in
without sprinkling 'ensure loaded' checks across 11 files.

Scope: 28 call sites across engine_branch_status, engine_branch_info,
engine_reader, engine_writer, engine_impl, engine_internal, engine_sync,
engine_split, restack_plan, remote_sync. state_core.go is left alone
(internal to state). All tests pass; behavior is identical.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #956**
  * **PR #957**
    * **PR #958** 👈
      * **PR #959**
        * **PR #960**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->