### PR TITLE
refactor(git): drop go-git fetch/push, use git CLI exclusively

### DIFF
--- a/internal/git/pull.go
+++ b/internal/git/pull.go
@@ -3,8 +3,6 @@ package git
 import (
 	"context"
 	"fmt"
-
-	gitcfg "github.com/go-git/go-git/v6/config"
 )
 
 // PullResult represents the result of a pull operation
@@ -34,10 +32,10 @@ func (r *runner) PullBranch(ctx context.Context, remote, branchName string) (Pul
 		return PullConflict, fmt.Errorf("failed to get local revision for %s: %w", branchName, err)
 	}
 
-	// Fetch with explicit refspec to update the remote-tracking branch
-	// This ensures refs/remotes/origin/<branch> is actually updated
-	refspec := gitcfg.RefSpec(fmt.Sprintf("refs/heads/%s:refs/remotes/%s/%s", branchName, remote, branchName))
-	_ = r.fetchRemoteRefSpecs(ctx, remote, []gitcfg.RefSpec{refspec})
+	// Fetch with explicit refspec to update the remote-tracking branch.
+	// This ensures refs/remotes/origin/<branch> is actually updated.
+	refspec := fmt.Sprintf("refs/heads/%s:refs/remotes/%s/%s", branchName, remote, branchName)
+	_ = r.fetchRemoteRefSpecs(ctx, remote, []string{refspec})
 
 	// Get the SHA of the remote branch
 	remoteRev, err := r.GetRemoteSha(remote, branchName)
