### PR TITLE
Merging 5 PRs

### DIFF
--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -694,12 +694,20 @@ func (d *demoGitRunner) UnstageAll(_ context.Context) error {
 	return nil
 }
 
-func (d *demoGitRunner) WriteMetadataBlob(_ *git.Meta) (string, error) {
-	return demoBlobSHA, nil
+func (d *demoGitRunner) WriteMetadataBlobsBatch(metas []*git.Meta) ([]string, error) {
+	shas := make([]string, len(metas))
+	for i := range shas {
+		shas[i] = demoBlobSHA
+	}
+	return shas, nil
 }
 
-func (d *demoGitRunner) WriteLocalMetadataBlob(_ *git.LocalMeta) (string, error) {
-	return demoBlobSHA, nil
+func (d *demoGitRunner) WriteLocalMetadataBlobsBatch(metas []*git.LocalMeta) ([]string, error) {
+	shas := make([]string, len(metas))
+	for i := range shas {
+		shas[i] = demoBlobSHA
+	}
+	return shas, nil
 }
 
 func (d *demoGitRunner) GetMetadataRefSHA(_ string) string {

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1165,8 +1164,9 @@ func (e *engineImpl) IsInManagedWorktree() (bool, *WorktreeInfo, error) {
 }
 
 // BatchMarkNeedsPRBodyUpdate marks multiple branches as needing PR body update in a single atomic operation.
-// It batch-reads local metadata, sets the flag, creates blobs in one git
-// hash-object call, and atomically updates all refs.
+// It batch-reads local metadata, sets the flag, writes all the blobs in one
+// `git hash-object` call via WriteLocalMetadataBlobsBatch, and atomically
+// updates all refs.
 func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(branchNames []string) error {
 	if len(branchNames) == 0 {
 		return nil
@@ -1175,9 +1175,7 @@ func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(branchNames []string) error {
 	// Batch read all local metadata in parallel
 	allMeta := e.batchReadLocalMetadata(branchNames)
 
-	// Marshal each branch's updated metadata to JSON; track parallel slices
-	// so we can map blob SHAs back to ref names after the batch call.
-	contents := make([]string, 0, len(branchNames))
+	metas := make([]*git.LocalMeta, 0, len(branchNames))
 	orderedNames := make([]string, 0, len(branchNames))
 	for _, name := range branchNames {
 		meta := allMeta[name]
@@ -1185,16 +1183,11 @@ func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(branchNames []string) error {
 			meta = &git.LocalMeta{}
 		}
 		meta.NeedsPRBodyUpdate = true
-
-		jsonData, err := json.Marshal(meta)
-		if err != nil {
-			return fmt.Errorf("failed to marshal local metadata for %s: %w", name, err)
-		}
-		contents = append(contents, string(jsonData))
+		metas = append(metas, meta)
 		orderedNames = append(orderedNames, name)
 	}
 
-	shas, err := e.git.CreateBlobsBatch(contents)
+	shas, err := e.git.WriteLocalMetadataBlobsBatch(metas)
 	if err != nil {
 		return fmt.Errorf("failed to create local metadata blobs: %w", err)
 	}

--- a/internal/engine/transaction.go
+++ b/internal/engine/transaction.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand/v2"
@@ -200,15 +199,11 @@ func (tx *MetadataTx) Commit(ctx context.Context) error {
 	slices.Sort(metaBranches)
 
 	if len(metaBranches) > 0 {
-		contents := make([]string, len(metaBranches))
+		metas := make([]*git.Meta, len(metaBranches))
 		for i, branch := range metaBranches {
-			jsonData, err := json.Marshal(tx.metaUpdates[branch])
-			if err != nil {
-				return fmt.Errorf("marshal meta for %s: %w", branch, err)
-			}
-			contents[i] = string(jsonData)
+			metas[i] = tx.metaUpdates[branch]
 		}
-		shas, err := tx.eng.git.CreateBlobsBatch(contents)
+		shas, err := tx.eng.git.WriteMetadataBlobsBatch(metas)
 		if err != nil {
 			return fmt.Errorf("write meta blobs: %w", err)
 		}
@@ -229,15 +224,11 @@ func (tx *MetadataTx) Commit(ctx context.Context) error {
 	slices.Sort(localBranches)
 
 	if len(localBranches) > 0 {
-		contents := make([]string, len(localBranches))
+		metas := make([]*git.LocalMeta, len(localBranches))
 		for i, branch := range localBranches {
-			jsonData, err := json.Marshal(tx.localUpdates[branch])
-			if err != nil {
-				return fmt.Errorf("marshal local meta for %s: %w", branch, err)
-			}
-			contents[i] = string(jsonData)
+			metas[i] = tx.localUpdates[branch]
 		}
-		shas, err := tx.eng.git.CreateBlobsBatch(contents)
+		shas, err := tx.eng.git.WriteLocalMetadataBlobsBatch(metas)
 		if err != nil {
 			return fmt.Errorf("write local meta blobs: %w", err)
 		}

--- a/internal/git/bench_test.go
+++ b/internal/git/bench_test.go
@@ -82,8 +82,8 @@ func (br *benchRepo) runGit(b *testing.B, args ...string) {
 	}
 }
 
-// BenchmarkGetRecentCommits measures the cost of walking N recent commits.
-// Phase 2 replaces the go-git CommitObject walk with `git log --format=...`.
+// BenchmarkGetRecentCommits measures the cost of walking N recent commits via
+// `git log --format=...`.
 func BenchmarkGetRecentCommits(b *testing.B) {
 	for _, count := range []int{50, 200} {
 		b.Run(fmt.Sprintf("count=%d", count), func(b *testing.B) {
@@ -142,7 +142,8 @@ func BenchmarkBatchGetRevisions(b *testing.B) {
 }
 
 // BenchmarkLoadAllBranchRevisions measures the cache-preload path used by
-// engine startup. Today this is a go-git Branches() iteration under goGitMu.
+// engine startup. One `git for-each-ref` invocation fills the revision cache
+// for all local branches.
 func BenchmarkLoadAllBranchRevisions(b *testing.B) {
 	br := newBenchRepo(b, 5, 20)
 	for b.Loop() {
@@ -152,8 +153,8 @@ func BenchmarkLoadAllBranchRevisions(b *testing.B) {
 	}
 }
 
-// BenchmarkGetMergeBase exercises the merge-base API. Phase 2 replaces
-// go-git's commit.MergeBase walk with `git merge-base <a> <b>`.
+// BenchmarkGetMergeBase exercises the merge-base API, implemented as a single
+// `git merge-base <a> <b>` invocation.
 func BenchmarkGetMergeBase(b *testing.B) {
 	br := newBenchRepo(b, 30, 2)
 	for b.Loop() {
@@ -182,9 +183,8 @@ func BenchmarkIsAncestor(b *testing.B) {
 	}
 }
 
-// BenchmarkHasStagedChanges exercises the go-git Worktree.Status() path used
-// by stackit's pre-commit guards. Phase 3 replaces it with
-// `git status --porcelain=v2 -z`.
+// BenchmarkHasStagedChanges exercises the pre-commit guard path
+// (`git diff --cached --quiet`).
 func BenchmarkHasStagedChanges(b *testing.B) {
 	br := newBenchRepo(b, 5, 0)
 	for b.Loop() {
@@ -194,9 +194,9 @@ func BenchmarkHasStagedChanges(b *testing.B) {
 	}
 }
 
-// BenchmarkHasStagedChanges_LargeTree measures the worktree walk on a tree
-// with many untracked files. This is the worst case for the current go-git
-// Status() implementation, which walks the entire tree in-process.
+// BenchmarkHasStagedChanges_LargeTree measures the diff-quiet check on a tree
+// with many untracked files. `git diff --cached --quiet` short-circuits on
+// exit code, so the untracked count should not blow up the cost.
 func BenchmarkHasStagedChanges_LargeTree(b *testing.B) {
 	br := newBenchRepo(b, 5, 0)
 	for i := range 1000 {
@@ -212,8 +212,7 @@ func BenchmarkHasStagedChanges_LargeTree(b *testing.B) {
 	}
 }
 
-// BenchmarkStageAll measures the cost of staging all changes via
-// worktree.AddWithOptions today; Phase 3 swaps in `git add -A`.
+// BenchmarkStageAll measures the cost of `git add -A`.
 func BenchmarkStageAll(b *testing.B) {
 	iter := 0
 	for b.Loop() {
@@ -232,9 +231,7 @@ func BenchmarkStageAll(b *testing.B) {
 	}
 }
 
-// BenchmarkGetConfig measures single-key config reads. Today this goes
-// through go-git's format.Config parser; Phase 5 swaps in `git config <key>`.
-// Expect a regression on this bench unless a small in-process cache is added.
+// BenchmarkGetConfig measures single-key config reads via `git config --get`.
 func BenchmarkGetConfig(b *testing.B) {
 	br := newBenchRepo(b, 1, 0)
 	br.runGit(b, "config", "stackit.bench.key", "bench-value")
@@ -337,10 +334,9 @@ func BenchmarkReadBlob(b *testing.B) {
 	}
 }
 
-// BenchmarkParallelGetRevision is the goGitMu-sensitive case: N goroutines
-// resolving distinct branch names concurrently. Today the goGitMu serializes
-// the underlying go-git reference lookup; after Phase 2 + Phase 6, parallel
-// callers should scale near-linearly.
+// BenchmarkParallelGetRevision measures the parallel-resolution path: N
+// goroutines resolving distinct branch names concurrently. With the revision
+// cache warm, this is dominated by cache hits and should scale near-linearly.
 func BenchmarkParallelGetRevision(b *testing.B) {
 	const branches = 20
 	br := newBenchRepo(b, 5, branches)
@@ -363,8 +359,8 @@ func BenchmarkParallelGetRevision(b *testing.B) {
 }
 
 // BenchmarkParallelGetMergeBase mirrors BenchmarkParallelGetRevision for
-// merge-base. Today merge-base also takes goGitMu (the inner CommitObject
-// walk requires it). Native `git merge-base` is parallel-safe.
+// merge-base. `git merge-base` is parallel-safe — each call spawns its own
+// subprocess and there's no process-wide lock in the runner.
 func BenchmarkParallelGetMergeBase(b *testing.B) {
 	br := newBenchRepo(b, 30, 4)
 	pairs := [][2]string{

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -156,30 +156,33 @@ func (r *runner) GetCurrentBranchOrSHA(ctx context.Context) (string, error) {
 	return r.GetCurrentRevision(ctx)
 }
 
-func (r *runner) GetMergedBranches(_ context.Context, target string) (map[string]bool, error) {
-	targetSHA, err := r.resolveRefSHA(target)
+// GetMergedBranches returns the set of local branches whose tip commit is
+// reachable from target — i.e., branches that have been merged into target.
+// Equivalent to running `isAncestor(branch, target)` for every branch, but
+// does it in one `git for-each-ref --merged` invocation instead of N
+// subprocesses.
+//
+// Squash-merged branches are intentionally not included: a squash leaves no
+// ancestor relationship, so the per-branch isAncestor loop never reported them
+// either. Callers that care about squash merges (engine_branch_status.go's
+// deletion policy) consult PR metadata first and only fall back to this map.
+func (r *runner) GetMergedBranches(ctx context.Context, target string) (map[string]bool, error) {
+	out, err := r.RunGitCommandWithContext(ctx,
+		"for-each-ref",
+		"--format=%(refname:short)",
+		"--merged", target,
+		"refs/heads/",
+	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve target %s: %w", target, err)
-	}
-
-	branches, err := r.allBranchHashes()
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to list branches merged into %s: %w", target, err)
 	}
 
 	merged := make(map[string]bool)
-	for branchName, branchSHA := range branches {
-		if branchSHA == targetSHA {
-			merged[branchName] = true
+	for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
+		if line == "" {
 			continue
 		}
-		isMerged, err := r.isAncestor(branchSHA, targetSHA)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check if %s is merged into %s: %w", branchName, target, err)
-		}
-		if isMerged {
-			merged[branchName] = true
-		}
+		merged[line] = true
 	}
 	return merged, nil
 }

--- a/internal/git/delete_packed_refs_test.go
+++ b/internal/git/delete_packed_refs_test.go
@@ -15,11 +15,12 @@ import (
 
 // Regression tests for the silent packed-refs deletion bug.
 //
-// go-git's filesystem Storer.RemoveReference only deletes the loose ref file.
-// If a ref lives in .git/packed-refs (e.g., because `git gc` or `git pack-refs`
-// ran), the call returns nil but the ref survives. That caused merge ship's
-// cleanup to silently leave a packed branch behind, recreate its metadata via
-// post-merge sync, and then prompt on a phantom metadata conflict.
+// The original implementation only deleted the loose ref file. If a ref lived
+// in .git/packed-refs (e.g., because `git gc` or `git pack-refs` ran), the
+// call returned nil but the ref survived. That caused merge ship's cleanup to
+// silently leave a packed branch behind, recreate its metadata via post-merge
+// sync, and then prompt on a phantom metadata conflict. The fix routes delete
+// through `git update-ref -d`, which rewrites packed-refs correctly.
 //
 // These tests pack the relevant refs before calling our delete APIs and assert
 // the refs are actually gone afterward.

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -57,8 +57,8 @@ func (r *runner) changedFilesBetween(ctx context.Context, base, head string) ([]
 	}
 
 	// Short-circuit on equal trees so we don't pay for a diff that we know
-	// will be empty. This preserves the optimization the prior go-git
-	// implementation had via TreeHash comparison.
+	// will be empty. Tree SHAs are content-addressed, so equal SHA ⇔ no
+	// changes — cheaper than walking the file-level diff.
 	baseTree, err := r.resolveTreeSHA(ctx, base)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve base %s: %w", base, err)

--- a/internal/git/gitdir.go
+++ b/internal/git/gitdir.go
@@ -25,7 +25,7 @@ func GetGitCommonDir(repoRoot string) string {
 
 // getGitDir returns the runner's worktree-specific git directory.
 func (r *runner) getGitDir(_ context.Context) string {
-	root := r.repoRoot
+	root := r.getRepoRoot()
 	if root == "" {
 		root, _ = os.Getwd()
 	}

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -75,8 +75,8 @@ type CommitReader interface {
 	GetCurrentRevision(ctx context.Context) (string, error)
 	BatchGetRevisions(branchNames []string) (map[string]string, []error)
 	// LoadAllBranchRevisions populates the revision cache for all local branches
-	// using one batched branch-ref load. Subsequent GetRevision calls
-	// for cached branches avoid go-git mutex contention entirely.
+	// using one `git for-each-ref` invocation. Subsequent GetRevision calls
+	// for cached branches resolve in-process without spawning git.
 	LoadAllBranchRevisions() error
 	GetCommitDate(branchName string) (time.Time, error)
 	GetCommitAuthor(branchName string) (string, error)
@@ -235,8 +235,8 @@ type ObjectOperations interface {
 	CreateBlob(content string) (string, error)
 	// CreateBlobsBatch writes N blobs in a single `git hash-object` invocation.
 	// Returns SHAs in input order. For small N (<3) callers should still use
-	// CreateBlob — the temp-file staging the batch path requires only pays
-	// off once the per-blob subprocess overhead would dominate.
+	// CreateBlob — the temp-file staging required by the batch path only pays
+	// off once per-blob subprocess overhead would dominate.
 	CreateBlobsBatch(contents []string) ([]string, error)
 	ReadBlob(sha string) (string, error)
 	CatFile(sha string) (string, error)

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -254,9 +254,11 @@ type MetadataOperations interface {
 	BatchReadLocalMetadata(branchNames []string) map[string]*LocalMeta
 	WriteLocalMetadata(branchName string, meta *LocalMeta) error
 
-	// Transaction support methods
-	WriteMetadataBlob(meta *Meta) (string, error)
-	WriteLocalMetadataBlob(meta *LocalMeta) (string, error)
+	// Transaction support methods. The batch forms marshal each entry and
+	// forward to CreateBlobsBatch — call them with len(metas) >= 1 from
+	// engine_writer.go and transaction.go's commit path.
+	WriteMetadataBlobsBatch(metas []*Meta) ([]string, error)
+	WriteLocalMetadataBlobsBatch(metas []*LocalMeta) ([]string, error)
 	GetMetadataRefSHA(branchName string) string
 	GetLocalMetadataRefSHA(branchName string) string
 

--- a/internal/git/merge_base_test.go
+++ b/internal/git/merge_base_test.go
@@ -76,13 +76,13 @@ func TestIsAncestor(t *testing.T) {
 	})
 }
 
-func TestIsAncestor_GoGitAfterFetch(t *testing.T) {
-	// This test verifies go-git can resolve and walk to a newly fetched commit.
-	// We test this by creating a scenario similar to a PR merge:
+func TestIsAncestor_AfterFetch(t *testing.T) {
+	// This test verifies the runner can resolve and walk to a newly fetched
+	// commit. We test this by creating a scenario similar to a PR merge:
 	// 1. Local repo has main at commit A
 	// 2. Remote has main at commit B (which includes A as ancestor)
 	// 3. We fetch but use a fresh runner that hasn't cached the commits
-	// 4. IsAncestor should still work via go-git
+	// 4. IsAncestor should still resolve through `git merge-base --is-ancestor`
 
 	t.Run("works after fetch with fresh runner", func(t *testing.T) {
 		// 1. Setup a "remote" repository

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -348,36 +348,48 @@ func (r *runner) ListMetadata() (map[string]string, error) {
 	return result, nil
 }
 
-// WriteMetadataBlob creates a blob containing the metadata JSON and returns its SHA.
-// This does NOT update any refs - use this for batched/transactional writes.
-func (r *runner) WriteMetadataBlob(meta *Meta) (string, error) {
-	jsonData, err := json.Marshal(meta)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal metadata: %w", err)
+// WriteMetadataBlobsBatch marshals each Meta to JSON and writes all the blobs
+// in one `git hash-object` invocation via CreateBlobsBatch. Returns SHAs in
+// input order. Does NOT update any refs — callers (transaction commit,
+// BatchMarkNeedsPRBodyUpdate) pair the SHAs with ref updates afterwards.
+func (r *runner) WriteMetadataBlobsBatch(metas []*Meta) ([]string, error) {
+	if len(metas) == 0 {
+		return nil, nil
 	}
-
-	sha, err := r.CreateBlob(string(jsonData))
-	if err != nil {
-		return "", fmt.Errorf("failed to create metadata blob: %w", err)
+	contents := make([]string, len(metas))
+	for i, meta := range metas {
+		jsonData, err := json.Marshal(meta)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal metadata at index %d: %w", i, err)
+		}
+		contents[i] = string(jsonData)
 	}
-
-	return sha, nil
+	shas, err := r.CreateBlobsBatch(contents)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metadata blobs: %w", err)
+	}
+	return shas, nil
 }
 
-// WriteLocalMetadataBlob creates a blob containing the local metadata JSON and returns its SHA.
-// This does NOT update any refs - use this for batched/transactional writes.
-func (r *runner) WriteLocalMetadataBlob(meta *LocalMeta) (string, error) {
-	jsonData, err := json.Marshal(meta)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal local metadata: %w", err)
+// WriteLocalMetadataBlobsBatch is the LocalMeta counterpart to
+// WriteMetadataBlobsBatch.
+func (r *runner) WriteLocalMetadataBlobsBatch(metas []*LocalMeta) ([]string, error) {
+	if len(metas) == 0 {
+		return nil, nil
 	}
-
-	sha, err := r.CreateBlob(string(jsonData))
-	if err != nil {
-		return "", fmt.Errorf("failed to create local metadata blob: %w", err)
+	contents := make([]string, len(metas))
+	for i, meta := range metas {
+		jsonData, err := json.Marshal(meta)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal local metadata at index %d: %w", i, err)
+		}
+		contents[i] = string(jsonData)
 	}
-
-	return sha, nil
+	shas, err := r.CreateBlobsBatch(contents)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create local metadata blobs: %w", err)
+	}
+	return shas, nil
 }
 
 // GetMetadataRefSHA returns the current SHA of a metadata ref, or empty string if not found.

--- a/internal/git/pull_test.go
+++ b/internal/git/pull_test.go
@@ -37,7 +37,7 @@ func TestPullBranch_Reproduction(t *testing.T) {
 	err = runner.InitDefaultRepo()
 	require.NoError(t, err)
 
-	// Warm up the runner's internal go-git state
+	// Warm up the runner's revision cache
 	initialLocalSha, err := runner.RunGitCommandWithContext(context.Background(), "rev-parse", "HEAD")
 	require.NoError(t, err)
 	_, err = runner.GetCommitAuthor(initialLocalSha)
@@ -75,9 +75,9 @@ func TestPullBranch_Reproduction(t *testing.T) {
 	// Verify that the pull succeeded (fast-forward should work)
 	require.Equal(t, git.PullDone, result, "PullBranch should return PullDone for a valid fast-forward")
 
-	// Verify that go-git can now see the new commit
+	// Verify the cached revision is updated to the newly fetched commit
 	_, err = runner.GetCommitAuthor(newRemoteSha)
-	require.NoError(t, err, "go-git should be able to see the newly fetched commit after reload")
+	require.NoError(t, err, "runner should resolve the newly fetched commit after reload")
 
 	// Verify that the local branch was actually updated
 	localSha, err := runner.RunGitCommandWithContext(ctx, "rev-parse", "main")
@@ -86,8 +86,8 @@ func TestPullBranch_Reproduction(t *testing.T) {
 }
 
 func TestReloadRepository(t *testing.T) {
-	// Test that PullBranch automatically reloads the repository cache after fetching
-	// This ensures go-git can see newly fetched commits
+	// Test that the runner can resolve commits created externally — the
+	// revision cache must invalidate / pass through to git for unknown SHAs.
 
 	// 1. Setup a repository
 	scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
@@ -101,30 +101,27 @@ func TestReloadRepository(t *testing.T) {
 	initialSha, err := runner.RunGitCommandWithContext(context.Background(), "rev-parse", "HEAD")
 	require.NoError(t, err)
 
-	// Verify we can access it via go-git
+	// Verify we can resolve the initial commit
 	_, err = runner.GetCommitAuthor(initialSha)
 	require.NoError(t, err)
 
-	// Create a new commit directly via git command (bypassing go-git)
+	// Create a new commit directly via git command (outside the runner's cache)
 	err = scene.Repo.CreateChangeAndCommit("new change", "new")
 	require.NoError(t, err)
 	newSha, err := scene.Repo.GetCurrentSHA()
 	require.NoError(t, err)
 
-	// The reload happens automatically inside PullBranch when it fetches
-	// We can verify this works by checking that go-git can see the new commit
-	// after operations that would trigger a reload (though in this test we're not
-	// actually fetching, so the reload mechanism is tested indirectly through PullBranch tests)
+	// PullBranch normally triggers the reload after fetch; this test verifies
+	// the runner falls through to git for SHAs that aren't in its cache. The
+	// full fetch+reload flow is exercised in TestPullBranch_WithReload below.
 
-	// Verify we can access the new commit via go-git
-	// Note: This test verifies the reload mechanism works, but the actual reload
-	// is tested in TestPullBranch_WithReload which exercises the full fetch+reload flow
+	// Verify the new commit is resolvable
 	_, err = runner.GetCommitAuthor(newSha)
-	require.NoError(t, err, "go-git should see the new commit")
+	require.NoError(t, err, "runner should resolve the new commit")
 
-	// Verify we can still access old commits
+	// Verify the initial commit is still resolvable
 	_, err = runner.GetCommitAuthor(initialSha)
-	require.NoError(t, err, "go-git should still see old commits")
+	require.NoError(t, err, "runner should still resolve old commits")
 }
 
 func TestPullBranch_WithReload(t *testing.T) {
@@ -174,14 +171,14 @@ func TestPullBranch_WithReload(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, remoteSha, localSha, "Local branch should match remote")
 
-	// 6. Verify go-git can see the new commit (this tests the reload mechanism in PullTrunk)
-	// Note: This test verifies the refspec fix works. The reload is tested in engine_sync.go
+	// 6. Verify the newly fetched commit is resolvable through the runner
+	// (this exercises the reload mechanism in PullBranch).
 	_, err = runner.GetCommitAuthor(remoteSha)
-	require.NoError(t, err, "go-git should be able to see the newly fetched commit")
+	require.NoError(t, err, "runner should resolve the newly fetched commit")
 
 	// Verify initial commit is still accessible
 	_, err = runner.GetCommitAuthor(initialSha)
-	require.NoError(t, err, "go-git should still see old commits")
+	require.NoError(t, err, "runner should still resolve old commits")
 }
 
 func TestPullBranch_WorktreeCorruptsMainWorkspace(t *testing.T) {

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -12,9 +12,8 @@ import (
 const DefaultRemote = "origin"
 
 // getRemote returns the configured remote for the current branch, falling
-// back to DefaultRemote. Implemented via `git config` rather than walking
-// go-git's typed config; the value is a single string and the call site
-// already accepts a fallback path.
+// back to DefaultRemote. Implemented via `git config --get` — the value is a
+// single string and the call site already accepts a fallback path.
 func (r *runner) getRemote() string {
 	branch, err := r.GetCurrentBranch()
 	if err != nil || branch == "" {
@@ -32,8 +31,7 @@ func (r *runner) getRemote() string {
 }
 
 // fetchRemoteShas lists the branch refs on a remote without modifying any
-// local refs. `git ls-remote --heads` matches the previous go-git behavior
-// of returning only refs/heads/*.
+// local refs. `git ls-remote --heads` returns only refs/heads/*.
 func (r *runner) fetchRemoteShas(ctx context.Context, remote string) (map[string]string, error) {
 	if ctx == nil {
 		ctx = context.Background()

--- a/internal/git/reset_test.go
+++ b/internal/git/reset_test.go
@@ -12,10 +12,9 @@ import (
 	"github.com/getstackit/stackit/testhelpers"
 )
 
-// TestHardReset_HonorsCanceledContext locks in the cancellation behavior that
-// the go-git-based implementation lacked: worktree.Reset() took no context, so
-// callers passing a canceled or deadline-exceeded ctx could not interrupt a
-// long-running reset.
+// TestHardReset_HonorsCanceledContext locks in the cancellation behavior: the
+// reset path is wired to RunGitCommandWithContext so callers passing a canceled
+// or deadline-exceeded ctx can interrupt a long-running reset.
 func TestHardReset_HonorsCanceledContext(t *testing.T) {
 	t.Parallel()
 	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
@@ -48,7 +47,7 @@ func TestHardReset_DiscardsUncommittedChanges(t *testing.T) {
 }
 
 // TestSoftReset_PreservesWorkingTree verifies the soft mode does not touch
-// the index or working tree, matching the previous go-git semantics.
+// the index or working tree.
 func TestSoftReset_PreservesWorkingTree(t *testing.T) {
 	t.Parallel()
 	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)

--- a/internal/git/revision_cache.go
+++ b/internal/git/revision_cache.go
@@ -3,7 +3,7 @@ package git
 import "sync"
 
 // revisionCache provides thread-safe caching of branch SHA revisions.
-// This avoids redundant go-git ref/revision resolution calls.
+// This avoids respawning `git rev-parse` for every revision lookup.
 // Keyed by branch name, values are full SHA hex strings.
 type revisionCache struct {
 	entries sync.Map // map[string]string (branchName -> SHA)

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -479,7 +479,11 @@ func (r *runner) ensureRepo() error {
 
 	dir := r.repoRoot
 	if dir == "" {
-		dir, _ = os.Getwd()
+		wd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("not a git repository: failed to resolve working directory: %w", err)
+		}
+		dir = wd
 	}
 
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -467,8 +467,7 @@ func (r *runner) infoLog(format string, args ...any) {
 // are validated by running the command in that directory.
 //
 // Outside a git repository the error message starts with "not a git
-// repository" so callers (and tests) can match on that phrase. This mirrors
-// the language go-git's PlainOpen used to return.
+// repository" so callers (and tests) can match on that phrase.
 func (r *runner) ensureRepo() error {
 	r.repoRootMu.Lock()
 	defer r.repoRootMu.Unlock()

--- a/internal/git/staging.go
+++ b/internal/git/staging.go
@@ -197,7 +197,7 @@ func (r *runner) StageHunks(ctx context.Context, hunks []Hunk) error {
 // stageNewFileHunk handles staging a single new file hunk by writing content to disk and staging it.
 func (r *runner) stageNewFileHunk(ctx context.Context, h Hunk) error {
 	content := extractContentFromHunk(h)
-	filePath := filepath.Join(r.repoRoot, h.File)
+	filePath := filepath.Join(r.getRepoRoot(), h.File)
 
 	// Create parent directories if they don't exist
 	if dir := filepath.Dir(filePath); dir != "." {
@@ -265,16 +265,17 @@ func (r *runner) rescueMisdetectedNewFiles(ctx context.Context, modHunks []Hunk)
 }
 
 // fileExistsInIndex checks if a file exists in the git index. Uses
-// `git ls-files --error-unmatch` which exits non-zero when the path is not
-// tracked; that's the cheapest one-shot index probe.
+// `git ls-files --error-unmatch` which exits 1 when the path is not tracked;
+// that's the cheapest one-shot index probe. Other non-zero exits (e.g., 128
+// for "not a git repo" or argument errors) surface as real errors so callers
+// don't silently treat them as "not tracked".
 func (r *runner) fileExistsInIndex(ctx context.Context, file string) (bool, error) {
 	_, err := r.RunGitCommandWithContext(ctx, "ls-files", "--error-unmatch", "-z", "--", file)
 	if err == nil {
 		return true, nil
 	}
 	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		// Any non-zero exit means the path isn't in the index.
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
 		return false, nil
 	}
 	return false, fmt.Errorf("failed to read index for %s: %w", file, err)

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -1131,17 +1131,17 @@ func (t *tracingRunner) WriteLocalMetadata(branchName string, meta *LocalMeta) e
 	return err
 }
 
-func (t *tracingRunner) WriteMetadataBlob(meta *Meta) (string, error) {
+func (t *tracingRunner) WriteMetadataBlobsBatch(metas []*Meta) ([]string, error) {
 	start := time.Now()
-	result, err := t.inner.WriteMetadataBlob(meta)
-	t.trace("WriteMetadataBlob", time.Since(start), err == nil, err)
+	result, err := t.inner.WriteMetadataBlobsBatch(metas)
+	t.trace("WriteMetadataBlobsBatch", time.Since(start), err == nil, err, slog.Int("count", len(metas)))
 	return result, err
 }
 
-func (t *tracingRunner) WriteLocalMetadataBlob(meta *LocalMeta) (string, error) {
+func (t *tracingRunner) WriteLocalMetadataBlobsBatch(metas []*LocalMeta) ([]string, error) {
 	start := time.Now()
-	result, err := t.inner.WriteLocalMetadataBlob(meta)
-	t.trace("WriteLocalMetadataBlob", time.Since(start), err == nil, err)
+	result, err := t.inner.WriteLocalMetadataBlobsBatch(metas)
+	t.trace("WriteLocalMetadataBlobsBatch", time.Since(start), err == nil, err, slog.Int("count", len(metas)))
 	return result, err
 }
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -272,8 +272,8 @@ func (r *runner) ResetWorktreeWorkingDir(ctx context.Context, worktreePath strin
 }
 
 // WorktreeHasUncommittedChanges checks if a worktree has uncommitted changes.
-// "Clean" means: no staged, unstaged, or untracked entries — matching the
-// prior go-git Status().IsClean() definition.
+// "Clean" means: no staged, unstaged, or untracked entries — equivalent to
+// `git status --porcelain --untracked-files=normal` returning empty output.
 func (r *runner) WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error) {
 	out, err := r.RunGitCommandRawWithContext(ctx,
 		"-C", worktreePath,

--- a/internal/git/worktree_ref_test.go
+++ b/internal/git/worktree_ref_test.go
@@ -43,8 +43,9 @@ func TestResolveRefInWorktree(t *testing.T) {
 	err = worktreeRunner.InitDefaultRepo()
 	require.NoError(t, err)
 
-	// Try to resolve 'main' from the worktree runner. go-git v6 should resolve
-	// refs through the worktree's common-dir without shelling out to git.
+	// Try to resolve 'main' from the worktree runner. `git rev-parse` follows
+	// the worktree's gitdir pointer back to the common dir, so refs are
+	// resolvable from inside a linked worktree.
 	resolvedSHA, err := worktreeRunner.GetRevision("main")
 	require.NoError(t, err, "Should be able to resolve 'main' from a worktree")
 	require.Equal(t, mainSHA, resolvedSHA)


### PR DESCRIPTION
This PR merges the following changes:

1. **#1027** refactor(git): batch GetMergedBranches via for-each-ref --merged
2. **#1028** refactor(git): add metadata blob batch writers, drop unused singletons
3. **#1029** refactor(git): route repoRoot reads through getRepoRoot, tighten ls-files exit-code check
4. **#1030** refactor(git): surface os.Getwd error in ensureRepo
5. **#1031** docs(git): drop stale go-git references from comments

### Stack

```
main
  └─ jonnii/20260527112020/batch-GetMergedBranches-via-for-each-ref (#1027)
    └─ jonnii/20260527112301/add-metadata-blob-batch-writers-drop-unused (#1028)
      └─ jonnii/20260527112359/route-repoRoot-reads-through-getRepoRoot-tighten (#1029)
        └─ jonnii/20260527112434/surface-os.Getwd-error-in-ensureRepo (#1030)
          └─ jonnii/20260527112904/drop-stale-go-git-references-from-comments (#1031)
```

Stackit-Stack-Size: 5
Stackit-PRs: 1027,1028,1029,1030,1031
