### PR TITLE
feat: accept --yes on the parent merge command for non-interactive use

### DIFF
--- a/internal/cli/stack/merge/merge.go
+++ b/internal/cli/stack/merge/merge.go
@@ -23,6 +23,7 @@ func NewMergeCmd(postMergeHandler PostMergeHandler) *cobra.Command {
 		dryRun bool
 		force  bool
 		wait   bool
+		yes    bool
 		scope  string
 		branch string
 	)
@@ -43,8 +44,13 @@ Subcommands:
 
 Use --scope or --branch to skip the initial prompts and go straight to strategy selection.
 
+Without a TTY, pass --yes to merge the next (bottom-most) ready PR without
+prompting (equivalent to 'merge next --yes'); it never consolidates. Use the
+'ship'/'drain' subcommands for other strategies.
+
 Examples:
   stackit merge                    # Launch interactive merge wizard
+  stackit merge --yes              # Non-interactive: merge the next ready PR
   stackit merge --scope=PROJ-100   # Merge all branches in scope PROJ-100
   stackit merge --branch=feature   # Merge from specific branch
   stackit merge status             # Show your mergeable work
@@ -55,9 +61,24 @@ Examples:
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
-				// Must be interactive for wizard mode
+				// The strategy-selection wizard needs a TTY. Non-interactively we
+				// can't safely guess between consolidating (ship) and incremental
+				// merges, so --yes routes to the conservative default — merge the
+				// next (bottom-most) ready PR, equivalent to `merge next`. It never
+				// consolidates and re-runs to drain the stack one PR at a time.
+				// Other strategies stay explicit via the subcommands.
 				if !ctx.Interactive {
-					return fmt.Errorf("merge wizard requires a TTY. Use 'merge next' or 'merge ship' for non-interactive mode (add --yes to skip prompts)")
+					if !yes && !dryRun {
+						return fmt.Errorf("merge wizard requires a TTY. For non-interactive use pass --yes to merge the next (bottom-most) PR, or use 'merge next'/'merge drain'/'merge ship' (each accepts --yes)")
+					}
+					return runMergeNext(ctx, mergeNextOptions{
+						dryRun: dryRun,
+						yes:    yes,
+						force:  force,
+						wait:   wait,
+						branch: branch,
+						scope:  scope,
+					}, postMergeHandler)
 				}
 
 				// runner.Cleanup is nil-safe so no extra guard is needed.
@@ -95,6 +116,7 @@ Examples:
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show merge plan without executing")
 	cmd.Flags().BoolVar(&force, "force", false, "Skip validation checks (draft PRs, failing CI)")
 	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for merge to complete (default: fire-and-forget)")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Non-interactive: merge the next (bottom-most) ready PR without prompting (equivalent to 'merge next --yes'). Use 'merge ship'/'merge drain' for other strategies.")
 	cmd.Flags().StringVar(&scope, "scope", "", "Pre-select scope to merge (skips scope prompt)")
 	cmd.Flags().StringVar(&branch, "branch", "", "Pre-select target branch to merge from (skips branch prompt)")
 	cmd.MarkFlagsMutuallyExclusive("scope", "branch")

--- a/internal/cli/stack/merge/merge_test.go
+++ b/internal/cli/stack/merge/merge_test.go
@@ -53,6 +53,10 @@ func TestNewMergeCmd(t *testing.T) {
 		waitFlag := cmd.Flags().Lookup("wait")
 		require.NotNil(t, waitFlag)
 
+		yesFlag := cmd.Flags().Lookup("yes")
+		require.NotNil(t, yesFlag)
+		require.Equal(t, "y", yesFlag.Shorthand)
+
 		scopeFlag := cmd.Flags().Lookup("scope")
 		require.NotNil(t, scopeFlag)
 

--- a/internal/integration/merge_subcommands_test.go
+++ b/internal/integration/merge_subcommands_test.go
@@ -4,6 +4,48 @@ import (
 	"testing"
 )
 
+func TestMergeParentNonInteractive(t *testing.T) {
+	t.Parallel()
+
+	t.Run("errors without --yes in non-interactive mode", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("a.txt", "content-a").
+			Run("create branch-a -m 'Add branch-a'")
+
+		sh.RunExpectError("merge").
+			OutputContains("pass --yes to merge the next")
+	})
+
+	t.Run("--yes --dry-run routes to the next (bottom PR) strategy", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("a.txt", "content-a").
+			Run("create branch-a -m 'Add branch-a'")
+		sh.Write("b.txt", "content-b").
+			Run("create branch-b -m 'Add branch-b'")
+
+		sh.SetPrMetadata("branch-a", PRMetadata{
+			Number: 101,
+			State:  "OPEN",
+			URL:    "https://github.com/owner/repo/pull/101",
+		})
+		sh.SetPrMetadata("branch-b", PRMetadata{
+			Number: 102,
+			State:  "OPEN",
+			URL:    "https://github.com/owner/repo/pull/102",
+		})
+
+		// Parent `merge --yes --dry-run` should behave like `merge next --dry-run`:
+		// target the bottom-most PR (branch-a / #101), not consolidate.
+		sh.Run("merge --yes --dry-run").
+			OutputContains("branch-a").
+			OutputContains("#101").
+			OutputContains("Dry-run mode")
+	})
+}
+
 func TestMergeNext(t *testing.T) {
 	t.Parallel()
 	t.Run("dry-run shows plan for bottom PR", func(t *testing.T) {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Bare 'stackit merge' launches a TTY strategy wizard, so non-interactively it
errored — and '--yes' wasn't even a recognized flag on the parent (cobra
reported 'unknown flag'), which is confusing for agents and scripts.

Add -y/--yes to the parent merge. In non-interactive mode it routes to the
conservative default: merge the next (bottom-most) ready PR — equivalent to
'merge next --yes'. This never consolidates (ship stays explicit), still gates
on validation (drafts/failing CI), and re-runs to drain the stack one PR at a
time. --dry-run previews the same plan. Without --yes (and not a dry-run),
non-interactive merge now errors with actionable guidance naming the
subcommands rather than 'unknown flag'.

Picking between consolidate and incremental merges unattended is consequential,
so only the unambiguous incremental path is automated; ship/drain remain
explicit opt-ins.

<hr/>

<!-- STACKIT-SECTION-START -->
**Harden non-interactive and scripted CLI workflows**

Makes stackit safe and predictable when used in automation, CI, or agent-driven workflows where no TTY is present.

Key changes:
- **auto-disable interactivity**: Detects non-TTY environments and the `STACKIT_NO_INTERACTIVE` env var to suppress prompts automatically; documents the flag in README
- **describe loudly in non-interactive**: `stackit describe` errors instead of silently no-oping when run without a TTY, and gains `-F`/`--message-file` for piping descriptions from stdin or a file
- **reject empty-branch creation**: `stackit create` now fails loudly when no changes are staged, preventing accidental empty branches in scripted flows
- **`-F` shorthand on split**: `stackit split` gains `-F` as the `--message-file` shorthand for consistency with `create` and `describe`
- **`--yes` on parent merge**: `stackit merge parent` accepts `--yes` to skip the confirmation prompt in non-interactive contexts
- **`log --json` as self-describing status source**: JSON output now includes enough metadata (PR numbers, parent relationships, diff stats) to drive external tooling without additional API calls

#### Stack


* **PR #1072**
  * **PR #1073**
    * **PR #1074**
      * **PR #1075**
        * **PR #1076** 👈
          * **PR #1077**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1078 by jonnii*