### PR TITLE
feat: auto-disable interactivity for non-TTY and STACKIT_NO_INTERACTIVE

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,18 @@ Stackit is designed to be easily scriptable. Use global flags to control behavio
 stackit sync --cwd /path/to/repo --no-interactive --no-verify
 ```
 
+Interactive features are also disabled automatically when there is no attached
+terminal (pipes, CI, agents). To force non-interactive mode without repeating
+`--no-interactive` on every command — handy for AI agents and scripts — set the
+environment variable once:
+
+```bash
+export STACKIT_NO_INTERACTIVE=1
+stackit create -F - < msg.txt   # no --no-interactive needed
+```
+
+An explicit `--interactive` always overrides both the env var and TTY detection.
+
 ---
 
 ## Configuration

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/getstackit/stackit/internal/cli/shell"
 	"github.com/getstackit/stackit/internal/cli/stack"
 	"github.com/getstackit/stackit/internal/cli/worktree"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // NewRootCmd creates the root cobra command
@@ -39,15 +40,23 @@ Version: ` + version + `
 Commit:  ` + commit + `
 		Date:    ` + date,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			if noInteractive {
+			// Resolve interactivity. Precedence:
+			//   1. --no-interactive / --quiet           -> off
+			//   2. explicit --interactive               -> honored as set
+			//   3. STACKIT_NO_INTERACTIVE env, or no TTY -> off
+			// This lets agents, CI, and pipes run without repeating
+			// --no-interactive on every command, while explicit flags always win.
+			switch {
+			case noInteractive || quiet:
+				interactive = false
+			case cmd.Flags().Changed("interactive"):
+				// honor the explicit --interactive value already in `interactive`
+			case utils.NonInteractiveEnv() || !utils.TerminalDetected():
 				interactive = false
 			}
+
 			if noVerify {
 				verify = false
-			}
-			if quiet {
-				// quiet implies no-interactive
-				interactive = false
 			}
 
 			// Sync the boolean values back to the flags so common.GetGlobalOptions works

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -216,6 +216,15 @@ func IsTTY() bool {
 	if atomic.LoadInt32(&interactiveMode) == 0 {
 		return false
 	}
+	return TerminalDetected()
+}
+
+// TerminalDetected reports whether a usable interactive terminal is attached,
+// independent of the configured interactive mode. It checks the TERM
+// environment, stdin/stdout isatty, and /dev/tty availability. Use this when
+// resolving the default interactivity before the interactive mode is set (e.g.
+// in the root command), where IsTTY's mode gate would not yet apply.
+func TerminalDetected() bool {
 	if !supportsTerminalControl() {
 		return false
 	}
@@ -231,6 +240,19 @@ func IsTTY() bool {
 	}
 	_ = f.Close()
 	return true
+}
+
+// NonInteractiveEnv reports whether STACKIT_NO_INTERACTIVE requests
+// non-interactive mode. Any value other than empty/"0"/"false"/"no" enables it,
+// letting agents and scripts opt out of prompts once instead of passing
+// --no-interactive on every command.
+func NonInteractiveEnv() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("STACKIT_NO_INTERACTIVE"))) {
+	case "", "0", "false", "no":
+		return false
+	default:
+		return true
+	}
 }
 
 func supportsTerminalControl() bool {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -23,3 +23,37 @@ func TestSupportsTerminalControl(t *testing.T) {
 		})
 	}
 }
+
+func TestNonInteractiveEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		val  string
+		set  bool
+		want bool
+	}{
+		{name: "unset", set: false, want: false},
+		{name: "empty", val: "", set: true, want: false},
+		{name: "zero", val: "0", set: true, want: false},
+		{name: "false", val: "false", set: true, want: false},
+		{name: "no", val: "no", set: true, want: false},
+		{name: "one", val: "1", set: true, want: true},
+		{name: "true", val: "true", set: true, want: true},
+		{name: "yes", val: "yes", set: true, want: true},
+		{name: "arbitrary", val: "please", set: true, want: true},
+		{name: "uppercase false", val: "FALSE", set: true, want: false},
+		{name: "padded", val: "  1  ", set: true, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv("STACKIT_NO_INTERACTIVE", tt.val)
+			} else {
+				t.Setenv("STACKIT_NO_INTERACTIVE", "")
+			}
+			if got := NonInteractiveEnv(); got != tt.want {
+				t.Fatalf("NonInteractiveEnv() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Resolve the interactive default in the root command so agents, CI, and pipes
don't have to repeat --no-interactive on every invocation:

- honor a STACKIT_NO_INTERACTIVE env var (set it once instead of per-command)
- auto-disable interactive features when no usable terminal is attached
- an explicit --interactive still overrides both

Extracts the terminal-detection from utils.IsTTY into utils.TerminalDetected
(mode-gate-free) so the root command can resolve interactivity before the
interactive mode is set, and adds utils.NonInteractiveEnv. Reduces the
per-command flag noise that inflates agent permission allowlists.

<hr/>

<!-- STACKIT-SECTION-START -->
**Harden non-interactive and scripted CLI workflows**

Makes stackit safe and predictable when used in automation, CI, or agent-driven workflows where no TTY is present.

Key changes:
- **auto-disable interactivity**: Detects non-TTY environments and the `STACKIT_NO_INTERACTIVE` env var to suppress prompts automatically; documents the flag in README
- **describe loudly in non-interactive**: `stackit describe` errors instead of silently no-oping when run without a TTY, and gains `-F`/`--message-file` for piping descriptions from stdin or a file
- **reject empty-branch creation**: `stackit create` now fails loudly when no changes are staged, preventing accidental empty branches in scripted flows
- **`-F` shorthand on split**: `stackit split` gains `-F` as the `--message-file` shorthand for consistency with `create` and `describe`
- **`--yes` on parent merge**: `stackit merge parent` accepts `--yes` to skip the confirmation prompt in non-interactive contexts
- **`log --json` as self-describing status source**: JSON output now includes enough metadata (PR numbers, parent relationships, diff stats) to drive external tooling without additional API calls

#### Stack


* **PR #1072** 👈
  * **PR #1073**
    * **PR #1074**
      * **PR #1075**
        * **PR #1076**
          * **PR #1077**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1078 by jonnii*