### PR TITLE
feat(server): structured audit logs on mutating calls

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -133,6 +133,36 @@ this doc revision and follow-on PRs):
   web app sends it automatically; scripts and direct API callers must
   include it.
 
+### Audit logging
+
+The server emits a single-line `audit action=...` log entry for every
+identity-changing or mutating action. The fields are key-quoted so they
+can be ingested by any structured log pipeline.
+
+| Action | Emitted by | Fields |
+|--------|------------|--------|
+| `login` | `GET /auth/callback` after a successful exchange | `actor`, `user_id`, `target` (post-login URL), `request_id` |
+| `denied` | `GET /auth/callback` for non-allowlisted users | `actor`, `request_id` |
+| `logout` | `POST /auth/logout` | `actor`, `request_id` |
+| `submit` | `POST /api/v1/repos/{id}/stacks/{branch}/submit` | `actor`, `repo`, `branch`, `request_id` |
+
+Every request also carries a `X-Request-ID` response header with the
+same value used as `request_id` in the audit lines. Pass it through
+your reverse proxy (Caddy, Cloudflare) for end-to-end correlation.
+
+### Log retention
+
+The container writes everything to stdout/stderr; retention is the
+platform's responsibility. A useful baseline:
+
+- **Railway / Fly / Heroku** — keep the platform default (7–14 days),
+  ship to an external sink (BetterStack, Datadog, S3) for longer.
+- **Self-hosted Docker** — pipe `docker logs` to journald or an
+  equivalent rotating sink; aim for 30+ days on the audit lines.
+
+The `audit action=` prefix is stable; alert on `audit action=denied`
+and on bursts of `audit action=submit` from a single `actor`.
+
 ### Calling the API from scripts
 
 ```bash

--- a/internal/api/auth/oauth.go
+++ b/internal/api/auth/oauth.go
@@ -15,6 +15,8 @@ import (
 
 	"golang.org/x/oauth2"
 	githuboauth "golang.org/x/oauth2/github"
+
+	"github.com/getstackit/stackit/internal/api/reqid"
 )
 
 // DefaultScopes is what the OAuth flow requests today. `read:user` gets the
@@ -188,7 +190,7 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.allow.Check(ctx, user.Login, tok.AccessToken); err != nil {
 		if errors.Is(err, ErrDenied) {
-			log.Printf("auth callback: denied login=%q", user.Login) //nolint:gosec // login is %q-quoted
+			log.Printf("audit action=denied actor=%q request_id=%s", user.Login, reqid.FromContext(ctx)) //nolint:gosec // login is %q-quoted
 			http.Redirect(w, r, h.cfg.DeniedPath, http.StatusFound)
 			return
 		}
@@ -211,7 +213,7 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	h.cfg.Cookies.clearReturn(w)
 
-	log.Printf("auth: login login=%q user_id=%d -> %s", user.Login, user.ID, target) //nolint:gosec // logged values are quoted/numeric/safe target
+	log.Printf("audit action=login actor=%q user_id=%d target=%s request_id=%s", user.Login, user.ID, target, reqid.FromContext(ctx)) //nolint:gosec // logged values are quoted/numeric/safe target
 	http.Redirect(w, r, target, http.StatusFound)
 }
 
@@ -221,7 +223,7 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) LogoutHandler(w http.ResponseWriter, r *http.Request) {
 	if cookie := readCookie(r, sessionCookieName); cookie != "" {
 		if sess, ok := h.store.Get(cookie); ok {
-			log.Printf("auth: logout login=%q", sess.GitHubLogin) //nolint:gosec // login is %q-quoted
+			log.Printf("audit action=logout actor=%q request_id=%s", sess.GitHubLogin, reqid.FromContext(r.Context())) //nolint:gosec // login is %q-quoted
 		}
 		h.store.Delete(cookie)
 	}

--- a/internal/api/handlers/submit.go
+++ b/internal/api/handlers/submit.go
@@ -3,10 +3,13 @@ package handlers
 import (
 	"encoding/json"
 	"io"
+	"log"
 	"net/http"
 
 	"github.com/getstackit/stackit/internal/actions/submit"
+	"github.com/getstackit/stackit/internal/api/auth"
 	"github.com/getstackit/stackit/internal/api/registry"
+	"github.com/getstackit/stackit/internal/api/reqid"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/output"
@@ -56,6 +59,15 @@ func (h *SubmitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !validateBranchName(w, rootBranch) {
 		return
 	}
+
+	// Audit line for a mutating call. "actor" is whichever GitHub login
+	// the session belongs to; unauthenticated submits (only possible
+	// when -auth-disabled is set on a private deploy) log actor=<none>.
+	actor := "<none>"
+	if sess := auth.SessionFromContext(r.Context()); sess != nil {
+		actor = sess.GitHubLogin
+	}
+	log.Printf("audit action=submit actor=%q repo=%q branch=%q request_id=%s", actor, entry.ID, rootBranch, reqid.FromContext(r.Context())) //nolint:gosec // values are %q-quoted
 
 	ctx := app.NewContext(entry.Engine,
 		app.WithRepoRoot(entry.RepoRoot),

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -9,28 +9,23 @@ import (
 	"runtime/debug"
 	"strings"
 	"time"
+
+	"github.com/getstackit/stackit/internal/api/reqid"
 )
 
 // requestIDHeader is the response header that carries the per-request ID. The
-// same value is stashed on the request context so handlers and the logger can
-// reference it.
-const requestIDHeader = "X-Request-ID"
+// same value is stashed on the request context (via package reqid) so
+// handlers and the logger can reference it.
+const requestIDHeader = reqid.HeaderName
 
 // maxRequestBodyBytes caps every request body. POST /submit takes no body
 // today; this is defense against runaway uploads against any endpoint.
 const maxRequestBodyBytes = 1 << 20 // 1 MiB
 
-type ctxKey int
-
-const ctxKeyRequestID ctxKey = iota
-
-// RequestIDFromContext returns the request ID associated with the context, or
-// the empty string if none was set.
+// RequestIDFromContext is kept here as a re-export for callers in the api
+// package; handlers in other packages import internal/api/reqid directly.
 func RequestIDFromContext(ctx context.Context) string {
-	if v, ok := ctx.Value(ctxKeyRequestID).(string); ok {
-		return v
-	}
-	return ""
+	return reqid.FromContext(ctx)
 }
 
 // recoverMiddleware catches panics in downstream handlers, logs them with a
@@ -63,7 +58,7 @@ func requestIDMiddleware(next http.Handler) http.Handler {
 			rid = newRequestID()
 		}
 		w.Header().Set(requestIDHeader, rid)
-		ctx := context.WithValue(r.Context(), ctxKeyRequestID, rid)
+		ctx := reqid.WithValue(r.Context(), rid)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/api/reqid/reqid.go
+++ b/internal/api/reqid/reqid.go
@@ -1,0 +1,29 @@
+// Package reqid holds the request-ID context plumbing shared between the
+// middleware that mints the ID (internal/api) and the handlers that want
+// to include it in audit log lines (internal/api/handlers). Lives in its
+// own package so neither side has to import the other.
+package reqid
+
+import "context"
+
+// HeaderName is the request/response header that carries the per-request
+// ID. Kept here so the middleware and the http client agree.
+const HeaderName = "X-Request-ID"
+
+type ctxKey struct{}
+
+// FromContext returns the request ID associated with ctx, or "" if none
+// was attached (e.g. tests calling a handler directly without going
+// through the middleware).
+func FromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(ctxKey{}).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// WithValue attaches a request ID to ctx. Only the middleware should call
+// this; handlers read via FromContext.
+func WithValue(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, ctxKey{}, id)
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


PR 4 (final) of the security pass (plan:
/Users/jonnii/.claude/plans/we-are-going-put-transient-taco.md). Emit a
single-line `audit action=...` log entry for every identity-changing or
mutating action so operators can detect abuse and correlate activity
with X-Request-ID. Format is key-quoted so the lines drop straight into
any structured log pipeline.

Events emitted:
  login    — successful OAuth callback (actor, user_id, target, request_id)
  denied   — allowlist rejection                  (actor, request_id)
  logout   — POST /auth/logout                    (actor, request_id)
  submit   — POST /repos/{id}/stacks/{br}/submit  (actor, repo, branch, request_id)

Extracts request-ID context plumbing into a new internal/api/reqid
package so handlers can reach the per-request ID without creating an
import cycle through internal/api. The submit handler now resolves the
session via auth.SessionFromContext for the actor field; auth handlers
already had the data and just gained the consistent prefix +
request_id field.

docs/deploy.md gains an Audit logging section listing the event fields
and a Log retention note pointing operators at platform-specific
defaults and what to alert on.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1779932878`.


* **PR #1006**
  * **PR #1007**
    * **PR #1008**
      * **PR #1009**
        * **PR #1011**
          * **PR #1015**
            * **PR #1016**
              * **PR #1017** 👈
                * **PR #1012**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->