### PR TITLE
refactor: eliminate duplicate CreatePullRequest logic and fix silent error swallowing

### DIFF
--- a/internal/github/client_real.go
+++ b/internal/github/client_real.go
@@ -51,52 +51,11 @@ func (c *StackitGitHubClient) GetOwnerRepo() (string, string) {
 
 // CreatePullRequest creates a new pull request
 func (c *StackitGitHubClient) CreatePullRequest(ctx context.Context, owner, repo string, opts CreatePROptions) (*PullRequestInfo, error) {
-	pr := &github.NewPullRequest{
-		Title: new(opts.Title),
-		Head:  new(opts.Head),
-		Base:  new(opts.Base),
-		Draft: new(opts.Draft),
-	}
-
-	if opts.Body != "" {
-		pr.Body = new(opts.Body)
-	}
-
-	createdPR, _, err := c.client.PullRequests.Create(ctx, owner, repo, pr)
+	warnings, createdPR, err := CreatePullRequest(ctx, c.client, owner, repo, opts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create pull request: %w", err)
+		return nil, err
 	}
-
 	result := ToPullRequestInfo(createdPR)
-	var warnings []string
-
-	// Add reviewers if specified
-	if len(opts.Reviewers) > 0 || len(opts.TeamReviewers) > 0 {
-		_, _, err := c.client.PullRequests.RequestReviewers(ctx, owner, repo, *createdPR.Number, github.ReviewersRequest{
-			Reviewers:     opts.Reviewers,
-			TeamReviewers: opts.TeamReviewers,
-		})
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to add reviewers: %v", err))
-		}
-	}
-
-	// Add labels if specified
-	if len(opts.Labels) > 0 {
-		_, _, err := c.client.Issues.AddLabelsToIssue(ctx, owner, repo, *createdPR.Number, opts.Labels)
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to add labels: %v", err))
-		}
-	}
-
-	// Add assignees if specified
-	if len(opts.Assignees) > 0 {
-		_, _, err := c.client.Issues.AddAssignees(ctx, owner, repo, *createdPR.Number, opts.Assignees)
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to add assignees: %v", err))
-		}
-	}
-
 	result.Warnings = warnings
 	return result, nil
 }

--- a/internal/github/pr_operations.go
+++ b/internal/github/pr_operations.go
@@ -54,8 +54,10 @@ type UpdatePROptions struct {
 	RerequestReview bool
 }
 
-// CreatePullRequest creates a new pull request
-func CreatePullRequest(ctx context.Context, client *github.Client, owner, repo string, opts CreatePROptions) (*github.PullRequest, error) {
+// CreatePullRequest creates a new pull request.
+// Returns warnings (non-fatal issues like failed label/assignee additions) and error,
+// matching the same contract as UpdatePullRequest.
+func CreatePullRequest(ctx context.Context, client *github.Client, owner, repo string, opts CreatePROptions) ([]string, *github.PullRequest, error) {
 	pr := &github.NewPullRequest{
 		Title: new(opts.Title),
 		Head:  new(opts.Head),
@@ -69,28 +71,39 @@ func CreatePullRequest(ctx context.Context, client *github.Client, owner, repo s
 
 	createdPR, _, err := client.PullRequests.Create(ctx, owner, repo, pr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create pull request: %w", err)
+		return nil, nil, fmt.Errorf("failed to create pull request: %w", err)
 	}
+
+	var warnings []string
 
 	// Add reviewers if specified
 	if len(opts.Reviewers) > 0 || len(opts.TeamReviewers) > 0 {
-		_, _, _ = client.PullRequests.RequestReviewers(ctx, owner, repo, *createdPR.Number, github.ReviewersRequest{
+		_, _, err := client.PullRequests.RequestReviewers(ctx, owner, repo, *createdPR.Number, github.ReviewersRequest{
 			Reviewers:     opts.Reviewers,
 			TeamReviewers: opts.TeamReviewers,
 		})
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("failed to add reviewers: %v", err))
+		}
 	}
 
 	// Add labels if specified
 	if len(opts.Labels) > 0 {
-		_, _, _ = client.Issues.AddLabelsToIssue(ctx, owner, repo, *createdPR.Number, opts.Labels)
+		_, _, err := client.Issues.AddLabelsToIssue(ctx, owner, repo, *createdPR.Number, opts.Labels)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("failed to add labels: %v", err))
+		}
 	}
 
 	// Add assignees if specified
 	if len(opts.Assignees) > 0 {
-		_, _, _ = client.Issues.AddAssignees(ctx, owner, repo, *createdPR.Number, opts.Assignees)
+		_, _, err := client.Issues.AddAssignees(ctx, owner, repo, *createdPR.Number, opts.Assignees)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("failed to add assignees: %v", err))
+		}
 	}
 
