### PR TITLE
Merging 5 PRs

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -351,11 +351,18 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 		// Sort for deterministic deletion order (helps with debugging and reproducibility)
 		sort.Strings(batchNames)
 
+		// Snapshot the branch→worktree map once for this batch instead of
+		// re-running `git worktree list --porcelain` per branch.
+		worktreeByBranch, err := eng.Git().WorktreeBranchMap(c)
+		if err != nil {
+			out.Debug("Failed to list worktrees for branch cleanup: %v", err)
+			worktreeByBranch = map[string]string{}
+		}
+
 		// Remove any worktrees that have these branches checked out
 		var failedWorktreeRemovals []string
 		for _, name := range batchNames {
-			_, err := removeWorktreeIfCheckedOut(c, name, eng, out)
-			if err != nil {
+			if _, err := removeWorktreeIfCheckedOut(c, name, worktreeByBranch, eng, out); err != nil {
 				out.Warn("Could not remove worktree for branch %s: %v", name, err)
 				failedWorktreeRemovals = append(failedWorktreeRemovals, name)
 			}
@@ -568,19 +575,14 @@ func applyReparent(ctx context.Context, eng engine.Engine, branch engine.Branch,
 // removeWorktreeIfCheckedOut removes the worktree if the branch is checked out in one.
 // Returns the worktree path that was removed (or empty string if none), and any error.
 //
+// The caller passes a precomputed branch→worktree map so we don't re-invoke
+// `git worktree list` per branch when cleaning a batch.
+//
 // Error handling strategy:
-//   - Errors when *checking* if a branch is in a worktree are swallowed (return nil error)
-//     because we don't want to block branch deletion if we can't determine worktree status.
 //   - Errors when *removing* a worktree are returned because they indicate a real problem
 //     that would prevent the branch from being deleted cleanly.
-func removeWorktreeIfCheckedOut(ctx context.Context, branchName string, eng engine.Engine, out output.Output) (string, error) {
-	worktreePath, err := eng.Git().GetWorktreePathForBranch(ctx, branchName)
-	if err != nil {
-		// Swallow error: don't block deletion if we can't check worktree status
-		out.Debug("Failed to check worktree for branch %s: %v", branchName, err)
-		return "", nil
-	}
-
+func removeWorktreeIfCheckedOut(ctx context.Context, branchName string, worktreeByBranch map[string]string, eng engine.Engine, out output.Output) (string, error) {
+	worktreePath := worktreeByBranch[branchName]
 	if worktreePath == "" {
 		return "", nil // Branch not in any worktree
 	}

--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -351,18 +351,18 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 		// Sort for deterministic deletion order (helps with debugging and reproducibility)
 		sort.Strings(batchNames)
 
-		// Snapshot the branch→worktree map once for this batch instead of
+		// Snapshot the worktree list once for this batch instead of
 		// re-running `git worktree list --porcelain` per branch.
-		worktreeByBranch, err := eng.Git().WorktreeBranchMap(c)
+		worktrees, err := eng.Git().ListWorktrees(c)
 		if err != nil {
 			out.Debug("Failed to list worktrees for branch cleanup: %v", err)
-			worktreeByBranch = map[string]string{}
+			worktrees = git.WorktreeList{}
 		}
 
 		// Remove any worktrees that have these branches checked out
 		var failedWorktreeRemovals []string
 		for _, name := range batchNames {
-			if _, err := removeWorktreeIfCheckedOut(c, name, worktreeByBranch, eng, out); err != nil {
+			if _, err := removeWorktreeIfCheckedOut(c, name, worktrees, eng, out); err != nil {
 				out.Warn("Could not remove worktree for branch %s: %v", name, err)
 				failedWorktreeRemovals = append(failedWorktreeRemovals, name)
 			}
@@ -575,14 +575,14 @@ func applyReparent(ctx context.Context, eng engine.Engine, branch engine.Branch,
 // removeWorktreeIfCheckedOut removes the worktree if the branch is checked out in one.
 // Returns the worktree path that was removed (or empty string if none), and any error.
 //
-// The caller passes a precomputed branch→worktree map so we don't re-invoke
+// The caller passes a precomputed WorktreeList so we don't re-invoke
 // `git worktree list` per branch when cleaning a batch.
 //
 // Error handling strategy:
 //   - Errors when *removing* a worktree are returned because they indicate a real problem
 //     that would prevent the branch from being deleted cleanly.
-func removeWorktreeIfCheckedOut(ctx context.Context, branchName string, worktreeByBranch map[string]string, eng engine.Engine, out output.Output) (string, error) {
-	worktreePath := worktreeByBranch[branchName]
+func removeWorktreeIfCheckedOut(ctx context.Context, branchName string, worktrees git.WorktreeList, eng engine.Engine, out output.Output) (string, error) {
+	worktreePath := worktrees.PathForBranch(branchName)
 	if worktreePath == "" {
 		return "", nil // Branch not in any worktree
 	}

--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -197,6 +197,17 @@ func Execute(ctx *app.Context, eng mergeExecuteEngine, opts ExecuteOptions) erro
 func executeSteps(ctx *app.Context, eng mergeExecuteEngine, opts ExecuteOptions) error {
 	plan := opts.Plan
 
+	// Snapshot the worktree list once for the whole merge plan. A multi-branch
+	// merge with several StepDeleteBranch steps used to spawn `git worktree
+	// list` per step via removeWorktreeForBranch; the snapshot covers every
+	// step in this run. Safe to reuse: deleting a branch can only invalidate
+	// its own entry, and we only ever read each entry once.
+	worktrees, err := eng.Git().ListWorktrees(ctx.Context)
+	if err != nil {
+		ctx.Output.Debug("Failed to list worktrees for merge plan: %v", err)
+		worktrees = git.WorktreeList{}
+	}
+
 	for i, step := range plan.Steps {
 		stepRef := &plan.Steps[i]
 
@@ -222,7 +233,7 @@ func executeSteps(ctx *app.Context, eng mergeExecuteEngine, opts ExecuteOptions)
 		}
 
 		// 2. Execute the step (with progress reporting for wait steps)
-		if err := executeStepWithProgress(ctx, step, i, eng, opts); err != nil {
+		if err := executeStepWithProgress(ctx, step, i, eng, opts, worktrees); err != nil {
 			ctx.Output.Debug("Step %d (%s) failed: %v", i+1, step.Description, err)
 			opts.Handler.EmitEvent(Event{
 				Phase:     phaseFromStep(stepRef),
@@ -247,16 +258,16 @@ func executeSteps(ctx *app.Context, eng mergeExecuteEngine, opts ExecuteOptions)
 }
 
 // executeStepWithProgress executes a step with progress reporting
-func executeStepWithProgress(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecuteEngine, opts ExecuteOptions) error {
+func executeStepWithProgress(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecuteEngine, opts ExecuteOptions, worktrees git.WorktreeList) error {
 	// Special handling for wait steps to report progress
 	if step.StepType == StepWaitCI {
 		return executeWaitCIWithProgress(ctx, step, stepIndex, eng, opts)
 	}
-	return executeStep(ctx, step, stepIndex, eng, opts)
+	return executeStep(ctx, step, stepIndex, eng, opts, worktrees)
 }
 
 // executeStep executes a single step
-func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecuteEngine, opts ExecuteOptions) error {
+func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecuteEngine, opts ExecuteOptions, worktrees git.WorktreeList) error {
 	trunk := eng.Trunk() // Cache trunk for this function scope
 	githubClient := ctx.GitHub()
 	out := ctx.Output
@@ -380,7 +391,7 @@ func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecut
 		if branch.IsTracked() {
 			// Check if branch is checked out in a worktree and remove it first
 			// Git refuses to delete a branch that is checked out in any worktree
-			if err := removeWorktreeForBranch(ctx.Context, step.BranchName, eng, out); err != nil {
+			if err := removeWorktreeForBranch(ctx.Context, step.BranchName, worktrees, eng, out); err != nil {
 				out.Warn("Failed to remove worktree for branch %s: %v", step.BranchName, err)
 				// Continue anyway - deletion might still work if worktree is gone
 			}
@@ -435,14 +446,11 @@ func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecut
 // removeWorktreeForBranch removes any worktree that has the given branch checked out.
 // This is necessary because git refuses to delete a branch that is checked out in any worktree.
 // Returns nil if no worktree exists or if removal succeeds.
-func removeWorktreeForBranch(ctx context.Context, branchName string, eng mergeExecuteEngine, out output.Output) error {
-	worktreePath, err := eng.Git().GetWorktreePathForBranch(ctx, branchName)
-	if err != nil {
-		// Don't block deletion if we can't check worktree status
-		out.Debug("Failed to check worktree for branch %s: %v", branchName, err)
-		return nil
-	}
-
+//
+// worktrees is a snapshot taken by the caller; passing it avoids spawning
+// `git worktree list` per merge step.
+func removeWorktreeForBranch(ctx context.Context, branchName string, worktrees git.WorktreeList, eng mergeExecuteEngine, out output.Output) error {
+	worktreePath := worktrees.PathForBranch(branchName)
 	if worktreePath == "" {
 		return nil // Branch not in any worktree
 	}

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -465,6 +465,10 @@ func (d *demoGitRunner) GetWorktreePathForBranch(_ context.Context, _ string) (s
 	return "", nil
 }
 
+func (d *demoGitRunner) WorktreeBranchMap(_ context.Context) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
 func (d *demoGitRunner) GetWorktreeCurrentBranch(_ context.Context, _ string) (string, error) {
 	return "", nil
 }

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -453,8 +453,8 @@ func (d *demoGitRunner) ForceRemoveWorktree(_ context.Context, _ string) error {
 	return nil
 }
 
-func (d *demoGitRunner) ListWorktrees(_ context.Context) ([]string, error) {
-	return []string{}, nil
+func (d *demoGitRunner) ListWorktrees(_ context.Context) (git.WorktreeList, error) {
+	return git.WorktreeList{}, nil
 }
 
 func (d *demoGitRunner) PruneWorktrees(_ context.Context) error {
@@ -463,10 +463,6 @@ func (d *demoGitRunner) PruneWorktrees(_ context.Context) error {
 
 func (d *demoGitRunner) GetWorktreePathForBranch(_ context.Context, _ string) (string, error) {
 	return "", nil
-}
-
-func (d *demoGitRunner) WorktreeBranchMap(_ context.Context) (map[string]string, error) {
-	return map[string]string{}, nil
 }
 
 func (d *demoGitRunner) GetWorktreeCurrentBranch(_ context.Context, _ string) (string, error) {

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -106,8 +106,8 @@ func (e *engineImpl) GetChangedFiles(ctx context.Context, base, head string) ([]
 	return e.git.GetChangedFiles(ctx, base, head)
 }
 
-// ListWorktrees returns a list of worktree paths
-func (e *engineImpl) ListWorktrees(ctx context.Context) ([]string, error) {
+// ListWorktrees returns every working tree registered with the repo.
+func (e *engineImpl) ListWorktrees(ctx context.Context) (git.WorktreeList, error) {
 	return e.git.ListWorktrees(ctx)
 }
 

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -99,12 +99,16 @@ func (e *engineImpl) ResetTrunkToRemote(ctx context.Context) error {
 }
 
 // restackBranch rebases a branch onto its parent
-// If the parent has been merged/deleted, it will automatically reparent to the nearest valid ancestor
+// If the parent has been merged/deleted, it will automatically reparent to the nearest valid ancestor.
+// worktrees is a snapshot of `git worktree list` taken by the caller — used to
+// avoid spawning `git worktree list` per branch when resetting another
+// worktree's working directory.
 func (e *engineImpl) restackBranch(
 	ctx context.Context,
 	branch Branch,
 	metaMap map[string]*git.Meta,
 	revMap map[string]string,
+	worktrees git.WorktreeList,
 ) (RestackBranchResult, error) {
 	branchName := branch.GetName()
 	if e.IsTrunk(branch) {
@@ -203,7 +207,7 @@ func (e *engineImpl) restackBranch(
 				// This is best-effort: sync checks for uncommitted changes before proceeding,
 				// so failure here just means the worktree may be briefly out of sync with HEAD.
 				// The ResetWorktreeWorkingDir command itself is logged via debugLog.
-				if worktreePath, wtErr := e.git.GetWorktreePathForBranch(ctx, branchName); wtErr == nil && worktreePath != "" {
+				if worktreePath := worktrees.PathForBranch(branchName); worktreePath != "" {
 					_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
 				}
 			}
@@ -273,7 +277,7 @@ func (e *engineImpl) restackBranch(
 			// If the branch is checked out in a different worktree, reset that worktree.
 			// This is best-effort: sync checks for uncommitted changes before proceeding,
 			// so failure here just means the worktree may be briefly out of sync with HEAD.
-			if worktreePath, wtErr := e.git.GetWorktreePathForBranch(ctx, branchName); wtErr == nil && worktreePath != "" {
+			if worktreePath := worktrees.PathForBranch(branchName); worktreePath != "" {
 				_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
 			}
 		}
@@ -440,7 +444,7 @@ func (e *engineImpl) restackBranch(
 	// that appears as staged changes reverting the rebased commits.
 	// This is best-effort: sync checks for uncommitted changes before proceeding,
 	// so failure here just means the worktree may be briefly out of sync with HEAD.
-	if worktreePath, wtErr := e.git.GetWorktreePathForBranch(ctx, branchName); wtErr == nil && worktreePath != "" {
+	if worktreePath := worktrees.PathForBranch(branchName); worktreePath != "" {
 		_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
 	}
 
@@ -495,6 +499,7 @@ func (e *engineImpl) restackBranchWithValidatedRebase(
 	plan *RestackPlan,
 	metaMap map[string]*git.Meta,
 	revMap map[string]string,
+	worktrees git.WorktreeList,
 ) (RestackBranchResult, error) {
 	branchName := branch.GetName()
 	if e.IsTrunk(branch) {
@@ -514,9 +519,9 @@ func (e *engineImpl) restackBranchWithValidatedRebase(
 
 	switch item.Action {
 	case RestackPlanApplyFrozen, RestackPlanApplyAnchor:
-		return e.applyPlannedRefUpdate(ctx, branch, item, metaMap, revMap)
+		return e.applyPlannedRefUpdate(ctx, branch, item, metaMap, revMap, worktrees)
 	case RestackPlanApplyValidated:
-		return e.applyValidatedRestack(ctx, branch, validation, item, metaMap, revMap)
+		return e.applyValidatedRestack(ctx, branch, validation, item, metaMap, revMap, worktrees)
 	default:
 		return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("unknown restack plan action for %s", branchName)
 	}
@@ -529,6 +534,7 @@ func (e *engineImpl) applyValidatedRestack(
 	item RestackPlanItem,
 	metaMap map[string]*git.Meta,
 	revMap map[string]string,
+	worktrees git.WorktreeList,
 ) (RestackBranchResult, error) {
 	branchName := branch.GetName()
 	newRev := ""
@@ -557,7 +563,7 @@ func (e *engineImpl) applyValidatedRestack(
 		parentRev = rev
 	}
 
-	result, err := e.applyBranchAndMetadata(ctx, branch, item, newRev, parentRev, metaMap, revMap)
+	result, err := e.applyBranchAndMetadata(ctx, branch, item, newRev, parentRev, metaMap, revMap, worktrees)
 	if err != nil {
 		return result, err
 	}
@@ -574,6 +580,7 @@ func (e *engineImpl) applyPlannedRefUpdate(
 	item RestackPlanItem,
 	metaMap map[string]*git.Meta,
 	revMap map[string]string,
+	worktrees git.WorktreeList,
 ) (RestackBranchResult, error) {
 	if item.TargetRev == "" {
 		return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("missing target revision for %s", item.Branch)
@@ -588,7 +595,7 @@ func (e *engineImpl) applyPlannedRefUpdate(
 		parentRev = rev
 	}
 
-	return e.applyBranchAndMetadata(ctx, branch, item, item.TargetRev, parentRev, metaMap, revMap)
+	return e.applyBranchAndMetadata(ctx, branch, item, item.TargetRev, parentRev, metaMap, revMap, worktrees)
 }
 
 func (e *engineImpl) applyBranchAndMetadata(
@@ -599,6 +606,7 @@ func (e *engineImpl) applyBranchAndMetadata(
 	parentRev string,
 	metaMap map[string]*git.Meta,
 	revMap map[string]string,
+	worktrees git.WorktreeList,
 ) (RestackBranchResult, error) {
 	branchName := branch.GetName()
 	meta := (*git.Meta)(nil)
@@ -639,7 +647,7 @@ func (e *engineImpl) applyBranchAndMetadata(
 		return RestackBranchResult{Result: RestackConflict, RebasedBranchBase: parentRev}, fmt.Errorf("failed to update refs atomically: %w", err)
 	}
 
-	if worktreePath, wtErr := e.git.GetWorktreePathForBranch(ctx, branchName); wtErr == nil && worktreePath != "" {
+	if worktreePath := worktrees.PathForBranch(branchName); worktreePath != "" {
 		_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
 	}
 
@@ -743,6 +751,15 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 	// Fetch ALL revisions in parallel
 	allRevisions, _ := e.git.BatchGetRevisions(involvedBranchNames)
 
+	// Snapshot the worktree list once. Restacking N branches used to call
+	// `git worktree list` N times for the "reset other worktree's working dir"
+	// check; the snapshot is stable across the restack loop since we don't
+	// add or remove worktrees here.
+	worktrees, err := e.git.ListWorktrees(ctx)
+	if err != nil {
+		worktrees = git.WorktreeList{}
+	}
+
 	// 2. Apply the restack changes
 	results := make(map[string]RestackBranchResult)
 	needsRebuild := false
@@ -752,9 +769,9 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 		var result RestackBranchResult
 		var err error
 		if validation != nil {
-			result, err = e.restackBranchWithValidatedRebase(ctx, branch, validation, plan, allMeta, allRevisions)
+			result, err = e.restackBranchWithValidatedRebase(ctx, branch, validation, plan, allMeta, allRevisions, worktrees)
 		} else {
-			result, err = e.restackBranch(ctx, branch, allMeta, allRevisions)
+			result, err = e.restackBranch(ctx, branch, allMeta, allRevisions, worktrees)
 		}
 		results[branchName] = result
 

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -227,40 +227,117 @@ func (e *engineImpl) DeleteBranch(ctx context.Context, branch Branch) error {
 	return nil
 }
 
-// DeleteBranches deletes multiple branches and returns the children that need restacking
+// DeleteBranches deletes multiple branches and returns the children that need restacking.
+//
+// All ref deletions (heads, metadata, local-metadata) for every branch in the
+// batch go through a single `git update-ref --stdin` invocation. The previous
+// implementation looped DeleteBranch per branch, spawning 4+ git subprocesses
+// per branch — at ~30-50ms each that dominated cleanup time during sync.
 func (e *engineImpl) DeleteBranches(ctx context.Context, branches Branches) ([]string, error) {
-	// Identify all children of all branches to be deleted
-	allChildren := make(map[string]bool)
-	toDeleteSet := make(map[string]bool)
+	if len(branches) == 0 {
+		return nil, nil
+	}
+
+	// Validate: no trunk in the batch.
+	if slices.ContainsFunc(branches, func(b Branch) bool { return e.IsTrunk(b) }) {
+		return nil, fmt.Errorf("cannot delete trunk branch")
+	}
+
+	// Snapshot in-memory state under one lock acquisition: children and parent
+	// for each branch, and whether the current branch is being deleted.
+	toDeleteSet := make(map[string]bool, len(branches))
+	childrenByBranch := make(map[string][]string, len(branches))
+	parentByBranch := make(map[string]string, len(branches))
+	var needCheckoutTrunk bool
+
+	e.mu.Lock()
+	trunkName := e.trunk
 	for _, b := range branches {
-		branchName := b.GetName()
-		toDeleteSet[branchName] = true
-		e.mu.RLock()
-		children := e.state.childrenMap[branchName]
-		e.mu.RUnlock()
-		for _, child := range children {
-			allChildren[child] = true
+		name := b.GetName()
+		toDeleteSet[name] = true
+		if name == e.currentBranch {
+			needCheckoutTrunk = true
+		}
+		childrenByBranch[name] = slices.Clone(e.state.childrenMap[name])
+		parent := trunkName
+		if state := e.readState(name); state != nil {
+			parent = state.Parent
+		}
+		parentByBranch[name] = parent
+	}
+	e.mu.Unlock()
+
+	// If the current branch is being deleted, switch to trunk first so we
+	// don't end up detached after `update-ref -d refs/heads/<current>`.
+	if needCheckoutTrunk {
+		if err := e.git.CheckoutBranch(ctx, trunkName); err != nil {
+			return nil, fmt.Errorf("failed to switch to trunk before deleting current branch: %w", err)
+		}
+		e.mu.Lock()
+		e.currentBranch = e.trunk
+		e.mu.Unlock()
+	}
+
+	// One ref-deletion batch covers heads + metadata + local-metadata for every
+	// branch. update-ref --stdin tolerates missing refs (no oldvalue), so an
+	// already-deleted head or absent local-metadata won't fail the batch.
+	refsToDelete := make([]string, 0, 3*len(branches))
+	for _, b := range branches {
+		name := b.GetName()
+		refsToDelete = append(refsToDelete,
+			"refs/heads/"+name,
+			git.MetadataRefPrefix+name,
+			git.LocalMetadataRefPrefix+name,
+		)
+	}
+	if err := e.git.DeleteRefsBatch(ctx, refsToDelete); err != nil {
+		return nil, fmt.Errorf("failed to delete branch refs: %w", err)
+	}
+
+	// Reparent surviving children of each deleted branch to that branch's
+	// parent. Children that are themselves being deleted in this batch are
+	// skipped — callers are expected to pass branches in a topological order
+	// (children before parents) so the parent already reflects the right
+	// grandparent by the time we get here.
+	allSurvivingChildren := make(map[string]bool)
+	var reparentErr error
+	for _, b := range branches {
+		name := b.GetName()
+		var surviving []string
+		for _, child := range childrenByBranch[name] {
+			if !toDeleteSet[child] {
+				surviving = append(surviving, child)
+				allSurvivingChildren[child] = true
+			}
+		}
+		if len(surviving) == 0 {
+			continue
+		}
+		parentBranch := e.GetBranch(parentByBranch[name])
+		if err := e.ReparentBranches(ctx, surviving, parentBranch); err != nil {
+			reparentErr = fmt.Errorf("failed to reparent children of %s: %w", name, err)
+			break
 		}
 	}
 
-	// Remove branches that are also being deleted from the children set
-	for _, b := range branches {
-		delete(allChildren, b.GetName())
-	}
-
-	// Delete branches
-	for _, b := range branches {
-		if err := e.DeleteBranch(ctx, b); err != nil {
-			return nil, fmt.Errorf("failed to delete branch %s: %w", b.GetName(), err)
+	// Clean up in-memory state for the deleted branches.
+	e.mu.Lock()
+	for name := range toDeleteSet {
+		e.state.removeBranch(name)
+		if i := slices.Index(e.state.branches, name); i >= 0 {
+			e.state.setBranches(slices.Delete(e.state.branches, i, i+1))
 		}
 	}
+	e.mu.Unlock()
 
-	// Convert children map to slice
-	childrenToRestack := make([]string, 0, len(allChildren))
-	for child := range allChildren {
+	childrenToRestack := make([]string, 0, len(allSurvivingChildren))
+	for child := range allSurvivingChildren {
 		childrenToRestack = append(childrenToRestack, child)
 	}
 
+	if reparentErr != nil {
+		return childrenToRestack, reparentErr
+	}
 	return childrenToRestack, nil
 }
 

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -101,7 +101,7 @@ type WorkingTree interface {
 	GetCommitTemplate(ctx context.Context) (string, error)
 	GetUnmergedFiles(ctx context.Context) ([]string, error)
 	ParseStagedHunks(ctx context.Context) ([]git.Hunk, error)
-	ListWorktrees(ctx context.Context) ([]string, error)
+	ListWorktrees(ctx context.Context) (git.WorktreeList, error)
 	IsRebaseInProgress(ctx context.Context) bool
 	GetRebaseHead() (string, error)
 	HasUncommittedChanges(ctx context.Context) bool

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -194,10 +194,9 @@ type WorktreeOperations interface {
 	AddWorktreeWithOptions(ctx context.Context, path string, branch string, detach bool, noCheckout bool) error
 	RemoveWorktree(ctx context.Context, path string) error
 	ForceRemoveWorktree(ctx context.Context, path string) error
-	ListWorktrees(ctx context.Context) ([]string, error)
+	ListWorktrees(ctx context.Context) (WorktreeList, error)
 	PruneWorktrees(ctx context.Context) error
 	GetWorktreePathForBranch(ctx context.Context, branchName string) (string, error)
-	WorktreeBranchMap(ctx context.Context) (map[string]string, error)
 	GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error)
 	ResetWorktreeWorkingDir(ctx context.Context, worktreePath string) error
 	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -197,6 +197,7 @@ type WorktreeOperations interface {
 	ListWorktrees(ctx context.Context) ([]string, error)
 	PruneWorktrees(ctx context.Context) error
 	GetWorktreePathForBranch(ctx context.Context, branchName string) (string, error)
+	WorktreeBranchMap(ctx context.Context) (map[string]string, error)
 	GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error)
 	ResetWorktreeWorkingDir(ctx context.Context, worktreePath string) error
 	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -894,6 +894,13 @@ func (t *tracingRunner) GetWorktreePathForBranch(ctx context.Context, branchName
 	return result, err
 }
 
+func (t *tracingRunner) WorktreeBranchMap(ctx context.Context) (map[string]string, error) {
+	start := time.Now()
+	result, err := t.inner.WorktreeBranchMap(ctx)
+	t.trace("WorktreeBranchMap", time.Since(start), err == nil, err, slog.Int("count", len(result)))
+	return result, err
+}
+
 func (t *tracingRunner) GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error) {
 	start := time.Now()
 	result, err := t.inner.GetWorktreeCurrentBranch(ctx, worktreePath)

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -873,10 +873,10 @@ func (t *tracingRunner) ForceRemoveWorktree(ctx context.Context, path string) er
 	return err
 }
 
-func (t *tracingRunner) ListWorktrees(ctx context.Context) ([]string, error) {
+func (t *tracingRunner) ListWorktrees(ctx context.Context) (WorktreeList, error) {
 	start := time.Now()
 	result, err := t.inner.ListWorktrees(ctx)
-	t.trace("ListWorktrees", time.Since(start), err == nil, err)
+	t.trace("ListWorktrees", time.Since(start), err == nil, err, slog.Int("count", len(result)))
 	return result, err
 }
 
@@ -891,13 +891,6 @@ func (t *tracingRunner) GetWorktreePathForBranch(ctx context.Context, branchName
 	start := time.Now()
 	result, err := t.inner.GetWorktreePathForBranch(ctx, branchName)
 	t.trace("GetWorktreePathForBranch", time.Since(start), err == nil, err, slog.String("branch", branchName))
-	return result, err
-}
-
-func (t *tracingRunner) WorktreeBranchMap(ctx context.Context) (map[string]string, error) {
-	start := time.Now()
-	result, err := t.inner.WorktreeBranchMap(ctx)
-	t.trace("WorktreeBranchMap", time.Since(start), err == nil, err, slog.Int("count", len(result)))
 	return result, err
 }
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -183,6 +183,35 @@ func (r *runner) GetWorktreePathForBranch(ctx context.Context, branchName string
 	return "", nil
 }
 
+// WorktreeBranchMap returns a map of branch name to worktree path for every
+// branch currently checked out in any worktree. Use this instead of looping
+// GetWorktreePathForBranch when you need to test many branches — one git
+// subprocess instead of N.
+func (r *runner) WorktreeBranchMap(ctx context.Context) (map[string]string, error) {
+	output, err := r.RunGitCommandWithContext(ctx, "worktree", "list", "--porcelain")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list worktrees: %w", err)
+	}
+
+	result := make(map[string]string)
+	if output == "" {
+		return result, nil
+	}
+
+	var currentWorktree string
+	for line := range strings.SplitSeq(output, "\n") {
+		if after, ok := strings.CutPrefix(line, "worktree "); ok {
+			currentWorktree = after
+		} else if after, ok := strings.CutPrefix(line, "branch "); ok {
+			if currentWorktree != "" {
+				branchName := strings.TrimPrefix(after, "refs/heads/")
+				result[branchName] = currentWorktree
+			}
+		}
+	}
+	return result, nil
+}
+
 // ResetWorktreeWorkingDir resets a worktree's working directory to match HEAD.
 // This is used after updating a branch ref to sync the worktree's working directory.
 func (r *runner) ResetWorktreeWorkingDir(ctx context.Context, worktreePath string) error {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -11,6 +11,37 @@ import (
 // WorktreeRefPrefix is the prefix for Git refs where worktree metadata is stored (local-only)
 const WorktreeRefPrefix = "refs/stackit/worktrees/"
 
+// Worktree represents a single entry from `git worktree list`.
+type Worktree struct {
+	Path   string
+	Branch string // empty when the worktree is at detached HEAD
+}
+
+// WorktreeList is the parsed result of one `git worktree list --porcelain`
+// invocation. Callers should pass it down per-batch instead of calling
+// ListWorktrees per branch — see PathForBranch for the common lookup.
+type WorktreeList []Worktree
+
+// PathForBranch returns the worktree path where branchName is checked out,
+// or "" if no worktree currently has it.
+func (l WorktreeList) PathForBranch(branchName string) string {
+	for _, w := range l {
+		if w.Branch == branchName {
+			return w.Path
+		}
+	}
+	return ""
+}
+
+// Paths returns just the worktree paths.
+func (l WorktreeList) Paths() []string {
+	out := make([]string, len(l))
+	for i, w := range l {
+		out[i] = w.Path
+	}
+	return out
+}
+
 // WorktreeMeta represents worktree tracking metadata stored in local Git refs
 type WorktreeMeta struct {
 	Name         string    `json:"name,omitempty"` // User-provided name for display (new worktrees only)
@@ -61,24 +92,41 @@ func (r *runner) ForceRemoveWorktree(ctx context.Context, path string) error {
 	return nil
 }
 
-func (r *runner) ListWorktrees(ctx context.Context) ([]string, error) {
+// ListWorktrees returns every working tree registered with the repo,
+// including the branch (if any) checked out in each. Callers needing to look
+// up many branches should call this once and reuse the result rather than
+// invoking git per branch — see WorktreeList.PathForBranch.
+func (r *runner) ListWorktrees(ctx context.Context) (WorktreeList, error) {
 	output, err := r.RunGitCommandWithContext(ctx, "worktree", "list", "--porcelain")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list worktrees: %w", err)
 	}
 
 	if output == "" {
-		return []string{}, nil
+		return WorktreeList{}, nil
 	}
 
-	lines := strings.Split(strings.TrimSpace(output), "\n")
-	var worktrees []string
-	for _, line := range lines {
-		if len(line) > 9 && line[:9] == "worktree " {
-			worktrees = append(worktrees, line[9:])
+	var result WorktreeList
+	var current Worktree
+	flush := func() {
+		if current.Path != "" {
+			result = append(result, current)
+		}
+		current = Worktree{}
+	}
+	for line := range strings.SplitSeq(output, "\n") {
+		switch {
+		case line == "":
+			flush()
+		case strings.HasPrefix(line, "worktree "):
+			flush()
+			current.Path = strings.TrimPrefix(line, "worktree ")
+		case strings.HasPrefix(line, "branch "):
+			current.Branch = strings.TrimPrefix(strings.TrimPrefix(line, "branch "), "refs/heads/")
 		}
 	}
-	return worktrees, nil
+	flush()
+	return result, nil
 }
 
 // PruneWorktrees removes stale worktree entries from .git/worktrees.
@@ -181,35 +229,6 @@ func (r *runner) GetWorktreePathForBranch(ctx context.Context, branchName string
 	}
 
 	return "", nil
-}
-
-// WorktreeBranchMap returns a map of branch name to worktree path for every
-// branch currently checked out in any worktree. Use this instead of looping
-// GetWorktreePathForBranch when you need to test many branches — one git
-// subprocess instead of N.
-func (r *runner) WorktreeBranchMap(ctx context.Context) (map[string]string, error) {
-	output, err := r.RunGitCommandWithContext(ctx, "worktree", "list", "--porcelain")
-	if err != nil {
-		return nil, fmt.Errorf("failed to list worktrees: %w", err)
-	}
-
-	result := make(map[string]string)
-	if output == "" {
-		return result, nil
-	}
-
-	var currentWorktree string
-	for line := range strings.SplitSeq(output, "\n") {
-		if after, ok := strings.CutPrefix(line, "worktree "); ok {
-			currentWorktree = after
-		} else if after, ok := strings.CutPrefix(line, "branch "); ok {
-			if currentWorktree != "" {
-				branchName := strings.TrimPrefix(after, "refs/heads/")
-				result[branchName] = currentWorktree
-			}
-		}
-	}
-	return result, nil
 }
 
 // ResetWorktreeWorkingDir resets a worktree's working directory to match HEAD.

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -40,7 +40,7 @@ func TestWorktree(t *testing.T) {
 		// List worktrees
 		worktrees, err := runner.ListWorktrees(context.Background())
 		require.NoError(t, err)
-		require.Contains(t, worktrees, worktreePath)
+		require.Contains(t, worktrees.Paths(), worktreePath)
 
 		// Remove worktree
 		err = runner.RemoveWorktree(context.Background(), worktreePath)
@@ -49,7 +49,7 @@ func TestWorktree(t *testing.T) {
 		// Verify worktree is gone from list
 		worktrees, err = runner.ListWorktrees(context.Background())
 		require.NoError(t, err)
-		require.NotContains(t, worktrees, worktreePath)
+		require.NotContains(t, worktrees.Paths(), worktreePath)
 	})
 
 	t.Run("add detached worktree", func(t *testing.T) {


### PR DESCRIPTION
This PR merges the following changes:

1. **#984** perf: cache worktree list during branch cleanup
2. **#985** perf: batch all ref deletions in engine.DeleteBranches
3. **#986** refactor: model worktree list as a typed WorktreeList
4. **#987** perf: snapshot worktree list once per restack batch
5. **#988** perf: snapshot worktree list once per merge plan

### Stack

```
main
  └─ perf-cache-worktree-list-during-cleanup (#984)
    └─ perf-batch-engine-delete-branches (#985)
      └─ perf-typed-worktree-list (#986)
        └─ perf-cache-worktree-list-during-restack (#987)
          └─ perf-cache-worktree-list-during-merge (#988)
```

Stackit-Stack-Size: 5
Stackit-PRs: 984,985,986,987,988
