### PR TITLE
Merging 2 PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ stack-submit --stack         # Creates/updates all PRs in the stack
 ### Navigation
 | Command | Description |
 |:---|:---|
+| `stackit state` | Snapshot of the stack, working tree, and any in-progress operation (`--json` for a complete machine-readable snapshot) |
 | `stackit log` | Display the branch tree |
 | `stackit checkout` | Interactive branch switcher |
 | `stackit up` / `down` | Move to the child or parent branch |
@@ -440,12 +441,16 @@ stackit create -F - < msg.txt   # no --no-interactive needed
 
 An explicit `--interactive` always overrides both the env var and TTY detection.
 
-For machine-readable status, `stackit log --json` is a complete, self-describing
-source: each branch reports its structure (`parent`, `children`), PR/CI state
-(`pr.state`, `pr.ci_status`, `pr.review_status`), and stack health
-(`needs_restack`, `is_locked`, `is_frozen`, `scope`). The status booleans are
-always present (an explicit `false`, never omitted), so a single call covers what
-previously required both `log --json` and `info --stack --json`.
+For machine-readable status, **`stackit state --json`** is the single snapshot to
+read: the current branch and trunk, working-tree state (`staged`/`unstaged`/
+`untracked`), any in-progress `operation` (`rebase`/`merge`) with its
+`conflicted_files`, and the full `stack`. The embedded `stack` is the same shape as
+`stackit log --json` — each branch reports its structure (`parent`, `children`),
+PR/CI state (`pr.state`, `pr.ci_status`, `pr.review_status`), and stack health
+(`needs_restack`, `is_locked`, `is_frozen`, `scope`), with the status booleans
+always present (an explicit `false`, never omitted). One `stackit state --json`
+call replaces combining `git status`, `stackit log --json`, and `stackit info`
+(and `stackit status` still passes through to `git status`).
 
 ---
 

--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -289,8 +289,23 @@ func getUntrackedBranchNames(ctx *app.Context) []string {
 	return untracked.Names()
 }
 
-// logActionJSON generates JSON output for the log command
+// logActionJSON generates JSON output for the log command.
 func logActionJSON(ctx *app.Context, opts LogOptions) error {
+	result := BuildLogJSON(ctx, opts)
+
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+	ctx.Output.Info("%s", string(data))
+	return nil
+}
+
+// BuildLogJSON builds the structured log result (branch tree, PR/CI status, and
+// per-branch health) without printing it, so other commands — e.g. `status` —
+// can embed the same stack snapshot. The CI status prefetch always runs to
+// provide complete data.
+func BuildLogJSON(ctx *app.Context, opts LogOptions) LogJSONResult {
 	eng := ctx.Engine
 	currentBranch := eng.CurrentBranch()
 	currentBranchName := ""
@@ -461,12 +476,5 @@ func logActionJSON(ctx *app.Context, opts LogOptions) error {
 		return cmp.Compare(a.Name, b.Name)
 	})
 
-	// Output JSON
-	data, err := json.MarshalIndent(result, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %w", err)
-	}
-	ctx.Output.Info("%s", string(data))
-
-	return nil
+	return result
 }

