### PR TITLE
refactor(server): migrate stdlib log to slog with structured, leveled output

### DIFF
--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"io/fs"
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -35,8 +36,28 @@ var (
 
 func main() {
 	if err := run(); err != nil {
-		log.Fatal(err)
+		slog.Error("startup failed", "error", err)
+		os.Exit(1)
 	}
+}
+
+// setupLogging configures the default slog logger. Production deploys
+// (PORT or STACKIT_PUBLIC set) emit JSON with a level field so log
+// aggregators tag entries correctly; local runs use the text handler
+// for readability. Output goes to stdout so platforms like Railway
+// don't classify everything as error (which is what happens when the
+// stdlib log package writes to stderr).
+func setupLogging(jsonOutput bool) {
+	opts := &slog.HandlerOptions{Level: slog.LevelInfo}
+	var handler slog.Handler
+	if jsonOutput {
+		handler = slog.NewJSONHandler(os.Stdout, opts)
+	} else {
+		handler = slog.NewTextHandler(os.Stdout, opts)
+	}
+	slog.SetDefault(slog.New(handler))
+	log.SetFlags(0)
+	log.SetOutput(os.Stdout)
 }
 
 func run() error {
@@ -55,7 +76,10 @@ func run() error {
 	)
 	flag.Parse()
 
-	log.Printf("stackit-server version=%s commit=%s built=%s", version, commit, date)
+	publicMode := os.Getenv("PORT") != "" || os.Getenv("STACKIT_PUBLIC") != ""
+	setupLogging(publicMode)
+
+	slog.Info("stackit-server starting", "version", version, "commit", commit, "built", date)
 
 	// Honor $PORT when -port wasn't passed explicitly. PaaS hosts (Railway,
 	// Fly, Heroku) inject the port this way.
@@ -75,7 +99,7 @@ func run() error {
 	if err := resolvePort(port, portExplicit, os.Getenv("PORT")); err != nil {
 		return err
 	}
-	resolveBind(bind, bindExplicit, os.Getenv("PORT") != "" || os.Getenv("STACKIT_PUBLIC") != "")
+	resolveBind(bind, bindExplicit, publicMode)
 
 	staticFS, err := fs.Sub(staticFiles, "static")
 	if err != nil {
@@ -90,7 +114,7 @@ func run() error {
 	reg := registry.New()
 	defer func() {
 		if closeErr := reg.Close(); closeErr != nil {
-			log.Printf("registry close: %v", closeErr)
+			slog.Error("registry close failed", "error", closeErr)
 		}
 	}()
 
@@ -106,7 +130,7 @@ func run() error {
 				// server — other configured repos may still be usable,
 				// and a future "add repo from GitHub" flow will clone
 				// these on demand. Log and skip instead.
-				log.Printf("repo %q not registered: %v", rc.ID, err)
+				slog.Warn("repo not registered", "repo", rc.ID, "error", err)
 			}
 		}
 	default:
@@ -127,11 +151,10 @@ func run() error {
 			if cwdExplicit {
 				return err
 			}
-			log.Printf("no default repo registered: %v", err)
+			slog.Info("no default repo registered", "error", err)
 		}
 	}
 
-	publicMode := os.Getenv("PORT") != "" || os.Getenv("STACKIT_PUBLIC") != ""
 	authBuild, err := buildAuthConfig(*authDisabled, publicMode)
 	if err != nil {
 		return err
@@ -141,12 +164,12 @@ func run() error {
 		authCfg = authBuild.cfg
 		defer func() {
 			if closeErr := authBuild.store.Close(); closeErr != nil {
-				log.Printf("session store close: %v", closeErr)
+				slog.Error("session store close failed", "error", closeErr)
 			}
 		}()
-		log.Printf("auth: GitHub OAuth gate enabled")
+		slog.Info("auth: GitHub OAuth gate enabled")
 	} else {
-		log.Printf("auth: DISABLED (no STACKIT_GITHUB_* env or -auth-disabled set). Do not expose this port publicly.")
+		slog.Warn("auth: DISABLED (no STACKIT_GITHUB_* env or -auth-disabled set). Do not expose this port publicly.")
 	}
 
 	server := api.NewServer(api.ServerConfig{
@@ -169,7 +192,7 @@ func run() error {
 
 	select {
 	case sig := <-stop:
-		log.Printf("received %s, shutting down", sig)
+		slog.Info("shutting down", "signal", sig.String())
 		ctx, cancel := context.WithTimeout(context.Background(), *shutdownGrace)
 		defer cancel()
 		return server.Shutdown(ctx)
@@ -196,7 +219,7 @@ func addRegistryEntry(reg *registry.Registry, rc repoConfig) error {
 
 	gh := runtimeCtx.GitHub()
 	if gh == nil && runtimeCtx.GitHubError() != nil {
-		log.Printf("[%s] GitHub client unavailable: %v", rc.ID, runtimeCtx.GitHubError())
+		slog.Warn("GitHub client unavailable", "repo", rc.ID, "error", runtimeCtx.GitHubError())
 	}
 
 	entry := registry.NewEntry(registry.EntryConfig{

--- a/internal/api/auth/oauth.go
+++ b/internal/api/auth/oauth.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -132,7 +132,7 @@ func (h *Handler) resolveUserInfoURL() string {
 func (h *Handler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 	state, err := randomToken(16)
 	if err != nil {
-		log.Printf("login: random state: %v", err)
+		slog.Error("login: random state failed", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -160,7 +160,7 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	wantState := readCookie(r, stateCookieName)
 	h.cfg.Cookies.clearState(w)
 	if wantState == "" || gotState == "" || !constantTimeStringEq(gotState, wantState) {
-		log.Printf("auth callback: bad state")
+		slog.Warn("auth callback: bad state")
 		http.Error(w, "invalid auth state", http.StatusBadRequest)
 		return
 	}
@@ -168,7 +168,7 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	code := q.Get("code")
 	if code == "" {
 		// GitHub redirects here with `error=...` when the user denies.
-		log.Printf("auth callback: missing code (oauth_error=%q)", q.Get("error")) //nolint:gosec // logged value is %q-quoted
+		slog.Warn("auth callback: missing code", "oauth_error", q.Get("error")) //nolint:gosec // value emitted as a structured slog field, not concatenated
 		http.Redirect(w, r, h.cfg.DeniedPath, http.StatusFound)
 		return
 	}
@@ -176,32 +176,32 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	tok, err := h.oauth2cfg.Exchange(ctx, code)
 	if err != nil {
-		log.Printf("auth callback: token exchange: %v", err)
+		slog.Warn("auth callback: token exchange failed", "error", err)
 		http.Error(w, "token exchange failed", http.StatusBadGateway)
 		return
 	}
 
 	user, err := h.fetchGitHubUser(ctx, tok.AccessToken)
 	if err != nil {
-		log.Printf("auth callback: fetch user: %v", err)
+		slog.Warn("auth callback: fetch user failed", "error", err)
 		http.Error(w, "github user lookup failed", http.StatusBadGateway)
 		return
 	}
 
 	if err := h.allow.Check(ctx, user.Login, tok.AccessToken); err != nil {
 		if errors.Is(err, ErrDenied) {
-			log.Printf("audit action=denied actor=%q request_id=%s", user.Login, reqid.FromContext(ctx)) //nolint:gosec // login is %q-quoted
+			slog.Info("audit", "action", "denied", "actor", user.Login, "request_id", reqid.FromContext(ctx))
 			http.Redirect(w, r, h.cfg.DeniedPath, http.StatusFound)
 			return
 		}
-		log.Printf("auth callback: allowlist check error: %v", err)
+		slog.Error("auth callback: allowlist check failed", "error", err)
 		http.Error(w, "allowlist check failed", http.StatusBadGateway)
 		return
 	}
 
 	sess, err := h.store.Create(user.Login, user.ID, tok.AccessToken)
 	if err != nil {
-		log.Printf("auth callback: create session: %v", err)
+		slog.Error("auth callback: create session failed", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -213,7 +213,7 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	h.cfg.Cookies.clearReturn(w)
 
-	log.Printf("audit action=login actor=%q user_id=%d target=%s request_id=%s", user.Login, user.ID, target, reqid.FromContext(ctx)) //nolint:gosec // logged values are quoted/numeric/safe target
+	slog.Info("audit", "action", "login", "actor", user.Login, "user_id", user.ID, "target", target, "request_id", reqid.FromContext(ctx)) //nolint:gosec // values emitted as structured slog fields
 	http.Redirect(w, r, target, http.StatusFound)
 }
 
@@ -223,7 +223,7 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) LogoutHandler(w http.ResponseWriter, r *http.Request) {
 	if cookie := readCookie(r, sessionCookieName); cookie != "" {
 		if sess, ok := h.store.Get(cookie); ok {
-			log.Printf("audit action=logout actor=%q request_id=%s", sess.GitHubLogin, reqid.FromContext(r.Context())) //nolint:gosec // login is %q-quoted
+			slog.Info("audit", "action", "logout", "actor", sess.GitHubLogin, "request_id", reqid.FromContext(r.Context())) //nolint:gosec // values emitted as structured slog fields
 		}
 		h.store.Delete(cookie)
 	}

--- a/internal/api/handlers/submit.go
+++ b/internal/api/handlers/submit.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 
 	"github.com/getstackit/stackit/internal/actions/submit"
@@ -67,7 +67,7 @@ func (h *SubmitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if sess := auth.SessionFromContext(r.Context()); sess != nil {
 		actor = sess.GitHubLogin
 	}
-	log.Printf("audit action=submit actor=%q repo=%q branch=%q request_id=%s", actor, entry.ID, rootBranch, reqid.FromContext(r.Context())) //nolint:gosec // values are %q-quoted
+	slog.Info("audit", "action", "submit", "actor", actor, "repo", entry.ID, "branch", rootBranch, "request_id", reqid.FromContext(r.Context())) //nolint:gosec // values emitted as structured slog fields
 
 	ctx := app.NewContext(entry.Engine,
 		app.WithRepoRoot(entry.RepoRoot),

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"log"
+	"log/slog"
 	"net/http"
 	"runtime/debug"
 	"strings"
@@ -21,6 +21,20 @@ const requestIDHeader = reqid.HeaderName
 // maxRequestBodyBytes caps every request body. POST /submit takes no body
 // today; this is defense against runaway uploads against any endpoint.
 const maxRequestBodyBytes = 1 << 20 // 1 MiB
+
+// cspHeader is the Content-Security-Policy applied to every response. The
+// sha256 hash in script-src is the embedded Next.js bootstrap inline script;
+// if a future web build changes that script, the browser will print the new
+// hash in the console — paste it in here. Multiple hashes can be listed
+// space-separated if more inline scripts get added.
+const cspHeader = "default-src 'self'; " +
+	"img-src 'self' data: https:; " +
+	"style-src 'self' 'unsafe-inline'; " +
+	"script-src 'self' 'sha256-OBTN3RiyCV4Bq7dFqZ5a2pAXjnCcCYeTJMO2I/LYKeo='; " +
+	"connect-src 'self'; " +
+	"frame-ancestors 'none'; " +
+	"base-uri 'self'; " +
+	"form-action 'self'"
 
 // RequestIDFromContext is kept here as a re-export for callers in the api
 // package; handlers in other packages import internal/api/reqid directly.
@@ -39,7 +53,7 @@ func recoverMiddleware(next http.Handler) http.Handler {
 				return
 			}
 			rid := RequestIDFromContext(r.Context())
-			log.Printf("panic recovered request_id=%s %s %s: %v\n%s", rid, r.Method, r.URL.Path, rec, debug.Stack()) //nolint:gosec // method and path are safe to log
+			slog.Error("panic recovered", "request_id", rid, "method", r.Method, "path", r.URL.Path, "panic", rec, "stack", string(debug.Stack())) //nolint:gosec // values emitted as structured slog fields
 			// If the handler already wrote a status, we can't change it.
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 		}()
@@ -100,15 +114,7 @@ func securityHeadersMiddleware(next http.Handler) http.Handler {
 		h.Set("X-Frame-Options", "DENY")
 		h.Set("Referrer-Policy", "no-referrer")
 		h.Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
-		h.Set("Content-Security-Policy",
-			"default-src 'self'; "+
-				"img-src 'self' data: https:; "+
-				"style-src 'self' 'unsafe-inline'; "+
-				"script-src 'self'; "+
-				"connect-src 'self'; "+
-				"frame-ancestors 'none'; "+
-				"base-uri 'self'; "+
-				"form-action 'self'")
+		h.Set("Content-Security-Policy", cspHeader)
 		next.ServeHTTP(w, r)
 	})
 }
@@ -157,7 +163,8 @@ func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 }
 
 // loggingMiddleware logs each request with method, path, status, duration,
-// and request ID.
+// and request ID. The level reflects the response status so 5xx surfaces
+// as error and 4xx as warn in log aggregators.
 func loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
@@ -165,8 +172,20 @@ func loggingMiddleware(next http.Handler) http.Handler {
 
 		next.ServeHTTP(sw, r)
 
-		rid := RequestIDFromContext(r.Context())
-		log.Printf("%s %s %d %s rid=%s", r.Method, r.URL.Path, sw.status, time.Since(start).Round(time.Millisecond), rid) //nolint:gosec // method and path are safe to log
+		level := slog.LevelInfo
+		switch {
+		case sw.status >= 500:
+			level = slog.LevelError
+		case sw.status >= 400:
+			level = slog.LevelWarn
+		}
+		slog.LogAttrs(r.Context(), level, "request",
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+			slog.Int("status", sw.status),
+			slog.Duration("duration", time.Since(start).Round(time.Millisecond)),
+			slog.String("request_id", RequestIDFromContext(r.Context())),
+		)
 	})
 }
 

--- a/internal/api/registry/registry.go
+++ b/internal/api/registry/registry.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"regexp"
 	"sort"
 	"sync"
@@ -125,7 +125,7 @@ func makeWatcherCallback(entry *RepoEntry) func() {
 
 	return func() {
 		if err := entry.Engine.Rebuild(trunkName); err != nil {
-			log.Printf("[%s] engine rebuild failed: %v", entry.ID, err)
+			slog.Error("engine rebuild failed", "repo", entry.ID, "error", err)
 			return
 		}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -169,7 +169,7 @@ func (s *Server) Start() error {
 		MaxHeaderBytes:    1 << 20, // 1 MiB
 	}
 
-	log.Printf("stackit-web server listening on http://%s:%d", displayHost(s.config.BindAddr), s.config.Port)
+	slog.Info("stackit-web server listening", "url", fmt.Sprintf("http://%s:%d", displayHost(s.config.BindAddr), s.config.Port))
 	return s.httpServer.ListenAndServe()
 }
 

--- a/internal/api/watcher/watcher.go
+++ b/internal/api/watcher/watcher.go
@@ -6,7 +6,7 @@ package watcher
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -55,14 +55,14 @@ func (w *RefWatcher) Start() error {
 			continue // Directory may not exist yet
 		}
 		if err := addRecursive(fsw, dir); err != nil {
-			log.Printf("warning: failed to watch %s: %v", dir, err)
+			slog.Warn("failed to watch directory", "dir", dir, "error", err)
 		}
 	}
 
 	// Also watch HEAD for branch switches
 	headPath := filepath.Join(w.repoRoot, ".git", "HEAD")
 	if err := fsw.Add(headPath); err != nil {
-		log.Printf("warning: failed to watch HEAD: %v", err)
+		slog.Warn("failed to watch HEAD", "path", headPath, "error", err)
 	}
 
 	var timer *time.Timer
@@ -100,7 +100,7 @@ func (w *RefWatcher) Start() error {
 			if !ok {
 				return nil
 			}
-			log.Printf("watcher error: %v", err)
+			slog.Error("watcher error", "error", err)
 		}
 	}
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Switch apps/server and internal/api/* from the stdlib log package to log/slog.
JSON handler is used when PORT or STACKIT_PUBLIC is set (hosted/Railway) so log
aggregators see a level field and can classify entries correctly; text handler is
used locally. All output goes to stdout so platforms don't tag everything as error.
Request log level reflects status (5xx→error, 4xx→warn). Audit events use
structured fields instead of printf-style formatting.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1779938183`.


* **PR #1055**
  * **PR #1056**
    * **PR #1057**
      * **PR #1058**
        * **PR #1059** 👈
          * **PR #1060**
            * **PR #1061**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->