### PR TITLE
chore(server): add env:init mise task to populate .env via gh + openssl

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -184,6 +184,53 @@ run = "pnpm --filter @stackit/web dev"
 description = "Run the server in development mode (auto-reloads on file changes)"
 run = "watchexec -r -e go -w apps/server -w internal -w api -- go run ./apps/server --port 8080"
 
+[tasks."env:init"]
+description = "Generate .env from .env.template, filling values from gh CLI + openssl where possible"
+run = """
+  set -e
+  if [ -f .env ]; then
+    echo ".env already exists. Remove it first to regenerate, or edit it by hand." >&2
+    exit 1
+  fi
+  if [ ! -f .env.template ]; then
+    echo ".env.template not found at project root." >&2
+    exit 1
+  fi
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "gh CLI not found. Install from https://cli.github.com." >&2
+    exit 1
+  fi
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "gh not authenticated. Run 'gh auth login' first." >&2
+    exit 1
+  fi
+  if ! command -v openssl >/dev/null 2>&1; then
+    echo "openssl not found." >&2
+    exit 1
+  fi
+
+  GH_USER=$(gh api user --jq .login)
+  SESSION_KEY=$(openssl rand -base64 32)
+
+  awk -v user="$GH_USER" -v key="$SESSION_KEY" '
+    /^STACKIT_ALLOWED_GH_USERS=$/ { print "STACKIT_ALLOWED_GH_USERS=" user; next }
+    /^STACKIT_SESSION_KEY=$/      { print "STACKIT_SESSION_KEY=" key; next }
+    { print }
+  ' .env.template > .env
+
+  echo "Wrote .env with:"
+  echo "  STACKIT_ALLOWED_GH_USERS=$GH_USER  (from gh api user)"
+  echo "  STACKIT_SESSION_KEY=<32 random bytes>"
+  echo
+  echo "Still required for public-mode auth (manual — GitHub does not expose these via API):"
+  echo "  STACKIT_GITHUB_CLIENT_ID"
+  echo "  STACKIT_GITHUB_CLIENT_SECRET"
+  echo
+  echo "Create an OAuth app at https://github.com/settings/developers and set"
+  echo "the callback URL to \\$STACKIT_BASE_URL/auth/callback, then paste the"
+  echo "credentials into .env."
+"""
+
 [tasks."server:build:embedded"]
 description = "Build stackit-server with embedded exported web assets"
 depends = ["web:sync-static"]


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1055**
  * **PR #1056**
    * **PR #1057**
      * **PR #1058** 👈
        * **PR #1059**
          * **PR #1060**
            * **PR #1061**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1062 by jonnii*