### PR TITLE
fix(merge): surface DeleteBranch failures during ship cleanup

### DIFF
--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -381,13 +381,15 @@ func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecut
 			// Check if branch is checked out in a worktree and remove it first
 			// Git refuses to delete a branch that is checked out in any worktree
 			if err := removeWorktreeForBranch(ctx.Context, step.BranchName, eng, out); err != nil {
-				out.Debug("Failed to remove worktree for branch %s: %v", step.BranchName, err)
+				out.Warn("Failed to remove worktree for branch %s: %v", step.BranchName, err)
 				// Continue anyway - deletion might still work if worktree is gone
 			}
 
 			if err := eng.DeleteBranch(ctx.Context, branch); err != nil {
-				// Non-fatal - branch might already be deleted
-				out.Debug("Failed to delete branch %s (may already be deleted): %v", step.BranchName, err)
+				// Surface as warning so cleanup doesn't silently lie about success.
+				// Engine already swallows "branch not found" — any error here is a real failure
+				// the user needs to know about (e.g., branch checked out in another worktree).
+				out.Warn("Failed to delete branch %s: %v", step.BranchName, err)
 			}
 		}
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

When a per-branch delete step failed during merge ship's cleanup
phase, the error was logged at debug level and the step still reported
✓. That hides real failures (e.g., branch checked out in a separate
worktree) and makes "Cleanup merged branches" lie about success.

Raise the failure to a Warn so the user actually sees the problem and
can recover the leftover branch + metadata refs.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #970** 👈
  * **PR #971**
    * **PR #972**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #973*