### PR TITLE
feat(server): publish multi-arch container to ghcr.io

### DIFF
--- a/.github/workflows/docker-main.yml
+++ b/.github/workflows/docker-main.yml
@@ -1,0 +1,83 @@
+name: Docker (main)
+
+# Build and publish stackit-server container images on every push to main so
+# Railway (and any other ghcr.io consumer) can auto-deploy without cutting a
+# release tag. Goreleaser builds snapshot images locally with its snapshot
+# version, then we re-tag those as :main and :<short-sha> and push.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Enable pnpm
+        run: corepack enable
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser (snapshot, server images only)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --snapshot --clean --skip=archive,homebrew,scoop,nfpm,sbom,announce
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Re-tag and push main + sha images
+        env:
+          GHCR_IMAGE: ghcr.io/getstackit/stackit-server
+        run: |
+          set -euo pipefail
+          SNAP_VERSION=$(jq -r .version dist/metadata.json)
+          SHORT_SHA="${GITHUB_SHA::7}"
+          echo "snapshot version: ${SNAP_VERSION}; short sha: ${SHORT_SHA}"
+          for arch in amd64 arm64; do
+            src="${GHCR_IMAGE}:${SNAP_VERSION}-${arch}"
+            docker tag "$src" "${GHCR_IMAGE}:main-${arch}"
+            docker tag "$src" "${GHCR_IMAGE}:${SHORT_SHA}-${arch}"
+            docker push "${GHCR_IMAGE}:main-${arch}"
+            docker push "${GHCR_IMAGE}:${SHORT_SHA}-${arch}"
+          done
+          docker manifest rm "${GHCR_IMAGE}:main" 2>/dev/null || true
+          docker manifest create "${GHCR_IMAGE}:main" \
+            "${GHCR_IMAGE}:main-amd64" "${GHCR_IMAGE}:main-arm64"
+          docker manifest push "${GHCR_IMAGE}:main"
+          docker manifest create "${GHCR_IMAGE}:${SHORT_SHA}" \
+            "${GHCR_IMAGE}:${SHORT_SHA}-amd64" "${GHCR_IMAGE}:${SHORT_SHA}-arm64"
+          docker manifest push "${GHCR_IMAGE}:${SHORT_SHA}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,19 @@ jobs:
       - name: Enable pnpm
         run: corepack enable
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ apps/web/.next/
 apps/web/out/
 apps/api/static/assets/
 .overmind.sock
+
+# goreleaser output
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -79,6 +79,46 @@ archives:
         formats: [zip]
     files:
       - README.md
+dockers:
+  - id: server-amd64
+    image_templates:
+      - 'ghcr.io/getstackit/stackit-server:{{ .Version }}-amd64'
+    ids: [server]
+    dockerfile: Dockerfile.server
+    use: buildx
+    goos: linux
+    goarch: amd64
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.source=https://github.com/getstackit/stackit"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.revision={{.Commit}}"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+  - id: server-arm64
+    image_templates:
+      - 'ghcr.io/getstackit/stackit-server:{{ .Version }}-arm64'
+    ids: [server]
+    dockerfile: Dockerfile.server
+    use: buildx
+    goos: linux
+    goarch: arm64
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.source=https://github.com/getstackit/stackit"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.revision={{.Commit}}"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+
+docker_manifests:
+  - name_template: 'ghcr.io/getstackit/stackit-server:{{ .Version }}'
+    image_templates:
+      - 'ghcr.io/getstackit/stackit-server:{{ .Version }}-amd64'
+      - 'ghcr.io/getstackit/stackit-server:{{ .Version }}-arm64'
+  - name_template: 'ghcr.io/getstackit/stackit-server:latest'
+    image_templates:
+      - 'ghcr.io/getstackit/stackit-server:{{ .Version }}-amd64'
+      - 'ghcr.io/getstackit/stackit-server:{{ .Version }}-arm64'
+
 checksum:
   name_template: 'checksums.txt'
 

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,12 @@
+# Image for stackit-server. Goreleaser builds binaries via cross-compile and
+# drops the linux/amd64 or linux/arm64 binary into the build context, where
+# this COPY picks it up. Alpine (not distroless-static) because the server
+# shells out to git for every git op — distroless has no git binary.
+FROM alpine:3.20
+
+RUN apk add --no-cache git ca-certificates tzdata
+
+COPY stackit-server /usr/local/bin/stackit-server
+
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/stackit-server"]


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Ship stackit-server as 'ghcr.io/getstackit/stackit-server' so it can
be pulled from Railway and other hosts. Alpine base (not distroless)
because the server shells out to git for every git op. Each release
tag produces 'vX.Y.Z' and 'latest'; every push to main publishes
'main' and a short-sha tag via a separate workflow that re-tags the
goreleaser snapshot output. Validated locally with a snapshot build
and a docker run hitting /api/v1/repos.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1006**
  * **PR #1007**
    * **PR #1008** 👈
      * **PR #1009**
        * **PR #1011**
          * **PR #1015**
            * **PR #1016**
              * **PR #1017**
                * **PR #1012**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1054 by jonnii*