### PR TITLE
feat(server): -repos-config flag for serving multiple repos

### DIFF
--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"errors"
 	"flag"
+	"fmt"
 	"io/fs"
 	"log"
 	"net/http"
@@ -32,31 +33,16 @@ func main() {
 
 func run() error {
 	var (
-		port          = flag.Int("port", 8080, "Port to listen on")
-		cwd           = flag.String("cwd", "", "Working directory for repository detection")
-		remote        = flag.String("remote", "origin", "Git remote name used in API responses")
-		corsOrigins   = flag.String("cors", "http://localhost:3000,http://localhost:5173", "Comma-separated allowed CORS origins")
-		apiPrefix     = flag.String("api-prefix", "/api/v1", "Canonical API prefix")
-		enableLegacy  = flag.Bool("legacy-api-prefix", true, "Also expose legacy /api endpoints")
-		shutdownGrace = flag.Duration("shutdown-timeout", 10*time.Second, "Graceful shutdown timeout")
+		port            = flag.Int("port", 8080, "Port to listen on")
+		cwd             = flag.String("cwd", "", "Working directory for repository detection (single-repo shortcut; ignored when -repos-config is set)")
+		reposConfigPath = flag.String("repos-config", "", "Path to a JSON file listing repos to serve (mutually exclusive with -cwd)")
+		remote          = flag.String("remote", "origin", "Default git remote name for the single-repo -cwd shortcut")
+		corsOrigins     = flag.String("cors", "http://localhost:3000,http://localhost:5173", "Comma-separated allowed CORS origins")
+		apiPrefix       = flag.String("api-prefix", "/api/v1", "Canonical API prefix")
+		enableLegacy    = flag.Bool("legacy-api-prefix", true, "Also expose legacy /api endpoints")
+		shutdownGrace   = flag.Duration("shutdown-timeout", 10*time.Second, "Graceful shutdown timeout")
 	)
 	flag.Parse()
-
-	opts := app.GetDefaultGlobalOptions()
-	opts.Cwd = *cwd
-	opts.Interactive = false
-
-	runtimeCtx, err := app.GetContext(context.Background(), opts)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if runtimeCtx.Logger != nil {
-			if closeErr := runtimeCtx.Logger.Close(); closeErr != nil {
-				log.Printf("failed to close logger: %v", closeErr)
-			}
-		}
-	}()
 
 	staticFS, err := fs.Sub(staticFiles, "static")
 	if err != nil {
@@ -68,21 +54,35 @@ func run() error {
 		prefixes = append(prefixes, "/api")
 	}
 
-	gh := runtimeCtx.GitHub()
-	if gh == nil && runtimeCtx.GitHubError() != nil {
-		log.Printf("GitHub client unavailable: %v", runtimeCtx.GitHubError())
-	}
-
 	reg := registry.New()
-	if err := reg.Add(&registry.RepoEntry{
-		ID:          "default",
-		DisplayName: "default",
-		RepoRoot:    runtimeCtx.RepoRoot,
-		Remote:      *remote,
-		Engine:      runtimeCtx.Engine,
-		GitHub:      gh,
-	}); err != nil {
-		return err
+	defer func() {
+		if closeErr := reg.Close(); closeErr != nil {
+			log.Printf("registry close: %v", closeErr)
+		}
+	}()
+
+	switch {
+	case *reposConfigPath != "":
+		cfg, err := loadReposConfig(*reposConfigPath)
+		if err != nil {
+			return err
+		}
+		for _, rc := range cfg.Repos {
+			if err := addRegistryEntry(reg, rc); err != nil {
+				return fmt.Errorf("repo %q: %w", rc.ID, err)
+			}
+		}
+	default:
+		// Single-repo shortcut. `-cwd ""` falls back to git discovery
+		// from the process cwd, matching the previous behavior.
+		if err := addRegistryEntry(reg, repoConfig{
+			ID:          "default",
+			DisplayName: "default",
+			Path:        *cwd,
+			Remote:      *remote,
+		}); err != nil {
+			return err
+		}
 	}
 
 	server := api.NewServer(api.ServerConfig{
@@ -113,6 +113,39 @@ func run() error {
 		}
 		return nil
 	}
+}
+
+// addRegistryEntry resolves rc into an engine via app.GetContext and adds
+// the resulting RepoEntry to reg, registering a logger-close callback so
+// reg.Close releases the file handle on shutdown.
+func addRegistryEntry(reg *registry.Registry, rc repoConfig) error {
+	opts := app.GetDefaultGlobalOptions()
+	opts.Cwd = rc.Path
+	opts.Interactive = false
+
+	runtimeCtx, err := app.GetContext(context.Background(), opts)
+	if err != nil {
+		return err
+	}
+
+	gh := runtimeCtx.GitHub()
+	if gh == nil && runtimeCtx.GitHubError() != nil {
+		log.Printf("[%s] GitHub client unavailable: %v", rc.ID, runtimeCtx.GitHubError())
+	}
+
+	entry := &registry.RepoEntry{
+		ID:          rc.ID,
+		DisplayName: rc.DisplayName,
+		RepoRoot:    runtimeCtx.RepoRoot,
+		Remote:      rc.Remote,
+		Engine:      runtimeCtx.Engine,
+		GitHub:      gh,
+	}
+	if runtimeCtx.Logger != nil {
+		entry.AddCloser(runtimeCtx.Logger.Close)
+	}
+
+	return reg.Add(entry)
 }
 
 func parseCSV(raw string) []string {

--- a/apps/server/repos_config.go
+++ b/apps/server/repos_config.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+)
+
+// reposConfig is the on-disk shape of the -repos-config file. Multiple repos
+// can be listed; each one becomes a separate registry entry at startup.
+type reposConfig struct {
+	Repos []repoConfig `json:"repos"`
+}
+
+type repoConfig struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName,omitempty"`
+	Path        string `json:"path"`
+	Remote      string `json:"remote,omitempty"`
+}
+
+// repoIDPattern restricts repo IDs to characters that survive in URL paths
+// without escaping. Mirrors the registry's own constraint so config errors
+// surface at startup, not at first request.
+var repoIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// loadReposConfig reads and validates the JSON repos config at path. It
+// returns a normalized config (DisplayName and Remote defaulted) so callers
+// don't need to re-check.
+func loadReposConfig(path string) (*reposConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read repos config %s: %w", path, err)
+	}
+
+	var cfg reposConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse repos config %s: %w", path, err)
+	}
+	if len(cfg.Repos) == 0 {
+		return nil, fmt.Errorf("repos config %s: must list at least one repo", path)
+	}
+
+	seen := make(map[string]bool, len(cfg.Repos))
+	for i := range cfg.Repos {
+		r := &cfg.Repos[i]
+		if r.ID == "" {
+			return nil, fmt.Errorf("repos config %s: repo[%d] missing id", path, i)
+		}
+		if !repoIDPattern.MatchString(r.ID) {
+			return nil, fmt.Errorf("repos config %s: repo[%d] id %q must match %s", path, i, r.ID, repoIDPattern)
+		}
+		if seen[r.ID] {
+			return nil, fmt.Errorf("repos config %s: duplicate id %q", path, r.ID)
+		}
+		seen[r.ID] = true
+
+		if r.Path == "" {
+			return nil, fmt.Errorf("repos config %s: repo %q missing path", path, r.ID)
+		}
+		if r.DisplayName == "" {
+			r.DisplayName = r.ID
+		}
+		if r.Remote == "" {
+			r.Remote = "origin"
+		}
+	}
+	return &cfg, nil
+}

