### PR TITLE
Harden non-interactive and scripted CLI workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,18 @@ Stackit is designed to be easily scriptable. Use global flags to control behavio
 stackit sync --cwd /path/to/repo --no-interactive --no-verify
 ```
 
+Interactive features are also disabled automatically when there is no attached
+terminal (pipes, CI, agents). To force non-interactive mode without repeating
+`--no-interactive` on every command — handy for AI agents and scripts — set the
+environment variable once:
+
+```bash
+export STACKIT_NO_INTERACTIVE=1
+stackit create -F - < msg.txt   # no --no-interactive needed
+```
+
+An explicit `--interactive` always overrides both the env var and TTY detection.
+
 ---
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -440,6 +440,13 @@ stackit create -F - < msg.txt   # no --no-interactive needed
 
 An explicit `--interactive` always overrides both the env var and TTY detection.
 
+For machine-readable status, `stackit log --json` is a complete, self-describing
+source: each branch reports its structure (`parent`, `children`), PR/CI state
+(`pr.state`, `pr.ci_status`, `pr.review_status`), and stack health
+(`needs_restack`, `is_locked`, `is_frozen`, `scope`). The status booleans are
+always present (an explicit `false`, never omitted), so a single call covers what
+previously required both `log --json` and `info --stack --json`.
+
 ---
 
 ## Configuration

--- a/internal/actions/create/create.go
+++ b/internal/actions/create/create.go
@@ -32,6 +32,10 @@ type Options struct {
 	SelectedChildren []string
 	// Worktree creates a dedicated worktree for this stack (only valid from trunk)
 	Worktree bool
+	// AllowEmpty permits creating a branch with no commit when the working tree
+	// has unstaged/untracked changes in non-interactive mode (otherwise that is
+	// treated as a "forgot to stage" mistake and rejected).
+	AllowEmpty bool
 }
 
 // Action creates a new branch stacked on top of the current branch.
@@ -70,6 +74,7 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 		actions.WithFlag(opts.Patch, "--patch"),
 		actions.WithFlag(opts.Update, "--update"),
 		actions.WithFlag(opts.Worktree, "--worktree"),
+		actions.WithFlag(opts.AllowEmpty, "--allow-empty"),
 	)
 	actions.TakeBestEffortSnapshot(ctx, snapshotOpts)
 
@@ -110,6 +115,24 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 				hasStaged = true
 				h.OnStep(StepStaging, handler.StatusCompleted, "Changes staged")
 			}
+		}
+	}
+
+	// Guard against the common non-interactive footgun: the working tree has
+	// changes but nothing is staged (e.g. forgot `git add`), which would
+	// silently produce an empty branch. A genuinely clean tree still allows an
+	// intentional empty scaffolding branch.
+	if !hasStaged && !opts.AllowEmpty && !h.IsInteractive() {
+		hasUnstaged, err := eng.HasUnstagedChanges(ctx.Context)
+		if err != nil {
+			return Result{}, fmt.Errorf("failed to check unstaged changes: %w", err)
+		}
+		hasUntracked, err := eng.HasUntrackedFiles(ctx.Context)
+		if err != nil {
+			return Result{}, fmt.Errorf("failed to check untracked files: %w", err)
+		}
+		if hasUnstaged || hasUntracked {
+			return Result{}, fmt.Errorf("nothing staged but the working tree has changes; stage them with 'git add' (or pass --all/-a), or pass --allow-empty to create an empty branch")
 		}
 	}
 

--- a/internal/actions/describe/describe.go
+++ b/internal/actions/describe/describe.go
@@ -90,7 +90,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 				return applyStackDescription(ctx, *currentBranch, stackRoot, desc, TruncateDescription(desc.Description, 60))
 			}
 		}
-		return fmt.Errorf("must specify --message or run in interactive mode")
+		return fmt.Errorf("nothing to set: pass --title/-m, --message-file/-F, pipe a description via stdin, or run in interactive mode")
 	}
 
 	existingDesc := eng.GetStackDescription(*currentBranch)

--- a/internal/actions/describe/describe_test.go
+++ b/internal/actions/describe/describe_test.go
@@ -172,7 +172,7 @@ func TestDescribeAction(t *testing.T) {
 		handler := &testDescribeHandler{interactive: false}
 		err := describe.Action(s.Context, describe.Options{}, handler)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "must specify --message or run in interactive mode")
+		require.Contains(t, err.Error(), "nothing to set")
 	})
 }
 

--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -45,13 +45,19 @@ type LogJSONResult struct {
 
 // LogBranchInfo represents a single branch in JSON output
 type LogBranchInfo struct {
-	Name         string     `json:"name"`
-	Parent       string     `json:"parent,omitempty"`
-	IsCurrent    bool       `json:"is_current"`
-	IsTrunk      bool       `json:"is_trunk"`
-	IsLocked     bool       `json:"is_locked,omitempty"`
-	IsFrozen     bool       `json:"is_frozen,omitempty"`
-	NeedsRestack bool       `json:"needs_restack,omitempty"`
+	Name      string `json:"name"`
+	Parent    string `json:"parent,omitempty"`
+	IsCurrent bool   `json:"is_current"`
+	IsTrunk   bool   `json:"is_trunk"`
+	// Status booleans are always emitted (no omitempty) so consumers can rely on
+	// `log --json` as a complete, self-describing status source: an explicit
+	// false is unambiguous, whereas an omitted field is indistinguishable from
+	// "this field isn't reported". This is what lets agents read PR/CI status and
+	// needs_restack/locked/frozen from a single command instead of also querying
+	// `info --stack --json`.
+	IsLocked     bool       `json:"is_locked"`
+	IsFrozen     bool       `json:"is_frozen"`
+	NeedsRestack bool       `json:"needs_restack"`
 	Commits      int        `json:"commits"`
 	Additions    int        `json:"additions,omitempty"`
 	Deletions    int        `json:"deletions,omitempty"`

--- a/internal/cli/branch/create.go
+++ b/internal/cli/branch/create.go
@@ -14,6 +14,7 @@ import (
 func NewCreateCmd() *cobra.Command {
 	var (
 		all         bool
+		allowEmpty  bool
 		insert      bool
 		message     string
 		messageFile string
@@ -30,8 +31,11 @@ func NewCreateCmd() *cobra.Command {
 		Long: `Create a new branch stacked on top of the current branch and commit staged changes.
 
 If no branch name is specified, generate a branch name from the commit message.
