### PR TITLE
feat(hooks): add pre/post command lifecycle hooks

### DIFF
--- a/internal/actions/hooks/resolve.go
+++ b/internal/actions/hooks/resolve.go
@@ -1,0 +1,103 @@
+// Package hooks orchestrates hook discovery, approval, and execution at the
+// actions layer. The pure executor lives in internal/hooks; this package
+// adds the interactive approval gate and the bridge to app.Context.
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	corehooks "github.com/getstackit/stackit/internal/hooks"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+)
+
+// PromptMessage produces the confirmation prompt shown when a hook needs
+// first-time approval. Phase is rendered verbatim so users can tell which
+// lifecycle slot a command would run in.
+func PromptMessage(phase, hook string) string {
+	return fmt.Sprintf("This repo wants to run %q at %s. Allow?", hook, phase)
+}
+
+// ResolveApproved loads the per-repo approval list for the phase, prompting
+// the user for any unapproved commands. Empty input is handled cheaply: no
+// config reads or prompts happen when commands is empty.
+//
+// Must run from the main goroutine — it may prompt interactively.
+func ResolveApproved(ctx *app.Context, phase string, commands []string) ([]string, error) {
+	out := ctx.Output
+
+	// Filter empty/whitespace-only entries up front.
+	filtered := commands[:0:0]
+	for _, hook := range commands {
+		if trimmed := strings.TrimSpace(hook); trimmed != "" {
+			filtered = append(filtered, hook)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil, nil
+	}
+
+	repoCfg, err := config.LoadConfig(ctx.RepoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load repo config: %w", err)
+	}
+
+	approved := make([]string, 0, len(filtered))
+	for _, hook := range filtered {
+		if repoCfg.IsHookApproved(phase, hook) {
+			approved = append(approved, hook)
+			continue
+		}
+
+		allow, promptErr := tui.PromptConfirm(PromptMessage(phase, hook), false)
+		if promptErr != nil {
+			out.Info("Skipping hook (prompt failed): %s", hook)
+			continue
+		}
+		if !allow {
+			out.Info("Skipping hook: %s", hook)
+			continue
+		}
+
+		if err := repoCfg.AddApprovedHook(phase, hook); err != nil {
+			out.Warn("Failed to save hook approval: %v", err)
+		}
+		approved = append(approved, hook)
+	}
+
+	return approved, nil
+}
+
+// RunOptions controls how a list of resolved hooks is executed.
+type RunOptions struct {
+	// Dir is the working directory for each hook process. Defaults to the
+	// caller's cwd if empty.
+	Dir string
+	// Env is a list of NAME=value strings appended to os.Environ() for each
+	// hook invocation. nil is allowed.
+	Env []string
+	// Blocking, when true, causes the first non-zero exit to abort the rest
+	// and return the error to the caller. When false, errors are surfaced as
+	// warnings on out and execution continues.
+	Blocking bool
+}
+
+// Run executes a pre-resolved list of hook commands with the shared executor.
+// On Blocking=true the first failure returns immediately; on Blocking=false
+// failures are logged and the remaining hooks still run.
+func Run(ctx context.Context, hookCmds []string, out output.Output, opts RunOptions) error {
+	for _, hook := range hookCmds {
+		out.Info("Running hook: %s", hook)
+		if err := corehooks.Run(ctx, hook, opts.Dir, opts.Env, corehooks.DefaultTimeout); err != nil {
+			if opts.Blocking {
+				return fmt.Errorf("hook %q failed: %w", hook, err)
+			}
+			out.Warn("Hook failed: %s: %v", hook, err)
+		}
+	}
+	return nil
+}

--- a/internal/actions/worktree/hooks.go
+++ b/internal/actions/worktree/hooks.go
@@ -3,95 +3,41 @@ package worktree
 import (
 	"context"
 	"fmt"
-	"strings"
 
+	"github.com/getstackit/stackit/internal/actions/hooks"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/config"
-	"github.com/getstackit/stackit/internal/hooks"
 	"github.com/getstackit/stackit/internal/output"
-	"github.com/getstackit/stackit/internal/tui"
 )
 
-// ResolveApprovedHooks loads the project config, checks for approvals, and prompts
-// the user for any unapproved hooks. Returns the list of approved hook commands.
-// This must be called from the main thread (it may prompt interactively).
+// ResolveApprovedHooks loads the project config and returns the approved
+// post-worktree-create hook commands, prompting for any unapproved entries.
+// Must be called from the main thread (may prompt interactively).
 func ResolveApprovedHooks(ctx *app.Context) ([]string, error) {
-	out := ctx.Output
-
-	// Load project config from repo root
 	projectCfg, err := config.LoadProjectConfig(ctx.RepoRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load project config: %w", err)
 	}
-
-	// Get hooks to run, filtering out empty/whitespace-only entries
-	var hookCmds []string
-	for _, hook := range projectCfg.Hooks.PostWorktreeCreate {
-		if trimmed := strings.TrimSpace(hook); trimmed != "" {
-			hookCmds = append(hookCmds, hook)
-		}
-	}
-	if len(hookCmds) == 0 {
-		return nil, nil
-	}
-
-	// Load repo config for approvals
-	repoCfg, err := config.LoadConfig(ctx.RepoRoot)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load repo config: %w", err)
-	}
-
-	// For each hook, check approval or prompt
-	approved := make([]string, 0, len(hookCmds))
-
-	for _, hook := range hookCmds {
-		if repoCfg.IsHookApproved(config.PhasePostWorktreeCreate, hook) {
-			approved = append(approved, hook)
-			continue
-		}
-
-		// Prompt user (default No for security)
-		msg := fmt.Sprintf("This repo wants to run %q after creating worktrees. Allow?", hook)
-		allow, promptErr := tui.PromptConfirm(msg, false)
-		if promptErr != nil {
-			out.Info("Skipping hook (prompt failed): %s", hook)
-			continue
-		}
-		if !allow {
-			out.Info("Skipping hook: %s", hook)
-			continue
-		}
-
-		// Save approval (writes immediately to git config)
-		if err := repoCfg.AddApprovedHook(config.PhasePostWorktreeCreate, hook); err != nil {
-			out.Warn("Failed to save hook approval: %v", err)
-		}
-		approved = append(approved, hook)
-	}
-
-	return approved, nil
+	return hooks.ResolveApproved(ctx, config.PhasePostWorktreeCreate, projectCfg.Hooks.PostWorktreeCreate)
 }
 
 // RunResolvedHooks executes a pre-resolved list of hooks in the given directory.