--- a/apps/server/repos_config_test.go
+++ b/apps/server/repos_config_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeTemp(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "repos.json")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+	return path
+}
+
+func TestLoadReposConfig_ValidatesAndDefaults(t *testing.T) {
+	t.Parallel()
+
+	path := writeTemp(t, `{
+	  "repos": [
+	    {"id": "a", "path": "/tmp/a"},
+	    {"id": "b", "displayName": "Repo B", "path": "/tmp/b", "remote": "upstream"}
+	  ]
+	}`)
+
+	cfg, err := loadReposConfig(path)
+	require.NoError(t, err)
+	require.Len(t, cfg.Repos, 2)
+
+	// Defaults filled in for repo a
+	require.Equal(t, "a", cfg.Repos[0].ID)
+	require.Equal(t, "a", cfg.Repos[0].DisplayName)
+	require.Equal(t, "origin", cfg.Repos[0].Remote)
+
+	// Explicit values preserved for repo b
+	require.Equal(t, "Repo B", cfg.Repos[1].DisplayName)
+	require.Equal(t, "upstream", cfg.Repos[1].Remote)
+}
+
+func TestLoadReposConfig_RejectsBadInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "empty repos", body: `{"repos": []}`, want: "must list at least one repo"},
+		{name: "missing id", body: `{"repos": [{"path": "/tmp/a"}]}`, want: "missing id"},
+		{name: "invalid id", body: `{"repos": [{"id": "a/b", "path": "/tmp/a"}]}`, want: "must match"},
+		{name: "duplicate id", body: `{"repos": [{"id": "a", "path": "/x"}, {"id": "a", "path": "/y"}]}`, want: "duplicate id"},
+		{name: "missing path", body: `{"repos": [{"id": "a"}]}`, want: "missing path"},
+		{name: "malformed json", body: `not json`, want: "parse repos config"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := writeTemp(t, tt.body)
+			_, err := loadReposConfig(path)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestLoadReposConfig_MissingFile(t *testing.T) {
+	t.Parallel()
+	_, err := loadReposConfig(filepath.Join(t.TempDir(), "nope.json"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "read repos config")
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The server can now serve N repositories listed in a JSON config file,
each becoming its own registry entry with its own engine and GitHub
client. The new -repos-config flag points at a file shaped like:

  {
    "repos": [
      {"id": "stackit", "path": "/repos/stackit"},
      {"id": "myproj", "displayName": "My Project",
       "path": "/repos/myproj", "remote": "upstream"}
    ]
  }

IDs are constrained to URL-safe characters so they survive in
/api/v1/repos/{repoID}/... paths without escaping. -cwd is preserved
as a single-repo shortcut and synthesises an entry with id "default"
so existing dev workflows (`stackit-server -cwd .`) keep working.

Each entry registers a logger-close callback so registry.Close releases
file handles for every repo on shutdown.

JSON is used (not TOML) to avoid pulling in a new dependency — the
project already uses encoding/json for similar config files.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #975**
  * **PR #976**
    * **PR #977**
      * **PR #978** 👈
        * **PR #979**
          * **PR #980**
            * **PR #981**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1005*