### PR TITLE
Merging 9 PRs

### DIFF
--- a/.github/workflows/docker-main.yml
+++ b/.github/workflows/docker-main.yml
@@ -1,0 +1,83 @@
+name: Docker (main)
+
+# Build and publish stackit-server container images on every push to main so
+# Railway (and any other ghcr.io consumer) can auto-deploy without cutting a
+# release tag. Goreleaser builds snapshot images locally with its snapshot
+# version, then we re-tag those as :main and :<short-sha> and push.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Enable pnpm
+        run: corepack enable
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser (snapshot, server images only)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --snapshot --clean --skip=archive,homebrew,scoop,nfpm,sbom,announce
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Re-tag and push main + sha images
+        env:
+          GHCR_IMAGE: ghcr.io/getstackit/stackit-server
+        run: |
+          set -euo pipefail
+          SNAP_VERSION=$(jq -r .version dist/metadata.json)
+          SHORT_SHA="${GITHUB_SHA::7}"
+          echo "snapshot version: ${SNAP_VERSION}; short sha: ${SHORT_SHA}"
+          for arch in amd64 arm64; do
+            src="${GHCR_IMAGE}:${SNAP_VERSION}-${arch}"
+            docker tag "$src" "${GHCR_IMAGE}:main-${arch}"
+            docker tag "$src" "${GHCR_IMAGE}:${SHORT_SHA}-${arch}"
+            docker push "${GHCR_IMAGE}:main-${arch}"
+            docker push "${GHCR_IMAGE}:${SHORT_SHA}-${arch}"
+          done
+          docker manifest rm "${GHCR_IMAGE}:main" 2>/dev/null || true
+          docker manifest create "${GHCR_IMAGE}:main" \
+            "${GHCR_IMAGE}:main-amd64" "${GHCR_IMAGE}:main-arm64"
+          docker manifest push "${GHCR_IMAGE}:main"
+          docker manifest create "${GHCR_IMAGE}:${SHORT_SHA}" \
+            "${GHCR_IMAGE}:${SHORT_SHA}-amd64" "${GHCR_IMAGE}:${SHORT_SHA}-arm64"
+          docker manifest push "${GHCR_IMAGE}:${SHORT_SHA}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,19 @@ jobs:
       - name: Enable pnpm
         run: corepack enable
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ apps/web/.next/
 apps/web/out/
 apps/api/static/assets/
 .overmind.sock
+
+# goreleaser output
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -79,6 +79,46 @@ archives:
         formats: [zip]
     files:
       - README.md
+dockers:
+  - id: server-amd64
+    image_templates:
+      - 'ghcr.io/getstackit/stackit-server:{{ .Version }}-amd64'
+    ids: [server]
+    dockerfile: Dockerfile.server
+    use: buildx
+    goos: linux
+    goarch: amd64
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.source=https://github.com/getstackit/stackit"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.revision={{.Commit}}"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+  - id: server-arm64
+    image_templates:
+      - 'ghcr.io/getstackit/stackit-server:{{ .Version }}-arm64'
+    ids: [server]
+    dockerfile: Dockerfile.server
+    use: buildx
+    goos: linux
+    goarch: arm64
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.source=https://github.com/getstackit/stackit"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.revision={{.Commit}}"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+
+docker_manifests:
+  - name_template: 'ghcr.io/getstackit/stackit-server:{{ .Version }}'
+    image_templates:
+      - 'ghcr.io/getstackit/stackit-server:{{ .Version }}-amd64'
+      - 'ghcr.io/getstackit/stackit-server:{{ .Version }}-arm64'
+  - name_template: 'ghcr.io/getstackit/stackit-server:latest'
+    image_templates:
+      - 'ghcr.io/getstackit/stackit-server:{{ .Version }}-amd64'
+      - 'ghcr.io/getstackit/stackit-server:{{ .Version }}-arm64'
+
 checksum:
   name_template: 'checksums.txt'
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -79,45 +79,23 @@ archives:
         formats: [zip]
     files:
       - README.md
-dockers:
-  - id: server-amd64
-    image_templates:
-      - 'ghcr.io/getstackit/stackit-server:{{ .Version }}-amd64'
+dockers_v2:
+  - id: server
     ids: [server]
     dockerfile: Dockerfile.server
-    use: buildx
-    goos: linux
-    goarch: amd64
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.source=https://github.com/getstackit/stackit"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.revision={{.Commit}}"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-  - id: server-arm64
-    image_templates:
-      - 'ghcr.io/getstackit/stackit-server:{{ .Version }}-arm64'
-    ids: [server]
-    dockerfile: Dockerfile.server
-    use: buildx
-    goos: linux
-    goarch: arm64
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.source=https://github.com/getstackit/stackit"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.revision={{.Commit}}"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-
-docker_manifests:
-  - name_template: 'ghcr.io/getstackit/stackit-server:{{ .Version }}'
-    image_templates:
-      - 'ghcr.io/getstackit/stackit-server:{{ .Version }}-amd64'
-      - 'ghcr.io/getstackit/stackit-server:{{ .Version }}-arm64'
-  - name_template: 'ghcr.io/getstackit/stackit-server:latest'
-    image_templates:
-      - 'ghcr.io/getstackit/stackit-server:{{ .Version }}-amd64'
-      - 'ghcr.io/getstackit/stackit-server:{{ .Version }}-arm64'
+    images:
+      - ghcr.io/getstackit/stackit-server
+    tags:
+      - "{{ .Version }}"
+      - "{{ if not .IsSnapshot }}latest{{ end }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      "org.opencontainers.image.source": "https://github.com/getstackit/stackit"
+      "org.opencontainers.image.version": "{{.Version}}"
+      "org.opencontainers.image.revision": "{{.Commit}}"
+      "org.opencontainers.image.created": "{{.Date}}"
 
 checksum:
   name_template: 'checksums.txt'

--- a/.mise/tasks/server/publish-dev
+++ b/.mise/tasks/server/publish-dev
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#MISE description="Build and push a snapshot stackit-server image to ghcr.io without a release"
+#MISE alias="server:publish:dev"
+set -euo pipefail
+
+# Push a snapshot multi-arch image to ghcr.io for ad-hoc dogfooding (Railway,
+# remote pulls, etc.) without cutting a release tag. Uses goreleaser snapshot
+# mode to build the per-arch images locally, then re-tags and pushes them
+# under TAG (default: dev).
+#
+# Usage:
+#   mise run server:publish:dev                # pushes :dev (+ amd64/arm64)
+#   TAG=preview mise run server:publish:dev    # pushes :preview
+#   SKIP_BUILD=1 mise run server:publish:dev   # reuse existing dist/ output
+
+IMAGE="${IMAGE:-ghcr.io/getstackit/stackit-server}"
+TAG="${TAG:-dev}"
+SKIP_BUILD="${SKIP_BUILD:-0}"
+
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[0;33m'
+RED=$'\033[0;31m'
+RESET=$'\033[0m'
+
+log()  { printf "%s==>%s %s\n" "$GREEN" "$RESET" "$*"; }
+warn() { printf "%s==>%s %s\n" "$YELLOW" "$RESET" "$*" >&2; }
+die()  { printf "%serror:%s %s\n" "$RED" "$RESET" "$*" >&2; exit 1; }
+
+command -v docker >/dev/null    || die "docker not on PATH"
+command -v goreleaser >/dev/null || die "goreleaser not on PATH (mise should install it)"
+command -v jq >/dev/null         || die "jq not on PATH"
+
+# Verify we can push to GHCR before spending 90s on a build.
+if ! docker buildx imagetools inspect "$IMAGE:latest" >/dev/null 2>&1; then
+  if ! grep -q '"ghcr.io"' "${HOME}/.docker/config.json" 2>/dev/null; then
+    warn "Not logged into ghcr.io — attempting via 'gh auth token'."
+    if command -v gh >/dev/null && gh auth token >/dev/null 2>&1; then
+      gh auth token | docker login ghcr.io \
+        -u "$(gh api user --jq .login)" --password-stdin
+    else
+      die "Login to ghcr.io first. Run: gh auth refresh -s write:packages,read:packages && \\
+       echo \$(gh auth token) | docker login ghcr.io -u \$(gh api user --jq .login) --password-stdin"
+    fi
+  fi
+fi
+
+if [ "$SKIP_BUILD" != "1" ]; then
+  log "Building snapshot images (multi-arch, this takes a few minutes)..."
+  goreleaser release --snapshot --clean \
+    --skip=archive,homebrew,scoop,nfpm,sbom,announce,publish
+else
+  log "SKIP_BUILD=1 — reusing existing dist/"
+  [ -f dist/metadata.json ] || die "dist/metadata.json missing; can't skip build"
+fi
+
+SNAP_VERSION="$(jq -r .version dist/metadata.json)"
+log "Snapshot version: ${SNAP_VERSION}"
+log "Pushing to ${IMAGE}:${TAG} (+ ${TAG}-amd64, ${TAG}-arm64)"
+
+for arch in amd64 arm64; do
+  src="${IMAGE}:${SNAP_VERSION}-${arch}"
+  dst="${IMAGE}:${TAG}-${arch}"
+  docker tag "$src" "$dst"
+  docker push "$dst"
+done
+
+# Manifest may already exist locally from a previous run; recreate it cleanly.
+docker manifest rm "${IMAGE}:${TAG}" >/dev/null 2>&1 || true
+docker manifest create "${IMAGE}:${TAG}" \
+  "${IMAGE}:${TAG}-amd64" \
+  "${IMAGE}:${TAG}-arm64"
+docker manifest push "${IMAGE}:${TAG}"
+
+log "Done. Pull with:  docker pull ${IMAGE}:${TAG}"
+log "Verify multi-arch: docker buildx imagetools inspect ${IMAGE}:${TAG}"

--- a/.mise/tasks/server/publish-dev
+++ b/.mise/tasks/server/publish-dev
@@ -30,19 +30,29 @@ command -v docker >/dev/null    || die "docker not on PATH"
 command -v goreleaser >/dev/null || die "goreleaser not on PATH (mise should install it)"
 command -v jq >/dev/null         || die "jq not on PATH"
 
-# Verify we can push to GHCR before spending 90s on a build.
-if ! docker buildx imagetools inspect "$IMAGE:latest" >/dev/null 2>&1; then
-  if ! grep -q '"ghcr.io"' "${HOME}/.docker/config.json" 2>/dev/null; then
-    warn "Not logged into ghcr.io — attempting via 'gh auth token'."
-    if command -v gh >/dev/null && gh auth token >/dev/null 2>&1; then
-      gh auth token | docker login ghcr.io \
-        -u "$(gh api user --jq .login)" --password-stdin
-    else
-      die "Login to ghcr.io first. Run: gh auth refresh -s write:packages,read:packages && \\
-       echo \$(gh auth token) | docker login ghcr.io -u \$(gh api user --jq .login) --password-stdin"
-    fi
-  fi
-fi
+# Auth to ghcr.io before spending 90s on a build. We always reset the
+# docker credential here because cached creds from a prior login with
+# narrower scopes (e.g. missing write:packages) succeed at login time but
+# fail at push time — leading to wasted builds. Pulling a fresh token from
+# `gh auth` and re-logging in every run avoids that footgun.
+command -v gh >/dev/null \
+  || die "gh CLI not on PATH (used to mint a ghcr.io token)"
+gh auth token >/dev/null 2>&1 \
+  || die "gh CLI not logged in. Run: gh auth login"
+
+scopes="$(gh auth status 2>&1 | sed -n 's/.*Token scopes: //p')"
+case "$scopes" in
+  *"write:packages"*) ;;
+  *)
+    die "gh token is missing the 'write:packages' scope (got: ${scopes:-none}).
+       Run: gh auth refresh -s write:packages,read:packages"
+    ;;
+esac
+
+log "Logging into ghcr.io with current gh token"
+docker logout ghcr.io >/dev/null 2>&1 || true
+gh auth token | docker login ghcr.io \
+  -u "$(gh api user --jq .login)" --password-stdin >/dev/null
 
 if [ "$SKIP_BUILD" != "1" ]; then
   log "Building snapshot images (multi-arch, this takes a few minutes)..."

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,12 +1,17 @@
-# Image for stackit-server. Goreleaser builds binaries via cross-compile and
-# drops the linux/amd64 or linux/arm64 binary into the build context, where
-# this COPY picks it up. Alpine (not distroless-static) because the server
-# shells out to git for every git op — distroless has no git binary.
+# Image for stackit-server. Goreleaser dockers_v2 builds binaries via
+# cross-compile and arranges them under linux/<arch>/ in the build context,
+# which TARGETPLATFORM ("linux/amd64" or "linux/arm64") then selects.
+# Alpine (not distroless-static) because the server shells out to git for
+# every git op — distroless has no git binary.
 FROM alpine:3.20
 
-RUN apk add --no-cache git ca-certificates tzdata
+RUN apk add --no-cache git ca-certificates tzdata \
+ && addgroup -S -g 10001 stackit \
+ && adduser -S -D -H -u 10001 -G stackit stackit
 
-COPY stackit-server /usr/local/bin/stackit-server
+ARG TARGETPLATFORM
+COPY --chown=stackit:stackit $TARGETPLATFORM/stackit-server /usr/local/bin/stackit-server
 
+USER stackit:stackit
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/stackit-server"]

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,12 @@
+# Image for stackit-server. Goreleaser builds binaries via cross-compile and
+# drops the linux/amd64 or linux/arm64 binary into the build context, where
+# this COPY picks it up. Alpine (not distroless-static) because the server
+# shells out to git for every git op — distroless has no git binary.
+FROM alpine:3.20
+
+RUN apk add --no-cache git ca-certificates tzdata
+
+COPY stackit-server /usr/local/bin/stackit-server
+
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/stackit-server"]

--- a/apps/server/auth.go
+++ b/apps/server/auth.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/getstackit/stackit/internal/api"
+	"github.com/getstackit/stackit/internal/api/auth"
+)
+
+// authBuildResult is what buildAuthConfig returns when auth is enabled.
+type authBuildResult struct {
+	cfg   *api.AuthConfig
+	store auth.Store // exposed separately so main can close it on shutdown
+}
+
+// buildAuthConfig wires up the OAuth handler, session store, and allowlist
+// from environment variables. Returns (nil, nil, nil) when auth is
+// explicitly disabled; an error when required env is missing in public
+// mode.
+func buildAuthConfig(authDisabled, publicMode bool) (*authBuildResult, error) {
+	if authDisabled {
+		if publicMode {
+			return nil, errors.New("-auth-disabled is not allowed when $PORT or $STACKIT_PUBLIC are set; remove the flag or unset the env vars")
+		}
+		return nil, nil
+	}
+
+	clientID := strings.TrimSpace(os.Getenv("STACKIT_GITHUB_CLIENT_ID"))
+	clientSecret := strings.TrimSpace(os.Getenv("STACKIT_GITHUB_CLIENT_SECRET"))
+	baseURL := strings.TrimSpace(os.Getenv("STACKIT_BASE_URL"))
+	sessionKey := strings.TrimSpace(os.Getenv("STACKIT_SESSION_KEY"))
+
+	// Outside public mode, missing OAuth config is "off by default" —
+	// users running a local dev binary shouldn't have to set env vars to
+	// boot. They can pass -auth-disabled explicitly to make the intent
+	// clear, or just leave the OAuth env unset.
+	if clientID == "" && clientSecret == "" && baseURL == "" && sessionKey == "" {
+		if publicMode {
+			return nil, errors.New("public mode requires STACKIT_GITHUB_CLIENT_ID, STACKIT_GITHUB_CLIENT_SECRET, STACKIT_BASE_URL, STACKIT_SESSION_KEY (and STACKIT_ALLOWED_GH_USERS or STACKIT_ALLOWED_GH_ORG); pass -auth-disabled if you really mean to run open")
+		}
+		return nil, nil
+	}
+
+	if clientID == "" {
+		return nil, errors.New("STACKIT_GITHUB_CLIENT_ID is required when configuring auth")
+	}
+	if clientSecret == "" {
+		return nil, errors.New("STACKIT_GITHUB_CLIENT_SECRET is required when configuring auth")
+	}
+	if baseURL == "" {
+		return nil, errors.New("STACKIT_BASE_URL is required when configuring auth")
+	}
+	if sessionKey == "" {
+		return nil, errors.New("STACKIT_SESSION_KEY is required when configuring auth (generate with: openssl rand -base64 32)")
+	}
+
+	cipher, err := auth.NewCipher(sessionKey)
+	if err != nil {
+		return nil, fmt.Errorf("STACKIT_SESSION_KEY: %w", err)
+	}
+
+	allow, err := auth.NewAllowlist(auth.AllowlistConfig{
+		Users: parseCSV(os.Getenv("STACKIT_ALLOWED_GH_USERS")),
+		Org:   strings.TrimSpace(os.Getenv("STACKIT_ALLOWED_GH_ORG")),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("allowlist: %w", err)
+	}
+
+	store := auth.NewMemoryStore(cipher)
+
+	handler, err := auth.NewHandler(auth.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		BaseURL:      baseURL,
+		Cookies:      auth.CookieOptions{Secure: publicMode || strings.HasPrefix(baseURL, "https://")},
+	}, store, allow, cipher)
+	if err != nil {
+		_ = store.Close()
+		return nil, err
+	}
+
+	return &authBuildResult{
+		cfg:   &api.AuthConfig{Handler: handler, SessionStore: store},
+		store: store,
+	}, nil
+}