--- a/internal/actions/state.go
+++ b/internal/actions/state.go
@@ -1,0 +1,203 @@
+package actions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
+)
+
+// StateOptions configures the state command.
+type StateOptions struct {
+	JSON bool
+}
+
+// StateResult is a complete machine-readable snapshot of the repository's
+// stack, working tree, and any in-progress operation. Agents read this single
+// result instead of fanning out across separate branch/git-status/log/info
+// calls, and it removes brittle scraping of `.git` for conflict state.
+type StateResult struct {
+	CurrentBranch string            `json:"current_branch"` // "" when detached
+	Detached      bool              `json:"detached"`
+	Trunk         string            `json:"trunk"`
+	WorkingTree   WorkingTreeStatus `json:"working_tree"`
+	Operation     OperationStatus   `json:"operation"`
+	Stack         LogJSONResult     `json:"stack"`
+}
+
+// WorkingTreeStatus reports the staged/unstaged/untracked state of the worktree.
+type WorkingTreeStatus struct {
+	Clean     bool `json:"clean"`
+	Staged    bool `json:"staged"`
+	Unstaged  bool `json:"unstaged"`
+	Untracked bool `json:"untracked"`
+}
+
+// OperationStatus reports an in-progress git/stackit operation and its conflicts.
+type OperationStatus struct {
+	// Kind is "none", "rebase", or "merge".
+	Kind string `json:"kind"`
+	// InProgress is true when a rebase or merge is mid-flight.
+	InProgress bool `json:"in_progress"`
+	// StackitHalted is true when a `stackit continue` is pending (a stackit
+	// operation was interrupted by a conflict).
+	StackitHalted bool `json:"stackit_halted"`
+	// ConflictedFiles lists unmerged paths (always present, possibly empty).
+	ConflictedFiles []string `json:"conflicted_files"`
+}
+
+// StateAction prints a complete snapshot of the stack and working tree.
+func StateAction(ctx *app.Context, opts StateOptions) error {
+	result := BuildState(ctx, opts)
+
+	if opts.JSON {
+		data, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal JSON: %w", err)
+		}
+		ctx.Output.Info("%s", string(data))
+		return nil
+	}
+
+	printStateHuman(ctx, result)
+	return nil
+}
+
+// BuildState gathers the snapshot without printing it.
+func BuildState(ctx *app.Context, _ StateOptions) StateResult {
+	eng := ctx.Engine
+
+	result := StateResult{
+		Trunk: eng.Trunk().GetName(),
+		Stack: BuildLogJSON(ctx, LogOptions{Style: LogStyleNormal, JSON: true}),
+	}
+
+	if cur := eng.CurrentBranch(); cur != nil {
+		result.CurrentBranch = cur.GetName()
+	} else {
+		result.Detached = true
+	}
+
+	// Working-tree state. A failed check is non-fatal for a read-only snapshot;
+	// log it and fall back to the safe default (false).
+	check := func(name string, fn func(context.Context) (bool, error)) bool {
+		v, err := fn(ctx.Context)
+		if err != nil {
+			ctx.Output.Debug("state: %s check failed: %v", name, err)
+		}
+		return v
+	}
+	staged := check("staged", eng.HasStagedChanges)
+	unstaged := check("unstaged", eng.HasUnstagedChanges)
+	untracked := check("untracked", eng.HasUntrackedFiles)
+	result.WorkingTree = WorkingTreeStatus{
+		Staged:    staged,
+		Unstaged:  unstaged,
+		Untracked: untracked,
+		Clean:     !staged && !unstaged && !untracked,
+	}
+
+	// In-progress operation + conflicts.
+	g := eng.Git()
+	op := OperationStatus{Kind: "none", ConflictedFiles: []string{}}
+	switch {
+	case g.IsRebaseInProgress(ctx.Context):
+		op.Kind = "rebase"
+		op.InProgress = true
+	case g.IsMergeInProgress(ctx.Context):
+		op.Kind = "merge"
+		op.InProgress = true
+	}
+	if op.InProgress {
+		files, err := g.GetUnmergedFiles(ctx.Context)
+		if err != nil {
+			ctx.Output.Debug("state: failed to list unmerged files: %v", err)
+		} else {
+			op.ConflictedFiles = files
+		}
+	}
+	// A pending continuation file means a stackit operation halted on a conflict.
+	if _, err := config.GetContinuationState(ctx.RepoRoot); err == nil {
+		op.StackitHalted = true
+	}
+	result.Operation = op
+
+	return result
+}
+
+func printStateHuman(ctx *app.Context, r StateResult) {
+	out := ctx.Output
+
+	if r.Detached {
+		out.Info("HEAD detached (trunk: %s)", r.Trunk)
+	} else {
+		out.Info("On %s (trunk: %s)", r.CurrentBranch, r.Trunk)
+	}
+
+	if r.WorkingTree.Clean {
+		out.Info("Working tree: clean")
+	} else {
+		var parts []string
+		if r.WorkingTree.Staged {
+			parts = append(parts, "staged")
+		}
+		if r.WorkingTree.Unstaged {
+			parts = append(parts, "unstaged")
+		}
+		if r.WorkingTree.Untracked {
+			parts = append(parts, "untracked")
+		}
+		out.Info("Working tree: %s changes", strings.Join(parts, ", "))
+	}
+
+	if r.Operation.InProgress {
+		out.Info("%s in progress — %d conflicted file(s); resolve and run `stackit continue`",
+			r.Operation.Kind, len(r.Operation.ConflictedFiles))
+		for _, f := range r.Operation.ConflictedFiles {
+			out.Info("    %s", f)
+		}
+	}
+
+	out.Newline()
+	if r.Stack.Summary.TotalBranches == 0 {
+		out.Info("No tracked branches.")
+		return
+	}
+
+	out.Info("Stack (%d branches):", r.Stack.Summary.TotalBranches)
+	for _, b := range r.Stack.Branches {
+		if b.IsTrunk {
+			continue
+		}
+		marker := "  "
+		if b.IsCurrent {
+			marker = "▸ "
+		}
+		line := marker + b.Name
+		if b.PR != nil {
+			line += fmt.Sprintf("  #%d %s", b.PR.Number, b.PR.State)
+			if b.PR.CIStatus != "" {
+				line += " ci:" + b.PR.CIStatus
+			}
+		} else {
+			line += "  (no PR)"
+		}
+		var flags []string
+		if b.NeedsRestack {
+			flags = append(flags, "needs-restack")
+		}
+		if b.IsLocked {
+			flags = append(flags, "locked")
+		}
+		if b.IsFrozen {
+			flags = append(flags, "frozen")
+		}
+		if len(flags) > 0 {
+			line += "  [" + strings.Join(flags, ", ") + "]"
+		}
+		out.Info("%s", line)
+	}
+}

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-absorb.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-absorb.md
@@ -11,8 +11,7 @@ Absorb staged fixes into the commits that last touched the changed lines.
 1. Inspect:
 
    ```bash
-   git status --short
-   stackit log --no-interactive
+   stackit state --json
    ```
 
 2. Stage intended fixes:

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-extract.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-extract.md
@@ -11,8 +11,7 @@ Move files or commits off the current branch onto a new sibling, parent, or chil
 1. Inspect:
 
    ```bash
-   git status --short
-   stackit log --no-interactive
+   stackit state --json
    git log --oneline -5
    ```
 

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-fix.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-fix.md
@@ -11,8 +11,7 @@ Diagnose stack problems and apply the smallest safe repair.
 1. Inspect:
 
    ```bash
-   git status --short
-   stackit log --no-interactive
+   stackit state --json
    stackit doctor --no-interactive
    ```
 

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-fold.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-fold.md
@@ -11,8 +11,7 @@ Fold a branch into its parent when it is too small to review separately.
 1. Inspect:
 
    ```bash
-   git status --short
-   stackit log --no-interactive
+   stackit state --json
    ```
 
 2. Check preconditions before folding (folding rewrites stack structure):

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-resolve.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-resolve.md
@@ -11,10 +11,11 @@ Resolve an in-progress Stackit conflict and continue the operation.
 1. Inspect:
 
    ```bash
-   git status --short
-   git diff --name-only --diff-filter=U
-   stackit log --no-interactive
+   stackit state --json
    ```
