### PR TITLE
feat(server): gate API behind GitHub OAuth + allowlist

### DIFF
--- a/apps/server/auth.go
+++ b/apps/server/auth.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/getstackit/stackit/internal/api"
+	"github.com/getstackit/stackit/internal/api/auth"
+)
+
+// authBuildResult is what buildAuthConfig returns when auth is enabled.
+type authBuildResult struct {
+	cfg   *api.AuthConfig
+	store auth.Store // exposed separately so main can close it on shutdown
+}
+
+// buildAuthConfig wires up the OAuth handler, session store, and allowlist
+// from environment variables. Returns (nil, nil, nil) when auth is
+// explicitly disabled; an error when required env is missing in public
+// mode.
+func buildAuthConfig(authDisabled, publicMode bool) (*authBuildResult, error) {
+	if authDisabled {
+		if publicMode {
+			return nil, errors.New("-auth-disabled is not allowed when $PORT or $STACKIT_PUBLIC are set; remove the flag or unset the env vars")
+		}
+		return nil, nil
+	}
+
+	clientID := strings.TrimSpace(os.Getenv("STACKIT_GITHUB_CLIENT_ID"))
+	clientSecret := strings.TrimSpace(os.Getenv("STACKIT_GITHUB_CLIENT_SECRET"))
+	baseURL := strings.TrimSpace(os.Getenv("STACKIT_BASE_URL"))
+	sessionKey := strings.TrimSpace(os.Getenv("STACKIT_SESSION_KEY"))
+
+	// Outside public mode, missing OAuth config is "off by default" —
+	// users running a local dev binary shouldn't have to set env vars to
+	// boot. They can pass -auth-disabled explicitly to make the intent
+	// clear, or just leave the OAuth env unset.
+	if clientID == "" && clientSecret == "" && baseURL == "" && sessionKey == "" {
+		if publicMode {
+			return nil, errors.New("public mode requires STACKIT_GITHUB_CLIENT_ID, STACKIT_GITHUB_CLIENT_SECRET, STACKIT_BASE_URL, STACKIT_SESSION_KEY (and STACKIT_ALLOWED_GH_USERS or STACKIT_ALLOWED_GH_ORG); pass -auth-disabled if you really mean to run open")
+		}
+		return nil, nil
+	}
+
+	if clientID == "" {
+		return nil, errors.New("STACKIT_GITHUB_CLIENT_ID is required when configuring auth")
+	}
+	if clientSecret == "" {
+		return nil, errors.New("STACKIT_GITHUB_CLIENT_SECRET is required when configuring auth")
+	}
+	if baseURL == "" {
+		return nil, errors.New("STACKIT_BASE_URL is required when configuring auth")
+	}
+	if sessionKey == "" {
+		return nil, errors.New("STACKIT_SESSION_KEY is required when configuring auth (generate with: openssl rand -base64 32)")
+	}
+
+	cipher, err := auth.NewCipher(sessionKey)
+	if err != nil {
+		return nil, fmt.Errorf("STACKIT_SESSION_KEY: %w", err)
+	}
+
+	allow, err := auth.NewAllowlist(auth.AllowlistConfig{
+		Users: parseCSV(os.Getenv("STACKIT_ALLOWED_GH_USERS")),
+		Org:   strings.TrimSpace(os.Getenv("STACKIT_ALLOWED_GH_ORG")),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("allowlist: %w", err)
+	}
+
+	store := auth.NewMemoryStore(cipher)
+
+	handler, err := auth.NewHandler(auth.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		BaseURL:      baseURL,
+		Cookies:      auth.CookieOptions{Secure: publicMode || strings.HasPrefix(baseURL, "https://")},
+	}, store, allow, cipher)
+	if err != nil {
+		_ = store.Close()
+		return nil, err
+	}
+
+	return &authBuildResult{
+		cfg:   &api.AuthConfig{Handler: handler, SessionStore: store},
+		store: store,
+	}, nil
+}

--- a/apps/server/auth_test.go
+++ b/apps/server/auth_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/getstackit/stackit/internal/api/auth"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildAuthConfig_DisabledLocalOK(t *testing.T) {
+	t.Parallel()
+
+	r, err := buildAuthConfig(true, false)
+	require.NoError(t, err)
+	require.Nil(t, r)
+}
+
+func TestBuildAuthConfig_DisabledInPublicModeRefused(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildAuthConfig(true, true)
+	require.Error(t, err)
+}
+
+func TestBuildAuthConfig_NoEnvLocalFallsThroughToUnauthed(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel; these tests share process env.
+	withEnv(t, map[string]string{
+		"STACKIT_GITHUB_CLIENT_ID":     "",
+		"STACKIT_GITHUB_CLIENT_SECRET": "",
+		"STACKIT_BASE_URL":             "",
+		"STACKIT_SESSION_KEY":          "",
+		"STACKIT_ALLOWED_GH_USERS":     "",
+		"STACKIT_ALLOWED_GH_ORG":       "",
+	})
+
+	r, err := buildAuthConfig(false, false)
+	require.NoError(t, err)
+	require.Nil(t, r, "no env + local mode = no auth, no error")
+}
+
+func TestBuildAuthConfig_NoEnvInPublicModeRefused(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel; these tests share process env.
+	withEnv(t, map[string]string{
+		"STACKIT_GITHUB_CLIENT_ID":     "",
+		"STACKIT_GITHUB_CLIENT_SECRET": "",
+		"STACKIT_BASE_URL":             "",
+		"STACKIT_SESSION_KEY":          "",
+		"STACKIT_ALLOWED_GH_USERS":     "",
+		"STACKIT_ALLOWED_GH_ORG":       "",
+	})
+
+	_, err := buildAuthConfig(false, true)
+	require.Error(t, err)
+}
+
+func TestBuildAuthConfig_PartialEnvErrors(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel; these tests share process env.
+	withEnv(t, map[string]string{
+		"STACKIT_GITHUB_CLIENT_ID":     "id",
+		"STACKIT_GITHUB_CLIENT_SECRET": "",
+		"STACKIT_BASE_URL":             "https://example.com",
+		"STACKIT_SESSION_KEY":          mustKey(t),
+		"STACKIT_ALLOWED_GH_USERS":     "jonnii",
+	})
+
+	_, err := buildAuthConfig(false, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "STACKIT_GITHUB_CLIENT_SECRET")
+}
+
+func TestBuildAuthConfig_HappyPath(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel; these tests share process env.
+	withEnv(t, map[string]string{
+		"STACKIT_GITHUB_CLIENT_ID":     "id",
+		"STACKIT_GITHUB_CLIENT_SECRET": "secret",
+		"STACKIT_BASE_URL":             "https://example.com",
+		"STACKIT_SESSION_KEY":          mustKey(t),
+		"STACKIT_ALLOWED_GH_USERS":     "jonnii",
+	})
+
+	r, err := buildAuthConfig(false, false)
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	require.NotNil(t, r.cfg.Handler)
+	require.NotNil(t, r.cfg.SessionStore)
+	require.NoError(t, r.store.Close())
+}
+
+func TestBuildAuthConfig_EmptyAllowlistErrors(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel; these tests share process env.
+	withEnv(t, map[string]string{
+		"STACKIT_GITHUB_CLIENT_ID":     "id",
+		"STACKIT_GITHUB_CLIENT_SECRET": "secret",
+		"STACKIT_BASE_URL":             "https://example.com",
+		"STACKIT_SESSION_KEY":          mustKey(t),
+		"STACKIT_ALLOWED_GH_USERS":     "",
+		"STACKIT_ALLOWED_GH_ORG":       "",
+	})
+
+	_, err := buildAuthConfig(false, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "allowlist")
+}
+
+func withEnv(t *testing.T, kvs map[string]string) {
+	t.Helper()
+	for k, v := range kvs {
+		t.Setenv(k, v)
+	}
+}
+
+func mustKey(t *testing.T) string {
+	t.Helper()
+	k, err := auth.GenerateSessionKey()
+	require.NoError(t, err)
+	return k
+}

--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -42,6 +42,7 @@ func run() error {
 		apiPrefix       = flag.String("api-prefix", "/api/v1", "Canonical API prefix")
 		enableLegacy    = flag.Bool("legacy-api-prefix", true, "Also expose legacy /api endpoints")
 		shutdownGrace   = flag.Duration("shutdown-timeout", 10*time.Second, "Graceful shutdown timeout")
+		authDisabled    = flag.Bool("auth-disabled", false, "Disable GitHub OAuth gate. Refused in public mode ($PORT or $STACKIT_PUBLIC).")
 	)
 	flag.Parse()
 
@@ -103,6 +104,24 @@ func run() error {
 		}
 	}
 
