### PR TITLE
feat: add stackit state command with a complete --json snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ stack-submit --stack         # Creates/updates all PRs in the stack
 ### Navigation
 | Command | Description |
 |:---|:---|
+| `stackit state` | Snapshot of the stack, working tree, and any in-progress operation (`--json` for a complete machine-readable snapshot) |
 | `stackit log` | Display the branch tree |
 | `stackit checkout` | Interactive branch switcher |
 | `stackit up` / `down` | Move to the child or parent branch |
@@ -440,12 +441,16 @@ stackit create -F - < msg.txt   # no --no-interactive needed
 
 An explicit `--interactive` always overrides both the env var and TTY detection.
 
-For machine-readable status, `stackit log --json` is a complete, self-describing
-source: each branch reports its structure (`parent`, `children`), PR/CI state
-(`pr.state`, `pr.ci_status`, `pr.review_status`), and stack health
-(`needs_restack`, `is_locked`, `is_frozen`, `scope`). The status booleans are
-always present (an explicit `false`, never omitted), so a single call covers what
-previously required both `log --json` and `info --stack --json`.
+For machine-readable status, **`stackit state --json`** is the single snapshot to
+read: the current branch and trunk, working-tree state (`staged`/`unstaged`/
+`untracked`), any in-progress `operation` (`rebase`/`merge`) with its
+`conflicted_files`, and the full `stack`. The embedded `stack` is the same shape as
+`stackit log --json` — each branch reports its structure (`parent`, `children`),
+PR/CI state (`pr.state`, `pr.ci_status`, `pr.review_status`), and stack health
+(`needs_restack`, `is_locked`, `is_frozen`, `scope`), with the status booleans
+always present (an explicit `false`, never omitted). One `stackit state --json`
+call replaces combining `git status`, `stackit log --json`, and `stackit info`
+(and `stackit status` still passes through to `git status`).
 
 ---
 

--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -289,8 +289,23 @@ func getUntrackedBranchNames(ctx *app.Context) []string {
 	return untracked.Names()
 }
 
-// logActionJSON generates JSON output for the log command
+// logActionJSON generates JSON output for the log command.
 func logActionJSON(ctx *app.Context, opts LogOptions) error {
+	result := BuildLogJSON(ctx, opts)
+
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+	ctx.Output.Info("%s", string(data))
+	return nil
+}
+
+// BuildLogJSON builds the structured log result (branch tree, PR/CI status, and
+// per-branch health) without printing it, so other commands — e.g. `status` —
+// can embed the same stack snapshot. The CI status prefetch always runs to
+// provide complete data.
+func BuildLogJSON(ctx *app.Context, opts LogOptions) LogJSONResult {
 	eng := ctx.Engine
 	currentBranch := eng.CurrentBranch()
 	currentBranchName := ""
@@ -461,12 +476,5 @@ func logActionJSON(ctx *app.Context, opts LogOptions) error {
 		return cmp.Compare(a.Name, b.Name)
 	})
 
-	// Output JSON
-	data, err := json.MarshalIndent(result, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %w", err)
-	}
-	ctx.Output.Info("%s", string(data))
-
-	return nil
+	return result
 }

