### PR TITLE
feat(web): repo picker and multi-repo client

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { RepoProvider } from "@/components/providers/repo-provider";
 import { ThemeProvider } from "@/components/providers/theme-provider";
 import "./globals.css";
 
@@ -31,9 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <ThemeProvider>
-          <TooltipProvider>
-            <RepoProvider>{children}</RepoProvider>
-          </TooltipProvider>
+          <TooltipProvider>{children}</TooltipProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,239 +1,29 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import dynamic from "next/dynamic";
-import { useRepo } from "@/components/providers/repo-provider";
-import { OwnerSwimlane } from "@/components/swimlane/owner-swimlane";
-import { getLastActiveDate } from "@/lib/swimlane-grouping";
-import { BranchDetail } from "@/components/branch-detail/branch-detail";
-import { StackDetailPanel } from "@/components/branch-detail/stack-detail";
-import { DetailEmptyState } from "@/components/branch-detail/detail-empty-state";
-import { EventFeed } from "@/components/layout/event-feed";
-import { Header } from "@/components/layout/header";
-import { Separator } from "@/components/ui/separator";
-import { RecentlyMerged } from "@/components/recently-merged/recently-merged";
-import { BackgroundMesh } from "@/components/ui/background-mesh";
-import { SkeletonSwimlane } from "@/components/ui/skeleton-shimmer";
-import { useUrlSelection } from "@/hooks/use-url-selection";
-import { groupStacksByOwner } from "@/lib/swimlane-grouping";
+import { usePathname } from "next/navigation";
+import { RepoProvider } from "@/components/providers/repo-provider";
+import { RepoPicker } from "@/components/repo-picker/repo-picker";
+import { RepoView } from "@/components/repo-picker/repo-view";
 
