### PR TITLE
feat: add user menu to header and extend it to repo picker page

### DIFF
--- a/apps/web/src/components/layout/__tests__/user-menu.test.tsx
+++ b/apps/web/src/components/layout/__tests__/user-menu.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { UserMenu } from "../user-menu";
+
+const useAuthMock = vi.fn();
+
+vi.mock("@/components/providers/auth-provider", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+const logout = vi.fn();
+
+function authValue(overrides: Record<string, unknown> = {}) {
+  return {
+    user: { login: "octocat", id: 1 },
+    disabled: false,
+    loginURL: "/auth/login",
+    isLoading: false,
+    logout,
+    ...overrides,
+  };
+}
+
+describe("UserMenu", () => {
+  beforeEach(() => {
+    useAuthMock.mockReset();
+    logout.mockReset();
+  });
+
+  it("renders nothing when there is no user", () => {
+    useAuthMock.mockReturnValue(authValue({ user: null }));
+    const { container } = render(<UserMenu />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the signed-in login and avatar initial in the trigger", () => {
+    useAuthMock.mockReturnValue(authValue());
+    render(<UserMenu />);
+    const trigger = screen.getByTestId("user-menu-trigger");
+    expect(trigger).toHaveTextContent("octocat");
+    expect(trigger).toHaveTextContent("O");
+  });
+
+  it("opens the menu on click and signs out", () => {
+    useAuthMock.mockReturnValue(authValue());
+    render(<UserMenu />);
+
+    fireEvent.click(screen.getByTestId("user-menu-trigger"));
+    fireEvent.click(screen.getByTestId("user-menu-logout"));
+
+    expect(logout).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides sign-out in disabled (local) mode", () => {
+    useAuthMock.mockReturnValue(authValue({ disabled: true }));
+    render(<UserMenu />);
+
+    fireEvent.click(screen.getByTestId("user-menu-trigger"));
+
+    expect(screen.queryByTestId("user-menu-logout")).toBeNull();
+    // The menu still opens to show the identity label.
+    expect(screen.getByRole("menu")).toHaveTextContent("Signed in as");
+  });
+});

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -1,18 +1,26 @@
+import Link from "next/link";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
+import { UserMenu } from "@/components/layout/user-menu";
 import { formatTimeAgo } from "@/lib/time";
 import type { RepoResponse } from "@/lib/api";
 
 interface HeaderProps {
-  repo: RepoResponse | null;
-  lastUpdated: Date | null;
-  refresh: () => void;
+  // All props are optional so the header can render on the repo picker page,
+  // which has no active repo and no refreshable view. The repo name, the
+  // "updated" timestamp, and the refresh button each appear only when their
+  // data is provided.
+  repo?: RepoResponse | null;
+  lastUpdated?: Date | null;
+  refresh?: () => void;
 }
 
 export function Header({ repo, lastUpdated, refresh }: HeaderProps) {
   return (
     <header className="relative flex items-center justify-between px-4 py-2 border-b shrink-0">
       <div className="flex items-center gap-3">
-        <span className="font-semibold text-sm">stackit</span>
+        <Link href="/" className="font-semibold text-sm hover:text-foreground/80 transition-colors">
+          stackit
+        </Link>
         {repo && (
           <span className="text-sm text-muted-foreground font-mono">
             {repo.owner}/{repo.repo}
@@ -26,13 +34,16 @@ export function Header({ repo, lastUpdated, refresh }: HeaderProps) {
           </span>
         )}
         <ThemeToggle />
-        <button
-          onClick={refresh}
-          className="text-xs text-muted-foreground hover:text-foreground"
-          title="Refresh"
-        >
-          &#x21BB;
-        </button>
+        {refresh && (
+          <button
+            onClick={refresh}
+            className="text-xs text-muted-foreground hover:text-foreground"
+            title="Refresh"
+          >
+            &#x21BB;
+          </button>
+        )}
+        <UserMenu />
       </div>
       {/* Animated gradient accent bar */}
       <div

--- a/apps/web/src/components/layout/user-menu.tsx
+++ b/apps/web/src/components/layout/user-menu.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { LogOut } from "lucide-react";
+import { useAuth } from "@/components/providers/auth-provider";
+
+// UserMenu renders the signed-in identity in the header as an avatar + login
+// that opens a small popover. It pulls the user from auth context, so it
+// renders nothing when there is no session (e.g. before auth resolves, or in
+// tests without a provider). Sign-out is hidden in disabled/local mode where
+// it would be a no-op and would wrongly flip the app into the login screen.
+//
+// Self-contained rather than built on a dropdown primitive — the app has no
+// popover/dropdown UI primitive, and a single menu doesn't justify adding one.
+export function UserMenu() {
+  const { user, disabled, logout } = useAuth();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  if (!user) {
+    return null;
+  }
+
+  const initial = user.login.charAt(0).toUpperCase();
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        data-testid="user-menu-trigger"
+        className="flex items-center gap-2 rounded-md px-1 py-0.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <span className="flex h-6 w-6 items-center justify-center rounded-full bg-foreground text-xs font-medium text-background">
+          {initial}
+        </span>
+        <span className="max-w-[14ch] truncate">{user.login}</span>
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 z-50 mt-2 w-48 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
+        >
+          <div className="flex flex-col px-2 py-1.5">
+            <span className="text-xs text-muted-foreground">Signed in as</span>
+            <span className="truncate text-sm font-medium">{user.login}</span>
+          </div>
+          {!disabled && (
+            <>
+              <div className="my-1 h-px bg-border" />
+              <button
+                type="button"
+                role="menuitem"
+                data-testid="user-menu-logout"
+                onClick={() => {
+                  setOpen(false);
+                  void logout();
+                }}
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+              >
+                <LogOut className="h-4 w-4" />
+                Sign out
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/providers/auth-provider.tsx
+++ b/apps/web/src/components/providers/auth-provider.tsx
@@ -17,6 +17,10 @@ interface AuthContextValue {
   isLoading: boolean;
   loginURL: string;
   logout: () => Promise<void>;
+  // disabled mirrors the AuthProvider `disable` prop: true in local/dev mode
+  // where there is no real session. Consumers use it to hide sign-out, which
+  // would be a no-op (and would wrongly flip the app into the login screen).
+  disabled: boolean;
 }
 
 const AuthContext = createContext<AuthContextValue>({
@@ -24,6 +28,7 @@ const AuthContext = createContext<AuthContextValue>({
   isLoading: true,
   loginURL: "/auth/login",
   logout: async () => {},
+  disabled: false,
 });
 
 export function useAuth() {
@@ -58,30 +63,38 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [error, setError] = useState<string | null>(null);
   const [needsLogin, setNeedsLogin] = useState(false);
 
-  const refresh = useCallback(async () => {
-    setError(null);
-    try {
-      const me = await fetchMe();
-      setUser(me);
-      setNeedsLogin(false);
-    } catch (e) {
-      if (e instanceof UnauthorizedError) {
-        setUser(null);
-        setNeedsLogin(true);
-      } else {
-        setError(e instanceof Error ? e.message : String(e));
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
+  // Fetch the current user on mount. The async work lives inside the effect
+  // (not a synchronously-called callback) so all setState happens after an
+  // await — the pattern the set-state-in-effect lint rule expects. The
+  // `active` guard drops results that resolve after unmount.
   useEffect(() => {
     if (disable) {
       return;
     }
-    void refresh();
-  }, [disable, refresh]);
+    let active = true;
+    (async () => {
+      try {
+        const me = await fetchMe();
+        if (!active) return;
+        setUser(me);
+        setNeedsLogin(false);
+        setError(null);
+      } catch (e) {
+        if (!active) return;
+        if (e instanceof UnauthorizedError) {
+          setUser(null);
+          setNeedsLogin(true);
+        } else {
+          setError(e instanceof Error ? e.message : String(e));
+        }
+      } finally {
+        if (active) setIsLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [disable]);
 
   const logout = useCallback(async () => {
     try {
@@ -113,7 +126,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }
 
   return (
-    <AuthContext.Provider value={{ user, isLoading: false, loginURL, logout }}>
+    <AuthContext.Provider
+      value={{ user, isLoading: false, loginURL, logout, disabled: Boolean(disable) }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/apps/web/src/components/repo-picker/repo-picker.tsx
+++ b/apps/web/src/components/repo-picker/repo-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   Card,
@@ -9,6 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Header } from "@/components/layout/header";
 import { fetchRepos, type RepoSummary } from "@/lib/api";
 import { buildRepoPath } from "@/lib/repo-route";
 import { AddRepository } from "./add-repository";
@@ -72,9 +73,10 @@ export function RepoPicker({ autoOpenSingle = false }: RepoPickerProps) {
     );
   }
 
+  let body: ReactNode;
   if (error) {
-    return (
-      <div className="flex h-screen flex-col items-center justify-center gap-2 text-sm">
+    body = (
+      <div className="flex flex-1 flex-col items-center justify-center gap-2 text-sm">
         <p className="text-destructive">{error}</p>
         <p className="text-muted-foreground">
           Make sure stackit-server is running on{" "}
@@ -82,19 +84,15 @@ export function RepoPicker({ autoOpenSingle = false }: RepoPickerProps) {
         </p>
       </div>
     );
-  }
-
-  if (repos === null) {
-    return (
-      <div className="flex h-screen items-center justify-center text-sm text-muted-foreground">
+  } else if (repos === null) {
+    body = (
+      <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
         Loading repositories…
       </div>
     );
-  }
-
-  if (repos.length === 0) {
-    return (
-      <div className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 px-6 py-12">
+  } else if (repos.length === 0) {
+    body = (
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-12">
         <header className="flex flex-col gap-1">
           <h1 className="text-2xl font-semibold">No repositories configured</h1>
           <p className="text-sm text-muted-foreground">
@@ -104,51 +102,58 @@ export function RepoPicker({ autoOpenSingle = false }: RepoPickerProps) {
         <AddRepository onAdded={(repo) => openRepo(repo)} />
       </div>
     );
+  } else {
+    body = (
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-12">
+        <header className="flex flex-col gap-1">
+          <h1 className="text-2xl font-semibold">Choose a repository</h1>
+          <p className="text-sm text-muted-foreground">
+            Stackit is serving {repos.length}{" "}
+            {repos.length === 1 ? "repository" : "repositories"}.
+          </p>
+        </header>
+
+        <ul className="flex flex-col gap-3" data-testid="repo-list">
+          {repos.map((repo) => (
+            <li key={repo.id}>
+              <button
+                type="button"
+                data-testid={`repo-card-${repo.id}`}
+                onClick={() => openRepo(repo)}
+                className="block w-full text-left transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
+              >
+                <Card>
+                  <CardHeader>
+                    <CardTitle>{repo.displayName || repo.id}</CardTitle>
+                    <CardDescription>
+                      <span className="font-mono">{repo.id}</span>
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="flex gap-4 text-xs text-muted-foreground">
+                    <span>
+                      trunk: <span className="font-mono">{repo.trunk}</span>
+                    </span>
+                    {repo.currentBranch && (
+                      <span>
+                        current: <span className="font-mono">{repo.currentBranch}</span>
+                      </span>
+                    )}
+                  </CardContent>
+                </Card>
+              </button>
+            </li>
+          ))}
+        </ul>
+
+        <AddRepository onAdded={(repo) => openRepo(repo)} />
+      </div>
+    );
   }
 
   return (
-    <div className="mx-auto flex min-h-screen max-w-3xl flex-col gap-6 px-6 py-12">
-      <header className="flex flex-col gap-1">
-        <h1 className="text-2xl font-semibold">Choose a repository</h1>
-        <p className="text-sm text-muted-foreground">
-          Stackit is serving {repos.length}{" "}
-          {repos.length === 1 ? "repository" : "repositories"}.
-        </p>
-      </header>
-
-      <ul className="flex flex-col gap-3" data-testid="repo-list">
-        {repos.map((repo) => (
-          <li key={repo.id}>
-            <button
-              type="button"
-              data-testid={`repo-card-${repo.id}`}
-              onClick={() => openRepo(repo)}
-              className="block w-full text-left transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
-            >
-              <Card>
-                <CardHeader>
-                  <CardTitle>{repo.displayName || repo.id}</CardTitle>
-                  <CardDescription>
-                    <span className="font-mono">{repo.id}</span>
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="flex gap-4 text-xs text-muted-foreground">
-                  <span>
-                    trunk: <span className="font-mono">{repo.trunk}</span>
-                  </span>
-                  {repo.currentBranch && (
-                    <span>
-                      current: <span className="font-mono">{repo.currentBranch}</span>
-                    </span>
-                  )}
-                </CardContent>
-              </Card>
-            </button>
-          </li>
-        ))}
-      </ul>
-
-      <AddRepository onAdded={(repo) => openRepo(repo)} />
+    <div className="flex min-h-screen flex-col">
+      <Header />
+      <main className="flex flex-1 flex-col overflow-y-auto">{body}</main>
     </div>
   );
 }

--- a/docs/web.md
+++ b/docs/web.md
@@ -81,7 +81,7 @@ layout.tsx
 └── ThemeProvider → TooltipProvider
     └── [[...slug]]/page.tsx → AppShell
         └── ConfigProvider → AuthProvider → RepoProvider (per-repo view)
-        ├── Header (repo info, refresh, theme toggle)
+        ├── Header (repo info, refresh, theme toggle, user menu)
         ├── LeftPanel (scrollable)
         │   ├── OwnerSwimlane ("You")
         │   │   └── StackColumn (per stack)


### PR DESCRIPTION

- Add UserMenu component showing signed-in user with sign-out option
- Make Header props optional so it renders on pages without an active repo
- Include Header on the repo picker page for consistent chrome
- Expose disabled flag from AuthProvider to hide sign-out in local mode
- Refactor AuthProvider useEffect to satisfy react-hooks lint rules
- Downgrade eslint 10.x → 9.x for eslint-config-next compatibility
- Add localhost:5100 to default CORS origins