### PR TITLE
Merging 7 PRs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,48 @@
+# Template for stackit-server environment variables.
+#
+# Copy to .env (gitignored) and fill in the blanks. Both `mise run dev` and
+# `mise run dev:server` load .env via the [env] block in mise.toml, so the
+# values flow into the server process automatically.
+#
+# Required only when running in "public mode" — i.e. when $PORT or
+# $STACKIT_PUBLIC is set (Railway, Fly, Heroku, etc). For purely local
+# development (`mise run dev`), every STACKIT_GITHUB_* / STACKIT_SESSION_KEY
+# / STACKIT_ALLOWED_GH_* variable can stay blank and the server will start
+# with auth disabled.
+
+# --- GitHub OAuth app (https://github.com/settings/developers) ----------------
+# Create an OAuth App with:
+#   Homepage URL:                 $STACKIT_BASE_URL
+#   Authorization callback URL:   $STACKIT_BASE_URL/auth/callback
+# Then copy the client id + secret here.
+STACKIT_GITHUB_CLIENT_ID=
+STACKIT_GITHUB_CLIENT_SECRET=
+
+# Public URL the OAuth callback redirects back to. Use http://localhost:8080
+# locally; the deployed URL on a PaaS (e.g. https://stackit.up.railway.app).
+STACKIT_BASE_URL=http://localhost:8080
+
+# Random 32-byte key used to encrypt session cookies. Generate with:
+#   openssl rand -base64 32
+STACKIT_SESSION_KEY=
+
+# --- Allowlist (at least one of USERS or ORG required when auth is on) --------
+# Comma-separated GitHub usernames that may log in.
+STACKIT_ALLOWED_GH_USERS=
+# GitHub organization whose members may log in.
+STACKIT_ALLOWED_GH_ORG=
+
+# --- Multi-repo checkout root -------------------------------------------------
+# Base directory under which per-repo checkouts live as <reposRoot>/<owner>/<name>.
+# Required when -repos-config entries use owner+name instead of an absolute path.
+STACKIT_REPOS_ROOT=
+
+# --- Public mode override (rare) ----------------------------------------------
+# Set non-empty to force public-mode behavior (binds 0.0.0.0, requires auth)
+# even without $PORT. Leave blank for local dev.
+# STACKIT_PUBLIC=
+
+# --- Port override ------------------------------------------------------------
+# PaaS hosts inject $PORT automatically; set it here only if running the
+# binary directly without `mise run dev`.
+# PORT=8080

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.10.1
+          version: v2.11.3
           args: --timeout=5m
 
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.10.1
+          version: v2.11.3
           args: --timeout=5m
 
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ apps/api/static/assets/
 
 # goreleaser output
 dist/
+
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ apps/web/out/
 apps/api/static/assets/
 .overmind.sock
 
+# Local env (template lives at .env.template)
+.env
+.env.local
+
 # goreleaser output
 dist/
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,6 +39,9 @@ builds:
     binary: stackit-server
     ldflags:
       - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
 
 upx:
   - enabled: true