+
+   `operation.conflicted_files` lists the unmerged paths; `operation.kind` and
+   `operation.stackit_halted` tell you what's in progress.
 
 2. Read each conflicted file and resolve markers.
 

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-restack.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-restack.md
@@ -11,13 +11,13 @@ Rebase stack branches according to Stackit metadata.
 1. Inspect:
 
    ```bash
-   git status --short
-   stackit log --no-interactive
+   stackit state --json
    ```
 
-2. Precondition: if `git status --short` is non-empty, stop and tell the user to
-   commit (via `stackit create`/`stackit modify`) or stash before restacking — a
-   dirty tree will fail the rebase mid-flight.
+2. Precondition: if the state JSON's `working_tree.clean` is false (uncommitted
+   changes), stop and tell the user to commit (via `stackit create`/`stackit
+   modify`) or stash before restacking — a dirty tree will fail the rebase
+   mid-flight.
 
 3. Choose the narrowest scope that covers what changed:
    - Current stack: `stackit restack --upstack --no-interactive`

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-review.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-review.md
@@ -11,7 +11,7 @@ Review stack PRs for high-confidence issues and report findings locally.
 1. Gather stack PRs:
 
    ```bash
-   stackit log --json --no-interactive
+   stackit state --json
    ```
 
 2. For each open non-draft PR selected for review:

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-split.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-split.md
@@ -17,7 +17,7 @@ Split committed changes on the current branch into another stacked branch.
 2. Inspect branch context:
 
    ```bash
-   stackit log --no-interactive
+   stackit state --json
    git log --oneline <parent-branch>..HEAD
    git diff --name-status <parent-branch>..HEAD
    ```

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-status.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-status.md
@@ -11,8 +11,7 @@ Report stack state without mutating anything.
 Run:
 
 ```bash
-git status --short
-stackit log --json --no-interactive
+stackit state --json
 ```
 
 Summarize:

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-submit.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-submit.md
@@ -11,9 +11,7 @@ Submit branches as PRs or update existing PRs. This touches remotes, so confirm 
 1. Inspect:
 
    ```bash
-   git status --short
-   stackit log --no-interactive
-   stackit info --json --no-interactive
+   stackit state --json
    ```
 
 2. If there are uncommitted changes, warn and stop unless the user asked to submit anyway.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-sync.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-sync.md
