### PR TITLE
refactor(git): rewrite ConfigStore on top of `git config` CLI

### DIFF
--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -3,12 +3,13 @@
 package git
 
 import (
+	"errors"
 	"fmt"
+	"os/exec"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
-
-	format "github.com/go-git/go-git/v6/plumbing/format/config"
 )
 
 // GetCurrentDate returns the current date and time in yyyyMMddHHmmss format in UTC
@@ -17,8 +18,8 @@ func GetCurrentDate() string {
 	return now.Format("20060102150405")
 }
 
-// ConfigStore provides typed access to git config with a simpler interface
-// than the full Runner. It operates directly on the repository via git commands.
+// ConfigStore provides typed access to git config. Implemented via direct
+// `git config` invocations rather than parsing the config file in process.
 type ConfigStore struct {
 	repoRoot string
 }
@@ -28,103 +29,62 @@ func NewConfigStore(repoRoot string) *ConfigStore {
 	return &ConfigStore{repoRoot: repoRoot}
 }
 
-type configKey struct {
-	section    string
-	subsection string
-	name       string
+// runGitConfig invokes `git config` in the configured repo. Returns the
+// trimmed stdout on success; on non-zero exit returns the trimmed stdout
+// (which may be empty) and the *exec.ExitError so callers can match exit
+// codes for "key not found" (1) and "nothing to unset" (5).
+func (c *ConfigStore) runGitConfig(args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"config"}, args...)...)
+	cmd.Dir = c.repoRoot
+	out, err := cmd.Output()
+	return strings.TrimRight(string(out), "\n"), err
 }
 