+	publicMode := os.Getenv("PORT") != "" || os.Getenv("STACKIT_PUBLIC") != ""
+	authBuild, err := buildAuthConfig(*authDisabled, publicMode)
+	if err != nil {
+		return err
+	}
+	var authCfg *api.AuthConfig
+	if authBuild != nil {
+		authCfg = authBuild.cfg
+		defer func() {
+			if closeErr := authBuild.store.Close(); closeErr != nil {
+				log.Printf("session store close: %v", closeErr)
+			}
+		}()
+		log.Printf("auth: GitHub OAuth gate enabled")
+	} else {
+		log.Printf("auth: DISABLED (no STACKIT_GITHUB_* env or -auth-disabled set). Do not expose this port publicly.")
+	}
+
 	server := api.NewServer(api.ServerConfig{
 		BindAddr:    *bind,
 		Port:        *port,
@@ -110,6 +129,7 @@ func run() error {
 		APIPrefixes: prefixes,
 		StaticFS:    staticFS,
 		Registry:    reg,
+		Auth:        authCfg,
 	})
 
 	errCh := make(chan error, 1)

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,9 +2,17 @@
 
 import { Suspense } from "react";
 import { useSearchParams } from "next/navigation";
+import { AuthProvider } from "@/components/providers/auth-provider";
 import { RepoProvider } from "@/components/providers/repo-provider";
 import { RepoPicker } from "@/components/repo-picker/repo-picker";
 import { RepoView } from "@/components/repo-picker/repo-view";
+
+// NEXT_PUBLIC_STACKIT_AUTH_DISABLED=1 short-circuits the /auth/me check
+// at build time. Useful for `next dev` against a server started with
+// -auth-disabled, or for builds intended for deployments where the
+// operator has fronted the server with platform auth (Tailscale,
+// Cloudflare Access).
+const AUTH_DISABLED = process.env.NEXT_PUBLIC_STACKIT_AUTH_DISABLED === "1";
 
 // Single root page driving both the unscoped picker and the per-repo view.
 //
@@ -31,7 +39,9 @@ function Home() {
 export default function Page() {
   return (
     <Suspense fallback={null}>
-      <Home />
+      <AuthProvider disable={AUTH_DISABLED}>
+        <Home />
+      </AuthProvider>
     </Suspense>
   );
 }

--- a/apps/web/src/components/providers/auth-provider.tsx
+++ b/apps/web/src/components/providers/auth-provider.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import {
+  authLoginURL,
+  fetchMe,
+  logout as apiLogout,
+  type MeResponse,
+  UnauthorizedError,
+} from "@/lib/api";
+
+interface AuthContextValue {
+  // user is null while loading; remains null after a 401 (the provider will
+  // render the login screen instead of children in that case).
+  user: MeResponse | null;
+  isLoading: boolean;
+  loginURL: string;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  isLoading: true,
+  loginURL: "/auth/login",
+  logout: async () => {},
+});
+
+export function useAuth() {
+  return useContext(AuthContext);
+}
+
+interface AuthProviderProps {
+  children: React.ReactNode;
+  // disable lets us short-circuit the auth check in dev / local-mode
+  // deployments where the server doesn't run /auth/*. The provider then
+  // pretends the user is signed in with a placeholder identity.
+  disable?: boolean;
+}
+
+const PLACEHOLDER_LOCAL_USER: MeResponse = { login: "local", id: 0 };
+
+// AuthProvider gates the rest of the app on a /auth/me check. While the
+// fetch is pending it renders nothing; on 401 it swaps in a sign-in card;
+// on success it renders children with the user identity exposed via
+// context. Network failures other than 401 render a small error message
+// so the app doesn't silently hang on a broken backend.
+export function AuthProvider({ children, disable }: AuthProviderProps) {
+  const [user, setUser] = useState<MeResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(!disable);
+  const [error, setError] = useState<string | null>(null);
+  const [needsLogin, setNeedsLogin] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      const me = await fetchMe();
+      setUser(me);
+      setNeedsLogin(false);
+    } catch (e) {
+      if (e instanceof UnauthorizedError) {
+        setUser(null);
+        setNeedsLogin(true);
+      } else {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (disable) {
+      setUser(PLACEHOLDER_LOCAL_USER);
+      return;
+    }
+    void refresh();
+  }, [disable, refresh]);
+
+  const logout = useCallback(async () => {
+    try {
+      await apiLogout();
+    } finally {
+      setUser(null);
+      setNeedsLogin(true);
+    }
+  }, []);
+
+  const returnTo =
+    typeof window !== "undefined" ? window.location.pathname + window.location.search : "/";
+  const loginURL = authLoginURL(returnTo);
+
+  if (isLoading) {
+    return <AuthBoundary>Loading…</AuthBoundary>;
+  }
+  if (error) {
+    return (
+      <AuthBoundary>
+        <p className="text-sm text-muted-foreground">
+          Couldn&apos;t reach the API: {error}
+        </p>
+      </AuthBoundary>
+    );
+  }
+  if (needsLogin) {
+    return <SignIn loginURL={loginURL} />;
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, isLoading: false, loginURL, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+function AuthBoundary({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center p-8">
+      <div className="max-w-md text-center">{children}</div>
+    </div>
+  );
+}
+
+function SignIn({ loginURL }: { loginURL: string }) {
+  return (
+    <AuthBoundary>
+      <h1 className="mb-2 text-2xl font-semibold">stackit</h1>
+      <p className="mb-6 text-sm text-muted-foreground">
+        Sign in with GitHub to continue.
+      </p>
+      <a
+        href={loginURL}
+        className="inline-flex items-center justify-center rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background hover:opacity-90"
+      >
+        Sign in with GitHub
+      </a>
+    </AuthBoundary>
+  );
+}

--- a/apps/web/src/lib/__tests__/api.test.ts
+++ b/apps/web/src/lib/__tests__/api.test.ts
@@ -38,7 +38,9 @@ describe("fetchRepos", () => {
 
     const result = await fetchRepos();
     expect(result).toEqual(data);
-    expect(mockFetch).toHaveBeenCalledWith("http://localhost:8080/api/v1/repos");
+    expect(mockFetch).toHaveBeenCalledWith("http://localhost:8080/api/v1/repos", {
+      credentials: "include",
+    });
   });
 });
 
@@ -50,7 +52,8 @@ describe("fetchView", () => {
     const result = await fetchView("stackit");
     expect(result).toEqual(data);
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/view"
+      "http://localhost:8080/api/v1/repos/stackit/view",
+      { credentials: "include" }
     );
   });
 });
@@ -63,7 +66,8 @@ describe("fetchRepo", () => {
     const result = await fetchRepo("stackit");
     expect(result).toEqual(data);
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/repo"
+      "http://localhost:8080/api/v1/repos/stackit/repo",
+      { credentials: "include" }
     );
   });
 });
@@ -74,7 +78,8 @@ describe("fetchStacks", () => {
     const result = await fetchStacks("stackit");
     expect(result).toEqual([]);
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/stacks"
+      "http://localhost:8080/api/v1/repos/stackit/stacks",
+      { credentials: "include" }
     );
   });
 });
@@ -85,7 +90,8 @@ describe("fetchStack", () => {
 
     await fetchStack("stackit", "feat/foo");
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/stacks/feat%2Ffoo"
+      "http://localhost:8080/api/v1/repos/stackit/stacks/feat%2Ffoo",
+      { credentials: "include" }
     );
   });
 });
@@ -96,7 +102,8 @@ describe("fetchBranch", () => {
 
     await fetchBranch("stackit", "feat/bar");
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/branches/feat%2Fbar"
+      "http://localhost:8080/api/v1/repos/stackit/branches/feat%2Fbar",
+      { credentials: "include" }
     );
   });
 });
@@ -107,7 +114,8 @@ describe("fetchBranchDiff", () => {
 
     await fetchBranchDiff("stackit", "feat/bar");
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/branch-diff?branch=feat%2Fbar"
+      "http://localhost:8080/api/v1/repos/stackit/branch-diff?branch=feat%2Fbar",
+      { credentials: "include" }
     );
   });
 });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -126,14 +126,59 @@ export interface ViewResponse {
   recentlyMerged?: TrunkCommitResponse[];
 }
 
