### PR TITLE
fix(web): default API_BASE to same-origin, fixing connect-src CSP violation

### DIFF
--- a/apps/web/src/components/repo-picker/repo-picker.tsx
+++ b/apps/web/src/components/repo-picker/repo-picker.tsx
@@ -38,7 +38,7 @@ export function RepoPicker() {
         <p className="text-destructive">{error}</p>
         <p className="text-muted-foreground">
           Make sure stackit-server is running on{" "}
-          {process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"}
+          {process.env.NEXT_PUBLIC_API_URL || "the same origin as this page"}
         </p>
       </div>
     );

--- a/apps/web/src/components/repo-picker/repo-view.tsx
+++ b/apps/web/src/components/repo-picker/repo-view.tsx
@@ -151,7 +151,7 @@ export function RepoView() {
         <p className="text-destructive">{error}</p>
         <p className="text-sm text-muted-foreground">
           Make sure stackit-web is running on{" "}
-          {process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"}
+          {process.env.NEXT_PUBLIC_API_URL || "the same origin as this page"}
         </p>
         <button
           onClick={refresh}

--- a/apps/web/src/lib/__tests__/api.test.ts
+++ b/apps/web/src/lib/__tests__/api.test.ts
@@ -38,7 +38,7 @@ describe("fetchRepos", () => {
 
     const result = await fetchRepos();
     expect(result).toEqual(data);
-    expect(mockFetch).toHaveBeenCalledWith("http://localhost:8080/api/v1/repos", {
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/repos", {
       credentials: "include",
     });
   });
@@ -52,7 +52,7 @@ describe("fetchView", () => {
     const result = await fetchView("stackit");
     expect(result).toEqual(data);
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/view",
+      "/api/v1/repos/stackit/view",
       { credentials: "include" }
     );
   });
@@ -66,7 +66,7 @@ describe("fetchRepo", () => {
     const result = await fetchRepo("stackit");
     expect(result).toEqual(data);
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/repo",
+      "/api/v1/repos/stackit/repo",
       { credentials: "include" }
     );
   });
@@ -78,7 +78,7 @@ describe("fetchStacks", () => {
     const result = await fetchStacks("stackit");
     expect(result).toEqual([]);
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/stacks",
+      "/api/v1/repos/stackit/stacks",
       { credentials: "include" }
     );
   });
@@ -90,7 +90,7 @@ describe("fetchStack", () => {
 
     await fetchStack("stackit", "feat/foo");
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/stacks/feat%2Ffoo",
+      "/api/v1/repos/stackit/stacks/feat%2Ffoo",
       { credentials: "include" }
     );
   });
@@ -102,7 +102,7 @@ describe("fetchBranch", () => {
 
     await fetchBranch("stackit", "feat/bar");
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/branches/feat%2Fbar",
+      "/api/v1/repos/stackit/branches/feat%2Fbar",
       { credentials: "include" }
     );
   });
@@ -114,7 +114,7 @@ describe("fetchBranchDiff", () => {
 
     await fetchBranchDiff("stackit", "feat/bar");
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/branch-diff?branch=feat%2Fbar",
+      "/api/v1/repos/stackit/branch-diff?branch=feat%2Fbar",
       { credentials: "include" }
     );
   });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,6 +1,10 @@
 // API client for stackit-web server
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+// Empty default = same-origin requests. The embedded production build is
+// served from the Go server itself, so relative URLs hit the right host
+// without baking it in at build time. Set NEXT_PUBLIC_API_URL when running
+// `next dev` against a separate Go server on another port.
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 // CSRF_HEADER must be sent on every non-safe request. The server doesn't
 // inspect the value, only the header's presence — see

--- a/apps/web/src/lib/use-sse.ts
+++ b/apps/web/src/lib/use-sse.ts
@@ -3,7 +3,8 @@
 import { useEffect, useEffectEvent } from "react";
 import type { FeedEvent } from "@/lib/api";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+// Empty default = same-origin requests. See api.ts for rationale.
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 type SSECallback = () => void;
 

--- a/docs/web.md
+++ b/docs/web.md
@@ -109,7 +109,11 @@ All fetch functions live in `src/lib/api.ts`:
 | `fetchBranch(name)` | GET | `/api/branches/{name}` | Single branch detail |
 | `submitStack(root)` | POST | `/api/submit/{root}` | Trigger stack submission |
 
-The API base URL is configured via `NEXT_PUBLIC_API_URL` (defaults to `http://localhost:8080`).
+The API base URL is configured via `NEXT_PUBLIC_API_URL`. Default is empty
+(same-origin) so the embedded production build, served by the Go binary,
+hits whatever host the page came from. Set it explicitly when running
+`next dev` on `:3000` against a Go server on a different port — e.g.
+`NEXT_PUBLIC_API_URL=http://localhost:8080` in `apps/web/.env.local`.
 
 ### Type Contracts
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Production builds are served by the Go binary itself, so relative URLs
are correct and no NEXT_PUBLIC_API_URL needs to be baked in. Set
NEXT_PUBLIC_API_URL=http://localhost:8080 in apps/web/.env.local when
running next dev against a separate Go server.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1779938183`.


* **PR #1055**
  * **PR #1056**
    * **PR #1057**
      * **PR #1058**
        * **PR #1059**
          * **PR #1060**
            * **PR #1061** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->