### PR TITLE
feat(api): add registry package for multi-repo support

### DIFF
--- a/internal/api/registry/registry.go
+++ b/internal/api/registry/registry.go
@@ -1,0 +1,131 @@
+// Package registry holds the set of repositories served by the stackit
+// server, keyed by a stable repoID. Each entry owns the per-repository
+// engine and (in follow-up changes) its own ref watcher and event
+// broadcaster, so multiple repositories can be served from one process
+// without leaking events between them.
+package registry
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"sync"
+
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
+)
+
+// idPattern restricts repo IDs to characters that survive in URL paths
+// without escaping, keeping the routing surface simple.
+var idPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// RepoEntry is the per-repository state required to serve API requests for
+// one repo. Per-repo broadcaster and watcher are wired in by a follow-up PR.
+type RepoEntry struct {
+	ID          string
+	DisplayName string
+	RepoRoot    string
+	Remote      string
+	Engine      engine.Engine
+	GitHub      github.Client
+
+	closers []func() error
+}
+
+// AddCloser registers a teardown function that Registry.Close will invoke
+// in reverse-registration order. Use it to attach lifecycle hooks (logger
+// closers, watcher stoppers, etc.) when constructing an entry.
+func (e *RepoEntry) AddCloser(fn func() error) {
+	if fn == nil {
+		return
+	}
+	e.closers = append(e.closers, fn)
+}
+
+func (e *RepoEntry) close() error {
+	var errs []error
+	for i := len(e.closers) - 1; i >= 0; i-- {
+		if err := e.closers[i](); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	e.closers = nil
+	return errors.Join(errs...)
+}
+
+// Registry is a goroutine-safe collection of RepoEntries keyed by ID.
+type Registry struct {
+	mu      sync.RWMutex
+	entries map[string]*RepoEntry
+}
+
+// New returns an empty registry.
+func New() *Registry {
+	return &Registry{entries: make(map[string]*RepoEntry)}
+}
+
+// Add inserts an entry. The entry's ID must be non-empty, match the allowed
+// pattern, and be unique within the registry.
+func (r *Registry) Add(e *RepoEntry) error {
+	if e == nil {
+		return errors.New("registry: nil entry")
+	}
+	if e.ID == "" {
+		return errors.New("registry: entry has empty ID")
+	}
+	if !idPattern.MatchString(e.ID) {
+		return fmt.Errorf("registry: invalid repo ID %q (must match %s)", e.ID, idPattern)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.entries[e.ID]; exists {
+		return fmt.Errorf("registry: duplicate repo ID %q", e.ID)
+	}
+	r.entries[e.ID] = e
+	return nil
+}
+
+// Get returns the entry for id. The bool is false when no such entry
+// exists, matching the comma-ok idiom of map access.
+func (r *Registry) Get(id string) (*RepoEntry, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	e, ok := r.entries[id]
+	return e, ok
+}
+
+// List returns every entry sorted by ID so callers (and tests) get a stable
+// ordering for serialization.
+func (r *Registry) List() []*RepoEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]*RepoEntry, 0, len(r.entries))
+	for _, e := range r.entries {
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// Len reports the number of registered entries.
+func (r *Registry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.entries)
+}
+
+// Close runs every entry's closers and returns the joined error. The
+// registry is unusable afterwards.
+func (r *Registry) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var errs []error
+	for _, e := range r.entries {
+		if err := e.close(); err != nil {
+			errs = append(errs, fmt.Errorf("registry: closing %q: %w", e.ID, err))
+		}
+	}
+	r.entries = nil
+	return errors.Join(errs...)
+}

