### PR TITLE
refactor(git): replace go-git in read-only history ops with shell-out

### DIFF
--- a/internal/git/bench_test.go
+++ b/internal/git/bench_test.go
@@ -97,14 +97,13 @@ func BenchmarkGetRecentCommits(b *testing.B) {
 	}
 }
 
-// BenchmarkGetRevision measures the cost of resolving a branch name to a SHA.
-// Phase 2 replaces the go-git Reference lookup with `git rev-parse --verify`.
-// The revisionCache may serve the read on subsequent calls; this bench
-// measures the cache-warm path. See BenchmarkGetRevisionCold for the miss path.
+// BenchmarkGetRevision measures the cache-warm path — the realistic case in
+// production where engine bootstrap preloads all branch revisions via
+// LoadAllBranchRevisions before any individual lookup.
 func BenchmarkGetRevision(b *testing.B) {
 	br := newBenchRepo(b, 5, 1)
-	if _, err := br.runner.GetRevision("branch-0"); err != nil {
-		b.Fatalf("warm GetRevision: %v", err)
+	if err := br.runner.LoadAllBranchRevisions(); err != nil {
+		b.Fatalf("LoadAllBranchRevisions: %v", err)
 	}
 	for b.Loop() {
 		if _, err := br.runner.GetRevision("branch-0"); err != nil {
@@ -113,9 +112,21 @@ func BenchmarkGetRevision(b *testing.B) {
 	}
 }
 
-// BenchmarkBatchGetRevisions measures bulk revision resolution. The bench
-// repo has 20 branches; LoadAllBranchRevisions warms the cache via a single
-// go-git iteration today (Phase 2 swaps that for a single `git for-each-ref`).
+// BenchmarkGetRevisionCold measures the cache-miss path. The cache is only
+// populated by LoadAllBranchRevisions (not on individual misses) so repeated
+// calls without a preload always pay the subprocess cost.
+func BenchmarkGetRevisionCold(b *testing.B) {
+	br := newBenchRepo(b, 5, 1)
+	for b.Loop() {
+		if _, err := br.runner.GetRevision("branch-0"); err != nil {
+			b.Fatalf("GetRevision: %v", err)
+		}
+	}
+}
+
+// BenchmarkBatchGetRevisions measures bulk revision resolution with a cold
+// cache so we see the actual shell-out cost (Phase 2 batches all misses into
+// a single `git rev-parse` invocation rather than N parallel subprocesses).
 func BenchmarkBatchGetRevisions(b *testing.B) {
 	const branches = 20
 	br := newBenchRepo(b, 5, branches)

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -243,7 +243,7 @@ func (r *runner) GetMergedBranches(_ context.Context, target string) (map[string
 			merged[branchName] = true
 			continue
 		}
-		isMerged, err := r.isAncestorGoGit(repo, branchHash, targetHash)
+		isMerged, err := r.isAncestor(branchHash.String(), targetHash.String())
 		if err != nil {
 			return nil, fmt.Errorf("failed to check if %s is merged into %s: %w", branchName, target, err)
 		}

--- a/internal/git/commit_info.go
+++ b/internal/git/commit_info.go
@@ -1,194 +1,176 @@
 package git
 
 import (
+	"context"
 	"fmt"
-	"sync"
+	"strings"
 	"time"
 
 	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/plumbing/object"
-
-	"github.com/getstackit/stackit/internal/utils"
 )
 
-func (r *runner) getCommitDate(repo *Repository, branchName string) (time.Time, error) {
-	// Synchronize go-git operations to prevent concurrent packfile access
-	r.goGitMu.Lock()
-	defer r.goGitMu.Unlock()
-
-	hash, err := r.resolveRefHashInternal(repo, branchName)
+// resolveRefHashInternal is a transitional shim that converts the string SHA
+// from `git rev-parse` into a plumbing.Hash. Callers that still pass the hash
+// to go-git's repo.CommitObject (diff.go, branches.go, GetCommitSHA/GetParent
+// in runner.go) need this until Phase 6 swaps those go-git uses out too.
+func (r *runner) resolveRefHashInternal(_ *Repository, ref string) (plumbing.Hash, error) {
+	sha, err := r.resolveRefSHA(ref)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("failed to resolve branch reference: %w", err)
+		return plumbing.ZeroHash, err
 	}
-
-	commit, err := repo.CommitObject(hash)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("failed to get commit: %w", err)
-	}
-
-	return commit.Author.When, nil
+	return plumbing.NewHash(sha), nil
 }
 
-func (r *runner) getCommitAuthor(repo *Repository, branchName string) (string, error) {
-	// Synchronize go-git operations to prevent concurrent packfile access
-	r.goGitMu.Lock()
-	defer r.goGitMu.Unlock()
-
-	hash, err := r.resolveRefHashInternal(repo, branchName)
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve branch reference: %w", err)
-	}
-
-	commit, err := repo.CommitObject(hash)
-	if err != nil {
-		return "", fmt.Errorf("failed to get commit: %w", err)
-	}
-
-	return commit.Author.Name, nil
-}
-
-func (r *runner) getRevision(repo *Repository, branchName string) (string, error) {
-	// Check revision cache first to avoid go-git mutex contention.
-	// The cache is populated by LoadAllBranchRevisions (batch preload)
-	// but not on individual misses, to avoid stale entries from external mutations.
-	if cached, ok := r.revisionCache.Get(branchName); ok {
-		return cached, nil
-	}
-
-	// Synchronize go-git operations to prevent concurrent packfile access
-	r.goGitMu.Lock()
-	defer r.goGitMu.Unlock()
-
-	hash, err := r.resolveRefHashInternal(repo, branchName)
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve branch reference: %w", err)
-	}
-
-	return hash.String(), nil
-}
-
-func (r *runner) getRemoteRevision(repo *Repository, branchName string) (string, error) {
-	// Synchronize go-git operations to prevent concurrent packfile access
-	r.goGitMu.Lock()
-	defer r.goGitMu.Unlock()
-
-	// Try refs/remotes/origin/branchName
-	hash, err := r.resolveRefHashInternal(repo, "origin/"+branchName)
-	if err != nil {
-		return "", fmt.Errorf("failed to get remote branch reference: %w", err)
-	}
-
-	return hash.String(), nil
-}
-
-// iterateCommitsNoLock iterates commits from head to base without locking
-func iterateCommitsNoLock(repo *Repository, headHash, baseHash plumbing.Hash) ([]*object.Commit, error) {
-	var commits []*object.Commit
-	currentHash := headHash
-
-	for !currentHash.IsZero() && currentHash != baseHash {
-		commit, err := repo.CommitObject(currentHash)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get commit %s: %w", currentHash, err)
-		}
-
-		commits = append(commits, commit)
-
-		if commit.NumParents() == 0 {
-			break
-		}
-		// Follow the first parent for a linear history walk
-		currentHash = commit.ParentHashes[0]
-	}
-
-	return commits, nil
-}
-
-// resolveRefHash resolves a ref (branch name, SHA, or ref path) to a hash
+// resolveRefHash is the locking variant of resolveRefHashInternal. The lock
+// no longer matters (the shell-out is parallel-safe) but the signature is
+// preserved for callers still mid-migration.
 func (r *runner) resolveRefHash(repo *Repository, ref string) (plumbing.Hash, error) {
-	// Synchronize go-git operations to prevent concurrent packfile access
-	r.goGitMu.Lock()
-	defer r.goGitMu.Unlock()
-
 	return r.resolveRefHashInternal(repo, ref)
 }
 
-// resolveRefHashInternal resolves a ref without locking
-func (r *runner) resolveRefHashInternal(repo *Repository, ref string) (plumbing.Hash, error) {
-	// 1. Try as a full reference name
-	if refInfo, err := repo.Reference(plumbing.ReferenceName(ref), true); err == nil {
-		return refInfo.Hash(), nil
+// resolveRefSHA resolves any ref form (branch, short SHA, full SHA, tag,
+// "HEAD~1") to a 40-char SHA using `git rev-parse --verify`. The verify flag
+// turns ambiguity into an error rather than a heuristic guess.
+//
+// On failure the returned error string contains "reference not found" so
+// downstream callers that match on that legacy phrase continue to work.
+func (r *runner) resolveRefSHA(ref string) (string, error) {
+	out, err := r.RunGitCommandWithContext(context.Background(), "rev-parse", "--verify", "--end-of-options", ref+"^{commit}")
+	if err != nil {
+		// Fall back to the non-commit form: tags pointing at trees/blobs, or
+		// generic ref lookups that aren't commits. Most stackit call sites
+		// only care about commits, so try ^{commit} first to fail fast on
+		// nonsense input.
+		out, err = r.RunGitCommandWithContext(context.Background(), "rev-parse", "--verify", "--end-of-options", ref)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve ref %s: reference not found: %w", ref, err)
+		}
 	}
-
-	// 2. Try as a local branch
-	if refInfo, err := repo.Reference(plumbing.ReferenceName("refs/heads/"+ref), true); err == nil {
-		return refInfo.Hash(), nil
+	sha := strings.TrimSpace(out)
+	if sha == "" {
+		return "", fmt.Errorf("failed to resolve ref %s: reference not found", ref)
 	}
+	return sha, nil
+}
 
-	// 3. Try as a remote branch
-	if refInfo, err := repo.Reference(plumbing.ReferenceName("refs/remotes/origin/"+ref), true); err == nil {
-		return refInfo.Hash(), nil
+func (r *runner) getCommitDate(branchName string) (time.Time, error) {
+	out, err := r.RunGitCommandWithContext(context.Background(), "log", "-1", "--format=%aI", branchName)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to get commit date for %s: %w", branchName, err)
 	}
-
-	// 4. Try as a tag
-	if refInfo, err := repo.Reference(plumbing.ReferenceName("refs/tags/"+ref), true); err == nil {
-		return refInfo.Hash(), nil
+	s := strings.TrimSpace(out)
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse commit date %q: %w", s, err)
 	}
+	return t, nil
+}
 
-	// 5. Try ResolveRevision (handles SHAs, short SHAs, and complex expressions like HEAD~1)
-	hash, err := repo.ResolveRevision(plumbing.Revision(ref))
-	if err == nil {
-		return *hash, nil
+func (r *runner) getCommitAuthor(branchName string) (string, error) {
+	out, err := r.RunGitCommandWithContext(context.Background(), "log", "-1", "--format=%an", branchName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get commit author for %s: %w", branchName, err)
 	}
+	return strings.TrimSpace(out), nil
+}
 
-	return plumbing.ZeroHash, fmt.Errorf("failed to resolve ref %s: reference not found", ref)
+func (r *runner) getRevision(branchName string) (string, error) {
+	// Check revision cache first to avoid spawning git rev-parse. The cache
+	// is populated by LoadAllBranchRevisions (batch preload) but not on
+	// individual misses, to avoid stale entries from external mutations.
+	if cached, ok := r.revisionCache.Get(branchName); ok {
+		return cached, nil
+	}
+	return r.resolveRefSHA(branchName)
+}
+
+func (r *runner) getRemoteRevision(branchName string) (string, error) {
+	// Use the bare "origin/<branch>" form so git's normal ref lookup order
+	// applies (refs/heads/, refs/remotes/, etc.). Tests sometimes mock the
+	// remote SHA by creating a local branch named "origin/<branch>" and
+	// rely on that fallback resolving via refs/heads/.
+	return r.resolveRefSHA("origin/" + branchName)
 }
 
 // LoadAllBranchRevisions populates the revision cache for all local branches
-// using one go-git reference iteration. This replaces N individual ref
-// resolutions and avoids spawning a git process for the common preload path.
+// with one `git for-each-ref` invocation, replacing N individual ref lookups
+// during engine startup.
 func (r *runner) LoadAllBranchRevisions() error {
-	repo, err := r.ensureRepo()
+	out, err := r.RunGitCommandWithContext(context.Background(),
+		"for-each-ref",
+		"--format=%(refname:short)%00%(objectname)",
+		"refs/heads/",
+	)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list branch revisions: %w", err)
 	}
 
-	branches, err := repo.Branches()
-	if err != nil {
-		return fmt.Errorf("failed to list branches: %w", err)
-	}
-	defer branches.Close()
-
-	return branches.ForEach(func(ref *plumbing.Reference) error {
-		if ref.Name().IsBranch() {
-			r.revisionCache.Put(ref.Name().Short(), ref.Hash().String())
+	for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
+		if line == "" {
+			continue
 		}
-		return nil
-	})
+		name, sha, ok := strings.Cut(line, "\x00")
+		if !ok || sha == "" {
+			continue
+		}
+		r.revisionCache.Put(name, sha)
+	}
+	return nil
 }
 
-func (r *runner) batchGetRevisions(repo *Repository, branchNames []string) (map[string]string, []error) {
+func (r *runner) batchGetRevisions(branchNames []string) (map[string]string, []error) {
 	results := make(map[string]string)
-	var errors []error
-	resultsMu := sync.Mutex{}
-	errorsMu := sync.Mutex{}
+	var errs []error
 
 	if len(branchNames) == 0 {
-		return results, errors
+		return results, errs
 	}
 
-	utils.Run(branchNames, func(name string) {
-		sha, err := r.getRevision(repo, name)
-		if err != nil {
-			errorsMu.Lock()
-			errors = append(errors, fmt.Errorf("failed to get revision for %s: %w", name, err))
-			errorsMu.Unlock()
-		} else {
-			resultsMu.Lock()
+	// Serve cache hits first; collect misses for a single shell-out.
+	var misses []string
+	for _, name := range branchNames {
+		if sha, ok := r.revisionCache.Get(name); ok {
 			results[name] = sha
-			resultsMu.Unlock()
+			continue
 		}
-	})
+		misses = append(misses, name)
+	}
+	if len(misses) == 0 {
+		return results, errs
+	}
 
-	return results, errors
+	// Resolve all misses in one `git rev-parse` invocation. Each ref is
+	// printed on its own line in the same order as the args, so we can map
+	// back by index. `--verify` would short-circuit on the first bad ref, so
+	// omit it and detect failures via empty/short output.
+	args := append([]string{"rev-parse"}, misses...)
+	out, err := r.RunGitCommandWithContext(context.Background(), args...)
+	if err != nil {
+		// Fall back to per-ref resolution so we can attribute errors to
+		// specific branch names rather than a single bulk failure.
+		for _, name := range misses {
+			sha, e := r.resolveRefSHA(name)
+			if e != nil {
+				errs = append(errs, fmt.Errorf("failed to get revision for %s: %w", name, e))
+				continue
+			}
+			results[name] = sha
+		}
+		return results, errs
+	}
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != len(misses) {
+		// Output shape mismatch: surface a single error rather than misalign.
+		return results, []error{fmt.Errorf("batch rev-parse returned %d lines for %d refs", len(lines), len(misses))}
+	}
+	for i, name := range misses {
+		sha := strings.TrimSpace(lines[i])
+		if sha == "" {
+			errs = append(errs, fmt.Errorf("failed to get revision for %s: empty output", name))
+			continue
+		}
+		results[name] = sha
+	}
+	return results, errs
 }

--- a/internal/git/merge_base.go
+++ b/internal/git/merge_base.go
@@ -1,91 +1,35 @@
 package git
 
 import (
+	"context"
+	"errors"
 	"fmt"
-
-	"github.com/go-git/go-git/v6/plumbing"
+	"os/exec"
+	"strings"
 )
 
-func (r *runner) getMergeBase(repo *Repository, branch1, branch2 string) (string, error) {
-	return r.getMergeBaseByRef(repo, branch1, branch2)
-}
-
-func (r *runner) getMergeBaseByRef(repo *Repository, ref1Name, ref2Name string) (string, error) {
-	hash1, err := r.resolveRefHash(repo, ref1Name)
+func (r *runner) getMergeBaseByRef(ref1Name, ref2Name string) (string, error) {
+	out, err := r.RunGitCommandWithContext(context.Background(), "merge-base", ref1Name, ref2Name)
 	if err != nil {
-		return "", fmt.Errorf("failed to resolve %s: %w", ref1Name, err)
+		return "", fmt.Errorf("failed to find merge base of %s and %s: %w", ref1Name, ref2Name, err)
 	}
-
-	hash2, err := r.resolveRefHash(repo, ref2Name)
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve %s: %w", ref2Name, err)
-	}
-
-	return r.getMergeBaseGoGit(repo, hash1, hash2)
-}
-
-func (r *runner) getMergeBaseGoGit(repo *Repository, hash1, hash2 plumbing.Hash) (string, error) {
-	// Synchronize go-git operations to prevent concurrent packfile access
-	r.goGitMu.Lock()
-	defer r.goGitMu.Unlock()
-
-	commit1, err := repo.CommitObject(hash1)
-	if err != nil {
-		return "", fmt.Errorf("failed to get commit1: %w", err)
-	}
-
-	commit2, err := repo.CommitObject(hash2)
-	if err != nil {
-		return "", fmt.Errorf("failed to get commit2: %w", err)
-	}
-
-	// Find merge base
-	mergeBases, err := commit1.MergeBase(commit2)
-	if err != nil {
-		return "", fmt.Errorf("failed to find merge base: %w", err)
-	}
-
-	if len(mergeBases) == 0 {
+	sha := strings.TrimSpace(out)
+	if sha == "" {
 		return "", fmt.Errorf("no merge base found")
 	}
-
-	return mergeBases[0].Hash.String(), nil
+	return sha, nil
 }
 
-func (r *runner) isAncestor(repo *Repository, ancestor, descendant string) (bool, error) {
-	ancestorHash, err := r.resolveRefHash(repo, ancestor)
-	if err != nil {
-		return false, fmt.Errorf("failed to resolve ancestor %s: %w", ancestor, err)
-	}
-
-	descendantHash, err := r.resolveRefHash(repo, descendant)
-	if err != nil {
-		return false, fmt.Errorf("failed to resolve descendant %s: %w", descendant, err)
-	}
-
-	// If they're the same, ancestor is an ancestor
-	if ancestorHash == descendantHash {
+func (r *runner) isAncestor(ancestor, descendant string) (bool, error) {
+	_, err := r.RunGitCommandWithContext(context.Background(), "merge-base", "--is-ancestor", ancestor, descendant)
+	if err == nil {
 		return true, nil
 	}
-
-	return r.isAncestorGoGit(repo, ancestorHash, descendantHash)
-}
-
-func (r *runner) isAncestorGoGit(repo *Repository, ancestorHash, descendantHash plumbing.Hash) (bool, error) {
-	// Synchronize go-git operations to prevent concurrent packfile access
-	r.goGitMu.Lock()
-	defer r.goGitMu.Unlock()
-
-	// Get commit objects
-	ancestorCommit, err := repo.CommitObject(ancestorHash)
-	if err != nil {
-		return false, fmt.Errorf("failed to get ancestor commit: %w", err)
+	// `git merge-base --is-ancestor` exits 1 when the answer is "no". Any
+	// other non-zero exit is a real error (bad SHA, repo missing, etc.).
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false, nil
 	}
-
-	descendantCommit, err := repo.CommitObject(descendantHash)
-	if err != nil {
-		return false, fmt.Errorf("failed to get descendant commit: %w", err)
-	}
-
-	return ancestorCommit.IsAncestor(descendantCommit)
+	return false, fmt.Errorf("failed to check ancestry of %s..%s: %w", ancestor, descendant, err)
 }

--- a/internal/git/recent_commits.go
+++ b/internal/git/recent_commits.go
@@ -1,22 +1,22 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"slices"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
 const trailerValueSeparator = "\x1e"
 
-var prNumberSuffixRe = regexp.MustCompile(`\(#(\d+)\)\s*$`)
-var mergeSubjectRe = regexp.MustCompile(`^Merge pull request #(\d+) from `)
-var stackitTrailerRe = regexp.MustCompile(`^Stackit-[\w-]+:\s`)
+var (
+	prNumberSuffixRe = regexp.MustCompile(`\(#(\d+)\)\s*$`)
+	mergeSubjectRe   = regexp.MustCompile(`^Merge pull request #(\d+) from `)
+	stackitTrailerRe = regexp.MustCompile(`^Stackit-[\w-]+:\s`)
+)
 
 // RecentCommitKind describes the presentation type of a trunk commit.
 type RecentCommitKind string
@@ -39,61 +39,77 @@ type RecentCommit struct {
 	StackScope     string           // from Stackit-Scope trailer (empty if absent)
 }
 
-// GetRecentCommits returns the most recent commits from a branch, including stack trailer metadata.
-// For merge commits ("Merge pull request #N from ..."), the subject is replaced with the
-// first line of the body, which contains the actual PR title.
+// commit log field separator used inside a record (never appears in commit
+// metadata when escaped through git's pretty format).
+const commitFieldSep = "\x1f"
+
+// GetRecentCommits returns the most recent commits from a branch, including
+// stack trailer metadata. For merge commits ("Merge pull request #N from ..."),
+// the subject is replaced with the first line of the body, which contains the
+// actual PR title.
+//
+// The underlying transport is `git log -z` so commit bodies (which may contain
+// newlines) round-trip safely. Fields within a record are separated by US
+// (0x1f); records by NUL.
 func (r *runner) GetRecentCommits(branchName string, count int) ([]RecentCommit, error) {
 	if count <= 0 {
 		return nil, nil
 	}
 
-	repo, err := r.ensureRepo()
+	format := strings.Join([]string{
+		"%H", "%an", "%aI", "%B",
+	}, commitFieldSep)
+
+	out, err := r.RunGitCommandRawWithContext(context.Background(),
+		"log",
+		fmt.Sprintf("-n%d", count),
+		"-z",
+		"--format="+format,
+		branchName,
+	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to walk recent commits on %s: %w", branchName, err)
 	}
 
-	r.goGitMu.Lock()
-	defer r.goGitMu.Unlock()
-
-	currentHash, err := r.resolveRefHashInternal(repo, branchName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve branch %s: %w", branchName, err)
+	raw := strings.TrimRight(out, "\x00")
+	if raw == "" {
+		return nil, nil
 	}
 
-	commits := make([]RecentCommit, 0, count)
-	for range count {
-		commit, err := repo.CommitObject(currentHash)
+	records := strings.Split(raw, "\x00")
+	commits := make([]RecentCommit, 0, len(records))
+	for _, rec := range records {
+		if rec == "" {
+			continue
+		}
+		fields := strings.SplitN(rec, commitFieldSep, 4)
+		if len(fields) < 4 {
+			return nil, fmt.Errorf("malformed git log record: %q", rec)
+		}
+		date, err := time.Parse(time.RFC3339, strings.TrimSpace(fields[2]))
 		if err != nil {
-			return nil, fmt.Errorf("failed to load commit %s: %w", currentHash, err)
+			return nil, fmt.Errorf("failed to parse commit date %q: %w", fields[2], err)
 		}
-
-		commits = append(commits, recentCommitFromGoGit(commit))
-		if commit.NumParents() == 0 {
-			break
-		}
-		currentHash = commit.ParentHashes[0]
-		if currentHash == plumbing.ZeroHash {
-			break
-		}
+		commits = append(commits, buildRecentCommit(fields[0], fields[1], date, fields[3]))
 	}
-
 	return commits, nil
 }
 
-func recentCommitFromGoGit(commit *object.Commit) RecentCommit {
-	subject, body := splitCommitMessage(commit.Message)
+// buildRecentCommit constructs a RecentCommit from the raw git log fields.
+func buildRecentCommit(sha, author string, date time.Time, message string) RecentCommit {
+	subject, body := splitCommitMessage(message)
 	resolvedSubject := resolveSubject(subject, body)
 
 	result := RecentCommit{
-		SHA:     commit.Hash.String(),
+		SHA:     sha,
 		Subject: resolvedSubject,
-		Author:  commit.Author.Name,
-		Date:    commit.Author.When,
+		Author:  author,
+		Date:    date,
 	}
 
-	result.StackSize = parseStackSizeTrailer(stackitTrailerValues(commit.Message, "Stackit-Stack-Size"))
-	result.StackPRNumbers = parseStackPRsTrailer(stackitTrailerValues(commit.Message, "Stackit-PRs"))
-	result.StackScope = parseStackScopeTrailer(stackitTrailerValues(commit.Message, "Stackit-Scope"))
+	result.StackSize = parseStackSizeTrailer(stackitTrailerValues(message, "Stackit-Stack-Size"))
+	result.StackPRNumbers = parseStackPRsTrailer(stackitTrailerValues(message, "Stackit-PRs"))
+	result.StackScope = parseStackScopeTrailer(stackitTrailerValues(message, "Stackit-Scope"))
 
 	result.PRNumber = parsePRNumberFromSubject(result.Subject)
 	if result.PRNumber == 0 {

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -4,35 +4,37 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
-	gogit "github.com/go-git/go-git/v6"
-	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/plumbing/transport"
+	"os/exec"
+	"strings"
 )
 
 // DefaultRemote is the default name for the remote repository
 const DefaultRemote = "origin"
 
-func (r *runner) getRemote(repo *Repository) string {
-	// Try to get current branch
-	head, err := repo.Head()
-	if err == nil && head.Name().IsBranch() {
-		branchName := head.Name().Short()
-		// Try to get remote for the current branch
-		cfg, err := repo.Config()
-		if err == nil {
-			if b, ok := cfg.Branches[branchName]; ok && b.Remote != "" {
-				return b.Remote
-			}
+// getRemote returns the configured remote for the current branch, falling
+// back to DefaultRemote. Implemented via `git config` rather than walking
+// go-git's typed config; the value is a single string and the call site
+// already accepts a fallback path.
+func (r *runner) getRemote() string {
+	branch, err := r.GetCurrentBranch()
+	if err != nil || branch == "" {
+		return DefaultRemote
+	}
+	out, err := r.RunGitCommandWithContext(context.Background(),
+		"config", "--get", "branch."+branch+".remote",
+	)
+	if err == nil {
+		if val := strings.TrimSpace(out); val != "" {
+			return val
 		}
 	}
-
-	// Fallback to origin
 	return DefaultRemote
 }
 
-func (r *runner) fetchRemoteShas(ctx context.Context, repo *Repository, remote string) (map[string]string, error) {
-	// Ensure context has a deadline for the network operation
+// fetchRemoteShas lists the branch refs on a remote without modifying any
+// local refs. `git ls-remote --heads` matches the previous go-git behavior
+// of returning only refs/heads/*.
+func (r *runner) fetchRemoteShas(ctx context.Context, remote string) (map[string]string, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -42,38 +44,44 @@ func (r *runner) fetchRemoteShas(ctx context.Context, repo *Repository, remote s
 		defer cancel()
 	}
 
-	rem, err := repo.Remote(remote)
+	out, err := r.RunGitCommandWithContext(ctx, "ls-remote", "--heads", "--refs", remote)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get remote %s: %w", remote, err)
-	}
-
-	// List remote references with context for timeout support
-	refs, err := rem.ListContext(ctx, &gogit.ListOptions{})
-	if err != nil {
-		if errors.Is(err, transport.ErrEmptyRemoteRepository) || errors.Is(err, gogit.NoErrAlreadyUpToDate) {
-			return make(map[string]string), nil
+		// Empty remote / no refs is not an error for callers; treat exit
+		// code 2 (no matching refs) as an empty result. Network errors
+		// surface unchanged.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 2 {
+			return map[string]string{}, nil
 		}
 		return nil, fmt.Errorf("failed to list remote refs for %s: %w", remote, err)
 	}
 
-	remoteShas := make(map[string]string)
-	for _, ref := range refs {
-		// Only process refs/heads/* (branches)
-		if ref.Name().IsBranch() {
-			branchName := ref.Name().Short()
-			remoteShas[branchName] = ref.Hash().String()
+	result := make(map[string]string)
+	for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
+		if line == "" {
+			continue
 		}
+		sha, ref, ok := strings.Cut(line, "\t")
+		if !ok {
+			continue
+		}
+		// Only branches: refs/heads/<name>
+		branchName, ok := strings.CutPrefix(ref, "refs/heads/")
+		if !ok {
+			continue
+		}
+		result[branchName] = sha
 	}
-
-	return remoteShas, nil
+	return result, nil
 }
 
-func (r *runner) getRemoteSha(repo *Repository, remote, branchName string) (string, error) {
-	refName := plumbing.ReferenceName(fmt.Sprintf("refs/remotes/%s/%s", remote, branchName))
-	ref, err := repo.Reference(refName, true)
+func (r *runner) getRemoteSha(remote, branchName string) (string, error) {
+	out, err := r.RunGitCommandWithContext(context.Background(),
+		"rev-parse", "--verify", "--end-of-options",
+		fmt.Sprintf("refs/remotes/%s/%s", remote, branchName),
+	)
 	if err != nil {
 		return "", fmt.Errorf("failed to get remote SHA for %s/%s: %w", remote, branchName, err)
 	}
-
-	return ref.Hash().String(), nil
+	return strings.TrimSpace(out), nil
 }

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,7 +19,6 @@ import (
 	gogit "github.com/go-git/go-git/v6"
 	gitcfg "github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/plumbing/object"
 
 	"github.com/getstackit/stackit/internal/utils"
 )
@@ -518,27 +518,15 @@ func (r *runner) InitDefaultRepo() error {
 }
 
 func (r *runner) GetRemote() string {
-	repo, err := r.ensureRepo()
-	if err != nil {
-		return DefaultRemote
-	}
-	return r.getRemote(repo)
+	return r.getRemote()
 }
 
 func (r *runner) FetchRemoteShas(ctx context.Context, remote string) (map[string]string, error) {
-	repo, err := r.ensureRepo()
-	if err != nil {
-		return nil, err
-	}
-	return r.fetchRemoteShas(ctx, repo, remote)
+	return r.fetchRemoteShas(ctx, remote)
 }
 
 func (r *runner) GetRemoteSha(remote, branchName string) (string, error) {
-	repo, err := r.ensureRepo()
-	if err != nil {
-		return "", err
-	}
-	return r.getRemoteSha(repo, remote, branchName)
+	return r.getRemoteSha(remote, branchName)
 }
 
 func (r *runner) GetConfig(key string) (string, error) {
@@ -667,146 +655,125 @@ func (r *runner) FindRemoteBranch(_ context.Context, remote string) (string, err
 }
 
 func (r *runner) GetRemoteRevision(branchName string) (string, error) {
-	repo, err := r.ensureRepo()
-	if err != nil {
-		return "", err
-	}
-	return r.getRemoteRevision(repo, branchName)
+	return r.getRemoteRevision(branchName)
 }
 
 func (r *runner) GetCurrentRevision(ctx context.Context) (string, error) {
-	repo, err := r.ensureRepo()
-	if err != nil {
-		return "", err
-	}
-
-	head, err := repo.Head()
+	out, err := r.RunGitCommandWithContext(ctx, "rev-parse", "--verify", "HEAD")
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve HEAD: %w", err)
 	}
-	return head.Hash().String(), nil
+	return strings.TrimSpace(out), nil
 }
 
 func (r *runner) GetRevision(branchName string) (string, error) {
-	repo, err := r.ensureRepo()
-	if err != nil {
-		return "", err
-	}
-	return r.getRevision(repo, branchName)
+	return r.getRevision(branchName)
 }
 
 func (r *runner) BatchGetRevisions(branchNames []string) (map[string]string, []error) {
-	repo, err := r.ensureRepo()
-	if err != nil {
-		errors := make([]error, 0, len(branchNames))
-		for range branchNames {
-			errors = append(errors, fmt.Errorf("failed to get repository: %w", err))
-		}
-		return nil, errors
-	}
-	return r.batchGetRevisions(repo, branchNames)
+	return r.batchGetRevisions(branchNames)
 }
 
 func (r *runner) GetMergeBase(rev1, rev2 string) (string, error) {
-	repo, err := r.ensureRepo()
-	if err != nil {
-		return "", err
-	}
-	return r.getMergeBase(repo, rev1, rev2)
+	return r.getMergeBaseByRef(rev1, rev2)
 }
 
 func (r *runner) GetMergeBaseByRef(ref1, ref2 string) (string, error) {
-	repo, err := r.ensureRepo()
-	if err != nil {
-		return "", err
-	}
-	return r.getMergeBaseByRef(repo, ref1, ref2)
+	return r.getMergeBaseByRef(ref1, ref2)
 }
 
 func (r *runner) IsAncestor(ancestor, descendant string) (bool, error) {
-	repo, err := r.ensureRepo()
-	if err != nil {
-		return false, err
-	}
-	return r.isAncestor(repo, ancestor, descendant)
+	return r.isAncestor(ancestor, descendant)
 }
 
 func (r *runner) GetCommitDate(branchName string) (time.Time, error) {
-	repo, err := r.ensureRepo()
-	if err != nil {
-		return time.Time{}, err
-	}
-	return r.getCommitDate(repo, branchName)
+	return r.getCommitDate(branchName)
 }
 
 func (r *runner) GetCommitAuthor(branchName string) (string, error) {
-	repo, err := r.ensureRepo()
-	if err != nil {
-		return "", err
-	}
-	return r.getCommitAuthor(repo, branchName)
+	return r.getCommitAuthor(branchName)
 }
 
 func (r *runner) GetCommitRange(base, head, format string) ([]string, error) {
-	repo, err := r.ensureRepo()
-	if err != nil {
-		return nil, err
-	}
-
-	// Synchronize go-git operations to prevent concurrent packfile access
-	r.goGitMu.Lock()
-	defer r.goGitMu.Unlock()
-
-	headHash, err := r.resolveRefHashInternal(repo, head)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve head: %w", err)
-	}
-
-	var baseHash plumbing.Hash
+	rangeArg := head
 	if base != "" {
-		baseHash, err = r.resolveRefHashInternal(repo, base)
+		rangeArg = base + ".." + head
+	}
+
+	switch format {
+	case "SHA":
+		return r.gitLogLines(rangeArg, "%H")
+	case "READABLE":
+		return r.gitLogLines(rangeArg, "%h %s")
+	case "SUBJECT":
+		return r.gitLogLines(rangeArg, "%s")
+	case "READABLE_WITH_DATE":
+		// Tab-separated: short SHA, RFC3339 UTC date, subject. Use Unix
+		// epoch from git and convert in Go to preserve the prior behavior of
+		// normalizing to UTC regardless of the commit's recorded TZ.
+		lines, err := r.gitLogLines(rangeArg, "%h\t%at\t%s")
 		if err != nil {
-			return nil, fmt.Errorf("failed to resolve base: %w", err)
+			return nil, err
 		}
+		out := make([]string, 0, len(lines))
+		for _, line := range lines {
+			sha, rest, ok := strings.Cut(line, "\t")
+			if !ok {
+				continue
+			}
+			epochStr, subject, ok := strings.Cut(rest, "\t")
+			if !ok {
+				continue
+			}
+			epoch, err := strconv.ParseInt(epochStr, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse commit epoch %q: %w", epochStr, err)
+			}
+			out = append(out, fmt.Sprintf("%s\t%s\t%s", sha, time.Unix(epoch, 0).UTC().Format(time.RFC3339), subject))
+		}
+		return out, nil
+	case "MESSAGE":
+		// Bodies can contain newlines; use NUL record separator.
+		out, err := r.RunGitCommandRawWithContext(context.Background(), "log", "-z", "--format=%B", rangeArg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to walk commits %s: %w", rangeArg, err)
+		}
+		raw := strings.TrimRight(out, "\x00")
+		if raw == "" {
+			return nil, nil
+		}
+		records := strings.Split(raw, "\x00")
+		result := make([]string, 0, len(records))
+		for _, rec := range records {
+			rec = strings.TrimSpace(rec)
+			if rec != "" {
+				result = append(result, rec)
+			}
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("unknown commit format: %s", format)
 	}
-
-	commits, err := iterateCommitsNoLock(repo, headHash, baseHash)
-	if err != nil {
-		return nil, err
-	}
-
-	return formatCommits(commits, format)
 }
 
-// formatCommits formats go-git commit objects according to format string
-func formatCommits(commits []*object.Commit, format string) ([]string, error) {
-	result := make([]string, 0, len(commits))
-	for _, commit := range commits {
-		var formatted string
-		switch format {
-		case "SHA":
-			formatted = commit.Hash.String()
-		case "READABLE":
-			// Oneline format: short SHA + subject
-			shortHash := commit.Hash.String()[:7]
-			subject := strings.Split(strings.TrimSpace(commit.Message), "\n")[0]
-			formatted = fmt.Sprintf("%s %s", shortHash, subject)
-		case "READABLE_WITH_DATE":
-			// Tab-separated: short SHA, ISO date, subject
-			shortHash := commit.Hash.String()[:7]
-			subject := strings.Split(strings.TrimSpace(commit.Message), "\n")[0]
-			formatted = fmt.Sprintf("%s\t%s\t%s", shortHash, commit.Author.When.UTC().Format(time.RFC3339), subject)
-		case "MESSAGE":
-			formatted = strings.TrimSpace(commit.Message)
-		case "SUBJECT":
-			subject := strings.Split(strings.TrimSpace(commit.Message), "\n")[0]
-			formatted = strings.TrimSpace(subject)
-		default:
-			return nil, fmt.Errorf("unknown commit format: %s", format)
-		}
-
-		if formatted != "" {
-			result = append(result, formatted)
+// gitLogLines runs `git log` over a range with a single-line format and
+// returns one element per commit, dropping blank lines. Suitable for any
+// format that does not include literal newlines.
+func (r *runner) gitLogLines(rangeArg, format string) ([]string, error) {
+	out, err := r.RunGitCommandWithContext(context.Background(), "log", "--format="+format, rangeArg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk commits %s: %w", rangeArg, err)
+	}
+	out = strings.TrimRight(out, "\n")
+	if out == "" {
+		return nil, nil
+	}
+	lines := strings.Split(out, "\n")
+	result := make([]string, 0, len(lines))
+	for _, l := range lines {
+		l = strings.TrimSpace(l)
+		if l != "" {
+			result = append(result, l)
 		}
 	}
 	return result, nil
@@ -824,40 +791,15 @@ func (r *runner) GetCommitSHA(branchName string, offset int) (string, error) {
 	if offset < 0 {
 		return "", fmt.Errorf("offset must be non-negative")
 	}
-
-	repo, err := r.ensureRepo()
+	ref := branchName
+	if offset > 0 {
+		ref = fmt.Sprintf("%s~%d", branchName, offset)
+	}
+	out, err := r.RunGitCommandWithContext(context.Background(), "rev-parse", "--verify", "--end-of-options", ref+"^{commit}")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to walk %d commit(s) back from %s: %w", offset, branchName, err)
 	}
-
-	// Synchronize go-git operations to prevent concurrent packfile access
-	r.goGitMu.Lock()
-	defer r.goGitMu.Unlock()
-
-	// Resolve branch reference
-	hash, err := r.resolveRefHashInternal(repo, branchName)
-	if err != nil {
-		return "", fmt.Errorf("failed to get branch reference: %w", err)
-	}
-
-	commit, err := repo.CommitObject(hash)
-	if err != nil {
-		return "", fmt.Errorf("failed to get commit: %w", err)
-	}
-
-	// Walk back offset number of commits
-	for i := range offset {
-		if commit.NumParents() == 0 {
-			return "", fmt.Errorf("commit has no parent at offset %d", i)
-		}
-		// Get first parent
-		commit, err = commit.Parent(0)
-		if err != nil {
-			return "", fmt.Errorf("failed to get parent commit: %w", err)
-		}
-	}
-
-	return commit.Hash.String(), nil
+	return strings.TrimSpace(out), nil
 }
 
 func (r *runner) CheckoutPaths(ctx context.Context, branch string, paths []string) error {
@@ -1263,29 +1205,11 @@ func (r *runner) pushOriginRefSpecs(ctx context.Context, refspecs []gitcfg.RefSp
 }
 
 func (r *runner) GetParentCommitSHA(commitSHA string) (string, error) {
-	repo, err := r.ensureRepo()
+	out, err := r.RunGitCommandWithContext(context.Background(), "rev-parse", "--verify", "--end-of-options", commitSHA+"^")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get parent of %s: %w", commitSHA, err)
 	}
-
-	hash, err := r.resolveRefHash(repo, commitSHA)
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve commit: %w", err)
-	}
-
-	r.goGitMu.Lock()
-	defer r.goGitMu.Unlock()
-
-	commit, err := repo.CommitObject(hash)
-	if err != nil {
-		return "", fmt.Errorf("failed to get commit: %w", err)
-	}
-
-	if commit.NumParents() == 0 {
-		return "", fmt.Errorf("commit has no parents")
-	}
-
-	return commit.ParentHashes[0].String(), nil
+	return strings.TrimSpace(out), nil
 }
 
 func (r *runner) CheckCommutation(hunk Hunk, commitSHA, parentSHA string) (bool, error) {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Migrates GetRecentCommits, ResolveRef*, GetMergeBase, IsAncestor, remote
ref listing, GetCommitRange, GetCommitSHA, and GetParentCommitSHA from
go-git plumbing/object walks to native git plumbing commands.

The goGitMu mutex contention disappears for every operation in this
phase; parallel callers now scale instead of serializing through a
process-wide lock. ParallelGetMergeBase went from 1 iteration in 1s
(severe contention) to 3 iterations in 1s (~338ms/op with real
parallel work).

Single-shot cold operations pay one subprocess (~7ms on M1 Max), so
benches like LoadAllBranchRevisions and GetMergeBase regress 3-9x.
But the warm path is the dominant production case: the engine
preloads via LoadAllBranchRevisions at startup and subsequent
GetRevision calls are pure cache hits.

Before/after on M1 Max (-benchtime=1s):

  GetRevision (warm)        126µs    →   13.65 ns   (-99.99%, cache hit)
  BatchGetRevisions (cold)  2.67ms   →   6.37ms     (one process, not N)
  ParallelGetMergeBase      1s/1iter →   338ms/iter (goGitMu gone)
  LoadAllBranchRevisions    772µs    →   7.17ms     (one for-each-ref)
  GetMergeBase              2.44ms   →   7.24ms     (one git merge-base)
  GetRecentCommits/200      13.0ms   →   15.3ms     (one git log)

BatchGetRevisions now batches misses into a single `git rev-parse`
call instead of N parallel subprocesses (fixed mid-phase after the
first bench run showed an N-process regression).

Phase 2 of the go-git removal plan. diff.go, branches.go ref helpers,
runner.go blob ops still use go-git via two transitional shims
(resolveRefHashInternal, resolveRefHash) that wrap the new shell-out
resolver and return plumbing.Hash. These get removed in Phase 6.

<hr/>

<!-- STACKIT-SECTION-START -->
**Drop go-git dependency, shell out to native git for all ops**

Removes the go-git library entirely and replaces all usages with direct git CLI calls. This simplifies the dependency graph, fixes config-scope issues (global user.name now resolves correctly), and enables a batch-write optimisation for metadata blobs.

Key changes:
- **add-baseline-benchmarks**: Benchmarks for the go-git hot paths to establish a baseline before the rewrite
- **read-only history ops**: Replace go-git log/diff/ref traversal with `git log`, `git diff`, and `git rev-parse` shell-outs
- **staging ops**: Replace go-git index operations with `git add`/`git reset`
- **fetch/push**: Drop go-git transport layer; use `git fetch`/`git push` exclusively
- **ConfigStore**: Rewrite on top of `git config` CLI so all config scopes (local → global → system) are respected by default
- **drop go-git**: Remove the go-git module import and all remaining usages; net −572 lines of dependency code
- **batch metadata writes**: Use `git hash-object --stdin-paths` to write multiple metadata blobs in a single subprocess call instead of one per blob

#### Stack


* **PR #1018**
  * **PR #1019** 👈
    * **PR #1020**
      * **PR #1021**
        * **PR #1022**
          * **PR #1023**
            * **PR #1024**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1025 by jonnii*