### PR TITLE
fix: reject silent empty-branch creation when changes aren't staged

### DIFF
--- a/internal/actions/create/create.go
+++ b/internal/actions/create/create.go
@@ -32,6 +32,10 @@ type Options struct {
 	SelectedChildren []string
 	// Worktree creates a dedicated worktree for this stack (only valid from trunk)
 	Worktree bool
+	// AllowEmpty permits creating a branch with no commit when the working tree
+	// has unstaged/untracked changes in non-interactive mode (otherwise that is
+	// treated as a "forgot to stage" mistake and rejected).
+	AllowEmpty bool
 }
 
 // Action creates a new branch stacked on top of the current branch.
@@ -70,6 +74,7 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 		actions.WithFlag(opts.Patch, "--patch"),
 		actions.WithFlag(opts.Update, "--update"),
 		actions.WithFlag(opts.Worktree, "--worktree"),
+		actions.WithFlag(opts.AllowEmpty, "--allow-empty"),
 	)
 	actions.TakeBestEffortSnapshot(ctx, snapshotOpts)
 
@@ -110,6 +115,24 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 				hasStaged = true
 				h.OnStep(StepStaging, handler.StatusCompleted, "Changes staged")
 			}
+		}
+	}
+
+	// Guard against the common non-interactive footgun: the working tree has
+	// changes but nothing is staged (e.g. forgot `git add`), which would
+	// silently produce an empty branch. A genuinely clean tree still allows an
+	// intentional empty scaffolding branch.
+	if !hasStaged && !opts.AllowEmpty && !h.IsInteractive() {
+		hasUnstaged, err := eng.HasUnstagedChanges(ctx.Context)
+		if err != nil {
+			return Result{}, fmt.Errorf("failed to check unstaged changes: %w", err)
+		}
+		hasUntracked, err := eng.HasUntrackedFiles(ctx.Context)
+		if err != nil {
+			return Result{}, fmt.Errorf("failed to check untracked files: %w", err)
+		}
+		if hasUnstaged || hasUntracked {
+			return Result{}, fmt.Errorf("nothing staged but the working tree has changes; stage them with 'git add' (or pass --all/-a), or pass --allow-empty to create an empty branch")
 		}
 	}
 