+// --- Auth Types ---
+
+export interface MeResponse {
+  login: string;
+  id: number;
+}
+
+// UnauthorizedError is thrown by fetchAPI on a 401. Callers (the auth
+// provider) translate it into a redirect to /auth/login; other consumers
+// can treat it as a fatal error.
+export class UnauthorizedError extends Error {
+  constructor() {
+    super("unauthenticated");
+    this.name = "UnauthorizedError";
+  }
+}
+
 // --- Fetch Functions ---
 
 async function fetchAPI<T>(path: string): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`);
+  // credentials: include sends the session cookie cross-origin during
+  // `next dev` (web on :3000, API on :8080). The server's CORS layer
+  // sets Allow-Credentials: true for configured origins.
+  const res = await fetch(`${API_BASE}${path}`, { credentials: "include" });
+  if (res.status === 401) {
+    throw new UnauthorizedError();
+  }
   if (!res.ok) {
     throw new Error(`API error: ${res.status} ${res.statusText}`);
   }
   return res.json();
+}
+
+export function fetchMe(): Promise<MeResponse> {
+  return fetchAPI<MeResponse>("/auth/me");
+}
+
+export function authLoginURL(returnTo?: string): string {
+  const path = "/auth/login";
+  if (!returnTo) {
+    return `${API_BASE}${path}`;
+  }
+  return `${API_BASE}${path}?return=${encodeURIComponent(returnTo)}`;
+}
+
+export async function logout(): Promise<void> {
+  const res = await fetch(`${API_BASE}/auth/logout`, {
+    method: "POST",
+    credentials: "include",
+  });
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`logout failed: ${res.status}`);
+  }
 }
 
 function repoPath(repoId: string, suffix: string): string {
@@ -215,8 +260,11 @@ export interface SubmitResponse {
 export async function submitStack(repoId: string, rootBranch: string): Promise<SubmitResponse> {
   const res = await fetch(
     `${API_BASE}${repoPath(repoId, `stacks/${encodeURIComponent(rootBranch)}/submit`)}`,
-    { method: "POST" }
+    { method: "POST", credentials: "include" }
   );
+  if (res.status === 401) {
+    throw new UnauthorizedError();
+  }
   const data: SubmitResponse = await res.json();
   if (!res.ok && !data.message) {
     throw new Error(`API error: ${res.status} ${res.statusText}`);

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -53,8 +53,14 @@ running `stackit init` inside each one before starting the container.
 
 | Var | Purpose |
 |-----|---------|
-| `PORT` | Listen port. Honored when `-port` isn't passed explicitly — needed for Railway, Fly, Heroku. Defaults to `8080`. |
-| `STACKIT_PUBLIC` | If set (any value), flips the default bind from `127.0.0.1` to `0.0.0.0`. `PORT` does the same thing implicitly. |
+| `PORT` | Listen port. Honored when `-port` isn't passed explicitly — needed for Railway, Fly, Heroku. Defaults to `8080`. Setting this also implicitly switches the server into "public mode" (binds `0.0.0.0`, requires auth env). |
+| `STACKIT_PUBLIC` | Explicit version of the same signal. Set when you mean to expose the server publicly without `$PORT` (e.g. behind a tunnel). |
+| `STACKIT_BASE_URL` | The canonical https:// URL the server is reachable at. Required when auth is enabled (used to build the OAuth callback URL). |
+| `STACKIT_GITHUB_CLIENT_ID` | GitHub OAuth App client ID. |
+| `STACKIT_GITHUB_CLIENT_SECRET` | GitHub OAuth App client secret. |
+| `STACKIT_SESSION_KEY` | Base64-encoded 32-byte key for AES-GCM-encrypting access tokens at rest. Generate with `openssl rand -base64 32`. |
+| `STACKIT_ALLOWED_GH_USERS` | Comma-separated GitHub logins allowed to sign in. |
+| `STACKIT_ALLOWED_GH_ORG` | GitHub org slug; members may sign in. At least one of `_USERS` or `_ORG` is required. |
 
 ### Flags
 
@@ -66,8 +72,26 @@ The most useful flags:
 | `-port` | `8080` | Listen port; overrides `$PORT`. |
 | `-bind` | `127.0.0.1` (or `0.0.0.0` if `$PORT`/`$STACKIT_PUBLIC` are set) | Interface to bind on. Pass `-bind 0.0.0.0` explicitly to expose the server on a host where the heuristics don't fire. |
 | `-cors` | `http://localhost:3000,http://localhost:5173` | Comma-separated allowed CORS origins. Loopback origins are **not** allowed implicitly — list each origin you want to accept. |
+| `-auth-disabled` | `false` | Skip the GitHub OAuth gate. **Refused** when `$PORT` or `$STACKIT_PUBLIC` is set. Use only for local dev or when fronted by platform auth (Tailscale, Cloudflare Access). |
 
 Run `stackit-server -h` inside the container for the full list.
+
+### GitHub OAuth setup
+
+1. Create a GitHub OAuth App at [github.com/settings/developers](https://github.com/settings/developers).
+   - Homepage URL: your `STACKIT_BASE_URL`.
+   - Authorization callback URL: `${STACKIT_BASE_URL}/auth/callback`.
+2. Copy the client ID + secret into env.
+3. Generate a session key:
+   ```bash
+   openssl rand -base64 32
+   ```
+4. Set the allowlist (at least one of):
+   ```
+   STACKIT_ALLOWED_GH_USERS=jonnii,teammate
+   STACKIT_ALLOWED_GH_ORG=getstackit
+   ```
+5. Boot the server. The startup log prints `auth: GitHub OAuth gate enabled` when configured correctly.
 
 ## Security posture
 

--- a/internal/api/auth/allowlist.go
+++ b/internal/api/auth/allowlist.go
@@ -1,0 +1,129 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// ErrDenied is returned by Allowlist.Check when the logged-in user is not
+// permitted. Handlers translate this into a redirect to /auth/denied.
+var ErrDenied = errors.New("user not in allowlist")
+
+// Allowlist is the gate the OAuth callback runs against after exchanging
+// the GitHub code for an identity. It supports two independent rules:
+//
+//   - Users: exact-match GitHub logins (case-insensitive)
+//   - Org:   membership in a GitHub organization (verified via API)
+//
+// At least one rule must be configured; otherwise the gate is open and
+// the constructor refuses to build.
+type Allowlist struct {
+	users map[string]struct{}
+	org   string
+
+	// orgChecker is split out so tests can fake the GitHub membership
+	// lookup without spinning up an httptest server for every case.
+	orgChecker orgMembershipChecker
+}
+
+type orgMembershipChecker interface {
+	IsMember(ctx context.Context, org, login, accessToken string) (bool, error)
+}
+
+// AllowlistConfig is the operator-supplied input. ConfigFromEnv reads
+// these out of process env; callers in tests build the struct directly.
+type AllowlistConfig struct {
+	Users []string
+	Org   string
+}
+
+// NewAllowlist normalizes the config and validates at least one rule is
+// present. An empty allowlist is rejected because a public-facing deploy
+// with no gate is exactly the misconfiguration we're trying to prevent.
+func NewAllowlist(cfg AllowlistConfig) (*Allowlist, error) {
+	users := make(map[string]struct{}, len(cfg.Users))
+	for _, u := range cfg.Users {
+		u = strings.ToLower(strings.TrimSpace(u))
+		if u == "" {
+			continue
+		}
+		users[u] = struct{}{}
+	}
+	org := strings.TrimSpace(cfg.Org)
+	if len(users) == 0 && org == "" {
+		return nil, errors.New("allowlist requires at least one user or one org")
+	}
+	return &Allowlist{
+		users:      users,
+		org:        org,
+		orgChecker: githubOrgChecker{},
+	}, nil
+}
+
+// SetOrgChecker overrides the org membership checker. Tests use this to
+// inject deterministic membership without hitting GitHub.
+func (a *Allowlist) SetOrgChecker(c orgMembershipChecker) {
+	a.orgChecker = c
+}
+
+// Check returns nil if login is allowed, ErrDenied if not. The token is
+// only used for the org membership API call; user-list hits short-circuit
+// without any network I/O.
+func (a *Allowlist) Check(ctx context.Context, login, accessToken string) error {
+	loginLC := strings.ToLower(strings.TrimSpace(login))
+	if loginLC == "" {
+		return ErrDenied
+	}
+	if _, ok := a.users[loginLC]; ok {
+		return nil
+	}
+	if a.org == "" {
+		return ErrDenied
+	}
+	member, err := a.orgChecker.IsMember(ctx, a.org, login, accessToken)
+	if err != nil {
+		return fmt.Errorf("check org membership: %w", err)
+	}
+	if !member {
+		return ErrDenied
+	}
+	return nil
+}
+
+// githubOrgChecker hits the real GitHub API. We keep this dependency-free
+// (no go-github client) so the package's footprint stays small and tests
+// don't need to mock the wider github package.
+type githubOrgChecker struct{}
+
+func (githubOrgChecker) IsMember(ctx context.Context, org, login, accessToken string) (bool, error) {
+	// GET /orgs/{org}/members/{username} returns 204 if the auth'd user
+	// can see that login is a member, 302 if they can but the requester
+	// isn't a public member, 404 otherwise. We treat 204 and 302 as
+	// "yes", everything else as "no".
+	url := fmt.Sprintf("https://api.github.com/orgs/%s/members/%s", org, login)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusNoContent, http.StatusFound:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected status from membership API: %d", resp.StatusCode)
+	}
+}

--- a/internal/api/auth/allowlist_test.go
+++ b/internal/api/auth/allowlist_test.go
@@ -1,0 +1,90 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeOrgChecker struct {
+	members map[string]bool
+	err     error
+	calls   int
+}
+
+func (f *fakeOrgChecker) IsMember(_ context.Context, _, login, _ string) (bool, error) {
+	f.calls++
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.members[login], nil
+}
+
+func TestNewAllowlist_RequiresAtLeastOneRule(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewAllowlist(AllowlistConfig{})
+	require.Error(t, err)
+}
+
+func TestAllowlist_UserExactMatchCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	a, err := NewAllowlist(AllowlistConfig{Users: []string{"Jonnii", "  someone  ", ""}})
+	require.NoError(t, err)
+	a.SetOrgChecker(&fakeOrgChecker{}) // no network
+
+	require.NoError(t, a.Check(context.Background(), "jonnii", ""))
+	require.NoError(t, a.Check(context.Background(), "SOMEONE", ""))
+	require.ErrorIs(t, a.Check(context.Background(), "stranger", ""), ErrDenied)
+}
+
+func TestAllowlist_OrgMembershipPath(t *testing.T) {
+	t.Parallel()
+
+	checker := &fakeOrgChecker{members: map[string]bool{"jonnii": true}}
+	a, err := NewAllowlist(AllowlistConfig{Org: "getstackit"})
+	require.NoError(t, err)
+	a.SetOrgChecker(checker)
+
+	require.NoError(t, a.Check(context.Background(), "jonnii", "tok"))
+	require.Equal(t, 1, checker.calls)
+
+	require.ErrorIs(t, a.Check(context.Background(), "stranger", "tok"), ErrDenied)
+}
+
+func TestAllowlist_UserMatchSkipsOrgCheck(t *testing.T) {
+	t.Parallel()
+
+	checker := &fakeOrgChecker{}
+	a, err := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}, Org: "getstackit"})
+	require.NoError(t, err)
+	a.SetOrgChecker(checker)
+
+	require.NoError(t, a.Check(context.Background(), "jonnii", "tok"))
+	require.Equal(t, 0, checker.calls, "user-list hit must not consume an API call")
+}
+
+func TestAllowlist_OrgCheckerError(t *testing.T) {
+	t.Parallel()
+
+	checker := &fakeOrgChecker{err: errors.New("boom")}
+	a, err := NewAllowlist(AllowlistConfig{Org: "getstackit"})
+	require.NoError(t, err)
+	a.SetOrgChecker(checker)
+
+	err = a.Check(context.Background(), "jonnii", "tok")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrDenied, "infrastructure error must surface, not silently deny")
+}
+
+func TestAllowlist_EmptyLoginDenied(t *testing.T) {
+	t.Parallel()
+
+	a, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	a.SetOrgChecker(&fakeOrgChecker{})
+
+	require.ErrorIs(t, a.Check(context.Background(), "", "tok"), ErrDenied)
+}

