### PR TITLE
perf(engine): batch revision lookups in TakeSnapshot

### DIFF
--- a/internal/engine/undo.go
+++ b/internal/engine/undo.go
@@ -117,16 +117,10 @@ func (e *engineImpl) TakeSnapshot(opts SnapshotOptions) error {
 	// Get current branch
 	currentBranch := e.currentBranch
 
-	// Get all branch SHAs
-	branchSHAs := make(map[string]string)
-	for _, branchName := range e.state.branches {
-		branch := e.GetBranch(branchName)
-		sha, err := branch.GetRevision()
-		if err != nil {
-			// Skip branches that can't be resolved (might be deleted)
-			continue
-		}
-		branchSHAs[branchName] = sha
+	// Get all branch SHAs in one git rev-parse call; misses (deleted branches) are omitted.
+	branchSHAs, _ := e.git.BatchGetRevisions(e.state.branches)
+	if branchSHAs == nil {
+		branchSHAs = make(map[string]string)
 	}
 
 	// Get all metadata ref SHAs


### PR DESCRIPTION

Replaces the per-branch GetRevision loop with a single BatchGetRevisions call.
BatchGetRevisions resolves all branch SHAs in one git rev-parse invocation
(with cache-hit short-circuit), rather than one call per branch. Misses are
omitted from the result map, preserving the existing skip-on-error behaviour.

Hits every mutating command: create, modify, absorb, restack.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1079** 👈
  * **PR #1080**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->