-// No prompting is performed — safe for parallel use.
+// Failures are warned, not blocking — matches the existing worktree behavior.
 func RunResolvedHooks(hookCmds []string, worktreePath string, out output.Output) {
-	for _, hook := range hookCmds {
-		out.Info("Running hook: %s", hook)
-		if err := hooks.Run(context.Background(), hook, worktreePath, nil, hooks.DefaultTimeout); err != nil {
-			out.Warn("Hook failed: %s: %v", hook, err)
-		}
-	}
+	_ = hooks.Run(context.Background(), hookCmds, out, hooks.RunOptions{
+		Dir:      worktreePath,
+		Blocking: false,
+	})
 }
 
-// RunPostCreateHooks runs any configured post-worktree-create hooks.
-// It loads the project config, checks for approvals, prompts for unapproved hooks,
-// and executes approved hooks in the worktree directory.
+// RunPostCreateHooks runs any configured post-worktree-create hooks. It loads
+// the project config, resolves approvals, and executes approved hooks in the
+// worktree directory.
 func RunPostCreateHooks(ctx *app.Context, worktreePath string) error {
 	approved, err := ResolveApprovedHooks(ctx)
 	if err != nil {
 		return err
 	}
-
 	RunResolvedHooks(approved, worktreePath, ctx.Output)
 	return nil
 }

--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -51,7 +51,14 @@ func RunWithOptions(cmd *cobra.Command, opts app.GlobalOptions, fn func(ctx *app
 		}
 	}
 