--- a/apps/server/auth_test.go
+++ b/apps/server/auth_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/getstackit/stackit/internal/api/auth"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildAuthConfig_DisabledLocalOK(t *testing.T) {
+	t.Parallel()
+
+	r, err := buildAuthConfig(true, false)
+	require.NoError(t, err)
+	require.Nil(t, r)
+}
+
+func TestBuildAuthConfig_DisabledInPublicModeRefused(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildAuthConfig(true, true)
+	require.Error(t, err)
+}
+
+func TestBuildAuthConfig_NoEnvLocalFallsThroughToUnauthed(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel; these tests share process env.
+	withEnv(t, map[string]string{
+		"STACKIT_GITHUB_CLIENT_ID":     "",
+		"STACKIT_GITHUB_CLIENT_SECRET": "",
+		"STACKIT_BASE_URL":             "",
+		"STACKIT_SESSION_KEY":          "",
+		"STACKIT_ALLOWED_GH_USERS":     "",
+		"STACKIT_ALLOWED_GH_ORG":       "",
+	})
+
+	r, err := buildAuthConfig(false, false)
+	require.NoError(t, err)
+	require.Nil(t, r, "no env + local mode = no auth, no error")
+}
+
+func TestBuildAuthConfig_NoEnvInPublicModeRefused(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel; these tests share process env.
+	withEnv(t, map[string]string{
+		"STACKIT_GITHUB_CLIENT_ID":     "",
+		"STACKIT_GITHUB_CLIENT_SECRET": "",
+		"STACKIT_BASE_URL":             "",
+		"STACKIT_SESSION_KEY":          "",
+		"STACKIT_ALLOWED_GH_USERS":     "",
+		"STACKIT_ALLOWED_GH_ORG":       "",
+	})
+
+	_, err := buildAuthConfig(false, true)
+	require.Error(t, err)
+}
+
+func TestBuildAuthConfig_PartialEnvErrors(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel; these tests share process env.
+	withEnv(t, map[string]string{
+		"STACKIT_GITHUB_CLIENT_ID":     "id",
+		"STACKIT_GITHUB_CLIENT_SECRET": "",
+		"STACKIT_BASE_URL":             "https://example.com",
+		"STACKIT_SESSION_KEY":          mustKey(t),
+		"STACKIT_ALLOWED_GH_USERS":     "jonnii",
+	})
+
+	_, err := buildAuthConfig(false, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "STACKIT_GITHUB_CLIENT_SECRET")
+}
+
+func TestBuildAuthConfig_HappyPath(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel; these tests share process env.
+	withEnv(t, map[string]string{
+		"STACKIT_GITHUB_CLIENT_ID":     "id",
+		"STACKIT_GITHUB_CLIENT_SECRET": "secret",
+		"STACKIT_BASE_URL":             "https://example.com",
+		"STACKIT_SESSION_KEY":          mustKey(t),
+		"STACKIT_ALLOWED_GH_USERS":     "jonnii",
+	})
+
+	r, err := buildAuthConfig(false, false)
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	require.NotNil(t, r.cfg.Handler)
+	require.NotNil(t, r.cfg.SessionStore)
+	require.NoError(t, r.store.Close())
+}
+
+func TestBuildAuthConfig_EmptyAllowlistErrors(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel; these tests share process env.
+	withEnv(t, map[string]string{
+		"STACKIT_GITHUB_CLIENT_ID":     "id",
+		"STACKIT_GITHUB_CLIENT_SECRET": "secret",
+		"STACKIT_BASE_URL":             "https://example.com",
+		"STACKIT_SESSION_KEY":          mustKey(t),
+		"STACKIT_ALLOWED_GH_USERS":     "",
+		"STACKIT_ALLOWED_GH_ORG":       "",
+	})
+
+	_, err := buildAuthConfig(false, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "allowlist")
+}
+
+func withEnv(t *testing.T, kvs map[string]string) {
+	t.Helper()
+	for k, v := range kvs {
+		t.Setenv(k, v)
+	}
+}
+
+func mustKey(t *testing.T) string {
+	t.Helper()
+	k, err := auth.GenerateSessionKey()
+	require.NoError(t, err)
+	return k
+}

--- a/apps/server/bind.go
+++ b/apps/server/bind.go
@@ -1,0 +1,17 @@
+package main
+
+// resolveBind picks the default bind address when the operator did not pass
+// -bind explicitly. Locally we want 127.0.0.1 so the API isn't reachable to
+// other users on the host; PaaS / container deploys flip to 0.0.0.0 because
+// the platform's router is on a different interface. publicHint is true when
+// $PORT or $STACKIT_PUBLIC are set, both of which signal a hosted runtime.
+func resolveBind(flagBind *string, bindExplicit, publicHint bool) {
+	if bindExplicit {
+		return
+	}
+	if publicHint {
+		*flagBind = "0.0.0.0"
+		return
+	}
+	*flagBind = "127.0.0.1"
+}

--- a/apps/server/bind_test.go
+++ b/apps/server/bind_test.go
@@ -1,0 +1,31 @@
+package main
+
+import "testing"
+
+func TestResolveBind(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		bind       string
+		explicit   bool
+		publicHint bool
+		want       string
+	}{
+		{name: "explicit operator value wins", bind: "10.0.0.5", explicit: true, want: "10.0.0.5"},
+		{name: "explicit empty value wins too", bind: "", explicit: true, want: ""},
+		{name: "PaaS hint flips to all interfaces", publicHint: true, want: "0.0.0.0"},
+		{name: "local default is loopback", want: "127.0.0.1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := tc.bind
+			resolveBind(&b, tc.explicit, tc.publicHint)
+			if b != tc.want {
+				t.Fatalf("resolveBind(%q, explicit=%v, publicHint=%v) = %q, want %q",
+					tc.bind, tc.explicit, tc.publicHint, b, tc.want)
+			}
+		})
+	}
+}

--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -44,6 +44,18 @@ func run() error {
 	)
 	flag.Parse()
 
+	// Honor $PORT when -port wasn't passed explicitly. PaaS hosts (Railway,
+	// Fly, Heroku) inject the port this way.
+	portExplicit := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "port" {
+			portExplicit = true
+		}
+	})
+	if err := resolvePort(port, portExplicit, os.Getenv("PORT")); err != nil {
+		return err
+	}
+
 	staticFS, err := fs.Sub(staticFiles, "static")
 	if err != nil {
 		return err

--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -42,6 +42,7 @@ func run() error {
 		apiPrefix       = flag.String("api-prefix", "/api/v1", "Canonical API prefix")
 		enableLegacy    = flag.Bool("legacy-api-prefix", true, "Also expose legacy /api endpoints")
 		shutdownGrace   = flag.Duration("shutdown-timeout", 10*time.Second, "Graceful shutdown timeout")
+		authDisabled    = flag.Bool("auth-disabled", false, "Disable GitHub OAuth gate. Refused in public mode ($PORT or $STACKIT_PUBLIC).")
 	)
 	flag.Parse()
 
@@ -103,6 +104,24 @@ func run() error {
 		}
 	}
 
+	publicMode := os.Getenv("PORT") != "" || os.Getenv("STACKIT_PUBLIC") != ""
+	authBuild, err := buildAuthConfig(*authDisabled, publicMode)
+	if err != nil {
+		return err
+	}
+	var authCfg *api.AuthConfig
+	if authBuild != nil {
+		authCfg = authBuild.cfg
+		defer func() {
+			if closeErr := authBuild.store.Close(); closeErr != nil {
+				log.Printf("session store close: %v", closeErr)
+			}
+		}()
+		log.Printf("auth: GitHub OAuth gate enabled")
+	} else {
+		log.Printf("auth: DISABLED (no STACKIT_GITHUB_* env or -auth-disabled set). Do not expose this port publicly.")
+	}
+
 	server := api.NewServer(api.ServerConfig{
 		BindAddr:    *bind,
 		Port:        *port,
@@ -110,6 +129,7 @@ func run() error {
 		APIPrefixes: prefixes,
 		StaticFS:    staticFS,
 		Registry:    reg,
+		Auth:        authCfg,
 	})
 
 	errCh := make(chan error, 1)

--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -34,6 +34,7 @@ func main() {
 func run() error {
 	var (
 		port            = flag.Int("port", 8080, "Port to listen on")
+		bind            = flag.String("bind", "", "Interface to bind on. Defaults to 127.0.0.1; switches to 0.0.0.0 when $PORT or $STACKIT_PUBLIC is set.")
 		cwd             = flag.String("cwd", "", "Working directory for repository detection (single-repo shortcut; ignored when -repos-config is set)")
 		reposConfigPath = flag.String("repos-config", "", "Path to a JSON file listing repos to serve (mutually exclusive with -cwd)")
 		remote          = flag.String("remote", "origin", "Default git remote name for the single-repo -cwd shortcut")
@@ -47,14 +48,19 @@ func run() error {
 	// Honor $PORT when -port wasn't passed explicitly. PaaS hosts (Railway,
 	// Fly, Heroku) inject the port this way.
 	portExplicit := false
+	bindExplicit := false
 	flag.Visit(func(f *flag.Flag) {
-		if f.Name == "port" {
+		switch f.Name {
+		case "port":
 			portExplicit = true
+		case "bind":
+			bindExplicit = true
 		}
 	})
 	if err := resolvePort(port, portExplicit, os.Getenv("PORT")); err != nil {
 		return err
 	}
+	resolveBind(bind, bindExplicit, os.Getenv("PORT") != "" || os.Getenv("STACKIT_PUBLIC") != "")
 
 	staticFS, err := fs.Sub(staticFiles, "static")
 	if err != nil {
@@ -98,6 +104,7 @@ func run() error {
 	}
 
 	server := api.NewServer(api.ServerConfig{
+		BindAddr:    *bind,
 		Port:        *port,
 		CORSOrigins: parseCSV(*corsOrigins),
 		APIPrefixes: prefixes,

--- a/apps/server/port.go
+++ b/apps/server/port.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// resolvePort applies a $PORT fallback when -port wasn't passed explicitly.
+// flagPort is the destination flag pointer. When portExplicit is true the
+// env value is ignored (the operator wins). An empty env is a no-op.
+func resolvePort(flagPort *int, portExplicit bool, env string) error {
+	if portExplicit {
+		return nil
+	}
+	env = strings.TrimSpace(env)
+	if env == "" {
+		return nil
+	}
+	p, err := strconv.Atoi(env)
+	if err != nil {
+		return fmt.Errorf("invalid PORT env %q: %w", env, err)
+	}
+	*flagPort = p
+	return nil
+}

--- a/apps/server/port_test.go
+++ b/apps/server/port_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		start          int
+		portExplicit   bool
+		env            string
+		wantPort       int
+		wantErrContain string
+	}{
+		{
+			name:     "no env keeps default",
+			start:    8080,
+			env:      "",
+			wantPort: 8080,
+		},
+		{
+			name:     "env populates default",
+			start:    8080,
+			env:      "3000",
+			wantPort: 3000,
+		},
+		{
+			name:     "explicit flag wins over env",
+			start:    9999,
+			env:      "3000",
+			wantPort: 9999, portExplicit: true,
+		},
+		{
+			name:     "whitespace env is treated as unset",
+			start:    8080,
+			env:      "   ",
+			wantPort: 8080,
+		},
+		{
+			name:           "invalid env returns error",
+			start:          8080,
+			env:            "not-a-number",
+			wantErrContain: "invalid PORT env",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			port := tt.start
+			err := resolvePort(&port, tt.portExplicit, tt.env)
+			if tt.wantErrContain != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErrContain)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantPort, port)
+		})
+	}
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,21 +1,21 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import { Suspense } from "react";
+import { useSearchParams } from "next/navigation";
 import { RepoProvider } from "@/components/providers/repo-provider";
 import { RepoPicker } from "@/components/repo-picker/repo-picker";
 import { RepoView } from "@/components/repo-picker/repo-view";
 
 // Single root page driving both the unscoped picker and the per-repo view.
 //
-// The Next.js build is `output: 'export'` (static HTML) and the Go static
-// handler falls back to the root index.html for any extension-less path —
-// effectively SPA mode. We read the pathname on the client and either show
-// the picker (path "/") or render RepoView wrapped in RepoProvider scoped
-// to the first path segment.
-export default function Home() {
-  const pathname = usePathname();
-  const segments = (pathname || "/").split("/").filter(Boolean);
-  const repoId = segments[0] ? decodeURIComponent(segments[0]) : "";
+// The Next.js build is `output: 'export'`, so only the root URL is emitted.
+// We scope to a repo via the `?repo=<id>` query string rather than a path
+// segment — that way the same static index.html handles every repo in both
+// `next dev` and the embedded production server, with no per-repo route to
+// pre-generate.
+function Home() {
+  const params = useSearchParams();
+  const repoId = params.get("repo") ?? "";
 
   if (!repoId) {
     return <RepoPicker />;
@@ -25,5 +25,13 @@ export default function Home() {
     <RepoProvider repoId={repoId}>
       <RepoView />
     </RepoProvider>
+  );
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={null}>
+      <Home />
+    </Suspense>
   );
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,9 +2,17 @@
 
 import { Suspense } from "react";
 import { useSearchParams } from "next/navigation";
+import { AuthProvider } from "@/components/providers/auth-provider";
 import { RepoProvider } from "@/components/providers/repo-provider";
 import { RepoPicker } from "@/components/repo-picker/repo-picker";
 import { RepoView } from "@/components/repo-picker/repo-view";
+
+// NEXT_PUBLIC_STACKIT_AUTH_DISABLED=1 short-circuits the /auth/me check
+// at build time. Useful for `next dev` against a server started with
+// -auth-disabled, or for builds intended for deployments where the
+// operator has fronted the server with platform auth (Tailscale,
+// Cloudflare Access).
+const AUTH_DISABLED = process.env.NEXT_PUBLIC_STACKIT_AUTH_DISABLED === "1";
 
 // Single root page driving both the unscoped picker and the per-repo view.
 //
@@ -31,7 +39,9 @@ function Home() {
 export default function Page() {
   return (
     <Suspense fallback={null}>
-      <Home />
+      <AuthProvider disable={AUTH_DISABLED}>
+        <Home />
+      </AuthProvider>
     </Suspense>
   );
 }

--- a/apps/web/src/components/providers/auth-provider.tsx
+++ b/apps/web/src/components/providers/auth-provider.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import {
+  authLoginURL,
+  fetchMe,
+  logout as apiLogout,
+  type MeResponse,
+  UnauthorizedError,
+} from "@/lib/api";
+
+interface AuthContextValue {
+  // user is null while loading; remains null after a 401 (the provider will
+  // render the login screen instead of children in that case).
+  user: MeResponse | null;
+  isLoading: boolean;
+  loginURL: string;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  isLoading: true,
+  loginURL: "/auth/login",
+  logout: async () => {},
+});
+
+export function useAuth() {
+  return useContext(AuthContext);
+}
+
+interface AuthProviderProps {
+  children: React.ReactNode;
+  // disable lets us short-circuit the auth check in dev / local-mode
+  // deployments where the server doesn't run /auth/*. The provider then
+  // pretends the user is signed in with a placeholder identity.
+  disable?: boolean;
+}
+
+const PLACEHOLDER_LOCAL_USER: MeResponse = { login: "local", id: 0 };
+
+// AuthProvider gates the rest of the app on a /auth/me check. While the
+// fetch is pending it renders nothing; on 401 it swaps in a sign-in card;
+// on success it renders children with the user identity exposed via
+// context. Network failures other than 401 render a small error message
+// so the app doesn't silently hang on a broken backend.
+export function AuthProvider({ children, disable }: AuthProviderProps) {
+  const [user, setUser] = useState<MeResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(!disable);
+  const [error, setError] = useState<string | null>(null);
+  const [needsLogin, setNeedsLogin] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      const me = await fetchMe();
+      setUser(me);
+      setNeedsLogin(false);
+    } catch (e) {
+      if (e instanceof UnauthorizedError) {
+        setUser(null);
+        setNeedsLogin(true);
+      } else {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (disable) {
+      setUser(PLACEHOLDER_LOCAL_USER);
+      return;
+    }
+    void refresh();
+  }, [disable, refresh]);
+
+  const logout = useCallback(async () => {
+    try {
+      await apiLogout();
+    } finally {
+      setUser(null);
+      setNeedsLogin(true);
+    }
+  }, []);
+
+  const returnTo =
+    typeof window !== "undefined" ? window.location.pathname + window.location.search : "/";
+  const loginURL = authLoginURL(returnTo);
+
+  if (isLoading) {
+    return <AuthBoundary>Loading…</AuthBoundary>;
+  }
+  if (error) {
+    return (
+      <AuthBoundary>
+        <p className="text-sm text-muted-foreground">
+          Couldn&apos;t reach the API: {error}
+        </p>
+      </AuthBoundary>
+    );
+  }
+  if (needsLogin) {
+    return <SignIn loginURL={loginURL} />;
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, isLoading: false, loginURL, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+function AuthBoundary({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center p-8">
+      <div className="max-w-md text-center">{children}</div>
+    </div>
+  );
+}
+
+function SignIn({ loginURL }: { loginURL: string }) {
+  return (
+    <AuthBoundary>
+      <h1 className="mb-2 text-2xl font-semibold">stackit</h1>
+      <p className="mb-6 text-sm text-muted-foreground">
+        Sign in with GitHub to continue.
+      </p>
+      <a
+        href={loginURL}
+        className="inline-flex items-center justify-center rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background hover:opacity-90"
+      >
+        Sign in with GitHub
+      </a>
+    </AuthBoundary>
+  );
+}

--- a/apps/web/src/components/repo-picker/__tests__/repo-picker.test.tsx
+++ b/apps/web/src/components/repo-picker/__tests__/repo-picker.test.tsx
@@ -40,7 +40,7 @@ describe("RepoPicker", () => {
     expect(screen.getByText("Other Project")).toBeDefined();
   });
 
-  it("navigates to /{repoId} on click", async () => {
+  it("navigates to /?repo={repoId} on click", async () => {
     mockRepos({
       repos: [{ id: "stackit", displayName: "Stackit", trunk: "main" }],
     });
@@ -49,7 +49,7 @@ describe("RepoPicker", () => {
 
     const card = await screen.findByTestId("repo-card-stackit");
     fireEvent.click(card);
-    expect(mockPush).toHaveBeenCalledWith("/stackit");
+    expect(mockPush).toHaveBeenCalledWith("/?repo=stackit");
   });
 
   it("shows the empty-state message when no repos are configured", async () => {

--- a/apps/web/src/components/repo-picker/repo-picker.tsx
+++ b/apps/web/src/components/repo-picker/repo-picker.tsx
@@ -80,7 +80,7 @@ export function RepoPicker() {
             <button
               type="button"
               data-testid={`repo-card-${repo.id}`}
-              onClick={() => router.push(`/${encodeURIComponent(repo.id)}`)}
+              onClick={() => router.push(`/?repo=${encodeURIComponent(repo.id)}`)}
               className="block w-full text-left transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
             >
               <Card>

--- a/apps/web/src/lib/__tests__/api.test.ts
+++ b/apps/web/src/lib/__tests__/api.test.ts
@@ -38,7 +38,9 @@ describe("fetchRepos", () => {
 
     const result = await fetchRepos();
     expect(result).toEqual(data);
-    expect(mockFetch).toHaveBeenCalledWith("http://localhost:8080/api/v1/repos");
+    expect(mockFetch).toHaveBeenCalledWith("http://localhost:8080/api/v1/repos", {
+      credentials: "include",
+    });
   });
 });
 
@@ -50,7 +52,8 @@ describe("fetchView", () => {
     const result = await fetchView("stackit");
     expect(result).toEqual(data);
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/view"
+      "http://localhost:8080/api/v1/repos/stackit/view",
+      { credentials: "include" }
     );
   });
 });
@@ -63,7 +66,8 @@ describe("fetchRepo", () => {
     const result = await fetchRepo("stackit");
     expect(result).toEqual(data);
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/repo"
+      "http://localhost:8080/api/v1/repos/stackit/repo",
+      { credentials: "include" }
     );
   });
 });
@@ -74,7 +78,8 @@ describe("fetchStacks", () => {
     const result = await fetchStacks("stackit");
     expect(result).toEqual([]);
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/stacks"
+      "http://localhost:8080/api/v1/repos/stackit/stacks",
+      { credentials: "include" }
     );
   });
 });
@@ -85,7 +90,8 @@ describe("fetchStack", () => {
 
     await fetchStack("stackit", "feat/foo");
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/stacks/feat%2Ffoo"
+      "http://localhost:8080/api/v1/repos/stackit/stacks/feat%2Ffoo",
+      { credentials: "include" }
     );
   });
 });
@@ -96,7 +102,8 @@ describe("fetchBranch", () => {
 
     await fetchBranch("stackit", "feat/bar");
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/branches/feat%2Fbar"
+      "http://localhost:8080/api/v1/repos/stackit/branches/feat%2Fbar",
+      { credentials: "include" }
     );
   });
 });
