### PR TITLE
feat(api): per-repo broadcaster and watcher

### DIFF
--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -133,14 +133,14 @@ func addRegistryEntry(reg *registry.Registry, rc repoConfig) error {
 		log.Printf("[%s] GitHub client unavailable: %v", rc.ID, runtimeCtx.GitHubError())
 	}
 
-	entry := &registry.RepoEntry{
+	entry := registry.NewEntry(registry.EntryConfig{
 		ID:          rc.ID,
 		DisplayName: rc.DisplayName,
 		RepoRoot:    runtimeCtx.RepoRoot,
 		Remote:      rc.Remote,
 		Engine:      runtimeCtx.Engine,
 		GitHub:      gh,
-	}
+	})
 	if runtimeCtx.Logger != nil {
 		entry.AddCloser(runtimeCtx.Logger.Close)
 	}

--- a/internal/api/handlers/events.go
+++ b/internal/api/handlers/events.go
@@ -3,99 +3,25 @@ package handlers
 import (
 	"fmt"
 	"net/http"
-	"sync"
 	"time"
+
+	"github.com/getstackit/stackit/internal/api/registry"
 )
 
-// EventBroadcaster manages SSE connections and broadcasts events.
-type EventBroadcaster struct {
-	mu         sync.RWMutex
-	clients    map[chan string]struct{}
-	shutdownCh chan struct{}
-	closed     bool
-}
-
-// NewEventBroadcaster creates a new SSE event broadcaster.
-func NewEventBroadcaster() *EventBroadcaster {
-	return &EventBroadcaster{
-		clients:    make(map[chan string]struct{}),
-		shutdownCh: make(chan struct{}),
-	}
-}
-
-// Broadcast sends an SSE event to all connected clients.
-func (b *EventBroadcaster) Broadcast(event, data string) {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-	if b.closed {
-		return
-	}
-
-	msg := fmt.Sprintf("event: %s\ndata: %s\n\n", event, data)
-	for ch := range b.clients {
-		select {
-		case ch <- msg:
-		default:
-			// Drop message if client buffer is full
-		}
-	}
-}
-
-// Done returns a channel that closes when the broadcaster is shutting down.
-func (b *EventBroadcaster) Done() <-chan struct{} {
-	return b.shutdownCh
-}
-
-// Close notifies all subscribers to exit and prevents future broadcasts.
-// It closes every active client channel so SSE handlers blocked on a receive
-// unblock promptly and graceful HTTP shutdown can complete.
-func (b *EventBroadcaster) Close() {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if b.closed {
-		return
-	}
-	b.closed = true
-	close(b.shutdownCh)
-	for ch := range b.clients {
-		close(ch)
-		delete(b.clients, ch)
-	}
-}
-
-func (b *EventBroadcaster) subscribe() (chan string, bool) {
-	ch := make(chan string, 16)
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if b.closed {
-		close(ch)
-		return nil, false
-	}
-	b.clients[ch] = struct{}{}
-	return ch, true
-}
-
-func (b *EventBroadcaster) unsubscribe(ch chan string) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if _, ok := b.clients[ch]; !ok {
-		return
-	}
-	delete(b.clients, ch)
-	close(ch)
-}
-
-// EventsHandler serves the SSE stream at GET /api/events and /api/v1/events.
+// EventsHandler streams server-sent events from the per-repo broadcaster.
+// Each connection is scoped to one repo: subscribers to /repos/A/events
+// only see events broadcast on repo A.
 type EventsHandler struct {
-	broadcaster *EventBroadcaster
+	reg *registry.Registry
 }
 
