### PR TITLE
refactor(engine): auto-rebuild after delete, auto-sync stack ID after reparent

### DIFF
--- a/internal/actions/fold/fold_keep.go
+++ b/internal/actions/fold/fold_keep.go
@@ -41,14 +41,10 @@ func foldWithKeep(gctx context.Context, ctx *app.Context, currentBranch, parentB
 		}
 	}
 
-	// Delete the parent branch (this will reparent current branch and siblings to grandparent)
+	// Delete the parent branch (engine reparents children to grandparent and
+	// rebuilds internally).
 	if err := eng.DeleteBranch(gctx, parentBranch); err != nil {
 		return fmt.Errorf("failed to delete parent branch: %w", err)
-	}
-
-	// Rebuild engine to reflect the deletion
-	if err := eng.Rebuild(eng.Trunk().GetName()); err != nil {
-		return fmt.Errorf("failed to rebuild engine: %w", err)
 	}
 
 	// The current branch absorbed the parent via merge, so it needs a fresh
@@ -64,14 +60,11 @@ func foldWithKeep(gctx context.Context, ctx *app.Context, currentBranch, parentB
 		}
 	}
 
-	// For each sibling, reparent to current branch (preserving divergence) and sync stack ID
+	// Reparent each sibling onto the current branch. Stack ID is propagated
+	// automatically by ReparentBranch.
 	for _, sibling := range siblings {
 		if err := eng.ReparentBranch(gctx, sibling, refreshedCurrent); err != nil {
 			return fmt.Errorf("failed to reparent %s to %s: %w", sibling.GetName(), currentBranch.GetName(), err)
-		}
-		// Sync stack ID to match the new parent's stack
-		if err := eng.SyncStackIDFromParent(gctx, sibling); err != nil {
-			splog.Debug("Failed to sync stack ID for %s: %v", sibling.GetName(), err)
 		}
 	}
 

