### PR TITLE
docs(hooks): document lifecycle phases, env vars, and recipes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ api/openapi/       API contract source of truth
 ## Documentation
 
 - `docs/config.md` - Configuration system, keys, layered config
+- `docs/hooks.md` - Lifecycle hook configuration, env vars, approval flow, recipes
 - `docs/recipes.md` - Step-by-step file lists for cross-cutting changes
 - `docs/shipping.md` - Merge strategies, consolidation, multi-stack shipping
 - `docs/tui.md` - TUI patterns, BaseModel, styling, components

--- a/docs/config.md
+++ b/docs/config.md
@@ -232,7 +232,7 @@ The table below shows all options available in `.stackit.yaml`. The "Team Fallba
 | `worktree.autoClean` | bool | `true` | Auto-remove clean, empty managed worktrees during sync | Yes |
 | `split.hunkSelector` | string | `tui` | Hunk selector mode (tui/git) | Yes |
 | `maxConcurrency` | int | `0` | Max concurrent operations (0 = auto) | Yes |
-| `hooks.post-worktree-create` | string[] | `[]` | Post-worktree-create commands | No (requires approval) |
+| `hooks.<phase>` | string[] | `[]` | Lifecycle hook commands per phase (e.g. `pre-modify`, `post-submit`, `post-worktree-create`); see `docs/hooks.md` | No (requires approval) |
 
 ### Layered Configuration Example
 