--- a/internal/api/auth/cookie.go
+++ b/internal/api/auth/cookie.go
@@ -1,0 +1,112 @@
+package auth
+
+import (
+	"net/http"
+	"time"
+)
+
+// Cookie names. Kept short, namespaced under "stackit_" so they're easy to
+// recognize in browser devtools and don't collide with anything the
+// embedded Next app might want for its own state.
+const (
+	sessionCookieName = "stackit_session"
+	stateCookieName   = "stackit_oauth_state"
+	returnCookieName  = "stackit_return"
+)
+
+// CookieOptions controls the attributes the auth package puts on cookies.
+// Secure should be true in production (we're behind HTTPS at the proxy),
+// and false in tests or local dev where the browser refuses Secure
+// cookies on http://localhost.
+type CookieOptions struct {
+	Secure bool
+}
+
+func (o CookieOptions) sameSite() http.SameSite {
+	// Lax is the right default for session cookies: cookies travel on
+	// top-level navigations from another origin (so clicking a PR link in
+	// Slack drops you into the app authenticated) but not on cross-site
+	// XHR/form POSTs (so OAuth state isn't compromised). Mutating
+	// endpoints rely on the CSRF header layer (PR 3) for the extra factor.
+	return http.SameSiteLaxMode
+}
+
+func (o CookieOptions) setSession(w http.ResponseWriter, sessionID string, expires time.Time) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    sessionID,
+		Path:     "/",
+		Expires:  expires,
+		HttpOnly: true,
+		Secure:   o.Secure,
+		SameSite: o.sameSite(),
+	})
+}
+
+func (o CookieOptions) clearSession(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   o.Secure,
+		SameSite: o.sameSite(),
+	})
+}
+
+func (o CookieOptions) setState(w http.ResponseWriter, state string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     stateCookieName,
+		Value:    state,
+		Path:     "/auth/",
+		MaxAge:   600,
+		HttpOnly: true,
+		Secure:   o.Secure,
+		SameSite: o.sameSite(),
+	})
+}
+
+func (o CookieOptions) clearState(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     stateCookieName,
+		Value:    "",
+		Path:     "/auth/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   o.Secure,
+		SameSite: o.sameSite(),
+	})
+}
+
+func (o CookieOptions) setReturn(w http.ResponseWriter, target string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     returnCookieName,
+		Value:    target,
+		Path:     "/auth/",
+		MaxAge:   600,
+		HttpOnly: true,
+		Secure:   o.Secure,
+		SameSite: o.sameSite(),
+	})
+}
+
+func (o CookieOptions) clearReturn(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     returnCookieName,
+		Value:    "",
+		Path:     "/auth/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   o.Secure,
+		SameSite: o.sameSite(),
+	})
+}
+
+func readCookie(r *http.Request, name string) string {
+	c, err := r.Cookie(name)
+	if err != nil {
+		return ""
+	}
+	return c.Value
+}

--- a/internal/api/auth/crypto.go
+++ b/internal/api/auth/crypto.go
@@ -1,0 +1,88 @@
+// Package auth implements GitHub OAuth + session cookies + an allowlist
+// gate so stackit-server can be safely exposed on the public web.
+//
+// The package is internal to the api layer: handlers, middleware, and
+// cryptographic helpers live here together so the surface a consumer
+// composes is just (Config, Store, Handler, Allowlist, RequireSession).
+package auth
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+)
+
+// SessionKeyBytes is the required key length for the AES-GCM cipher.
+const SessionKeyBytes = 32
+
+// Cipher AES-GCM-encrypts short blobs (currently the user's GitHub access
+// token) before they sit in the in-memory session store. The key comes from
+// STACKIT_SESSION_KEY; rotation requires a process restart, which also
+// invalidates every existing session — that's fine for the in-memory store.
+type Cipher struct {
+	aead cipher.AEAD
+}
+
+// NewCipher decodes a base64-encoded 32-byte key and returns a ready
+// AES-256-GCM cipher.
+func NewCipher(base64Key string) (*Cipher, error) {
+	if base64Key == "" {
+		return nil, errors.New("session key is empty")
+	}
+	key, err := base64.StdEncoding.DecodeString(base64Key)
+	if err != nil {
+		// Tolerate URL-safe base64 too; some operators paste the openssl
+		// output without thinking about the alphabet.
+		key, err = base64.RawStdEncoding.DecodeString(base64Key)
+		if err != nil {
+			return nil, fmt.Errorf("session key is not valid base64: %w", err)
+		}
+	}
+	if len(key) != SessionKeyBytes {
+		return nil, fmt.Errorf("session key must decode to %d bytes (got %d)", SessionKeyBytes, len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("aes cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("gcm: %w", err)
+	}
+	return &Cipher{aead: aead}, nil
+}
+
+// Seal encrypts plaintext with a fresh random nonce. The returned slice is
+// nonce || ciphertext+tag; the caller stores it as-is.
+func (c *Cipher) Seal(plaintext []byte) ([]byte, error) {
+	nonce := make([]byte, c.aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("nonce: %w", err)
+	}
+	return c.aead.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+// Open reverses Seal. It rejects anything shorter than a nonce and surfaces
+// AEAD verification failures verbatim.
+func (c *Cipher) Open(blob []byte) ([]byte, error) {
+	ns := c.aead.NonceSize()
+	if len(blob) < ns {
+		return nil, errors.New("ciphertext too short")
+	}
+	nonce, ct := blob[:ns], blob[ns:]
+	return c.aead.Open(nil, nonce, ct, nil)
+}
+
+// GenerateSessionKey returns a fresh base64-encoded key in the format the
+// server expects. The operator runs `openssl rand -base64 32` in
+// docs/deploy.md; this is the in-Go equivalent used by tests.
+func GenerateSessionKey() (string, error) {
+	key := make([]byte, SessionKeyBytes)
+	if _, err := rand.Read(key); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(key), nil
+}

--- a/internal/api/auth/crypto_test.go
+++ b/internal/api/auth/crypto_test.go
@@ -1,0 +1,85 @@
+package auth
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCipher_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	key, err := GenerateSessionKey()
+	require.NoError(t, err)
+
+	c, err := NewCipher(key)
+	require.NoError(t, err)
+
+	plain := []byte("ghp_super_secret_personal_access_token")
+	blob, err := c.Seal(plain)
+	require.NoError(t, err)
+	require.NotEqual(t, plain, blob, "ciphertext must differ from plaintext")
+
+	got, err := c.Open(blob)
+	require.NoError(t, err)
+	require.Equal(t, plain, got)
+}
+
+func TestCipher_DifferentNoncesPerSeal(t *testing.T) {
+	t.Parallel()
+
+	key, _ := GenerateSessionKey()
+	c, _ := NewCipher(key)
+
+	a, _ := c.Seal([]byte("same"))
+	b, _ := c.Seal([]byte("same"))
+
+	require.NotEqual(t, a, b, "two seals of the same plaintext must use different nonces")
+}
+
+func TestCipher_RejectsTamperedBlob(t *testing.T) {
+	t.Parallel()
+
+	key, _ := GenerateSessionKey()
+	c, _ := NewCipher(key)
+
+	blob, _ := c.Seal([]byte("hello"))
+	blob[len(blob)-1] ^= 0x01 // flip last bit of the auth tag
+
+	_, err := c.Open(blob)
+	require.Error(t, err)
+}
+
+func TestNewCipher_RejectsBadKeys(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		key  string
+	}{
+		{"empty", ""},
+		{"not base64", "@@@not base64@@@"},
+		{"too short", base64.StdEncoding.EncodeToString(make([]byte, 16))},
+		{"too long", base64.StdEncoding.EncodeToString(make([]byte, 64))},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewCipher(tc.key)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestCipher_OpenRejectsShortBlob(t *testing.T) {
+	t.Parallel()
+
+	key, _ := GenerateSessionKey()
+	c, _ := NewCipher(key)
+
+	_, err := c.Open([]byte("x"))
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "too short"))
+}

--- a/internal/api/auth/middleware.go
+++ b/internal/api/auth/middleware.go
@@ -1,0 +1,35 @@
+package auth
+
+import (
+	"net/http"
+)
+
+// RequireSession returns a middleware that ensures the request carries a
+// valid session cookie before forwarding to next. Failed checks emit
+// 401 JSON; passed checks attach the Session to the request context for
+// downstream handlers to read via SessionFromContext.
+//
+// This middleware does *not* set cookie attributes or talk to GitHub —
+// it's a pure store lookup. Sessions are created elsewhere (the OAuth
+// callback) and revoked elsewhere (logout, TTL sweep).
+func RequireSession(store Store, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cookie := readCookie(r, sessionCookieName)
+		if cookie == "" {
+			writeUnauthorized(w)
+			return
+		}
+		sess, ok := store.Get(cookie)
+		if !ok {
+			writeUnauthorized(w)
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(contextWithSession(r.Context(), sess)))
+	})
+}
+
+func writeUnauthorized(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnauthorized)
+	_, _ = w.Write([]byte(`{"error":"unauthenticated"}`))
+}