@@ -107,7 +114,8 @@ describe("fetchBranchDiff", () => {
 
     await fetchBranchDiff("stackit", "feat/bar");
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/branch-diff?branch=feat%2Fbar"
+      "http://localhost:8080/api/v1/repos/stackit/branch-diff?branch=feat%2Fbar",
+      { credentials: "include" }
     );
   });
 });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -126,14 +126,59 @@ export interface ViewResponse {
   recentlyMerged?: TrunkCommitResponse[];
 }
 
+// --- Auth Types ---
+
+export interface MeResponse {
+  login: string;
+  id: number;
+}
+
+// UnauthorizedError is thrown by fetchAPI on a 401. Callers (the auth
+// provider) translate it into a redirect to /auth/login; other consumers
+// can treat it as a fatal error.
+export class UnauthorizedError extends Error {
+  constructor() {
+    super("unauthenticated");
+    this.name = "UnauthorizedError";
+  }
+}
+
 // --- Fetch Functions ---
 
 async function fetchAPI<T>(path: string): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`);
+  // credentials: include sends the session cookie cross-origin during
+  // `next dev` (web on :3000, API on :8080). The server's CORS layer
+  // sets Allow-Credentials: true for configured origins.
+  const res = await fetch(`${API_BASE}${path}`, { credentials: "include" });
+  if (res.status === 401) {
+    throw new UnauthorizedError();
+  }
   if (!res.ok) {
     throw new Error(`API error: ${res.status} ${res.statusText}`);
   }
   return res.json();
+}
+
+export function fetchMe(): Promise<MeResponse> {
+  return fetchAPI<MeResponse>("/auth/me");
+}
+
+export function authLoginURL(returnTo?: string): string {
+  const path = "/auth/login";
+  if (!returnTo) {
+    return `${API_BASE}${path}`;
+  }
+  return `${API_BASE}${path}?return=${encodeURIComponent(returnTo)}`;
+}
+
+export async function logout(): Promise<void> {
+  const res = await fetch(`${API_BASE}/auth/logout`, {
+    method: "POST",
+    credentials: "include",
+  });
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`logout failed: ${res.status}`);
+  }
 }
 
 function repoPath(repoId: string, suffix: string): string {
@@ -215,8 +260,11 @@ export interface SubmitResponse {
 export async function submitStack(repoId: string, rootBranch: string): Promise<SubmitResponse> {
   const res = await fetch(
     `${API_BASE}${repoPath(repoId, `stacks/${encodeURIComponent(rootBranch)}/submit`)}`,
-    { method: "POST" }
+    { method: "POST", credentials: "include" }
   );
+  if (res.status === 401) {
+    throw new UnauthorizedError();
+  }
   const data: SubmitResponse = await res.json();
   if (!res.ok && !data.message) {
     throw new Error(`API error: ${res.status} ${res.statusText}`);

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2,6 +2,12 @@
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 
+// CSRF_HEADER must be sent on every non-safe request. The server doesn't
+// inspect the value, only the header's presence — see
+// internal/api/auth/middleware.go (RequireCSRFHeader).
+const CSRF_HEADER = "X-Stackit-CSRF";
+const CSRF_HEADER_VALUE = "1";
+
 // --- Response Types (matching Go API types) ---
 
 export interface RepoResponse {
@@ -175,6 +181,7 @@ export async function logout(): Promise<void> {
   const res = await fetch(`${API_BASE}/auth/logout`, {
     method: "POST",
     credentials: "include",
+    headers: { [CSRF_HEADER]: CSRF_HEADER_VALUE },
   });
   if (!res.ok && res.status !== 204) {
     throw new Error(`logout failed: ${res.status}`);
@@ -260,7 +267,11 @@ export interface SubmitResponse {
 export async function submitStack(repoId: string, rootBranch: string): Promise<SubmitResponse> {
   const res = await fetch(
     `${API_BASE}${repoPath(repoId, `stacks/${encodeURIComponent(rootBranch)}/submit`)}`,
-    { method: "POST", credentials: "include" }
+    {
+      method: "POST",
+      credentials: "include",
+      headers: { [CSRF_HEADER]: CSRF_HEADER_VALUE },
+    }
   );
   if (res.status === 401) {
     throw new UnauthorizedError();

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -133,6 +133,36 @@ this doc revision and follow-on PRs):
   web app sends it automatically; scripts and direct API callers must
   include it.
 
+### Audit logging
+
+The server emits a single-line `audit action=...` log entry for every
+identity-changing or mutating action. The fields are key-quoted so they
+can be ingested by any structured log pipeline.
+
+| Action | Emitted by | Fields |
+|--------|------------|--------|
+| `login` | `GET /auth/callback` after a successful exchange | `actor`, `user_id`, `target` (post-login URL), `request_id` |
+| `denied` | `GET /auth/callback` for non-allowlisted users | `actor`, `request_id` |
+| `logout` | `POST /auth/logout` | `actor`, `request_id` |
+| `submit` | `POST /api/v1/repos/{id}/stacks/{branch}/submit` | `actor`, `repo`, `branch`, `request_id` |
+
+Every request also carries a `X-Request-ID` response header with the
+same value used as `request_id` in the audit lines. Pass it through
+your reverse proxy (Caddy, Cloudflare) for end-to-end correlation.
+
+### Log retention
+
+The container writes everything to stdout/stderr; retention is the
+platform's responsibility. A useful baseline:
+
+- **Railway / Fly / Heroku** — keep the platform default (7–14 days),
+  ship to an external sink (BetterStack, Datadog, S3) for longer.
+- **Self-hosted Docker** — pipe `docker logs` to journald or an
+  equivalent rotating sink; aim for 30+ days on the audit lines.
+
+The `audit action=` prefix is stable; alert on `audit action=denied`
+and on bursts of `audit action=submit` from a single `actor`.
+
 ### Calling the API from scripts
 
 ```bash

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -53,8 +53,14 @@ running `stackit init` inside each one before starting the container.
 
 | Var | Purpose |
 |-----|---------|
-| `PORT` | Listen port. Honored when `-port` isn't passed explicitly — needed for Railway, Fly, Heroku. Defaults to `8080`. |
-| `STACKIT_PUBLIC` | If set (any value), flips the default bind from `127.0.0.1` to `0.0.0.0`. `PORT` does the same thing implicitly. |
+| `PORT` | Listen port. Honored when `-port` isn't passed explicitly — needed for Railway, Fly, Heroku. Defaults to `8080`. Setting this also implicitly switches the server into "public mode" (binds `0.0.0.0`, requires auth env). |
+| `STACKIT_PUBLIC` | Explicit version of the same signal. Set when you mean to expose the server publicly without `$PORT` (e.g. behind a tunnel). |
+| `STACKIT_BASE_URL` | The canonical https:// URL the server is reachable at. Required when auth is enabled (used to build the OAuth callback URL). |
+| `STACKIT_GITHUB_CLIENT_ID` | GitHub OAuth App client ID. |
+| `STACKIT_GITHUB_CLIENT_SECRET` | GitHub OAuth App client secret. |
+| `STACKIT_SESSION_KEY` | Base64-encoded 32-byte key for AES-GCM-encrypting access tokens at rest. Generate with `openssl rand -base64 32`. |
+| `STACKIT_ALLOWED_GH_USERS` | Comma-separated GitHub logins allowed to sign in. |
+| `STACKIT_ALLOWED_GH_ORG` | GitHub org slug; members may sign in. At least one of `_USERS` or `_ORG` is required. |
 
 ### Flags
 
@@ -66,8 +72,26 @@ The most useful flags:
 | `-port` | `8080` | Listen port; overrides `$PORT`. |
 | `-bind` | `127.0.0.1` (or `0.0.0.0` if `$PORT`/`$STACKIT_PUBLIC` are set) | Interface to bind on. Pass `-bind 0.0.0.0` explicitly to expose the server on a host where the heuristics don't fire. |
 | `-cors` | `http://localhost:3000,http://localhost:5173` | Comma-separated allowed CORS origins. Loopback origins are **not** allowed implicitly — list each origin you want to accept. |
+| `-auth-disabled` | `false` | Skip the GitHub OAuth gate. **Refused** when `$PORT` or `$STACKIT_PUBLIC` is set. Use only for local dev or when fronted by platform auth (Tailscale, Cloudflare Access). |
 
 Run `stackit-server -h` inside the container for the full list.
+
+### GitHub OAuth setup
+
+1. Create a GitHub OAuth App at [github.com/settings/developers](https://github.com/settings/developers).
+   - Homepage URL: your `STACKIT_BASE_URL`.
+   - Authorization callback URL: `${STACKIT_BASE_URL}/auth/callback`.
+2. Copy the client ID + secret into env.
+3. Generate a session key:
+   ```bash
+   openssl rand -base64 32
+   ```
+4. Set the allowlist (at least one of):
+   ```
+   STACKIT_ALLOWED_GH_USERS=jonnii,teammate
+   STACKIT_ALLOWED_GH_ORG=getstackit
+   ```
+5. Boot the server. The startup log prints `auth: GitHub OAuth gate enabled` when configured correctly.
 
 ## Security posture
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -108,7 +108,7 @@ The container is safe to run on a public hostname **only** behind:
    and creates PRs using the container's GitHub credentials.
 
 Built-in security controls (the server hardening pass that lands with
-this doc revision):
+this doc revision and follow-on PRs):
 
 - Process runs as the unprivileged `stackit` user (uid 10001) inside the
   container — neither user nor group is `root`.
@@ -125,6 +125,26 @@ this doc revision):
 - CORS allowlist is exact-match; no implicit loopback bypass.
 - Branch names supplied via path/query are validated against the same
   rules `stackit` enforces locally before reaching git.
+- GitHub OAuth gate via `STACKIT_GITHUB_*` + an allowlist. Every
+  `/api/*` route requires a valid session; the user's access token is
+  stored AES-GCM-encrypted at rest in the session store.
+- CSRF gate on every non-safe HTTP method: the server requires a
+  `X-Stackit-CSRF: 1` request header on POST/PUT/PATCH/DELETE. The
+  web app sends it automatically; scripts and direct API callers must
+  include it.
+
+### Calling the API from scripts
+
+```bash
+# Establish a session via your browser first; copy the stackit_session
+# cookie into the call, then add the CSRF header for mutating requests.
+curl https://stackit.example.com/api/v1/repos \
+  -H "Cookie: stackit_session=$STACKIT_SESSION"
+
+curl -X POST https://stackit.example.com/api/v1/repos/default/stacks/main/submit \
+  -H "Cookie: stackit_session=$STACKIT_SESSION" \
+  -H "X-Stackit-CSRF: 1"
+```
 
 ## Local smoke test
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -54,6 +54,7 @@ running `stackit init` inside each one before starting the container.
 | Var | Purpose |
 |-----|---------|
 | `PORT` | Listen port. Honored when `-port` isn't passed explicitly — needed for Railway, Fly, Heroku. Defaults to `8080`. |
+| `STACKIT_PUBLIC` | If set (any value), flips the default bind from `127.0.0.1` to `0.0.0.0`. `PORT` does the same thing implicitly. |
 
 ### Flags
 
@@ -63,9 +64,43 @@ The most useful flags:
 |------|---------|---------|
 | `-repos-config` | _(empty)_ | Path to the JSON repos file. Required for multi-repo mode. |
 | `-port` | `8080` | Listen port; overrides `$PORT`. |
-| `-cors` | `http://localhost:3000,http://localhost:5173` | Comma-separated allowed CORS origins. |
+| `-bind` | `127.0.0.1` (or `0.0.0.0` if `$PORT`/`$STACKIT_PUBLIC` are set) | Interface to bind on. Pass `-bind 0.0.0.0` explicitly to expose the server on a host where the heuristics don't fire. |
+| `-cors` | `http://localhost:3000,http://localhost:5173` | Comma-separated allowed CORS origins. Loopback origins are **not** allowed implicitly — list each origin you want to accept. |
 
 Run `stackit-server -h` inside the container for the full list.