+	if err := RunCommandHooks(ctx, cmd, PhasePre); err != nil {
+		return HandleCommandError(err)
+	}
+
 	err = fn(ctx)
+	// Post-hooks fire regardless of fn outcome so users can observe success
+	// and failure both. Their errors are surfaced as warnings (non-blocking).
+	_ = RunCommandHooks(ctx, cmd, PhasePost)
 	if err != nil {
 		return HandleCommandError(err)
 	}

--- a/internal/cli/common/hookmiddleware.go
+++ b/internal/cli/common/hookmiddleware.go
@@ -1,0 +1,106 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/getstackit/stackit/internal/actions/hooks"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+)
+
+// PhasePrefix identifies whether a hook fires before or after the command.
+type PhasePrefix string
+
+const (
+	PhasePre  PhasePrefix = "pre"
+	PhasePost PhasePrefix = "post"
+)
+
+// CommandPhase returns the lookup key under hooks: in .stackit.yaml for the
+// given cobra command and phase, e.g. "pre-modify" or "post-worktree-create".
+// The leading "stackit " segment is stripped; remaining path segments are
+// joined by hyphens.
+func CommandPhase(cmd *cobra.Command, phase PhasePrefix) string {
+	parts := strings.Fields(cmd.CommandPath())
+	if len(parts) > 0 && parts[0] == "stackit" {
+		parts = parts[1:]
+	}
+	if len(parts) == 0 {
+		return string(phase)
+	}
+	return string(phase) + "-" + strings.Join(parts, "-")
+}
+
+// RunCommandHooks fires the configured hooks for the given lifecycle phase.
+//
+// Zero-cost when absent: the only work performed when no hook is configured
+// for this command + phase is a slice-length check against the in-memory
+// project config that was already loaded during context construction.
+//
+// Returns the hook's error verbatim for pre-hooks (so the caller can abort
+// the command). For post-hooks, errors are surfaced as warnings on
+// ctx.Output and nil is returned.
+func RunCommandHooks(ctx *app.Context, cmd *cobra.Command, phase PhasePrefix) error {
+	if !ctx.Verify {
+		return nil
+	}
+	projectCfg := projectConfigFrom(ctx)
+	if projectCfg == nil {
+		return nil
+	}
+
+	phaseKey := CommandPhase(cmd, phase)
+	hookCmds := projectCfg.Hooks.For(phaseKey)
+	if len(hookCmds) == 0 {
+		return nil
+	}
+
+	approved, err := hooks.ResolveApproved(ctx, phaseKey, hookCmds)
+	if err != nil {
+		return fmt.Errorf("resolve hooks for %s: %w", phaseKey, err)
+	}
+	if len(approved) == 0 {
+		return nil
+	}
+
+	return hooks.Run(ctx, approved, ctx.Output, hooks.RunOptions{
+		Dir:      ctx.RepoRoot,
+		Env:      hookEnv(ctx, cmd, phaseKey),
+		Blocking: phase == PhasePre,
+	})
+}
+
+func projectConfigFrom(ctx *app.Context) *config.ProjectConfig {
+	if ctx.Config == nil {
+		return nil
+	}
+	return ctx.Config.ProjectConfig()
+}
+
+func hookEnv(ctx *app.Context, cmd *cobra.Command, phaseKey string) []string {
+	env := []string{
+		"STACKIT_HOOK_PHASE=" + phaseKey,
+		"STACKIT_COMMAND=" + cmd.Name(),
+	}
+	if ctx.Engine != nil {
+		if cur := ctx.Engine.CurrentBranch(); cur != nil {
+			env = append(env, "STACKIT_BRANCH="+cur.GetName())
+			if parent := cur.GetParent(); parent != nil {
+				env = append(env, "STACKIT_PARENT="+parent.GetName())
+			}
+			if pr, err := cur.GetPrInfo(); err == nil && pr != nil {
+				if n := pr.Number(); n != nil {
+					env = append(env, fmt.Sprintf("STACKIT_PR_NUMBER=%d", *n))
+				}
+				if s := pr.State(); s != "" {
+					env = append(env, "STACKIT_PR_STATE="+s)
+				}
+				env = append(env, fmt.Sprintf("STACKIT_PR_DRAFT=%t", pr.IsDraft()))
+			}
+		}
+	}
+	return env
+}