--- a/internal/api/auth/middleware_test.go
+++ b/internal/api/auth/middleware_test.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireSession_NoCookie401(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore(newTestCipher(t))
+	t.Cleanup(func() { _ = store.Close() })
+
+	called := false
+	h := RequireSession(store, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		called = true
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repos", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+	require.False(t, called)
+	require.Contains(t, rr.Body.String(), "unauthenticated")
+}
+
+func TestRequireSession_UnknownCookie401(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore(newTestCipher(t))
+	t.Cleanup(func() { _ = store.Close() })
+
+	h := RequireSession(store, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("downstream handler should not run")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repos", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "not-a-real-session"})
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestRequireSession_ValidSessionPassesAndAttachesContext(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore(newTestCipher(t))
+	t.Cleanup(func() { _ = store.Close() })
+
+	sess, _ := store.Create("jonnii", 1, "tok")
+
+	var seen *Session
+	h := RequireSession(store, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = SessionFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repos", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sess.ID})
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, seen)
+	require.Equal(t, "jonnii", seen.GitHubLogin)
+}

--- a/internal/api/auth/oauth.go
+++ b/internal/api/auth/oauth.go
@@ -1,0 +1,359 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+	githuboauth "golang.org/x/oauth2/github"
+)
+
+// DefaultScopes is what the OAuth flow requests today. `read:user` gets the
+// identity needed for the allowlist check; `repo` captures push scope up
+// front so when per-user push lands later the user doesn't re-consent.
+var DefaultScopes = []string{"read:user", "repo"}
+
+// Config is the operator-supplied OAuth configuration. ClientID/Secret are
+// the values from the GitHub OAuth App. BaseURL is the canonical https:// URL
+// the server is reachable at (used to build the callback URL because the
+// server cannot infer its public hostname).
+type Config struct {
+	ClientID     string
+	ClientSecret string //nolint:gosec // field name reflects the OAuth spec; not a literal secret
+	BaseURL      string
+	Scopes       []string
+	// AfterCallbackPath is where the user lands after a successful login.
+	// Defaults to "/". Settable for tests.
+	AfterCallbackPath string
+	// DeniedPath is where allowlist denials redirect to. Defaults to
+	// "/auth/denied". The static handler serves a small page at this path;
+	// if the frontend doesn't render one, the browser sees a generic 404
+	// from the SPA which is still a clear signal.
+	DeniedPath string
+	// Cookies controls Secure-flag behavior.
+	Cookies CookieOptions
+}
+
+// Handler bundles the OAuth state needed by the login/callback/logout/me
+// HTTP handlers. Build one in main.go; mount its methods at the auth
+// routes.
+type Handler struct {
+	cfg       Config
+	store     Store
+	allow     *Allowlist
+	cipher    *Cipher
+	oauth2cfg *oauth2.Config
+
+	// httpClient is the http client used for the GitHub user lookup. Split
+	// out so tests can swap in a transport pointed at httptest.Server.
+	httpClient *http.Client
+
+	// userInfoURL overrides the GitHub /user endpoint. Populated by
+	// SetGitHubEndpointForTest; production default empty means
+	// https://api.github.com/user.
+	userInfoURL string
+}
+
+// NewHandler validates the config and returns a ready Handler.
+func NewHandler(cfg Config, store Store, allow *Allowlist, cipher *Cipher) (*Handler, error) {
+	if cfg.ClientID == "" || cfg.ClientSecret == "" {
+		return nil, errors.New("oauth client id and secret are required")
+	}
+	if cfg.BaseURL == "" {
+		return nil, errors.New("oauth base url is required")
+	}
+	scopes := cfg.Scopes
+	if len(scopes) == 0 {
+		scopes = DefaultScopes
+	}
+	if cfg.AfterCallbackPath == "" {
+		cfg.AfterCallbackPath = "/"
+	}
+	if cfg.DeniedPath == "" {
+		cfg.DeniedPath = "/auth/denied"
+	}
+
+	callbackURL, err := joinURL(cfg.BaseURL, "/auth/callback")
+	if err != nil {
+		return nil, err
+	}
+
+	o := &oauth2.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		Scopes:       scopes,
+		RedirectURL:  callbackURL,
+		Endpoint:     githuboauth.Endpoint,
+	}
+
+	return &Handler{
+		cfg:        cfg,
+		store:      store,
+		allow:      allow,
+		cipher:     cipher,
+		oauth2cfg:  o,
+		httpClient: http.DefaultClient,
+	}, nil
+}
+
+// SetGitHubEndpointForTest swaps the OAuth provider endpoint and HTTP
+// client. Tests point both at an httptest.Server stubbing GitHub's auth +
+// API surface.
+func (h *Handler) SetGitHubEndpointForTest(endpoint oauth2.Endpoint, userInfoURL string, client *http.Client) {
+	h.oauth2cfg.Endpoint = endpoint
+	h.userInfoURL = userInfoURL
+	h.httpClient = client
+}
+
+// userInfoURL is the GitHub URL we GET after token exchange to learn who
+// the user is. Production-default empty -> falls back to api.github.com.
+// Tests set it to their httptest URL.
+func (h *Handler) resolveUserInfoURL() string {
+	if h.userInfoURL != "" {
+		return h.userInfoURL
+	}
+	return "https://api.github.com/user"
+}
+
+// LoginHandler kicks off the OAuth flow. It mints a fresh `state` value,
+// stores it in a short-lived cookie, optionally remembers the desired
+// post-login URL via ?return=, and 302s the user to GitHub.
+func (h *Handler) LoginHandler(w http.ResponseWriter, r *http.Request) {
+	state, err := randomToken(16)
+	if err != nil {
+		log.Printf("login: random state: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	h.cfg.Cookies.setState(w, state)
+
+	// Only honor a ?return= when it's a server-relative path. Anything
+	// else (especially absolute URLs to other hosts) is an open-redirect
+	// risk, so we silently drop it.
+	if ret := r.URL.Query().Get("return"); isSafeReturnPath(ret) {
+		h.cfg.Cookies.setReturn(w, ret)
+	}
+
+	url := h.oauth2cfg.AuthCodeURL(state, oauth2.AccessTypeOnline)
+	http.Redirect(w, r, url, http.StatusFound)
+}
+
+// CallbackHandler completes the OAuth flow: verifies state, exchanges the
+// code for a token, fetches the GitHub user, checks the allowlist, creates
+// a session, and redirects the user to the app (or to DeniedPath on a
+// non-allowlisted login).
+func (h *Handler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	gotState := q.Get("state")
+	wantState := readCookie(r, stateCookieName)
+	h.cfg.Cookies.clearState(w)
+	if wantState == "" || gotState == "" || !constantTimeStringEq(gotState, wantState) {
+		log.Printf("auth callback: bad state")
+		http.Error(w, "invalid auth state", http.StatusBadRequest)
+		return
+	}
+
+	code := q.Get("code")
+	if code == "" {
+		// GitHub redirects here with `error=...` when the user denies.
+		log.Printf("auth callback: missing code (oauth_error=%q)", q.Get("error")) //nolint:gosec // logged value is %q-quoted
+		http.Redirect(w, r, h.cfg.DeniedPath, http.StatusFound)
+		return
+	}
+
+	ctx := r.Context()
+	tok, err := h.oauth2cfg.Exchange(ctx, code)
+	if err != nil {
+		log.Printf("auth callback: token exchange: %v", err)
+		http.Error(w, "token exchange failed", http.StatusBadGateway)
+		return
+	}
+
+	user, err := h.fetchGitHubUser(ctx, tok.AccessToken)
+	if err != nil {
+		log.Printf("auth callback: fetch user: %v", err)
+		http.Error(w, "github user lookup failed", http.StatusBadGateway)
+		return
+	}
+
+	if err := h.allow.Check(ctx, user.Login, tok.AccessToken); err != nil {
+		if errors.Is(err, ErrDenied) {
+			log.Printf("auth callback: denied login=%q", user.Login) //nolint:gosec // login is %q-quoted
+			http.Redirect(w, r, h.cfg.DeniedPath, http.StatusFound)
+			return
+		}
+		log.Printf("auth callback: allowlist check error: %v", err)
+		http.Error(w, "allowlist check failed", http.StatusBadGateway)
+		return
+	}
+
+	sess, err := h.store.Create(user.Login, user.ID, tok.AccessToken)
+	if err != nil {
+		log.Printf("auth callback: create session: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	h.cfg.Cookies.setSession(w, sess.ID, sess.ExpiresAt)
+
+	target := h.cfg.AfterCallbackPath
+	if ret := readCookie(r, returnCookieName); isSafeReturnPath(ret) {
+		target = ret
+	}
+	h.cfg.Cookies.clearReturn(w)
+
+	log.Printf("auth: login login=%q user_id=%d -> %s", user.Login, user.ID, target) //nolint:gosec // logged values are quoted/numeric/safe target
+	http.Redirect(w, r, target, http.StatusFound)
+}
+
+// LogoutHandler drops the session both server-side (Store.Delete) and
+// client-side (clears the cookie). Always returns 204 so the web app can
+// fire-and-forget the call.
+func (h *Handler) LogoutHandler(w http.ResponseWriter, r *http.Request) {
+	if cookie := readCookie(r, sessionCookieName); cookie != "" {
+		if sess, ok := h.store.Get(cookie); ok {
+			log.Printf("auth: logout login=%q", sess.GitHubLogin) //nolint:gosec // login is %q-quoted
+		}
+		h.store.Delete(cookie)
+	}
+	h.cfg.Cookies.clearSession(w)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// MeResponse is the body served by GET /auth/me.
+type MeResponse struct {
+	Login string `json:"login"`
+	ID    int64  `json:"id"`
+}
+
+// MeHandler returns the logged-in user's identity, or 401 if no session.
+// The web app calls this on load to decide between rendering the app and
+// redirecting to /auth/login.
+func (h *Handler) MeHandler(w http.ResponseWriter, r *http.Request) {
+	sess := SessionFromContext(r.Context())
+	if sess == nil {
+		cookie := readCookie(r, sessionCookieName)
+		if cookie == "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"unauthenticated"}`))
+			return
+		}
+		s, ok := h.store.Get(cookie)
+		if !ok {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"unauthenticated"}`))
+			return
+		}
+		sess = s
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(MeResponse{
+		Login: sess.GitHubLogin,
+		ID:    sess.GitHubUserID,
+	})
+}
+
+// gitHubUser is the subset of /user we care about.
+type gitHubUser struct {
+	Login string `json:"login"`
+	ID    int64  `json:"id"`
+}
+
+func (h *Handler) fetchGitHubUser(ctx context.Context, accessToken string) (*gitHubUser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.resolveUserInfoURL(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github /user: status %d", resp.StatusCode)
+	}
+	var u gitHubUser
+	if err := json.NewDecoder(resp.Body).Decode(&u); err != nil {
+		return nil, fmt.Errorf("decode github /user: %w", err)
+	}
+	if u.Login == "" {
+		return nil, errors.New("github /user returned empty login")
+	}
+	return &u, nil
+}
+
+func randomToken(n int) (string, error) {
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// constantTimeStringEq is hmac.Equal-style comparison for state tokens. We
+// don't need full crypto strength but using a constant-time compare keeps
+// timing-channel concerns off the table.
+func constantTimeStringEq(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	var v byte
+	for i := 0; i < len(a); i++ {
+		v |= a[i] ^ b[i]
+	}
+	return v == 0
+}
+
+// isSafeReturnPath returns true when target is a path on this server
+// (starts with `/`, doesn't start with `//` or `/\`, doesn't contain a
+// scheme). Anything else is treated as an open-redirect attempt.
+func isSafeReturnPath(target string) bool {
+	if target == "" {
+		return false
+	}
+	if !strings.HasPrefix(target, "/") {
+		return false
+	}
+	if strings.HasPrefix(target, "//") || strings.HasPrefix(target, "/\\") {
+		return false
+	}
+	// Reject URLs with a scheme even if path-ish.
+	if u, err := url.Parse(target); err == nil && u.Scheme != "" {
+		return false
+	}
+	return true
+}
+
+func joinURL(base, suffix string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("base url: %w", err)
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return "", fmt.Errorf("base url scheme must be http(s), got %q", u.Scheme)
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + suffix
+	return u.String(), nil
+}
+
+// LoginExpiryProbe is the time after which a session would be considered
+// stale. Exposed for tests / health-check style code.
+func LoginExpiryProbe(now time.Time) time.Time {
+	return now.Add(SessionTTL)
+}

--- a/internal/api/auth/oauth_test.go
+++ b/internal/api/auth/oauth_test.go
@@ -1,0 +1,414 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+func TestIsSafeReturnPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"/", true},
+		{"/stacks/main", true},
+		{"//evil.com", false},
+		{`/\evil.com`, false},
+		{"http://evil.com", false},
+		{"javascript:alert(1)", false},
+		{"relative/path", false},
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, isSafeReturnPath(tc.in), "input=%q", tc.in)
+	}
+}
+
+func TestConstantTimeStringEq(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, constantTimeStringEq("abc", "abc"))
+	require.False(t, constantTimeStringEq("abc", "abd"))
+	require.False(t, constantTimeStringEq("", "x"))
+	require.False(t, constantTimeStringEq("abc", "ab"))
+	require.True(t, constantTimeStringEq("", ""))
+}
+
+func TestJoinURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		base, suffix, want string
+		wantErr            bool
+	}{
+		{"https://stackit.example.com", "/auth/callback", "https://stackit.example.com/auth/callback", false},
+		{"https://stackit.example.com/", "/auth/callback", "https://stackit.example.com/auth/callback", false},
+		{"http://localhost:8080", "/auth/callback", "http://localhost:8080/auth/callback", false},
+		{"ftp://nope.com", "/auth/callback", "", true},
+		{":://broken", "/auth/callback", "", true},
+	}
+	for _, tc := range cases {
+		got, err := joinURL(tc.base, tc.suffix)
+		if tc.wantErr {
+			require.Errorf(t, err, "base=%q", tc.base)
+			continue
+		}
+		require.NoErrorf(t, err, "base=%q", tc.base)
+		require.Equal(t, tc.want, got)
+	}
+}
+
+// stubGitHub stands in for the GitHub OAuth + /user endpoints. The Handler
+// is pointed at it via SetGitHubEndpointForTest.
+type stubGitHub struct {
+	server      *httptest.Server
+	authCalls   int
+	tokenCalls  int
+	userCalls   int
+	denyToken   bool
+	userLogin   string
+	userID      int64
+	emitState   string // recorded state from the most recent auth request
+	mintedCode  string
+	mintedToken string
+}
+
+func newStubGitHub(t *testing.T) *stubGitHub {
+	t.Helper()
+	s := &stubGitHub{
+		userLogin:   "jonnii",
+		userID:      42,
+		mintedCode:  "test-code",
+		mintedToken: "test-access-token",
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login/oauth/authorize", func(w http.ResponseWriter, r *http.Request) {
+		s.authCalls++
+		s.emitState = r.URL.Query().Get("state")
+		// Production GitHub 302s back to the redirect URL with code+state.
+		// In tests we don't actually want the redirect — the Handler is
+		// driven directly by the test. So we just record state and 200.
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/login/oauth/access_token", func(w http.ResponseWriter, r *http.Request) {
+		s.tokenCalls++
+		if s.denyToken {
+			http.Error(w, "denied", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": s.mintedToken,
+			"token_type":   "bearer",
+			"scope":        "read:user repo",
+		})
+	})
+	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+		s.userCalls++
+		if got := r.Header.Get("Authorization"); got != "Bearer "+s.mintedToken {
+			http.Error(w, "bad auth", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"login": s.userLogin,
+			"id":    s.userID,
+		})
+	})
+	s.server = httptest.NewServer(mux)
+	t.Cleanup(s.server.Close)
+	return s
+}
+
+func (s *stubGitHub) oauth2Endpoint() oauth2.Endpoint {
+	return oauth2.Endpoint{
+		AuthURL:  s.server.URL + "/login/oauth/authorize",
+		TokenURL: s.server.URL + "/login/oauth/access_token",
+	}
+}
+
+func (s *stubGitHub) userURL() string {
+	return s.server.URL + "/user"
+}
+
+func buildTestHandler(t *testing.T, allow *Allowlist, stub *stubGitHub) (*Handler, *MemoryStore) {
+	t.Helper()
+	cipher := newTestCipher(t)
+	store := NewMemoryStore(cipher)
+	t.Cleanup(func() { _ = store.Close() })
+
+	h, err := NewHandler(Config{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		BaseURL:      "http://localhost:8080",
+	}, store, allow, cipher)
+	require.NoError(t, err)
+	h.SetGitHubEndpointForTest(stub.oauth2Endpoint(), stub.userURL(), stub.server.Client())
+	return h, store
+}
+
+func TestLoginHandler_SetsStateCookieAndRedirects(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, _ := buildTestHandler(t, allow, stub)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	rr := httptest.NewRecorder()
+	h.LoginHandler(rr, req)
+
+	require.Equal(t, http.StatusFound, rr.Code)
+	loc := rr.Header().Get("Location")
+	require.Contains(t, loc, "/login/oauth/authorize")
+	require.Contains(t, loc, "client_id=test-client")
+	require.Contains(t, loc, "state=")
+
+	// State cookie must be HttpOnly and scoped to /auth/.
+	cookies := rr.Result().Cookies()
+	var state *http.Cookie
+	for _, c := range cookies {
+		if c.Name == stateCookieName {
+			state = c
+		}
+	}
+	require.NotNil(t, state)
+	require.True(t, state.HttpOnly)
+	require.Equal(t, "/auth/", state.Path)
+	require.NotEmpty(t, state.Value)
+}
+
+func TestCallbackHandler_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, store := buildTestHandler(t, allow, stub)
+
+	// Simulate a callback with matching state cookie + state query.
+	state := "abc123"
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=test-code&state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: stateCookieName, Value: state})
+	rr := httptest.NewRecorder()
+
+	h.CallbackHandler(rr, req)
+
+	require.Equal(t, http.StatusFound, rr.Code)
+	require.Equal(t, "/", rr.Header().Get("Location"))
+
+	// Session cookie set.
+	var sessionCookie *http.Cookie
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == sessionCookieName {
+			sessionCookie = c
+		}
+	}
+	require.NotNil(t, sessionCookie)
+	require.True(t, sessionCookie.HttpOnly)
+	require.NotEmpty(t, sessionCookie.Value)
+
+	// Store now has the session under that cookie value.
+	sess, ok := store.Get(sessionCookie.Value)
+	require.True(t, ok)
+	require.Equal(t, "jonnii", sess.GitHubLogin)
+	require.Equal(t, int64(42), sess.GitHubUserID)
+
+	tok, err := sess.AccessToken(store.cipher)
+	require.NoError(t, err)
+	require.Equal(t, "test-access-token", tok)
+}
+
+func TestCallbackHandler_StateMismatchRejected(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, _ := buildTestHandler(t, allow, stub)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=test-code&state=mismatched", nil)
+	req.AddCookie(&http.Cookie{Name: stateCookieName, Value: "different"})
+	rr := httptest.NewRecorder()
+
+	h.CallbackHandler(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestCallbackHandler_MissingStateCookieRejected(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, _ := buildTestHandler(t, allow, stub)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=test-code&state=anything", nil)
+	rr := httptest.NewRecorder()
+
+	h.CallbackHandler(rr, req)
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestCallbackHandler_AllowlistDeniedRedirectsToDeniedPath(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"someone-else"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, store := buildTestHandler(t, allow, stub)
+
+	state := "s"
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=test-code&state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: stateCookieName, Value: state})
+	rr := httptest.NewRecorder()
+
+	h.CallbackHandler(rr, req)
+
+	require.Equal(t, http.StatusFound, rr.Code)
+	require.Equal(t, "/auth/denied", rr.Header().Get("Location"))
+
+	// No session cookie issued.
+	for _, c := range rr.Result().Cookies() {
+		require.NotEqual(t, sessionCookieName, c.Name, "no session for denied user")
+	}
+	// And no session in the store.
+	store.mu.RLock()
+	require.Equal(t, 0, len(store.sessions))
+	store.mu.RUnlock()
+}
+
+func TestCallbackHandler_HonorsSafeReturnPath(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, _ := buildTestHandler(t, allow, stub)
+
+	state := "s"
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=test-code&state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: stateCookieName, Value: state})
+	req.AddCookie(&http.Cookie{Name: returnCookieName, Value: "/stacks/foo"})
+	rr := httptest.NewRecorder()
+
+	h.CallbackHandler(rr, req)
+	require.Equal(t, "/stacks/foo", rr.Header().Get("Location"))
+}
+
+func TestCallbackHandler_RejectsUnsafeReturnPath(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, _ := buildTestHandler(t, allow, stub)
+
+	state := "s"
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=test-code&state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: stateCookieName, Value: state})
+	req.AddCookie(&http.Cookie{Name: returnCookieName, Value: "//evil.example.com/steal"})
+	rr := httptest.NewRecorder()
+
+	h.CallbackHandler(rr, req)
+	require.Equal(t, "/", rr.Header().Get("Location"), "open-redirect attempt must be ignored")
+}
+
+func TestLogoutHandler_ClearsCookieAndStore(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, store := buildTestHandler(t, allow, stub)
+
+	sess, _ := store.Create("jonnii", 1, "tok")
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sess.ID})
+	rr := httptest.NewRecorder()
+	h.LogoutHandler(rr, req)
+
+	require.Equal(t, http.StatusNoContent, rr.Code)
+	_, ok := store.Get(sess.ID)
+	require.False(t, ok, "session must be deleted server-side")
+
+	var cleared *http.Cookie
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == sessionCookieName {
+			cleared = c
+		}
+	}
+	require.NotNil(t, cleared)
+	require.Equal(t, -1, cleared.MaxAge)
+}
+
+func TestMeHandler_401WithoutSession(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, _ := buildTestHandler(t, allow, stub)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/me", nil)
+	rr := httptest.NewRecorder()
+	h.MeHandler(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestMeHandler_ReturnsCurrentUser(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, store := buildTestHandler(t, allow, stub)
+
+	sess, _ := store.Create("jonnii", 42, "tok")
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/me", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sess.ID})
+	rr := httptest.NewRecorder()
+	h.MeHandler(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp MeResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Equal(t, "jonnii", resp.Login)
+	require.Equal(t, int64(42), resp.ID)
+}
+
+// sanity check that GitHub-style query encoding in the auth URL survives a
+// round trip — guards against the test stub diverging from what
+// golang.org/x/oauth2 actually emits.
+func TestLoginHandler_AuthURLEncodesScopes(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, _ := buildTestHandler(t, allow, stub)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	rr := httptest.NewRecorder()
+	h.LoginHandler(rr, req)
+
+	loc, err := url.Parse(rr.Header().Get("Location"))
+	require.NoError(t, err)
+	require.Equal(t, "read:user repo", loc.Query().Get("scope"))
+	require.True(t, strings.HasSuffix(loc.Path, "/login/oauth/authorize"))
+}

--- a/internal/api/auth/session.go
+++ b/internal/api/auth/session.go
@@ -1,0 +1,215 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// SessionTTL is how long a session lives from creation. Sessions don't slide
+// — once expired the user re-authenticates. 30 days matches the default GH
+// PAT-style cadence we'd want for a dev tool.
+const SessionTTL = 30 * 24 * time.Hour
+
+// sessionSweepInterval is how often the in-memory store walks itself to
+// evict expired sessions. Slow enough not to thrash, fast enough that a
+// memory leak from churning sessions never gets large.
+const sessionSweepInterval = 5 * time.Minute
+
+// Session is the per-user record the store holds. The GitHub access token
+// is encrypted at rest with the server's Cipher; everything else is
+// plaintext because it's needed for routing/auditing and isn't sensitive
+// on its own.
+type Session struct {
+	ID             string
+	GitHubLogin    string
+	GitHubUserID   int64
+	encryptedToken []byte
+	CreatedAt      time.Time
+	ExpiresAt      time.Time
+}
+
+// AccessToken decrypts the stored GitHub token for an outbound API call.
+// Callers should not retain the result longer than the one request that
+// needs it — re-decrypt each time so the plaintext lives on the stack.
+func (s *Session) AccessToken(c *Cipher) (string, error) {
+	if len(s.encryptedToken) == 0 {
+		return "", errors.New("session has no access token")
+	}
+	plain, err := c.Open(s.encryptedToken)
+	if err != nil {
+		return "", fmt.Errorf("decrypt access token: %w", err)
+	}
+	return string(plain), nil
+}
+
+// Store is the surface used by handlers. The default implementation is
+// MemoryStore; tests inject their own fakes against the same interface.
+type Store interface {
+	Create(login string, githubUserID int64, accessToken string) (*Session, error)
+	Get(id string) (*Session, bool)
+	Delete(id string)
+	Close() error
+}
+
+// MemoryStore keeps sessions in a process-local map. Restarting the server
+// drops every session — that's the documented behavior in docs/deploy.md.
+// If you ever scale this horizontally, swap to a SQLite/Redis-backed Store
+// behind the same interface.
+type MemoryStore struct {
+	cipher *Cipher
+	now    func() time.Time
+	ttl    time.Duration
+
+	mu       sync.RWMutex
+	sessions map[string]*Session
+
+	stop chan struct{}
+	done chan struct{}
+}
+
+// NewMemoryStore returns a Store backed by a map. The background sweeper
+// goroutine is started immediately; Close() stops it.
+func NewMemoryStore(c *Cipher) *MemoryStore {
+	s := &MemoryStore{
+		cipher:   c,
+		now:      time.Now,
+		ttl:      SessionTTL,
+		sessions: make(map[string]*Session),
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+	go s.sweepLoop(sessionSweepInterval)
+	return s
+}
+
+// Create allocates an opaque 32-byte session ID, encrypts the supplied
+// GitHub token, and stores the result. The caller sets a cookie with the
+// returned Session.ID.
+func (s *MemoryStore) Create(login string, githubUserID int64, accessToken string) (*Session, error) {
+	id, err := newSessionID()
+	if err != nil {
+		return nil, err
+	}
+	var ct []byte
+	if accessToken != "" {
+		ct, err = s.cipher.Seal([]byte(accessToken))
+		if err != nil {
+			return nil, err
+		}
+	}
+	now := s.now()
+	sess := &Session{
+		ID:             id,
+		GitHubLogin:    login,
+		GitHubUserID:   githubUserID,
+		encryptedToken: ct,
+		CreatedAt:      now,
+		ExpiresAt:      now.Add(s.ttl),
+	}
+	s.mu.Lock()
+	s.sessions[id] = sess
+	s.mu.Unlock()
+	return sess, nil
+}
+
+// Get returns the session if it exists and hasn't expired. Expired sessions
+// are evicted lazily on read in addition to the periodic sweep, so a long
+// gap between sweeps can't keep a session alive past its ExpiresAt.
+func (s *MemoryStore) Get(id string) (*Session, bool) {
+	if id == "" {
+		return nil, false
+	}
+	s.mu.RLock()
+	sess, ok := s.sessions[id]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if s.now().After(sess.ExpiresAt) {
+		s.Delete(id)
+		return nil, false
+	}
+	return sess, true
+}
+
+// Delete is a no-op for unknown IDs.
+func (s *MemoryStore) Delete(id string) {
+	s.mu.Lock()
+	delete(s.sessions, id)
+	s.mu.Unlock()
+}
+
+// Close stops the sweeper. Safe to call multiple times.
+func (s *MemoryStore) Close() error {
+	select {
+	case <-s.stop:
+		// already closed
+	default:
+		close(s.stop)
+	}
+	<-s.done
+	return nil
+}
+
+func (s *MemoryStore) sweepLoop(interval time.Duration) {
+	defer close(s.done)
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-t.C:
+			s.sweepExpired()
+		}
+	}
+}
+
+func (s *MemoryStore) sweepExpired() {
+	now := s.now()
+	s.mu.Lock()
+	for id, sess := range s.sessions {
+		if now.After(sess.ExpiresAt) {
+			delete(s.sessions, id)
+		}
+	}
+	s.mu.Unlock()
+}
+
+// SetClockForTest swaps the time source. Tests use this to advance past
+// ExpiresAt without sleeping.
+func (s *MemoryStore) SetClockForTest(now func() time.Time) {
+	s.mu.Lock()
+	s.now = now
+	s.mu.Unlock()
+}
+
+func newSessionID() (string, error) {
+	var buf [32]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", fmt.Errorf("random session id: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf[:]), nil
+}
+
+// sessionCtxKey isolates the session value on request contexts.
+type sessionCtxKey struct{}
+
+// SessionFromContext returns the session attached by RequireSession, or
+// nil if no session is in scope. Handlers behind RequireSession can
+// assume non-nil; unprotected handlers must nil-check.
+func SessionFromContext(ctx context.Context) *Session {
+	if v, ok := ctx.Value(sessionCtxKey{}).(*Session); ok {
+		return v
+	}
+	return nil
+}
+
+func contextWithSession(ctx context.Context, sess *Session) context.Context {
+	return context.WithValue(ctx, sessionCtxKey{}, sess)
+}

--- a/internal/api/auth/session_test.go
+++ b/internal/api/auth/session_test.go
@@ -1,0 +1,122 @@
+package auth
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCipher(t *testing.T) *Cipher {
+	t.Helper()
+	key, err := GenerateSessionKey()
+	require.NoError(t, err)
+	c, err := NewCipher(key)
+	require.NoError(t, err)
+	return c
+}
+
+func TestMemoryStore_CreateGetDelete(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore(newTestCipher(t))
+	t.Cleanup(func() { _ = store.Close() })
+
+	sess, err := store.Create("jonnii", 42, "ghp_token")
+	require.NoError(t, err)
+	require.NotEmpty(t, sess.ID)
+	require.Equal(t, "jonnii", sess.GitHubLogin)
+	require.Equal(t, int64(42), sess.GitHubUserID)
+
+	got, ok := store.Get(sess.ID)
+	require.True(t, ok)
+	require.Equal(t, sess.ID, got.ID)
+
+	tok, err := got.AccessToken(store.cipher)
+	require.NoError(t, err)
+	require.Equal(t, "ghp_token", tok)
+
+	store.Delete(sess.ID)
+	_, ok = store.Get(sess.ID)
+	require.False(t, ok)
+}
+
+func TestMemoryStore_ExpiresLazily(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore(newTestCipher(t))
+	t.Cleanup(func() { _ = store.Close() })
+
+	sess, err := store.Create("jonnii", 1, "tok")
+	require.NoError(t, err)
+
+	// Advance the store's clock past ExpiresAt; the next Get evicts.
+	future := sess.ExpiresAt.Add(time.Second)
+	store.SetClockForTest(func() time.Time { return future })
+
+	_, ok := store.Get(sess.ID)
+	require.False(t, ok, "expired session must not be returned")
+
+	// And the entry should be gone from the underlying map (lazy evict).
+	store.mu.RLock()
+	_, present := store.sessions[sess.ID]
+	store.mu.RUnlock()
+	require.False(t, present)
+}
+
+func TestMemoryStore_SweepRemovesExpired(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore(newTestCipher(t))
+	t.Cleanup(func() { _ = store.Close() })
+
+	sess, _ := store.Create("jonnii", 1, "tok")
+
+	store.SetClockForTest(func() time.Time { return sess.ExpiresAt.Add(time.Second) })
+	store.sweepExpired()
+
+	_, ok := store.Get(sess.ID)
+	require.False(t, ok)
+}
+
+func TestMemoryStore_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore(newTestCipher(t))
+	t.Cleanup(func() { _ = store.Close() })
+
+	var wg sync.WaitGroup
+	for i := range 100 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			s, err := store.Create("user", int64(i), "tok")
+			require.NoError(t, err)
+			_, ok := store.Get(s.ID)
+			require.True(t, ok)
+			store.Delete(s.ID)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestSessionFromContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	require.Nil(t, SessionFromContext(ctx))
+
+	sess := &Session{ID: "x", GitHubLogin: "y"}
+	ctx2 := contextWithSession(ctx, sess)
+	require.Equal(t, sess, SessionFromContext(ctx2))
+}
+
+func TestMemoryStore_CloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore(newTestCipher(t))
+	require.NoError(t, store.Close())
+	require.NoError(t, store.Close())
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/getstackit/stackit/internal/api/auth"
 	"github.com/getstackit/stackit/internal/api/handlers"
 	"github.com/getstackit/stackit/internal/api/registry"
 )
