### PR TITLE
refactor(engine): drop redundant lowercase getter wrappers

### DIFF
--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -152,11 +152,6 @@ func (e *engineImpl) GetExplicitScope(branch Branch) Scope {
 	return Empty()
 }
 
-// getExplicitScope is an internal method for Branch type
-func (e *engineImpl) getExplicitScope(branch Branch) Scope {
-	return e.GetExplicitScope(branch)
-}
-
 // IsUpToDate checks if a branch is up to date with its parent
 // A branch is up to date if its parent revision matches the stored parent revision
 func (e *engineImpl) IsUpToDate(branch Branch) bool {

--- a/internal/engine/engine_pr.go
+++ b/internal/engine/engine_pr.go
@@ -42,11 +42,6 @@ func NewPrInfoFromMeta(meta *git.Meta) *PrInfo {
 	)
 }
 
-// getPrInfo is an internal method for Branch type
-func (e *engineImpl) getPrInfo(branch Branch) (*PrInfo, error) {
-	return e.GetPrInfo(branch)
-}
-
 // GetMergedDownstack returns the merged downstack history for a branch
 func (e *engineImpl) GetMergedDownstack(branch Branch) []git.MergedParent {
 	meta, err := e.readMetadata(branch.GetName())
@@ -54,11 +49,6 @@ func (e *engineImpl) GetMergedDownstack(branch Branch) []git.MergedParent {
 		return nil
 	}
 	return meta.GetMergedDownstack()
-}
-
-// getMergedDownstack is an internal method for Branch type
-func (e *engineImpl) getMergedDownstack(branch Branch) []git.MergedParent {
-	return e.GetMergedDownstack(branch)
 }
 
 // UpsertPrInfo updates or creates PR information for a branch with retry logic
@@ -192,11 +182,6 @@ func (e *engineImpl) GetPRSubmissionStatus(branch Branch) (PRSubmissionStatus, e
 		PRNumber:    prInfo.Number(),
 		PRInfo:      prInfo,
 	}, nil
-}
-
-// getPRSubmissionStatus is an internal method for Branch type
-func (e *engineImpl) getPRSubmissionStatus(branch Branch) (PRSubmissionStatus, error) {
-	return e.GetPRSubmissionStatus(branch)
 }
 
 // prTitleNeedsUpdate checks if the PR title needs to be updated due to scope changes

--- a/internal/engine/engine_reader.go
+++ b/internal/engine/engine_reader.go
@@ -98,11 +98,6 @@ func (e *engineImpl) GetParent(branch Branch) *Branch {
 	return nil
 }
 
-// getParent is an internal method for Branch type
-func (e *engineImpl) getParent(branch Branch) *Branch {
-	return e.GetParent(branch) // Delegate to existing implementation for now
-}
-
 // FindMostRecentTrackedAncestors finds the most recent tracked ancestors of a branch
 // by checking the branch's commit history against tracked branch tips.
 // Returns a slice of branch names that point to the most recent tracked commit in history.

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -237,12 +237,13 @@ type Branch struct {
 
 type branchReader interface {
 	BranchReader
+	// Branch-internal accessors. These complement the public BranchReader
+	// methods that operate on branch names with versions that take a Branch
+	// value, used by Branch's own getters. Engine is the only implementor.
 	GetParent(branch Branch) *Branch
-	getParent(branch Branch) *Branch
-	getPrInfo(branch Branch) (*PrInfo, error)
-	getMergedDownstack(branch Branch) []git.MergedParent
-	getExplicitScope(branch Branch) Scope
-	getPRSubmissionStatus(branch Branch) (PRSubmissionStatus, error)
+	GetMergedDownstack(branch Branch) []git.MergedParent
+	GetExplicitScope(branch Branch) Scope
+	GetPRSubmissionStatus(branch Branch) (PRSubmissionStatus, error)
 }
 
 // NewBranch creates a new immutable Branch
@@ -334,12 +335,12 @@ func (b Branch) GetAllCommits(format CommitFormat) ([]string, error) {
 
 // GetParent returns the parent branch (nil if no parent)
 func (b Branch) GetParent() *Branch {
-	return b.reader.getParent(b)
+	return b.reader.GetParent(b)
 }
 
 // GetPrInfo returns PR information for this branch
 func (b Branch) GetPrInfo() (*PrInfo, error) {
-	return b.reader.getPrInfo(b)
+	return b.reader.GetPrInfo(b)
 }
 
 // HasPR reports whether this branch has a submitted PR number recorded.
@@ -350,12 +351,12 @@ func (b Branch) HasPR() bool {
 
 // GetMergedDownstack returns the merged downstack history for this branch
 func (b Branch) GetMergedDownstack() []git.MergedParent {
-	return b.reader.getMergedDownstack(b)
+	return b.reader.GetMergedDownstack(b)
 }
 
 // GetExplicitScope returns the explicit scope set for this branch (no inheritance)
 func (b Branch) GetExplicitScope() Scope {
-	return b.reader.getExplicitScope(b)
+	return b.reader.GetExplicitScope(b)
 }
 
 // IsLocked checks if the branch is locked for modifications
@@ -414,7 +415,7 @@ func (b Branch) EnsureCanModify() error {
 
 // GetPRSubmissionStatus returns the PR submission status for this branch
 func (b Branch) GetPRSubmissionStatus() (PRSubmissionStatus, error) {
-	return b.reader.getPRSubmissionStatus(b)
+	return b.reader.GetPRSubmissionStatus(b)
 }
 
 // DefaultPRTitle returns the default PR title for this branch.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The Branch type uses an internal branchReader interface to call back into
engine. That interface previously declared both Get* and get* versions of
five accessors (getParent, getPrInfo, getMergedDownstack, getExplicitScope,
getPRSubmissionStatus), with the lowercase ones implemented as trivial
pass-throughs:

  func (e *engineImpl) getParent(branch Branch) *Branch {
      return e.GetParent(branch)
  }

Nothing distinguishes them — same lock semantics, same return type. The
duplication was historical drift, not a deliberate locking convention.

Drop the five wrapper methods, drop their declarations from branchReader,
and have Branch's getters call the capital versions directly. Net: ~25
lines deleted, identical behavior, no more "why are there two of these"
question for future readers.

Phase 6 of the engine refactor runbook.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1039**
  * **PR #1040**
    * **PR #1041**
      * **PR #1042**
        * **PR #1043** 👈
          * **PR #1044**
            * **PR #1045**
              * **PR #1046**
                * **PR #1047**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1048 by jonnii*