--- a/internal/cli/common/hookmiddleware_test.go
+++ b/internal/cli/common/hookmiddleware_test.go
@@ -1,0 +1,47 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandPhase(t *testing.T) {
+	t.Parallel()
+
+	build := func() *cobra.Command {
+		root := &cobra.Command{Use: "stackit"}
+		modify := &cobra.Command{Use: "modify"}
+		root.AddCommand(modify)
+		wt := &cobra.Command{Use: "worktree"}
+		wtCreate := &cobra.Command{Use: "create"}
+		wt.AddCommand(wtCreate)
+		root.AddCommand(wt)
+		return root
+	}
+
+	tests := []struct {
+		name     string
+		path     []string // walk from root by Use
+		phase    PhasePrefix
+		expected string
+	}{
+		{name: "pre-modify on top-level command", path: []string{"modify"}, phase: PhasePre, expected: "pre-modify"},
+		{name: "post-modify on top-level command", path: []string{"modify"}, phase: PhasePost, expected: "post-modify"},
+		{name: "nested worktree create", path: []string{"worktree", "create"}, phase: PhasePost, expected: "post-worktree-create"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := build()
+			cmd := root
+			for _, segment := range tt.path {
+				next, _, err := cmd.Find([]string{segment})
+				assert.NoError(t, err)
+				cmd = next
+			}
+			assert.Equal(t, tt.expected, CommandPhase(cmd, tt.phase))
+		})
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -67,8 +67,8 @@ Commit:  ` + commit + `
 	pf.BoolVar(&debug, "debug", false, "Write debug output to the terminal.")
 	pf.BoolVar(&interactive, "interactive", true, "Enable interactive features like prompts, pagers, and editors.")
 	pf.BoolVar(&noInteractive, "no-interactive", false, "Disable interactive features.")
-	pf.BoolVar(&verify, "verify", true, "Enable git hooks.")
-	pf.BoolVar(&noVerify, "no-verify", false, "Disable git hooks.")
+	pf.BoolVar(&verify, "verify", true, "Enable git and stackit hooks.")
+	pf.BoolVar(&noVerify, "no-verify", false, "Disable git and stackit hooks.")
 	pf.BoolVarP(&quiet, "quiet", "q", false, "Minimize output to the terminal. Implies --no-interactive.")
 
 	rootCmd.AddCommand(newAbortCmd())

--- a/internal/config/config_git.go
+++ b/internal/config/config_git.go
@@ -62,6 +62,13 @@ func (c *GitConfig) IsInitialized() bool {
 	return c.store.Exists(KeyTrunk)
 }
 
+// ProjectConfig returns the loaded project config (.stackit.yaml) attached to
+// this GitConfig, or nil if this instance was loaded without project fallback.
+// Callers must not mutate the returned value.
+func (c *GitConfig) ProjectConfig() *ProjectConfig {
+	return c.project
+}
+
 // Trunk returns the primary trunk branch name.
 // Priority: personal git config > team project config > default.
 func (c *GitConfig) Trunk() string {

--- a/internal/config/interface.go
+++ b/internal/config/interface.go
@@ -44,6 +44,9 @@ type Configurer interface {
 	NavigationLocation() string
 	NavigationShowMerged() bool
 
+	// Project config access (.stackit.yaml). Returns nil if unloaded.
+	ProjectConfig() *ProjectConfig
+
 	// Hook approvals
 	ApprovedHooks(phase string) []string
 	IsHookApproved(phase, command string) bool

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -83,10 +83,27 @@ type ProjectConfig struct {
 	Navigation     NavigationConfig `yaml:"navigation,omitempty"`
 }
 
-// HooksConfig contains hook configurations
+// HooksConfig contains hook configurations.
+//
+// PostWorktreeCreate keeps its dedicated field for the legacy worktree-create
+// integration. All other phases (pre-modify, post-submit, ...) flow through
+// the inline Phases map and are matched by their kebab-case phase name.
 type HooksConfig struct {
-	// PostWorktreeCreate contains commands to run after creating a worktree
-	PostWorktreeCreate []string `yaml:"post-worktree-create"`
+	// PostWorktreeCreate contains commands to run after creating a worktree.
+	PostWorktreeCreate []string `yaml:"post-worktree-create,omitempty"`
+	// Phases captures every other hook phase under hooks: in .stackit.yaml.
+	// Keys are phase names like "pre-modify"; values are shell command lists.
+	Phases map[string][]string `yaml:",inline"`
+}
+
+// For returns the hook command list configured for the given phase, looking
+// up both the explicit field for PostWorktreeCreate and the inline Phases map.
+// Returns nil for an unknown phase.
+func (h HooksConfig) For(phase string) []string {
+	if phase == PhasePostWorktreeCreate {
+		return h.PostWorktreeCreate
+	}
+	return h.Phases[phase]
 }
 
 // knownTopLevelKeys contains all valid top-level keys in .stackit.yaml

--- a/internal/config/project_config_test.go
+++ b/internal/config/project_config_test.go
@@ -89,6 +89,57 @@ func TestLoadProjectConfig(t *testing.T) {
 	})
 }
 
+func TestHooksConfigInlinePhases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inline phase keys parse alongside explicit worktree field", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+
+		configContent := `hooks:
+  post-worktree-create:
+    - mise trust
+  pre-modify:
+    - scripts/check-review.sh
+  post-submit:
+    - scripts/notify.sh
+`
+		err := os.WriteFile(filepath.Join(tmpDir, ProjectConfigFileName), []byte(configContent), 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadProjectConfig(tmpDir)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"mise trust"}, cfg.Hooks.PostWorktreeCreate)
+		assert.Equal(t, []string{"scripts/check-review.sh"}, cfg.Hooks.Phases["pre-modify"])
+		assert.Equal(t, []string{"scripts/notify.sh"}, cfg.Hooks.Phases["post-submit"])
+
+		// For() abstracts the lookup so callers don't care which field a phase lives in.
+		assert.Equal(t, []string{"mise trust"}, cfg.Hooks.For(PhasePostWorktreeCreate))
+		assert.Equal(t, []string{"scripts/check-review.sh"}, cfg.Hooks.For("pre-modify"))
+		assert.Nil(t, cfg.Hooks.For("never-configured"))
+	})
+
+	t.Run("worktree-create does not leak into inline map", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+
+		configContent := `hooks:
+  post-worktree-create:
+    - mise trust
+`
+		err := os.WriteFile(filepath.Join(tmpDir, ProjectConfigFileName), []byte(configContent), 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadProjectConfig(tmpDir)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"mise trust"}, cfg.Hooks.PostWorktreeCreate)
+		_, present := cfg.Hooks.Phases["post-worktree-create"]
+		assert.False(t, present, "explicit field should consume the key, not the inline map")
+	})
+}
+
 func TestHasPostWorktreeCreateHooks(t *testing.T) {
 	t.Run("returns true when hooks exist", func(t *testing.T) {
 		cfg := &ProjectConfig{

--- a/internal/integration/lifecycle_hooks_test.go
+++ b/internal/integration/lifecycle_hooks_test.go
@@ -1,0 +1,73 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLifecycleHooks_PreModifyBlocks(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t)
+
+	sh.WriteFile("seed.txt", "seed").Run("create feature -m 'feat: seed'")
+
+	writeProjectConfig(t, sh.Dir(), `hooks:
+  pre-modify:
+    - "false"
+`)
+	// Pre-approve so the hook runs without an interactive prompt.
+	sh.Git("config --add stackit.hooks.approved.pre-modify false")
+
+	sh.WriteFile("seed.txt", "updated")
+	sh.RunExpectError("modify -a")
+	require.Contains(t, sh.lastOutput, "Running hook: false", "hook should be invoked")
+	require.Contains(t, sh.lastOutput, "hook \"false\" failed", "hook failure should be reported")
+}
+
+func TestLifecycleHooks_NoVerifyBypasses(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t)
+
+	sh.WriteFile("seed.txt", "seed").Run("create feature -m 'feat: seed'")
+
+	writeProjectConfig(t, sh.Dir(), `hooks:
+  pre-modify:
+    - "false"
+`)
+	sh.Git("config --add stackit.hooks.approved.pre-modify false")
+
+	sh.WriteFile("seed.txt", "updated")
+	sh.Run("--no-verify modify -a")
+	require.NotContains(t, sh.lastOutput, "Running hook:", "no hook should run with --no-verify")
+}
+
+func TestLifecycleHooks_ZeroCostWhenUnconfigured(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t)
+
+	// No .stackit.yaml hooks section at all.
+	sh.WriteFile("seed.txt", "seed").Run("create feature -m 'feat: seed'")
+	sh.WriteFile("seed.txt", "updated")
+	sh.Run("modify -a")
+
+	require.NotContains(t, sh.lastOutput, "Running hook:", "no hook lines should appear when nothing is configured")
+}
+
+func TestLifecycleHooks_PostHookFailureIsWarning(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t)
+
+	sh.WriteFile("seed.txt", "seed").Run("create feature -m 'feat: seed'")
+
+	writeProjectConfig(t, sh.Dir(), `hooks:
+  post-modify:
+    - "false"
+`)
+	sh.Git("config --add stackit.hooks.approved.post-modify false")
+
+	sh.WriteFile("seed.txt", "updated")
+	// Modify still succeeds; post-hook failure is surfaced as a warning, not blocking.
+	sh.Run("modify -a")
+	require.Contains(t, sh.lastOutput, "Hook failed: false", "post-hook failure should be warned")
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Extend the hooks: block in .stackit.yaml so it accepts any phase name
("pre-modify", "post-submit", ...) via an inline map alongside the
existing post-worktree-create field. Add a HooksConfig.For(phase) helper
to abstract the lookup.

A new middleware in internal/cli/common fires the matching hooks around
every command that flows through common.Run. The fast path is a slice
length check against the project config that GitConfig already loaded —
no extra I/O when no hook is configured, satisfying the
zero-cost-when-absent constraint.

Pre-hook failures block the command; post-hook failures surface as
warnings. The existing --no-verify flag now disables stackit hooks in
addition to git hooks. Hooks receive a small env-var payload
(STACKIT_HOOK_PHASE, STACKIT_COMMAND, STACKIT_BRANCH, STACKIT_PR_*) from
data already in memory — no GitHub fetch.

Approval flow is generalized in internal/actions/hooks alongside an
executor wrapper. The existing worktree-create path now delegates to
the shared helper.

<hr/>

<!-- STACKIT-SECTION-START -->
**Add pre/post command lifecycle hooks with per-phase approval**

Adds configurable pre- and post-command lifecycle hooks to stackit. Users can define shell commands that run before or after any stackit subcommand, gated behind a per-user approval flow that persists approved commands to user config.

Key changes:
- **extract-shared-runner**: Moves the hook execution engine out of worktree-specific code into `internal/hooks/runner.go`, making it reusable across all hook sites
- **generalize-hook-approval-keys**: Generalizes config approval storage from worktree-scoped keys to per-phase family keys (`IsHookApproved`/`AddApprovedHook`), enabling fine-grained approval tracking for any lifecycle phase
- **add-lifecycle-hooks**: Adds `hooks.ResolveApproved` action (approval gate + runner facade in `internal/actions/hooks/`) and `RunCommandHooks` cobra middleware that fires configured hooks before/after any command; phase keys follow the pattern `pre-<command>` / `post-<command>`
- **document-lifecycle-phases**: New `docs/hooks.md` covering phase naming, env vars, configuration examples, and recipes
- **tighten-resolve-API**: Cleans up the resolve API, drops deprecated config wrapper functions, and adds unit tests for `ResolveApproved` and config approval logic

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1779963946`.


* **PR #1049**
  * **PR #1050**
    * **PR #1051** 👈
      * **PR #1052**
        * **PR #1053**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->