@@ -110,9 +108,8 @@ func (r *runner) PullBranch(ctx context.Context, remote, branchName string) (Pul
 }
 
 func (r *runner) Fetch(ctx context.Context, remote, branch string) error {
-	refspec := gitcfg.RefSpec(fmt.Sprintf("refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch))
-	err := r.fetchRemoteRefSpecs(ctx, remote, []gitcfg.RefSpec{refspec})
-	if err != nil {
+	refspec := fmt.Sprintf("refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
+	if err := r.fetchRemoteRefSpecs(ctx, remote, []string{refspec}); err != nil {
 		return fmt.Errorf("failed to fetch %s from %s: %w", branch, remote, err)
 	}
 	return nil

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -16,8 +16,6 @@ import (
 	"sync"
 	"time"
 
-	gogit "github.com/go-git/go-git/v6"
-	gitcfg "github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 
 	"github.com/getstackit/stackit/internal/utils"
@@ -1013,19 +1011,19 @@ func (r *runner) PushMetadataRefs(ctx context.Context, branches []string) error 
 		return nil
 	}
 	// git push origin +refs/stackit/metadata/branch1 +refs/stackit/metadata/branch2 ...
-	// We use the '+' prefix to force the push because metadata refs point to blobs,
-	// and updates to non-commit objects are always considered non-fast-forward by Git.
-	refspecs := make([]gitcfg.RefSpec, 0, len(branches))
+	// The '+' prefix forces the push: metadata refs point to blobs, and
+	// updates to non-commit objects are always considered non-fast-forward
+	// by Git.
+	refspecs := make([]string, 0, len(branches))
 	for _, branch := range branches {
-		refspecs = append(refspecs, gitcfg.RefSpec(fmt.Sprintf("+refs/stackit/metadata/%s", branch)))
+		refspecs = append(refspecs, fmt.Sprintf("+refs/stackit/metadata/%s", branch))
 	}
 	return r.pushOriginRefSpecs(ctx, refspecs)
 }
 
 func (r *runner) FetchMetadataRefs(ctx context.Context) error {
-	// git fetch origin 'refs/stackit/metadata/*:refs/stackit/remote-metadata/*'
-	return r.fetchRemoteRefSpecs(ctx, "origin", []gitcfg.RefSpec{
-		gitcfg.RefSpec("+refs/stackit/metadata/*:refs/stackit/remote-metadata/*"),
+	return r.fetchRemoteRefSpecs(ctx, "origin", []string{
+		"+refs/stackit/metadata/*:refs/stackit/remote-metadata/*",
 	})
 }
 
@@ -1033,20 +1031,16 @@ func (r *runner) PushStackMetaRefs(ctx context.Context, stackIDs []string) error
 	if len(stackIDs) == 0 {
 		return nil
 	}
-	// git push origin +refs/stackit/stacks/id1 +refs/stackit/stacks/id2 ...
-	// We use the '+' prefix to force the push because stack metadata refs point to blobs,
-	// and updates to non-commit objects are always considered non-fast-forward by Git.
-	refspecs := make([]gitcfg.RefSpec, 0, len(stackIDs))
+	refspecs := make([]string, 0, len(stackIDs))
 	for _, stackID := range stackIDs {
-		refspecs = append(refspecs, gitcfg.RefSpec(fmt.Sprintf("+refs/stackit/stacks/%s", stackID)))
+		refspecs = append(refspecs, fmt.Sprintf("+refs/stackit/stacks/%s", stackID))
 	}
 	return r.pushOriginRefSpecs(ctx, refspecs)
 }
 
 func (r *runner) FetchStackMetaRefs(ctx context.Context) error {
-	// git fetch origin 'refs/stackit/stacks/*:refs/stackit/remote-stacks/*'
-	return r.fetchRemoteRefSpecs(ctx, "origin", []gitcfg.RefSpec{
-		gitcfg.RefSpec("+refs/stackit/stacks/*:refs/stackit/remote-stacks/*"),
+	return r.fetchRemoteRefSpecs(ctx, "origin", []string{
+		"+refs/stackit/stacks/*:refs/stackit/remote-stacks/*",
 	})
 }
 
@@ -1054,18 +1048,16 @@ func (r *runner) DeleteRemoteStackMetaRefs(ctx context.Context, stackIDs []strin
 	if len(stackIDs) == 0 {
 		return nil
 	}
-	// git push origin --delete refs/stackit/stacks/id1 refs/stackit/stacks/id2 ...
-	refspecs := make([]gitcfg.RefSpec, 0, len(stackIDs))
+	refspecs := make([]string, 0, len(stackIDs))
 	for _, stackID := range stackIDs {
-		refspecs = append(refspecs, gitcfg.RefSpec(fmt.Sprintf(":refs/stackit/stacks/%s", stackID)))
+		refspecs = append(refspecs, fmt.Sprintf(":refs/stackit/stacks/%s", stackID))
 	}
 	return r.pushOriginRefSpecs(ctx, refspecs)
 }
 
 func (r *runner) DeleteRemoteMetadataRef(ctx context.Context, branch string) error {
-	// git push origin --delete refs/stackit/metadata/<branch>
-	return r.pushOriginRefSpecs(ctx, []gitcfg.RefSpec{
-		gitcfg.RefSpec(fmt.Sprintf(":refs/stackit/metadata/%s", branch)),
+	return r.pushOriginRefSpecs(ctx, []string{
+		fmt.Sprintf(":refs/stackit/metadata/%s", branch),
 	})
 }
 
@@ -1073,10 +1065,9 @@ func (r *runner) BatchDeleteRemoteMetadataRefs(ctx context.Context, branches []s
 	if len(branches) == 0 {
 		return nil
 	}
-	// git push origin --delete refs/stackit/metadata/branch1 refs/stackit/metadata/branch2 ...
-	refspecs := make([]gitcfg.RefSpec, 0, len(branches))
+	refspecs := make([]string, 0, len(branches))
 	for _, branch := range branches {
-		refspecs = append(refspecs, gitcfg.RefSpec(fmt.Sprintf(":refs/stackit/metadata/%s", branch)))
+		refspecs = append(refspecs, fmt.Sprintf(":refs/stackit/metadata/%s", branch))
 	}
 	return r.pushOriginRefSpecs(ctx, refspecs)
 }
@@ -1085,24 +1076,21 @@ func (r *runner) TestRemoteRefCompatibility(ctx context.Context) error {
 	testRef := "refs/stackit/metadata/stackit-compat-test"
 	testContent := fmt.Sprintf(`{"test":true,"timestamp":%d}`, time.Now().Unix())
 
-	// Create test blob
 	sha, err := r.CreateBlob(testContent)
 	if err != nil {
 		return fmt.Errorf("failed to create test blob: %w", err)
 	}
 
-	// Try to push test ref
 	if err := r.UpdateRef(testRef, sha); err != nil {
 		return fmt.Errorf("failed to update local test ref: %w", err)
 	}
 
-	if err := r.pushOriginRefSpecs(ctx, []gitcfg.RefSpec{gitcfg.RefSpec("+" + testRef)}); err != nil {
-		_ = r.DeleteRef(ctx, testRef) // Cleanup local
+	if err := r.pushOriginRefSpecs(ctx, []string{"+" + testRef}); err != nil {
+		_ = r.DeleteRef(ctx, testRef)
 		return fmt.Errorf("remote rejected metadata ref push: %w", err)
 	}
 
-	// Cleanup: delete remote and local test ref
-	_ = r.pushOriginRefSpecs(ctx, []gitcfg.RefSpec{gitcfg.RefSpec(":" + testRef)})
+	_ = r.pushOriginRefSpecs(ctx, []string{":" + testRef})
 	_ = r.DeleteRef(ctx, testRef)
 
 	return nil
@@ -1115,91 +1103,26 @@ func ctxOrBackground(ctx context.Context) context.Context {
 	return ctx
 }
 
-func refSpecStrings(refspecs []gitcfg.RefSpec) []string {
-	args := make([]string, 0, len(refspecs))
-	for _, refspec := range refspecs {
-		args = append(args, refspec.String())
-	}
-	return args
-}
-
-func forceForRefSpecs(refspecs []gitcfg.RefSpec) bool {
-	for _, refspec := range refspecs {
-		if refspec.IsForceUpdate() {
-			return true
-		}
-	}
-	return false
-}
-
-func (r *runner) fetchRemoteRefSpecs(ctx context.Context, remote string, refspecs []gitcfg.RefSpec) error {
+func (r *runner) fetchRemoteRefSpecs(ctx context.Context, remote string, refspecs []string) error {
 	if len(refspecs) == 0 {
 		return nil
 	}
-
-	repo, err := r.ensureRepo()
-	if err != nil {
-		return err
-	}
-
 	ctx = ctxOrBackground(ctx)
-
-	r.goGitMu.Lock()
-	err = repo.FetchContext(ctx, &gogit.FetchOptions{
-		RemoteName: remote,
-		RefSpecs:   refspecs,
-		Force:      forceForRefSpecs(refspecs),
-	})
-	r.goGitMu.Unlock()
-	switch {
-	case err == nil:
-		return r.ReloadRepository()
-	case errors.Is(err, gogit.NoErrAlreadyUpToDate):
-		return nil
-	}
-
-	args := append([]string{"fetch", remote}, refSpecStrings(refspecs)...)
-	if _, fallbackErr := r.RunGitCommandWithContext(ctx, args...); fallbackErr != nil {
-		return errors.Join(
-			fmt.Errorf("go-git fetch failed: %w", err),
-			fmt.Errorf("git fetch fallback failed: %w", fallbackErr),
-		)
+	args := append([]string{"fetch", remote}, refspecs...)
+	if _, err := r.RunGitCommandWithContext(ctx, args...); err != nil {
+		return fmt.Errorf("git fetch failed: %w", err)
 	}
 	return r.ReloadRepository()
 }
 
-func (r *runner) pushOriginRefSpecs(ctx context.Context, refspecs []gitcfg.RefSpec) error {
+func (r *runner) pushOriginRefSpecs(ctx context.Context, refspecs []string) error {
 	if len(refspecs) == 0 {
 		return nil
 	}
-
-	repo, err := r.ensureRepo()
-	if err != nil {
-		return err
-	}
-
 	ctx = ctxOrBackground(ctx)
-
-	r.goGitMu.Lock()
-	err = repo.PushContext(ctx, &gogit.PushOptions{
-		RemoteName: "origin",
-		RefSpecs:   refspecs,
-		Force:      forceForRefSpecs(refspecs),
-	})
-	r.goGitMu.Unlock()
-	switch {
-	case err == nil:
-		return nil
-	case errors.Is(err, gogit.NoErrAlreadyUpToDate):
-		return nil
-	}
-
-	args := append([]string{"push", "origin"}, refSpecStrings(refspecs)...)
-	if _, fallbackErr := r.RunGitCommandWithContext(ctx, args...); fallbackErr != nil {
-		return errors.Join(
-			fmt.Errorf("go-git push failed: %w", err),
-			fmt.Errorf("git push fallback failed: %w", fallbackErr),
-		)
+	args := append([]string{"push", "origin"}, refspecs...)
+	if _, err := r.RunGitCommandWithContext(ctx, args...); err != nil {
+		return fmt.Errorf("git push failed: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The previous fetchRemoteRefSpecs / pushOriginRefSpecs functions tried
go-git first and fell back to native `git fetch`/`git push` on error.
In practice any non-trivial auth setup (credential helpers, ssh-agent,
GH App tokens) hit the fallback, so the native path was already the
production path. The go-git primary was carrying complexity without
contributing to behavior.

This phase removes the go-git path entirely. Both functions now invoke
the git CLI directly. As a side effect:

- gitcfg.RefSpec is gone from runner.go and pull.go; all internal APIs
  use []string for refspecs (which is what they were stringified to
  anyway when shelling out).
- The errors.Join "go-git failed + native failed" reporting collapses
  to a single git error.
- runner.go drops its gogit and gitcfg imports.
- goGitMu locks around FetchContext/PushContext go away.

Phase 4 of the go-git removal plan. Remaining go-git uses: blob ops in
runner.go, ref helpers in branches.go, repository.Open in repository.go,
diff tree-hash comparison in diff.go — all targeted by Phases 5 and 6.

<hr/>

<!-- STACKIT-SECTION-START -->
**Drop go-git dependency, shell out to native git for all ops**

Removes the go-git library entirely and replaces all usages with direct git CLI calls. This simplifies the dependency graph, fixes config-scope issues (global user.name now resolves correctly), and enables a batch-write optimisation for metadata blobs.

Key changes:
- **add-baseline-benchmarks**: Benchmarks for the go-git hot paths to establish a baseline before the rewrite
- **read-only history ops**: Replace go-git log/diff/ref traversal with `git log`, `git diff`, and `git rev-parse` shell-outs
- **staging ops**: Replace go-git index operations with `git add`/`git reset`
- **fetch/push**: Drop go-git transport layer; use `git fetch`/`git push` exclusively
- **ConfigStore**: Rewrite on top of `git config` CLI so all config scopes (local → global → system) are respected by default
- **drop go-git**: Remove the go-git module import and all remaining usages; net −572 lines of dependency code
- **batch metadata writes**: Use `git hash-object --stdin-paths` to write multiple metadata blobs in a single subprocess call instead of one per blob

#### Stack


* **PR #1018**
  * **PR #1019**
    * **PR #1020**
      * **PR #1021** 👈
        * **PR #1022**
          * **PR #1023**
            * **PR #1024**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1025 by jonnii*