@@ -25,6 +26,21 @@ type ServerConfig struct {
 	APIPrefixes []string
 	StaticFS    fs.FS
 	Registry    *registry.Registry
+
+	// Auth bundles the OAuth handler, session store, and surrounding state
+	// needed to gate /api/* routes behind GitHub login. When nil the server
+	// runs without authentication; that mode is only safe on a private
+	// network (localhost dev, tunneled access). apps/server refuses to
+	// start unauthenticated when STACKIT_PUBLIC or $PORT are set unless
+	// -auth-disabled is passed explicitly.
+	Auth *AuthConfig
+}
+
+// AuthConfig is the runtime auth setup. SessionStore must outlive the
+// Server's lifetime (close it after Shutdown returns).
+type AuthConfig struct {
+	Handler      *auth.Handler
+	SessionStore auth.Store
 }
 
 // Server is the stackit-web HTTP server. Per-repo state (engine, watcher,
@@ -88,10 +104,32 @@ func (s *Server) Start() error {
 		apiMux.Handle("GET "+prefix+"/events", eventsHandler)
 	}
 
+	// Apply session enforcement to /api/* only. /auth/* and static assets
+	// stay unauthenticated so the user can complete the login flow and
+	// land on the SPA shell.
+	var protectedAPI http.Handler = apiMux
+	if s.config.Auth != nil {
+		protectedAPI = auth.RequireSession(s.config.Auth.SessionStore, apiMux)
+	}
+
+	authMux := http.NewServeMux()
+	if s.config.Auth != nil {
+		h := s.config.Auth.Handler
+		authMux.HandleFunc("GET /auth/login", h.LoginHandler)
+		authMux.HandleFunc("GET /auth/callback", h.CallbackHandler)
+		authMux.HandleFunc("POST /auth/logout", h.LogoutHandler)
+		authMux.HandleFunc("GET /auth/me", h.MeHandler)
+	}
+
 	webHandler := newStaticHandler(s.config.StaticFS)
 	root := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isAPIPath(r.URL.Path, prefixes) {
-			apiMux.ServeHTTP(w, r)
+			protectedAPI.ServeHTTP(w, r)
+			return
+		}
+
+		if s.config.Auth != nil && strings.HasPrefix(r.URL.Path, "/auth/") {
+			authMux.ServeHTTP(w, r)
 			return
 		}
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

