### PR TITLE
refactor(engine): push metadata-ref transport down into engine

### DIFF
--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -312,11 +312,11 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	}
 
 	// Fetch and apply remote metadata for all branches in the stack
-	if err := eng.Git().FetchMetadataRefs(ctx.Context); err != nil {
+	if err := eng.FetchRemoteMetadata(ctx.Context); err != nil {
 		out.Debug("No remote metadata to fetch: %v", err)
 	} else {
 		// Configure refspec so future git fetch commands also fetch metadata
-		if err := eng.Git().EnsureMetadataRefspecConfigured(); err != nil {
+		if err := eng.ConfigureRemoteMetadataSync(ctx.Context); err != nil {
 			out.Debug("Failed to configure metadata refspec: %v", err)
 		}
 		if err := eng.LoadRemoteMetadataCache(); err != nil {

--- a/internal/actions/info.go
+++ b/internal/actions/info.go
@@ -82,7 +82,7 @@ func InfoAction(ctx *app.Context, opts InfoOptions) error {
 		}
 
 		// For remote branches, fetch metadata to show the latest info
-		if err := eng.Git().FetchMetadataRefs(ctx.Context); err != nil {
+		if err := eng.FetchRemoteMetadata(ctx.Context); err != nil {
 			out.Debug("Failed to fetch remote metadata: %v", err)
 		} else {
 			if err := eng.LoadRemoteMetadataCache(); err != nil {

--- a/internal/actions/pr_updates.go
+++ b/internal/actions/pr_updates.go
@@ -222,19 +222,19 @@ func PushMetadataAndSyncPRs(ctx *app.Context, branchNames []string) error {
 
 	// Check if remote sync is enabled; if not, run compatibility test first
 	if !eng.IsRemoteSyncEnabled() {
-		if err := eng.Git().TestRemoteRefCompatibility(ctx.Context); err != nil {
+		if err := eng.TestRemoteMetadataCompatibility(ctx.Context); err != nil {
 			out.Debug("Remote metadata sync not supported: %v", err)
 			return nil // Non-fatal
 		}
 		eng.SetRemoteSyncEnabled(true)
 		// Configure refspec so future git fetch commands also fetch metadata
-		if err := eng.Git().EnsureMetadataRefspecConfigured(); err != nil {
+		if err := eng.ConfigureRemoteMetadataSync(ctx.Context); err != nil {
 			out.Debug("Failed to configure metadata refspec: %v", err)
 		}
 	}
 
 	// Push metadata refs
-	if err := eng.Git().PushMetadataRefs(ctx.Context, branchNames); err != nil {
+	if err := eng.PushMetadataForBranches(ctx.Context, branchNames); err != nil {
 		out.Debug("Failed to push metadata refs: %v", err)
 		return err
 	}

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -635,18 +635,18 @@ func pushMetadataRefs(ctx *app.Context, branches engine.Branches) error {
 
 	// Check if remote sync is enabled; if not, run compatibility test first
 	if !rm.IsRemoteSyncEnabled() {
-		if err := ctx.Git().TestRemoteRefCompatibility(ctx.Context); err != nil {
+		if err := rm.TestRemoteMetadataCompatibility(ctx.Context); err != nil {
 			return fmt.Errorf("remote does not support metadata refs (GitHub compatibility check failed): %w", err)
 		}
 		rm.SetRemoteSyncEnabled(true)
 		// Configure refspec so future git fetch commands also fetch metadata
-		if err := ctx.Git().EnsureMetadataRefspecConfigured(); err != nil {
+		if err := rm.ConfigureRemoteMetadataSync(ctx.Context); err != nil {
 			ctx.Output.Debug("Failed to configure metadata refspec: %v", err)
 		}
 	}
 
 	// Push metadata refs
-	if err := ctx.Git().PushMetadataRefs(ctx.Context, branchNames); err != nil {
+	if err := rm.PushMetadataForBranches(ctx.Context, branchNames); err != nil {
 		// Check if this looks like a race condition (concurrent push)
 		if isRaceConditionError(err) {
 			return fmt.Errorf("metadata push rejected due to concurrent changes by another user. Run 'st sync' to pull the latest metadata, then retry: %w", err)

--- a/internal/actions/sync/metadata_sync.go
+++ b/internal/actions/sync/metadata_sync.go
@@ -41,7 +41,7 @@ func processRemoteMetadata(ctx *app.Context, opts *Options, handler Handler) err
 		out.Debug("Failed to configure metadata refspec: %v", err)
 	}
 	// Also configure stack metadata refspec
-	if err := ctx.Git().EnsureStackMetaRefspecConfigured(); err != nil {
+	if err := eng.ConfigureStackMetadataSync(ctx.Context); err != nil {
 		out.Debug("Failed to configure stack metadata refspec: %v", err)
 	}
 	ctx.Logger.Info("configure remote metadata sync completed durationMs=%d", time.Since(configStart).Milliseconds())

--- a/internal/actions/sync/stack_metadata_gc.go
+++ b/internal/actions/sync/stack_metadata_gc.go
@@ -22,7 +22,7 @@ func gcOrphanedStackMetadata(ctx *app.Context) *StackMetadataGCResult {
 	}
 
 	// 1. Get all local stack metadata refs (returns map[stackID]sha)
-	allStackRefs, err := ctx.Git().ListStackMetas()
+	allStackRefs, err := ctx.Engine.ListStackMetadata()
 	if err != nil {
 		ctx.Logger.Debug("failed to list stack metadata refs error=%v", err)
 		return result
@@ -67,7 +67,7 @@ func gcOrphanedStackMetadata(ctx *app.Context) *StackMetadataGCResult {
 	if err := ctx.Git().DeleteRefsBatch(ctx.Context, refs); err != nil {
 		ctx.Logger.Debug("batch delete of local stack refs failed, falling back per-ref error=%v", err)
 		for _, stackID := range orphaned {
-			if perRefErr := ctx.Git().DeleteStackMeta(ctx.Context, stackID); perRefErr != nil {
+			if perRefErr := ctx.Engine.DeleteStackMetadata(ctx.Context, stackID); perRefErr != nil {
 				result.Errors = append(result.Errors, "failed to delete local stack ref "+stackID+": "+perRefErr.Error())
 				ctx.Logger.Debug("failed to delete local stack ref stackID=%v error=%v", stackID, perRefErr)
 			} else {
@@ -80,7 +80,7 @@ func gcOrphanedStackMetadata(ctx *app.Context) *StackMetadataGCResult {
 
 	// 5. Delete remote refs (best-effort, non-fatal)
 	if len(result.DeletedStackIDs) > 0 {
-		if err := ctx.Git().DeleteRemoteStackMetaRefs(ctx.Context, result.DeletedStackIDs); err != nil {
+		if err := ctx.Engine.DeleteRemoteStackMetadata(ctx.Context, result.DeletedStackIDs); err != nil {
 			// This is expected to fail if refs don't exist on remote, so just log it
 			ctx.Logger.Debug("failed to delete remote stack refs (may not exist) error=%v", err)
 		}

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -119,7 +119,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 		// Also fetch stack metadata refs (stack-level descriptions, etc.)
 		stackFetchStart := time.Now()
-		if err := ctx.Git().FetchStackMetaRefs(gctx); err != nil {
+		if err := ctx.Engine.FetchStackMetadata(gctx); err != nil {
 			ctx.Logger.Debug("fetch stack metadata refs failed (non-fatal) error=%v", err)
 		}
 		ctx.Logger.Info("fetch stack metadata refs completed durationMs=%v", time.Since(stackFetchStart).Milliseconds())

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -89,6 +89,23 @@ type RemoteMetadataManager interface {
 	DeleteMetadata(ctx context.Context, branchName string) error
 	FetchRemoteMetadata(ctx context.Context) error
 	ConfigureRemoteMetadataSync(ctx context.Context) error
+	// TestRemoteMetadataCompatibility probes the configured remote to verify it
+	// accepts the metadata-ref namespace. Adapter code should call this instead
+	// of reaching to the git runner directly.
+	TestRemoteMetadataCompatibility(ctx context.Context) error
+	// PushMetadataForBranches pushes the metadata refs for the given branch
+	// names to origin.
+	PushMetadataForBranches(ctx context.Context, branchNames []string) error
+	// ConfigureStackMetadataSync adds the stack-metadata refspec to origin.
+	ConfigureStackMetadataSync(ctx context.Context) error
+	// FetchStackMetadata fetches stack-metadata refs from origin.
+	FetchStackMetadata(ctx context.Context) error
+	// ListStackMetadata returns a map of local stack IDs to their ref SHAs.
+	ListStackMetadata() (map[string]string, error)
+	// DeleteStackMetadata removes a single local stack-metadata ref.
+	DeleteStackMetadata(ctx context.Context, stackID string) error
+	// DeleteRemoteStackMetadata pushes ref-deletions for the given stack IDs.
+	DeleteRemoteStackMetadata(ctx context.Context, stackIDs []string) error
 	// GetStackIDsForBranches returns the unique stack IDs for the given branches.
 	// This is used to determine which stack refs need to be pushed to remote.
 	GetStackIDsForBranches(branches Branches) []string

--- a/internal/engine/metadata_transport.go
+++ b/internal/engine/metadata_transport.go
@@ -1,0 +1,51 @@
+package engine
+
+import "context"
+
+// Metadata transport methods. Engine owns the metadata-ref namespace
+// (refs/stackit/metadata/* and refs/stackit/stacks/*) and is the single point
+// where adapter code should reach to push, fetch, or test remote support — no
+// adapter should be calling git.Runner directly for these.
+
+// TestRemoteMetadataCompatibility probes the configured remote to verify that
+// it accepts the metadata-ref namespace. Returns nil on success.
+func (e *engineImpl) TestRemoteMetadataCompatibility(ctx context.Context) error {
+	return e.git.TestRemoteRefCompatibility(ctx)
+}
+
+// PushMetadataForBranches pushes metadata refs for the given branch names to
+// origin. A no-op when the list is empty.
+func (e *engineImpl) PushMetadataForBranches(ctx context.Context, branchNames []string) error {
+	return e.git.PushMetadataRefs(ctx, branchNames)
+}
+
+// ConfigureStackMetadataSync adds the stack-metadata refspec to origin so
+// subsequent `git fetch origin` invocations pick up stack-ref changes.
+func (e *engineImpl) ConfigureStackMetadataSync(_ context.Context) error {
+	return e.git.EnsureStackMetaRefspecConfigured()
+}
+
+// FetchStackMetadata fetches stack-metadata refs from origin into the
+// remote-stacks namespace.
+func (e *engineImpl) FetchStackMetadata(ctx context.Context) error {
+	return e.git.FetchStackMetaRefs(ctx)
+}
+
+// ListStackMetadata returns a map of local stack IDs to their ref SHAs. Used
+// by stack-metadata GC during sync.
+func (e *engineImpl) ListStackMetadata() (map[string]string, error) {
+	return e.git.ListStackMetas()
+}
+
+// DeleteStackMetadata removes a single local stack-metadata ref. Used as the
+// per-ref fallback in the GC path when the batched ref-update fails.
+func (e *engineImpl) DeleteStackMetadata(ctx context.Context, stackID string) error {
+	return e.git.DeleteStackMeta(ctx, stackID)
+}
+
+// DeleteRemoteStackMetadata pushes ref-deletions for the given stack IDs to
+// origin. Best-effort: callers typically treat failure as non-fatal because the
+// remote refs may already be absent.
+func (e *engineImpl) DeleteRemoteStackMetadata(ctx context.Context, stackIDs []string) error {
+	return e.git.DeleteRemoteStackMetaRefs(ctx, stackIDs)
+}

--- a/internal/engine/remote_sync.go
+++ b/internal/engine/remote_sync.go
@@ -488,13 +488,14 @@ func (e *engineImpl) DeleteMetadata(ctx context.Context, branchName string) erro
 	})
 }
 
-// FetchRemoteMetadata fetches metadata refs from origin
+// FetchRemoteMetadata fetches metadata refs from origin into the remote-metadata
+// namespace, so the cache loader sees the latest authored values.
 func (e *engineImpl) FetchRemoteMetadata(ctx context.Context) error {
-	_, err := e.git.RunGitCommandWithContext(ctx, "fetch", "origin", "+refs/stackit/metadata/*:refs/stackit/remote-metadata/*")
-	return err
+	return e.git.FetchMetadataRefs(ctx)
 }
 
-// ConfigureRemoteMetadataSync adds the metadata refspec to origin
+// ConfigureRemoteMetadataSync adds the metadata refspec to origin so subsequent
+// `git fetch origin` invocations pick up metadata changes automatically.
 func (e *engineImpl) ConfigureRemoteMetadataSync(_ context.Context) error {
 	return e.git.EnsureMetadataRefspecConfigured()
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Adapter code (pr_updates, submit, sync, get, info) was reaching past
engine to call git.Runner methods that operate on the stackit metadata-ref
namespace — TestRemoteRefCompatibility, EnsureMetadataRefspecConfigured,
PushMetadataRefs, FetchMetadataRefs, EnsureStackMetaRefspecConfigured,
FetchStackMetaRefs, ListStackMetas, DeleteStackMeta,
DeleteRemoteStackMetaRefs. That's transport plumbing for engine's own ref
namespace — actions shouldn't need to know the namespace exists.

Adds seven engine methods to RemoteMetadataManager covering the full
metadata transport surface:

  - TestRemoteMetadataCompatibility
  - PushMetadataForBranches
  - ConfigureStackMetadataSync
  - FetchStackMetadata
  - ListStackMetadata
  - DeleteStackMetadata
  - DeleteRemoteStackMetadata

(`ConfigureRemoteMetadataSync` and `FetchRemoteMetadata` already existed but
were bypassed by callers; those bypasses are now routed through engine too.)

The new methods live in a new `metadata_transport.go` next to the existing
`remote_sync.go` so the transport surface is discoverable as a group.

`engine.FetchRemoteMetadata` previously reimplemented git.FetchMetadataRefs
with an inline `git fetch` invocation; now it delegates to the git method
to avoid drift.

Phase F1 of the engine refactor round-2 runbook.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1779911059`.


* **PR #1039**
  * **PR #1040**
    * **PR #1041**
      * **PR #1042**
        * **PR #1043**
          * **PR #1044** 👈
            * **PR #1045**
              * **PR #1046**
                * **PR #1047**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->