### PR TITLE
feat(server): harden HTTP middleware for public deploy

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,12 +1,17 @@
-# Image for stackit-server. Goreleaser builds binaries via cross-compile and
-# drops the linux/amd64 or linux/arm64 binary into the build context, where
-# this COPY picks it up. Alpine (not distroless-static) because the server
-# shells out to git for every git op — distroless has no git binary.
+# Image for stackit-server. Goreleaser dockers_v2 builds binaries via
+# cross-compile and arranges them under linux/<arch>/ in the build context,
+# which TARGETPLATFORM ("linux/amd64" or "linux/arm64") then selects.
+# Alpine (not distroless-static) because the server shells out to git for
+# every git op — distroless has no git binary.
 FROM alpine:3.20
 
-RUN apk add --no-cache git ca-certificates tzdata
+RUN apk add --no-cache git ca-certificates tzdata \
+ && addgroup -S -g 10001 stackit \
+ && adduser -S -D -H -u 10001 -G stackit stackit
 
-COPY stackit-server /usr/local/bin/stackit-server
+ARG TARGETPLATFORM
+COPY --chown=stackit:stackit $TARGETPLATFORM/stackit-server /usr/local/bin/stackit-server
 
+USER stackit:stackit
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/stackit-server"]

--- a/apps/server/bind.go
+++ b/apps/server/bind.go
@@ -1,0 +1,17 @@
+package main
+
+// resolveBind picks the default bind address when the operator did not pass
+// -bind explicitly. Locally we want 127.0.0.1 so the API isn't reachable to
+// other users on the host; PaaS / container deploys flip to 0.0.0.0 because
+// the platform's router is on a different interface. publicHint is true when
+// $PORT or $STACKIT_PUBLIC are set, both of which signal a hosted runtime.
+func resolveBind(flagBind *string, bindExplicit, publicHint bool) {
+	if bindExplicit {
+		return
+	}
+	if publicHint {
+		*flagBind = "0.0.0.0"
+		return
+	}
+	*flagBind = "127.0.0.1"
+}

--- a/apps/server/bind_test.go
+++ b/apps/server/bind_test.go
@@ -1,0 +1,31 @@
+package main
+
+import "testing"
+
+func TestResolveBind(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		bind       string
+		explicit   bool
+		publicHint bool
+		want       string
+	}{
+		{name: "explicit operator value wins", bind: "10.0.0.5", explicit: true, want: "10.0.0.5"},
+		{name: "explicit empty value wins too", bind: "", explicit: true, want: ""},
+		{name: "PaaS hint flips to all interfaces", publicHint: true, want: "0.0.0.0"},
+		{name: "local default is loopback", want: "127.0.0.1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := tc.bind
+			resolveBind(&b, tc.explicit, tc.publicHint)
+			if b != tc.want {
+				t.Fatalf("resolveBind(%q, explicit=%v, publicHint=%v) = %q, want %q",
+					tc.bind, tc.explicit, tc.publicHint, b, tc.want)
+			}
+		})
+	}
+}

