### PR TITLE
fix: correct and harden Claude/Codex agent integration templates

### DIFF
--- a/.claude/rules/stackit-workflow.md
+++ b/.claude/rules/stackit-workflow.md
@@ -47,6 +47,8 @@ Run `/stackit` for the full guide.
 
 Claude's permission system matches Bash commands by prefix. Every literal piece of a command becomes part of the match string, so commands with a consistent shape across runs let a small number of rules cover everything. Inconsistent shapes blow up `.claude/settings.local.json` (one entry per literal commit message, redirection variant, etc.) and cause redundant approval prompts.
 
+**Drop the per-command `--no-interactive` flag where you can.** Set `STACKIT_NO_INTERACTIVE=1` in the environment once (stackit also auto-disables interactive features when there's no TTY); commands then keep a shorter, more stable shape — `stackit create -F -` instead of `stackit create -F - --no-interactive` on every call — so fewer permission rules cover them. An explicit `--interactive` still overrides the env var when you need it.
+
 **Run one command per Bash call.** Don't chain with `&&`. Each command should match its own rule (`Bash(git add:*)`, `Bash(stackit:*)`) rather than requiring a permission entry for the full compound string — which is what generates entries like `Bash(git add -A && stackit create -m "feat: very specific message" 2>&1)`.
 
 ```bash
@@ -74,7 +76,7 @@ echo "feat: anything" | stackit create -F -
 msg=$(mktemp -t stackit-msg) && printf "feat: anything" > "$msg" && stackit create --message-file "$msg"
 ```
 
-`create`, `modify`, `squash`, and `split --by-file` all accept `--message-file` (`-F`, except for `split` where `-F` is taken). The flag errors loudly on empty input, missing files, or being passed alongside `-m`, so silent fallthrough to other input paths can't mask a typo.
+`create`, `modify`, `squash`, and `split --by-file` all accept `--message-file` with the `-F` shorthand (on `split`, `-F` reads the message; pass `--by-file-interactive` by long name). The flag errors loudly on empty input, missing files, or being passed alongside `-m`, so silent fallthrough to other input paths can't mask a typo.
 
 ## Common Pitfalls
 

--- a/internal/cli/integrations/agents/templates/agents-block.md
+++ b/internal/cli/integrations/agents/templates/agents-block.md
@@ -13,17 +13,18 @@ or would benefit from early review of foundational work.
 
 ### Workflow
 ```bash
-git add -A                        # Stage first
-stackit create -m "feat: ..."     # Create stacked branch
+git add -A                              # Stage first
+echo "feat: ..." | stackit create -F -  # Create stacked branch (message via stdin)
 # ... continue working ...
-stackit submit                    # Submit all PRs
+stackit submit                          # Submit all PRs
 ```
 
 ### Key Commands
 | Command | Purpose |
 |---------|---------|
-| `stackit create -m "msg"` | Create stacked branch |
+| `echo "feat: msg" \| stackit create -F -` | Create stacked branch |
 | `stackit submit` | Push & create/update PRs |
+| `stackit restack --upstack` | Rebase children after editing a branch (never manual `git rebase`) |
 | `stackit sync` | Pull trunk, cleanup merged |
 | `stackit log` | Visualize branch tree |
 

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-absorb.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-absorb.md
@@ -31,13 +31,23 @@ Absorb staged fixes into the commits that last touched the changed lines.
 
 5. Determine a verification command from project docs or common files. Prefer the lightest command that covers the changed packages.
 
-6. Verify the stack:
+6. Verify the stack (structured output, stop at the first failing depth):
 
    ```bash
-   stackit foreach --upstack "<check-command>"
+   stackit foreach --stack --json --find-first-failure --no-interactive "<check-command>"
    ```
 
-7. If a branch fails, fix the earliest failing branch from the absorb output sources: unabsorbable hunks, new files, or code absorbed too far upstack. Commit the fix at that source branch, then restack.
+   Parse `results[]` for the first entry with a non-zero exit code — that is the
+   earliest failing branch.
+
+7. If a branch fails, fix the earliest failing branch from the absorb output
+   sources: unabsorbable hunks, new files, or code absorbed too far upstack. Commit
+   the fix at that source branch (`stackit modify --no-interactive`), then restack
+   that branch and its descendants:
+
+   ```bash
+   stackit restack --branch <failing-branch> --upstack --no-interactive
+   ```
 
 8. Finish with:
 

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-describe.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-describe.md
@@ -20,14 +20,19 @@ Generate or refresh stack and PR descriptions from the current branch history.
    - **Description** — markdown body with a summary paragraph, bullet points of
      key changes (grouped by branch/concern), and a concrete test plan.
 
-3. Set the description (this is what actually writes it — the bare command only
-   *displays* in non-interactive mode and changes nothing):
+3. Set the description with explicit flags (a bare non-interactive `describe`
+   with no input now errors with "nothing to set" — it does not write anything):
 
    ```bash
    stackit describe -m "<title>" -d "<description>" --no-interactive
    ```
 
-   `-d` requires `-m`, and the body supports multiline text.
+   `-d` requires `-m`, and the body supports multiline text. Alternatively pipe
+   the whole thing in editor format (first line title, blank line, then body):
+
+   ```bash
+   printf '<title>\n\n<description>' | stackit describe -F - --no-interactive
+   ```
 
 4. Confirm what was set and report it:
 

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-describe.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-describe.md
@@ -15,18 +15,24 @@ Generate or refresh stack and PR descriptions from the current branch history.
    git log --oneline --decorate -20
    ```
 
-2. Read PR template if present:
+2. Generate a title and description from the history:
+   - **Title** — max 72 chars, imperative mood, summarizes the whole stack.
+   - **Description** — markdown body with a summary paragraph, bullet points of
+     key changes (grouped by branch/concern), and a concrete test plan.
+
+3. Set the description (this is what actually writes it — the bare command only
+   *displays* in non-interactive mode and changes nothing):
 
    ```bash
-   git ls-files .github/pull_request_template.md CONTRIBUTING.md
+   stackit describe -m "<title>" -d "<description>" --no-interactive
    ```
 
-3. Run the Stackit description command available in this repo:
+   `-d` requires `-m`, and the body supports multiline text.
+
+4. Confirm what was set and report it:
 
    ```bash
-   stackit describe --no-interactive
+   stackit describe --show --no-interactive
    ```
-
-4. Report which descriptions were generated or updated.
 
 Descriptions should include a concrete summary and test plan. Do not use placeholders.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-extract.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-extract.md
@@ -18,15 +18,16 @@ Move files or commits off the current branch onto a new sibling, parent, or chil
 
 2. Confirm with the user what should be extracted (file list or commit set) and where it should go: a sibling off the same parent, a new parent, or a new child.
 
-3. Choose the split form:
+3. Choose the split form. Pipe the message via `--message-file -` (split has no
+   `-F` shorthand — `-F` means `--by-file-interactive`):
 
    | Goal | Command |
    |---|---|
-   | Extract files to a sibling branch (current branch keeps the files) | `stackit split --by-file <files> --as-sibling --name "<branch>" --message "<message>" --no-interactive` |
-   | Extract files to a new parent (current branch loses the files) | `stackit split --by-file <files> --name "<branch>" --message "<message>" --no-interactive` |
-   | Extract files to a new child branch | `stackit split --by-file <files> --above --name "<branch>" --message "<message>" --no-interactive` |
-   | Split commit history into siblings | `stackit split --by-commit --as-sibling` |
-   | Extract specific hunks via patch | `stackit split --patch <patch-file> --above --name "<branch>" --message "<message>" --no-interactive` |
+   | Extract files to a sibling branch (current branch keeps the files) | `printf '<message>' \| stackit split --by-file <files> --as-sibling --name "<branch>" --message-file - --no-interactive` |
+   | Extract files to a new parent (current branch loses the files) | `printf '<message>' \| stackit split --by-file <files> --name "<branch>" --message-file - --no-interactive` |
+   | Extract files to a new child branch | `printf '<message>' \| stackit split --by-file <files> --above --name "<branch>" --message-file - --no-interactive` |
+   | Split commit history into siblings | `stackit split --by-commit --as-sibling` — **interactive only**: `--by-commit` launches a selection wizard that needs a TTY, so it is unsuitable for autonomous runs. Use `--by-file`/`--patch` instead, or ask the user to run it. |
+   | Extract specific hunks via patch | `printf '<message>' \| stackit split --patch <patch-file> --above --name "<branch>" --message-file - --no-interactive` |
 
 4. Verify:
 

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-extract.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-extract.md
@@ -18,16 +18,16 @@ Move files or commits off the current branch onto a new sibling, parent, or chil
 
 2. Confirm with the user what should be extracted (file list or commit set) and where it should go: a sibling off the same parent, a new parent, or a new child.
 
-3. Choose the split form. Pipe the message via `--message-file -` (split has no
-   `-F` shorthand — `-F` means `--by-file-interactive`):
+3. Choose the split form. Pipe the message via `-F -` (the `--message-file`
+   shorthand, consistent with create/modify/squash):
 
    | Goal | Command |
    |---|---|
-   | Extract files to a sibling branch (current branch keeps the files) | `printf '<message>' \| stackit split --by-file <files> --as-sibling --name "<branch>" --message-file - --no-interactive` |
-   | Extract files to a new parent (current branch loses the files) | `printf '<message>' \| stackit split --by-file <files> --name "<branch>" --message-file - --no-interactive` |
-   | Extract files to a new child branch | `printf '<message>' \| stackit split --by-file <files> --above --name "<branch>" --message-file - --no-interactive` |
+   | Extract files to a sibling branch (current branch keeps the files) | `printf '<message>' \| stackit split --by-file <files> --as-sibling --name "<branch>" -F - --no-interactive` |
+   | Extract files to a new parent (current branch loses the files) | `printf '<message>' \| stackit split --by-file <files> --name "<branch>" -F - --no-interactive` |
+   | Extract files to a new child branch | `printf '<message>' \| stackit split --by-file <files> --above --name "<branch>" -F - --no-interactive` |
    | Split commit history into siblings | `stackit split --by-commit --as-sibling` — **interactive only**: `--by-commit` launches a selection wizard that needs a TTY, so it is unsuitable for autonomous runs. Use `--by-file`/`--patch` instead, or ask the user to run it. |
-   | Extract specific hunks via patch | `printf '<message>' \| stackit split --patch <patch-file> --above --name "<branch>" --message-file - --no-interactive` |
+   | Extract specific hunks via patch | `printf '<message>' \| stackit split --patch <patch-file> --above --name "<branch>" -F - --no-interactive` |
 
 4. Verify:
 

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-fix.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-fix.md
@@ -18,10 +18,14 @@ Diagnose stack problems and apply the smallest safe repair.
 
 2. If an operation is in progress, inspect conflicts and route to `stack-resolve`.
 
-3. If branches need ancestry repair, run:
+3. If branches need ancestry repair, restack with the narrowest scope that covers
+   the breakage. Anchor with `--branch <root>` when you know which stack is broken;
+   otherwise cover multiple independent stacks:
 
    ```bash
-   stackit restack --upstack --no-interactive
+   stackit restack --branch <root> --upstack --no-interactive          # known stack
+   stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive  # several
+   stackit restack --all-stacks --continue-on-conflict --no-interactive               # all stacks
    ```
 
 4. If the last Stackit operation clearly caused the problem and rollback is safest, ask before:

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-fold.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-fold.md
@@ -15,18 +15,32 @@ Fold a branch into its parent when it is too small to review separately.
    stackit log --no-interactive
    ```
 
-2. Confirm the target branch and parent with the user, because folding rewrites stack structure.
+2. Check preconditions before folding (folding rewrites stack structure):
+   - Fold **leaf branches first** — a branch with children cannot be folded until
+     its children are folded or moved.
+   - Skip **locked or frozen** branches, and skip if the **parent** is locked/frozen.
+   - Do **not** fold across different scopes.
+   - Do **not** fold into trunk unless the user explicitly asks (requires `--allow-trunk`).
 
-3. Run the fold command appropriate for the current Stackit CLI:
+3. Confirm the target branch and parent with the user.
+
+4. Preview the fold before applying it:
+
+   ```bash
+   stackit fold --dry-run --no-interactive
+   ```
+
+5. Run the fold:
 
    ```bash
    stackit fold --no-interactive
    ```
 
-4. Restack descendants if Stackit reports they need it:
+6. `stackit fold` automatically restacks descendants — only restack manually if it
+   reports remaining work:
 
    ```bash
-   stackit restack --upstack --no-interactive
+   stackit restack --branch <parent-branch> --upstack --no-interactive
    ```
 
-5. Verify with `stackit log --no-interactive`.
+7. Verify with `stackit log --no-interactive`.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-modify.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-modify.md
@@ -8,46 +8,46 @@ Amend the current stacked branch or add a follow-up commit to it.
 
 ## Workflow
 
-1. Inspect:
+1. Check for changes first:
 
    ```bash
    git status --short
-   git diff --stat
-   git diff --cached --stat
-   stackit log --no-interactive
-   git log --oneline -5
    ```
 
-2. If there are no changes, stop.
+   If there are no changes, stop.
 
-3. Stage changes unless the user explicitly requested staged-only behavior:
+2. Stage changes unless the user explicitly requested staged-only behavior:
 
    ```bash
    git add -A
    ```
 
-4. Amend by default:
+3. Amend, keeping the existing message (the default — use this when you are only
+   adding code to the current commit):
 
    ```bash
    stackit modify --no-interactive --no-edit
    ```
 
-   If a new message is needed:
+   If the commit's intent changed and the message should be regenerated, pipe it
+   via stdin (keeps permission rules stable across messages):
 
    ```bash
-   stackit modify --no-interactive -m "<message>"
+   printf '%s\n' "<message>" | stackit modify --no-interactive -F -
    ```
 
-   If the user asked for a new commit on this branch:
+   If the user asked for a *new* commit on this branch rather than an amend:
 
    ```bash
-   stackit modify --no-interactive -c -m "<message>"
+   printf '%s\n' "<message>" | stackit modify --no-interactive -c -F -
    ```
 
-5. Verify:
+4. Verify (run `stackit log` only after the mutation):
 
    ```bash
    stackit log --no-interactive
    ```
 
-Never use `git commit --amend`; `stackit modify` handles stack metadata.
+`stackit modify` automatically restacks descendant branches — do not run a manual
+`stackit restack` or `git rebase` afterward. Never use `git commit --amend`;
+`stackit modify` handles stack metadata.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-plan.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-plan.md
@@ -59,10 +59,13 @@ Split uncommitted working-tree changes into multiple stacked branches. Primary o
    <check-command>
    ```
 
-   **Verify each branch is non-empty.** `stackit create` with nothing staged
-   produces an *empty* branch. If `git diff --cached --stat` is empty before
-   create, or `git log -1 --stat` shows no files after, STOP — do not continue
-   to the next branch. Recover with:
+   **Verify each branch is non-empty.** `stackit create` rejects a create when the
+   working tree has unstaged changes but nothing staged, yet it still creates an
+   *empty* branch on a fully clean tree — exactly the case here, where a bad
+   `git checkout <sha> -- <files>` (wrong path, no match) stages nothing. So keep
+   this check: if `git diff --cached --stat` is empty before create, or
+   `git log -1 --stat` shows no files after, STOP — do not continue to the next
+   branch. Recover with:
 
    ```bash
    git checkout -B "$ORIGINAL" "$BACKUP_SHA"

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-plan.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-plan.md
@@ -44,7 +44,7 @@ Split uncommitted working-tree changes into multiple stacked branches. Primary o
    BACKUP="stack-plan-backup-$(date +%s)"
    git checkout -b "$BACKUP"
    git add -A
-   git commit -m "stack-plan: backup of all changes"
+   printf 'stack-plan: backup of all changes' | git commit -F -
    BACKUP_SHA=$(git rev-parse HEAD)
    git checkout "$ORIGINAL"
    ```
@@ -53,17 +53,32 @@ Split uncommitted working-tree changes into multiple stacked branches. Primary o
 
    ```bash
    git checkout "$BACKUP_SHA" -- <files-for-this-branch>
-   git diff --cached --stat
+   git diff --cached --stat            # MUST be non-empty before creating
    printf '%s\n' "<message>" | stackit create -F - <name> --no-interactive
-   git log -1 --stat
+   git log -1 --stat                   # verify the new branch actually committed the files
    <check-command>
    ```
 
-8. On full success:
+   **Verify each branch is non-empty.** `stackit create` with nothing staged
+   produces an *empty* branch. If `git diff --cached --stat` is empty before
+   create, or `git log -1 --stat` shows no files after, STOP — do not continue
+   to the next branch. Recover with:
 
    ```bash
-   git branch -D "$BACKUP"
-   stackit log --no-interactive
+   git checkout -B "$ORIGINAL" "$BACKUP_SHA"
    ```
 
-If any execution step fails, stop and point the user at the backup branch. See [stack-plan-recovery.md](../stackit/references/stack-plan-recovery.md).
+8. Stop conditions:
+   - **Success:** every planned branch created non-empty and `<check-command>`
+     passed on each. Then clean up:
+
+     ```bash
+     git branch -D "$BACKUP"
+     stackit log --no-interactive
+     ```
+
+   - **Failure:** any create produced an empty branch, any check failed, or any
+     step errored. STOP immediately, restore the original branch from the backup
+     (`git checkout -B "$ORIGINAL" "$BACKUP_SHA"`), and report what happened. Do
+     not delete the backup branch. See
+     [stack-plan-recovery.md](../stackit/references/stack-plan-recovery.md).

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-restack.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-restack.md
@@ -15,26 +15,22 @@ Rebase stack branches according to Stackit metadata.
    stackit log --no-interactive
    ```
 
-2. For the current stack:
+2. Precondition: if `git status --short` is non-empty, stop and tell the user to
+   commit (via `stackit create`/`stackit modify`) or stash before restacking — a
+   dirty tree will fail the rebase mid-flight.
 
-   ```bash
-   stackit restack --upstack --no-interactive
-   ```
+3. Choose the narrowest scope that covers what changed:
+   - Current stack: `stackit restack --upstack --no-interactive`
+   - A specific root: `stackit restack --branch <root> --upstack --no-interactive`
+   - Several independent roots: `stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`
+   - Every independent stack (only if requested): `stackit restack --all-stacks --continue-on-conflict --no-interactive`
 
-3. For a specific root:
+4. If conflicts occur: resolve the files, stage them, then run
+   `stackit continue --no-interactive` to finish (or invoke `stack-resolve`). Do
+   not use raw `git rebase`. If `--continue-on-conflict` reports skipped branches,
+   no rebase is active for them — restack one with
+   `stackit restack --branch <conflicted-branch> --upstack --no-interactive`, then
+   resolve and `stackit continue`.
 
-   ```bash
-   stackit restack --branch <root> --upstack --no-interactive
-   ```
-
-4. Restack all stacks only if explicitly requested:
-
-   ```bash
-   stackit restack --all-stacks --continue-on-conflict --no-interactive
-   ```
-
-5. If conflicts occur, resolve files and use `stack-resolve`.
-
-6. Verify with `stackit log --no-interactive`.
-
-Do not use raw `git rebase` for stack branches.
+5. Verify with `stackit log --no-interactive`. When done, report the result and
+   suggest `stackit submit` to update PRs, then stop.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-review.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-review.md
@@ -33,3 +33,19 @@ Review stack PRs for high-confidence issues and report findings locally.
 5. Return findings first, ordered by severity, with file and line references.
 
 If no issues meet the bar, say so and mention residual test gaps.
+
+## Applying feedback
+
+This skill reports findings; it does not push fixes by default. If the user asks
+you to apply changes, use stackit — never `gh pr` edits or a manual `git rebase`:
+
+```bash
+stackit checkout <reviewed-branch> --no-interactive
+# edit files...
+git add -A
+stackit modify --no-interactive          # amends the branch; auto-restacks descendants
+stackit submit --no-interactive           # update the PRs
+```
+
+For a fix that belongs on a different branch in the stack, use `stackit absorb`
+instead of amending the wrong commit.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-status.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-status.md
@@ -23,4 +23,13 @@ Summarize:
 - Branches needing restack.
 - Failing CI or ready-to-merge signals when present.
 
+When you detect an issue, recommend the matching command (don't invent one):
+
+| Detected | Recommend |
+|---|---|
+| Branches need restack | `stackit restack --branch <root> --upstack --no-interactive` (or `--stacks a,b` for several) |
+| Branch has no PR | `stackit submit --no-interactive` |
+| PR approved / ready to merge | `stackit merge ship --yes --no-interactive` (or `merge next --yes`) |
+| Trunk behind remote | `stackit sync --no-interactive` |
+
 Use plain `stackit log --no-interactive` when the user wants the visual stack.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-status.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-status.md
@@ -29,7 +29,7 @@ When you detect an issue, recommend the matching command (don't invent one):
 |---|---|
 | Branches need restack | `stackit restack --branch <root> --upstack --no-interactive` (or `--stacks a,b` for several) |
 | Branch has no PR | `stackit submit --no-interactive` |
-| PR approved / ready to merge | `stackit merge ship --yes --no-interactive` (or `merge next --yes`) |
+| PR approved / ready to merge | `stackit merge --yes --no-interactive` (merge the next ready PR) or `stackit merge ship --yes --no-interactive` (consolidate the whole stack) |
 | Trunk behind remote | `stackit sync --no-interactive` |
 
 Use plain `stackit log --no-interactive` when the user wants the visual stack.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-submit.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-submit.md
@@ -18,7 +18,8 @@ Submit branches as PRs or update existing PRs. This touches remotes, so confirm 
 
 2. If there are uncommitted changes, warn and stop unless the user asked to submit anyway.
 
-3. Check for PR template:
+3. Check for a PR template, and if one exists, read it and follow its structure
+   when generating PR bodies (otherwise skip straight to submit):
 
    ```bash
    git ls-files .github/pull_request_template.md CONTRIBUTING.md
@@ -44,4 +45,6 @@ Submit branches as PRs or update existing PRs. This touches remotes, so confirm 
 
 5. Report created or updated PR URLs from the command output.
 
-Do not use `gh pr create`; Stackit owns PR parentage and metadata.
+Do not use `gh pr create`; Stackit owns PR parentage and metadata. Do not submit
+PRs with placeholder content (TODO/TBD, empty sections) — generate a real summary
+and test plan, or leave the field for stackit to auto-generate.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-sync.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-sync.md
@@ -15,21 +15,38 @@ Sync with trunk and clean up branches that have landed.
    stackit log --no-interactive
    ```
 
-2. If there are uncommitted changes, stop and ask whether to stash, commit, or abort.
+2. If there are uncommitted changes, stop and ask the user to commit (via
+   `stackit create`/`stackit modify`) or abort. Do not stash.
 
-3. Run:
-
-   ```bash
-   stackit sync --no-interactive
-   ```
-
-4. If Stackit reports branches needing restack:
+3. Preview what sync would do:
 
    ```bash
-   stackit restack --upstack --no-interactive
+   stackit sync --dry-run --json --restack --no-interactive
    ```
 
-5. Verify:
+   Parse `would_clean` (branches to delete), `would_restack`, and
+   `would_restack_stacks` (independent stack roots) from the JSON.
+
+4. If **all** branches would be deleted, stop and confirm with the user first.
+
+5. Run cleanup without restacking, so restack can use a refreshed scope:
+
+   ```bash
+   stackit sync --no-restack --no-interactive
+   ```
+
+6. Recompute the restack scope (cleanup/reparenting may have changed roots):
+
+   ```bash
+   stackit sync --dry-run --json --restack --no-interactive
+   ```
+
+   Then restack using the refreshed `would_restack_stacks`:
+   - One root → `stackit restack --branch <root> --upstack --no-interactive`
+   - Several roots → `stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`
+   - Roots unavailable / all stacks affected → `stackit restack --all-stacks --continue-on-conflict --no-interactive`
+
+7. Verify:
 
    ```bash
    stackit log --no-interactive

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-verify.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-verify.md
@@ -17,16 +17,14 @@ Run verification across stack branches.
 
 2. Determine check command from user input, project docs, or common files. Prefer `mise run check` when available.
 
-3. Run across the current stack:
+3. Run across the current stack with structured output, stopping at the first
+   failing depth:
 
    ```bash
-   stackit foreach --stack "<check-command>"
+   stackit foreach --stack --json --find-first-failure --no-interactive "<check-command>"
    ```
 
-   For current branch and descendants:
+   For current branch and descendants only, swap `--stack` for `--upstack`.
 
-   ```bash
-   stackit foreach --upstack "<check-command>"
-   ```
-
-4. Report the first failing branch and relevant output. If all pass, report that clearly.
+4. Parse `results[]` for the first entry with a non-zero `exit_code` — report that
+   failing branch and its output. If all pass, report that clearly.

--- a/internal/cli/integrations/agents/templates/codex/skill/SKILL.md
+++ b/internal/cli/integrations/agents/templates/codex/skill/SKILL.md
@@ -9,7 +9,7 @@ Stackit manages stacked Git branches: small dependent PRs instead of one large r
 
 ## Always
 
-- Pass `--no-interactive` on Stackit commands. Add `--force` for absorb and `--yes` for undo. Bare `stackit merge` is an interactive wizard that needs a TTY — for non-interactive merges use a subcommand: `stackit merge ship --yes` (consolidate into one PR) or `stackit merge next --yes` (merge the bottom PR).
+- Pass `--no-interactive` on Stackit commands (or set `STACKIT_NO_INTERACTIVE=1` once in the environment instead of repeating the flag — interactive features also auto-disable when there's no TTY). Add `--force` for absorb and `--yes` for undo. Bare `stackit merge` (no flags) opens a TTY wizard; non-interactively, `stackit merge --yes` merges the next (bottom) ready PR, or `stackit merge ship --yes` consolidates the whole stack into one PR.
 - Stage changes before `stackit create`.
 - Pipe commit messages via `-F -`: `printf '%s\n' "feat: x" | stackit create -F - --no-interactive`.
 - After any mutation, run `stackit log --no-interactive` and report the resulting stack.

--- a/internal/cli/integrations/agents/templates/codex/skill/SKILL.md
+++ b/internal/cli/integrations/agents/templates/codex/skill/SKILL.md
@@ -9,7 +9,7 @@ Stackit manages stacked Git branches: small dependent PRs instead of one large r
 
 ## Always
 
-- Pass `--no-interactive` on Stackit commands. Add `--force` for absorb and `--yes` for undo/merge when those commands otherwise prompt.
+- Pass `--no-interactive` on Stackit commands. Add `--force` for absorb and `--yes` for undo. Bare `stackit merge` is an interactive wizard that needs a TTY — for non-interactive merges use a subcommand: `stackit merge ship --yes` (consolidate into one PR) or `stackit merge next --yes` (merge the bottom PR).
 - Stage changes before `stackit create`.
 - Pipe commit messages via `-F -`: `printf '%s\n' "feat: x" | stackit create -F - --no-interactive`.
 - After any mutation, run `stackit log --no-interactive` and report the resulting stack.

--- a/internal/cli/integrations/agents/templates/codex/skill/references/stack-plan-recovery.md
+++ b/internal/cli/integrations/agents/templates/codex/skill/references/stack-plan-recovery.md
@@ -12,16 +12,20 @@ A partial run may leave:
 
 ## Start Over
 
+Reset the original branch to the backup in one step (`-B` already moves the branch
+to the given start point, so no separate `git reset` is needed):
+
 ```bash
-git checkout stack-plan-backup-<timestamp>
-git checkout -B <original-branch>
-git reset --hard stack-plan-backup-<timestamp>
+git checkout -B <original-branch> stack-plan-backup-<timestamp>
 ```
 
-Then delete partial stacked branches newest-first with:
+If `stack-plan` created partial stacked branches, unwind them with `stackit undo`.
+Each call reverts one prior Stackit snapshot — run it until the partial-run
+branches are gone, checking after each:
 
 ```bash
 stackit undo --no-interactive --yes
+stackit log --no-interactive
 ```
 
 ## Continue From The Last Successful Branch

--- a/internal/cli/integrations/agents/templates/codex/skill/references/workflows.md
+++ b/internal/cli/integrations/agents/templates/codex/skill/references/workflows.md
@@ -20,7 +20,7 @@ If branch config requires a scope, retry with `--scope <value>`.
 
 ## Add Work To An Existing Branch
 
-- Follow-up commit: `git add -A` then `git commit -m "..."`
+- Follow-up commit: `git add -A` then `printf '%s\n' "<message>" | git commit -F -`
 - Amend latest commit: `stackit modify --no-interactive`
 - Distribute fixes through the stack: `stackit absorb --force --no-interactive`
 

--- a/internal/cli/integrations/agents/templates/commands/stack-absorb.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-absorb.md
@@ -11,7 +11,7 @@ Absorb staged changes into the correct commits, then intelligently fix any broke
 ## Context
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Stack state: !`stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive`
 
 ## How Absorb Works
 
@@ -26,7 +26,7 @@ Absorb assigns each change to the commit that last modified those lines. This ma
 ### Phase 1: Absorb with JSON Output
 
 ```bash
-stackit absorb --json --force --no-interactive 2>&1
+stackit absorb --json --force --no-interactive
 ```
 
 Parse the JSON output to understand:
@@ -50,7 +50,7 @@ Save this information - you'll need it to find fixes.
      - "Let me specify" - I'll provide the command
 
 ```bash
-stackit foreach --stack --json --find-first-failure --jobs 0 "<build-command>" 2>&1
+stackit foreach --stack --json --find-first-failure --jobs 0 "<build-command>"
 ```
 
 Parse `.results` in the foreach JSON output and find entries whose `status` is not `"done"` or whose `exit_code` is non-zero. `--find-first-failure` stops before descendant depths, so the failed results are the earliest failing branches. The failing branch is where to fix.
@@ -68,7 +68,7 @@ For each broken branch, identify what's missing by reading the error.
   stackit checkout <failing-branch> --no-interactive
   # Edit the file to add the missing code from the unabsorbable hunk content
   git add <files>
-  git commit -m "fix: add <missing-item> dependency"
+  printf 'fix: add <missing-item> dependency' | git commit -F -
   stackit restack --branch <failing-branch> --upstack --no-interactive
   ```
 
@@ -79,7 +79,7 @@ For each broken branch, identify what's missing by reading the error.
   stackit checkout <failing-branch> --no-interactive
   # Copy the relevant code from the new file
   git add <files>
-  git commit -m "fix: add <missing-item> from new file"
+  printf 'fix: add <missing-item> from new file' | git commit -F -
   stackit restack --branch <failing-branch> --upstack --no-interactive
   ```
 
@@ -90,14 +90,14 @@ For each broken branch, identify what's missing by reading the error.
   stackit checkout <failing-branch> --no-interactive
   # Apply the code from the absorbed hunk content
   git add <files>
-  git commit -m "fix: bring down <missing-item> from upstack"
+  printf 'fix: bring down <missing-item> from upstack' | git commit -F -
   stackit restack --branch <failing-branch> --upstack --no-interactive
   ```
 
 ### Phase 4: Verify Fix
 
 ```bash
-stackit foreach --branch <failing-branch> --upstack --json --find-first-failure --jobs 0 "<build-command>" 2>&1
+stackit foreach --branch <failing-branch> --upstack --json --find-first-failure --jobs 0 "<build-command>"
 ```
 
 If another branch fails, repeat Phase 3 for that branch.
@@ -136,7 +136,7 @@ Looking for hashPassword in unabsorbable hunks... Found!
 $ stackit checkout add-login --no-interactive
 # Edit utils/crypto.go to add hashPassword from unabsorbable content
 $ git add utils/crypto.go
-$ git commit -m "fix: add hashPassword dependency"
+$ printf 'fix: add hashPassword dependency' | git commit -F -
 $ stackit restack --branch add-login --upstack --no-interactive
 
 $ stackit foreach --branch add-login --upstack --json --find-first-failure --jobs 0 "<build-command>"

--- a/internal/cli/integrations/agents/templates/commands/stack-create.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-create.md
@@ -8,7 +8,7 @@ argument-hint: [-m "message"] [--scope <scope>] [branch-name]
 # Stack Create
 
 ## Context
-- Working tree: !`git status --short --branch 2>&1`
+- Working tree: !`git status --short --branch`
 
 ## Arguments
 $ARGUMENTS

--- a/internal/cli/integrations/agents/templates/commands/stack-describe.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-describe.md
@@ -10,9 +10,9 @@ Generate a comprehensive description for the current stack based on all changes.
 
 ## Context
 - Current branch: !`git branch --show-current`
-- Stack state: !`stackit log --no-interactive 2>&1`
-- Stack info: !`stackit info --stack --json --no-interactive 2>&1`
-- Current description: !`stackit describe --show --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive`
+- Stack info: !`stackit info --stack --json --no-interactive`
+- Current description: !`stackit describe --show --no-interactive`
 
 ## Instructions
 
@@ -22,7 +22,7 @@ For each branch in the stack (from the stack info JSON), gather:
 
 1. **Commit messages** - Already available in `commit_messages` field
 2. **Diff statistics** - Already available in `diff_stats` field
-3. **File changes** - Use `git diff <parent>..<branch> --stat` for summary
+3. **File changes** - Prefer the loaded `diff_stats`; only run `git diff <parent>..<branch> --stat` if you need per-file detail it doesn't cover
 
 If the stack has complex changes, optionally read key files to understand:
 - What features are being added

--- a/internal/cli/integrations/agents/templates/commands/stack-describe.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-describe.md
@@ -57,7 +57,11 @@ Run the describe command:
 stackit describe -m "<title>" -d "<description>" --no-interactive
 ```
 
-Note: The description argument supports multiline text.
+Note: The description argument supports multiline text. You can also pipe the
+title and body in editor format (first line title, blank line, then body) via
+`-F -`: `printf '<title>\n\n<description>' | stackit describe -F - --no-interactive`.
+A bare non-interactive `describe` with no input errors ("nothing to set") rather
+than silently doing nothing.
 
 ### Step 4: Confirm Success
 

--- a/internal/cli/integrations/agents/templates/commands/stack-extract.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-extract.md
@@ -11,7 +11,7 @@ Extract commits or file changes from the current branch to a new independent bra
 ## Context
 - Current branch: !`git branch --show-current`
 - Recent commits: !`git log --oneline -5`
-- Stack state: !`stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive`
 
 ## Instructions
 

--- a/internal/cli/integrations/agents/templates/commands/stack-fix.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-fix.md
@@ -11,7 +11,8 @@ Diagnose and fix stack problems, including build/lint/test failures.
 ## Context
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Stack state: !`stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive`
+- Diagnostics: !`stackit doctor --no-interactive`
 
 ## Instructions
 
@@ -72,19 +73,20 @@ Fix any lint errors, unused variables, or build failures NOW. This prevents havi
 
 #### Step 4: Stage and continue
 ```bash
-stackit add .
-stackit continue
+git add -A
+stackit continue --no-interactive
 ```
 
-#### Step 5: If you amended a commit, restack children
-If you made additional fixes and amended them into a commit:
+#### Step 5: If you need to amend a commit, use stackit modify
+If you made additional fixes that belong in the current branch's commit, amend with
+`stackit modify` (never `git commit --amend`) — it rewrites the commit AND restacks
+descendants in one step:
 ```bash
 git add -A
-git commit --amend --no-edit
-stackit restack --branch <amended-branch> --upstack --no-interactive
+stackit modify --no-edit --no-interactive
 ```
 
-Child branches need restacking after an amend because the commit SHA changed.
+`stackit modify` auto-restacks children after the amend, so no separate restack is needed.
 
 #### Step 6: Verify
 ```bash
@@ -123,12 +125,12 @@ Prefer JSON output so branch, status, exit code, and command output are machine-
 
 For the current stack:
 ```bash
-stackit foreach --stack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
+stackit foreach --stack --json --find-first-failure --jobs 0 "<check-command>"
 ```
 
 For a known stack root or affected branch, avoid checking out first and anchor traversal explicitly:
 ```bash
-stackit foreach --branch <branch-or-root> --upstack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
+stackit foreach --branch <branch-or-root> --upstack --json --find-first-failure --jobs 0 "<check-command>"
 ```
 
 This starts at the selected root/branch and walks toward leaves. A failing branch at the earliest failing depth is where the bug was introduced. Multiple branches can fail at the same depth; inspect each failed result and fix the branch that matches the reported problem.
@@ -156,10 +158,10 @@ stackit checkout <failing-branch> --no-interactive
 #### Step 4: Fix the issue
 - Read the error output to understand the problem
 - Make the necessary code changes
-- Stage and commit:
+- Stage and commit (pipe the message via stdin so permission rules stay stable):
   ```bash
   git add -A
-  git commit -m "fix: <description>"
+  printf 'fix: <description>' | git commit -F -
   ```
 
 #### Step 5: Propagate the fix via restack
@@ -174,7 +176,7 @@ This rebases all child branches onto the fixed branch, propagating your fix.
 
 #### Step 6: Verify all branches now pass
 ```bash
-stackit foreach --branch <failing-branch> --upstack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
+stackit foreach --branch <failing-branch> --upstack --json --find-first-failure --jobs 0 "<check-command>"
 ```
 
 If it stops at another failure, repeat from Step 2 (there may be multiple independent issues).

--- a/internal/cli/integrations/agents/templates/commands/stack-fold.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-fold.md
@@ -10,8 +10,8 @@ Fold (squash) granular branches into their parent branches.
 
 ## Context
 - Current branch: !`git branch --show-current`
-- Stack state: !`stackit log --no-interactive 2>&1`
-- Stack info: !`stackit info --stack --json --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive`
+- Stack info: !`stackit info --stack --json --no-interactive`
 
 ## Instructions
 
@@ -33,8 +33,12 @@ Fold (squash) granular branches into their parent branches.
 5. Before each fold, verify:
    - Branch has no children (fold leaf branches first)
    - Parent still not locked/frozen
-6. Execute: `stackit checkout <branch> --no-interactive && stackit fold --no-interactive`
-7. After each fold, restack only the affected parent and descendants: `stackit restack --branch <parent-branch> --upstack --no-interactive`
+6. Execute as two separate commands (don't chain with `&&` — keeps permission rules stable):
+   ```bash
+   stackit checkout <branch> --no-interactive
+   stackit fold --no-interactive
+   ```
+7. `stackit fold` automatically restacks descendants. Only restack manually if it reports remaining work: `stackit restack --branch <parent-branch> --upstack --no-interactive`
 8. Show final stack state
 
 ## Tool Trust

--- a/internal/cli/integrations/agents/templates/commands/stack-modify.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-modify.md
@@ -9,10 +9,10 @@ argument-hint: [-m "message"] [-a] [-c] [--no-edit]
 
 ## Context
 - Current branch: !`git branch --show-current`
-- Unstaged changes: !`git diff --stat 2>&1 | head -20`
-- Staged changes: !`git diff --cached --stat 2>&1 | head -20`
-- Recent commits on branch: !`git log --oneline -5 2>&1`
-- Stack state: !`stackit log --no-interactive 2>&1`
+- Unstaged changes: !`git diff --stat | head -20`
+- Staged changes: !`git diff --cached --stat | head -20`
+- Recent commits on branch: !`git log --oneline -5`
+- Stack state: !`stackit log --no-interactive`
 
 ## Arguments
 $ARGUMENTS
@@ -27,31 +27,31 @@ Modify the current branch by amending its commit or creating a new commit. Autom
 
 ### Steps
 
-1. **Check for changes:**
-   - If no staged changes and no unstaged changes, inform user and stop
-   - If no staged changes but unstaged changes exist, run `git add --all` to stage them
-   - If user provided `-a`, run `git add --all` first
+1. **Check for changes and stage:**
+   - If there are no staged and no unstaged changes, inform user and stop.
+   - Otherwise run `git add -A` once to stage everything (this is the same whether
+     or not the user passed `-a` — don't double-stage). Skip only if the user
+     explicitly asked to amend with the currently-staged set only.
 
 2. **Determine the message:**
-   - If `-m "message"` provided, use that message
-   - If `--no-edit` or `-n` provided, keep the existing commit message (amend mode only)
-   - If neither provided and amending, generate a message describing what changed based on the diff, then use `-m`
-   - If neither provided and creating new commit (`-c`), generate a message based on the diff
+   - If `--no-edit` or `-n` provided, keep the existing commit message (amend mode only).
+   - If `-m "message"` provided, use that message.
+   - If neither provided, generate a message describing the change from the diff
+     (always — both for amend and for a new commit with `-c`).
 
-3. **Run the command:**
+3. **Run the command** (pipe generated messages via stdin so permission rules stay
+   stable across messages):
    ```bash
-   # Amend (default) with message
-   stackit modify -m "<message>"
-
-   # Amend keeping existing message
+   # Amend (default), keeping the existing message
    stackit modify --no-edit
 
-   # New commit
-   stackit modify -c -m "<message>"
+   # Amend with a regenerated message
+   printf '%s\n' "<message>" | stackit modify -F -
 
-   # Stage all + amend
-   stackit modify -a -m "<message>"
+   # New commit on this branch
+   printf '%s\n' "<message>" | stackit modify -c -F -
    ```
+   Changes are already staged from Step 1, so no `-a` is needed.
 
 4. **Handle results:**
    - On success, report what was modified and that descendants were restacked

--- a/internal/cli/integrations/agents/templates/commands/stack-plan.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-plan.md
@@ -14,7 +14,7 @@ Analyze uncommitted working tree changes, suggest a logical stacking structure, 
 ## Context
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Stack state: !`stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive`
 
 ## Arguments
 $ARGUMENTS
@@ -263,7 +263,7 @@ Dry Run - Setup
 BACKUP_BRANCH="stack-plan-backup-<timestamp>"
 git checkout -b "$BACKUP_BRANCH"
 git add -A
-git commit -m "stack-plan: backup of all changes"
+printf 'stack-plan: backup of all changes' | git commit -F -
 BACKUP_COMMIT=<commit-sha>
 git checkout <original-branch>
 
@@ -300,7 +300,7 @@ git checkout -b "$BACKUP_BRANCH"
 
 # Stage and commit ALL changes (including untracked)
 git add -A
-git commit -m "stack-plan: backup of all changes"
+printf 'stack-plan: backup of all changes' | git commit -F -
 
 # Record the backup commit SHA
 BACKUP_COMMIT=$(git rev-parse HEAD)

--- a/internal/cli/integrations/agents/templates/commands/stack-resolve.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-resolve.md
@@ -1,7 +1,7 @@
 ---
 description: Resolve rebase conflicts with AI assistance
 model: claude-sonnet-4-20250514
-allowed-tools: Read, Edit, AskUserQuestion, Bash(git show *), Bash(git diff *), Bash(git add *), Bash(git rebase --continue), Bash(grep *), Bash(stackit *), Bash(make *), Bash(npm *), Bash(yarn *), Bash(pnpm *), Bash(go *), Bash(cargo *), Bash(mise run *)
+allowed-tools: Read, Edit, AskUserQuestion, Bash(git show *), Bash(git diff *), Bash(git add *), Bash(grep *), Bash(stackit *), Bash(make *), Bash(npm *), Bash(yarn *), Bash(pnpm *), Bash(go *), Bash(cargo *), Bash(mise run *)
 ---
 
 # Conflict Resolution
@@ -108,13 +108,17 @@ After all conflicts are resolved:
 
 2. **If validation passes:**
    ```bash
-   git rebase --continue
+   stackit continue --no-interactive
    ```
+   Use `stackit continue` (not raw `git rebase --continue`): it finishes the
+   rebase **and** resumes restacking the remaining branches in the stack, keeping
+   stackit's metadata consistent. Raw git would leave the rest of the stack
+   un-restacked.
 
 3. **If validation fails:**
    - Explain what broke
    - Offer to help fix the issue
-   - Do NOT continue the rebase until tests pass
+   - Do NOT continue until tests pass
 
 ### Phase 6: Post-Resolution
 

--- a/internal/cli/integrations/agents/templates/commands/stack-restack.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-restack.md
@@ -9,7 +9,7 @@ allowed-tools: Bash(stackit:*), Bash(git:*), AskUserQuestion, Skill
 ## Context
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Stack state: !`stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive`
 
 ## Task
 

--- a/internal/cli/integrations/agents/templates/commands/stack-review.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-review.md
@@ -16,7 +16,7 @@ Perform code reviews on PRs in the stack. Finds bugs, checks CLAUDE.md complianc
 ## Context
 - Current branch: !`git branch --show-current`
 - Repo: !`gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null`
-- Stack state: !`stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive`
 
 ## Arguments
 $ARGUMENTS
@@ -51,7 +51,7 @@ Perform code reviews on stack PRs in parallel, reporting high-confidence issues 
 Get all branches in the stack that have open PRs:
 
 ```bash
-stackit log --json --no-interactive 2>&1
+stackit log --json --no-interactive
 ```
 
 Parse the JSON to identify branches with PRs. For each branch, check if the PR is reviewable:
@@ -274,10 +274,12 @@ For each actionable comment:
 
 ```bash
 git add -A
-git commit -m "refactor: apply PR review feedback
+git commit -F - <<'EOF'
+refactor: apply PR review feedback
 
 Applied reviewer suggestions:
-- <list of changes>"
+- <list of changes>
+EOF
 ```
 
 Batch-resolve threads:

--- a/internal/cli/integrations/agents/templates/commands/stack-split.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-split.md
@@ -557,20 +557,20 @@ new file mode 100644
 - `--below` (default): Extract to a new PARENT branch (downstack)
 - `--as-sibling`: Extract to an independent branch on the same parent
 
-**Examples** (pipe the message via `--message-file -`; note `split` has no `-F`
-shorthand — `-F` means `--by-file-interactive`):
+**Examples** (pipe the message via `-F -`, the `--message-file` shorthand —
+consistent with create/modify/squash):
 ```bash
 # Extract files to child branch (upstack)
-printf 'Extract utilities' | stackit split --by-file internal/utils.go --above -n "refactor-utils" --message-file -
+printf 'Extract utilities' | stackit split --by-file internal/utils.go --above -n "refactor-utils" -F -
 
 # Extract files to parent branch (downstack, default)
-printf 'Extract config' | stackit split --by-file internal/config.go -n "config-changes" --message-file -
+printf 'Extract config' | stackit split --by-file internal/config.go -n "config-changes" -F -
 
 # Preview a file-level split without executing
 stackit split --by-file internal/utils.go --above --dry-run -n "refactor-utils"
 
 # Hunk-level split using a patch file
-printf 'Part 2' | stackit split --patch /tmp/extract.patch --above -n "feature-part-2" --message-file -
+printf 'Part 2' | stackit split --patch /tmp/extract.patch --above -n "feature-part-2" -F -
 ```
 
 **Note:** `--by-file` extracts entire files to the new branch, not just the changes to those files. Use `--patch` or `--by-hunk` for hunk-level splitting within files.

--- a/internal/cli/integrations/agents/templates/commands/stack-split.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-split.md
@@ -31,7 +31,7 @@ Split the committed changes on the current branch between this branch and a new 
 ## Context
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Stack state: !`stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive`
 
 ## Arguments
 $ARGUMENTS
@@ -67,8 +67,8 @@ Cannot Split: Working Directory Not Clean
 You have uncommitted changes. Please commit or stash them first.
 
 Options:
-- Commit changes: git add -A && git commit -m "WIP"
 - Stash changes: git stash
+- Commit changes: git add -A, then stackit modify (amend current commit) or stackit create (new branch)
 - Discard changes: git checkout -- .
 
 Then re-run /stack-split
@@ -432,7 +432,7 @@ After the split completes:
 <check-command>
 
 # Switch to parent and verify it also builds
-git checkout <current-branch>
+stackit checkout <current-branch> --no-interactive
 <check-command>
 ```
 
@@ -557,19 +557,20 @@ new file mode 100644
 - `--below` (default): Extract to a new PARENT branch (downstack)
 - `--as-sibling`: Extract to an independent branch on the same parent
 
-**Examples:**
+**Examples** (pipe the message via `--message-file -`; note `split` has no `-F`
+shorthand — `-F` means `--by-file-interactive`):
 ```bash
 # Extract files to child branch (upstack)
-stackit split --by-file internal/utils.go --above -n "refactor-utils" -m "Extract utilities"
+printf 'Extract utilities' | stackit split --by-file internal/utils.go --above -n "refactor-utils" --message-file -
 
 # Extract files to parent branch (downstack, default)
-stackit split --by-file internal/config.go -n "config-changes" -m "Extract config"
+printf 'Extract config' | stackit split --by-file internal/config.go -n "config-changes" --message-file -
 
 # Preview a file-level split without executing
 stackit split --by-file internal/utils.go --above --dry-run -n "refactor-utils"
 
 # Hunk-level split using a patch file
-stackit split --patch /tmp/extract.patch --above -n "feature-part-2" -m "Part 2"
+printf 'Part 2' | stackit split --patch /tmp/extract.patch --above -n "feature-part-2" --message-file -
 ```
 
 **Note:** `--by-file` extracts entire files to the new branch, not just the changes to those files. Use `--patch` or `--by-hunk` for hunk-level splitting within files.

--- a/internal/cli/integrations/agents/templates/commands/stack-status.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-status.md
@@ -10,8 +10,7 @@ Show the current stack state, identify issues, and provide actionable recommenda
 ## Context
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Stack state (json — PR/CI status, structure): !`stackit log --json --no-interactive`
-- Stack info (json — per-branch needs_restack, locked/frozen, scope): !`stackit info --stack --json --no-interactive`
+- Stack state (json — complete: structure, PR/CI status, and per-branch needs_restack/is_locked/is_frozen/scope): !`stackit log --json --no-interactive`
 
 ## Task
 
@@ -26,7 +25,8 @@ If the user wants the visual tree, run `stackit log --no-interactive` and show i
 
 ### Step 2: Health Analysis
 
-Parse the stack state JSON and branch info JSON, then highlight issues:
+Parse the stack JSON (a single `stackit log --json` carries everything — PR/CI
+status plus `needs_restack`/`is_locked`/`is_frozen`/`scope`), then highlight issues:
 
 **High Priority Issues (act now):**
 - CI failing on any branch

--- a/internal/cli/integrations/agents/templates/commands/stack-status.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-status.md
@@ -10,18 +10,19 @@ Show the current stack state, identify issues, and provide actionable recommenda
 ## Context
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Stack state (text): !`stackit log --no-interactive 2>&1`
-- Stack state (json): !`stackit log --json --no-interactive 2>&1`
-- Branch info: !`stackit info --json --no-interactive 2>&1`
+- Stack state (json — PR/CI status, structure): !`stackit log --json --no-interactive`
+- Stack info (json — per-branch needs_restack, locked/frozen, scope): !`stackit info --stack --json --no-interactive`
 
 ## Task
 
 ### Step 1: Display Stack Overview
 
-Based on the stack state context, show:
-- Current position in the stack (marked with "current")
+Summarize from the JSON context:
+- Current position in the stack (the branch with `is_current: true`)
 - Parent/child relationships
 - Any branches that need attention
+
+If the user wants the visual tree, run `stackit log --no-interactive` and show it.
 
 ### Step 2: Health Analysis
 

--- a/internal/cli/integrations/agents/templates/commands/stack-submit.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-submit.md
@@ -11,8 +11,8 @@ Submit branches to GitHub and create/update PRs.
 
 ## Context
 - Current branch: !`git branch --show-current`
-- Stack state: !`stackit log --no-interactive 2>&1`
-- Branch info: !`stackit info --json --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive`
+- Branch info: !`stackit info --json --no-interactive`
 
 ## Arguments
 $ARGUMENTS
@@ -35,21 +35,25 @@ From the stack state, identify which branches need PR descriptions generated:
 
 Run submit command:
 
-**Current branch only:**
+**Current branch and its ancestors (default):**
 ```bash
 stackit submit --no-interactive
 ```
 
-**Entire stack:**
+**Entire stack (also includes descendants):**
 ```bash
 stackit submit --stack --no-interactive
 ```
 
 **As drafts:** add `--draft`
 
-When stackit prompts for title and body (in interactive mode) or when generating PR content:
-- **Title**: Use first commit subject, keep under 72 chars
-- **Body**: Summarize changes with bullet points + include test plan
+Under `--no-interactive`, stackit does **not** prompt for title/body — the PR
+title comes from each branch's commit subject and the stack footer is
+auto-generated. The interactive `--edit-title`/`--edit-description` flags don't
+apply here. To control content non-interactively:
+- **Title**: write a clear commit subject (under 72 chars); it becomes the PR title.
+- **Stack description/footer**: set it before submitting with
+  `stackit describe -m "<title>" -d "<body>" --no-interactive` (see `/stack-describe`).
 
 Check `.github/pull_request_template.md` and `CONTRIBUTING.md` for format requirements.
 

--- a/internal/cli/integrations/agents/templates/commands/stack-sync.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-sync.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(stackit:*), Bash(git:*), AskUserQuestion, Skill
 
 ## Context
 - Current branch: !`git branch --show-current`
-- Stack state: !`stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive`
 
 ## Task
 
@@ -28,7 +28,7 @@ Sync the stack with trunk: pull latest, cleanup merged branches, restack.
 
 If `--continue-on-conflict` reports skipped conflicts, no rebase is active for those skipped branches. To resolve one, run `stackit restack --branch <conflicted-branch> --upstack --no-interactive`, then resolve conflicts and run `stackit continue`.
 
-You can call multiple tools in a single response.
+These steps are sequential — each depends on the previous step's result, so run them one at a time rather than batching.
 
 ## Follow-up
 

--- a/internal/cli/integrations/agents/templates/commands/stack-tidy.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-tidy.md
@@ -10,10 +10,15 @@ Clean up commits across the stack by squashing fixup/WIP commits into meaningful
 
 ## Context
 - Current branch: !`git branch --show-current`
-- Stack state: !`stackit log --no-interactive 2>&1`
-- Stack info: !`stackit info --stack --json --no-interactive 2>&1`
+- Uncommitted changes: !`git status --short`
+- Stack state: !`stackit log --no-interactive`
+- Stack info: !`stackit info --stack --json --no-interactive`
 
 ## Task
+
+**Precondition:** if the Context shows uncommitted changes, stop and ask the user
+to commit (via `stackit create`/`stackit modify`), stash, or abort before tidying.
+Squashing checks out and rewrites branches, which fails on a dirty working tree.
 
 ### Step 1: Gather Commit Data
 
@@ -43,7 +48,7 @@ For each commit, classify as **cleanup** or **meaningful**:
 | Condition | Strategy | Action |
 |-----------|----------|--------|
 | 0 or 1 commits | **SKIP** | Nothing to tidy |
-| 1 meaningful + rest noise | **SQUASH** | `stackit squash -m "<meaningful msg>" --no-edit --no-interactive` |
+| 1 meaningful + rest noise | **SQUASH** | `printf '%s\n' "<meaningful msg>" \| stackit squash -F - --no-interactive` |
 | 0 meaningful (all noise) | **SQUASH** | `stackit squash --no-edit --no-interactive` (keeps oldest msg) |
 | 2+ meaningful commits | **REVIEW** | Show commits, suggest manual action |
 

--- a/internal/cli/integrations/agents/templates/commands/stack-verify.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-verify.md
@@ -12,7 +12,7 @@ Run verification checks on all branches in the stack and report results.
 ## Context
 - Current branch: !`git branch --show-current`
 - Git status: !`git status --short`
-- Stack state: !`stackit log --no-interactive 2>&1`
+- Stack state: !`stackit log --no-interactive`
 
 ## Arguments
 $ARGUMENTS
@@ -35,17 +35,17 @@ If provided in arguments, use that. Otherwise:
 
 **Quick mode (default)** - run branches at each depth in parallel and stop after the first failing depth:
 ```bash
-stackit foreach --stack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
+stackit foreach --stack --json --find-first-failure --jobs 0 "<check-command>"
 ```
 
 **Full diagnostic mode** - check all branches and collect every failure:
 ```bash
-stackit foreach --stack --json --parallel --jobs 0 --no-fail-fast "<check-command>" 2>&1
+stackit foreach --stack --json --parallel --jobs 0 --no-fail-fast "<check-command>"
 ```
 
 **Anchored mode** - if a branch or independent stack root is known, avoid checkout navigation and verify that upstack only:
 ```bash
-stackit foreach --branch <branch-or-root> --upstack --json --find-first-failure --jobs 0 "<check-command>" 2>&1
+stackit foreach --branch <branch-or-root> --upstack --json --find-first-failure --jobs 0 "<check-command>"
 ```
 
 If uncertain which mode to use, prompt with `AskUserQuestion`:

--- a/internal/cli/integrations/agents/templates/skill/commands/branch.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/branch.md
@@ -11,6 +11,7 @@ Commands for creating, modifying, and managing individual branches.
 | `git commit` (new branches) | `stackit create` |
 | `git checkout -b` | `stackit create` |
 | `gh pr create` | `stackit submit` |
+| `git rebase` (stack branches) | `stackit restack --branch <branch> --upstack` (or `--all-stacks`) |
 
 **Required workflow for new stacked branches:**
 ```bash
@@ -66,7 +67,7 @@ echo "feat: add user authentication" | stackit create -F - --all --no-interactiv
 
 ### Multiple commits per branch
 **A stacked branch can have multiple commits.** You don't need a new branch for every commit:
-- Add another commit: `git add . && git commit -m "message"`
+- Add another commit (run as separate calls; pipe the message via stdin): `git add -A` then `printf 'message' | git commit -F -`
 - Amend current commit: `stackit modify --no-interactive`
 - Absorb fixes to correct commits: `stackit absorb --no-interactive`
 

--- a/internal/cli/integrations/agents/templates/skill/commands/recovery.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/recovery.md
@@ -90,15 +90,18 @@ stackit submit --no-interactive
 ### Uncommitted Changes Blocking Operation
 
 ```bash
-# Option 1: Commit them
-git add .
-stackit modify --no-interactive
-
-# Option 2: Stash them
+# Option 1 (safe default): Stash them, do the operation, then restore
 git stash
-
-# Do operation, then restore
+# ...run the blocked operation...
 git stash pop
+```
+
+```bash
+# Option 2: Commit them — ONLY if the changes belong to the current branch's
+# commit. `stackit modify` amends whatever commit is checked out, so do not use
+# it to park unrelated changes (that silently corrupts an unrelated commit).
+git add -A
+stackit modify --no-interactive
 ```
 
 ## Diagnostic Workflows

--- a/internal/cli/integrations/agents/templates/skill/commands/stack.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/stack.md
@@ -13,7 +13,7 @@ Commands for managing the entire stack or multiple branches.
 | `stackit restack --stacks <root1>,<root2> --continue-on-conflict --no-interactive` | Rebase specific independent stack roots while letting unrelated selected roots continue past conflicts |
 | `stackit sync --no-interactive` | Pull trunk, delete merged branches, restack |
 | `stackit info --stack --json --no-interactive` | Export full stack metadata as JSON for analysis |
-| `stackit merge` | Merge approved PRs and cleanup |
+| `stackit merge ship --yes --no-interactive` | Consolidate the stack into one PR and merge (subcommand required — bare `stackit merge` is a wizard that needs a TTY; `merge next --yes` merges just the bottom PR) |
 | `stackit fold --no-interactive` | Fold current branch into its parent |
 
 ## Bulk Operations
@@ -22,8 +22,8 @@ Commands for managing the entire stack or multiple branches.
 |---------|-------------|
 | `stackit foreach --no-interactive` | Run command on each branch in stack |
 | `stackit submit --no-interactive` | Push branches and create/update PRs |
-| `stackit reorder` | Interactively reorder branches |
-| `stackit move` | Rebase branch onto new parent |
+| `stackit reorder` | Reorder branches (editor-driven — opens an editor, so there is no agent-safe non-interactive form) |
+| `stackit move -y` | Rebase branch onto new parent (`-y/--yes` to skip the prompt) |
 
 ## Common Flag Patterns
 
@@ -72,15 +72,17 @@ stackit foreach --no-interactive "git status --short"
 
 ### Start a feature stack
 ```bash
-git add .
+git add -A
 echo "feat: implement user authentication" | stackit create -F - --no-interactive
 
-# Add tests to the same branch (branches can have multiple commits)
-git add .
-git commit -m "test: add auth tests"
+# Add tests to the same branch (branches can have multiple commits).
+# git commit is allowed for follow-up commits on an existing branch; pipe the
+# message via -F - so permission rules stay stable across messages.
+git add -A
+printf 'test: add auth tests' | git commit -F -
 
 # Work on next part as a separate stacked branch
-git add .
+git add -A
 echo "feat: add JWT token validation" | stackit create -F - --no-interactive
 ```
 
@@ -91,10 +93,9 @@ stackit submit --no-interactive --stack
 
 ### After code review changes
 ```bash
-git add .
+git add -A
 stackit modify --no-interactive
-# Propagate the amend to descendants of this branch only
-stackit restack --branch $(git branch --show-current) --upstack --no-interactive
+# stackit modify automatically restacks descendants — no manual restack needed.
 stackit submit --no-interactive
 ```
 

--- a/internal/cli/integrations/agents/templates/skill/commands/stack.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/stack.md
@@ -13,7 +13,7 @@ Commands for managing the entire stack or multiple branches.
 | `stackit restack --stacks <root1>,<root2> --continue-on-conflict --no-interactive` | Rebase specific independent stack roots while letting unrelated selected roots continue past conflicts |
 | `stackit sync --no-interactive` | Pull trunk, delete merged branches, restack |
 | `stackit info --stack --json --no-interactive` | Export full stack metadata as JSON for analysis |
-| `stackit merge ship --yes --no-interactive` | Consolidate the stack into one PR and merge (subcommand required — bare `stackit merge` is a wizard that needs a TTY; `merge next --yes` merges just the bottom PR) |
+| `stackit merge --yes --no-interactive` | Merge the next (bottom) ready PR non-interactively (bare `stackit merge` with no flags opens a TTY wizard). Use `stackit merge ship --yes --no-interactive` to consolidate the whole stack into one PR. |
 | `stackit fold --no-interactive` | Fold current branch into its parent |
 
 ## Bulk Operations

--- a/internal/cli/integrations/agents/templates/skill/reference.md
+++ b/internal/cli/integrations/agents/templates/skill/reference.md
@@ -72,7 +72,7 @@ bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
 | `stackit foreach` | Run command on each branch in stack |
 | `stackit submit --no-interactive` | Push branches and create/update PRs |
 | `stackit sync --no-interactive` | Pull trunk, delete merged branches, restack |
-| `stackit merge ship --yes --no-interactive` | Consolidate stack into one PR and merge (subcommand required — bare `stackit merge` is a TTY wizard; `merge next --yes` merges just the bottom PR) |
+| `stackit merge --yes --no-interactive` | Merge the next (bottom) ready PR non-interactively (bare `stackit merge` with no flags opens a TTY wizard); use `stackit merge ship --yes --no-interactive` to consolidate the whole stack into one PR |
 | `stackit reorder` | Reorder branches (editor-driven — no agent-safe non-interactive form) |
 | `stackit move -y` | Rebase branch onto new parent (`-y` skips the prompt) |
 

--- a/internal/cli/integrations/agents/templates/skill/reference.md
+++ b/internal/cli/integrations/agents/templates/skill/reference.md
@@ -15,6 +15,7 @@ Quick reference for all stackit commands. For detailed documentation, see:
 | `git commit` (new branches) | `stackit create` |
 | `git checkout -b` | `stackit create` |
 | `gh pr create` | `stackit submit` |
+| `git rebase` (stack branches) | `stackit restack --branch <branch> --upstack` (or `--all-stacks`) |
 
 **Required workflow for new stacked branches:**
 ```bash
@@ -71,9 +72,9 @@ bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
 | `stackit foreach` | Run command on each branch in stack |
 | `stackit submit --no-interactive` | Push branches and create/update PRs |
 | `stackit sync --no-interactive` | Pull trunk, delete merged branches, restack |
-| `stackit merge` | Merge approved PRs and cleanup |
-| `stackit reorder` | Interactively reorder branches |
-| `stackit move` | Rebase branch onto new parent |
+| `stackit merge ship --yes --no-interactive` | Consolidate stack into one PR and merge (subcommand required — bare `stackit merge` is a TTY wizard; `merge next --yes` merges just the bottom PR) |
+| `stackit reorder` | Reorder branches (editor-driven — no agent-safe non-interactive form) |
+| `stackit move -y` | Rebase branch onto new parent (`-y` skips the prompt) |
 
 ## Recovery & Utilities
 
@@ -91,7 +92,8 @@ bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
 ## Common Flag Patterns
 
 ### stackit create --no-interactive
-- `-m "message"` - Commit message
+- `-F, --message-file` - Read commit message from a file; use `-` for stdin (preferred — keeps permission rules stable across messages)
+- `-m "message"` - Inline commit message (mutually exclusive with `-F`)
 - `--all` - Stage all changes first
 - `--insert` - Insert between current and child
 
@@ -107,21 +109,22 @@ bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
 
 ### Start a new feature
 ```bash
-git add .
+git add -A
 echo "feat: add new feature" | stackit create -F - --no-interactive
 ```
 
 ### Stack another change
 ```bash
-git add .
+git add -A
 echo "feat: extend feature" | stackit create -F - --no-interactive
 ```
 
 ### Add more commits to current branch
 ```bash
-# A stacked branch can have multiple commits - no need to create a new branch
-git add .
-git commit -m "test: add tests for feature"
+# A stacked branch can have multiple commits - no need to create a new branch.
+# git commit is allowed for follow-up commits; pipe the message via stdin.
+git add -A
+printf 'test: add tests for feature' | git commit -F -
 ```
 
 ### Submit for review
@@ -131,10 +134,9 @@ stackit submit --no-interactive --stack
 
 ### After code review changes
 ```bash
-git add .
+git add -A
 stackit modify --no-interactive
-# Scope the restack to just this branch and its descendants
-stackit restack --branch $(git branch --show-current) --upstack --no-interactive
+# stackit modify automatically restacks descendants — no manual restack needed.
 stackit submit --no-interactive
 ```
 

--- a/internal/cli/integrations/agents/templates/skill/scripts/analyze_stack.sh
+++ b/internal/cli/integrations/agents/templates/skill/scripts/analyze_stack.sh
@@ -38,29 +38,45 @@ echo -e "${BLUE}Current Stack:${NC}"
 stackit log
 echo
 
+# Fetch authoritative stack metadata once as JSON (the source of truth for
+# branch relationships, sizes, and PR state) instead of scraping rendered output.
+STACK_JSON=$(stackit log short --json --no-interactive 2>/dev/null || echo '{}')
+github_available=$(echo "$STACK_JSON" | jq -r '.github_available // false')
+
 echo -e "${BLUE}Health Checks:${NC}"
 
 # Check for uncommitted changes
 if ! git diff-index --quiet HEAD -- 2>/dev/null; then
     echo -e "${YELLOW}⚠️  Uncommitted changes detected${NC}"
     echo "→ Run: git status"
-    echo "→ Consider: git add . (then) stackit modify"
+    echo "→ Consider: git add -A (then) stackit modify"
     echo
 fi
 
-# Check for branches without PRs
-# Count branches marked with ● (no PR) in stackit log output
-branches_no_pr=$(stackit log 2>/dev/null | grep -c "●" || true)
-if [ "$branches_no_pr" -gt 0 ]; then
-    echo -e "${YELLOW}ℹ️  $branches_no_pr branch(es) without PRs${NC}"
-    echo "→ Run: stackit submit --stack"
-    echo
+# Check for branches without PRs (non-trunk branches with no "pr" field).
+# Only meaningful when GitHub data is available.
+branches_no_pr=0
+if [ "$github_available" = "true" ]; then
+    branches_no_pr=$(echo "$STACK_JSON" | jq '[.branches[]? | select((.is_trunk | not) and (has("pr") | not))] | length')
+    if [ "$branches_no_pr" -gt 0 ]; then
+        echo -e "${YELLOW}ℹ️  $branches_no_pr branch(es) without PRs${NC}"
+        echo "→ Run: stackit submit --stack"
+        echo
+    fi
 fi
 
-# Check if sync needed (look for merged PRs)
-if stackit log full 2>&1 | grep -qi "merged\|closed"; then
-    echo -e "${YELLOW}ℹ️  Some PRs have been merged/closed${NC}"
+# Check if sync needed (any PR merged or closed)
+merged_or_closed=$(echo "$STACK_JSON" | jq '[.branches[]? | select(.pr.state == "MERGED" or .pr.state == "CLOSED")] | length')
+if [ "$merged_or_closed" -gt 0 ]; then
+    echo -e "${YELLOW}ℹ️  $merged_or_closed PR(s) have been merged/closed${NC}"
     echo "→ Run: stackit sync --restack"
+    echo
+fi
+
+# Surface failing CI when GitHub data is available
+failing_ci=$(echo "$STACK_JSON" | jq -r '[.branches[]? | select(.pr.ci_status == "failing") | .name] | join(", ")')
+if [ -n "$failing_ci" ]; then
+    echo -e "${RED}⚠️  Failing CI on: $failing_ci${NC}"
     echo
 fi
 
@@ -83,49 +99,20 @@ if [ "$current_branch" = "$trunk_branch" ]; then
     echo
 fi
 
-# Check for large branches that might need splitting
+# Check for large branches that might need splitting, using the additions/deletions
+# already reported per branch in the JSON (>500 changed lines).
 echo -e "${BLUE}Branch Size Analysis:${NC}"
 large_branch_found=false
 
-# Get list of tracked branches (non-trunk branches in the stack)
-tracked_branches=$(stackit log --no-interactive 2>/dev/null | grep -oE '[a-zA-Z0-9_/-]+' | grep -v "^main$\|^master$\|^$trunk_branch$" | sort -u)
-
-for branch in $tracked_branches; do
-    # Skip if branch doesn't exist
-    if ! git rev-parse --verify "$branch" > /dev/null 2>&1; then
-        continue
-    fi
-
-    # Get parent branch (the branch this one is based on)
-    parent=$(git log --format=%D "$branch" -1 2>/dev/null | grep -oE 'origin/[^,]+' | head -1 | sed 's|origin/||' || echo "$trunk_branch")
-    if [ -z "$parent" ]; then
-        parent="$trunk_branch"
-    fi
-
-    # Calculate diff stats against merge-base with trunk
-    merge_base=$(git merge-base "$trunk_branch" "$branch" 2>/dev/null || echo "")
-    if [ -n "$merge_base" ]; then
-        # Get stats: files changed, insertions, deletions
-        stats=$(git diff --shortstat "$merge_base".."$branch" 2>/dev/null || echo "")
-        if [ -n "$stats" ]; then
-            files_changed=$(echo "$stats" | grep -oE '[0-9]+ file' | grep -oE '[0-9]+' || echo "0")
-            insertions=$(echo "$stats" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo "0")
-            deletions=$(echo "$stats" | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo "0")
-            total_lines=$((insertions + deletions))
-
-            # Warn if branch is large (>500 lines or >10 files)
-            if [ "$total_lines" -gt 500 ] || [ "$files_changed" -gt 10 ]; then
-                if [ "$large_branch_found" = false ]; then
-                    large_branch_found=true
-                fi
-                echo -e "${YELLOW}⚠️  Large branch: $branch${NC}"
-                echo "   $files_changed files, +$insertions/-$deletions lines ($total_lines total)"
-                echo "→ Consider: stackit split (to break into smaller PRs)"
-                echo
-            fi
-        fi
-    fi
-done
+while IFS=$'\t' read -r branch additions deletions; do
+    [ -z "$branch" ] && continue
+    total_lines=$((additions + deletions))
+    large_branch_found=true
+    echo -e "${YELLOW}⚠️  Large branch: $branch${NC}"
+    echo "   +$additions/-$deletions lines ($total_lines total)"
+    echo "→ Consider: stackit split (to break into smaller PRs)"
+    echo
+done < <(echo "$STACK_JSON" | jq -r '.branches[]? | select((.is_trunk | not) and ((.additions + .deletions) > 500)) | "\(.name)\t\(.additions)\t\(.deletions)"')
 
 if [ "$large_branch_found" = false ]; then
     echo -e "${GREEN}✓ All branches are reasonably sized${NC}"
@@ -151,10 +138,10 @@ echo -e "${BLUE}Suggested Next Steps:${NC}"
 
 if [ "$branches_no_pr" -gt 0 ]; then
     echo "1. Submit branches: stackit submit --stack"
-elif stackit log full 2>&1 | grep -qi "merged\|closed"; then
+elif [ "$merged_or_closed" -gt 0 ]; then
     echo "1. Sync with trunk: stackit sync --restack"
 elif ! git diff-index --quiet HEAD -- 2>/dev/null; then
-    echo "1. Commit changes: git add . (then) stackit modify"
+    echo "1. Commit changes: git add -A (then) stackit modify"
 else
     echo -e "${GREEN}✓ Stack is healthy! Ready for development.${NC}"
 fi

--- a/internal/cli/integrations/agents/templates/skill/workflows/absorb-conflict.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/absorb-conflict.md
@@ -93,7 +93,7 @@ The change can be directly applied to the target commit's version:
 
 ```bash
 # 1. Checkout the target branch
-git checkout <target-branch>
+stackit checkout <target-branch> --no-interactive
 
 # 2. Manually apply the semantic change
 # Edit the file to make the same logical change,
@@ -135,9 +135,10 @@ stackit absorb --no-interactive --force
 If the change doesn't belong in any existing commit:
 
 ```bash
-# 1. Keep the staged changes
-# 2. Create a new commit on top
-stackit create --no-interactive "description of change"
+# The change is already staged from the absorb attempt, so create a new branch
+# with a commit on top. Pipe the message via -F - — a bare positional arg is
+# treated as the BRANCH NAME, not the commit message.
+echo "<type>: description of change" | stackit create -F - --no-interactive
 ```
 
 ### Strategy D: Interactive Resolution

--- a/internal/cli/integrations/agents/templates/skill/workflows/conflict-resolution.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/conflict-resolution.md
@@ -191,13 +191,12 @@ Once all conflicts are resolved and verified:
 
 ```bash
 # Stage all resolved files
-git add .
+git add -A
 
-# Continue the operation
+# Continue the operation — always use stackit continue, NOT raw git.
+# It finishes the rebase AND resumes restacking the remaining branches,
+# keeping stackit metadata consistent.
 stackit continue --no-interactive
-
-# Or if using git directly
-git rebase --continue
 ```
 
 ## Common Conflict Patterns
@@ -302,13 +301,11 @@ func newFunction() {
 If resolution is too complex or you want to reconsider:
 
 ```bash
-# Abort the operation
+# Abort the operation — use stackit abort, NOT raw git rebase --abort, so the
+# whole halted stackit operation (restack/sync/merge/absorb) is cancelled cleanly.
 stackit abort --no-interactive
 
-# Or with git
-git rebase --abort
-
-# Then undo stackit command
+# Then, if you also want to revert the stackit command's metadata changes:
 stackit undo --no-interactive --yes
 ```
 
@@ -325,7 +322,8 @@ echo "feat: add phone validation" | stackit create -F - --no-interactive
 
 # Also good: Multiple commits in one branch for related work
 echo "feat: add validation helpers" | stackit create -F - --no-interactive
-git add . && git commit -m "test: add validation tests"
+git add -A
+printf 'test: add validation tests' | git commit -F -
 
 # Risky: Large, sweeping changes
 echo "feat: refactor entire validation system" | stackit create -F - --no-interactive
@@ -341,11 +339,10 @@ stackit sync --no-interactive --restack
 ### 3. Restack After Changes
 
 ```bash
-# After modifying a branch, restack only that branch's descendants
+# After modifying a branch, stackit modify automatically restacks its descendants.
 stackit modify --no-interactive
-stackit restack --branch $(git branch --show-current) --upstack --no-interactive
 
-# If modifications affected multiple independent stacks, prefer:
+# Only restack manually if modifications affected multiple independent stacks:
 # stackit restack --all-stacks --continue-on-conflict --no-interactive
 ```
 
@@ -374,7 +371,7 @@ stackit log --no-interactive  # Note branch order
 # Resolve first conflict
 git status  # See conflicted files
 # ... resolve conflicts ...
-git add .
+git add -A
 stackit continue --no-interactive
 
 # Before moving to next conflict, verify
@@ -383,7 +380,7 @@ stackit log --no-interactive  # Confirm structure still correct
 
 # Continue to next conflict
 # ... resolve conflicts ...
-git add .
+git add -A
 stackit continue --no-interactive
 
 # Repeat until complete
@@ -395,7 +392,7 @@ stackit continue --no-interactive
 
 ```bash
 # Stage all resolved files
-git add .
+git add -A
 stackit continue --no-interactive
 ```
 
@@ -416,7 +413,7 @@ stackit undo --no-interactive --yes
 # Or fix the build issue
 <build-command>  # See error (check README.md for project's build command)
 # Fix the issue
-git add .
+git add -A
 stackit continue --no-interactive
 ```
 

--- a/internal/cli/integrations/agents/templates/skill/workflows/fix-absorb.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/fix-absorb.md
@@ -42,21 +42,24 @@ Absorb Fix Progress:
    - "What command should I use to build the project?"
    - "What command should I use to run tests?"
 
-## Step 2: Build and Test Each Branch
+## Step 2: Build and Test the Whole Stack at Once
 
-Starting from the **bottom** of the stack (earliest branch), build and test each branch:
+Don't check out and build each branch by hand — run the build across the whole
+stack in one pass and let stackit stop at the first failing depth:
 
 ```bash
-# Get list of branches in stack order
-stackit log --no-interactive
-
-# For each branch (bottom to top):
-git checkout <branch-name>
-<build-command>
-<test-command>
+stackit foreach --stack --find-first-failure --no-interactive "<build-command>"
 ```
 
-**Mark which branches fail** - you'll need this for Step 3.
+`--find-first-failure` runs branches depth-by-depth and stops at the first depth
+that fails, so the reported branch is the earliest break — exactly the one to fix.
+Only drop down to a single branch (Step 3) for that reported failure:
+
+```bash
+stackit checkout <failing-branch> --no-interactive
+```
+
+**Note the failing branch and error** - you'll need them for Step 3.
 
 ## Step 3: Identify Failed Branches
 
@@ -64,7 +67,7 @@ For each failed branch, analyze the error:
 
 ```bash
 # Example: Build failed on branch "add-validation"
-git checkout add-validation
+stackit checkout add-validation --no-interactive
 
 # Run build and capture error
 <build-command> 2>&1 | tee build-error.log
@@ -112,8 +115,8 @@ For each missing dependency, move it to the failing branch:
 # If the needed change is in a single commit
 git cherry-pick <commit-hash>
 
-# Resolve conflicts if needed
-git add .
+# Resolve conflicts if needed (cherry-pick has no stackit equivalent)
+git add -A
 git cherry-pick --continue
 ```
 
@@ -133,18 +136,22 @@ git add path/to/file.go
 stackit modify --no-interactive  # Amends current branch's commit
 ```
 
-### Option C: Interactive rebase (advanced)
+### Option C: Reorder branches (advanced)
+
+If the dependency lives on a *later branch* and needs to come earlier, reorder
+the branches with stackit rather than a manual `git rebase -i` (which bypasses
+stackit metadata and hangs a non-interactive agent):
 
 ```bash
-# Reorder commits to move dependencies earlier
-git rebase -i <parent-branch>
+# Opens an editor to reorder the branches between trunk and the current branch,
+# then restacks all descendants. Editor-driven — run it where a human can edit.
+stackit reorder
+```
 
-# In editor, reorder commits so dependencies come first
-# Save and close
+To move a single branch onto a different parent non-interactively:
 
-# Resolve conflicts
-git add .
-git rebase --continue
+```bash
+stackit move --source <branch> --onto <new-parent> -y --no-interactive
 ```
 
 ## Step 6: Verify Entire Stack
@@ -216,7 +223,7 @@ git show abc123
 # → Shows validateUser function definition
 
 # 3. Cherry-pick it
-git checkout add-validation
+stackit checkout add-validation --no-interactive
 git cherry-pick abc123
 
 # 4. Verify fix

--- a/internal/cli/integrations/agents/templates/skill/workflows/stack-fold.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/stack-fold.md
@@ -43,7 +43,9 @@ Present your findings to the user. For each recommendation, include:
 ### 5. Execute Fold
 Wait for user confirmation. If confirmed, perform the fold:
 ```bash
-# Fold branch into parent (keeps parent name)
+# Folds the current branch into its parent; the combined branch takes the PARENT
+# name by default. Do NOT pass --keep unless you specifically want to retain the
+# child (current) branch's name instead.
 stackit checkout <branch-to-fold> --no-interactive
 stackit fold --no-interactive
 ```

--- a/internal/cli/integrations/agents/templates/subagents/commit-message.md
+++ b/internal/cli/integrations/agents/templates/subagents/commit-message.md
@@ -63,7 +63,10 @@ Generate a commit message for the staged changes above.
 1. Check CONTRIBUTING guidelines for commit message requirements
 2. Check README for any commit conventions mentioned
 3. Look at recent commits for the established style
-4. If no conventions are specified, use a clear imperative sentence (e.g., "Add user authentication")
+4. If no conventions are specified, default to Conventional Commits:
+   `<type>: <description>` where type is one of
+   feat, fix, docs, style, refactor, perf, test, chore, ci
+   (e.g., `feat: add user authentication`)
 
 **General guidelines:**
 - First line under 72 characters
@@ -85,3 +88,17 @@ END_MESSAGE
 ## Parsing the Response
 
 Extract the commit message between `MESSAGE:` and `END_MESSAGE` markers. The message may be a single line or include a body separated by a blank line. Trim leading/trailing whitespace from the extracted content.
+
+## Applying the Message
+
+Apply the generated message with stackit — never `git commit` for a new stacked
+branch. Pipe it via `-F -` so the literal message stays off the command line
+(keeps permission rules stable):
+
+```bash
+# New stacked branch (changes already staged)
+printf '%s\n' "<message>" | stackit create -F - --no-interactive
+
+# Amend the current branch's commit with a new message
+printf '%s\n' "<message>" | stackit modify -F - --no-interactive
+```

--- a/internal/cli/integrations/agents/templates/subagents/review-triage.md
+++ b/internal/cli/integrations/agents/templates/subagents/review-triage.md
@@ -93,6 +93,23 @@ Parse the JSON from the response. Each thread object contains:
 
 Use the `suggested_change` field as guidance when applying edits, but always verify against the actual code.
 
+## After Classification
+
+To get the actionable fixes back onto the PR, use stackit — not `gh` or a manual
+push. On the branch under review:
+
+```bash
+stackit checkout <branch> --no-interactive
+# apply the edits...
+git add -A
+stackit modify --no-interactive          # amends the commit; auto-restacks descendants
+stackit submit --no-interactive           # update the PR(s)
+```
+
+If a fix belongs on a different branch in the stack, route it with `stackit absorb`
+rather than amending the wrong commit. Resolve the GitHub review threads after the
+update lands.
+
 **Error handling - malformed response:** If the subagent returns invalid JSON or an unexpected format:
 1. Log the raw response for debugging
 2. Fall back to classifying threads manually in the main agent


### PR DESCRIPTION

Audit and fix the shipped agent-integration templates (Claude commands/skill/
subagents and Codex commands/skill) that instruct coding agents to drive the
stackit CLI. Flag and behavior claims were verified against the real CLI.

Correctness:
- describe: the Codex variant now sets the description (-m/-d) instead of the
  no-op bare command, reaching parity with the Claude variant
- merge: use 'merge ship/next --yes' for non-interactive merges; bare 'merge'
  is a TTY-only wizard
- remove forbidden raw git from prompts: 'git rebase --continue/-i' ->
  'stackit continue' / 'stackit reorder'; navigation 'git checkout' ->
  'stackit checkout'
- absorb-conflict: pass the create message via '-F -' (a bare positional was
  being used as the branch name)
- analyze_stack.sh: read 'stackit log short --json' (parent/pr/sizes) instead
  of scraping rendered TUI output (the prior glyph count was semantically wrong)

Codex/Claude parity:
- fold/sync/restack/plan/review/fix/absorb/submit/status/modify/verify Codex
  variants brought up to the Claude safety/behavior guidance: dry-run previews,
  preconditions, conflict recovery, empty-branch verification, structured
  foreach (--json --find-first-failure), issue->command recommendations

Permission stability & eval speed:
- strip non-functional '2>&1'; replace literal '-m'/'&&' chaining with stdin
  ('-F -' / '--message-file -') and separate commands
- front-load decisions, drop redundant context reads and dead round-trips

Build and the agents integration tests pass.