### PR TITLE
feat(server): require X-Stackit-CSRF on mutating endpoints

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2,6 +2,12 @@
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 
+// CSRF_HEADER must be sent on every non-safe request. The server doesn't
+// inspect the value, only the header's presence — see
+// internal/api/auth/middleware.go (RequireCSRFHeader).
+const CSRF_HEADER = "X-Stackit-CSRF";
+const CSRF_HEADER_VALUE = "1";
+
 // --- Response Types (matching Go API types) ---
 
 export interface RepoResponse {
@@ -175,6 +181,7 @@ export async function logout(): Promise<void> {
   const res = await fetch(`${API_BASE}/auth/logout`, {
     method: "POST",
     credentials: "include",
+    headers: { [CSRF_HEADER]: CSRF_HEADER_VALUE },
   });
   if (!res.ok && res.status !== 204) {
     throw new Error(`logout failed: ${res.status}`);
@@ -260,7 +267,11 @@ export interface SubmitResponse {
 export async function submitStack(repoId: string, rootBranch: string): Promise<SubmitResponse> {
   const res = await fetch(
     `${API_BASE}${repoPath(repoId, `stacks/${encodeURIComponent(rootBranch)}/submit`)}`,
-    { method: "POST", credentials: "include" }
+    {
+      method: "POST",
+      credentials: "include",
+      headers: { [CSRF_HEADER]: CSRF_HEADER_VALUE },
+    }
   );
   if (res.status === 401) {
     throw new UnauthorizedError();

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -108,7 +108,7 @@ The container is safe to run on a public hostname **only** behind:
    and creates PRs using the container's GitHub credentials.
 
 Built-in security controls (the server hardening pass that lands with
-this doc revision):
+this doc revision and follow-on PRs):
 
 - Process runs as the unprivileged `stackit` user (uid 10001) inside the
   container — neither user nor group is `root`.
@@ -125,6 +125,26 @@ this doc revision):
 - CORS allowlist is exact-match; no implicit loopback bypass.
 - Branch names supplied via path/query are validated against the same
   rules `stackit` enforces locally before reaching git.
+- GitHub OAuth gate via `STACKIT_GITHUB_*` + an allowlist. Every
+  `/api/*` route requires a valid session; the user's access token is
+  stored AES-GCM-encrypted at rest in the session store.
+- CSRF gate on every non-safe HTTP method: the server requires a
+  `X-Stackit-CSRF: 1` request header on POST/PUT/PATCH/DELETE. The
+  web app sends it automatically; scripts and direct API callers must
+  include it.
+
+### Calling the API from scripts
+
+```bash
+# Establish a session via your browser first; copy the stackit_session
+# cookie into the call, then add the CSRF header for mutating requests.
+curl https://stackit.example.com/api/v1/repos \
+  -H "Cookie: stackit_session=$STACKIT_SESSION"
+
+curl -X POST https://stackit.example.com/api/v1/repos/default/stacks/main/submit \
+  -H "Cookie: stackit_session=$STACKIT_SESSION" \
+  -H "X-Stackit-CSRF: 1"
+```
 
 ## Local smoke test
 

--- a/internal/api/auth/middleware.go
+++ b/internal/api/auth/middleware.go
@@ -33,3 +33,43 @@ func writeUnauthorized(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusUnauthorized)
 	_, _ = w.Write([]byte(`{"error":"unauthenticated"}`))
 }
+
+// CSRFHeader is the custom request header the web client adds on every
+// non-safe request. Its presence — not value — is what matters: browsers
+// can't set a custom header on a cross-origin request without a CORS
+// preflight, and the server's CORS allowlist is exact-match. That means
+// only configured origins can satisfy this check, which is enough to
+// block cookie-based CSRF without a per-request token.
+const CSRFHeader = "X-Stackit-CSRF"
+
+// safeMethods are the HTTP methods that don't change server state and so
+// don't need CSRF protection. Everything else does.
+var safeMethods = map[string]struct{}{
+	http.MethodGet:     {},
+	http.MethodHead:    {},
+	http.MethodOptions: {},
+}
+
+// RequireCSRFHeader gates non-safe methods on the presence of a custom
+// CSRFHeader. Safe methods pass through untouched. Failures emit a 403
+// JSON response so clients can distinguish "your auth is bad" (401) from
+// "your call shape is wrong" (403).
+//
+// Pair this with RequireSession on /api/*: RequireSession says "you must
+// be logged in", RequireCSRFHeader says "and this isn't a cross-site
+// drive-by".
+func RequireCSRFHeader(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := safeMethods[r.Method]; ok {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if r.Header.Get(CSRFHeader) == "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":"missing csrf header"}`))
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/api/auth/middleware_test.go
+++ b/internal/api/auth/middleware_test.go
@@ -46,6 +46,79 @@ func TestRequireSession_UnknownCookie401(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, rr.Code)
 }
 
+func TestRequireCSRFHeader_AllowsSafeMethodsWithoutHeader(t *testing.T) {
+	t.Parallel()
+
+	called := 0
+	h := RequireCSRFHeader(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called++
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for _, m := range []string{http.MethodGet, http.MethodHead, http.MethodOptions} {
+		req := httptest.NewRequest(m, "/api/v1/repos", nil)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		require.Equalf(t, http.StatusOK, rr.Code, "method %s should pass without header", m)
+	}
+	require.Equal(t, 3, called)
+}
+
+func TestRequireCSRFHeader_BlocksMutatingMethodsWithoutHeader(t *testing.T) {
+	t.Parallel()
+
+	h := RequireCSRFHeader(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("downstream handler should not run")
+	}))
+
+	for _, m := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		req := httptest.NewRequest(m, "/api/v1/repos/default/stacks/main/submit", nil)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		require.Equalf(t, http.StatusForbidden, rr.Code, "method %s without header should be 403", m)
+		require.Contains(t, rr.Body.String(), "missing csrf header")
+	}
+}
+
+func TestRequireCSRFHeader_AllowsMutatingMethodsWithHeader(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	h := RequireCSRFHeader(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repos/default/stacks/main/submit", nil)
+	req.Header.Set(CSRFHeader, "1")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.True(t, called)
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestRequireCSRFHeader_AnyNonEmptyValueAccepted(t *testing.T) {
+	t.Parallel()
+
+	// The presence of the header is what matters, not its content.
+	// Browsers can't set a custom header on a cross-origin request without
+	// preflight, so the value doesn't need to be unguessable.
+	for _, v := range []string{"1", "true", "yes-please", "x"} {
+		called := false
+		h := RequireCSRFHeader(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			called = true
+		}))
+
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set(CSRFHeader, v)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Truef(t, called, "value %q should be accepted", v)
+	}
+}
+
 func TestRequireSession_ValidSessionPassesAndAttachesContext(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -146,7 +146,7 @@ func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 			h := w.Header()
 			h.Set("Access-Control-Allow-Origin", origin)
 			h.Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-			h.Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Request-ID")
+			h.Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Request-ID, X-Stackit-CSRF")
 			h.Set("Access-Control-Allow-Credentials", "true")
 			h.Set("Access-Control-Max-Age", "86400")
 			h.Add("Vary", "Origin")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -111,6 +111,10 @@ func (s *Server) Start() error {
 	if s.config.Auth != nil {
 		protectedAPI = auth.RequireSession(s.config.Auth.SessionStore, apiMux)
 	}
+	// CSRF header check wraps protectedAPI so it covers POST /submit. Safe
+	// methods (GET/HEAD/OPTIONS) pass through untouched, so the read API
+	// is unaffected.
+	protectedAPI = auth.RequireCSRFHeader(protectedAPI)
 
 	authMux := http.NewServeMux()
 	if s.config.Auth != nil {
@@ -120,6 +124,10 @@ func (s *Server) Start() error {
 		authMux.HandleFunc("POST /auth/logout", h.LogoutHandler)
 		authMux.HandleFunc("GET /auth/me", h.MeHandler)
 	}
+	// /auth/logout is a POST and needs the same CSRF gate as /api/*.
+	// Login and callback are GETs and pass through. The CSRF middleware
+	// short-circuits safe methods so wrapping the whole mux is fine.
+	authHandler := auth.RequireCSRFHeader(http.Handler(authMux))
 
 	webHandler := newStaticHandler(s.config.StaticFS)
 	root := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -129,7 +137,7 @@ func (s *Server) Start() error {
 		}
 
 		if s.config.Auth != nil && strings.HasPrefix(r.URL.Path, "/auth/") {
-			authMux.ServeHTTP(w, r)
+			authHandler.ServeHTTP(w, r)
 			return
 		}
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

PR 3 of the security pass (plan:
/Users/jonnii/.claude/plans/we-are-going-put-transient-taco.md). Adds
RequireCSRFHeader middleware that demands a custom request header on
every non-safe method (POST/PUT/PATCH/DELETE) and 403s otherwise. Safe
methods pass through, so the entire read API is unaffected.

The header's presence — not value — is what matters: browsers cannot
set a custom header on a cross-origin request without a CORS preflight,
and the server's CORS allowlist is exact-match (PR 1). Together that
means only configured origins can satisfy this check, which is enough
to block cookie-based CSRF without a per-request token. A SameSite=Lax
session cookie + this header is the standard pattern for SPA APIs.

Wired around both the /api/* and /auth/* handlers so it covers POST
/submit and POST /auth/logout. Web client now sends X-Stackit-CSRF: 1
on every non-GET fetch (submitStack, logout). docs/deploy.md documents
the header so script and curl users can satisfy it.

Allow-Headers in the CORS response is extended to include the new
header so browsers send it in cross-origin requests.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1006**
  * **PR #1007**
    * **PR #1008**
      * **PR #1009**
        * **PR #1011**
          * **PR #1015**
            * **PR #1016** 👈
              * **PR #1017**
                * **PR #1012**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1054 by jonnii*