### PR TITLE
docs: use stackit state --json as the one-call preflight in agent skills

### DIFF
--- a/internal/cli/integrations/agents/templates/codex/commands/stack-absorb.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-absorb.md
@@ -11,8 +11,7 @@ Absorb staged fixes into the commits that last touched the changed lines.
 1. Inspect:
 
    ```bash
-   git status --short
-   stackit log --no-interactive
+   stackit state --json
    ```
 
 2. Stage intended fixes:

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-extract.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-extract.md
@@ -11,8 +11,7 @@ Move files or commits off the current branch onto a new sibling, parent, or chil
 1. Inspect:
 
    ```bash
-   git status --short
-   stackit log --no-interactive
+   stackit state --json
    git log --oneline -5
    ```
 

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-fix.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-fix.md
@@ -11,8 +11,7 @@ Diagnose stack problems and apply the smallest safe repair.
 1. Inspect:
 
    ```bash
-   git status --short
-   stackit log --no-interactive
+   stackit state --json
    stackit doctor --no-interactive
    ```
 

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-fold.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-fold.md
@@ -11,8 +11,7 @@ Fold a branch into its parent when it is too small to review separately.
 1. Inspect:
 
    ```bash
-   git status --short
-   stackit log --no-interactive
+   stackit state --json
    ```
 
 2. Check preconditions before folding (folding rewrites stack structure):

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-resolve.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-resolve.md
@@ -11,10 +11,11 @@ Resolve an in-progress Stackit conflict and continue the operation.
 1. Inspect:
 
    ```bash
-   git status --short
-   git diff --name-only --diff-filter=U
-   stackit log --no-interactive
+   stackit state --json
    ```
+
+   `operation.conflicted_files` lists the unmerged paths; `operation.kind` and
+   `operation.stackit_halted` tell you what's in progress.
 
 2. Read each conflicted file and resolve markers.
 

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-restack.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-restack.md
@@ -11,13 +11,13 @@ Rebase stack branches according to Stackit metadata.
 1. Inspect:
 
    ```bash
-   git status --short
-   stackit log --no-interactive
+   stackit state --json
    ```
 
-2. Precondition: if `git status --short` is non-empty, stop and tell the user to
-   commit (via `stackit create`/`stackit modify`) or stash before restacking — a
-   dirty tree will fail the rebase mid-flight.
+2. Precondition: if the state JSON's `working_tree.clean` is false (uncommitted
+   changes), stop and tell the user to commit (via `stackit create`/`stackit
+   modify`) or stash before restacking — a dirty tree will fail the rebase
+   mid-flight.
 
 3. Choose the narrowest scope that covers what changed:
    - Current stack: `stackit restack --upstack --no-interactive`

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-review.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-review.md
@@ -11,7 +11,7 @@ Review stack PRs for high-confidence issues and report findings locally.
 1. Gather stack PRs:
 
    ```bash
-   stackit log --json --no-interactive
+   stackit state --json
    ```
 
 2. For each open non-draft PR selected for review:

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-split.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-split.md
@@ -17,7 +17,7 @@ Split committed changes on the current branch into another stacked branch.
 2. Inspect branch context:
 
    ```bash
-   stackit log --no-interactive
+   stackit state --json
    git log --oneline <parent-branch>..HEAD
    git diff --name-status <parent-branch>..HEAD
    ```

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-status.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-status.md
@@ -11,8 +11,7 @@ Report stack state without mutating anything.
 Run:
 
 ```bash
-git status --short
-stackit log --json --no-interactive
+stackit state --json
 ```
 
 Summarize:

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-submit.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-submit.md
@@ -11,9 +11,7 @@ Submit branches as PRs or update existing PRs. This touches remotes, so confirm 
 1. Inspect:
 
    ```bash
-   git status --short
-   stackit log --no-interactive
-   stackit info --json --no-interactive
+   stackit state --json
    ```
 
 2. If there are uncommitted changes, warn and stop unless the user asked to submit anyway.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-sync.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-sync.md