@@ -281,19 +281,24 @@ if cfg.HasTrunk() {
 
 ## Hook Approval System
 
-Post-worktree-create hooks defined in `.stackit.yaml` require user approval before execution. Approvals are stored in git config (not shared).
+Hooks defined in `.stackit.yaml` require per-user approval before they
+execute. Approvals are stored in local git config and never shared.
 
 ### Flow
 
-1. Hook defined in `.stackit.yaml` (shared)
-2. User runs a command that creates a worktree
-3. Stackit prompts for approval if hook not yet approved
-4. Approval saved to `stackit.hooks.approvedPostWorktreeCreate` (local)
-5. Subsequent runs skip the prompt
+1. Hook defined in `.stackit.yaml` (shared, committed).
+2. User runs a command that would fire the hook.
+3. Stackit prompts for approval if the command isn't yet approved.
+4. Approval saved to `stackit.hooks.approved.<phase>` (local git config).
+5. Subsequent runs skip the prompt.
 
-### Implementation
+Approvals stored under the legacy single key
+`stackit.hooks.approvedPostWorktreeCreate` are read transparently for
+backward compatibility.
 
-See `internal/actions/worktree/hooks.go` for the hook execution logic.
+See `docs/hooks.md` for the full reference: phase names, env-var payload,
+`--no-verify` semantics, and example recipes (including the "block modify
+on review" hook).
 
 ## Continuation State
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,179 @@
+# Hooks
+
+Stackit can run user-defined shell commands at specific points in a command's
+lifecycle. Hooks are configured per-repo in `.stackit.yaml` and require
+explicit approval per user before they execute.
+
+> The runner is **zero-cost when no hook is configured.** If `.stackit.yaml`
+> has no `pre-modify` entry, `stackit modify` does no extra work — no I/O,
+> no extra git call, no GitHub fetch. Hooks never *introduce* network calls;
+> if a hook wants fresh GitHub data, the hook itself fetches it.
+
+## Configuration
+
+Hooks live under `hooks:` in `.stackit.yaml`. Each phase is a list of shell
+command strings, executed via `sh -c`:
+
+```yaml
+hooks:
+  post-worktree-create:
+    - "mise trust"
+    - "mise run shims"
+  pre-modify:
+    - "scripts/check-review.sh"
+  post-submit:
+    - "scripts/notify.sh"
+```
+
+### Phase names
+
+The phase key is `<pre|post>-<command-path>`. The command path is the cobra
+command path without the leading `stackit `, joined by hyphens.
+
+| Command | Pre-phase | Post-phase |
+|---|---|---|
+| `stackit modify` | `pre-modify` | `post-modify` |
+| `stackit submit` | `pre-submit` | `post-submit` |
+| `stackit absorb` | `pre-absorb` | `post-absorb` |
+| `stackit worktree create` | — | `post-worktree-create` |
+
+Any command that goes through `common.Run` participates in the lifecycle.
+Read-only commands (`log`, `status`, `get`) do not fire hooks today.
+
+### Failure semantics
+
+- **Pre-hook non-zero exit:** the command is aborted with the hook's stderr
+  surfaced to the user. Subsequent hooks in the same phase do not run.
+- **Post-hook non-zero exit:** the command's result is unaffected; the
+  failure is surfaced as a warning on stdout.
+
+### Hook timeout
+
+Each hook is killed after 60 seconds (`hooks.DefaultTimeout`). This is not
+currently configurable per-phase.
+
+## Approval system
+
+Hooks defined in `.stackit.yaml` (shared, committed) do not run until the
+local user approves them. Approvals are stored per-user in git config and
+never leave the machine.
+
+### Flow
+
+1. Repo defines hook in `.stackit.yaml`.
+2. User runs a command that would fire the hook.
+3. Stackit prompts: `This repo wants to run "<cmd>" at <phase>. Allow?`.
+4. On approval, the command is added to
+   `stackit.hooks.approved.<phase>` in local git config.
+5. Subsequent runs of that exact command skip the prompt.
+
+### Managing approvals
+
+```bash
+# List approvals for a phase
+git config --get-all stackit.hooks.approved.pre-modify
+
+# Pre-approve a hook command without prompting
+git config --add stackit.hooks.approved.pre-modify "scripts/check-review.sh"
+
+# Remove a single approval
+git config --unset stackit.hooks.approved.pre-modify "scripts/check-review.sh"
+
+# Clear all approvals for a phase
+git config --unset-all stackit.hooks.approved.pre-modify
+```
+
+### Legacy key
+
+Approvals from versions before per-phase keys are stored under the single key
+`stackit.hooks.approvedPostWorktreeCreate`. New code reads both, dedupes,
+and writes only to the per-phase key. No automatic migration is performed.
+
+## Skipping hooks: `--no-verify`
+
+The persistent flag `--no-verify` disables both git hooks and stackit hooks
+for the invocation:
+
+```bash
+stackit modify --no-verify    # skips pre-modify and post-modify
+```
+
+## Hook payload
+
+When a hook fires, stackit sets a small env-var payload on the spawned
+process. All values come from data already in memory — no fresh GitHub
+fetch is performed.
+
+| Variable | Value |
+|---|---|
+| `STACKIT_HOOK_PHASE` | Full phase name, e.g. `pre-modify` |
+| `STACKIT_COMMAND` | Leaf cobra command name, e.g. `modify` |
+| `STACKIT_BRANCH` | Current branch name (if available) |
+| `STACKIT_PARENT` | Parent branch name (if available) |
+| `STACKIT_PR_NUMBER` | PR number from local metadata (if submitted) |
+| `STACKIT_PR_STATE` | `OPEN`, `MERGED`, or `CLOSED` (from local metadata) |
+| `STACKIT_PR_DRAFT` | `true` or `false` (from local metadata) |
+
+`STACKIT_PR_*` fields reflect the last `sync` snapshot — they can be stale.
+Hooks that need fresh GitHub state should fetch it themselves (see recipe
+below).
+
+## Recipes
+
+### Block `stackit modify` once review has started
+
+A hook that fetches the live PR review decision and refuses to amend if
+anyone has reviewed or been formally requested for changes:
+
+```sh
+#!/bin/sh
+# scripts/check-review.sh
+# Configure in .stackit.yaml:
+#   hooks:
+#     pre-modify:
+#       - "scripts/check-review.sh"
+set -e
+
+if [ -z "$STACKIT_PR_NUMBER" ]; then
+  exit 0  # No PR yet — nothing to protect.
+fi
+
+decision=$(gh pr view "$STACKIT_BRANCH" \
+  --json reviewDecision -q .reviewDecision 2>/dev/null || true)
+case "$decision" in
+  APPROVED|CHANGES_REQUESTED)
+    echo "blocked: PR #$STACKIT_PR_NUMBER review in progress (decision=$decision)" >&2
+    echo "use 'stackit modify --no-verify' if you really want to rewrite history." >&2
+    exit 1
+    ;;
+esac
+```
+
+### Lint before submitting
+
+```yaml
+hooks:
+  pre-submit:
+    - "mise run lint"
+```
+
+### Send a notification after a successful merge
+
+```yaml
+hooks:
+  post-submit:
+    - "scripts/notify-slack.sh"
+```
+
+`scripts/notify-slack.sh` reads `$STACKIT_BRANCH` and `$STACKIT_PR_NUMBER`
+from the environment.
+
+## Implementation
+
+| Concern | Location |
+|---|---|
+| Shell executor (`sh -c` + timeout) | `internal/hooks/runner.go` |
+| Approval gate + per-hook orchestration | `internal/actions/hooks/resolve.go` |
+| Cobra lifecycle middleware | `internal/cli/common/hookmiddleware.go` |
+| YAML schema (`hooks.For(phase)`) | `internal/config/project_config.go` |
+| Per-phase approval keys | `internal/config/config_git.go` |


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Add docs/hooks.md as the canonical reference for the new command-lifecycle
hooks: phase naming, failure semantics, env-var payload, the approval
flow, and --no-verify behavior. Includes the canonical "block modify on
review" recipe that fetches review state via `gh` from inside the hook
so stackit itself stays network-free.

Wire the new doc into docs/config.md's Hook Approval System section and
the AGENTS.md documentation index.

<hr/>

<!-- STACKIT-SECTION-START -->
**Add pre/post command lifecycle hooks with per-phase approval**

Adds configurable pre- and post-command lifecycle hooks to stackit. Users can define shell commands that run before or after any stackit subcommand, gated behind a per-user approval flow that persists approved commands to user config.

Key changes:
- **extract-shared-runner**: Moves the hook execution engine out of worktree-specific code into `internal/hooks/runner.go`, making it reusable across all hook sites
- **generalize-hook-approval-keys**: Generalizes config approval storage from worktree-scoped keys to per-phase family keys (`IsHookApproved`/`AddApprovedHook`), enabling fine-grained approval tracking for any lifecycle phase
- **add-lifecycle-hooks**: Adds `hooks.ResolveApproved` action (approval gate + runner facade in `internal/actions/hooks/`) and `RunCommandHooks` cobra middleware that fires configured hooks before/after any command; phase keys follow the pattern `pre-<command>` / `post-<command>`
- **document-lifecycle-phases**: New `docs/hooks.md` covering phase naming, env vars, configuration examples, and recipes
- **tighten-resolve-API**: Cleans up the resolve API, drops deprecated config wrapper functions, and adds unit tests for `ResolveApproved` and config approval logic

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1779963946`.


* **PR #1049**
  * **PR #1050**
    * **PR #1051**
      * **PR #1052** 👈
        * **PR #1053**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->