--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -5,7 +5,6 @@ import (
 	"embed"
 	"errors"
 	"flag"
-	"fmt"
 	"io/fs"
 	"log"
 	"net/http"
@@ -37,6 +36,7 @@ func run() error {
 		bind            = flag.String("bind", "", "Interface to bind on. Defaults to 127.0.0.1; switches to 0.0.0.0 when $PORT or $STACKIT_PUBLIC is set.")
 		cwd             = flag.String("cwd", "", "Working directory for repository detection (single-repo shortcut; ignored when -repos-config is set)")
 		reposConfigPath = flag.String("repos-config", "", "Path to a JSON file listing repos to serve (mutually exclusive with -cwd)")
+		reposRoot       = flag.String("repos-root", os.Getenv("STACKIT_REPOS_ROOT"), "Base directory under which per-repo checkouts live (<reposRoot>/<owner>/<name>). Overrides reposRoot in -repos-config.")
 		remote          = flag.String("remote", "origin", "Default git remote name for the single-repo -cwd shortcut")
 		corsOrigins     = flag.String("cors", "http://localhost:3000,http://localhost:5173", "Comma-separated allowed CORS origins")
 		apiPrefix       = flag.String("api-prefix", "/api/v1", "Canonical API prefix")
@@ -50,12 +50,15 @@ func run() error {
 	// Fly, Heroku) inject the port this way.
 	portExplicit := false
 	bindExplicit := false
+	cwdExplicit := false
 	flag.Visit(func(f *flag.Flag) {
 		switch f.Name {
 		case "port":
 			portExplicit = true
 		case "bind":
 			bindExplicit = true
+		case "cwd":
+			cwdExplicit = true
 		}
 	})
 	if err := resolvePort(port, portExplicit, os.Getenv("PORT")); err != nil {
@@ -82,25 +85,38 @@ func run() error {
 
 	switch {
 	case *reposConfigPath != "":
-		cfg, err := loadReposConfig(*reposConfigPath)
+		cfg, err := loadReposConfig(*reposConfigPath, *reposRoot)
 		if err != nil {
 			return err
 		}
 		for _, rc := range cfg.Repos {
 			if err := addRegistryEntry(reg, rc); err != nil {
-				return fmt.Errorf("repo %q: %w", rc.ID, err)
+				// A missing checkout shouldn't take down the whole
+				// server — other configured repos may still be usable,
+				// and a future "add repo from GitHub" flow will clone
+				// these on demand. Log and skip instead.
+				log.Printf("repo %q not registered: %v", rc.ID, err)
 			}
 		}
 	default:
 		// Single-repo shortcut. `-cwd ""` falls back to git discovery
-		// from the process cwd, matching the previous behavior.
-		if err := addRegistryEntry(reg, repoConfig{
+		// from the process cwd. Discovery is best-effort when -cwd was
+		// not passed explicitly: hosted deploys (Railway, Fly, ...)
+		// often start the binary from a non-repo directory and should
+		// still come up with an empty registry rather than crashing.
+		// When -cwd is set explicitly the operator asked for that
+		// path, so failure remains fatal.
+		err := addRegistryEntry(reg, repoConfig{
 			ID:          "default",
 			DisplayName: "default",
 			Path:        *cwd,
 			Remote:      *remote,
-		}); err != nil {
-			return err
+		})
+		if err != nil {
+			if cwdExplicit {
+				return err
+			}
+			log.Printf("no default repo registered: %v", err)
 		}
 	}
 

--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -24,6 +24,15 @@ import (
 //go:embed all:static
 var staticFiles embed.FS
 
+// Build metadata injected via -ldflags by goreleaser (production) and the
+// `mise run build` task (local). Defaults are surfaced by `go run` and bare
+// `go build` so the binary is still self-identifying.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
 	if err := run(); err != nil {
 		log.Fatal(err)
@@ -45,6 +54,8 @@ func run() error {
 		authDisabled    = flag.Bool("auth-disabled", false, "Disable GitHub OAuth gate. Refused in public mode ($PORT or $STACKIT_PUBLIC).")
 	)
 	flag.Parse()
+
+	log.Printf("stackit-server version=%s commit=%s built=%s", version, commit, date)
 
 	// Honor $PORT when -port wasn't passed explicitly. PaaS hosts (Railway,
 	// Fly, Heroku) inject the port this way.

--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"io/fs"
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -35,8 +36,28 @@ var (
 
 func main() {
 	if err := run(); err != nil {
-		log.Fatal(err)
+		slog.Error("startup failed", "error", err)
+		os.Exit(1)
 	}
+}
+
+// setupLogging configures the default slog logger. Production deploys
+// (PORT or STACKIT_PUBLIC set) emit JSON with a level field so log
+// aggregators tag entries correctly; local runs use the text handler
+// for readability. Output goes to stdout so platforms like Railway
+// don't classify everything as error (which is what happens when the
+// stdlib log package writes to stderr).
+func setupLogging(jsonOutput bool) {
+	opts := &slog.HandlerOptions{Level: slog.LevelInfo}
+	var handler slog.Handler
+	if jsonOutput {
+		handler = slog.NewJSONHandler(os.Stdout, opts)
+	} else {
+		handler = slog.NewTextHandler(os.Stdout, opts)
+	}
+	slog.SetDefault(slog.New(handler))
+	log.SetFlags(0)
+	log.SetOutput(os.Stdout)
 }
 
 func run() error {
@@ -55,7 +76,10 @@ func run() error {
 	)
 	flag.Parse()
 
-	log.Printf("stackit-server version=%s commit=%s built=%s", version, commit, date)
+	publicMode := os.Getenv("PORT") != "" || os.Getenv("STACKIT_PUBLIC") != ""
+	setupLogging(publicMode)
+
+	slog.Info("stackit-server starting", "version", version, "commit", commit, "built", date)
 
 	// Honor $PORT when -port wasn't passed explicitly. PaaS hosts (Railway,
 	// Fly, Heroku) inject the port this way.
@@ -75,7 +99,7 @@ func run() error {
 	if err := resolvePort(port, portExplicit, os.Getenv("PORT")); err != nil {
 		return err
 	}
-	resolveBind(bind, bindExplicit, os.Getenv("PORT") != "" || os.Getenv("STACKIT_PUBLIC") != "")
+	resolveBind(bind, bindExplicit, publicMode)
 
 	staticFS, err := fs.Sub(staticFiles, "static")
 	if err != nil {
@@ -90,7 +114,7 @@ func run() error {
 	reg := registry.New()
 	defer func() {
 		if closeErr := reg.Close(); closeErr != nil {
-			log.Printf("registry close: %v", closeErr)
+			slog.Error("registry close failed", "error", closeErr)
 		}
 	}()
 
@@ -106,7 +130,7 @@ func run() error {
 				// server — other configured repos may still be usable,
 				// and a future "add repo from GitHub" flow will clone
 				// these on demand. Log and skip instead.
-				log.Printf("repo %q not registered: %v", rc.ID, err)
+				slog.Warn("repo not registered", "repo", rc.ID, "error", err)
 			}
 		}
 	default:
@@ -127,11 +151,10 @@ func run() error {
 			if cwdExplicit {
 				return err
 			}
-			log.Printf("no default repo registered: %v", err)
+			slog.Info("no default repo registered", "error", err)
 		}
 	}
 
-	publicMode := os.Getenv("PORT") != "" || os.Getenv("STACKIT_PUBLIC") != ""
 	authBuild, err := buildAuthConfig(*authDisabled, publicMode)
 	if err != nil {
 		return err
@@ -141,12 +164,12 @@ func run() error {
 		authCfg = authBuild.cfg
 		defer func() {
 			if closeErr := authBuild.store.Close(); closeErr != nil {
-				log.Printf("session store close: %v", closeErr)
+				slog.Error("session store close failed", "error", closeErr)
 			}
 		}()
-		log.Printf("auth: GitHub OAuth gate enabled")
+		slog.Info("auth: GitHub OAuth gate enabled")
 	} else {
-		log.Printf("auth: DISABLED (no STACKIT_GITHUB_* env or -auth-disabled set). Do not expose this port publicly.")
+		slog.Warn("auth: DISABLED (no STACKIT_GITHUB_* env or -auth-disabled set). Do not expose this port publicly.")
 	}
 
 	server := api.NewServer(api.ServerConfig{
@@ -169,7 +192,7 @@ func run() error {
 
 	select {
 	case sig := <-stop:
-		log.Printf("received %s, shutting down", sig)
+		slog.Info("shutting down", "signal", sig.String())
 		ctx, cancel := context.WithTimeout(context.Background(), *shutdownGrace)
 		defer cancel()
 		return server.Shutdown(ctx)
@@ -196,7 +219,7 @@ func addRegistryEntry(reg *registry.Registry, rc repoConfig) error {
 
 	gh := runtimeCtx.GitHub()
 	if gh == nil && runtimeCtx.GitHubError() != nil {
-		log.Printf("[%s] GitHub client unavailable: %v", rc.ID, runtimeCtx.GitHubError())
+		slog.Warn("GitHub client unavailable", "repo", rc.ID, "error", runtimeCtx.GitHubError())
 	}
 
 	entry := registry.NewEntry(registry.EntryConfig{

--- a/apps/server/repos_config.go
+++ b/apps/server/repos_config.go
@@ -4,20 +4,44 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
+	"strings"
 )
 
-// reposConfig is the on-disk shape of the -repos-config file. Multiple repos
-// can be listed; each one becomes a separate registry entry at startup.
+// reposConfig is the on-disk shape of the -repos-config file. The shape is
+// modeled after a future "users add repos from GitHub" flow: each entry
+// carries the GitHub owner/name coordinates, and the local checkout lives
+// under a shared reposRoot at <reposRoot>/<owner>/<name>. The legacy
+// absolute-path mode is preserved for one-off setups that can't sit under
+// a shared root.
 type reposConfig struct {
-	Repos []repoConfig `json:"repos"`
+	// ReposRoot is the base directory under which per-repo checkouts live.
+	// Can be overridden by the -repos-root flag or STACKIT_REPOS_ROOT env;
+	// the resolved value is what loadReposConfig validates against.
+	ReposRoot string       `json:"reposRoot,omitempty"`
+	Repos     []repoConfig `json:"repos"`
 }
 
 type repoConfig struct {
-	ID          string `json:"id"`
+	// ID is the URL-safe identifier used in /api/v1/repos/{repoID}/... .
+	// It defaults to "<owner>-<name>" when owner/name are set and id is
+	// omitted, so most config entries only need owner+name.
+	ID          string `json:"id,omitempty"`
 	DisplayName string `json:"displayName,omitempty"`
-	Path        string `json:"path"`
-	Remote      string `json:"remote,omitempty"`
+
+	// Owner and Name are the GitHub coordinates for the repo. When set,
+	// the local checkout is expected at <reposRoot>/<owner>/<name>. These
+	// are the fields a future "add repo from GitHub" UI will populate.
+	Owner string `json:"owner,omitempty"`
+	Name  string `json:"name,omitempty"`
+
+	// Path is an explicit override for the on-disk checkout location.
+	// Absolute paths are used as-is; relative paths resolve against
+	// reposRoot. When empty, Path is derived from <reposRoot>/<owner>/<name>.
+	Path string `json:"path,omitempty"`
+
+	Remote string `json:"remote,omitempty"`
 }
 
 // repoIDPattern restricts repo IDs to characters that survive in URL paths
@@ -25,10 +49,11 @@ type repoConfig struct {
 // surface at startup, not at first request.
 var repoIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
-// loadReposConfig reads and validates the JSON repos config at path. It
-// returns a normalized config (DisplayName and Remote defaulted) so callers
-// don't need to re-check.
-func loadReposConfig(path string) (*reposConfig, error) {
+// loadReposConfig reads and validates the JSON repos config at path,
+// applying rootOverride (from -repos-root / STACKIT_REPOS_ROOT) over the
+// reposRoot field in the file. The returned config is normalized: every
+// repo has an absolute Path, a non-empty ID/DisplayName, and a Remote.
+func loadReposConfig(path, rootOverride string) (*reposConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read repos config %s: %w", path, err)
@@ -38,6 +63,17 @@ func loadReposConfig(path string) (*reposConfig, error) {
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parse repos config %s: %w", path, err)
 	}
+	if rootOverride != "" {
+		cfg.ReposRoot = rootOverride
+	}
+	if cfg.ReposRoot != "" {
+		abs, err := filepath.Abs(cfg.ReposRoot)
+		if err != nil {
+			return nil, fmt.Errorf("repos config %s: reposRoot %q: %w", path, cfg.ReposRoot, err)
+		}
+		cfg.ReposRoot = abs
+	}
+
 	if len(cfg.Repos) == 0 {
 		return nil, fmt.Errorf("repos config %s: must list at least one repo", path)
 	}
@@ -45,8 +81,8 @@ func loadReposConfig(path string) (*reposConfig, error) {
 	seen := make(map[string]bool, len(cfg.Repos))
 	for i := range cfg.Repos {
 		r := &cfg.Repos[i]
-		if r.ID == "" {
-			return nil, fmt.Errorf("repos config %s: repo[%d] missing id", path, i)
+		if err := normalizeRepoEntry(r, cfg.ReposRoot); err != nil {
+			return nil, fmt.Errorf("repos config %s: repo[%d]: %w", path, i, err)
 		}
 		if !repoIDPattern.MatchString(r.ID) {
 			return nil, fmt.Errorf("repos config %s: repo[%d] id %q must match %s", path, i, r.ID, repoIDPattern)
@@ -55,16 +91,53 @@ func loadReposConfig(path string) (*reposConfig, error) {
 			return nil, fmt.Errorf("repos config %s: duplicate id %q", path, r.ID)
 		}
 		seen[r.ID] = true
-
-		if r.Path == "" {
-			return nil, fmt.Errorf("repos config %s: repo %q missing path", path, r.ID)
-		}
-		if r.DisplayName == "" {
-			r.DisplayName = r.ID
-		}
-		if r.Remote == "" {
-			r.Remote = "origin"
-		}
 	}
 	return &cfg, nil
+}
+
+// normalizeRepoEntry fills in defaults and resolves Path. It enforces that
+// each entry has enough information to locate a checkout — either an
+// explicit path or GitHub owner+name plus a reposRoot.
+func normalizeRepoEntry(r *repoConfig, reposRoot string) error {
+	r.Owner = strings.TrimSpace(r.Owner)
+	r.Name = strings.TrimSpace(r.Name)
+	r.Path = strings.TrimSpace(r.Path)
+
+	if r.ID == "" {
+		if r.Owner != "" && r.Name != "" {
+			r.ID = r.Owner + "-" + r.Name
+		} else {
+			return fmt.Errorf("missing id (set id, or owner+name)")
+		}
+	}
+
+	switch {
+	case filepath.IsAbs(r.Path):
+		// Absolute path: used verbatim.
+	case r.Path != "":
+		if reposRoot == "" {
+			return fmt.Errorf("repo %q: relative path %q requires reposRoot", r.ID, r.Path)
+		}
+		r.Path = filepath.Join(reposRoot, r.Path)
+	case r.Owner != "" && r.Name != "":
+		if reposRoot == "" {
+			return fmt.Errorf("repo %q: owner+name requires reposRoot (set -repos-root, STACKIT_REPOS_ROOT, or reposRoot in the config file)", r.ID)
+		}
+		r.Path = filepath.Join(reposRoot, r.Owner, r.Name)
+	default:
+		return fmt.Errorf("repo %q: must set path, or owner+name", r.ID)
+	}
+
+	if r.DisplayName == "" {
+		switch {
+		case r.Owner != "" && r.Name != "":
+			r.DisplayName = r.Owner + "/" + r.Name
+		default:
+			r.DisplayName = r.ID
+		}
+	}
+	if r.Remote == "" {
+		r.Remote = "origin"
+	}
+	return nil
 }

--- a/apps/server/repos_config_test.go
+++ b/apps/server/repos_config_test.go
@@ -16,28 +16,76 @@ func writeTemp(t *testing.T, body string) string {
 	return path
 }
 
-func TestLoadReposConfig_ValidatesAndDefaults(t *testing.T) {
+func TestLoadReposConfig_OwnerNameDerivesPathFromRoot(t *testing.T) {
 	t.Parallel()
 
+	root := t.TempDir()
 	path := writeTemp(t, `{
+	  "reposRoot": "`+root+`",
 	  "repos": [
-	    {"id": "a", "path": "/tmp/a"},
-	    {"id": "b", "displayName": "Repo B", "path": "/tmp/b", "remote": "upstream"}
+	    {"owner": "getstackit", "name": "stackit"},
+	    {"id": "claude", "owner": "anthropics", "name": "claude-code", "displayName": "Claude Code"}
 	  ]
 	}`)
 
-	cfg, err := loadReposConfig(path)
+	cfg, err := loadReposConfig(path, "")
 	require.NoError(t, err)
 	require.Len(t, cfg.Repos, 2)
 
-	// Defaults filled in for repo a
-	require.Equal(t, "a", cfg.Repos[0].ID)
-	require.Equal(t, "a", cfg.Repos[0].DisplayName)
+	// id defaulted to <owner>-<name>; displayName to <owner>/<name>; path under reposRoot.
+	require.Equal(t, "getstackit-stackit", cfg.Repos[0].ID)
+	require.Equal(t, "getstackit/stackit", cfg.Repos[0].DisplayName)
+	require.Equal(t, filepath.Join(root, "getstackit", "stackit"), cfg.Repos[0].Path)
 	require.Equal(t, "origin", cfg.Repos[0].Remote)
 
-	// Explicit values preserved for repo b
-	require.Equal(t, "Repo B", cfg.Repos[1].DisplayName)
-	require.Equal(t, "upstream", cfg.Repos[1].Remote)
+	// Explicit id + displayName preserved.
+	require.Equal(t, "claude", cfg.Repos[1].ID)
+	require.Equal(t, "Claude Code", cfg.Repos[1].DisplayName)
+	require.Equal(t, filepath.Join(root, "anthropics", "claude-code"), cfg.Repos[1].Path)
+}
+
+func TestLoadReposConfig_RootOverrideWinsOverFile(t *testing.T) {
+	t.Parallel()
+
+	fileRoot := t.TempDir()
+	cliRoot := t.TempDir()
+	path := writeTemp(t, `{
+	  "reposRoot": "`+fileRoot+`",
+	  "repos": [{"owner": "a", "name": "b"}]
+	}`)
+
+	cfg, err := loadReposConfig(path, cliRoot)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(cliRoot, "a", "b"), cfg.Repos[0].Path)
+}
+
+func TestLoadReposConfig_AbsolutePathBypassesRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	abs := filepath.Join(t.TempDir(), "somewhere")
+	path := writeTemp(t, `{
+	  "reposRoot": "`+root+`",
+	  "repos": [{"id": "a", "path": "`+abs+`"}]
+	}`)
+
+	cfg, err := loadReposConfig(path, "")
+	require.NoError(t, err)
+	require.Equal(t, abs, cfg.Repos[0].Path)
+}
+
+func TestLoadReposConfig_RelativePathResolvesAgainstRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := writeTemp(t, `{
+	  "reposRoot": "`+root+`",
+	  "repos": [{"id": "a", "path": "team/proj"}]
+	}`)
+
+	cfg, err := loadReposConfig(path, "")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(root, "team", "proj"), cfg.Repos[0].Path)
 }
 
 func TestLoadReposConfig_RejectsBadInput(t *testing.T) {
@@ -49,10 +97,12 @@ func TestLoadReposConfig_RejectsBadInput(t *testing.T) {
 		want string
 	}{
 		{name: "empty repos", body: `{"repos": []}`, want: "must list at least one repo"},
-		{name: "missing id", body: `{"repos": [{"path": "/tmp/a"}]}`, want: "missing id"},
+		{name: "missing id and owner+name", body: `{"repos": [{"path": "/tmp/a"}]}`, want: "missing id"},
 		{name: "invalid id", body: `{"repos": [{"id": "a/b", "path": "/tmp/a"}]}`, want: "must match"},
 		{name: "duplicate id", body: `{"repos": [{"id": "a", "path": "/x"}, {"id": "a", "path": "/y"}]}`, want: "duplicate id"},
-		{name: "missing path", body: `{"repos": [{"id": "a"}]}`, want: "missing path"},
+		{name: "owner+name without root", body: `{"repos": [{"owner": "a", "name": "b"}]}`, want: "requires reposRoot"},
+		{name: "no path and no owner/name", body: `{"repos": [{"id": "a"}]}`, want: "must set path, or owner+name"},
+		{name: "relative path without root", body: `{"repos": [{"id": "a", "path": "rel"}]}`, want: "requires reposRoot"},
 		{name: "malformed json", body: `not json`, want: "parse repos config"},
 	}
 
@@ -60,7 +110,7 @@ func TestLoadReposConfig_RejectsBadInput(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			path := writeTemp(t, tt.body)
-			_, err := loadReposConfig(path)
+			_, err := loadReposConfig(path, "")
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tt.want)
 		})
@@ -69,7 +119,7 @@ func TestLoadReposConfig_RejectsBadInput(t *testing.T) {
 
 func TestLoadReposConfig_MissingFile(t *testing.T) {
 	t.Parallel()
-	_, err := loadReposConfig(filepath.Join(t.TempDir(), "nope.json"))
+	_, err := loadReposConfig(filepath.Join(t.TempDir(), "nope.json"), "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "read repos config")
 }

--- a/apps/web/src/components/repo-picker/repo-picker.tsx
+++ b/apps/web/src/components/repo-picker/repo-picker.tsx
@@ -38,7 +38,7 @@ export function RepoPicker() {
         <p className="text-destructive">{error}</p>
         <p className="text-muted-foreground">
           Make sure stackit-server is running on{" "}
-          {process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"}
+          {process.env.NEXT_PUBLIC_API_URL || "the same origin as this page"}
         </p>
       </div>
     );

--- a/apps/web/src/components/repo-picker/repo-view.tsx
+++ b/apps/web/src/components/repo-picker/repo-view.tsx
@@ -151,7 +151,7 @@ export function RepoView() {
         <p className="text-destructive">{error}</p>
         <p className="text-sm text-muted-foreground">
           Make sure stackit-web is running on{" "}
-          {process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"}
+          {process.env.NEXT_PUBLIC_API_URL || "the same origin as this page"}
         </p>
         <button
           onClick={refresh}

--- a/apps/web/src/lib/__tests__/api.test.ts
+++ b/apps/web/src/lib/__tests__/api.test.ts
@@ -38,7 +38,7 @@ describe("fetchRepos", () => {
 
     const result = await fetchRepos();
     expect(result).toEqual(data);
-    expect(mockFetch).toHaveBeenCalledWith("http://localhost:8080/api/v1/repos", {
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/repos", {
       credentials: "include",
     });
   });
@@ -52,7 +52,7 @@ describe("fetchView", () => {
     const result = await fetchView("stackit");
     expect(result).toEqual(data);
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/view",
+      "/api/v1/repos/stackit/view",
       { credentials: "include" }
     );
   });
@@ -66,7 +66,7 @@ describe("fetchRepo", () => {
     const result = await fetchRepo("stackit");
     expect(result).toEqual(data);
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/repo",
+      "/api/v1/repos/stackit/repo",
       { credentials: "include" }
     );
   });
@@ -78,7 +78,7 @@ describe("fetchStacks", () => {
     const result = await fetchStacks("stackit");
     expect(result).toEqual([]);
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/stacks",
+      "/api/v1/repos/stackit/stacks",
       { credentials: "include" }
     );
   });
@@ -90,7 +90,7 @@ describe("fetchStack", () => {
 
     await fetchStack("stackit", "feat/foo");
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/stacks/feat%2Ffoo",
+      "/api/v1/repos/stackit/stacks/feat%2Ffoo",
       { credentials: "include" }
     );
   });
@@ -102,7 +102,7 @@ describe("fetchBranch", () => {
 
     await fetchBranch("stackit", "feat/bar");
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/branches/feat%2Fbar",
+      "/api/v1/repos/stackit/branches/feat%2Fbar",
       { credentials: "include" }
     );
   });
@@ -114,7 +114,7 @@ describe("fetchBranchDiff", () => {
 
     await fetchBranchDiff("stackit", "feat/bar");
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8080/api/v1/repos/stackit/branch-diff?branch=feat%2Fbar",
+      "/api/v1/repos/stackit/branch-diff?branch=feat%2Fbar",
       { credentials: "include" }
     );
   });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,6 +1,10 @@
 // API client for stackit-web server
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+// Empty default = same-origin requests. The embedded production build is
+// served from the Go server itself, so relative URLs hit the right host
+// without baking it in at build time. Set NEXT_PUBLIC_API_URL when running
+// `next dev` against a separate Go server on another port.
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 // CSRF_HEADER must be sent on every non-safe request. The server doesn't
 // inspect the value, only the header's presence — see

--- a/apps/web/src/lib/use-sse.ts
+++ b/apps/web/src/lib/use-sse.ts
@@ -3,7 +3,8 @@
 import { useEffect, useEffectEvent } from "react";
 import type { FeedEvent } from "@/lib/api";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+// Empty default = same-origin requests. See api.ts for rationale.
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 type SSECallback = () => void;
 

--- a/docs/web.md
+++ b/docs/web.md
@@ -109,7 +109,11 @@ All fetch functions live in `src/lib/api.ts`:
 | `fetchBranch(name)` | GET | `/api/branches/{name}` | Single branch detail |
 | `submitStack(root)` | POST | `/api/submit/{root}` | Trigger stack submission |
 
-The API base URL is configured via `NEXT_PUBLIC_API_URL` (defaults to `http://localhost:8080`).
+The API base URL is configured via `NEXT_PUBLIC_API_URL`. Default is empty
+(same-origin) so the embedded production build, served by the Go binary,
+hits whatever host the page came from. Set it explicitly when running
+`next dev` on `:3000` against a Go server on a different port — e.g.
+`NEXT_PUBLIC_API_URL=http://localhost:8080` in `apps/web/.env.local`.
 
 ### Type Contracts
 

--- a/internal/api/auth/oauth.go
+++ b/internal/api/auth/oauth.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -132,7 +132,7 @@ func (h *Handler) resolveUserInfoURL() string {
 func (h *Handler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 	state, err := randomToken(16)
 	if err != nil {
-		log.Printf("login: random state: %v", err)
+		slog.Error("login: random state failed", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -160,7 +160,7 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	wantState := readCookie(r, stateCookieName)
 	h.cfg.Cookies.clearState(w)
 	if wantState == "" || gotState == "" || !constantTimeStringEq(gotState, wantState) {
-		log.Printf("auth callback: bad state")
+		slog.Warn("auth callback: bad state")
 		http.Error(w, "invalid auth state", http.StatusBadRequest)
 		return
 	}
@@ -168,7 +168,7 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	code := q.Get("code")
 	if code == "" {
 		// GitHub redirects here with `error=...` when the user denies.
-		log.Printf("auth callback: missing code (oauth_error=%q)", q.Get("error")) //nolint:gosec // logged value is %q-quoted
+		slog.Warn("auth callback: missing code", "oauth_error", q.Get("error")) //nolint:gosec // value emitted as a structured slog field, not concatenated
 		http.Redirect(w, r, h.cfg.DeniedPath, http.StatusFound)
 		return
 	}
@@ -176,32 +176,32 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	tok, err := h.oauth2cfg.Exchange(ctx, code)
 	if err != nil {
-		log.Printf("auth callback: token exchange: %v", err)
+		slog.Warn("auth callback: token exchange failed", "error", err)
 		http.Error(w, "token exchange failed", http.StatusBadGateway)
 		return
 	}
 
 	user, err := h.fetchGitHubUser(ctx, tok.AccessToken)
 	if err != nil {
-		log.Printf("auth callback: fetch user: %v", err)
+		slog.Warn("auth callback: fetch user failed", "error", err)
 		http.Error(w, "github user lookup failed", http.StatusBadGateway)
 		return
 	}
 
 	if err := h.allow.Check(ctx, user.Login, tok.AccessToken); err != nil {
 		if errors.Is(err, ErrDenied) {
-			log.Printf("audit action=denied actor=%q request_id=%s", user.Login, reqid.FromContext(ctx)) //nolint:gosec // login is %q-quoted
+			slog.Info("audit", "action", "denied", "actor", user.Login, "request_id", reqid.FromContext(ctx))
 			http.Redirect(w, r, h.cfg.DeniedPath, http.StatusFound)
 			return
 		}
-		log.Printf("auth callback: allowlist check error: %v", err)
+		slog.Error("auth callback: allowlist check failed", "error", err)
 		http.Error(w, "allowlist check failed", http.StatusBadGateway)
 		return
 	}
 
 	sess, err := h.store.Create(user.Login, user.ID, tok.AccessToken)
 	if err != nil {
-		log.Printf("auth callback: create session: %v", err)
+		slog.Error("auth callback: create session failed", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -213,7 +213,7 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	h.cfg.Cookies.clearReturn(w)
 
-	log.Printf("audit action=login actor=%q user_id=%d target=%s request_id=%s", user.Login, user.ID, target, reqid.FromContext(ctx)) //nolint:gosec // logged values are quoted/numeric/safe target
+	slog.Info("audit", "action", "login", "actor", user.Login, "user_id", user.ID, "target", target, "request_id", reqid.FromContext(ctx)) //nolint:gosec // values emitted as structured slog fields
 	http.Redirect(w, r, target, http.StatusFound)
 }
 
@@ -223,7 +223,7 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) LogoutHandler(w http.ResponseWriter, r *http.Request) {
 	if cookie := readCookie(r, sessionCookieName); cookie != "" {
 		if sess, ok := h.store.Get(cookie); ok {
-			log.Printf("audit action=logout actor=%q request_id=%s", sess.GitHubLogin, reqid.FromContext(r.Context())) //nolint:gosec // login is %q-quoted
+			slog.Info("audit", "action", "logout", "actor", sess.GitHubLogin, "request_id", reqid.FromContext(r.Context())) //nolint:gosec // values emitted as structured slog fields
 		}
 		h.store.Delete(cookie)
 	}

--- a/internal/api/csp.go
+++ b/internal/api/csp.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io/fs"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// scriptTagRe captures the attribute list and inline body of every <script>
+// tag. The (?s) flag lets `.` span newlines so multi-line scripts match.
+var scriptTagRe = regexp.MustCompile(`(?s)<script([^>]*)>(.*?)</script>`)
+
+// scriptHasSrcRe matches `src=` as a real attribute (preceded by start or
+// whitespace) so we don't false-positive on `data-src=`, `nosrc=`, etc.
+var scriptHasSrcRe = regexp.MustCompile(`(?:^|\s)src\s*=`)
+
+// buildCSP returns the Content-Security-Policy header value derived from the
+// embedded static site. It computes a sha256 hash for every inline <script>
+// body found in *.html files under staticFS, so each Next build is allowed
+// without a manual paste-in. External scripts (with a src= attribute) are
+// covered by 'self' and contribute no hash.
+func buildCSP(staticFS fs.FS) (string, error) {
+	hashes, err := inlineScriptHashes(staticFS)
+	if err != nil {
+		return "", err
+	}
+
+	scriptSrc := "'self'"
+	if len(hashes) > 0 {
+		scriptSrc = "'self' " + strings.Join(hashes, " ")
+	}
+
+	return "default-src 'self'; " +
+		"img-src 'self' data: https:; " +
+		"style-src 'self' 'unsafe-inline'; " +
+		"script-src " + scriptSrc + "; " +
+		"connect-src 'self'; " +
+		"frame-ancestors 'none'; " +
+		"base-uri 'self'; " +
+		"form-action 'self'", nil
+}
+
+// inlineScriptHashes returns CSP-formatted sha256 hashes for every distinct
+// inline <script> body across all HTML files in staticFS. Sorted for stable
+// header output across runs.
+func inlineScriptHashes(staticFS fs.FS) ([]string, error) {
+	if staticFS == nil {
+		return nil, nil
+	}
+
+	seen := make(map[string]struct{})
+	err := fs.WalkDir(staticFS, ".", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(strings.ToLower(path), ".html") {
+			return nil
+		}
+
+		data, err := fs.ReadFile(staticFS, path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+
+		for _, m := range scriptTagRe.FindAllSubmatch(data, -1) {
+			attrs, body := m[1], m[2]
+			if scriptHasSrcRe.Match(attrs) {
+				continue
+			}
+			if len(bytes.TrimSpace(body)) == 0 {
+				continue
+			}
+			sum := sha256.Sum256(body)
+			seen["'sha256-"+base64.StdEncoding.EncodeToString(sum[:])+"'"] = struct{}{}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]string, 0, len(seen))
+	for h := range seen {
+		out = append(out, h)
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/internal/api/csp_test.go
+++ b/internal/api/csp_test.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCSP_HashesInlineScripts(t *testing.T) {
+	t.Parallel()
+
+	inline1 := `self.__next_f=self.__next_f||[];self.__next_f.push([0,"x"])`
+	inline2 := `console.log("hi")`
+	expected1 := sha256Hash(inline1)
+	expected2 := sha256Hash(inline2)
+
+	fs := fstest.MapFS{
+		"index.html": {Data: []byte(`<html><head>` +
+			`<script>` + inline1 + `</script>` +
+			`<script src="/_next/static/chunks/main.js" async></script>` +
+			`</head><body><script>` + inline2 + `</script></body></html>`)},
+		"other.html": {Data: []byte(`<script>` + inline1 + `</script>`)}, // duplicate; should dedupe
+		"asset.js":   {Data: []byte(`console.log("ignored")`)},           // not html; skipped
+	}
+
+	csp, err := buildCSP(fs)
+	require.NoError(t, err)
+
+	require.Contains(t, csp, "'sha256-"+expected1+"'")
+	require.Contains(t, csp, "'sha256-"+expected2+"'")
+	require.Contains(t, csp, "frame-ancestors 'none'")
+	require.Contains(t, csp, "default-src 'self'")
+
+	// Duplicate inline script should appear exactly once in the header.
+	require.Equal(t, 1, strings.Count(csp, "'sha256-"+expected1+"'"))
+}
+
+func TestBuildCSP_NilFS(t *testing.T) {
+	t.Parallel()
+
+	csp, err := buildCSP(nil)
+	require.NoError(t, err)
+	require.Contains(t, csp, "script-src 'self';")
+}
+
+func TestBuildCSP_SkipsScriptsWithSrc(t *testing.T) {
+	t.Parallel()
+
+	// A <script src="..."> with content between the tags shouldn't produce a
+	// hash (browser ignores the body when src is set, so hashing it would be
+	// dead config that drifts with each build).
+	fs := fstest.MapFS{
+		"index.html": {Data: []byte(`<script src="/x.js">SHOULD_NOT_HASH</script>`)},
+	}
+	csp, err := buildCSP(fs)
+	require.NoError(t, err)
+	require.NotContains(t, csp, "SHOULD_NOT_HASH")
+	require.NotContains(t, csp, sha256Hash("SHOULD_NOT_HASH"))
+}
+
+func TestBuildCSP_SkipsEmptyScripts(t *testing.T) {
+	t.Parallel()
+
+	fs := fstest.MapFS{
+		"index.html": {Data: []byte(`<script></script><script>  </script>`)},
+	}
+	csp, err := buildCSP(fs)
+	require.NoError(t, err)
+	require.Equal(t, "default-src 'self'; "+
+		"img-src 'self' data: https:; "+
+		"style-src 'self' 'unsafe-inline'; "+
+		"script-src 'self'; "+
+		"connect-src 'self'; "+
+		"frame-ancestors 'none'; "+
+		"base-uri 'self'; "+
+		"form-action 'self'", csp)
+}
+
+func sha256Hash(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return base64.StdEncoding.EncodeToString(sum[:])
+}

--- a/internal/api/handlers/submit.go
+++ b/internal/api/handlers/submit.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 
 	"github.com/getstackit/stackit/internal/actions/submit"
@@ -67,7 +67,7 @@ func (h *SubmitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if sess := auth.SessionFromContext(r.Context()); sess != nil {
 		actor = sess.GitHubLogin
 	}
-	log.Printf("audit action=submit actor=%q repo=%q branch=%q request_id=%s", actor, entry.ID, rootBranch, reqid.FromContext(r.Context())) //nolint:gosec // values are %q-quoted
+	slog.Info("audit", "action", "submit", "actor", actor, "repo", entry.ID, "branch", rootBranch, "request_id", reqid.FromContext(r.Context())) //nolint:gosec // values emitted as structured slog fields
 
 	ctx := app.NewContext(entry.Engine,
 		app.WithRepoRoot(entry.RepoRoot),

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -22,20 +22,6 @@ const requestIDHeader = reqid.HeaderName
 // today; this is defense against runaway uploads against any endpoint.
 const maxRequestBodyBytes = 1 << 20 // 1 MiB
 
-// cspHeader is the Content-Security-Policy applied to every response. The
-// sha256 hash in script-src is the embedded Next.js bootstrap inline script;
-// if a future web build changes that script, the browser will print the new
-// hash in the console — paste it in here. Multiple hashes can be listed
-// space-separated if more inline scripts get added.
-const cspHeader = "default-src 'self'; " +
-	"img-src 'self' data: https:; " +
-	"style-src 'self' 'unsafe-inline'; " +
-	"script-src 'self' 'sha256-OBTN3RiyCV4Bq7dFqZ5a2pAXjnCcCYeTJMO2I/LYKeo='; " +
-	"connect-src 'self'; " +
-	"frame-ancestors 'none'; " +
-	"base-uri 'self'; " +
-	"form-action 'self'"
-
 // RequestIDFromContext is kept here as a re-export for callers in the api
 // package; handlers in other packages import internal/api/reqid directly.
 func RequestIDFromContext(ctx context.Context) string {
@@ -104,17 +90,17 @@ func sanitizeIncomingRequestID(s string) string {
 }
 
 // securityHeadersMiddleware sets the baseline browser security headers we want
-// on every response. CSP here matches the embedded Next.js shell; if the
-// frontend starts pulling third-party scripts/images, tighten or extend
-// connect-src/script-src to match.
-func securityHeadersMiddleware(next http.Handler) http.Handler {
+// on every response. The CSP is computed once at server startup from the
+// embedded static site (see buildCSP) so every web build is allowed without
+// a manual hash paste-in.
+func securityHeadersMiddleware(csp string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h := w.Header()
 		h.Set("X-Content-Type-Options", "nosniff")
 		h.Set("X-Frame-Options", "DENY")
 		h.Set("Referrer-Policy", "no-referrer")
 		h.Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
-		h.Set("Content-Security-Policy", cspHeader)
+		h.Set("Content-Security-Policy", csp)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"log"
+	"log/slog"
 	"net/http"
 	"runtime/debug"
 	"strings"
@@ -21,6 +21,20 @@ const requestIDHeader = reqid.HeaderName
 // maxRequestBodyBytes caps every request body. POST /submit takes no body
 // today; this is defense against runaway uploads against any endpoint.
 const maxRequestBodyBytes = 1 << 20 // 1 MiB
+
+// cspHeader is the Content-Security-Policy applied to every response. The
+// sha256 hash in script-src is the embedded Next.js bootstrap inline script;
+// if a future web build changes that script, the browser will print the new
+// hash in the console — paste it in here. Multiple hashes can be listed
+// space-separated if more inline scripts get added.
+const cspHeader = "default-src 'self'; " +
+	"img-src 'self' data: https:; " +
+	"style-src 'self' 'unsafe-inline'; " +
+	"script-src 'self' 'sha256-OBTN3RiyCV4Bq7dFqZ5a2pAXjnCcCYeTJMO2I/LYKeo='; " +
+	"connect-src 'self'; " +
+	"frame-ancestors 'none'; " +
+	"base-uri 'self'; " +
+	"form-action 'self'"
 
 // RequestIDFromContext is kept here as a re-export for callers in the api
 // package; handlers in other packages import internal/api/reqid directly.
@@ -39,7 +53,7 @@ func recoverMiddleware(next http.Handler) http.Handler {
 				return
 			}
 			rid := RequestIDFromContext(r.Context())
-			log.Printf("panic recovered request_id=%s %s %s: %v\n%s", rid, r.Method, r.URL.Path, rec, debug.Stack()) //nolint:gosec // method and path are safe to log
+			slog.Error("panic recovered", "request_id", rid, "method", r.Method, "path", r.URL.Path, "panic", rec, "stack", string(debug.Stack())) //nolint:gosec // values emitted as structured slog fields
 			// If the handler already wrote a status, we can't change it.
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 		}()
@@ -100,15 +114,7 @@ func securityHeadersMiddleware(next http.Handler) http.Handler {
 		h.Set("X-Frame-Options", "DENY")
 		h.Set("Referrer-Policy", "no-referrer")
 		h.Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
-		h.Set("Content-Security-Policy",
-			"default-src 'self'; "+
-				"img-src 'self' data: https:; "+
-				"style-src 'self' 'unsafe-inline'; "+
-				"script-src 'self'; "+
-				"connect-src 'self'; "+
-				"frame-ancestors 'none'; "+
-				"base-uri 'self'; "+
-				"form-action 'self'")
+		h.Set("Content-Security-Policy", cspHeader)
 		next.ServeHTTP(w, r)
 	})
 }
@@ -157,7 +163,8 @@ func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 }
 
 // loggingMiddleware logs each request with method, path, status, duration,
-// and request ID.
+// and request ID. The level reflects the response status so 5xx surfaces
+// as error and 4xx as warn in log aggregators.
 func loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
@@ -165,8 +172,20 @@ func loggingMiddleware(next http.Handler) http.Handler {
 
 		next.ServeHTTP(sw, r)
 
-		rid := RequestIDFromContext(r.Context())
-		log.Printf("%s %s %d %s rid=%s", r.Method, r.URL.Path, sw.status, time.Since(start).Round(time.Millisecond), rid) //nolint:gosec // method and path are safe to log
+		level := slog.LevelInfo
+		switch {
+		case sw.status >= 500:
+			level = slog.LevelError
+		case sw.status >= 400:
+			level = slog.LevelWarn
+		}
+		slog.LogAttrs(r.Context(), level, "request",
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+			slog.Int("status", sw.status),
+			slog.Duration("duration", time.Since(start).Round(time.Millisecond)),
+			slog.String("request_id", RequestIDFromContext(r.Context())),
+		)
 	})
 }
 

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -151,7 +151,7 @@ func TestRequestIDMiddlewareRejectsUnsafeIncomingID(t *testing.T) {
 func TestSecurityHeadersMiddlewareSetsBaseline(t *testing.T) {
 	t.Parallel()
 
-	handler := securityHeadersMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := securityHeadersMiddleware("default-src 'self'; frame-ancestors 'none'", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 

--- a/internal/api/registry/registry.go
+++ b/internal/api/registry/registry.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"regexp"
 	"sort"
 	"sync"
@@ -125,7 +125,7 @@ func makeWatcherCallback(entry *RepoEntry) func() {
 
 	return func() {
 		if err := entry.Engine.Rebuild(trunkName); err != nil {
-			log.Printf("[%s] engine rebuild failed: %v", entry.ID, err)
+			slog.Error("engine rebuild failed", "repo", entry.ID, "error", err)
 			return
 		}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -169,7 +169,7 @@ func (s *Server) Start() error {
 		MaxHeaderBytes:    1 << 20, // 1 MiB
 	}
 
-	log.Printf("stackit-web server listening on http://%s:%d", displayHost(s.config.BindAddr), s.config.Port)
+	slog.Info("stackit-web server listening", "url", fmt.Sprintf("http://%s:%d", displayHost(s.config.BindAddr), s.config.Port))
 	return s.httpServer.ListenAndServe()
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -58,6 +58,11 @@ func NewServer(cfg ServerConfig) *Server {
 
 // Start begins serving HTTP requests. It blocks until the server is stopped.
 func (s *Server) Start() error {
+	csp, err := buildCSP(s.config.StaticFS)
+	if err != nil {
+		return fmt.Errorf("build CSP from static FS: %w", err)
+	}
+
 	apiMux := http.NewServeMux()
 	prefixes := normalizeAPIPrefixes(s.config.APIPrefixes)
 
@@ -156,7 +161,7 @@ func (s *Server) Start() error {
 	handler := loggingMiddleware(root)
 	handler = maxBodyMiddleware(handler)
 	handler = corsMiddleware(s.config.CORSOrigins, handler)
-	handler = securityHeadersMiddleware(handler)
+	handler = securityHeadersMiddleware(csp, handler)
 	handler = requestIDMiddleware(handler)
 	handler = recoverMiddleware(handler)
 

--- a/internal/api/watcher/watcher.go
+++ b/internal/api/watcher/watcher.go
@@ -6,7 +6,7 @@ package watcher
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -55,14 +55,14 @@ func (w *RefWatcher) Start() error {
 			continue // Directory may not exist yet
 		}
 		if err := addRecursive(fsw, dir); err != nil {
-			log.Printf("warning: failed to watch %s: %v", dir, err)
+			slog.Warn("failed to watch directory", "dir", dir, "error", err)
 		}
 	}
 
 	// Also watch HEAD for branch switches
 	headPath := filepath.Join(w.repoRoot, ".git", "HEAD")
 	if err := fsw.Add(headPath); err != nil {
-		log.Printf("warning: failed to watch HEAD: %v", err)
+		slog.Warn("failed to watch HEAD", "path", headPath, "error", err)
 	}
 
 	var timer *time.Timer
@@ -100,7 +100,7 @@ func (w *RefWatcher) Start() error {
 			if !ok {
 				return nil
 			}
-			log.Printf("watcher error: %v", err)
+			slog.Error("watcher error", "error", err)
 		}
 	}
 }

--- a/mise.toml
+++ b/mise.toml
@@ -6,6 +6,9 @@ STACKIT_NO_LOGGING = "1"                                    # Used for tests
 GOBIN = "{{ config_root }}/bin"
 PROJECT_ROOT = "{{ config_root }}"
 _.path = ["{{ config_root }}/bin", "{{ env.HOME }}/go/bin"]
+# Local secrets / OAuth config for `mise run dev`. .env is gitignored; see
+# .env.template for the full list of variables. Missing file is tolerated.
+_.file = ".env"
 
 [tools]
 # Go toolchain

--- a/mise.toml
+++ b/mise.toml
@@ -55,9 +55,10 @@ run = """
   mkdir -p bin
   COMMIT=$(git rev-parse --short HEAD)
   DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  go build -ldflags "-X main.version=dev-local -X main.commit=$COMMIT -X main.date=$DATE" -o bin/stackit ./apps/cli
+  LDFLAGS="-X main.version=dev-local -X main.commit=$COMMIT -X main.date=$DATE"
+  go build -ldflags "$LDFLAGS" -o bin/stackit ./apps/cli
   ./scripts/sync-web-static.sh
-  go build -o bin/stackit-server ./apps/server
+  go build -ldflags "$LDFLAGS" -o bin/stackit-server ./apps/server
   if [ -d ./apps/st-tui ]; then
     go build -o bin/st-tui ./apps/st-tui
   fi
@@ -185,7 +186,10 @@ description = "Build stackit-server with embedded exported web assets"
 depends = ["web:sync-static"]
 run = """
   mkdir -p bin
-  go build -o bin/stackit-server ./apps/server
+  COMMIT=$(git rev-parse --short HEAD)
+  DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  LDFLAGS="-X main.version=dev-local -X main.commit=$COMMIT -X main.date=$DATE"
+  go build -ldflags "$LDFLAGS" -o bin/stackit-server ./apps/server
 """
 
 [tasks."server:run:embedded"]

--- a/mise.toml
+++ b/mise.toml
@@ -21,7 +21,10 @@ pnpm = "10.32.1"
 "go:github.com/DarthSim/overmind/v2" = "latest"
 
 # Linting
-golangci-lint = "latest"
+# Pinned (not "latest") so local matches CI exactly — a drift here means lint
+# passes locally but fails in CI (or vice versa). Keep in sync with the
+# golangci-lint-action version in .github/workflows/{test,release}.yml.
+golangci-lint = "2.11.3"
 
 # Development tools
 "aqua:watchexec/watchexec" = "latest"   # File watcher for dev auto-reload

--- a/mise.toml
+++ b/mise.toml
@@ -184,6 +184,53 @@ run = "pnpm --filter @stackit/web dev"
 description = "Run the server in development mode (auto-reloads on file changes)"
 run = "watchexec -r -e go -w apps/server -w internal -w api -- go run ./apps/server --port 8080"
 
+[tasks."env:init"]
+description = "Generate .env from .env.template, filling values from gh CLI + openssl where possible"
+run = """
+  set -e
+  if [ -f .env ]; then
+    echo ".env already exists. Remove it first to regenerate, or edit it by hand." >&2
+    exit 1
+  fi
+  if [ ! -f .env.template ]; then
+    echo ".env.template not found at project root." >&2
+    exit 1
+  fi
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "gh CLI not found. Install from https://cli.github.com." >&2
+    exit 1
+  fi
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "gh not authenticated. Run 'gh auth login' first." >&2
+    exit 1
+  fi
+  if ! command -v openssl >/dev/null 2>&1; then
+    echo "openssl not found." >&2
+    exit 1
+  fi
+
+  GH_USER=$(gh api user --jq .login)
+  SESSION_KEY=$(openssl rand -base64 32)
+
+  awk -v user="$GH_USER" -v key="$SESSION_KEY" '
+    /^STACKIT_ALLOWED_GH_USERS=$/ { print "STACKIT_ALLOWED_GH_USERS=" user; next }
+    /^STACKIT_SESSION_KEY=$/      { print "STACKIT_SESSION_KEY=" key; next }
+    { print }
+  ' .env.template > .env
+
+  echo "Wrote .env with:"
+  echo "  STACKIT_ALLOWED_GH_USERS=$GH_USER  (from gh api user)"
+  echo "  STACKIT_SESSION_KEY=<32 random bytes>"
+  echo
+  echo "Still required for public-mode auth (manual — GitHub does not expose these via API):"
+  echo "  STACKIT_GITHUB_CLIENT_ID"
+  echo "  STACKIT_GITHUB_CLIENT_SECRET"
+  echo
+  echo "Create an OAuth app at https://github.com/settings/developers and set"
+  echo "the callback URL to \\$STACKIT_BASE_URL/auth/callback, then paste the"
+  echo "credentials into .env."
+"""
+
 [tasks."server:build:embedded"]
 description = "Build stackit-server with embedded exported web assets"
 depends = ["web:sync-static"]


### PR DESCRIPTION
This PR merges the following changes:

1. **#1055** feat(server): multi-repo config with reposRoot and owner/name coords
2. **#1056** feat(server): log version, commit, build date on startup
3. **#1057** chore(server): document required env vars via .env.template
4. **#1058** chore(server): add env:init mise task to populate .env via gh + openssl
5. **#1059** refactor(server): migrate stdlib log to slog with structured, leveled output
6. **#1060** feat(server): auto-compute CSP script-src hashes from embedded static FS
7. **#1061** fix(web): default API_BASE to same-origin, fixing connect-src CSP violation

### Stack

```
main
  └─ jonnii/20260528015543/multi-repo-config-with-reposRoot-and-owner/name (#1055)
    └─ jonnii/20260528020530/log-version-commit-build-date-on-startup (#1056)
      └─ jonnii/20260528021012/document-required-env-vars-via-.env.template (#1057)
        └─ jonnii/20260528021204/add-env-init-mise-task-to-populate-.env-via-gh (#1058)
          └─ jonnii/20260528023816/migrate-stdlib-log-to-slog-with-structured (#1059)
            └─ jonnii/20260528024634/auto-compute-CSP-script-src-hashes-from-embedded (#1060)
              └─ jonnii/20260528025410/default-API_BASE-to-same-origin-fixing (#1061)
```

Stackit-Stack-Size: 7
Stackit-PRs: 1055,1056,1057,1058,1059,1060,1061
