### PR TITLE
refactor(git,engine): plumb context through batch blob writers

### DIFF
--- a/internal/actions/describe/describe.go
+++ b/internal/actions/describe/describe.go
@@ -139,7 +139,7 @@ func markStackAndPushMetadata(ctx *app.Context, eng engine.Engine, stackRoot str
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
 	root := eng.GetBranch(stackRoot)
 	if root.IsTracked() {
-		if err := eng.BatchMarkNeedsPRBodyUpdate(graph.CollectBranches(root).Names()); err != nil {
+		if err := eng.BatchMarkNeedsPRBodyUpdate(ctx, graph.CollectBranches(root).Names()); err != nil {
 			out.Debug("Failed to mark branches for PR body update: %v", err)
 		}
 	}

--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -365,7 +365,7 @@ func restackAndMark(ctx *app.Context, plan *movePlan, sourceBranch engine.Branch
 	if plan.oldParentName != eng.Trunk().GetName() {
 		affectedBranches = append(affectedBranches, plan.oldParentName)
 	}
-	if err := eng.BatchMarkNeedsPRBodyUpdate(affectedBranches); err != nil {
+	if err := eng.BatchMarkNeedsPRBodyUpdate(ctx, affectedBranches); err != nil {
 		out.Debug("Failed to mark branches for PR body update: %v", err)
 	}
 

--- a/internal/actions/scope/action.go
+++ b/internal/actions/scope/action.go
@@ -70,7 +70,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		out.Info("Unset explicit scope for branch %s. It will now inherit from its parent.", style.ColorBranchName(currentBranch, false))
 
 		// Mark branch for PR update and push metadata (defer GitHub API calls to sync)
-		if err := eng.BatchMarkNeedsPRBodyUpdate([]string{currentBranch}); err != nil {
+		if err := eng.BatchMarkNeedsPRBodyUpdate(ctx, []string{currentBranch}); err != nil {
 			out.Debug("Failed to mark branch for PR body update: %v", err)
 		}
 		if err := actions.PushMetadataOnly(ctx, eng, []string{currentBranch}); err != nil {
@@ -117,7 +117,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	// Mark branch for PR update and push metadata (defer GitHub API calls to sync)
-	if err := eng.BatchMarkNeedsPRBodyUpdate([]string{currentBranch}); err != nil {
+	if err := eng.BatchMarkNeedsPRBodyUpdate(ctx, []string{currentBranch}); err != nil {
 		out.Debug("Failed to mark branch for PR body update: %v", err)
 	}
 	if err := actions.PushMetadataOnly(ctx, eng, []string{currentBranch}); err != nil {

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -568,7 +568,7 @@ func (d *demoGitRunner) CreateBlob(_ string) (string, error) {
 	return demoBlobSHA, nil
 }
 
-func (d *demoGitRunner) CreateBlobsBatch(contents []string) ([]string, error) {
+func (d *demoGitRunner) CreateBlobsBatch(_ context.Context, contents []string) ([]string, error) {
 	shas := make([]string, len(contents))
 	for i := range shas {
 		shas[i] = demoBlobSHA
@@ -694,7 +694,7 @@ func (d *demoGitRunner) UnstageAll(_ context.Context) error {
 	return nil
 }
 
-func (d *demoGitRunner) WriteMetadataBlobsBatch(metas []*git.Meta) ([]string, error) {
+func (d *demoGitRunner) WriteMetadataBlobsBatch(_ context.Context, metas []*git.Meta) ([]string, error) {
 	shas := make([]string, len(metas))
 	for i := range shas {
 		shas[i] = demoBlobSHA
@@ -702,7 +702,7 @@ func (d *demoGitRunner) WriteMetadataBlobsBatch(metas []*git.Meta) ([]string, er
 	return shas, nil
 }
 
-func (d *demoGitRunner) WriteLocalMetadataBlobsBatch(metas []*git.LocalMeta) ([]string, error) {
+func (d *demoGitRunner) WriteLocalMetadataBlobsBatch(_ context.Context, metas []*git.LocalMeta) ([]string, error) {
 	shas := make([]string, len(metas))
 	for i := range shas {
 		shas[i] = demoBlobSHA

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -1167,7 +1167,7 @@ func (e *engineImpl) IsInManagedWorktree() (bool, *WorktreeInfo, error) {
 // It batch-reads local metadata, sets the flag, writes all the blobs in one
 // `git hash-object` call via WriteLocalMetadataBlobsBatch, and atomically
 // updates all refs.
-func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(branchNames []string) error {
+func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(ctx context.Context, branchNames []string) error {
 	if len(branchNames) == 0 {
 		return nil
 	}
@@ -1187,7 +1187,7 @@ func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(branchNames []string) error {
 		orderedNames = append(orderedNames, name)
 	}
 
-	shas, err := e.git.WriteLocalMetadataBlobsBatch(metas)
+	shas, err := e.git.WriteLocalMetadataBlobsBatch(ctx, metas)
 	if err != nil {
 		return fmt.Errorf("failed to create local metadata blobs: %w", err)
 	}
@@ -1201,7 +1201,7 @@ func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(branchNames []string) error {
 	}
 
 	// Atomic batch update all refs
-	return e.git.UpdateRefsBatch(context.Background(), updates)
+	return e.git.UpdateRefsBatch(ctx, updates)
 }
 
 // ClearNeedsPRBodyUpdate clears the PR body update flag for a branch

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -138,7 +138,7 @@ type BranchTracking interface {
 	SetFrozen(ctx context.Context, branches Branches, frozen bool) (BatchFreezeResult, error)
 
 	// BatchMarkNeedsPRBodyUpdate marks multiple branches as needing PR body update in a single atomic operation
-	BatchMarkNeedsPRBodyUpdate(branchNames []string) error
+	BatchMarkNeedsPRBodyUpdate(ctx context.Context, branchNames []string) error
 	// ClearNeedsPRBodyUpdate clears the PR body update flag for a branch
 	ClearNeedsPRBodyUpdate(branchName string) error
 	// GetBranchesNeedingPRBodyUpdate returns all branches that need PR body updates

--- a/internal/engine/pr_body_update_test.go
+++ b/internal/engine/pr_body_update_test.go
@@ -1,6 +1,7 @@
 package engine_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,7 +25,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		require.Empty(t, needsUpdate)
 
 		// Mark branch as needing update
-		err := eng.BatchMarkNeedsPRBodyUpdate([]string{"feature"})
+		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature"})
 		require.NoError(t, err)
 
 		// Now it should be in the list
@@ -42,7 +43,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark and then clear
-		err := eng.BatchMarkNeedsPRBodyUpdate([]string{"feature"})
+		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature"})
 		require.NoError(t, err)
 
 		err = eng.ClearNeedsPRBodyUpdate("feature")
@@ -77,7 +78,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark branch
-		err := eng.BatchMarkNeedsPRBodyUpdate([]string{"feature"})
+		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature"})
 		require.NoError(t, err)
 
 		// Rebuild engine to simulate fresh state
@@ -103,7 +104,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark only feature-a
-		err := eng.BatchMarkNeedsPRBodyUpdate([]string{"feature-a"})
+		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature-a"})
 		require.NoError(t, err)
 
 		needsUpdate := eng.GetBranchesNeedingPRBodyUpdate()
@@ -111,7 +112,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		require.NotContains(t, needsUpdate, "feature-b")
 
 		// Mark feature-b too
-		err = eng.BatchMarkNeedsPRBodyUpdate([]string{"feature-b"})
+		err = eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature-b"})
 		require.NoError(t, err)
 
 		needsUpdate = eng.GetBranchesNeedingPRBodyUpdate()
@@ -141,7 +142,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark both at once
-		err := eng.BatchMarkNeedsPRBodyUpdate([]string{"feature-a", "feature-b"})
+		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature-a", "feature-b"})
 		require.NoError(t, err)
 
 		needsUpdate := eng.GetBranchesNeedingPRBodyUpdate()
@@ -155,10 +156,10 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 
 		eng := s.Engine
 
-		err := eng.BatchMarkNeedsPRBodyUpdate([]string{})
+		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{})
 		require.NoError(t, err)
 
-		err = eng.BatchMarkNeedsPRBodyUpdate(nil)
+		err = eng.BatchMarkNeedsPRBodyUpdate(context.Background(), nil)
 		require.NoError(t, err)
 	})
 }

--- a/internal/engine/transaction.go
+++ b/internal/engine/transaction.go
@@ -203,7 +203,7 @@ func (tx *MetadataTx) Commit(ctx context.Context) error {
 		for i, branch := range metaBranches {
 			metas[i] = tx.metaUpdates[branch]
 		}
-		shas, err := tx.eng.git.WriteMetadataBlobsBatch(metas)
+		shas, err := tx.eng.git.WriteMetadataBlobsBatch(ctx, metas)
 		if err != nil {
 			return fmt.Errorf("write meta blobs: %w", err)
 		}
@@ -228,7 +228,7 @@ func (tx *MetadataTx) Commit(ctx context.Context) error {
 		for i, branch := range localBranches {
 			metas[i] = tx.localUpdates[branch]
 		}
-		shas, err := tx.eng.git.WriteLocalMetadataBlobsBatch(metas)
+		shas, err := tx.eng.git.WriteLocalMetadataBlobsBatch(ctx, metas)
 		if err != nil {
 			return fmt.Errorf("write local meta blobs: %w", err)
 		}

--- a/internal/git/bench_test.go
+++ b/internal/git/bench_test.go
@@ -311,7 +311,7 @@ func BenchmarkCreateBlobsBatch(b *testing.B) {
 				for j := range n {
 					contents[j] = fmt.Sprintf("blob-iter-%d-idx-%d", iter, j)
 				}
-				if _, err := br.runner.CreateBlobsBatch(contents); err != nil {
+				if _, err := br.runner.CreateBlobsBatch(context.Background(), contents); err != nil {
 					b.Fatalf("CreateBlobsBatch: %v", err)
 				}
 				iter++

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -236,8 +236,9 @@ type ObjectOperations interface {
 	// CreateBlobsBatch writes N blobs in a single `git hash-object` invocation.
 	// Returns SHAs in input order. For small N (<3) callers should still use
 	// CreateBlob — the temp-file staging required by the batch path only pays
-	// off once per-blob subprocess overhead would dominate.
-	CreateBlobsBatch(contents []string) ([]string, error)
+	// off once per-blob subprocess overhead would dominate. ctx is honored for
+	// the underlying git invocation so long-running batches can be canceled.
+	CreateBlobsBatch(ctx context.Context, contents []string) ([]string, error)
 	ReadBlob(sha string) (string, error)
 	CatFile(sha string) (string, error)
 }
@@ -256,9 +257,10 @@ type MetadataOperations interface {
 
 	// Transaction support methods. The batch forms marshal each entry and
 	// forward to CreateBlobsBatch — call them with len(metas) >= 1 from
-	// engine_writer.go and transaction.go's commit path.
-	WriteMetadataBlobsBatch(metas []*Meta) ([]string, error)
-	WriteLocalMetadataBlobsBatch(metas []*LocalMeta) ([]string, error)
+	// engine_writer.go and transaction.go's commit path. ctx is honored for
+	// the underlying git hash-object invocation.
+	WriteMetadataBlobsBatch(ctx context.Context, metas []*Meta) ([]string, error)
+	WriteLocalMetadataBlobsBatch(ctx context.Context, metas []*LocalMeta) ([]string, error)
 	GetMetadataRefSHA(branchName string) string
 	GetLocalMetadataRefSHA(branchName string) string
 

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -352,7 +352,7 @@ func (r *runner) ListMetadata() (map[string]string, error) {
 // in one `git hash-object` invocation via CreateBlobsBatch. Returns SHAs in
 // input order. Does NOT update any refs — callers (transaction commit,
 // BatchMarkNeedsPRBodyUpdate) pair the SHAs with ref updates afterwards.
-func (r *runner) WriteMetadataBlobsBatch(metas []*Meta) ([]string, error) {
+func (r *runner) WriteMetadataBlobsBatch(ctx context.Context, metas []*Meta) ([]string, error) {
 	if len(metas) == 0 {
 		return nil, nil
 	}
@@ -364,7 +364,7 @@ func (r *runner) WriteMetadataBlobsBatch(metas []*Meta) ([]string, error) {
 		}
 		contents[i] = string(jsonData)
 	}
-	shas, err := r.CreateBlobsBatch(contents)
+	shas, err := r.CreateBlobsBatch(ctx, contents)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metadata blobs: %w", err)
 	}
@@ -373,7 +373,7 @@ func (r *runner) WriteMetadataBlobsBatch(metas []*Meta) ([]string, error) {
 
 // WriteLocalMetadataBlobsBatch is the LocalMeta counterpart to
 // WriteMetadataBlobsBatch.
-func (r *runner) WriteLocalMetadataBlobsBatch(metas []*LocalMeta) ([]string, error) {
+func (r *runner) WriteLocalMetadataBlobsBatch(ctx context.Context, metas []*LocalMeta) ([]string, error) {
 	if len(metas) == 0 {
 		return nil, nil
 	}
@@ -385,7 +385,7 @@ func (r *runner) WriteLocalMetadataBlobsBatch(metas []*LocalMeta) ([]string, err
 		}
 		contents[i] = string(jsonData)
 	}
-	shas, err := r.CreateBlobsBatch(contents)
+	shas, err := r.CreateBlobsBatch(ctx, contents)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create local metadata blobs: %w", err)
 	}

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -917,7 +917,7 @@ func (r *runner) CreateBlob(content string) (string, error) {
 // For very small N the overhead of staging temp files exceeds the savings
 // from collapsing subprocess calls; callers with N==1 should use CreateBlob
 // directly. We still handle N==0/1 here so the method's contract holds.
-func (r *runner) CreateBlobsBatch(contents []string) ([]string, error) {
+func (r *runner) CreateBlobsBatch(ctx context.Context, contents []string) ([]string, error) {
 	if len(contents) == 0 {
 		return nil, nil
 	}
@@ -947,7 +947,7 @@ func (r *runner) CreateBlobsBatch(contents []string) ([]string, error) {
 	}
 
 	stdin := strings.Join(paths, "\n") + "\n"
-	out, err := r.runGitInternal(context.Background(), stdin, nil, true, "hash-object", "-w", "--stdin-paths")
+	out, err := r.runGitInternal(ctx, stdin, nil, true, "hash-object", "-w", "--stdin-paths")
 	if err != nil {
 		return nil, fmt.Errorf("failed to batch-create blobs: %w", err)
 	}

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -1040,9 +1040,9 @@ func (t *tracingRunner) CreateBlob(content string) (string, error) {
 	return result, err
 }
 
-func (t *tracingRunner) CreateBlobsBatch(contents []string) ([]string, error) {
+func (t *tracingRunner) CreateBlobsBatch(ctx context.Context, contents []string) ([]string, error) {
 	start := time.Now()
-	result, err := t.inner.CreateBlobsBatch(contents)
+	result, err := t.inner.CreateBlobsBatch(ctx, contents)
 	t.trace("CreateBlobsBatch", time.Since(start), err == nil, err, slog.Int("count", len(contents)))
 	return result, err
 }
@@ -1131,16 +1131,16 @@ func (t *tracingRunner) WriteLocalMetadata(branchName string, meta *LocalMeta) e
 	return err
 }
 
-func (t *tracingRunner) WriteMetadataBlobsBatch(metas []*Meta) ([]string, error) {
+func (t *tracingRunner) WriteMetadataBlobsBatch(ctx context.Context, metas []*Meta) ([]string, error) {
 	start := time.Now()
-	result, err := t.inner.WriteMetadataBlobsBatch(metas)
+	result, err := t.inner.WriteMetadataBlobsBatch(ctx, metas)
 	t.trace("WriteMetadataBlobsBatch", time.Since(start), err == nil, err, slog.Int("count", len(metas)))
 	return result, err
 }
 
-func (t *tracingRunner) WriteLocalMetadataBlobsBatch(metas []*LocalMeta) ([]string, error) {
+func (t *tracingRunner) WriteLocalMetadataBlobsBatch(ctx context.Context, metas []*LocalMeta) ([]string, error) {
 	start := time.Now()
-	result, err := t.inner.WriteLocalMetadataBlobsBatch(metas)
+	result, err := t.inner.WriteLocalMetadataBlobsBatch(ctx, metas)
 	t.trace("WriteLocalMetadataBlobsBatch", time.Since(start), err == nil, err, slog.Int("count", len(metas)))
 	return result, err
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

CreateBlobsBatch, WriteMetadataBlobsBatch, and WriteLocalMetadataBlobsBatch
hardcoded context.Background() for git hash-object invocations that can
be large and slow. Callers (transaction commit, BatchMarkNeedsPRBodyUpdate)
already have a ctx — pass it through so a cancelled CLI session aborts
the batch instead of blocking on git.

Engine.BatchMarkNeedsPRBodyUpdate now also takes ctx and uses it for the
follow-up UpdateRefsBatch, fixing a second context.Background() hidden
on the atomic ref-write path.

The interface change ripples to move/describe/scope actions and the
pr_body_update test, plus the demo runner and bench test, all updated
in lockstep.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1033**
  * **PR #1034**
    * **PR #1035**
      * **PR #1036** 👈
        * **PR #1037**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1038 by jonnii*