### PR TITLE
feat: prompt for stack description on multi-PR ship

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -35,6 +35,7 @@ command path without the leading `stackit `, joined by hyphens.
 | `stackit modify` | `pre-modify` | `post-modify` |
 | `stackit submit` | `pre-submit` | `post-submit` |
 | `stackit absorb` | `pre-absorb` | `post-absorb` |
+| `stackit merge ship` | `pre-merge-ship` | `post-merge-ship` |
 | `stackit worktree create` | — | `post-worktree-create` |
 
 Every command that goes through `common.Run` participates in the lifecycle —
@@ -159,6 +160,84 @@ hooks:
   pre-submit:
     - "mise run lint"
 ```
+
+### Auto-generate a stack description before shipping
+
+When `stackit merge ship` runs on a stack with more than one PR that has no
+description, it prompts you to add a title (see
+[Stack Description Prompt](shipping.md#stack-description-prompt)). A
+`pre-merge-ship` hook can fill that description in automatically before the
+consolidation PR is created. Because the hook runs *before* the ship checks for
+a description, setting one in the hook means the interactive prompt is skipped.
+
+**Simple: derive a title from the existing PRs**
+
+```yaml
+hooks:
+  pre-merge-ship:
+    - "scripts/auto-describe.sh"
+```
+
+```sh
+#!/bin/sh
+# scripts/auto-describe.sh
+# Generates a stack description using the GitHub CLI, then applies it with
+# 'stackit describe'.
+set -e
+
+if [ -z "$STACKIT_BRANCH" ]; then
+  exit 0
+fi
+
+# Example: generate a title from the PR titles in the stack
+title=$(gh pr list --head "$STACKIT_BRANCH" --json title --jq '.[0].title' 2>/dev/null || true)
+if [ -n "$title" ]; then
+  stackit describe -m "$title"
+fi
+```
+
+**Smarter: let Claude Code describe the stack**
+
+Stackit ships a `/stack-describe` command for Claude Code (installed via
+`stackit agent install`) that analyzes every branch's commits and diffs,
+generates a title and a structured description, and applies it with
+`stackit describe`. A `pre-merge-ship` hook can run it headlessly so the
+consolidation PR gets a high-quality, AI-written summary with no manual step.
+
+```yaml
+hooks:
+  pre-merge-ship:
+    - "scripts/claude-describe.sh"
+```
+
+```sh
+#!/bin/sh
+# scripts/claude-describe.sh
+# Asks Claude Code to generate and apply a stack description via the
+# /stack-describe command. Requires the `claude` CLI to be installed and
+# authenticated, and the stackit agent commands installed
+# (`stackit agent install`).
+set -e
+
+# Only describe stacks that don't already have one (avoids spending tokens on
+# stacks you've already described by hand). `describe --show` prints a "no
+# description set" line when the stack is undescribed.
+if ! stackit describe --show --no-interactive 2>/dev/null | grep -qi "no description set"; then
+  exit 0
+fi
+
+# Skip gracefully if the CLI isn't available (e.g. in CI).
+command -v claude >/dev/null 2>&1 || exit 0
+
+# Run the slash command non-interactively. The hook is an automated context, so
+# pre-approve the tools /stack-describe needs instead of prompting.
+claude -p "/stack-describe" \
+  --allowedTools "Bash(stackit:*)" "Bash(git:*)" "Read" "Glob" "Grep"
+```
+
+> Tip: the hook runs from the repo root with `STACKIT_BRANCH` and the other
+> `STACKIT_*` variables set, so the same script also works as a `pre-submit`
+> hook if you prefer to describe stacks when first opening PRs.
 
 ### Send a notification after a successful merge
 

--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -119,6 +119,30 @@ stackit merge ship
 - All-or-nothing deployment semantics
 - Features that must ship together
 
+#### Stack Description Prompt
+
+When shipping a stack with **more than one PR** that has no stack description
+set, `merge ship` prompts you to add a title before the consolidation PR is
+created. The consolidation PR uses the stack title/description for its own
+title and body, so setting one keeps the merged PR readable.
+
+- **Interactive:** you are asked `Add a title for this stack now?`. Entering a
+  title stores it via `stackit describe` semantics; declining or leaving it
+  blank proceeds without a description.
+- **Non-interactive or `--yes`:** a warning is printed
+  (`Run 'stackit describe' to add one.`) and the ship continues unblocked, so
+  CI flows are unaffected.
+
+The prompt is best-effort — cancelling it never aborts the ship.
+
+To skip the prompt entirely, either set a description ahead of time with
+`stackit describe`, or automate it with a `pre-merge-ship` hook. Because the
+hook runs before the ship checks for a description, a hook that sets one causes
+the prompt to be skipped automatically. See
+[Auto-generate a stack description before shipping](hooks.md#auto-generate-a-stack-description-before-shipping)
+in the hooks guide — including an example that uses Claude Code's
+`/stack-describe` command.
+
 ### Octopus Merge
 
 The consolidation strategy uses Git's octopus merge feature. Unlike squashing, octopus merge:

--- a/internal/cli/stack/merge/merge_test.go
+++ b/internal/cli/stack/merge/merge_test.go
@@ -7,7 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	mergeAction "github.com/getstackit/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/tui"
 	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
@@ -244,6 +246,122 @@ func TestMergeNextUsesCreateMergePlan(t *testing.T) {
 		require.NotEmpty(t, plan.BranchesToMerge)
 		require.Equal(t, "branch-a", plan.BranchesToMerge[0].BranchName)
 		require.Equal(t, 101, plan.BranchesToMerge[0].PRNumber)
+	})
+}
+
+// stubConfirm replaces tui.PromptConfirm for the duration of a test and
+// restores it on cleanup.
+func stubConfirm(t *testing.T, answer bool) {
+	t.Helper()
+	orig := tui.PromptConfirm
+	tui.PromptConfirm = func(string, bool) (bool, error) { return answer, nil }
+	t.Cleanup(func() { tui.PromptConfirm = orig })
+}
+
+// stubTextInput replaces tui.PromptTextInput for the duration of a test and
+// restores it on cleanup.
+func stubTextInput(t *testing.T, value string) {
+	t.Helper()
+	orig := tui.PromptTextInput
+	tui.PromptTextInput = func(string, string) (string, error) { return value, nil }
+	t.Cleanup(func() { tui.PromptTextInput = orig })
+}
+
+// TestPromptForShipDescription is not parallel: its subtests stub the
+// package-level tui.PromptConfirm/PromptTextInput vars, so they must run
+// sequentially to avoid racing on that shared state.
+func TestPromptForShipDescription(t *testing.T) {
+	newStack := func(t *testing.T) *scenario.Scenario {
+		t.Helper()
+		return scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"branch-a": "main",
+				"branch-b": "branch-a",
+			})
+	}
+
+	branches := []mergeAction.BranchMergeInfo{
+		{BranchName: "branch-a", PRNumber: 101},
+		{BranchName: "branch-b", PRNumber: 102},
+	}
+
+	t.Run("no-op for empty branch list", func(t *testing.T) {
+		s := newStack(t)
+
+		promptForShipDescription(s.Context, nil, false)
+		require.Empty(t, s.Output.String())
+	})
+
+	t.Run("skips silently when a description is already set", func(t *testing.T) {
+		s := newStack(t)
+		require.NoError(t, s.Engine.SetStackDescription(context.Background(),
+			s.Engine.GetBranch("branch-a"),
+			&git.StackDescription{Title: "Existing title"}))
+
+		// PromptConfirm should never be reached when a description exists.
+		orig := tui.PromptConfirm
+		tui.PromptConfirm = func(string, bool) (bool, error) {
+			t.Fatal("should not prompt when description exists")
+			return false, nil
+		}
+		t.Cleanup(func() { tui.PromptConfirm = orig })
+
+		promptForShipDescription(s.Context, branches, false)
+		require.Empty(t, s.Output.String())
+	})
+
+	t.Run("warns and continues in non-interactive mode", func(t *testing.T) {
+		s := newStack(t)
+		s.Context.Interactive = false
+
+		promptForShipDescription(s.Context, branches, false)
+		require.Contains(t, s.Output.String(), "2 PRs")
+		require.Contains(t, s.Output.String(), "stackit describe")
+
+		// No description should have been set.
+		require.Nil(t, s.Engine.GetStackDescription(s.Engine.GetBranch("branch-a")))
+	})
+
+	t.Run("warns and continues when --yes skips the prompt", func(t *testing.T) {
+		s := newStack(t)
+		s.Context.Interactive = true
+
+		promptForShipDescription(s.Context, branches, true)
+		require.Contains(t, s.Output.String(), "stackit describe")
+		require.Nil(t, s.Engine.GetStackDescription(s.Engine.GetBranch("branch-a")))
+	})
+
+	t.Run("does not set a description when the user declines", func(t *testing.T) {
+		s := newStack(t)
+		s.Context.Interactive = true
+		stubConfirm(t, false)
+
+		promptForShipDescription(s.Context, branches, false)
+		require.Nil(t, s.Engine.GetStackDescription(s.Engine.GetBranch("branch-a")))
+	})
+
+	t.Run("sets the description from the entered title", func(t *testing.T) {
+		s := newStack(t)
+		s.Context.Interactive = true
+		stubConfirm(t, true)
+		stubTextInput(t, "  My stack title  ")
+
+		promptForShipDescription(s.Context, branches, false)
+
+		desc := s.Engine.GetStackDescription(s.Engine.GetBranch("branch-a"))
+		require.NotNil(t, desc)
+		require.Equal(t, "My stack title", desc.Title)
+		require.Contains(t, s.Output.String(), "My stack title")
+	})
+
+	t.Run("does not set a description for a blank title", func(t *testing.T) {
+		s := newStack(t)
+		s.Context.Interactive = true
+		stubConfirm(t, true)
+		stubTextInput(t, "   ")
+
+		promptForShipDescription(s.Context, branches, false)
+		require.Nil(t, s.Engine.GetStackDescription(s.Engine.GetBranch("branch-a")))
 	})
 }
 

--- a/internal/cli/stack/merge/ship.go
+++ b/internal/cli/stack/merge/ship.go
@@ -3,6 +3,7 @@ package merge
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/cli/common"
 	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/github"
 	"github.com/getstackit/stackit/internal/tui"
 )
@@ -149,6 +151,12 @@ func runMergeShip(ctx *app.Context, opts mergeShipOptions, postMergeHandler Post
 		return err
 	}
 
+	// Prompt for a stack description on multi-PR stacks that have none set.
+	// Best-effort: a failure here never blocks the ship.
+	if len(plan.BranchesToMerge) > 1 {
+		promptForShipDescription(ctx, plan.BranchesToMerge, opts.yes)
+	}
+
 	// Confirm unless --yes
 	if !opts.yes && ctx.Interactive {
 		confirmed, err := tui.PromptConfirm("Proceed with ship merge?", false)
@@ -204,6 +212,48 @@ func runMergeShip(ctx *app.Context, opts mergeShipOptions, postMergeHandler Post
 	}
 
 	return nil
+}
+
+// promptForShipDescription checks whether the stack has a description and, when
+// interactive and not skipped via --yes, prompts the user to set one. For
+// non-interactive or --yes invocations it prints a warning and continues.
+//
+// This is best-effort: any prompt cancellation or failure is treated as
+// "leave the description unset" and never blocks the ship.
+func promptForShipDescription(ctx *app.Context, branches []mergeAction.BranchMergeInfo, skipPrompt bool) {
+	out := ctx.Output
+	if len(branches) == 0 {
+		return
+	}
+
+	rootBranch := ctx.Engine.GetBranch(branches[0].BranchName)
+	desc := ctx.Engine.GetStackDescription(rootBranch)
+	if desc != nil && !desc.IsEmpty() {
+		return
+	}
+
+	if !ctx.Interactive || skipPrompt {
+		out.Warn("Stack has %d PRs but no description is set. Run 'stackit describe' to add one.", len(branches))
+		return
+	}
+
+	out.Warn("This stack has %d PRs but no description is set.", len(branches))
+	addDesc, err := tui.PromptConfirm("Add a title for this stack now?", true)
+	if err != nil || !addDesc {
+		return
+	}
+
+	title, err := tui.PromptTextInput("Stack title:", "")
+	if err != nil || strings.TrimSpace(title) == "" {
+		return
+	}
+
+	newDesc := &git.StackDescription{Title: strings.TrimSpace(title)}
+	if err := ctx.Engine.SetStackDescription(ctx.Context, rootBranch, newDesc); err != nil {
+		out.Warn("Failed to set stack description: %v", err)
+	} else {
+		out.Info("Set stack title: %s", newDesc.Title)
+	}
 }
 
 func runMultiStackShip(ctx *app.Context, opts shipMultiStackOptions) error {

--- a/internal/tui/prompts.go
+++ b/internal/tui/prompts.go
@@ -248,8 +248,9 @@ func NewConfirmModel(prompt string, defaultValue bool) tea.Model {
 	}
 }
 
-// PromptTextInput prompts the user for text input
-func PromptTextInput(prompt, defaultValue string) (string, error) {
+// PromptTextInput prompts the user for text input. It is a var so tests can
+// stub it, mirroring PromptConfirm.
+var PromptTextInput = func(prompt, defaultValue string) (string, error) {
 	if err := CheckInteractiveAllowed(); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary

Closes #1065

- When `st merge ship` is run on a stack with **more than one PR** and no description is set, the user is now interactively prompted to add a title before the final confirmation
- In non-interactive mode (or when `--yes` is passed) a warning is printed instead, so CI/automation flows are unaffected
- Documents the `pre-merge-ship` / `post-merge-ship` hook phases in `docs/hooks.md`, with a recipe showing how to auto-generate descriptions using an agent before the consolidation PR is created

## How it works

The description prompt is inserted in `runMergeShip()` after the GitHub client is confirmed available and before the confirmation prompt:

1. Checks `len(plan.BranchesToMerge) > 1` — only triggers on multi-PR stacks
2. Reads the stack description from the engine; skips if one is already set
3. Interactive: warns and offers "Add a title for this stack now?" with a text input
4. Non-interactive / `--yes`: warns with a tip to run `stackit describe`

Because `common.Run` already fires `pre-<command-path>` hooks for every command, the `pre-merge-ship` hook phase works automatically — no hook dispatch code was needed, only documentation.

## Test plan

- [ ] Run `st merge ship` on a multi-PR stack with no description → prompted to add title
- [ ] Run `st merge ship --yes` on a multi-PR stack with no description → warning printed, proceeds
- [ ] Run `st merge ship` on a single-PR stack with no description → no prompt
- [ ] Run `st merge ship` on a multi-PR stack **with** a description → no prompt
- [ ] Configure `pre-merge-ship` hook in `.stackit.yaml`, verify it fires before the description check

https://claude.ai/code/session_013KnXuQQC4X1dW1TmCm57td

---
_Generated by [Claude Code](https://claude.ai/code/session_013KnXuQQC4X1dW1TmCm57td)_