### PR TITLE
perf: short-circuit + fast-tree-equality in branch-deletion planning, plus timing logs

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -199,13 +199,17 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[
 	c := ctx.Context
 
 	ctx.Logger.Info("identifyBranchesToDelete started force=%v inManagedWorktree=%v", opts.Force, opts.InManagedWorktree)
+	identifyStart := time.Now()
 
 	// Collect non-trunk candidate branch names
 	allTrackedBranches := eng.AllBranches()
 	candidateNames := allTrackedBranches.WithoutTrunk().Names()
 
 	// Single batch call to engine for deletion statuses
+	batchStart := time.Now()
 	statuses, err := eng.BatchGetDeletionStatuses(c, candidateNames)
+	ctx.Logger.Info("BatchGetDeletionStatuses completed durationMs=%d candidateCount=%d ok=%v",
+		time.Since(batchStart).Milliseconds(), len(candidateNames), err == nil)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get deletion statuses: %w", err)
 	}
@@ -245,7 +249,8 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[
 		ctx.Logger.Info("identifyBranchesToDelete marked for deletion branch=%v reason=%v unpushed=%v", name, status.Reason, status.HasUnpushedChanges)
 	}
 
-	ctx.Logger.Info("identifyBranchesToDelete completed toDeleteCount=%v skippedCount=%v", len(deleteStatuses), len(skippedInWorktree))
+	ctx.Logger.Info("identifyBranchesToDelete completed durationMs=%d toDeleteCount=%v skippedCount=%v",
+		time.Since(identifyStart).Milliseconds(), len(deleteStatuses), len(skippedInWorktree))
 
 	return deleteStatuses, skippedInWorktree, utilityBranches, nil
 }

--- a/internal/actions/sync/branch_sync.go
+++ b/internal/actions/sync/branch_sync.go
@@ -24,7 +24,15 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, handler H
 	// Get all tracked branches
 	allBranches := nav.AllBranches()
 
+	syncStart := time.Now()
+	var statusCheckTotalMs int64
+	statusCheckCount := 0
 	branchesSynced := 0