+
+## Security posture
+
+The container is safe to run on a public hostname **only** behind:
+
+1. **TLS termination.** The server speaks plain HTTP; the PaaS / reverse
+   proxy in front (Railway, Fly, Cloudflare, Caddy, nginx) must terminate
+   HTTPS. The `Strict-Transport-Security` header the server emits assumes
+   this.
+2. **An authentication gateway** until in-process auth lands. Use Tailscale,
+   Cloudflare Access, an oauth2-proxy sidecar, or similar. Without one,
+   any caller can read every repo's branches/diffs and trigger
+   `POST /api/v1/repos/{id}/stacks/{branch}/submit`, which pushes branches
+   and creates PRs using the container's GitHub credentials.
+
+Built-in security controls (the server hardening pass that lands with
+this doc revision):
+
+- Process runs as the unprivileged `stackit` user (uid 10001) inside the
+  container — neither user nor group is `root`.
+- Default bind is `127.0.0.1`; the `$PORT`/`$STACKIT_PUBLIC` heuristic
+  flips to `0.0.0.0` so PaaS routers can reach the port.
+- Request body capped at 1 MiB; `MaxHeaderBytes` at 1 MiB; `WriteTimeout`
+  30 s, `IdleTimeout` 120 s, `ReadHeaderTimeout` 10 s.
+- Panic recovery middleware: a panicking handler returns 500 but cannot
+  kill the process.
+- Per-request `X-Request-ID` (16 random bytes) echoed back and logged.
+- Security headers on every response: `X-Content-Type-Options: nosniff`,
+  `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, `HSTS` with a
+  two-year max-age, and a CSP locked to `'self'` for scripts/connects.
+- CORS allowlist is exact-match; no implicit loopback bypass.
+- Branch names supplied via path/query are validated against the same
+  rules `stackit` enforces locally before reaching git.
 
 ## Local smoke test
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,143 @@
+# Deploying stackit-server
+
+This guide covers running the hosted multi-repo `stackit-server` container.
+At the time of writing the container ships **Phase 1 + Phase 6** from
+[`docs/plans/server/README.md`](plans/server/README.md): multiple repos,
+served via a config file, with no authentication yet. OAuth, clone-from-URL,
+and per-user repo scoping arrive in later phases.
+
+Treat the container as a single-tenant deployment behind your own
+authentication (a tunnel like Tailscale, an oauth2-proxy, etc.) until the
+auth phases land.
+
+## Image
+
+Published to [GitHub Container Registry](https://github.com/getstackit/stackit/pkgs/container/stackit-server)
+as `ghcr.io/getstackit/stackit-server`.
+
+| Tag | Source |
+|-----|--------|
+| `vX.Y.Z` | Cut from a release tag |
+| `latest` | Most recent release |
+| `main` | Latest push to the `main` branch |
+| `<short-sha>` | Specific commit on `main` |
+
+All tags are multi-arch (`linux/amd64`, `linux/arm64`).
+
+## Configuration
+
+The container reads its repo list from a JSON file. Mount a volume at `/data`
+(or anywhere) and point `-repos-config` at a file inside it.
+
+```json
+{
+  "repos": [
+    { "id": "stackit",  "displayName": "Stackit",  "path": "/data/repos/stackit" },
+    { "id": "myapp",    "displayName": "My App",    "path": "/data/repos/myapp" }
+  ]
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | yes | URL-safe identifier (`[a-zA-Z0-9_-]+`) used in `/api/v1/repos/{id}/...` routes |
+| `path` | yes | Absolute path inside the container to a git working tree |
+| `displayName` | no | Human label shown in the web UI; defaults to `id` |
+| `remote` | no | Git remote name; defaults to `origin` |
+
+You are responsible for cloning the repos into the mounted volume and
+running `stackit init` inside each one before starting the container.
+(Clone-from-URL + auto-init are Phase 4.)
+
+### Environment
+
+| Var | Purpose |
+|-----|---------|
+| `PORT` | Listen port. Honored when `-port` isn't passed explicitly — needed for Railway, Fly, Heroku. Defaults to `8080`. |
+
+### Flags
+
+The most useful flags:
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `-repos-config` | _(empty)_ | Path to the JSON repos file. Required for multi-repo mode. |
+| `-port` | `8080` | Listen port; overrides `$PORT`. |
+| `-cors` | `http://localhost:3000,http://localhost:5173` | Comma-separated allowed CORS origins. |
+
+Run `stackit-server -h` inside the container for the full list.
+
+## Local smoke test
+
+```bash
+# Clone something into ./data/repos/ first
+mkdir -p data/repos
+git clone https://github.com/getstackit/stackit data/repos/stackit
+(cd data/repos/stackit && stackit init)
+cat > data/repos.json <<'EOF'
+{ "repos": [ { "id": "stackit", "path": "/data/repos/stackit" } ] }
+EOF
+
+docker run --rm -p 8080:8080 \
+  -v "$(pwd)/data:/data" \
+  ghcr.io/getstackit/stackit-server:latest \
+  -repos-config /data/repos.json
+
+# In another terminal:
+curl -s localhost:8080/api/v1/repos | jq
+open http://localhost:8080
+```
+
+## Railway
+
+1. **Service** — deploy from image `ghcr.io/getstackit/stackit-server:main`
+   (or pin to `:latest` / `:vX.Y.Z`).
+2. **Volume** — mount at `/data`. Use at least a few GB; clones land here.
+3. **Variables** — Railway injects `PORT` automatically; no other vars are
+   required for the Phase 1 container.
+4. **Start command** — leave blank to use the image's `ENTRYPOINT`, then set
+   the **Command** (Railway's arg override) to:
+   ```
+   -repos-config /data/repos.json
+   ```
+5. **Seed the volume** — clone repos into `/data/repos/<id>/`, run
+   `stackit init` in each, and create `/data/repos.json`. Do this once via
+   a one-shot Railway shell session, then redeploy. (A `repo init` API
+   endpoint replaces this manual step in Phase 4.)
+
+## Pushing a snapshot without a release
+
+For ad-hoc dogfooding (e.g. validating a feature branch on Railway before
+merging) you can push a multi-arch image straight from your laptop without
+cutting a release tag:
+
+```bash
+gh auth refresh -s write:packages,read:packages    # one-time
+mise run server:publish:dev                        # pushes :dev (+arch tags)
+TAG=preview mise run server:publish:dev            # pushes :preview
+```
+
+The script wraps `goreleaser release --snapshot`, then re-tags and pushes
+the per-arch images and a manifest under `$TAG` (default `dev`). Skip the
+~90 s rebuild with `SKIP_BUILD=1` when you only want to re-push.
+
+## Updating
+
+- Pin to `:vX.Y.Z` for reproducible deploys; bump tag and redeploy.
+- Use `:main` for continuous deploys off the trunk — Railway can be
+  configured to redeploy whenever the GHCR tag is updated.
+- Use `:<short-sha>` to roll back to a known-good commit.
+
+## What's not in this container yet
+
+These all land in later phases:
+
+- **GitHub OAuth** (Phase 3) — every request currently hits the server with
+  no identity, and there is no per-user repo scoping.
+- **Clone-from-URL** (Phase 4) — repos must be pre-cloned into the mounted
+  volume.
+- **Persistent registry** (Phase 2) — runtime `POST /api/v1/repos` is not
+  available; edits to `repos.json` require a restart.
+
+See [`docs/plans/server/README.md`](plans/server/README.md) for the full
+phase plan.

--- a/internal/api/auth/allowlist.go
+++ b/internal/api/auth/allowlist.go
@@ -1,0 +1,129 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// ErrDenied is returned by Allowlist.Check when the logged-in user is not
+// permitted. Handlers translate this into a redirect to /auth/denied.
+var ErrDenied = errors.New("user not in allowlist")
+
+// Allowlist is the gate the OAuth callback runs against after exchanging
+// the GitHub code for an identity. It supports two independent rules:
+//
+//   - Users: exact-match GitHub logins (case-insensitive)
+//   - Org:   membership in a GitHub organization (verified via API)
+//
+// At least one rule must be configured; otherwise the gate is open and
+// the constructor refuses to build.
+type Allowlist struct {
+	users map[string]struct{}
+	org   string
+
+	// orgChecker is split out so tests can fake the GitHub membership
+	// lookup without spinning up an httptest server for every case.
+	orgChecker orgMembershipChecker
+}
+
+type orgMembershipChecker interface {
+	IsMember(ctx context.Context, org, login, accessToken string) (bool, error)
+}
+
+// AllowlistConfig is the operator-supplied input. ConfigFromEnv reads
+// these out of process env; callers in tests build the struct directly.
+type AllowlistConfig struct {
+	Users []string
+	Org   string
+}
+
+// NewAllowlist normalizes the config and validates at least one rule is
+// present. An empty allowlist is rejected because a public-facing deploy
+// with no gate is exactly the misconfiguration we're trying to prevent.
+func NewAllowlist(cfg AllowlistConfig) (*Allowlist, error) {
+	users := make(map[string]struct{}, len(cfg.Users))
+	for _, u := range cfg.Users {
+		u = strings.ToLower(strings.TrimSpace(u))
+		if u == "" {
+			continue
+		}
+		users[u] = struct{}{}
+	}
+	org := strings.TrimSpace(cfg.Org)
+	if len(users) == 0 && org == "" {
+		return nil, errors.New("allowlist requires at least one user or one org")
+	}
+	return &Allowlist{
+		users:      users,
+		org:        org,
+		orgChecker: githubOrgChecker{},
+	}, nil
+}
+
+// SetOrgChecker overrides the org membership checker. Tests use this to
+// inject deterministic membership without hitting GitHub.
+func (a *Allowlist) SetOrgChecker(c orgMembershipChecker) {
+	a.orgChecker = c
+}
+
+// Check returns nil if login is allowed, ErrDenied if not. The token is
+// only used for the org membership API call; user-list hits short-circuit
+// without any network I/O.
+func (a *Allowlist) Check(ctx context.Context, login, accessToken string) error {
+	loginLC := strings.ToLower(strings.TrimSpace(login))
+	if loginLC == "" {
+		return ErrDenied
+	}
+	if _, ok := a.users[loginLC]; ok {
+		return nil
+	}
+	if a.org == "" {
+		return ErrDenied
+	}
+	member, err := a.orgChecker.IsMember(ctx, a.org, login, accessToken)
+	if err != nil {
+		return fmt.Errorf("check org membership: %w", err)
+	}
+	if !member {
+		return ErrDenied
+	}
+	return nil
+}
+
+// githubOrgChecker hits the real GitHub API. We keep this dependency-free
+// (no go-github client) so the package's footprint stays small and tests
+// don't need to mock the wider github package.
+type githubOrgChecker struct{}
+
+func (githubOrgChecker) IsMember(ctx context.Context, org, login, accessToken string) (bool, error) {
+	// GET /orgs/{org}/members/{username} returns 204 if the auth'd user
+	// can see that login is a member, 302 if they can but the requester
+	// isn't a public member, 404 otherwise. We treat 204 and 302 as
+	// "yes", everything else as "no".
+	url := fmt.Sprintf("https://api.github.com/orgs/%s/members/%s", org, login)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusNoContent, http.StatusFound:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected status from membership API: %d", resp.StatusCode)
+	}
+}

--- a/internal/api/auth/allowlist_test.go
+++ b/internal/api/auth/allowlist_test.go
@@ -1,0 +1,90 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeOrgChecker struct {
+	members map[string]bool
+	err     error
+	calls   int
+}
+
+func (f *fakeOrgChecker) IsMember(_ context.Context, _, login, _ string) (bool, error) {
+	f.calls++
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.members[login], nil
+}
+
+func TestNewAllowlist_RequiresAtLeastOneRule(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewAllowlist(AllowlistConfig{})
+	require.Error(t, err)
+}
+
+func TestAllowlist_UserExactMatchCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	a, err := NewAllowlist(AllowlistConfig{Users: []string{"Jonnii", "  someone  ", ""}})
+	require.NoError(t, err)
+	a.SetOrgChecker(&fakeOrgChecker{}) // no network
+
+	require.NoError(t, a.Check(context.Background(), "jonnii", ""))
+	require.NoError(t, a.Check(context.Background(), "SOMEONE", ""))
+	require.ErrorIs(t, a.Check(context.Background(), "stranger", ""), ErrDenied)
+}
+
+func TestAllowlist_OrgMembershipPath(t *testing.T) {
+	t.Parallel()
+
+	checker := &fakeOrgChecker{members: map[string]bool{"jonnii": true}}
+	a, err := NewAllowlist(AllowlistConfig{Org: "getstackit"})
+	require.NoError(t, err)
+	a.SetOrgChecker(checker)
+
+	require.NoError(t, a.Check(context.Background(), "jonnii", "tok"))
+	require.Equal(t, 1, checker.calls)
+
+	require.ErrorIs(t, a.Check(context.Background(), "stranger", "tok"), ErrDenied)
+}
+
+func TestAllowlist_UserMatchSkipsOrgCheck(t *testing.T) {
+	t.Parallel()
+
+	checker := &fakeOrgChecker{}
+	a, err := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}, Org: "getstackit"})
+	require.NoError(t, err)
+	a.SetOrgChecker(checker)
+
+	require.NoError(t, a.Check(context.Background(), "jonnii", "tok"))
+	require.Equal(t, 0, checker.calls, "user-list hit must not consume an API call")
+}
+
+func TestAllowlist_OrgCheckerError(t *testing.T) {
+	t.Parallel()
+
+	checker := &fakeOrgChecker{err: errors.New("boom")}
+	a, err := NewAllowlist(AllowlistConfig{Org: "getstackit"})
+	require.NoError(t, err)
+	a.SetOrgChecker(checker)
+
+	err = a.Check(context.Background(), "jonnii", "tok")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrDenied, "infrastructure error must surface, not silently deny")
+}
+
+func TestAllowlist_EmptyLoginDenied(t *testing.T) {
+	t.Parallel()
+
+	a, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	a.SetOrgChecker(&fakeOrgChecker{})
+
+	require.ErrorIs(t, a.Check(context.Background(), "", "tok"), ErrDenied)
+}

--- a/internal/api/auth/cookie.go
+++ b/internal/api/auth/cookie.go
@@ -1,0 +1,112 @@
+package auth
+
+import (
+	"net/http"
+	"time"
+)
+
+// Cookie names. Kept short, namespaced under "stackit_" so they're easy to
+// recognize in browser devtools and don't collide with anything the
+// embedded Next app might want for its own state.
+const (
+	sessionCookieName = "stackit_session"
+	stateCookieName   = "stackit_oauth_state"
+	returnCookieName  = "stackit_return"
+)
+
+// CookieOptions controls the attributes the auth package puts on cookies.
+// Secure should be true in production (we're behind HTTPS at the proxy),
+// and false in tests or local dev where the browser refuses Secure
+// cookies on http://localhost.
+type CookieOptions struct {
+	Secure bool
+}
+
+func (o CookieOptions) sameSite() http.SameSite {
+	// Lax is the right default for session cookies: cookies travel on
+	// top-level navigations from another origin (so clicking a PR link in
+	// Slack drops you into the app authenticated) but not on cross-site
+	// XHR/form POSTs (so OAuth state isn't compromised). Mutating
+	// endpoints rely on the CSRF header layer (PR 3) for the extra factor.
+	return http.SameSiteLaxMode
+}
+
+func (o CookieOptions) setSession(w http.ResponseWriter, sessionID string, expires time.Time) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    sessionID,
+		Path:     "/",
+		Expires:  expires,
+		HttpOnly: true,
+		Secure:   o.Secure,
+		SameSite: o.sameSite(),
+	})
+}
+
+func (o CookieOptions) clearSession(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   o.Secure,
+		SameSite: o.sameSite(),
+	})
+}
+
+func (o CookieOptions) setState(w http.ResponseWriter, state string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     stateCookieName,
+		Value:    state,
+		Path:     "/auth/",
+		MaxAge:   600,
+		HttpOnly: true,
+		Secure:   o.Secure,
+		SameSite: o.sameSite(),
+	})
+}
+
+func (o CookieOptions) clearState(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     stateCookieName,
+		Value:    "",
+		Path:     "/auth/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   o.Secure,
+		SameSite: o.sameSite(),
+	})
+}
+
+func (o CookieOptions) setReturn(w http.ResponseWriter, target string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     returnCookieName,
+		Value:    target,
+		Path:     "/auth/",
+		MaxAge:   600,
+		HttpOnly: true,
+		Secure:   o.Secure,
+		SameSite: o.sameSite(),
+	})
+}
+
+func (o CookieOptions) clearReturn(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     returnCookieName,
+		Value:    "",
+		Path:     "/auth/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   o.Secure,
+		SameSite: o.sameSite(),
+	})
+}
+
+func readCookie(r *http.Request, name string) string {
+	c, err := r.Cookie(name)
+	if err != nil {
+		return ""
+	}
+	return c.Value
+}

--- a/internal/api/auth/crypto.go
+++ b/internal/api/auth/crypto.go
@@ -1,0 +1,88 @@
+// Package auth implements GitHub OAuth + session cookies + an allowlist
+// gate so stackit-server can be safely exposed on the public web.
+//
+// The package is internal to the api layer: handlers, middleware, and
+// cryptographic helpers live here together so the surface a consumer
+// composes is just (Config, Store, Handler, Allowlist, RequireSession).
+package auth
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+)
+
+// SessionKeyBytes is the required key length for the AES-GCM cipher.
+const SessionKeyBytes = 32
+
+// Cipher AES-GCM-encrypts short blobs (currently the user's GitHub access
+// token) before they sit in the in-memory session store. The key comes from
+// STACKIT_SESSION_KEY; rotation requires a process restart, which also
+// invalidates every existing session — that's fine for the in-memory store.
+type Cipher struct {
+	aead cipher.AEAD
+}
+
+// NewCipher decodes a base64-encoded 32-byte key and returns a ready
+// AES-256-GCM cipher.
+func NewCipher(base64Key string) (*Cipher, error) {
+	if base64Key == "" {
+		return nil, errors.New("session key is empty")
+	}
+	key, err := base64.StdEncoding.DecodeString(base64Key)
+	if err != nil {
+		// Tolerate URL-safe base64 too; some operators paste the openssl
+		// output without thinking about the alphabet.
+		key, err = base64.RawStdEncoding.DecodeString(base64Key)
+		if err != nil {
+			return nil, fmt.Errorf("session key is not valid base64: %w", err)
+		}
+	}
+	if len(key) != SessionKeyBytes {
+		return nil, fmt.Errorf("session key must decode to %d bytes (got %d)", SessionKeyBytes, len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("aes cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("gcm: %w", err)
+	}
+	return &Cipher{aead: aead}, nil
+}
+
+// Seal encrypts plaintext with a fresh random nonce. The returned slice is
+// nonce || ciphertext+tag; the caller stores it as-is.
+func (c *Cipher) Seal(plaintext []byte) ([]byte, error) {
+	nonce := make([]byte, c.aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("nonce: %w", err)
+	}
+	return c.aead.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+// Open reverses Seal. It rejects anything shorter than a nonce and surfaces
+// AEAD verification failures verbatim.
+func (c *Cipher) Open(blob []byte) ([]byte, error) {
+	ns := c.aead.NonceSize()
+	if len(blob) < ns {
+		return nil, errors.New("ciphertext too short")
+	}
+	nonce, ct := blob[:ns], blob[ns:]
+	return c.aead.Open(nil, nonce, ct, nil)
+}
+
+// GenerateSessionKey returns a fresh base64-encoded key in the format the
+// server expects. The operator runs `openssl rand -base64 32` in
+// docs/deploy.md; this is the in-Go equivalent used by tests.
+func GenerateSessionKey() (string, error) {
+	key := make([]byte, SessionKeyBytes)
+	if _, err := rand.Read(key); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(key), nil
+}

--- a/internal/api/auth/crypto_test.go
+++ b/internal/api/auth/crypto_test.go
@@ -1,0 +1,85 @@
+package auth
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCipher_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	key, err := GenerateSessionKey()
+	require.NoError(t, err)
+
+	c, err := NewCipher(key)
+	require.NoError(t, err)
+
+	plain := []byte("ghp_super_secret_personal_access_token")
+	blob, err := c.Seal(plain)
+	require.NoError(t, err)
+	require.NotEqual(t, plain, blob, "ciphertext must differ from plaintext")
+
+	got, err := c.Open(blob)
+	require.NoError(t, err)
+	require.Equal(t, plain, got)
+}
+
+func TestCipher_DifferentNoncesPerSeal(t *testing.T) {
+	t.Parallel()
+
+	key, _ := GenerateSessionKey()
+	c, _ := NewCipher(key)
+
+	a, _ := c.Seal([]byte("same"))
+	b, _ := c.Seal([]byte("same"))
+
+	require.NotEqual(t, a, b, "two seals of the same plaintext must use different nonces")
+}
+
+func TestCipher_RejectsTamperedBlob(t *testing.T) {
+	t.Parallel()
+
+	key, _ := GenerateSessionKey()
+	c, _ := NewCipher(key)
+
+	blob, _ := c.Seal([]byte("hello"))
+	blob[len(blob)-1] ^= 0x01 // flip last bit of the auth tag
+
+	_, err := c.Open(blob)
+	require.Error(t, err)
+}
+
+func TestNewCipher_RejectsBadKeys(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		key  string
+	}{
+		{"empty", ""},
+		{"not base64", "@@@not base64@@@"},
+		{"too short", base64.StdEncoding.EncodeToString(make([]byte, 16))},
+		{"too long", base64.StdEncoding.EncodeToString(make([]byte, 64))},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewCipher(tc.key)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestCipher_OpenRejectsShortBlob(t *testing.T) {
+	t.Parallel()
+
+	key, _ := GenerateSessionKey()
+	c, _ := NewCipher(key)
+
+	_, err := c.Open([]byte("x"))
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "too short"))
+}

--- a/internal/api/auth/middleware.go
+++ b/internal/api/auth/middleware.go
@@ -33,3 +33,43 @@ func writeUnauthorized(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusUnauthorized)
 	_, _ = w.Write([]byte(`{"error":"unauthenticated"}`))
 }
