### PR TITLE
refactor(engine): drop Options.Writer and best-effort metadata-cleanup warnings

### DIFF
--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -250,7 +250,6 @@ func CreateAction(ctx *app.Context, opts CreateOptions) (*CreateResult, error) {
 			Trunk:             mainCfg.Trunk(),
 			MaxUndoStackDepth: mainCfg.UndoStackDepth(),
 			Git:               mainGit,
-			Writer:            os.Stderr,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create engine for main repo: %w", err)

--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -373,7 +373,6 @@ func NewContextAutoWithWriter(ctx context.Context, repoRoot string, opts GlobalO
 		Trunk:             trunk,
 		MaxUndoStackDepth: maxUndoDepth,
 		MaxConcurrency:    maxConcurrency,
-		Writer:            writer,
 		Git:               gitRunner,
 		LoadMode:          loadMode,
 	})

--- a/internal/engine/branch_mutations.go
+++ b/internal/engine/branch_mutations.go
@@ -103,15 +103,11 @@ func (e *engineImpl) DeleteBranch(ctx context.Context, branch Branch) error {
 		}
 	}
 
-	// Delete metadata
-	if err := e.git.DeleteMetadata(ctx, branchName); err != nil {
-		_, _ = fmt.Fprintf(e.writer, "Warning: failed to delete metadata ref for %s: %v\n", branchName, err)
-	}
-
-	// Delete local metadata
-	if err := e.git.DeleteRef(ctx, fmt.Sprintf("%s%s", git.LocalMetadataRefPrefix, branchName)); err != nil {
-		_, _ = fmt.Fprintf(e.writer, "Warning: failed to delete local metadata ref for %s: %v\n", branchName, err)
-	}
+	// Best-effort metadata cleanup. The branch ref is already gone, so any
+	// remaining metadata refs are orphans that `sync` reconciles later — no
+	// user-actionable signal here.
+	_ = e.git.DeleteMetadata(ctx, branchName)
+	_ = e.git.DeleteRef(ctx, fmt.Sprintf("%s%s", git.LocalMetadataRefPrefix, branchName))
 
 	// Reparent children to grandparent, preserving divergence points so
 	// children don't carry the deleted branch's commits after restacking.
@@ -336,20 +332,15 @@ func (e *engineImpl) RenameBranch(ctx context.Context, oldBranch, newBranch Bran
 		return err
 	}
 
-	// Rename metadata ref
-	if err := e.git.RenameMetadata(oldName, newName); err != nil {
-		// Log but continue if metadata rename fails
-		_, _ = fmt.Fprintf(e.writer, "Warning: failed to rename metadata ref: %v\n", err)
-	}
+	// Best-effort metadata-ref rename. The branch rename already succeeded;
+	// orphaned refs are reconciled by `sync`.
+	_ = e.git.RenameMetadata(oldName, newName)
 
