### PR TITLE
refactor(git): add metadata blob batch writers, drop unused singletons

### DIFF
--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -694,12 +694,20 @@ func (d *demoGitRunner) UnstageAll(_ context.Context) error {
 	return nil
 }
 
-func (d *demoGitRunner) WriteMetadataBlob(_ *git.Meta) (string, error) {
-	return demoBlobSHA, nil
+func (d *demoGitRunner) WriteMetadataBlobsBatch(metas []*git.Meta) ([]string, error) {
+	shas := make([]string, len(metas))
+	for i := range shas {
+		shas[i] = demoBlobSHA
+	}
+	return shas, nil
 }
 
-func (d *demoGitRunner) WriteLocalMetadataBlob(_ *git.LocalMeta) (string, error) {
-	return demoBlobSHA, nil
+func (d *demoGitRunner) WriteLocalMetadataBlobsBatch(metas []*git.LocalMeta) ([]string, error) {
+	shas := make([]string, len(metas))
+	for i := range shas {
+		shas[i] = demoBlobSHA
+	}
+	return shas, nil
 }
 
 func (d *demoGitRunner) GetMetadataRefSHA(_ string) string {

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1165,8 +1164,9 @@ func (e *engineImpl) IsInManagedWorktree() (bool, *WorktreeInfo, error) {
 }
 
 // BatchMarkNeedsPRBodyUpdate marks multiple branches as needing PR body update in a single atomic operation.
-// It batch-reads local metadata, sets the flag, creates blobs in one git
-// hash-object call, and atomically updates all refs.
+// It batch-reads local metadata, sets the flag, writes all the blobs in one
+// `git hash-object` call via WriteLocalMetadataBlobsBatch, and atomically
+// updates all refs.
 func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(branchNames []string) error {
 	if len(branchNames) == 0 {
 		return nil
@@ -1175,9 +1175,7 @@ func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(branchNames []string) error {
 	// Batch read all local metadata in parallel
 	allMeta := e.batchReadLocalMetadata(branchNames)
 
-	// Marshal each branch's updated metadata to JSON; track parallel slices
-	// so we can map blob SHAs back to ref names after the batch call.
-	contents := make([]string, 0, len(branchNames))
+	metas := make([]*git.LocalMeta, 0, len(branchNames))
 	orderedNames := make([]string, 0, len(branchNames))
 	for _, name := range branchNames {
 		meta := allMeta[name]
@@ -1185,16 +1183,11 @@ func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(branchNames []string) error {
 			meta = &git.LocalMeta{}
 		}
 		meta.NeedsPRBodyUpdate = true
-
-		jsonData, err := json.Marshal(meta)
-		if err != nil {
-			return fmt.Errorf("failed to marshal local metadata for %s: %w", name, err)
-		}
-		contents = append(contents, string(jsonData))
+		metas = append(metas, meta)
 		orderedNames = append(orderedNames, name)
 	}
 
-	shas, err := e.git.CreateBlobsBatch(contents)
+	shas, err := e.git.WriteLocalMetadataBlobsBatch(metas)
 	if err != nil {
 		return fmt.Errorf("failed to create local metadata blobs: %w", err)
 	}

--- a/internal/engine/transaction.go
+++ b/internal/engine/transaction.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand/v2"
@@ -200,15 +199,11 @@ func (tx *MetadataTx) Commit(ctx context.Context) error {
 	slices.Sort(metaBranches)
 
 	if len(metaBranches) > 0 {
-		contents := make([]string, len(metaBranches))
+		metas := make([]*git.Meta, len(metaBranches))
 		for i, branch := range metaBranches {
-			jsonData, err := json.Marshal(tx.metaUpdates[branch])
-			if err != nil {
-				return fmt.Errorf("marshal meta for %s: %w", branch, err)
-			}
-			contents[i] = string(jsonData)
+			metas[i] = tx.metaUpdates[branch]
 		}
-		shas, err := tx.eng.git.CreateBlobsBatch(contents)
+		shas, err := tx.eng.git.WriteMetadataBlobsBatch(metas)
 		if err != nil {
 			return fmt.Errorf("write meta blobs: %w", err)
 		}
@@ -229,15 +224,11 @@ func (tx *MetadataTx) Commit(ctx context.Context) error {
 	slices.Sort(localBranches)
 
 	if len(localBranches) > 0 {
-		contents := make([]string, len(localBranches))
+		metas := make([]*git.LocalMeta, len(localBranches))
 		for i, branch := range localBranches {
-			jsonData, err := json.Marshal(tx.localUpdates[branch])
-			if err != nil {
-				return fmt.Errorf("marshal local meta for %s: %w", branch, err)
-			}
-			contents[i] = string(jsonData)
+			metas[i] = tx.localUpdates[branch]
 		}
-		shas, err := tx.eng.git.CreateBlobsBatch(contents)
+		shas, err := tx.eng.git.WriteLocalMetadataBlobsBatch(metas)
 		if err != nil {
 			return fmt.Errorf("write local meta blobs: %w", err)
 		}

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -254,9 +254,11 @@ type MetadataOperations interface {
 	BatchReadLocalMetadata(branchNames []string) map[string]*LocalMeta
 	WriteLocalMetadata(branchName string, meta *LocalMeta) error
 
-	// Transaction support methods
-	WriteMetadataBlob(meta *Meta) (string, error)
-	WriteLocalMetadataBlob(meta *LocalMeta) (string, error)
+	// Transaction support methods. The batch forms marshal each entry and
+	// forward to CreateBlobsBatch — call them with len(metas) >= 1 from
+	// engine_writer.go and transaction.go's commit path.
+	WriteMetadataBlobsBatch(metas []*Meta) ([]string, error)
+	WriteLocalMetadataBlobsBatch(metas []*LocalMeta) ([]string, error)
 	GetMetadataRefSHA(branchName string) string
 	GetLocalMetadataRefSHA(branchName string) string
 

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -348,36 +348,48 @@ func (r *runner) ListMetadata() (map[string]string, error) {
 	return result, nil
 }
 
-// WriteMetadataBlob creates a blob containing the metadata JSON and returns its SHA.
-// This does NOT update any refs - use this for batched/transactional writes.
-func (r *runner) WriteMetadataBlob(meta *Meta) (string, error) {
-	jsonData, err := json.Marshal(meta)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal metadata: %w", err)
+// WriteMetadataBlobsBatch marshals each Meta to JSON and writes all the blobs
+// in one `git hash-object` invocation via CreateBlobsBatch. Returns SHAs in
+// input order. Does NOT update any refs — callers (transaction commit,
+// BatchMarkNeedsPRBodyUpdate) pair the SHAs with ref updates afterwards.
+func (r *runner) WriteMetadataBlobsBatch(metas []*Meta) ([]string, error) {
+	if len(metas) == 0 {
+		return nil, nil
 	}
-
-	sha, err := r.CreateBlob(string(jsonData))
-	if err != nil {
-		return "", fmt.Errorf("failed to create metadata blob: %w", err)
+	contents := make([]string, len(metas))
+	for i, meta := range metas {
+		jsonData, err := json.Marshal(meta)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal metadata at index %d: %w", i, err)
+		}
+		contents[i] = string(jsonData)
 	}
-
-	return sha, nil
+	shas, err := r.CreateBlobsBatch(contents)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metadata blobs: %w", err)
+	}
+	return shas, nil
 }
 
-// WriteLocalMetadataBlob creates a blob containing the local metadata JSON and returns its SHA.
-// This does NOT update any refs - use this for batched/transactional writes.
-func (r *runner) WriteLocalMetadataBlob(meta *LocalMeta) (string, error) {
-	jsonData, err := json.Marshal(meta)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal local metadata: %w", err)
+// WriteLocalMetadataBlobsBatch is the LocalMeta counterpart to
+// WriteMetadataBlobsBatch.
+func (r *runner) WriteLocalMetadataBlobsBatch(metas []*LocalMeta) ([]string, error) {
+	if len(metas) == 0 {
+		return nil, nil
 	}
-
-	sha, err := r.CreateBlob(string(jsonData))
-	if err != nil {
-		return "", fmt.Errorf("failed to create local metadata blob: %w", err)
+	contents := make([]string, len(metas))
+	for i, meta := range metas {
+		jsonData, err := json.Marshal(meta)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal local metadata at index %d: %w", i, err)
+		}
+		contents[i] = string(jsonData)
 	}
-
-	return sha, nil
+	shas, err := r.CreateBlobsBatch(contents)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create local metadata blobs: %w", err)
+	}
+	return shas, nil
 }
 
 // GetMetadataRefSHA returns the current SHA of a metadata ref, or empty string if not found.

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -1131,17 +1131,17 @@ func (t *tracingRunner) WriteLocalMetadata(branchName string, meta *LocalMeta) e
 	return err
 }
 
-func (t *tracingRunner) WriteMetadataBlob(meta *Meta) (string, error) {
+func (t *tracingRunner) WriteMetadataBlobsBatch(metas []*Meta) ([]string, error) {
 	start := time.Now()
-	result, err := t.inner.WriteMetadataBlob(meta)
-	t.trace("WriteMetadataBlob", time.Since(start), err == nil, err)
+	result, err := t.inner.WriteMetadataBlobsBatch(metas)
+	t.trace("WriteMetadataBlobsBatch", time.Since(start), err == nil, err, slog.Int("count", len(metas)))
 	return result, err
 }
 
-func (t *tracingRunner) WriteLocalMetadataBlob(meta *LocalMeta) (string, error) {
+func (t *tracingRunner) WriteLocalMetadataBlobsBatch(metas []*LocalMeta) ([]string, error) {
 	start := time.Now()
-	result, err := t.inner.WriteLocalMetadataBlob(meta)
-	t.trace("WriteLocalMetadataBlob", time.Since(start), err == nil, err)
+	result, err := t.inner.WriteLocalMetadataBlobsBatch(metas)
+	t.trace("WriteLocalMetadataBlobsBatch", time.Since(start), err == nil, err, slog.Int("count", len(metas)))
 	return result, err
 }
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Introduces WriteMetadataBlobsBatch and WriteLocalMetadataBlobsBatch on
the Runner interface and routes engine_writer.BatchMarkNeedsPRBodyUpdate
and transaction.Commit through them. The previous code duplicated the
`json.Marshal` + `CreateBlobsBatch` loop at both engine call sites; the
batch helpers keep the marshal logic in the git layer.

Removes the singleton WriteMetadataBlob / WriteLocalMetadataBlob — they
had no remaining production callers after the metadata-flush paths
moved to CreateBlobsBatch in 3124b8bb.

The tracing wrapper now traces the batch entry point with a count
attribute, and the demo runner returns one demoBlobSHA per input.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1779883625`.


* **PR #1027**
  * **PR #1028** 👈
    * **PR #1029**
      * **PR #1030**
        * **PR #1031**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->