+
+// CSRFHeader is the custom request header the web client adds on every
+// non-safe request. Its presence — not value — is what matters: browsers
+// can't set a custom header on a cross-origin request without a CORS
+// preflight, and the server's CORS allowlist is exact-match. That means
+// only configured origins can satisfy this check, which is enough to
+// block cookie-based CSRF without a per-request token.
+const CSRFHeader = "X-Stackit-CSRF"
+
+// safeMethods are the HTTP methods that don't change server state and so
+// don't need CSRF protection. Everything else does.
+var safeMethods = map[string]struct{}{
+	http.MethodGet:     {},
+	http.MethodHead:    {},
+	http.MethodOptions: {},
+}
+
+// RequireCSRFHeader gates non-safe methods on the presence of a custom
+// CSRFHeader. Safe methods pass through untouched. Failures emit a 403
+// JSON response so clients can distinguish "your auth is bad" (401) from
+// "your call shape is wrong" (403).
+//
+// Pair this with RequireSession on /api/*: RequireSession says "you must
+// be logged in", RequireCSRFHeader says "and this isn't a cross-site
+// drive-by".
+func RequireCSRFHeader(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := safeMethods[r.Method]; ok {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if r.Header.Get(CSRFHeader) == "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":"missing csrf header"}`))
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/api/auth/middleware.go
+++ b/internal/api/auth/middleware.go
@@ -1,0 +1,35 @@
+package auth
+
+import (
+	"net/http"
+)
+
+// RequireSession returns a middleware that ensures the request carries a
+// valid session cookie before forwarding to next. Failed checks emit
+// 401 JSON; passed checks attach the Session to the request context for
+// downstream handlers to read via SessionFromContext.
+//
+// This middleware does *not* set cookie attributes or talk to GitHub —
+// it's a pure store lookup. Sessions are created elsewhere (the OAuth
+// callback) and revoked elsewhere (logout, TTL sweep).
+func RequireSession(store Store, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cookie := readCookie(r, sessionCookieName)
+		if cookie == "" {
+			writeUnauthorized(w)
+			return
+		}
+		sess, ok := store.Get(cookie)
+		if !ok {
+			writeUnauthorized(w)
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(contextWithSession(r.Context(), sess)))
+	})
+}
+
+func writeUnauthorized(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnauthorized)
+	_, _ = w.Write([]byte(`{"error":"unauthenticated"}`))
+}

--- a/internal/api/auth/middleware_test.go
+++ b/internal/api/auth/middleware_test.go
@@ -46,6 +46,79 @@ func TestRequireSession_UnknownCookie401(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, rr.Code)
 }
 
+func TestRequireCSRFHeader_AllowsSafeMethodsWithoutHeader(t *testing.T) {
+	t.Parallel()
+
+	called := 0
+	h := RequireCSRFHeader(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called++
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for _, m := range []string{http.MethodGet, http.MethodHead, http.MethodOptions} {
+		req := httptest.NewRequest(m, "/api/v1/repos", nil)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		require.Equalf(t, http.StatusOK, rr.Code, "method %s should pass without header", m)
+	}
+	require.Equal(t, 3, called)
+}
+
+func TestRequireCSRFHeader_BlocksMutatingMethodsWithoutHeader(t *testing.T) {
+	t.Parallel()
+
+	h := RequireCSRFHeader(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("downstream handler should not run")
+	}))
+
+	for _, m := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		req := httptest.NewRequest(m, "/api/v1/repos/default/stacks/main/submit", nil)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		require.Equalf(t, http.StatusForbidden, rr.Code, "method %s without header should be 403", m)
+		require.Contains(t, rr.Body.String(), "missing csrf header")
+	}
+}
+
+func TestRequireCSRFHeader_AllowsMutatingMethodsWithHeader(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	h := RequireCSRFHeader(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repos/default/stacks/main/submit", nil)
+	req.Header.Set(CSRFHeader, "1")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.True(t, called)
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestRequireCSRFHeader_AnyNonEmptyValueAccepted(t *testing.T) {
+	t.Parallel()
+
+	// The presence of the header is what matters, not its content.
+	// Browsers can't set a custom header on a cross-origin request without
+	// preflight, so the value doesn't need to be unguessable.
+	for _, v := range []string{"1", "true", "yes-please", "x"} {
+		called := false
+		h := RequireCSRFHeader(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			called = true
+		}))
+
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set(CSRFHeader, v)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+
+		require.Truef(t, called, "value %q should be accepted", v)
+	}
+}
+
 func TestRequireSession_ValidSessionPassesAndAttachesContext(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/auth/middleware_test.go
+++ b/internal/api/auth/middleware_test.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireSession_NoCookie401(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore(newTestCipher(t))
+	t.Cleanup(func() { _ = store.Close() })
+
+	called := false
+	h := RequireSession(store, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		called = true
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repos", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+	require.False(t, called)
+	require.Contains(t, rr.Body.String(), "unauthenticated")
+}
+
+func TestRequireSession_UnknownCookie401(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore(newTestCipher(t))
+	t.Cleanup(func() { _ = store.Close() })
+
+	h := RequireSession(store, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("downstream handler should not run")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repos", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "not-a-real-session"})
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestRequireSession_ValidSessionPassesAndAttachesContext(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore(newTestCipher(t))
+	t.Cleanup(func() { _ = store.Close() })
+
+	sess, _ := store.Create("jonnii", 1, "tok")
+
+	var seen *Session
+	h := RequireSession(store, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = SessionFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repos", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sess.ID})
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, seen)
+	require.Equal(t, "jonnii", seen.GitHubLogin)
+}

--- a/internal/api/auth/oauth.go
+++ b/internal/api/auth/oauth.go
@@ -15,6 +15,8 @@ import (
 
 	"golang.org/x/oauth2"
 	githuboauth "golang.org/x/oauth2/github"
+
+	"github.com/getstackit/stackit/internal/api/reqid"
 )
 
 // DefaultScopes is what the OAuth flow requests today. `read:user` gets the
@@ -188,7 +190,7 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.allow.Check(ctx, user.Login, tok.AccessToken); err != nil {
 		if errors.Is(err, ErrDenied) {
-			log.Printf("auth callback: denied login=%q", user.Login) //nolint:gosec // login is %q-quoted
+			log.Printf("audit action=denied actor=%q request_id=%s", user.Login, reqid.FromContext(ctx)) //nolint:gosec // login is %q-quoted
 			http.Redirect(w, r, h.cfg.DeniedPath, http.StatusFound)
 			return
 		}
@@ -211,7 +213,7 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	h.cfg.Cookies.clearReturn(w)
 
-	log.Printf("auth: login login=%q user_id=%d -> %s", user.Login, user.ID, target) //nolint:gosec // logged values are quoted/numeric/safe target
+	log.Printf("audit action=login actor=%q user_id=%d target=%s request_id=%s", user.Login, user.ID, target, reqid.FromContext(ctx)) //nolint:gosec // logged values are quoted/numeric/safe target
 	http.Redirect(w, r, target, http.StatusFound)
 }
 
@@ -221,7 +223,7 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) LogoutHandler(w http.ResponseWriter, r *http.Request) {
 	if cookie := readCookie(r, sessionCookieName); cookie != "" {
 		if sess, ok := h.store.Get(cookie); ok {
-			log.Printf("auth: logout login=%q", sess.GitHubLogin) //nolint:gosec // login is %q-quoted
+			log.Printf("audit action=logout actor=%q request_id=%s", sess.GitHubLogin, reqid.FromContext(r.Context())) //nolint:gosec // login is %q-quoted
 		}
 		h.store.Delete(cookie)
 	}

--- a/internal/api/auth/oauth.go
+++ b/internal/api/auth/oauth.go
@@ -1,0 +1,359 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+	githuboauth "golang.org/x/oauth2/github"
+)
+
+// DefaultScopes is what the OAuth flow requests today. `read:user` gets the
+// identity needed for the allowlist check; `repo` captures push scope up
+// front so when per-user push lands later the user doesn't re-consent.
+var DefaultScopes = []string{"read:user", "repo"}
+
+// Config is the operator-supplied OAuth configuration. ClientID/Secret are
+// the values from the GitHub OAuth App. BaseURL is the canonical https:// URL
+// the server is reachable at (used to build the callback URL because the
+// server cannot infer its public hostname).
+type Config struct {
+	ClientID     string
+	ClientSecret string //nolint:gosec // field name reflects the OAuth spec; not a literal secret
+	BaseURL      string
+	Scopes       []string
+	// AfterCallbackPath is where the user lands after a successful login.
+	// Defaults to "/". Settable for tests.
+	AfterCallbackPath string
+	// DeniedPath is where allowlist denials redirect to. Defaults to
+	// "/auth/denied". The static handler serves a small page at this path;
+	// if the frontend doesn't render one, the browser sees a generic 404
+	// from the SPA which is still a clear signal.
+	DeniedPath string
+	// Cookies controls Secure-flag behavior.
+	Cookies CookieOptions
+}
+
+// Handler bundles the OAuth state needed by the login/callback/logout/me
+// HTTP handlers. Build one in main.go; mount its methods at the auth
+// routes.
+type Handler struct {
+	cfg       Config
+	store     Store
+	allow     *Allowlist
+	cipher    *Cipher
+	oauth2cfg *oauth2.Config
+
+	// httpClient is the http client used for the GitHub user lookup. Split
+	// out so tests can swap in a transport pointed at httptest.Server.
+	httpClient *http.Client
+
+	// userInfoURL overrides the GitHub /user endpoint. Populated by
+	// SetGitHubEndpointForTest; production default empty means
+	// https://api.github.com/user.
+	userInfoURL string
+}
+
+// NewHandler validates the config and returns a ready Handler.
+func NewHandler(cfg Config, store Store, allow *Allowlist, cipher *Cipher) (*Handler, error) {
+	if cfg.ClientID == "" || cfg.ClientSecret == "" {
+		return nil, errors.New("oauth client id and secret are required")
+	}
+	if cfg.BaseURL == "" {
+		return nil, errors.New("oauth base url is required")
+	}
+	scopes := cfg.Scopes
+	if len(scopes) == 0 {
+		scopes = DefaultScopes
+	}
+	if cfg.AfterCallbackPath == "" {
+		cfg.AfterCallbackPath = "/"
+	}
+	if cfg.DeniedPath == "" {
+		cfg.DeniedPath = "/auth/denied"
+	}
+
+	callbackURL, err := joinURL(cfg.BaseURL, "/auth/callback")
+	if err != nil {
+		return nil, err
+	}
+
+	o := &oauth2.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		Scopes:       scopes,
+		RedirectURL:  callbackURL,
+		Endpoint:     githuboauth.Endpoint,
+	}
+
+	return &Handler{
+		cfg:        cfg,
+		store:      store,
+		allow:      allow,
+		cipher:     cipher,
+		oauth2cfg:  o,
+		httpClient: http.DefaultClient,
+	}, nil
+}
+
+// SetGitHubEndpointForTest swaps the OAuth provider endpoint and HTTP
+// client. Tests point both at an httptest.Server stubbing GitHub's auth +
+// API surface.
+func (h *Handler) SetGitHubEndpointForTest(endpoint oauth2.Endpoint, userInfoURL string, client *http.Client) {
+	h.oauth2cfg.Endpoint = endpoint
+	h.userInfoURL = userInfoURL
+	h.httpClient = client
+}
+
+// userInfoURL is the GitHub URL we GET after token exchange to learn who
+// the user is. Production-default empty -> falls back to api.github.com.
+// Tests set it to their httptest URL.
+func (h *Handler) resolveUserInfoURL() string {
+	if h.userInfoURL != "" {
+		return h.userInfoURL
+	}
+	return "https://api.github.com/user"
+}
+
+// LoginHandler kicks off the OAuth flow. It mints a fresh `state` value,
+// stores it in a short-lived cookie, optionally remembers the desired
+// post-login URL via ?return=, and 302s the user to GitHub.
+func (h *Handler) LoginHandler(w http.ResponseWriter, r *http.Request) {
+	state, err := randomToken(16)
+	if err != nil {
+		log.Printf("login: random state: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	h.cfg.Cookies.setState(w, state)
+
+	// Only honor a ?return= when it's a server-relative path. Anything
+	// else (especially absolute URLs to other hosts) is an open-redirect
+	// risk, so we silently drop it.
+	if ret := r.URL.Query().Get("return"); isSafeReturnPath(ret) {
+		h.cfg.Cookies.setReturn(w, ret)
+	}
+
+	url := h.oauth2cfg.AuthCodeURL(state, oauth2.AccessTypeOnline)
+	http.Redirect(w, r, url, http.StatusFound)
+}
+
+// CallbackHandler completes the OAuth flow: verifies state, exchanges the
+// code for a token, fetches the GitHub user, checks the allowlist, creates
+// a session, and redirects the user to the app (or to DeniedPath on a
+// non-allowlisted login).
+func (h *Handler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	gotState := q.Get("state")
+	wantState := readCookie(r, stateCookieName)
+	h.cfg.Cookies.clearState(w)
+	if wantState == "" || gotState == "" || !constantTimeStringEq(gotState, wantState) {
+		log.Printf("auth callback: bad state")
+		http.Error(w, "invalid auth state", http.StatusBadRequest)
+		return
+	}
+
+	code := q.Get("code")
+	if code == "" {
+		// GitHub redirects here with `error=...` when the user denies.
+		log.Printf("auth callback: missing code (oauth_error=%q)", q.Get("error")) //nolint:gosec // logged value is %q-quoted
+		http.Redirect(w, r, h.cfg.DeniedPath, http.StatusFound)
+		return
+	}
+
+	ctx := r.Context()
+	tok, err := h.oauth2cfg.Exchange(ctx, code)
+	if err != nil {
+		log.Printf("auth callback: token exchange: %v", err)
+		http.Error(w, "token exchange failed", http.StatusBadGateway)
+		return
+	}
+
+	user, err := h.fetchGitHubUser(ctx, tok.AccessToken)
+	if err != nil {
+		log.Printf("auth callback: fetch user: %v", err)
+		http.Error(w, "github user lookup failed", http.StatusBadGateway)
+		return
+	}
+
+	if err := h.allow.Check(ctx, user.Login, tok.AccessToken); err != nil {
+		if errors.Is(err, ErrDenied) {
+			log.Printf("auth callback: denied login=%q", user.Login) //nolint:gosec // login is %q-quoted
+			http.Redirect(w, r, h.cfg.DeniedPath, http.StatusFound)
+			return
+		}
+		log.Printf("auth callback: allowlist check error: %v", err)
+		http.Error(w, "allowlist check failed", http.StatusBadGateway)
+		return
+	}
+
+	sess, err := h.store.Create(user.Login, user.ID, tok.AccessToken)
+	if err != nil {
+		log.Printf("auth callback: create session: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	h.cfg.Cookies.setSession(w, sess.ID, sess.ExpiresAt)
+
+	target := h.cfg.AfterCallbackPath
+	if ret := readCookie(r, returnCookieName); isSafeReturnPath(ret) {
+		target = ret
+	}
+	h.cfg.Cookies.clearReturn(w)
+
+	log.Printf("auth: login login=%q user_id=%d -> %s", user.Login, user.ID, target) //nolint:gosec // logged values are quoted/numeric/safe target
+	http.Redirect(w, r, target, http.StatusFound)
+}
+
+// LogoutHandler drops the session both server-side (Store.Delete) and
+// client-side (clears the cookie). Always returns 204 so the web app can
+// fire-and-forget the call.
+func (h *Handler) LogoutHandler(w http.ResponseWriter, r *http.Request) {
+	if cookie := readCookie(r, sessionCookieName); cookie != "" {
+		if sess, ok := h.store.Get(cookie); ok {
+			log.Printf("auth: logout login=%q", sess.GitHubLogin) //nolint:gosec // login is %q-quoted
+		}
+		h.store.Delete(cookie)
+	}
+	h.cfg.Cookies.clearSession(w)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// MeResponse is the body served by GET /auth/me.
+type MeResponse struct {
+	Login string `json:"login"`
+	ID    int64  `json:"id"`
+}
+
+// MeHandler returns the logged-in user's identity, or 401 if no session.
+// The web app calls this on load to decide between rendering the app and
+// redirecting to /auth/login.
+func (h *Handler) MeHandler(w http.ResponseWriter, r *http.Request) {
+	sess := SessionFromContext(r.Context())
+	if sess == nil {
+		cookie := readCookie(r, sessionCookieName)
+		if cookie == "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"unauthenticated"}`))
+			return
+		}
+		s, ok := h.store.Get(cookie)
+		if !ok {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"unauthenticated"}`))
+			return
+		}
+		sess = s
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(MeResponse{
+		Login: sess.GitHubLogin,
+		ID:    sess.GitHubUserID,
+	})
+}
+
+// gitHubUser is the subset of /user we care about.
+type gitHubUser struct {
+	Login string `json:"login"`
+	ID    int64  `json:"id"`
+}
+
+func (h *Handler) fetchGitHubUser(ctx context.Context, accessToken string) (*gitHubUser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.resolveUserInfoURL(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github /user: status %d", resp.StatusCode)
+	}
+	var u gitHubUser
+	if err := json.NewDecoder(resp.Body).Decode(&u); err != nil {
+		return nil, fmt.Errorf("decode github /user: %w", err)
+	}
+	if u.Login == "" {
+		return nil, errors.New("github /user returned empty login")
+	}
+	return &u, nil
+}
+
+func randomToken(n int) (string, error) {
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// constantTimeStringEq is hmac.Equal-style comparison for state tokens. We
+// don't need full crypto strength but using a constant-time compare keeps
+// timing-channel concerns off the table.
+func constantTimeStringEq(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	var v byte
+	for i := 0; i < len(a); i++ {
+		v |= a[i] ^ b[i]
+	}
+	return v == 0
+}
+
+// isSafeReturnPath returns true when target is a path on this server
+// (starts with `/`, doesn't start with `//` or `/\`, doesn't contain a
+// scheme). Anything else is treated as an open-redirect attempt.
+func isSafeReturnPath(target string) bool {
+	if target == "" {
+		return false
+	}
+	if !strings.HasPrefix(target, "/") {
+		return false
+	}
+	if strings.HasPrefix(target, "//") || strings.HasPrefix(target, "/\\") {
+		return false
+	}
+	// Reject URLs with a scheme even if path-ish.
+	if u, err := url.Parse(target); err == nil && u.Scheme != "" {
+		return false
+	}
+	return true
+}
+
+func joinURL(base, suffix string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("base url: %w", err)
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return "", fmt.Errorf("base url scheme must be http(s), got %q", u.Scheme)
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + suffix
+	return u.String(), nil
+}
+
+// LoginExpiryProbe is the time after which a session would be considered
+// stale. Exposed for tests / health-check style code.
+func LoginExpiryProbe(now time.Time) time.Time {
+	return now.Add(SessionTTL)
+}

