### PR TITLE
perf: expose new SHA on RestackBranchResult to skip per-branch GetRevision

### DIFF
--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -342,15 +342,20 @@ func reportPlannedResults(ctx *app.Context, branches engine.Branches, plannedRes
 func reportRestackResult(ctx *app.Context, branch engine.Branch, result engine.RestackBranchResult, currentBranchName string, callback RestackProgressCallback) {
 	branchName := branch.GetName()
 
-	// Get new revision if available.
+	// Use the new revision the engine already captured during restack. Falling
+	// back to branch.GetRevision is fine if it's not set (RestackUnneeded
+	// leaves NewRev empty), but the common Done path doesn't need an extra
+	// git call.
 	newRev := ""
 	if result.Result == engine.RestackDone {
-		if rev, err := branch.GetRevision(); err == nil {
-			if len(rev) > 7 {
-				newRev = rev[:7]
-			} else {
-				newRev = rev
-			}
+		rev := result.NewRev
+		if rev == "" {
+			rev, _ = branch.GetRevision()
+		}
+		if len(rev) > 7 {
+			newRev = rev[:7]
+		} else {
+			newRev = rev
 		}
 	}
 

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -217,6 +217,7 @@ func (e *engineImpl) restackBranch(
 			return RestackBranchResult{
 				Result:            RestackDone,
 				RebasedBranchBase: remoteSha,
+				NewRev:            remoteSha,
 			}, nil
 		}
 
@@ -287,6 +288,7 @@ func (e *engineImpl) restackBranch(
 		return RestackBranchResult{
 			Result:            RestackDone,
 			RebasedBranchBase: trunkRev,
+			NewRev:            trunkRev,
 		}, nil
 	}
 
@@ -494,6 +496,7 @@ func (e *engineImpl) restackBranch(
 	return RestackBranchResult{
 		Result:              RestackDone,
 		RebasedBranchBase:   parentRev,
+		NewRev:              newRev,
 		Reparented:          reparented,
 		OldParent:           oldParent,
 		NewParent:           parent,
@@ -674,6 +677,7 @@ func (e *engineImpl) applyBranchAndMetadata(
 	return RestackBranchResult{
 		Result:            RestackDone,
 		RebasedBranchBase: parentRev,
+		NewRev:            newRev,
 		Reparented:        item.Reparented,
 		OldParent:         item.OldParent,
 		NewParent:         item.NewParent,
@@ -805,16 +809,17 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 			progress(branch, result)
 		}
 
-		if err == nil && (result.Result == RestackDone || result.Result == RestackUnneeded) {
-			// Update the revision map with the current SHA of the branch.
-			// This is important because subsequent branches in the batch might
-			// use this branch as their parent.
-			if currentSha, err := e.git.GetRevision(branchName); err == nil {
-				if allRevisions == nil {
-					allRevisions = make(map[string]string)
-				}
-				allRevisions[branchName] = currentSha
+		if err == nil && result.Result == RestackDone && result.NewRev != "" {
+			// Update the revision map with the new SHA for downstream branches
+			// in the batch. The new SHA was already computed inside restackBranch
+			// / applyBranchAndMetadata — using it here avoids a per-branch
+			// GetRevision subprocess. For RestackUnneeded we leave the map alone
+			// because the branch's SHA didn't change and allRevisions already
+			// holds the pre-restack value from BatchGetRevisions.
+			if allRevisions == nil {
+				allRevisions = make(map[string]string)
 			}
+			allRevisions[branchName] = result.NewRev
 		}
 
 		if err != nil {

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -778,6 +778,7 @@ const (
 type RestackBranchResult struct {
 	Result              RestackResult
 	RebasedBranchBase   string     // The new parent revision after successful rebase (only set if Result is RestackDone or RestackConflict)
+	NewRev              string     // The new branch revision after this restack (set when Result is RestackDone; empty for Unneeded / Conflict)
 	Reparented          bool       // True if the branch was reparented due to merged/deleted parent
 	OldParent           string     // The old parent branch name (only set if Reparented is true)
 	NewParent           string     // The new parent branch name (only set if Reparented is true)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The restack loop in engine.restackBranches called e.git.GetRevision per branch
(line ~786) to refresh allRevisions after each iteration so downstream
branches see the updated parent SHA. reportRestackResult in internal/actions/
common.go also called branch.GetRevision per branch to populate the
progress callback's NewRev. Both ended up running an extra git lookup for
every restacked branch.

restackBranch and applyBranchAndMetadata already capture the new SHA before
returning (from Rebase + GetCurrentRevision in the regular path, and from
remoteSha / trunkRev in the frozen and anchor paths). Expose it as
RestackBranchResult.NewRev and consume it on both ends. For RestackUnneeded
the loop now leaves allRevisions alone since the branch SHA didn't change
and the map already has the pre-restack value from BatchGetRevisions.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #993**
  * **PR #994** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #995*