--- a/internal/actions/state.go
+++ b/internal/actions/state.go
@@ -1,0 +1,203 @@
+package actions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+)
+
+// StateOptions configures the state command.
+type StateOptions struct {
+	JSON bool
+}
+
+// StateResult is a complete machine-readable snapshot of the repository's
+// stack, working tree, and any in-progress operation. Agents read this single
+// result instead of fanning out across separate branch/git-status/log/info
+// calls, and it removes brittle scraping of `.git` for conflict state.
+type StateResult struct {
+	CurrentBranch string            `json:"current_branch"` // "" when detached
+	Detached      bool              `json:"detached"`
+	Trunk         string            `json:"trunk"`
+	WorkingTree   WorkingTreeStatus `json:"working_tree"`
+	Operation     OperationStatus   `json:"operation"`
+	Stack         LogJSONResult     `json:"stack"`
+}
+
+// WorkingTreeStatus reports the staged/unstaged/untracked state of the worktree.
+type WorkingTreeStatus struct {
+	Clean     bool `json:"clean"`
+	Staged    bool `json:"staged"`
+	Unstaged  bool `json:"unstaged"`
+	Untracked bool `json:"untracked"`
+}
+
+// OperationStatus reports an in-progress git/stackit operation and its conflicts.
+type OperationStatus struct {
+	// Kind is "none", "rebase", or "merge".
+	Kind string `json:"kind"`
+	// InProgress is true when a rebase or merge is mid-flight.
+	InProgress bool `json:"in_progress"`
+	// StackitHalted is true when a `stackit continue` is pending (a stackit
+	// operation was interrupted by a conflict).
+	StackitHalted bool `json:"stackit_halted"`
+	// ConflictedFiles lists unmerged paths (always present, possibly empty).
+	ConflictedFiles []string `json:"conflicted_files"`
+}
+
+// StateAction prints a complete snapshot of the stack and working tree.
+func StateAction(ctx *app.Context, opts StateOptions) error {
+	result := BuildState(ctx, opts)
+
+	if opts.JSON {
+		data, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal JSON: %w", err)
+		}
+		ctx.Output.Info("%s", string(data))
+		return nil
+	}
+
+	printStateHuman(ctx, result)
+	return nil
+}
+
+// BuildState gathers the snapshot without printing it.
+func BuildState(ctx *app.Context, _ StateOptions) StateResult {
+	eng := ctx.Engine
+
+	result := StateResult{
+		Trunk: eng.Trunk().GetName(),
+		Stack: BuildLogJSON(ctx, LogOptions{Style: LogStyleNormal, JSON: true}),
+	}
+
+	if cur := eng.CurrentBranch(); cur != nil {
+		result.CurrentBranch = cur.GetName()
+	} else {
+		result.Detached = true
+	}
+
+	// Working-tree state. A failed check is non-fatal for a read-only snapshot;
+	// log it and fall back to the safe default (false).
+	check := func(name string, fn func(context.Context) (bool, error)) bool {
+		v, err := fn(ctx.Context)
+		if err != nil {
+			ctx.Output.Debug("state: %s check failed: %v", name, err)
+		}
+		return v
+	}
+	staged := check("staged", eng.HasStagedChanges)
+	unstaged := check("unstaged", eng.HasUnstagedChanges)
+	untracked := check("untracked", eng.HasUntrackedFiles)
+	result.WorkingTree = WorkingTreeStatus{
+		Staged:    staged,
+		Unstaged:  unstaged,
+		Untracked: untracked,
+		Clean:     !staged && !unstaged && !untracked,
+	}
+
+	// In-progress operation + conflicts.
+	g := eng.Git()
+	op := OperationStatus{Kind: "none", ConflictedFiles: []string{}}
+	switch {
+	case g.IsRebaseInProgress(ctx.Context):
+		op.Kind = "rebase"
+		op.InProgress = true
+	case g.IsMergeInProgress(ctx.Context):
+		op.Kind = "merge"
+		op.InProgress = true
+	}
+	if op.InProgress {
+		files, err := g.GetUnmergedFiles(ctx.Context)
+		if err != nil {
+			ctx.Output.Debug("state: failed to list unmerged files: %v", err)
+		} else {
+			op.ConflictedFiles = files
+		}
+	}
+	// A pending continuation file means a stackit operation halted on a conflict.
+	if _, err := config.GetContinuationState(ctx.RepoRoot); err == nil {
+		op.StackitHalted = true
+	}
+	result.Operation = op
+
+	return result
+}
+
+func printStateHuman(ctx *app.Context, r StateResult) {
+	out := ctx.Output
+
+	if r.Detached {
+		out.Info("HEAD detached (trunk: %s)", r.Trunk)
+	} else {
+		out.Info("On %s (trunk: %s)", r.CurrentBranch, r.Trunk)
+	}
+
+	if r.WorkingTree.Clean {
+		out.Info("Working tree: clean")
+	} else {
+		var parts []string
+		if r.WorkingTree.Staged {
+			parts = append(parts, "staged")
+		}
+		if r.WorkingTree.Unstaged {
+			parts = append(parts, "unstaged")
+		}
+		if r.WorkingTree.Untracked {
+			parts = append(parts, "untracked")
+		}
+		out.Info("Working tree: %s changes", strings.Join(parts, ", "))
+	}
+
+	if r.Operation.InProgress {
+		out.Info("%s in progress — %d conflicted file(s); resolve and run `stackit continue`",
+			r.Operation.Kind, len(r.Operation.ConflictedFiles))
+		for _, f := range r.Operation.ConflictedFiles {
+			out.Info("    %s", f)
+		}
+	}
+
+	out.Newline()
+	if r.Stack.Summary.TotalBranches == 0 {
+		out.Info("No tracked branches.")
+		return
+	}
+
+	out.Info("Stack (%d branches):", r.Stack.Summary.TotalBranches)
+	for _, b := range r.Stack.Branches {
+		if b.IsTrunk {
+			continue
+		}
+		marker := "  "
+		if b.IsCurrent {
+			marker = "▸ "
+		}
+		line := marker + b.Name
+		if b.PR != nil {
+			line += fmt.Sprintf("  #%d %s", b.PR.Number, b.PR.State)
+			if b.PR.CIStatus != "" {
+				line += " ci:" + b.PR.CIStatus
+			}
+		} else {
+			line += "  (no PR)"
+		}
+		var flags []string
+		if b.NeedsRestack {
+			flags = append(flags, "needs-restack")
+		}
+		if b.IsLocked {
+			flags = append(flags, "locked")
+		}
+		if b.IsFrozen {
+			flags = append(flags, "frozen")
+		}
+		if len(flags) > 0 {
+			line += "  [" + strings.Join(flags, ", ") + "]"
+		}
+		out.Info("%s", line)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -124,6 +124,7 @@ Commit:  ` + commit + `
 	rootCmd.AddCommand(branch.NewSquashCmd())
 	rootCmd.AddCommand(newScopeCmd())
 	rootCmd.AddCommand(shell.NewShellCmd())
+	rootCmd.AddCommand(newStateCmd())
 	rootCmd.AddCommand(stack.NewSubmitCmd())
 	rootCmd.AddCommand(stack.NewSyncCmd())
 	rootCmd.AddCommand(navigation.NewTopCmd())

--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+)
+
+// newStateCmd creates the state command.
+func newStateCmd() *cobra.Command {
+	var jsonOut bool
+
+	cmd := &cobra.Command{
+		Use:   "state",
+		Short: "Show a snapshot of the stack, working tree, and any in-progress operation",
+		Long: `Show a complete snapshot of the current stack in a single call.
+
+Combines the current branch and trunk, working-tree state (staged/unstaged/
+untracked), any in-progress rebase/merge with its conflicted files, and the full
+stack (structure, PR/CI status, and per-branch needs_restack/locked/frozen/scope).
+
+Use --json for one machine-readable snapshot — agents and scripts read everything
+from a single call instead of combining git status, stackit log, and stackit info.
+
+Examples:
+  stackit state            # Human-readable summary
+  stackit state --json     # Complete machine-readable snapshot`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return common.Run(cmd, func(ctx *app.Context) error {
+				return actions.StateAction(ctx, actions.StateOptions{JSON: jsonOut})
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output a complete machine-readable snapshot as JSON")
+
+	return cmd
+}

--- a/internal/cli/state_test.go
+++ b/internal/cli/state_test.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStateCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := newStateCmd()
+
+	require.Equal(t, "state", cmd.Use)
+	require.NotEmpty(t, cmd.Short)
+	require.NotEmpty(t, cmd.Long)
+
+	jsonFlag := cmd.Flags().Lookup("json")
+	require.NotNil(t, jsonFlag, "state should have a --json flag")
+}

--- a/internal/integration/json_output_test.go
+++ b/internal/integration/json_output_test.go
@@ -388,3 +388,56 @@ func TestJSONOutput(t *testing.T) {
 		}
 	})
 }