-const BranchDiffWorkspace = dynamic(
-  () =>
-    import("@/components/branch-detail/branch-diff-workspace").then(
-      (m) => m.BranchDiffWorkspace
-    ),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-        Loading diff workspace...
-      </div>
-    ),
-  }
-);
-
+// Single root page driving both the unscoped picker and the per-repo view.
+//
+// The Next.js build is `output: 'export'` (static HTML) and the Go static
+// handler falls back to the root index.html for any extension-less path —
+// effectively SPA mode. We read the pathname on the client and either show
+// the picker (path "/") or render RepoView wrapped in RepoProvider scoped
+// to the first path segment.
 export default function Home() {
-  const {
-    repo,
-    stackDetails,
-    loading,
-    error,
-    lastUpdated,
-    refresh,
-  } = useRepo();
+  const pathname = usePathname();
+  const segments = (pathname || "/").split("/").filter(Boolean);
+  const repoId = segments[0] ? decodeURIComponent(segments[0]) : "";
 
-  const {
-    selection,
-    selectedBranch,
-    selectedStack,
-    selectedBranchStack,
-    handleSelectBranch,
-    handleClearSelection,
-    handleSelectStack,
-    handleNavigateToBranch,
-    handleStackBranchSelect,
-  } = useUrlSelection(stackDetails);
-
-  const { yourStacks, otherOwners } = useMemo(
-    () => groupStacksByOwner(stackDetails, repo?.currentUser),
-    [stackDetails, repo?.currentUser]
-  );
-
-  const [recentCommitsPreference, setRecentCommitsPreference] = useState(true);
-  const hasSelection = selectedBranch || selectedStack;
-  const showRecentCommits = selectedBranch ? false : recentCommitsPreference;
-  const branchOverlayMode = Boolean(selectedBranch && selectedBranchStack);
-  const stacksAndHistoryContent =
-    stackDetails.length > 0 ? (
-      <div className="flex flex-col justify-end min-h-full">
-        {/* Swimlanes: only this area scrolls horizontally */}
-        <div className="overflow-x-auto">
-          <div className="flex items-end gap-6 p-6 pb-4 min-w-max">
-            {/* Your stacks */}
-            {yourStacks.length > 0 && (
-              <OwnerSwimlane
-                label="You"
-                stacks={yourStacks}
-                selectedBranch={selection?.type === "branch" ? selection.name : null}
-                selectedStack={selection?.type === "stack" ? selection.rootBranch : null}
-                onSelectBranch={handleSelectBranch}
-                onSelectStack={handleSelectStack}
-                compact={branchOverlayMode}
-              />
-            )}
-
-            {/* Teammate swimlanes */}
-            {otherOwners.map(([owner, stacks]) => (
-              <OwnerSwimlane
-                key={owner}
-                label={`@${owner}`}
-                lastActive={getLastActiveDate(stacks)}
-                stacks={stacks}
-                selectedBranch={selection?.type === "branch" ? selection.name : null}
-                selectedStack={selection?.type === "stack" ? selection.rootBranch : null}
-                onSelectBranch={handleSelectBranch}
-                onSelectStack={handleSelectStack}
-                compact={branchOverlayMode}
-              />
-            ))}
-          </div>
-        </div>
-
-        {/* Trunk line */}
-        <div className="flex items-center gap-2 px-6 pb-2 shrink-0">
-          <div className="flex-1 h-[2px] bg-gradient-to-r from-transparent via-muted-foreground/30 to-muted-foreground/30" />
-          {selectedBranch ? (
-            <span className="text-xs font-mono text-muted-foreground/70 px-2">
-              {repo?.trunk}
-            </span>
-          ) : (
-            <button
-              onClick={() => setRecentCommitsPreference((prev) => !prev)}
-              className="text-xs font-mono text-muted-foreground/70 px-2 hover:text-muted-foreground transition-colors cursor-pointer"
-            >
-              {repo?.trunk}
-            </button>
-          )}
-          <div className="flex-1 h-[2px] bg-gradient-to-l from-transparent via-muted-foreground/30 to-muted-foreground/30" />
-        </div>
-
-        {/* Recent trunk commits */}
-        <div
-          className="grid transition-[grid-template-rows,opacity] duration-300 ease-in-out"
-          style={{
-            gridTemplateRows: showRecentCommits ? "1fr" : "0fr",
-            opacity: showRecentCommits ? 1 : 0,
-          }}
-        >
-          <div className="overflow-hidden">
-            <RecentlyMerged compact={branchOverlayMode} />
-          </div>
-        </div>
-      </div>
-    ) : (
-      <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
-        No stacks found
-      </div>
-    );
-
-  if (loading) {
-    return (
-      <>
-        <BackgroundMesh />
-        <SkeletonSwimlane />
-      </>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="flex flex-col items-center justify-center h-screen gap-4">
-        <p className="text-destructive">{error}</p>
-        <p className="text-sm text-muted-foreground">
-          Make sure stackit-web is running on{" "}
-          {process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"}
-        </p>
-        <button
-          onClick={refresh}
-          className="text-sm underline text-muted-foreground hover:text-foreground"
-        >
-          Retry
-        </button>
-      </div>
-    );
+  if (!repoId) {
+    return <RepoPicker />;
   }
 
   return (
-    <div className="flex flex-col h-screen">
-      <BackgroundMesh />
-      <Header repo={repo ?? null} lastUpdated={lastUpdated ?? null} refresh={refresh} />
-
-      {/* Main content: stacks area + detail panel */}
-      <div className="flex flex-1 overflow-hidden">
-        <div className="flex flex-1 flex-col overflow-hidden">
-          {branchOverlayMode && selectedBranch && selectedBranchStack ? (
-            <>
-              <div className="min-h-0 flex-1 overflow-hidden border-b">
-                <BranchDiffWorkspace
-                  branch={selectedBranch}
-                  onExit={handleClearSelection}
-                />
-              </div>
-              <div className="h-[30vh] min-h-[180px] max-h-[340px] overflow-y-auto overflow-x-hidden bg-background/70">
-                {stacksAndHistoryContent}
-              </div>
-            </>
-          ) : (
-            <div className="flex-1 overflow-y-auto overflow-x-hidden">
-              {stacksAndHistoryContent}
-            </div>
-          )}
-        </div>
-
-        {/* Right: detail + event feed panel (always visible) */}
-        <div className="flex shrink-0">
-          <Separator orientation="vertical" />
-          <div className="w-[480px] shrink-0 flex flex-col overflow-hidden">
-            {branchOverlayMode && selectedBranchStack ? (
-              <div className="flex-1 overflow-auto p-4">
-                <StackDetailPanel
-                  stack={selectedBranchStack}
-                  onSelectBranch={handleStackBranchSelect}
-                  selectedBranchName={selectedBranch?.name ?? null}
-                />
-              </div>
-            ) : hasSelection ? (
-              <div className="flex-1 overflow-auto p-4">
-                {selectedBranch && (
-                  <BranchDetail
-                    branch={selectedBranch}
-                    onNavigateToBranch={handleNavigateToBranch}
-                  />
-                )}
-                {selectedStack && (
-                  <StackDetailPanel
-                    stack={selectedStack}
-                    onSelectBranch={handleStackBranchSelect}
-                    selectedBranchName={null}
-                  />
-                )}
-              </div>
-            ) : (
-              <div className="flex-1">
-                <DetailEmptyState />
-              </div>
-            )}
-            {!branchOverlayMode && (
-              <>
-                <Separator />
-                <div className="p-3 overflow-auto">
-                  <EventFeed />
-                </div>
-              </>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
+    <RepoProvider repoId={repoId}>
+      <RepoView />
+    </RepoProvider>
   );
 }

--- a/apps/web/src/components/branch-detail/branch-diff.tsx
+++ b/apps/web/src/components/branch-detail/branch-diff.tsx
@@ -226,6 +226,7 @@ function parseConventionalCommit(message: string): ConventionalCommit | null {
 }
 
 export function BranchDiff({ branchName, revision, commits, onExit }: BranchDiffProps) {
+  const { repoId } = useRepo();
   const [diff, setDiff] = useState<BranchDiffResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -245,7 +246,7 @@ export function BranchDiff({ branchName, revision, commits, onExit }: BranchDiff
       setDiff(null);
     });
 
-    fetchBranchDiff(branchName)
+    fetchBranchDiff(repoId, branchName)
       .then((result) => {
         if (!active) return;
         setDiff(result);
@@ -262,7 +263,7 @@ export function BranchDiff({ branchName, revision, commits, onExit }: BranchDiff
     return () => {
       active = false;
     };
-  }, [branchName, revision]);
+  }, [branchName, revision, repoId]);
 
   const parsed = useMemo(() => {
     if (!diff?.patch.trim()) {

--- a/apps/web/src/components/branch-detail/stack-detail.tsx
+++ b/apps/web/src/components/branch-detail/stack-detail.tsx
@@ -29,7 +29,7 @@ export function StackDetailPanel({
   const status = stackStatusInfo[stack.status] || stackStatusInfo.incomplete;
   const issues = collectIssues(stack.branches);
   const stats = computeStackStats(stack.branches);
-  const { refresh } = useRepo();
+  const { refresh, repoId } = useRepo();
 
   const allHavePRs = stack.branches.every((b) => b.pr != null);
 
@@ -40,7 +40,7 @@ export function StackDetailPanel({
     setSubmitting(true);
     setSubmitResult(null);
     try {
-      const result = await submitStack(stack.rootBranch);
+      const result = await submitStack(repoId, stack.rootBranch);
       setSubmitResult(result);
       refresh();
     } catch (err) {

--- a/apps/web/src/components/providers/repo-provider.tsx
+++ b/apps/web/src/components/providers/repo-provider.tsx
@@ -23,6 +23,7 @@ import { diffViews } from "@/lib/diff-views";
 const MAX_EVENTS = 100;
 
 interface RepoState {
+  repoId: string;
   repo: RepoResponse | null;
   stackDetails: StackDetail[];
   recentlyMerged: TrunkCommitResponse[];
@@ -42,7 +43,7 @@ export function useRepo() {
   return ctx;
 }
 
-export function RepoProvider({ children }: { children: ReactNode }) {
+export function RepoProvider({ repoId, children }: { repoId: string; children: ReactNode }) {
   const [repo, setRepo] = useState<RepoResponse | null>(null);
   const [stackDetails, setStackDetails] = useState<StackDetail[]>([]);
   const [recentlyMerged, setRecentlyMerged] = useState<TrunkCommitResponse[]>([]);
@@ -68,7 +69,7 @@ export function RepoProvider({ children }: { children: ReactNode }) {
 
   const loadData = useCallback(async () => {
     try {
-      const view = await fetchView();
+      const view = await fetchView(repoId);
       setRepo(view.repo);
 
       // TODO: Remove sample stacks — for UI development only
@@ -185,7 +186,7 @@ export function RepoProvider({ children }: { children: ReactNode }) {
     } finally {
       setLoading(false);
     }
-  }, [addEvents]);
+  }, [addEvents, repoId]);
 
   // Initial load
   useEffect(() => {
@@ -197,11 +198,12 @@ export function RepoProvider({ children }: { children: ReactNode }) {
   }, [loadData]);
 
   // SSE updates trigger refresh; server events get added directly
-  useSSE(loadData, addEvent);
+  useSSE(repoId, loadData, addEvent);
 
   return (
     <RepoContext.Provider
       value={{
+        repoId,
         repo,
         stackDetails,
         recentlyMerged,

--- a/apps/web/src/components/repo-picker/__tests__/repo-picker.test.tsx
+++ b/apps/web/src/components/repo-picker/__tests__/repo-picker.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { RepoPicker } from "../repo-picker";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockPush.mockReset();
+});
+
+function mockRepos(data: unknown) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve(data),
+  });
+}
+
+describe("RepoPicker", () => {
+  it("renders a card for every registered repo", async () => {
+    mockRepos({
+      repos: [
+        { id: "stackit", displayName: "Stackit", trunk: "main", currentBranch: "feature/x" },
+        { id: "other", displayName: "Other Project", trunk: "main" },
+      ],
+    });
+
+    render(<RepoPicker />);
+
+    expect(await screen.findByTestId("repo-card-stackit")).toBeDefined();
+    expect(screen.getByTestId("repo-card-other")).toBeDefined();
+    expect(screen.getByText("Stackit")).toBeDefined();
+    expect(screen.getByText("Other Project")).toBeDefined();
+  });
+
+  it("navigates to /{repoId} on click", async () => {
+    mockRepos({
+      repos: [{ id: "stackit", displayName: "Stackit", trunk: "main" }],
+    });
+
+    render(<RepoPicker />);
+
+    const card = await screen.findByTestId("repo-card-stackit");
+    fireEvent.click(card);
+    expect(mockPush).toHaveBeenCalledWith("/stackit");
+  });
+
+  it("shows the empty-state message when no repos are configured", async () => {
+    mockRepos({ repos: [] });
+
+    render(<RepoPicker />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No repositories configured/i)).toBeDefined();
+    });
+  });
+
+  it("renders an error message when the fetch fails", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+
+    render(<RepoPicker />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/API error: 500/)).toBeDefined();
+    });
+  });
+});

--- a/apps/web/src/components/repo-picker/repo-picker.tsx
+++ b/apps/web/src/components/repo-picker/repo-picker.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { fetchRepos, type RepoSummary } from "@/lib/api";
+
+export function RepoPicker() {
+  const router = useRouter();
+  const [repos, setRepos] = useState<RepoSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    fetchRepos()
+      .then((resp) => {
+        if (!active) return;
+        setRepos(resp.repos);
+      })
+      .catch((err) => {
+        if (!active) return;
+        setError(err instanceof Error ? err.message : "Failed to load repos");
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (error) {
+    return (
+      <div className="flex h-screen flex-col items-center justify-center gap-2 text-sm">
+        <p className="text-destructive">{error}</p>
+        <p className="text-muted-foreground">
+          Make sure stackit-server is running on{" "}
+          {process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"}
+        </p>
+      </div>
+    );
+  }
+
+  if (repos === null) {
+    return (
+      <div className="flex h-screen items-center justify-center text-sm text-muted-foreground">
+        Loading repositories…
+      </div>
+    );
+  }
+
+  if (repos.length === 0) {
+    return (
+      <div className="flex h-screen flex-col items-center justify-center gap-2 text-sm">
+        <p className="font-medium">No repositories configured</p>
+        <p className="text-muted-foreground">
+          Pass <code className="rounded bg-muted px-1 py-0.5">-repos-config</code>{" "}
+          when starting the server, or use <code className="rounded bg-muted px-1 py-0.5">-cwd .</code> for single-repo mode.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex min-h-screen max-w-3xl flex-col gap-6 px-6 py-12">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold">Choose a repository</h1>
+        <p className="text-sm text-muted-foreground">
+          Stackit is serving {repos.length}{" "}
+          {repos.length === 1 ? "repository" : "repositories"}.
+        </p>
+      </header>
+
+      <ul className="flex flex-col gap-3" data-testid="repo-list">
+        {repos.map((repo) => (
+          <li key={repo.id}>
+            <button
+              type="button"
+              data-testid={`repo-card-${repo.id}`}
+              onClick={() => router.push(`/${encodeURIComponent(repo.id)}`)}
+              className="block w-full text-left transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
+            >
+              <Card>
+                <CardHeader>
+                  <CardTitle>{repo.displayName || repo.id}</CardTitle>
+                  <CardDescription>
+                    <span className="font-mono">{repo.id}</span>
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="flex gap-4 text-xs text-muted-foreground">
+                  <span>
+                    trunk: <span className="font-mono">{repo.trunk}</span>
+                  </span>
+                  {repo.currentBranch && (
+                    <span>
+                      current: <span className="font-mono">{repo.currentBranch}</span>
+                    </span>
+                  )}
+                </CardContent>
+              </Card>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/components/repo-picker/repo-view.tsx
+++ b/apps/web/src/components/repo-picker/repo-view.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import dynamic from "next/dynamic";
+import { useRepo } from "@/components/providers/repo-provider";
+import { OwnerSwimlane } from "@/components/swimlane/owner-swimlane";
+import { getLastActiveDate } from "@/lib/swimlane-grouping";
+import { BranchDetail } from "@/components/branch-detail/branch-detail";
+import { StackDetailPanel } from "@/components/branch-detail/stack-detail";
+import { DetailEmptyState } from "@/components/branch-detail/detail-empty-state";
+import { EventFeed } from "@/components/layout/event-feed";
+import { Header } from "@/components/layout/header";
+import { Separator } from "@/components/ui/separator";
+import { RecentlyMerged } from "@/components/recently-merged/recently-merged";
+import { BackgroundMesh } from "@/components/ui/background-mesh";
+import { SkeletonSwimlane } from "@/components/ui/skeleton-shimmer";
+import { useUrlSelection } from "@/hooks/use-url-selection";
+import { groupStacksByOwner } from "@/lib/swimlane-grouping";
+
+const BranchDiffWorkspace = dynamic(
+  () =>
+    import("@/components/branch-detail/branch-diff-workspace").then(
+      (m) => m.BranchDiffWorkspace
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        Loading diff workspace...
+      </div>
+    ),
+  }
+);
+
+export function RepoView() {
+  const {
+    repo,
+    stackDetails,
+    loading,
+    error,
+    lastUpdated,
+    refresh,
+  } = useRepo();
+
+  const {
+    selection,
+    selectedBranch,
+    selectedStack,
+    selectedBranchStack,
+    handleSelectBranch,
+    handleClearSelection,
+    handleSelectStack,
+    handleNavigateToBranch,
+    handleStackBranchSelect,
+  } = useUrlSelection(stackDetails);
+
+  const { yourStacks, otherOwners } = useMemo(
+    () => groupStacksByOwner(stackDetails, repo?.currentUser),
+    [stackDetails, repo?.currentUser]
+  );
+
+  const [recentCommitsPreference, setRecentCommitsPreference] = useState(true);
+  const hasSelection = selectedBranch || selectedStack;
+  const showRecentCommits = selectedBranch ? false : recentCommitsPreference;
+  const branchOverlayMode = Boolean(selectedBranch && selectedBranchStack);
+  const stacksAndHistoryContent =
+    stackDetails.length > 0 ? (
+      <div className="flex flex-col justify-end min-h-full">
+        {/* Swimlanes: only this area scrolls horizontally */}
+        <div className="overflow-x-auto">
+          <div className="flex items-end gap-6 p-6 pb-4 min-w-max">
+            {/* Your stacks */}
+            {yourStacks.length > 0 && (
+              <OwnerSwimlane
+                label="You"
+                stacks={yourStacks}
+                selectedBranch={selection?.type === "branch" ? selection.name : null}
+                selectedStack={selection?.type === "stack" ? selection.rootBranch : null}
+                onSelectBranch={handleSelectBranch}
+                onSelectStack={handleSelectStack}
+                compact={branchOverlayMode}
+              />
+            )}
+
+            {/* Teammate swimlanes */}
+            {otherOwners.map(([owner, stacks]) => (
+              <OwnerSwimlane
+                key={owner}
+                label={`@${owner}`}
+                lastActive={getLastActiveDate(stacks)}
+                stacks={stacks}
+                selectedBranch={selection?.type === "branch" ? selection.name : null}
+                selectedStack={selection?.type === "stack" ? selection.rootBranch : null}
+                onSelectBranch={handleSelectBranch}
+                onSelectStack={handleSelectStack}
+                compact={branchOverlayMode}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Trunk line */}
+        <div className="flex items-center gap-2 px-6 pb-2 shrink-0">
+          <div className="flex-1 h-[2px] bg-gradient-to-r from-transparent via-muted-foreground/30 to-muted-foreground/30" />
+          {selectedBranch ? (
+            <span className="text-xs font-mono text-muted-foreground/70 px-2">
+              {repo?.trunk}
+            </span>
+          ) : (
+            <button
+              onClick={() => setRecentCommitsPreference((prev) => !prev)}
+              className="text-xs font-mono text-muted-foreground/70 px-2 hover:text-muted-foreground transition-colors cursor-pointer"
+            >
+              {repo?.trunk}
+            </button>
+          )}
+          <div className="flex-1 h-[2px] bg-gradient-to-l from-transparent via-muted-foreground/30 to-muted-foreground/30" />
+        </div>
+
+        {/* Recent trunk commits */}
+        <div
+          className="grid transition-[grid-template-rows,opacity] duration-300 ease-in-out"
+          style={{
+            gridTemplateRows: showRecentCommits ? "1fr" : "0fr",
+            opacity: showRecentCommits ? 1 : 0,
+          }}
+        >
+          <div className="overflow-hidden">
+            <RecentlyMerged compact={branchOverlayMode} />
+          </div>
+        </div>
+      </div>
+    ) : (
+      <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+        No stacks found
+      </div>
+    );
+
+  if (loading) {
+    return (
+      <>
+        <BackgroundMesh />
+        <SkeletonSwimlane />
+      </>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-screen gap-4">
+        <p className="text-destructive">{error}</p>
+        <p className="text-sm text-muted-foreground">
+          Make sure stackit-web is running on{" "}
+          {process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"}
+        </p>
+        <button
+          onClick={refresh}
+          className="text-sm underline text-muted-foreground hover:text-foreground"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-screen">
+      <BackgroundMesh />
+      <Header repo={repo ?? null} lastUpdated={lastUpdated ?? null} refresh={refresh} />
+
+      {/* Main content: stacks area + detail panel */}
+      <div className="flex flex-1 overflow-hidden">
+        <div className="flex flex-1 flex-col overflow-hidden">
+          {branchOverlayMode && selectedBranch && selectedBranchStack ? (
+            <>
+              <div className="min-h-0 flex-1 overflow-hidden border-b">
+                <BranchDiffWorkspace
+                  branch={selectedBranch}
+                  onExit={handleClearSelection}
+                />
+              </div>
+              <div className="h-[30vh] min-h-[180px] max-h-[340px] overflow-y-auto overflow-x-hidden bg-background/70">
+                {stacksAndHistoryContent}
+              </div>
+            </>
+          ) : (
+            <div className="flex-1 overflow-y-auto overflow-x-hidden">
+              {stacksAndHistoryContent}
+            </div>
+          )}
+        </div>
+
+        {/* Right: detail + event feed panel (always visible) */}
+        <div className="flex shrink-0">
+          <Separator orientation="vertical" />
+          <div className="w-[480px] shrink-0 flex flex-col overflow-hidden">
+            {branchOverlayMode && selectedBranchStack ? (
+              <div className="flex-1 overflow-auto p-4">
+                <StackDetailPanel
+                  stack={selectedBranchStack}
+                  onSelectBranch={handleStackBranchSelect}
+                  selectedBranchName={selectedBranch?.name ?? null}
+                />
+              </div>
+            ) : hasSelection ? (
+              <div className="flex-1 overflow-auto p-4">
+                {selectedBranch && (
+                  <BranchDetail
+                    branch={selectedBranch}
+                    onNavigateToBranch={handleNavigateToBranch}
+                  />
+                )}
+                {selectedStack && (
+                  <StackDetailPanel
+                    stack={selectedStack}
+                    onSelectBranch={handleStackBranchSelect}
+                    selectedBranchName={null}
+                  />
+                )}
+              </div>
+            ) : (
+              <div className="flex-1">
+                <DetailEmptyState />
+              </div>
+            )}
+            {!branchOverlayMode && (
+              <>
+                <Separator />
+                <div className="p-3 overflow-auto">
+                  <EventFeed />
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/__tests__/api.test.ts
+++ b/apps/web/src/lib/__tests__/api.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   fetchView,
   fetchRepo,
+  fetchRepos,
   fetchStacks,
   fetchStack,
   fetchBranch,
@@ -30,43 +31,61 @@ function mockError(status: number, statusText: string) {
   });
 }
 
+describe("fetchRepos", () => {
+  it("fetches the unscoped repos index", async () => {
+    const data = { repos: [{ id: "stackit", displayName: "Stackit", trunk: "main" }] };
+    mockOk(data);
+
+    const result = await fetchRepos();
+    expect(result).toEqual(data);
+    expect(mockFetch).toHaveBeenCalledWith("http://localhost:8080/api/v1/repos");
+  });
+});
+
 describe("fetchView", () => {
-  it("fetches from /api/view", async () => {
+  it("scopes to repoId", async () => {
     const data = { repo: {}, stacks: [] };
     mockOk(data);
 
-    const result = await fetchView();
+    const result = await fetchView("stackit");
     expect(result).toEqual(data);
-    expect(mockFetch).toHaveBeenCalledWith("http://localhost:8080/api/view");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/api/v1/repos/stackit/view"
+    );
   });
 });
 
 describe("fetchRepo", () => {
-  it("fetches from /api/repo", async () => {
+  it("scopes to repoId", async () => {
     const data = { owner: "test", repo: "repo", trunk: "main", currentBranch: "main", remote: "origin" };
     mockOk(data);
 
-    const result = await fetchRepo();
+    const result = await fetchRepo("stackit");
     expect(result).toEqual(data);
-    expect(mockFetch).toHaveBeenCalledWith("http://localhost:8080/api/repo");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/api/v1/repos/stackit/repo"
+    );
   });
 });
 
 describe("fetchStacks", () => {
-  it("fetches from /api/stacks", async () => {
+  it("scopes to repoId", async () => {
     mockOk([]);
-    const result = await fetchStacks();
+    const result = await fetchStacks("stackit");
     expect(result).toEqual([]);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:8080/api/v1/repos/stackit/stacks"
+    );
   });
 });
 
 describe("fetchStack", () => {
-  it("encodes branch name in URL", async () => {
+  it("encodes both repoId and branch name in URL", async () => {
     mockOk({ rootBranch: "feat/foo", branches: [] });
 
-    await fetchStack("feat/foo");
+    await fetchStack("stackit", "feat/foo");
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/stacks/feat%2Ffoo"
+      "http://localhost:8080/api/v1/repos/stackit/stacks/feat%2Ffoo"
     );
   });
 });
@@ -75,9 +94,9 @@ describe("fetchBranch", () => {
   it("encodes branch name in URL", async () => {
     mockOk({ name: "feat/bar" });
 
-    await fetchBranch("feat/bar");
+    await fetchBranch("stackit", "feat/bar");
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/branches/feat%2Fbar"
+      "http://localhost:8080/api/v1/repos/stackit/branches/feat%2Fbar"
     );
   });
 });
@@ -86,9 +105,9 @@ describe("fetchBranchDiff", () => {
   it("sends encoded branch name in query string", async () => {
     mockOk({ branch: "feat/bar", baseRevision: "abc", headRevision: "def", patch: "" });
 
-    await fetchBranchDiff("feat/bar");
+    await fetchBranchDiff("stackit", "feat/bar");
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/branch-diff?branch=feat%2Fbar"
+      "http://localhost:8080/api/v1/repos/stackit/branch-diff?branch=feat%2Fbar"
     );
   });
 });
@@ -97,12 +116,12 @@ describe("error handling", () => {
   it("throws on non-ok response", async () => {
     mockError(404, "Not Found");
 
-    await expect(fetchRepo()).rejects.toThrow("API error: 404 Not Found");
+    await expect(fetchRepo("stackit")).rejects.toThrow("API error: 404 Not Found");
   });
 
   it("throws on 500 response", async () => {
     mockError(500, "Internal Server Error");
 
-    await expect(fetchView()).rejects.toThrow("API error: 500 Internal Server Error");
+    await expect(fetchView("stackit")).rejects.toThrow("API error: 500 Internal Server Error");
   });
 });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -13,6 +13,17 @@ export interface RepoResponse {
   currentUser?: string;
 }
 
+export interface RepoSummary {
+  id: string;
+  displayName: string;
+  trunk: string;
+  currentBranch?: string;
+}
+
+export interface ReposListResponse {
+  repos: RepoSummary[];
+}
+
 export interface StackSummary {
   rootBranch: string;
   title: string;
@@ -125,35 +136,41 @@ async function fetchAPI<T>(path: string): Promise<T> {
   return res.json();
 }
 
-export function fetchView(): Promise<ViewResponse> {
-  return fetchAPI<ViewResponse>("/api/view");
+function repoPath(repoId: string, suffix: string): string {
+  return `/api/v1/repos/${encodeURIComponent(repoId)}/${suffix}`;
 }
 
-export function fetchRepo(): Promise<RepoResponse> {
-  return fetchAPI<RepoResponse>("/api/repo");
+export function fetchRepos(): Promise<ReposListResponse> {
+  return fetchAPI<ReposListResponse>("/api/v1/repos");
 }
 
-export function fetchStacks(): Promise<StackSummary[]> {
-  return fetchAPI<StackSummary[]>("/api/stacks");
+export function fetchView(repoId: string): Promise<ViewResponse> {
+  return fetchAPI<ViewResponse>(repoPath(repoId, "view"));
 }
 
-export function fetchStack(rootBranch: string): Promise<StackDetail> {
-  return fetchAPI<StackDetail>(`/api/stacks/${encodeURIComponent(rootBranch)}`);
+export function fetchRepo(repoId: string): Promise<RepoResponse> {
+  return fetchAPI<RepoResponse>(repoPath(repoId, "repo"));
 }
 
-export function fetchBranches(): Promise<BranchResponse[]> {
-  return fetchAPI<BranchResponse[]>("/api/branches");
+export function fetchStacks(repoId: string): Promise<StackSummary[]> {
+  return fetchAPI<StackSummary[]>(repoPath(repoId, "stacks"));
 }
 
-export function fetchBranch(name: string): Promise<BranchResponse> {
-  return fetchAPI<BranchResponse>(
-    `/api/branches/${encodeURIComponent(name)}`
-  );
+export function fetchStack(repoId: string, rootBranch: string): Promise<StackDetail> {
+  return fetchAPI<StackDetail>(repoPath(repoId, `stacks/${encodeURIComponent(rootBranch)}`));
 }
 
-export function fetchBranchDiff(name: string): Promise<BranchDiffResponse> {
+export function fetchBranches(repoId: string): Promise<BranchResponse[]> {
+  return fetchAPI<BranchResponse[]>(repoPath(repoId, "branches"));
+}
+
+export function fetchBranch(repoId: string, name: string): Promise<BranchResponse> {
+  return fetchAPI<BranchResponse>(repoPath(repoId, `branches/${encodeURIComponent(name)}`));
+}
+
+export function fetchBranchDiff(repoId: string, name: string): Promise<BranchDiffResponse> {
   return fetchAPI<BranchDiffResponse>(
-    `/api/branch-diff?branch=${encodeURIComponent(name)}`
+    repoPath(repoId, `branch-diff?branch=${encodeURIComponent(name)}`)
   );
 }
 
@@ -195,9 +212,9 @@ export interface SubmitResponse {
 
 // --- Mutation Functions ---
 
-export async function submitStack(rootBranch: string): Promise<SubmitResponse> {
+export async function submitStack(repoId: string, rootBranch: string): Promise<SubmitResponse> {
   const res = await fetch(
-    `${API_BASE}/api/submit/${encodeURIComponent(rootBranch)}`,
+    `${API_BASE}${repoPath(repoId, `stacks/${encodeURIComponent(rootBranch)}/submit`)}`,
     { method: "POST" }
   );
   const data: SubmitResponse = await res.json();

--- a/apps/web/src/lib/use-sse.ts
+++ b/apps/web/src/lib/use-sse.ts
@@ -8,11 +8,12 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 type SSECallback = () => void;
 
 /**
- * Hook that connects to the SSE event stream and calls onUpdate
- * whenever stack refresh events are received.
+ * Connects to the per-repo SSE event stream and calls onUpdate whenever
+ * the server signals that the repo's view should be refetched.
  * Optionally calls onEvent for server-sourced feed events.
  */
 export function useSSE(
+  repoId: string,
   onUpdate: SSECallback,
   onEvent?: (event: FeedEvent) => void
 ) {
@@ -22,7 +23,8 @@ export function useSSE(
   });
 
   useEffect(() => {
-    const eventSource = new EventSource(`${API_BASE}/api/events`);
+    const url = `${API_BASE}/api/v1/repos/${encodeURIComponent(repoId)}/events`;
+    const eventSource = new EventSource(url);
 
     eventSource.addEventListener("stacks_updated", () => {
       handleUpdate();
@@ -58,5 +60,5 @@ export function useSSE(
     return () => {
       eventSource.close();
     };
-  }, []);
+  }, [repoId]);
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Adds a repo picker as the root page and threads a repoId through the
provider, SSE hook, and every fetch function so the UI can switch
between repositories served by the same backend.

Routing approach: a single root page reads window pathname via
usePathname(). "/" renders RepoPicker (lists registered repos from
GET /api/v1/repos); "/<repoId>" wraps RepoView (the existing Home
component) in a RepoProvider scoped to that repo. This avoids Next's
output=export limitation around dynamic route segments
(generateStaticParams can't enumerate runtime-configured repos) while
the existing Go static handler's SPA fallback to root index.html lets
client-side routing serve any /<repoId> URL.

RepoProvider now takes a repoId prop and exposes it on the context;
useSSE accepts repoId and subscribes to /api/v1/repos/{repoId}/events.
Every api.ts function gains a repoId first argument and constructs
URLs from /api/v1/repos/{repoId}/.... A new fetchRepos() backs the
picker.

Tests: api.test.ts asserts each function hits the scoped URL; a new
repo-picker.test.tsx covers list rendering, navigation, empty state,
and the error path.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #975**
  * **PR #976**
    * **PR #977**
      * **PR #978**
        * **PR #979**
          * **PR #980**
            * **PR #981** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1005*