### PR TITLE
fix: describe fails loudly in non-interactive and accepts -F/--message-file

### DIFF
--- a/internal/actions/describe/describe.go
+++ b/internal/actions/describe/describe.go
@@ -90,7 +90,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 				return applyStackDescription(ctx, *currentBranch, stackRoot, desc, TruncateDescription(desc.Description, 60))
 			}
 		}
-		return fmt.Errorf("must specify --message or run in interactive mode")
+		return fmt.Errorf("nothing to set: pass --title/-m, --message-file/-F, pipe a description via stdin, or run in interactive mode")
 	}
 
 	existingDesc := eng.GetStackDescription(*currentBranch)

--- a/internal/actions/describe/describe_test.go
+++ b/internal/actions/describe/describe_test.go
@@ -172,7 +172,7 @@ func TestDescribeAction(t *testing.T) {
 		handler := &testDescribeHandler{interactive: false}
 		err := describe.Action(s.Context, describe.Options{}, handler)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "must specify --message or run in interactive mode")
+		require.Contains(t, err.Error(), "nothing to set")
 	})
 }
 

--- a/internal/cli/describe.go
+++ b/internal/cli/describe.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/getstackit/stackit/internal/actions/describe"
@@ -14,6 +16,7 @@ func newDescribeCmd() *cobra.Command {
 	var (
 		message     string
 		description string
+		messageFile string
 		clearFlag   bool
 		show        bool
 	)
@@ -32,12 +35,36 @@ Examples:
   stackit describe                              # Opens editor to set/edit description
   stackit describe -m "Auth Feature"            # Set title only (short flag like git commit)
   stackit describe -m "Auth" -d "OAuth2 impl"   # Set title and description
+  printf "Auth\n\nOAuth2 impl" | stackit describe -F -   # Read title+body from stdin
+  stackit describe -F desc.txt                  # Read title+body from a file
   stackit describe --show                       # Display current description
   stackit describe --clear                      # Remove description`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			// If no flags and no message, default to editor (interactive) or show
-			effectiveShow := show || (message == "" && !clearFlag && !utils.IsInteractive())
+			title, desc := message, description
+
+			// -F/--message-file supplies the full description in editor format
+			// (first line title, blank line, then body). Mutually exclusive with
+			// -m/-d so the input source is unambiguous.
+			if messageFile != "" {
+				if message != "" || description != "" {
+					return fmt.Errorf("cannot use --message-file with --title/--description; pass only one")
+				}
+				content, err := common.ReadMessage("", messageFile)
+				if err != nil {
+					return err
+				}
+				parsed := describe.ParseEditorContent(content)
+				if parsed == nil {
+					return fmt.Errorf("--message-file content has no title (first non-empty line)")
+				}
+				title, desc = parsed.Title, parsed.Description
+			}
+
+			// Only show when explicitly asked. A no-input non-interactive
+			// invocation falls through to the action, which errors clearly
+			// instead of silently resolving to show (a no-op for a set attempt).
+			effectiveShow := show
 			globalOpts := common.GetGlobalOptions(cmd)
 			if effectiveShow {
 				globalOpts = common.ApplyReadOnlyCurrentBranch(globalOpts)
@@ -45,8 +72,8 @@ Examples:
 
 			return common.RunWithOptions(cmd, globalOpts, func(ctx *app.Context) error {
 				opts := describe.Options{
-					Title:       message,
-					Description: description,
+					Title:       title,
+					Description: desc,
 					Clear:       clearFlag,
 					Show:        effectiveShow,
 				}
@@ -61,6 +88,7 @@ Examples:
 
 	cmd.Flags().StringVarP(&message, "title", "m", "", "Set the stack title (non-interactive)")
 	cmd.Flags().StringVarP(&description, "description", "d", "", "Set the stack description body (requires -m)")
+	cmd.Flags().StringVarP(&messageFile, "message-file", "F", "", "Read the title and description from a file (use \"-\" for stdin): first line is the title, then a blank line, then the body. Mutually exclusive with --title/--description.")
 	cmd.Flags().BoolVar(&clearFlag, "clear", false, "Remove the stack description")
 	cmd.Flags().BoolVar(&show, "show", false, "Display the current stack description")
 

--- a/internal/integration/messagefile_test.go
+++ b/internal/integration/messagefile_test.go
@@ -85,6 +85,38 @@ func TestMessageFile(t *testing.T) {
 			OutputContains("feat: extracted from file")
 	})
 
+	t.Run("describe reads title and body from file", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("feature", "content").
+			Run("create feature -m 'feat: x'")
+
+		msgPath := writeMessageFile(t, "Auth Feature\n\nOAuth2 implementation\n")
+		sh.Run("describe -F " + msgPath).
+			Run("describe --show").
+			OutputContains("Auth Feature").
+			OutputContains("OAuth2 implementation")
+	})
+
+	t.Run("describe errors with no input in non-interactive mode", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("feature", "content").
+			Run("create feature -m 'feat: x'")
+		sh.RunExpectError("describe").
+			OutputContains("nothing to set")
+	})
+
+	t.Run("describe errors when both --title and --message-file are given", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("feature", "content").Run("create feature -m 'feat: x'")
+		msgPath := writeMessageFile(t, "Title\n\nBody")
+		sh.RunExpectError("describe -m 'inline' -F " + msgPath).
+			OutputContains("cannot use --message-file with --title")
+	})
+
 	t.Run("create errors when both --message and --message-file are given", func(t *testing.T) {
 		t.Parallel()
 		runMutexTest(t, "create feature -m 'inline' -F ")


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Previously 'stackit describe --no-interactive' with no flags silently resolved
to show-mode: a set attempt did nothing and exited 0, and the action's stdin
path was unreachable dead code.

- only resolve show-mode from an explicit --show; a no-input non-interactive
  invocation now errors clearly ('nothing to set: pass --title/-m,
  --message-file/-F, pipe a description via stdin, or run interactively')
- add -F/--message-file (file or '-' for stdin) reading editor-format content
  (first line title, blank line, then body), reusing common.ReadMessage for
  parity with create/modify/squash/split
- mutually exclusive with --title/--description

This makes describe consistent with the other message-taking commands and
removes a silent agent footgun.

<hr/>

<!-- STACKIT-SECTION-START -->
**Harden non-interactive and scripted CLI workflows**

Makes stackit safe and predictable when used in automation, CI, or agent-driven workflows where no TTY is present.

Key changes:
- **auto-disable interactivity**: Detects non-TTY environments and the `STACKIT_NO_INTERACTIVE` env var to suppress prompts automatically; documents the flag in README
- **describe loudly in non-interactive**: `stackit describe` errors instead of silently no-oping when run without a TTY, and gains `-F`/`--message-file` for piping descriptions from stdin or a file
- **reject empty-branch creation**: `stackit create` now fails loudly when no changes are staged, preventing accidental empty branches in scripted flows
- **`-F` shorthand on split**: `stackit split` gains `-F` as the `--message-file` shorthand for consistency with `create` and `describe`
- **`--yes` on parent merge**: `stackit merge parent` accepts `--yes` to skip the confirmation prompt in non-interactive contexts
- **`log --json` as self-describing status source**: JSON output now includes enough metadata (PR numbers, parent relationships, diff stats) to drive external tooling without additional API calls

#### Stack


* **PR #1072**
  * **PR #1073** 👈
    * **PR #1074**
      * **PR #1075**
        * **PR #1076**
          * **PR #1077**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1078 by jonnii*