### PR TITLE
perf: push deleted metadata refs once per cleanup pass

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -335,6 +335,21 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 	out := ctx.Output
 	c := ctx.Context
 
+	// Push every successfully-deleted branch's remote metadata ref in a single
+	// `git push --delete` after the loop. The deletion loop runs one batch per
+	// topological layer; without this, a 3-deep chain would issue 3 separate
+	// network roundtrips even though one would do. Deferred so previously-
+	// completed batches still push if a later batch fails.
+	var deletedBranchNames []string
+	defer func() {
+		if len(deletedBranchNames) == 0 {
+			return
+		}
+		if err := eng.Git().BatchDeleteRemoteMetadataRefs(c, deletedBranchNames); err != nil {
+			out.Debug("Failed to batch delete remote metadata: %v", err)
+		}
+	}()
+
 	previousCount := len(plan.branches)
 	for {
 		var batchNames []string
@@ -404,10 +419,8 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 			return fmt.Errorf("failed to delete branches [%s]: %w", strings.Join(batchNames, ", "), err)
 		}
 
-		// Batch delete remote metadata
-		if err := eng.Git().BatchDeleteRemoteMetadataRefs(c, batchNames); err != nil {
-			out.Debug("Failed to batch delete remote metadata: %v", err)
-		}
+		// Defer the remote metadata push to one combined call after the loop.
+		deletedBranchNames = append(deletedBranchNames, batchNames...)
 
 		// Cleanup plan and update parent blockers
 		for _, name := range batchNames {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

executeDeletions called BatchDeleteRemoteMetadataRefs inside the topological
batch loop, so a cleanup that processed branches in N layers issued N
`git push --delete` calls — each one a separate network roundtrip even
though the refspecs were independent.

Accumulate every successfully-deleted branch name across batches and push
them once via a defer at the function entry. Defer keeps the behavior
identical when a later batch returns early: already-completed batches still
get their remote metadata cleaned up.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #990** 👈
  * **PR #991**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #992*