### PR TITLE
fix(git): log debug breadcrumb when getRemote falls back to default

### DIFF
--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -14,9 +14,18 @@ const DefaultRemote = "origin"
 // getRemote returns the configured remote for the current branch, falling
 // back to DefaultRemote. Implemented via `git config --get` — the value is a
 // single string and the call site already accepts a fallback path.
+//
+// A failure to resolve the current branch (e.g. detached HEAD, corrupted
+// repo) is logged at debug level rather than surfaced, because callers want
+// a usable remote name; the debug line is the only breadcrumb when an
+// unhealthy repo masquerades as a clean "branch with no upstream → origin".
 func (r *runner) getRemote() string {
 	branch, err := r.GetCurrentBranch()
-	if err != nil || branch == "" {
+	if err != nil {
+		r.debugLog("getRemote: GetCurrentBranch failed, falling back to %s: %v", DefaultRemote, err)
+		return DefaultRemote
+	}
+	if branch == "" {
 		return DefaultRemote
 	}
 	out, err := r.RunGitCommandWithContext(context.Background(),


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

getRemote() returns DefaultRemote ('origin') whenever the current
branch can't be resolved. The previous behavior silently swallowed any
error from GetCurrentBranch — a detached HEAD, a corrupted repo, or a
repository moved out from under the process all looked identical to a
clean 'branch with no upstream' state.

Log the failure at debug level so the breadcrumb survives without
disturbing the caller contract (still returns 'origin'). The branch ==
\"\" path stays silent because that's the legitimate detached-HEAD case.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1033**
  * **PR #1034**
    * **PR #1035** 👈
      * **PR #1036**
        * **PR #1037**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1038 by jonnii*