### PR TITLE
refactor(engine): consolidate duplicate ancestor-walk helpers

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -535,22 +535,6 @@ func appendStrandedRoots(eng engine.Engine, graph *engine.StackGraph, deleteStat
 	return queue
 }
 
-// findNonDeletingAncestor finds the nearest ancestor that is not marked for deletion
-func findNonDeletingAncestor(startParent string, plan *deletionPlan, eng engine.Engine) string {
-	current := startParent
-	for {
-		if !plan.isDeleting(current) {
-			return current
-		}
-		branch := eng.GetBranch(current)
-		parent := branch.GetParent()
-		if parent == nil {
-			return eng.Trunk().GetName()
-		}
-		current = parent.GetName()
-	}
-}
-
 // reparentBranchIfNecessary updates a branch's parent if its current parent is being deleted.
 // Returns the name of the new parent if changed, or empty string if not changed.
 func reparentBranchIfNecessary(ctx context.Context, branch engine.Branch, plan *deletionPlan, eng engine.Engine, out output.Output) (string, error) {
@@ -558,7 +542,7 @@ func reparentBranchIfNecessary(ctx context.Context, branch engine.Branch, plan *
 	parentName := getParentName(branch)
 
 	// Find nearest ancestor that isn't being deleted
-	newParentName := findNonDeletingAncestor(parentName, plan, eng)
+	newParentName := eng.FindNearestNonExcludedAncestor(parentName, plan.isDeleting)
 
 	// If parent changed, update it
 	if newParentName != parentName {

--- a/internal/actions/delete/delete.go
+++ b/internal/actions/delete/delete.go
@@ -189,7 +189,9 @@ func preReparentChildrenWithPreservedDivergence(ctx *app.Context, toDelete engin
 		}
 
 		targetParentName := deleted.GetParentOrTrunk()
-		targetParentName = findNearestNonDeletingAncestorForDelete(eng, toDeleteSet, targetParentName)
+		targetParentName = eng.FindNearestNonExcludedAncestor(targetParentName, func(name string) bool {
+			return toDeleteSet[name]
+		})
 
 		for _, child := range graph.ChildBranches(deleted) {
 			childName := child.GetName()
@@ -218,18 +220,6 @@ func shouldPreserveDivergenceOnDelete(kind engine.DeletionReasonKind) bool {
 	default:
 		return false
 	}
-}
-
-func findNearestNonDeletingAncestorForDelete(eng engine.Engine, toDeleteSet map[string]bool, startParent string) string {
-	current := startParent
-	for toDeleteSet[current] {
-		parent := eng.GetBranch(current).GetParent()
-		if parent == nil {
-			return eng.Trunk().GetName()
-		}
-		current = parent.GetName()
-	}
-	return current
 }
 
 func mergeUniqueBranchNames(a []string, b []string) []string {

--- a/internal/engine/engine_reader.go
+++ b/internal/engine/engine_reader.go
@@ -98,6 +98,23 @@ func (e *engineImpl) GetParent(branch Branch) *Branch {
 	return nil
 }
 
+// FindNearestNonExcludedAncestor walks the parent chain starting from
+// startParent and returns the first branch name for which isExcluded returns
+// false. Falls back to trunk if every ancestor up the chain is excluded.
+// Used by branch-deletion and similar workflows that need to reparent
+// children past a set of branches being removed.
+func (e *engineImpl) FindNearestNonExcludedAncestor(startParent string, isExcluded func(name string) bool) string {
+	current := startParent
+	for isExcluded(current) {
+		parent := e.GetBranch(current).GetParent()
+		if parent == nil {
+			return e.Trunk().GetName()
+		}
+		current = parent.GetName()
+	}
+	return current
+}
+
 // FindMostRecentTrackedAncestors finds the most recent tracked ancestors of a branch
 // by checking the branch's commit history against tracked branch tips.
 // Returns a slice of branch names that point to the most recent tracked commit in history.

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -19,6 +19,10 @@ type StackNavigator interface {
 	BranchesDepthFirst(startBranch Branch) iter.Seq2[Branch, int]
 	SortBranchesTopologically(branches Branches) Branches
 	FindBranchForCommit(commitSHA string) (string, error)
+	// FindNearestNonExcludedAncestor walks the parent chain from startParent
+	// and returns the first ancestor for which isExcluded returns false. Falls
+	// back to trunk if every ancestor up the chain is excluded.
+	FindNearestNonExcludedAncestor(startParent string, isExcluded func(name string) bool) string
 	ValidateOnBranch() (string, error)
 	IsBranchEmpty(ctx context.Context, branchName string) (bool, error)
 	GetScope(branch Branch) Scope


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

clean_branches.go and delete/delete.go each had their own walk-up-the-
parent-chain-skipping-excluded-branches helper:

  findNonDeletingAncestor(startParent, plan, eng)         clean_branches
  findNearestNonDeletingAncestorForDelete(eng, set, ...)  delete

Identical control flow; only the "is-excluded" predicate differed (one
queried *deletionPlan, the other a map[string]bool).

Adds engine.StackNavigator.FindNearestNonExcludedAncestor(startParent,
isExcluded) taking a predicate function, so callers pass either
`plan.isDeleting` or a closure over their map without converting between
data shapes. Both action-side helpers deleted.

Phase F6 of the engine refactor round-2 runbook.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1039**
  * **PR #1040**
    * **PR #1041**
      * **PR #1042**
        * **PR #1043**
          * **PR #1044**
            * **PR #1045**
              * **PR #1046**
                * **PR #1047** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1048 by jonnii*