--- a/internal/api/auth/oauth_test.go
+++ b/internal/api/auth/oauth_test.go
@@ -1,0 +1,414 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+func TestIsSafeReturnPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"/", true},
+		{"/stacks/main", true},
+		{"//evil.com", false},
+		{`/\evil.com`, false},
+		{"http://evil.com", false},
+		{"javascript:alert(1)", false},
+		{"relative/path", false},
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, isSafeReturnPath(tc.in), "input=%q", tc.in)
+	}
+}
+
+func TestConstantTimeStringEq(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, constantTimeStringEq("abc", "abc"))
+	require.False(t, constantTimeStringEq("abc", "abd"))
+	require.False(t, constantTimeStringEq("", "x"))
+	require.False(t, constantTimeStringEq("abc", "ab"))
+	require.True(t, constantTimeStringEq("", ""))
+}
+
+func TestJoinURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		base, suffix, want string
+		wantErr            bool
+	}{
+		{"https://stackit.example.com", "/auth/callback", "https://stackit.example.com/auth/callback", false},
+		{"https://stackit.example.com/", "/auth/callback", "https://stackit.example.com/auth/callback", false},
+		{"http://localhost:8080", "/auth/callback", "http://localhost:8080/auth/callback", false},
+		{"ftp://nope.com", "/auth/callback", "", true},
+		{":://broken", "/auth/callback", "", true},
+	}
+	for _, tc := range cases {
+		got, err := joinURL(tc.base, tc.suffix)
+		if tc.wantErr {
+			require.Errorf(t, err, "base=%q", tc.base)
+			continue
+		}
+		require.NoErrorf(t, err, "base=%q", tc.base)
+		require.Equal(t, tc.want, got)
+	}
+}
+
+// stubGitHub stands in for the GitHub OAuth + /user endpoints. The Handler
+// is pointed at it via SetGitHubEndpointForTest.
+type stubGitHub struct {
+	server      *httptest.Server
+	authCalls   int
+	tokenCalls  int
+	userCalls   int
+	denyToken   bool
+	userLogin   string
+	userID      int64
+	emitState   string // recorded state from the most recent auth request
+	mintedCode  string
+	mintedToken string
+}
+
+func newStubGitHub(t *testing.T) *stubGitHub {
+	t.Helper()
+	s := &stubGitHub{
+		userLogin:   "jonnii",
+		userID:      42,
+		mintedCode:  "test-code",
+		mintedToken: "test-access-token",
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login/oauth/authorize", func(w http.ResponseWriter, r *http.Request) {
+		s.authCalls++
+		s.emitState = r.URL.Query().Get("state")
+		// Production GitHub 302s back to the redirect URL with code+state.
+		// In tests we don't actually want the redirect — the Handler is
+		// driven directly by the test. So we just record state and 200.
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/login/oauth/access_token", func(w http.ResponseWriter, r *http.Request) {
+		s.tokenCalls++
+		if s.denyToken {
+			http.Error(w, "denied", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": s.mintedToken,
+			"token_type":   "bearer",
+			"scope":        "read:user repo",
+		})
+	})
+	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+		s.userCalls++
+		if got := r.Header.Get("Authorization"); got != "Bearer "+s.mintedToken {
+			http.Error(w, "bad auth", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"login": s.userLogin,
+			"id":    s.userID,
+		})
+	})
+	s.server = httptest.NewServer(mux)
+	t.Cleanup(s.server.Close)
+	return s
+}
+
+func (s *stubGitHub) oauth2Endpoint() oauth2.Endpoint {
+	return oauth2.Endpoint{
+		AuthURL:  s.server.URL + "/login/oauth/authorize",
+		TokenURL: s.server.URL + "/login/oauth/access_token",
+	}
+}
+
+func (s *stubGitHub) userURL() string {
+	return s.server.URL + "/user"
+}
+
+func buildTestHandler(t *testing.T, allow *Allowlist, stub *stubGitHub) (*Handler, *MemoryStore) {
+	t.Helper()
+	cipher := newTestCipher(t)
+	store := NewMemoryStore(cipher)
+	t.Cleanup(func() { _ = store.Close() })
+
+	h, err := NewHandler(Config{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		BaseURL:      "http://localhost:8080",
+	}, store, allow, cipher)
+	require.NoError(t, err)
+	h.SetGitHubEndpointForTest(stub.oauth2Endpoint(), stub.userURL(), stub.server.Client())
+	return h, store
+}
+
+func TestLoginHandler_SetsStateCookieAndRedirects(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, _ := buildTestHandler(t, allow, stub)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	rr := httptest.NewRecorder()
+	h.LoginHandler(rr, req)
+
+	require.Equal(t, http.StatusFound, rr.Code)
+	loc := rr.Header().Get("Location")
+	require.Contains(t, loc, "/login/oauth/authorize")
+	require.Contains(t, loc, "client_id=test-client")
+	require.Contains(t, loc, "state=")
+
+	// State cookie must be HttpOnly and scoped to /auth/.
+	cookies := rr.Result().Cookies()
+	var state *http.Cookie
+	for _, c := range cookies {
+		if c.Name == stateCookieName {
+			state = c
+		}
+	}
+	require.NotNil(t, state)
+	require.True(t, state.HttpOnly)
+	require.Equal(t, "/auth/", state.Path)
+	require.NotEmpty(t, state.Value)
+}
+
+func TestCallbackHandler_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, store := buildTestHandler(t, allow, stub)
+
+	// Simulate a callback with matching state cookie + state query.
+	state := "abc123"
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=test-code&state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: stateCookieName, Value: state})
+	rr := httptest.NewRecorder()
+
+	h.CallbackHandler(rr, req)
+
+	require.Equal(t, http.StatusFound, rr.Code)
+	require.Equal(t, "/", rr.Header().Get("Location"))
+
+	// Session cookie set.
+	var sessionCookie *http.Cookie
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == sessionCookieName {
+			sessionCookie = c
+		}
+	}
+	require.NotNil(t, sessionCookie)
+	require.True(t, sessionCookie.HttpOnly)
+	require.NotEmpty(t, sessionCookie.Value)
+
+	// Store now has the session under that cookie value.
+	sess, ok := store.Get(sessionCookie.Value)
+	require.True(t, ok)
+	require.Equal(t, "jonnii", sess.GitHubLogin)
+	require.Equal(t, int64(42), sess.GitHubUserID)
+
+	tok, err := sess.AccessToken(store.cipher)
+	require.NoError(t, err)
+	require.Equal(t, "test-access-token", tok)
+}
+
+func TestCallbackHandler_StateMismatchRejected(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, _ := buildTestHandler(t, allow, stub)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=test-code&state=mismatched", nil)
+	req.AddCookie(&http.Cookie{Name: stateCookieName, Value: "different"})
+	rr := httptest.NewRecorder()
+
+	h.CallbackHandler(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestCallbackHandler_MissingStateCookieRejected(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, _ := buildTestHandler(t, allow, stub)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=test-code&state=anything", nil)
+	rr := httptest.NewRecorder()
+
+	h.CallbackHandler(rr, req)
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestCallbackHandler_AllowlistDeniedRedirectsToDeniedPath(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"someone-else"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, store := buildTestHandler(t, allow, stub)
+
+	state := "s"
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=test-code&state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: stateCookieName, Value: state})
+	rr := httptest.NewRecorder()
+
+	h.CallbackHandler(rr, req)
+
+	require.Equal(t, http.StatusFound, rr.Code)
+	require.Equal(t, "/auth/denied", rr.Header().Get("Location"))
+
+	// No session cookie issued.
+	for _, c := range rr.Result().Cookies() {
+		require.NotEqual(t, sessionCookieName, c.Name, "no session for denied user")
+	}
+	// And no session in the store.
+	store.mu.RLock()
+	require.Equal(t, 0, len(store.sessions))
+	store.mu.RUnlock()
+}
+
+func TestCallbackHandler_HonorsSafeReturnPath(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, _ := buildTestHandler(t, allow, stub)
+
+	state := "s"
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=test-code&state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: stateCookieName, Value: state})
+	req.AddCookie(&http.Cookie{Name: returnCookieName, Value: "/stacks/foo"})
+	rr := httptest.NewRecorder()
+
+	h.CallbackHandler(rr, req)
+	require.Equal(t, "/stacks/foo", rr.Header().Get("Location"))
+}
+
+func TestCallbackHandler_RejectsUnsafeReturnPath(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, _ := buildTestHandler(t, allow, stub)
+
+	state := "s"
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=test-code&state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: stateCookieName, Value: state})
+	req.AddCookie(&http.Cookie{Name: returnCookieName, Value: "//evil.example.com/steal"})
+	rr := httptest.NewRecorder()
+
+	h.CallbackHandler(rr, req)
+	require.Equal(t, "/", rr.Header().Get("Location"), "open-redirect attempt must be ignored")
+}
+
+func TestLogoutHandler_ClearsCookieAndStore(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, store := buildTestHandler(t, allow, stub)
+
+	sess, _ := store.Create("jonnii", 1, "tok")
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sess.ID})
+	rr := httptest.NewRecorder()
+	h.LogoutHandler(rr, req)
+
+	require.Equal(t, http.StatusNoContent, rr.Code)
+	_, ok := store.Get(sess.ID)
+	require.False(t, ok, "session must be deleted server-side")
+
+	var cleared *http.Cookie
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == sessionCookieName {
+			cleared = c
+		}
+	}
+	require.NotNil(t, cleared)
+	require.Equal(t, -1, cleared.MaxAge)
+}
+
+func TestMeHandler_401WithoutSession(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, _ := buildTestHandler(t, allow, stub)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/me", nil)
+	rr := httptest.NewRecorder()
+	h.MeHandler(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestMeHandler_ReturnsCurrentUser(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, store := buildTestHandler(t, allow, stub)
+
+	sess, _ := store.Create("jonnii", 42, "tok")
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/me", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sess.ID})
+	rr := httptest.NewRecorder()
+	h.MeHandler(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp MeResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	require.Equal(t, "jonnii", resp.Login)
+	require.Equal(t, int64(42), resp.ID)
+}
+
+// sanity check that GitHub-style query encoding in the auth URL survives a
+// round trip — guards against the test stub diverging from what
+// golang.org/x/oauth2 actually emits.
+func TestLoginHandler_AuthURLEncodesScopes(t *testing.T) {
+	t.Parallel()
+
+	allow, _ := NewAllowlist(AllowlistConfig{Users: []string{"jonnii"}})
+	allow.SetOrgChecker(&fakeOrgChecker{})
+	stub := newStubGitHub(t)
+	h, _ := buildTestHandler(t, allow, stub)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	rr := httptest.NewRecorder()
+	h.LoginHandler(rr, req)
+
+	loc, err := url.Parse(rr.Header().Get("Location"))
+	require.NoError(t, err)
+	require.Equal(t, "read:user repo", loc.Query().Get("scope"))
+	require.True(t, strings.HasSuffix(loc.Path, "/login/oauth/authorize"))
+}

--- a/internal/api/auth/session.go
+++ b/internal/api/auth/session.go
@@ -1,0 +1,215 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// SessionTTL is how long a session lives from creation. Sessions don't slide
+// — once expired the user re-authenticates. 30 days matches the default GH
+// PAT-style cadence we'd want for a dev tool.
+const SessionTTL = 30 * 24 * time.Hour
+
+// sessionSweepInterval is how often the in-memory store walks itself to
+// evict expired sessions. Slow enough not to thrash, fast enough that a
+// memory leak from churning sessions never gets large.
+const sessionSweepInterval = 5 * time.Minute
+
+// Session is the per-user record the store holds. The GitHub access token
+// is encrypted at rest with the server's Cipher; everything else is
+// plaintext because it's needed for routing/auditing and isn't sensitive
+// on its own.
+type Session struct {
+	ID             string
+	GitHubLogin    string
+	GitHubUserID   int64
+	encryptedToken []byte
+	CreatedAt      time.Time
+	ExpiresAt      time.Time
+}
+
+// AccessToken decrypts the stored GitHub token for an outbound API call.
+// Callers should not retain the result longer than the one request that
+// needs it — re-decrypt each time so the plaintext lives on the stack.
+func (s *Session) AccessToken(c *Cipher) (string, error) {
+	if len(s.encryptedToken) == 0 {
+		return "", errors.New("session has no access token")
+	}
+	plain, err := c.Open(s.encryptedToken)
+	if err != nil {
+		return "", fmt.Errorf("decrypt access token: %w", err)
+	}
+	return string(plain), nil
+}
+
+// Store is the surface used by handlers. The default implementation is
+// MemoryStore; tests inject their own fakes against the same interface.
+type Store interface {
+	Create(login string, githubUserID int64, accessToken string) (*Session, error)
+	Get(id string) (*Session, bool)
+	Delete(id string)
+	Close() error
+}
+
+// MemoryStore keeps sessions in a process-local map. Restarting the server
+// drops every session — that's the documented behavior in docs/deploy.md.
+// If you ever scale this horizontally, swap to a SQLite/Redis-backed Store
+// behind the same interface.
+type MemoryStore struct {
+	cipher *Cipher
+	now    func() time.Time
+	ttl    time.Duration
+
+	mu       sync.RWMutex
+	sessions map[string]*Session
+
+	stop chan struct{}
+	done chan struct{}
+}
+
+// NewMemoryStore returns a Store backed by a map. The background sweeper
+// goroutine is started immediately; Close() stops it.
+func NewMemoryStore(c *Cipher) *MemoryStore {
+	s := &MemoryStore{
+		cipher:   c,
+		now:      time.Now,
+		ttl:      SessionTTL,
+		sessions: make(map[string]*Session),
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+	go s.sweepLoop(sessionSweepInterval)
+	return s
+}
+
+// Create allocates an opaque 32-byte session ID, encrypts the supplied
+// GitHub token, and stores the result. The caller sets a cookie with the
+// returned Session.ID.
+func (s *MemoryStore) Create(login string, githubUserID int64, accessToken string) (*Session, error) {
+	id, err := newSessionID()
+	if err != nil {
+		return nil, err
+	}
+	var ct []byte
+	if accessToken != "" {
+		ct, err = s.cipher.Seal([]byte(accessToken))
+		if err != nil {
+			return nil, err
+		}
+	}
+	now := s.now()
+	sess := &Session{
+		ID:             id,
+		GitHubLogin:    login,
+		GitHubUserID:   githubUserID,
+		encryptedToken: ct,
+		CreatedAt:      now,
+		ExpiresAt:      now.Add(s.ttl),
+	}
+	s.mu.Lock()
+	s.sessions[id] = sess
+	s.mu.Unlock()
+	return sess, nil
+}
+
+// Get returns the session if it exists and hasn't expired. Expired sessions
+// are evicted lazily on read in addition to the periodic sweep, so a long
+// gap between sweeps can't keep a session alive past its ExpiresAt.
+func (s *MemoryStore) Get(id string) (*Session, bool) {
+	if id == "" {
+		return nil, false
+	}
+	s.mu.RLock()
+	sess, ok := s.sessions[id]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if s.now().After(sess.ExpiresAt) {
+		s.Delete(id)
+		return nil, false
+	}
+	return sess, true
+}
+
+// Delete is a no-op for unknown IDs.
+func (s *MemoryStore) Delete(id string) {
+	s.mu.Lock()
+	delete(s.sessions, id)
+	s.mu.Unlock()
+}
+
+// Close stops the sweeper. Safe to call multiple times.
+func (s *MemoryStore) Close() error {
+	select {
+	case <-s.stop:
+		// already closed
+	default:
+		close(s.stop)
+	}
+	<-s.done
+	return nil
+}
+
+func (s *MemoryStore) sweepLoop(interval time.Duration) {
+	defer close(s.done)
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-t.C:
+			s.sweepExpired()
+		}
+	}
+}
+
+func (s *MemoryStore) sweepExpired() {
+	now := s.now()
+	s.mu.Lock()
+	for id, sess := range s.sessions {
+		if now.After(sess.ExpiresAt) {
+			delete(s.sessions, id)
+		}
+	}
+	s.mu.Unlock()
+}
+
+// SetClockForTest swaps the time source. Tests use this to advance past
+// ExpiresAt without sleeping.
+func (s *MemoryStore) SetClockForTest(now func() time.Time) {
+	s.mu.Lock()
+	s.now = now
+	s.mu.Unlock()
+}
+
+func newSessionID() (string, error) {
+	var buf [32]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", fmt.Errorf("random session id: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf[:]), nil
+}
+
+// sessionCtxKey isolates the session value on request contexts.
+type sessionCtxKey struct{}
+
+// SessionFromContext returns the session attached by RequireSession, or
+// nil if no session is in scope. Handlers behind RequireSession can
+// assume non-nil; unprotected handlers must nil-check.
+func SessionFromContext(ctx context.Context) *Session {
+	if v, ok := ctx.Value(sessionCtxKey{}).(*Session); ok {
+		return v
+	}
+	return nil
+}
+
+func contextWithSession(ctx context.Context, sess *Session) context.Context {
+	return context.WithValue(ctx, sessionCtxKey{}, sess)
+}

--- a/internal/api/auth/session_test.go
+++ b/internal/api/auth/session_test.go
@@ -1,0 +1,122 @@
+package auth
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCipher(t *testing.T) *Cipher {
+	t.Helper()
+	key, err := GenerateSessionKey()
+	require.NoError(t, err)
+	c, err := NewCipher(key)
+	require.NoError(t, err)
+	return c
+}
+
+func TestMemoryStore_CreateGetDelete(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore(newTestCipher(t))
+	t.Cleanup(func() { _ = store.Close() })
+
+	sess, err := store.Create("jonnii", 42, "ghp_token")
+	require.NoError(t, err)
+	require.NotEmpty(t, sess.ID)
+	require.Equal(t, "jonnii", sess.GitHubLogin)
+	require.Equal(t, int64(42), sess.GitHubUserID)
+
+	got, ok := store.Get(sess.ID)
+	require.True(t, ok)
+	require.Equal(t, sess.ID, got.ID)
+
+	tok, err := got.AccessToken(store.cipher)
+	require.NoError(t, err)
+	require.Equal(t, "ghp_token", tok)
+
+	store.Delete(sess.ID)
+	_, ok = store.Get(sess.ID)
+	require.False(t, ok)
+}
+
+func TestMemoryStore_ExpiresLazily(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore(newTestCipher(t))
+	t.Cleanup(func() { _ = store.Close() })
+
+	sess, err := store.Create("jonnii", 1, "tok")
+	require.NoError(t, err)
+
+	// Advance the store's clock past ExpiresAt; the next Get evicts.
+	future := sess.ExpiresAt.Add(time.Second)
+	store.SetClockForTest(func() time.Time { return future })
+
+	_, ok := store.Get(sess.ID)
+	require.False(t, ok, "expired session must not be returned")
+
+	// And the entry should be gone from the underlying map (lazy evict).
+	store.mu.RLock()
+	_, present := store.sessions[sess.ID]
+	store.mu.RUnlock()
+	require.False(t, present)
+}
+
+func TestMemoryStore_SweepRemovesExpired(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore(newTestCipher(t))
+	t.Cleanup(func() { _ = store.Close() })
+
+	sess, _ := store.Create("jonnii", 1, "tok")
+
+	store.SetClockForTest(func() time.Time { return sess.ExpiresAt.Add(time.Second) })
+	store.sweepExpired()
+
+	_, ok := store.Get(sess.ID)
+	require.False(t, ok)
+}
+
+func TestMemoryStore_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore(newTestCipher(t))
+	t.Cleanup(func() { _ = store.Close() })
+
+	var wg sync.WaitGroup
+	for i := range 100 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			s, err := store.Create("user", int64(i), "tok")
+			require.NoError(t, err)
+			_, ok := store.Get(s.ID)
+			require.True(t, ok)
+			store.Delete(s.ID)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestSessionFromContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	require.Nil(t, SessionFromContext(ctx))
+
+	sess := &Session{ID: "x", GitHubLogin: "y"}
+	ctx2 := contextWithSession(ctx, sess)
+	require.Equal(t, sess, SessionFromContext(ctx2))
+}
+
+func TestMemoryStore_CloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemoryStore(newTestCipher(t))
+	require.NoError(t, store.Close())
+	require.NoError(t, store.Close())
+}

