### PR TITLE
perf: replace O(n²) bubble sort and manual reversal with slices stdlib

### DIFF
--- a/internal/engine/engine_reader.go
+++ b/internal/engine/engine_reader.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"iter"
@@ -196,30 +197,24 @@ func (e *engineImpl) SortBranchesTopologically(branches Branches) Branches {
 		return branches
 	}
 
-	// Build a full graph once and sort by computed depth, then name for stability.
+	// Build the graph once and pre-compute each branch's depth to avoid
+	// repeated lookups inside the sort comparator (O(n²) → O(n log n)).
 	graph := e.Graph(SortStrategyAlphabetical)
-	result := make(Branches, len(branches))
-	copy(result, branches)
-	for i := 0; i < len(result)-1; i++ {
-		for j := i + 1; j < len(result); j++ {
-			left := graph.GetNode(result[i].GetName())
-			right := graph.GetNode(result[j].GetName())
-			leftDepth := 0
-			rightDepth := 0
-			if left != nil {
-				leftDepth = left.Depth
-			}
-			if right != nil {
-				rightDepth = right.Depth
-			}
-
-			swap := leftDepth > rightDepth ||
-				(leftDepth == rightDepth && result[i].GetName() > result[j].GetName())
-			if swap {
-				result[i], result[j] = result[j], result[i]
-			}
+	depth := make(map[string]int, len(branches))
+	for _, b := range branches {
+		if node := graph.GetNode(b.GetName()); node != nil {
+			depth[b.GetName()] = node.Depth
 		}
 	}
+
+	result := make([]Branch, len(branches))
+	copy(result, branches)
+	slices.SortFunc(result, func(a, b Branch) int {
+		if c := cmp.Compare(depth[a.GetName()], depth[b.GetName()]); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.GetName(), b.GetName())
+	})
 
 	return result
 }

--- a/internal/engine/stack_graph.go
+++ b/internal/engine/stack_graph.go
@@ -333,9 +333,7 @@ func (g *StackGraph) Range(branch Branch, rng StackRange) Branches {
 			current = node.Parent
 		}
 		// Reverse to go from trunk-ward to the starting branch
-		for i, j := 0, len(ancestors)-1; i < j; i, j = i+1, j-1 {
-			ancestors[i], ancestors[j] = ancestors[j], ancestors[i]
-		}
+		slices.Reverse(ancestors)
 		result = append(result, ancestors...)
 	}
 


### PR DESCRIPTION
## Summary

- `SortBranchesTopologically` in `engine_reader.go` was using a nested-loop bubble sort that called `graph.GetNode()` on every comparison — O(n²) graph lookups total. Pre-compute depths into a map once (O(n)), then sort with `slices.SortFunc` for O(n log n) overall.
- Replace a hand-rolled three-variable swap loop in `stack_graph.go` with `slices.Reverse`, which expresses the intent directly and is already in the imported package.

## Test plan

- [ ] `go build ./internal/engine/...` compiles cleanly
- [ ] `go test ./internal/engine/... -run "TestGraph|TestStack|TestBranch"` passes

https://claude.ai/code/session_01RmLYfGLtvr4oAExxWnFeei

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmLYfGLtvr4oAExxWnFeei)_