### PR TITLE
feat(api): GET /api/v1/repos lists registered repositories

### DIFF
--- a/internal/api/handlers/repos.go
+++ b/internal/api/handlers/repos.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/getstackit/stackit/internal/api/registry"
+	httpcontract "github.com/getstackit/stackit/internal/contracts/http"
+)
+
+// ReposListHandler serves GET /api/v1/repos — the unscoped index of repos
+// the server is configured to serve. Clients use this to render a picker
+// before scoping subsequent calls to /api/v1/repos/{repoID}/...
+type ReposListHandler struct {
+	reg *registry.Registry
+}
+
+// NewReposListHandler creates a handler backed by reg.
+func NewReposListHandler(reg *registry.Registry) *ReposListHandler {
+	return &ReposListHandler{reg: reg}
+}
+
+// ServeHTTP returns one RepoSummary per registry entry, sorted by ID.
+func (h *ReposListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	entries := h.reg.List()
+	summaries := make([]httpcontract.RepoSummary, 0, len(entries))
+	for _, entry := range entries {
+		summary := httpcontract.RepoSummary{
+			ID:          entry.ID,
+			DisplayName: entry.DisplayName,
+		}
+		if entry.Engine != nil {
+			summary.Trunk = entry.Engine.Trunk().GetName()
+			if current := entry.Engine.CurrentBranch(); current != nil {
+				summary.CurrentBranch = current.GetName()
+			}
+		}
+		summaries = append(summaries, summary)
+	}
+
+	writeJSON(w, httpcontract.ReposListResponse{Repos: summaries})
+}

--- a/internal/api/handlers/repos_test.go
+++ b/internal/api/handlers/repos_test.go
@@ -1,0 +1,76 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/api/registry"
+	httpcontract "github.com/getstackit/stackit/internal/contracts/http"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+func TestReposListHandler_ListsRegisteredRepos(t *testing.T) {
+	t.Parallel()
+
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	reg := registry.New()
+	require.NoError(t, reg.Add(&registry.RepoEntry{
+		ID:          "alpha",
+		DisplayName: "Alpha",
+		Engine:      s.Engine,
+	}))
+	require.NoError(t, reg.Add(&registry.RepoEntry{
+		ID:          "beta",
+		DisplayName: "Beta",
+		Engine:      s.Engine,
+	}))
+
+	handler := NewReposListHandler(reg)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repos", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp httpcontract.ReposListResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(t, resp.Repos, 2)
+	require.Equal(t, "alpha", resp.Repos[0].ID)
+	require.Equal(t, "Alpha", resp.Repos[0].DisplayName)
+	require.Equal(t, "main", resp.Repos[0].Trunk)
+	require.Equal(t, "beta", resp.Repos[1].ID)
+}
+
+func TestReposListHandler_EmptyRegistry(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReposListHandler(registry.New())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repos", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp httpcontract.ReposListResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Empty(t, resp.Repos)
+}
+
+func TestReposListHandler_RejectsNonGET(t *testing.T) {
+	t.Parallel()
+
+	handler := NewReposListHandler(registry.New())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repos", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -67,8 +67,12 @@ func (s *Server) Start() error {
 	branchDiffHandler := handlers.NewBranchDiffHandler(reg)
 	submitHandler := handlers.NewSubmitHandler(reg)
 	eventsHandler := handlers.NewEventsHandler(s.broadcaster)
+	reposListHandler := handlers.NewReposListHandler(reg)
 
 	for _, prefix := range prefixes {
+		// Unscoped index of available repos.
+		apiMux.Handle("GET "+prefix+"/repos", reposListHandler)
+
 		// New multi-repo routes. {repoID} resolves through the registry;
 		// unknown IDs return 404 from inside the handler.
 		apiMux.Handle("GET "+prefix+"/repos/{repoID}/view", viewHandler)

--- a/internal/contracts/http/responses.go
+++ b/internal/contracts/http/responses.go
@@ -5,6 +5,20 @@
 // to evolve independently.
 package httpcontract
 
+// RepoSummary is one entry in ReposListResponse — the metadata clients
+// need to render a repo picker without hitting per-repo endpoints.
+type RepoSummary struct {
+	ID            string `json:"id"`
+	DisplayName   string `json:"displayName"`
+	Trunk         string `json:"trunk"`
+	CurrentBranch string `json:"currentBranch,omitempty"`
+}
+
+// ReposListResponse is the response shape for GET /api/v1/repos.
+type ReposListResponse struct {
+	Repos []RepoSummary `json:"repos"`
+}
+
 // ViewResponse is the combined response for the frontend view.
 // It bundles repo metadata and all stack details into a single payload
 // to avoid N+1 API calls.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Adds an unscoped index endpoint so clients can render a picker without
hitting per-repo endpoints. Each entry reports id, displayName, trunk,
and (if known) currentBranch.

Contracts: introduces RepoSummary and ReposListResponse — mirrored on
the web side in the App Router restructure that follows.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #975**
  * **PR #976**
    * **PR #977**
      * **PR #978**
        * **PR #979** 👈
          * **PR #980**
            * **PR #981**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1005*