### PR TITLE
Add pre/post command lifecycle hooks with per-phase approval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ api/openapi/       API contract source of truth
 ## Documentation
 
 - `docs/config.md` - Configuration system, keys, layered config
+- `docs/hooks.md` - Lifecycle hook configuration, env vars, approval flow, recipes
 - `docs/recipes.md` - Step-by-step file lists for cross-cutting changes
 - `docs/shipping.md` - Merge strategies, consolidation, multi-stack shipping
 - `docs/tui.md` - TUI patterns, BaseModel, styling, components

--- a/docs/config.md
+++ b/docs/config.md
@@ -232,7 +232,7 @@ The table below shows all options available in `.stackit.yaml`. The "Team Fallba
 | `worktree.autoClean` | bool | `true` | Auto-remove clean, empty managed worktrees during sync | Yes |
 | `split.hunkSelector` | string | `tui` | Hunk selector mode (tui/git) | Yes |
 | `maxConcurrency` | int | `0` | Max concurrent operations (0 = auto) | Yes |
-| `hooks.post-worktree-create` | string[] | `[]` | Post-worktree-create commands | No (requires approval) |
+| `hooks.<phase>` | string[] | `[]` | Lifecycle hook commands per phase (e.g. `pre-modify`, `post-submit`, `post-worktree-create`); see `docs/hooks.md` | No (requires approval) |
 
 ### Layered Configuration Example
 
