### PR TITLE
fix(merge): drop remote metadata ref when ship deletes a branch

### DIFF
--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -390,6 +390,12 @@ func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecut
 				// Engine already swallows "branch not found" — any error here is a real failure
 				// the user needs to know about (e.g., branch checked out in another worktree).
 				out.Warn("Failed to delete branch %s: %v", step.BranchName, err)
+			} else {
+				// Drop the remote metadata ref so it doesn't linger on origin and surface as
+				// a phantom conflict next time someone runs sync.
+				if err := eng.Git().BatchDeleteRemoteMetadataRefs(ctx.Context, []string{step.BranchName}); err != nil {
+					out.Debug("Failed to delete remote metadata ref for %s: %v", step.BranchName, err)
+				}
 			}
 		}
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Ship pushes a lockReason=consolidating value to refs/stackit/metadata/{branch}
on origin before the branches are merged. After the local branch + metadata
are deleted in cleanup, the remote ref was left dangling — harmless in steady
state because ComputeAllMetadataDiffs filters branches that no longer exist
locally, but it accumulates on the remote and surfaces as a phantom conflict
prompt if the local branch sticks around (e.g., when a delete step fails).

Mirror the pattern in actions/delete and actions/clean_branches: after a
successful DeleteBranch, batch-delete the remote metadata ref via
git push origin :refs/stackit/metadata/{branch}.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #970**
  * **PR #971** 👈
    * **PR #972**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #973*