### PR TITLE
refactor(hooks): tighten resolve API + drop deprecated wrappers

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -37,8 +37,10 @@ command path without the leading `stackit `, joined by hyphens.
 | `stackit absorb` | `pre-absorb` | `post-absorb` |
 | `stackit worktree create` | — | `post-worktree-create` |
 
-Any command that goes through `common.Run` participates in the lifecycle.
-Read-only commands (`log`, `status`, `get`) do not fire hooks today.
+Every command that goes through `common.Run` participates in the lifecycle —
+including read-only commands like `log`, `status`, and `get`. When no hook is
+configured for a given command + phase the runner short-circuits, so the
+practical cost on uninstrumented commands is one slice-length check.
 
 ### Failure semantics
 
@@ -107,7 +109,8 @@ fetch is performed.
 | Variable | Value |
 |---|---|
 | `STACKIT_HOOK_PHASE` | Full phase name, e.g. `pre-modify` |
-| `STACKIT_COMMAND` | Leaf cobra command name, e.g. `modify` |
+| `STACKIT_COMMAND` | Leaf cobra command name, e.g. `create` |
+| `STACKIT_COMMAND_PATH` | Full command path, kebab-cased, e.g. `worktree-create` |
 | `STACKIT_BRANCH` | Current branch name (if available) |
 | `STACKIT_PARENT` | Parent branch name (if available) |
 | `STACKIT_PR_NUMBER` | PR number from local metadata (if submitted) |
@@ -138,7 +141,7 @@ if [ -z "$STACKIT_PR_NUMBER" ]; then
   exit 0  # No PR yet — nothing to protect.
 fi
 
-decision=$(gh pr view "$STACKIT_BRANCH" \
+decision=$(gh pr view "$STACKIT_PR_NUMBER" \
   --json reviewDecision -q .reviewDecision 2>/dev/null || true)
 case "$decision" in
   APPROVED|CHANGES_REQUESTED)

--- a/internal/actions/hooks/resolve.go
+++ b/internal/actions/hooks/resolve.go
@@ -1,6 +1,6 @@
 // Package hooks orchestrates hook discovery, approval, and execution at the
 // actions layer. The pure executor lives in internal/hooks; this package
-// adds the interactive approval gate and the bridge to app.Context.
+// adds the interactive approval gate and the runner facade.
 package hooks
 
 import (
@@ -8,31 +8,46 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/actions/handler"
 	"github.com/getstackit/stackit/internal/config"
 	corehooks "github.com/getstackit/stackit/internal/hooks"
 	"github.com/getstackit/stackit/internal/output"
-	"github.com/getstackit/stackit/internal/tui"
 )
 
-// PromptMessage produces the confirmation prompt shown when a hook needs
+// promptMessage produces the confirmation prompt shown when a hook needs
 // first-time approval. Phase is rendered verbatim so users can tell which
 // lifecycle slot a command would run in.
