### PR TITLE
docs: add deploy guide for hosted stackit-server

### DIFF
--- a/.mise/tasks/server/publish-dev
+++ b/.mise/tasks/server/publish-dev
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#MISE description="Build and push a snapshot stackit-server image to ghcr.io without a release"
+#MISE alias="server:publish:dev"
+set -euo pipefail
+
+# Push a snapshot multi-arch image to ghcr.io for ad-hoc dogfooding (Railway,
+# remote pulls, etc.) without cutting a release tag. Uses goreleaser snapshot
+# mode to build the per-arch images locally, then re-tags and pushes them
+# under TAG (default: dev).
+#
+# Usage:
+#   mise run server:publish:dev                # pushes :dev (+ amd64/arm64)
+#   TAG=preview mise run server:publish:dev    # pushes :preview
+#   SKIP_BUILD=1 mise run server:publish:dev   # reuse existing dist/ output
+
+IMAGE="${IMAGE:-ghcr.io/getstackit/stackit-server}"
+TAG="${TAG:-dev}"
+SKIP_BUILD="${SKIP_BUILD:-0}"
+
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[0;33m'
+RED=$'\033[0;31m'
+RESET=$'\033[0m'
+
+log()  { printf "%s==>%s %s\n" "$GREEN" "$RESET" "$*"; }
+warn() { printf "%s==>%s %s\n" "$YELLOW" "$RESET" "$*" >&2; }
+die()  { printf "%serror:%s %s\n" "$RED" "$RESET" "$*" >&2; exit 1; }
+
+command -v docker >/dev/null    || die "docker not on PATH"
+command -v goreleaser >/dev/null || die "goreleaser not on PATH (mise should install it)"
+command -v jq >/dev/null         || die "jq not on PATH"
+
+# Verify we can push to GHCR before spending 90s on a build.
+if ! docker buildx imagetools inspect "$IMAGE:latest" >/dev/null 2>&1; then
+  if ! grep -q '"ghcr.io"' "${HOME}/.docker/config.json" 2>/dev/null; then
+    warn "Not logged into ghcr.io — attempting via 'gh auth token'."
+    if command -v gh >/dev/null && gh auth token >/dev/null 2>&1; then
+      gh auth token | docker login ghcr.io \
+        -u "$(gh api user --jq .login)" --password-stdin
+    else
+      die "Login to ghcr.io first. Run: gh auth refresh -s write:packages,read:packages && \\
+       echo \$(gh auth token) | docker login ghcr.io -u \$(gh api user --jq .login) --password-stdin"
+    fi
+  fi
+fi
+
+if [ "$SKIP_BUILD" != "1" ]; then
+  log "Building snapshot images (multi-arch, this takes a few minutes)..."
+  goreleaser release --snapshot --clean \
+    --skip=archive,homebrew,scoop,nfpm,sbom,announce,publish
+else
+  log "SKIP_BUILD=1 — reusing existing dist/"
+  [ -f dist/metadata.json ] || die "dist/metadata.json missing; can't skip build"
+fi
+
+SNAP_VERSION="$(jq -r .version dist/metadata.json)"
+log "Snapshot version: ${SNAP_VERSION}"
+log "Pushing to ${IMAGE}:${TAG} (+ ${TAG}-amd64, ${TAG}-arm64)"
+
+for arch in amd64 arm64; do
+  src="${IMAGE}:${SNAP_VERSION}-${arch}"
+  dst="${IMAGE}:${TAG}-${arch}"
+  docker tag "$src" "$dst"
+  docker push "$dst"
+done
+
+# Manifest may already exist locally from a previous run; recreate it cleanly.
+docker manifest rm "${IMAGE}:${TAG}" >/dev/null 2>&1 || true
+docker manifest create "${IMAGE}:${TAG}" \
+  "${IMAGE}:${TAG}-amd64" \
+  "${IMAGE}:${TAG}-arm64"
+docker manifest push "${IMAGE}:${TAG}"
+
+log "Done. Pull with:  docker pull ${IMAGE}:${TAG}"
+log "Verify multi-arch: docker buildx imagetools inspect ${IMAGE}:${TAG}"

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,143 @@
+# Deploying stackit-server
+
+This guide covers running the hosted multi-repo `stackit-server` container.
+At the time of writing the container ships **Phase 1 + Phase 6** from
+[`docs/plans/server/README.md`](plans/server/README.md): multiple repos,
+served via a config file, with no authentication yet. OAuth, clone-from-URL,
+and per-user repo scoping arrive in later phases.
+
+Treat the container as a single-tenant deployment behind your own
+authentication (a tunnel like Tailscale, an oauth2-proxy, etc.) until the
+auth phases land.
+
+## Image
+
+Published to [GitHub Container Registry](https://github.com/getstackit/stackit/pkgs/container/stackit-server)
+as `ghcr.io/getstackit/stackit-server`.
+
+| Tag | Source |
+|-----|--------|
+| `vX.Y.Z` | Cut from a release tag |
+| `latest` | Most recent release |
+| `main` | Latest push to the `main` branch |
+| `<short-sha>` | Specific commit on `main` |
+
+All tags are multi-arch (`linux/amd64`, `linux/arm64`).
+
+## Configuration
+
+The container reads its repo list from a JSON file. Mount a volume at `/data`
+(or anywhere) and point `-repos-config` at a file inside it.
+
+```json
+{
+  "repos": [
+    { "id": "stackit",  "displayName": "Stackit",  "path": "/data/repos/stackit" },
+    { "id": "myapp",    "displayName": "My App",    "path": "/data/repos/myapp" }
+  ]
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | yes | URL-safe identifier (`[a-zA-Z0-9_-]+`) used in `/api/v1/repos/{id}/...` routes |
+| `path` | yes | Absolute path inside the container to a git working tree |
+| `displayName` | no | Human label shown in the web UI; defaults to `id` |
+| `remote` | no | Git remote name; defaults to `origin` |
+
+You are responsible for cloning the repos into the mounted volume and
+running `stackit init` inside each one before starting the container.
+(Clone-from-URL + auto-init are Phase 4.)
+
+### Environment
+
+| Var | Purpose |
+|-----|---------|
+| `PORT` | Listen port. Honored when `-port` isn't passed explicitly — needed for Railway, Fly, Heroku. Defaults to `8080`. |
+
+### Flags
+
+The most useful flags:
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `-repos-config` | _(empty)_ | Path to the JSON repos file. Required for multi-repo mode. |
+| `-port` | `8080` | Listen port; overrides `$PORT`. |
+| `-cors` | `http://localhost:3000,http://localhost:5173` | Comma-separated allowed CORS origins. |
+
+Run `stackit-server -h` inside the container for the full list.
+
+## Local smoke test
+
+```bash
+# Clone something into ./data/repos/ first
+mkdir -p data/repos
+git clone https://github.com/getstackit/stackit data/repos/stackit
+(cd data/repos/stackit && stackit init)
+cat > data/repos.json <<'EOF'
+{ "repos": [ { "id": "stackit", "path": "/data/repos/stackit" } ] }
+EOF
+
+docker run --rm -p 8080:8080 \
+  -v "$(pwd)/data:/data" \
+  ghcr.io/getstackit/stackit-server:latest \
+  -repos-config /data/repos.json
+
+# In another terminal:
+curl -s localhost:8080/api/v1/repos | jq
+open http://localhost:8080
+```
+
+## Railway
+
+1. **Service** — deploy from image `ghcr.io/getstackit/stackit-server:main`
+   (or pin to `:latest` / `:vX.Y.Z`).
+2. **Volume** — mount at `/data`. Use at least a few GB; clones land here.
+3. **Variables** — Railway injects `PORT` automatically; no other vars are
+   required for the Phase 1 container.
+4. **Start command** — leave blank to use the image's `ENTRYPOINT`, then set
+   the **Command** (Railway's arg override) to:
+   ```
+   -repos-config /data/repos.json
+   ```
+5. **Seed the volume** — clone repos into `/data/repos/<id>/`, run
+   `stackit init` in each, and create `/data/repos.json`. Do this once via
+   a one-shot Railway shell session, then redeploy. (A `repo init` API
+   endpoint replaces this manual step in Phase 4.)
+
+## Pushing a snapshot without a release
+
+For ad-hoc dogfooding (e.g. validating a feature branch on Railway before
+merging) you can push a multi-arch image straight from your laptop without
+cutting a release tag:
+
+```bash
+gh auth refresh -s write:packages,read:packages    # one-time
+mise run server:publish:dev                        # pushes :dev (+arch tags)
+TAG=preview mise run server:publish:dev            # pushes :preview
+```
+
+The script wraps `goreleaser release --snapshot`, then re-tags and pushes
+the per-arch images and a manifest under `$TAG` (default `dev`). Skip the
+~90 s rebuild with `SKIP_BUILD=1` when you only want to re-push.
+
+## Updating
+
+- Pin to `:vX.Y.Z` for reproducible deploys; bump tag and redeploy.
+- Use `:main` for continuous deploys off the trunk — Railway can be
+  configured to redeploy whenever the GHCR tag is updated.
+- Use `:<short-sha>` to roll back to a known-good commit.
+
+## What's not in this container yet
+
+These all land in later phases:
+
+- **GitHub OAuth** (Phase 3) — every request currently hits the server with
+  no identity, and there is no per-user repo scoping.
+- **Clone-from-URL** (Phase 4) — repos must be pre-cloned into the mounted
+  volume.
+- **Persistent registry** (Phase 2) — runtime `POST /api/v1/repos` is not
+  available; edits to `repos.json` require a restart.
+
+See [`docs/plans/server/README.md`](plans/server/README.md) for the full
+phase plan.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Cover what's actually in the Phase 1 + Phase 6 container today:
repos.json + pre-cloned trees + stackit init. Call out which Phase
features are still missing (OAuth, clone-from-URL, runtime repo
add) so operators aren't confused by their absence. Includes a
local docker smoke test and Railway-specific steps.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1006**
  * **PR #1007**
    * **PR #1008**
      * **PR #1009** 👈
        * **PR #1011**
          * **PR #1015**
            * **PR #1016**
              * **PR #1017**
                * **PR #1012**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1054 by jonnii*