-// NewEventsHandler creates a handler for events endpoints.
-func NewEventsHandler(broadcaster *EventBroadcaster) *EventsHandler {
-	return &EventsHandler{broadcaster: broadcaster}
+// NewEventsHandler creates a handler that resolves the per-request repo
+// from the registry and streams from that repo's broadcaster.
+func NewEventsHandler(reg *registry.Registry) *EventsHandler {
+	return &EventsHandler{reg: reg}
 }
 
-// ServeHTTP handles the SSE connection.
+// ServeHTTP handles the SSE connection for one repo.
 func (h *EventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -108,18 +34,27 @@ func (h *EventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	entry, ok := resolveRepo(h.reg, w, r)
+	if !ok {
+		return
+	}
+	if entry.Broadcaster == nil {
+		http.Error(w, "events unavailable for this repo", http.StatusServiceUnavailable)
+		return
+	}
+
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 
-	ch, ok := h.broadcaster.subscribe()
+	ch, ok := entry.Broadcaster.Subscribe()
 	if !ok {
 		http.Error(w, "server shutting down", http.StatusServiceUnavailable)
 		return
 	}
-	defer h.broadcaster.unsubscribe(ch)
+	defer entry.Broadcaster.Unsubscribe(ch)
 
-	// Send initial heartbeat
+	// Send initial heartbeat so the client knows the stream is alive.
 	if _, err := fmt.Fprintf(w, "event: connected\ndata: {\"timestamp\":\"%s\"}\n\n", time.Now().Format(time.RFC3339)); err != nil {
 		return
 	}
@@ -129,7 +64,7 @@ func (h *EventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		select {
 		case <-r.Context().Done():
 			return
-		case <-h.broadcaster.Done():
+		case <-entry.Broadcaster.Done():
 			return
 		case msg, ok := <-ch:
 			if !ok {

--- a/internal/api/handlers/events_test.go
+++ b/internal/api/handlers/events_test.go
@@ -5,6 +5,10 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/api/registry"
 )
 
 type signalingResponseWriter struct {
@@ -29,10 +33,18 @@ func (w *signalingResponseWriter) Write(p []byte) (int, error) {
 }
 
 func TestEventsHandlerReturnsWhenBroadcasterCloses(t *testing.T) {
-	broadcaster := NewEventBroadcaster()
-	handler := NewEventsHandler(broadcaster)
+	t.Parallel()
 
-	req := httptest.NewRequest(http.MethodGet, "/api/events", nil)
+	reg := registry.New()
+	broadcaster := registry.NewBroadcaster()
+	require.NoError(t, reg.Add(&registry.RepoEntry{
+		ID:          "default",
+		Broadcaster: broadcaster,
+	}))
+	handler := NewEventsHandler(reg)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repos/default/events", nil)
+	req.SetPathValue("repoID", "default")
 	recorder := newSignalingResponseWriter()
 
 	done := make(chan struct{})
@@ -54,4 +66,22 @@ func TestEventsHandlerReturnsWhenBroadcasterCloses(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("handler did not exit after broadcaster shutdown")
 	}
+}
+
+func TestEventsHandlerReturns404ForUnknownRepo(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.New()
+	require.NoError(t, reg.Add(&registry.RepoEntry{
+		ID:          "default",
+		Broadcaster: registry.NewBroadcaster(),
+	}))
+	handler := NewEventsHandler(reg)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repos/missing/events", nil)
+	req.SetPathValue("repoID", "missing")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
 }

--- a/internal/api/registry/broadcaster.go
+++ b/internal/api/registry/broadcaster.go
@@ -1,0 +1,93 @@
+package registry
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Broadcaster fans out SSE messages to subscribed clients. Each RepoEntry
+// owns one so events stay scoped to a single repo — a client subscribed to
+// /repos/A/events never receives B's refresh notifications.
+type Broadcaster struct {
+	mu         sync.RWMutex
+	clients    map[chan string]struct{}
+	shutdownCh chan struct{}
+	closed     bool
+}
+
+// NewBroadcaster creates a new event broadcaster.
+func NewBroadcaster() *Broadcaster {
+	return &Broadcaster{
+		clients:    make(map[chan string]struct{}),
+		shutdownCh: make(chan struct{}),
+	}
+}
+
+// Broadcast sends an SSE event to every subscribed client. Slow clients
+// drop the message rather than blocking the broadcast.
+func (b *Broadcaster) Broadcast(event, data string) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if b.closed {
+		return
+	}
+
+	msg := fmt.Sprintf("event: %s\ndata: %s\n\n", event, data)
+	for ch := range b.clients {
+		select {
+		case ch <- msg:
+		default:
+			// Drop message if the client's buffer is full.
+		}
+	}
+}
+
+// Done returns a channel that closes when the broadcaster is shutting down.
+// SSE handlers select on this to exit promptly during server shutdown.
+func (b *Broadcaster) Done() <-chan struct{} {
+	return b.shutdownCh
+}
+
+// Close notifies all subscribers to exit and prevents future broadcasts.
+// It closes every active client channel so SSE handlers blocked on a
+// receive unblock immediately. Safe to call multiple times.
+func (b *Broadcaster) Close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return
+	}
+	b.closed = true
+	close(b.shutdownCh)
+	for ch := range b.clients {
+		close(ch)
+		delete(b.clients, ch)
+	}
+}
+
+// Subscribe returns a buffered channel that receives every broadcast
+// message until Unsubscribe is called or the broadcaster is closed. The
+// bool is false when the broadcaster is already shut down.
+func (b *Broadcaster) Subscribe() (chan string, bool) {
+	ch := make(chan string, 16)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		close(ch)
+		return nil, false
+	}
+	b.clients[ch] = struct{}{}
+	return ch, true
+}
+
+// Unsubscribe removes ch from the broadcast set and closes it. Safe to
+// call from a defer even if ch was already removed (e.g. by Close).
+func (b *Broadcaster) Unsubscribe(ch chan string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, ok := b.clients[ch]; !ok {
+		return
+	}
+	delete(b.clients, ch)
+	close(ch)
+}

--- a/internal/api/registry/registry.go
+++ b/internal/api/registry/registry.go
@@ -1,27 +1,49 @@
 // Package registry holds the set of repositories served by the stackit
 // server, keyed by a stable repoID. Each entry owns the per-repository
-// engine and (in follow-up changes) its own ref watcher and event
-// broadcaster, so multiple repositories can be served from one process
-// without leaking events between them.
+// engine, GitHub client, event broadcaster, and ref watcher — so multiple
+// repositories can be served from one process without leaking events
+// between them.
 package registry
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"regexp"
 	"sort"
 	"sync"
+	"time"
 
+	"github.com/getstackit/stackit/internal/api/watcher"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/github"
 )
+
+// watcherDebounce is the interval the ref watcher coalesces filesystem
+// events over before notifying the engine. Matches the previous server-
+// scoped value.
+const watcherDebounce = 200 * time.Millisecond
 
 // idPattern restricts repo IDs to characters that survive in URL paths
 // without escaping, keeping the routing surface simple.
 var idPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
+// EntryConfig is the input to NewEntry. It captures the per-repo state the
+// constructor needs to wire up the broadcaster + watcher.
+type EntryConfig struct {
+	ID          string
+	DisplayName string
+	RepoRoot    string
+	Remote      string
+	Engine      engine.Engine
+	GitHub      github.Client
+}
+
 // RepoEntry is the per-repository state required to serve API requests for
-// one repo. Per-repo broadcaster and watcher are wired in by a follow-up PR.
+// one repo. Constructed via NewEntry so the watcher + broadcaster lifecycle
+// stays consistent across call sites; raw struct literals are still usable
+// in tests where neither is needed.
 type RepoEntry struct {
 	ID          string
 	DisplayName string
@@ -30,12 +52,48 @@ type RepoEntry struct {
 	Engine      engine.Engine
 	GitHub      github.Client
 
+	Broadcaster *Broadcaster
+	Watcher     *watcher.RefWatcher
+
 	closers []func() error
+}
+
+// NewEntry constructs a ready-to-use entry with a broadcaster, a ref
+// watcher (when RepoRoot is set), and closers that cleanly tear down both
+// when registry.Close is called. The watcher goroutine starts immediately.
+func NewEntry(cfg EntryConfig) *RepoEntry {
+	entry := &RepoEntry{
+		ID:          cfg.ID,
+		DisplayName: cfg.DisplayName,
+		RepoRoot:    cfg.RepoRoot,
+		Remote:      cfg.Remote,
+		Engine:      cfg.Engine,
+		GitHub:      cfg.GitHub,
+		Broadcaster: NewBroadcaster(),
+	}
+	entry.AddCloser(func() error { entry.Broadcaster.Close(); return nil })
+
+	if cfg.RepoRoot != "" && cfg.Engine != nil {
+		entry.Watcher = watcher.NewRefWatcher(cfg.RepoRoot, watcherDebounce, makeWatcherCallback(entry))
+		watcherDone := make(chan error, 1)
+		go func() {
+			watcherDone <- entry.Watcher.Start()
+		}()
+		entry.AddCloser(func() error {
+			entry.Watcher.Stop()
+			if err := <-watcherDone; err != nil {
+				return fmt.Errorf("ref watcher: %w", err)
+			}
+			return nil
+		})
+	}
+
+	return entry
 }
 
 // AddCloser registers a teardown function that Registry.Close will invoke
 // in reverse-registration order. Use it to attach lifecycle hooks (logger
-// closers, watcher stoppers, etc.) when constructing an entry.
+// closers, etc.) when constructing an entry.
 func (e *RepoEntry) AddCloser(fn func() error) {
 	if fn == nil {
 		return
@@ -52,6 +110,40 @@ func (e *RepoEntry) close() error {
 	}
 	e.closers = nil
 	return errors.Join(errs...)
+}
+
+// makeWatcherCallback returns the function the ref watcher invokes when
+// the repo's refs change. It rebuilds the engine, detects branch switches,
+// and re-broadcasts both "branch_switched" and "refresh" so connected SSE
+// clients refetch.
+func makeWatcherCallback(entry *RepoEntry) func() {
+	trunkName := entry.Engine.Trunk().GetName()
+	var lastCurrentBranch string
+	if cb := entry.Engine.CurrentBranch(); cb != nil {
+		lastCurrentBranch = cb.GetName()
+	}
+
+	return func() {
+		if err := entry.Engine.Rebuild(trunkName); err != nil {
+			log.Printf("[%s] engine rebuild failed: %v", entry.ID, err)
+			return
+		}
+
+		if cb := entry.Engine.CurrentBranch(); cb != nil {
+			newBranch := cb.GetName()
+			if lastCurrentBranch != "" && newBranch != lastCurrentBranch {
+				data, _ := json.Marshal(map[string]string{
+					"from":      lastCurrentBranch,
+					"to":        newBranch,
+					"timestamp": time.Now().Format(time.RFC3339),
+				})
+				entry.Broadcaster.Broadcast("branch_switched", string(data))
+			}
+			lastCurrentBranch = newBranch
+		}
+
+		entry.Broadcaster.Broadcast("refresh", "{}")
+	}
 }
 
 // Registry is a goroutine-safe collection of RepoEntries keyed by ID.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -3,18 +3,15 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/fs"
 	"log"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/getstackit/stackit/internal/api/handlers"
 	"github.com/getstackit/stackit/internal/api/registry"
-	"github.com/getstackit/stackit/internal/api/watcher"
 )
 
 // ServerConfig holds configuration for the API server.
@@ -26,31 +23,17 @@ type ServerConfig struct {
 	Registry    *registry.Registry
 }
 
-// Server is the stackit-web HTTP server.
+// Server is the stackit-web HTTP server. Per-repo state (engine, watcher,
+// broadcaster) lives on each registry entry — the server only owns
+// transport-level concerns.
 type Server struct {
-	config            ServerConfig
-	broadcaster       *handlers.EventBroadcaster
-	httpServer        *http.Server
-	refWatcher        *watcher.RefWatcher
-	watcherWG         sync.WaitGroup
-	lastCurrentBranch string
+	config     ServerConfig
+	httpServer *http.Server
 }
 
-// NewServer creates a new API server backed by the given registry. Per-repo
-// engine and GitHub client state lives on each registry entry; the server
-// only owns transport-level concerns and (for now) a single broadcaster +
-// watcher that follow the first registered repo. A follow-up change moves
-// the watcher and broadcaster onto each entry so events are per-repo.
+// NewServer creates a new API server backed by the given registry.
 func NewServer(cfg ServerConfig) *Server {
-	return &Server{
-		config:      cfg,
-		broadcaster: handlers.NewEventBroadcaster(),
-	}
-}
-
-// Broadcaster returns the event broadcaster for triggering SSE updates.
-func (s *Server) Broadcaster() *handlers.EventBroadcaster {
-	return s.broadcaster
+	return &Server{config: cfg}
 }
 
 // Start begins serving HTTP requests. It blocks until the server is stopped.
@@ -66,7 +49,7 @@ func (s *Server) Start() error {
 	branchesHandler := handlers.NewBranchesHandler(reg)
 	branchDiffHandler := handlers.NewBranchDiffHandler(reg)
 	submitHandler := handlers.NewSubmitHandler(reg)
-	eventsHandler := handlers.NewEventsHandler(s.broadcaster)
+	eventsHandler := handlers.NewEventsHandler(reg)
 	reposListHandler := handlers.NewReposListHandler(reg)
 
 	for _, prefix := range prefixes {
@@ -119,47 +102,6 @@ func (s *Server) Start() error {
 	handler := corsMiddleware(s.config.CORSOrigins, root)
 	handler = loggingMiddleware(handler)
 
-	// Start watching the first registered repo's refs so the engine stays
-	// current. A follow-up change spawns one watcher per registry entry so
-	// every repo's refs are tracked independently.
-	if reg != nil {
-		if entries := reg.List(); len(entries) > 0 {
-			entry := entries[0]
-			if entry.RepoRoot != "" {
-				trunkName := entry.Engine.Trunk().GetName()
-				if cb := entry.Engine.CurrentBranch(); cb != nil {
-					s.lastCurrentBranch = cb.GetName()
-				}
-				s.refWatcher = watcher.NewRefWatcher(entry.RepoRoot, 200*time.Millisecond, func() {
-					if err := entry.Engine.Rebuild(trunkName); err != nil {
-						log.Printf("engine rebuild failed: %v", err)
-						return
-					}
-
-					if cb := entry.Engine.CurrentBranch(); cb != nil {
-						newBranch := cb.GetName()
-						if s.lastCurrentBranch != "" && newBranch != s.lastCurrentBranch {
-							data, _ := json.Marshal(map[string]string{
-								"from":      s.lastCurrentBranch,
-								"to":        newBranch,
-								"timestamp": time.Now().Format(time.RFC3339),
-							})
-							s.broadcaster.Broadcast("branch_switched", string(data))
-						}
-						s.lastCurrentBranch = newBranch
-					}
-
-					s.broadcaster.Broadcast("refresh", "{}")
-				})
-				s.watcherWG.Go(func() {
-					if err := s.refWatcher.Start(); err != nil {
-						log.Printf("ref watcher stopped: %v", err)
-					}
-				})
-			}
-		}
-	}
-
 	s.httpServer = &http.Server{
 		Addr:              fmt.Sprintf(":%d", s.config.Port),
 		Handler:           handler,
@@ -170,25 +112,9 @@ func (s *Server) Start() error {
 	return s.httpServer.ListenAndServe()
 }
 
-// Shutdown gracefully stops the server.
+// Shutdown gracefully stops the server. The registry's watchers and
+// broadcasters are torn down separately by main.go's defer reg.Close().
 func (s *Server) Shutdown(ctx context.Context) error {
-	s.broadcaster.Close()
-	if s.refWatcher != nil {
-		s.refWatcher.Stop()
-	}
-
-	// Wait for the ref watcher goroutine to exit, bounded by ctx.
-	watcherDone := make(chan struct{})
-	go func() {
-		s.watcherWG.Wait()
-		close(watcherDone)
-	}()
-	select {
-	case <-watcherDone:
-	case <-ctx.Done():
-		log.Printf("ref watcher did not exit before shutdown deadline")
-	}
-
 	if s.httpServer != nil {
 		return s.httpServer.Shutdown(ctx)
 	}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/api/registry"
 )
 
 func TestNormalizeAPIPrefixes(t *testing.T) {
@@ -66,16 +70,29 @@ func TestIsAPIPath(t *testing.T) {
 	}
 }
 
-func TestServerShutdownClosesBroadcaster(t *testing.T) {
+func TestServerShutdownIsIdempotentWithoutHTTPServer(t *testing.T) {
 	server := NewServer(ServerConfig{})
 
 	if err := server.Shutdown(context.Background()); err != nil {
 		t.Fatalf("shutdown returned error: %v", err)
 	}
+}
+
+func TestRegistryCloseClosesEntryBroadcasters(t *testing.T) {
+	reg := registry.New()
+	b := registry.NewBroadcaster()
+	entry := &registry.RepoEntry{
+		ID:          "default",
+		Broadcaster: b,
+	}
+	entry.AddCloser(func() error { b.Close(); return nil })
+	require.NoError(t, reg.Add(entry))
+
+	require.NoError(t, reg.Close())
 
 	select {
-	case <-server.Broadcaster().Done():
+	case <-b.Done():
 	case <-time.After(time.Second):
-		t.Fatal("broadcaster was not closed during shutdown")
+		t.Fatal("broadcaster was not closed after registry.Close")
 	}
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Each registry entry now owns its own event broadcaster and ref watcher
so events stay scoped to a single repo. A client connected to
/repos/A/events never receives B's refresh notifications, and touching
B's refs never wakes A's engine. Verified end-to-end: switching
branches in repo A fires events only on A's SSE stream.

Lifecycle moves entirely onto the entry: NewEntry starts the watcher
goroutine and registers closers that stop it and close the broadcaster
when reg.Close runs at shutdown. Server.Shutdown is now a thin wrapper
around http.Server.Shutdown — no more watcher/broadcaster bookkeeping
on the server struct.

Broadcaster is moved from internal/api/handlers to internal/api/registry
to keep RepoEntry self-contained without an import cycle (handlers
already imports registry). Subscribe/Unsubscribe are exported because
EventsHandler now lives outside the broadcaster's package.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1779846876`.


* **PR #975**
  * **PR #976**
    * **PR #977**
      * **PR #978**
        * **PR #979**
          * **PR #980** 👈
            * **PR #981**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->