### PR TITLE
perf: cache worktree list during branch cleanup

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -351,11 +351,18 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 		// Sort for deterministic deletion order (helps with debugging and reproducibility)
 		sort.Strings(batchNames)
 
+		// Snapshot the branch→worktree map once for this batch instead of
+		// re-running `git worktree list --porcelain` per branch.
+		worktreeByBranch, err := eng.Git().WorktreeBranchMap(c)
+		if err != nil {
+			out.Debug("Failed to list worktrees for branch cleanup: %v", err)
+			worktreeByBranch = map[string]string{}
+		}
+
 		// Remove any worktrees that have these branches checked out
 		var failedWorktreeRemovals []string
 		for _, name := range batchNames {
-			_, err := removeWorktreeIfCheckedOut(c, name, eng, out)
-			if err != nil {
+			if _, err := removeWorktreeIfCheckedOut(c, name, worktreeByBranch, eng, out); err != nil {
 				out.Warn("Could not remove worktree for branch %s: %v", name, err)
 				failedWorktreeRemovals = append(failedWorktreeRemovals, name)
 			}
@@ -568,19 +575,14 @@ func applyReparent(ctx context.Context, eng engine.Engine, branch engine.Branch,
 // removeWorktreeIfCheckedOut removes the worktree if the branch is checked out in one.
 // Returns the worktree path that was removed (or empty string if none), and any error.
 //
+// The caller passes a precomputed branch→worktree map so we don't re-invoke
+// `git worktree list` per branch when cleaning a batch.
+//
 // Error handling strategy:
-//   - Errors when *checking* if a branch is in a worktree are swallowed (return nil error)
-//     because we don't want to block branch deletion if we can't determine worktree status.
 //   - Errors when *removing* a worktree are returned because they indicate a real problem
 //     that would prevent the branch from being deleted cleanly.
-func removeWorktreeIfCheckedOut(ctx context.Context, branchName string, eng engine.Engine, out output.Output) (string, error) {
-	worktreePath, err := eng.Git().GetWorktreePathForBranch(ctx, branchName)
-	if err != nil {
-		// Swallow error: don't block deletion if we can't check worktree status
-		out.Debug("Failed to check worktree for branch %s: %v", branchName, err)
-		return "", nil
-	}
-
+func removeWorktreeIfCheckedOut(ctx context.Context, branchName string, worktreeByBranch map[string]string, eng engine.Engine, out output.Output) (string, error) {
+	worktreePath := worktreeByBranch[branchName]
 	if worktreePath == "" {
 		return "", nil // Branch not in any worktree
 	}

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -465,6 +465,10 @@ func (d *demoGitRunner) GetWorktreePathForBranch(_ context.Context, _ string) (s
 	return "", nil
 }
 
+func (d *demoGitRunner) WorktreeBranchMap(_ context.Context) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
 func (d *demoGitRunner) GetWorktreeCurrentBranch(_ context.Context, _ string) (string, error) {
 	return "", nil
 }

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -197,6 +197,7 @@ type WorktreeOperations interface {
 	ListWorktrees(ctx context.Context) ([]string, error)
 	PruneWorktrees(ctx context.Context) error
 	GetWorktreePathForBranch(ctx context.Context, branchName string) (string, error)
+	WorktreeBranchMap(ctx context.Context) (map[string]string, error)
 	GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error)
 	ResetWorktreeWorkingDir(ctx context.Context, worktreePath string) error
 	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -894,6 +894,13 @@ func (t *tracingRunner) GetWorktreePathForBranch(ctx context.Context, branchName
 	return result, err
 }
 
+func (t *tracingRunner) WorktreeBranchMap(ctx context.Context) (map[string]string, error) {
+	start := time.Now()
+	result, err := t.inner.WorktreeBranchMap(ctx)
+	t.trace("WorktreeBranchMap", time.Since(start), err == nil, err, slog.Int("count", len(result)))
+	return result, err
+}
+
 func (t *tracingRunner) GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error) {
 	start := time.Now()
 	result, err := t.inner.GetWorktreeCurrentBranch(ctx, worktreePath)

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -183,6 +183,35 @@ func (r *runner) GetWorktreePathForBranch(ctx context.Context, branchName string
 	return "", nil
 }
 
+// WorktreeBranchMap returns a map of branch name to worktree path for every
+// branch currently checked out in any worktree. Use this instead of looping
+// GetWorktreePathForBranch when you need to test many branches — one git
+// subprocess instead of N.
+func (r *runner) WorktreeBranchMap(ctx context.Context) (map[string]string, error) {
+	output, err := r.RunGitCommandWithContext(ctx, "worktree", "list", "--porcelain")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list worktrees: %w", err)
+	}
+
+	result := make(map[string]string)
+	if output == "" {
+		return result, nil
+	}
+
+	var currentWorktree string
+	for line := range strings.SplitSeq(output, "\n") {
+		if after, ok := strings.CutPrefix(line, "worktree "); ok {
+			currentWorktree = after
+		} else if after, ok := strings.CutPrefix(line, "branch "); ok {
+			if currentWorktree != "" {
+				branchName := strings.TrimPrefix(after, "refs/heads/")
+				result[branchName] = currentWorktree
+			}
+		}
+	}
+	return result, nil
+}
+
 // ResetWorktreeWorkingDir resets a worktree's working directory to match HEAD.
 // This is used after updating a branch ref to sync the worktree's working directory.
 func (r *runner) ResetWorktreeWorkingDir(ctx context.Context, worktreePath string) error {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

executeDeletions called git worktree list --porcelain once per branch via
removeWorktreeIfCheckedOut, even when no worktrees existed. For a sync that
cleans N branches that's N identical subprocess invocations.

Add Runner.WorktreeBranchMap that parses the porcelain output once into a
branchName->worktreePath map, snapshot it once per cleanup batch, and look up
each branch in-memory. The per-branch git call disappears entirely.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #984** 👈
  * **PR #985**
    * **PR #986**
      * **PR #987**
        * **PR #988**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #989*