-If your working directory contains no changes, an empty branch will be created.
-If you have any unstaged changes, you will be asked whether you'd like to stage them.
+If your working directory is clean, an empty branch will be created.
+If you have any unstaged changes, you will be asked whether you'd like to stage them
+(interactive). In non-interactive mode, having changes that aren't staged is treated
+as a "forgot to stage" mistake and rejected — stage them, pass --all, or pass
+--allow-empty to create an empty branch anyway.
 
 Examples:
   stackit create -m "feat: add login"             # Inline message
@@ -67,6 +71,7 @@ Examples:
 					Verbose:       verbose,
 					BranchPattern: branchPattern,
 					Worktree:      worktree,
+					AllowEmpty:    allowEmpty,
 				}
 
 				// Create runner and handler
@@ -91,6 +96,7 @@ Examples:
 
 	// Add flags
 	cmd.Flags().BoolVarP(&all, "all", "a", false, "Stage all unstaged changes before creating the branch, including to untracked files")
+	cmd.Flags().BoolVar(&allowEmpty, "allow-empty", false, "Allow creating a branch with no commit even when the working tree has unstaged/untracked changes (otherwise this is rejected in non-interactive mode)")
 	cmd.Flags().BoolVarP(&insert, "insert", "i", false, "Insert this branch between the current branch and its child. If there are multiple children, prompts you to select which should be moved onto the new branch")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "Specify a commit message")
 	cmd.Flags().StringVarP(&messageFile, "message-file", "F", "", "Read commit message from a file (use \"-\" for stdin). Mutually exclusive with --message.")

--- a/internal/cli/branch/split.go
+++ b/internal/cli/branch/split.go
@@ -39,7 +39,7 @@ Has three forms: split --by-commit, split --by-hunk, and split --by-file.
 split --by-commit slices up the commit history, allowing you to select split points.
 split --by-hunk interactively stages changes to create new single-commit branches.
 split --by-file <files> extracts specified files into a new branch.
-split -F (--by-file-interactive) shows an interactive file selector.
+split --by-file-interactive shows an interactive file selector.
 split without options will launch an interactive wizard.
 
 Direction options (for --by-hunk and --by-file):
@@ -70,7 +70,8 @@ Examples:
   stackit split --by-file path/to/file.go --as-sibling # Extract to sibling branch
   stackit split --by-file path/to/file.go --dry-run   # Preview the split
   stackit split --by-commit --as-sibling              # Split commits as siblings
