### PR TITLE
feat: serve API server repos from the Postgres store

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,25 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         go-version: ['stable']
-    
+
+    services:
+      # Postgres backs the API server's repo store (internal/api/store). Store
+      # tests connect directly via STACKIT_TEST_DATABASE_URL (no testcontainers
+      # / Docker-in-Docker needed); other packages ignore it.
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: stackit
+          POSTGRES_PASSWORD: stackit
+          POSTGRES_DB: stackit_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U stackit"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -41,6 +59,7 @@ jobs:
       - name: Run tests
         env:
           STACKIT_NO_LOGGING: "1"
+          STACKIT_TEST_DATABASE_URL: postgres://stackit:stackit@localhost:5432/stackit_test?sslmode=disable
         run: |
           PACKAGES="$(bash scripts/go-test-packages.sh all)"
           if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then

--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/api"
 	"github.com/getstackit/stackit/internal/api/registry"
+	"github.com/getstackit/stackit/internal/api/store"
 	"github.com/getstackit/stackit/internal/app"
 )
 
@@ -62,17 +63,17 @@ func setupLogging(jsonOutput bool) {
 
 func run() error {
 	var (
-		port            = flag.Int("port", 8080, "Port to listen on")
-		bind            = flag.String("bind", "", "Interface to bind on. Defaults to 127.0.0.1; switches to 0.0.0.0 when $PORT or $STACKIT_PUBLIC is set.")
-		cwd             = flag.String("cwd", "", "Working directory for repository detection (single-repo shortcut; ignored when -repos-config is set)")
-		reposConfigPath = flag.String("repos-config", "", "Path to a JSON file listing repos to serve (mutually exclusive with -cwd)")
-		reposRoot       = flag.String("repos-root", os.Getenv("STACKIT_REPOS_ROOT"), "Base directory under which per-repo checkouts live (<reposRoot>/<owner>/<name>). Overrides reposRoot in -repos-config.")
-		remote          = flag.String("remote", "origin", "Default git remote name for the single-repo -cwd shortcut")
-		corsOrigins     = flag.String("cors", "http://localhost:3000,http://localhost:5173", "Comma-separated allowed CORS origins")
-		apiPrefix       = flag.String("api-prefix", "/api/v1", "Canonical API prefix")
-		enableLegacy    = flag.Bool("legacy-api-prefix", true, "Also expose legacy /api endpoints")
-		shutdownGrace   = flag.Duration("shutdown-timeout", 10*time.Second, "Graceful shutdown timeout")
-		authDisabled    = flag.Bool("auth-disabled", false, "Disable GitHub OAuth gate. Refused in public mode ($PORT or $STACKIT_PUBLIC).")
+		port          = flag.Int("port", 8080, "Port to listen on")
+		bind          = flag.String("bind", "", "Interface to bind on. Defaults to 127.0.0.1; switches to 0.0.0.0 when $PORT or $STACKIT_PUBLIC is set.")
+		cwd           = flag.String("cwd", "", "Working directory for repository detection (single-repo shortcut; ignored when -database-url is set)")
+		databaseURL   = flag.String("database-url", os.Getenv("STACKIT_DATABASE_URL"), "PostgreSQL connection string. When set, repos are served from the DB instead of the -cwd single-repo shortcut.")
+		reposRoot     = flag.String("repos-root", os.Getenv("STACKIT_REPOS_ROOT"), "Base directory under which per-repo checkouts live (<reposRoot>/<owner>/<name>) for DB-sourced repos.")
+		remote        = flag.String("remote", "origin", "Default git remote name for the single-repo -cwd shortcut")
+		corsOrigins   = flag.String("cors", "http://localhost:3000,http://localhost:5173", "Comma-separated allowed CORS origins")
+		apiPrefix     = flag.String("api-prefix", "/api/v1", "Canonical API prefix")
+		enableLegacy  = flag.Bool("legacy-api-prefix", true, "Also expose legacy /api endpoints")
+		shutdownGrace = flag.Duration("shutdown-timeout", 10*time.Second, "Graceful shutdown timeout")
+		authDisabled  = flag.Bool("auth-disabled", false, "Disable GitHub OAuth gate. Refused in public mode ($PORT or $STACKIT_PUBLIC).")
 	)
 	flag.Parse()
 
@@ -119,12 +120,22 @@ func run() error {
 	}()
 
 	switch {
-	case *reposConfigPath != "":
-		cfg, err := loadReposConfig(*reposConfigPath, *reposRoot)
+	case *databaseURL != "":
+		st, err := store.Open(context.Background(), *databaseURL)
 		if err != nil {
 			return err
 		}
-		for _, rc := range cfg.Repos {
+		defer func() {
+			if closeErr := st.Close(); closeErr != nil {
+				slog.Error("repo store close failed", "error", closeErr)
+			}
+		}()
+
+		repos, err := loadReposFromDB(context.Background(), st, *reposRoot)
+		if err != nil {
+			return err
+		}
+		for _, rc := range repos {
 			if err := addRegistryEntry(reg, rc); err != nil {
 				// A missing checkout shouldn't take down the whole
 				// server — other configured repos may still be usable,

--- a/apps/server/repos_config.go
+++ b/apps/server/repos_config.go
@@ -1,47 +1,37 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 )
 
-// reposConfig is the on-disk shape of the -repos-config file. The shape is
-// modeled after a future "users add repos from GitHub" flow: each entry
-// carries the GitHub owner/name coordinates, and the local checkout lives
-// under a shared reposRoot at <reposRoot>/<owner>/<name>. The legacy
-// absolute-path mode is preserved for one-off setups that can't sit under
-// a shared root.
-type reposConfig struct {
-	// ReposRoot is the base directory under which per-repo checkouts live.
-	// Can be overridden by the -repos-root flag or STACKIT_REPOS_ROOT env;
-	// the resolved value is what loadReposConfig validates against.
-	ReposRoot string       `json:"reposRoot,omitempty"`
-	Repos     []repoConfig `json:"repos"`
-}
-
+// repoConfig is the resolved configuration for one served repo. Repos are
+// sourced from the Postgres repo store (internal/api/store); each row is mapped
+// into this shape and run through normalizeRepoEntry so path resolution,
+// ID/DisplayName defaulting, and validation live in one place. The shape mirrors
+// a "users add repos from GitHub" flow: an entry carries GitHub owner/name
+// coordinates, and the local checkout lives under a shared reposRoot at
+// <reposRoot>/<owner>/<name>. An explicit absolute Path is preserved for one-off
+// setups that can't sit under a shared root.
 type repoConfig struct {
 	// ID is the URL-safe identifier used in /api/v1/repos/{repoID}/... .
-	// It defaults to "<owner>-<name>" when owner/name are set and id is
-	// omitted, so most config entries only need owner+name.
-	ID          string `json:"id,omitempty"`
-	DisplayName string `json:"displayName,omitempty"`
+	// It defaults to "<owner>-<name>" when owner/name are set and id is empty.
+	ID          string
+	DisplayName string
 
-	// Owner and Name are the GitHub coordinates for the repo. When set,
-	// the local checkout is expected at <reposRoot>/<owner>/<name>. These
-	// are the fields a future "add repo from GitHub" UI will populate.
-	Owner string `json:"owner,omitempty"`
-	Name  string `json:"name,omitempty"`
+	// Owner and Name are the GitHub coordinates. When set, the local checkout
+	// is expected at <reposRoot>/<owner>/<name>.
+	Owner string
+	Name  string
 
-	// Path is an explicit override for the on-disk checkout location.
-	// Absolute paths are used as-is; relative paths resolve against
-	// reposRoot. When empty, Path is derived from <reposRoot>/<owner>/<name>.
-	Path string `json:"path,omitempty"`
+	// Path is an explicit override for the on-disk checkout location. Absolute
+	// paths are used as-is; relative paths resolve against reposRoot. When empty,
+	// Path is derived from <reposRoot>/<owner>/<name>.
+	Path string
 
-	Remote string `json:"remote,omitempty"`
+	Remote string
 }
 
 // repoIDPattern restricts repo IDs to characters that survive in URL paths
@@ -49,55 +39,9 @@ type repoConfig struct {
 // surface at startup, not at first request.
 var repoIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
-// loadReposConfig reads and validates the JSON repos config at path,
-// applying rootOverride (from -repos-root / STACKIT_REPOS_ROOT) over the
-// reposRoot field in the file. The returned config is normalized: every
-// repo has an absolute Path, a non-empty ID/DisplayName, and a Remote.
-func loadReposConfig(path, rootOverride string) (*reposConfig, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("read repos config %s: %w", path, err)
-	}
-
-	var cfg reposConfig
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("parse repos config %s: %w", path, err)
-	}
-	if rootOverride != "" {
-		cfg.ReposRoot = rootOverride
-	}
-	if cfg.ReposRoot != "" {
-		abs, err := filepath.Abs(cfg.ReposRoot)
-		if err != nil {
-			return nil, fmt.Errorf("repos config %s: reposRoot %q: %w", path, cfg.ReposRoot, err)
-		}
-		cfg.ReposRoot = abs
-	}
-
-	if len(cfg.Repos) == 0 {
-		return nil, fmt.Errorf("repos config %s: must list at least one repo", path)
-	}
-
-	seen := make(map[string]bool, len(cfg.Repos))
-	for i := range cfg.Repos {
-		r := &cfg.Repos[i]
-		if err := normalizeRepoEntry(r, cfg.ReposRoot); err != nil {
-			return nil, fmt.Errorf("repos config %s: repo[%d]: %w", path, i, err)
-		}
-		if !repoIDPattern.MatchString(r.ID) {
-			return nil, fmt.Errorf("repos config %s: repo[%d] id %q must match %s", path, i, r.ID, repoIDPattern)
-		}
-		if seen[r.ID] {
-			return nil, fmt.Errorf("repos config %s: duplicate id %q", path, r.ID)
-		}
-		seen[r.ID] = true
-	}
-	return &cfg, nil
-}
-
-// normalizeRepoEntry fills in defaults and resolves Path. It enforces that
-// each entry has enough information to locate a checkout — either an
-// explicit path or GitHub owner+name plus a reposRoot.
+// normalizeRepoEntry fills in defaults and resolves Path. It enforces that each
+// entry has enough information to locate a checkout — either an explicit path or
+// GitHub owner+name plus a reposRoot.
 func normalizeRepoEntry(r *repoConfig, reposRoot string) error {
 	r.Owner = strings.TrimSpace(r.Owner)
 	r.Name = strings.TrimSpace(r.Name)
@@ -121,7 +65,7 @@ func normalizeRepoEntry(r *repoConfig, reposRoot string) error {
 		r.Path = filepath.Join(reposRoot, r.Path)
 	case r.Owner != "" && r.Name != "":
 		if reposRoot == "" {
-			return fmt.Errorf("repo %q: owner+name requires reposRoot (set -repos-root, STACKIT_REPOS_ROOT, or reposRoot in the config file)", r.ID)
+			return fmt.Errorf("repo %q: owner+name requires reposRoot (set -repos-root or STACKIT_REPOS_ROOT)", r.ID)
 		}
 		r.Path = filepath.Join(reposRoot, r.Owner, r.Name)
 	default:

--- a/apps/server/repos_config_test.go
+++ b/apps/server/repos_config_test.go
@@ -1,125 +1,94 @@
 package main
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func writeTemp(t *testing.T, body string) string {
-	t.Helper()
-	dir := t.TempDir()
-	path := filepath.Join(dir, "repos.json")
-	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
-	return path
-}
-
-func TestLoadReposConfig_OwnerNameDerivesPathFromRoot(t *testing.T) {
+func TestNormalizeRepoEntry_OwnerNameDerivesPathFromRoot(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
-	path := writeTemp(t, `{
-	  "reposRoot": "`+root+`",
-	  "repos": [
-	    {"owner": "getstackit", "name": "stackit"},
-	    {"id": "claude", "owner": "anthropics", "name": "claude-code", "displayName": "Claude Code"}
-	  ]
-	}`)
 
-	cfg, err := loadReposConfig(path, "")
-	require.NoError(t, err)
-	require.Len(t, cfg.Repos, 2)
+	r := repoConfig{Owner: "getstackit", Name: "stackit"}
+	require.NoError(t, normalizeRepoEntry(&r, root))
 
-	// id defaulted to <owner>-<name>; displayName to <owner>/<name>; path under reposRoot.
-	require.Equal(t, "getstackit-stackit", cfg.Repos[0].ID)
-	require.Equal(t, "getstackit/stackit", cfg.Repos[0].DisplayName)
-	require.Equal(t, filepath.Join(root, "getstackit", "stackit"), cfg.Repos[0].Path)
-	require.Equal(t, "origin", cfg.Repos[0].Remote)
-
-	// Explicit id + displayName preserved.
-	require.Equal(t, "claude", cfg.Repos[1].ID)
-	require.Equal(t, "Claude Code", cfg.Repos[1].DisplayName)
-	require.Equal(t, filepath.Join(root, "anthropics", "claude-code"), cfg.Repos[1].Path)
+	// id defaulted to <owner>-<name>; displayName to <owner>/<name>; path under root.
+	require.Equal(t, "getstackit-stackit", r.ID)
+	require.Equal(t, "getstackit/stackit", r.DisplayName)
+	require.Equal(t, filepath.Join(root, "getstackit", "stackit"), r.Path)
+	require.Equal(t, "origin", r.Remote)
 }
 
-func TestLoadReposConfig_RootOverrideWinsOverFile(t *testing.T) {
+func TestNormalizeRepoEntry_ExplicitIDAndDisplayNamePreserved(t *testing.T) {
 	t.Parallel()
 
-	fileRoot := t.TempDir()
-	cliRoot := t.TempDir()
-	path := writeTemp(t, `{
-	  "reposRoot": "`+fileRoot+`",
-	  "repos": [{"owner": "a", "name": "b"}]
-	}`)
+	root := t.TempDir()
 
-	cfg, err := loadReposConfig(path, cliRoot)
-	require.NoError(t, err)
-	require.Equal(t, filepath.Join(cliRoot, "a", "b"), cfg.Repos[0].Path)
+	r := repoConfig{ID: "claude", DisplayName: "Claude Code", Owner: "anthropics", Name: "claude-code"}
+	require.NoError(t, normalizeRepoEntry(&r, root))
+
+	require.Equal(t, "claude", r.ID)
+	require.Equal(t, "Claude Code", r.DisplayName)
+	require.Equal(t, filepath.Join(root, "anthropics", "claude-code"), r.Path)
 }
 
-func TestLoadReposConfig_AbsolutePathBypassesRoot(t *testing.T) {
+func TestNormalizeRepoEntry_AbsolutePathBypassesRoot(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
 	abs := filepath.Join(t.TempDir(), "somewhere")
-	path := writeTemp(t, `{
-	  "reposRoot": "`+root+`",
-	  "repos": [{"id": "a", "path": "`+abs+`"}]
-	}`)
 
-	cfg, err := loadReposConfig(path, "")
-	require.NoError(t, err)
-	require.Equal(t, abs, cfg.Repos[0].Path)
+	r := repoConfig{ID: "a", Path: abs}
+	require.NoError(t, normalizeRepoEntry(&r, root))
+	require.Equal(t, abs, r.Path)
 }
 
-func TestLoadReposConfig_RelativePathResolvesAgainstRoot(t *testing.T) {
+func TestNormalizeRepoEntry_RelativePathResolvesAgainstRoot(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
-	path := writeTemp(t, `{
-	  "reposRoot": "`+root+`",
-	  "repos": [{"id": "a", "path": "team/proj"}]
-	}`)
 
-	cfg, err := loadReposConfig(path, "")
-	require.NoError(t, err)
-	require.Equal(t, filepath.Join(root, "team", "proj"), cfg.Repos[0].Path)
+	r := repoConfig{ID: "a", Path: "team/proj"}
+	require.NoError(t, normalizeRepoEntry(&r, root))
+	require.Equal(t, filepath.Join(root, "team", "proj"), r.Path)
 }
 
-func TestLoadReposConfig_RejectsBadInput(t *testing.T) {
+func TestNormalizeRepoEntry_RejectsBadInput(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		body string
-		want string
+		name      string
+		entry     repoConfig
+		reposRoot string
+		want      string
 	}{
-		{name: "empty repos", body: `{"repos": []}`, want: "must list at least one repo"},
-		{name: "missing id and owner+name", body: `{"repos": [{"path": "/tmp/a"}]}`, want: "missing id"},
-		{name: "invalid id", body: `{"repos": [{"id": "a/b", "path": "/tmp/a"}]}`, want: "must match"},
-		{name: "duplicate id", body: `{"repos": [{"id": "a", "path": "/x"}, {"id": "a", "path": "/y"}]}`, want: "duplicate id"},
-		{name: "owner+name without root", body: `{"repos": [{"owner": "a", "name": "b"}]}`, want: "requires reposRoot"},
-		{name: "no path and no owner/name", body: `{"repos": [{"id": "a"}]}`, want: "must set path, or owner+name"},
-		{name: "relative path without root", body: `{"repos": [{"id": "a", "path": "rel"}]}`, want: "requires reposRoot"},
-		{name: "malformed json", body: `not json`, want: "parse repos config"},
+		{name: "missing id and owner+name", entry: repoConfig{Path: "/tmp/a"}, want: "missing id"},
+		{name: "owner+name without root", entry: repoConfig{Owner: "a", Name: "b"}, want: "requires reposRoot"},
+		{name: "no path and no owner/name", entry: repoConfig{ID: "a"}, want: "must set path, or owner+name"},
+		{name: "relative path without root", entry: repoConfig{ID: "a", Path: "rel"}, want: "requires reposRoot"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			path := writeTemp(t, tt.body)
-			_, err := loadReposConfig(path, "")
+			entry := tt.entry
+			err := normalizeRepoEntry(&entry, tt.reposRoot)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tt.want)
 		})
 	}
 }
 
-func TestLoadReposConfig_MissingFile(t *testing.T) {
+func TestRepoIDPattern(t *testing.T) {
 	t.Parallel()
-	_, err := loadReposConfig(filepath.Join(t.TempDir(), "nope.json"), "")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "read repos config")
+
+	for _, id := range []string{"a", "stackit", "my-repo", "my_repo", "repo123", "getstackit-stackit"} {
+		require.True(t, repoIDPattern.MatchString(id), "want valid: %q", id)
+	}
+	for _, id := range []string{"a/b", "a b", "a.b", "a@b", ""} {
+		require.False(t, repoIDPattern.MatchString(id), "want invalid: %q", id)
+	}
 }

--- a/apps/server/repos_db.go
+++ b/apps/server/repos_db.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+
+	"github.com/getstackit/stackit/internal/api/store"
+)
+
+// loadReposFromDB reads repo rows from the store and resolves each into a
+// registerable repoConfig via normalizeRepoEntry, so DB-sourced repos undergo
+// the same path resolution, defaulting, and ID validation the JSON config used
+// to. Invalid or duplicate rows are logged and skipped rather than failing
+// startup — a single bad row shouldn't take down the whole server.
+//
+// reposRoot is the resolved checkout root (-repos-root / STACKIT_REPOS_ROOT);
+// it is made absolute here, once, before per-entry resolution.
+func loadReposFromDB(ctx context.Context, st *store.Store, reposRoot string) ([]repoConfig, error) {
+	if reposRoot != "" {
+		abs, err := filepath.Abs(reposRoot)
+		if err != nil {
+			return nil, fmt.Errorf("repos-root %q: %w", reposRoot, err)
+		}
+		reposRoot = abs
+	}
+
+	rows, err := st.ListRepos(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]repoConfig, 0, len(rows))
+	seen := make(map[string]bool, len(rows))
+	for _, r := range rows {
+		rc := repoConfig{
+			ID:          r.ID,
+			DisplayName: r.DisplayName,
+			Owner:       r.Owner,
+			Name:        r.Name,
+			Path:        r.Path,
+			Remote:      r.Remote,
+		}
+		if err := normalizeRepoEntry(&rc, reposRoot); err != nil {
+			slog.Warn("repo skipped (invalid config)", "repo", r.ID, "error", err)
+			continue
+		}
+		if !repoIDPattern.MatchString(rc.ID) {
+			slog.Warn("repo skipped (invalid id)", "id", rc.ID)
+			continue
+		}
+		if seen[rc.ID] {
+			slog.Warn("repo skipped (duplicate id)", "id", rc.ID)
+			continue
+		}
+		seen[rc.ID] = true
+		out = append(out, rc)
+	}
+	return out, nil
+}


### PR DESCRIPTION

Make the Postgres repo store the source of truth for which repos the API
server serves, replacing the static JSON -repos-config file.

- Drop the -repos-config flag, loadReposConfig, and the reposConfig file
  wrapper. Add -database-url (STACKIT_DATABASE_URL); when set, repos load
  from the DB.
- Keep the -cwd single-repo shortcut for local/hosted single-repo deploys
  (it is not JSON and is orthogonal to the multi-repo source).
- repoConfig, normalizeRepoEntry, and repoIDPattern are retained and reused:
  loadReposFromDB maps each DB row through normalizeRepoEntry so path
  resolution, defaulting, and ID validation stay in one place. Invalid or
  duplicate rows are logged and skipped rather than failing startup.
- Add a Postgres service to the CI test job so store tests run via
  STACKIT_TEST_DATABASE_URL (no Docker-in-Docker).

Initial population is via SQL until a runtime POST /api/v1/repos add-repo
endpoint lands (follow-up).

<hr/>


#### Stack


* **PR #1067**
  * **PR #1068** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>


---
*Merged via consolidation into #1244 by jonnii*