### PR TITLE
feat(server): fall back to $PORT env when -port isn't set

### DIFF
--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -44,6 +44,18 @@ func run() error {
 	)
 	flag.Parse()
 
+	// Honor $PORT when -port wasn't passed explicitly. PaaS hosts (Railway,
+	// Fly, Heroku) inject the port this way.
+	portExplicit := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "port" {
+			portExplicit = true
+		}
+	})
+	if err := resolvePort(port, portExplicit, os.Getenv("PORT")); err != nil {
+		return err
+	}
+
 	staticFS, err := fs.Sub(staticFiles, "static")
 	if err != nil {
 		return err

--- a/apps/server/port.go
+++ b/apps/server/port.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// resolvePort applies a $PORT fallback when -port wasn't passed explicitly.
+// flagPort is the destination flag pointer. When portExplicit is true the
+// env value is ignored (the operator wins). An empty env is a no-op.
+func resolvePort(flagPort *int, portExplicit bool, env string) error {
+	if portExplicit {
+		return nil
+	}
+	env = strings.TrimSpace(env)
+	if env == "" {
+		return nil
+	}
+	p, err := strconv.Atoi(env)
+	if err != nil {
+		return fmt.Errorf("invalid PORT env %q: %w", env, err)
+	}
+	*flagPort = p
+	return nil
+}

--- a/apps/server/port_test.go
+++ b/apps/server/port_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		start          int
+		portExplicit   bool
+		env            string
+		wantPort       int
+		wantErrContain string
+	}{
+		{
+			name:     "no env keeps default",
+			start:    8080,
+			env:      "",
+			wantPort: 8080,
+		},
+		{
+			name:     "env populates default",
+			start:    8080,
+			env:      "3000",
+			wantPort: 3000,
+		},
+		{
+			name:     "explicit flag wins over env",
+			start:    9999,
+			env:      "3000",
+			wantPort: 9999, portExplicit: true,
+		},
+		{
+			name:     "whitespace env is treated as unset",
+			start:    8080,
+			env:      "   ",
+			wantPort: 8080,
+		},
+		{
+			name:           "invalid env returns error",
+			start:          8080,
+			env:            "not-a-number",
+			wantErrContain: "invalid PORT env",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			port := tt.start
+			err := resolvePort(&port, tt.portExplicit, tt.env)
+			if tt.wantErrContain != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErrContain)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantPort, port)
+		})
+	}
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


PaaS hosts like Railway inject the listen port via $PORT. Honor it
when the operator didn't pass -port explicitly so the container can
bind correctly without a custom launch wrapper. An explicit -port
still wins.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1779932878`.


* **PR #1006**
  * **PR #1007** 👈
    * **PR #1008**
      * **PR #1009**
        * **PR #1011**
          * **PR #1015**
            * **PR #1016**
              * **PR #1017**
                * **PR #1012**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->