--- a/internal/api/handlers/branch_diff.go
+++ b/internal/api/handlers/branch_diff.go
@@ -35,6 +35,9 @@ func (h *BranchDiffHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing branch query parameter", http.StatusBadRequest)
 		return
 	}
+	if !validateBranchName(w, branchName) {
+		return
+	}
 
 	branch := entry.Engine.GetBranch(branchName)
 	if !branch.IsTracked() {

--- a/internal/api/handlers/branches.go
+++ b/internal/api/handlers/branches.go
@@ -35,9 +35,12 @@ func (h *BranchesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	branchName := r.PathValue("name")
 	if branchName == "" {
 		h.listBranches(w, r, entry)
-	} else {
-		h.getBranch(w, r, entry, branchName)
+		return
 	}
+	if !validateBranchName(w, branchName) {
+		return
+	}
+	h.getBranch(w, r, entry, branchName)
 }
 
 func (h *BranchesHandler) listBranches(w http.ResponseWriter, r *http.Request, entry *registry.RepoEntry) {

--- a/internal/api/handlers/common.go
+++ b/internal/api/handlers/common.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/getstackit/stackit/internal/api/registry"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // defaultRepoID is the ID assigned to the single bootstrap repo when the
@@ -26,4 +27,16 @@ func resolveRepo(reg *registry.Registry, w http.ResponseWriter, r *http.Request)
 		return nil, false
 	}
 	return entry, true
+}
+
+// validateBranchName runs branch name through the same validator the CLI
+// uses (utils.ValidateBranchName) before any handler hands it to git. The
+// error message intentionally does not include the user-supplied name so
+// the response can't reflect arbitrary content back to a caller.
+func validateBranchName(w http.ResponseWriter, name string) bool {
+	if err := utils.ValidateBranchName(name); err != nil {
+		http.Error(w, "invalid branch name", http.StatusBadRequest)
+		return false
+	}
+	return true
 }

--- a/internal/api/handlers/events.go
+++ b/internal/api/handlers/events.go
@@ -34,6 +34,13 @@ func (h *EventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// SSE is long-lived; opt out of the server-wide WriteTimeout so the
+	// connection isn't dropped after the first 30 seconds. Failing here is
+	// not fatal — without it the connection is shorter-lived but otherwise
+	// works.
+	rc := http.NewResponseController(w)
+	_ = rc.SetWriteDeadline(time.Time{})
+
 	entry, ok := resolveRepo(h.reg, w, r)
 	if !ok {
 		return

--- a/internal/api/handlers/submit.go
+++ b/internal/api/handlers/submit.go
@@ -3,10 +3,13 @@ package handlers
 import (
 	"encoding/json"
 	"io"
+	"log"
 	"net/http"
 
 	"github.com/getstackit/stackit/internal/actions/submit"
+	"github.com/getstackit/stackit/internal/api/auth"
 	"github.com/getstackit/stackit/internal/api/registry"
+	"github.com/getstackit/stackit/internal/api/reqid"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/output"
@@ -56,6 +59,15 @@ func (h *SubmitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !validateBranchName(w, rootBranch) {
 		return
 	}
+
+	// Audit line for a mutating call. "actor" is whichever GitHub login
+	// the session belongs to; unauthenticated submits (only possible
+	// when -auth-disabled is set on a private deploy) log actor=<none>.
+	actor := "<none>"
+	if sess := auth.SessionFromContext(r.Context()); sess != nil {
+		actor = sess.GitHubLogin
+	}
+	log.Printf("audit action=submit actor=%q repo=%q branch=%q request_id=%s", actor, entry.ID, rootBranch, reqid.FromContext(r.Context())) //nolint:gosec // values are %q-quoted
 
 	ctx := app.NewContext(entry.Engine,
 		app.WithRepoRoot(entry.RepoRoot),

--- a/internal/api/handlers/submit.go
+++ b/internal/api/handlers/submit.go
@@ -53,6 +53,9 @@ func (h *SubmitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	if !validateBranchName(w, rootBranch) {
+		return
+	}
 
 	ctx := app.NewContext(entry.Engine,
 		app.WithRepoRoot(entry.RepoRoot),

--- a/internal/api/handlers/validation_test.go
+++ b/internal/api/handlers/validation_test.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/api/registry"
+)
+
+// validatingHandlers is the set of API handlers that must reject malformed
+// branch names at the HTTP boundary, before any value reaches the git layer.
+// Each case wires up the handler exactly the way the router wires it in
+// production, with branchValue arriving via either a path value or a query
+// param depending on the handler.
+type validationCase struct {
+	name   string
+	build  func(reg *registry.Registry) http.Handler
+	method string
+	url    string
+	// setRequest mutates the request to attach the bad branch value the
+	// handler reads (path value or query param).
+	setRequest func(req *http.Request, branch string)
+}
+
+var validationCases = []validationCase{
+	{
+		name:   "BranchesHandler getBranch path value",
+		build:  func(reg *registry.Registry) http.Handler { return NewBranchesHandler(reg) },
+		method: http.MethodGet,
+		url:    "/api/v1/branches/x",
+		setRequest: func(req *http.Request, branch string) {
+			req.SetPathValue("name", branch)
+		},
+	},
+	{
+		name:   "BranchDiffHandler branch query",
+		build:  func(reg *registry.Registry) http.Handler { return NewBranchDiffHandler(reg) },
+		method: http.MethodGet,
+		url:    "/api/v1/branch-diff?branch=x",
+		setRequest: func(req *http.Request, branch string) {
+			q := req.URL.Query()
+			q.Set("branch", branch)
+			req.URL.RawQuery = q.Encode()
+		},
+	},
+	{
+		name:   "SubmitHandler rootBranch path value",
+		build:  func(reg *registry.Registry) http.Handler { return NewSubmitHandler(reg) },
+		method: http.MethodPost,
+		url:    "/api/v1/stacks/x/submit",
+		setRequest: func(req *http.Request, branch string) {
+			req.SetPathValue("rootBranch", branch)
+		},
+	},
+}
+
+func TestHandlers_RejectMalformedBranchNames(t *testing.T) {
+	t.Parallel()
+
+	// Names ValidateBranchName must reject. Cover the most security-relevant
+	// failure modes: leading hyphen (argname injection), traversal (..),
+	// invalid characters, and length.
+	badNames := []struct {
+		name  string
+		input string
+	}{
+		{"leading hyphen", "--upload-pack=evil"},
+		{"consecutive dots", "feature/..main"},
+		{"invalid character semicolon", "feature;rm -rf /"},
+		{"invalid character newline", "feature\nrm"},
+		{"trailing slash", "feature/"},
+		{"leading slash", "/feature"},
+		{"too long", strings.Repeat("a", 300)},
+	}
+
+	for _, vc := range validationCases {
+		for _, bad := range badNames {
+			t.Run(vc.name+"/"+bad.name, func(t *testing.T) {
+				t.Parallel()
+
+				reg := registry.New()
+				require.NoError(t, reg.Add(&registry.RepoEntry{ID: "default"}))
+
+				req := httptest.NewRequest(vc.method, vc.url, nil)
+				vc.setRequest(req, bad.input)
+
+				rr := httptest.NewRecorder()
+				vc.build(reg).ServeHTTP(rr, req)
+
+				require.Equalf(t, http.StatusBadRequest, rr.Code,
+					"%s: expected 400 for %q, got %d (body=%q)",
+					vc.name, bad.input, rr.Code, rr.Body.String())
+				require.NotContainsf(t, rr.Body.String(), bad.input,
+					"response body must not reflect the supplied branch name back at the caller")
+			})
+		}
+	}
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -9,28 +9,23 @@ import (
 	"runtime/debug"
 	"strings"
 	"time"
+
+	"github.com/getstackit/stackit/internal/api/reqid"
 )
 
 // requestIDHeader is the response header that carries the per-request ID. The
-// same value is stashed on the request context so handlers and the logger can
-// reference it.
-const requestIDHeader = "X-Request-ID"
+// same value is stashed on the request context (via package reqid) so
+// handlers and the logger can reference it.
+const requestIDHeader = reqid.HeaderName
 
 // maxRequestBodyBytes caps every request body. POST /submit takes no body
 // today; this is defense against runaway uploads against any endpoint.
 const maxRequestBodyBytes = 1 << 20 // 1 MiB
 
-type ctxKey int
-
-const ctxKeyRequestID ctxKey = iota
-
-// RequestIDFromContext returns the request ID associated with the context, or
-// the empty string if none was set.
+// RequestIDFromContext is kept here as a re-export for callers in the api
+// package; handlers in other packages import internal/api/reqid directly.
 func RequestIDFromContext(ctx context.Context) string {
-	if v, ok := ctx.Value(ctxKeyRequestID).(string); ok {
-		return v
-	}
-	return ""
+	return reqid.FromContext(ctx)
 }
 
 // recoverMiddleware catches panics in downstream handlers, logs them with a
@@ -63,7 +58,7 @@ func requestIDMiddleware(next http.Handler) http.Handler {
 			rid = newRequestID()
 		}
 		w.Header().Set(requestIDHeader, rid)
-		ctx := context.WithValue(r.Context(), ctxKeyRequestID, rid)
+		ctx := reqid.WithValue(r.Context(), rid)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,15 +1,139 @@
 package api
 
 import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"log"
-	"net"
 	"net/http"
-	"net/url"
+	"runtime/debug"
 	"strings"
 	"time"
 )
 
-// corsMiddleware adds CORS headers for the given allowed origins.
+// requestIDHeader is the response header that carries the per-request ID. The
+// same value is stashed on the request context so handlers and the logger can
+// reference it.
+const requestIDHeader = "X-Request-ID"
+
+// maxRequestBodyBytes caps every request body. POST /submit takes no body
+// today; this is defense against runaway uploads against any endpoint.
+const maxRequestBodyBytes = 1 << 20 // 1 MiB
+
+type ctxKey int
+
+const ctxKeyRequestID ctxKey = iota
+
+// RequestIDFromContext returns the request ID associated with the context, or
+// the empty string if none was set.
+func RequestIDFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(ctxKeyRequestID).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// recoverMiddleware catches panics in downstream handlers, logs them with a
+// stack trace, and returns a 500. Without this, a single panicking handler
+// kills the whole server process.
+func recoverMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			rec := recover()
+			if rec == nil {
+				return
+			}
+			rid := RequestIDFromContext(r.Context())
+			log.Printf("panic recovered request_id=%s %s %s: %v\n%s", rid, r.Method, r.URL.Path, rec, debug.Stack()) //nolint:gosec // method and path are safe to log
+			// If the handler already wrote a status, we can't change it.
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+// requestIDMiddleware assigns each request an opaque ID, echoes it as a
+// response header, and stashes it on the context for handlers/logging. If
+// the client supplied an X-Request-ID we adopt it (so traces can be
+// stitched across a proxy), capped at 64 chars and ASCII-only.
+func requestIDMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rid := sanitizeIncomingRequestID(r.Header.Get(requestIDHeader))
+		if rid == "" {
+			rid = newRequestID()
+		}
+		w.Header().Set(requestIDHeader, rid)
+		ctx := context.WithValue(r.Context(), ctxKeyRequestID, rid)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func newRequestID() string {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		// rand.Read on modern OSes only fails in pathological conditions.
+		// Fall back to a timestamp so we still produce *something*.
+		return "rid-" + time.Now().UTC().Format("20060102T150405.000000000")
+	}
+	return hex.EncodeToString(buf[:])
+}
+
+// sanitizeIncomingRequestID accepts a caller-supplied ID only if it's short
+// and ASCII-printable. Anything else gets dropped so we don't reflect attacker
+// input into headers or log lines.
+func sanitizeIncomingRequestID(s string) string {
+	if s == "" || len(s) > 64 {
+		return ""
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < 0x20 || c > 0x7e {
+			return ""
+		}
+	}
+	return s
+}
+
+// securityHeadersMiddleware sets the baseline browser security headers we want
+// on every response. CSP here matches the embedded Next.js shell; if the
+// frontend starts pulling third-party scripts/images, tighten or extend
+// connect-src/script-src to match.
+func securityHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("X-Frame-Options", "DENY")
+		h.Set("Referrer-Policy", "no-referrer")
+		h.Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
+		h.Set("Content-Security-Policy",
+			"default-src 'self'; "+
+				"img-src 'self' data: https:; "+
+				"style-src 'self' 'unsafe-inline'; "+
+				"script-src 'self'; "+
+				"connect-src 'self'; "+
+				"frame-ancestors 'none'; "+
+				"base-uri 'self'; "+
+				"form-action 'self'")
+		next.ServeHTTP(w, r)
+	})
+}
+
+// maxBodyMiddleware caps each request body at maxRequestBodyBytes. Reads past
+// the limit return an error from the handler's Read call, and http.MaxBytesReader
+// surfaces a 413 if the handler doesn't handle it explicitly.
+func maxBodyMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil {
+			r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// corsMiddleware adds CORS headers for the given allowed origins. Origins
+// must be configured explicitly via -cors; there is no implicit loopback
+// allowance, so the server is safe to run on a host shared with untrusted
+// processes.
 func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 	originSet := make(map[string]struct{}, len(allowedOrigins))
 	for _, o := range allowedOrigins {
@@ -17,12 +141,15 @@ func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		origin := r.Header.Get("Origin")
-		if _, ok := originSet[origin]; ok || isLocalDevOrigin(origin) {
-			w.Header().Set("Access-Control-Allow-Origin", origin)
-			w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-			w.Header().Set("Access-Control-Max-Age", "86400")
+		origin := strings.TrimRight(r.Header.Get("Origin"), "/")
+		if _, ok := originSet[origin]; ok {
+			h := w.Header()
+			h.Set("Access-Control-Allow-Origin", origin)
+			h.Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			h.Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Request-ID")
+			h.Set("Access-Control-Allow-Credentials", "true")
+			h.Set("Access-Control-Max-Age", "86400")
+			h.Add("Vary", "Origin")
 		}
 
 		if r.Method == http.MethodOptions {
@@ -34,29 +161,8 @@ func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 	})
 }
 
-func isLocalDevOrigin(origin string) bool {
-	if origin == "" {
-		return false
-	}
-
-	u, err := url.Parse(origin)
-	if err != nil {
-		return false
-	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return false
-	}
-
-	host := u.Hostname()
-	if host == "localhost" {
-		return true
-	}
-
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
-}
-
-// loggingMiddleware logs each request with method, path, status, and duration.
+// loggingMiddleware logs each request with method, path, status, duration,
+// and request ID.
 func loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
@@ -64,7 +170,8 @@ func loggingMiddleware(next http.Handler) http.Handler {
 
 		next.ServeHTTP(sw, r)
 
-		log.Printf("%s %s %d %s", r.Method, r.URL.Path, sw.status, time.Since(start).Round(time.Millisecond)) //nolint:gosec // method and path are safe to log
+		rid := RequestIDFromContext(r.Context())
+		log.Printf("%s %s %d %s rid=%s", r.Method, r.URL.Path, sw.status, time.Since(start).Round(time.Millisecond), rid) //nolint:gosec // method and path are safe to log
 	})
 }
 
@@ -79,7 +186,7 @@ func (w *statusWriter) WriteHeader(code int) {
 }
 
 // Unwrap allows http.ResponseController to access the underlying ResponseWriter
-// for features like Flush.
+// for features like Flush and SetWriteDeadline (SSE).
 func (w *statusWriter) Unwrap() http.ResponseWriter {
 	return w.ResponseWriter
 }

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -146,7 +146,7 @@ func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 			h := w.Header()
 			h.Set("Access-Control-Allow-Origin", origin)
 			h.Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-			h.Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Request-ID")
+			h.Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Request-ID, X-Stackit-CSRF")
 			h.Set("Access-Control-Allow-Credentials", "true")
 			h.Set("Access-Control-Max-Age", "86400")
 			h.Add("Vary", "Origin")

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -1,9 +1,14 @@
 package api
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestStatusWriterImplementsFlusherWhenWrappedWriterDoes(t *testing.T) {
@@ -32,26 +37,32 @@ func TestCORSMiddlewareAllowsConfiguredOrigin(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "http://example.com" {
-		t.Fatalf("expected configured origin to be allowed, got %q", got)
-	}
+	require.Equal(t, "http://example.com", rr.Header().Get("Access-Control-Allow-Origin"))
+	require.Equal(t, "GET, POST, OPTIONS", rr.Header().Get("Access-Control-Allow-Methods"))
+	require.Equal(t, "true", rr.Header().Get("Access-Control-Allow-Credentials"))
+	require.Contains(t, rr.Header().Get("Access-Control-Allow-Headers"), "Authorization")
+	require.Equal(t, "Origin", rr.Header().Get("Vary"))
 }
 
-func TestCORSMiddlewareAllowsLocalhostAnyPort(t *testing.T) {
+func TestCORSMiddlewareRejectsLoopbackOriginByDefault(t *testing.T) {
 	t.Parallel()
 
-	handler := corsMiddleware(nil, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+	// Previously the middleware allowed any loopback origin automatically.
+	// On a public deploy that opens an attack surface for anything else
+	// running on the host, so the rule was removed; localhost must be in
+	// -cors to be accepted.
+	for _, origin := range []string{"http://localhost:5100", "http://127.0.0.1:3000", "http://[::1]:5173"} {
+		handler := corsMiddleware(nil, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
 
-	req := httptest.NewRequest(http.MethodGet, "/api/view", nil)
-	req.Header.Set("Origin", "http://localhost:5100")
+		req := httptest.NewRequest(http.MethodGet, "/api/view", nil)
+		req.Header.Set("Origin", origin)
 
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
 
-	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:5100" {
-		t.Fatalf("expected localhost origin to be allowed, got %q", got)
+		require.Emptyf(t, rr.Header().Get("Access-Control-Allow-Origin"), "origin %q should not be auto-allowed", origin)
 	}
 }
 
@@ -68,32 +79,148 @@ func TestCORSMiddlewareRejectsUnconfiguredNonLocalOrigin(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "" {
-		t.Fatalf("expected non-local, unconfigured origin to be rejected, got %q", got)
+	require.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestRecoverMiddlewareConvertsPanicTo500(t *testing.T) {
+	t.Parallel()
+
+	handler := recoverMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic("boom")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+
+	require.NotPanics(t, func() { handler.ServeHTTP(rr, req) })
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestRequestIDMiddlewareGeneratesAndEchoes(t *testing.T) {
+	t.Parallel()
+
+	var observed string
+	handler := requestIDMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		observed = RequestIDFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.NotEmpty(t, observed)
+	require.Equal(t, observed, rr.Header().Get(requestIDHeader))
+}
+
+func TestRequestIDMiddlewareAdoptsSafeIncomingID(t *testing.T) {
+	t.Parallel()
+
+	handler := requestIDMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(requestIDHeader, "trace-abc-123")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, "trace-abc-123", rr.Header().Get(requestIDHeader))
+}
+
+func TestRequestIDMiddlewareRejectsUnsafeIncomingID(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		strings.Repeat("a", 65), // too long
+		"contains\nnewline",
+		"contains\x00null",
+		"unicode-😀",
+	}
+	for _, in := range cases {
+		handler := requestIDMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set(requestIDHeader, in)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		got := rr.Header().Get(requestIDHeader)
+		require.NotEqualf(t, in, got, "should not adopt unsafe id %q", in)
+		require.NotEmpty(t, got, "should still emit a generated id")
 	}
 }
 
-func TestIsLocalDevOrigin(t *testing.T) {
+func TestSecurityHeadersMiddlewareSetsBaseline(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name   string
-		origin string
-		want   bool
-	}{
-		{name: "localhost with port", origin: "http://localhost:5100", want: true},
-		{name: "ipv4 loopback", origin: "http://127.0.0.1:3000", want: true},
-		{name: "ipv6 loopback", origin: "http://[::1]:5173", want: true},
-		{name: "non-loopback host", origin: "http://example.com:3000", want: false},
-		{name: "invalid", origin: "not a url", want: false},
-	}
+	handler := securityHeadersMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			if got := isLocalDevOrigin(tc.origin); got != tc.want {
-				t.Fatalf("isLocalDevOrigin(%q): want %v, got %v", tc.origin, tc.want, got)
-			}
-		})
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, "nosniff", rr.Header().Get("X-Content-Type-Options"))
+	require.Equal(t, "DENY", rr.Header().Get("X-Frame-Options"))
+	require.Equal(t, "no-referrer", rr.Header().Get("Referrer-Policy"))
+	require.Contains(t, rr.Header().Get("Strict-Transport-Security"), "max-age=")
+	require.Contains(t, rr.Header().Get("Content-Security-Policy"), "default-src 'self'")
+	require.Contains(t, rr.Header().Get("Content-Security-Policy"), "frame-ancestors 'none'")
+}
+
+func TestMaxBodyMiddlewareCapsRequestBody(t *testing.T) {
+	t.Parallel()
+
+	var readErr error
+	handler := maxBodyMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, readErr = io.ReadAll(r.Body)
+		if readErr != nil {
+			http.Error(w, readErr.Error(), http.StatusRequestEntityTooLarge)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	body := bytes.Repeat([]byte("a"), maxRequestBodyBytes+1)
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Error(t, readErr)
+	require.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
+}
+
+func TestMaxBodyMiddlewareAllowsSmallBody(t *testing.T) {
+	t.Parallel()
+
+	handler := maxBodyMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, []byte("ok"), b)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("ok"))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestSanitizeIncomingRequestID(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"trace-1", "trace-1"},
+		{strings.Repeat("x", 64), strings.Repeat("x", 64)},
+		{strings.Repeat("x", 65), ""},
+		{"a\tb", ""},   // tab is < 0x20
+		{"a\x7fb", ""}, // DEL is > 0x7e
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, sanitizeIncomingRequestID(tc.in), "input=%q", tc.in)
 	}
 }

