### PR TITLE
Merging 3 PRs

### DIFF
--- a/internal/actions/checkout_test.go
+++ b/internal/actions/checkout_test.go
@@ -20,7 +20,7 @@ func TestCheckoutActionWorktreeSwitchIncludesTargetBranch(t *testing.T) {
 
 	err := s.Engine.RegisterWorktree("feature", s.Context.RepoRoot)
 	require.NoError(t, err)
-	defer func() { _ = s.Engine.UnregisterWorktree("feature") }()
+	defer func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") }()
 
 	s.Checkout("main")
 

--- a/internal/actions/create/create_test.go
+++ b/internal/actions/create/create_test.go
@@ -325,7 +325,7 @@ func TestCreateAction_Worktree(t *testing.T) {
 
 		// Clean up worktree
 		_ = eng.RemoveWorktree(s.Context.Context, worktreeInfo.Path)
-		_ = eng.UnregisterWorktree(stackRoot)
+		_ = eng.UnregisterWorktree(s.Context.Context, stackRoot)
 	})
 
 	t.Run("fails with -w flag when not on trunk", func(t *testing.T) {

--- a/internal/actions/delete/delete.go
+++ b/internal/actions/delete/delete.go
@@ -282,7 +282,7 @@ func cleanupWorktreesForDeletedStacks(ctx *app.Context, deletedStackRoots []stri
 		}
 
 		// Unregister the worktree from the registry
-		if unregErr := ctx.Engine.UnregisterWorktree(stackRoot); unregErr != nil {
+		if unregErr := ctx.Engine.UnregisterWorktree(ctx.Context, stackRoot); unregErr != nil {
 			ctx.Output.Debug("Failed to unregister worktree for %s: %v", stackRoot, unregErr)
 		}
 	}

--- a/internal/actions/doctor/stack_state.go
+++ b/internal/actions/doctor/stack_state.go
@@ -38,7 +38,7 @@ func checkStackState(ctx context.Context, eng engine.Engine, handler Handler, wa
 		if !branchSet[branchName] {
 			orphanedCount++
 			if fix {
-				if err := eng.Git().DeleteMetadata(branchName); err != nil {
+				if err := eng.Git().DeleteMetadata(ctx, branchName); err != nil {
 					warnings++
 					handler.OnCheck("orphaned_metadata", CheckWarning, fmt.Sprintf("orphaned metadata for '%s' (fix failed: %v)", branchName, err))
 				} else {

--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -390,6 +390,12 @@ func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecut
 				// Engine already swallows "branch not found" — any error here is a real failure
 				// the user needs to know about (e.g., branch checked out in another worktree).
 				out.Warn("Failed to delete branch %s: %v", step.BranchName, err)
+			} else {
+				// Drop the remote metadata ref so it doesn't linger on origin and surface as
+				// a phantom conflict next time someone runs sync.
+				if err := eng.Git().BatchDeleteRemoteMetadataRefs(ctx.Context, []string{step.BranchName}); err != nil {
+					out.Debug("Failed to delete remote metadata ref for %s: %v", step.BranchName, err)
+				}
 			}
 		}
 

--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -381,13 +381,15 @@ func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecut
 			// Check if branch is checked out in a worktree and remove it first
 			// Git refuses to delete a branch that is checked out in any worktree
 			if err := removeWorktreeForBranch(ctx.Context, step.BranchName, eng, out); err != nil {
-				out.Debug("Failed to remove worktree for branch %s: %v", step.BranchName, err)
+				out.Warn("Failed to remove worktree for branch %s: %v", step.BranchName, err)
 				// Continue anyway - deletion might still work if worktree is gone
 			}
 
 			if err := eng.DeleteBranch(ctx.Context, branch); err != nil {
-				// Non-fatal - branch might already be deleted
-				out.Debug("Failed to delete branch %s (may already be deleted): %v", step.BranchName, err)
+				// Surface as warning so cleanup doesn't silently lie about success.
+				// Engine already swallows "branch not found" — any error here is a real failure
+				// the user needs to know about (e.g., branch checked out in another worktree).
+				out.Warn("Failed to delete branch %s: %v", step.BranchName, err)
 			}
 		}
 

--- a/internal/actions/metadata.go
+++ b/internal/actions/metadata.go
@@ -25,7 +25,7 @@ func PushMetadataOnly(ctx *app.Context, eng MetadataPushEngine, branchNames []st
 
 	// Check if remote sync is enabled; if not, run compatibility test first
 	if !eng.IsRemoteSyncEnabled() {
-		if err := eng.Git().TestRemoteRefCompatibility(); err != nil {
+		if err := eng.Git().TestRemoteRefCompatibility(ctx.Context); err != nil {
 			out.Debug("Remote metadata sync not supported: %v", err)
 			return nil // Non-fatal
 		}

--- a/internal/actions/pr_updates.go
+++ b/internal/actions/pr_updates.go
@@ -222,7 +222,7 @@ func PushMetadataAndSyncPRs(ctx *app.Context, branchNames []string) error {
 
 	// Check if remote sync is enabled; if not, run compatibility test first
 	if !eng.IsRemoteSyncEnabled() {
-		if err := eng.Git().TestRemoteRefCompatibility(); err != nil {
+		if err := eng.Git().TestRemoteRefCompatibility(ctx.Context); err != nil {
 			out.Debug("Remote metadata sync not supported: %v", err)
 			return nil // Non-fatal
 		}

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -630,7 +630,7 @@ func pushMetadataRefs(ctx *app.Context, branches engine.Branches) error {
 
 	// Check if remote sync is enabled; if not, run compatibility test first
 	if !rm.IsRemoteSyncEnabled() {
-		if err := ctx.Git().TestRemoteRefCompatibility(); err != nil {
+		if err := ctx.Git().TestRemoteRefCompatibility(ctx.Context); err != nil {
 			return fmt.Errorf("remote does not support metadata refs (GitHub compatibility check failed): %w", err)
 		}
 		rm.SetRemoteSyncEnabled(true)

--- a/internal/actions/sync/stack_metadata_gc.go
+++ b/internal/actions/sync/stack_metadata_gc.go
@@ -56,7 +56,7 @@ func gcOrphanedStackMetadata(ctx *app.Context) *StackMetadataGCResult {
 
 	// 4. Delete local refs
 	for _, stackID := range orphaned {
-		if err := ctx.Git().DeleteStackMeta(stackID); err != nil {
+		if err := ctx.Git().DeleteStackMeta(ctx.Context, stackID); err != nil {
 			result.Errors = append(result.Errors, "failed to delete local stack ref "+stackID+": "+err.Error())
 			ctx.Logger.Debug("failed to delete local stack ref stackID=%v error=%v", stackID, err)
 		} else {

--- a/internal/actions/sync/worktree_cleanup.go
+++ b/internal/actions/sync/worktree_cleanup.go
@@ -96,7 +96,7 @@ func cleanOrphanedWorktrees(ctx *app.Context, dirtyAnchors map[string]bool) *Wor
 			continue
 		}
 
-		if unregErr := ctx.Engine.UnregisterWorktree(wt.AnchorBranch); unregErr != nil {
+		if unregErr := ctx.Engine.UnregisterWorktree(ctx.Context, wt.AnchorBranch); unregErr != nil {
 			result.Errors = append(result.Errors,
 				"failed to unregister worktree for "+wt.AnchorBranch+": "+unregErr.Error())
 			ctx.Output.Debug("Failed to unregister worktree for %s: %v", wt.AnchorBranch, unregErr)

--- a/internal/actions/untrack/action.go
+++ b/internal/actions/untrack/action.go
@@ -50,13 +50,13 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Untrack recursively (descendants first, then the branch itself)
 	// Actually order doesn't strictly matter for metadata deletion but it's cleaner
 	for _, descendant := range descendants {
-		if err := eng.UntrackBranch(descendant.GetName()); err != nil {
+		if err := eng.UntrackBranch(ctx.Context, descendant.GetName()); err != nil {
 			return fmt.Errorf("failed to untrack descendant %s: %w", descendant.GetName(), err)
 		}
 		ctx.Output.Info("Stopped tracking %s.", style.ColorBranchName(descendant.GetName(), false))
 	}
 
-	if err := eng.UntrackBranch(branchName); err != nil {
+	if err := eng.UntrackBranch(ctx.Context, branchName); err != nil {
 		return fmt.Errorf("failed to untrack branch %s: %w", branchName, err)
 	}
 	ctx.Output.Info("Stopped tracking %s.", style.ColorBranchName(branchName, false))

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -173,7 +173,7 @@ func RemoveAction(ctx *app.Context, opts RemoveOptions) error {
 		}
 	}
 
-	if unregErr := ctx.Engine.UnregisterWorktree(snapshot.Info.AnchorBranch); unregErr != nil {
+	if unregErr := ctx.Engine.UnregisterWorktree(ctx.Context, snapshot.Info.AnchorBranch); unregErr != nil {
 		if pathRemoved {
 			return rollback(fmt.Errorf("failed to unregister worktree: %w", unregErr))
 		}
@@ -406,7 +406,7 @@ func createAnchoredWorktree(ctx *app.Context, eng engine.Engine, repoRoot string
 
 	cleanup := func() {
 		if registered {
-			if err := eng.UnregisterWorktree(anchorBranchName); err != nil {
+			if err := eng.UnregisterWorktree(ctx.Context, anchorBranchName); err != nil {
 				out.Debug("Failed to unregister worktree during rollback: %v", err)
 			}
 		}
@@ -868,7 +868,7 @@ func DetachAction(ctx *app.Context, opts DetachOptions) error {
 		out.Debug("Deleted anchor branch %s", snapshot.Info.AnchorBranch)
 	}
 
-	if unregErr := ctx.Engine.UnregisterWorktree(snapshot.Info.AnchorBranch); unregErr != nil {
+	if unregErr := ctx.Engine.UnregisterWorktree(ctx.Context, snapshot.Info.AnchorBranch); unregErr != nil {
 		return rollback(fmt.Errorf("failed to unregister worktree: %w", unregErr))
 	}
 	unregistered = true

--- a/internal/actions/worktree/actions_test.go
+++ b/internal/actions/worktree/actions_test.go
@@ -40,7 +40,7 @@ func TestListAction(t *testing.T) {
 		assert.True(t, result.Worktrees[0].NeedsRepair)
 
 		// Clean up
-		_ = s.Engine.UnregisterWorktree("feature-stack")
+		_ = s.Engine.UnregisterWorktree(s.Context, "feature-stack")
 	})
 
 	t.Run("marks legacy registrations", func(t *testing.T) {
@@ -60,7 +60,7 @@ func TestListAction(t *testing.T) {
 		assert.True(t, result.Worktrees[0].NeedsRepair)
 		assert.Equal(t, []string{"feature"}, result.Worktrees[0].RootBranches)
 
-		_ = s.Engine.UnregisterWorktree("feature")
+		_ = s.Engine.UnregisterWorktree(s.Context, "feature")
 	})
 }
 
@@ -146,7 +146,7 @@ func TestOpenAction(t *testing.T) {
 		assert.Contains(t, err.Error(), "does not exist")
 
 		// Clean up
-		_ = s.Engine.UnregisterWorktree("feature-stack")
+		_ = s.Engine.UnregisterWorktree(s.Context, "feature-stack")
 	})
 
 	t.Run("returns path when worktree exists", func(t *testing.T) {
@@ -165,7 +165,7 @@ func TestOpenAction(t *testing.T) {
 		assert.Equal(t, repoRoot, path)
 
 		// Clean up
-		_ = s.Engine.UnregisterWorktree("feature-stack")
+		_ = s.Engine.UnregisterWorktree(s.Context, "feature-stack")
 	})
 }
 
@@ -191,7 +191,7 @@ func TestCreateAction(t *testing.T) {
 
 		// Clean up worktree
 		_ = s.Engine.RemoveWorktree(s.Context.Context, result.Path)
-		_ = s.Engine.UnregisterWorktree(result.AnchorBranch)
+		_ = s.Engine.UnregisterWorktree(s.Context, result.AnchorBranch)
 	})
 
 	t.Run("fails when name is empty", func(t *testing.T) {
@@ -235,7 +235,7 @@ func TestCreateAction(t *testing.T) {
 
 		// Clean up
 		_ = s.Engine.RemoveWorktree(s.Context.Context, result.Path)
-		_ = s.Engine.UnregisterWorktree(result.AnchorBranch)
+		_ = s.Engine.UnregisterWorktree(s.Context, result.AnchorBranch)
 	})
 
 	t.Run("creates worktree with anchor branch", func(t *testing.T) {
@@ -266,7 +266,7 @@ func TestCreateAction(t *testing.T) {
 
 		// Clean up worktree
 		_ = s.Engine.RemoveWorktree(s.Context.Context, result.Path)
-		_ = s.Engine.UnregisterWorktree(result.AnchorBranch)
+		_ = s.Engine.UnregisterWorktree(s.Context, result.AnchorBranch)
 	})
 
 	t.Run("creates worktree with scope", func(t *testing.T) {
@@ -287,7 +287,7 @@ func TestCreateAction(t *testing.T) {
 
 		// Clean up worktree
 		_ = s.Engine.RemoveWorktree(s.Context.Context, result.Path)
-		_ = s.Engine.UnregisterWorktree(result.AnchorBranch)
+		_ = s.Engine.UnregisterWorktree(s.Context, result.AnchorBranch)
 	})
 }
 
@@ -320,6 +320,6 @@ func TestRepairAction(t *testing.T) {
 		assert.True(t, s.Engine.GetBranch(result.Repaired[0].AnchorBranch).IsWorktreeAnchor())
 		assert.Equal(t, result.Repaired[0].AnchorBranch, s.Engine.GetBranch("feature").GetParent().GetName())
 
-		_ = s.Engine.UnregisterWorktree(result.Repaired[0].AnchorBranch)
+		_ = s.Engine.UnregisterWorktree(s.Context, result.Repaired[0].AnchorBranch)
 	})
 }

--- a/internal/actions/worktree/repair.go
+++ b/internal/actions/worktree/repair.go
@@ -85,7 +85,7 @@ func repairEntry(ctx *app.Context, entry Entry) (RepairEntry, error) {
 		}
 
 		if !entry.Exists {
-			if err := ctx.Engine.UnregisterWorktree(wtInfo.AnchorBranch); err != nil {
+			if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
 				return RepairEntry{}, fmt.Errorf("failed to remove stale registration: %w", err)
 			}
 			return RepairEntry{
@@ -123,8 +123,8 @@ func repairEntry(ctx *app.Context, entry Entry) (RepairEntry, error) {
 			if err := ctx.Engine.RegisterWorktreeWithName(stackRootName, wtInfo.Path, wtInfo.Name); err != nil {
 				return RepairEntry{}, fmt.Errorf("failed to register worktree under anchor %s: %w", stackRootName, err)
 			}
-			if err := ctx.Engine.UnregisterWorktree(wtInfo.AnchorBranch); err != nil {
-				_ = ctx.Engine.UnregisterWorktree(stackRootName)
+			if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
+				_ = ctx.Engine.UnregisterWorktree(ctx.Context, stackRootName)
 				return RepairEntry{}, fmt.Errorf("failed to remove stale registration %s: %w", style.ColorBranchName(wtInfo.AnchorBranch, false), err)
 			}
 			return RepairEntry{
@@ -187,7 +187,7 @@ func convertLegacyRegistration(ctx *app.Context, wtInfo engine.WorktreeInfo, roo
 	registered := false
 	cleanup := func() {
 		if registered {
-			_ = ctx.Engine.UnregisterWorktree(anchorBranchName)
+			_ = ctx.Engine.UnregisterWorktree(ctx.Context, anchorBranchName)
 		}
 		if rootReparented {
 			_ = ctx.Engine.ReparentBranch(ctx.Context, ctx.Engine.GetBranch(rootBranchName), ctx.Engine.GetBranch(originalParent))
@@ -221,7 +221,7 @@ func convertLegacyRegistration(ctx *app.Context, wtInfo engine.WorktreeInfo, roo
 		return "", fmt.Errorf("failed to register worktree under anchor %s: %w", style.ColorBranchName(anchorBranchName, false), err)
 	}
 	registered = true
-	if err := ctx.Engine.UnregisterWorktree(wtInfo.AnchorBranch); err != nil {
+	if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
 		cleanup()
 		return "", fmt.Errorf("failed to remove legacy registration %s: %w", style.ColorBranchName(wtInfo.AnchorBranch, false), err)
 	}

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -541,7 +541,7 @@ func (d *demoGitRunner) UpdateRef(_, _ string) error {
 	return nil
 }
 
-func (d *demoGitRunner) DeleteRef(_ string) error {
+func (d *demoGitRunner) DeleteRef(_ context.Context, _ string) error {
 	return nil
 }
 
@@ -584,7 +584,7 @@ func (d *demoGitRunner) WriteMetadata(_ string, _ *git.Meta) error {
 	return nil
 }
 
-func (d *demoGitRunner) DeleteMetadata(_ string) error {
+func (d *demoGitRunner) DeleteMetadata(_ context.Context, _ string) error {
 	return nil
 }
 
@@ -654,7 +654,7 @@ func (d *demoGitRunner) BatchDeleteRemoteMetadataRefs(_ context.Context, _ []str
 	return nil
 }
 
-func (d *demoGitRunner) TestRemoteRefCompatibility() error {
+func (d *demoGitRunner) TestRemoteRefCompatibility(_ context.Context) error {
 	return nil
 }
 
@@ -666,7 +666,7 @@ func (d *demoGitRunner) WriteWorktreeMeta(_ string, _ *git.WorktreeMeta) error {
 	return nil
 }
 
-func (d *demoGitRunner) DeleteWorktreeMeta(_ string) error {
+func (d *demoGitRunner) DeleteWorktreeMeta(_ context.Context, _ string) error {
 	return nil
 }
 
@@ -714,7 +714,7 @@ func (d *demoGitRunner) WriteStackMeta(_ string, _ *git.StackMeta) error {
 	return nil
 }
 
-func (d *demoGitRunner) DeleteStackMeta(_ string) error {
+func (d *demoGitRunner) DeleteStackMeta(_ context.Context, _ string) error {
 	return nil
 }
 

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -145,9 +145,9 @@ func (e *engineImpl) TrackBranch(ctx context.Context, branchName string, parentB
 }
 
 // UntrackBranch stops tracking a branch by deleting its metadata
-func (e *engineImpl) UntrackBranch(branchName string) error {
+func (e *engineImpl) UntrackBranch(ctx context.Context, branchName string) error {
 	// Delete metadata
-	if err := e.git.DeleteMetadata(branchName); err != nil {
+	if err := e.git.DeleteMetadata(ctx, branchName); err != nil {
 		return fmt.Errorf("failed to delete metadata ref: %w", err)
 	}
 
@@ -195,12 +195,12 @@ func (e *engineImpl) DeleteBranch(ctx context.Context, branch Branch) error {
 	}
 
 	// Delete metadata
-	if err := e.git.DeleteMetadata(branchName); err != nil {
+	if err := e.git.DeleteMetadata(ctx, branchName); err != nil {
 		_, _ = fmt.Fprintf(e.writer, "Warning: failed to delete metadata ref for %s: %v\n", branchName, err)
 	}
 
 	// Delete local metadata
-	if err := e.git.DeleteRef(fmt.Sprintf("%s%s", git.LocalMetadataRefPrefix, branchName)); err != nil {
+	if err := e.git.DeleteRef(ctx, fmt.Sprintf("%s%s", git.LocalMetadataRefPrefix, branchName)); err != nil {
 		_, _ = fmt.Fprintf(e.writer, "Warning: failed to delete local metadata ref for %s: %v\n", branchName, err)
 	}
 
@@ -693,7 +693,7 @@ func (e *engineImpl) RenameBranch(ctx context.Context, oldBranch, newBranch Bran
 	if sha, err := e.git.GetRef(oldLocalRef); err == nil {
 		if err := e.git.UpdateRef(newLocalRef, sha); err != nil {
 			_, _ = fmt.Fprintf(e.writer, "Warning: failed to update new local metadata ref: %v\n", err)
-		} else if err := e.git.DeleteRef(oldLocalRef); err != nil {
+		} else if err := e.git.DeleteRef(ctx, oldLocalRef); err != nil {
 			_, _ = fmt.Fprintf(e.writer, "Warning: failed to delete old local metadata ref: %v\n", err)
 		}
 	}
@@ -926,8 +926,8 @@ func (e *engineImpl) RegisterWorktreeWithName(anchorBranch string, path string, 
 }
 
 // UnregisterWorktree removes worktree registration for a stack root
-func (e *engineImpl) UnregisterWorktree(stackRoot string) error {
-	return e.git.DeleteWorktreeMeta(stackRoot)
+func (e *engineImpl) UnregisterWorktree(ctx context.Context, stackRoot string) error {
+	return e.git.DeleteWorktreeMeta(ctx, stackRoot)
 }
 
 // GetWorktreeForStack returns worktree info for a stack root, or nil if none

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -123,7 +123,7 @@ type BranchReader interface {
 // BranchTracking handles branch tracking operations
 type BranchTracking interface {
 	TrackBranch(ctx context.Context, branchName string, parentBranchName string) error
-	UntrackBranch(branchName string) error
+	UntrackBranch(ctx context.Context, branchName string) error
 	SetParent(ctx context.Context, branch Branch, parentBranch Branch) error
 	// ReparentBranch changes a branch's parent while automatically preserving
 	// its divergence point. Preferred over SetParent for existing branches.
@@ -233,7 +233,7 @@ type WorktreeRegistry interface {
 	// RegisterWorktreeWithName registers a worktree with a user-friendly name
 	RegisterWorktreeWithName(anchorBranch string, path string, name string) error
 	// UnregisterWorktree removes worktree registration for a stack root
-	UnregisterWorktree(stackRoot string) error
+	UnregisterWorktree(ctx context.Context, stackRoot string) error
 	// GetWorktreeForStack returns worktree info for a stack root, or nil if none
 	GetWorktreeForStack(stackRoot string) (*WorktreeInfo, error)
 	// ListManagedWorktrees returns all stackit-managed worktrees

--- a/internal/engine/worktree_test.go
+++ b/internal/engine/worktree_test.go
@@ -49,7 +49,7 @@ func TestWorktreeRegistry_StackRootForBranch(t *testing.T) {
 	assert.Equal(t, "branch1", stackRoot)
 
 	// Clean up
-	_ = s.Engine.UnregisterWorktree("branch1")
+	_ = s.Engine.UnregisterWorktree(s.Context, "branch1")
 }
 
 func TestCreateTemporaryWorktree(t *testing.T) {

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -86,18 +86,36 @@ func (r *runner) CreateAndCheckoutBranch(ctx context.Context, branchName string)
 }
 
 func (r *runner) DeleteBranch(ctx context.Context, branchName string) error {
-	repo, err := r.ensureRepo()
-	if err != nil {
-		return err
-	}
+	refName := fmt.Sprintf("refs/heads/%s", branchName)
 
 	r.goGitMu.Lock()
 	defer r.goGitMu.Unlock()
-	err = repo.Storer.RemoveReference(plumbing.NewBranchReferenceName(branchName))
-	if err != nil {
+
+	// Use native git instead of go-git's RemoveReference: go-git's filesystem
+	// storer only handles loose refs, so deleting a branch packed into
+	// .git/packed-refs silently no-ops (returns nil while the ref survives).
+	// `git update-ref -d` rewrites packed-refs correctly and is lenient when
+	// the ref doesn't exist.
+	if _, err := r.RunGitCommandWithContext(ctx, "update-ref", "-d", refName); err != nil {
 		return fmt.Errorf("failed to delete branch %s: %w", branchName, err)
 	}
+
+	if err := r.verifyRefDeleted(ctx, refName); err != nil {
+		return fmt.Errorf("failed to delete branch %s: %w", branchName, err)
+	}
+
 	r.revisionCache.Delete(branchName)
+	return nil
+}
+
+// verifyRefDeleted returns an error if the ref still resolves after a delete.
+// Defense against silent failures in the underlying storage layer (e.g. when a
+// ref deletion appears to succeed but a packed entry survives).
+func (r *runner) verifyRefDeleted(ctx context.Context, refName string) error {
+	_, err := r.RunGitCommandRawWithContext(ctx, "show-ref", "--verify", "--quiet", refName)
+	if err == nil {
+		return fmt.Errorf("ref %s still resolves after delete", refName)
+	}
 	return nil
 }
 

--- a/internal/git/delete_packed_refs_test.go
+++ b/internal/git/delete_packed_refs_test.go
@@ -1,0 +1,137 @@
+package git_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+)
+
+// Regression tests for the silent packed-refs deletion bug.
+//
+// go-git's filesystem Storer.RemoveReference only deletes the loose ref file.
+// If a ref lives in .git/packed-refs (e.g., because `git gc` or `git pack-refs`
+// ran), the call returns nil but the ref survives. That caused merge ship's
+// cleanup to silently leave a packed branch behind, recreate its metadata via
+// post-merge sync, and then prompt on a phantom metadata conflict.
+//
+// These tests pack the relevant refs before calling our delete APIs and assert
+// the refs are actually gone afterward.
+
+func TestDeleteBranch_RemovesPackedRef(t *testing.T) {
+	t.Parallel()
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	ctx := context.Background()
+
+	require.NoError(t, scene.Repo.CreateBranch("packed-feature"))
+	packAllRefs(t, scene.Dir)
+
+	requireLooseRefAbsent(t, scene.Dir, "refs/heads/packed-feature")
+	requirePackedRefPresent(t, scene.Dir, "refs/heads/packed-feature")
+
+	require.NoError(t, runner.DeleteBranch(ctx, "packed-feature"))
+
+	requireRefAbsent(t, runner, "refs/heads/packed-feature")
+	requirePackedRefAbsent(t, scene.Dir, "refs/heads/packed-feature")
+}
+
+func TestDeleteBranch_NoErrorWhenBranchMissing(t *testing.T) {
+	t.Parallel()
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+
+	// `git update-ref -d` is lenient for missing refs; deleting a never-existed
+	// branch should succeed so callers can treat "already gone" as a no-op
+	// without branching on error types.
+	require.NoError(t, runner.DeleteBranch(context.Background(), "nope"))
+}
+
+func TestDeleteRef_RemovesPackedRef(t *testing.T) {
+	t.Parallel()
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+
+	sha, err := runner.CreateBlob("payload")
+	require.NoError(t, err)
+	require.NoError(t, runner.UpdateRef("refs/stackit/metadata/packed-feature", sha))
+	packAllRefs(t, scene.Dir)
+
+	requireLooseRefAbsent(t, scene.Dir, "refs/stackit/metadata/packed-feature")
+	requirePackedRefPresent(t, scene.Dir, "refs/stackit/metadata/packed-feature")
+
+	require.NoError(t, runner.DeleteRef(context.Background(), "refs/stackit/metadata/packed-feature"))
+
+	requireRefAbsent(t, runner, "refs/stackit/metadata/packed-feature")
+	requirePackedRefAbsent(t, scene.Dir, "refs/stackit/metadata/packed-feature")
+}
+
+func TestDeleteMetadata_RemovesPackedRef(t *testing.T) {
+	t.Parallel()
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+
+	// Covers the merge-ship symptom directly: cleanup deletes branch metadata
+	// via this entry point, which previously left packed metadata refs behind
+	// to be resurrected by the next sync as a phantom conflict.
+	sha, err := runner.CreateBlob(`{"parentBranchName":"main"}`)
+	require.NoError(t, err)
+	require.NoError(t, runner.UpdateRef("refs/stackit/metadata/packed-feature", sha))
+	packAllRefs(t, scene.Dir)
+
+	require.NoError(t, runner.DeleteMetadata(context.Background(), "packed-feature"))
+
+	requireRefAbsent(t, runner, "refs/stackit/metadata/packed-feature")
+	requirePackedRefAbsent(t, scene.Dir, "refs/stackit/metadata/packed-feature")
+}
+
+func packAllRefs(t *testing.T, repoDir string) {
+	t.Helper()
+	// `--all` packs all refs under refs/, including non-branch refs like
+	// refs/stackit/metadata/*. `--prune` removes the loose files after packing
+	// so the test reflects the same state seen in user repos that ran git gc.
+	out, err := scriptGit(repoDir, "pack-refs", "--all", "--prune")
+	require.NoError(t, err, "pack-refs failed: %s", out)
+}
+
+func scriptGit(repoDir string, args ...string) (string, error) {
+	r := git.NewRunnerWithPath(repoDir, nil)
+	return r.RunGitCommandWithContext(context.Background(), args...)
+}
+
+func requireRefAbsent(t *testing.T, runner git.Runner, refName string) {
+	t.Helper()
+	_, err := runner.GetRef(refName)
+	require.Error(t, err, "ref %s should not resolve", refName)
+}
+
+func requireLooseRefAbsent(t *testing.T, repoDir, refName string) {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(repoDir, ".git", refName))
+	require.True(t, os.IsNotExist(err), "expected no loose ref file for %s, got err=%v", refName, err)
+}
+
+func requirePackedRefPresent(t *testing.T, repoDir, refName string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repoDir, ".git", "packed-refs"))
+	require.NoError(t, err, "reading packed-refs")
+	require.True(t, strings.Contains(string(data), " "+refName+"\n"),
+		"expected packed-refs to contain %s; contents:\n%s", refName, data)
+}
+
+func requirePackedRefAbsent(t *testing.T, repoDir, refName string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repoDir, ".git", "packed-refs"))
+	if os.IsNotExist(err) {
+		return
+	}
+	require.NoError(t, err)
+	require.False(t, strings.Contains(string(data), " "+refName+"\n"),
+		"packed-refs still contains %s after delete; contents:\n%s", refName, data)
+}

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -43,7 +43,7 @@ type RemoteOperations interface {
 	FetchMetadataRefs(ctx context.Context) error
 	DeleteRemoteMetadataRef(ctx context.Context, branch string) error
 	BatchDeleteRemoteMetadataRefs(ctx context.Context, branches []string) error
-	TestRemoteRefCompatibility() error
+	TestRemoteRefCompatibility(ctx context.Context) error
 	PushStackMetaRefs(ctx context.Context, stackIDs []string) error
 	FetchStackMetaRefs(ctx context.Context) error
 	DeleteRemoteStackMetaRefs(ctx context.Context, stackIDs []string) error
@@ -206,7 +206,7 @@ type WorktreeOperations interface {
 type WorktreeRegistryOperations interface {
 	ReadWorktreeMeta(stackRoot string) (*WorktreeMeta, error)
 	WriteWorktreeMeta(stackRoot string, meta *WorktreeMeta) error
-	DeleteWorktreeMeta(stackRoot string) error
+	DeleteWorktreeMeta(ctx context.Context, stackRoot string) error
 	ListWorktreeMetas() (map[string]*WorktreeMeta, error)
 }
 
@@ -226,7 +226,7 @@ type RefOperations interface {
 	UpdateRefsBatchWithLog(ctx context.Context, updates []RefUpdate, reflogMessage string) error
 	DeleteRefsBatch(ctx context.Context, refNames []string) error
 	VerifyRef(ctx context.Context, refName string) error
-	DeleteRef(name string) error
+	DeleteRef(ctx context.Context, name string) error
 	ListRefs(prefix string) (map[string]string, error)
 }
 
@@ -242,7 +242,7 @@ type MetadataOperations interface {
 	ReadMetadata(branchName string) (*Meta, error)
 	BatchReadMetadata(branchNames []string) (map[string]*Meta, map[string]error)
 	WriteMetadata(branchName string, meta *Meta) error
-	DeleteMetadata(branchName string) error
+	DeleteMetadata(ctx context.Context, branchName string) error
 	RenameMetadata(oldName, newName string) error
 	ListMetadata() (map[string]string, error)
 	ReadLocalMetadata(branchName string) (*LocalMeta, error)
@@ -268,7 +268,7 @@ type MetadataOperations interface {
 type StackMetadataOperations interface {
 	ReadStackMeta(stackID string) (*StackMeta, error)
 	WriteStackMeta(stackID string, meta *StackMeta) error
-	DeleteStackMeta(stackID string) error
+	DeleteStackMeta(ctx context.Context, stackID string) error
 	ListStackMetas() (map[string]string, error)
 
 	// Transaction support methods

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -241,9 +242,9 @@ func (r *runner) WriteMetadata(branchName string, meta *Meta) error {
 	return nil
 }
 
-func (r *runner) DeleteMetadata(branchName string) error {
+func (r *runner) DeleteMetadata(ctx context.Context, branchName string) error {
 	refName := fmt.Sprintf("%s%s", MetadataRefPrefix, branchName)
-	err := r.DeleteRef(refName)
+	err := r.DeleteRef(ctx, refName)
 	r.metadataCache.Delete(branchName)
 	return err
 }

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -952,18 +952,22 @@ func (r *runner) UpdateRef(name, sha string) error {
 	return nil
 }
 
-func (r *runner) DeleteRef(name string) error {
-	repo, err := r.ensureRepo()
-	if err != nil {
-		return err
-	}
-
+func (r *runner) DeleteRef(ctx context.Context, name string) error {
 	r.goGitMu.Lock()
 	defer r.goGitMu.Unlock()
 
-	if err := repo.Storer.RemoveReference(plumbing.ReferenceName(name)); err != nil {
+	// Use native git instead of go-git's RemoveReference: go-git's filesystem
+	// storer only handles loose refs, so deleting a ref packed into
+	// .git/packed-refs silently no-ops. `git update-ref -d` rewrites
+	// packed-refs correctly and is lenient when the ref doesn't exist.
+	if _, err := r.RunGitCommandWithContext(ctx, "update-ref", "-d", name); err != nil {
+		return fmt.Errorf("failed to delete ref %s: %w", name, err)
+	}
+
+	if err := r.verifyRefDeleted(ctx, name); err != nil {
 		return err
 	}
+
 	r.metadataCache.InvalidateForRefNames([]string{name})
 	r.invalidateRevisionCacheForRefNames([]string{name})
 	return nil
@@ -1131,7 +1135,7 @@ func (r *runner) BatchDeleteRemoteMetadataRefs(ctx context.Context, branches []s
 	return r.pushOriginRefSpecs(ctx, refspecs)
 }
 
-func (r *runner) TestRemoteRefCompatibility() error {
+func (r *runner) TestRemoteRefCompatibility(ctx context.Context) error {
 	testRef := "refs/stackit/metadata/stackit-compat-test"
 	testContent := fmt.Sprintf(`{"test":true,"timestamp":%d}`, time.Now().Unix())
 
@@ -1146,14 +1150,14 @@ func (r *runner) TestRemoteRefCompatibility() error {
 		return fmt.Errorf("failed to update local test ref: %w", err)
 	}
 
-	if err := r.pushOriginRefSpecs(context.Background(), []gitcfg.RefSpec{gitcfg.RefSpec("+" + testRef)}); err != nil {
-		_ = r.DeleteRef(testRef) // Cleanup local
+	if err := r.pushOriginRefSpecs(ctx, []gitcfg.RefSpec{gitcfg.RefSpec("+" + testRef)}); err != nil {
+		_ = r.DeleteRef(ctx, testRef) // Cleanup local
 		return fmt.Errorf("remote rejected metadata ref push: %w", err)
 	}
 
 	// Cleanup: delete remote and local test ref
-	_ = r.pushOriginRefSpecs(context.Background(), []gitcfg.RefSpec{gitcfg.RefSpec(":" + testRef)})
-	_ = r.DeleteRef(testRef)
+	_ = r.pushOriginRefSpecs(ctx, []gitcfg.RefSpec{gitcfg.RefSpec(":" + testRef)})
+	_ = r.DeleteRef(ctx, testRef)
 
 	return nil
 }

--- a/internal/git/stack_metadata.go
+++ b/internal/git/stack_metadata.go
@@ -11,6 +11,7 @@ package git
 //   - refs/stackit/remote-stacks/ - Fetched remote stack metadata
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -100,8 +101,8 @@ func (r *runner) WriteStackMeta(stackID string, meta *StackMeta) error {
 }
 
 // DeleteStackMeta deletes stack metadata for a given stack ID.
-func (r *runner) DeleteStackMeta(stackID string) error {
-	return r.DeleteRef(StackMetaRefName(stackID))
+func (r *runner) DeleteStackMeta(ctx context.Context, stackID string) error {
+	return r.DeleteRef(ctx, StackMetaRefName(stackID))
 }
 
 // ListStackMetas returns a map of stack IDs to their ref SHAs.

--- a/internal/git/stack_metadata_test.go
+++ b/internal/git/stack_metadata_test.go
@@ -1,6 +1,7 @@
 package git_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -68,7 +69,7 @@ func TestStackMetaOperations(t *testing.T) {
 		require.NoError(t, err)
 
 		// Delete
-		err = runner.DeleteStackMeta(stackID)
+		err = runner.DeleteStackMeta(context.Background(), stackID)
 		require.NoError(t, err)
 
 		// Verify deleted

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -239,9 +239,9 @@ func (t *tracingRunner) BatchDeleteRemoteMetadataRefs(ctx context.Context, branc
 	return err
 }
 
-func (t *tracingRunner) TestRemoteRefCompatibility() error {
+func (t *tracingRunner) TestRemoteRefCompatibility(ctx context.Context) error {
 	start := time.Now()
-	err := t.inner.TestRemoteRefCompatibility()
+	err := t.inner.TestRemoteRefCompatibility(ctx)
 	t.trace("TestRemoteRefCompatibility", time.Since(start), err == nil, err)
 	return err
 }
@@ -931,9 +931,9 @@ func (t *tracingRunner) WriteWorktreeMeta(stackRoot string, meta *WorktreeMeta) 
 	return err
 }
 
-func (t *tracingRunner) DeleteWorktreeMeta(stackRoot string) error {
+func (t *tracingRunner) DeleteWorktreeMeta(ctx context.Context, stackRoot string) error {
 	// Don't trace - delegates to DeleteRef which is traced
-	return t.inner.DeleteWorktreeMeta(stackRoot)
+	return t.inner.DeleteWorktreeMeta(ctx, stackRoot)
 }
 
 func (t *tracingRunner) ListWorktreeMetas() (map[string]*WorktreeMeta, error) {
@@ -1017,9 +1017,9 @@ func (t *tracingRunner) VerifyRef(ctx context.Context, refName string) error {
 	return err
 }
 
-func (t *tracingRunner) DeleteRef(name string) error {
+func (t *tracingRunner) DeleteRef(ctx context.Context, name string) error {
 	start := time.Now()
-	err := t.inner.DeleteRef(name)
+	err := t.inner.DeleteRef(ctx, name)
 	t.trace("DeleteRef", time.Since(start), err == nil, err, slog.String("ref", name))
 	return err
 }
@@ -1076,9 +1076,9 @@ func (t *tracingRunner) WriteMetadata(branchName string, meta *Meta) error {
 	return err
 }
 
-func (t *tracingRunner) DeleteMetadata(branchName string) error {
+func (t *tracingRunner) DeleteMetadata(ctx context.Context, branchName string) error {
 	// Don't trace - delegates to DeleteRef which is traced
-	return t.inner.DeleteMetadata(branchName)
+	return t.inner.DeleteMetadata(ctx, branchName)
 }
 
 func (t *tracingRunner) ClearMetadataCache() {
@@ -1215,9 +1215,9 @@ func (t *tracingRunner) WriteStackMeta(stackID string, meta *StackMeta) error {
 	return err
 }
 
-func (t *tracingRunner) DeleteStackMeta(stackID string) error {
+func (t *tracingRunner) DeleteStackMeta(ctx context.Context, stackID string) error {
 	// Don't trace - delegates to DeleteRef which is traced
-	return t.inner.DeleteStackMeta(stackID)
+	return t.inner.DeleteStackMeta(ctx, stackID)
 }
 
 func (t *tracingRunner) ListStackMetas() (map[string]string, error) {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -142,9 +142,9 @@ func (r *runner) WriteWorktreeMeta(stackRoot string, meta *WorktreeMeta) error {
 }
 
 // DeleteWorktreeMeta deletes worktree metadata for a stack root
-func (r *runner) DeleteWorktreeMeta(stackRoot string) error {
+func (r *runner) DeleteWorktreeMeta(ctx context.Context, stackRoot string) error {
 	refName := fmt.Sprintf("%s%s", WorktreeRefPrefix, stackRoot)
-	return r.DeleteRef(refName)
+	return r.DeleteRef(ctx, refName)
 }
 
 // GetWorktreePathForBranch returns the worktree path where a branch is checked out.

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -121,7 +121,7 @@ func TestWorktreeRegistry(t *testing.T) {
 		require.NoError(t, err)
 
 		// Delete it
-		err = runner.DeleteWorktreeMeta("feature-branch")
+		err = runner.DeleteWorktreeMeta(context.Background(), "feature-branch")
 		require.NoError(t, err)
 
 		// Verify it's gone


### PR DESCRIPTION
This PR merges the following changes:

1. **#970** fix(merge): surface DeleteBranch failures during ship cleanup
2. **#971** fix(merge): drop remote metadata ref when ship deletes a branch
3. **#972** fix(git): handle packed refs in DeleteBranch and DeleteRef

### Stack

```
main
  └─ fix/merge-warn-delete-failure (#970)
    └─ fix/merge-cleanup-remote-metadata (#971)
      └─ fix/git-delete-handles-packed-refs (#972)
```

Stackit-Stack-Size: 3
Stackit-PRs: 970,971,972
