### PR TITLE
refactor(hooks): extract shared runner from worktree hooks

### DIFF
--- a/internal/actions/worktree/hooks.go
+++ b/internal/actions/worktree/hooks.go
@@ -3,19 +3,14 @@ package worktree
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/hooks"
 	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/tui"
 )
-
-// HookTimeout is the maximum duration a hook can run before being killed
-const HookTimeout = 60 * time.Second
 
 // ResolveApprovedHooks loads the project config, checks for approvals, and prompts
 // the user for any unapproved hooks. Returns the list of approved hook commands.
@@ -30,13 +25,13 @@ func ResolveApprovedHooks(ctx *app.Context) ([]string, error) {
 	}
 
 	// Get hooks to run, filtering out empty/whitespace-only entries
-	var hooks []string
+	var hookCmds []string
 	for _, hook := range projectCfg.Hooks.PostWorktreeCreate {
 		if trimmed := strings.TrimSpace(hook); trimmed != "" {
-			hooks = append(hooks, hook)
+			hookCmds = append(hookCmds, hook)
 		}
 	}
-	if len(hooks) == 0 {
+	if len(hookCmds) == 0 {
 		return nil, nil
 	}
 
@@ -47,9 +42,9 @@ func ResolveApprovedHooks(ctx *app.Context) ([]string, error) {
 	}
 
 	// For each hook, check approval or prompt
-	approved := make([]string, 0, len(hooks))
+	approved := make([]string, 0, len(hookCmds))
 
-	for _, hook := range hooks {
+	for _, hook := range hookCmds {
 		if repoCfg.IsPostWorktreeCreateHookApproved(hook) {
 			approved = append(approved, hook)
 			continue
@@ -79,10 +74,10 @@ func ResolveApprovedHooks(ctx *app.Context) ([]string, error) {
 
 // RunResolvedHooks executes a pre-resolved list of hooks in the given directory.
 // No prompting is performed — safe for parallel use.
-func RunResolvedHooks(hooks []string, worktreePath string, out output.Output) {
-	for _, hook := range hooks {
+func RunResolvedHooks(hookCmds []string, worktreePath string, out output.Output) {
+	for _, hook := range hookCmds {
 		out.Info("Running hook: %s", hook)
-		if err := runHookWithTimeout(hook, worktreePath, HookTimeout); err != nil {
+		if err := hooks.Run(context.Background(), hook, worktreePath, nil, hooks.DefaultTimeout); err != nil {
 			out.Warn("Hook failed: %s: %v", hook, err)
 		}
 	}
@@ -99,22 +94,4 @@ func RunPostCreateHooks(ctx *app.Context, worktreePath string) error {
 
 	RunResolvedHooks(approved, worktreePath, ctx.Output)
 	return nil
-}
-
-// runHookWithTimeout executes a hook command with a timeout.
-// Returns an error if the command fails or times out.
-func runHookWithTimeout(hook string, dir string, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "sh", "-c", hook)
-	cmd.Dir = dir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	err := cmd.Run()
-	if ctx.Err() == context.DeadlineExceeded {
-		return fmt.Errorf("timed out after %s", timeout)
-	}
-	return err
 }

--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -1,0 +1,39 @@
+// Package hooks executes user-defined hook commands with a timeout and
+// optional environment-variable injection. It is shared between
+// worktree-create hooks and (future) command lifecycle hooks.
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// DefaultTimeout is the maximum duration a hook can run before being killed.
+const DefaultTimeout = 60 * time.Second
+
+// Run executes a single hook command via `sh -c`.
+//
+// dir sets the working directory for the spawned process. env, if non-empty,
+// is appended to os.Environ() for the process. stdout/stderr are inherited
+// from the current process so hook output reaches the user.
+func Run(ctx context.Context, command, dir string, env []string, timeout time.Duration) error {
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, "sh", "-c", command)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
+
+	err := cmd.Run()
+	if runCtx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("timed out after %s", timeout)
+	}
+	return err
+}

--- a/internal/hooks/runner_test.go
+++ b/internal/hooks/runner_test.go
@@ -1,0 +1,61 @@
+package hooks_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/getstackit/stackit/internal/hooks"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun_Success(t *testing.T) {
+	t.Parallel()
+	err := hooks.Run(context.Background(), "true", t.TempDir(), nil, time.Second)
+	require.NoError(t, err)
+}
+
+func TestRun_NonZeroExit(t *testing.T) {
+	t.Parallel()
+	err := hooks.Run(context.Background(), "exit 7", t.TempDir(), nil, time.Second)
+	require.Error(t, err)
+}
+
+func TestRun_Timeout(t *testing.T) {
+	t.Parallel()
+	err := hooks.Run(context.Background(), "sleep 5", t.TempDir(), nil, 50*time.Millisecond)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timed out")
+}
+
+func TestRun_EnvInjection(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	err := hooks.Run(
+		context.Background(),
+		`test "$STACKIT_TEST_VAR" = "hello"`,
+		dir,
+		[]string{"STACKIT_TEST_VAR=hello"},
+		time.Second,
+	)
+	require.NoError(t, err)
+}
+
+func TestRun_WorkingDirectory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	err := hooks.Run(
+		context.Background(),
+		// `pwd -P` resolves symlinks (macOS uses /private/var symlink for /tmp).
+		`test "$(pwd -P)" = "$(cd `+shellQuote(dir)+` && pwd -P)"`,
+		dir,
+		nil,
+		time.Second,
+	)
+	require.NoError(t, err)
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Promote runHookWithTimeout and HookTimeout out of internal/actions/worktree
into a new internal/hooks package as hooks.Run and hooks.DefaultTimeout.
The new package is layer-neutral (importable by actions, cli, tui) and
takes an explicit context plus an env slice so future callers can inject
payload env vars without touching the executor.

Worktree's RunResolvedHooks now delegates to hooks.Run; behavior is
unchanged. This preps for command-lifecycle hooks landing in a follow-up.

<hr/>

<!-- STACKIT-SECTION-START -->
**Add pre/post command lifecycle hooks with per-phase approval**

Adds configurable pre- and post-command lifecycle hooks to stackit. Users can define shell commands that run before or after any stackit subcommand, gated behind a per-user approval flow that persists approved commands to user config.

Key changes:
- **extract-shared-runner**: Moves the hook execution engine out of worktree-specific code into `internal/hooks/runner.go`, making it reusable across all hook sites
- **generalize-hook-approval-keys**: Generalizes config approval storage from worktree-scoped keys to per-phase family keys (`IsHookApproved`/`AddApprovedHook`), enabling fine-grained approval tracking for any lifecycle phase
- **add-lifecycle-hooks**: Adds `hooks.ResolveApproved` action (approval gate + runner facade in `internal/actions/hooks/`) and `RunCommandHooks` cobra middleware that fires configured hooks before/after any command; phase keys follow the pattern `pre-<command>` / `post-<command>`
- **document-lifecycle-phases**: New `docs/hooks.md` covering phase naming, env vars, configuration examples, and recipes
- **tighten-resolve-API**: Cleans up the resolve API, drops deprecated config wrapper functions, and adds unit tests for `ResolveApproved` and config approval logic

#### Stack


* **PR #1049** 👈
  * **PR #1050**
    * **PR #1051**
      * **PR #1052**
        * **PR #1053**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1063 by jonnii*