+	defer func() {
+		ctx.Logger.Info("syncStackBranches completed durationMs=%d branchCount=%d branchesSynced=%d statusChecksMs=%d statusCheckCount=%d",
+			time.Since(syncStart).Milliseconds(), len(allBranches), branchesSynced, statusCheckTotalMs, statusCheckCount)
+	}()
+
 	for _, branch := range allBranches {
 		// Check for context cancellation
 		if err := gctx.Err(); err != nil {
@@ -59,7 +67,10 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, handler H
 		}
 
 		// Check if branch is behind remote
+		statusStart := time.Now()
 		status, err := eng.GetBranchRemoteStatus(branch)
+		statusCheckTotalMs += time.Since(statusStart).Milliseconds()
+		statusCheckCount++
 		if err != nil {
 			// Can't determine status, skip
 			continue

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -434,7 +434,20 @@ func (e *engineImpl) evaluateDeletionStatus(ctx context.Context, branchName stri
 		}
 	}
 
-	// 5. Check if empty (no diff from parent) with an associated PR
+	// 5. Check if empty (no diff from parent) with an associated PR.
+	//
+	// Rule 5 only fires when the branch is empty AND has a PR. Establishing
+	// the PR side first lets us skip the IsDiffEmpty tree comparison entirely
+	// for the (common) case of branches without PR metadata — that comparison
+	// dominated branch-deletion planning when scaled to 20+ candidate branches.
+	if meta == nil {
+		return DeletionStatus{SafeToDelete: false, Reason: "", Kind: DeletionReasonNone}
+	}
+	prInfoMeta := meta.GetPrInfo()
+	if prInfoMeta == nil || prInfoMeta.Number == nil || *prInfoMeta.Number == 0 {
+		return DeletionStatus{SafeToDelete: false, Reason: "", Kind: DeletionReasonNone}
+	}
+
 	parent := branch.GetParent()
 	parentName := trunkName
 	if parent != nil {
@@ -448,15 +461,8 @@ func (e *engineImpl) evaluateDeletionStatus(ctx context.Context, branchName stri
 		}
 	}
 	if parentRev != "" {
-		empty, err := e.git.IsDiffEmpty(ctx, branchName, parentRev)
-		if err == nil && empty {
-			// Only delete empty branches if they have a PR
-			if meta != nil {
-				metaPrInfo := meta.GetPrInfo()
-				if metaPrInfo != nil && metaPrInfo.Number != nil && *metaPrInfo.Number != 0 {
-					return DeletionStatus{SafeToDelete: true, Reason: "empty", Kind: DeletionReasonEmptyWithPR}
-				}
-			}
+		if empty, err := e.git.IsDiffEmpty(ctx, branchName, parentRev); err == nil && empty {
+			return DeletionStatus{SafeToDelete: true, Reason: "empty", Kind: DeletionReasonEmptyWithPR}
 		}
 	}
 

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 )
 
-func (r *runner) IsDiffEmpty(ctx context.Context, branchName, base string) (bool, error) {
+func (r *runner) IsDiffEmpty(_ context.Context, branchName, base string) (bool, error) {
 	branchRev, err := r.GetRevision(branchName)
 	if err != nil {
 		return false, fmt.Errorf("failed to get branch revision: %w", err)
@@ -16,11 +16,37 @@ func (r *runner) IsDiffEmpty(ctx context.Context, branchName, base string) (bool
 		return true, nil
 	}
 
-	changedFiles, err := r.changedFilesBetween(ctx, base, branchRev)
+	// Two refs at different commits can still represent identical content if
+	// their trees match (e.g. revert chain, no-op rebase). Compare commit
+	// TreeHash directly instead of walking the file-level diff — go-git tree
+	// hashes are content-addressed, so equal hash ⇔ no changes. This skips
+	// the O(tree-size) DiffContext call that dominated branch-deletion
+	// planning.
+	repo, err := r.ensureRepo()
 	if err != nil {
 		return false, err
 	}
-	return len(changedFiles) == 0, nil
+
+	r.goGitMu.Lock()
+	defer r.goGitMu.Unlock()
+
+	baseHash, err := r.resolveRefHashInternal(repo, base)
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve base %s: %w", base, err)
+	}
+	headHash, err := r.resolveRefHashInternal(repo, branchRev)
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve head %s: %w", branchRev, err)
+	}
+	baseCommit, err := repo.CommitObject(baseHash)
+	if err != nil {
+		return false, fmt.Errorf("failed to load base commit %s: %w", base, err)
+	}
+	headCommit, err := repo.CommitObject(headHash)
+	if err != nil {
+		return false, fmt.Errorf("failed to load head commit %s: %w", branchRev, err)
+	}
+	return baseCommit.TreeHash == headCommit.TreeHash, nil
 }
 
 func (r *runner) GetChangedFiles(ctx context.Context, base, head string) ([]string, error) {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

A sync with 23 candidate branches and zero actual deletions spent 6.5s in
identifyBranchesToDelete and 3.7s in syncStackBranches, opaque in the log.
Two fixes plus instrumentation:

1. evaluateDeletionStatus rule 5 (empty-with-PR) hoists the PR check ahead
   of the diff. Branches without PR metadata can't satisfy rule 5 no matter
   what the diff says, so the expensive IsDiffEmpty call is skipped for the
   common case of untracked-on-GitHub branches.

2. IsDiffEmpty stops enumerating file changes via Tree.DiffContext. Go-git
   tree hashes are content-addressed (equal hash ⇔ identical content), so a
   direct Commit.TreeHash comparison answers the question in O(1) commit
   loads instead of O(tree-size) per branch. Two diff_test.go tests exercise
   the equality + inequality paths.

3. Add INFO timing logs around BatchGetDeletionStatuses, the full
   identifyBranchesToDelete pass, and syncStackBranches (total time +
   aggregate GetBranchRemoteStatus cost). syncStackBranches's per-branch
   GetBranchRemoteStatus loop is still serial — instrumented here so the
   next sync attributes the remaining cost precisely before we batch it.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #997**
  * **PR #998**
    * **PR #999** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1000*