### PR TITLE
fix(git): distinguish detached HEAD from real errors in GetWorktreeCurrentBranch

### DIFF
--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -286,13 +286,17 @@ func (r *runner) WorktreeHasUncommittedChanges(ctx context.Context, worktreePath
 }
 
 // GetWorktreeCurrentBranch returns the name of the branch currently checked out in a worktree.
-// Returns empty string if the worktree is in detached HEAD state.
+// Returns empty string if the worktree is in detached HEAD state. Real failures
+// (worktree missing, repo corruption, context cancellation) are surfaced — git
+// uses exit code 1 specifically for "not a symbolic ref" when `-q` is passed,
+// reserving 128 (and others) for genuine errors.
 func (r *runner) GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error) {
-	out, err := r.RunGitCommandWithContext(ctx, "-C", worktreePath, "symbolic-ref", "--short", "HEAD")
+	out, err := r.RunGitCommandWithContext(ctx, "-C", worktreePath, "symbolic-ref", "-q", "--short", "HEAD")
 	if err != nil {
-		// Detached HEAD: symbolic-ref exits non-zero. Treat as empty rather
-		// than an error to match the prior behavior.
-		return "", nil //nolint:nilerr
+		if isExitCode(err, 1) {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to read HEAD of worktree %s: %w", worktreePath, err)
 	}
 	return strings.TrimSpace(out), nil
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


The shell-out path was swallowing every non-zero exit from
'symbolic-ref' as 'detached HEAD', so a missing worktree, broken repo,
or cancelled context all looked identical to genuinely-detached state.

Pass '-q' (silences the error message, returns exit 1 for 'not a
symbolic ref' rather than 128), then check the exit code explicitly:

  exit 0  -> branch name
  exit 1  -> truly detached, return "" with no error
  other   -> surface as wrapped error

The previous go-git path returned plumbing.ErrReferenceNotFound for
detached HEAD and propagated other errors. This restores that
distinction.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1779891359`.


* **PR #1033**
  * **PR #1034** 👈
    * **PR #1035**
      * **PR #1036**
        * **PR #1037**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->