-	// Rename local metadata ref
 	oldLocalRef := fmt.Sprintf("%s%s", git.LocalMetadataRefPrefix, oldName)
 	newLocalRef := fmt.Sprintf("%s%s", git.LocalMetadataRefPrefix, newName)
 	if sha, err := e.git.GetRef(oldLocalRef); err == nil {
-		if err := e.git.UpdateRef(newLocalRef, sha); err != nil {
-			_, _ = fmt.Fprintf(e.writer, "Warning: failed to update new local metadata ref: %v\n", err)
-		} else if err := e.git.DeleteRef(ctx, oldLocalRef); err != nil {
-			_, _ = fmt.Fprintf(e.writer, "Warning: failed to delete old local metadata ref: %v\n", err)
+		if updateErr := e.git.UpdateRef(newLocalRef, sha); updateErr == nil {
+			_ = e.git.DeleteRef(ctx, oldLocalRef)
 		}
 	}
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -15,7 +15,6 @@ package engine
 
 import (
 	"context"
-	"io"
 
 	"github.com/getstackit/stackit/internal/git"
 )
@@ -150,10 +149,6 @@ type Options struct {
 
 	// Git is the git runner to use. If nil, a default real git runner is used.
 	Git git.Runner
-
-	// Writer is the output writer for warnings and informational messages.
-	// If nil, os.Stderr is used.
-	Writer io.Writer
 
 	// LoadMode controls how much metadata is read at construction time.
 	// Zero value (LoadModeFull) matches the pre-lite behavior — readers see

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -3,9 +3,7 @@ package engine
 import (
 	"context"
 	"fmt"
-	"io"
 	"maps"
-	"os"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -23,7 +21,6 @@ type engineImpl struct {
 	maxUndoStackDepth int
 	maxConcurrency    int
 	git               git.Runner
-	writer            io.Writer
 	mu                sync.RWMutex
 	worktreeMu        sync.Mutex // serializes worktree add/remove/prune to avoid git races on .git/worktrees/
 
@@ -114,9 +111,6 @@ type WorktreeEngineOptions struct {
 
 	// Snapshot is the parent engine's state snapshot.
 	Snapshot WorktreeSnapshot
-
-	// Writer is the output writer for warnings. If nil, os.Stderr is used.
-	Writer io.Writer
 }
 
 // NewEngineForWorktree creates an engine for a worktree session using a snapshot
@@ -127,11 +121,6 @@ func NewEngineForWorktree(opts WorktreeEngineOptions) (Engine, error) {
 
 	if err := g.InitDefaultRepo(); err != nil {
 		return nil, fmt.Errorf("failed to initialize worktree git repository: %w", err)
-	}
-
-	writer := opts.Writer
-	if writer == nil {
-		writer = os.Stderr
 	}
 
 	// Sort children for deterministic traversal (snapshot should already be sorted,
@@ -148,7 +137,6 @@ func NewEngineForWorktree(opts WorktreeEngineOptions) (Engine, error) {
 		maxUndoStackDepth: 0, // No undo in temporary worktrees
 		maxConcurrency:    opts.Snapshot.MaxConcurrency,
 		git:               g,
-		writer:            writer,
 	}
 
 	// Get current branch (1 cheap git call — needed for worktree's HEAD)
@@ -190,11 +178,6 @@ func NewEngine(opts Options) (Engine, error) {
 		maxDepth = DefaultMaxUndoStackDepth
 	}
 
-	writer := opts.Writer
-	if writer == nil {
-		writer = os.Stderr
-	}
-
 	e := &engineImpl{
 		repoRoot:          opts.RepoRoot,
 		trunk:             opts.Trunk,
@@ -203,7 +186,6 @@ func NewEngine(opts Options) (Engine, error) {
 		maxUndoStackDepth: maxDepth,
 		maxConcurrency:    opts.MaxConcurrency,
 		git:               g,
-		writer:            writer,
 	}
 
 	currentBranch, err := g.GetCurrentBranch()


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The Writer field on engine.Options (and engine.WorktreeEngineOptions) only
existed to surface 5 "Warning: failed to ..." messages from best-effort
metadata-ref cleanups in DeleteBranch and RenameBranch. Those warnings are
non-actionable — the main op already succeeded, and any orphaned refs are
reconciled by the next `sync` — so the engine had no business reaching for
an io.Writer at all.

Drops the field, the engineImpl.writer member, both NewEngine* constructor
shims, and the two adapter-layer sites that set it (app/context.go and
actions/worktree/actions.go). The 5 fmt.Fprintf sites become silent
underscore-discards; engine no longer imports io/os.

Phase 4 of the engine refactor runbook.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1039**
  * **PR #1040**
    * **PR #1041** 👈
      * **PR #1042**
        * **PR #1043**
          * **PR #1044**
            * **PR #1045**
              * **PR #1046**
                * **PR #1047**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1048 by jonnii*