-func parseConfigKey(key string) (configKey, error) {
-	parts := strings.Split(key, ".")
-	switch {
-	case len(parts) == 2:
-		return configKey{section: parts[0], name: parts[1]}, nil
-	case len(parts) >= 3:
-		return configKey{
-			section:    parts[0],
-			subsection: strings.Join(parts[1:len(parts)-1], "."),
-			name:       parts[len(parts)-1],
-		}, nil
-	default:
-		return configKey{}, fmt.Errorf("invalid config key %q", key)
+func isExitCode(err error, codes ...int) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
 	}
-}
-
-func (c *ConfigStore) loadConfig() (*Repository, *format.Config, error) {
-	repo, err := OpenRepository(c.repoRoot)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	cfg, err := repo.Config()
-	if err != nil {
-		_ = repo.Close()
-		return nil, nil, err
-	}
-	if cfg.Raw == nil {
-		cfg.Raw = format.New()
-	}
-	return repo, cfg.Raw, nil
+	return slices.Contains(codes, exitErr.ExitCode())
 }
 
 // Get retrieves a single config value from local git config.
 // Returns empty string if the key doesn't exist.
 func (c *ConfigStore) Get(key string) (string, error) {
-	parsed, err := parseConfigKey(key)
-	if err != nil {
-		return "", err
+	out, err := c.runGitConfig("--get", key)
+	if err == nil {
+		return out, nil
 	}
-
-	repo, cfg, err := c.loadConfig()
-	if err != nil {
-		return "", err
+	// Exit code 1: key not found. Treat as empty, no error.
+	if isExitCode(err, 1) {
+		return "", nil
 	}
-	defer func() { _ = repo.Close() }()
-	if parsed.subsection == "" {
-		return cfg.Section(parsed.section).Option(parsed.name), nil
-	}
-	return cfg.Section(parsed.section).Subsection(parsed.subsection).Option(parsed.name), nil
+	return "", fmt.Errorf("failed to get config %s: %w", key, err)
 }
 
 // GetAll retrieves all values for a multi-value config key.
 // Returns empty slice if the key doesn't exist.
 func (c *ConfigStore) GetAll(key string) ([]string, error) {
-	parsed, err := parseConfigKey(key)
+	out, err := c.runGitConfig("--get-all", key)
 	if err != nil {
-		return nil, err
+		if isExitCode(err, 1) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get config %s: %w", key, err)
 	}
-
-	repo, cfg, err := c.loadConfig()
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = repo.Close() }()
-	var values []string
-	if parsed.subsection == "" {
-		values = cfg.Section(parsed.section).OptionAll(parsed.name)
-	} else {
-		values = cfg.Section(parsed.section).Subsection(parsed.subsection).OptionAll(parsed.name)
-	}
-	if len(values) == 0 {
+	if out == "" {
 		return nil, nil
 	}
+	values := strings.Split(out, "\n")
 	return values, nil
 }
 
 // Set sets a config value in local git config.
 func (c *ConfigStore) Set(key, value string) error {
-	parsed, err := parseConfigKey(key)
-	if err != nil {
-		return err
+	if _, err := c.runGitConfig(key, value); err != nil {
+		return fmt.Errorf("failed to set config %s: %w", key, err)
 	}
-
-	repo, raw, err := c.loadConfig()
-	if err != nil {
-		return err
-	}
-	defer func() { _ = repo.Close() }()
-	raw.SetOption(parsed.section, parsed.subsection, parsed.name, value)
-	return repo.SetConfigRaw(raw)
+	return nil
 }
 
 // SetBool sets a boolean config value.
@@ -139,39 +99,24 @@ func (c *ConfigStore) SetInt(key string, value int) error {
 
 // Add adds a value to a multi-value config key.
 func (c *ConfigStore) Add(key, value string) error {
-	parsed, err := parseConfigKey(key)
-	if err != nil {
-		return err
+	if _, err := c.runGitConfig("--add", key, value); err != nil {
+		return fmt.Errorf("failed to add config %s: %w", key, err)
 	}
-
-	repo, raw, err := c.loadConfig()
-	if err != nil {
-		return err
-	}
-	defer func() { _ = repo.Close() }()
-	raw.AddOption(parsed.section, parsed.subsection, parsed.name, value)
-	return repo.SetConfigRaw(raw)
+	return nil
 }
 
 // Unset removes all values for a config key.
 // Does not return an error if the key doesn't exist.
 func (c *ConfigStore) Unset(key string) error {
-	parsed, err := parseConfigKey(key)
-	if err != nil {
-		return err
+	_, err := c.runGitConfig("--unset-all", key)
+	if err == nil {
+		return nil
 	}
-
-	repo, raw, err := c.loadConfig()
-	if err != nil {
-		return err
+	// Exit code 5: no such section/key. Treat as success (idempotent unset).
+	if isExitCode(err, 5) {
+		return nil
 	}
-	defer func() { _ = repo.Close() }()
-	if parsed.subsection == "" {
-		raw.Section(parsed.section).RemoveOption(parsed.name)
-	} else {
-		raw.Section(parsed.section).Subsection(parsed.subsection).RemoveOption(parsed.name)
-	}
-	return repo.SetConfigRaw(raw)
+	return fmt.Errorf("failed to unset config %s: %w", key, err)
 }
 
 // GetBool retrieves a boolean config value.
@@ -186,14 +131,12 @@ func (c *ConfigStore) GetBool(key string) (bool, error) {
 
 // GetBoolWithDefault retrieves a boolean config value with a default.
 func (c *ConfigStore) GetBoolWithDefault(key string, defaultValue bool) bool {
-	val, err := c.GetBool(key)
-	if err != nil {
-		return defaultValue
-	}
-	// If key doesn't exist, Get returns empty string, GetBool returns false
-	// We need to check if the key actually exists
 	raw, _ := c.Get(key)
 	if raw == "" {
+		return defaultValue
+	}
+	val, err := strconv.ParseBool(raw)
+	if err != nil {
 		return defaultValue
 	}
 	return val
@@ -215,7 +158,7 @@ func (c *ConfigStore) GetIntWithDefault(key string, defaultValue int) int {
 	if raw == "" {
 		return defaultValue
 	}
-	val, err := c.GetInt(key)
+	val, err := strconv.Atoi(raw)
 	if err != nil {
 		return defaultValue
 	}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


The ConfigStore was loading the entire git config file into memory via
go-git's format.Config parser, mutating in-process, and writing back on
every Set/Add/Unset. Replace with direct `git config` invocations
(--get / --get-all / --add / --unset-all / plain set).

Behavioral parity:
- Unset stays idempotent: exit code 5 ("nothing to unset") → nil error.
- Get/GetAll on a missing key still return empty + nil error (exit 1).
- GetBoolWithDefault / GetIntWithDefault rebuilt to parse the raw value
  directly rather than chaining through GetBool/GetInt.

Bench on M1 Max (-benchtime=1s):
  GetConfig 6.17ms → 6.17ms (already shell-out on Runner path)
  SetConfig  357µs → 6.78ms (one process vs in-mem read-modify-write)

SetConfig regresses 19x because we now pay subprocess overhead per
write. Real-world impact is minimal — config writes happen 1-2 times
per session, not in tight loops. The win is consistency: a single
canonical implementation, no in-process config cache that can disagree
with what `git config` would print, and no need for a *gogit.Repository
handle just to set a key.

Phase 5 of the go-git removal plan. branches.go still has plumbing
imports for branch ref construction; those collapse into Phase 6
together with the blob ops migration and dep removal.

<hr/>

<!-- STACKIT-SECTION-START -->
**Drop go-git dependency, shell out to native git for all ops**

Removes the go-git library entirely and replaces all usages with direct git CLI calls. This simplifies the dependency graph, fixes config-scope issues (global user.name now resolves correctly), and enables a batch-write optimisation for metadata blobs.

Key changes:
- **add-baseline-benchmarks**: Benchmarks for the go-git hot paths to establish a baseline before the rewrite
- **read-only history ops**: Replace go-git log/diff/ref traversal with `git log`, `git diff`, and `git rev-parse` shell-outs
- **staging ops**: Replace go-git index operations with `git add`/`git reset`
- **fetch/push**: Drop go-git transport layer; use `git fetch`/`git push` exclusively
- **ConfigStore**: Rewrite on top of `git config` CLI so all config scopes (local → global → system) are respected by default
- **drop go-git**: Remove the go-git module import and all remaining usages; net −572 lines of dependency code
- **batch metadata writes**: Use `git hash-object --stdin-paths` to write multiple metadata blobs in a single subprocess call instead of one per blob

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1779880138`.


* **PR #1018**
  * **PR #1019**
    * **PR #1020**
      * **PR #1021**
        * **PR #1022** 👈
          * **PR #1023**
            * **PR #1024**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->