--- a/internal/api/reqid/reqid.go
+++ b/internal/api/reqid/reqid.go
@@ -1,0 +1,29 @@
+// Package reqid holds the request-ID context plumbing shared between the
+// middleware that mints the ID (internal/api) and the handlers that want
+// to include it in audit log lines (internal/api/handlers). Lives in its
+// own package so neither side has to import the other.
+package reqid
+
+import "context"
+
+// HeaderName is the request/response header that carries the per-request
+// ID. Kept here so the middleware and the http client agree.
+const HeaderName = "X-Request-ID"
+
+type ctxKey struct{}
+
+// FromContext returns the request ID associated with ctx, or "" if none
+// was attached (e.g. tests calling a handler directly without going
+// through the middleware).
+func FromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(ctxKey{}).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// WithValue attaches a request ID to ctx. Only the middleware should call
+// this; handlers read via FromContext.
+func WithValue(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, ctxKey{}, id)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -111,6 +111,10 @@ func (s *Server) Start() error {
 	if s.config.Auth != nil {
 		protectedAPI = auth.RequireSession(s.config.Auth.SessionStore, apiMux)
 	}
+	// CSRF header check wraps protectedAPI so it covers POST /submit. Safe
+	// methods (GET/HEAD/OPTIONS) pass through untouched, so the read API
+	// is unaffected.
+	protectedAPI = auth.RequireCSRFHeader(protectedAPI)
 
 	authMux := http.NewServeMux()
 	if s.config.Auth != nil {
@@ -120,6 +124,10 @@ func (s *Server) Start() error {
 		authMux.HandleFunc("POST /auth/logout", h.LogoutHandler)
 		authMux.HandleFunc("GET /auth/me", h.MeHandler)
 	}
+	// /auth/logout is a POST and needs the same CSRF gate as /api/*.
+	// Login and callback are GETs and pass through. The CSRF middleware
+	// short-circuits safe methods so wrapping the whole mux is fine.
+	authHandler := auth.RequireCSRFHeader(http.Handler(authMux))
 
 	webHandler := newStaticHandler(s.config.StaticFS)
 	root := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -129,7 +137,7 @@ func (s *Server) Start() error {
 		}
 
 		if s.config.Auth != nil && strings.HasPrefix(r.URL.Path, "/auth/") {
-			authMux.ServeHTTP(w, r)
+			authHandler.ServeHTTP(w, r)
 			return
 		}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/getstackit/stackit/internal/api/auth"
 	"github.com/getstackit/stackit/internal/api/handlers"
 	"github.com/getstackit/stackit/internal/api/registry"
 )
@@ -25,6 +26,21 @@ type ServerConfig struct {
 	APIPrefixes []string
 	StaticFS    fs.FS
 	Registry    *registry.Registry
+
+	// Auth bundles the OAuth handler, session store, and surrounding state
+	// needed to gate /api/* routes behind GitHub login. When nil the server
+	// runs without authentication; that mode is only safe on a private
+	// network (localhost dev, tunneled access). apps/server refuses to
+	// start unauthenticated when STACKIT_PUBLIC or $PORT are set unless
+	// -auth-disabled is passed explicitly.
+	Auth *AuthConfig
+}
+
+// AuthConfig is the runtime auth setup. SessionStore must outlive the
+// Server's lifetime (close it after Shutdown returns).
+type AuthConfig struct {
+	Handler      *auth.Handler
+	SessionStore auth.Store
 }
 
 // Server is the stackit-web HTTP server. Per-repo state (engine, watcher,
@@ -88,10 +104,32 @@ func (s *Server) Start() error {
 		apiMux.Handle("GET "+prefix+"/events", eventsHandler)
 	}
 
+	// Apply session enforcement to /api/* only. /auth/* and static assets
+	// stay unauthenticated so the user can complete the login flow and
+	// land on the SPA shell.
+	var protectedAPI http.Handler = apiMux
+	if s.config.Auth != nil {
+		protectedAPI = auth.RequireSession(s.config.Auth.SessionStore, apiMux)
+	}
+
+	authMux := http.NewServeMux()
+	if s.config.Auth != nil {
+		h := s.config.Auth.Handler
+		authMux.HandleFunc("GET /auth/login", h.LoginHandler)
+		authMux.HandleFunc("GET /auth/callback", h.CallbackHandler)
+		authMux.HandleFunc("POST /auth/logout", h.LogoutHandler)
+		authMux.HandleFunc("GET /auth/me", h.MeHandler)
+	}
+
 	webHandler := newStaticHandler(s.config.StaticFS)
 	root := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isAPIPath(r.URL.Path, prefixes) {
-			apiMux.ServeHTTP(w, r)
+			protectedAPI.ServeHTTP(w, r)
+			return
+		}
+
+		if s.config.Auth != nil && strings.HasPrefix(r.URL.Path, "/auth/") {
+			authMux.ServeHTTP(w, r)
 			return
 		}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -16,6 +16,10 @@ import (
 
 // ServerConfig holds configuration for the API server.
 type ServerConfig struct {
+	// BindAddr is the host/IP to listen on. Empty means "all interfaces".
+	// apps/server picks a safe default (127.0.0.1) and switches to the
+	// public-facing form when PORT or STACKIT_PUBLIC is set.
+	BindAddr    string
 	Port        int
 	CORSOrigins []string
 	APIPrefixes []string
@@ -99,16 +103,27 @@ func (s *Server) Start() error {
 		http.NotFound(w, r)
 	})
 
-	handler := corsMiddleware(s.config.CORSOrigins, root)
-	handler = loggingMiddleware(handler)
+	// Middleware order (outermost first). recover wraps everything so a
+	// panic in any inner layer can't kill the process; logging is innermost
+	// so it sees the final status written by handlers (and by any earlier
+	// middleware that short-circuits).
+	handler := loggingMiddleware(root)
+	handler = maxBodyMiddleware(handler)
+	handler = corsMiddleware(s.config.CORSOrigins, handler)
+	handler = securityHeadersMiddleware(handler)
+	handler = requestIDMiddleware(handler)
+	handler = recoverMiddleware(handler)
 
 	s.httpServer = &http.Server{
-		Addr:              fmt.Sprintf(":%d", s.config.Port),
+		Addr:              fmt.Sprintf("%s:%d", s.config.BindAddr, s.config.Port),
 		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		MaxHeaderBytes:    1 << 20, // 1 MiB
 	}
 
-	log.Printf("stackit-web server listening on http://localhost:%d", s.config.Port)
+	log.Printf("stackit-web server listening on http://%s:%d", displayHost(s.config.BindAddr), s.config.Port)
 	return s.httpServer.ListenAndServe()
 }
 
@@ -152,6 +167,17 @@ func normalizeAPIPrefixes(prefixes []string) []string {
 		return []string{"/api/v1", "/api"}
 	}
 	return normalized
+}
+
+// displayHost returns a user-friendly host for the startup log line. Empty
+// bind address means "listen on all interfaces", which we surface as
+// "localhost" because that's what the operator will type in a browser to
+// reach the server locally.
+func displayHost(bind string) string {
+	if bind == "" || bind == "0.0.0.0" || bind == "::" {
+		return "localhost"
+	}
+	return bind
 }
 
 func isAPIPath(path string, prefixes []string) bool {

--- a/internal/api/static.go
+++ b/internal/api/static.go
@@ -42,6 +42,14 @@ func newStaticHandler(staticFS fs.FS) http.Handler {
 
 		if staticFS != nil {
 			if _, err := fs.Stat(staticFS, cleanPath); err == nil {
+				// Next emits hashed asset paths under _next/static/, which are
+				// safe to cache aggressively. Everything else (HTML, manifests,
+				// etc.) should re-validate so deploys take effect immediately.
+				if strings.HasPrefix(cleanPath, "_next/static/") {
+					w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+				} else {
+					w.Header().Set("Cache-Control", "no-cache")
+				}
 				fileServer.ServeHTTP(w, r)
 				return
 			}
@@ -60,6 +68,7 @@ func newStaticHandler(staticFS fs.FS) http.Handler {
 
 func writeIndex(w http.ResponseWriter, indexHTML []byte) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(indexHTML)
 }


### PR DESCRIPTION
This PR merges the following changes:

1. **#1006** fix(web): route picker selection via ?repo= query string
2. **#1007** feat(server): fall back to $PORT env when -port isn't set
3. **#1008** feat(server): publish multi-arch container to ghcr.io
4. **#1009** docs: add deploy guide for hosted stackit-server
5. **#1011** feat(server): harden HTTP middleware for public deploy
6. **#1015** feat(server): gate API behind GitHub OAuth + allowlist
7. **#1016** feat(server): require X-Stackit-CSRF on mutating endpoints
8. **#1017** feat(server): structured audit logs on mutating calls
9. **#1012** build: publish dev

### Stack

```
main
  └─ fix/web-picker-query-route (#1006)
    └─ feat/server-port-env (#1007)
      └─ feat/server-docker (#1008)
        └─ docs/server-deploy (#1009)
          └─ feat/server-harden-http-middleware (#1011)
            └─ feat/server-github-oauth (#1015)
              └─ feat/server-csrf (#1016)
                └─ feat/server-audit-logs (#1017)
                  └─ jonnii/20260527024604/publish-dev (#1012)
```

Stackit-Stack-Size: 9
Stackit-PRs: 1006,1007,1008,1009,1011,1015,1016,1017,1012