@@ -11,8 +11,7 @@ Sync with trunk and clean up branches that have landed.
 1. Inspect:
 
    ```bash
-   git status --short
-   stackit log --no-interactive
+   stackit state --json
    ```
 
 2. If there are uncommitted changes, stop and ask the user to commit (via

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-verify.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-verify.md
@@ -11,8 +11,7 @@ Run verification across stack branches.
 1. Inspect:
 
    ```bash
-   stackit log --no-interactive
-   git status --short
+   stackit state --json
    ```
 
 2. Determine check command from user input, project docs, or common files. Prefer `mise run check` when available.

--- a/internal/cli/integrations/agents/templates/codex/skill/SKILL.md
+++ b/internal/cli/integrations/agents/templates/codex/skill/SKILL.md
@@ -27,10 +27,13 @@ If there is no work to act on, say so and stop.
 Run once at the start of a Stackit-related session:
 
 ```bash
-stackit log --json --no-interactive
+stackit state --json
 ```
 
-Surface failing CI, branches ready to merge, and branches needing restack when relevant.
+This single call returns the current branch, working-tree state, any in-progress
+operation, and the full `stack` (PR/CI status + per-branch needs_restack/locked/
+frozen/scope). Surface failing CI, branches ready to merge, and branches needing
+restack when relevant.
 
 ## Skill Selection
 

--- a/internal/cli/integrations/agents/templates/commands/stack-absorb.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-absorb.md
@@ -9,9 +9,7 @@ allowed-tools: Bash(stackit:*), Bash(git:*), Read, Edit, Glob, Grep, AskUserQues
 Absorb staged changes into the correct commits, then intelligently fix any broken branches by drawing from the right sources.
 
 ## Context
-- Current branch: !`git branch --show-current`
-- Git status: !`git status --short`
-- Stack state: !`stackit log --no-interactive`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 
 ## How Absorb Works
 

--- a/internal/cli/integrations/agents/templates/commands/stack-extract.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-extract.md
@@ -9,9 +9,8 @@ allowed-tools: Bash(stackit:*), Bash(git:*), Read, Glob, Grep
 Extract commits or file changes from the current branch to a new independent branch.
 
 ## Context
-- Current branch: !`git branch --show-current`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 - Recent commits: !`git log --oneline -5`
-- Stack state: !`stackit log --no-interactive`
 
 ## Instructions
 

--- a/internal/cli/integrations/agents/templates/commands/stack-fix.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-fix.md
@@ -9,9 +9,7 @@ allowed-tools: Bash(stackit:*), Bash(git:*), Read, Edit, Glob, Grep, AskUserQues
 Diagnose and fix stack problems, including build/lint/test failures.
 
 ## Context
-- Current branch: !`git branch --show-current`
-- Git status: !`git status --short`
-- Stack state: !`stackit log --no-interactive`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 - Diagnostics: !`stackit doctor --no-interactive`
 
 ## Instructions

--- a/internal/cli/integrations/agents/templates/commands/stack-plan.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-plan.md
@@ -12,9 +12,7 @@ Analyze uncommitted working tree changes, suggest a logical stacking structure, 
 **Primary objective: Never lose someone's work.**
 
 ## Context
-- Current branch: !`git branch --show-current`
-- Git status: !`git status --short`
-- Stack state: !`stackit log --no-interactive`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 
 ## Arguments
 $ARGUMENTS

--- a/internal/cli/integrations/agents/templates/commands/stack-resolve.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-resolve.md
@@ -9,9 +9,7 @@ allowed-tools: Read, Edit, AskUserQuestion, Bash(git show *), Bash(git diff *), 
 Resolve rebase conflicts during stackit operations with AI assistance.
 
 ## Context
-- Current operation: !`cat .git/rebase-merge/message 2>/dev/null || echo "No rebase in progress"`
-- Conflicted files: !`git diff --name-only --diff-filter=U 2>/dev/null || echo "No conflicts detected"`
-- Current branch: !`git branch --show-current 2>/dev/null || cat .git/rebase-merge/head-name 2>/dev/null | sed 's|refs/heads/||'`
+- State (json — `operation.kind`/`operation.in_progress`, `operation.conflicted_files`, `operation.stackit_halted`, current branch): !`stackit state --json`
 - Project type: !`if [ -f "mise.toml" ]; then echo "mise"; elif [ -f "Makefile" ]; then echo "make"; elif [ -f "package.json" ]; then echo "npm/yarn"; elif [ -f "Cargo.toml" ]; then echo "cargo"; elif [ -f "go.mod" ]; then echo "go"; else echo "unknown"; fi`
 
 ## Instructions

--- a/internal/cli/integrations/agents/templates/commands/stack-restack.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-restack.md
@@ -7,9 +7,7 @@ allowed-tools: Bash(stackit:*), Bash(git:*), AskUserQuestion, Skill
 # Stack Restack
 
 ## Context
-- Current branch: !`git branch --show-current`
-- Git status: !`git status --short`
-- Stack state: !`stackit log --no-interactive`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 
 ## Task
 

--- a/internal/cli/integrations/agents/templates/commands/stack-review.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-review.md
@@ -14,9 +14,8 @@ Perform code reviews on PRs in the stack. Finds bugs, checks CLAUDE.md complianc
 - **Apply mode** (`--apply`): Apply existing review comments from GitHub and mark resolved
 
 ## Context
-- Current branch: !`git branch --show-current`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 - Repo: !`gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null`
-- Stack state: !`stackit log --no-interactive`
 
 ## Arguments
 $ARGUMENTS

--- a/internal/cli/integrations/agents/templates/commands/stack-split.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-split.md
@@ -29,9 +29,7 @@ Split the committed changes on the current branch between this branch and a new 
 **Primary objective: Never lose someone's work.**
 
 ## Context
-- Current branch: !`git branch --show-current`
-- Git status: !`git status --short`
-- Stack state: !`stackit log --no-interactive`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 
 ## Arguments
 $ARGUMENTS

--- a/internal/cli/integrations/agents/templates/commands/stack-status.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-status.md
@@ -8,25 +8,24 @@ allowed-tools: Bash(stackit:*), Bash(git:*)
 
 Show the current stack state, identify issues, and provide actionable recommendations.
 ## Context
-- Current branch: !`git branch --show-current`
-- Git status: !`git status --short`
-- Stack state (json — complete: structure, PR/CI status, and per-branch needs_restack/is_locked/is_frozen/scope): !`stackit log --json --no-interactive`
+- State (json — complete snapshot: current branch, working tree, in-progress operation, and the full stack with PR/CI status and per-branch needs_restack/is_locked/is_frozen/scope): !`stackit state --json`
 
 ## Task
 
 ### Step 1: Display Stack Overview
 
-Summarize from the JSON context:
-- Current position in the stack (the branch with `is_current: true`)
-- Parent/child relationships
-- Any branches that need attention
+Summarize from the `stackit state --json` context:
+- Current position (`current_branch`, or the `.stack.branches` entry with `is_current: true`)
+- Working tree (`working_tree`) and any in-progress `operation`
+- Parent/child relationships and any branches that need attention
 
 If the user wants the visual tree, run `stackit log --no-interactive` and show it.
 
 ### Step 2: Health Analysis
 
-Parse the stack JSON (a single `stackit log --json` carries everything — PR/CI
-status plus `needs_restack`/`is_locked`/`is_frozen`/`scope`), then highlight issues:
+Parse the state JSON — a single `stackit state --json` carries everything: the
+working tree, in-progress `operation`, and the full `stack` (PR/CI status plus
+`needs_restack`/`is_locked`/`is_frozen`/`scope` per branch). Highlight issues:
 
 **High Priority Issues (act now):**
 - CI failing on any branch

--- a/internal/cli/integrations/agents/templates/commands/stack-submit.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-submit.md
@@ -10,9 +10,7 @@ argument-hint: [--stack | --draft]
 Submit branches to GitHub and create/update PRs.
 
 ## Context
-- Current branch: !`git branch --show-current`
-- Stack state: !`stackit log --no-interactive`
-- Branch info: !`stackit info --json --no-interactive`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 
 ## Arguments
 $ARGUMENTS

--- a/internal/cli/integrations/agents/templates/commands/stack-sync.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-sync.md
@@ -7,8 +7,7 @@ allowed-tools: Bash(stackit:*), Bash(git:*), AskUserQuestion, Skill
 # Stack Sync
 
 ## Context
-- Current branch: !`git branch --show-current`
-- Stack state: !`stackit log --no-interactive`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 
 ## Task
 

--- a/internal/cli/integrations/agents/templates/commands/stack-verify.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-verify.md
@@ -10,9 +10,7 @@ argument-hint: [check-command]
 Run verification checks on all branches in the stack and report results.
 
 ## Context
-- Current branch: !`git branch --show-current`
-- Git status: !`git status --short`
-- Stack state: !`stackit log --no-interactive`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 
 ## Arguments
 $ARGUMENTS

--- a/internal/cli/integrations/agents/templates/skill/SKILL.md
+++ b/internal/cli/integrations/agents/templates/skill/SKILL.md
@@ -54,12 +54,14 @@ When calling `stackit` commands, **ALWAYS** include the `--no-interactive` flag.
 
 **Run at session start** to proactively identify issues:
 ```bash
-stackit log --json --no-interactive
+stackit state --json
 ```
 
-This returns a JSON report with:
-- `branches`: Array of branch status (current, parent/children, PR status, CI status, needs_restack)
-- `summary`: Counts for total branches, approved branches, and branches in review
+This single call returns a complete JSON snapshot:
+- `current_branch` / `trunk`, and `working_tree` (staged/unstaged/untracked/clean)
+- `operation`: any in-progress rebase/merge with `conflicted_files`
+- `stack.branches`: array of branch status (current, parent/children, PR/CI status, needs_restack/is_locked/is_frozen/scope)
+- `stack.summary`: counts for total branches, approved branches, and branches in review
 
 **When to mention health issues proactively:**
 If the health check reveals issues, inform the user:

--- a/internal/cli/integrations/agents/templates/skill/commands/stack.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/stack.md
@@ -12,7 +12,8 @@ Commands for managing the entire stack or multiple branches.
 | `stackit restack --all-stacks --continue-on-conflict --no-interactive` | Rebase every independent stack rooted at trunk, skipping conflicted stacks so unrelated stacks still proceed |
 | `stackit restack --stacks <root1>,<root2> --continue-on-conflict --no-interactive` | Rebase specific independent stack roots while letting unrelated selected roots continue past conflicts |
 | `stackit sync --no-interactive` | Pull trunk, delete merged branches, restack |
-| `stackit info --stack --json --no-interactive` | Export full stack metadata as JSON for analysis |
+| `stackit state --json` | Complete one-call snapshot: current branch, working tree, in-progress operation, and the full stack (PR/CI + needs_restack/locked/frozen/scope) |
+| `stackit info --stack --json --no-interactive` | Export full per-branch metadata incl. commit messages and diff stats (use when you need commit messages, which `state` omits) |
 | `stackit merge --yes --no-interactive` | Merge the next (bottom) ready PR non-interactively (bare `stackit merge` with no flags opens a TTY wizard). Use `stackit merge ship --yes --no-interactive` to consolidate the whole stack into one PR. |
 | `stackit fold --no-interactive` | Fold current branch into its parent |
 

--- a/internal/cli/integrations/agents/templates/skill/reference.md
+++ b/internal/cli/integrations/agents/templates/skill/reference.md
@@ -36,6 +36,7 @@ bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
 
 | Command | Description |
 |---------|-------------|
+| `stackit state --json` | Complete one-call snapshot (branch, working tree, in-progress operation, full stack) — preferred for programmatic reads |
 | `stackit log` | Display the branch tree visualization |
 | `stackit log full` | Show tree with GitHub PR status and CI checks |
 | `stackit checkout [branch]` | Switch to a specific branch |

--- a/internal/cli/integrations/agents/templates/skill/scripts/analyze_stack.sh
+++ b/internal/cli/integrations/agents/templates/skill/scripts/analyze_stack.sh
@@ -38,15 +38,19 @@ echo -e "${BLUE}Current Stack:${NC}"
 stackit log
 echo
 
-# Fetch authoritative stack metadata once as JSON (the source of truth for
-# branch relationships, sizes, and PR state) instead of scraping rendered output.
-STACK_JSON=$(stackit log short --json --no-interactive 2>/dev/null || echo '{}')
-github_available=$(echo "$STACK_JSON" | jq -r '.github_available // false')
+# Fetch one authoritative snapshot as JSON: the working tree, any in-progress
+# operation, and the full stack (branch relationships, sizes, PR/CI state). This
+# replaces scraping rendered output and separate git probes for dirty/rebase state.
+STATE_JSON=$(stackit state --json 2>/dev/null || echo '{}')
+github_available=$(echo "$STATE_JSON" | jq -r '.stack.github_available // false')
+# Use `== false` rather than `// default`: jq's `//` treats a boolean false as
+# empty, so `.working_tree.clean // true` would wrongly yield true on a dirty tree.
+working_tree_dirty=$(echo "$STATE_JSON" | jq -r '.working_tree.clean == false')
 
 echo -e "${BLUE}Health Checks:${NC}"
 
-# Check for uncommitted changes
-if ! git diff-index --quiet HEAD -- 2>/dev/null; then
+# Uncommitted changes (from the snapshot's working_tree)
+if [ "$working_tree_dirty" = "true" ]; then
     echo -e "${YELLOW}⚠️  Uncommitted changes detected${NC}"
     echo "→ Run: git status"
     echo "→ Consider: git add -A (then) stackit modify"
@@ -57,7 +61,7 @@ fi
 # Only meaningful when GitHub data is available.
 branches_no_pr=0
 if [ "$github_available" = "true" ]; then
-    branches_no_pr=$(echo "$STACK_JSON" | jq '[.branches[]? | select((.is_trunk | not) and (has("pr") | not))] | length')
+    branches_no_pr=$(echo "$STATE_JSON" | jq '[.stack.branches[]? | select((.is_trunk | not) and (has("pr") | not))] | length')
     if [ "$branches_no_pr" -gt 0 ]; then
         echo -e "${YELLOW}ℹ️  $branches_no_pr branch(es) without PRs${NC}"
         echo "→ Run: stackit submit --stack"
@@ -66,7 +70,7 @@ if [ "$github_available" = "true" ]; then
 fi
 
 # Check if sync needed (any PR merged or closed)
-merged_or_closed=$(echo "$STACK_JSON" | jq '[.branches[]? | select(.pr.state == "MERGED" or .pr.state == "CLOSED")] | length')
+merged_or_closed=$(echo "$STATE_JSON" | jq '[.stack.branches[]? | select(.pr.state == "MERGED" or .pr.state == "CLOSED")] | length')
 if [ "$merged_or_closed" -gt 0 ]; then
     echo -e "${YELLOW}ℹ️  $merged_or_closed PR(s) have been merged/closed${NC}"
     echo "→ Run: stackit sync --restack"
@@ -74,26 +78,28 @@ if [ "$merged_or_closed" -gt 0 ]; then
 fi
 
 # Surface failing CI when GitHub data is available
-failing_ci=$(echo "$STACK_JSON" | jq -r '[.branches[]? | select(.pr.ci_status == "failing") | .name] | join(", ")')
+failing_ci=$(echo "$STATE_JSON" | jq -r '[.stack.branches[]? | select(.pr.ci_status == "failing") | .name] | join(", ")')
 if [ -n "$failing_ci" ]; then
     echo -e "${RED}⚠️  Failing CI on: $failing_ci${NC}"
     echo
 fi
 
-# Check for rebase in progress
-if [ -d "$(git rev-parse --git-dir)/rebase-merge" ] || [ -d "$(git rev-parse --git-dir)/rebase-apply" ]; then
-    echo -e "${RED}⚠️  Rebase in progress${NC}"
+# In-progress operation (from the snapshot's operation field)
+op_kind=$(echo "$STATE_JSON" | jq -r '.operation.kind // "none"')
+if [ "$op_kind" != "none" ]; then
+    n_conflicts=$(echo "$STATE_JSON" | jq -r '(.operation.conflicted_files // []) | length')
+    echo -e "${RED}⚠️  $op_kind in progress ($n_conflicts conflicted file(s))${NC}"
     echo "→ Resolve conflicts and run: stackit continue"
     echo "→ Or abort with: stackit abort"
     echo
 fi
 
-# Get current branch
-current_branch=$(git branch --show-current)
+# Current branch and trunk (from the snapshot)
+current_branch=$(echo "$STATE_JSON" | jq -r '.current_branch // ""')
+trunk_branch=$(echo "$STATE_JSON" | jq -r '.trunk // "main"')
 
 # Check if on trunk
-trunk_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main")
-if [ "$current_branch" = "$trunk_branch" ]; then
+if [ -n "$current_branch" ] && [ "$current_branch" = "$trunk_branch" ]; then
     echo -e "${YELLOW}ℹ️  Currently on trunk branch ($trunk_branch)${NC}"
     echo "→ Consider: stackit checkout (to switch to a feature branch)"
     echo
@@ -112,7 +118,7 @@ while IFS=$'\t' read -r branch additions deletions; do
     echo "   +$additions/-$deletions lines ($total_lines total)"
     echo "→ Consider: stackit split (to break into smaller PRs)"
     echo
-done < <(echo "$STACK_JSON" | jq -r '.branches[]? | select((.is_trunk | not) and ((.additions + .deletions) > 500)) | "\(.name)\t\(.additions)\t\(.deletions)"')
+done < <(echo "$STATE_JSON" | jq -r '.stack.branches[]? | select((.is_trunk | not) and ((.additions + .deletions) > 500)) | "\(.name)\t\(.additions)\t\(.deletions)"')
 
 if [ "$large_branch_found" = false ]; then
     echo -e "${GREEN}✓ All branches are reasonably sized${NC}"
@@ -140,7 +146,7 @@ if [ "$branches_no_pr" -gt 0 ]; then
     echo "1. Submit branches: stackit submit --stack"
 elif [ "$merged_or_closed" -gt 0 ]; then
     echo "1. Sync with trunk: stackit sync --restack"
-elif ! git diff-index --quiet HEAD -- 2>/dev/null; then
+elif [ "$working_tree_dirty" = "true" ]; then
     echo "1. Commit changes: git add -A (then) stackit modify"
 else
     echo -e "${GREEN}✓ Stack is healthy! Ready for development.${NC}"


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Now that 'stackit state --json' returns a complete snapshot (branch, working
tree, in-progress operation, and the full stack), collapse the multi-command
Context/Inspect preflights in the agent templates to a single call.

Converted (Claude + Codex) where it consolidates >=2 calls and the skill needs
branch/stack/working-tree/operation data: status, absorb, fix, restack, verify,
split, plan, sync, submit, review, extract, resolve. stack-resolve in particular
drops the brittle .git/rebase-merge scraping for operation.conflicted_files.
Updated the skill health-check + reference tables to point at state --json.

Intentionally NOT converted:
- create / modify: kept light (a quick git status check) — state's GitHub CI
  prefetch would be wasted latency on a staging-only preflight
- describe / tidy / fold: keep 'info --stack --json', which carries commit
  messages and diff stats that state omits

stackit state was named to avoid shadowing 'git status' (which still passes
through to git).

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1083**
  * **PR #1084** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1085 by jonnii*