### PR TITLE
refactor(git): route repoRoot reads through getRepoRoot, tighten ls-files exit-code check

### DIFF
--- a/internal/git/gitdir.go
+++ b/internal/git/gitdir.go
@@ -25,7 +25,7 @@ func GetGitCommonDir(repoRoot string) string {
 
 // getGitDir returns the runner's worktree-specific git directory.
 func (r *runner) getGitDir(_ context.Context) string {
-	root := r.repoRoot
+	root := r.getRepoRoot()
 	if root == "" {
 		root, _ = os.Getwd()
 	}

--- a/internal/git/staging.go
+++ b/internal/git/staging.go
@@ -197,7 +197,7 @@ func (r *runner) StageHunks(ctx context.Context, hunks []Hunk) error {
 // stageNewFileHunk handles staging a single new file hunk by writing content to disk and staging it.
 func (r *runner) stageNewFileHunk(ctx context.Context, h Hunk) error {
 	content := extractContentFromHunk(h)
-	filePath := filepath.Join(r.repoRoot, h.File)
+	filePath := filepath.Join(r.getRepoRoot(), h.File)
 
 	// Create parent directories if they don't exist
 	if dir := filepath.Dir(filePath); dir != "." {
@@ -265,16 +265,17 @@ func (r *runner) rescueMisdetectedNewFiles(ctx context.Context, modHunks []Hunk)
 }
 
 // fileExistsInIndex checks if a file exists in the git index. Uses
-// `git ls-files --error-unmatch` which exits non-zero when the path is not
-// tracked; that's the cheapest one-shot index probe.
+// `git ls-files --error-unmatch` which exits 1 when the path is not tracked;
+// that's the cheapest one-shot index probe. Other non-zero exits (e.g., 128
+// for "not a git repo" or argument errors) surface as real errors so callers
+// don't silently treat them as "not tracked".
 func (r *runner) fileExistsInIndex(ctx context.Context, file string) (bool, error) {
 	_, err := r.RunGitCommandWithContext(ctx, "ls-files", "--error-unmatch", "-z", "--", file)
 	if err == nil {
 		return true, nil
 	}
 	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		// Any non-zero exit means the path isn't in the index.
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
 		return false, nil
 	}
 	return false, fmt.Errorf("failed to read index for %s: %w", file, err)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Two small consistency fixes:

- staging.stageNewFileHunk and gitdir.getGitDir were reading r.repoRoot
  directly, bypassing the repoRootMu-protected getter. They're reached
  only after ensureRepo has populated the field, so it was harmless in
  practice, but inconsistent with the rest of the package. Both now
  call r.getRepoRoot().

- staging.fileExistsInIndex was treating any non-zero exit from
  `git ls-files --error-unmatch` as "not in index". Exit 1 is the
  "untracked" signal; other codes (128 for not-a-repo, etc.) should
  surface as real errors. Matches the existing convention in
  staging.diffHasChanges, merge_base.isAncestor, and
  remote.fetchRemoteShas.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1779883625`.


* **PR #1027**
  * **PR #1028**
    * **PR #1029** 👈
      * **PR #1030**
        * **PR #1031**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->