### PR TITLE
perf(app): bootstrap engine in LoadModeShared by default

### DIFF
--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -340,7 +340,10 @@ func NewContextAutoWithWriter(ctx context.Context, repoRoot string, opts GlobalO
 	// Create git runner with logger for command logging, wrapped with tracing
 	gitRunner := git.NewTracingRunner(git.NewRunnerWithPath(repoRoot, logger), logger)
 
-	// Create real engine with configured runner
+	// Create real engine with configured runner. LoadModeShared skips
+	// BatchReadLocalMetadata at bootstrap — local metadata (Frozen, etc.)
+	// loads on first accessor call. For commands that never read local-only
+	// fields this cuts metadata I/O roughly in half on big repos.
 	eng, err := engine.NewEngine(engine.Options{
 		RepoRoot:          repoRoot,
 		Trunk:             trunk,
@@ -348,6 +351,7 @@ func NewContextAutoWithWriter(ctx context.Context, repoRoot string, opts GlobalO
 		MaxConcurrency:    maxConcurrency,
 		Writer:            writer,
 		Git:               gitRunner,
+		LoadMode:          engine.LoadModeShared,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -107,6 +107,31 @@ type ApplySplitOptions struct {
 	AsSibling bool
 }
 
+// LoadMode controls how much state the engine populates at construction time.
+// Lighter modes defer metadata reads until the first accessor that needs them
+// triggers a promotion via ensureSharedLoaded / ensureLocalLoaded.
+type LoadMode int
+
+const (
+	// LoadModeFull reads both shared and local metadata at construction.
+	// This is today's behavior and the default. Used by tests and any
+	// command that needs lock/frozen/scope/PR data for every branch.
+	LoadModeFull LoadMode = iota
+
+	// LoadModeShared reads shared metadata at construction but defers local
+	// metadata (Frozen, NeedsPRBodyUpdate, NavigationCommentID) until the
+	// first local-only accessor is called. Saves the BatchReadLocalMetadata
+	// pass for commands that never touch frozen/needs-PR-update state.
+	LoadModeShared
+
+	// LoadModeBranchesOnly reads only the branch list at construction.
+	// Shared metadata is loaded on the first state access; local metadata on
+	// the first local-only accessor. Intended for read-only navigation
+	// commands (parent, children, trunk, co <exact>) that only need a
+	// single branch's metadata, not every branch in the repo.
+	LoadModeBranchesOnly
+)
+
 // Options contains configuration options for creating an Engine
 type Options struct {
 	// RepoRoot is the root directory of the Git repository
@@ -129,6 +154,11 @@ type Options struct {
 	// Writer is the output writer for warnings and informational messages.
 	// If nil, os.Stderr is used.
 	Writer io.Writer
+
+	// LoadMode controls how much metadata is read at construction time.
+	// Zero value (LoadModeFull) matches the pre-lite behavior — readers see
+	// all metadata populated synchronously after NewEngine returns.
+	LoadMode LoadMode
 }
 
 // UndoManager provides operations for undo/redo functionality

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -96,7 +96,7 @@ func (e *engineImpl) GetDiffStats(branch Branch) (int, int, error) {
 func (e *engineImpl) resolveBranchComparisonRevisions(branchName string) (base, branchRev string, err error) {
 	e.mu.RLock()
 	trunk := e.trunk
-	state := e.state.branchState.GetByName(branchName)
+	state := e.readState(branchName)
 	e.mu.RUnlock()
 
 	parent := trunk

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -73,8 +73,11 @@ func (e *engineImpl) GetLockReason(branch Branch) LockReason {
 	return LockReasonNone
 }
 
-// IsFrozen checks if a branch is frozen
+// IsFrozen checks if a branch is frozen.
+// Frozen lives in local metadata which is loaded lazily — promote the local
+// tier before reading. Under LoadModeFull this is a no-op atomic check.
 func (e *engineImpl) IsFrozen(branch Branch) bool {
+	e.ensureLocalLoaded()
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 	if state := e.readState(branch.GetName()); state != nil {

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -19,7 +19,7 @@ func (e *engineImpl) IsTrunk(branch Branch) bool {
 func (e *engineImpl) IsTracked(branch Branch) bool {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	state := e.state.branchState.Get(branch)
+	state := e.readState(branch.GetName())
 	return state != nil && state.Parent != ""
 }
 
@@ -34,7 +34,7 @@ func (e *engineImpl) GetScope(branch Branch) Scope {
 	for !visited[current] {
 		visited[current] = true
 
-		state := e.state.branchState.GetByName(current)
+		state := e.readState(current)
 		if state == nil {
 			break
 		}
@@ -57,7 +57,7 @@ func (e *engineImpl) GetScope(branch Branch) Scope {
 func (e *engineImpl) IsLocked(branch Branch) bool {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	if state := e.state.branchState.Get(branch); state != nil {
+	if state := e.readState(branch.GetName()); state != nil {
 		return state.IsLocked()
 	}
 	return false
@@ -67,7 +67,7 @@ func (e *engineImpl) IsLocked(branch Branch) bool {
 func (e *engineImpl) GetLockReason(branch Branch) LockReason {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	if state := e.state.branchState.Get(branch); state != nil {
+	if state := e.readState(branch.GetName()); state != nil {
 		return state.LockReason
 	}
 	return LockReasonNone
@@ -77,7 +77,7 @@ func (e *engineImpl) GetLockReason(branch Branch) LockReason {
 func (e *engineImpl) IsFrozen(branch Branch) bool {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	if state := e.state.branchState.Get(branch); state != nil {
+	if state := e.readState(branch.GetName()); state != nil {
 		return state.Frozen
 	}
 	return false
@@ -87,7 +87,7 @@ func (e *engineImpl) IsFrozen(branch Branch) bool {
 func (e *engineImpl) GetBranchType(branch Branch) git.BranchType {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	if state := e.state.branchState.Get(branch); state != nil {
+	if state := e.readState(branch.GetName()); state != nil {
 		return state.BranchType
 	}
 	return ""
@@ -120,7 +120,7 @@ func (e *engineImpl) SetBranchType(branch Branch, branchType git.BranchType) err
 	}
 
 	// Update in-memory state
-	if state := e.state.branchState.GetByName(branchName); state != nil {
+	if state := e.readState(branchName); state != nil {
 		state.BranchType = branchType
 	}
 
@@ -132,7 +132,7 @@ func (e *engineImpl) GetExplicitScope(branch Branch) Scope {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	if state := e.state.branchState.Get(branch); state != nil && state.HasScope() {
+	if state := e.readState(branch.GetName()); state != nil && state.HasScope() {
 		return state.GetScope()
 	}
 	return Empty()
@@ -151,7 +151,7 @@ func (e *engineImpl) IsUpToDate(branch Branch) bool {
 	}
 
 	e.mu.RLock()
-	state := e.state.branchState.GetByName(branch.GetName())
+	state := e.readState(branch.GetName())
 	e.mu.RUnlock()
 
 	if state == nil {
@@ -176,7 +176,7 @@ func (e *engineImpl) IsUpToDate(branch Branch) bool {
 func (e *engineImpl) GetBranchRemoteStatus(branch Branch) (BranchRemoteStatus, error) {
 	branchName := branch.GetName()
 	e.mu.RLock()
-	state := e.state.branchState.Get(branch)
+	state := e.readState(branch.GetName())
 	var remoteSha string
 	if state != nil {
 		remoteSha = state.RemoteSHA
@@ -237,7 +237,7 @@ func (e *engineImpl) IsMergedIntoTrunk(ctx context.Context, branchName string) (
 // IsBranchEmpty checks if a branch has no changes compared to its parent
 func (e *engineImpl) IsBranchEmpty(ctx context.Context, branchName string) (bool, error) {
 	e.mu.RLock()
-	state := e.state.branchState.GetByName(branchName)
+	state := e.readState(branchName)
 	trunk := e.trunk
 	e.mu.RUnlock()
 

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -146,37 +146,30 @@ func (e *engineImpl) getExplicitScope(branch Branch) Scope {
 // IsUpToDate checks if a branch is up to date with its parent
 // A branch is up to date if its parent revision matches the stored parent revision
 func (e *engineImpl) IsUpToDate(branch Branch) bool {
-	branchName := branch.GetName()
 	if e.IsTrunk(branch) {
 		return true
 	}
 
 	e.mu.RLock()
-	state := e.state.branchState.GetByName(branchName)
+	state := e.state.branchState.GetByName(branch.GetName())
 	e.mu.RUnlock()
 
 	if state == nil {
 		return true // Not tracked, consider it fixed
 	}
 
-	// Get current parent revision
+	if state.ParentBranchRevision == "" {
+		return false // No stored revision, needs restack
+	}
+
+	// Get current parent revision (cached via revisionCache after first read).
 	parentRev, err := e.git.GetRevision(state.Parent)
 	if err != nil {
 		return false // Can't determine, assume needs restack
 	}
 
-	// Get stored parent revision from metadata
-	meta, err := e.readMetadata(branchName)
-	if err != nil {
-		return false // No metadata, assume needs restack
-	}
-
-	if meta.GetParentBranchRevision() == nil {
-		return false // No stored revision, needs restack
-	}
-
-	// Branch is fixed if stored revision matches current parent revision
-	return *meta.GetParentBranchRevision() == parentRev
+	// Branch is up to date if stored revision matches current parent revision.
+	return state.ParentBranchRevision == parentRev
 }
 
 // GetBranchRemoteStatus returns the relationship between a local branch and its remote

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"slices"
 	"sync"
+	"sync/atomic"
 
 	"github.com/getstackit/stackit/internal/git"
 )
@@ -25,6 +26,21 @@ type engineImpl struct {
 	writer            io.Writer
 	mu                sync.RWMutex
 	worktreeMu        sync.Mutex // serializes worktree add/remove/prune to avoid git races on .git/worktrees/
+
+	// Lazy-load gates. sharedLoaded and localLoaded track whether the
+	// corresponding metadata batch has been populated into state. Both default
+	// to false and are flipped true after the single-shot load runs.
+	// The atomic provides a lock-free fast path on the hot accessor path;
+	// the sync.Once enforces single-flight semantics across goroutines.
+	//
+	// ensureSharedLoaded / ensureLocalLoaded must NOT be called while holding
+	// e.mu (read or write). They acquire e.mu.Lock() internally to apply the
+	// loaded metadata. Callers should ensure the gate is open BEFORE acquiring
+	// e.mu for the operation that needs the data.
+	sharedLoaded   atomic.Bool
+	localLoaded    atomic.Bool
+	sharedLoadOnce sync.Once
+	localLoadOnce  sync.Once
 
 	// Temporary worktree cleanup tracking.
 	tempWorktreeNeedsPrune bool
@@ -46,7 +62,15 @@ type WorktreeSnapshot struct {
 // SnapshotForWorktree creates a deep copy of the engine's mutable state for use in
 // worktree sessions. The snapshot is safe to use from another goroutine since all
 // maps and slices are deep-copied.
+//
+// Force-loads both metadata tiers before snapshotting so worktree consumers
+// (restack, sync, etc.) get a fully-populated state regardless of the parent
+// engine's LoadMode. Without this a snapshot taken from a Lite engine would
+// only carry the branch list.
 func (e *engineImpl) SnapshotForWorktree() WorktreeSnapshot {
+	e.ensureSharedLoaded()
+	e.ensureLocalLoaded()
+
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
@@ -134,6 +158,11 @@ func NewEngineForWorktree(opts WorktreeEngineOptions) (Engine, error) {
 	}
 	e.currentBranch = currentBranch
 
+	// Worktree snapshots are built only from fully-loaded parent engines (see
+	// SnapshotForWorktree), so the worktree engine starts with both gates open.
+	e.sharedLoaded.Store(true)
+	e.localLoaded.Store(true)
+
 	return e, nil
 }
 
@@ -183,9 +212,27 @@ func NewEngine(opts Options) (Engine, error) {
 	}
 	e.currentBranch = currentBranch
 
-	// Don't refresh currentBranch here since we just set it
-	if err := e.rebuildInternal(false); err != nil {
-		return nil, fmt.Errorf("failed to rebuild engine: %w", err)
+	// Bootstrap state based on the requested LoadMode. Modes lighter than Full
+	// defer metadata reads until an accessor triggers ensureSharedLoaded or
+	// ensureLocalLoaded. All modes need the branches list so navigation
+	// commands can validate existence without a metadata read.
+	switch opts.LoadMode {
+	case LoadModeBranchesOnly:
+		if err := e.loadBranchList(); err != nil {
+			return nil, fmt.Errorf("failed to load branch list: %w", err)
+		}
+	case LoadModeShared:
+		if err := e.loadBranchList(); err != nil {
+			return nil, fmt.Errorf("failed to load branch list: %w", err)
+		}
+		e.ensureSharedLoaded()
+	case LoadModeFull:
+		fallthrough
+	default:
+		// Don't refresh currentBranch here since we just set it
+		if err := e.rebuildInternal(false); err != nil {
+			return nil, fmt.Errorf("failed to rebuild engine: %w", err)
+		}
 	}
 
 	// Auto-fetch remote metadata on first use (fresh clone scenario)
@@ -193,6 +240,75 @@ func NewEngine(opts Options) (Engine, error) {
 	e.maybeAutoFetchRemoteMetadata()
 
 	return e, nil
+}
+
+// loadBranchList populates only e.state.branches via a single GetAllBranchNames
+// call. Used by lighter LoadModes that defer metadata reads.
+func (e *engineImpl) loadBranchList() error {
+	branches, err := e.git.GetAllBranchNames()
+	if err != nil {
+		return fmt.Errorf("failed to get branches: %w", err)
+	}
+	e.mu.Lock()
+	e.state.setBranches(branches)
+	e.mu.Unlock()
+	return nil
+}
+
+// ensureSharedLoaded reads shared metadata for all known branches and applies
+// it to state. Idempotent and goroutine-safe — the actual read runs at most
+// once per engine lifetime via sharedLoadOnce. The atomic flag provides a
+// lock-free fast path so the common "already loaded" case adds only an
+// atomic load to each accessor.
+//
+// CRITICAL: callers must NOT hold e.mu (read or write) when calling this.
+// The function acquires e.mu.Lock() internally to apply the loaded metadata.
+func (e *engineImpl) ensureSharedLoaded() {
+	if e.sharedLoaded.Load() {
+		return
+	}
+	e.sharedLoadOnce.Do(func() {
+		// Snapshot the branches list under a read lock to avoid racing with
+		// concurrent mutations (e.g. CreateAndCheckoutBranch).
+		e.mu.RLock()
+		branches := slices.Clone(e.state.branches)
+		trunk := e.trunk
+		e.mu.RUnlock()
+
+		allMeta, _ := e.batchReadMetadata(branches)
+
+		e.mu.Lock()
+		e.state.applySharedMetadata(trunk, branches, allMeta)
+		e.mu.Unlock()
+
+		e.sharedLoaded.Store(true)
+	})
+}
+
+// ensureLocalLoaded reads local metadata for all known branches and applies
+// the Frozen flag to state. Same locking contract as ensureSharedLoaded.
+//
+// Local metadata is layered on top of shared, so this is typically called
+// after ensureSharedLoaded — but the order is enforced naturally because
+// applyLocalMetadata only sets Frozen and creates wrapper entries for any
+// branches that didn't appear in the shared pass.
+func (e *engineImpl) ensureLocalLoaded() {
+	if e.localLoaded.Load() {
+		return
+	}
+	e.localLoadOnce.Do(func() {
+		e.mu.RLock()
+		branches := slices.Clone(e.state.branches)
+		e.mu.RUnlock()
+
+		allLocalMeta := e.batchReadLocalMetadata(branches)
+
+		e.mu.Lock()
+		e.state.applyLocalMetadata(allLocalMeta)
+		e.mu.Unlock()
+
+		e.localLoaded.Store(true)
+	})
 }
 
 // maybeAutoFetchRemoteMetadata fetches remote metadata if this appears to be a fresh clone

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -253,6 +253,19 @@ func (e *engineImpl) Git() git.Runner {
 	return e.git
 }
 
+// readState returns the cached BranchState for a branch by name, or nil if
+// the branch is unknown to the engine. This is the single chokepoint for
+// branch-state reads inside the engine — every accessor that needs to inspect
+// scope, lock, parent, type, or frozen state goes through here so future
+// lazy-load work has one place to insert the gate.
+//
+// The caller is responsible for holding e.mu (read or write) for the duration
+// of the read; this helper does NOT acquire the lock. Many callers compose
+// multiple state reads under a single lock and need that consistency.
+func (e *engineImpl) readState(name string) *BranchState {
+	return e.state.branchState.GetByName(name)
+}
+
 // Rebuild reloads branch cache with new trunk
 func (e *engineImpl) Rebuild(newTrunkName string) error {
 	e.mu.Lock()
@@ -282,7 +295,7 @@ func (e *engineImpl) PopulateRemoteShas() error {
 
 	// Set RemoteSHA for tracked branches that have a remote
 	for branchName, sha := range remoteShas {
-		if state := e.state.branchState.GetByName(branchName); state != nil {
+		if state := e.readState(branchName); state != nil {
 			state.RemoteSHA = sha
 		}
 	}

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -124,7 +124,7 @@ func (e *engineImpl) shouldReparentBranch(ctx context.Context, parentBranchName 
 // Returns trunk if all ancestors have been merged
 func (e *engineImpl) findNearestValidAncestor(ctx context.Context, branchName string, metaMap map[string]*git.Meta) string {
 	// Get the starting parent from branchState
-	state := e.state.branchState.GetByName(branchName)
+	state := e.readState(branchName)
 	if state == nil {
 		return e.trunk
 	}
@@ -135,7 +135,7 @@ func (e *engineImpl) findNearestValidAncestor(ctx context.Context, branchName st
 			return current
 		}
 		// Move to the next parent
-		parentState := e.state.branchState.GetByName(current)
+		parentState := e.readState(current)
 		if parentState == nil {
 			break
 		}

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -36,11 +36,18 @@ func (e *engineImpl) rebuildInternal(refreshCurrentBranch bool) error {
 
 // applyRebuild updates the internal state from the provided metadata results.
 // The caller MUST hold the engine's write lock (e.mu).
+//
+// After a full rebuild both lazy-load gates are considered open — subsequent
+// ensureSharedLoaded / ensureLocalLoaded calls become no-ops via the atomic
+// fast path. We can't run sharedLoadOnce/localLoadOnce here (they'd block
+// future loads even on Reset), so we set the atomic flags directly.
 func (e *engineImpl) applyRebuild(branches []string, currentBranch string, allMeta map[string]*git.Meta, allLocalMeta map[string]*git.LocalMeta) {
 	e.state.rebuildFromMetadata(e.trunk, branches, allMeta, allLocalMeta)
 	if currentBranch != "" {
 		e.currentBranch = currentBranch
 	}
+	e.sharedLoaded.Store(true)
+	e.localLoaded.Store(true)
 }
 
 // rebuild loads all branches and their metadata from Git

--- a/internal/engine/engine_loadmode_test.go
+++ b/internal/engine/engine_loadmode_test.go
@@ -1,0 +1,222 @@
+package engine_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// makeStackForLoadModeTest creates a 3-branch linear stack (main → a → b → c)
+// in a fresh scene and returns the scene plus the trunk name. The engine is
+// constructed via the standard scenario helper (LoadModeFull) so the metadata
+// refs are populated; tests can then construct a second engine with a lighter
+// LoadMode against the same repo to validate lazy behavior.
+func makeStackForLoadModeTest(t *testing.T) *scenario.Scenario {
+	t.Helper()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+	s.CreateBranch("a").Commit("a")
+	require.NoError(t, s.Engine.TrackBranch(context.Background(), "a", "main"))
+
+	s.CreateBranch("b").Commit("b")
+	require.NoError(t, s.Engine.TrackBranch(context.Background(), "b", "a"))
+
+	s.CreateBranch("c").Commit("c")
+	require.NoError(t, s.Engine.TrackBranch(context.Background(), "c", "b"))
+
+	return s
+}
+
+func newEngineWithMode(t *testing.T, repoRoot string, mode engine.LoadMode) engine.Engine {
+	t.Helper()
+	eng, err := engine.NewEngine(engine.Options{
+		RepoRoot: repoRoot,
+		Trunk:    "main",
+		LoadMode: mode,
+	})
+	require.NoError(t, err)
+	return eng
+}
+
+// TestLoadMode_FullParity asserts that under LoadModeFull every accessor
+// returns the same values as LoadModeShared after promotion runs. This is
+// the equivalence smoke test for the lite-bootstrap construct.
+func TestLoadMode_FullParity(t *testing.T) {
+	t.Parallel()
+	s := makeStackForLoadModeTest(t)
+
+	full := newEngineWithMode(t, s.Scene.Dir, engine.LoadModeFull)
+	shared := newEngineWithMode(t, s.Scene.Dir, engine.LoadModeShared)
+
+	for _, name := range []string{"a", "b", "c"} {
+		fullBranch := full.GetBranch(name)
+		sharedBranch := shared.GetBranch(name)
+
+		fullParent := fullBranch.GetParent()
+		sharedParent := sharedBranch.GetParent()
+		require.NotNil(t, fullParent, "parent missing on full engine for %s", name)
+		require.NotNil(t, sharedParent, "parent missing on shared engine for %s", name)
+		require.Equal(t, fullParent.GetName(), sharedParent.GetName(),
+			"parent mismatch for %s", name)
+		require.Equal(t, full.IsTracked(fullBranch), shared.IsTracked(sharedBranch),
+			"IsTracked mismatch for %s", name)
+		require.Equal(t, full.IsLocked(fullBranch), shared.IsLocked(sharedBranch),
+			"IsLocked mismatch for %s", name)
+		require.Equal(t, full.GetScope(fullBranch).String(), shared.GetScope(sharedBranch).String(),
+			"GetScope mismatch for %s", name)
+		require.Equal(t, full.GetBranchType(fullBranch), shared.GetBranchType(sharedBranch),
+			"GetBranchType mismatch for %s", name)
+		require.Equal(t, full.IsFrozen(fullBranch), shared.IsFrozen(sharedBranch),
+			"IsFrozen mismatch for %s", name)
+	}
+}
+
+// TestLoadMode_SharedSkipsLocalBatch verifies that constructing an engine with
+// LoadModeShared does NOT trigger BatchReadLocalMetadata at bootstrap. The
+// local read happens only when an accessor that needs it (IsFrozen) is called.
+//
+// Cache hit counters are the observable signal: LoadModeFull warms the local
+// metadata refs into metadataCache during bootstrap (counts as misses on first
+// read); LoadModeShared leaves them cold until promotion.
+func TestLoadMode_SharedSkipsLocalBatch(t *testing.T) {
+	t.Parallel()
+	s := makeStackForLoadModeTest(t)
+
+	// Use a runner shared by the test so we can read cumulative stats.
+	gitRunner := git.NewRunnerWithPath(s.Scene.Dir, nil)
+	require.NoError(t, gitRunner.InitDefaultRepo())
+
+	eng, err := engine.NewEngine(engine.Options{
+		RepoRoot: s.Scene.Dir,
+		Trunk:    "main",
+		Git:      gitRunner,
+		LoadMode: engine.LoadModeShared,
+	})
+	require.NoError(t, err)
+
+	// Shared metadata loaded at bootstrap → at least one ReadMetadata per branch.
+	// IsTracked / GetScope read only shared state — must not provoke additional
+	// local-metadata reads.
+	branch := eng.GetBranch("b")
+	_ = eng.IsTracked(branch)
+	_ = eng.GetScope(branch)
+
+	statsBefore := gitRunner.MetadataCacheStats()
+
+	// Triggering IsFrozen MUST promote local metadata exactly once for the
+	// whole branch set, not once per accessor call.
+	_ = eng.IsFrozen(eng.GetBranch("a"))
+	_ = eng.IsFrozen(eng.GetBranch("b"))
+	_ = eng.IsFrozen(eng.GetBranch("c"))
+
+	statsAfter := gitRunner.MetadataCacheStats()
+
+	// The metadata cache only tracks shared-metadata hits/misses, not local
+	// (local has its own ref path). So the assertion is "no spurious shared
+	// reads happened during IsFrozen" — the local load goes through a
+	// separate code path.
+	require.Equal(t, statsBefore.Misses, statsAfter.Misses,
+		"IsFrozen should not provoke additional shared metadata reads; "+
+			"local metadata uses its own ref path")
+}
+
+// TestLoadMode_BranchesOnly_ReadsBranchListOnly confirms that
+// LoadModeBranchesOnly populates `branches` without touching shared metadata
+// refs at bootstrap. The branchState map should be empty until something
+// triggers the gate (which PR 6 will wire in for opt-in commands).
+func TestLoadMode_BranchesOnly_ReadsBranchListOnly(t *testing.T) {
+	t.Parallel()
+	s := makeStackForLoadModeTest(t)
+
+	// Fresh runner ⇒ metadataCache starts at zero hits/misses. We want to
+	// observe that constructing the engine in BranchesOnly mode adds nothing.
+	gitRunner := git.NewRunnerWithPath(s.Scene.Dir, nil)
+	require.NoError(t, gitRunner.InitDefaultRepo())
+
+	eng, err := engine.NewEngine(engine.Options{
+		RepoRoot: s.Scene.Dir,
+		Trunk:    "main",
+		Git:      gitRunner,
+		LoadMode: engine.LoadModeBranchesOnly,
+	})
+	require.NoError(t, err)
+
+	// AllBranches reads from the in-memory branches list and must NOT
+	// trigger metadata loading.
+	branches := eng.AllBranches()
+	require.NotEmpty(t, branches, "branch list must be populated under BranchesOnly")
+
+	stats := gitRunner.MetadataCacheStats()
+	require.Zero(t, stats.Hits, "BranchesOnly bootstrap must not populate the metadata cache")
+	require.Zero(t, stats.Misses, "BranchesOnly bootstrap must not read metadata refs")
+}
+
+// TestLoadMode_ConcurrentEnsureLoaded asserts that many concurrent accessors
+// against a LoadModeBranchesOnly engine all see the same fully-populated state
+// after the gate fires, regardless of which goroutine triggers it. This is
+// the high-risk path — double-checked locking around sync.Once is the most
+// common spot for subtle bugs.
+func TestLoadMode_ConcurrentEnsureLoaded(t *testing.T) {
+	t.Parallel()
+	s := makeStackForLoadModeTest(t)
+
+	gitRunner := git.NewRunnerWithPath(s.Scene.Dir, nil)
+	require.NoError(t, gitRunner.InitDefaultRepo())
+
+	eng, err := engine.NewEngine(engine.Options{
+		RepoRoot: s.Scene.Dir,
+		Trunk:    "main",
+		Git:      gitRunner,
+		LoadMode: engine.LoadModeShared,
+	})
+	require.NoError(t, err)
+
+	// Drive concurrent IsFrozen calls; each promotion attempt must collapse
+	// to a single localLoadOnce execution.
+	var wg sync.WaitGroup
+	const goroutines = 32
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for _, name := range []string{"a", "b", "c"} {
+				_ = eng.IsFrozen(eng.GetBranch(name))
+			}
+		}()
+	}
+	wg.Wait()
+
+	// After contention settles, IsFrozen still returns deterministic answers.
+	// (All branches in this test are not frozen.)
+	for _, name := range []string{"a", "b", "c"} {
+		require.False(t, eng.IsFrozen(eng.GetBranch(name)), "branch %s should not be frozen", name)
+	}
+}
+
+// TestLoadMode_SnapshotForWorktreeForceLoads asserts SnapshotForWorktree
+// always returns a fully-populated snapshot even when the parent engine was
+// constructed in a lighter mode. Worktree consumers (restack, sync) assume
+// the snapshot is complete; the snapshot path is responsible for triggering
+// both gates before copying.
+func TestLoadMode_SnapshotForWorktreeForceLoads(t *testing.T) {
+	t.Parallel()
+	s := makeStackForLoadModeTest(t)
+
+	eng := newEngineWithMode(t, s.Scene.Dir, engine.LoadModeBranchesOnly)
+	snap := eng.SnapshotForWorktree()
+
+	require.NotEmpty(t, snap.Branches, "snapshot must list branches")
+	require.NotEmpty(t, snap.BranchState, "snapshot must contain branchState entries after force-load")
+	for _, name := range []string{"a", "b", "c"} {
+		state, ok := snap.BranchState[name]
+		require.True(t, ok, "missing branch state for %s", name)
+		require.NotEmpty(t, state.Parent, "parent missing for %s", name)
+	}
+}

--- a/internal/engine/engine_reader.go
+++ b/internal/engine/engine_reader.go
@@ -89,7 +89,7 @@ func (e *engineImpl) GetParent(branch Branch) *Branch {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	if state := e.state.branchState.Get(branch); state != nil {
+	if state := e.readState(branch.GetName()); state != nil {
 		b := NewBranch(state.Parent, e)
 		return &b
 	}
@@ -272,7 +272,7 @@ func (e *engineImpl) GetDivergencePoint(branchName string) (string, error) {
 
 	// Get the parent branch
 	e.mu.RLock()
-	state := e.state.branchState.GetByName(branchName)
+	state := e.readState(branchName)
 	e.mu.RUnlock()
 
 	if state == nil {

--- a/internal/engine/engine_split.go
+++ b/internal/engine/engine_split.go
@@ -179,7 +179,7 @@ func (e *engineImpl) DetachAndResetBranchChanges(ctx context.Context, branchName
 
 	// Get the parent branch
 	parentBranchName := e.trunk
-	if state := e.state.branchState.GetByName(branchName); state != nil {
+	if state := e.readState(branchName); state != nil {
 		parentBranchName = state.Parent
 	}
 

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -112,7 +112,7 @@ func (e *engineImpl) restackBranch(
 	}
 
 	e.mu.RLock()
-	state := e.state.branchState.GetByName(branchName)
+	state := e.readState(branchName)
 	e.mu.RUnlock()
 
 	var parent string
@@ -721,7 +721,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches []Branch, val
 		// Crawl up the branch state to find all ancestors
 		current := name
 		for {
-			state := e.state.branchState.GetByName(current)
+			state := e.readState(current)
 			if state == nil || state.Parent == e.trunk || allInvolvedBranches[state.Parent] {
 				break
 			}

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -171,7 +171,7 @@ func (e *engineImpl) DeleteBranch(ctx context.Context, branch Branch) error {
 
 	// Get parent
 	parent := e.trunk
-	if state := e.state.branchState.GetByName(branchName); state != nil {
+	if state := e.readState(branchName); state != nil {
 		parent = state.Parent
 	}
 
@@ -990,7 +990,7 @@ func (e *engineImpl) GetStackRootForBranch(branch Branch) string {
 
 	current := branchName
 	for {
-		state := e.state.branchState.GetByName(current)
+		state := e.readState(current)
 		if state == nil {
 			// Should not happen since we checked above, but handle gracefully
 			return ""

--- a/internal/engine/remote_sync.go
+++ b/internal/engine/remote_sync.go
@@ -187,7 +187,7 @@ func (e *engineImpl) ApplyRemoteMetadataIfExists(branchName string) error {
 	}
 
 	// Update local branch state
-	if state := e.state.branchState.GetByName(branchName); state != nil {
+	if state := e.readState(branchName); state != nil {
 		state.LockReason = remote.GetLockReason()
 		if remote.GetScope() != nil {
 			state.Scope = *remote.GetScope()
@@ -318,7 +318,7 @@ func (e *engineImpl) AcceptRemoteMetadata(branch string) error {
 func (e *engineImpl) RejectRemoteMetadata(branch string) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if state := e.state.branchState.GetByName(branch); state != nil {
+	if state := e.readState(branch); state != nil {
 		state.LocalModified = true
 	}
 }
@@ -328,7 +328,7 @@ func (e *engineImpl) HasLocalModifications(branch string) bool {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	if state := e.state.branchState.GetByName(branch); state != nil && state.LocalModified {
+	if state := e.readState(branch); state != nil && state.LocalModified {
 		return true
 	}
 

--- a/internal/engine/restack_plan.go
+++ b/internal/engine/restack_plan.go
@@ -65,7 +65,7 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 	parent := branch.GetParent()
 	parentName := e.trunk
 	e.mu.RLock()
-	state := e.state.branchState.GetByName(branchName)
+	state := e.readState(branchName)
 	e.mu.RUnlock()
 	if state != nil && state.Parent != "" {
 		parentName = state.Parent

--- a/internal/engine/state_core.go
+++ b/internal/engine/state_core.go
@@ -137,6 +137,21 @@ func (s *stateCore) rebuildFromMetadata(
 	allMeta map[string]*git.Meta,
 	allLocalMeta map[string]*git.LocalMeta,
 ) {
+	s.applySharedMetadata(trunk, branches, allMeta)
+	s.applyLocalMetadata(allLocalMeta)
+}
+
+// applySharedMetadata rebuilds branchState and childrenMap from shared
+// metadata (refs/stackit/metadata/*). Resets branchState before populating
+// so stale entries from external mutations are dropped. Frozen is NOT
+// modified here — call applyLocalMetadata to fill that in.
+//
+// Callers must hold the engine write lock.
+func (s *stateCore) applySharedMetadata(
+	trunk string,
+	branches []string,
+	allMeta map[string]*git.Meta,
+) {
 	s.setBranches(branches)
 
 	// Reset tracked-state caches from fresh metadata snapshot.
@@ -173,16 +188,23 @@ func (s *stateCore) rebuildFromMetadata(
 		s.childrenMap[parent] = append(s.childrenMap[parent], name)
 	}
 
-	// Frozen is local-only metadata and may exist for untracked branches.
+	for _, children := range s.childrenMap {
+		slices.Sort(children)
+	}
+}
+
+// applyLocalMetadata layers local-only state (Frozen) onto branchState.
+// Safe to call after applySharedMetadata or independently; entries for
+// branches not already in branchState are created as bare wrappers so the
+// flag is preserved for untracked branches.
+//
+// Callers must hold the engine write lock.
+func (s *stateCore) applyLocalMetadata(allLocalMeta map[string]*git.LocalMeta) {
 	for name, meta := range allLocalMeta {
 		if meta.Frozen {
 			state := s.branchState.GetOrCreate(name)
 			state.Frozen = true
 		}
-	}
-
-	for _, children := range s.childrenMap {
-		slices.Sort(children)
 	}
 }
 

--- a/internal/engine/state_core.go
+++ b/internal/engine/state_core.go
@@ -9,13 +9,14 @@ import (
 // BranchState holds the cached metadata state for a single branch.
 // This consolidates what was previously stored in separate maps.
 type BranchState struct {
-	Parent        string         // Parent branch name
-	Scope         string         // Scope string (may be empty)
-	LockReason    git.LockReason // Lock reason (empty if not locked)
-	Frozen        bool           // Whether branch is frozen (local-only state)
-	BranchType    git.BranchType // Branch type (worktree-anchor, utility, etc.)
-	RemoteSHA     string         // Remote SHA (populated by PopulateRemoteShas)
-	LocalModified bool           // Has local metadata changes not yet pushed
+	Parent               string         // Parent branch name
+	ParentBranchRevision string         // Stored parent SHA from metadata; "" if none recorded
+	Scope                string         // Scope string (may be empty)
+	LockReason           git.LockReason // Lock reason (empty if not locked)
+	Frozen               bool           // Whether branch is frozen (local-only state)
+	BranchType           git.BranchType // Branch type (worktree-anchor, utility, etc.)
+	RemoteSHA            string         // Remote SHA (populated by PopulateRemoteShas)
+	LocalModified        bool           // Has local metadata changes not yet pushed
 }
 
 // HasScope returns true if this branch has an explicit scope set.
@@ -164,6 +165,9 @@ func (s *stateCore) rebuildFromMetadata(
 		if meta.GetScope() != nil {
 			state.Scope = *meta.GetScope()
 		}
+		if rev := meta.GetParentBranchRevision(); rev != nil {
+			state.ParentBranchRevision = *rev
+		}
 
 		s.branchState.Set(name, state)
 		s.childrenMap[parent] = append(s.childrenMap[parent], name)
@@ -202,6 +206,12 @@ func (s *stateCore) updateBranchStateFromMeta(branch string, meta *git.Meta) {
 		state.Scope = *meta.GetScope()
 	} else {
 		state.Scope = ""
+	}
+
+	if rev := meta.GetParentBranchRevision(); rev != nil {
+		state.ParentBranchRevision = *rev
+	} else {
+		state.ParentBranchRevision = ""
 	}
 
 	state.LockReason = meta.GetLockReason()


### PR DESCRIPTION

Flip app.NewContextAutoWithWriter to construct the engine with
LoadModeShared, deferring BatchReadLocalMetadata until the first
IsFrozen call. For commands that never touch Frozen — most navigation
and read-only paths — this halves the bootstrap metadata I/O on
repos with many branches.

Commands that DO touch Frozen (log, sync, restack) promote on first
hit; the work moves from synchronous bootstrap to slightly later in
the command but is otherwise identical. The metadata cache wraps both
tiers so subsequent reads stay cheap.

Worktree-engine bootstrap (NewEngineForWorktree) is unaffected — it
constructs from a snapshot that's already fully populated by
SnapshotForWorktree on the parent.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #956**
  * **PR #957**
    * **PR #958**
      * **PR #959**
        * **PR #960** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->