### PR TITLE
fix(git): honor context cancellation in reset paths

### DIFF
--- a/internal/git/reset.go
+++ b/internal/git/reset.go
@@ -3,12 +3,10 @@ package git
 import (
 	"context"
 	"fmt"
-
-	gogit "github.com/go-git/go-git/v6"
 )
 
 func (r *runner) ResetMerge(ctx context.Context, revision string) error {
-	err := r.resetWorktree(ctx, revision, gogit.MergeReset)
+	err := r.resetWorktree(ctx, revision, "--merge")
 	if err != nil {
 		return fmt.Errorf("failed to reset --merge to %s: %w", revision, err)
 	}
@@ -17,7 +15,7 @@ func (r *runner) ResetMerge(ctx context.Context, revision string) error {
 }
 
 func (r *runner) HardReset(ctx context.Context, revision string) error {
-	err := r.resetWorktree(ctx, revision, gogit.HardReset)
+	err := r.resetWorktree(ctx, revision, "--hard")
 	if err != nil {
 		return fmt.Errorf("failed to hard reset to %s: %w", revision, err)
 	}
@@ -26,7 +24,7 @@ func (r *runner) HardReset(ctx context.Context, revision string) error {
 }
 
 func (r *runner) SoftReset(ctx context.Context, revision string) error {
-	err := r.resetWorktree(ctx, revision, gogit.SoftReset)
+	err := r.resetWorktree(ctx, revision, "--soft")
 	if err != nil {
 		return fmt.Errorf("failed to soft reset to %s: %w", revision, err)
 	}
@@ -35,33 +33,22 @@ func (r *runner) SoftReset(ctx context.Context, revision string) error {
 }
 
 func (r *runner) MixedReset(ctx context.Context, revision string) error {
-	err := r.resetWorktree(ctx, revision, gogit.MixedReset)
+	err := r.resetWorktree(ctx, revision, "--mixed")
 	if err == nil {
 		r.revisionCache.InvalidateAll()
 	}
 	return err
 }
 
-func (r *runner) resetWorktree(_ context.Context, revision string, mode gogit.ResetMode) error {
-	repo, err := r.ensureRepo()
-	if err != nil {
-		return err
-	}
-	worktree, err := repo.Worktree()
-	if err != nil {
-		return err
-	}
-
+// resetWorktree shells out to native git so the caller's context (deadline,
+// cancellation) is honored. go-git's worktree.Reset() takes no context, so a
+// hung reset (e.g., huge working tree) could not be interrupted.
+func (r *runner) resetWorktree(ctx context.Context, revision, modeFlag string) error {
 	r.goGitMu.Lock()
 	defer r.goGitMu.Unlock()
 
-	hash, err := r.resolveRefHashInternal(repo, revision)
-	if err != nil {
+	if _, err := r.RunGitCommandWithContext(ctx, "reset", modeFlag, revision); err != nil {
 		return err
 	}
-
-	return worktree.Reset(&gogit.ResetOptions{
-		Commit: hash,
-		Mode:   mode,
-	})
+	return nil
 }


### PR DESCRIPTION

resetWorktree blanked the caller's context and used go-git's
worktree.Reset(), which has no context field — so HardReset, SoftReset,
MixedReset, and ResetMerge could not be interrupted by a deadline or
signal. A hung reset (huge working tree, slow filesystem) would run to
completion regardless of the caller's cancellation.

Switch to native `git reset <mode> <revision>` via RunGitCommandWithContext.
Same precedent as commit d8173f4b which moved checkout paths back to
native git after the broader go-git migration: object/revision walks
benefit from go-git, but working-tree mutations don't, and they lose
context cancellation in the process.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1003**
  * **PR #1004** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->