-  stackit split --by-file file.go --message-file msg.txt  # Read commit message from file (no -F shorthand on split; -F is --by-file-interactive)`,
+  stackit split --by-file file.go -F msg.txt           # Read commit message from a file
+  printf "Extract" | stackit split --by-file file.go -F -  # Read commit message from stdin`,
 		SilenceUsage: true,
 		// Disable default help flag to allow -h for --by-hunk
 		DisableFlagParsing: false,
@@ -175,13 +176,13 @@ Examples:
 	cmd.Flags().BoolVarP(&byCommit, "by-commit", "c", false, "Split by commit - slice up the history of this branch")
 	cmd.Flags().BoolVarP(&byHunk, "by-hunk", "h", false, "Split by hunk - split into new single-commit branches")
 	cmd.Flags().StringSliceVarP(&byFile, "by-file", "f", nil, "Split by file - extracts specified files to a new parent branch")
-	cmd.Flags().BoolVarP(&byFileInteractive, "by-file-interactive", "F", false, "Split by file (interactive) - select files to extract")
+	cmd.Flags().BoolVar(&byFileInteractive, "by-file-interactive", false, "Split by file (interactive) - select files to extract")
 
 	// Additional options
 	cmd.Flags().BoolVar(&asSibling, "as-sibling", false, "Create split branches as siblings instead of a chain")
 	cmd.Flags().StringVarP(&name, "name", "n", "", "Name for the new split branch (default: auto-generated)")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "Commit message for extraction (only with --by-file)")
-	cmd.Flags().StringVar(&messageFile, "message-file", "", "Read commit message from a file (use \"-\" for stdin) (only with --by-file or --by-hunk --patch). Mutually exclusive with --message. Note: split has no -F shorthand for this flag (taken by --by-file-interactive).")
+	cmd.Flags().StringVarP(&messageFile, "message-file", "F", "", "Read commit message from a file (use \"-\" for stdin) (only with --by-file or --by-hunk --patch). Mutually exclusive with --message.")
 
 	// Direction options (for hunk and file modes)
 	cmd.Flags().BoolVar(&above, "above", false, "Insert new branch above current (as child, upstack)")