PR 2 of the security pass (plan:
/Users/jonnii/.claude/plans/we-are-going-put-transient-taco.md). Adds an
internal/api/auth package and wires it into the server so every /api/*
route requires a session, sessions are created via GitHub's OAuth
Authorization Code flow, and only allowlisted users can complete the
flow.

The auth package is self-contained: AES-GCM cipher (crypto.go) for
encrypting GitHub access tokens at rest in the session store; an
in-memory session store with a TTL sweeper (session.go); HttpOnly +
Secure + SameSite=Lax cookies for the session and a short-lived state
cookie for the OAuth flow (cookie.go); an Allowlist with case-insensitive
user matching and a separate org-membership API check (allowlist.go); a
Handler with LoginHandler/CallbackHandler/LogoutHandler/MeHandler
(oauth.go); a RequireSession middleware that 401s unauthenticated
callers (middleware.go). The state token and stored sessions are
constant-time compared; ?return= is rejected unless it's a server-
relative path so a malicious GitHub redirect can't bounce the browser
off the server.

The user's GitHub access token is captured at callback with scope
"read:user repo" and stays encrypted in the session. The submit path
still uses the server-side GitHub client today — per-user push (using
the session token) is a follow-on once RepoEntry / submit are
refactored for it. Capturing the broader scope up front avoids a
second consent prompt when that work lands.

apps/server gains -auth-disabled (refused in public mode) and the
STACKIT_GITHUB_CLIENT_ID / _SECRET / SESSION_KEY / BASE_URL /
ALLOWED_GH_USERS / ALLOWED_GH_ORG env vars. The web app gains an
AuthProvider that calls /auth/me on mount, renders a "Sign in with
GitHub" card on 401, and exposes user identity via useAuth().
fetchAPI now sends credentials: include so the session cookie travels
in cross-origin dev (web on :3000, API on :8080).

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1006**
  * **PR #1007**
    * **PR #1008**
      * **PR #1009**
        * **PR #1011**
          * **PR #1015** 👈
            * **PR #1016**
              * **PR #1017**
                * **PR #1012**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1054 by jonnii*