### PR TITLE
Merging 2 PRs

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -335,6 +335,21 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 	out := ctx.Output
 	c := ctx.Context
 
+	// Push every successfully-deleted branch's remote metadata ref in a single
+	// `git push --delete` after the loop. The deletion loop runs one batch per
+	// topological layer; without this, a 3-deep chain would issue 3 separate
+	// network roundtrips even though one would do. Deferred so previously-
+	// completed batches still push if a later batch fails.
+	var deletedBranchNames []string
+	defer func() {
+		if len(deletedBranchNames) == 0 {
+			return
+		}
+		if err := eng.Git().BatchDeleteRemoteMetadataRefs(c, deletedBranchNames); err != nil {
+			out.Debug("Failed to batch delete remote metadata: %v", err)
+		}
+	}()
+
 	previousCount := len(plan.branches)
 	for {
 		var batchNames []string
@@ -404,10 +419,8 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 			return fmt.Errorf("failed to delete branches [%s]: %w", strings.Join(batchNames, ", "), err)
 		}
 
-		// Batch delete remote metadata
-		if err := eng.Git().BatchDeleteRemoteMetadataRefs(c, batchNames); err != nil {
-			out.Debug("Failed to batch delete remote metadata: %v", err)
-		}
+		// Defer the remote metadata push to one combined call after the loop.
+		deletedBranchNames = append(deletedBranchNames, batchNames...)
 
 		// Cleanup plan and update parent blockers
 		for _, name := range batchNames {

--- a/internal/actions/sync/stack_metadata_gc.go
+++ b/internal/actions/sync/stack_metadata_gc.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // StackMetadataGCResult contains the results of stack metadata garbage collection.
@@ -54,14 +55,27 @@ func gcOrphanedStackMetadata(ctx *app.Context) *StackMetadataGCResult {
 
 	ctx.Logger.Info("found orphaned stack metadata refs count=%v", len(orphaned))
 
-	// 4. Delete local refs
+	// 4. Delete local refs in a single update-ref --stdin batch. The previous
+	// per-orphan DeleteStackMeta loop spawned 2 git subprocesses per ref
+	// (update-ref -d + show-ref --verify) — same N+1 pattern fixed for branch
+	// deletion. If the atomic batch fails, fall back to per-ref so partial
+	// progress is still reported.
+	refs := make([]string, 0, len(orphaned))
 	for _, stackID := range orphaned {
-		if err := ctx.Git().DeleteStackMeta(ctx.Context, stackID); err != nil {
-			result.Errors = append(result.Errors, "failed to delete local stack ref "+stackID+": "+err.Error())
-			ctx.Logger.Debug("failed to delete local stack ref stackID=%v error=%v", stackID, err)
-		} else {
-			result.DeletedStackIDs = append(result.DeletedStackIDs, stackID)
+		refs = append(refs, git.StackMetaRefName(stackID))
+	}
+	if err := ctx.Git().DeleteRefsBatch(ctx.Context, refs); err != nil {
+		ctx.Logger.Debug("batch delete of local stack refs failed, falling back per-ref error=%v", err)
+		for _, stackID := range orphaned {
+			if perRefErr := ctx.Git().DeleteStackMeta(ctx.Context, stackID); perRefErr != nil {
+				result.Errors = append(result.Errors, "failed to delete local stack ref "+stackID+": "+perRefErr.Error())
+				ctx.Logger.Debug("failed to delete local stack ref stackID=%v error=%v", stackID, perRefErr)
+			} else {
+				result.DeletedStackIDs = append(result.DeletedStackIDs, stackID)
+			}
 		}
+	} else {
+		result.DeletedStackIDs = append(result.DeletedStackIDs, orphaned...)
 	}
 
 	// 5. Delete remote refs (best-effort, non-fatal)


### PR DESCRIPTION
This PR merges the following changes:

1. **#990** perf: push deleted metadata refs once per cleanup pass
2. **#991** perf: batch local stack metadata ref deletion

### Stack

```
main
  └─ perf-hoist-remote-metadata-push (#990)
    └─ perf-batch-stack-metadata-gc (#991)
```

Stackit-Stack-Size: 2
Stackit-PRs: 990,991