--- a/internal/cli/describe.go
+++ b/internal/cli/describe.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/getstackit/stackit/internal/actions/describe"
@@ -14,6 +16,7 @@ func newDescribeCmd() *cobra.Command {
 	var (
 		message     string
 		description string
+		messageFile string
 		clearFlag   bool
 		show        bool
 	)
@@ -32,12 +35,36 @@ Examples:
   stackit describe                              # Opens editor to set/edit description
   stackit describe -m "Auth Feature"            # Set title only (short flag like git commit)
   stackit describe -m "Auth" -d "OAuth2 impl"   # Set title and description
+  printf "Auth\n\nOAuth2 impl" | stackit describe -F -   # Read title+body from stdin
+  stackit describe -F desc.txt                  # Read title+body from a file
   stackit describe --show                       # Display current description
   stackit describe --clear                      # Remove description`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			// If no flags and no message, default to editor (interactive) or show
-			effectiveShow := show || (message == "" && !clearFlag && !utils.IsInteractive())
+			title, desc := message, description
+
+			// -F/--message-file supplies the full description in editor format
+			// (first line title, blank line, then body). Mutually exclusive with
+			// -m/-d so the input source is unambiguous.
+			if messageFile != "" {
+				if message != "" || description != "" {
+					return fmt.Errorf("cannot use --message-file with --title/--description; pass only one")
+				}
+				content, err := common.ReadMessage("", messageFile)
+				if err != nil {
+					return err
+				}
+				parsed := describe.ParseEditorContent(content)
+				if parsed == nil {
+					return fmt.Errorf("--message-file content has no title (first non-empty line)")
+				}
+				title, desc = parsed.Title, parsed.Description
+			}
+
+			// Only show when explicitly asked. A no-input non-interactive
+			// invocation falls through to the action, which errors clearly
+			// instead of silently resolving to show (a no-op for a set attempt).
+			effectiveShow := show
 			globalOpts := common.GetGlobalOptions(cmd)
 			if effectiveShow {
 				globalOpts = common.ApplyReadOnlyCurrentBranch(globalOpts)
@@ -45,8 +72,8 @@ Examples:
 
 			return common.RunWithOptions(cmd, globalOpts, func(ctx *app.Context) error {
 				opts := describe.Options{
-					Title:       message,
-					Description: description,
+					Title:       title,
+					Description: desc,
 					Clear:       clearFlag,
 					Show:        effectiveShow,
 				}
@@ -61,6 +88,7 @@ Examples:
 
 	cmd.Flags().StringVarP(&message, "title", "m", "", "Set the stack title (non-interactive)")
 	cmd.Flags().StringVarP(&description, "description", "d", "", "Set the stack description body (requires -m)")
+	cmd.Flags().StringVarP(&messageFile, "message-file", "F", "", "Read the title and description from a file (use \"-\" for stdin): first line is the title, then a blank line, then the body. Mutually exclusive with --title/--description.")
 	cmd.Flags().BoolVar(&clearFlag, "clear", false, "Remove the stack description")
 	cmd.Flags().BoolVar(&show, "show", false, "Display the current stack description")
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/getstackit/stackit/internal/cli/shell"
 	"github.com/getstackit/stackit/internal/cli/stack"
 	"github.com/getstackit/stackit/internal/cli/worktree"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // NewRootCmd creates the root cobra command
@@ -39,15 +40,23 @@ Version: ` + version + `
 Commit:  ` + commit + `
 		Date:    ` + date,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			if noInteractive {
+			// Resolve interactivity. Precedence:
+			//   1. --no-interactive / --quiet           -> off
+			//   2. explicit --interactive               -> honored as set
+			//   3. STACKIT_NO_INTERACTIVE env, or no TTY -> off
+			// This lets agents, CI, and pipes run without repeating
+			// --no-interactive on every command, while explicit flags always win.
+			switch {
+			case noInteractive || quiet:
+				interactive = false
+			case cmd.Flags().Changed("interactive"):
+				// honor the explicit --interactive value already in `interactive`
+			case utils.NonInteractiveEnv() || !utils.TerminalDetected():
 				interactive = false
 			}
+
 			if noVerify {
 				verify = false
-			}
-			if quiet {
-				// quiet implies no-interactive
-				interactive = false
 			}
 
 			// Sync the boolean values back to the flags so common.GetGlobalOptions works

--- a/internal/cli/stack/merge/merge.go
+++ b/internal/cli/stack/merge/merge.go
@@ -23,6 +23,7 @@ func NewMergeCmd(postMergeHandler PostMergeHandler) *cobra.Command {
 		dryRun bool
 		force  bool
 		wait   bool
+		yes    bool
 		scope  string
 		branch string
 	)
@@ -43,8 +44,13 @@ Subcommands:
 
 Use --scope or --branch to skip the initial prompts and go straight to strategy selection.
 
+Without a TTY, pass --yes to merge the next (bottom-most) ready PR without
+prompting (equivalent to 'merge next --yes'); it never consolidates. Use the
+'ship'/'drain' subcommands for other strategies.
+
 Examples:
   stackit merge                    # Launch interactive merge wizard
+  stackit merge --yes              # Non-interactive: merge the next ready PR
   stackit merge --scope=PROJ-100   # Merge all branches in scope PROJ-100
   stackit merge --branch=feature   # Merge from specific branch
   stackit merge status             # Show your mergeable work
@@ -55,9 +61,24 @@ Examples:
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
-				// Must be interactive for wizard mode
+				// The strategy-selection wizard needs a TTY. Non-interactively we
+				// can't safely guess between consolidating (ship) and incremental
+				// merges, so --yes routes to the conservative default — merge the
+				// next (bottom-most) ready PR, equivalent to `merge next`. It never
+				// consolidates and re-runs to drain the stack one PR at a time.
+				// Other strategies stay explicit via the subcommands.
 				if !ctx.Interactive {
-					return fmt.Errorf("merge wizard requires a TTY. Use 'merge next' or 'merge ship' for non-interactive mode (add --yes to skip prompts)")
+					if !yes && !dryRun {
+						return fmt.Errorf("merge wizard requires a TTY. For non-interactive use pass --yes to merge the next (bottom-most) PR, or use 'merge next'/'merge drain'/'merge ship' (each accepts --yes)")
+					}
+					return runMergeNext(ctx, mergeNextOptions{
+						dryRun: dryRun,
+						yes:    yes,
+						force:  force,
+						wait:   wait,
+						branch: branch,
+						scope:  scope,
+					}, postMergeHandler)
 				}
 
 				// runner.Cleanup is nil-safe so no extra guard is needed.
@@ -95,6 +116,7 @@ Examples:
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show merge plan without executing")
 	cmd.Flags().BoolVar(&force, "force", false, "Skip validation checks (draft PRs, failing CI)")
 	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for merge to complete (default: fire-and-forget)")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Non-interactive: merge the next (bottom-most) ready PR without prompting (equivalent to 'merge next --yes'). Use 'merge ship'/'merge drain' for other strategies.")
 	cmd.Flags().StringVar(&scope, "scope", "", "Pre-select scope to merge (skips scope prompt)")
 	cmd.Flags().StringVar(&branch, "branch", "", "Pre-select target branch to merge from (skips branch prompt)")
 	cmd.MarkFlagsMutuallyExclusive("scope", "branch")

--- a/internal/cli/stack/merge/merge_test.go
+++ b/internal/cli/stack/merge/merge_test.go
@@ -53,6 +53,10 @@ func TestNewMergeCmd(t *testing.T) {
 		waitFlag := cmd.Flags().Lookup("wait")
 		require.NotNil(t, waitFlag)
 
+		yesFlag := cmd.Flags().Lookup("yes")
+		require.NotNil(t, yesFlag)
+		require.Equal(t, "y", yesFlag.Shorthand)
+
 		scopeFlag := cmd.Flags().Lookup("scope")
 		require.NotNil(t, scopeFlag)
 

--- a/internal/integration/create_allow_empty_test.go
+++ b/internal/integration/create_allow_empty_test.go
@@ -1,0 +1,67 @@
+package integration
+
+import "testing"
+
+// TestCreateEmptyBranchGuard verifies that, in non-interactive mode, `create`
+// refuses to silently produce an empty branch when the working tree has changes
+// that simply weren't staged (the common "forgot to git add" agent footgun),
+// while still allowing intentional empty branches on a clean tree or with
+// --allow-empty.
+func TestCreateEmptyBranchGuard(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects create when unstaged tracked changes exist but nothing staged", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("base", "v1").
+			Run("create base -m 'feat: base'")
+		// Modify the tracked file, then unstage so it is a dirty-but-unstaged change.
+		sh.WriteFile("base_test.txt", "v2").
+			Git("reset HEAD base_test.txt")
+		sh.RunExpectError("create next -m 'feat: next'").
+			OutputContains("nothing staged but the working tree has changes")
+	})
+
+	t.Run("rejects create when untracked files exist but nothing staged", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("base", "v1").
+			Run("create base -m 'feat: base'")
+		sh.WriteFile("untracked.txt", "x").
+			Git("reset HEAD untracked.txt")
+		sh.RunExpectError("create next -m 'feat: next'").
+			OutputContains("nothing staged but the working tree has changes")
+	})
+
+	t.Run("--allow-empty creates a branch despite unstaged changes", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("base", "v1").
+			Run("create base -m 'feat: base'")
+		sh.WriteFile("base_test.txt", "v2").
+			Git("reset HEAD base_test.txt")
+		sh.Run("create next --allow-empty -m 'feat: empty'").
+			OnBranch("next")
+	})
+
+	t.Run("--all stages the changes and avoids the guard", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("base", "v1").
+			Run("create base -m 'feat: base'")
+		sh.WriteFile("base_test.txt", "v2").
+			Git("reset HEAD base_test.txt")
+		sh.Run("create next --all -m 'feat: next'").
+			OnBranch("next")
+	})
+
+	t.Run("clean tree still creates an empty scaffolding branch", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("base", "v1").
+			Run("create base -m 'feat: base'")
+		// Working tree is clean here; an empty branch is intentional.
+		sh.Run("create scaffold -m 'feat: scaffold'").
+			OnBranch("scaffold")
+	})
+}

--- a/internal/integration/json_output_test.go
+++ b/internal/integration/json_output_test.go
@@ -101,6 +101,24 @@ func TestJSONOutput(t *testing.T) {
 		require.True(t, foundRestackNeeded, "feature-b should show NeedsRestack=true")
 	})
 
+	t.Run("log --json always emits status booleans even when false", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// A healthy, unlocked branch: the status booleans are all false but must
+		// still appear, so `log --json` is a complete, self-describing status
+		// source (an explicit false is unambiguous; an omitted field is not).
+		sh.Write("feature_a", "content a").
+			Run("create feature-a -m 'Add feature A'")
+
+		sh.Run("log --json")
+		output := sh.Output()
+
+		require.Contains(t, output, "\"needs_restack\": false")
+		require.Contains(t, output, "\"is_locked\": false")
+		require.Contains(t, output, "\"is_frozen\": false")
+	})
+
 	t.Run("log --quiet outputs minimal when healthy", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)

--- a/internal/integration/merge_subcommands_test.go
+++ b/internal/integration/merge_subcommands_test.go
@@ -4,6 +4,48 @@ import (
 	"testing"
 )
 
+func TestMergeParentNonInteractive(t *testing.T) {
+	t.Parallel()
+
+	t.Run("errors without --yes in non-interactive mode", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("a.txt", "content-a").
+			Run("create branch-a -m 'Add branch-a'")
+
+		sh.RunExpectError("merge").
+			OutputContains("pass --yes to merge the next")
+	})
+
+	t.Run("--yes --dry-run routes to the next (bottom PR) strategy", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("a.txt", "content-a").
+			Run("create branch-a -m 'Add branch-a'")
+		sh.Write("b.txt", "content-b").
+			Run("create branch-b -m 'Add branch-b'")
+
+		sh.SetPrMetadata("branch-a", PRMetadata{
+			Number: 101,
+			State:  "OPEN",
+			URL:    "https://github.com/owner/repo/pull/101",
+		})
+		sh.SetPrMetadata("branch-b", PRMetadata{
+			Number: 102,
+			State:  "OPEN",
+			URL:    "https://github.com/owner/repo/pull/102",
+		})
+
+		// Parent `merge --yes --dry-run` should behave like `merge next --dry-run`:
+		// target the bottom-most PR (branch-a / #101), not consolidate.
+		sh.Run("merge --yes --dry-run").
+			OutputContains("branch-a").
+			OutputContains("#101").
+			OutputContains("Dry-run mode")
+	})
+}
+
 func TestMergeNext(t *testing.T) {
 	t.Parallel()
 	t.Run("dry-run shows plan for bottom PR", func(t *testing.T) {

--- a/internal/integration/messagefile_test.go
+++ b/internal/integration/messagefile_test.go
@@ -85,6 +85,38 @@ func TestMessageFile(t *testing.T) {
 			OutputContains("feat: extracted from file")
 	})
 
+	t.Run("describe reads title and body from file", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("feature", "content").
+			Run("create feature -m 'feat: x'")
+
+		msgPath := writeMessageFile(t, "Auth Feature\n\nOAuth2 implementation\n")
+		sh.Run("describe -F " + msgPath).
+			Run("describe --show").
+			OutputContains("Auth Feature").
+			OutputContains("OAuth2 implementation")
+	})
+
+	t.Run("describe errors with no input in non-interactive mode", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("feature", "content").
+			Run("create feature -m 'feat: x'")
+		sh.RunExpectError("describe").
+			OutputContains("nothing to set")
+	})
+
+	t.Run("describe errors when both --title and --message-file are given", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("feature", "content").Run("create feature -m 'feat: x'")
+		msgPath := writeMessageFile(t, "Title\n\nBody")
+		sh.RunExpectError("describe -m 'inline' -F " + msgPath).
+			OutputContains("cannot use --message-file with --title")
+	})
+
 	t.Run("create errors when both --message and --message-file are given", func(t *testing.T) {
 		t.Parallel()
 		runMutexTest(t, "create feature -m 'inline' -F ")

--- a/internal/integration/messagefile_test.go
+++ b/internal/integration/messagefile_test.go
@@ -79,7 +79,8 @@ func TestMessageFile(t *testing.T) {
 			Run("create feature -m 'Add feature'")
 
 		msgPath := writeMessageFile(t, "feat: extracted from file\n")
-		sh.Run("split --by-file file_test.txt --as-sibling --message-file " + msgPath).
+		// -F is the shorthand for --message-file (consistent with create/modify/squash).
+		sh.Run("split --by-file file_test.txt --as-sibling -F " + msgPath).
 			Checkout("feature_split").
 			Git("log -1 --format=%s").
 			OutputContains("feat: extracted from file")

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -216,6 +216,15 @@ func IsTTY() bool {
 	if atomic.LoadInt32(&interactiveMode) == 0 {
 		return false
 	}
+	return TerminalDetected()
+}
+
+// TerminalDetected reports whether a usable interactive terminal is attached,
+// independent of the configured interactive mode. It checks the TERM
+// environment, stdin/stdout isatty, and /dev/tty availability. Use this when
+// resolving the default interactivity before the interactive mode is set (e.g.
+// in the root command), where IsTTY's mode gate would not yet apply.
+func TerminalDetected() bool {
 	if !supportsTerminalControl() {
 		return false
 	}
@@ -231,6 +240,19 @@ func IsTTY() bool {
 	}
 	_ = f.Close()
 	return true
+}
+
+// NonInteractiveEnv reports whether STACKIT_NO_INTERACTIVE requests
+// non-interactive mode. Any value other than empty/"0"/"false"/"no" enables it,
+// letting agents and scripts opt out of prompts once instead of passing
+// --no-interactive on every command.
+func NonInteractiveEnv() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("STACKIT_NO_INTERACTIVE"))) {
+	case "", "0", "false", "no":
+		return false
+	default:
+		return true
+	}
 }
 
 func supportsTerminalControl() bool {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -23,3 +23,37 @@ func TestSupportsTerminalControl(t *testing.T) {
 		})
 	}
 }
+
+func TestNonInteractiveEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		val  string
+		set  bool
+		want bool
+	}{
+		{name: "unset", set: false, want: false},
+		{name: "empty", val: "", set: true, want: false},
+		{name: "zero", val: "0", set: true, want: false},
+		{name: "false", val: "false", set: true, want: false},
+		{name: "no", val: "no", set: true, want: false},
+		{name: "one", val: "1", set: true, want: true},
+		{name: "true", val: "true", set: true, want: true},
+		{name: "yes", val: "yes", set: true, want: true},
+		{name: "arbitrary", val: "please", set: true, want: true},
+		{name: "uppercase false", val: "FALSE", set: true, want: false},
+		{name: "padded", val: "  1  ", set: true, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv("STACKIT_NO_INTERACTIVE", tt.val)
+			} else {
+				t.Setenv("STACKIT_NO_INTERACTIVE", "")
+			}
+			if got := NonInteractiveEnv(); got != tt.want {
+				t.Fatalf("NonInteractiveEnv() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Harden non-interactive and scripted CLI workflows**

Makes stackit safe and predictable when used in automation, CI, or agent-driven workflows where no TTY is present.

Key changes:
- **auto-disable interactivity**: Detects non-TTY environments and the `STACKIT_NO_INTERACTIVE` env var to suppress prompts automatically; documents the flag in README
- **describe loudly in non-interactive**: `stackit describe` errors instead of silently no-oping when run without a TTY, and gains `-F`/`--message-file` for piping descriptions from stdin or a file
- **reject empty-branch creation**: `stackit create` now fails loudly when no changes are staged, preventing accidental empty branches in scripted flows
- **`-F` shorthand on split**: `stackit split` gains `-F` as the `--message-file` shorthand for consistency with `create` and `describe`
- **`--yes` on parent merge**: `stackit merge parent` accepts `--yes` to skip the confirmation prompt in non-interactive contexts
- **`log --json` as self-describing status source**: JSON output now includes enough metadata (PR numbers, parent relationships, diff stats) to drive external tooling without additional API calls

This PR merges the following changes:

1. **#1072** feat: auto-disable interactivity for non-TTY and STACKIT_NO_INTERACTIVE
2. **#1073** fix: describe fails loudly in non-interactive and accepts -F/--message-file
3. **#1074** fix: reject silent empty-branch creation when changes aren't staged
4. **#1075** feat: make -F the --message-file shorthand on split
5. **#1076** feat: accept --yes on the parent merge command for non-interactive use
6. **#1077** feat: make log --json a complete, self-describing status source

### Stack

```
main
  └─ jonnii/20260529035139/auto-disable-interactivity-for-non-TTY-and (#1072)
    └─ jonnii/20260529035517/describe-fails-loudly-in-non-interactive-and (#1073)
      └─ jonnii/20260529040207/reject-silent-empty-branch-creation-when-changes (#1074)
        └─ jonnii/20260529040411/make-F-the-message-file-shorthand-on-split (#1075)
          └─ jonnii/20260529040956/accept-yes-on-the-parent-merge-command-for (#1076)
            └─ jonnii/20260529041554/make-log-json-a-complete-self-describing (#1077)
```

Stackit-Stack-Size: 6
Stackit-PRs: 1072,1073,1074,1075,1076,1077
