### PR TITLE
chore: instrument executeDeletions with per-step timing

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
@@ -345,11 +346,16 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 		if len(deletedBranchNames) == 0 {
 			return
 		}
-		if err := eng.Git().BatchDeleteRemoteMetadataRefs(c, deletedBranchNames); err != nil {
+		pushStart := time.Now()
+		err := eng.Git().BatchDeleteRemoteMetadataRefs(c, deletedBranchNames)
+		ctx.Logger.Info("delete remote metadata refs completed durationMs=%d branchCount=%d ok=%v",
+			time.Since(pushStart).Milliseconds(), len(deletedBranchNames), err == nil)
+		if err != nil {
 			out.Debug("Failed to batch delete remote metadata: %v", err)
 		}
 	}()
 
+	batchIdx := 0
 	previousCount := len(plan.branches)
 	for {
 		var batchNames []string
@@ -365,23 +371,36 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 
 		// Sort for deterministic deletion order (helps with debugging and reproducibility)
 		sort.Strings(batchNames)
+		batchIdx++
 
 		// Snapshot the worktree list once for this batch instead of
 		// re-running `git worktree list --porcelain` per branch.
+		listStart := time.Now()
 		worktrees, err := eng.Git().ListWorktrees(c)
+		ctx.Logger.Info("list worktrees for cleanup batch completed durationMs=%d batch=%d worktreeCount=%d",
+			time.Since(listStart).Milliseconds(), batchIdx, len(worktrees))
 		if err != nil {
 			out.Debug("Failed to list worktrees for branch cleanup: %v", err)
 			worktrees = git.WorktreeList{}
 		}
 
 		// Remove any worktrees that have these branches checked out
+		removeStart := time.Now()
 		var failedWorktreeRemovals []string
+		worktreesRemoved := 0
 		for _, name := range batchNames {
-			if _, err := removeWorktreeIfCheckedOut(c, name, worktrees, eng, out); err != nil {
+			removed, err := removeWorktreeIfCheckedOut(c, name, worktrees, eng, out)
+			if err != nil {
 				out.Warn("Could not remove worktree for branch %s: %v", name, err)
 				failedWorktreeRemovals = append(failedWorktreeRemovals, name)
+				continue
+			}
+			if removed != "" {
+				worktreesRemoved++
 			}
 		}
+		ctx.Logger.Info("remove worktrees for cleanup batch completed durationMs=%d batch=%d branchCount=%d worktreesRemoved=%d worktreesFailed=%d",
+			time.Since(removeStart).Milliseconds(), batchIdx, len(batchNames), worktreesRemoved, len(failedWorktreeRemovals))
 
 		// Filter out branches where worktree removal failed
 		if len(failedWorktreeRemovals) > 0 {
@@ -415,8 +434,12 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 		}
 
 		// Batch delete from engine
-		if _, err := eng.DeleteBranches(c, branches.Build()); err != nil {
-			return fmt.Errorf("failed to delete branches [%s]: %w", strings.Join(batchNames, ", "), err)
+		engineStart := time.Now()
+		_, engineErr := eng.DeleteBranches(c, branches.Build())
+		ctx.Logger.Info("engine delete branches batch completed durationMs=%d batch=%d branchCount=%d ok=%v",
+			time.Since(engineStart).Milliseconds(), batchIdx, len(batchNames), engineErr == nil)
+		if engineErr != nil {
+			return fmt.Errorf("failed to delete branches [%s]: %w", strings.Join(batchNames, ", "), engineErr)
 		}
 
 		// Defer the remote metadata push to one combined call after the loop.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The "clean branches" log line records the wall-clock duration of the entire
ExecuteBranchDeletions call but nothing inside it. A recent sync logged
84053ms cleaning 2 branches with zero intermediate output, leaving no way to
tell whether the time went to the worktree list, the engine batch delete,
the per-branch worktree removals, or the deferred remote metadata push.

Add INFO-level timing logs around each sub-step so future slow runs can be
attributed to a specific cause without re-instrumenting:
  - list worktrees for cleanup batch
  - remove worktrees for cleanup batch (counts removed/failed)
  - engine delete branches batch
  - delete remote metadata refs (the deferred push)

The per-batch logs include a batch index so multi-layer topological deletions
are distinguishable. No behavior change.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #997** 👈
  * **PR #998**
    * **PR #999**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1000*