### PR TITLE
refactor(git): surface os.Getwd error in ensureRepo

### DIFF
--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -479,7 +479,11 @@ func (r *runner) ensureRepo() error {
 
 	dir := r.repoRoot
 	if dir == "" {
-		dir, _ = os.Getwd()
+		wd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("not a git repository: failed to resolve working directory: %w", err)
+		}
+		dir = wd
 	}
 
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Previously `dir, _ = os.Getwd()` discarded the error and left dir == ""
on failure, causing the downstream `exec.Command("git", ...)` to run
in the parent process's cwd. If that cwd happened to be inside another
repo the discovery would silently succeed against the wrong root; in
the more common failure mode (cwd unlinked) the user got a confusing
"not a git repository at " message with an empty path.

Now the cwd resolution error is wrapped and returned directly, so the
actual cause is visible in the error chain.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1779883625`.


* **PR #1027**
  * **PR #1028**
    * **PR #1029**
      * **PR #1030** 👈
        * **PR #1031**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->