### PR TITLE
refactor(config): generalize hook approval keys to per-phase family

### DIFF
--- a/internal/actions/worktree/hooks.go
+++ b/internal/actions/worktree/hooks.go
@@ -45,7 +45,7 @@ func ResolveApprovedHooks(ctx *app.Context) ([]string, error) {
 	approved := make([]string, 0, len(hookCmds))
 
 	for _, hook := range hookCmds {
-		if repoCfg.IsPostWorktreeCreateHookApproved(hook) {
+		if repoCfg.IsHookApproved(config.PhasePostWorktreeCreate, hook) {
 			approved = append(approved, hook)
 			continue
 		}
@@ -63,7 +63,7 @@ func ResolveApprovedHooks(ctx *app.Context) ([]string, error) {
 		}
 
 		// Save approval (writes immediately to git config)
-		if err := repoCfg.AddApprovedPostWorktreeCreateHook(hook); err != nil {
+		if err := repoCfg.AddApprovedHook(config.PhasePostWorktreeCreate, hook); err != nil {
 			out.Warn("Failed to save hook approval: %v", err)
 		}
 		approved = append(approved, hook)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -952,7 +952,7 @@ func showConfigWithSources(repoRoot string, w io.Writer) error {
 	formatLine("navigation.showMerged", strconv.FormatBool(cfg.NavigationShowMerged()), navShowMergedSource)
 
 	// approved hooks (personal only, no team fallback)
-	approvedHooks := cfg.ApprovedPostWorktreeCreateHooks()
+	approvedHooks := cfg.ApprovedHooks(config.PhasePostWorktreeCreate)
 	if len(approvedHooks) > 0 {
 		formatLine("hooks.approved", strings.Join(approvedHooks, ", "), sourcePersonal)
 	} else {

--- a/internal/config/config_git.go
+++ b/internal/config/config_git.go
@@ -392,63 +392,138 @@ func (c *GitConfig) SetSplitHunkSelector(selector string) error {
 	return c.store.Set(KeySplitHunkSelector, selector)
 }
 
-// ApprovedPostWorktreeCreateHooks returns the list of approved hooks.
-func (c *GitConfig) ApprovedPostWorktreeCreateHooks() []string {
-	hooks, _ := c.store.GetAll(KeyApprovedHooks)
-	return hooks
-}
-
-// IsPostWorktreeCreateHookApproved checks if a hook is approved.
-func (c *GitConfig) IsPostWorktreeCreateHookApproved(hook string) bool {
-	return slices.Contains(c.ApprovedPostWorktreeCreateHooks(), hook)
-}
-
-// AddApprovedPostWorktreeCreateHook adds a hook to the approved list.
-func (c *GitConfig) AddApprovedPostWorktreeCreateHook(hook string) error {
-	if c.IsPostWorktreeCreateHookApproved(hook) {
-		return nil // Already approved
+// ApprovedHooks returns the list of approved hook commands for the given phase.
+//
+// For PhasePostWorktreeCreate, results include any approvals stored under the
+// legacy single-key form (KeyApprovedHooks) in addition to the new per-phase
+// key. Approvals appearing in both keys are deduplicated.
+func (c *GitConfig) ApprovedHooks(phase string) []string {
+	primary, _ := c.store.GetAll(KeyApprovedHookPrefix + phase)
+	if phase != PhasePostWorktreeCreate {
+		return primary
 	}
-	return c.store.Add(KeyApprovedHooks, hook)
-}
-
-// RemoveApprovedPostWorktreeCreateHook removes a hook from the approved list.
-func (c *GitConfig) RemoveApprovedPostWorktreeCreateHook(hook string) error {
-	// Get all current hooks
-	hooks := c.ApprovedPostWorktreeCreateHooks()
-	if !slices.Contains(hooks, hook) {
-		return nil // Not in list
+	legacy, _ := c.store.GetAll(KeyApprovedHooks)
+	if len(legacy) == 0 {
+		return primary
 	}
-
-	// Build the list of hooks to keep
-	hooksToKeep := make([]string, 0, len(hooks)-1)
-	for _, h := range hooks {
-		if h != hook {
-			hooksToKeep = append(hooksToKeep, h)
+	merged := make([]string, 0, len(primary)+len(legacy))
+	seen := make(map[string]bool, len(primary)+len(legacy))
+	for _, h := range primary {
+		if !seen[h] {
+			merged = append(merged, h)
+			seen[h] = true
 		}
 	}
+	for _, h := range legacy {
+		if !seen[h] {
+			merged = append(merged, h)
+			seen[h] = true
+		}
+	}
+	return merged
+}
 
-	// Remove all hooks first
-	if err := c.store.Unset(KeyApprovedHooks); err != nil {
+// IsHookApproved reports whether the command is approved for the given phase.
+func (c *GitConfig) IsHookApproved(phase, command string) bool {
+	return slices.Contains(c.ApprovedHooks(phase), command)
+}
+
+// AddApprovedHook records an approval for the given phase. Approvals are
+// written to the per-phase key; the legacy key is read but never written.
+func (c *GitConfig) AddApprovedHook(phase, command string) error {
+	if c.IsHookApproved(phase, command) {
+		return nil
+	}
+	return c.store.Add(KeyApprovedHookPrefix+phase, command)
+}
+
+// RemoveApprovedHook removes the approval for the given phase. For
+// PhasePostWorktreeCreate, the command is removed from both the per-phase
+// key and the legacy key if present in either.
+func (c *GitConfig) RemoveApprovedHook(phase, command string) error {
+	if err := removeFromMultiKey(c.store, KeyApprovedHookPrefix+phase, command); err != nil {
 		return err
 	}
-
-	// Re-add the ones we want to keep
-	// If this fails, try to restore the original state
-	for _, h := range hooksToKeep {
-		if err := c.store.Add(KeyApprovedHooks, h); err != nil {
-			// Try to restore original hooks
-			for _, original := range hooks {
-				_ = c.store.Add(KeyApprovedHooks, original)
-			}
-			return fmt.Errorf("failed to update hooks, attempted recovery: %w", err)
-		}
+	if phase == PhasePostWorktreeCreate {
+		return removeFromMultiKey(c.store, KeyApprovedHooks, command)
 	}
 	return nil
 }
 
+// ClearApprovedHooks removes all approvals for the given phase. For
+// PhasePostWorktreeCreate, this also clears the legacy key.
+func (c *GitConfig) ClearApprovedHooks(phase string) error {
+	if err := c.store.Unset(KeyApprovedHookPrefix + phase); err != nil {
+		return err
+	}
+	if phase == PhasePostWorktreeCreate {
+		return c.store.Unset(KeyApprovedHooks)
+	}
+	return nil
+}
+
+// ApprovedPostWorktreeCreateHooks returns the list of approved hooks.
+//
+// Deprecated: use ApprovedHooks(PhasePostWorktreeCreate).
+func (c *GitConfig) ApprovedPostWorktreeCreateHooks() []string {
+	return c.ApprovedHooks(PhasePostWorktreeCreate)
+}
+
+// IsPostWorktreeCreateHookApproved checks if a hook is approved.
+//
+// Deprecated: use IsHookApproved(PhasePostWorktreeCreate, hook).
+func (c *GitConfig) IsPostWorktreeCreateHookApproved(hook string) bool {
+	return c.IsHookApproved(PhasePostWorktreeCreate, hook)
+}
+
+// AddApprovedPostWorktreeCreateHook adds a hook to the approved list.
+//
+// Deprecated: use AddApprovedHook(PhasePostWorktreeCreate, hook).
+func (c *GitConfig) AddApprovedPostWorktreeCreateHook(hook string) error {
+	return c.AddApprovedHook(PhasePostWorktreeCreate, hook)
+}
+
+// RemoveApprovedPostWorktreeCreateHook removes a hook from the approved list.
+//
+// Deprecated: use RemoveApprovedHook(PhasePostWorktreeCreate, hook).
+func (c *GitConfig) RemoveApprovedPostWorktreeCreateHook(hook string) error {
+	return c.RemoveApprovedHook(PhasePostWorktreeCreate, hook)
+}
+
 // ClearApprovedPostWorktreeCreateHooks removes all hook approvals.
+//
+// Deprecated: use ClearApprovedHooks(PhasePostWorktreeCreate).
 func (c *GitConfig) ClearApprovedPostWorktreeCreateHooks() error {
-	return c.store.Unset(KeyApprovedHooks)
+	return c.ClearApprovedHooks(PhasePostWorktreeCreate)
+}
+
+// removeFromMultiKey removes a single value from a multi-value git config key
+// by reading all values, unsetting the key, and re-adding the remaining ones.
+// If the value is absent the key is left untouched. On a re-add failure the
+// original values are restored on a best-effort basis.
+func removeFromMultiKey(store *git.ConfigStore, key, value string) error {
+	current, _ := store.GetAll(key)
+	if !slices.Contains(current, value) {
+		return nil
+	}
+	keep := make([]string, 0, len(current)-1)
+	for _, v := range current {
+		if v != value {
+			keep = append(keep, v)
+		}
+	}
+	if err := store.Unset(key); err != nil {
+		return err
+	}
+	for _, v := range keep {
+		if err := store.Add(key, v); err != nil {
+			for _, original := range current {
+				_ = store.Add(key, original)
+			}
+			return fmt.Errorf("failed to update %s, attempted recovery: %w", key, err)
+		}
+	}
+	return nil
 }
 
 // MaxConcurrency returns the maximum number of concurrent validation operations.

--- a/internal/config/interface.go
+++ b/internal/config/interface.go
@@ -45,6 +45,8 @@ type Configurer interface {
 	NavigationShowMerged() bool
 
 	// Hook approvals
+	ApprovedHooks(phase string) []string
+	IsHookApproved(phase, command string) bool
 	ApprovedPostWorktreeCreateHooks() []string
 	IsPostWorktreeCreateHookApproved(hook string) bool
 

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -26,7 +26,13 @@ const (
 	// KeySplitHunkSelector is the hunk selector mode for split (tui or git).
 	KeySplitHunkSelector = "stackit.split.hunkSelector"
 	// KeyApprovedHooks stores approved post-worktree-create hooks (multi-value).
+	//
+	// Deprecated: kept as a compat read-path. New approvals are written under
+	// the per-phase family KeyApprovedHookPrefix+<phase>.
 	KeyApprovedHooks = "stackit.hooks.approvedPostWorktreeCreate"
+	// KeyApprovedHookPrefix is the prefix for per-phase hook approval keys.
+	// Full key form: <prefix><phase>, e.g. "stackit.hooks.approved.pre-modify".
+	KeyApprovedHookPrefix = "stackit.hooks.approved."
 	// KeyMaxConcurrency is the maximum number of concurrent validation operations.
 	KeyMaxConcurrency = "stackit.maxConcurrency"
 	// KeyNavigationWhen controls when navigation is displayed (always/never/multiple).
@@ -108,3 +114,9 @@ const (
 
 // ValidSubmitWeb contains the allowed submit.web values.
 var ValidSubmitWeb = []string{SubmitWebAlways, SubmitWebCreated, SubmitWebNever}
+
+// Hook phase identifiers. These are the suffix used after KeyApprovedHookPrefix
+// and as the YAML key under .stackit.yaml's `hooks:` block.
+const (
+	PhasePostWorktreeCreate = "post-worktree-create"
+)

--- a/internal/config/repo_config_test.go
+++ b/internal/config/repo_config_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/testhelpers"
 )
 
@@ -538,5 +539,110 @@ func TestConfigApprovedPostWorktreeCreateHooks(t *testing.T) {
 		cfg2, err := LoadConfig(scene.Dir)
 		require.NoError(t, err)
 		require.Empty(t, cfg2.ApprovedPostWorktreeCreateHooks())
+	})
+}
+
+func TestConfigApprovedHooks_GenericPhase(t *testing.T) {
+	t.Parallel()
+
+	t.Run("add and read approvals for an arbitrary phase", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+
+		require.False(t, cfg.IsHookApproved("pre-modify", "scripts/check.sh"))
+		require.NoError(t, cfg.AddApprovedHook("pre-modify", "scripts/check.sh"))
+		require.True(t, cfg.IsHookApproved("pre-modify", "scripts/check.sh"))
+
+		cfg2, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		require.Equal(t, []string{"scripts/check.sh"}, cfg2.ApprovedHooks("pre-modify"))
+	})
+
+	t.Run("approvals are scoped per phase", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+
+		require.NoError(t, cfg.AddApprovedHook("pre-modify", "shared.sh"))
+		require.True(t, cfg.IsHookApproved("pre-modify", "shared.sh"))
+		require.False(t, cfg.IsHookApproved("pre-submit", "shared.sh"))
+	})
+
+	t.Run("remove and clear work for arbitrary phases", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+
+		require.NoError(t, cfg.AddApprovedHook("pre-modify", "a"))
+		require.NoError(t, cfg.AddApprovedHook("pre-modify", "b"))
+		require.NoError(t, cfg.RemoveApprovedHook("pre-modify", "a"))
+		require.Equal(t, []string{"b"}, cfg.ApprovedHooks("pre-modify"))
+
+		require.NoError(t, cfg.ClearApprovedHooks("pre-modify"))
+		require.Empty(t, cfg.ApprovedHooks("pre-modify"))
+	})
+}
+
+func TestConfigApprovedHooks_LegacyKeyCompat(t *testing.T) {
+	t.Parallel()
+
+	t.Run("legacy key entries surface via the new generic reader", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		// Write directly to the legacy single-key form.
+		store := git.NewConfigStore(scene.Dir)
+		require.NoError(t, store.Add(KeyApprovedHooks, "legacy-only"))
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		require.Equal(t, []string{"legacy-only"}, cfg.ApprovedHooks(PhasePostWorktreeCreate))
+		require.True(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "legacy-only"))
+	})
+
+	t.Run("union of legacy + per-phase keys deduplicates", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		store := git.NewConfigStore(scene.Dir)
+		require.NoError(t, store.Add(KeyApprovedHooks, "shared"))
+		require.NoError(t, store.Add(KeyApprovedHooks, "legacy-only"))
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		require.NoError(t, cfg.AddApprovedHook(PhasePostWorktreeCreate, "shared"))
+		require.NoError(t, cfg.AddApprovedHook(PhasePostWorktreeCreate, "new-only"))
+
+		got := cfg.ApprovedHooks(PhasePostWorktreeCreate)
+		require.ElementsMatch(t, []string{"shared", "legacy-only", "new-only"}, got)
+		require.Len(t, got, 3, "shared entry should appear once even though it's in both keys")
+	})
+
+	t.Run("remove for legacy phase strips from both keys", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		store := git.NewConfigStore(scene.Dir)
+		require.NoError(t, store.Add(KeyApprovedHooks, "drop-me"))
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		require.NoError(t, cfg.AddApprovedHook(PhasePostWorktreeCreate, "drop-me"))
+
+		require.NoError(t, cfg.RemoveApprovedHook(PhasePostWorktreeCreate, "drop-me"))
+		require.False(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "drop-me"))
+
+		// Verify both stores are empty.
+		legacy, _ := store.GetAll(KeyApprovedHooks)
+		require.Empty(t, legacy)
+		newKey, _ := store.GetAll(KeyApprovedHookPrefix + PhasePostWorktreeCreate)
+		require.Empty(t, newKey)
 	})
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Introduce KeyApprovedHookPrefix ("stackit.hooks.approved.<phase>") so future
hook phases (pre-modify, post-submit, ...) each get their own approval
list. Add ApprovedHooks(phase), IsHookApproved, AddApprovedHook,
RemoveApprovedHook, and ClearApprovedHooks on GitConfig.

The legacy single key (stackit.hooks.approvedPostWorktreeCreate) is kept
as a compat read-path: reading PhasePostWorktreeCreate approvals unions
both keys and dedupes; remove/clear strip from both. New writes go to the
per-phase key only. No automatic migration.

The old method names are kept as thin deprecated wrappers around the new
API so existing callers (and the Configurer interface) keep working.

<hr/>

<!-- STACKIT-SECTION-START -->
**Add pre/post command lifecycle hooks with per-phase approval**

Adds configurable pre- and post-command lifecycle hooks to stackit. Users can define shell commands that run before or after any stackit subcommand, gated behind a per-user approval flow that persists approved commands to user config.

Key changes:
- **extract-shared-runner**: Moves the hook execution engine out of worktree-specific code into `internal/hooks/runner.go`, making it reusable across all hook sites
- **generalize-hook-approval-keys**: Generalizes config approval storage from worktree-scoped keys to per-phase family keys (`IsHookApproved`/`AddApprovedHook`), enabling fine-grained approval tracking for any lifecycle phase
- **add-lifecycle-hooks**: Adds `hooks.ResolveApproved` action (approval gate + runner facade in `internal/actions/hooks/`) and `RunCommandHooks` cobra middleware that fires configured hooks before/after any command; phase keys follow the pattern `pre-<command>` / `post-<command>`
- **document-lifecycle-phases**: New `docs/hooks.md` covering phase naming, env vars, configuration examples, and recipes
- **tighten-resolve-API**: Cleans up the resolve API, drops deprecated config wrapper functions, and adds unit tests for `ResolveApproved` and config approval logic

#### Stack


* **PR #1049**
  * **PR #1050** 👈
    * **PR #1051**
      * **PR #1052**
        * **PR #1053**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1063 by jonnii*