### PR TITLE
feat: add stackit share command for Slack-ready stack output

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ stack-submit --stack         # Creates/updates all PRs in the stack
 | `stackit trunk` | Return to the main/trunk branch |
 | `stackit children` | Show the children of the current branch |
 | `stackit parent` | Show the parent of the current branch |
+| `stackit share` | Print the current stack as Slack-ready markdown for copy-paste |
 
 ### Branch Management
 | Command | Description |

--- a/internal/actions/share.go
+++ b/internal/actions/share.go
@@ -1,0 +1,132 @@
+package actions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+)
+
+// DefaultShareMarker is appended to the current branch's line in shared output.
+const DefaultShareMarker = "👈"
+
+// ShareOptions configures how the stack is rendered for sharing.
+type ShareOptions struct {
+	// BranchName selects the stack to share. Defaults to the current branch.
+	BranchName string
+	// Marker indicates the current branch in the output. Defaults to
+	// DefaultShareMarker.
+	Marker string
+}
+
+// ShareAction renders the current stack as Slack-flavored markdown (mrkdwn)
+// suitable for copy-pasting into a Slack message. Each branch is emitted as a
+// bullet: branches with an open PR become a clickable link (#<number> <title>),
+// while branches without a PR fall back to their branch name so the stack is
+// still complete before submit. Branches are listed base-first, mirroring the
+// stack navigation footer that Stackit writes into PR bodies.
+func ShareAction(ctx *app.Context, opts ShareOptions) error {
+	eng := ctx.Engine
+
+	currentBranch := eng.CurrentBranch()
+	branchName := opts.BranchName
+	if branchName == "" {
+		if currentBranch == nil {
+			return errors.ErrNotOnBranch
+		}
+		branchName = currentBranch.GetName()
+	}
+
+	branchObj := eng.GetBranch(branchName)
+	if branchObj.IsTrunk() {
+		return fmt.Errorf("%q is the trunk branch; check out a branch in a stack to share it", branchName)
+	}
+	if !branchObj.IsTracked() {
+		return fmt.Errorf("%q is not a tracked branch; check out or pass a branch that's part of a stack", branchName)
+	}
+
+	currentName := ""
+	if currentBranch != nil {
+		currentName = currentBranch.GetName()
+	}
+
+	marker := opts.Marker
+	if marker == "" {
+		marker = DefaultShareMarker
+	}
+
+	graph := eng.Graph(engine.SortStrategyAlphabetical)
+	base := eng.GetBranch(shareStackBase(eng, branchName))
+
+	var sb strings.Builder
+	for b, depth := range eng.BranchesDepthFirst(base) {
+		if b.IsTrunk() || b.IsWorktreeAnchor() {
+			continue
+		}
+		if !graph.IsRelated(b, branchObj) {
+			continue
+		}
+		sb.WriteString(shareLeaf(b, depth, currentName, marker))
+		sb.WriteString("\n")
+	}
+
+	output := strings.TrimRight(sb.String(), "\n")
+	if output == "" {
+		return fmt.Errorf("no branches to share in the current stack")
+	}
+
+	ctx.Output.Info("%s", output)
+	return nil
+}
+
+// shareStackBase walks up to the branch directly above trunk, which is the root
+// of the visible stack.
+func shareStackBase(eng engine.Engine, branchName string) string {
+	branch := eng.GetBranch(branchName)
+	parent := branch.GetParent()
+	if parent == nil || parent.IsTrunk() {
+		return branchName
+	}
+	return shareStackBase(eng, parent.GetName())
+}
+
+// shareLeaf renders a single branch as a Slack mrkdwn bullet, indented by depth.
+func shareLeaf(branch engine.Branch, depth int, currentName, marker string) string {
+	var (
+		prNumber       *int
+		prTitle, prURL string
+	)
+	if prInfo, err := branch.GetPrInfo(); err == nil && prInfo != nil {
+		prNumber = prInfo.Number()
+		prTitle = prInfo.Title()
+		prURL = prInfo.URL()
+	}
+
+	indent := strings.Repeat("    ", depth)
+	line := indent + "• " + shareLabel(branch.GetName(), prNumber, prTitle, prURL)
+	if branch.GetName() == currentName {
+		line += " " + marker
+	}
+	return line
+}
+
+// shareLabel renders the Slack mrkdwn label for a branch. A branch with an open
+// PR becomes a clickable link (<url|#123 title>), falling back to bare text when
+// the URL is unknown; a branch without a PR falls back to its name so the stack
+// is still complete before submit.
+func shareLabel(name string, prNumber *int, prTitle, prURL string) string {
+	if prNumber == nil {
+		return fmt.Sprintf("`%s` _(no PR)_", name)
+	}
+
+	text := fmt.Sprintf("#%d", *prNumber)
+	if prTitle != "" {
+		text = fmt.Sprintf("#%d %s", *prNumber, prTitle)
+	}
+	if prURL == "" {
+		return text
+	}
+	return fmt.Sprintf("<%s|%s>", prURL, text)
+}

