### PR TITLE
feat: make log --json a complete, self-describing status source

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,13 @@ stackit create -F - < msg.txt   # no --no-interactive needed
 
 An explicit `--interactive` always overrides both the env var and TTY detection.
 
+For machine-readable status, `stackit log --json` is a complete, self-describing
+source: each branch reports its structure (`parent`, `children`), PR/CI state
+(`pr.state`, `pr.ci_status`, `pr.review_status`), and stack health
+(`needs_restack`, `is_locked`, `is_frozen`, `scope`). The status booleans are
+always present (an explicit `false`, never omitted), so a single call covers what
+previously required both `log --json` and `info --stack --json`.
+
 ---
 
 ## Configuration

--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -45,13 +45,19 @@ type LogJSONResult struct {
 
 // LogBranchInfo represents a single branch in JSON output
 type LogBranchInfo struct {
-	Name         string     `json:"name"`
-	Parent       string     `json:"parent,omitempty"`
-	IsCurrent    bool       `json:"is_current"`
-	IsTrunk      bool       `json:"is_trunk"`
-	IsLocked     bool       `json:"is_locked,omitempty"`
-	IsFrozen     bool       `json:"is_frozen,omitempty"`
-	NeedsRestack bool       `json:"needs_restack,omitempty"`
+	Name      string `json:"name"`
+	Parent    string `json:"parent,omitempty"`
+	IsCurrent bool   `json:"is_current"`
+	IsTrunk   bool   `json:"is_trunk"`
+	// Status booleans are always emitted (no omitempty) so consumers can rely on
+	// `log --json` as a complete, self-describing status source: an explicit
+	// false is unambiguous, whereas an omitted field is indistinguishable from
+	// "this field isn't reported". This is what lets agents read PR/CI status and
+	// needs_restack/locked/frozen from a single command instead of also querying
+	// `info --stack --json`.
+	IsLocked     bool       `json:"is_locked"`
+	IsFrozen     bool       `json:"is_frozen"`
+	NeedsRestack bool       `json:"needs_restack"`
 	Commits      int        `json:"commits"`
 	Additions    int        `json:"additions,omitempty"`
 	Deletions    int        `json:"deletions,omitempty"`

--- a/internal/integration/json_output_test.go
+++ b/internal/integration/json_output_test.go
@@ -101,6 +101,24 @@ func TestJSONOutput(t *testing.T) {
 		require.True(t, foundRestackNeeded, "feature-b should show NeedsRestack=true")
 	})
 
+	t.Run("log --json always emits status booleans even when false", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// A healthy, unlocked branch: the status booleans are all false but must
+		// still appear, so `log --json` is a complete, self-describing status
+		// source (an explicit false is unambiguous; an omitted field is not).
+		sh.Write("feature_a", "content a").
+			Run("create feature-a -m 'Add feature A'")
+
+		sh.Run("log --json")
+		output := sh.Output()
+
+		require.Contains(t, output, "\"needs_restack\": false")
+		require.Contains(t, output, "\"is_locked\": false")
+		require.Contains(t, output, "\"is_frozen\": false")
+	})
+
 	t.Run("log --quiet outputs minimal when healthy", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


log --json already carried both PR/CI state and stack-health metadata
(needs_restack, is_locked, is_frozen, scope), but those status booleans used
omitempty — so a false value was omitted and indistinguishable from 'this field
isn't reported'. Agents therefore couldn't rely on a single command and were
querying both log --json and info --stack --json.

Always emit is_locked/is_frozen/needs_restack (drop omitempty) so an explicit
false is unambiguous and one 'stackit log --json' call fully describes stack
health. Documents log --json as the canonical machine-readable status source.

<hr/>

<!-- STACKIT-SECTION-START -->
**Harden non-interactive and scripted CLI workflows**

Makes stackit safe and predictable when used in automation, CI, or agent-driven workflows where no TTY is present.

Key changes:
- **auto-disable interactivity**: Detects non-TTY environments and the `STACKIT_NO_INTERACTIVE` env var to suppress prompts automatically; documents the flag in README
- **describe loudly in non-interactive**: `stackit describe` errors instead of silently no-oping when run without a TTY, and gains `-F`/`--message-file` for piping descriptions from stdin or a file
- **reject empty-branch creation**: `stackit create` now fails loudly when no changes are staged, preventing accidental empty branches in scripted flows
- **`-F` shorthand on split**: `stackit split` gains `-F` as the `--message-file` shorthand for consistency with `create` and `describe`
- **`--yes` on parent merge**: `stackit merge parent` accepts `--yes` to skip the confirmation prompt in non-interactive contexts
- **`log --json` as self-describing status source**: JSON output now includes enough metadata (PR numbers, parent relationships, diff stats) to drive external tooling without additional API calls

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780051956`.


* **PR #1072**
  * **PR #1073**
    * **PR #1074**
      * **PR #1075**
        * **PR #1076**
          * **PR #1077** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->