### PR TITLE
Merging 5 PRs

### DIFF
--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -520,7 +520,7 @@ func validateBranchAncestry(ctx *app.Context, branches engine.Branches) error {
 			}
 
 			// Parent exists - verify they have a common ancestor
-			_, err = ctx.Engine.Git().GetMergeBase(parentRev, branchRev)
+			_, err = ctx.Engine.Git().GetMergeBase(ctx.Context, parentRev, branchRev)
 			if err != nil {
 				return fmt.Errorf("branch %s and parent %s have no common ancestor: %w",
 					branchName, parentName, err)

--- a/internal/actions/describe/describe.go
+++ b/internal/actions/describe/describe.go
@@ -139,7 +139,7 @@ func markStackAndPushMetadata(ctx *app.Context, eng engine.Engine, stackRoot str
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
 	root := eng.GetBranch(stackRoot)
 	if root.IsTracked() {
-		if err := eng.BatchMarkNeedsPRBodyUpdate(graph.CollectBranches(root).Names()); err != nil {
+		if err := eng.BatchMarkNeedsPRBodyUpdate(ctx, graph.CollectBranches(root).Names()); err != nil {
 			out.Debug("Failed to mark branches for PR body update: %v", err)
 		}
 	}

--- a/internal/actions/doctor/stack_state.go
+++ b/internal/actions/doctor/stack_state.go
@@ -11,7 +11,7 @@ import (
 // checkStackState performs stack state and metadata integrity checks
 func checkStackState(ctx context.Context, eng engine.Engine, handler Handler, warnings int, errors int, fix bool) (int, int) {
 	// Get all branches
-	allBranches, err := eng.Git().GetAllBranchNames()
+	allBranches, err := eng.Git().GetAllBranchNames(ctx)
 	if err != nil {
 		errors++
 		handler.OnCheck("branch_list", CheckError, fmt.Sprintf("failed to get branch names: %v", err))

--- a/internal/actions/fold/fold.go
+++ b/internal/actions/fold/fold.go
@@ -54,7 +54,7 @@ func showDryRun(ctx *app.Context, current, parent engine.Branch) {
 	if err != nil {
 		out.Debug("Failed to get revision for grandparent %s: %v", grandparentName, err)
 		var mbErr error
-		baseRev, mbErr = eng.GetMergeBase(eng.Trunk().GetName(), parent.GetName())
+		baseRev, mbErr = eng.GetMergeBase(ctx, eng.Trunk().GetName(), parent.GetName())
 		if mbErr != nil {
 			out.Debug("Failed to get merge base for %s: %v", parent.GetName(), mbErr)
 		}

--- a/internal/actions/fold/fold_test.go
+++ b/internal/actions/fold/fold_test.go
@@ -29,7 +29,7 @@ func TestFoldAction(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify branch2 is deleted
-		branches, err := s.Engine.Git().GetAllBranchNames()
+		branches, err := s.Engine.Git().GetAllBranchNames(context.Background())
 		require.NoError(t, err)
 		require.NotContains(t, branches, "branch2")
 
@@ -67,7 +67,7 @@ func TestFoldAction(t *testing.T) {
 		require.Equal(t, "branch1", parent.GetName())
 
 		// Verify branch2 is deleted
-		branches, err := s.Engine.Git().GetAllBranchNames()
+		branches, err := s.Engine.Git().GetAllBranchNames(context.Background())
 		require.NoError(t, err)
 		require.NotContains(t, branches, "branch2")
 	})
@@ -87,7 +87,7 @@ func TestFoldAction(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify branch1 is deleted
-		branches, err := s.Engine.Git().GetAllBranchNames()
+		branches, err := s.Engine.Git().GetAllBranchNames(context.Background())
 		require.NoError(t, err)
 		require.NotContains(t, branches, "branch1")
 
@@ -125,7 +125,7 @@ func TestFoldAction(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify branch1 is deleted
-		branches, err := s.Engine.Git().GetAllBranchNames()
+		branches, err := s.Engine.Git().GetAllBranchNames(context.Background())
 		require.NoError(t, err)
 		require.NotContains(t, branches, "branch1")
 
@@ -276,7 +276,7 @@ func TestFoldAction(t *testing.T) {
 		require.NoError(t, err)
 
 		// branch3 should be deleted and branch4 should now be a child of branch2.
-		branches, err := s.Engine.Git().GetAllBranchNames()
+		branches, err := s.Engine.Git().GetAllBranchNames(context.Background())
 		require.NoError(t, err)
 		require.NotContains(t, branches, "branch3")
 		require.Equal(t, "branch2", s.Engine.GetBranch("branch4").GetParent().GetName())
@@ -402,7 +402,7 @@ func TestFoldAction(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify branch2 is deleted and we're on branch1
-		branches, _ := s.Engine.Git().GetAllBranchNames()
+		branches, _ := s.Engine.Git().GetAllBranchNames(context.Background())
 		require.NotContains(t, branches, "branch2")
 		current, _ := s.Scene.Repo.CurrentBranchName()
 		require.Equal(t, "branch1", current)
@@ -468,7 +468,7 @@ func TestFoldAction(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify branch1 is deleted
-		branches, _ := s.Engine.Git().GetAllBranchNames()
+		branches, _ := s.Engine.Git().GetAllBranchNames(context.Background())
 		require.NotContains(t, branches, "branch1")
 
 		// Verify we're on main
@@ -569,7 +569,7 @@ func TestFoldAction(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify branch2 still exists
-		branches, err := s.Engine.Git().GetAllBranchNames()
+		branches, err := s.Engine.Git().GetAllBranchNames(context.Background())
 		require.NoError(t, err)
 		require.Contains(t, branches, "branch2")
 

--- a/internal/actions/init/init.go
+++ b/internal/actions/init/init.go
@@ -35,7 +35,7 @@ func Action(ctx context.Context, repoRoot string, opts Options, handler Handler)
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
-	branchNames, err := runner.GetAllBranchNames()
+	branchNames, err := runner.GetAllBranchNames(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get branches: %w", err)
 	}

--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -365,7 +365,7 @@ func restackAndMark(ctx *app.Context, plan *movePlan, sourceBranch engine.Branch
 	if plan.oldParentName != eng.Trunk().GetName() {
 		affectedBranches = append(affectedBranches, plan.oldParentName)
 	}
-	if err := eng.BatchMarkNeedsPRBodyUpdate(affectedBranches); err != nil {
+	if err := eng.BatchMarkNeedsPRBodyUpdate(ctx, affectedBranches); err != nil {
 		out.Debug("Failed to mark branches for PR body update: %v", err)
 	}
 

--- a/internal/actions/pop_test.go
+++ b/internal/actions/pop_test.go
@@ -1,6 +1,7 @@
 package actions_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,7 +33,7 @@ func TestPopAction(t *testing.T) {
 		require.Equal(t, "main", currentBranch)
 
 		// Verify branch1 is deleted
-		branches, err := s.Engine.Git().GetAllBranchNames()
+		branches, err := s.Engine.Git().GetAllBranchNames(context.Background())
 		require.NoError(t, err)
 		require.NotContains(t, branches, "branch1")
 
@@ -63,7 +64,7 @@ func TestPopAction(t *testing.T) {
 		require.Equal(t, "main", parent.GetName())
 
 		// Verify branch1 is deleted
-		branches, err := s.Engine.Git().GetAllBranchNames()
+		branches, err := s.Engine.Git().GetAllBranchNames(context.Background())
 		require.NoError(t, err)
 		require.NotContains(t, branches, "branch1")
 	})

--- a/internal/actions/scope/action.go
+++ b/internal/actions/scope/action.go
@@ -70,7 +70,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		out.Info("Unset explicit scope for branch %s. It will now inherit from its parent.", style.ColorBranchName(currentBranch, false))
 
 		// Mark branch for PR update and push metadata (defer GitHub API calls to sync)
-		if err := eng.BatchMarkNeedsPRBodyUpdate([]string{currentBranch}); err != nil {
+		if err := eng.BatchMarkNeedsPRBodyUpdate(ctx, []string{currentBranch}); err != nil {
 			out.Debug("Failed to mark branch for PR body update: %v", err)
 		}
 		if err := actions.PushMetadataOnly(ctx, eng, []string{currentBranch}); err != nil {
@@ -117,7 +117,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	// Mark branch for PR update and push metadata (defer GitHub API calls to sync)
-	if err := eng.BatchMarkNeedsPRBodyUpdate([]string{currentBranch}); err != nil {
+	if err := eng.BatchMarkNeedsPRBodyUpdate(ctx, []string{currentBranch}); err != nil {
 		out.Debug("Failed to mark branch for PR body update: %v", err)
 	}
 	if err := actions.PushMetadataOnly(ctx, eng, []string{currentBranch}); err != nil {

--- a/internal/actions/split/split_file.go
+++ b/internal/actions/split/split_file.go
@@ -637,7 +637,7 @@ func promptForFiles(ctx context.Context, branchToSplit engine.Branch, eng splitB
 	parentBranchName := branchToSplit.GetParentOrTrunk()
 
 	// Get merge base between branch and parent
-	mergeBase, err := eng.GetMergeBase(branchToSplit.GetName(), parentBranchName)
+	mergeBase, err := eng.GetMergeBase(ctx, branchToSplit.GetName(), parentBranchName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get merge base: %w", err)
 	}

--- a/internal/actions/track/action.go
+++ b/internal/actions/track/action.go
@@ -53,7 +53,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 			if err != nil {
 				return fmt.Errorf("failed to get branch revision: %w", err)
 			}
-			isAnc, err := eng.IsAncestor(parentRev, branchRev)
+			isAnc, err := eng.IsAncestor(ctx.Context, parentRev, branchRev)
 			if err != nil {
 				return fmt.Errorf("failed to check ancestry: %w", err)
 			}
@@ -166,7 +166,7 @@ func trackBranchRecursively(ctx *app.Context, branchName string, handler Handler
 		}
 
 		// Check if candidate is a child (has this branch as merge base)
-		mergeBase, err := eng.GetMergeBase(candidate, branchName)
+		mergeBase, err := eng.GetMergeBase(ctx.Context, candidate, branchName)
 		if err != nil {
 			continue
 		}

--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -109,7 +109,7 @@ func CompleteBranches(cmd *cobra.Command, _ []string, _ string) ([]string, cobra
 	if cwd != "" {
 		runner = git.NewRunnerWithPath(cwd, nil)
 	}
-	branches, err := runner.GetAllBranchNames()
+	branches, err := runner.GetAllBranchNames(cmd.Context())
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}

--- a/internal/cli/navigation/trunk.go
+++ b/internal/cli/navigation/trunk.go
@@ -62,7 +62,7 @@ func handleAddTrunk(ctx *app.Context, trunkName string) error {
 	runner := ctx.Git()
 	repoRoot := ctx.RepoRoot
 	// Verify the branch exists
-	branches, err := runner.GetAllBranchNames()
+	branches, err := runner.GetAllBranchNames(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get branches: %w", err)
 	}

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -87,7 +87,7 @@ func (d *demoGitRunner) GetCurrentBranch() (string, error) {
 	return d.currentBranch, nil
 }
 
-func (d *demoGitRunner) GetAllBranchNames() ([]string, error) {
+func (d *demoGitRunner) GetAllBranchNames(_ context.Context) ([]string, error) {
 	names := make([]string, len(d.branches))
 	for i, b := range d.branches {
 		names[i] = b.Name
@@ -176,15 +176,15 @@ func (d *demoGitRunner) LoadAllBranchRevisions() error {
 	return nil
 }
 
-func (d *demoGitRunner) GetMergeBase(_, _ string) (string, error) {
+func (d *demoGitRunner) GetMergeBase(_ context.Context, _, _ string) (string, error) {
 	return "merge-base-sha", nil
 }
 
-func (d *demoGitRunner) GetMergeBaseByRef(_, _ string) (string, error) {
+func (d *demoGitRunner) GetMergeBaseByRef(_ context.Context, _, _ string) (string, error) {
 	return "merge-base-sha", nil
 }
 
-func (d *demoGitRunner) IsAncestor(_, _ string) (bool, error) {
+func (d *demoGitRunner) IsAncestor(_ context.Context, _, _ string) (bool, error) {
 	return true, nil
 }
 
@@ -196,7 +196,7 @@ func (d *demoGitRunner) GetCommitAuthor(_ string) (string, error) {
 	return "Demo User", nil
 }
 
-func (d *demoGitRunner) GetCommitRange(_, _, _ string) ([]string, error) {
+func (d *demoGitRunner) GetCommitRange(_ context.Context, _, _, _ string) ([]string, error) {
 	return []string{"commit message"}, nil
 }
 
@@ -297,11 +297,11 @@ func (d *demoGitRunner) GetReflog(_ context.Context, _ int, _ string) (string, e
 	return "", nil
 }
 
-func (d *demoGitRunner) GetCommitRangeSHAs(_, _ string) ([]string, error) {
+func (d *demoGitRunner) GetCommitRangeSHAs(_ context.Context, _, _ string) ([]string, error) {
 	return []string{"sha1", "sha2"}, nil
 }
 
-func (d *demoGitRunner) GetCommitHistorySHAs(_ string) ([]string, error) {
+func (d *demoGitRunner) GetCommitHistorySHAs(_ context.Context, _ string) ([]string, error) {
 	return []string{"sha1", "sha2"}, nil
 }
 
@@ -425,7 +425,7 @@ func (d *demoGitRunner) GetCommitLog(_, _ string) (string, error) {
 	return "demo commit", nil
 }
 
-func (d *demoGitRunner) GetRecentCommits(_ string, _ int) ([]git.RecentCommit, error) {
+func (d *demoGitRunner) GetRecentCommits(_ context.Context, _ string, _ int) ([]git.RecentCommit, error) {
 	return nil, nil
 }
 

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -568,7 +568,7 @@ func (d *demoGitRunner) CreateBlob(_ string) (string, error) {
 	return demoBlobSHA, nil
 }
 
-func (d *demoGitRunner) CreateBlobsBatch(contents []string) ([]string, error) {
+func (d *demoGitRunner) CreateBlobsBatch(_ context.Context, contents []string) ([]string, error) {
 	shas := make([]string, len(contents))
 	for i := range shas {
 		shas[i] = demoBlobSHA
@@ -694,7 +694,7 @@ func (d *demoGitRunner) UnstageAll(_ context.Context) error {
 	return nil
 }
 
-func (d *demoGitRunner) WriteMetadataBlobsBatch(metas []*git.Meta) ([]string, error) {
+func (d *demoGitRunner) WriteMetadataBlobsBatch(_ context.Context, metas []*git.Meta) ([]string, error) {
 	shas := make([]string, len(metas))
 	for i := range shas {
 		shas[i] = demoBlobSHA
@@ -702,7 +702,7 @@ func (d *demoGitRunner) WriteMetadataBlobsBatch(metas []*git.Meta) ([]string, er
 	return shas, nil
 }
 
-func (d *demoGitRunner) WriteLocalMetadataBlobsBatch(metas []*git.LocalMeta) ([]string, error) {
+func (d *demoGitRunner) WriteLocalMetadataBlobsBatch(_ context.Context, metas []*git.LocalMeta) ([]string, error) {
 	shas := make([]string, len(metas))
 	for i := range shas {
 		shas[i] = demoBlobSHA

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -152,7 +153,7 @@ func (e *engineImpl) PreloadBranchData() {
 // GetRecentTrunkCommits returns the most recent commits on the trunk branch,
 // including any stack trailer metadata embedded in consolidation merge commits.
 func (e *engineImpl) GetRecentTrunkCommits(count int) ([]git.RecentCommit, error) {
-	return e.git.GetRecentCommits(e.trunk, count)
+	return e.git.GetRecentCommits(context.Background(), e.trunk, count)
 }
 
 // GetAllCommits returns commits for a branch in various formats
@@ -187,5 +188,5 @@ func (e *engineImpl) GetAllCommits(branch Branch, format CommitFormat) ([]string
 
 	// Use GetCommitRange directly to handle formatting in-process via go-git,
 	// avoiding per-commit git process spawns.
-	return e.git.GetCommitRange(baseRevision, branchRevision, string(format))
+	return e.git.GetCommitRange(context.Background(), baseRevision, branchRevision, string(format))
 }

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -286,7 +286,7 @@ func (e *engineImpl) GetBranchRemoteStatus(branch Branch) (BranchRemoteStatus, e
 	// They differ, compute common ancestor to determine relation
 	remote := e.git.GetRemote()
 	remoteBranchRef := "refs/remotes/" + remote + "/" + branchName
-	commonAncestor, err := e.git.GetMergeBaseByRef(branchName, remoteBranchRef)
+	commonAncestor, err := e.git.GetMergeBaseByRef(context.Background(), branchName, remoteBranchRef)
 	if err == nil {
 		status.CommonAncestor = commonAncestor
 	}

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -92,8 +92,8 @@ func (e *engineImpl) GetUntrackedFileHunks(ctx context.Context) ([]git.Hunk, err
 }
 
 // GetMergeBase returns the merge base between two revisions
-func (e *engineImpl) GetMergeBase(rev1, rev2 string) (string, error) {
-	return e.git.GetMergeBase(rev1, rev2)
+func (e *engineImpl) GetMergeBase(ctx context.Context, rev1, rev2 string) (string, error) {
+	return e.git.GetMergeBase(ctx, rev1, rev2)
 }
 
 // IsDiffEmpty checks if the diff between base and head is empty
@@ -183,8 +183,8 @@ func (e *engineImpl) GetCommitSHA(branchName string, offset int) (string, error)
 }
 
 // IsAncestor checks if one commit is an ancestor of another
-func (e *engineImpl) IsAncestor(ancestor, descendant string) (bool, error) {
-	return e.git.IsAncestor(ancestor, descendant)
+func (e *engineImpl) IsAncestor(ctx context.Context, ancestor, descendant string) (bool, error) {
+	return e.git.IsAncestor(ctx, ancestor, descendant)
 }
 
 // IsRebaseInProgress checks if a rebase is in progress

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -245,7 +245,7 @@ func NewEngine(opts Options) (Engine, error) {
 // loadBranchList populates only e.state.branches via a single GetAllBranchNames
 // call. Used by lighter LoadModes that defer metadata reads.
 func (e *engineImpl) loadBranchList() error {
-	branches, err := e.git.GetAllBranchNames()
+	branches, err := e.git.GetAllBranchNames(context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to get branches: %w", err)
 	}

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -12,7 +12,7 @@ import (
 // refreshCurrentBranch indicates whether to refresh currentBranch from Git
 func (e *engineImpl) rebuildInternal(refreshCurrentBranch bool) error {
 	// Get all branch names
-	branches, err := e.git.GetAllBranchNames()
+	branches, err := e.git.GetAllBranchNames(context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to get branches: %w", err)
 	}
@@ -56,7 +56,7 @@ func (e *engineImpl) rebuild() error {
 	e.git.ClearMetadataCache()
 
 	// 1. Get all branch names (slow)
-	branches, err := e.git.GetAllBranchNames()
+	branches, err := e.git.GetAllBranchNames(context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to get branches: %w", err)
 	}

--- a/internal/engine/engine_reader.go
+++ b/internal/engine/engine_reader.go
@@ -152,7 +152,7 @@ func (e *engineImpl) FindMostRecentTrackedAncestors(ctx context.Context, branchN
 	}
 
 	// Get history of the branch we're tracking
-	history, err := e.git.GetCommitHistorySHAs(branchName)
+	history, err := e.git.GetCommitHistorySHAs(ctx, branchName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/engine_split.go
+++ b/internal/engine/engine_split.go
@@ -184,7 +184,7 @@ func (e *engineImpl) DetachAndResetBranchChanges(ctx context.Context, branchName
 	}
 
 	// Get the merge base between this branch and its parent
-	mergeBase, err := e.git.GetMergeBase(branchName, parentBranchName)
+	mergeBase, err := e.git.GetMergeBase(ctx, branchName, parentBranchName)
 	if err != nil {
 		return fmt.Errorf("failed to get merge base: %w", err)
 	}

--- a/internal/engine/engine_squash.go
+++ b/internal/engine/engine_squash.go
@@ -44,7 +44,7 @@ func (e *engineImpl) SquashCurrentBranch(ctx context.Context, opts SquashOptions
 	}
 
 	// Get commit range SHAs from parent to current branch
-	commitSHAs, err := e.git.GetCommitRangeSHAs(parentBranchRevision, branchRevision)
+	commitSHAs, err := e.git.GetCommitRangeSHAs(ctx, parentBranchRevision, branchRevision)
 	if err != nil {
 		return fmt.Errorf("failed to get commit range: %w", err)
 	}

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -371,14 +371,14 @@ func (e *engineImpl) restackBranch(
 	// was set to a revision that was never actually an ancestor.
 	// This check MUST run before the early-exit checks to match buildRebaseSpecs behavior.
 	if oldParentRev != "" {
-		if isAncestor, _ := e.git.IsAncestor(oldParentRev, branchName); !isAncestor {
-			if mergeBase, err := e.git.GetMergeBase(branchName, parent); err == nil {
+		if isAncestor, _ := e.git.IsAncestor(ctx, oldParentRev, branchName); !isAncestor {
+			if mergeBase, err := e.git.GetMergeBase(ctx, branchName, parent); err == nil {
 				oldParentRev = mergeBase
 			}
 		}
 	} else {
 		// No old parent revision in metadata, try to find merge base
-		if mergeBase, err := e.git.GetMergeBase(branchName, parent); err == nil {
+		if mergeBase, err := e.git.GetMergeBase(ctx, branchName, parent); err == nil {
 			oldParentRev = mergeBase
 		}
 	}

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -107,7 +107,7 @@ func (e *engineImpl) TrackBranch(ctx context.Context, branchName string, parentB
 	branchExists := slices.Contains(e.state.branches, branchName)
 	if !branchExists {
 		// Refresh branches list
-		branches, err := e.git.GetAllBranchNames()
+		branches, err := e.git.GetAllBranchNames(ctx)
 		if err != nil {
 			e.mu.Unlock()
 			return fmt.Errorf("failed to get branches: %w", err)
@@ -125,7 +125,7 @@ func (e *engineImpl) TrackBranch(ctx context.Context, branchName string, parentB
 		parentExists := slices.Contains(e.state.branches, parentBranchName)
 		if !parentExists {
 			// Refresh branches list to check again
-			branches, err := e.git.GetAllBranchNames()
+			branches, err := e.git.GetAllBranchNames(ctx)
 			if err != nil {
 				e.mu.Unlock()
 				return fmt.Errorf("failed to get branches: %w", err)
@@ -419,7 +419,7 @@ func (e *engineImpl) SetParent(ctx context.Context, branch Branch, parentBranch 
 
 	return e.WithRetry(ctx, func() error {
 		// Get new parent revision (may run multiple times on retry)
-		parentRev, err := e.git.GetMergeBase(branchName, parentBranchName)
+		parentRev, err := e.git.GetMergeBase(ctx, branchName, parentBranchName)
 		if err != nil {
 			return fmt.Errorf("failed to get merge base: %w", err)
 		}
@@ -441,7 +441,7 @@ func (e *engineImpl) SetParent(ctx context.Context, branch Branch, parentBranch 
 		shouldUpdateRevision := true
 		if oldParent != "" && oldParent != parentBranchName && meta.GetParentBranchRevision() != nil && *meta.GetParentBranchRevision() != "" {
 			// Check if existing revision is still a valid ancestor of the branch
-			if isAncestor, _ := e.git.IsAncestor(*meta.GetParentBranchRevision(), branchName); isAncestor {
+			if isAncestor, _ := e.git.IsAncestor(ctx, *meta.GetParentBranchRevision(), branchName); isAncestor {
 				// Check if the old parent was merged into the new parent (the "merge" case)
 				if merged, _ := e.git.IsMerged(ctx, oldParent, parentBranchName); merged {
 					shouldUpdateRevision = false
@@ -504,7 +504,7 @@ func (e *engineImpl) setParentPreservingDivergence(ctx context.Context, branch B
 
 	// Set the correct divergence point so restacking replays only this
 	// branch's commits, not commits from the old parent.
-	isAncestor, err := e.git.IsAncestor(oldDivergencePoint, branch.GetName())
+	isAncestor, err := e.git.IsAncestor(ctx, oldDivergencePoint, branch.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to check ancestry of divergence point %s for %s: %w", oldDivergencePoint, branch.GetName(), err)
 	}

--- a/internal/engine/engine_writer.go
+++ b/internal/engine/engine_writer.go
@@ -1167,7 +1167,7 @@ func (e *engineImpl) IsInManagedWorktree() (bool, *WorktreeInfo, error) {
 // It batch-reads local metadata, sets the flag, writes all the blobs in one
 // `git hash-object` call via WriteLocalMetadataBlobsBatch, and atomically
 // updates all refs.
-func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(branchNames []string) error {
+func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(ctx context.Context, branchNames []string) error {
 	if len(branchNames) == 0 {
 		return nil
 	}
@@ -1187,7 +1187,7 @@ func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(branchNames []string) error {
 		orderedNames = append(orderedNames, name)
 	}
 
-	shas, err := e.git.WriteLocalMetadataBlobsBatch(metas)
+	shas, err := e.git.WriteLocalMetadataBlobsBatch(ctx, metas)
 	if err != nil {
 		return fmt.Errorf("failed to create local metadata blobs: %w", err)
 	}
@@ -1201,7 +1201,7 @@ func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(branchNames []string) error {
 	}
 
 	// Atomic batch update all refs
-	return e.git.UpdateRefsBatch(context.Background(), updates)
+	return e.git.UpdateRefsBatch(ctx, updates)
 }
 
 // ClearNeedsPRBodyUpdate clears the PR body update flag for a branch

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -138,7 +138,7 @@ type BranchTracking interface {
 	SetFrozen(ctx context.Context, branches Branches, frozen bool) (BatchFreezeResult, error)
 
 	// BatchMarkNeedsPRBodyUpdate marks multiple branches as needing PR body update in a single atomic operation
-	BatchMarkNeedsPRBodyUpdate(branchNames []string) error
+	BatchMarkNeedsPRBodyUpdate(ctx context.Context, branchNames []string) error
 	// ClearNeedsPRBodyUpdate clears the PR body update flag for a branch
 	ClearNeedsPRBodyUpdate(branchName string) error
 	// GetBranchesNeedingPRBodyUpdate returns all branches that need PR body updates

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -80,12 +80,12 @@ type BranchInfo interface {
 
 // GitDiffer handles diff and merge operations
 type GitDiffer interface {
-	GetMergeBase(rev1, rev2 string) (string, error)
+	GetMergeBase(ctx context.Context, rev1, rev2 string) (string, error)
 	GetChangedFiles(ctx context.Context, base, head string) ([]string, error)
 	IsDiffEmpty(ctx context.Context, base, head string) (bool, error)
 	ShowDiff(ctx context.Context, left, right string, stat bool) (string, error)
 	ShowCommits(ctx context.Context, base, head string, patch, stat bool) (string, error)
-	IsAncestor(ancestor, descendant string) (bool, error)
+	IsAncestor(ctx context.Context, ancestor, descendant string) (bool, error)
 	// GetDiffBetween returns raw diff between two refs, suitable for parsing into hunks.
 	GetDiffBetween(ctx context.Context, base, head string, files ...string) (string, error)
 }

--- a/internal/engine/pr_body_update_test.go
+++ b/internal/engine/pr_body_update_test.go
@@ -1,6 +1,7 @@
 package engine_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,7 +25,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		require.Empty(t, needsUpdate)
 
 		// Mark branch as needing update
-		err := eng.BatchMarkNeedsPRBodyUpdate([]string{"feature"})
+		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature"})
 		require.NoError(t, err)
 
 		// Now it should be in the list
@@ -42,7 +43,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark and then clear
-		err := eng.BatchMarkNeedsPRBodyUpdate([]string{"feature"})
+		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature"})
 		require.NoError(t, err)
 
 		err = eng.ClearNeedsPRBodyUpdate("feature")
@@ -77,7 +78,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark branch
-		err := eng.BatchMarkNeedsPRBodyUpdate([]string{"feature"})
+		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature"})
 		require.NoError(t, err)
 
 		// Rebuild engine to simulate fresh state
@@ -103,7 +104,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark only feature-a
-		err := eng.BatchMarkNeedsPRBodyUpdate([]string{"feature-a"})
+		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature-a"})
 		require.NoError(t, err)
 
 		needsUpdate := eng.GetBranchesNeedingPRBodyUpdate()
@@ -111,7 +112,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		require.NotContains(t, needsUpdate, "feature-b")
 
 		// Mark feature-b too
-		err = eng.BatchMarkNeedsPRBodyUpdate([]string{"feature-b"})
+		err = eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature-b"})
 		require.NoError(t, err)
 
 		needsUpdate = eng.GetBranchesNeedingPRBodyUpdate()
@@ -141,7 +142,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark both at once
-		err := eng.BatchMarkNeedsPRBodyUpdate([]string{"feature-a", "feature-b"})
+		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature-a", "feature-b"})
 		require.NoError(t, err)
 
 		needsUpdate := eng.GetBranchesNeedingPRBodyUpdate()
@@ -155,10 +156,10 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 
 		eng := s.Engine
 
-		err := eng.BatchMarkNeedsPRBodyUpdate([]string{})
+		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{})
 		require.NoError(t, err)
 
-		err = eng.BatchMarkNeedsPRBodyUpdate(nil)
+		err = eng.BatchMarkNeedsPRBodyUpdate(context.Background(), nil)
 		require.NoError(t, err)
 	})
 }

--- a/internal/engine/rebase_validator_bench_test.go
+++ b/internal/engine/rebase_validator_bench_test.go
@@ -129,7 +129,7 @@ func benchmarkWideStack(b *testing.B, numBranches int) {
 	setupBenchmark()
 
 	mainRev, _ := s.Engine.GetRevision(s.Engine.Trunk())
-	oldBase, _ := s.Engine.Git().GetMergeBase(mainBranch, branchName(0))
+	oldBase, _ := s.Engine.Git().GetMergeBase(context.Background(), mainBranch, branchName(0))
 
 	// Build specs
 	specs := make([]engine.RebaseSpec, numBranches)
@@ -174,7 +174,7 @@ func benchmarkLinearStack(b *testing.B, depth int) {
 	setupBenchmark()
 
 	mainRev, _ := s.Engine.GetRevision(s.Engine.Trunk())
-	oldBase, _ := s.Engine.Git().GetMergeBase(mainBranch, branchName(0))
+	oldBase, _ := s.Engine.Git().GetMergeBase(context.Background(), mainBranch, branchName(0))
 
 	// Build specs for chained rebases
 	specs := make([]engine.RebaseSpec, depth)
@@ -227,7 +227,7 @@ func benchmarkMixedStack(b *testing.B) {
 	setupBenchmark()
 
 	mainRev, _ := s.Engine.GetRevision(s.Engine.Trunk())
-	oldBase, _ := s.Engine.Git().GetMergeBase(mainBranch, "feature-a")
+	oldBase, _ := s.Engine.Git().GetMergeBase(context.Background(), mainBranch, "feature-a")
 
 	// Get revisions for chaining
 	featureARev, _ := s.Engine.GetRevision(s.Engine.GetBranch("feature-a"))

--- a/internal/engine/rebase_validator_test.go
+++ b/internal/engine/rebase_validator_test.go
@@ -41,7 +41,7 @@ func TestValidateRebases(t *testing.T) {
 		// Get revisions
 		mainRev, err := s.Engine.GetRevision(s.Engine.Trunk())
 		require.NoError(t, err)
-		branch1OldBase, err := s.Engine.Git().GetMergeBase("main", "branch1")
+		branch1OldBase, err := s.Engine.Git().GetMergeBase(context.Background(), "main", "branch1")
 		require.NoError(t, err)
 
 		specs := []engine.RebaseSpec{
@@ -114,7 +114,7 @@ func TestValidateRebases(t *testing.T) {
 		mainRev, err := s.Engine.GetRevision(s.Engine.Trunk())
 		require.NoError(t, err)
 
-		branch1OldBase, _ := s.Engine.Git().GetMergeBase("main", "branch1")
+		branch1OldBase, _ := s.Engine.Git().GetMergeBase(context.Background(), "main", "branch1")
 		branch1Rev, _ := s.Engine.GetRevision(s.Engine.GetBranch("branch1"))
 		branch2Rev, _ := s.Engine.GetRevision(s.Engine.GetBranch("branch2"))
 
@@ -211,7 +211,7 @@ func TestValidateRebases(t *testing.T) {
 		// Get SHAs (this is what move.go does - resolves to SHAs before validation)
 		mainRev, _ := s.Engine.GetRevision(s.Engine.Trunk())
 		branch1OldSHA, _ := s.Engine.GetRevision(s.Engine.GetBranch("branch1"))
-		branch1OldBase, _ := s.Engine.Git().GetMergeBase("main", "branch1")
+		branch1OldBase, _ := s.Engine.Git().GetMergeBase(context.Background(), "main", "branch1")
 
 		// Build specs using SHAs (not branch names) - mimicking what move.go does
 		specs := []engine.RebaseSpec{
@@ -255,7 +255,7 @@ func TestValidateRebases(t *testing.T) {
 			Commit("main update")
 
 		mainRev, _ := s.Engine.GetRevision(s.Engine.Trunk())
-		branch1OldBase, _ := s.Engine.Git().GetMergeBase("main", "branch1")
+		branch1OldBase, _ := s.Engine.Git().GetMergeBase(context.Background(), "main", "branch1")
 
 		specs := []engine.RebaseSpec{
 			{
@@ -330,7 +330,7 @@ func TestValidateRebases(t *testing.T) {
 		// Get revisions
 		mainRev, err := s.Engine.GetRevision(s.Engine.Trunk())
 		require.NoError(t, err)
-		branch1OldBase, err := s.Engine.Git().GetMergeBase("main", "branch1")
+		branch1OldBase, err := s.Engine.Git().GetMergeBase(context.Background(), "main", "branch1")
 		require.NoError(t, err)
 
 		specs := []engine.RebaseSpec{
@@ -448,7 +448,7 @@ func TestRestackBranchesWithValidatedRebasesUsesValidationSHA(t *testing.T) {
 
 	mainRev, err := s.Engine.GetRevision(s.Engine.Trunk())
 	require.NoError(t, err)
-	oldBase, err := s.Engine.Git().GetMergeBase("main", "branch1")
+	oldBase, err := s.Engine.Git().GetMergeBase(context.Background(), "main", "branch1")
 	require.NoError(t, err)
 
 	validation, err := s.Engine.ValidateRebases(context.Background(), []engine.RebaseSpec{{
@@ -610,7 +610,7 @@ func TestValidateRebasesParallel(t *testing.T) {
 		require.NoError(t, err)
 
 		// Get old bases for all branches (they all share the same old main)
-		oldBase, _ := s.Engine.Git().GetMergeBase("main", "feature-a")
+		oldBase, _ := s.Engine.Git().GetMergeBase(context.Background(), "main", "feature-a")
 
 		// Build specs for all branches
 		specs := []engine.RebaseSpec{
@@ -657,7 +657,7 @@ func TestValidateRebasesParallel(t *testing.T) {
 			Commit("main update")
 
 		mainRev, _ := s.Engine.GetRevision(s.Engine.Trunk())
-		oldMainBase, _ := s.Engine.Git().GetMergeBase("main", "feature-a")
+		oldMainBase, _ := s.Engine.Git().GetMergeBase(context.Background(), "main", "feature-a")
 
 		// Get SHAs for depth-1 branches (for depth-2 rebases)
 		featureARev, _ := s.Engine.GetRevision(s.Engine.GetBranch("feature-a"))
@@ -739,7 +739,7 @@ func TestValidateRebasesParallel(t *testing.T) {
 			Commit("main update")
 
 		mainRev, _ := s.Engine.GetRevision(s.Engine.Trunk())
-		oldBase, _ := s.Engine.Git().GetMergeBase("main", "branch1")
+		oldBase, _ := s.Engine.Git().GetMergeBase(context.Background(), "main", "branch1")
 		branch1Rev, _ := s.Engine.GetRevision(s.Engine.GetBranch("branch1"))
 		branch3Rev, _ := s.Engine.GetRevision(s.Engine.GetBranch("branch3"))
 
@@ -774,7 +774,7 @@ func TestValidateRebasesParallel(t *testing.T) {
 		s.Checkout("main").Commit("main update")
 
 		mainRev, _ := s.Engine.GetRevision(s.Engine.Trunk())
-		oldBase, _ := s.Engine.Git().GetMergeBase("main", "branch1")
+		oldBase, _ := s.Engine.Git().GetMergeBase(context.Background(), "main", "branch1")
 
 		specs := []engine.RebaseSpec{
 			{Branch: "branch1", NewParent: mainRev, OldUpstream: oldBase},
@@ -809,7 +809,7 @@ func TestValidateRebasesParallel(t *testing.T) {
 		s.Checkout("main").Commit("main update")
 
 		mainRev, _ := s.Engine.GetRevision(s.Engine.Trunk())
-		oldBase, _ := s.Engine.Git().GetMergeBase("main", "branch1")
+		oldBase, _ := s.Engine.Git().GetMergeBase(context.Background(), "main", "branch1")
 
 		specs := []engine.RebaseSpec{
 			{Branch: "branch1", NewParent: mainRev, OldUpstream: oldBase},
@@ -878,7 +878,7 @@ func TestValidateRebasesParallel(t *testing.T) {
 		s.Checkout("main").Commit("main update")
 
 		mainRev, _ := s.Engine.GetRevision(s.Engine.Trunk())
-		oldBase, _ := s.Engine.Git().GetMergeBase("main", "branch1")
+		oldBase, _ := s.Engine.Git().GetMergeBase(context.Background(), "main", "branch1")
 
 		specs := []engine.RebaseSpec{
 			{Branch: "branch1", NewParent: mainRev, OldUpstream: oldBase},
@@ -904,7 +904,7 @@ func TestValidateRebasesParallel(t *testing.T) {
 			})
 
 		mainRev, _ := s.Engine.GetRevision(s.Engine.Trunk())
-		oldBase, _ := s.Engine.Git().GetMergeBase("main", "branch1")
+		oldBase, _ := s.Engine.Git().GetMergeBase(context.Background(), "main", "branch1")
 
 		specs := []engine.RebaseSpec{
 			{Branch: "branch1", NewParent: mainRev, OldUpstream: oldBase},

--- a/internal/engine/restack_plan.go
+++ b/internal/engine/restack_plan.go
@@ -150,19 +150,19 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 	}
 
 	if oldParentRev != "" {
-		isAncestor, err := e.git.IsAncestor(oldParentRev, branchName)
+		isAncestor, err := e.git.IsAncestor(ctx, oldParentRev, branchName)
 		if err != nil {
 			isAncestor = false
 		}
 		if !isAncestor {
-			mergeBase, err := e.git.GetMergeBase(branchName, parentName)
+			mergeBase, err := e.git.GetMergeBase(ctx, branchName, parentName)
 			if err != nil {
 				return item, false
 			}
 			oldParentRev = mergeBase
 		}
 	} else {
-		mergeBase, err := e.git.GetMergeBase(branchName, parentName)
+		mergeBase, err := e.git.GetMergeBase(ctx, branchName, parentName)
 		if err != nil {
 			return item, false
 		}

--- a/internal/engine/transaction.go
+++ b/internal/engine/transaction.go
@@ -203,7 +203,7 @@ func (tx *MetadataTx) Commit(ctx context.Context) error {
 		for i, branch := range metaBranches {
 			metas[i] = tx.metaUpdates[branch]
 		}
-		shas, err := tx.eng.git.WriteMetadataBlobsBatch(metas)
+		shas, err := tx.eng.git.WriteMetadataBlobsBatch(ctx, metas)
 		if err != nil {
 			return fmt.Errorf("write meta blobs: %w", err)
 		}
@@ -228,7 +228,7 @@ func (tx *MetadataTx) Commit(ctx context.Context) error {
 		for i, branch := range localBranches {
 			metas[i] = tx.localUpdates[branch]
 		}
-		shas, err := tx.eng.git.WriteLocalMetadataBlobsBatch(metas)
+		shas, err := tx.eng.git.WriteLocalMetadataBlobsBatch(ctx, metas)
 		if err != nil {
 			return fmt.Errorf("write local meta blobs: %w", err)
 		}

--- a/internal/engine/undo.go
+++ b/internal/engine/undo.go
@@ -349,7 +349,7 @@ func (e *engineImpl) RestoreSnapshot(ctx context.Context, snapshotID string) err
 	defer e.mu.Unlock()
 
 	// Get current branches
-	currentBranches, err := e.git.GetAllBranchNames()
+	currentBranches, err := e.git.GetAllBranchNames(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get current branches: %w", err)
 	}

--- a/internal/git/bench_test.go
+++ b/internal/git/bench_test.go
@@ -311,7 +311,7 @@ func BenchmarkCreateBlobsBatch(b *testing.B) {
 				for j := range n {
 					contents[j] = fmt.Sprintf("blob-iter-%d-idx-%d", iter, j)
 				}
-				if _, err := br.runner.CreateBlobsBatch(contents); err != nil {
+				if _, err := br.runner.CreateBlobsBatch(context.Background(), contents); err != nil {
 					b.Fatalf("CreateBlobsBatch: %v", err)
 				}
 				iter++

--- a/internal/git/bench_test.go
+++ b/internal/git/bench_test.go
@@ -89,7 +89,7 @@ func BenchmarkGetRecentCommits(b *testing.B) {
 		b.Run(fmt.Sprintf("count=%d", count), func(b *testing.B) {
 			br := newBenchRepo(b, count+5, 0)
 			for b.Loop() {
-				if _, err := br.runner.GetRecentCommits("main", count); err != nil {
+				if _, err := br.runner.GetRecentCommits(context.Background(), "main", count); err != nil {
 					b.Fatalf("GetRecentCommits: %v", err)
 				}
 			}
@@ -158,7 +158,7 @@ func BenchmarkLoadAllBranchRevisions(b *testing.B) {
 func BenchmarkGetMergeBase(b *testing.B) {
 	br := newBenchRepo(b, 30, 2)
 	for b.Loop() {
-		if _, err := br.runner.GetMergeBase("branch-0", "branch-1"); err != nil {
+		if _, err := br.runner.GetMergeBase(context.Background(), "branch-0", "branch-1"); err != nil {
 			b.Fatalf("GetMergeBase: %v", err)
 		}
 	}
@@ -177,7 +177,7 @@ func BenchmarkIsAncestor(b *testing.B) {
 		b.Fatalf("resolve descendant sha: %v", err)
 	}
 	for b.Loop() {
-		if _, err := br.runner.IsAncestor(ancestorSHA, descendantSHA); err != nil {
+		if _, err := br.runner.IsAncestor(context.Background(), ancestorSHA, descendantSHA); err != nil {
 			b.Fatalf("IsAncestor: %v", err)
 		}
 	}
@@ -375,7 +375,7 @@ func BenchmarkParallelGetMergeBase(b *testing.B) {
 		for pb.Next() {
 			p := pairs[i%len(pairs)]
 			i++
-			if _, err := br.runner.GetMergeBase(p[0], p[1]); err != nil {
+			if _, err := br.runner.GetMergeBase(context.Background(), p[0], p[1]); err != nil {
 				b.Fatalf("GetMergeBase: %v", err)
 			}
 		}

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -15,8 +15,8 @@ func (r *runner) GetCurrentBranch() (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
-func (r *runner) GetAllBranchNames() ([]string, error) {
-	branches, err := r.allBranchHashes()
+func (r *runner) GetAllBranchNames(ctx context.Context) ([]string, error) {
+	branches, err := r.allBranchHashes(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -189,8 +189,8 @@ func (r *runner) GetMergedBranches(ctx context.Context, target string) (map[stri
 
 // allBranchHashes returns a map of local branch name → SHA via a single
 // `git for-each-ref` invocation.
-func (r *runner) allBranchHashes() (map[string]string, error) {
-	out, err := r.RunGitCommandWithContext(context.Background(),
+func (r *runner) allBranchHashes(ctx context.Context) (map[string]string, error) {
+	out, err := r.RunGitCommandWithContext(ctx,
 		"for-each-ref",
 		"--format=%(refname:short)%00%(objectname)",
 		"refs/heads/",

--- a/internal/git/config.go
+++ b/internal/git/config.go
@@ -48,8 +48,11 @@ func isExitCode(err error, codes ...int) bool {
 	return slices.Contains(codes, exitErr.ExitCode())
 }
 
-// Get retrieves a single config value from local git config.
-// Returns empty string if the key doesn't exist.
+// Get retrieves a single config value, reading git's merged config
+// (system → global → local) — the same precedence `git config --get`
+// applies when invoked from inside the repo. Returns empty string if the
+// key isn't set in any scope. Use this for keys whose canonical home is
+// often the user's global config (e.g. user.name, user.email).
 func (c *ConfigStore) Get(key string) (string, error) {
 	out, err := c.runGitConfig("--get", key)
 	if err == nil {

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -52,7 +52,7 @@ type RemoteOperations interface {
 // BranchReader provides read access to branch information.
 type BranchReader interface {
 	GetCurrentBranch() (string, error)
-	GetAllBranchNames() ([]string, error)
+	GetAllBranchNames(ctx context.Context) ([]string, error)
 	GetCurrentBranchOrSHA(ctx context.Context) (string, error)
 }
 
@@ -80,21 +80,21 @@ type CommitReader interface {
 	LoadAllBranchRevisions() error
 	GetCommitDate(branchName string) (time.Time, error)
 	GetCommitAuthor(branchName string) (string, error)
-	GetCommitRange(base, head, format string) ([]string, error)
-	GetCommitRangeSHAs(base, head string) ([]string, error)
-	GetCommitHistorySHAs(branchName string) ([]string, error)
+	GetCommitRange(ctx context.Context, base, head, format string) ([]string, error)
+	GetCommitRangeSHAs(ctx context.Context, base, head string) ([]string, error)
+	GetCommitHistorySHAs(ctx context.Context, branchName string) ([]string, error)
 	GetCommitSHA(branchName string, offset int) (string, error)
 	GetCommitLog(sha, format string) (string, error)
-	GetRecentCommits(branchName string, count int) ([]RecentCommit, error)
+	GetRecentCommits(ctx context.Context, branchName string, count int) ([]RecentCommit, error)
 	GetCommitTemplate(ctx context.Context) (string, error)
 	GetParentCommitSHA(commitSHA string) (string, error)
 }
 
 // DiffOperations provides access to diff and comparison operations.
 type DiffOperations interface {
-	GetMergeBase(rev1, rev2 string) (string, error)
-	GetMergeBaseByRef(ref1, ref2 string) (string, error)
-	IsAncestor(ancestor, descendant string) (bool, error)
+	GetMergeBase(ctx context.Context, rev1, rev2 string) (string, error)
+	GetMergeBaseByRef(ctx context.Context, ref1, ref2 string) (string, error)
+	IsAncestor(ctx context.Context, ancestor, descendant string) (bool, error)
 	IsMerged(ctx context.Context, branchName, target string) (bool, error)
 	GetMergedBranches(ctx context.Context, target string) (map[string]bool, error)
 	IsDiffEmpty(ctx context.Context, branchName, base string) (bool, error)

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -236,8 +236,9 @@ type ObjectOperations interface {
 	// CreateBlobsBatch writes N blobs in a single `git hash-object` invocation.
 	// Returns SHAs in input order. For small N (<3) callers should still use
 	// CreateBlob — the temp-file staging required by the batch path only pays
-	// off once per-blob subprocess overhead would dominate.
-	CreateBlobsBatch(contents []string) ([]string, error)
+	// off once per-blob subprocess overhead would dominate. ctx is honored for
+	// the underlying git invocation so long-running batches can be canceled.
+	CreateBlobsBatch(ctx context.Context, contents []string) ([]string, error)
 	ReadBlob(sha string) (string, error)
 	CatFile(sha string) (string, error)
 }
@@ -256,9 +257,10 @@ type MetadataOperations interface {
 
 	// Transaction support methods. The batch forms marshal each entry and
 	// forward to CreateBlobsBatch — call them with len(metas) >= 1 from
-	// engine_writer.go and transaction.go's commit path.
-	WriteMetadataBlobsBatch(metas []*Meta) ([]string, error)
-	WriteLocalMetadataBlobsBatch(metas []*LocalMeta) ([]string, error)
+	// engine_writer.go and transaction.go's commit path. ctx is honored for
+	// the underlying git hash-object invocation.
+	WriteMetadataBlobsBatch(ctx context.Context, metas []*Meta) ([]string, error)
+	WriteLocalMetadataBlobsBatch(ctx context.Context, metas []*LocalMeta) ([]string, error)
 	GetMetadataRefSHA(branchName string) string
 	GetLocalMetadataRefSHA(branchName string) string
 

--- a/internal/git/merge_base.go
+++ b/internal/git/merge_base.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 )
 
-func (r *runner) getMergeBaseByRef(ref1Name, ref2Name string) (string, error) {
-	out, err := r.RunGitCommandWithContext(context.Background(), "merge-base", ref1Name, ref2Name)
+func (r *runner) getMergeBaseByRef(ctx context.Context, ref1Name, ref2Name string) (string, error) {
+	out, err := r.RunGitCommandWithContext(ctx, "merge-base", ref1Name, ref2Name)
 	if err != nil {
 		return "", fmt.Errorf("failed to find merge base of %s and %s: %w", ref1Name, ref2Name, err)
 	}
@@ -20,8 +20,8 @@ func (r *runner) getMergeBaseByRef(ref1Name, ref2Name string) (string, error) {
 	return sha, nil
 }
 
-func (r *runner) isAncestor(ancestor, descendant string) (bool, error) {
-	_, err := r.RunGitCommandWithContext(context.Background(), "merge-base", "--is-ancestor", ancestor, descendant)
+func (r *runner) isAncestor(ctx context.Context, ancestor, descendant string) (bool, error) {
+	_, err := r.RunGitCommandWithContext(ctx, "merge-base", "--is-ancestor", ancestor, descendant)
 	if err == nil {
 		return true, nil
 	}

--- a/internal/git/merge_base_test.go
+++ b/internal/git/merge_base_test.go
@@ -31,7 +31,7 @@ func TestIsAncestor(t *testing.T) {
 		require.NoError(t, err)
 
 		// Initial should be ancestor of second
-		isAncestor, err := runner.IsAncestor(initialSha, secondSha)
+		isAncestor, err := runner.IsAncestor(context.Background(), initialSha, secondSha)
 		require.NoError(t, err)
 		require.True(t, isAncestor, "initial commit should be ancestor of second commit")
 	})
@@ -54,7 +54,7 @@ func TestIsAncestor(t *testing.T) {
 		require.NoError(t, err)
 
 		// Second should NOT be ancestor of initial
-		isAncestor, err := runner.IsAncestor(secondSha, initialSha)
+		isAncestor, err := runner.IsAncestor(context.Background(), secondSha, initialSha)
 		require.NoError(t, err)
 		require.False(t, isAncestor, "second commit should not be ancestor of initial commit")
 	})
@@ -70,7 +70,7 @@ func TestIsAncestor(t *testing.T) {
 		require.NoError(t, err)
 
 		// Same commit should be considered its own ancestor
-		isAncestor, err := runner.IsAncestor(sha, sha)
+		isAncestor, err := runner.IsAncestor(context.Background(), sha, sha)
 		require.NoError(t, err)
 		require.True(t, isAncestor, "commit should be its own ancestor")
 	})
@@ -124,12 +124,12 @@ func TestIsAncestor_AfterFetch(t *testing.T) {
 		require.NoError(t, err)
 
 		// 6. Test IsAncestor with the newly fetched commit
-		isAncestor, err := runner.IsAncestor(initialSha, newSha)
+		isAncestor, err := runner.IsAncestor(context.Background(), initialSha, newSha)
 		require.NoError(t, err)
 		require.True(t, isAncestor, "initial should be ancestor of new commit after fetch")
 
 		// Also verify the reverse is false
-		isAncestor, err = runner.IsAncestor(newSha, initialSha)
+		isAncestor, err = runner.IsAncestor(context.Background(), newSha, initialSha)
 		require.NoError(t, err)
 		require.False(t, isAncestor, "new commit should not be ancestor of initial")
 	})
@@ -165,20 +165,20 @@ func TestIsAncestor_AfterFetch(t *testing.T) {
 		require.NoError(t, err)
 
 		// Neither should be ancestor of the other (diverged)
-		isAncestor, err := runner.IsAncestor(shaA, shaB)
+		isAncestor, err := runner.IsAncestor(context.Background(), shaA, shaB)
 		require.NoError(t, err)
 		require.False(t, isAncestor, "diverged commit A should not be ancestor of B")
 
-		isAncestor, err = runner.IsAncestor(shaB, shaA)
+		isAncestor, err = runner.IsAncestor(context.Background(), shaB, shaA)
 		require.NoError(t, err)
 		require.False(t, isAncestor, "diverged commit B should not be ancestor of A")
 
 		// But initial should be ancestor of both
-		isAncestor, err = runner.IsAncestor(initialSha, shaA)
+		isAncestor, err = runner.IsAncestor(context.Background(), initialSha, shaA)
 		require.NoError(t, err)
 		require.True(t, isAncestor, "initial should be ancestor of A")
 
-		isAncestor, err = runner.IsAncestor(initialSha, shaB)
+		isAncestor, err = runner.IsAncestor(context.Background(), initialSha, shaB)
 		require.NoError(t, err)
 		require.True(t, isAncestor, "initial should be ancestor of B")
 	})

--- a/internal/git/merge_detection.go
+++ b/internal/git/merge_detection.go
@@ -90,7 +90,7 @@ func (r *runner) GetUnmergedFiles(ctx context.Context) ([]string, error) {
 
 func (r *runner) IsMerged(ctx context.Context, branchName, target string) (bool, error) {
 	// Get merge base
-	mergeBase, err := r.GetMergeBase(branchName, target)
+	mergeBase, err := r.GetMergeBase(ctx, branchName, target)
 	if err != nil {
 		return false, fmt.Errorf("failed to get merge base: %w", err)
 	}
@@ -113,7 +113,7 @@ func (r *runner) IsMerged(ctx context.Context, branchName, target string) (bool,
 	if err != nil {
 		// If cherry fails, fall back to simpler check
 		// Check if branch tip is reachable from trunk
-		return r.IsAncestor(branchRev, target)
+		return r.IsAncestor(ctx, branchRev, target)
 	}
 
 	// If cherry output is empty or all lines start with '-', branch is merged

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -352,7 +352,7 @@ func (r *runner) ListMetadata() (map[string]string, error) {
 // in one `git hash-object` invocation via CreateBlobsBatch. Returns SHAs in
 // input order. Does NOT update any refs — callers (transaction commit,
 // BatchMarkNeedsPRBodyUpdate) pair the SHAs with ref updates afterwards.
-func (r *runner) WriteMetadataBlobsBatch(metas []*Meta) ([]string, error) {
+func (r *runner) WriteMetadataBlobsBatch(ctx context.Context, metas []*Meta) ([]string, error) {
 	if len(metas) == 0 {
 		return nil, nil
 	}
@@ -364,7 +364,7 @@ func (r *runner) WriteMetadataBlobsBatch(metas []*Meta) ([]string, error) {
 		}
 		contents[i] = string(jsonData)
 	}
-	shas, err := r.CreateBlobsBatch(contents)
+	shas, err := r.CreateBlobsBatch(ctx, contents)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metadata blobs: %w", err)
 	}
@@ -373,7 +373,7 @@ func (r *runner) WriteMetadataBlobsBatch(metas []*Meta) ([]string, error) {
 
 // WriteLocalMetadataBlobsBatch is the LocalMeta counterpart to
 // WriteMetadataBlobsBatch.
-func (r *runner) WriteLocalMetadataBlobsBatch(metas []*LocalMeta) ([]string, error) {
+func (r *runner) WriteLocalMetadataBlobsBatch(ctx context.Context, metas []*LocalMeta) ([]string, error) {
 	if len(metas) == 0 {
 		return nil, nil
 	}
@@ -385,7 +385,7 @@ func (r *runner) WriteLocalMetadataBlobsBatch(metas []*LocalMeta) ([]string, err
 		}
 		contents[i] = string(jsonData)
 	}
-	shas, err := r.CreateBlobsBatch(contents)
+	shas, err := r.CreateBlobsBatch(ctx, contents)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create local metadata blobs: %w", err)
 	}

--- a/internal/git/pull.go
+++ b/internal/git/pull.go
@@ -49,7 +49,7 @@ func (r *runner) PullBranch(ctx context.Context, remote, branchName string) (Pul
 	}
 
 	// Check if it's a fast-forward (remote is ahead of local)
-	isRemoteAhead, err := r.IsAncestor(oldRev, remoteRev)
+	isRemoteAhead, err := r.IsAncestor(ctx, oldRev, remoteRev)
 	if err == nil && isRemoteAhead {
 		// Before updating the ref, check if this branch is checked out in another worktree.
 		// update-ref is global and will affect all worktrees, so we need to sync any
@@ -98,7 +98,7 @@ func (r *runner) PullBranch(ctx context.Context, remote, branchName string) (Pul
 	}
 
 	// Check if local is already ahead of remote
-	isLocalAhead, _ := r.IsAncestor(remoteRev, oldRev)
+	isLocalAhead, _ := r.IsAncestor(ctx, remoteRev, oldRev)
 	if isLocalAhead {
 		return PullUnneeded, nil
 	}

--- a/internal/git/recent_commits.go
+++ b/internal/git/recent_commits.go
@@ -51,7 +51,7 @@ const commitFieldSep = "\x1f"
 // The underlying transport is `git log -z` so commit bodies (which may contain
 // newlines) round-trip safely. Fields within a record are separated by US
 // (0x1f); records by NUL.
-func (r *runner) GetRecentCommits(branchName string, count int) ([]RecentCommit, error) {
+func (r *runner) GetRecentCommits(ctx context.Context, branchName string, count int) ([]RecentCommit, error) {
 	if count <= 0 {
 		return nil, nil
 	}
@@ -60,7 +60,7 @@ func (r *runner) GetRecentCommits(branchName string, count int) ([]RecentCommit,
 		"%H", "%an", "%aI", "%B",
 	}, commitFieldSep)
 
-	out, err := r.RunGitCommandRawWithContext(context.Background(),
+	out, err := r.RunGitCommandRawWithContext(ctx,
 		"log",
 		fmt.Sprintf("-n%d", count),
 		"-z",

--- a/internal/git/recent_commits_test.go
+++ b/internal/git/recent_commits_test.go
@@ -1,6 +1,7 @@
 package git_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,7 +26,7 @@ func TestGetRecentCommits_DuplicateTrailers(t *testing.T) {
 	require.NoError(t, err)
 
 	runner := git.NewRunnerWithPath(scene.Dir, nil)
-	commits, err := runner.GetRecentCommits("main", 1)
+	commits, err := runner.GetRecentCommits(context.Background(), "main", 1)
 	require.NoError(t, err)
 	require.Len(t, commits, 1)
 
@@ -47,7 +48,7 @@ func TestGetRecentCommits_WithoutTrailers(t *testing.T) {
 	require.NoError(t, err)
 
 	runner := git.NewRunnerWithPath(scene.Dir, nil)
-	commits, err := runner.GetRecentCommits("main", 1)
+	commits, err := runner.GetRecentCommits(context.Background(), "main", 1)
 	require.NoError(t, err)
 	require.Len(t, commits, 1)
 
@@ -83,7 +84,7 @@ func TestGetRecentCommits_MultipleCommits(t *testing.T) {
 	require.NoError(t, err)
 
 	runner := git.NewRunnerWithPath(scene.Dir, nil)
-	commits, err := runner.GetRecentCommits("main", 3)
+	commits, err := runner.GetRecentCommits(context.Background(), "main", 3)
 	require.NoError(t, err)
 	require.Len(t, commits, 3)
 
@@ -116,7 +117,7 @@ func TestGetRecentCommits_ParsesPRNumberSuffix(t *testing.T) {
 	require.NoError(t, err)
 
 	runner := git.NewRunnerWithPath(scene.Dir, nil)
-	commits, err := runner.GetRecentCommits("main", 1)
+	commits, err := runner.GetRecentCommits(context.Background(), "main", 1)
 	require.NoError(t, err)
 	require.Len(t, commits, 1)
 	require.Equal(t, 123, commits[0].PRNumber)
@@ -142,7 +143,7 @@ func TestGetRecentCommits_MergeCommitSkipsTrailerSubject(t *testing.T) {
 	require.NoError(t, err)
 
 	runner := git.NewRunnerWithPath(scene.Dir, nil)
-	commits, err := runner.GetRecentCommits("main", 1)
+	commits, err := runner.GetRecentCommits(context.Background(), "main", 1)
 	require.NoError(t, err)
 	require.Len(t, commits, 1)
 
@@ -169,7 +170,7 @@ func TestGetRecentCommits_MergeCommitWithTitleBeforeTrailers(t *testing.T) {
 	require.NoError(t, err)
 
 	runner := git.NewRunnerWithPath(scene.Dir, nil)
-	commits, err := runner.GetRecentCommits("main", 1)
+	commits, err := runner.GetRecentCommits(context.Background(), "main", 1)
 	require.NoError(t, err)
 	require.Len(t, commits, 1)
 

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -14,9 +14,18 @@ const DefaultRemote = "origin"
 // getRemote returns the configured remote for the current branch, falling
 // back to DefaultRemote. Implemented via `git config --get` — the value is a
 // single string and the call site already accepts a fallback path.
+//
+// A failure to resolve the current branch (e.g. detached HEAD, corrupted
+// repo) is logged at debug level rather than surfaced, because callers want
+// a usable remote name; the debug line is the only breadcrumb when an
+// unhealthy repo masquerades as a clean "branch with no upstream → origin".
 func (r *runner) getRemote() string {
 	branch, err := r.GetCurrentBranch()
-	if err != nil || branch == "" {
+	if err != nil {
+		r.debugLog("getRemote: GetCurrentBranch failed, falling back to %s: %v", DefaultRemote, err)
+		return DefaultRemote
+	}
+	if branch == "" {
 		return DefaultRemote
 	}
 	out, err := r.RunGitCommandWithContext(context.Background(),

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -917,7 +917,7 @@ func (r *runner) CreateBlob(content string) (string, error) {
 // For very small N the overhead of staging temp files exceeds the savings
 // from collapsing subprocess calls; callers with N==1 should use CreateBlob
 // directly. We still handle N==0/1 here so the method's contract holds.
-func (r *runner) CreateBlobsBatch(contents []string) ([]string, error) {
+func (r *runner) CreateBlobsBatch(ctx context.Context, contents []string) ([]string, error) {
 	if len(contents) == 0 {
 		return nil, nil
 	}
@@ -947,7 +947,7 @@ func (r *runner) CreateBlobsBatch(contents []string) ([]string, error) {
 	}
 
 	stdin := strings.Join(paths, "\n") + "\n"
-	out, err := r.runGitInternal(context.Background(), stdin, nil, true, "hash-object", "-w", "--stdin-paths")
+	out, err := r.runGitInternal(ctx, stdin, nil, true, "hash-object", "-w", "--stdin-paths")
 	if err != nil {
 		return nil, fmt.Errorf("failed to batch-create blobs: %w", err)
 	}

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -673,16 +673,16 @@ func (r *runner) BatchGetRevisions(branchNames []string) (map[string]string, []e
 	return r.batchGetRevisions(branchNames)
 }
 
-func (r *runner) GetMergeBase(rev1, rev2 string) (string, error) {
-	return r.getMergeBaseByRef(rev1, rev2)
+func (r *runner) GetMergeBase(ctx context.Context, rev1, rev2 string) (string, error) {
+	return r.getMergeBaseByRef(ctx, rev1, rev2)
 }
 
-func (r *runner) GetMergeBaseByRef(ref1, ref2 string) (string, error) {
-	return r.getMergeBaseByRef(ref1, ref2)
+func (r *runner) GetMergeBaseByRef(ctx context.Context, ref1, ref2 string) (string, error) {
+	return r.getMergeBaseByRef(ctx, ref1, ref2)
 }
 
-func (r *runner) IsAncestor(ancestor, descendant string) (bool, error) {
-	return r.isAncestor(ancestor, descendant)
+func (r *runner) IsAncestor(ctx context.Context, ancestor, descendant string) (bool, error) {
+	return r.isAncestor(ctx, ancestor, descendant)
 }
 
 func (r *runner) GetCommitDate(branchName string) (time.Time, error) {
@@ -693,7 +693,7 @@ func (r *runner) GetCommitAuthor(branchName string) (string, error) {
 	return r.getCommitAuthor(branchName)
 }
 
-func (r *runner) GetCommitRange(base, head, format string) ([]string, error) {
+func (r *runner) GetCommitRange(ctx context.Context, base, head, format string) ([]string, error) {
 	rangeArg := head
 	if base != "" {
 		rangeArg = base + ".." + head
@@ -701,16 +701,16 @@ func (r *runner) GetCommitRange(base, head, format string) ([]string, error) {
 
 	switch format {
 	case "SHA":
-		return r.gitLogLines(rangeArg, "%H")
+		return r.gitLogLines(ctx, rangeArg, "%H")
 	case "READABLE":
-		return r.gitLogLines(rangeArg, "%h %s")
+		return r.gitLogLines(ctx, rangeArg, "%h %s")
 	case "SUBJECT":
-		return r.gitLogLines(rangeArg, "%s")
+		return r.gitLogLines(ctx, rangeArg, "%s")
 	case "READABLE_WITH_DATE":
 		// Tab-separated: short SHA, RFC3339 UTC date, subject. Use Unix
 		// epoch from git and convert in Go to preserve the prior behavior of
 		// normalizing to UTC regardless of the commit's recorded TZ.
-		lines, err := r.gitLogLines(rangeArg, "%h\t%at\t%s")
+		lines, err := r.gitLogLines(ctx, rangeArg, "%h\t%at\t%s")
 		if err != nil {
 			return nil, err
 		}
@@ -733,7 +733,7 @@ func (r *runner) GetCommitRange(base, head, format string) ([]string, error) {
 		return out, nil
 	case "MESSAGE":
 		// Bodies can contain newlines; use NUL record separator.
-		out, err := r.RunGitCommandRawWithContext(context.Background(), "log", "-z", "--format=%B", rangeArg)
+		out, err := r.RunGitCommandRawWithContext(ctx, "log", "-z", "--format=%B", rangeArg)
 		if err != nil {
 			return nil, fmt.Errorf("failed to walk commits %s: %w", rangeArg, err)
 		}
@@ -758,8 +758,8 @@ func (r *runner) GetCommitRange(base, head, format string) ([]string, error) {
 // gitLogLines runs `git log` over a range with a single-line format and
 // returns one element per commit, dropping blank lines. Suitable for any
 // format that does not include literal newlines.
-func (r *runner) gitLogLines(rangeArg, format string) ([]string, error) {
-	out, err := r.RunGitCommandWithContext(context.Background(), "log", "--format="+format, rangeArg)
+func (r *runner) gitLogLines(ctx context.Context, rangeArg, format string) ([]string, error) {
+	out, err := r.RunGitCommandWithContext(ctx, "log", "--format="+format, rangeArg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to walk commits %s: %w", rangeArg, err)
 	}
@@ -778,12 +778,12 @@ func (r *runner) gitLogLines(rangeArg, format string) ([]string, error) {
 	return result, nil
 }
 
-func (r *runner) GetCommitRangeSHAs(base, head string) ([]string, error) {
-	return r.GetCommitRange(base, head, "SHA")
+func (r *runner) GetCommitRangeSHAs(ctx context.Context, base, head string) ([]string, error) {
+	return r.GetCommitRange(ctx, base, head, "SHA")
 }
 
-func (r *runner) GetCommitHistorySHAs(branchName string) ([]string, error) {
-	return r.GetCommitRangeSHAs("", branchName)
+func (r *runner) GetCommitHistorySHAs(ctx context.Context, branchName string) ([]string, error) {
+	return r.GetCommitRangeSHAs(ctx, "", branchName)
 }
 
 func (r *runner) GetCommitSHA(branchName string, offset int) (string, error) {

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -1040,9 +1040,9 @@ func (t *tracingRunner) CreateBlob(content string) (string, error) {
 	return result, err
 }
 
-func (t *tracingRunner) CreateBlobsBatch(contents []string) ([]string, error) {
+func (t *tracingRunner) CreateBlobsBatch(ctx context.Context, contents []string) ([]string, error) {
 	start := time.Now()
-	result, err := t.inner.CreateBlobsBatch(contents)
+	result, err := t.inner.CreateBlobsBatch(ctx, contents)
 	t.trace("CreateBlobsBatch", time.Since(start), err == nil, err, slog.Int("count", len(contents)))
 	return result, err
 }
@@ -1131,16 +1131,16 @@ func (t *tracingRunner) WriteLocalMetadata(branchName string, meta *LocalMeta) e
 	return err
 }
 
-func (t *tracingRunner) WriteMetadataBlobsBatch(metas []*Meta) ([]string, error) {
+func (t *tracingRunner) WriteMetadataBlobsBatch(ctx context.Context, metas []*Meta) ([]string, error) {
 	start := time.Now()
-	result, err := t.inner.WriteMetadataBlobsBatch(metas)
+	result, err := t.inner.WriteMetadataBlobsBatch(ctx, metas)
 	t.trace("WriteMetadataBlobsBatch", time.Since(start), err == nil, err, slog.Int("count", len(metas)))
 	return result, err
 }
 
-func (t *tracingRunner) WriteLocalMetadataBlobsBatch(metas []*LocalMeta) ([]string, error) {
+func (t *tracingRunner) WriteLocalMetadataBlobsBatch(ctx context.Context, metas []*LocalMeta) ([]string, error) {
 	start := time.Now()
-	result, err := t.inner.WriteLocalMetadataBlobsBatch(metas)
+	result, err := t.inner.WriteLocalMetadataBlobsBatch(ctx, metas)
 	t.trace("WriteLocalMetadataBlobsBatch", time.Since(start), err == nil, err, slog.Int("count", len(metas)))
 	return result, err
 }

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -255,9 +255,9 @@ func (t *tracingRunner) GetCurrentBranch() (string, error) {
 	return result, err
 }
 
-func (t *tracingRunner) GetAllBranchNames() ([]string, error) {
+func (t *tracingRunner) GetAllBranchNames(ctx context.Context) ([]string, error) {
 	start := time.Now()
-	result, err := t.inner.GetAllBranchNames()
+	result, err := t.inner.GetAllBranchNames(ctx)
 	t.trace("GetAllBranchNames", time.Since(start), err == nil, err)
 	return result, err
 }
@@ -385,21 +385,21 @@ func (t *tracingRunner) GetCommitAuthor(branchName string) (string, error) {
 	return result, err
 }
 
-func (t *tracingRunner) GetCommitRange(base, head, format string) ([]string, error) {
+func (t *tracingRunner) GetCommitRange(ctx context.Context, base, head, format string) ([]string, error) {
 	start := time.Now()
-	result, err := t.inner.GetCommitRange(base, head, format)
+	result, err := t.inner.GetCommitRange(ctx, base, head, format)
 	t.trace("GetCommitRange", time.Since(start), err == nil, err, slog.String("base", base), slog.String("head", head))
 	return result, err
 }
 
-func (t *tracingRunner) GetCommitRangeSHAs(base, head string) ([]string, error) {
+func (t *tracingRunner) GetCommitRangeSHAs(ctx context.Context, base, head string) ([]string, error) {
 	// Don't trace - delegates to GetCommitRange which is traced
-	return t.inner.GetCommitRangeSHAs(base, head)
+	return t.inner.GetCommitRangeSHAs(ctx, base, head)
 }
 
-func (t *tracingRunner) GetCommitHistorySHAs(branchName string) ([]string, error) {
+func (t *tracingRunner) GetCommitHistorySHAs(ctx context.Context, branchName string) ([]string, error) {
 	// Don't trace - delegates to GetCommitRangeSHAs which delegates to GetCommitRange
-	return t.inner.GetCommitHistorySHAs(branchName)
+	return t.inner.GetCommitHistorySHAs(ctx, branchName)
 }
 
 func (t *tracingRunner) GetCommitSHA(branchName string, offset int) (string, error) {
@@ -416,9 +416,9 @@ func (t *tracingRunner) GetCommitLog(sha, format string) (string, error) {
 	return result, err
 }
 
-func (t *tracingRunner) GetRecentCommits(branchName string, count int) ([]RecentCommit, error) {
+func (t *tracingRunner) GetRecentCommits(ctx context.Context, branchName string, count int) ([]RecentCommit, error) {
 	start := time.Now()
-	result, err := t.inner.GetRecentCommits(branchName, count)
+	result, err := t.inner.GetRecentCommits(ctx, branchName, count)
 	t.trace("GetRecentCommits", time.Since(start), err == nil, err, slog.String("branch", branchName), slog.Int("count", count))
 	return result, err
 }
@@ -439,23 +439,23 @@ func (t *tracingRunner) GetParentCommitSHA(commitSHA string) (string, error) {
 
 // DiffOperations methods
 
-func (t *tracingRunner) GetMergeBase(rev1, rev2 string) (string, error) {
+func (t *tracingRunner) GetMergeBase(ctx context.Context, rev1, rev2 string) (string, error) {
 	start := time.Now()
-	result, err := t.inner.GetMergeBase(rev1, rev2)
+	result, err := t.inner.GetMergeBase(ctx, rev1, rev2)
 	t.trace("GetMergeBase", time.Since(start), err == nil, err, slog.String("rev1", rev1), slog.String("rev2", rev2))
 	return result, err
 }
 
-func (t *tracingRunner) GetMergeBaseByRef(ref1, ref2 string) (string, error) {
+func (t *tracingRunner) GetMergeBaseByRef(ctx context.Context, ref1, ref2 string) (string, error) {
 	start := time.Now()
-	result, err := t.inner.GetMergeBaseByRef(ref1, ref2)
+	result, err := t.inner.GetMergeBaseByRef(ctx, ref1, ref2)
 	t.trace("GetMergeBaseByRef", time.Since(start), err == nil, err, slog.String("ref1", ref1), slog.String("ref2", ref2))
 	return result, err
 }
 
-func (t *tracingRunner) IsAncestor(ancestor, descendant string) (bool, error) {
+func (t *tracingRunner) IsAncestor(ctx context.Context, ancestor, descendant string) (bool, error) {
 	start := time.Now()
-	result, err := t.inner.IsAncestor(ancestor, descendant)
+	result, err := t.inner.IsAncestor(ctx, ancestor, descendant)
 	t.trace("IsAncestor", time.Since(start), err == nil, err, slog.String("ancestor", ancestor), slog.String("descendant", descendant))
 	return result, err
 }

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -286,13 +286,17 @@ func (r *runner) WorktreeHasUncommittedChanges(ctx context.Context, worktreePath
 }
 
 // GetWorktreeCurrentBranch returns the name of the branch currently checked out in a worktree.
-// Returns empty string if the worktree is in detached HEAD state.
+// Returns empty string if the worktree is in detached HEAD state. Real failures
+// (worktree missing, repo corruption, context cancellation) are surfaced — git
+// uses exit code 1 specifically for "not a symbolic ref" when `-q` is passed,
+// reserving 128 (and others) for genuine errors.
 func (r *runner) GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error) {
-	out, err := r.RunGitCommandWithContext(ctx, "-C", worktreePath, "symbolic-ref", "--short", "HEAD")
+	out, err := r.RunGitCommandWithContext(ctx, "-C", worktreePath, "symbolic-ref", "-q", "--short", "HEAD")
 	if err != nil {
-		// Detached HEAD: symbolic-ref exits non-zero. Treat as empty rather
-		// than an error to match the prior behavior.
-		return "", nil //nolint:nilerr
+		if isExitCode(err, 1) {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to read HEAD of worktree %s: %w", worktreePath, err)
 	}
 	return strings.TrimSpace(out), nil
 }


### PR DESCRIPTION
This PR merges the following changes:

1. **#1033** docs(git): clarify ConfigStore.Get reads merged config scope
2. **#1034** fix(git): distinguish detached HEAD from real errors in GetWorktreeCurrentBranch
3. **#1035** fix(git): log debug breadcrumb when getRemote falls back to default
4. **#1036** refactor(git,engine): plumb context through batch blob writers
5. **#1037** refactor(git,engine): plumb context through read-path git operations

### Stack

```
main
  └─ jonnii/20260527125414/clarify-ConfigStore.Get-reads-merged-config-scope (#1033)
    └─ jonnii/20260527125518/distinguish-detached-HEAD-from-real-errors-in (#1034)
      └─ jonnii/20260527125602/log-debug-breadcrumb-when-getRemote-falls-back-to (#1035)
        └─ jonnii/20260527132010/plumb-context-through-batch-blob-writers (#1036)
          └─ jonnii/20260527135952/plumb-context-through-read-path-git-operations (#1037)
```

Stackit-Stack-Size: 5
Stackit-PRs: 1033,1034,1035,1036,1037
