### PR TITLE
feat(server): auto-compute CSP script-src hashes from embedded static FS

### DIFF
--- a/internal/api/csp.go
+++ b/internal/api/csp.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io/fs"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// scriptTagRe captures the attribute list and inline body of every <script>
+// tag. The (?s) flag lets `.` span newlines so multi-line scripts match.
+var scriptTagRe = regexp.MustCompile(`(?s)<script([^>]*)>(.*?)</script>`)
+
+// scriptHasSrcRe matches `src=` as a real attribute (preceded by start or
+// whitespace) so we don't false-positive on `data-src=`, `nosrc=`, etc.
+var scriptHasSrcRe = regexp.MustCompile(`(?:^|\s)src\s*=`)
+
+// buildCSP returns the Content-Security-Policy header value derived from the
+// embedded static site. It computes a sha256 hash for every inline <script>
+// body found in *.html files under staticFS, so each Next build is allowed
+// without a manual paste-in. External scripts (with a src= attribute) are
+// covered by 'self' and contribute no hash.
+func buildCSP(staticFS fs.FS) (string, error) {
+	hashes, err := inlineScriptHashes(staticFS)
+	if err != nil {
+		return "", err
+	}
+
+	scriptSrc := "'self'"
+	if len(hashes) > 0 {
+		scriptSrc = "'self' " + strings.Join(hashes, " ")
+	}
+
+	return "default-src 'self'; " +
+		"img-src 'self' data: https:; " +
+		"style-src 'self' 'unsafe-inline'; " +
+		"script-src " + scriptSrc + "; " +
+		"connect-src 'self'; " +
+		"frame-ancestors 'none'; " +
+		"base-uri 'self'; " +
+		"form-action 'self'", nil
+}
+
+// inlineScriptHashes returns CSP-formatted sha256 hashes for every distinct
+// inline <script> body across all HTML files in staticFS. Sorted for stable
+// header output across runs.
+func inlineScriptHashes(staticFS fs.FS) ([]string, error) {
+	if staticFS == nil {
+		return nil, nil
+	}
+
+	seen := make(map[string]struct{})
+	err := fs.WalkDir(staticFS, ".", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(strings.ToLower(path), ".html") {
+			return nil
+		}
+
+		data, err := fs.ReadFile(staticFS, path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+
+		for _, m := range scriptTagRe.FindAllSubmatch(data, -1) {
+			attrs, body := m[1], m[2]
+			if scriptHasSrcRe.Match(attrs) {
+				continue
+			}
+			if len(bytes.TrimSpace(body)) == 0 {
+				continue
+			}
+			sum := sha256.Sum256(body)
+			seen["'sha256-"+base64.StdEncoding.EncodeToString(sum[:])+"'"] = struct{}{}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]string, 0, len(seen))
+	for h := range seen {
+		out = append(out, h)
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/internal/api/csp_test.go
+++ b/internal/api/csp_test.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCSP_HashesInlineScripts(t *testing.T) {
+	t.Parallel()
+
+	inline1 := `self.__next_f=self.__next_f||[];self.__next_f.push([0,"x"])`
+	inline2 := `console.log("hi")`
+	expected1 := sha256Hash(inline1)
+	expected2 := sha256Hash(inline2)
+
+	fs := fstest.MapFS{
+		"index.html": {Data: []byte(`<html><head>` +
+			`<script>` + inline1 + `</script>` +
+			`<script src="/_next/static/chunks/main.js" async></script>` +
+			`</head><body><script>` + inline2 + `</script></body></html>`)},
+		"other.html": {Data: []byte(`<script>` + inline1 + `</script>`)}, // duplicate; should dedupe
+		"asset.js":   {Data: []byte(`console.log("ignored")`)},           // not html; skipped
+	}
+
+	csp, err := buildCSP(fs)
+	require.NoError(t, err)
+
+	require.Contains(t, csp, "'sha256-"+expected1+"'")
+	require.Contains(t, csp, "'sha256-"+expected2+"'")
+	require.Contains(t, csp, "frame-ancestors 'none'")
+	require.Contains(t, csp, "default-src 'self'")
+
+	// Duplicate inline script should appear exactly once in the header.
+	require.Equal(t, 1, strings.Count(csp, "'sha256-"+expected1+"'"))
+}
+
+func TestBuildCSP_NilFS(t *testing.T) {
+	t.Parallel()
+
+	csp, err := buildCSP(nil)
+	require.NoError(t, err)
+	require.Contains(t, csp, "script-src 'self';")
+}
+
+func TestBuildCSP_SkipsScriptsWithSrc(t *testing.T) {
+	t.Parallel()
+
+	// A <script src="..."> with content between the tags shouldn't produce a
+	// hash (browser ignores the body when src is set, so hashing it would be
+	// dead config that drifts with each build).
+	fs := fstest.MapFS{
+		"index.html": {Data: []byte(`<script src="/x.js">SHOULD_NOT_HASH</script>`)},
+	}
+	csp, err := buildCSP(fs)
+	require.NoError(t, err)
+	require.NotContains(t, csp, "SHOULD_NOT_HASH")
+	require.NotContains(t, csp, sha256Hash("SHOULD_NOT_HASH"))
+}
+
+func TestBuildCSP_SkipsEmptyScripts(t *testing.T) {
+	t.Parallel()
+
+	fs := fstest.MapFS{
+		"index.html": {Data: []byte(`<script></script><script>  </script>`)},
+	}
+	csp, err := buildCSP(fs)
+	require.NoError(t, err)
+	require.Equal(t, "default-src 'self'; "+
+		"img-src 'self' data: https:; "+
+		"style-src 'self' 'unsafe-inline'; "+
+		"script-src 'self'; "+
+		"connect-src 'self'; "+
+		"frame-ancestors 'none'; "+
+		"base-uri 'self'; "+
+		"form-action 'self'", csp)
+}
+
+func sha256Hash(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return base64.StdEncoding.EncodeToString(sum[:])
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -22,20 +22,6 @@ const requestIDHeader = reqid.HeaderName
 // today; this is defense against runaway uploads against any endpoint.
 const maxRequestBodyBytes = 1 << 20 // 1 MiB
 
-// cspHeader is the Content-Security-Policy applied to every response. The
-// sha256 hash in script-src is the embedded Next.js bootstrap inline script;
-// if a future web build changes that script, the browser will print the new
-// hash in the console — paste it in here. Multiple hashes can be listed
-// space-separated if more inline scripts get added.
-const cspHeader = "default-src 'self'; " +
-	"img-src 'self' data: https:; " +
-	"style-src 'self' 'unsafe-inline'; " +
-	"script-src 'self' 'sha256-OBTN3RiyCV4Bq7dFqZ5a2pAXjnCcCYeTJMO2I/LYKeo='; " +
-	"connect-src 'self'; " +
-	"frame-ancestors 'none'; " +
-	"base-uri 'self'; " +
-	"form-action 'self'"
-
 // RequestIDFromContext is kept here as a re-export for callers in the api
 // package; handlers in other packages import internal/api/reqid directly.
 func RequestIDFromContext(ctx context.Context) string {
@@ -104,17 +90,17 @@ func sanitizeIncomingRequestID(s string) string {
 }
 
 // securityHeadersMiddleware sets the baseline browser security headers we want
-// on every response. CSP here matches the embedded Next.js shell; if the
-// frontend starts pulling third-party scripts/images, tighten or extend
-// connect-src/script-src to match.
-func securityHeadersMiddleware(next http.Handler) http.Handler {
+// on every response. The CSP is computed once at server startup from the
+// embedded static site (see buildCSP) so every web build is allowed without
+// a manual hash paste-in.
+func securityHeadersMiddleware(csp string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h := w.Header()
 		h.Set("X-Content-Type-Options", "nosniff")
 		h.Set("X-Frame-Options", "DENY")
 		h.Set("Referrer-Policy", "no-referrer")
 		h.Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
-		h.Set("Content-Security-Policy", cspHeader)
+		h.Set("Content-Security-Policy", csp)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -151,7 +151,7 @@ func TestRequestIDMiddlewareRejectsUnsafeIncomingID(t *testing.T) {
 func TestSecurityHeadersMiddlewareSetsBaseline(t *testing.T) {
 	t.Parallel()
 
-	handler := securityHeadersMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := securityHeadersMiddleware("default-src 'self'; frame-ancestors 'none'", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -58,6 +58,11 @@ func NewServer(cfg ServerConfig) *Server {
 
 // Start begins serving HTTP requests. It blocks until the server is stopped.
 func (s *Server) Start() error {
+	csp, err := buildCSP(s.config.StaticFS)
+	if err != nil {
+		return fmt.Errorf("build CSP from static FS: %w", err)
+	}
+
 	apiMux := http.NewServeMux()
 	prefixes := normalizeAPIPrefixes(s.config.APIPrefixes)
 
@@ -156,7 +161,7 @@ func (s *Server) Start() error {
 	handler := loggingMiddleware(root)
 	handler = maxBodyMiddleware(handler)
 	handler = corsMiddleware(s.config.CORSOrigins, handler)
-	handler = securityHeadersMiddleware(handler)
+	handler = securityHeadersMiddleware(csp, handler)
 	handler = requestIDMiddleware(handler)
 	handler = recoverMiddleware(handler)
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Walk all HTML files in the embedded Next.js static export at startup,
extract every inline <script> body, and sha256-hash each one into
script-src. Removes the manual hash paste-in cycle that broke on every
web build.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1055**
  * **PR #1056**
    * **PR #1057**
      * **PR #1058**
        * **PR #1059**
          * **PR #1060** 👈
            * **PR #1061**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1062 by jonnii*