--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -34,6 +34,7 @@ func main() {
 func run() error {
 	var (
 		port            = flag.Int("port", 8080, "Port to listen on")
+		bind            = flag.String("bind", "", "Interface to bind on. Defaults to 127.0.0.1; switches to 0.0.0.0 when $PORT or $STACKIT_PUBLIC is set.")
 		cwd             = flag.String("cwd", "", "Working directory for repository detection (single-repo shortcut; ignored when -repos-config is set)")
 		reposConfigPath = flag.String("repos-config", "", "Path to a JSON file listing repos to serve (mutually exclusive with -cwd)")
 		remote          = flag.String("remote", "origin", "Default git remote name for the single-repo -cwd shortcut")
@@ -47,14 +48,19 @@ func run() error {
 	// Honor $PORT when -port wasn't passed explicitly. PaaS hosts (Railway,
 	// Fly, Heroku) inject the port this way.
 	portExplicit := false
+	bindExplicit := false
 	flag.Visit(func(f *flag.Flag) {
-		if f.Name == "port" {
+		switch f.Name {
+		case "port":
 			portExplicit = true
+		case "bind":
+			bindExplicit = true
 		}
 	})
 	if err := resolvePort(port, portExplicit, os.Getenv("PORT")); err != nil {
 		return err
 	}
+	resolveBind(bind, bindExplicit, os.Getenv("PORT") != "" || os.Getenv("STACKIT_PUBLIC") != "")
 
 	staticFS, err := fs.Sub(staticFiles, "static")
 	if err != nil {
@@ -98,6 +104,7 @@ func run() error {
 	}
 
 	server := api.NewServer(api.ServerConfig{
+		BindAddr:    *bind,
 		Port:        *port,
 		CORSOrigins: parseCSV(*corsOrigins),
 		APIPrefixes: prefixes,

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -54,6 +54,7 @@ running `stackit init` inside each one before starting the container.
 | Var | Purpose |
 |-----|---------|
 | `PORT` | Listen port. Honored when `-port` isn't passed explicitly — needed for Railway, Fly, Heroku. Defaults to `8080`. |
+| `STACKIT_PUBLIC` | If set (any value), flips the default bind from `127.0.0.1` to `0.0.0.0`. `PORT` does the same thing implicitly. |
 
 ### Flags
 
@@ -63,9 +64,43 @@ The most useful flags:
 |------|---------|---------|
 | `-repos-config` | _(empty)_ | Path to the JSON repos file. Required for multi-repo mode. |
 | `-port` | `8080` | Listen port; overrides `$PORT`. |
-| `-cors` | `http://localhost:3000,http://localhost:5173` | Comma-separated allowed CORS origins. |
+| `-bind` | `127.0.0.1` (or `0.0.0.0` if `$PORT`/`$STACKIT_PUBLIC` are set) | Interface to bind on. Pass `-bind 0.0.0.0` explicitly to expose the server on a host where the heuristics don't fire. |
+| `-cors` | `http://localhost:3000,http://localhost:5173` | Comma-separated allowed CORS origins. Loopback origins are **not** allowed implicitly — list each origin you want to accept. |
 
 Run `stackit-server -h` inside the container for the full list.
+
+## Security posture
+
+The container is safe to run on a public hostname **only** behind:
+
+1. **TLS termination.** The server speaks plain HTTP; the PaaS / reverse
+   proxy in front (Railway, Fly, Cloudflare, Caddy, nginx) must terminate
+   HTTPS. The `Strict-Transport-Security` header the server emits assumes
+   this.
+2. **An authentication gateway** until in-process auth lands. Use Tailscale,
+   Cloudflare Access, an oauth2-proxy sidecar, or similar. Without one,
+   any caller can read every repo's branches/diffs and trigger
+   `POST /api/v1/repos/{id}/stacks/{branch}/submit`, which pushes branches
+   and creates PRs using the container's GitHub credentials.
+
+Built-in security controls (the server hardening pass that lands with
+this doc revision):
+
+- Process runs as the unprivileged `stackit` user (uid 10001) inside the
+  container — neither user nor group is `root`.
+- Default bind is `127.0.0.1`; the `$PORT`/`$STACKIT_PUBLIC` heuristic
+  flips to `0.0.0.0` so PaaS routers can reach the port.
+- Request body capped at 1 MiB; `MaxHeaderBytes` at 1 MiB; `WriteTimeout`
+  30 s, `IdleTimeout` 120 s, `ReadHeaderTimeout` 10 s.
+- Panic recovery middleware: a panicking handler returns 500 but cannot
+  kill the process.
+- Per-request `X-Request-ID` (16 random bytes) echoed back and logged.
+- Security headers on every response: `X-Content-Type-Options: nosniff`,
+  `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, `HSTS` with a
+  two-year max-age, and a CSP locked to `'self'` for scripts/connects.
+- CORS allowlist is exact-match; no implicit loopback bypass.
+- Branch names supplied via path/query are validated against the same
+  rules `stackit` enforces locally before reaching git.
 
 ## Local smoke test
 

--- a/internal/api/handlers/branch_diff.go
+++ b/internal/api/handlers/branch_diff.go
@@ -35,6 +35,9 @@ func (h *BranchDiffHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing branch query parameter", http.StatusBadRequest)
 		return
 	}
+	if !validateBranchName(w, branchName) {
+		return
+	}
 
 	branch := entry.Engine.GetBranch(branchName)
 	if !branch.IsTracked() {

--- a/internal/api/handlers/branches.go
+++ b/internal/api/handlers/branches.go
@@ -35,9 +35,12 @@ func (h *BranchesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	branchName := r.PathValue("name")
 	if branchName == "" {
 		h.listBranches(w, r, entry)
-	} else {
-		h.getBranch(w, r, entry, branchName)
+		return
 	}
+	if !validateBranchName(w, branchName) {
+		return
+	}
+	h.getBranch(w, r, entry, branchName)
 }
 
 func (h *BranchesHandler) listBranches(w http.ResponseWriter, r *http.Request, entry *registry.RepoEntry) {

--- a/internal/api/handlers/common.go
+++ b/internal/api/handlers/common.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/getstackit/stackit/internal/api/registry"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // defaultRepoID is the ID assigned to the single bootstrap repo when the
@@ -26,4 +27,16 @@ func resolveRepo(reg *registry.Registry, w http.ResponseWriter, r *http.Request)
 		return nil, false
 	}
 	return entry, true
+}
+
+// validateBranchName runs branch name through the same validator the CLI
+// uses (utils.ValidateBranchName) before any handler hands it to git. The
+// error message intentionally does not include the user-supplied name so
+// the response can't reflect arbitrary content back to a caller.
+func validateBranchName(w http.ResponseWriter, name string) bool {
+	if err := utils.ValidateBranchName(name); err != nil {
+		http.Error(w, "invalid branch name", http.StatusBadRequest)
+		return false
+	}
+	return true
 }

--- a/internal/api/handlers/events.go
+++ b/internal/api/handlers/events.go
@@ -34,6 +34,13 @@ func (h *EventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// SSE is long-lived; opt out of the server-wide WriteTimeout so the
+	// connection isn't dropped after the first 30 seconds. Failing here is
+	// not fatal — without it the connection is shorter-lived but otherwise
+	// works.
+	rc := http.NewResponseController(w)
+	_ = rc.SetWriteDeadline(time.Time{})
+
 	entry, ok := resolveRepo(h.reg, w, r)
 	if !ok {
 		return

--- a/internal/api/handlers/submit.go
+++ b/internal/api/handlers/submit.go
@@ -53,6 +53,9 @@ func (h *SubmitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	if !validateBranchName(w, rootBranch) {
+		return
+	}
 
 	ctx := app.NewContext(entry.Engine,
 		app.WithRepoRoot(entry.RepoRoot),

--- a/internal/api/handlers/validation_test.go
+++ b/internal/api/handlers/validation_test.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/api/registry"
+)
+
+// validatingHandlers is the set of API handlers that must reject malformed
+// branch names at the HTTP boundary, before any value reaches the git layer.
+// Each case wires up the handler exactly the way the router wires it in
+// production, with branchValue arriving via either a path value or a query
+// param depending on the handler.
+type validationCase struct {
+	name   string
+	build  func(reg *registry.Registry) http.Handler
+	method string
+	url    string
+	// setRequest mutates the request to attach the bad branch value the
+	// handler reads (path value or query param).
+	setRequest func(req *http.Request, branch string)
+}
+
+var validationCases = []validationCase{
+	{
+		name:   "BranchesHandler getBranch path value",
+		build:  func(reg *registry.Registry) http.Handler { return NewBranchesHandler(reg) },
+		method: http.MethodGet,
+		url:    "/api/v1/branches/x",
+		setRequest: func(req *http.Request, branch string) {
+			req.SetPathValue("name", branch)
+		},
+	},
+	{
+		name:   "BranchDiffHandler branch query",
+		build:  func(reg *registry.Registry) http.Handler { return NewBranchDiffHandler(reg) },
+		method: http.MethodGet,
+		url:    "/api/v1/branch-diff?branch=x",
+		setRequest: func(req *http.Request, branch string) {
+			q := req.URL.Query()
+			q.Set("branch", branch)
+			req.URL.RawQuery = q.Encode()
+		},
+	},
+	{
+		name:   "SubmitHandler rootBranch path value",
+		build:  func(reg *registry.Registry) http.Handler { return NewSubmitHandler(reg) },
+		method: http.MethodPost,
+		url:    "/api/v1/stacks/x/submit",
+		setRequest: func(req *http.Request, branch string) {
+			req.SetPathValue("rootBranch", branch)
+		},
+	},
+}
+
+func TestHandlers_RejectMalformedBranchNames(t *testing.T) {
+	t.Parallel()
+
+	// Names ValidateBranchName must reject. Cover the most security-relevant
+	// failure modes: leading hyphen (argname injection), traversal (..),
+	// invalid characters, and length.
+	badNames := []struct {
+		name  string
+		input string
+	}{
+		{"leading hyphen", "--upload-pack=evil"},
+		{"consecutive dots", "feature/..main"},
+		{"invalid character semicolon", "feature;rm -rf /"},
+		{"invalid character newline", "feature\nrm"},
+		{"trailing slash", "feature/"},
+		{"leading slash", "/feature"},
+		{"too long", strings.Repeat("a", 300)},
+	}
+
+	for _, vc := range validationCases {
+		for _, bad := range badNames {
+			t.Run(vc.name+"/"+bad.name, func(t *testing.T) {
+				t.Parallel()
+
+				reg := registry.New()
+				require.NoError(t, reg.Add(&registry.RepoEntry{ID: "default"}))
+
+				req := httptest.NewRequest(vc.method, vc.url, nil)
+				vc.setRequest(req, bad.input)
+
+				rr := httptest.NewRecorder()
+				vc.build(reg).ServeHTTP(rr, req)
+
+				require.Equalf(t, http.StatusBadRequest, rr.Code,
+					"%s: expected 400 for %q, got %d (body=%q)",
+					vc.name, bad.input, rr.Code, rr.Body.String())
+				require.NotContainsf(t, rr.Body.String(), bad.input,
+					"response body must not reflect the supplied branch name back at the caller")
+			})
+		}
+	}
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,15 +1,139 @@
 package api
 
 import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"log"
-	"net"
 	"net/http"
-	"net/url"
+	"runtime/debug"
 	"strings"
 	"time"
 )
 
-// corsMiddleware adds CORS headers for the given allowed origins.
+// requestIDHeader is the response header that carries the per-request ID. The
+// same value is stashed on the request context so handlers and the logger can
+// reference it.
+const requestIDHeader = "X-Request-ID"
+
+// maxRequestBodyBytes caps every request body. POST /submit takes no body
+// today; this is defense against runaway uploads against any endpoint.
+const maxRequestBodyBytes = 1 << 20 // 1 MiB
+
+type ctxKey int
+
+const ctxKeyRequestID ctxKey = iota
+
+// RequestIDFromContext returns the request ID associated with the context, or
+// the empty string if none was set.
+func RequestIDFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(ctxKeyRequestID).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// recoverMiddleware catches panics in downstream handlers, logs them with a
+// stack trace, and returns a 500. Without this, a single panicking handler
+// kills the whole server process.
+func recoverMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			rec := recover()
+			if rec == nil {
+				return
+			}
+			rid := RequestIDFromContext(r.Context())
+			log.Printf("panic recovered request_id=%s %s %s: %v\n%s", rid, r.Method, r.URL.Path, rec, debug.Stack()) //nolint:gosec // method and path are safe to log
+			// If the handler already wrote a status, we can't change it.
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+// requestIDMiddleware assigns each request an opaque ID, echoes it as a
+// response header, and stashes it on the context for handlers/logging. If
+// the client supplied an X-Request-ID we adopt it (so traces can be
+// stitched across a proxy), capped at 64 chars and ASCII-only.
+func requestIDMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rid := sanitizeIncomingRequestID(r.Header.Get(requestIDHeader))
+		if rid == "" {
+			rid = newRequestID()
+		}
+		w.Header().Set(requestIDHeader, rid)
+		ctx := context.WithValue(r.Context(), ctxKeyRequestID, rid)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func newRequestID() string {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		// rand.Read on modern OSes only fails in pathological conditions.
+		// Fall back to a timestamp so we still produce *something*.
+		return "rid-" + time.Now().UTC().Format("20060102T150405.000000000")
+	}
+	return hex.EncodeToString(buf[:])
+}
+
+// sanitizeIncomingRequestID accepts a caller-supplied ID only if it's short
+// and ASCII-printable. Anything else gets dropped so we don't reflect attacker
+// input into headers or log lines.
+func sanitizeIncomingRequestID(s string) string {
+	if s == "" || len(s) > 64 {
+		return ""
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < 0x20 || c > 0x7e {
+			return ""
+		}
+	}
+	return s
+}
+
+// securityHeadersMiddleware sets the baseline browser security headers we want
+// on every response. CSP here matches the embedded Next.js shell; if the
+// frontend starts pulling third-party scripts/images, tighten or extend
+// connect-src/script-src to match.
+func securityHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("X-Frame-Options", "DENY")
+		h.Set("Referrer-Policy", "no-referrer")
+		h.Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
+		h.Set("Content-Security-Policy",
+			"default-src 'self'; "+
+				"img-src 'self' data: https:; "+
+				"style-src 'self' 'unsafe-inline'; "+
+				"script-src 'self'; "+
+				"connect-src 'self'; "+
+				"frame-ancestors 'none'; "+
+				"base-uri 'self'; "+
+				"form-action 'self'")
+		next.ServeHTTP(w, r)
+	})
+}
+
+// maxBodyMiddleware caps each request body at maxRequestBodyBytes. Reads past
+// the limit return an error from the handler's Read call, and http.MaxBytesReader
+// surfaces a 413 if the handler doesn't handle it explicitly.
+func maxBodyMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil {
+			r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// corsMiddleware adds CORS headers for the given allowed origins. Origins
+// must be configured explicitly via -cors; there is no implicit loopback
+// allowance, so the server is safe to run on a host shared with untrusted
+// processes.
 func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 	originSet := make(map[string]struct{}, len(allowedOrigins))
 	for _, o := range allowedOrigins {
@@ -17,12 +141,15 @@ func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		origin := r.Header.Get("Origin")
-		if _, ok := originSet[origin]; ok || isLocalDevOrigin(origin) {
-			w.Header().Set("Access-Control-Allow-Origin", origin)
-			w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-			w.Header().Set("Access-Control-Max-Age", "86400")
+		origin := strings.TrimRight(r.Header.Get("Origin"), "/")
+		if _, ok := originSet[origin]; ok {
+			h := w.Header()
+			h.Set("Access-Control-Allow-Origin", origin)
+			h.Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			h.Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Request-ID")
+			h.Set("Access-Control-Allow-Credentials", "true")
+			h.Set("Access-Control-Max-Age", "86400")
+			h.Add("Vary", "Origin")
 		}
 
 		if r.Method == http.MethodOptions {
@@ -34,29 +161,8 @@ func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 	})
 }
 
-func isLocalDevOrigin(origin string) bool {
-	if origin == "" {
-		return false
-	}
-
-	u, err := url.Parse(origin)
-	if err != nil {
-		return false
-	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return false
-	}
-
-	host := u.Hostname()
-	if host == "localhost" {
-		return true
-	}
-
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
-}
-
-// loggingMiddleware logs each request with method, path, status, and duration.
+// loggingMiddleware logs each request with method, path, status, duration,
+// and request ID.
 func loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
@@ -64,7 +170,8 @@ func loggingMiddleware(next http.Handler) http.Handler {
 
 		next.ServeHTTP(sw, r)
 
-		log.Printf("%s %s %d %s", r.Method, r.URL.Path, sw.status, time.Since(start).Round(time.Millisecond)) //nolint:gosec // method and path are safe to log
+		rid := RequestIDFromContext(r.Context())
+		log.Printf("%s %s %d %s rid=%s", r.Method, r.URL.Path, sw.status, time.Since(start).Round(time.Millisecond), rid) //nolint:gosec // method and path are safe to log
 	})
 }
 
@@ -79,7 +186,7 @@ func (w *statusWriter) WriteHeader(code int) {
 }
 
 // Unwrap allows http.ResponseController to access the underlying ResponseWriter
-// for features like Flush.
+// for features like Flush and SetWriteDeadline (SSE).
 func (w *statusWriter) Unwrap() http.ResponseWriter {
 	return w.ResponseWriter
 }

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -1,9 +1,14 @@
 package api
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestStatusWriterImplementsFlusherWhenWrappedWriterDoes(t *testing.T) {
@@ -32,26 +37,32 @@ func TestCORSMiddlewareAllowsConfiguredOrigin(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "http://example.com" {
-		t.Fatalf("expected configured origin to be allowed, got %q", got)
-	}
+	require.Equal(t, "http://example.com", rr.Header().Get("Access-Control-Allow-Origin"))
+	require.Equal(t, "GET, POST, OPTIONS", rr.Header().Get("Access-Control-Allow-Methods"))
+	require.Equal(t, "true", rr.Header().Get("Access-Control-Allow-Credentials"))
+	require.Contains(t, rr.Header().Get("Access-Control-Allow-Headers"), "Authorization")
+	require.Equal(t, "Origin", rr.Header().Get("Vary"))
 }
 
-func TestCORSMiddlewareAllowsLocalhostAnyPort(t *testing.T) {
+func TestCORSMiddlewareRejectsLoopbackOriginByDefault(t *testing.T) {
 	t.Parallel()
 
-	handler := corsMiddleware(nil, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+	// Previously the middleware allowed any loopback origin automatically.
+	// On a public deploy that opens an attack surface for anything else
+	// running on the host, so the rule was removed; localhost must be in
+	// -cors to be accepted.
+	for _, origin := range []string{"http://localhost:5100", "http://127.0.0.1:3000", "http://[::1]:5173"} {
+		handler := corsMiddleware(nil, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
 
-	req := httptest.NewRequest(http.MethodGet, "/api/view", nil)
-	req.Header.Set("Origin", "http://localhost:5100")
+		req := httptest.NewRequest(http.MethodGet, "/api/view", nil)
+		req.Header.Set("Origin", origin)
 
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
 
-	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:5100" {
-		t.Fatalf("expected localhost origin to be allowed, got %q", got)
+		require.Emptyf(t, rr.Header().Get("Access-Control-Allow-Origin"), "origin %q should not be auto-allowed", origin)
 	}
 }
 
@@ -68,32 +79,148 @@ func TestCORSMiddlewareRejectsUnconfiguredNonLocalOrigin(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "" {
-		t.Fatalf("expected non-local, unconfigured origin to be rejected, got %q", got)
+	require.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestRecoverMiddlewareConvertsPanicTo500(t *testing.T) {
+	t.Parallel()
+
+	handler := recoverMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic("boom")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+
+	require.NotPanics(t, func() { handler.ServeHTTP(rr, req) })
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestRequestIDMiddlewareGeneratesAndEchoes(t *testing.T) {
+	t.Parallel()
+
+	var observed string
+	handler := requestIDMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		observed = RequestIDFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.NotEmpty(t, observed)
+	require.Equal(t, observed, rr.Header().Get(requestIDHeader))
+}
+
+func TestRequestIDMiddlewareAdoptsSafeIncomingID(t *testing.T) {
+	t.Parallel()
+
+	handler := requestIDMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(requestIDHeader, "trace-abc-123")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, "trace-abc-123", rr.Header().Get(requestIDHeader))
+}
+
+func TestRequestIDMiddlewareRejectsUnsafeIncomingID(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		strings.Repeat("a", 65), // too long
+		"contains\nnewline",
+		"contains\x00null",
+		"unicode-😀",
+	}
+	for _, in := range cases {
+		handler := requestIDMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set(requestIDHeader, in)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		got := rr.Header().Get(requestIDHeader)
+		require.NotEqualf(t, in, got, "should not adopt unsafe id %q", in)
+		require.NotEmpty(t, got, "should still emit a generated id")
 	}
 }
 
-func TestIsLocalDevOrigin(t *testing.T) {
+func TestSecurityHeadersMiddlewareSetsBaseline(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name   string
-		origin string
-		want   bool
-	}{
-		{name: "localhost with port", origin: "http://localhost:5100", want: true},
-		{name: "ipv4 loopback", origin: "http://127.0.0.1:3000", want: true},
-		{name: "ipv6 loopback", origin: "http://[::1]:5173", want: true},
-		{name: "non-loopback host", origin: "http://example.com:3000", want: false},
-		{name: "invalid", origin: "not a url", want: false},
-	}
+	handler := securityHeadersMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			if got := isLocalDevOrigin(tc.origin); got != tc.want {
-				t.Fatalf("isLocalDevOrigin(%q): want %v, got %v", tc.origin, tc.want, got)
-			}
-		})
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, "nosniff", rr.Header().Get("X-Content-Type-Options"))
+	require.Equal(t, "DENY", rr.Header().Get("X-Frame-Options"))
+	require.Equal(t, "no-referrer", rr.Header().Get("Referrer-Policy"))
+	require.Contains(t, rr.Header().Get("Strict-Transport-Security"), "max-age=")
+	require.Contains(t, rr.Header().Get("Content-Security-Policy"), "default-src 'self'")
+	require.Contains(t, rr.Header().Get("Content-Security-Policy"), "frame-ancestors 'none'")
+}
+
+func TestMaxBodyMiddlewareCapsRequestBody(t *testing.T) {
+	t.Parallel()
+
+	var readErr error
+	handler := maxBodyMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, readErr = io.ReadAll(r.Body)
+		if readErr != nil {
+			http.Error(w, readErr.Error(), http.StatusRequestEntityTooLarge)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	body := bytes.Repeat([]byte("a"), maxRequestBodyBytes+1)
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Error(t, readErr)
+	require.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
+}
+
+func TestMaxBodyMiddlewareAllowsSmallBody(t *testing.T) {
+	t.Parallel()
+
+	handler := maxBodyMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, []byte("ok"), b)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("ok"))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestSanitizeIncomingRequestID(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"trace-1", "trace-1"},
+		{strings.Repeat("x", 64), strings.Repeat("x", 64)},
+		{strings.Repeat("x", 65), ""},
+		{"a\tb", ""},   // tab is < 0x20
+		{"a\x7fb", ""}, // DEL is > 0x7e
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, sanitizeIncomingRequestID(tc.in), "input=%q", tc.in)
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -16,6 +16,10 @@ import (
 
 // ServerConfig holds configuration for the API server.
 type ServerConfig struct {
+	// BindAddr is the host/IP to listen on. Empty means "all interfaces".
+	// apps/server picks a safe default (127.0.0.1) and switches to the
+	// public-facing form when PORT or STACKIT_PUBLIC is set.
+	BindAddr    string
 	Port        int
 	CORSOrigins []string
 	APIPrefixes []string
@@ -99,16 +103,27 @@ func (s *Server) Start() error {
 		http.NotFound(w, r)
 	})
 
-	handler := corsMiddleware(s.config.CORSOrigins, root)
-	handler = loggingMiddleware(handler)
+	// Middleware order (outermost first). recover wraps everything so a
+	// panic in any inner layer can't kill the process; logging is innermost
+	// so it sees the final status written by handlers (and by any earlier
+	// middleware that short-circuits).
+	handler := loggingMiddleware(root)
+	handler = maxBodyMiddleware(handler)
+	handler = corsMiddleware(s.config.CORSOrigins, handler)
+	handler = securityHeadersMiddleware(handler)
+	handler = requestIDMiddleware(handler)
+	handler = recoverMiddleware(handler)
 
 	s.httpServer = &http.Server{
-		Addr:              fmt.Sprintf(":%d", s.config.Port),
+		Addr:              fmt.Sprintf("%s:%d", s.config.BindAddr, s.config.Port),
 		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		MaxHeaderBytes:    1 << 20, // 1 MiB
 	}
 
-	log.Printf("stackit-web server listening on http://localhost:%d", s.config.Port)
+	log.Printf("stackit-web server listening on http://%s:%d", displayHost(s.config.BindAddr), s.config.Port)
 	return s.httpServer.ListenAndServe()
 }
 
@@ -152,6 +167,17 @@ func normalizeAPIPrefixes(prefixes []string) []string {
 		return []string{"/api/v1", "/api"}
 	}
 	return normalized
+}
+
+// displayHost returns a user-friendly host for the startup log line. Empty
+// bind address means "listen on all interfaces", which we surface as
+// "localhost" because that's what the operator will type in a browser to
+// reach the server locally.
+func displayHost(bind string) string {
+	if bind == "" || bind == "0.0.0.0" || bind == "::" {
+		return "localhost"
+	}
+	return bind
 }
 
 func isAPIPath(path string, prefixes []string) bool {

--- a/internal/api/static.go
+++ b/internal/api/static.go
@@ -42,6 +42,14 @@ func newStaticHandler(staticFS fs.FS) http.Handler {
 
 		if staticFS != nil {
 			if _, err := fs.Stat(staticFS, cleanPath); err == nil {
+				// Next emits hashed asset paths under _next/static/, which are
+				// safe to cache aggressively. Everything else (HTML, manifests,
+				// etc.) should re-validate so deploys take effect immediately.
+				if strings.HasPrefix(cleanPath, "_next/static/") {
+					w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+				} else {
+					w.Header().Set("Cache-Control", "no-cache")
+				}
 				fileServer.ServeHTTP(w, r)
 				return
 			}
@@ -60,6 +68,7 @@ func newStaticHandler(staticFS fs.FS) http.Handler {
 
 func writeIndex(w http.ResponseWriter, indexHTML []byte) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(indexHTML)
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Land the no-architecture security controls needed before stackit-server
can be exposed on the public web. The four-PR security pass is documented
at /Users/jonnii/.claude/plans/we-are-going-put-transient-taco.md; this
is the first phase.

Adds, around the existing handler chain, in outermost-first order:
panic recovery, X-Request-ID generation/propagation, baseline security
headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options,
Referrer-Policy), and a 1 MiB request-body cap. Drops the always-on
loopback CORS bypass so localhost has to be in -cors like any other
origin, advertises POST in Allow-Methods (the route table already
exposes POST /submit), and enables credentials so cookie-based auth can
land in the next PR. Sets WriteTimeout/IdleTimeout/MaxHeaderBytes on
http.Server; the SSE events handler clears its write deadline so the
new WriteTimeout doesn't drop long-lived streams.

Validates branch names from path/query against utils.ValidateBranchName
before they reach the engine, returning 400 without reflecting the
caller-supplied value back. Defaults the listen address to 127.0.0.1
and only flips to 0.0.0.0 when \$PORT or \$STACKIT_PUBLIC is set so the
desktop binary isn't reachable to other host users. Drops the
container's root user in favor of a uid 10001 stackit user.

Authentication and CSRF protection still come in PR 2 + PR 3 of the
plan; this PR closes the open-by-default holes that exist regardless
of which auth model lands.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1779932878`.


* **PR #1006**
  * **PR #1007**
    * **PR #1008**
      * **PR #1009**
        * **PR #1011** 👈
          * **PR #1015**
            * **PR #1016**
              * **PR #1017**
                * **PR #1012**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->