-	return createdPR, nil
+	return warnings, createdPR, nil
 }
 
 // UpdatePullRequest updates an existing pull request

--- a/internal/github/pr_operations_test.go
+++ b/internal/github/pr_operations_test.go
@@ -24,7 +24,7 @@ func TestCreatePullRequest(t *testing.T) {
 			Draft: false,
 		}
 
-		pr, err := githubpkg.CreatePullRequest(context.Background(), client, owner, repo, opts)
+		_, pr, err := githubpkg.CreatePullRequest(context.Background(), client, owner, repo, opts)
 		require.NoError(t, err)
 		require.NotNil(t, pr)
 		require.NotNil(t, pr.Number)
@@ -48,7 +48,7 @@ func TestCreatePullRequest(t *testing.T) {
 			Draft: true,
 		}
 
-		pr, err := githubpkg.CreatePullRequest(context.Background(), client, owner, repo, opts)
+		_, pr, err := githubpkg.CreatePullRequest(context.Background(), client, owner, repo, opts)
 		require.NoError(t, err)
 		require.NotNil(t, pr)
 		require.True(t, *pr.Draft)
@@ -65,7 +65,7 @@ func TestCreatePullRequest(t *testing.T) {
 			Reviewers: []string{"reviewer1", "reviewer2"},
 		}
 
-		pr, err := githubpkg.CreatePullRequest(context.Background(), client, owner, repo, opts)
+		_, pr, err := githubpkg.CreatePullRequest(context.Background(), client, owner, repo, opts)
 		require.NoError(t, err)
 		require.NotNil(t, pr)
 		// Reviewers are requested (non-fatal if it fails, so we just check PR was created)
@@ -83,7 +83,7 @@ func TestCreatePullRequest(t *testing.T) {
 			TeamReviewers: []string{"team1", "team2"},
 		}
 
-		pr, err := githubpkg.CreatePullRequest(context.Background(), client, owner, repo, opts)
+		_, pr, err := githubpkg.CreatePullRequest(context.Background(), client, owner, repo, opts)
 		require.NoError(t, err)
 		require.NotNil(t, pr)
 		require.NotNil(t, pr.Number)
@@ -102,7 +102,7 @@ func TestUpdatePullRequest(t *testing.T) {
 			Head:  "feature-branch",
 			Base:  "main",
 		}
-		createdPR, err := githubpkg.CreatePullRequest(context.Background(), client, owner, repo, createOpts)
+		_, createdPR, err := githubpkg.CreatePullRequest(context.Background(), client, owner, repo, createOpts)
 		require.NoError(t, err)
 		require.NotNil(t, createdPR.Number)
 
@@ -134,7 +134,7 @@ func TestUpdatePullRequest(t *testing.T) {
 			Head:  "feature-branch",
 			Base:  "main",
 		}
-		createdPR, err := githubpkg.CreatePullRequest(context.Background(), client, owner, repo, createOpts)
+		_, createdPR, err := githubpkg.CreatePullRequest(context.Background(), client, owner, repo, createOpts)
 		require.NoError(t, err)
 
 		// Update base branch
@@ -167,7 +167,7 @@ func TestUpdatePullRequest(t *testing.T) {
 			Head:  "feature-branch",
 			Base:  "main",
 		}
-		createdPR, err := githubpkg.CreatePullRequest(context.Background(), client, owner, repo, createOpts)
+		_, createdPR, err := githubpkg.CreatePullRequest(context.Background(), client, owner, repo, createOpts)
 		require.NoError(t, err)
 
 		// Update with reviewers
@@ -192,7 +192,7 @@ func TestGetPullRequestByBranch(t *testing.T) {
 			Head:  branchName,
 			Base:  "main",
 		}
-		createdPR, err := githubpkg.CreatePullRequest(context.Background(), client, owner, repo, createOpts)
+		_, createdPR, err := githubpkg.CreatePullRequest(context.Background(), client, owner, repo, createOpts)
 		require.NoError(t, err)
 
 		// Get PR by branch


### PR DESCRIPTION
## Summary

- `CreatePullRequest` in `client_real.go` duplicated ~40 lines of PR creation logic from `pr_operations.go` instead of delegating like `UpdatePullRequest` already does
- The standalone function in `pr_operations.go` silently swallowed errors from reviewer/label/assignee API calls with `_, _, _ =`, making failures invisible to callers
- Updated `CreatePullRequest` to return `([]string, *github.PullRequest, error)` matching the `UpdatePullRequest` warning contract, then collapsed the client method to 4 lines of delegation

## Test plan

- [ ] `go test ./internal/github/...` passes (all `TestCreatePullRequest` subtests green)
- [ ] `go test ./internal/actions/submit/...` passes
- [ ] `go build ./...` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_018sKVqTtTq3kkygBnJMNB5Z)_