@@ -11,8 +11,7 @@ Sync with trunk and clean up branches that have landed.
 1. Inspect:
 
    ```bash
-   git status --short
-   stackit log --no-interactive
+   stackit state --json
    ```
 
 2. If there are uncommitted changes, stop and ask the user to commit (via

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-verify.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-verify.md
@@ -11,8 +11,7 @@ Run verification across stack branches.
 1. Inspect:
 
    ```bash
-   stackit log --no-interactive
-   git status --short
+   stackit state --json
    ```
 
 2. Determine check command from user input, project docs, or common files. Prefer `mise run check` when available.

--- a/internal/cli/integrations/agents/templates/codex/skill/SKILL.md
+++ b/internal/cli/integrations/agents/templates/codex/skill/SKILL.md
@@ -27,10 +27,13 @@ If there is no work to act on, say so and stop.
 Run once at the start of a Stackit-related session:
 
 ```bash
-stackit log --json --no-interactive
+stackit state --json
 ```
 
-Surface failing CI, branches ready to merge, and branches needing restack when relevant.
+This single call returns the current branch, working-tree state, any in-progress
+operation, and the full `stack` (PR/CI status + per-branch needs_restack/locked/
+frozen/scope). Surface failing CI, branches ready to merge, and branches needing
+restack when relevant.
 
 ## Skill Selection
 

--- a/internal/cli/integrations/agents/templates/commands/stack-absorb.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-absorb.md
@@ -9,9 +9,7 @@ allowed-tools: Bash(stackit:*), Bash(git:*), Read, Edit, Glob, Grep, AskUserQues
 Absorb staged changes into the correct commits, then intelligently fix any broken branches by drawing from the right sources.
 
 ## Context
-- Current branch: !`git branch --show-current`
-- Git status: !`git status --short`
-- Stack state: !`stackit log --no-interactive`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 
 ## How Absorb Works
 

--- a/internal/cli/integrations/agents/templates/commands/stack-extract.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-extract.md
@@ -9,9 +9,8 @@ allowed-tools: Bash(stackit:*), Bash(git:*), Read, Glob, Grep
 Extract commits or file changes from the current branch to a new independent branch.
 
 ## Context
-- Current branch: !`git branch --show-current`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 - Recent commits: !`git log --oneline -5`
-- Stack state: !`stackit log --no-interactive`
 
 ## Instructions
 

--- a/internal/cli/integrations/agents/templates/commands/stack-fix.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-fix.md
@@ -9,9 +9,7 @@ allowed-tools: Bash(stackit:*), Bash(git:*), Read, Edit, Glob, Grep, AskUserQues
 Diagnose and fix stack problems, including build/lint/test failures.
 
 ## Context
-- Current branch: !`git branch --show-current`
-- Git status: !`git status --short`
-- Stack state: !`stackit log --no-interactive`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 - Diagnostics: !`stackit doctor --no-interactive`
 
 ## Instructions

--- a/internal/cli/integrations/agents/templates/commands/stack-plan.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-plan.md
@@ -12,9 +12,7 @@ Analyze uncommitted working tree changes, suggest a logical stacking structure, 
 **Primary objective: Never lose someone's work.**
 
 ## Context
-- Current branch: !`git branch --show-current`
-- Git status: !`git status --short`
-- Stack state: !`stackit log --no-interactive`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 
 ## Arguments
 $ARGUMENTS

--- a/internal/cli/integrations/agents/templates/commands/stack-resolve.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-resolve.md
@@ -9,9 +9,7 @@ allowed-tools: Read, Edit, AskUserQuestion, Bash(git show *), Bash(git diff *), 
 Resolve rebase conflicts during stackit operations with AI assistance.
 
 ## Context
-- Current operation: !`cat .git/rebase-merge/message 2>/dev/null || echo "No rebase in progress"`
-- Conflicted files: !`git diff --name-only --diff-filter=U 2>/dev/null || echo "No conflicts detected"`
-- Current branch: !`git branch --show-current 2>/dev/null || cat .git/rebase-merge/head-name 2>/dev/null | sed 's|refs/heads/||'`
+- State (json — `operation.kind`/`operation.in_progress`, `operation.conflicted_files`, `operation.stackit_halted`, current branch): !`stackit state --json`
 - Project type: !`if [ -f "mise.toml" ]; then echo "mise"; elif [ -f "Makefile" ]; then echo "make"; elif [ -f "package.json" ]; then echo "npm/yarn"; elif [ -f "Cargo.toml" ]; then echo "cargo"; elif [ -f "go.mod" ]; then echo "go"; else echo "unknown"; fi`
 
 ## Instructions

--- a/internal/cli/integrations/agents/templates/commands/stack-restack.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-restack.md
@@ -7,9 +7,7 @@ allowed-tools: Bash(stackit:*), Bash(git:*), AskUserQuestion, Skill
 # Stack Restack
 
 ## Context
-- Current branch: !`git branch --show-current`
-- Git status: !`git status --short`
-- Stack state: !`stackit log --no-interactive`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 
 ## Task
 

--- a/internal/cli/integrations/agents/templates/commands/stack-review.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-review.md
@@ -14,9 +14,8 @@ Perform code reviews on PRs in the stack. Finds bugs, checks CLAUDE.md complianc
 - **Apply mode** (`--apply`): Apply existing review comments from GitHub and mark resolved
 
 ## Context
-- Current branch: !`git branch --show-current`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 - Repo: !`gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null`
-- Stack state: !`stackit log --no-interactive`
 
 ## Arguments
 $ARGUMENTS

--- a/internal/cli/integrations/agents/templates/commands/stack-split.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-split.md
@@ -29,9 +29,7 @@ Split the committed changes on the current branch between this branch and a new 
 **Primary objective: Never lose someone's work.**
 
 ## Context
-- Current branch: !`git branch --show-current`
-- Git status: !`git status --short`
-- Stack state: !`stackit log --no-interactive`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 
 ## Arguments
 $ARGUMENTS

--- a/internal/cli/integrations/agents/templates/commands/stack-status.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-status.md
@@ -8,25 +8,24 @@ allowed-tools: Bash(stackit:*), Bash(git:*)
 
 Show the current stack state, identify issues, and provide actionable recommendations.
 ## Context
-- Current branch: !`git branch --show-current`
-- Git status: !`git status --short`
-- Stack state (json — complete: structure, PR/CI status, and per-branch needs_restack/is_locked/is_frozen/scope): !`stackit log --json --no-interactive`
+- State (json — complete snapshot: current branch, working tree, in-progress operation, and the full stack with PR/CI status and per-branch needs_restack/is_locked/is_frozen/scope): !`stackit state --json`
 
 ## Task
 
 ### Step 1: Display Stack Overview
 
-Summarize from the JSON context:
-- Current position in the stack (the branch with `is_current: true`)
-- Parent/child relationships
-- Any branches that need attention
+Summarize from the `stackit state --json` context:
+- Current position (`current_branch`, or the `.stack.branches` entry with `is_current: true`)
+- Working tree (`working_tree`) and any in-progress `operation`
+- Parent/child relationships and any branches that need attention
 
 If the user wants the visual tree, run `stackit log --no-interactive` and show it.
 
 ### Step 2: Health Analysis
 
-Parse the stack JSON (a single `stackit log --json` carries everything — PR/CI
-status plus `needs_restack`/`is_locked`/`is_frozen`/`scope`), then highlight issues:
+Parse the state JSON — a single `stackit state --json` carries everything: the
+working tree, in-progress `operation`, and the full `stack` (PR/CI status plus
+`needs_restack`/`is_locked`/`is_frozen`/`scope` per branch). Highlight issues:
 
 **High Priority Issues (act now):**
 - CI failing on any branch

--- a/internal/cli/integrations/agents/templates/commands/stack-submit.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-submit.md
@@ -10,9 +10,7 @@ argument-hint: [--stack | --draft]
 Submit branches to GitHub and create/update PRs.
 
 ## Context
-- Current branch: !`git branch --show-current`
-- Stack state: !`stackit log --no-interactive`
-- Branch info: !`stackit info --json --no-interactive`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 
 ## Arguments
 $ARGUMENTS

--- a/internal/cli/integrations/agents/templates/commands/stack-sync.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-sync.md
@@ -7,8 +7,7 @@ allowed-tools: Bash(stackit:*), Bash(git:*), AskUserQuestion, Skill
 # Stack Sync
 
 ## Context
-- Current branch: !`git branch --show-current`
-- Stack state: !`stackit log --no-interactive`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 
 ## Task
 

--- a/internal/cli/integrations/agents/templates/commands/stack-verify.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-verify.md
@@ -10,9 +10,7 @@ argument-hint: [check-command]
 Run verification checks on all branches in the stack and report results.
 
 ## Context
-- Current branch: !`git branch --show-current`
-- Git status: !`git status --short`
-- Stack state: !`stackit log --no-interactive`
+- State (json — current branch, working tree, in-progress operation, full stack): !`stackit state --json`
 
 ## Arguments
 $ARGUMENTS

--- a/internal/cli/integrations/agents/templates/skill/SKILL.md
+++ b/internal/cli/integrations/agents/templates/skill/SKILL.md
@@ -54,12 +54,14 @@ When calling `stackit` commands, **ALWAYS** include the `--no-interactive` flag.
 
 **Run at session start** to proactively identify issues:
 ```bash
-stackit log --json --no-interactive
+stackit state --json
 ```
 
-This returns a JSON report with:
-- `branches`: Array of branch status (current, parent/children, PR status, CI status, needs_restack)
-- `summary`: Counts for total branches, approved branches, and branches in review
+This single call returns a complete JSON snapshot:
+- `current_branch` / `trunk`, and `working_tree` (staged/unstaged/untracked/clean)
+- `operation`: any in-progress rebase/merge with `conflicted_files`
+- `stack.branches`: array of branch status (current, parent/children, PR/CI status, needs_restack/is_locked/is_frozen/scope)
+- `stack.summary`: counts for total branches, approved branches, and branches in review
 
 **When to mention health issues proactively:**
 If the health check reveals issues, inform the user:

--- a/internal/cli/integrations/agents/templates/skill/commands/stack.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/stack.md
@@ -12,7 +12,8 @@ Commands for managing the entire stack or multiple branches.
 | `stackit restack --all-stacks --continue-on-conflict --no-interactive` | Rebase every independent stack rooted at trunk, skipping conflicted stacks so unrelated stacks still proceed |
 | `stackit restack --stacks <root1>,<root2> --continue-on-conflict --no-interactive` | Rebase specific independent stack roots while letting unrelated selected roots continue past conflicts |
 | `stackit sync --no-interactive` | Pull trunk, delete merged branches, restack |
-| `stackit info --stack --json --no-interactive` | Export full stack metadata as JSON for analysis |
+| `stackit state --json` | Complete one-call snapshot: current branch, working tree, in-progress operation, and the full stack (PR/CI + needs_restack/locked/frozen/scope) |
+| `stackit info --stack --json --no-interactive` | Export full per-branch metadata incl. commit messages and diff stats (use when you need commit messages, which `state` omits) |
 | `stackit merge --yes --no-interactive` | Merge the next (bottom) ready PR non-interactively (bare `stackit merge` with no flags opens a TTY wizard). Use `stackit merge ship --yes --no-interactive` to consolidate the whole stack into one PR. |
 | `stackit fold --no-interactive` | Fold current branch into its parent |
 

--- a/internal/cli/integrations/agents/templates/skill/reference.md
+++ b/internal/cli/integrations/agents/templates/skill/reference.md
@@ -36,6 +36,7 @@ bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
 
 | Command | Description |
 |---------|-------------|
+| `stackit state --json` | Complete one-call snapshot (branch, working tree, in-progress operation, full stack) — preferred for programmatic reads |
 | `stackit log` | Display the branch tree visualization |
 | `stackit log full` | Show tree with GitHub PR status and CI checks |
 | `stackit checkout [branch]` | Switch to a specific branch |

--- a/internal/cli/integrations/agents/templates/skill/scripts/analyze_stack.sh
+++ b/internal/cli/integrations/agents/templates/skill/scripts/analyze_stack.sh
@@ -38,15 +38,19 @@ echo -e "${BLUE}Current Stack:${NC}"
 stackit log
 echo
 
-# Fetch authoritative stack metadata once as JSON (the source of truth for
-# branch relationships, sizes, and PR state) instead of scraping rendered output.
-STACK_JSON=$(stackit log short --json --no-interactive 2>/dev/null || echo '{}')
-github_available=$(echo "$STACK_JSON" | jq -r '.github_available // false')
+# Fetch one authoritative snapshot as JSON: the working tree, any in-progress
+# operation, and the full stack (branch relationships, sizes, PR/CI state). This
+# replaces scraping rendered output and separate git probes for dirty/rebase state.
+STATE_JSON=$(stackit state --json 2>/dev/null || echo '{}')
+github_available=$(echo "$STATE_JSON" | jq -r '.stack.github_available // false')
+# Use `== false` rather than `// default`: jq's `//` treats a boolean false as
+# empty, so `.working_tree.clean // true` would wrongly yield true on a dirty tree.
+working_tree_dirty=$(echo "$STATE_JSON" | jq -r '.working_tree.clean == false')
 
 echo -e "${BLUE}Health Checks:${NC}"
 
-# Check for uncommitted changes
-if ! git diff-index --quiet HEAD -- 2>/dev/null; then
+# Uncommitted changes (from the snapshot's working_tree)
+if [ "$working_tree_dirty" = "true" ]; then
     echo -e "${YELLOW}⚠️  Uncommitted changes detected${NC}"
     echo "→ Run: git status"
     echo "→ Consider: git add -A (then) stackit modify"
@@ -57,7 +61,7 @@ fi
 # Only meaningful when GitHub data is available.
 branches_no_pr=0
 if [ "$github_available" = "true" ]; then
-    branches_no_pr=$(echo "$STACK_JSON" | jq '[.branches[]? | select((.is_trunk | not) and (has("pr") | not))] | length')
+    branches_no_pr=$(echo "$STATE_JSON" | jq '[.stack.branches[]? | select((.is_trunk | not) and (has("pr") | not))] | length')
     if [ "$branches_no_pr" -gt 0 ]; then
         echo -e "${YELLOW}ℹ️  $branches_no_pr branch(es) without PRs${NC}"
         echo "→ Run: stackit submit --stack"
@@ -66,7 +70,7 @@ if [ "$github_available" = "true" ]; then
 fi
 
 # Check if sync needed (any PR merged or closed)
-merged_or_closed=$(echo "$STACK_JSON" | jq '[.branches[]? | select(.pr.state == "MERGED" or .pr.state == "CLOSED")] | length')
+merged_or_closed=$(echo "$STATE_JSON" | jq '[.stack.branches[]? | select(.pr.state == "MERGED" or .pr.state == "CLOSED")] | length')
 if [ "$merged_or_closed" -gt 0 ]; then
     echo -e "${YELLOW}ℹ️  $merged_or_closed PR(s) have been merged/closed${NC}"
     echo "→ Run: stackit sync --restack"
@@ -74,26 +78,28 @@ if [ "$merged_or_closed" -gt 0 ]; then
 fi
 
 # Surface failing CI when GitHub data is available
-failing_ci=$(echo "$STACK_JSON" | jq -r '[.branches[]? | select(.pr.ci_status == "failing") | .name] | join(", ")')
+failing_ci=$(echo "$STATE_JSON" | jq -r '[.stack.branches[]? | select(.pr.ci_status == "failing") | .name] | join(", ")')
 if [ -n "$failing_ci" ]; then
     echo -e "${RED}⚠️  Failing CI on: $failing_ci${NC}"
     echo
 fi
 
-# Check for rebase in progress
-if [ -d "$(git rev-parse --git-dir)/rebase-merge" ] || [ -d "$(git rev-parse --git-dir)/rebase-apply" ]; then
-    echo -e "${RED}⚠️  Rebase in progress${NC}"
+# In-progress operation (from the snapshot's operation field)
+op_kind=$(echo "$STATE_JSON" | jq -r '.operation.kind // "none"')
+if [ "$op_kind" != "none" ]; then
+    n_conflicts=$(echo "$STATE_JSON" | jq -r '(.operation.conflicted_files // []) | length')
+    echo -e "${RED}⚠️  $op_kind in progress ($n_conflicts conflicted file(s))${NC}"
     echo "→ Resolve conflicts and run: stackit continue"
     echo "→ Or abort with: stackit abort"
     echo
 fi
 
-# Get current branch
-current_branch=$(git branch --show-current)
+# Current branch and trunk (from the snapshot)
+current_branch=$(echo "$STATE_JSON" | jq -r '.current_branch // ""')
+trunk_branch=$(echo "$STATE_JSON" | jq -r '.trunk // "main"')
 
 # Check if on trunk
-trunk_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main")
-if [ "$current_branch" = "$trunk_branch" ]; then
+if [ -n "$current_branch" ] && [ "$current_branch" = "$trunk_branch" ]; then
     echo -e "${YELLOW}ℹ️  Currently on trunk branch ($trunk_branch)${NC}"
     echo "→ Consider: stackit checkout (to switch to a feature branch)"
     echo
@@ -112,7 +118,7 @@ while IFS=$'\t' read -r branch additions deletions; do
     echo "   +$additions/-$deletions lines ($total_lines total)"
     echo "→ Consider: stackit split (to break into smaller PRs)"
     echo
-done < <(echo "$STACK_JSON" | jq -r '.branches[]? | select((.is_trunk | not) and ((.additions + .deletions) > 500)) | "\(.name)\t\(.additions)\t\(.deletions)"')
+done < <(echo "$STATE_JSON" | jq -r '.stack.branches[]? | select((.is_trunk | not) and ((.additions + .deletions) > 500)) | "\(.name)\t\(.additions)\t\(.deletions)"')
 
 if [ "$large_branch_found" = false ]; then
     echo -e "${GREEN}✓ All branches are reasonably sized${NC}"
@@ -140,7 +146,7 @@ if [ "$branches_no_pr" -gt 0 ]; then
     echo "1. Submit branches: stackit submit --stack"
 elif [ "$merged_or_closed" -gt 0 ]; then
     echo "1. Sync with trunk: stackit sync --restack"
-elif ! git diff-index --quiet HEAD -- 2>/dev/null; then
+elif [ "$working_tree_dirty" = "true" ]; then
     echo "1. Commit changes: git add -A (then) stackit modify"
 else
     echo -e "${GREEN}✓ Stack is healthy! Ready for development.${NC}"

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -124,6 +124,7 @@ Commit:  ` + commit + `
 	rootCmd.AddCommand(branch.NewSquashCmd())
 	rootCmd.AddCommand(newScopeCmd())
 	rootCmd.AddCommand(shell.NewShellCmd())
+	rootCmd.AddCommand(newStateCmd())
 	rootCmd.AddCommand(stack.NewSubmitCmd())
 	rootCmd.AddCommand(stack.NewSyncCmd())
 	rootCmd.AddCommand(navigation.NewTopCmd())

--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+)
+
+// newStateCmd creates the state command.
+func newStateCmd() *cobra.Command {
+	var jsonOut bool
+
+	cmd := &cobra.Command{
+		Use:   "state",
+		Short: "Show a snapshot of the stack, working tree, and any in-progress operation",
+		Long: `Show a complete snapshot of the current stack in a single call.
+
+Combines the current branch and trunk, working-tree state (staged/unstaged/
+untracked), any in-progress rebase/merge with its conflicted files, and the full
+stack (structure, PR/CI status, and per-branch needs_restack/locked/frozen/scope).
+
+Use --json for one machine-readable snapshot — agents and scripts read everything
+from a single call instead of combining git status, stackit log, and stackit info.
+
+Examples:
+  stackit state            # Human-readable summary
+  stackit state --json     # Complete machine-readable snapshot`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return common.Run(cmd, func(ctx *app.Context) error {
+				return actions.StateAction(ctx, actions.StateOptions{JSON: jsonOut})
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output a complete machine-readable snapshot as JSON")
+
+	return cmd
+}

--- a/internal/cli/state_test.go
+++ b/internal/cli/state_test.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStateCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := newStateCmd()
+
+	require.Equal(t, "state", cmd.Use)
+	require.NotEmpty(t, cmd.Short)
+	require.NotEmpty(t, cmd.Long)
+
+	jsonFlag := cmd.Flags().Lookup("json")
+	require.NotNil(t, jsonFlag, "state should have a --json flag")
+}

--- a/internal/integration/json_output_test.go
+++ b/internal/integration/json_output_test.go
@@ -388,3 +388,56 @@ func TestJSONOutput(t *testing.T) {
 		}
 	})
 }