-func PromptMessage(phase, hook string) string {
+func promptMessage(phase, hook string) string {
 	return fmt.Sprintf("This repo wants to run %q at %s. Allow?", hook, phase)
 }
 
-// ResolveApproved loads the per-repo approval list for the phase, prompting
-// the user for any unapproved commands. Empty input is handled cheaply: no
-// config reads or prompts happen when commands is empty.
+// ResolveRequest carries the explicit dependencies needed to gate a list of
+// hook commands behind per-user approval. All fields are required except
+// Output, which may be nil to silence informational messages.
+type ResolveRequest struct {
+	// Phase is the lifecycle phase the hooks belong to (e.g. "pre-modify").
+	Phase string
+	// Commands is the configured hook command list for the phase. Empty
+	// strings are ignored.
+	Commands []string
+	// Config provides the approval read/write store. The same Configurer
+	// already loaded by app bootstrap is expected here — no extra disk read.
+	Config config.Configurer
+	// Prompter is used to ask the user about previously-unseen commands.
+	// Implementations decide whether the prompt defaults to yes or no.
+	Prompter handler.PromptHandler
+	// Output sinks user-facing skip/warn messages. nil is permitted.
+	Output output.Output
+}
+
+// ResolveApproved filters Commands down to the list the user has approved for
+// Phase, prompting for any unapproved entries. Empty input is handled
+// cheaply: no config writes or prompts happen when commands is empty.
 //
 // Must run from the main goroutine — it may prompt interactively.
-func ResolveApproved(ctx *app.Context, phase string, commands []string) ([]string, error) {
-	out := ctx.Output
-
-	// Filter empty/whitespace-only entries up front.
-	filtered := commands[:0:0]
-	for _, hook := range commands {
+func ResolveApproved(req ResolveRequest) ([]string, error) {
+	filtered := make([]string, 0, len(req.Commands))
+	for _, hook := range req.Commands {
 		if trimmed := strings.TrimSpace(hook); trimmed != "" {
 			filtered = append(filtered, hook)
 		}
@@ -40,31 +55,32 @@ func ResolveApproved(ctx *app.Context, phase string, commands []string) ([]strin
 	if len(filtered) == 0 {
 		return nil, nil
 	}
-
-	repoCfg, err := config.LoadConfig(ctx.RepoRoot)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load repo config: %w", err)
+	if req.Config == nil {
+		return nil, fmt.Errorf("resolve hooks: config is required")
+	}
+	if req.Prompter == nil {
+		return nil, fmt.Errorf("resolve hooks: prompter is required")
 	}
 
 	approved := make([]string, 0, len(filtered))
 	for _, hook := range filtered {
-		if repoCfg.IsHookApproved(phase, hook) {
+		if req.Config.IsHookApproved(req.Phase, hook) {
 			approved = append(approved, hook)
 			continue
 		}
 
-		allow, promptErr := tui.PromptConfirm(PromptMessage(phase, hook), false)
+		allow, promptErr := req.Prompter.PromptConfirm(promptMessage(req.Phase, hook))
 		if promptErr != nil {
-			out.Info("Skipping hook (prompt failed): %s", hook)
+			info(req.Output, "Skipping hook (prompt failed): %s", hook)
 			continue
 		}
 		if !allow {
-			out.Info("Skipping hook: %s", hook)
+			info(req.Output, "Skipping hook: %s", hook)
 			continue
 		}
 
-		if err := repoCfg.AddApprovedHook(phase, hook); err != nil {
-			out.Warn("Failed to save hook approval: %v", err)
+		if err := req.Config.AddApprovedHook(req.Phase, hook); err != nil {
+			warn(req.Output, "Failed to save hook approval: %v", err)
 		}
 		approved = append(approved, hook)
 	}
@@ -82,22 +98,39 @@ type RunOptions struct {
 	Env []string
 	// Blocking, when true, causes the first non-zero exit to abort the rest
 	// and return the error to the caller. When false, errors are surfaced as
-	// warnings on out and execution continues.
+	// warnings on Output and execution continues.
 	Blocking bool
+	// Output sinks per-hook progress and warning messages. nil is permitted
+	// but discouraged — failures become silent on the non-blocking path.
+	Output output.Output
 }
 
 // Run executes a pre-resolved list of hook commands with the shared executor.
 // On Blocking=true the first failure returns immediately; on Blocking=false
-// failures are logged and the remaining hooks still run.
-func Run(ctx context.Context, hookCmds []string, out output.Output, opts RunOptions) error {
+// failures are logged to opts.Output and the remaining hooks still run.
+func Run(ctx context.Context, hookCmds []string, opts RunOptions) error {
 	for _, hook := range hookCmds {
-		out.Info("Running hook: %s", hook)
+		info(opts.Output, "Running hook: %s", hook)
 		if err := corehooks.Run(ctx, hook, opts.Dir, opts.Env, corehooks.DefaultTimeout); err != nil {
 			if opts.Blocking {
 				return fmt.Errorf("hook %q failed: %w", hook, err)
 			}
-			out.Warn("Hook failed: %s: %v", hook, err)
+			warn(opts.Output, "Hook failed: %s: %v", hook, err)
 		}
 	}
 	return nil
+}
+
+func info(out output.Output, format string, args ...any) {
+	if out == nil {
+		return
+	}
+	out.Info(format, args...)
+}
+
+func warn(out output.Output, format string, args ...any) {
+	if out == nil {
+		return
+	}
+	out.Warn(format, args...)
 }

--- a/internal/actions/hooks/resolve_test.go
+++ b/internal/actions/hooks/resolve_test.go
@@ -1,0 +1,83 @@
+package hooks_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions/hooks"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/testhelpers"
+)
+
+// fakePrompter is a handler.PromptHandler that returns canned answers in
+// order. Useful for driving ResolveApproved through its prompt branch in
+// tests without setting up a TTY.
+type fakePrompter struct {
+	answers []bool
+	calls   []string
+}
+
+func (p *fakePrompter) PromptConfirm(message string) (bool, error) {
+	p.calls = append(p.calls, message)
+	if len(p.answers) == 0 {
+		return false, nil
+	}
+	a := p.answers[0]
+	p.answers = p.answers[1:]
+	return a, nil
+}
+
+func TestResolveApproved_PromptApproveAndPersist(t *testing.T) {
+	t.Parallel()
+
+	scene := testhelpers.NewSceneParallel(t, nil)
+	cfg, err := config.LoadConfig(scene.Dir)
+	require.NoError(t, err)
+
+	prompter := &fakePrompter{answers: []bool{true, false}}
+
+	approved, err := hooks.ResolveApproved(hooks.ResolveRequest{
+		Phase:    "pre-modify",
+		Commands: []string{"scripts/ok.sh", "scripts/declined.sh"},
+		Config:   cfg,
+		Prompter: prompter,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"scripts/ok.sh"}, approved, "approved hook should be returned; declined should be filtered out")
+	require.Len(t, prompter.calls, 2, "prompter should be called once per unapproved hook")
+
+	// Approval is persisted: a fresh Configurer sees the approval without
+	// prompting again, and the declined hook is still unapproved.
+	cfg2, err := config.LoadConfig(scene.Dir)
+	require.NoError(t, err)
+	require.True(t, cfg2.IsHookApproved("pre-modify", "scripts/ok.sh"))
+	require.False(t, cfg2.IsHookApproved("pre-modify", "scripts/declined.sh"))
+
+	// Re-running should skip the prompt entirely for the approved hook.
+	prompter2 := &fakePrompter{answers: []bool{true}}
+	approved2, err := hooks.ResolveApproved(hooks.ResolveRequest{
+		Phase:    "pre-modify",
+		Commands: []string{"scripts/ok.sh"},
+		Config:   cfg2,
+		Prompter: prompter2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"scripts/ok.sh"}, approved2)
+	require.Empty(t, prompter2.calls, "previously approved hook should not re-prompt")
+}
+
+func TestResolveApproved_EmptyCommandsIsZeroCost(t *testing.T) {
+	t.Parallel()
+
+	prompter := &fakePrompter{}
+	approved, err := hooks.ResolveApproved(hooks.ResolveRequest{
+		Phase:    "pre-modify",
+		Commands: []string{"   ", "\t"}, // whitespace-only entries
+		Config:   nil,                   // intentionally nil — fast path shouldn't read it
+		Prompter: nil,
+	})
+	require.NoError(t, err)
+	require.Empty(t, approved)
+	require.Empty(t, prompter.calls)
+}

--- a/internal/actions/worktree/hooks.go
+++ b/internal/actions/worktree/hooks.go
@@ -2,37 +2,49 @@ package worktree
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/getstackit/stackit/internal/actions/handler"
 	"github.com/getstackit/stackit/internal/actions/hooks"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
-// ResolveApprovedHooks loads the project config and returns the approved
-// post-worktree-create hook commands, prompting for any unapproved entries.
-// Must be called from the main thread (may prompt interactively).
+// ResolveApprovedHooks reads the post-worktree-create hook list from the
+// project config already attached to ctx and returns the approved subset,
+// prompting for any unapproved entries. Must be called from the main thread
+// (may prompt interactively).
 func ResolveApprovedHooks(ctx *app.Context) ([]string, error) {
-	projectCfg, err := config.LoadProjectConfig(ctx.RepoRoot)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load project config: %w", err)
+	if ctx.Config == nil {
+		return nil, nil
 	}
-	return hooks.ResolveApproved(ctx, config.PhasePostWorktreeCreate, projectCfg.Hooks.PostWorktreeCreate)
+	projectCfg := ctx.Config.ProjectConfig()
+	if projectCfg == nil {
+		return nil, nil
+	}
+	return hooks.ResolveApproved(hooks.ResolveRequest{
+		Phase:    config.PhasePostWorktreeCreate,
+		Commands: projectCfg.Hooks.PostWorktreeCreate,
+		Config:   ctx.Config,
+		Prompter: worktreePrompter{},
+		Output:   ctx.Output,
+	})
 }
 
 // RunResolvedHooks executes a pre-resolved list of hooks in the given directory.
 // Failures are warned, not blocking — matches the existing worktree behavior.
 func RunResolvedHooks(hookCmds []string, worktreePath string, out output.Output) {
-	_ = hooks.Run(context.Background(), hookCmds, out, hooks.RunOptions{
+	_ = hooks.Run(context.Background(), hookCmds, hooks.RunOptions{
 		Dir:      worktreePath,
 		Blocking: false,
+		Output:   out,
 	})
 }
 
-// RunPostCreateHooks runs any configured post-worktree-create hooks. It loads
-// the project config, resolves approvals, and executes approved hooks in the
-// worktree directory.
+// RunPostCreateHooks runs any configured post-worktree-create hooks. It reads
+// the project config from ctx, resolves approvals, and executes approved
+// hooks in the worktree directory.
 func RunPostCreateHooks(ctx *app.Context, worktreePath string) error {
 	approved, err := ResolveApprovedHooks(ctx)
 	if err != nil {
@@ -41,3 +53,13 @@ func RunPostCreateHooks(ctx *app.Context, worktreePath string) error {
 	RunResolvedHooks(approved, worktreePath, ctx.Output)
 	return nil
 }
+
+// worktreePrompter wraps tui.PromptConfirm with a default-no answer so
+// accidental Enter doesn't approve arbitrary post-worktree-create commands.
+type worktreePrompter struct{}
+
+func (worktreePrompter) PromptConfirm(message string) (bool, error) {
+	return tui.PromptConfirm(message, false)
+}
+
+var _ handler.PromptHandler = worktreePrompter{}

--- a/internal/cli/common/hookmiddleware.go
+++ b/internal/cli/common/hookmiddleware.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/getstackit/stackit/internal/actions/handler"
 	"github.com/getstackit/stackit/internal/actions/hooks"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // PhasePrefix identifies whether a hook fires before or after the command.
@@ -19,19 +21,25 @@ const (
 	PhasePost PhasePrefix = "post"
 )
 
-// CommandPhase returns the lookup key under hooks: in .stackit.yaml for the
-// given cobra command and phase, e.g. "pre-modify" or "post-worktree-create".
-// The leading "stackit " segment is stripped; remaining path segments are
-// joined by hyphens.
-func CommandPhase(cmd *cobra.Command, phase PhasePrefix) string {
+// commandPath returns the kebab-cased cobra command path with the leading
+// "stackit" segment stripped, e.g. "modify" or "worktree-create". Returns an
+// empty string for the root command.
+func commandPath(cmd *cobra.Command) string {
 	parts := strings.Fields(cmd.CommandPath())
 	if len(parts) > 0 && parts[0] == "stackit" {
 		parts = parts[1:]
 	}
-	if len(parts) == 0 {
+	return strings.Join(parts, "-")
+}
+
+// CommandPhase returns the lookup key under hooks: in .stackit.yaml for the
+// given cobra command and phase, e.g. "pre-modify" or "post-worktree-create".
+func CommandPhase(cmd *cobra.Command, phase PhasePrefix) string {
+	path := commandPath(cmd)
+	if path == "" {
 		return string(phase)
 	}
-	return string(phase) + "-" + strings.Join(parts, "-")
+	return string(phase) + "-" + path
 }
 
 // RunCommandHooks fires the configured hooks for the given lifecycle phase.
@@ -58,7 +66,13 @@ func RunCommandHooks(ctx *app.Context, cmd *cobra.Command, phase PhasePrefix) er
 		return nil
 	}
 
-	approved, err := hooks.ResolveApproved(ctx, phaseKey, hookCmds)
+	approved, err := hooks.ResolveApproved(hooks.ResolveRequest{
+		Phase:    phaseKey,
+		Commands: hookCmds,
+		Config:   ctx.Config,
+		Prompter: defaultPrompter{},
+		Output:   ctx.Output,
+	})
 	if err != nil {
 		return fmt.Errorf("resolve hooks for %s: %w", phaseKey, err)
 	}
@@ -66,10 +80,11 @@ func RunCommandHooks(ctx *app.Context, cmd *cobra.Command, phase PhasePrefix) er
 		return nil
 	}
 
-	return hooks.Run(ctx, approved, ctx.Output, hooks.RunOptions{
+	return hooks.Run(ctx, approved, hooks.RunOptions{
 		Dir:      ctx.RepoRoot,
 		Env:      hookEnv(ctx, cmd, phaseKey),
 		Blocking: phase == PhasePre,
+		Output:   ctx.Output,
 	})
 }
 
@@ -80,10 +95,23 @@ func projectConfigFrom(ctx *app.Context) *config.ProjectConfig {
 	return ctx.Config.ProjectConfig()
 }
 
+// defaultPrompter is a handler.PromptHandler that delegates to the shared
+// TUI confirmation prompt with a default-no answer. Default-no protects users
+// who hit Enter on an unexpected prompt from executing arbitrary commands.
+type defaultPrompter struct{}
+
+func (defaultPrompter) PromptConfirm(message string) (bool, error) {
+	return tui.PromptConfirm(message, false)
+}
+
+// Ensure defaultPrompter satisfies the interface at compile time.
+var _ handler.PromptHandler = defaultPrompter{}
+
 func hookEnv(ctx *app.Context, cmd *cobra.Command, phaseKey string) []string {
 	env := []string{
 		"STACKIT_HOOK_PHASE=" + phaseKey,
 		"STACKIT_COMMAND=" + cmd.Name(),
+		"STACKIT_COMMAND_PATH=" + commandPath(cmd),
 	}
 	if ctx.Engine != nil {
 		if cur := ctx.Engine.CurrentBranch(); cur != nil {

--- a/internal/config/config_git.go
+++ b/internal/config/config_git.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -469,45 +470,12 @@ func (c *GitConfig) ClearApprovedHooks(phase string) error {
 	return nil
 }
 
-// ApprovedPostWorktreeCreateHooks returns the list of approved hooks.
-//
-// Deprecated: use ApprovedHooks(PhasePostWorktreeCreate).
-func (c *GitConfig) ApprovedPostWorktreeCreateHooks() []string {
-	return c.ApprovedHooks(PhasePostWorktreeCreate)
-}
-
-// IsPostWorktreeCreateHookApproved checks if a hook is approved.
-//
-// Deprecated: use IsHookApproved(PhasePostWorktreeCreate, hook).
-func (c *GitConfig) IsPostWorktreeCreateHookApproved(hook string) bool {
-	return c.IsHookApproved(PhasePostWorktreeCreate, hook)
-}
-
-// AddApprovedPostWorktreeCreateHook adds a hook to the approved list.
-//
-// Deprecated: use AddApprovedHook(PhasePostWorktreeCreate, hook).
-func (c *GitConfig) AddApprovedPostWorktreeCreateHook(hook string) error {
-	return c.AddApprovedHook(PhasePostWorktreeCreate, hook)
-}
-
-// RemoveApprovedPostWorktreeCreateHook removes a hook from the approved list.
-//
-// Deprecated: use RemoveApprovedHook(PhasePostWorktreeCreate, hook).
-func (c *GitConfig) RemoveApprovedPostWorktreeCreateHook(hook string) error {
-	return c.RemoveApprovedHook(PhasePostWorktreeCreate, hook)
-}
-
-// ClearApprovedPostWorktreeCreateHooks removes all hook approvals.
-//
-// Deprecated: use ClearApprovedHooks(PhasePostWorktreeCreate).
-func (c *GitConfig) ClearApprovedPostWorktreeCreateHooks() error {
-	return c.ClearApprovedHooks(PhasePostWorktreeCreate)
-}
-
 // removeFromMultiKey removes a single value from a multi-value git config key
 // by reading all values, unsetting the key, and re-adding the remaining ones.
 // If the value is absent the key is left untouched. On a re-add failure the
-// original values are restored on a best-effort basis.
+// original values are restored on a best-effort basis; any errors during
+// recovery are joined into the returned error so the caller can see both the
+// primary failure and any incomplete rollback.
 func removeFromMultiKey(store *git.ConfigStore, key, value string) error {
 	current, _ := store.GetAll(key)
 	if !slices.Contains(current, value) {
@@ -524,10 +492,13 @@ func removeFromMultiKey(store *git.ConfigStore, key, value string) error {
 	}
 	for _, v := range keep {
 		if err := store.Add(key, v); err != nil {
+			recoveryErrs := []error{fmt.Errorf("failed to update %s: %w", key, err)}
 			for _, original := range current {
-				_ = store.Add(key, original)
+				if recoveryErr := store.Add(key, original); recoveryErr != nil {
+					recoveryErrs = append(recoveryErrs, fmt.Errorf("recovery: failed to restore %q: %w", original, recoveryErr))
+				}
 			}
-			return fmt.Errorf("failed to update %s, attempted recovery: %w", key, err)
+			return errors.Join(recoveryErrs...)
 		}
 	}
 	return nil

--- a/internal/config/config_git_test.go
+++ b/internal/config/config_git_test.go
@@ -328,23 +328,23 @@ func TestGitConfigApprovedHooks(t *testing.T) {
 		cfg, err := LoadGitConfig(scene.Dir)
 		require.NoError(t, err)
 
-		require.Empty(t, cfg.ApprovedPostWorktreeCreateHooks())
+		require.Empty(t, cfg.ApprovedHooks(PhasePostWorktreeCreate))
 
-		err = cfg.AddApprovedPostWorktreeCreateHook("mise trust")
+		err = cfg.AddApprovedHook(PhasePostWorktreeCreate, "mise trust")
 		require.NoError(t, err)
 
-		err = cfg.AddApprovedPostWorktreeCreateHook("npm install")
+		err = cfg.AddApprovedHook(PhasePostWorktreeCreate, "npm install")
 		require.NoError(t, err)
 
-		require.True(t, cfg.IsPostWorktreeCreateHookApproved("mise trust"))
-		require.True(t, cfg.IsPostWorktreeCreateHookApproved("npm install"))
-		require.False(t, cfg.IsPostWorktreeCreateHookApproved("other"))
+		require.True(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "mise trust"))
+		require.True(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "npm install"))
+		require.False(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "other"))
 
-		err = cfg.RemoveApprovedPostWorktreeCreateHook("mise trust")
+		err = cfg.RemoveApprovedHook(PhasePostWorktreeCreate, "mise trust")
 		require.NoError(t, err)
 
-		require.False(t, cfg.IsPostWorktreeCreateHookApproved("mise trust"))
-		require.True(t, cfg.IsPostWorktreeCreateHookApproved("npm install"))
+		require.False(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "mise trust"))
+		require.True(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "npm install"))
 	})
 
 	t.Run("clears all hooks", func(t *testing.T) {
@@ -354,16 +354,16 @@ func TestGitConfigApprovedHooks(t *testing.T) {
 		cfg, err := LoadGitConfig(scene.Dir)
 		require.NoError(t, err)
 
-		err = cfg.AddApprovedPostWorktreeCreateHook("mise trust")
+		err = cfg.AddApprovedHook(PhasePostWorktreeCreate, "mise trust")
 		require.NoError(t, err)
 
-		err = cfg.AddApprovedPostWorktreeCreateHook("npm install")
+		err = cfg.AddApprovedHook(PhasePostWorktreeCreate, "npm install")
 		require.NoError(t, err)
 
-		err = cfg.ClearApprovedPostWorktreeCreateHooks()
+		err = cfg.ClearApprovedHooks(PhasePostWorktreeCreate)
 		require.NoError(t, err)
 
-		require.Empty(t, cfg.ApprovedPostWorktreeCreateHooks())
+		require.Empty(t, cfg.ApprovedHooks(PhasePostWorktreeCreate))
 	})
 }
 
@@ -415,7 +415,7 @@ func TestMigrationFromJSON(t *testing.T) {
 		require.Equal(t, "/tmp/worktrees", cfg.WorktreeBasePath())
 		require.False(t, cfg.WorktreeAutoClean())
 		require.Equal(t, "git", cfg.SplitHunkSelector())
-		require.True(t, cfg.IsPostWorktreeCreateHookApproved("mise trust"))
+		require.True(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "mise trust"))
 
 		// Verify backup file exists
 		backupPath := filepath.Join(scene.Dir, ".git", ".stackit_config.migrated")

--- a/internal/config/interface.go
+++ b/internal/config/interface.go
@@ -50,8 +50,7 @@ type Configurer interface {
 	// Hook approvals
 	ApprovedHooks(phase string) []string
 	IsHookApproved(phase, command string) bool
-	ApprovedPostWorktreeCreateHooks() []string
-	IsPostWorktreeCreateHookApproved(hook string) bool
+	AddApprovedHook(phase, command string) error
 
 	// Deprecated methods (for backwards compatibility)
 	CombineCICommand() string

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -185,9 +185,11 @@ func migrateFromJSON(repoRoot string, store *git.ConfigStore) error {
 		}
 	}
 
-	// Migrate approved hooks
+	// Migrate approved hooks. Written under the per-phase key; the read path
+	// still understands the legacy single-key form for older repos that didn't
+	// go through this migration.
 	for _, hook := range oldConfig.ApprovedPostWorktreeCreateHooks {
-		if err := store.Add(KeyApprovedHooks, hook); err != nil {
+		if err := store.Add(KeyApprovedHookPrefix+PhasePostWorktreeCreate, hook); err != nil {
 			return fmt.Errorf("migrate approved hook: %w", err)
 		}
 	}

--- a/internal/config/repo_config_test.go
+++ b/internal/config/repo_config_test.go
@@ -401,145 +401,28 @@ func TestConfigSetCITimeout(t *testing.T) {
 	})
 }
 
-func TestConfigApprovedPostWorktreeCreateHooks(t *testing.T) {
+func TestConfigApprovedHooks_LegacyJSONMigration(t *testing.T) {
 	t.Parallel()
 
-	t.Run("returns empty list when nothing configured", func(t *testing.T) {
-		t.Parallel()
-		scene := testhelpers.NewSceneParallel(t, nil)
+	// Legacy .stackit_config JSON files predate per-phase git config keys.
+	// The migration path must surface ApprovedPostWorktreeCreateHooks under
+	// the new per-phase API so older repos keep working.
+	scene := testhelpers.NewSceneParallel(t, nil)
 
-		cfg, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-		require.Empty(t, cfg.ApprovedPostWorktreeCreateHooks())
-	})
+	configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
+	legacy := &RepoConfig{
+		Trunk:                           new("main"),
+		ApprovedPostWorktreeCreateHooks: []string{"mise trust", "npm install"},
+	}
+	configJSON, err := json.MarshalIndent(legacy, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configPath, configJSON, 0600))
 
-	t.Run("returns approved hooks when configured", func(t *testing.T) {
-		t.Parallel()
-		scene := testhelpers.NewSceneParallel(t, nil)
-
-		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
-		config := &RepoConfig{
-			Trunk:                           new("main"),
-			ApprovedPostWorktreeCreateHooks: []string{"mise trust", "npm install"},
-		}
-		configJSON, err := json.MarshalIndent(config, "", "  ")
-		require.NoError(t, err)
-		err = os.WriteFile(configPath, configJSON, 0600)
-		require.NoError(t, err)
-
-		cfg, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-		require.Equal(t, []string{"mise trust", "npm install"}, cfg.ApprovedPostWorktreeCreateHooks())
-	})
-
-	t.Run("IsPostWorktreeCreateHookApproved returns true for approved hook", func(t *testing.T) {
-		t.Parallel()
-		scene := testhelpers.NewSceneParallel(t, nil)
-
-		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
-		config := &RepoConfig{
-			Trunk:                           new("main"),
-			ApprovedPostWorktreeCreateHooks: []string{"mise trust"},
-		}
-		configJSON, err := json.MarshalIndent(config, "", "  ")
-		require.NoError(t, err)
-		err = os.WriteFile(configPath, configJSON, 0600)
-		require.NoError(t, err)
-
-		cfg, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-		require.True(t, cfg.IsPostWorktreeCreateHookApproved("mise trust"))
-		require.False(t, cfg.IsPostWorktreeCreateHookApproved("npm install"))
-	})
-
-	t.Run("AddApprovedPostWorktreeCreateHook adds new hook", func(t *testing.T) {
-		t.Parallel()
-		scene := testhelpers.NewSceneParallel(t, nil)
-
-		cfg, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-		require.False(t, cfg.IsPostWorktreeCreateHookApproved("mise trust"))
-
-		err = cfg.AddApprovedPostWorktreeCreateHook("mise trust")
-		require.NoError(t, err)
-		require.True(t, cfg.IsPostWorktreeCreateHookApproved("mise trust"))
-
-		// Reload to verify persistence (git config writes are immediate)
-		cfg2, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-		require.True(t, cfg2.IsPostWorktreeCreateHookApproved("mise trust"))
-	})
-
-	t.Run("AddApprovedPostWorktreeCreateHook does not duplicate", func(t *testing.T) {
-		t.Parallel()
-		scene := testhelpers.NewSceneParallel(t, nil)
-
-		cfg, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-
-		err = cfg.AddApprovedPostWorktreeCreateHook("mise trust")
-		require.NoError(t, err)
-		err = cfg.AddApprovedPostWorktreeCreateHook("mise trust") // Add again - should be no-op
-		require.NoError(t, err)
-		require.Len(t, cfg.ApprovedPostWorktreeCreateHooks(), 1)
-	})
-
-	t.Run("RemoveApprovedPostWorktreeCreateHook removes existing hook", func(t *testing.T) {
-		t.Parallel()
-		scene := testhelpers.NewSceneParallel(t, nil)
-
-		cfg, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-
-		err = cfg.AddApprovedPostWorktreeCreateHook("mise trust")
-		require.NoError(t, err)
-		err = cfg.AddApprovedPostWorktreeCreateHook("npm install")
-		require.NoError(t, err)
-		require.Len(t, cfg.ApprovedPostWorktreeCreateHooks(), 2)
-
-		err = cfg.RemoveApprovedPostWorktreeCreateHook("mise trust")
-		require.NoError(t, err)
-		require.Len(t, cfg.ApprovedPostWorktreeCreateHooks(), 1)
-		require.False(t, cfg.IsPostWorktreeCreateHookApproved("mise trust"))
-		require.True(t, cfg.IsPostWorktreeCreateHookApproved("npm install"))
-	})
-
-	t.Run("RemoveApprovedPostWorktreeCreateHook handles non-existent hook", func(t *testing.T) {
-		t.Parallel()
-		scene := testhelpers.NewSceneParallel(t, nil)
-
-		cfg, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-
-		err = cfg.AddApprovedPostWorktreeCreateHook("mise trust")
-		require.NoError(t, err)
-		err = cfg.RemoveApprovedPostWorktreeCreateHook("non-existent") // Should not error
-		require.NoError(t, err)
-		require.Len(t, cfg.ApprovedPostWorktreeCreateHooks(), 1)
-	})
-
-	t.Run("ClearApprovedPostWorktreeCreateHooks removes all hooks", func(t *testing.T) {
-		t.Parallel()
-		scene := testhelpers.NewSceneParallel(t, nil)
-
-		cfg, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-
-		err = cfg.AddApprovedPostWorktreeCreateHook("mise trust")
-		require.NoError(t, err)
-		err = cfg.AddApprovedPostWorktreeCreateHook("npm install")
-		require.NoError(t, err)
-		require.Len(t, cfg.ApprovedPostWorktreeCreateHooks(), 2)
-
-		err = cfg.ClearApprovedPostWorktreeCreateHooks()
-		require.NoError(t, err)
-		require.Empty(t, cfg.ApprovedPostWorktreeCreateHooks())
-
-		// Verify persistence by reloading
-		cfg2, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-		require.Empty(t, cfg2.ApprovedPostWorktreeCreateHooks())
-	})
+	cfg, err := LoadConfig(scene.Dir)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"mise trust", "npm install"}, cfg.ApprovedHooks(PhasePostWorktreeCreate))
+	require.True(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "mise trust"))
+	require.False(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "never-approved"))
 }
 
 func TestConfigApprovedHooks_GenericPhase(t *testing.T) {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Address review feedback on the lifecycle hook feature landed in #1048:

- ResolveApproved now takes an explicit ResolveRequest (Phase, Commands,
  Config, Prompter, Output) instead of *app.Context. The package no longer
  imports internal/tui or internal/app; the cli middleware builds the
  request from ctx and supplies a tui-backed handler.PromptHandler. The
  redundant config.LoadConfig disk read per command is gone — the same
  Configurer already loaded during context construction is reused.
- worktree.ResolveApprovedHooks reads ProjectConfig from ctx.Config
  instead of re-loading from disk, and forwards the new request shape.
- internal/cli/common.hookEnv now also emits STACKIT_COMMAND_PATH (full
  kebab-cased command path) alongside the existing leaf-only
  STACKIT_COMMAND, so scripts can disambiguate "worktree create" from
  any other "create".
- GitConfig.AddApprovedHook is promoted to the Configurer interface; the
  five deprecated *PostWorktreeCreateHook* wrappers are removed. The
  legacy JSON struct field stays for on-disk migration. migrate.go now
  writes approvals under the per-phase key.
- removeFromMultiKey joins primary + recovery errors with errors.Join so
  a partial rollback failure is visible.
- docs/hooks.md: correct the "read-only commands don't fire hooks"
  claim, swap the gh pr view recipe to use $STACKIT_PR_NUMBER instead
  of $STACKIT_BRANCH (branch lookup is ambiguous), and document
  STACKIT_COMMAND_PATH.
- New unit test exercises the interactive prompt branch and verifies
  approvals persist to the per-phase git config key.

<hr/>

<!-- STACKIT-SECTION-START -->
**Add pre/post command lifecycle hooks with per-phase approval**

Adds configurable pre- and post-command lifecycle hooks to stackit. Users can define shell commands that run before or after any stackit subcommand, gated behind a per-user approval flow that persists approved commands to user config.

Key changes:
- **extract-shared-runner**: Moves the hook execution engine out of worktree-specific code into `internal/hooks/runner.go`, making it reusable across all hook sites
- **generalize-hook-approval-keys**: Generalizes config approval storage from worktree-scoped keys to per-phase family keys (`IsHookApproved`/`AddApprovedHook`), enabling fine-grained approval tracking for any lifecycle phase
- **add-lifecycle-hooks**: Adds `hooks.ResolveApproved` action (approval gate + runner facade in `internal/actions/hooks/`) and `RunCommandHooks` cobra middleware that fires configured hooks before/after any command; phase keys follow the pattern `pre-<command>` / `post-<command>`
- **document-lifecycle-phases**: New `docs/hooks.md` covering phase naming, env vars, configuration examples, and recipes
- **tighten-resolve-API**: Cleans up the resolve API, drops deprecated config wrapper functions, and adds unit tests for `ResolveApproved` and config approval logic

#### Stack


* **PR #1049**
  * **PR #1050**
    * **PR #1051**
      * **PR #1052**
        * **PR #1053** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1063 by jonnii*