--- a/internal/cli/branch/create.go
+++ b/internal/cli/branch/create.go
@@ -14,6 +14,7 @@ import (
 func NewCreateCmd() *cobra.Command {
 	var (
 		all         bool
+		allowEmpty  bool
 		insert      bool
 		message     string
 		messageFile string
@@ -30,8 +31,11 @@ func NewCreateCmd() *cobra.Command {
 		Long: `Create a new branch stacked on top of the current branch and commit staged changes.
 
 If no branch name is specified, generate a branch name from the commit message.
-If your working directory contains no changes, an empty branch will be created.
-If you have any unstaged changes, you will be asked whether you'd like to stage them.
+If your working directory is clean, an empty branch will be created.
+If you have any unstaged changes, you will be asked whether you'd like to stage them
+(interactive). In non-interactive mode, having changes that aren't staged is treated
+as a "forgot to stage" mistake and rejected — stage them, pass --all, or pass
+--allow-empty to create an empty branch anyway.
 
 Examples:
   stackit create -m "feat: add login"             # Inline message
@@ -67,6 +71,7 @@ Examples:
 					Verbose:       verbose,
 					BranchPattern: branchPattern,
 					Worktree:      worktree,
+					AllowEmpty:    allowEmpty,
 				}
 
 				// Create runner and handler
@@ -91,6 +96,7 @@ Examples:
 
 	// Add flags
 	cmd.Flags().BoolVarP(&all, "all", "a", false, "Stage all unstaged changes before creating the branch, including to untracked files")
+	cmd.Flags().BoolVar(&allowEmpty, "allow-empty", false, "Allow creating a branch with no commit even when the working tree has unstaged/untracked changes (otherwise this is rejected in non-interactive mode)")
 	cmd.Flags().BoolVarP(&insert, "insert", "i", false, "Insert this branch between the current branch and its child. If there are multiple children, prompts you to select which should be moved onto the new branch")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "Specify a commit message")
 	cmd.Flags().StringVarP(&messageFile, "message-file", "F", "", "Read commit message from a file (use \"-\" for stdin). Mutually exclusive with --message.")

--- a/internal/integration/create_allow_empty_test.go
+++ b/internal/integration/create_allow_empty_test.go
@@ -1,0 +1,67 @@
+package integration
+
+import "testing"
+
+// TestCreateEmptyBranchGuard verifies that, in non-interactive mode, `create`
+// refuses to silently produce an empty branch when the working tree has changes
+// that simply weren't staged (the common "forgot to git add" agent footgun),
+// while still allowing intentional empty branches on a clean tree or with
+// --allow-empty.
+func TestCreateEmptyBranchGuard(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects create when unstaged tracked changes exist but nothing staged", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("base", "v1").
+			Run("create base -m 'feat: base'")
+		// Modify the tracked file, then unstage so it is a dirty-but-unstaged change.
+		sh.WriteFile("base_test.txt", "v2").
+			Git("reset HEAD base_test.txt")
+		sh.RunExpectError("create next -m 'feat: next'").
+			OutputContains("nothing staged but the working tree has changes")
+	})
+
+	t.Run("rejects create when untracked files exist but nothing staged", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("base", "v1").
+			Run("create base -m 'feat: base'")
+		sh.WriteFile("untracked.txt", "x").
+			Git("reset HEAD untracked.txt")
+		sh.RunExpectError("create next -m 'feat: next'").
+			OutputContains("nothing staged but the working tree has changes")
+	})
+
+	t.Run("--allow-empty creates a branch despite unstaged changes", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("base", "v1").
+			Run("create base -m 'feat: base'")
+		sh.WriteFile("base_test.txt", "v2").
+			Git("reset HEAD base_test.txt")
+		sh.Run("create next --allow-empty -m 'feat: empty'").
+			OnBranch("next")
+	})
+
+	t.Run("--all stages the changes and avoids the guard", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("base", "v1").
+			Run("create base -m 'feat: base'")
+		sh.WriteFile("base_test.txt", "v2").
+			Git("reset HEAD base_test.txt")
+		sh.Run("create next --all -m 'feat: next'").
+			OnBranch("next")
+	})
+
+	t.Run("clean tree still creates an empty scaffolding branch", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("base", "v1").
+			Run("create base -m 'feat: base'")
+		// Working tree is clean here; an empty branch is intentional.
+		sh.Run("create scaffold -m 'feat: scaffold'").
+			OnBranch("scaffold")
+	})
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

In non-interactive mode 'stackit create' silently produced an empty branch when
the working tree had changes that simply weren't staged — the common agent
'forgot to git add' footgun (and the failure mode stack-plan guards against).

Now create errors in that case:
  nothing staged but the working tree has changes; stage them with 'git add'
  (or pass --all/-a), or pass --allow-empty to create an empty branch

A genuinely clean tree still creates an intentional empty scaffolding branch,
and interactive mode still prompts to stage as before. Adds an --allow-empty
escape hatch for deliberately empty branches over a dirty tree.

<hr/>

<!-- STACKIT-SECTION-START -->
**Harden non-interactive and scripted CLI workflows**

Makes stackit safe and predictable when used in automation, CI, or agent-driven workflows where no TTY is present.

Key changes:
- **auto-disable interactivity**: Detects non-TTY environments and the `STACKIT_NO_INTERACTIVE` env var to suppress prompts automatically; documents the flag in README
- **describe loudly in non-interactive**: `stackit describe` errors instead of silently no-oping when run without a TTY, and gains `-F`/`--message-file` for piping descriptions from stdin or a file
- **reject empty-branch creation**: `stackit create` now fails loudly when no changes are staged, preventing accidental empty branches in scripted flows
- **`-F` shorthand on split**: `stackit split` gains `-F` as the `--message-file` shorthand for consistency with `create` and `describe`
- **`--yes` on parent merge**: `stackit merge parent` accepts `--yes` to skip the confirmation prompt in non-interactive contexts
- **`log --json` as self-describing status source**: JSON output now includes enough metadata (PR numbers, parent relationships, diff stats) to drive external tooling without additional API calls

#### Stack


* **PR #1072**
  * **PR #1073**
    * **PR #1074** 👈
      * **PR #1075**
        * **PR #1076**
          * **PR #1077**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1078 by jonnii*