### PR TITLE
refactor: remove unused parameter and dead variable

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -394,7 +394,7 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 		for i, name := range batchNames {
 			branch := eng.GetBranch(name)
 			branches[i] = branch
-			parents[name] = getParentName(branch, eng)
+			parents[name] = getParentName(branch)
 		}
 
 		// Batch delete from engine
@@ -432,7 +432,7 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 }
 
 // getParentName returns the name of the parent branch or trunk if no parent exists
-func getParentName(branch engine.Branch, _ engine.Engine) string {
+func getParentName(branch engine.Branch) string {
 	return branch.GetParentOrTrunk()
 }
 
@@ -512,7 +512,7 @@ func findNonDeletingAncestor(startParent string, plan *deletionPlan, eng engine.
 // Returns the name of the new parent if changed, or empty string if not changed.
 func reparentBranchIfNecessary(ctx context.Context, branch engine.Branch, plan *deletionPlan, eng engine.Engine, out output.Output) (string, error) {
 	branchName := branch.GetName()
-	parentName := getParentName(branch, eng)
+	parentName := getParentName(branch)
 
 	// Find nearest ancestor that isn't being deleted
 	newParentName := findNonDeletingAncestor(parentName, plan, eng)

--- a/internal/engine/engine_absorb.go
+++ b/internal/engine/engine_absorb.go
@@ -22,9 +22,6 @@ func (e *engineImpl) ApplyHunksToBranch(ctx context.Context, branch Branch, hunk
 	originalRef, _ := e.git.GetCurrentBranchOrSHA(ctx)
 	originalRef = strings.TrimSpace(originalRef)
 
-	// Track if we've modified branch state - used for cleanup on error
-	var branchModified bool
-
 	// Cleanup function to restore state on error
 	cleanup := func() {
 		// Reset any unmerged/dirty state
@@ -66,7 +63,6 @@ func (e *engineImpl) ApplyHunksToBranch(ctx context.Context, branch Branch, hunk
 	if err := e.git.CheckoutDetached(ctx, currentBase); err != nil {
 		return fmt.Errorf("failed to checkout base %s: %w", currentBase[:8], err)
 	}
-	branchModified = true
 
 	// Recreate branch commit by commit (oldest to newest)
 	for i := len(commitSHAs) - 1; i >= 0; i-- {
@@ -138,7 +134,6 @@ func (e *engineImpl) ApplyHunksToBranch(ctx context.Context, branch Branch, hunk
 			}
 		}
 	}
-	_ = branchModified // Mark as used
 
 	// Get new tip
 	newTip, err := e.git.GetCurrentRevision(ctx)


### PR DESCRIPTION
## Summary

- Drop the unused `engine.Engine` parameter from `getParentName` in `clean_branches.go` — the function body only calls `branch.GetParentOrTrunk()` and never references the engine, which directly violates the style rule against `_`-named parameters
- Remove the `branchModified` variable in `ApplyHunksToBranch` (`engine_absorb.go`) that was declared, assigned once, and then kept alive only by the suppression hack `_ = branchModified // Mark as used` — the variable was intended to gate cleanup in the defer but was never wired up; the defer already handles restoration unconditionally via `originalRef`

Both changes are pure dead-code removal with no behavior change.

## Test plan

- [ ] `go build ./internal/actions/... ./internal/engine/...` passes (verified locally)
- [ ] No callers of `getParentName` outside `clean_branches.go` (confirmed with `rg`)
- [ ] `ApplyHunksToBranch` cleanup path unchanged — `cleanup()` still called on all error paths in the loop; defer still restores `originalRef` on success and post-loop errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01NeUVGwtYDEVjFejfL4h4Yo)_