### PR TITLE
feat: make -F the --message-file shorthand on split

### DIFF
--- a/internal/cli/branch/split.go
+++ b/internal/cli/branch/split.go
@@ -39,7 +39,7 @@ Has three forms: split --by-commit, split --by-hunk, and split --by-file.
 split --by-commit slices up the commit history, allowing you to select split points.
 split --by-hunk interactively stages changes to create new single-commit branches.
 split --by-file <files> extracts specified files into a new branch.
-split -F (--by-file-interactive) shows an interactive file selector.
+split --by-file-interactive shows an interactive file selector.
 split without options will launch an interactive wizard.
 
 Direction options (for --by-hunk and --by-file):
@@ -70,7 +70,8 @@ Examples:
   stackit split --by-file path/to/file.go --as-sibling # Extract to sibling branch
   stackit split --by-file path/to/file.go --dry-run   # Preview the split
   stackit split --by-commit --as-sibling              # Split commits as siblings
-  stackit split --by-file file.go --message-file msg.txt  # Read commit message from file (no -F shorthand on split; -F is --by-file-interactive)`,
+  stackit split --by-file file.go -F msg.txt           # Read commit message from a file
+  printf "Extract" | stackit split --by-file file.go -F -  # Read commit message from stdin`,
 		SilenceUsage: true,
 		// Disable default help flag to allow -h for --by-hunk
 		DisableFlagParsing: false,
@@ -175,13 +176,13 @@ Examples:
 	cmd.Flags().BoolVarP(&byCommit, "by-commit", "c", false, "Split by commit - slice up the history of this branch")
 	cmd.Flags().BoolVarP(&byHunk, "by-hunk", "h", false, "Split by hunk - split into new single-commit branches")
 	cmd.Flags().StringSliceVarP(&byFile, "by-file", "f", nil, "Split by file - extracts specified files to a new parent branch")
-	cmd.Flags().BoolVarP(&byFileInteractive, "by-file-interactive", "F", false, "Split by file (interactive) - select files to extract")
+	cmd.Flags().BoolVar(&byFileInteractive, "by-file-interactive", false, "Split by file (interactive) - select files to extract")
 
 	// Additional options
 	cmd.Flags().BoolVar(&asSibling, "as-sibling", false, "Create split branches as siblings instead of a chain")
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Name for the new split branch (default: auto-generated)")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "Commit message for extraction (only with --by-file)")
-	cmd.Flags().StringVar(&messageFile, "message-file", "", "Read commit message from a file (use \"-\" for stdin) (only with --by-file or --by-hunk --patch). Mutually exclusive with --message. Note: split has no -F shorthand for this flag (taken by --by-file-interactive).")
+	cmd.Flags().StringVarP(&messageFile, "message-file", "F", "", "Read commit message from a file (use \"-\" for stdin) (only with --by-file or --by-hunk --patch). Mutually exclusive with --message.")
 
 	// Direction options (for hunk and file modes)
 	cmd.Flags().BoolVar(&above, "above", false, "Insert new branch above current (as child, upstack)")

--- a/internal/integration/messagefile_test.go
+++ b/internal/integration/messagefile_test.go
@@ -79,7 +79,8 @@ func TestMessageFile(t *testing.T) {
 			Run("create feature -m 'Add feature'")
 
 		msgPath := writeMessageFile(t, "feat: extracted from file\n")
-		sh.Run("split --by-file file_test.txt --as-sibling --message-file " + msgPath).
+		// -F is the shorthand for --message-file (consistent with create/modify/squash).
+		sh.Run("split --by-file file_test.txt --as-sibling -F " + msgPath).
 			Checkout("feature_split").
 			Git("log -1 --format=%s").
 			OutputContains("feat: extracted from file")


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Standardize -F to mean --message-file across all message-taking commands
(create, modify, squash, and now split). Previously split's -F was bound to
--by-file-interactive, the only command where -F did not mean message-file —
a consistency tax that forced agents to special-case split.

--by-file-interactive keeps its long form (its -F shorthand is dropped).

<hr/>

<!-- STACKIT-SECTION-START -->
**Harden non-interactive and scripted CLI workflows**

Makes stackit safe and predictable when used in automation, CI, or agent-driven workflows where no TTY is present.

Key changes:
- **auto-disable interactivity**: Detects non-TTY environments and the `STACKIT_NO_INTERACTIVE` env var to suppress prompts automatically; documents the flag in README
- **describe loudly in non-interactive**: `stackit describe` errors instead of silently no-oping when run without a TTY, and gains `-F`/`--message-file` for piping descriptions from stdin or a file
- **reject empty-branch creation**: `stackit create` now fails loudly when no changes are staged, preventing accidental empty branches in scripted flows
- **`-F` shorthand on split**: `stackit split` gains `-F` as the `--message-file` shorthand for consistency with `create` and `describe`
- **`--yes` on parent merge**: `stackit merge parent` accepts `--yes` to skip the confirmation prompt in non-interactive contexts
- **`log --json` as self-describing status source**: JSON output now includes enough metadata (PR numbers, parent relationships, diff stats) to drive external tooling without additional API calls

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780051956`.


* **PR #1072**
  * **PR #1073**
    * **PR #1074**
      * **PR #1075** 👈
        * **PR #1076**
          * **PR #1077**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->