@@ -281,19 +281,24 @@ if cfg.HasTrunk() {
 
 ## Hook Approval System
 
-Post-worktree-create hooks defined in `.stackit.yaml` require user approval before execution. Approvals are stored in git config (not shared).
+Hooks defined in `.stackit.yaml` require per-user approval before they
+execute. Approvals are stored in local git config and never shared.
 
 ### Flow
 
-1. Hook defined in `.stackit.yaml` (shared)
-2. User runs a command that creates a worktree
-3. Stackit prompts for approval if hook not yet approved
-4. Approval saved to `stackit.hooks.approvedPostWorktreeCreate` (local)
-5. Subsequent runs skip the prompt
+1. Hook defined in `.stackit.yaml` (shared, committed).
+2. User runs a command that would fire the hook.
+3. Stackit prompts for approval if the command isn't yet approved.
+4. Approval saved to `stackit.hooks.approved.<phase>` (local git config).
+5. Subsequent runs skip the prompt.
 
-### Implementation
+Approvals stored under the legacy single key
+`stackit.hooks.approvedPostWorktreeCreate` are read transparently for
+backward compatibility.
 
-See `internal/actions/worktree/hooks.go` for the hook execution logic.
+See `docs/hooks.md` for the full reference: phase names, env-var payload,
+`--no-verify` semantics, and example recipes (including the "block modify
+on review" hook).
 
 ## Continuation State
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,179 @@
+# Hooks
+
+Stackit can run user-defined shell commands at specific points in a command's
+lifecycle. Hooks are configured per-repo in `.stackit.yaml` and require
+explicit approval per user before they execute.
+
+> The runner is **zero-cost when no hook is configured.** If `.stackit.yaml`
+> has no `pre-modify` entry, `stackit modify` does no extra work — no I/O,
+> no extra git call, no GitHub fetch. Hooks never *introduce* network calls;
+> if a hook wants fresh GitHub data, the hook itself fetches it.
+
+## Configuration
+
+Hooks live under `hooks:` in `.stackit.yaml`. Each phase is a list of shell
+command strings, executed via `sh -c`:
+
+```yaml
+hooks:
+  post-worktree-create:
+    - "mise trust"
+    - "mise run shims"
+  pre-modify:
+    - "scripts/check-review.sh"
+  post-submit:
+    - "scripts/notify.sh"
+```
+
+### Phase names
+
+The phase key is `<pre|post>-<command-path>`. The command path is the cobra
+command path without the leading `stackit `, joined by hyphens.
+
+| Command | Pre-phase | Post-phase |
+|---|---|---|
+| `stackit modify` | `pre-modify` | `post-modify` |
+| `stackit submit` | `pre-submit` | `post-submit` |
+| `stackit absorb` | `pre-absorb` | `post-absorb` |
+| `stackit worktree create` | — | `post-worktree-create` |
+
+Any command that goes through `common.Run` participates in the lifecycle.
+Read-only commands (`log`, `status`, `get`) do not fire hooks today.
+
+### Failure semantics
+
+- **Pre-hook non-zero exit:** the command is aborted with the hook's stderr
+  surfaced to the user. Subsequent hooks in the same phase do not run.
+- **Post-hook non-zero exit:** the command's result is unaffected; the
+  failure is surfaced as a warning on stdout.
+
+### Hook timeout
+
+Each hook is killed after 60 seconds (`hooks.DefaultTimeout`). This is not
+currently configurable per-phase.
+
+## Approval system
+
+Hooks defined in `.stackit.yaml` (shared, committed) do not run until the
+local user approves them. Approvals are stored per-user in git config and
+never leave the machine.
+
+### Flow
+
+1. Repo defines hook in `.stackit.yaml`.
+2. User runs a command that would fire the hook.
+3. Stackit prompts: `This repo wants to run "<cmd>" at <phase>. Allow?`.
+4. On approval, the command is added to
+   `stackit.hooks.approved.<phase>` in local git config.
+5. Subsequent runs of that exact command skip the prompt.
+
+### Managing approvals
+
+```bash
+# List approvals for a phase
+git config --get-all stackit.hooks.approved.pre-modify
+
+# Pre-approve a hook command without prompting
+git config --add stackit.hooks.approved.pre-modify "scripts/check-review.sh"
+
+# Remove a single approval
+git config --unset stackit.hooks.approved.pre-modify "scripts/check-review.sh"
+
+# Clear all approvals for a phase
+git config --unset-all stackit.hooks.approved.pre-modify
+```
+
+### Legacy key
+
+Approvals from versions before per-phase keys are stored under the single key
+`stackit.hooks.approvedPostWorktreeCreate`. New code reads both, dedupes,
+and writes only to the per-phase key. No automatic migration is performed.
+
+## Skipping hooks: `--no-verify`
+
+The persistent flag `--no-verify` disables both git hooks and stackit hooks
+for the invocation:
+
+```bash
+stackit modify --no-verify    # skips pre-modify and post-modify
+```
+
+## Hook payload
+
+When a hook fires, stackit sets a small env-var payload on the spawned
+process. All values come from data already in memory — no fresh GitHub
+fetch is performed.
+
+| Variable | Value |
+|---|---|
+| `STACKIT_HOOK_PHASE` | Full phase name, e.g. `pre-modify` |
+| `STACKIT_COMMAND` | Leaf cobra command name, e.g. `modify` |
+| `STACKIT_BRANCH` | Current branch name (if available) |
+| `STACKIT_PARENT` | Parent branch name (if available) |
+| `STACKIT_PR_NUMBER` | PR number from local metadata (if submitted) |
+| `STACKIT_PR_STATE` | `OPEN`, `MERGED`, or `CLOSED` (from local metadata) |
+| `STACKIT_PR_DRAFT` | `true` or `false` (from local metadata) |
+
+`STACKIT_PR_*` fields reflect the last `sync` snapshot — they can be stale.
+Hooks that need fresh GitHub state should fetch it themselves (see recipe
+below).
+
+## Recipes
+
+### Block `stackit modify` once review has started
+
+A hook that fetches the live PR review decision and refuses to amend if
+anyone has reviewed or been formally requested for changes:
+
+```sh
+#!/bin/sh
+# scripts/check-review.sh
+# Configure in .stackit.yaml:
+#   hooks:
+#     pre-modify:
+#       - "scripts/check-review.sh"
+set -e
+
+if [ -z "$STACKIT_PR_NUMBER" ]; then
+  exit 0  # No PR yet — nothing to protect.
+fi
+
+decision=$(gh pr view "$STACKIT_BRANCH" \
+  --json reviewDecision -q .reviewDecision 2>/dev/null || true)
+case "$decision" in
+  APPROVED|CHANGES_REQUESTED)
+    echo "blocked: PR #$STACKIT_PR_NUMBER review in progress (decision=$decision)" >&2
+    echo "use 'stackit modify --no-verify' if you really want to rewrite history." >&2
+    exit 1
+    ;;
+esac
+```
+
+### Lint before submitting
+
+```yaml
+hooks:
+  pre-submit:
+    - "mise run lint"
+```
+
+### Send a notification after a successful merge
+
+```yaml
+hooks:
+  post-submit:
+    - "scripts/notify-slack.sh"
+```
+
+`scripts/notify-slack.sh` reads `$STACKIT_BRANCH` and `$STACKIT_PR_NUMBER`
+from the environment.
+
+## Implementation
+
+| Concern | Location |
+|---|---|
+| Shell executor (`sh -c` + timeout) | `internal/hooks/runner.go` |
+| Approval gate + per-hook orchestration | `internal/actions/hooks/resolve.go` |
+| Cobra lifecycle middleware | `internal/cli/common/hookmiddleware.go` |
+| YAML schema (`hooks.For(phase)`) | `internal/config/project_config.go` |
+| Per-phase approval keys | `internal/config/config_git.go` |

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -37,8 +37,10 @@ command path without the leading `stackit `, joined by hyphens.
 | `stackit absorb` | `pre-absorb` | `post-absorb` |
 | `stackit worktree create` | — | `post-worktree-create` |
 
-Any command that goes through `common.Run` participates in the lifecycle.
-Read-only commands (`log`, `status`, `get`) do not fire hooks today.
+Every command that goes through `common.Run` participates in the lifecycle —
+including read-only commands like `log`, `status`, and `get`. When no hook is
+configured for a given command + phase the runner short-circuits, so the
+practical cost on uninstrumented commands is one slice-length check.
 
 ### Failure semantics
 
@@ -107,7 +109,8 @@ fetch is performed.
 | Variable | Value |
 |---|---|
 | `STACKIT_HOOK_PHASE` | Full phase name, e.g. `pre-modify` |
-| `STACKIT_COMMAND` | Leaf cobra command name, e.g. `modify` |
+| `STACKIT_COMMAND` | Leaf cobra command name, e.g. `create` |
+| `STACKIT_COMMAND_PATH` | Full command path, kebab-cased, e.g. `worktree-create` |
 | `STACKIT_BRANCH` | Current branch name (if available) |
 | `STACKIT_PARENT` | Parent branch name (if available) |
 | `STACKIT_PR_NUMBER` | PR number from local metadata (if submitted) |
@@ -138,7 +141,7 @@ if [ -z "$STACKIT_PR_NUMBER" ]; then
   exit 0  # No PR yet — nothing to protect.
 fi
 
-decision=$(gh pr view "$STACKIT_BRANCH" \
+decision=$(gh pr view "$STACKIT_PR_NUMBER" \
   --json reviewDecision -q .reviewDecision 2>/dev/null || true)
 case "$decision" in
   APPROVED|CHANGES_REQUESTED)

--- a/internal/actions/hooks/resolve.go
+++ b/internal/actions/hooks/resolve.go
@@ -1,6 +1,6 @@
 // Package hooks orchestrates hook discovery, approval, and execution at the
 // actions layer. The pure executor lives in internal/hooks; this package
-// adds the interactive approval gate and the bridge to app.Context.
+// adds the interactive approval gate and the runner facade.
 package hooks
 
 import (
@@ -8,31 +8,46 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/actions/handler"
 	"github.com/getstackit/stackit/internal/config"
 	corehooks "github.com/getstackit/stackit/internal/hooks"
 	"github.com/getstackit/stackit/internal/output"
-	"github.com/getstackit/stackit/internal/tui"
 )
 
-// PromptMessage produces the confirmation prompt shown when a hook needs
+// promptMessage produces the confirmation prompt shown when a hook needs
 // first-time approval. Phase is rendered verbatim so users can tell which
 // lifecycle slot a command would run in.
-func PromptMessage(phase, hook string) string {
+func promptMessage(phase, hook string) string {
 	return fmt.Sprintf("This repo wants to run %q at %s. Allow?", hook, phase)
 }
 
-// ResolveApproved loads the per-repo approval list for the phase, prompting
-// the user for any unapproved commands. Empty input is handled cheaply: no
-// config reads or prompts happen when commands is empty.
+// ResolveRequest carries the explicit dependencies needed to gate a list of
+// hook commands behind per-user approval. All fields are required except
+// Output, which may be nil to silence informational messages.
+type ResolveRequest struct {
+	// Phase is the lifecycle phase the hooks belong to (e.g. "pre-modify").
+	Phase string
+	// Commands is the configured hook command list for the phase. Empty
+	// strings are ignored.
+	Commands []string
+	// Config provides the approval read/write store. The same Configurer
+	// already loaded by app bootstrap is expected here — no extra disk read.
+	Config config.Configurer
+	// Prompter is used to ask the user about previously-unseen commands.
+	// Implementations decide whether the prompt defaults to yes or no.
+	Prompter handler.PromptHandler
+	// Output sinks user-facing skip/warn messages. nil is permitted.
+	Output output.Output
+}
+
+// ResolveApproved filters Commands down to the list the user has approved for
+// Phase, prompting for any unapproved entries. Empty input is handled
+// cheaply: no config writes or prompts happen when commands is empty.
 //
 // Must run from the main goroutine — it may prompt interactively.
-func ResolveApproved(ctx *app.Context, phase string, commands []string) ([]string, error) {
-	out := ctx.Output
-
-	// Filter empty/whitespace-only entries up front.
-	filtered := commands[:0:0]
-	for _, hook := range commands {
+func ResolveApproved(req ResolveRequest) ([]string, error) {
+	filtered := make([]string, 0, len(req.Commands))
+	for _, hook := range req.Commands {
 		if trimmed := strings.TrimSpace(hook); trimmed != "" {
 			filtered = append(filtered, hook)
 		}
@@ -40,31 +55,32 @@ func ResolveApproved(ctx *app.Context, phase string, commands []string) ([]strin
 	if len(filtered) == 0 {
 		return nil, nil
 	}
-
-	repoCfg, err := config.LoadConfig(ctx.RepoRoot)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load repo config: %w", err)
+	if req.Config == nil {
+		return nil, fmt.Errorf("resolve hooks: config is required")
+	}
+	if req.Prompter == nil {
+		return nil, fmt.Errorf("resolve hooks: prompter is required")
 	}
 
 	approved := make([]string, 0, len(filtered))
 	for _, hook := range filtered {
-		if repoCfg.IsHookApproved(phase, hook) {
+		if req.Config.IsHookApproved(req.Phase, hook) {
 			approved = append(approved, hook)
 			continue
 		}
 
-		allow, promptErr := tui.PromptConfirm(PromptMessage(phase, hook), false)
+		allow, promptErr := req.Prompter.PromptConfirm(promptMessage(req.Phase, hook))
 		if promptErr != nil {
-			out.Info("Skipping hook (prompt failed): %s", hook)
+			info(req.Output, "Skipping hook (prompt failed): %s", hook)
 			continue
 		}
 		if !allow {
-			out.Info("Skipping hook: %s", hook)
+			info(req.Output, "Skipping hook: %s", hook)
 			continue
 		}
 
-		if err := repoCfg.AddApprovedHook(phase, hook); err != nil {
-			out.Warn("Failed to save hook approval: %v", err)
+		if err := req.Config.AddApprovedHook(req.Phase, hook); err != nil {
+			warn(req.Output, "Failed to save hook approval: %v", err)
 		}
 		approved = append(approved, hook)
 	}
@@ -82,22 +98,39 @@ type RunOptions struct {
 	Env []string
 	// Blocking, when true, causes the first non-zero exit to abort the rest
 	// and return the error to the caller. When false, errors are surfaced as
-	// warnings on out and execution continues.
+	// warnings on Output and execution continues.
 	Blocking bool
+	// Output sinks per-hook progress and warning messages. nil is permitted
+	// but discouraged — failures become silent on the non-blocking path.
+	Output output.Output
 }
 
 // Run executes a pre-resolved list of hook commands with the shared executor.
 // On Blocking=true the first failure returns immediately; on Blocking=false
-// failures are logged and the remaining hooks still run.
-func Run(ctx context.Context, hookCmds []string, out output.Output, opts RunOptions) error {
+// failures are logged to opts.Output and the remaining hooks still run.
+func Run(ctx context.Context, hookCmds []string, opts RunOptions) error {
 	for _, hook := range hookCmds {
-		out.Info("Running hook: %s", hook)
+		info(opts.Output, "Running hook: %s", hook)
 		if err := corehooks.Run(ctx, hook, opts.Dir, opts.Env, corehooks.DefaultTimeout); err != nil {
 			if opts.Blocking {
 				return fmt.Errorf("hook %q failed: %w", hook, err)
 			}
-			out.Warn("Hook failed: %s: %v", hook, err)
+			warn(opts.Output, "Hook failed: %s: %v", hook, err)
 		}
 	}
 	return nil
+}
+
+func info(out output.Output, format string, args ...any) {
+	if out == nil {
+		return
+	}
+	out.Info(format, args...)
+}
+
+func warn(out output.Output, format string, args ...any) {
+	if out == nil {
+		return
+	}
+	out.Warn(format, args...)
 }

--- a/internal/actions/hooks/resolve.go
+++ b/internal/actions/hooks/resolve.go
@@ -1,0 +1,103 @@
+// Package hooks orchestrates hook discovery, approval, and execution at the
+// actions layer. The pure executor lives in internal/hooks; this package
+// adds the interactive approval gate and the bridge to app.Context.
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+	corehooks "github.com/getstackit/stackit/internal/hooks"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
+)
+
+// PromptMessage produces the confirmation prompt shown when a hook needs
+// first-time approval. Phase is rendered verbatim so users can tell which
+// lifecycle slot a command would run in.
+func PromptMessage(phase, hook string) string {
+	return fmt.Sprintf("This repo wants to run %q at %s. Allow?", hook, phase)
+}
+
+// ResolveApproved loads the per-repo approval list for the phase, prompting
+// the user for any unapproved commands. Empty input is handled cheaply: no
+// config reads or prompts happen when commands is empty.
+//
+// Must run from the main goroutine — it may prompt interactively.
+func ResolveApproved(ctx *app.Context, phase string, commands []string) ([]string, error) {
+	out := ctx.Output
+
+	// Filter empty/whitespace-only entries up front.
+	filtered := commands[:0:0]
+	for _, hook := range commands {
+		if trimmed := strings.TrimSpace(hook); trimmed != "" {
+			filtered = append(filtered, hook)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil, nil
+	}
+
+	repoCfg, err := config.LoadConfig(ctx.RepoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load repo config: %w", err)
+	}
+
+	approved := make([]string, 0, len(filtered))
+	for _, hook := range filtered {
+		if repoCfg.IsHookApproved(phase, hook) {
+			approved = append(approved, hook)
+			continue
+		}
+
+		allow, promptErr := tui.PromptConfirm(PromptMessage(phase, hook), false)
+		if promptErr != nil {
+			out.Info("Skipping hook (prompt failed): %s", hook)
+			continue
+		}
+		if !allow {
+			out.Info("Skipping hook: %s", hook)
+			continue
+		}
+
+		if err := repoCfg.AddApprovedHook(phase, hook); err != nil {
+			out.Warn("Failed to save hook approval: %v", err)
+		}
+		approved = append(approved, hook)
+	}
+
+	return approved, nil
+}
+
+// RunOptions controls how a list of resolved hooks is executed.
+type RunOptions struct {
+	// Dir is the working directory for each hook process. Defaults to the
+	// caller's cwd if empty.
+	Dir string
+	// Env is a list of NAME=value strings appended to os.Environ() for each
+	// hook invocation. nil is allowed.
+	Env []string
+	// Blocking, when true, causes the first non-zero exit to abort the rest
+	// and return the error to the caller. When false, errors are surfaced as
+	// warnings on out and execution continues.
+	Blocking bool
+}
+
+// Run executes a pre-resolved list of hook commands with the shared executor.
+// On Blocking=true the first failure returns immediately; on Blocking=false
+// failures are logged and the remaining hooks still run.
+func Run(ctx context.Context, hookCmds []string, out output.Output, opts RunOptions) error {
+	for _, hook := range hookCmds {
+		out.Info("Running hook: %s", hook)
+		if err := corehooks.Run(ctx, hook, opts.Dir, opts.Env, corehooks.DefaultTimeout); err != nil {
+			if opts.Blocking {
+				return fmt.Errorf("hook %q failed: %w", hook, err)
+			}
+			out.Warn("Hook failed: %s: %v", hook, err)
+		}
+	}
+	return nil
+}

--- a/internal/actions/hooks/resolve_test.go
+++ b/internal/actions/hooks/resolve_test.go
@@ -1,0 +1,83 @@
+package hooks_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions/hooks"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/testhelpers"
+)
+
+// fakePrompter is a handler.PromptHandler that returns canned answers in
+// order. Useful for driving ResolveApproved through its prompt branch in
+// tests without setting up a TTY.
+type fakePrompter struct {
+	answers []bool
+	calls   []string
+}
+
+func (p *fakePrompter) PromptConfirm(message string) (bool, error) {
+	p.calls = append(p.calls, message)
+	if len(p.answers) == 0 {
+		return false, nil
+	}
+	a := p.answers[0]
+	p.answers = p.answers[1:]
+	return a, nil
+}
+
+func TestResolveApproved_PromptApproveAndPersist(t *testing.T) {
+	t.Parallel()
+
+	scene := testhelpers.NewSceneParallel(t, nil)
+	cfg, err := config.LoadConfig(scene.Dir)
+	require.NoError(t, err)
+
+	prompter := &fakePrompter{answers: []bool{true, false}}
+
+	approved, err := hooks.ResolveApproved(hooks.ResolveRequest{
+		Phase:    "pre-modify",
+		Commands: []string{"scripts/ok.sh", "scripts/declined.sh"},
+		Config:   cfg,
+		Prompter: prompter,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"scripts/ok.sh"}, approved, "approved hook should be returned; declined should be filtered out")
+	require.Len(t, prompter.calls, 2, "prompter should be called once per unapproved hook")
+
+	// Approval is persisted: a fresh Configurer sees the approval without
+	// prompting again, and the declined hook is still unapproved.
+	cfg2, err := config.LoadConfig(scene.Dir)
+	require.NoError(t, err)
+	require.True(t, cfg2.IsHookApproved("pre-modify", "scripts/ok.sh"))
+	require.False(t, cfg2.IsHookApproved("pre-modify", "scripts/declined.sh"))
+
+	// Re-running should skip the prompt entirely for the approved hook.
+	prompter2 := &fakePrompter{answers: []bool{true}}
+	approved2, err := hooks.ResolveApproved(hooks.ResolveRequest{
+		Phase:    "pre-modify",
+		Commands: []string{"scripts/ok.sh"},
+		Config:   cfg2,
+		Prompter: prompter2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"scripts/ok.sh"}, approved2)
+	require.Empty(t, prompter2.calls, "previously approved hook should not re-prompt")
+}
+
+func TestResolveApproved_EmptyCommandsIsZeroCost(t *testing.T) {
+	t.Parallel()
+
+	prompter := &fakePrompter{}
+	approved, err := hooks.ResolveApproved(hooks.ResolveRequest{
+		Phase:    "pre-modify",
+		Commands: []string{"   ", "\t"}, // whitespace-only entries
+		Config:   nil,                   // intentionally nil — fast path shouldn't read it
+		Prompter: nil,
+	})
+	require.NoError(t, err)
+	require.Empty(t, approved)
+	require.Empty(t, prompter.calls)
+}

--- a/internal/actions/worktree/hooks.go
+++ b/internal/actions/worktree/hooks.go
@@ -3,95 +3,41 @@ package worktree
 import (
 	"context"
 	"fmt"
-	"strings"
 
+	"github.com/getstackit/stackit/internal/actions/hooks"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/config"
-	"github.com/getstackit/stackit/internal/hooks"
 	"github.com/getstackit/stackit/internal/output"
-	"github.com/getstackit/stackit/internal/tui"
 )
 
-// ResolveApprovedHooks loads the project config, checks for approvals, and prompts
-// the user for any unapproved hooks. Returns the list of approved hook commands.
-// This must be called from the main thread (it may prompt interactively).
+// ResolveApprovedHooks loads the project config and returns the approved
+// post-worktree-create hook commands, prompting for any unapproved entries.
+// Must be called from the main thread (may prompt interactively).
 func ResolveApprovedHooks(ctx *app.Context) ([]string, error) {
-	out := ctx.Output
-
-	// Load project config from repo root
 	projectCfg, err := config.LoadProjectConfig(ctx.RepoRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load project config: %w", err)
 	}
-
-	// Get hooks to run, filtering out empty/whitespace-only entries
-	var hookCmds []string
-	for _, hook := range projectCfg.Hooks.PostWorktreeCreate {
-		if trimmed := strings.TrimSpace(hook); trimmed != "" {
-			hookCmds = append(hookCmds, hook)
-		}
-	}
-	if len(hookCmds) == 0 {
-		return nil, nil
-	}
-
-	// Load repo config for approvals
-	repoCfg, err := config.LoadConfig(ctx.RepoRoot)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load repo config: %w", err)
-	}
-
-	// For each hook, check approval or prompt
-	approved := make([]string, 0, len(hookCmds))
-
-	for _, hook := range hookCmds {
-		if repoCfg.IsHookApproved(config.PhasePostWorktreeCreate, hook) {
-			approved = append(approved, hook)
-			continue
-		}
-
-		// Prompt user (default No for security)
-		msg := fmt.Sprintf("This repo wants to run %q after creating worktrees. Allow?", hook)
-		allow, promptErr := tui.PromptConfirm(msg, false)
-		if promptErr != nil {
-			out.Info("Skipping hook (prompt failed): %s", hook)
-			continue
-		}
-		if !allow {
-			out.Info("Skipping hook: %s", hook)
-			continue
-		}
-
-		// Save approval (writes immediately to git config)
-		if err := repoCfg.AddApprovedHook(config.PhasePostWorktreeCreate, hook); err != nil {
-			out.Warn("Failed to save hook approval: %v", err)
-		}
-		approved = append(approved, hook)
-	}
-
-	return approved, nil
+	return hooks.ResolveApproved(ctx, config.PhasePostWorktreeCreate, projectCfg.Hooks.PostWorktreeCreate)
 }
 
 // RunResolvedHooks executes a pre-resolved list of hooks in the given directory.
-// No prompting is performed — safe for parallel use.
+// Failures are warned, not blocking — matches the existing worktree behavior.
 func RunResolvedHooks(hookCmds []string, worktreePath string, out output.Output) {
-	for _, hook := range hookCmds {
-		out.Info("Running hook: %s", hook)
-		if err := hooks.Run(context.Background(), hook, worktreePath, nil, hooks.DefaultTimeout); err != nil {
-			out.Warn("Hook failed: %s: %v", hook, err)
-		}
-	}
+	_ = hooks.Run(context.Background(), hookCmds, out, hooks.RunOptions{
+		Dir:      worktreePath,
+		Blocking: false,
+	})
 }
 
-// RunPostCreateHooks runs any configured post-worktree-create hooks.
-// It loads the project config, checks for approvals, prompts for unapproved hooks,
-// and executes approved hooks in the worktree directory.
+// RunPostCreateHooks runs any configured post-worktree-create hooks. It loads
+// the project config, resolves approvals, and executes approved hooks in the
+// worktree directory.
 func RunPostCreateHooks(ctx *app.Context, worktreePath string) error {
 	approved, err := ResolveApprovedHooks(ctx)
 	if err != nil {
 		return err
 	}
-
 	RunResolvedHooks(approved, worktreePath, ctx.Output)
 	return nil
 }

--- a/internal/actions/worktree/hooks.go
+++ b/internal/actions/worktree/hooks.go
@@ -45,7 +45,7 @@ func ResolveApprovedHooks(ctx *app.Context) ([]string, error) {
 	approved := make([]string, 0, len(hookCmds))
 
 	for _, hook := range hookCmds {
-		if repoCfg.IsPostWorktreeCreateHookApproved(hook) {
+		if repoCfg.IsHookApproved(config.PhasePostWorktreeCreate, hook) {
 			approved = append(approved, hook)
 			continue
 		}
@@ -63,7 +63,7 @@ func ResolveApprovedHooks(ctx *app.Context) ([]string, error) {
 		}
 
 		// Save approval (writes immediately to git config)
-		if err := repoCfg.AddApprovedPostWorktreeCreateHook(hook); err != nil {
+		if err := repoCfg.AddApprovedHook(config.PhasePostWorktreeCreate, hook); err != nil {
 			out.Warn("Failed to save hook approval: %v", err)
 		}
 		approved = append(approved, hook)

--- a/internal/actions/worktree/hooks.go
+++ b/internal/actions/worktree/hooks.go
@@ -2,37 +2,49 @@ package worktree
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/getstackit/stackit/internal/actions/handler"
 	"github.com/getstackit/stackit/internal/actions/hooks"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
-// ResolveApprovedHooks loads the project config and returns the approved
-// post-worktree-create hook commands, prompting for any unapproved entries.
-// Must be called from the main thread (may prompt interactively).
+// ResolveApprovedHooks reads the post-worktree-create hook list from the
+// project config already attached to ctx and returns the approved subset,
+// prompting for any unapproved entries. Must be called from the main thread
+// (may prompt interactively).
 func ResolveApprovedHooks(ctx *app.Context) ([]string, error) {
-	projectCfg, err := config.LoadProjectConfig(ctx.RepoRoot)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load project config: %w", err)
+	if ctx.Config == nil {
+		return nil, nil
 	}
-	return hooks.ResolveApproved(ctx, config.PhasePostWorktreeCreate, projectCfg.Hooks.PostWorktreeCreate)
+	projectCfg := ctx.Config.ProjectConfig()
+	if projectCfg == nil {
+		return nil, nil
+	}
+	return hooks.ResolveApproved(hooks.ResolveRequest{
+		Phase:    config.PhasePostWorktreeCreate,
+		Commands: projectCfg.Hooks.PostWorktreeCreate,
+		Config:   ctx.Config,
+		Prompter: worktreePrompter{},
+		Output:   ctx.Output,
+	})
 }
 
 // RunResolvedHooks executes a pre-resolved list of hooks in the given directory.
 // Failures are warned, not blocking — matches the existing worktree behavior.
 func RunResolvedHooks(hookCmds []string, worktreePath string, out output.Output) {
-	_ = hooks.Run(context.Background(), hookCmds, out, hooks.RunOptions{
+	_ = hooks.Run(context.Background(), hookCmds, hooks.RunOptions{
 		Dir:      worktreePath,
 		Blocking: false,
+		Output:   out,
 	})
 }
 
-// RunPostCreateHooks runs any configured post-worktree-create hooks. It loads
-// the project config, resolves approvals, and executes approved hooks in the
-// worktree directory.
+// RunPostCreateHooks runs any configured post-worktree-create hooks. It reads
+// the project config from ctx, resolves approvals, and executes approved
+// hooks in the worktree directory.
 func RunPostCreateHooks(ctx *app.Context, worktreePath string) error {
 	approved, err := ResolveApprovedHooks(ctx)
 	if err != nil {
@@ -41,3 +53,13 @@ func RunPostCreateHooks(ctx *app.Context, worktreePath string) error {
 	RunResolvedHooks(approved, worktreePath, ctx.Output)
 	return nil
 }
+
+// worktreePrompter wraps tui.PromptConfirm with a default-no answer so
+// accidental Enter doesn't approve arbitrary post-worktree-create commands.
+type worktreePrompter struct{}
+
+func (worktreePrompter) PromptConfirm(message string) (bool, error) {
+	return tui.PromptConfirm(message, false)
+}
+
+var _ handler.PromptHandler = worktreePrompter{}

--- a/internal/actions/worktree/hooks.go
+++ b/internal/actions/worktree/hooks.go
@@ -3,19 +3,14 @@ package worktree
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/hooks"
 	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/tui"
 )
-
-// HookTimeout is the maximum duration a hook can run before being killed
-const HookTimeout = 60 * time.Second
 
 // ResolveApprovedHooks loads the project config, checks for approvals, and prompts
 // the user for any unapproved hooks. Returns the list of approved hook commands.
@@ -30,13 +25,13 @@ func ResolveApprovedHooks(ctx *app.Context) ([]string, error) {
 	}
 
 	// Get hooks to run, filtering out empty/whitespace-only entries
-	var hooks []string
+	var hookCmds []string
 	for _, hook := range projectCfg.Hooks.PostWorktreeCreate {
 		if trimmed := strings.TrimSpace(hook); trimmed != "" {
-			hooks = append(hooks, hook)
+			hookCmds = append(hookCmds, hook)
 		}
 	}
-	if len(hooks) == 0 {
+	if len(hookCmds) == 0 {
 		return nil, nil
 	}
 
@@ -47,9 +42,9 @@ func ResolveApprovedHooks(ctx *app.Context) ([]string, error) {
 	}
 
 	// For each hook, check approval or prompt
-	approved := make([]string, 0, len(hooks))
+	approved := make([]string, 0, len(hookCmds))
 
-	for _, hook := range hooks {
+	for _, hook := range hookCmds {
 		if repoCfg.IsPostWorktreeCreateHookApproved(hook) {
 			approved = append(approved, hook)
 			continue
@@ -79,10 +74,10 @@ func ResolveApprovedHooks(ctx *app.Context) ([]string, error) {
 
 // RunResolvedHooks executes a pre-resolved list of hooks in the given directory.
 // No prompting is performed — safe for parallel use.
-func RunResolvedHooks(hooks []string, worktreePath string, out output.Output) {
-	for _, hook := range hooks {
+func RunResolvedHooks(hookCmds []string, worktreePath string, out output.Output) {
+	for _, hook := range hookCmds {
 		out.Info("Running hook: %s", hook)
-		if err := runHookWithTimeout(hook, worktreePath, HookTimeout); err != nil {
+		if err := hooks.Run(context.Background(), hook, worktreePath, nil, hooks.DefaultTimeout); err != nil {
 			out.Warn("Hook failed: %s: %v", hook, err)
 		}
 	}
@@ -99,22 +94,4 @@ func RunPostCreateHooks(ctx *app.Context, worktreePath string) error {
 
 	RunResolvedHooks(approved, worktreePath, ctx.Output)
 	return nil
-}
-
-// runHookWithTimeout executes a hook command with a timeout.
-// Returns an error if the command fails or times out.
-func runHookWithTimeout(hook string, dir string, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "sh", "-c", hook)
-	cmd.Dir = dir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	err := cmd.Run()
-	if ctx.Err() == context.DeadlineExceeded {
-		return fmt.Errorf("timed out after %s", timeout)
-	}
-	return err
 }

--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -51,7 +51,14 @@ func RunWithOptions(cmd *cobra.Command, opts app.GlobalOptions, fn func(ctx *app
 		}
 	}
 
+	if err := RunCommandHooks(ctx, cmd, PhasePre); err != nil {
+		return HandleCommandError(err)
+	}
+
 	err = fn(ctx)
+	// Post-hooks fire regardless of fn outcome so users can observe success
+	// and failure both. Their errors are surfaced as warnings (non-blocking).
+	_ = RunCommandHooks(ctx, cmd, PhasePost)
 	if err != nil {
 		return HandleCommandError(err)
 	}

--- a/internal/cli/common/hookmiddleware.go
+++ b/internal/cli/common/hookmiddleware.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/getstackit/stackit/internal/actions/handler"
 	"github.com/getstackit/stackit/internal/actions/hooks"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/tui"
 )
 
 // PhasePrefix identifies whether a hook fires before or after the command.
@@ -19,19 +21,25 @@ const (
 	PhasePost PhasePrefix = "post"
 )
 
-// CommandPhase returns the lookup key under hooks: in .stackit.yaml for the
-// given cobra command and phase, e.g. "pre-modify" or "post-worktree-create".
-// The leading "stackit " segment is stripped; remaining path segments are
-// joined by hyphens.
-func CommandPhase(cmd *cobra.Command, phase PhasePrefix) string {
+// commandPath returns the kebab-cased cobra command path with the leading
+// "stackit" segment stripped, e.g. "modify" or "worktree-create". Returns an
+// empty string for the root command.
+func commandPath(cmd *cobra.Command) string {
 	parts := strings.Fields(cmd.CommandPath())
 	if len(parts) > 0 && parts[0] == "stackit" {
 		parts = parts[1:]
 	}
-	if len(parts) == 0 {
+	return strings.Join(parts, "-")
+}
+
+// CommandPhase returns the lookup key under hooks: in .stackit.yaml for the
+// given cobra command and phase, e.g. "pre-modify" or "post-worktree-create".
+func CommandPhase(cmd *cobra.Command, phase PhasePrefix) string {
+	path := commandPath(cmd)
+	if path == "" {
 		return string(phase)
 	}
-	return string(phase) + "-" + strings.Join(parts, "-")
+	return string(phase) + "-" + path
 }
 
 // RunCommandHooks fires the configured hooks for the given lifecycle phase.
@@ -58,7 +66,13 @@ func RunCommandHooks(ctx *app.Context, cmd *cobra.Command, phase PhasePrefix) er
 		return nil
 	}
 
-	approved, err := hooks.ResolveApproved(ctx, phaseKey, hookCmds)
+	approved, err := hooks.ResolveApproved(hooks.ResolveRequest{
+		Phase:    phaseKey,
+		Commands: hookCmds,
+		Config:   ctx.Config,
+		Prompter: defaultPrompter{},
+		Output:   ctx.Output,
+	})
 	if err != nil {
 		return fmt.Errorf("resolve hooks for %s: %w", phaseKey, err)
 	}
@@ -66,10 +80,11 @@ func RunCommandHooks(ctx *app.Context, cmd *cobra.Command, phase PhasePrefix) er
 		return nil
 	}
 
-	return hooks.Run(ctx, approved, ctx.Output, hooks.RunOptions{
+	return hooks.Run(ctx, approved, hooks.RunOptions{
 		Dir:      ctx.RepoRoot,
 		Env:      hookEnv(ctx, cmd, phaseKey),
 		Blocking: phase == PhasePre,
+		Output:   ctx.Output,
 	})
 }
 
@@ -80,10 +95,23 @@ func projectConfigFrom(ctx *app.Context) *config.ProjectConfig {
 	return ctx.Config.ProjectConfig()
 }
 
+// defaultPrompter is a handler.PromptHandler that delegates to the shared
+// TUI confirmation prompt with a default-no answer. Default-no protects users
+// who hit Enter on an unexpected prompt from executing arbitrary commands.
+type defaultPrompter struct{}
+
+func (defaultPrompter) PromptConfirm(message string) (bool, error) {
+	return tui.PromptConfirm(message, false)
+}
+
+// Ensure defaultPrompter satisfies the interface at compile time.
+var _ handler.PromptHandler = defaultPrompter{}
+
 func hookEnv(ctx *app.Context, cmd *cobra.Command, phaseKey string) []string {
 	env := []string{
 		"STACKIT_HOOK_PHASE=" + phaseKey,
 		"STACKIT_COMMAND=" + cmd.Name(),
+		"STACKIT_COMMAND_PATH=" + commandPath(cmd),
 	}
 	if ctx.Engine != nil {
 		if cur := ctx.Engine.CurrentBranch(); cur != nil {

--- a/internal/cli/common/hookmiddleware.go
+++ b/internal/cli/common/hookmiddleware.go
@@ -1,0 +1,106 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/getstackit/stackit/internal/actions/hooks"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+)
+
+// PhasePrefix identifies whether a hook fires before or after the command.
+type PhasePrefix string
+
+const (
+	PhasePre  PhasePrefix = "pre"
+	PhasePost PhasePrefix = "post"
+)
+
+// CommandPhase returns the lookup key under hooks: in .stackit.yaml for the
+// given cobra command and phase, e.g. "pre-modify" or "post-worktree-create".
+// The leading "stackit " segment is stripped; remaining path segments are
+// joined by hyphens.
+func CommandPhase(cmd *cobra.Command, phase PhasePrefix) string {
+	parts := strings.Fields(cmd.CommandPath())
+	if len(parts) > 0 && parts[0] == "stackit" {
+		parts = parts[1:]
+	}
+	if len(parts) == 0 {
+		return string(phase)
+	}
+	return string(phase) + "-" + strings.Join(parts, "-")
+}
+
+// RunCommandHooks fires the configured hooks for the given lifecycle phase.
+//
+// Zero-cost when absent: the only work performed when no hook is configured
+// for this command + phase is a slice-length check against the in-memory
+// project config that was already loaded during context construction.
+//
+// Returns the hook's error verbatim for pre-hooks (so the caller can abort
+// the command). For post-hooks, errors are surfaced as warnings on
+// ctx.Output and nil is returned.
+func RunCommandHooks(ctx *app.Context, cmd *cobra.Command, phase PhasePrefix) error {
+	if !ctx.Verify {
+		return nil
+	}
+	projectCfg := projectConfigFrom(ctx)
+	if projectCfg == nil {
+		return nil
+	}
+
+	phaseKey := CommandPhase(cmd, phase)
+	hookCmds := projectCfg.Hooks.For(phaseKey)
+	if len(hookCmds) == 0 {
+		return nil
+	}
+
+	approved, err := hooks.ResolveApproved(ctx, phaseKey, hookCmds)
+	if err != nil {
+		return fmt.Errorf("resolve hooks for %s: %w", phaseKey, err)
+	}
+	if len(approved) == 0 {
+		return nil
+	}
+
+	return hooks.Run(ctx, approved, ctx.Output, hooks.RunOptions{
+		Dir:      ctx.RepoRoot,
+		Env:      hookEnv(ctx, cmd, phaseKey),
+		Blocking: phase == PhasePre,
+	})
+}
+
+func projectConfigFrom(ctx *app.Context) *config.ProjectConfig {
+	if ctx.Config == nil {
+		return nil
+	}
+	return ctx.Config.ProjectConfig()
+}
+
+func hookEnv(ctx *app.Context, cmd *cobra.Command, phaseKey string) []string {
+	env := []string{
+		"STACKIT_HOOK_PHASE=" + phaseKey,
+		"STACKIT_COMMAND=" + cmd.Name(),
+	}
+	if ctx.Engine != nil {
+		if cur := ctx.Engine.CurrentBranch(); cur != nil {
+			env = append(env, "STACKIT_BRANCH="+cur.GetName())
+			if parent := cur.GetParent(); parent != nil {
+				env = append(env, "STACKIT_PARENT="+parent.GetName())
+			}
+			if pr, err := cur.GetPrInfo(); err == nil && pr != nil {
+				if n := pr.Number(); n != nil {
+					env = append(env, fmt.Sprintf("STACKIT_PR_NUMBER=%d", *n))
+				}
+				if s := pr.State(); s != "" {
+					env = append(env, "STACKIT_PR_STATE="+s)
+				}
+				env = append(env, fmt.Sprintf("STACKIT_PR_DRAFT=%t", pr.IsDraft()))
+			}
+		}
+	}
+	return env
+}

--- a/internal/cli/common/hookmiddleware_test.go
+++ b/internal/cli/common/hookmiddleware_test.go
@@ -1,0 +1,47 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandPhase(t *testing.T) {
+	t.Parallel()
+
+	build := func() *cobra.Command {
+		root := &cobra.Command{Use: "stackit"}
+		modify := &cobra.Command{Use: "modify"}
+		root.AddCommand(modify)
+		wt := &cobra.Command{Use: "worktree"}
+		wtCreate := &cobra.Command{Use: "create"}
+		wt.AddCommand(wtCreate)
+		root.AddCommand(wt)
+		return root
+	}
+
+	tests := []struct {
+		name     string
+		path     []string // walk from root by Use
+		phase    PhasePrefix
+		expected string
+	}{
+		{name: "pre-modify on top-level command", path: []string{"modify"}, phase: PhasePre, expected: "pre-modify"},
+		{name: "post-modify on top-level command", path: []string{"modify"}, phase: PhasePost, expected: "post-modify"},
+		{name: "nested worktree create", path: []string{"worktree", "create"}, phase: PhasePost, expected: "post-worktree-create"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := build()
+			cmd := root
+			for _, segment := range tt.path {
+				next, _, err := cmd.Find([]string{segment})
+				assert.NoError(t, err)
+				cmd = next
+			}
+			assert.Equal(t, tt.expected, CommandPhase(cmd, tt.phase))
+		})
+	}
+}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -952,7 +952,7 @@ func showConfigWithSources(repoRoot string, w io.Writer) error {
 	formatLine("navigation.showMerged", strconv.FormatBool(cfg.NavigationShowMerged()), navShowMergedSource)
 
 	// approved hooks (personal only, no team fallback)
-	approvedHooks := cfg.ApprovedPostWorktreeCreateHooks()
+	approvedHooks := cfg.ApprovedHooks(config.PhasePostWorktreeCreate)
 	if len(approvedHooks) > 0 {
 		formatLine("hooks.approved", strings.Join(approvedHooks, ", "), sourcePersonal)
 	} else {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -67,8 +67,8 @@ Commit:  ` + commit + `
 	pf.BoolVar(&debug, "debug", false, "Write debug output to the terminal.")
 	pf.BoolVar(&interactive, "interactive", true, "Enable interactive features like prompts, pagers, and editors.")
 	pf.BoolVar(&noInteractive, "no-interactive", false, "Disable interactive features.")
-	pf.BoolVar(&verify, "verify", true, "Enable git hooks.")
-	pf.BoolVar(&noVerify, "no-verify", false, "Disable git hooks.")
+	pf.BoolVar(&verify, "verify", true, "Enable git and stackit hooks.")
+	pf.BoolVar(&noVerify, "no-verify", false, "Disable git and stackit hooks.")
 	pf.BoolVarP(&quiet, "quiet", "q", false, "Minimize output to the terminal. Implies --no-interactive.")
 
 	rootCmd.AddCommand(newAbortCmd())

--- a/internal/config/config_git.go
+++ b/internal/config/config_git.go
@@ -392,63 +392,138 @@ func (c *GitConfig) SetSplitHunkSelector(selector string) error {
 	return c.store.Set(KeySplitHunkSelector, selector)
 }
 
-// ApprovedPostWorktreeCreateHooks returns the list of approved hooks.
-func (c *GitConfig) ApprovedPostWorktreeCreateHooks() []string {
-	hooks, _ := c.store.GetAll(KeyApprovedHooks)
-	return hooks
-}
-
-// IsPostWorktreeCreateHookApproved checks if a hook is approved.
-func (c *GitConfig) IsPostWorktreeCreateHookApproved(hook string) bool {
-	return slices.Contains(c.ApprovedPostWorktreeCreateHooks(), hook)
-}
-
-// AddApprovedPostWorktreeCreateHook adds a hook to the approved list.
-func (c *GitConfig) AddApprovedPostWorktreeCreateHook(hook string) error {
-	if c.IsPostWorktreeCreateHookApproved(hook) {
-		return nil // Already approved
+// ApprovedHooks returns the list of approved hook commands for the given phase.
+//
+// For PhasePostWorktreeCreate, results include any approvals stored under the
+// legacy single-key form (KeyApprovedHooks) in addition to the new per-phase
+// key. Approvals appearing in both keys are deduplicated.
+func (c *GitConfig) ApprovedHooks(phase string) []string {
+	primary, _ := c.store.GetAll(KeyApprovedHookPrefix + phase)
+	if phase != PhasePostWorktreeCreate {
+		return primary
 	}
-	return c.store.Add(KeyApprovedHooks, hook)
-}
-
-// RemoveApprovedPostWorktreeCreateHook removes a hook from the approved list.
-func (c *GitConfig) RemoveApprovedPostWorktreeCreateHook(hook string) error {
-	// Get all current hooks
-	hooks := c.ApprovedPostWorktreeCreateHooks()
-	if !slices.Contains(hooks, hook) {
-		return nil // Not in list
+	legacy, _ := c.store.GetAll(KeyApprovedHooks)
+	if len(legacy) == 0 {
+		return primary
 	}
-
-	// Build the list of hooks to keep
-	hooksToKeep := make([]string, 0, len(hooks)-1)
-	for _, h := range hooks {
-		if h != hook {
-			hooksToKeep = append(hooksToKeep, h)
+	merged := make([]string, 0, len(primary)+len(legacy))
+	seen := make(map[string]bool, len(primary)+len(legacy))
+	for _, h := range primary {
+		if !seen[h] {
+			merged = append(merged, h)
+			seen[h] = true
 		}
 	}
+	for _, h := range legacy {
+		if !seen[h] {
+			merged = append(merged, h)
+			seen[h] = true
+		}
+	}
+	return merged
+}
 
-	// Remove all hooks first
-	if err := c.store.Unset(KeyApprovedHooks); err != nil {
+// IsHookApproved reports whether the command is approved for the given phase.
+func (c *GitConfig) IsHookApproved(phase, command string) bool {
+	return slices.Contains(c.ApprovedHooks(phase), command)
+}
+
+// AddApprovedHook records an approval for the given phase. Approvals are
+// written to the per-phase key; the legacy key is read but never written.
+func (c *GitConfig) AddApprovedHook(phase, command string) error {
+	if c.IsHookApproved(phase, command) {
+		return nil
+	}
+	return c.store.Add(KeyApprovedHookPrefix+phase, command)
+}
+
+// RemoveApprovedHook removes the approval for the given phase. For
+// PhasePostWorktreeCreate, the command is removed from both the per-phase
+// key and the legacy key if present in either.
+func (c *GitConfig) RemoveApprovedHook(phase, command string) error {
+	if err := removeFromMultiKey(c.store, KeyApprovedHookPrefix+phase, command); err != nil {
 		return err
 	}
-
-	// Re-add the ones we want to keep
-	// If this fails, try to restore the original state
-	for _, h := range hooksToKeep {
-		if err := c.store.Add(KeyApprovedHooks, h); err != nil {
-			// Try to restore original hooks
-			for _, original := range hooks {
-				_ = c.store.Add(KeyApprovedHooks, original)
-			}
-			return fmt.Errorf("failed to update hooks, attempted recovery: %w", err)
-		}
+	if phase == PhasePostWorktreeCreate {
+		return removeFromMultiKey(c.store, KeyApprovedHooks, command)
 	}
 	return nil
 }
 
+// ClearApprovedHooks removes all approvals for the given phase. For
+// PhasePostWorktreeCreate, this also clears the legacy key.
+func (c *GitConfig) ClearApprovedHooks(phase string) error {
+	if err := c.store.Unset(KeyApprovedHookPrefix + phase); err != nil {
+		return err
+	}
+	if phase == PhasePostWorktreeCreate {
+		return c.store.Unset(KeyApprovedHooks)
+	}
+	return nil
+}
+
+// ApprovedPostWorktreeCreateHooks returns the list of approved hooks.
+//
+// Deprecated: use ApprovedHooks(PhasePostWorktreeCreate).
+func (c *GitConfig) ApprovedPostWorktreeCreateHooks() []string {
+	return c.ApprovedHooks(PhasePostWorktreeCreate)
+}
+
+// IsPostWorktreeCreateHookApproved checks if a hook is approved.
+//
+// Deprecated: use IsHookApproved(PhasePostWorktreeCreate, hook).
+func (c *GitConfig) IsPostWorktreeCreateHookApproved(hook string) bool {
+	return c.IsHookApproved(PhasePostWorktreeCreate, hook)
+}
+
+// AddApprovedPostWorktreeCreateHook adds a hook to the approved list.
+//
+// Deprecated: use AddApprovedHook(PhasePostWorktreeCreate, hook).
+func (c *GitConfig) AddApprovedPostWorktreeCreateHook(hook string) error {
+	return c.AddApprovedHook(PhasePostWorktreeCreate, hook)
+}
+
+// RemoveApprovedPostWorktreeCreateHook removes a hook from the approved list.
+//
+// Deprecated: use RemoveApprovedHook(PhasePostWorktreeCreate, hook).
+func (c *GitConfig) RemoveApprovedPostWorktreeCreateHook(hook string) error {
+	return c.RemoveApprovedHook(PhasePostWorktreeCreate, hook)
+}
+
 // ClearApprovedPostWorktreeCreateHooks removes all hook approvals.
+//
+// Deprecated: use ClearApprovedHooks(PhasePostWorktreeCreate).
 func (c *GitConfig) ClearApprovedPostWorktreeCreateHooks() error {
-	return c.store.Unset(KeyApprovedHooks)
+	return c.ClearApprovedHooks(PhasePostWorktreeCreate)
+}
+
+// removeFromMultiKey removes a single value from a multi-value git config key
+// by reading all values, unsetting the key, and re-adding the remaining ones.
+// If the value is absent the key is left untouched. On a re-add failure the
+// original values are restored on a best-effort basis.
+func removeFromMultiKey(store *git.ConfigStore, key, value string) error {
+	current, _ := store.GetAll(key)
+	if !slices.Contains(current, value) {
+		return nil
+	}
+	keep := make([]string, 0, len(current)-1)
+	for _, v := range current {
+		if v != value {
+			keep = append(keep, v)
+		}
+	}
+	if err := store.Unset(key); err != nil {
+		return err
+	}
+	for _, v := range keep {
+		if err := store.Add(key, v); err != nil {
+			for _, original := range current {
+				_ = store.Add(key, original)
+			}
+			return fmt.Errorf("failed to update %s, attempted recovery: %w", key, err)
+		}
+	}
+	return nil
 }
 
 // MaxConcurrency returns the maximum number of concurrent validation operations.

--- a/internal/config/config_git.go
+++ b/internal/config/config_git.go
@@ -62,6 +62,13 @@ func (c *GitConfig) IsInitialized() bool {
 	return c.store.Exists(KeyTrunk)
 }
 
+// ProjectConfig returns the loaded project config (.stackit.yaml) attached to
+// this GitConfig, or nil if this instance was loaded without project fallback.
+// Callers must not mutate the returned value.
+func (c *GitConfig) ProjectConfig() *ProjectConfig {
+	return c.project
+}
+
 // Trunk returns the primary trunk branch name.
 // Priority: personal git config > team project config > default.
 func (c *GitConfig) Trunk() string {

--- a/internal/config/config_git.go
+++ b/internal/config/config_git.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -469,45 +470,12 @@ func (c *GitConfig) ClearApprovedHooks(phase string) error {
 	return nil
 }
 
-// ApprovedPostWorktreeCreateHooks returns the list of approved hooks.
-//
-// Deprecated: use ApprovedHooks(PhasePostWorktreeCreate).
-func (c *GitConfig) ApprovedPostWorktreeCreateHooks() []string {
-	return c.ApprovedHooks(PhasePostWorktreeCreate)
-}
-
-// IsPostWorktreeCreateHookApproved checks if a hook is approved.
-//
-// Deprecated: use IsHookApproved(PhasePostWorktreeCreate, hook).
-func (c *GitConfig) IsPostWorktreeCreateHookApproved(hook string) bool {
-	return c.IsHookApproved(PhasePostWorktreeCreate, hook)
-}
-
-// AddApprovedPostWorktreeCreateHook adds a hook to the approved list.
-//
-// Deprecated: use AddApprovedHook(PhasePostWorktreeCreate, hook).
-func (c *GitConfig) AddApprovedPostWorktreeCreateHook(hook string) error {
-	return c.AddApprovedHook(PhasePostWorktreeCreate, hook)
-}
-
-// RemoveApprovedPostWorktreeCreateHook removes a hook from the approved list.
-//
-// Deprecated: use RemoveApprovedHook(PhasePostWorktreeCreate, hook).
-func (c *GitConfig) RemoveApprovedPostWorktreeCreateHook(hook string) error {
-	return c.RemoveApprovedHook(PhasePostWorktreeCreate, hook)
-}
-
-// ClearApprovedPostWorktreeCreateHooks removes all hook approvals.
-//
-// Deprecated: use ClearApprovedHooks(PhasePostWorktreeCreate).
-func (c *GitConfig) ClearApprovedPostWorktreeCreateHooks() error {
-	return c.ClearApprovedHooks(PhasePostWorktreeCreate)
-}
-
 // removeFromMultiKey removes a single value from a multi-value git config key
 // by reading all values, unsetting the key, and re-adding the remaining ones.
 // If the value is absent the key is left untouched. On a re-add failure the
-// original values are restored on a best-effort basis.
+// original values are restored on a best-effort basis; any errors during
+// recovery are joined into the returned error so the caller can see both the
+// primary failure and any incomplete rollback.
 func removeFromMultiKey(store *git.ConfigStore, key, value string) error {
 	current, _ := store.GetAll(key)
 	if !slices.Contains(current, value) {
@@ -524,10 +492,13 @@ func removeFromMultiKey(store *git.ConfigStore, key, value string) error {
 	}
 	for _, v := range keep {
 		if err := store.Add(key, v); err != nil {
+			recoveryErrs := []error{fmt.Errorf("failed to update %s: %w", key, err)}
 			for _, original := range current {
-				_ = store.Add(key, original)
+				if recoveryErr := store.Add(key, original); recoveryErr != nil {
+					recoveryErrs = append(recoveryErrs, fmt.Errorf("recovery: failed to restore %q: %w", original, recoveryErr))
+				}
 			}
-			return fmt.Errorf("failed to update %s, attempted recovery: %w", key, err)
+			return errors.Join(recoveryErrs...)
 		}
 	}
 	return nil

--- a/internal/config/config_git_test.go
+++ b/internal/config/config_git_test.go
@@ -328,23 +328,23 @@ func TestGitConfigApprovedHooks(t *testing.T) {
 		cfg, err := LoadGitConfig(scene.Dir)
 		require.NoError(t, err)
 
-		require.Empty(t, cfg.ApprovedPostWorktreeCreateHooks())
+		require.Empty(t, cfg.ApprovedHooks(PhasePostWorktreeCreate))
 
-		err = cfg.AddApprovedPostWorktreeCreateHook("mise trust")
+		err = cfg.AddApprovedHook(PhasePostWorktreeCreate, "mise trust")
 		require.NoError(t, err)
 
-		err = cfg.AddApprovedPostWorktreeCreateHook("npm install")
+		err = cfg.AddApprovedHook(PhasePostWorktreeCreate, "npm install")
 		require.NoError(t, err)
 
-		require.True(t, cfg.IsPostWorktreeCreateHookApproved("mise trust"))
-		require.True(t, cfg.IsPostWorktreeCreateHookApproved("npm install"))
-		require.False(t, cfg.IsPostWorktreeCreateHookApproved("other"))
+		require.True(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "mise trust"))
+		require.True(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "npm install"))
+		require.False(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "other"))
 
-		err = cfg.RemoveApprovedPostWorktreeCreateHook("mise trust")
+		err = cfg.RemoveApprovedHook(PhasePostWorktreeCreate, "mise trust")
 		require.NoError(t, err)
 
-		require.False(t, cfg.IsPostWorktreeCreateHookApproved("mise trust"))
-		require.True(t, cfg.IsPostWorktreeCreateHookApproved("npm install"))
+		require.False(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "mise trust"))
+		require.True(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "npm install"))
 	})
 
 	t.Run("clears all hooks", func(t *testing.T) {
@@ -354,16 +354,16 @@ func TestGitConfigApprovedHooks(t *testing.T) {
 		cfg, err := LoadGitConfig(scene.Dir)
 		require.NoError(t, err)
 
-		err = cfg.AddApprovedPostWorktreeCreateHook("mise trust")
+		err = cfg.AddApprovedHook(PhasePostWorktreeCreate, "mise trust")
 		require.NoError(t, err)
 
-		err = cfg.AddApprovedPostWorktreeCreateHook("npm install")
+		err = cfg.AddApprovedHook(PhasePostWorktreeCreate, "npm install")
 		require.NoError(t, err)
 
-		err = cfg.ClearApprovedPostWorktreeCreateHooks()
+		err = cfg.ClearApprovedHooks(PhasePostWorktreeCreate)
 		require.NoError(t, err)
 
-		require.Empty(t, cfg.ApprovedPostWorktreeCreateHooks())
+		require.Empty(t, cfg.ApprovedHooks(PhasePostWorktreeCreate))
 	})
 }
 
@@ -415,7 +415,7 @@ func TestMigrationFromJSON(t *testing.T) {
 		require.Equal(t, "/tmp/worktrees", cfg.WorktreeBasePath())
 		require.False(t, cfg.WorktreeAutoClean())
 		require.Equal(t, "git", cfg.SplitHunkSelector())
-		require.True(t, cfg.IsPostWorktreeCreateHookApproved("mise trust"))
+		require.True(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "mise trust"))
 
 		// Verify backup file exists
 		backupPath := filepath.Join(scene.Dir, ".git", ".stackit_config.migrated")

--- a/internal/config/interface.go
+++ b/internal/config/interface.go
@@ -50,8 +50,7 @@ type Configurer interface {
 	// Hook approvals
 	ApprovedHooks(phase string) []string
 	IsHookApproved(phase, command string) bool
-	ApprovedPostWorktreeCreateHooks() []string
-	IsPostWorktreeCreateHookApproved(hook string) bool
+	AddApprovedHook(phase, command string) error
 
 	// Deprecated methods (for backwards compatibility)
 	CombineCICommand() string

--- a/internal/config/interface.go
+++ b/internal/config/interface.go
@@ -44,6 +44,9 @@ type Configurer interface {
 	NavigationLocation() string
 	NavigationShowMerged() bool
 
+	// Project config access (.stackit.yaml). Returns nil if unloaded.
+	ProjectConfig() *ProjectConfig
+
 	// Hook approvals
 	ApprovedHooks(phase string) []string
 	IsHookApproved(phase, command string) bool

--- a/internal/config/interface.go
+++ b/internal/config/interface.go
@@ -45,6 +45,8 @@ type Configurer interface {
 	NavigationShowMerged() bool
 
 	// Hook approvals
+	ApprovedHooks(phase string) []string
+	IsHookApproved(phase, command string) bool
 	ApprovedPostWorktreeCreateHooks() []string
 	IsPostWorktreeCreateHookApproved(hook string) bool
 

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -26,7 +26,13 @@ const (
 	// KeySplitHunkSelector is the hunk selector mode for split (tui or git).
 	KeySplitHunkSelector = "stackit.split.hunkSelector"
 	// KeyApprovedHooks stores approved post-worktree-create hooks (multi-value).
+	//
+	// Deprecated: kept as a compat read-path. New approvals are written under
+	// the per-phase family KeyApprovedHookPrefix+<phase>.
 	KeyApprovedHooks = "stackit.hooks.approvedPostWorktreeCreate"
+	// KeyApprovedHookPrefix is the prefix for per-phase hook approval keys.
+	// Full key form: <prefix><phase>, e.g. "stackit.hooks.approved.pre-modify".
+	KeyApprovedHookPrefix = "stackit.hooks.approved."
 	// KeyMaxConcurrency is the maximum number of concurrent validation operations.
 	KeyMaxConcurrency = "stackit.maxConcurrency"
 	// KeyNavigationWhen controls when navigation is displayed (always/never/multiple).
@@ -108,3 +114,9 @@ const (
 
 // ValidSubmitWeb contains the allowed submit.web values.
 var ValidSubmitWeb = []string{SubmitWebAlways, SubmitWebCreated, SubmitWebNever}
+
+// Hook phase identifiers. These are the suffix used after KeyApprovedHookPrefix
+// and as the YAML key under .stackit.yaml's `hooks:` block.
+const (
+	PhasePostWorktreeCreate = "post-worktree-create"
+)

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -185,9 +185,11 @@ func migrateFromJSON(repoRoot string, store *git.ConfigStore) error {
 		}
 	}
 
-	// Migrate approved hooks
+	// Migrate approved hooks. Written under the per-phase key; the read path
+	// still understands the legacy single-key form for older repos that didn't
+	// go through this migration.
 	for _, hook := range oldConfig.ApprovedPostWorktreeCreateHooks {
-		if err := store.Add(KeyApprovedHooks, hook); err != nil {
+		if err := store.Add(KeyApprovedHookPrefix+PhasePostWorktreeCreate, hook); err != nil {
 			return fmt.Errorf("migrate approved hook: %w", err)
 		}
 	}

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -83,10 +83,27 @@ type ProjectConfig struct {
 	Navigation     NavigationConfig `yaml:"navigation,omitempty"`
 }
 
-// HooksConfig contains hook configurations
+// HooksConfig contains hook configurations.
+//
+// PostWorktreeCreate keeps its dedicated field for the legacy worktree-create
+// integration. All other phases (pre-modify, post-submit, ...) flow through
+// the inline Phases map and are matched by their kebab-case phase name.
 type HooksConfig struct {
-	// PostWorktreeCreate contains commands to run after creating a worktree
-	PostWorktreeCreate []string `yaml:"post-worktree-create"`
+	// PostWorktreeCreate contains commands to run after creating a worktree.
+	PostWorktreeCreate []string `yaml:"post-worktree-create,omitempty"`
+	// Phases captures every other hook phase under hooks: in .stackit.yaml.
+	// Keys are phase names like "pre-modify"; values are shell command lists.
+	Phases map[string][]string `yaml:",inline"`
+}
+
+// For returns the hook command list configured for the given phase, looking
+// up both the explicit field for PostWorktreeCreate and the inline Phases map.
+// Returns nil for an unknown phase.
+func (h HooksConfig) For(phase string) []string {
+	if phase == PhasePostWorktreeCreate {
+		return h.PostWorktreeCreate
+	}
+	return h.Phases[phase]
 }
 
 // knownTopLevelKeys contains all valid top-level keys in .stackit.yaml

--- a/internal/config/project_config_test.go
+++ b/internal/config/project_config_test.go
@@ -89,6 +89,57 @@ func TestLoadProjectConfig(t *testing.T) {
 	})
 }
 
+func TestHooksConfigInlinePhases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inline phase keys parse alongside explicit worktree field", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+
+		configContent := `hooks:
+  post-worktree-create:
+    - mise trust
+  pre-modify:
+    - scripts/check-review.sh
+  post-submit:
+    - scripts/notify.sh
+`
+		err := os.WriteFile(filepath.Join(tmpDir, ProjectConfigFileName), []byte(configContent), 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadProjectConfig(tmpDir)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"mise trust"}, cfg.Hooks.PostWorktreeCreate)
+		assert.Equal(t, []string{"scripts/check-review.sh"}, cfg.Hooks.Phases["pre-modify"])
+		assert.Equal(t, []string{"scripts/notify.sh"}, cfg.Hooks.Phases["post-submit"])
+
+		// For() abstracts the lookup so callers don't care which field a phase lives in.
+		assert.Equal(t, []string{"mise trust"}, cfg.Hooks.For(PhasePostWorktreeCreate))
+		assert.Equal(t, []string{"scripts/check-review.sh"}, cfg.Hooks.For("pre-modify"))
+		assert.Nil(t, cfg.Hooks.For("never-configured"))
+	})
+
+	t.Run("worktree-create does not leak into inline map", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+
+		configContent := `hooks:
+  post-worktree-create:
+    - mise trust
+`
+		err := os.WriteFile(filepath.Join(tmpDir, ProjectConfigFileName), []byte(configContent), 0600)
+		require.NoError(t, err)
+
+		cfg, err := LoadProjectConfig(tmpDir)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"mise trust"}, cfg.Hooks.PostWorktreeCreate)
+		_, present := cfg.Hooks.Phases["post-worktree-create"]
+		assert.False(t, present, "explicit field should consume the key, not the inline map")
+	})
+}
+
 func TestHasPostWorktreeCreateHooks(t *testing.T) {
 	t.Run("returns true when hooks exist", func(t *testing.T) {
 		cfg := &ProjectConfig{

--- a/internal/config/repo_config_test.go
+++ b/internal/config/repo_config_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/testhelpers"
 )
 
@@ -538,5 +539,110 @@ func TestConfigApprovedPostWorktreeCreateHooks(t *testing.T) {
 		cfg2, err := LoadConfig(scene.Dir)
 		require.NoError(t, err)
 		require.Empty(t, cfg2.ApprovedPostWorktreeCreateHooks())
+	})
+}
+
+func TestConfigApprovedHooks_GenericPhase(t *testing.T) {
+	t.Parallel()
+
+	t.Run("add and read approvals for an arbitrary phase", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+
+		require.False(t, cfg.IsHookApproved("pre-modify", "scripts/check.sh"))
+		require.NoError(t, cfg.AddApprovedHook("pre-modify", "scripts/check.sh"))
+		require.True(t, cfg.IsHookApproved("pre-modify", "scripts/check.sh"))
+
+		cfg2, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		require.Equal(t, []string{"scripts/check.sh"}, cfg2.ApprovedHooks("pre-modify"))
+	})
+
+	t.Run("approvals are scoped per phase", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+
+		require.NoError(t, cfg.AddApprovedHook("pre-modify", "shared.sh"))
+		require.True(t, cfg.IsHookApproved("pre-modify", "shared.sh"))
+		require.False(t, cfg.IsHookApproved("pre-submit", "shared.sh"))
+	})
+
+	t.Run("remove and clear work for arbitrary phases", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+
+		require.NoError(t, cfg.AddApprovedHook("pre-modify", "a"))
+		require.NoError(t, cfg.AddApprovedHook("pre-modify", "b"))
+		require.NoError(t, cfg.RemoveApprovedHook("pre-modify", "a"))
+		require.Equal(t, []string{"b"}, cfg.ApprovedHooks("pre-modify"))
+
+		require.NoError(t, cfg.ClearApprovedHooks("pre-modify"))
+		require.Empty(t, cfg.ApprovedHooks("pre-modify"))
+	})
+}
+
+func TestConfigApprovedHooks_LegacyKeyCompat(t *testing.T) {
+	t.Parallel()
+
+	t.Run("legacy key entries surface via the new generic reader", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		// Write directly to the legacy single-key form.
+		store := git.NewConfigStore(scene.Dir)
+		require.NoError(t, store.Add(KeyApprovedHooks, "legacy-only"))
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		require.Equal(t, []string{"legacy-only"}, cfg.ApprovedHooks(PhasePostWorktreeCreate))
+		require.True(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "legacy-only"))
+	})
+
+	t.Run("union of legacy + per-phase keys deduplicates", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		store := git.NewConfigStore(scene.Dir)
+		require.NoError(t, store.Add(KeyApprovedHooks, "shared"))
+		require.NoError(t, store.Add(KeyApprovedHooks, "legacy-only"))
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		require.NoError(t, cfg.AddApprovedHook(PhasePostWorktreeCreate, "shared"))
+		require.NoError(t, cfg.AddApprovedHook(PhasePostWorktreeCreate, "new-only"))
+
+		got := cfg.ApprovedHooks(PhasePostWorktreeCreate)
+		require.ElementsMatch(t, []string{"shared", "legacy-only", "new-only"}, got)
+		require.Len(t, got, 3, "shared entry should appear once even though it's in both keys")
+	})
+
+	t.Run("remove for legacy phase strips from both keys", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, nil)
+
+		store := git.NewConfigStore(scene.Dir)
+		require.NoError(t, store.Add(KeyApprovedHooks, "drop-me"))
+
+		cfg, err := LoadConfig(scene.Dir)
+		require.NoError(t, err)
+		require.NoError(t, cfg.AddApprovedHook(PhasePostWorktreeCreate, "drop-me"))
+
+		require.NoError(t, cfg.RemoveApprovedHook(PhasePostWorktreeCreate, "drop-me"))
+		require.False(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "drop-me"))
+
+		// Verify both stores are empty.
+		legacy, _ := store.GetAll(KeyApprovedHooks)
+		require.Empty(t, legacy)
+		newKey, _ := store.GetAll(KeyApprovedHookPrefix + PhasePostWorktreeCreate)
+		require.Empty(t, newKey)
 	})
 }

--- a/internal/config/repo_config_test.go
+++ b/internal/config/repo_config_test.go
@@ -401,145 +401,28 @@ func TestConfigSetCITimeout(t *testing.T) {
 	})
 }
 
-func TestConfigApprovedPostWorktreeCreateHooks(t *testing.T) {
+func TestConfigApprovedHooks_LegacyJSONMigration(t *testing.T) {
 	t.Parallel()
 
-	t.Run("returns empty list when nothing configured", func(t *testing.T) {
-		t.Parallel()
-		scene := testhelpers.NewSceneParallel(t, nil)
+	// Legacy .stackit_config JSON files predate per-phase git config keys.
+	// The migration path must surface ApprovedPostWorktreeCreateHooks under
+	// the new per-phase API so older repos keep working.
+	scene := testhelpers.NewSceneParallel(t, nil)
 
-		cfg, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-		require.Empty(t, cfg.ApprovedPostWorktreeCreateHooks())
-	})
+	configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
+	legacy := &RepoConfig{
+		Trunk:                           new("main"),
+		ApprovedPostWorktreeCreateHooks: []string{"mise trust", "npm install"},
+	}
+	configJSON, err := json.MarshalIndent(legacy, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configPath, configJSON, 0600))
 
-	t.Run("returns approved hooks when configured", func(t *testing.T) {
-		t.Parallel()
-		scene := testhelpers.NewSceneParallel(t, nil)
-
-		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
-		config := &RepoConfig{
-			Trunk:                           new("main"),
-			ApprovedPostWorktreeCreateHooks: []string{"mise trust", "npm install"},
-		}
-		configJSON, err := json.MarshalIndent(config, "", "  ")
-		require.NoError(t, err)
-		err = os.WriteFile(configPath, configJSON, 0600)
-		require.NoError(t, err)
-
-		cfg, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-		require.Equal(t, []string{"mise trust", "npm install"}, cfg.ApprovedPostWorktreeCreateHooks())
-	})
-
-	t.Run("IsPostWorktreeCreateHookApproved returns true for approved hook", func(t *testing.T) {
-		t.Parallel()
-		scene := testhelpers.NewSceneParallel(t, nil)
-
-		configPath := filepath.Join(scene.Dir, ".git", ".stackit_config")
-		config := &RepoConfig{
-			Trunk:                           new("main"),
-			ApprovedPostWorktreeCreateHooks: []string{"mise trust"},
-		}
-		configJSON, err := json.MarshalIndent(config, "", "  ")
-		require.NoError(t, err)
-		err = os.WriteFile(configPath, configJSON, 0600)
-		require.NoError(t, err)
-
-		cfg, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-		require.True(t, cfg.IsPostWorktreeCreateHookApproved("mise trust"))
-		require.False(t, cfg.IsPostWorktreeCreateHookApproved("npm install"))
-	})
-
-	t.Run("AddApprovedPostWorktreeCreateHook adds new hook", func(t *testing.T) {
-		t.Parallel()
-		scene := testhelpers.NewSceneParallel(t, nil)
-
-		cfg, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-		require.False(t, cfg.IsPostWorktreeCreateHookApproved("mise trust"))
-
-		err = cfg.AddApprovedPostWorktreeCreateHook("mise trust")
-		require.NoError(t, err)
-		require.True(t, cfg.IsPostWorktreeCreateHookApproved("mise trust"))
-
-		// Reload to verify persistence (git config writes are immediate)
-		cfg2, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-		require.True(t, cfg2.IsPostWorktreeCreateHookApproved("mise trust"))
-	})
-
-	t.Run("AddApprovedPostWorktreeCreateHook does not duplicate", func(t *testing.T) {
-		t.Parallel()
-		scene := testhelpers.NewSceneParallel(t, nil)
-
-		cfg, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-
-		err = cfg.AddApprovedPostWorktreeCreateHook("mise trust")
-		require.NoError(t, err)
-		err = cfg.AddApprovedPostWorktreeCreateHook("mise trust") // Add again - should be no-op
-		require.NoError(t, err)
-		require.Len(t, cfg.ApprovedPostWorktreeCreateHooks(), 1)
-	})
-
-	t.Run("RemoveApprovedPostWorktreeCreateHook removes existing hook", func(t *testing.T) {
-		t.Parallel()
-		scene := testhelpers.NewSceneParallel(t, nil)
-
-		cfg, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-
-		err = cfg.AddApprovedPostWorktreeCreateHook("mise trust")
-		require.NoError(t, err)
-		err = cfg.AddApprovedPostWorktreeCreateHook("npm install")
-		require.NoError(t, err)
-		require.Len(t, cfg.ApprovedPostWorktreeCreateHooks(), 2)
-
-		err = cfg.RemoveApprovedPostWorktreeCreateHook("mise trust")
-		require.NoError(t, err)
-		require.Len(t, cfg.ApprovedPostWorktreeCreateHooks(), 1)
-		require.False(t, cfg.IsPostWorktreeCreateHookApproved("mise trust"))
-		require.True(t, cfg.IsPostWorktreeCreateHookApproved("npm install"))
-	})
-
-	t.Run("RemoveApprovedPostWorktreeCreateHook handles non-existent hook", func(t *testing.T) {
-		t.Parallel()
-		scene := testhelpers.NewSceneParallel(t, nil)
-
-		cfg, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-
-		err = cfg.AddApprovedPostWorktreeCreateHook("mise trust")
-		require.NoError(t, err)
-		err = cfg.RemoveApprovedPostWorktreeCreateHook("non-existent") // Should not error
-		require.NoError(t, err)
-		require.Len(t, cfg.ApprovedPostWorktreeCreateHooks(), 1)
-	})
-
-	t.Run("ClearApprovedPostWorktreeCreateHooks removes all hooks", func(t *testing.T) {
-		t.Parallel()
-		scene := testhelpers.NewSceneParallel(t, nil)
-
-		cfg, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-
-		err = cfg.AddApprovedPostWorktreeCreateHook("mise trust")
-		require.NoError(t, err)
-		err = cfg.AddApprovedPostWorktreeCreateHook("npm install")
-		require.NoError(t, err)
-		require.Len(t, cfg.ApprovedPostWorktreeCreateHooks(), 2)
-
-		err = cfg.ClearApprovedPostWorktreeCreateHooks()
-		require.NoError(t, err)
-		require.Empty(t, cfg.ApprovedPostWorktreeCreateHooks())
-
-		// Verify persistence by reloading
-		cfg2, err := LoadConfig(scene.Dir)
-		require.NoError(t, err)
-		require.Empty(t, cfg2.ApprovedPostWorktreeCreateHooks())
-	})
+	cfg, err := LoadConfig(scene.Dir)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"mise trust", "npm install"}, cfg.ApprovedHooks(PhasePostWorktreeCreate))
+	require.True(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "mise trust"))
+	require.False(t, cfg.IsHookApproved(PhasePostWorktreeCreate, "never-approved"))
 }
 
 func TestConfigApprovedHooks_GenericPhase(t *testing.T) {

--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -1,0 +1,39 @@
+// Package hooks executes user-defined hook commands with a timeout and
+// optional environment-variable injection. It is shared between
+// worktree-create hooks and (future) command lifecycle hooks.
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// DefaultTimeout is the maximum duration a hook can run before being killed.
+const DefaultTimeout = 60 * time.Second
+
+// Run executes a single hook command via `sh -c`.
+//
+// dir sets the working directory for the spawned process. env, if non-empty,
+// is appended to os.Environ() for the process. stdout/stderr are inherited
+// from the current process so hook output reaches the user.
+func Run(ctx context.Context, command, dir string, env []string, timeout time.Duration) error {
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, "sh", "-c", command)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
+
+	err := cmd.Run()
+	if runCtx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("timed out after %s", timeout)
+	}
+	return err
+}

--- a/internal/hooks/runner_test.go
+++ b/internal/hooks/runner_test.go
@@ -1,0 +1,61 @@
+package hooks_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/getstackit/stackit/internal/hooks"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun_Success(t *testing.T) {
+	t.Parallel()
+	err := hooks.Run(context.Background(), "true", t.TempDir(), nil, time.Second)
+	require.NoError(t, err)
+}
+
+func TestRun_NonZeroExit(t *testing.T) {
+	t.Parallel()
+	err := hooks.Run(context.Background(), "exit 7", t.TempDir(), nil, time.Second)
+	require.Error(t, err)
+}
+
+func TestRun_Timeout(t *testing.T) {
+	t.Parallel()
+	err := hooks.Run(context.Background(), "sleep 5", t.TempDir(), nil, 50*time.Millisecond)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timed out")
+}
+
+func TestRun_EnvInjection(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	err := hooks.Run(
+		context.Background(),
+		`test "$STACKIT_TEST_VAR" = "hello"`,
+		dir,
+		[]string{"STACKIT_TEST_VAR=hello"},
+		time.Second,
+	)
+	require.NoError(t, err)
+}
+
+func TestRun_WorkingDirectory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	err := hooks.Run(
+		context.Background(),
+		// `pwd -P` resolves symlinks (macOS uses /private/var symlink for /tmp).
+		`test "$(pwd -P)" = "$(cd `+shellQuote(dir)+` && pwd -P)"`,
+		dir,
+		nil,
+		time.Second,
+	)
+	require.NoError(t, err)
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/integration/lifecycle_hooks_test.go
+++ b/internal/integration/lifecycle_hooks_test.go
@@ -1,0 +1,73 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLifecycleHooks_PreModifyBlocks(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t)
+
+	sh.WriteFile("seed.txt", "seed").Run("create feature -m 'feat: seed'")
+
+	writeProjectConfig(t, sh.Dir(), `hooks:
+  pre-modify:
+    - "false"
+`)
+	// Pre-approve so the hook runs without an interactive prompt.
+	sh.Git("config --add stackit.hooks.approved.pre-modify false")
+
+	sh.WriteFile("seed.txt", "updated")
+	sh.RunExpectError("modify -a")
+	require.Contains(t, sh.lastOutput, "Running hook: false", "hook should be invoked")
+	require.Contains(t, sh.lastOutput, "hook \"false\" failed", "hook failure should be reported")
+}
+
+func TestLifecycleHooks_NoVerifyBypasses(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t)
+
+	sh.WriteFile("seed.txt", "seed").Run("create feature -m 'feat: seed'")
+
+	writeProjectConfig(t, sh.Dir(), `hooks:
+  pre-modify:
+    - "false"
+`)
+	sh.Git("config --add stackit.hooks.approved.pre-modify false")
+
+	sh.WriteFile("seed.txt", "updated")
+	sh.Run("--no-verify modify -a")
+	require.NotContains(t, sh.lastOutput, "Running hook:", "no hook should run with --no-verify")
+}
+
+func TestLifecycleHooks_ZeroCostWhenUnconfigured(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t)
+
+	// No .stackit.yaml hooks section at all.
+	sh.WriteFile("seed.txt", "seed").Run("create feature -m 'feat: seed'")
+	sh.WriteFile("seed.txt", "updated")
+	sh.Run("modify -a")
+
+	require.NotContains(t, sh.lastOutput, "Running hook:", "no hook lines should appear when nothing is configured")
+}
+
+func TestLifecycleHooks_PostHookFailureIsWarning(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t)
+
+	sh.WriteFile("seed.txt", "seed").Run("create feature -m 'feat: seed'")
+
+	writeProjectConfig(t, sh.Dir(), `hooks:
+  post-modify:
+    - "false"
+`)
+	sh.Git("config --add stackit.hooks.approved.post-modify false")
+
+	sh.WriteFile("seed.txt", "updated")
+	// Modify still succeeds; post-hook failure is surfaced as a warning, not blocking.
+	sh.Run("modify -a")
+	require.Contains(t, sh.lastOutput, "Hook failed: false", "post-hook failure should be warned")
+}


### PR DESCRIPTION
**Add pre/post command lifecycle hooks with per-phase approval**

Adds configurable pre- and post-command lifecycle hooks to stackit. Users can define shell commands that run before or after any stackit subcommand, gated behind a per-user approval flow that persists approved commands to user config.

Key changes:
- **extract-shared-runner**: Moves the hook execution engine out of worktree-specific code into `internal/hooks/runner.go`, making it reusable across all hook sites
- **generalize-hook-approval-keys**: Generalizes config approval storage from worktree-scoped keys to per-phase family keys (`IsHookApproved`/`AddApprovedHook`), enabling fine-grained approval tracking for any lifecycle phase
- **add-lifecycle-hooks**: Adds `hooks.ResolveApproved` action (approval gate + runner facade in `internal/actions/hooks/`) and `RunCommandHooks` cobra middleware that fires configured hooks before/after any command; phase keys follow the pattern `pre-<command>` / `post-<command>`
- **document-lifecycle-phases**: New `docs/hooks.md` covering phase naming, env vars, configuration examples, and recipes
- **tighten-resolve-API**: Cleans up the resolve API, drops deprecated config wrapper functions, and adds unit tests for `ResolveApproved` and config approval logic

This PR merges the following changes:

1. **#1049** refactor(hooks): extract shared runner from worktree hooks
2. **#1050** refactor(config): generalize hook approval keys to per-phase family
3. **#1051** feat(hooks): add pre/post command lifecycle hooks
4. **#1052** docs(hooks): document lifecycle phases, env vars, and recipes
5. **#1053** refactor(hooks): tighten resolve API + drop deprecated wrappers

### Stack

```
main
  └─ jonnii/20260527235542/extract-shared-runner-from-worktree-hooks (#1049)
    └─ jonnii/20260528000130/generalize-hook-approval-keys-to-per-phase-family (#1050)
      └─ jonnii/20260528001517/add-pre/post-command-lifecycle-hooks (#1051)
        └─ jonnii/20260528001700/document-lifecycle-phases-env-vars-and-recipes (#1052)
          └─ jonnii/20260528011237/tighten-resolve-API-drop-deprecated-wrappers (#1053)
```

Stackit-Stack-Size: 5
Stackit-PRs: 1049,1050,1051,1052,1053
