### PR TITLE
fix: handle BatchMarkNeedsPRBodyUpdate errors in scope and describe

### DIFF
--- a/internal/actions/describe/describe.go
+++ b/internal/actions/describe/describe.go
@@ -133,16 +133,15 @@ func applyStackDescription(ctx *app.Context, branch engine.Branch, stackRoot str
 // markStackAndPushMetadata marks all stack branches for PR update and pushes metadata refs.
 // Unlike PushMetadataAndSyncPRs, this does NOT immediately update GitHub PRs.
 func markStackAndPushMetadata(ctx *app.Context, eng engine.Engine, stackRoot string) error {
+	out := ctx.Output
+
 	// Mark all branches in the stack for PR body update
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
 	root := eng.GetBranch(stackRoot)
 	if root.IsTracked() {
-		branches := graph.CollectBranches(root)
-		branchNames := make([]string, len(branches))
-		for i, b := range branches {
-			branchNames[i] = b.GetName()
+		if err := eng.BatchMarkNeedsPRBodyUpdate(graph.CollectBranches(root).Names()); err != nil {
+			out.Debug("Failed to mark branches for PR body update: %v", err)
 		}
-		_ = eng.BatchMarkNeedsPRBodyUpdate(branchNames)
 	}
 
 	// Push metadata refs (fast git operation)

--- a/internal/actions/scope/action.go
+++ b/internal/actions/scope/action.go
@@ -70,7 +70,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		out.Info("Unset explicit scope for branch %s. It will now inherit from its parent.", style.ColorBranchName(currentBranch, false))
 
 		// Mark branch for PR update and push metadata (defer GitHub API calls to sync)
-		_ = eng.BatchMarkNeedsPRBodyUpdate([]string{currentBranch})
+		if err := eng.BatchMarkNeedsPRBodyUpdate([]string{currentBranch}); err != nil {
+			out.Debug("Failed to mark branch for PR body update: %v", err)
+		}
 		if err := actions.PushMetadataOnly(ctx, eng, []string{currentBranch}); err != nil {
 			out.Debug("Failed to push metadata changes: %v", err)
 		}
@@ -115,7 +117,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	// Mark branch for PR update and push metadata (defer GitHub API calls to sync)
-	_ = eng.BatchMarkNeedsPRBodyUpdate([]string{currentBranch})
+	if err := eng.BatchMarkNeedsPRBodyUpdate([]string{currentBranch}); err != nil {
+		out.Debug("Failed to mark branch for PR body update: %v", err)
+	}
 	if err := actions.PushMetadataOnly(ctx, eng, []string{currentBranch}); err != nil {
 		out.Debug("Failed to push metadata changes: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Three call sites in `scope/action.go` and `describe/describe.go` were silently dropping errors from `BatchMarkNeedsPRBodyUpdate` with `_ =`, violating the project's code style rule ("Always handle errors explicitly, never `_`")
- Brings these sites in line with the existing pattern in `move.go` which logs failures via `out.Debug`
- Removes a manual branch-name extraction loop in `describe.go` in favour of the existing `Branches.Names()` helper

## Test plan

- [x] `go test ./internal/actions/describe/... ./internal/actions/scope/...` passes
- [x] `go build ./...` compiles clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Six23eCMuzWfc89ZSBFmes)_