+
+func TestStateJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("produces a complete snapshot", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("feature_a", "content a").
+			Run("create feature-a -m 'Add feature A'")
+
+		sh.Run("state --json")
+		var result actions.StateResult
+		require.NoError(t, json.Unmarshal([]byte(sh.Output()), &result), "state --json should be valid JSON")
+
+		require.Equal(t, "feature-a", result.CurrentBranch)
+		require.False(t, result.Detached)
+		require.NotEmpty(t, result.Trunk)
+		// No in-progress operation on a fresh stack.
+		require.Equal(t, "none", result.Operation.Kind)
+		require.False(t, result.Operation.InProgress)
+		require.NotNil(t, result.Operation.ConflictedFiles)
+		// The staged file was committed by create, so the tree is clean.
+		require.True(t, result.WorkingTree.Clean)
+		// The stack is embedded (same shape as log --json).
+		require.GreaterOrEqual(t, result.Stack.Summary.TotalBranches, 1)
+	})
+
+	t.Run("reports a dirty working tree", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("feature_a", "content a").
+			Run("create feature-a -m 'Add feature A'")
+		sh.WriteFile("extra.txt", "x") // WriteFile stages the file
+
+		sh.Run("state --json")
+		var result actions.StateResult
+		require.NoError(t, json.Unmarshal([]byte(sh.Output()), &result))
+
+		require.False(t, result.WorkingTree.Clean)
+		require.True(t, result.WorkingTree.Staged)
+	})
+
+	t.Run("human output summarizes branch and stack", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Write("feature_a", "content a").
+			Run("create feature-a -m 'Add feature A'")
+
+		sh.Run("state").
+			OutputContains("On feature-a").
+			OutputContains("Stack")
+	})
+}


### PR DESCRIPTION
This PR merges the following changes:

1. **#1083** feat: add stackit state command with a complete --json snapshot
2. **#1084** docs: use stackit state --json as the one-call preflight in agent skills

### Stack

```
main
  └─ jonnii/20260529115036/add-stackit-status-command-with-a-complete-json (#1083)
    └─ jonnii/20260529122224/use-stackit-state-json-as-the-one-call (#1084)
```

Stackit-Stack-Size: 2
Stackit-PRs: 1083,1084
