### PR TITLE
refactor: model worktree list as a typed WorktreeList

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -351,18 +351,18 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 		// Sort for deterministic deletion order (helps with debugging and reproducibility)
 		sort.Strings(batchNames)
 
-		// Snapshot the branch→worktree map once for this batch instead of
+		// Snapshot the worktree list once for this batch instead of
 		// re-running `git worktree list --porcelain` per branch.
-		worktreeByBranch, err := eng.Git().WorktreeBranchMap(c)
+		worktrees, err := eng.Git().ListWorktrees(c)
 		if err != nil {
 			out.Debug("Failed to list worktrees for branch cleanup: %v", err)
-			worktreeByBranch = map[string]string{}
+			worktrees = git.WorktreeList{}
 		}
 
 		// Remove any worktrees that have these branches checked out
 		var failedWorktreeRemovals []string
 		for _, name := range batchNames {
-			if _, err := removeWorktreeIfCheckedOut(c, name, worktreeByBranch, eng, out); err != nil {
+			if _, err := removeWorktreeIfCheckedOut(c, name, worktrees, eng, out); err != nil {
 				out.Warn("Could not remove worktree for branch %s: %v", name, err)
 				failedWorktreeRemovals = append(failedWorktreeRemovals, name)
 			}
@@ -575,14 +575,14 @@ func applyReparent(ctx context.Context, eng engine.Engine, branch engine.Branch,
 // removeWorktreeIfCheckedOut removes the worktree if the branch is checked out in one.
 // Returns the worktree path that was removed (or empty string if none), and any error.
 //
-// The caller passes a precomputed branch→worktree map so we don't re-invoke
+// The caller passes a precomputed WorktreeList so we don't re-invoke
 // `git worktree list` per branch when cleaning a batch.
 //
 // Error handling strategy:
 //   - Errors when *removing* a worktree are returned because they indicate a real problem
 //     that would prevent the branch from being deleted cleanly.
-func removeWorktreeIfCheckedOut(ctx context.Context, branchName string, worktreeByBranch map[string]string, eng engine.Engine, out output.Output) (string, error) {
-	worktreePath := worktreeByBranch[branchName]
+func removeWorktreeIfCheckedOut(ctx context.Context, branchName string, worktrees git.WorktreeList, eng engine.Engine, out output.Output) (string, error) {
+	worktreePath := worktrees.PathForBranch(branchName)
 	if worktreePath == "" {
 		return "", nil // Branch not in any worktree
 	}

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -453,8 +453,8 @@ func (d *demoGitRunner) ForceRemoveWorktree(_ context.Context, _ string) error {
 	return nil
 }
 
-func (d *demoGitRunner) ListWorktrees(_ context.Context) ([]string, error) {
-	return []string{}, nil
+func (d *demoGitRunner) ListWorktrees(_ context.Context) (git.WorktreeList, error) {
+	return git.WorktreeList{}, nil
 }
 
 func (d *demoGitRunner) PruneWorktrees(_ context.Context) error {
@@ -463,10 +463,6 @@ func (d *demoGitRunner) PruneWorktrees(_ context.Context) error {
 
 func (d *demoGitRunner) GetWorktreePathForBranch(_ context.Context, _ string) (string, error) {
 	return "", nil
-}
-
-func (d *demoGitRunner) WorktreeBranchMap(_ context.Context) (map[string]string, error) {
-	return map[string]string{}, nil
 }
 
 func (d *demoGitRunner) GetWorktreeCurrentBranch(_ context.Context, _ string) (string, error) {

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -106,8 +106,8 @@ func (e *engineImpl) GetChangedFiles(ctx context.Context, base, head string) ([]
 	return e.git.GetChangedFiles(ctx, base, head)
 }
 
-// ListWorktrees returns a list of worktree paths
-func (e *engineImpl) ListWorktrees(ctx context.Context) ([]string, error) {
+// ListWorktrees returns every working tree registered with the repo.
+func (e *engineImpl) ListWorktrees(ctx context.Context) (git.WorktreeList, error) {
 	return e.git.ListWorktrees(ctx)
 }
 

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -101,7 +101,7 @@ type WorkingTree interface {
 	GetCommitTemplate(ctx context.Context) (string, error)
 	GetUnmergedFiles(ctx context.Context) ([]string, error)
 	ParseStagedHunks(ctx context.Context) ([]git.Hunk, error)
-	ListWorktrees(ctx context.Context) ([]string, error)
+	ListWorktrees(ctx context.Context) (git.WorktreeList, error)
 	IsRebaseInProgress(ctx context.Context) bool
 	GetRebaseHead() (string, error)
 	HasUncommittedChanges(ctx context.Context) bool

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -194,10 +194,9 @@ type WorktreeOperations interface {
 	AddWorktreeWithOptions(ctx context.Context, path string, branch string, detach bool, noCheckout bool) error
 	RemoveWorktree(ctx context.Context, path string) error
 	ForceRemoveWorktree(ctx context.Context, path string) error
-	ListWorktrees(ctx context.Context) ([]string, error)
+	ListWorktrees(ctx context.Context) (WorktreeList, error)
 	PruneWorktrees(ctx context.Context) error
 	GetWorktreePathForBranch(ctx context.Context, branchName string) (string, error)
-	WorktreeBranchMap(ctx context.Context) (map[string]string, error)
 	GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error)
 	ResetWorktreeWorkingDir(ctx context.Context, worktreePath string) error
 	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -873,10 +873,10 @@ func (t *tracingRunner) ForceRemoveWorktree(ctx context.Context, path string) er
 	return err
 }
 
-func (t *tracingRunner) ListWorktrees(ctx context.Context) ([]string, error) {
+func (t *tracingRunner) ListWorktrees(ctx context.Context) (WorktreeList, error) {
 	start := time.Now()
 	result, err := t.inner.ListWorktrees(ctx)
-	t.trace("ListWorktrees", time.Since(start), err == nil, err)
+	t.trace("ListWorktrees", time.Since(start), err == nil, err, slog.Int("count", len(result)))
 	return result, err
 }
 
@@ -891,13 +891,6 @@ func (t *tracingRunner) GetWorktreePathForBranch(ctx context.Context, branchName
 	start := time.Now()
 	result, err := t.inner.GetWorktreePathForBranch(ctx, branchName)
 	t.trace("GetWorktreePathForBranch", time.Since(start), err == nil, err, slog.String("branch", branchName))
-	return result, err
-}
-
-func (t *tracingRunner) WorktreeBranchMap(ctx context.Context) (map[string]string, error) {
-	start := time.Now()
-	result, err := t.inner.WorktreeBranchMap(ctx)
-	t.trace("WorktreeBranchMap", time.Since(start), err == nil, err, slog.Int("count", len(result)))
 	return result, err
 }
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -11,6 +11,37 @@ import (
 // WorktreeRefPrefix is the prefix for Git refs where worktree metadata is stored (local-only)
 const WorktreeRefPrefix = "refs/stackit/worktrees/"
 
+// Worktree represents a single entry from `git worktree list`.
+type Worktree struct {
+	Path   string
+	Branch string // empty when the worktree is at detached HEAD
+}
+
+// WorktreeList is the parsed result of one `git worktree list --porcelain`
+// invocation. Callers should pass it down per-batch instead of calling
+// ListWorktrees per branch — see PathForBranch for the common lookup.
+type WorktreeList []Worktree
+
+// PathForBranch returns the worktree path where branchName is checked out,
+// or "" if no worktree currently has it.
+func (l WorktreeList) PathForBranch(branchName string) string {
+	for _, w := range l {
+		if w.Branch == branchName {
+			return w.Path
+		}
+	}
+	return ""
+}
+
+// Paths returns just the worktree paths.
+func (l WorktreeList) Paths() []string {
+	out := make([]string, len(l))
+	for i, w := range l {
+		out[i] = w.Path
+	}
+	return out
+}
+
 // WorktreeMeta represents worktree tracking metadata stored in local Git refs
 type WorktreeMeta struct {
 	Name         string    `json:"name,omitempty"` // User-provided name for display (new worktrees only)
@@ -61,24 +92,41 @@ func (r *runner) ForceRemoveWorktree(ctx context.Context, path string) error {
 	return nil
 }
 
-func (r *runner) ListWorktrees(ctx context.Context) ([]string, error) {
+// ListWorktrees returns every working tree registered with the repo,
+// including the branch (if any) checked out in each. Callers needing to look
+// up many branches should call this once and reuse the result rather than
+// invoking git per branch — see WorktreeList.PathForBranch.
+func (r *runner) ListWorktrees(ctx context.Context) (WorktreeList, error) {
 	output, err := r.RunGitCommandWithContext(ctx, "worktree", "list", "--porcelain")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list worktrees: %w", err)
 	}
 
 	if output == "" {
-		return []string{}, nil
+		return WorktreeList{}, nil
 	}
 
-	lines := strings.Split(strings.TrimSpace(output), "\n")
-	var worktrees []string
-	for _, line := range lines {
-		if len(line) > 9 && line[:9] == "worktree " {
-			worktrees = append(worktrees, line[9:])
+	var result WorktreeList
+	var current Worktree
+	flush := func() {
+		if current.Path != "" {
+			result = append(result, current)
+		}
+		current = Worktree{}
+	}
+	for line := range strings.SplitSeq(output, "\n") {
+		switch {
+		case line == "":
+			flush()
+		case strings.HasPrefix(line, "worktree "):
+			flush()
+			current.Path = strings.TrimPrefix(line, "worktree ")
+		case strings.HasPrefix(line, "branch "):
+			current.Branch = strings.TrimPrefix(strings.TrimPrefix(line, "branch "), "refs/heads/")
 		}
 	}
-	return worktrees, nil
+	flush()
+	return result, nil
 }
 
 // PruneWorktrees removes stale worktree entries from .git/worktrees.
@@ -181,35 +229,6 @@ func (r *runner) GetWorktreePathForBranch(ctx context.Context, branchName string
 	}
 
 	return "", nil
-}
-
-// WorktreeBranchMap returns a map of branch name to worktree path for every
-// branch currently checked out in any worktree. Use this instead of looping
-// GetWorktreePathForBranch when you need to test many branches — one git
-// subprocess instead of N.
-func (r *runner) WorktreeBranchMap(ctx context.Context) (map[string]string, error) {
-	output, err := r.RunGitCommandWithContext(ctx, "worktree", "list", "--porcelain")
-	if err != nil {
-		return nil, fmt.Errorf("failed to list worktrees: %w", err)
-	}
-
-	result := make(map[string]string)
-	if output == "" {
-		return result, nil
-	}
-
-	var currentWorktree string
-	for line := range strings.SplitSeq(output, "\n") {
-		if after, ok := strings.CutPrefix(line, "worktree "); ok {
-			currentWorktree = after
-		} else if after, ok := strings.CutPrefix(line, "branch "); ok {
-			if currentWorktree != "" {
-				branchName := strings.TrimPrefix(after, "refs/heads/")
-				result[branchName] = currentWorktree
-			}
-		}
-	}
-	return result, nil
 }
 
 // ResetWorktreeWorkingDir resets a worktree's working directory to match HEAD.

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -40,7 +40,7 @@ func TestWorktree(t *testing.T) {
 		// List worktrees
 		worktrees, err := runner.ListWorktrees(context.Background())
 		require.NoError(t, err)
-		require.Contains(t, worktrees, worktreePath)
+		require.Contains(t, worktrees.Paths(), worktreePath)
 
 		// Remove worktree
 		err = runner.RemoveWorktree(context.Background(), worktreePath)
@@ -49,7 +49,7 @@ func TestWorktree(t *testing.T) {
 		// Verify worktree is gone from list
 		worktrees, err = runner.ListWorktrees(context.Background())
 		require.NoError(t, err)
-		require.NotContains(t, worktrees, worktreePath)
+		require.NotContains(t, worktrees.Paths(), worktreePath)
 	})
 
 	t.Run("add detached worktree", func(t *testing.T) {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Replace ListWorktrees's []string result and the redundant WorktreeBranchMap
helper with a single ListWorktrees that returns a typed WorktreeList.

WorktreeList is []Worktree (Path + Branch). It exposes PathForBranch for the
lookup-many-branches use case (the original WorktreeBranchMap consumer in
branch cleanup) and Paths for the simple paths-only callers (existing test).
One parse of `git worktree list --porcelain` now covers both shapes of
lookup, and the runner interface drops a method.

No behavior change — this is a type/API shape refactor to set up further
callers (restack, merge) that can also amortize the worktree list per batch.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1779760625`.


* **PR #984**
  * **PR #985**
    * **PR #986** 👈
      * **PR #987**
        * **PR #988**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->