### PR TITLE
refactor(engine): unify SetParent under explicit DivergenceMode

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -610,7 +610,7 @@ func applyReparent(ctx context.Context, eng engine.Engine, branch engine.Branch,
 	if opts.preserveDivergence {
 		return eng.ReparentBranch(ctx, branch, newParent)
 	}
-	return eng.SetParent(ctx, branch, newParent)
+	return eng.SetParent(ctx, branch, newParent, engine.DivergenceRecompute)
 }
 
 // removeWorktreeIfCheckedOut removes the worktree if the branch is checked out in one.

--- a/internal/actions/fold/fold_keep.go
+++ b/internal/actions/fold/fold_keep.go
@@ -49,13 +49,11 @@ func foldWithKeep(gctx context.Context, ctx *app.Context, currentBranch, parentB
 
 	// The current branch absorbed the parent via merge, so it needs a fresh
 	// merge-base calculation against the grandparent (now its parent).
-	// DeleteBranch preserved the old divergence point, which would cause
-	// restack to drop the merged commits. Using SetParent (not
-	// SetParentPreservingDivergence) is intentional here — we want the
-	// merge-base recalculation to include the absorbed commits.
+	// DeleteBranch preserved the old divergence point, which would drop the
+	// merged commits at restack; DivergenceRecompute pulls them back in.
 	refreshedCurrent := eng.GetBranch(currentBranch.GetName())
 	if grandparent := refreshedCurrent.GetParent(); grandparent != nil {
-		if err := eng.SetParent(gctx, refreshedCurrent, *grandparent); err != nil {
+		if err := eng.SetParent(gctx, refreshedCurrent, *grandparent, engine.DivergenceRecompute); err != nil {
 			return fmt.Errorf("failed to reset divergence for %s: %w", currentBranch.GetName(), err)
 		}
 	}

--- a/internal/actions/merge/execute_steps.go
+++ b/internal/actions/merge/execute_steps.go
@@ -137,7 +137,7 @@ func executeUpdatePRBase(ctx *app.Context, eng mergeExecuteEngine, step PlanStep
 	}
 
 	// Update parent to trunk
-	if err := eng.SetParent(ctx.Context, eng.GetBranch(step.BranchName), eng.GetBranch(trunkName)); err != nil {
+	if err := eng.SetParent(ctx.Context, eng.GetBranch(step.BranchName), eng.GetBranch(trunkName), engine.DivergenceRecompute); err != nil {
 		return fmt.Errorf("failed to update parent: %w", err)
 	}
 

--- a/internal/actions/split/split_file.go
+++ b/internal/actions/split/split_file.go
@@ -321,7 +321,7 @@ func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []s
 	}
 
 	// Update branchToSplit to have newBranch as its parent
-	if err := eng.SetParent(ctx, branchToSplit, newBranch); err != nil {
+	if err := eng.SetParent(ctx, branchToSplit, newBranch, engine.DivergenceRecompute); err != nil {
 		return nil, recoverWithRef(fmt.Errorf("failed to update parent of %s: %w", branchToSplit.GetName(), err))
 	}
 

--- a/internal/actions/split/split_hunk.go
+++ b/internal/actions/split/split_hunk.go
@@ -485,7 +485,7 @@ func splitByHunkBelowWithPatch(ctx *app.Context, branchToSplit engine.Branch, en
 	}
 
 	// Update branchToSplit to have newParentBranch as its parent
-	if err := eng.SetParent(gitCtx, branchToSplit, newParentBranch); err != nil {
+	if err := eng.SetParent(gitCtx, branchToSplit, newParentBranch, engine.DivergenceRecompute); err != nil {
 		return fmt.Errorf("failed to update parent of %s: %w", branchToSplit.GetName(), err)
 	}
 

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -237,7 +237,7 @@ func TestActionWithMockedGitHub(t *testing.T) {
 		require.NoError(t, err)
 
 		// Update parent relationship: B's parent is now A
-		err = s.Engine.SetParent(context.Background(), s.Engine.GetBranch("B"), s.Engine.GetBranch("A"))
+		err = s.Engine.SetParent(context.Background(), s.Engine.GetBranch("B"), s.Engine.GetBranch("A"), engine.DivergenceRecompute)
 		require.NoError(t, err)
 
 		// Verify that B and A have the same SHA (no commits between them)

--- a/internal/actions/undo/undo_test.go
+++ b/internal/actions/undo/undo_test.go
@@ -211,7 +211,7 @@ func TestUndoAfterMove(t *testing.T) {
 		require.NoError(t, err)
 
 		// Move feature2 to main
-		err = s.Engine.SetParent(s.Context, s.Engine.GetBranch("feature2"), s.Engine.GetBranch("main"))
+		err = s.Engine.SetParent(s.Context, s.Engine.GetBranch("feature2"), s.Engine.GetBranch("main"), engine.DivergenceRecompute)
 		require.NoError(t, err)
 
 		// Verify parent changed

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -98,7 +98,7 @@ func restoreAnchorBranch(ctx *app.Context, snapshot *worktreeSnapshot) error {
 		return fmt.Errorf("failed to recreate anchor branch %s: %w", anchorName, err)
 	}
 	anchorBranch := ctx.Engine.GetBranch(anchorName)
-	if err := ctx.Engine.SetParent(ctx.Context, anchorBranch, ctx.Engine.GetBranch(snapshot.AnchorParent)); err != nil {
+	if err := ctx.Engine.SetParent(ctx.Context, anchorBranch, ctx.Engine.GetBranch(snapshot.AnchorParent), engine.DivergenceRecompute); err != nil {
 		return fmt.Errorf("failed to restore anchor parent for %s: %w", anchorName, err)
 	}
 	if err := ctx.Engine.SetBranchType(anchorBranch, git.BranchTypeWorktreeAnchor); err != nil {
@@ -424,7 +424,7 @@ func createAnchoredWorktree(ctx *app.Context, eng engine.Engine, repoRoot string
 		}
 	}
 
-	if err := eng.SetParent(ctx.Context, anchorBranch, parentBranch); err != nil {
+	if err := eng.SetParent(ctx.Context, anchorBranch, parentBranch, engine.DivergenceRecompute); err != nil {
 		cleanup()
 		return nil, fmt.Errorf("failed to set parent: %w", err)
 	}

--- a/internal/actions/worktree/repair.go
+++ b/internal/actions/worktree/repair.go
@@ -197,7 +197,7 @@ func convertLegacyRegistration(ctx *app.Context, wtInfo engine.WorktreeInfo, roo
 		}
 	}
 
-	if err := ctx.Engine.SetParent(ctx.Context, anchorBranch, parentBranch); err != nil {
+	if err := ctx.Engine.SetParent(ctx.Context, anchorBranch, parentBranch, engine.DivergenceRecompute); err != nil {
 		cleanup()
 		return "", fmt.Errorf("failed to set parent on anchor branch %s: %w", style.ColorBranchName(anchorBranchName, false), err)
 	}

--- a/internal/engine/branch_tracking.go
+++ b/internal/engine/branch_tracking.go
@@ -61,8 +61,9 @@ func (e *engineImpl) TrackBranch(ctx context.Context, branchName string, parentB
 	}
 	e.mu.Unlock()
 
-	// SetParent handles its own transaction and locking
-	return e.SetParent(ctx, e.GetBranch(branchName), e.GetBranch(parentBranchName))
+	// New branches start without prior divergence metadata, so recompute the
+	// merge-base from scratch.
+	return e.SetParent(ctx, e.GetBranch(branchName), e.GetBranch(parentBranchName), DivergenceRecompute)
 }
 
 // UntrackBranch stops tracking a branch by deleting its metadata
@@ -76,15 +77,55 @@ func (e *engineImpl) UntrackBranch(ctx context.Context, branchName string) error
 	return e.rebuild()
 }
 
-// SetParent updates a branch's parent using transaction API with retry logic
-// for concurrent modification resilience.
-func (e *engineImpl) SetParent(ctx context.Context, branch Branch, parentBranch Branch) error {
+// DivergenceMode controls how SetParent updates a branch's recorded divergence
+// point (ParentBranchRevision) when its parent changes.
+type DivergenceMode int
+
+const (
+	// DivergencePreserve keeps the existing divergence point if it's still a
+	// valid ancestor of the branch. Use when the branch's own commits should
+	// not change — e.g., reparenting a branch onto a sibling stack.
+	DivergencePreserve DivergenceMode = iota
+
+	// DivergenceRecompute computes a fresh merge-base against the new parent
+	// (with a minor exception: if the old parent was merged into the new
+	// parent, the existing revision is retained as a stable anchor). Use when
+	// the branch has absorbed commits from a former parent (e.g. after a
+	// fold/merge), so that subsequent restacks include those commits.
+	DivergenceRecompute
+)
+
+// SetParent updates a branch's parent. The mode controls whether the existing
+// divergence point is preserved or recomputed; see DivergenceMode for the
+// trade-off. Retries on concurrent modification.
+func (e *engineImpl) SetParent(ctx context.Context, branch Branch, parentBranch Branch, mode DivergenceMode) error {
 	branchName := branch.GetName()
 	parentBranchName := parentBranch.GetName()
 
 	if branchName == parentBranchName {
 		return fmt.Errorf("branch %s cannot be its own parent", branchName)
 	}
+
+	switch mode {
+	case DivergencePreserve:
+		div, err := e.GetDivergencePoint(branchName)
+		if err != nil {
+			return fmt.Errorf("failed to determine divergence point for %s: %w", branchName, err)
+		}
+		return e.setParentPreservingDivergence(ctx, branch, parentBranch, div)
+	case DivergenceRecompute:
+		return e.setParentRecomputingDivergence(ctx, branch, parentBranch)
+	default:
+		return fmt.Errorf("unknown DivergenceMode: %d", mode)
+	}
+}
+
+// setParentRecomputingDivergence updates a branch's parent and refreshes the
+// divergence point by computing a new merge-base. Retries on concurrent
+// modification.
+func (e *engineImpl) setParentRecomputingDivergence(ctx context.Context, branch Branch, parentBranch Branch) error {
+	branchName := branch.GetName()
+	parentBranchName := parentBranch.GetName()
 
 	return e.WithRetry(ctx, func() error {
 		// Get new parent revision (may run multiple times on retry)

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -131,7 +131,7 @@ func TestSetParent(t *testing.T) {
 		require.Equal(t, "branch1", parent2.GetName())
 
 		// Change parent of branch2 to main
-		err = s.Engine.SetParent(context.Background(), s.Engine.GetBranch("branch2"), s.Engine.GetBranch("main"))
+		err = s.Engine.SetParent(context.Background(), s.Engine.GetBranch("branch2"), s.Engine.GetBranch("main"), engine.DivergenceRecompute)
 		require.NoError(t, err)
 
 		// Verify new parent
@@ -1367,7 +1367,7 @@ func TestSetParentScenarios(t *testing.T) {
 		s.RunGit("merge", "branch1", "--no-ff", "-m", "Merge branch1")
 
 		// 6. Reparent branch2 to main (what happens during 'stackit merge' or 'stackit sync')
-		err := s.Engine.SetParent(context.Background(), s.Engine.GetBranch("branch2"), s.Engine.GetBranch("main"))
+		err := s.Engine.SetParent(context.Background(), s.Engine.GetBranch("branch2"), s.Engine.GetBranch("main"), engine.DivergenceRecompute)
 		require.NoError(t, err)
 
 		// VERIFY: ParentBranchRevision should still be branch1OriginalSHA
@@ -1395,7 +1395,7 @@ func TestSetParentScenarios(t *testing.T) {
 		s.RunGit("merge", "branch1", "--no-ff", "-m", "Merge branch1 into branch2")
 
 		// 3. Reparent branch2 to main (branch1 will be deleted in a real fold)
-		err := s.Engine.SetParent(context.Background(), s.Engine.GetBranch("branch2"), s.Engine.GetBranch("main"))
+		err := s.Engine.SetParent(context.Background(), s.Engine.GetBranch("branch2"), s.Engine.GetBranch("main"), engine.DivergenceRecompute)
 		require.NoError(t, err)
 
 		// VERIFY: ParentBranchRevision should be updated to main's tip
@@ -1428,7 +1428,7 @@ func TestSetParentScenarios(t *testing.T) {
 		s.RunGit("rebase", "main")
 
 		// 3. Call SetParent with the same parent (main)
-		err := s.Engine.SetParent(context.Background(), s.Engine.GetBranch("branch1"), s.Engine.GetBranch("main"))
+		err := s.Engine.SetParent(context.Background(), s.Engine.GetBranch("branch1"), s.Engine.GetBranch("main"), engine.DivergenceRecompute)
 		require.NoError(t, err)
 
 		// VERIFY: ParentBranchRevision should be updated to mainNewSHA

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -309,13 +309,13 @@ func (e *engineImpl) restackBranch(
 		newParent := e.findNearestValidAncestor(ctx, branchName, metaMap)
 		e.mu.RUnlock()
 
-		// Reparent to the nearest valid ancestor. Using SetParent (not
-		// SetParentPreservingDivergence) is intentional here: the old parent
-		// was merged/deleted, so SetParent's shouldUpdateRevision logic
-		// correctly preserves the existing divergence point when the old
-		// parent was merged into the new parent. The subsequent restack then
-		// rebases the branch's own commits onto the new parent.
-		if err := e.SetParent(ctx, e.GetBranch(branchName), e.GetBranch(newParent)); err != nil {
+		// Reparent to the nearest valid ancestor. DivergenceRecompute is
+		// intentional: the old parent was merged/deleted, so SetParent's
+		// shouldUpdateRevision logic correctly preserves the existing
+		// divergence point when the old parent was merged into the new parent.
+		// The subsequent restack then rebases the branch's own commits onto
+		// the new parent.
+		if err := e.SetParent(ctx, e.GetBranch(branchName), e.GetBranch(newParent), DivergenceRecompute); err != nil {
 			return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to reparent %s to %s: %w", branchName, newParent, err)
 		}
 		parent = newParent

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -124,7 +124,7 @@ type BranchReader interface {
 type BranchTracking interface {
 	TrackBranch(ctx context.Context, branchName string, parentBranchName string) error
 	UntrackBranch(ctx context.Context, branchName string) error
-	SetParent(ctx context.Context, branch Branch, parentBranch Branch) error
+	SetParent(ctx context.Context, branch Branch, parentBranch Branch, mode DivergenceMode) error
 	// ReparentBranch changes a branch's parent while automatically preserving
 	// its divergence point. Preferred over SetParent for existing branches.
 	ReparentBranch(ctx context.Context, branch Branch, newParent Branch) error

--- a/internal/engine/undo_test.go
+++ b/internal/engine/undo_test.go
@@ -292,7 +292,7 @@ func TestRestoreSnapshot(t *testing.T) {
 		require.NoError(t, err)
 
 		// Modify metadata by changing parent
-		err = s.Engine.SetParent(context.Background(), s.Engine.GetBranch("feature"), s.Engine.GetBranch("main"))
+		err = s.Engine.SetParent(context.Background(), s.Engine.GetBranch("feature"), s.Engine.GetBranch("main"), engine.DivergenceRecompute)
 		require.NoError(t, err)
 
 		// Restore snapshot


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Previously, callers had to pick between two methods to express divergence
intent — SetParent (recompute merge-base) and SetParentPreservingDivergence
(keep existing div point). The choice was load-bearing but invisible at the
call site, requiring multi-line comments to explain (see the original
fold_keep.go note about "SetParent (not SetParentPreservingDivergence) is
intentional here").

Replace with a single SetParent(ctx, branch, parent, mode) that takes a
typed DivergenceMode (DivergencePreserve | DivergenceRecompute). The enum
value documents the intent at the call site; the explanatory comments shrink
from a paragraph to a line.

The body dispatches to two internal helpers that already existed
(setParentPreservingDivergence, and the recompute logic split out as
setParentRecomputingDivergence). ReparentBranch/ReparentBranches still wrap
the preserve path with stack-ID propagation, so most callers stay unchanged
— only direct SetParent users move to the new signature.

All 15 existing SetParent call sites map to DivergenceRecompute (preserving
prior behavior); none of them had bugs that would be uncovered by
introspection — this is purely a documentation/clarity win.

Phase 5 of the engine refactor runbook.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1779911059`.


* **PR #1039**
  * **PR #1040**
    * **PR #1041**
      * **PR #1042** 👈
        * **PR #1043**
          * **PR #1044**
            * **PR #1045**
              * **PR #1046**
                * **PR #1047**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->