--- a/internal/actions/fold/fold_normal.go
+++ b/internal/actions/fold/fold_normal.go
@@ -53,12 +53,8 @@ func foldNormal(gctx context.Context, ctx *app.Context, currentBranch, parentBra
 
 	// Restack all descendants of the parent
 	if len(descendants) > 0 {
-		// Rebuild engine to reflect the deletion
-		if err := eng.Rebuild(eng.Trunk().GetName()); err != nil {
-			return fmt.Errorf("failed to rebuild engine: %w", err)
-		}
-
-		// Rebuild graph with fresh engine state
+		// DeleteBranch rebuilds engine state internally; just refresh the graph
+		// snapshot (graphs are immutable copies of engine state at query time).
 		graph = eng.Graph(engine.SortStrategyAlphabetical)
 
 		// Get updated descendants list (current branch's children are now children of parent)

--- a/internal/engine/branch_mutations.go
+++ b/internal/engine/branch_mutations.go
@@ -120,13 +120,17 @@ func (e *engineImpl) DeleteBranch(ctx context.Context, branch Branch) error {
 
 	// Clean up in-memory cache for deleted branch
 	e.mu.Lock()
-	defer e.mu.Unlock()
-
 	e.state.removeBranch(branchName)
-
-	// Remove from branches list
 	if i := slices.Index(e.state.branches, branchName); i >= 0 {
 		e.state.setBranches(slices.Delete(e.state.branches, i, i+1))
+	}
+	e.mu.Unlock()
+
+	// Rebuild engine state from disk so callers don't need to track when to call
+	// eng.Rebuild() themselves. After this returns, GetBranch/GetParent/children
+	// reflect the post-deletion state across all cached relationships.
+	if err := e.rebuild(); err != nil {
+		return fmt.Errorf("deleted branch %s but failed to rebuild engine state: %w", branchName, err)
 	}
 
 	if reparentErr != nil {
@@ -246,6 +250,12 @@ func (e *engineImpl) DeleteBranches(ctx context.Context, branches Branches) ([]s
 	childrenToRestack := make([]string, 0, len(allSurvivingChildren))
 	for child := range allSurvivingChildren {
 		childrenToRestack = append(childrenToRestack, child)
+	}
+
+	// Rebuild engine state from disk so callers don't need to track when to
+	// call eng.Rebuild() themselves. One rebuild covers the entire batch.
+	if rebuildErr := e.rebuild(); rebuildErr != nil {
+		return childrenToRestack, fmt.Errorf("deleted branches but failed to rebuild engine state: %w", rebuildErr)
 	}
 
 	if reparentErr != nil {

--- a/internal/engine/branch_tracking.go
+++ b/internal/engine/branch_tracking.go
@@ -187,18 +187,29 @@ func (e *engineImpl) setParentPreservingDivergence(ctx context.Context, branch B
 // ReparentBranch changes a branch's parent while automatically preserving its
 // divergence point. This is the preferred way to reparent an existing branch
 // when the branch's own commits should not change.
+//
+// Automatically propagates the new parent's stack ID to the reparented branch
+// when the move crosses a stack boundary; same-stack reparenting is a no-op
+// for stack ID.
 func (e *engineImpl) ReparentBranch(ctx context.Context, branch Branch, newParent Branch) error {
 	div, err := e.GetDivergencePoint(branch.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to determine divergence point for %s: %w", branch.GetName(), err)
 	}
-	return e.setParentPreservingDivergence(ctx, branch, newParent, div)
+	if err := e.setParentPreservingDivergence(ctx, branch, newParent, div); err != nil {
+		return err
+	}
+	// Fetch the post-reparent branch so syncStackIDFromParent sees the new parent.
+	return e.syncStackIDFromParent(ctx, e.GetBranch(branch.GetName()))
 }
 
 // ReparentBranches changes multiple branches to the same new parent while
 // preserving each branch's divergence point. Divergence points are captured
 // for all branches before any reparenting begins, ensuring correctness when
 // branches in the list are related to each other.
+//
+// Automatically propagates the new parent's stack ID to each branch when the
+// move crosses a stack boundary.
 func (e *engineImpl) ReparentBranches(ctx context.Context, branchNames []string, newParent Branch) error {
 	divPoints := make(map[string]string, len(branchNames))
 	for _, name := range branchNames {
@@ -212,6 +223,9 @@ func (e *engineImpl) ReparentBranches(ctx context.Context, branchNames []string,
 	for _, name := range branchNames {
 		if err := e.setParentPreservingDivergence(ctx, e.GetBranch(name), newParent, divPoints[name]); err != nil {
 			return fmt.Errorf("failed to reparent %s to %s: %w", name, newParent.GetName(), err)
+		}
+		if err := e.syncStackIDFromParent(ctx, e.GetBranch(name)); err != nil {
+			return fmt.Errorf("failed to sync stack ID for %s: %w", name, err)
 		}
 	}
 	return nil

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -169,10 +169,6 @@ type BranchTracking interface {
 	CreateStackRef(stackID string, meta *git.StackMeta) error
 	// GetStackMeta returns the stack metadata for a stack ID.
 	GetStackMeta(stackID string) (*git.StackMeta, error)
-	// SyncStackIDFromParent updates a branch's stack ID to match its parent's.
-	// This should be called after reparenting operations to keep stack IDs consistent.
-	// Returns nil if the parent is trunk (keeps existing stack ID) or if no change is needed.
-	SyncStackIDFromParent(ctx context.Context, branch Branch) error
 }
 
 // BranchMutations handles branch lifecycle operations

--- a/internal/engine/stack_id.go
+++ b/internal/engine/stack_id.go
@@ -268,10 +268,15 @@ func (e *engineImpl) GetStackMeta(stackID string) (*git.StackMeta, error) {
 	return e.git.ReadStackMeta(stackID)
 }
 
-// SyncStackIDFromParent updates a branch's stack ID to match its parent's.
-// This should be called after reparenting operations to keep stack IDs consistent.
-// Returns nil if the parent is trunk (keeps existing stack ID) or if no change is needed.
-func (e *engineImpl) SyncStackIDFromParent(ctx context.Context, branch Branch) error {
+// syncStackIDFromParent updates a branch's stack ID to match its parent's and
+// propagates that stack ID to all descendants. Called automatically at the end
+// of ReparentBranch/ReparentBranches so callers don't need to remember; not
+// exported because external callers should reparent via ReparentBranch instead
+// of poking the stack ID directly.
+//
+// Returns nil if the parent is trunk (keeps existing stack ID), the parent has
+// no stack ID (legacy branch), or the branch is already in sync.
+func (e *engineImpl) syncStackIDFromParent(ctx context.Context, branch Branch) error {
 	parent := branch.GetParent()
 	if parent == nil {
 		// Parent is trunk - keep existing stack ID
@@ -290,7 +295,9 @@ func (e *engineImpl) SyncStackIDFromParent(ctx context.Context, branch Branch) e
 		return nil
 	}
 
-	return e.SetStackID(ctx, branch, parentStackID)
+	// Propagate to descendants so a cross-stack reparent moves the whole
+	// subtree under the new stack, not just the reparented branch.
+	return e.propagateStackID(ctx, branch.GetName(), parentStackID)
 }
 
 // GetStackIDsForBranches returns the unique stack IDs for the given branches.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Two contracts every caller had to remember are now enforced by the engine:

1. After DeleteBranch / DeleteBranches, engine state used to drift until the
   caller invoked eng.Rebuild(trunk). Now Delete{Branch,Branches} rebuild
   internally before returning.

2. After ReparentBranch / ReparentBranches across stacks, the reparented
   subtree carried its old stack ID until the caller called
   SyncStackIDFromParent. Of 15+ external ReparentBranch* call sites, exactly
   one (fold_keep) did this — every other cross-stack reparent silently kept
   the old stack ID. ReparentBranch* now propagates the new parent's stack ID
   to the branch AND all its descendants automatically.

The propagation reuses the existing propagateStackID helper, so the
move action's updateStackIDsAfterMove logic short-circuits on cross-stack
moves (descendants already updated) and remains the source of truth for
"move to trunk creates a new stack."

SyncStackIDFromParent is downgraded to a private syncStackIDFromParent and
removed from the BranchTracking interface — no external caller is left.

Callers updated:
- fold_keep.go: drop redundant Rebuild and SyncStackIDFromParent calls
- fold_normal.go: drop redundant Rebuild after DeleteBranch (graph still
  re-queried since graphs are immutable snapshots)

Phase 3 of the engine refactor runbook.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1779911059`.


* **PR #1039**
  * **PR #1040** 👈
    * **PR #1041**
      * **PR #1042**
        * **PR #1043**
          * **PR #1044**
            * **PR #1045**
              * **PR #1046**
                * **PR #1047**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->