### PR TITLE
fix(web): route picker selection via ?repo= query string

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,21 +1,21 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import { Suspense } from "react";
+import { useSearchParams } from "next/navigation";
 import { RepoProvider } from "@/components/providers/repo-provider";
 import { RepoPicker } from "@/components/repo-picker/repo-picker";
 import { RepoView } from "@/components/repo-picker/repo-view";
 
 // Single root page driving both the unscoped picker and the per-repo view.
 //
-// The Next.js build is `output: 'export'` (static HTML) and the Go static
-// handler falls back to the root index.html for any extension-less path —
-// effectively SPA mode. We read the pathname on the client and either show
-// the picker (path "/") or render RepoView wrapped in RepoProvider scoped
-// to the first path segment.
-export default function Home() {
-  const pathname = usePathname();
-  const segments = (pathname || "/").split("/").filter(Boolean);
-  const repoId = segments[0] ? decodeURIComponent(segments[0]) : "";
+// The Next.js build is `output: 'export'`, so only the root URL is emitted.
+// We scope to a repo via the `?repo=<id>` query string rather than a path
+// segment — that way the same static index.html handles every repo in both
+// `next dev` and the embedded production server, with no per-repo route to
+// pre-generate.
+function Home() {
+  const params = useSearchParams();
+  const repoId = params.get("repo") ?? "";
 
   if (!repoId) {
     return <RepoPicker />;
@@ -25,5 +25,13 @@ export default function Home() {
     <RepoProvider repoId={repoId}>
       <RepoView />
     </RepoProvider>
+  );
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={null}>
+      <Home />
+    </Suspense>
   );
 }

--- a/apps/web/src/components/repo-picker/__tests__/repo-picker.test.tsx
+++ b/apps/web/src/components/repo-picker/__tests__/repo-picker.test.tsx
@@ -40,7 +40,7 @@ describe("RepoPicker", () => {
     expect(screen.getByText("Other Project")).toBeDefined();
   });
 
-  it("navigates to /{repoId} on click", async () => {
+  it("navigates to /?repo={repoId} on click", async () => {
     mockRepos({
       repos: [{ id: "stackit", displayName: "Stackit", trunk: "main" }],
     });
@@ -49,7 +49,7 @@ describe("RepoPicker", () => {
 
     const card = await screen.findByTestId("repo-card-stackit");
     fireEvent.click(card);
-    expect(mockPush).toHaveBeenCalledWith("/stackit");
+    expect(mockPush).toHaveBeenCalledWith("/?repo=stackit");
   });
 
   it("shows the empty-state message when no repos are configured", async () => {

--- a/apps/web/src/components/repo-picker/repo-picker.tsx
+++ b/apps/web/src/components/repo-picker/repo-picker.tsx
@@ -80,7 +80,7 @@ export function RepoPicker() {
             <button
               type="button"
               data-testid={`repo-card-${repo.id}`}
-              onClick={() => router.push(`/${encodeURIComponent(repo.id)}`)}
+              onClick={() => router.push(`/?repo=${encodeURIComponent(repo.id)}`)}
               className="block w-full text-left transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
             >
               <Card>


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Next.js builds with output: 'export', so only the root URL is
pre-generated. Path-based routing relied on the Go static handler
falling back to index.html for extension-less paths, which works
in prod but not in 'next dev'. Switch to '/?repo=<id>' so the same
static index.html serves every repo in both environments without
a per-repo route.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1006** 👈
  * **PR #1007**
    * **PR #1008**
      * **PR #1009**
        * **PR #1011**
          * **PR #1015**
            * **PR #1016**
              * **PR #1017**
                * **PR #1012**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1054 by jonnii*