### PR TITLE
docs(git): clarify ConfigStore.Get reads merged config scope

### DIFF
--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -48,8 +48,11 @@ func isExitCode(err error, codes ...int) bool {
 	return slices.Contains(codes, exitErr.ExitCode())
 }
 
-// Get retrieves a single config value from local git config.
-// Returns empty string if the key doesn't exist.
+// Get retrieves a single config value, reading git's merged config
+// (system → global → local) — the same precedence `git config --get`
+// applies when invoked from inside the repo. Returns empty string if the
+// key isn't set in any scope. Use this for keys whose canonical home is
+// often the user's global config (e.g. user.name, user.email).
 func (c *ConfigStore) Get(key string) (string, error) {
 	out, err := c.runGitConfig("--get", key)
 	if err == nil {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Get() invokes 'git config --get' without --local, which reads merged
config (system, global, local). The previous comment said 'local git
config', which was leftover from the go-git implementation that read
local-only and didn't match the new shell-out behavior. Confirms the
intended behavior for user.name / user.email — fall through to the
user's global config when not overridden in-repo.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1033** 👈
  * **PR #1034**
    * **PR #1035**
      * **PR #1036**
        * **PR #1037**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1038 by jonnii*