+
+func TestStateJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("produces a complete snapshot", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("feature_a", "content a").
+			Run("create feature-a -m 'Add feature A'")
+
+		sh.Run("state --json")
+		var result actions.StateResult
+		require.NoError(t, json.Unmarshal([]byte(sh.Output()), &result), "state --json should be valid JSON")
+
+		require.Equal(t, "feature-a", result.CurrentBranch)
+		require.False(t, result.Detached)
+		require.NotEmpty(t, result.Trunk)
+		// No in-progress operation on a fresh stack.
+		require.Equal(t, "none", result.Operation.Kind)
+		require.False(t, result.Operation.InProgress)
+		require.NotNil(t, result.Operation.ConflictedFiles)
+		// The staged file was committed by create, so the tree is clean.
+		require.True(t, result.WorkingTree.Clean)
+		// The stack is embedded (same shape as log --json).
+		require.GreaterOrEqual(t, result.Stack.Summary.TotalBranches, 1)
+	})
+
+	t.Run("reports a dirty working tree", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("feature_a", "content a").
+			Run("create feature-a -m 'Add feature A'")
+		sh.WriteFile("extra.txt", "x") // WriteFile stages the file
+
+		sh.Run("state --json")
+		var result actions.StateResult
+		require.NoError(t, json.Unmarshal([]byte(sh.Output()), &result))
+
+		require.False(t, result.WorkingTree.Clean)
+		require.True(t, result.WorkingTree.Staged)
+	})
+
+	t.Run("human output summarizes branch and stack", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("feature_a", "content a").
+			Run("create feature-a -m 'Add feature A'")
+
+		sh.Run("state").
+			OutputContains("On feature-a").
+			OutputContains("Stack")
+	})
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Add a top-level 'stackit state' that returns one snapshot of everything an agent
or script needs, instead of fanning out across git status + stackit log +
stackit info:

- current branch + trunk, detached flag
- working tree: staged/unstaged/untracked/clean
- in-progress operation: rebase/merge + conflicted files + whether a
  'stackit continue' is pending (no more scraping .git for conflict state)
- the full stack (same shape as 'log --json': structure, PR/CI, and per-branch
  needs_restack/locked/frozen/scope)

--json emits the machine-readable snapshot; bare 'state' prints a concise human
summary. Extracts BuildLogJSON from the log action so state embeds the same stack
JSON. Named 'state' (not 'status') to avoid shadowing 'git status' — 'stackit
status' still passes through to git.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1083** 👈
  * **PR #1084**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1085 by jonnii*