--- a/internal/actions/share_internal_test.go
+++ b/internal/actions/share_internal_test.go
@@ -1,0 +1,63 @@
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShareLabel(t *testing.T) {
+	t.Parallel()
+
+	ptr := func(n int) *int { return &n }
+
+	tests := []struct {
+		name     string
+		branch   string
+		prNumber *int
+		prTitle  string
+		prURL    string
+		want     string
+	}{
+		{
+			name:   "no PR falls back to branch name",
+			branch: "feature-x",
+			want:   "`feature-x` _(no PR)_",
+		},
+		{
+			name:     "PR with url and title renders a Slack link",
+			branch:   "feature-x",
+			prNumber: ptr(123),
+			prTitle:  "Add the thing",
+			prURL:    "https://github.com/o/r/pull/123",
+			want:     "<https://github.com/o/r/pull/123|#123 Add the thing>",
+		},
+		{
+			name:     "PR with url but no title links the number only",
+			branch:   "feature-x",
+			prNumber: ptr(7),
+			prURL:    "https://github.com/o/r/pull/7",
+			want:     "<https://github.com/o/r/pull/7|#7>",
+		},
+		{
+			name:     "PR with title but no url is bare text",
+			branch:   "feature-x",
+			prNumber: ptr(9),
+			prTitle:  "Title here",
+			want:     "#9 Title here",
+		},
+		{
+			name:     "PR with neither title nor url is bare number",
+			branch:   "feature-x",
+			prNumber: ptr(9),
+			want:     "#9",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, shareLabel(tt.branch, tt.prNumber, tt.prTitle, tt.prURL))
+		})
+	}
+}

--- a/internal/cli/navigation/share.go
+++ b/internal/cli/navigation/share.go
@@ -1,0 +1,47 @@
+package navigation
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+)
+
+// NewShareCmd creates the share command.
+func NewShareCmd() *cobra.Command {
+	var (
+		branch string
+		marker string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "share",
+		Short: "Print the current stack as Slack-ready markdown for copy-paste",
+		Long: `Render the current stack as Slack-flavored markdown (mrkdwn) that you can
+copy and paste straight into a Slack message.
+
+Each branch is listed base-first as a bullet. Branches with an open PR become a
+clickable link (#<number> <title>); branches without a PR show their branch name
+so the stack is still complete before you submit. The branch you're on is marked.
+
+Examples:
+  stackit share                      # Share the current stack
+  stackit share --branch feature-x   # Share the stack containing feature-x
+  stackit share --marker '(here)'    # Use a custom current-branch marker`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return common.Run(cmd, func(ctx *app.Context) error {
+				return actions.ShareAction(ctx, actions.ShareOptions{
+					BranchName: branch,
+					Marker:     marker,
+				})
+			})
+		},
+	}
+
+	cmd.Flags().StringVarP(&branch, "branch", "b", "", "Share the stack containing this branch (defaults to the current branch)")
+	cmd.Flags().StringVar(&marker, "marker", "", "Marker appended to the current branch line (default \"👈\")")
+
+	return cmd
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -123,6 +123,7 @@ Commit:  ` + commit + `
 	rootCmd.AddCommand(branch.NewSplitCmd())
 	rootCmd.AddCommand(branch.NewSquashCmd())
 	rootCmd.AddCommand(newScopeCmd())
+	rootCmd.AddCommand(navigation.NewShareCmd())
 	rootCmd.AddCommand(shell.NewShellCmd())
 	rootCmd.AddCommand(stack.NewSubmitCmd())
 	rootCmd.AddCommand(stack.NewSyncCmd())

--- a/internal/integration/share_test.go
+++ b/internal/integration/share_test.go
@@ -1,0 +1,58 @@
+package integration
+
+import (
+	"testing"
+)
+
+// TestShareCommand verifies that `stackit share` renders the current stack as
+// Slack-ready markdown.
+func TestShareCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renders stack base-first with current marker", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// main -> a -> b -> c, currently on c.
+		sh.CreateLinearStack3()
+
+		sh.Run("share").
+			OutputContains("• `a` _(no PR)_").
+			OutputContains("• `b` _(no PR)_").
+			OutputContains("• `c` _(no PR)_ 👈")
+	})
+
+	t.Run("shares the stack for an explicit branch", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3()
+		sh.Checkout("main")
+
+		sh.Run("share --branch b").
+			OutputContains("• `a` _(no PR)_").
+			OutputContains("• `b` _(no PR)_").
+			OutputContains("• `c` _(no PR)_")
+	})
+
+	t.Run("uses a custom marker", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3()
+
+		sh.Run("share --marker (here)").
+			OutputContains("• `c` _(no PR)_ (here)")
+	})
+
+	t.Run("errors on trunk", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3()
+		sh.Checkout("main")
+
+		sh.RunExpectError("share").
+			OutputContains("trunk branch")
+	})
+}


### PR DESCRIPTION
Adds `stackit share`, which renders the current stack as Slack-flavored
markdown (mrkdwn) for copy-paste into a Slack message. Each branch is
listed base-first as a bullet; branches with an open PR become a
clickable link (#<number> <title>) and branches without a PR fall back
to their branch name so the stack is complete before submit. The current
branch is marked (default 👈, configurable via --marker).

This reuses the same stack-traversal approach as the PR-body navigation
footer (internal/pr/sections.go) but emits Slack mrkdwn instead of
GitHub-flavored markdown, keeping the dialect logic in one small action.