### PR TITLE
perf(git): batch metadata blob writes via git hash-object --stdin-paths

### DIFF
--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -568,6 +568,14 @@ func (d *demoGitRunner) CreateBlob(_ string) (string, error) {
 	return demoBlobSHA, nil
 }
 
+func (d *demoGitRunner) CreateBlobsBatch(contents []string) ([]string, error) {
+	shas := make([]string, len(contents))
+	for i := range shas {
+		shas[i] = demoBlobSHA
+	}
+	return shas, nil
+}
+
 func (d *demoGitRunner) ReadBlob(_ string) (string, error) {
 	return "{}", nil
 }

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1164,7 +1165,8 @@ func (e *engineImpl) IsInManagedWorktree() (bool, *WorktreeInfo, error) {
 }
 
 // BatchMarkNeedsPRBodyUpdate marks multiple branches as needing PR body update in a single atomic operation.
-// It batch-reads local metadata, sets the flag, creates blobs, and atomically updates all refs.
+// It batch-reads local metadata, sets the flag, creates blobs in one git
+// hash-object call, and atomically updates all refs.
 func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(branchNames []string) error {
 	if len(branchNames) == 0 {
 		return nil
@@ -1173,8 +1175,10 @@ func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(branchNames []string) error {
 	// Batch read all local metadata in parallel
 	allMeta := e.batchReadLocalMetadata(branchNames)
 
-	// Create blobs and collect ref updates
-	updates := make([]git.RefUpdate, 0, len(branchNames))
+	// Marshal each branch's updated metadata to JSON; track parallel slices
+	// so we can map blob SHAs back to ref names after the batch call.
+	contents := make([]string, 0, len(branchNames))
+	orderedNames := make([]string, 0, len(branchNames))
 	for _, name := range branchNames {
 		meta := allMeta[name]
 		if meta == nil {
@@ -1182,14 +1186,25 @@ func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(branchNames []string) error {
 		}
 		meta.NeedsPRBodyUpdate = true
 
-		sha, err := e.git.WriteLocalMetadataBlob(meta)
+		jsonData, err := json.Marshal(meta)
 		if err != nil {
-			return fmt.Errorf("failed to create local metadata blob for %s: %w", name, err)
+			return fmt.Errorf("failed to marshal local metadata for %s: %w", name, err)
 		}
-		updates = append(updates, git.RefUpdate{
+		contents = append(contents, string(jsonData))
+		orderedNames = append(orderedNames, name)
+	}
+
+	shas, err := e.git.CreateBlobsBatch(contents)
+	if err != nil {
+		return fmt.Errorf("failed to create local metadata blobs: %w", err)
+	}
+
+	updates := make([]git.RefUpdate, len(orderedNames))
+	for i, name := range orderedNames {
+		updates[i] = git.RefUpdate{
 			RefName: git.LocalMetadataRefName(name),
-			NewSHA:  sha,
-		})
+			NewSHA:  shas[i],
+		}
 	}
 
 	// Atomic batch update all refs

--- a/internal/engine/transaction.go
+++ b/internal/engine/transaction.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand/v2"
@@ -198,18 +199,26 @@ func (tx *MetadataTx) Commit(ctx context.Context) error {
 	}
 	slices.Sort(metaBranches)
 
-	for _, branch := range metaBranches {
-		meta := tx.metaUpdates[branch]
-		blobSHA, err := tx.eng.git.WriteMetadataBlob(meta)
-		if err != nil {
-			return fmt.Errorf("write blob for %s: %w", branch, err)
+	if len(metaBranches) > 0 {
+		contents := make([]string, len(metaBranches))
+		for i, branch := range metaBranches {
+			jsonData, err := json.Marshal(tx.metaUpdates[branch])
+			if err != nil {
+				return fmt.Errorf("marshal meta for %s: %w", branch, err)
+			}
+			contents[i] = string(jsonData)
 		}
-
-		refUpdates = append(refUpdates, git.RefUpdate{
-			RefName: git.MetadataRefName(branch),
-			NewSHA:  blobSHA,
-			OldSHA:  tx.originalMeta[branch], // CAS validation
-		})
+		shas, err := tx.eng.git.CreateBlobsBatch(contents)
+		if err != nil {
+			return fmt.Errorf("write meta blobs: %w", err)
+		}
+		for i, branch := range metaBranches {
+			refUpdates = append(refUpdates, git.RefUpdate{
+				RefName: git.MetadataRefName(branch),
+				NewSHA:  shas[i],
+				OldSHA:  tx.originalMeta[branch], // CAS validation
+			})
+		}
 	}
 
 	// Sort local metadata branches for deterministic order
@@ -219,18 +228,26 @@ func (tx *MetadataTx) Commit(ctx context.Context) error {
 	}
 	slices.Sort(localBranches)
 
-	for _, branch := range localBranches {
-		meta := tx.localUpdates[branch]
-		blobSHA, err := tx.eng.git.WriteLocalMetadataBlob(meta)
-		if err != nil {
-			return fmt.Errorf("write local blob for %s: %w", branch, err)
+	if len(localBranches) > 0 {
+		contents := make([]string, len(localBranches))
+		for i, branch := range localBranches {
+			jsonData, err := json.Marshal(tx.localUpdates[branch])
+			if err != nil {
+				return fmt.Errorf("marshal local meta for %s: %w", branch, err)
+			}
+			contents[i] = string(jsonData)
 		}
-
-		refUpdates = append(refUpdates, git.RefUpdate{
-			RefName: git.LocalMetadataRefName(branch),
-			NewSHA:  blobSHA,
-			OldSHA:  tx.originalLocalMeta[branch],
-		})
+		shas, err := tx.eng.git.CreateBlobsBatch(contents)
+		if err != nil {
+			return fmt.Errorf("write local meta blobs: %w", err)
+		}
+		for i, branch := range localBranches {
+			refUpdates = append(refUpdates, git.RefUpdate{
+				RefName: git.LocalMetadataRefName(branch),
+				NewSHA:  shas[i],
+				OldSHA:  tx.originalLocalMeta[branch],
+			})
+		}
 	}
 
 	// Add metadata deletions

--- a/internal/git/bench_test.go
+++ b/internal/git/bench_test.go
@@ -280,9 +280,9 @@ func BenchmarkCreateBlob(b *testing.B) {
 	}
 }
 
-// BenchmarkCreateBlobs_Sequential simulates the metadata-flush pattern in
-// engine_writer.go (BatchMarkNeedsPRBodyUpdate writes one blob per branch in
-// a loop). Phase 6 replaces this with WriteBlobsBatch.
+// BenchmarkCreateBlobs_Sequential simulates the original metadata-flush
+// pattern: one CreateBlob per branch in a loop. Each call is its own
+// subprocess.
 func BenchmarkCreateBlobs_Sequential(b *testing.B) {
 	for _, n := range []int{1, 10, 50} {
 		b.Run(fmt.Sprintf("blobs=%d", n), func(b *testing.B) {
@@ -294,6 +294,28 @@ func BenchmarkCreateBlobs_Sequential(b *testing.B) {
 					if _, err := br.runner.CreateBlob(content); err != nil {
 						b.Fatalf("CreateBlob: %v", err)
 					}
+				}
+				iter++
+			}
+		})
+	}
+}
+
+// BenchmarkCreateBlobsBatch exercises the optimized batched path used by
+// BatchMarkNeedsPRBodyUpdate and transaction commits — temp-file staging
+// plus a single `git hash-object -w --stdin-paths` invocation.
+func BenchmarkCreateBlobsBatch(b *testing.B) {
+	for _, n := range []int{1, 10, 50} {
+		b.Run(fmt.Sprintf("blobs=%d", n), func(b *testing.B) {
+			br := newBenchRepo(b, 1, 0)
+			iter := 0
+			for b.Loop() {
+				contents := make([]string, n)
+				for j := range n {
+					contents[j] = fmt.Sprintf("blob-iter-%d-idx-%d", iter, j)
+				}
+				if _, err := br.runner.CreateBlobsBatch(contents); err != nil {
+					b.Fatalf("CreateBlobsBatch: %v", err)
 				}
 				iter++
 			}

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -233,6 +233,11 @@ type RefOperations interface {
 // ObjectOperations provides low-level Git object operations.
 type ObjectOperations interface {
 	CreateBlob(content string) (string, error)
+	// CreateBlobsBatch writes N blobs in a single `git hash-object` invocation.
+	// Returns SHAs in input order. For small N (<3) callers should still use
+	// CreateBlob — the temp-file staging the batch path requires only pays
+	// off once the per-blob subprocess overhead would dominate.
+	CreateBlobsBatch(contents []string) ([]string, error)
 	ReadBlob(sha string) (string, error)
 	CatFile(sha string) (string, error)
 }

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -906,6 +906,64 @@ func (r *runner) CreateBlob(content string) (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
+// CreateBlobsBatch writes N blobs to the object store in a single
+// `git hash-object -w --stdin-paths` invocation. Each content is staged to a
+// temp file (so git's path-based hashing can read it) and the SHAs come back
+// on stdout in input order.
+//
+// For very small N the overhead of staging temp files exceeds the savings
+// from collapsing subprocess calls; callers with N==1 should use CreateBlob
+// directly. We still handle N==0/1 here so the method's contract holds.
+func (r *runner) CreateBlobsBatch(contents []string) ([]string, error) {
+	if len(contents) == 0 {
+		return nil, nil
+	}
+	if len(contents) == 1 {
+		sha, err := r.CreateBlob(contents[0])
+		if err != nil {
+			return nil, err
+		}
+		return []string{sha}, nil
+	}
+
+	tempDir, err := os.MkdirTemp("", "stackit-blob-batch-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp dir for blob batch: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	// Stage each blob to a deterministically-named file so we can pass the
+	// list to stdin in input order and rely on git's output order matching.
+	paths := make([]string, len(contents))
+	for i, content := range contents {
+		p := filepath.Join(tempDir, fmt.Sprintf("blob-%06d", i))
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			return nil, fmt.Errorf("failed to stage blob %d: %w", i, err)
+		}
+		paths[i] = p
+	}
+
+	stdin := strings.Join(paths, "\n") + "\n"
+	out, err := r.runGitInternal(context.Background(), stdin, nil, true, "hash-object", "-w", "--stdin-paths")
+	if err != nil {
+		return nil, fmt.Errorf("failed to batch-create blobs: %w", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != len(contents) {
+		return nil, fmt.Errorf("git hash-object returned %d shas for %d blobs", len(lines), len(contents))
+	}
+	shas := make([]string, len(lines))
+	for i, line := range lines {
+		sha := strings.TrimSpace(line)
+		if sha == "" {
+			return nil, fmt.Errorf("git hash-object returned empty sha at index %d", i)
+		}
+		shas[i] = sha
+	}
+	return shas, nil
+}
+
 func (r *runner) ReadBlob(sha string) (string, error) {
 	out, err := r.RunGitCommandRawWithContext(context.Background(), "cat-file", "blob", sha)
 	if err != nil {

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -1040,6 +1040,13 @@ func (t *tracingRunner) CreateBlob(content string) (string, error) {
 	return result, err
 }
 
+func (t *tracingRunner) CreateBlobsBatch(contents []string) ([]string, error) {
+	start := time.Now()
+	result, err := t.inner.CreateBlobsBatch(contents)
+	t.trace("CreateBlobsBatch", time.Since(start), err == nil, err, slog.Int("count", len(contents)))
+	return result, err
+}
+
 func (t *tracingRunner) ReadBlob(sha string) (string, error) {
 	// Don't trace - delegates to CatFile which is traced
 	return t.inner.ReadBlob(sha)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Adds Runner.CreateBlobsBatch and wires the engine's two hot metadata
flush paths (BatchMarkNeedsPRBodyUpdate, transaction.commit) to use it
instead of looping over CreateBlob. One subprocess + N temp-file
writes replaces N subprocesses.

The temp-file staging is required because git hash-object's batch
mode reads paths from stdin (--stdin-paths), not raw content. The
files are deterministically named so output SHAs come back in input
order. Singleton (N==1) writes still take the CreateBlob path —
staging overhead would dominate.

Bench on M1 Max (-benchtime=1s), 50 metadata blobs:

  CreateBlobs_Sequential/50  352.5ms (one subprocess per blob)
  CreateBlobsBatch/50         40.3ms (one subprocess total)
                              8.8x faster

For 10-branch syncs:
  CreateBlobs_Sequential/10   71.1ms
  CreateBlobsBatch/10         13.7ms (5.2x faster)

Singleton is unchanged (7.0ms vs 7.1ms — both pay one subprocess).

The 40ms / 50 blobs is still slower than the go-git in-process
baseline (~23ms) — temp-file IO + the subprocess floor are real costs
— but it closes most of the gap that the Phase 6 dep-removal
introduced.

Closes the WriteBlobsBatch follow-up called out in the Phase 6
commit body.

<hr/>

<!-- STACKIT-SECTION-START -->
**Drop go-git dependency, shell out to native git for all ops**

Removes the go-git library entirely and replaces all usages with direct git CLI calls. This simplifies the dependency graph, fixes config-scope issues (global user.name now resolves correctly), and enables a batch-write optimisation for metadata blobs.

Key changes:
- **add-baseline-benchmarks**: Benchmarks for the go-git hot paths to establish a baseline before the rewrite
- **read-only history ops**: Replace go-git log/diff/ref traversal with `git log`, `git diff`, and `git rev-parse` shell-outs
- **staging ops**: Replace go-git index operations with `git add`/`git reset`
- **fetch/push**: Drop go-git transport layer; use `git fetch`/`git push` exclusively
- **ConfigStore**: Rewrite on top of `git config` CLI so all config scopes (local → global → system) are respected by default
- **drop go-git**: Remove the go-git module import and all remaining usages; net −572 lines of dependency code
- **batch metadata writes**: Use `git hash-object --stdin-paths` to write multiple metadata blobs in a single subprocess call instead of one per blob

#### Stack


* **PR #1018**
  * **PR #1019**
    * **PR #1020**
      * **PR #1021**
        * **PR #1022**
          * **PR #1023**
            * **PR #1024** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1025 by jonnii*