--- a/internal/api/registry/registry_test.go
+++ b/internal/api/registry/registry_test.go
@@ -1,0 +1,160 @@
+package registry
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistry_AddValidatesID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		entry   *RepoEntry
+		wantErr string
+	}{
+		{name: "nil entry", entry: nil, wantErr: "nil entry"},
+		{name: "empty ID", entry: &RepoEntry{}, wantErr: "empty ID"},
+		{name: "slash in ID", entry: &RepoEntry{ID: "a/b"}, wantErr: "invalid repo ID"},
+		{name: "space in ID", entry: &RepoEntry{ID: "a b"}, wantErr: "invalid repo ID"},
+		{name: "dot in ID", entry: &RepoEntry{ID: "a.b"}, wantErr: "invalid repo ID"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := New()
+			err := r.Add(tt.entry)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestRegistry_AddAllowsValidIDs(t *testing.T) {
+	t.Parallel()
+
+	for _, id := range []string{"a", "stackit", "my-repo", "my_repo", "repo123", "ABC"} {
+		t.Run(id, func(t *testing.T) {
+			t.Parallel()
+			r := New()
+			require.NoError(t, r.Add(&RepoEntry{ID: id}))
+			_, ok := r.Get(id)
+			require.True(t, ok)
+		})
+	}
+}
+
+func TestRegistry_AddRejectsDuplicateID(t *testing.T) {
+	t.Parallel()
+	r := New()
+	require.NoError(t, r.Add(&RepoEntry{ID: "dup"}))
+	err := r.Add(&RepoEntry{ID: "dup"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate repo ID")
+}
+
+func TestRegistry_GetMissing(t *testing.T) {
+	t.Parallel()
+	r := New()
+	_, ok := r.Get("nope")
+	require.False(t, ok)
+}
+
+func TestRegistry_ListReturnsSortedByID(t *testing.T) {
+	t.Parallel()
+	r := New()
+	for _, id := range []string{"c", "a", "b"} {
+		require.NoError(t, r.Add(&RepoEntry{ID: id}))
+	}
+
+	got := r.List()
+	require.Len(t, got, 3)
+	require.Equal(t, "a", got[0].ID)
+	require.Equal(t, "b", got[1].ID)
+	require.Equal(t, "c", got[2].ID)
+}
+
+func TestRegistry_Len(t *testing.T) {
+	t.Parallel()
+	r := New()
+	require.Equal(t, 0, r.Len())
+	require.NoError(t, r.Add(&RepoEntry{ID: "a"}))
+	require.NoError(t, r.Add(&RepoEntry{ID: "b"}))
+	require.Equal(t, 2, r.Len())
+}
+
+func TestRegistry_CloseRunsClosersInReverseAndJoinsErrors(t *testing.T) {
+	t.Parallel()
+
+	var order []string
+	closerOK := func(name string) func() error {
+		return func() error {
+			order = append(order, name)
+			return nil
+		}
+	}
+
+	e := &RepoEntry{ID: "x"}
+	e.AddCloser(closerOK("first"))
+	e.AddCloser(closerOK("second"))
+	e.AddCloser(func() error { order = append(order, "third"); return errors.New("boom-third") })
+	e.AddCloser(func() error { order = append(order, "fourth"); return errors.New("boom-fourth") })
+
+	r := New()
+	require.NoError(t, r.Add(e))
+
+	err := r.Close()
+	require.Error(t, err)
+	// reverse-registration order
+	require.Equal(t, []string{"fourth", "third", "second", "first"}, order)
+	// both errors surfaced
+	require.Contains(t, err.Error(), "boom-fourth")
+	require.Contains(t, err.Error(), "boom-third")
+}
+
+func TestRegistry_CloseEmptiesRegistry(t *testing.T) {
+	t.Parallel()
+	r := New()
+	require.NoError(t, r.Add(&RepoEntry{ID: "a"}))
+	require.NoError(t, r.Close())
+	require.Equal(t, 0, r.Len())
+	_, ok := r.Get("a")
+	require.False(t, ok)
+}
+
+func TestRegistry_AddCloserIgnoresNil(t *testing.T) {
+	t.Parallel()
+	e := &RepoEntry{ID: "a"}
+	e.AddCloser(nil)
+
+	r := New()
+	require.NoError(t, r.Add(e))
+	require.NoError(t, r.Close())
+}
+
+func TestRegistry_ConcurrentAddAndGet(t *testing.T) {
+	t.Parallel()
+	r := New()
+
+	const n = 50
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			_ = r.Add(&RepoEntry{ID: fmt.Sprintf("r%d", i)})
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			_, _ = r.Get(fmt.Sprintf("r%d", i))
+		}(i)
+	}
+	wg.Wait()
+
+	require.Equal(t, n, r.Len())
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Introduces internal/api/registry — a goroutine-safe map of repoID to
RepoEntry — as the foundation for hosting multiple repositories from a
single stackit-server process. The package is unwired in this commit:
later changes refactor handlers to take a *Registry, switch routes to
/repos/{repoID}/..., and move the ref watcher and event broadcaster onto
RepoEntry so events stay scoped per repo.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #975**
  * **PR #976** 👈
    * **PR #977**
      * **PR #978**
        * **PR #979**
          * **PR #980**
            * **PR #981**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1005*