### PR TITLE
refactor(actions): prune redundant eng.Rebuild() calls; document the rest

### DIFF
--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -291,7 +291,10 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		}
 	}
 
-	// Refresh engine state after modifying branch references directly via git
+	// Absorb rewrites history via raw git operations (cherry-pick + reset on
+	// every modified branch), which engine doesn't observe through its own
+	// mutation paths. Rebuild reconciles cached ParentBranchRevision and
+	// branch tips with the post-rewrite state on disk.
 	if err := eng.Rebuild(""); err != nil {
 		return fmt.Errorf("failed to refresh engine after absorb: %w", err)
 	}

--- a/internal/actions/fold/fold_normal.go
+++ b/internal/actions/fold/fold_normal.go
@@ -12,14 +12,9 @@ import (
 )
 
 func foldNormal(gctx context.Context, ctx *app.Context, currentBranch, parentBranch engine.Branch, eng engine.Engine, splog output.Output, _ Options) error {
-	// Checkout parent branch
+	// Checkout parent branch (engine updates its currentBranch internally).
 	if err := eng.CheckoutBranch(gctx, parentBranch); err != nil {
 		return fmt.Errorf("failed to checkout parent branch: %w", err)
-	}
-
-	// Rebuild engine so it knows we're on the parent branch
-	if err := eng.Rebuild(eng.Trunk().GetName()); err != nil {
-		return fmt.Errorf("failed to rebuild engine: %w", err)
 	}
 
 	// Try fast-forward merge first, fallback to regular merge

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -338,7 +338,8 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		return fmt.Errorf("failed to checkout target branch %s: %w", targetBranch, err)
 	}
 
-	// Refresh engine
+	// `get` may have created local branches via raw git fetch above; rebuild
+	// so engine's branch list includes those new branches before we proceed.
 	if err := eng.Rebuild(""); err != nil {
 		return fmt.Errorf("failed to refresh engine: %w", err)
 	}

--- a/internal/actions/merge/execute_steps.go
+++ b/internal/actions/merge/execute_steps.go
@@ -146,11 +146,8 @@ func executeUpdatePRBase(ctx *app.Context, eng mergeExecuteEngine, step PlanStep
 		return fmt.Errorf("failed to update PR base: %w", err)
 	}
 
-	// Rebuild engine to reflect changes
-	if err := eng.Rebuild(trunkName); err != nil {
-		return fmt.Errorf("failed to rebuild engine: %w", err)
-	}
-
+	// SetParent above already committed metadata via transaction and refreshed
+	// in-memory state; no explicit Rebuild needed.
 	return nil
 }
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

P3 made DeleteBranch/DeleteBranches auto-rebuild, but the cleanup pass
missed two Rebuilds that were already redundant — and several legitimate
ones lacked any comment explaining why they were still needed. Now every
surviving eng.Rebuild() in actions has a one-line justification, so the
next reader doesn't have to re-derive whether it's required.

Removed (tests confirm no regression):

  - fold/fold_normal.go after CheckoutBranch: engine maintains
    currentBranch itself; rebuild was a no-op.
  - merge/execute_steps.go after SetParent: SetParent commits its
    metadata transaction and updates state in-place; rebuild was a no-op.

Kept and documented:

  - absorb.go: absorb rewrites history via raw git (cherry-pick + reset),
    which engine doesn't observe through its mutation paths.
  - get.go: raw git fetch may have created new local branches that
    engine's branch list doesn't yet know about.
  - restack.go: parallel worktree engines share .git with the main
    engine; the main engine needs to refresh to see their ref updates.
    (Existing comment was already adequate.)

Phase F2 of the engine refactor round-2 runbook.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1039**
  * **PR #1040**
    * **PR #1041**
      * **PR #1042**
        * **PR #1043**
          * **PR #1044**
            * **PR #1045** 👈
              * **PR #1046**
                * **PR #1047**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1048 by jonnii*