### PR TITLE
perf(engine): fix untrack N+1 rebuild with BatchUntrackBranches

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -62,6 +62,7 @@ git config --local --add stackit.trunks develop
 | `stackit.submit.reviewers` | string[] | `[]` | Default reviewers for PRs |
 | `stackit.submit.assignees` | string[] | `[]` | Default assignees for PRs |
 | `stackit.undo.depth` | int | `10` | Max undo snapshots to retain |
+| `stackit.undo.enabled` | bool | `true` | Take undo snapshots before mutations (set `false` to eliminate snapshot overhead for users who never run `stackit undo`) |
 | `stackit.worktree.basePath` | string | `""` | Base directory for worktrees |
 | `stackit.worktree.autoClean` | bool | `true` | Auto-remove clean, empty managed worktrees during sync |
 | `stackit.merge.method` | string | `""` | Merge strategy (squash/merge/rebase) |
@@ -228,6 +229,7 @@ The table below shows all options available in `.stackit.yaml`. The "Team Fallba
 | `ci.command` | string | `""` | CI validation command | Yes |
 | `ci.timeout` | int | `600` | CI timeout in seconds | Yes |
 | `undo.depth` | int | `10` | Max undo snapshots to retain | Yes |
+| `undo.enabled` | bool | `true` | Take undo snapshots before mutations | Yes |
 | `worktree.basePath` | string | `""` | Base directory for worktrees | Yes |
 | `worktree.autoClean` | bool | `true` | Auto-remove clean, empty managed worktrees during sync | Yes |
 | `split.hunkSelector` | string | `tui` | Hunk selector mode (tui/git) | Yes |

--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -207,8 +207,8 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[
 
 	// Single batch call to engine for deletion statuses
 	batchStart := time.Now()
-	statuses, err := eng.BatchGetDeletionStatuses(c, candidateNames)
-	ctx.Logger.Info("BatchGetDeletionStatuses completed durationMs=%d candidateCount=%d ok=%v",
+	statuses, err := eng.GetDeletionStatuses(c, candidateNames)
+	ctx.Logger.Info("GetDeletionStatuses completed durationMs=%d candidateCount=%d ok=%v",
 		time.Since(batchStart).Milliseconds(), len(candidateNames), err == nil)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get deletion statuses: %w", err)

--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -41,8 +41,11 @@ func printRerereResolved(ctx *app.Context, count int) {
 }
 
 // TakeBestEffortSnapshot records an undo snapshot and logs failures without
-// aborting the action.
+// aborting the action. It is a no-op when undo.enabled is false in config.
 func TakeBestEffortSnapshot(ctx *app.Context, opts engine.SnapshotOptions) {
+	if ctx.Config != nil && !ctx.Config.UndoEnabled() {
+		return
+	}
 	if err := ctx.Undo().TakeSnapshot(opts); err != nil {
 		ctx.Output.Debug("Failed to take snapshot: %v", err)
 	}

--- a/internal/actions/delete/delete.go
+++ b/internal/actions/delete/delete.go
@@ -79,7 +79,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) (Result, error) {
 
 	// Precompute deletion statuses once (used for confirmation and divergence-preserving reparenting).
 	toDeleteNames := toDelete.Names()
-	statuses, err := eng.BatchGetDeletionStatuses(ctx.Context, toDeleteNames)
+	statuses, err := eng.GetDeletionStatuses(ctx.Context, toDeleteNames)
 	if err != nil {
 		return Result{}, fmt.Errorf("failed to check deletion statuses: %w", err)
 	}

--- a/internal/actions/describe/describe.go
+++ b/internal/actions/describe/describe.go
@@ -139,7 +139,7 @@ func markStackAndPushMetadata(ctx *app.Context, eng engine.Engine, stackRoot str
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
 	root := eng.GetBranch(stackRoot)
 	if root.IsTracked() {
-		if err := eng.BatchMarkNeedsPRBodyUpdate(ctx, graph.CollectBranches(root).Names()); err != nil {
+		if err := eng.MarkBranchesForPRBodyUpdate(ctx, graph.CollectBranches(root).Names()); err != nil {
 			out.Debug("Failed to mark branches for PR body update: %v", err)
 		}
 	}

--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -140,6 +140,9 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 	// views are faster with lazy lookups than with a repo-wide preload.
 	if shouldPreloadLogBranchData(opts, len(visibleBranches), len(allBranches)) {
 		ctx.Engine.PreloadBranchData()
+		// Also warm diff-stats and commit-count caches so annotation goroutines
+		// get instant cache hits instead of spawning per-branch subprocesses.
+		ctx.Engine.PreloadBranchStats(visibleBranches.All())
 	}
 
 	// Collect annotations only for branches that will be rendered.
@@ -368,6 +371,10 @@ func BuildLogJSON(ctx *app.Context, opts LogOptions) LogJSONResult {
 	}
 	processableBranches := processable.Build()
 
+	// Warm the diff-stats and commit-count caches in parallel before the main
+	// annotation loop so that GetDiffStats / GetCommitCount are instant cache hits.
+	ctx.Engine.PreloadBranchStats(processableBranches.All())
+
 	if len(processableBranches) > 0 {
 		utils.Run(processableBranches.All(), func(branch engine.Branch) {
 			branchName := branch.GetName()
@@ -399,11 +406,11 @@ func BuildLogJSON(ctx *app.Context, opts LogOptions) LogJSONResult {
 				}
 			}
 
-			// Commits and diff stats
+			// Commits and diff stats (cache hits from PreloadBranchStats above)
 			if !branch.IsTrunk() {
-				commits, err := branch.GetAllCommits(engine.CommitFormatSHA)
+				count, err := branch.GetCommitCount()
 				if err == nil {
-					info.Commits = len(commits)
+					info.Commits = count
 				}
 
 				added, deleted, err := branch.GetDiffStats()

--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -365,7 +365,7 @@ func restackAndMark(ctx *app.Context, plan *movePlan, sourceBranch engine.Branch
 	if plan.oldParentName != eng.Trunk().GetName() {
 		affectedBranches = append(affectedBranches, plan.oldParentName)
 	}
-	if err := eng.BatchMarkNeedsPRBodyUpdate(ctx, affectedBranches); err != nil {
+	if err := eng.MarkBranchesForPRBodyUpdate(ctx, affectedBranches); err != nil {
 		out.Debug("Failed to mark branches for PR body update: %v", err)
 	}
 

--- a/internal/actions/scope/action.go
+++ b/internal/actions/scope/action.go
@@ -64,15 +64,11 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		if isOnTrunk {
 			return fmt.Errorf("cannot unset scope on trunk")
 		}
-		if err := eng.SetScope(ctx.Context, eng.GetBranch(currentBranch), engine.Empty()); err != nil {
+		if err := eng.SetScopeAndMarkForUpdate(ctx.Context, eng.GetBranch(currentBranch), engine.Empty()); err != nil {
 			return fmt.Errorf("failed to unset scope: %w", err)
 		}
 		out.Info("Unset explicit scope for branch %s. It will now inherit from its parent.", style.ColorBranchName(currentBranch, false))
-
-		// Mark branch for PR update and push metadata (defer GitHub API calls to sync)
-		if err := eng.BatchMarkNeedsPRBodyUpdate(ctx, []string{currentBranch}); err != nil {
-			out.Debug("Failed to mark branch for PR body update: %v", err)
-		}
+		// PR body update flag already set atomically inside SetScopeAndMarkForUpdate.
 		if err := actions.PushMetadataOnly(ctx, eng, []string{currentBranch}); err != nil {
 			out.Debug("Failed to push metadata changes: %v", err)
 		}
@@ -89,11 +85,11 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return fmt.Errorf("cannot set scope on trunk")
 	}
 
-	// Update the current branch's scope
+	// Update the current branch's scope and mark for PR body update in one transaction.
 	currentBranchObj := eng.GetBranch(currentBranch)
 	oldScope := eng.GetScope(currentBranchObj)
 	newScope := engine.NewScope(opts.Scope)
-	if err := eng.SetScope(ctx.Context, eng.GetBranch(currentBranch), newScope); err != nil {
+	if err := eng.SetScopeAndMarkForUpdate(ctx.Context, eng.GetBranch(currentBranch), newScope); err != nil {
 		return fmt.Errorf("failed to set scope: %w", err)
 	}
 
@@ -116,10 +112,8 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		}
 	}
 
-	// Mark branch for PR update and push metadata (defer GitHub API calls to sync)
-	if err := eng.BatchMarkNeedsPRBodyUpdate(ctx, []string{currentBranch}); err != nil {
-		out.Debug("Failed to mark branch for PR body update: %v", err)
-	}
+	// PR body update flag already set atomically inside SetScopeAndMarkForUpdate.
+	// Push metadata refs (fast git operation).
 	if err := actions.PushMetadataOnly(ctx, eng, []string{currentBranch}); err != nil {
 		out.Debug("Failed to push metadata changes: %v", err)
 	}

--- a/internal/actions/state.go
+++ b/internal/actions/state.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -81,18 +80,12 @@ func BuildState(ctx *app.Context, _ StateOptions) StateResult {
 		result.Detached = true
 	}
 
-	// Working-tree state. A failed check is non-fatal for a read-only snapshot;
-	// log it and fall back to the safe default (false).
-	check := func(name string, fn func(context.Context) (bool, error)) bool {
-		v, err := fn(ctx.Context)
-		if err != nil {
-			ctx.Output.Debug("state: %s check failed: %v", name, err)
-		}
-		return v
+	// Working-tree state via a single git status --porcelain call.
+	// A failed check is non-fatal; log and fall back to the safe default (false).
+	staged, unstaged, untracked, statusErr := eng.GetWorkingTreeStatus(ctx.Context)
+	if statusErr != nil {
+		ctx.Output.Debug("state: working-tree status check failed: %v", statusErr)
 	}
-	staged := check("staged", eng.HasStagedChanges)
-	unstaged := check("unstaged", eng.HasUnstagedChanges)
-	untracked := check("untracked", eng.HasUntrackedFiles)
 	result.WorkingTree = WorkingTreeStatus{
 		Staged:    staged,
 		Unstaged:  unstaged,

--- a/internal/actions/untrack/action.go
+++ b/internal/actions/untrack/action.go
@@ -55,7 +55,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	allNames = append(allNames, branchName)
 
 	// Delete all metadata refs in one batch and rebuild the engine once.
-	if err := eng.BatchUntrackBranches(ctx.Context, allNames); err != nil {
+	if err := eng.UntrackBranches(ctx.Context, allNames); err != nil {
 		return fmt.Errorf("failed to untrack branches: %w", err)
 	}
 

--- a/internal/actions/untrack/action.go
+++ b/internal/actions/untrack/action.go
@@ -47,19 +47,21 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		}
 	}
 
-	// Untrack recursively (descendants first, then the branch itself)
-	// Actually order doesn't strictly matter for metadata deletion but it's cleaner
-	for _, descendant := range descendants {
-		if err := eng.UntrackBranch(ctx.Context, descendant.GetName()); err != nil {
-			return fmt.Errorf("failed to untrack descendant %s: %w", descendant.GetName(), err)
-		}
-		ctx.Output.Info("Stopped tracking %s.", style.ColorBranchName(descendant.GetName(), false))
+	// Collect all names to untrack (descendants first for display, then the branch itself).
+	allNames := make([]string, 0, len(descendants)+1)
+	for _, d := range descendants {
+		allNames = append(allNames, d.GetName())
+	}
+	allNames = append(allNames, branchName)
+
+	// Delete all metadata refs in one batch and rebuild the engine once.
+	if err := eng.BatchUntrackBranches(ctx.Context, allNames); err != nil {
+		return fmt.Errorf("failed to untrack branches: %w", err)
 	}
 
-	if err := eng.UntrackBranch(ctx.Context, branchName); err != nil {
-		return fmt.Errorf("failed to untrack branch %s: %w", branchName, err)
+	for _, name := range allNames {
+		ctx.Output.Info("Stopped tracking %s.", style.ColorBranchName(name, false))
 	}
-	ctx.Output.Info("Stopped tracking %s.", style.ColorBranchName(branchName, false))
 
 	return nil
 }

--- a/internal/cli/stack/sync.go
+++ b/internal/cli/stack/sync.go
@@ -139,7 +139,7 @@ func syncDryRunJSON(ctx *app.Context, opts sync.Options) error {
 
 	// Batch-check deletion status for all candidates
 	if len(candidateNames) > 0 {
-		statuses, err := eng.BatchGetDeletionStatuses(ctx.Context, candidateNames)
+		statuses, err := eng.GetDeletionStatuses(ctx.Context, candidateNames)
 		if err == nil {
 			for _, name := range candidateNames {
 				if status, ok := statuses[name]; ok && status.SafeToDelete {

--- a/internal/config/config_git.go
+++ b/internal/config/config_git.go
@@ -249,6 +249,19 @@ func (c *GitConfig) UndoStackDepth() int {
 	return DefaultUndoDepth
 }
 
+// UndoEnabled reports whether undo snapshots should be taken.
+// When false, TakeBestEffortSnapshot is a no-op, eliminating snapshot overhead
+// for users who never run `stackit undo`.
+func (c *GitConfig) UndoEnabled() bool {
+	if c.store.Exists(KeyUndoEnabled) {
+		return c.store.GetBoolWithDefault(KeyUndoEnabled, DefaultUndoEnabled)
+	}
+	if c.project != nil && c.project.Undo.Enabled != nil {
+		return *c.project.Undo.Enabled
+	}
+	return DefaultUndoEnabled
+}
+
 // SetUndoStackDepth sets the max undo depth.
 func (c *GitConfig) SetUndoStackDepth(depth int) error {
 	if depth < 1 {

--- a/internal/config/interface.go
+++ b/internal/config/interface.go
@@ -20,6 +20,7 @@ type Configurer interface {
 
 	// Undo settings
 	UndoStackDepth() int
+	UndoEnabled() bool
 
 	// Worktree settings
 	WorktreeBasePath() string

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -13,6 +13,9 @@ const (
 	KeySubmitFooter = "stackit.submit.footer"
 	// KeyUndoDepth is the maximum number of undo snapshots to keep.
 	KeyUndoDepth = "stackit.undo.depth"
+	// KeyUndoEnabled controls whether undo snapshots are taken at all.
+	// Set to false to skip snapshot overhead for users who never run `stackit undo`.
+	KeyUndoEnabled = "stackit.undo.enabled"
 	// KeyWorktreeBasePath is the base path for worktrees.
 	KeyWorktreeBasePath = "stackit.worktree.basePath"
 	// KeyWorktreeAutoClean controls automatic worktree cleanup during sync.
@@ -63,6 +66,8 @@ const (
 	DefaultSubmitFooter = true
 	// DefaultUndoDepth is the default number of undo snapshots to keep.
 	DefaultUndoDepth = 10
+	// DefaultUndoEnabled is whether undo snapshots are taken by default.
+	DefaultUndoEnabled = true
 	// DefaultWorktreeAutoClean is whether to auto-clean worktrees by default.
 	DefaultWorktreeAutoClean = true
 	// DefaultCITimeout is the default CI timeout in seconds (10 minutes).

--- a/internal/config/metadata.go
+++ b/internal/config/metadata.go
@@ -157,6 +157,13 @@ var Options = []Option{
 		Default:     DefaultUndoDepth,
 		Section:     "undo",
 	},
+	{
+		YAMLPath:    "undo.enabled",
+		GitKey:      KeyUndoEnabled,
+		Description: "Take snapshots before mutations (set false to skip undo overhead)",
+		Default:     DefaultUndoEnabled,
+		Section:     "undo",
+	},
 
 	// Worktree section
 	{

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -42,7 +42,8 @@ type CIConfig struct {
 
 // UndoConfig contains undo settings
 type UndoConfig struct {
-	Depth int `yaml:"depth,omitempty"`
+	Depth   int   `yaml:"depth,omitempty"`
+	Enabled *bool `yaml:"enabled,omitempty"`
 }
 
 // WorktreeConfig contains worktree settings

--- a/internal/config/testdata/config_template.golden
+++ b/internal/config/testdata/config_template.golden
@@ -35,6 +35,7 @@
 # Undo history
 # undo:
 #   depth: 10 # Max snapshots
+#   enabled: true # Take snapshots before mutations (set false to skip undo overhead)
 
 # Worktree settings
 # worktree:

--- a/internal/engine/branch_tracking.go
+++ b/internal/engine/branch_tracking.go
@@ -77,9 +77,9 @@ func (e *engineImpl) UntrackBranch(ctx context.Context, branchName string) error
 	return e.rebuild()
 }
 
-// BatchUntrackBranches untracks multiple branches with a single metadata deletion
+// UntrackBranches stops tracking multiple branches with a single metadata deletion
 // and a single engine rebuild, rather than one rebuild per branch.
-func (e *engineImpl) BatchUntrackBranches(ctx context.Context, branchNames []string) error {
+func (e *engineImpl) UntrackBranches(ctx context.Context, branchNames []string) error {
 	if len(branchNames) == 0 {
 		return nil
 	}
@@ -343,7 +343,7 @@ func (e *engineImpl) SetScope(ctx context.Context, branch Branch, scope Scope) e
 
 // SetScopeAndMarkForUpdate sets the scope and marks the branch as needing a PR
 // body update in a single atomic transaction, saving one git ref write compared
-// to calling SetScope + BatchMarkNeedsPRBodyUpdate separately.
+// to calling SetScope + MarkBranchesForPRBodyUpdate separately.
 func (e *engineImpl) SetScopeAndMarkForUpdate(ctx context.Context, branch Branch, scope Scope) error {
 	branchName := branch.GetName()
 

--- a/internal/engine/branch_tracking.go
+++ b/internal/engine/branch_tracking.go
@@ -77,6 +77,26 @@ func (e *engineImpl) UntrackBranch(ctx context.Context, branchName string) error
 	return e.rebuild()
 }
 
+// BatchUntrackBranches untracks multiple branches with a single metadata deletion
+// and a single engine rebuild, rather than one rebuild per branch.
+func (e *engineImpl) BatchUntrackBranches(ctx context.Context, branchNames []string) error {
+	if len(branchNames) == 0 {
+		return nil
+	}
+	if len(branchNames) == 1 {
+		return e.UntrackBranch(ctx, branchNames[0])
+	}
+
+	refNames := make([]string, len(branchNames))
+	for i, name := range branchNames {
+		refNames[i] = fmt.Sprintf("%s%s", git.MetadataRefPrefix, name)
+	}
+	if err := e.git.DeleteRefsBatch(ctx, refNames); err != nil {
+		return fmt.Errorf("failed to delete metadata refs: %w", err)
+	}
+	return e.rebuild()
+}
+
 // DivergenceMode controls how SetParent updates a branch's recorded divergence
 // point (ParentBranchRevision) when its parent changes.
 type DivergenceMode int
@@ -315,6 +335,42 @@ func (e *engineImpl) SetScope(ctx context.Context, branch Branch, scope Scope) e
 		// Use transaction for atomic update
 		tx := e.BeginTx(fmt.Sprintf("set scope: %s", branchName))
 		if err := tx.UpdateMeta(branchName, meta); err != nil {
+			return err
+		}
+		return tx.Commit(ctx)
+	})
+}
+
+// SetScopeAndMarkForUpdate sets the scope and marks the branch as needing a PR
+// body update in a single atomic transaction, saving one git ref write compared
+// to calling SetScope + BatchMarkNeedsPRBodyUpdate separately.
+func (e *engineImpl) SetScopeAndMarkForUpdate(ctx context.Context, branch Branch, scope Scope) error {
+	branchName := branch.GetName()
+
+	return e.WithRetry(ctx, func() error {
+		meta, err := e.readMetadata(branchName)
+		if err != nil {
+			return fmt.Errorf("failed to read metadata: %w", err)
+		}
+
+		if scope.IsEmpty() {
+			meta = meta.WithScope(nil)
+		} else {
+			scopeStr := scope.String()
+			meta = meta.WithScope(&scopeStr)
+		}
+
+		localMeta, _ := e.readLocalMetadata(branchName)
+		if localMeta == nil {
+			localMeta = &git.LocalMeta{}
+		}
+		localMeta.NeedsPRBodyUpdate = true
+
+		tx := e.BeginTx(fmt.Sprintf("set scope+mark: %s", branchName))
+		if err := tx.UpdateMeta(branchName, meta); err != nil {
+			return err
+		}
+		if err := tx.UpdateLocalMeta(branchName, localMeta); err != nil {
 			return err
 		}
 		return tx.Commit(ctx)

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -33,8 +33,8 @@ func (e *engineImpl) GetRevisionForName(branchName string) (string, error) {
 	return e.git.GetRevision(branchName)
 }
 
-// BatchGetRevisions returns the SHAs for multiple branches
-func (e *engineImpl) BatchGetRevisions(branchNames []string) (map[string]string, []error) {
+// GetRevisions returns the SHAs for multiple branches.
+func (e *engineImpl) GetRevisions(branchNames []string) (map[string]string, []error) {
 	return e.git.BatchGetRevisions(branchNames)
 }
 

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/getstackit/stackit/internal/git"
@@ -37,47 +38,56 @@ func (e *engineImpl) BatchGetRevisions(branchNames []string) (map[string]string,
 	return e.git.BatchGetRevisions(branchNames)
 }
 
-// GetCommitCount returns the number of commits for a branch
+// GetCommitCount returns the number of commits for a branch.
+// Results are cached by (base, head) SHA pair and populated by PreloadBranchStats.
 func (e *engineImpl) GetCommitCount(branch Branch) (int, error) {
 	base, branchRev, err := e.resolveBranchComparisonRevisions(branch.GetName())
 	if err != nil {
 		return 0, err
 	}
-
-	// If revisions are same, count is 0
 	if branchRev == base {
 		return 0, nil
 	}
 
-	// For real git, we'd use a git helper. I'll use git.GetCommitRange count.
-	commits, err := e.GetAllCommits(branch, CommitFormatSHA)
+	cacheKey := base + ":" + branchRev
+	if v, ok := e.commitCountCache.Load(cacheKey); ok {
+		return v.(int), nil
+	}
+
+	out, err := e.git.RunGitCommandWithContext(context.Background(), "rev-list", "--count", base+".."+branchRev)
 	if err != nil {
 		return 0, err
 	}
-	return len(commits), nil
+	var count int
+	_, _ = fmt.Sscanf(strings.TrimSpace(out), "%d", &count)
+	e.commitCountCache.Store(cacheKey, count)
+	return count, nil
 }
 
-// GetDiffStats returns diff stats for a branch
+// GetDiffStats returns diff stats for a branch.
+// Results are cached by (base, head) SHA pair and populated by PreloadBranchStats.
 func (e *engineImpl) GetDiffStats(branch Branch) (int, int, error) {
 	base, branchRev, err := e.resolveBranchComparisonRevisions(branch.GetName())
 	if err != nil {
 		return 0, 0, err
 	}
-
-	// If revisions are same, stats are 0
 	if branchRev == base {
 		return 0, 0, nil
 	}
 
-	// Use git diff --numstat
+	cacheKey := base + ":" + branchRev
+	if v, ok := e.diffStatsCache.Load(cacheKey); ok {
+		stats := v.([2]int)
+		return stats[0], stats[1], nil
+	}
+
 	output, err := e.git.GetDiffNumstat(base, branchRev)
 	if err != nil {
 		return 0, 0, err
 	}
 
 	added, deleted := 0, 0
-	lines := strings.SplitSeq(strings.TrimSpace(output), "\n")
-	for line := range lines {
+	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
 		if line == "" {
 			continue
 		}
@@ -91,7 +101,27 @@ func (e *engineImpl) GetDiffStats(branch Branch) (int, int, error) {
 		}
 	}
 
+	e.diffStatsCache.Store(cacheKey, [2]int{added, deleted})
 	return added, deleted, nil
+}
+
+// PreloadBranchStats warms the diff-stats and commit-count caches for all given
+// branches in parallel. Call this before iterating branches in utils.Run so
+// subsequent GetDiffStats / GetCommitCount calls are instant cache hits.
+func (e *engineImpl) PreloadBranchStats(branches []Branch) {
+	var wg sync.WaitGroup
+	for _, b := range branches {
+		if b.IsTrunk() || b.IsWorktreeAnchor() {
+			continue
+		}
+		wg.Add(1)
+		go func(branch Branch) {
+			defer wg.Done()
+			_, _, _ = e.GetDiffStats(branch)
+			_, _ = e.GetCommitCount(branch)
+		}(b)
+	}
+	wg.Wait()
 }
 
 func (e *engineImpl) resolveBranchComparisonRevisions(branchName string) (base, branchRev string, err error) {

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -324,9 +324,9 @@ func (e *engineImpl) IsBranchEmpty(ctx context.Context, branchName string) (bool
 }
 
 // GetDeletionStatus checks if a branch should be deleted.
-// Thin wrapper around BatchGetDeletionStatuses for a single branch.
+// Thin wrapper around GetDeletionStatuses for a single branch.
 func (e *engineImpl) GetDeletionStatus(ctx context.Context, branchName string) (DeletionStatus, error) {
-	statuses, err := e.BatchGetDeletionStatuses(ctx, []string{branchName})
+	statuses, err := e.GetDeletionStatuses(ctx, []string{branchName})
 	if err != nil {
 		return DeletionStatus{}, err
 	}
@@ -336,10 +336,10 @@ func (e *engineImpl) GetDeletionStatus(ctx context.Context, branchName string) (
 	return DeletionStatus{SafeToDelete: false, Reason: "", Kind: DeletionReasonNone}, nil
 }
 
-// BatchGetDeletionStatuses checks deletion status for multiple branches in a single batch.
+// GetDeletionStatuses checks deletion status for multiple branches in a single batch.
 // It batch-fetches metadata, revisions, and merged status, then evaluates the canonical
 // deletion policy for each branch.
-func (e *engineImpl) BatchGetDeletionStatuses(ctx context.Context, branchNames []string) (map[string]DeletionStatus, error) {
+func (e *engineImpl) GetDeletionStatuses(ctx context.Context, branchNames []string) (map[string]DeletionStatus, error) {
 	results := make(map[string]DeletionStatus, len(branchNames))
 	if len(branchNames) == 0 {
 		return results, nil

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -72,6 +72,34 @@ func (e *engineImpl) HasUntrackedFiles(ctx context.Context) (bool, error) {
 	return e.git.HasUntrackedFiles(ctx)
 }
 
+// GetWorkingTreeStatus returns staged, unstaged, and untracked status in a
+// single git status --porcelain call instead of three separate subprocesses.
+func (e *engineImpl) GetWorkingTreeStatus(ctx context.Context) (staged, unstaged, untracked bool, err error) {
+	output, err := e.git.GetStatusPorcelain(ctx)
+	if err != nil {
+		return false, false, false, err
+	}
+	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+		if len(line) < 2 {
+			continue
+		}
+		x, y := line[0], line[1]
+		if x != ' ' && x != '?' {
+			staged = true
+		}
+		if y != ' ' && (x != '?' || y != '?') {
+			unstaged = true
+		}
+		if x == '?' && y == '?' {
+			untracked = true
+		}
+		if staged && unstaged && untracked {
+			break
+		}
+	}
+	return staged, unstaged, untracked, nil
+}
+
 // GetUntrackedFileHunks returns synthetic hunks for all untracked files.
 // This allows new files to be included in hunk-based operations like split.
 func (e *engineImpl) GetUntrackedFileHunks(ctx context.Context) ([]git.Hunk, error) {

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -42,6 +42,11 @@ type engineImpl struct {
 	// Temporary worktree cleanup tracking.
 	tempWorktreeNeedsPrune bool
 	tempWorktreePrunedOnce bool
+
+	// Per-request caches for expensive git operations.
+	// Key: "base:head" (both are resolved SHAs); value type noted inline.
+	diffStatsCache   sync.Map // value: [2]int{added, deleted}
+	commitCountCache sync.Map // value: int
 }
 
 // WorktreeSnapshot holds a deep copy of engine state for initializing worktree engines.

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -726,14 +726,14 @@ func TestGetDeletionStatus(t *testing.T) {
 	})
 }
 
-func TestBatchGetDeletionStatuses(t *testing.T) {
+func TestGetDeletionStatuses(t *testing.T) {
 	t.Parallel()
 
 	t.Run("empty list returns empty map", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
-		statuses, err := s.Engine.BatchGetDeletionStatuses(context.Background(), []string{})
+		statuses, err := s.Engine.GetDeletionStatuses(context.Background(), []string{})
 		require.NoError(t, err)
 		require.Empty(t, statuses)
 	})
@@ -753,7 +753,7 @@ func TestBatchGetDeletionStatuses(t *testing.T) {
 		err := s.Engine.Rebuild("main")
 		require.NoError(t, err)
 
-		statuses, err := s.Engine.BatchGetDeletionStatuses(context.Background(), []string{"main", "branch1", "branch2"})
+		statuses, err := s.Engine.GetDeletionStatuses(context.Background(), []string{"main", "branch1", "branch2"})
 		require.NoError(t, err)
 		require.Len(t, statuses, 3)
 
@@ -787,7 +787,7 @@ func TestBatchGetDeletionStatuses(t *testing.T) {
 		err = s.Engine.SetBranchType(branch, git.BranchTypeWorktreeAnchor)
 		require.NoError(t, err)
 
-		statuses, err := s.Engine.BatchGetDeletionStatuses(context.Background(), []string{"branch1"})
+		statuses, err := s.Engine.GetDeletionStatuses(context.Background(), []string{"branch1"})
 		require.NoError(t, err)
 		require.False(t, statuses["branch1"].SafeToDelete)
 	})

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -80,6 +80,10 @@ type BranchInfo interface {
 	// into their respective caches. Call before parallel annotation building
 	// to eliminate per-branch cache misses and mutex contention.
 	PreloadBranchData()
+	// PreloadBranchStats warms the diff-stats and commit-count caches for all
+	// given branches in parallel. Call before utils.Run iteration so subsequent
+	// GetDiffStats / GetCommitCount calls are instant cache hits.
+	PreloadBranchStats(branches []Branch)
 }
 
 // GitDiffer handles diff and merge operations
@@ -99,6 +103,9 @@ type WorkingTree interface {
 	HasStagedChanges(ctx context.Context) (bool, error)
 	HasUnstagedChanges(ctx context.Context) (bool, error)
 	HasUntrackedFiles(ctx context.Context) (bool, error)
+	// GetWorkingTreeStatus returns all three working-tree flags in one git call.
+	// Prefer this over calling Has* individually when multiple flags are needed.
+	GetWorkingTreeStatus(ctx context.Context) (staged, unstaged, untracked bool, err error)
 	GetUnstagedDiff(ctx context.Context, files ...string) (string, error)
 	GetUntrackedFileHunks(ctx context.Context) ([]git.Hunk, error)
 	GetPendingChanges(ctx context.Context) ([]PendingChange, error)
@@ -128,6 +135,9 @@ type BranchReader interface {
 type BranchTracking interface {
 	TrackBranch(ctx context.Context, branchName string, parentBranchName string) error
 	UntrackBranch(ctx context.Context, branchName string) error
+	// BatchUntrackBranches untracks multiple branches in a single operation,
+	// triggering only one engine rebuild instead of one per branch.
+	BatchUntrackBranches(ctx context.Context, branchNames []string) error
 	SetParent(ctx context.Context, branch Branch, parentBranch Branch, mode DivergenceMode) error
 	// ReparentBranch changes a branch's parent while automatically preserving
 	// its divergence point. Preferred over SetParent for existing branches.
@@ -137,6 +147,9 @@ type BranchTracking interface {
 	// any reparenting begins.
 	ReparentBranches(ctx context.Context, branchNames []string, newParent Branch) error
 	SetScope(ctx context.Context, branch Branch, scope Scope) error
+	// SetScopeAndMarkForUpdate sets the scope and marks the branch as needing a
+	// PR body update in one atomic transaction instead of two separate ref writes.
+	SetScopeAndMarkForUpdate(ctx context.Context, branch Branch, scope Scope) error
 	SetBranchType(branch Branch, branchType git.BranchType) error
 	SetLocked(ctx context.Context, branches Branches, reason LockReason) (BatchLockResult, error)
 	SetFrozen(ctx context.Context, branches Branches, frozen bool) (BatchFreezeResult, error)

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -41,7 +41,7 @@ type BranchStatus interface {
 	IsMergedIntoTrunk(ctx context.Context, branchName string) (bool, error)
 	IsBranchEmpty(ctx context.Context, branchName string) (bool, error)
 	GetDeletionStatus(ctx context.Context, branchName string) (DeletionStatus, error)
-	BatchGetDeletionStatuses(ctx context.Context, branchNames []string) (map[string]DeletionStatus, error)
+	GetDeletionStatuses(ctx context.Context, branchNames []string) (map[string]DeletionStatus, error)
 	GetScope(branch Branch) Scope
 	GetStackDescription(branch Branch) *git.StackDescription
 	IsLocked(branch Branch) bool
@@ -69,7 +69,7 @@ type BranchInfo interface {
 	GetParentCommitSHA(commitSHA string) (string, error)
 	GetCommitSHA(branchName string, offset int) (string, error)
 	GetRevisionForName(branchName string) (string, error)
-	BatchGetRevisions(branchNames []string) (map[string]string, []error)
+	GetRevisions(branchNames []string) (map[string]string, []error)
 	GetCurrentRevision(ctx context.Context) (string, error)
 	GetRecentTrunkCommits(count int) ([]git.RecentCommit, error)
 	GetReflog(ctx context.Context, count int, format string) (string, error)
@@ -134,10 +134,9 @@ type BranchReader interface {
 // BranchTracking handles branch tracking operations
 type BranchTracking interface {
 	TrackBranch(ctx context.Context, branchName string, parentBranchName string) error
-	UntrackBranch(ctx context.Context, branchName string) error
-	// BatchUntrackBranches untracks multiple branches in a single operation,
-	// triggering only one engine rebuild instead of one per branch.
-	BatchUntrackBranches(ctx context.Context, branchNames []string) error
+	// UntrackBranches stops tracking multiple branches, deleting their metadata
+	// and triggering a single engine rebuild.
+	UntrackBranches(ctx context.Context, branchNames []string) error
 	SetParent(ctx context.Context, branch Branch, parentBranch Branch, mode DivergenceMode) error
 	// ReparentBranch changes a branch's parent while automatically preserving
 	// its divergence point. Preferred over SetParent for existing branches.
@@ -154,8 +153,9 @@ type BranchTracking interface {
 	SetLocked(ctx context.Context, branches Branches, reason LockReason) (BatchLockResult, error)
 	SetFrozen(ctx context.Context, branches Branches, frozen bool) (BatchFreezeResult, error)
 
-	// BatchMarkNeedsPRBodyUpdate marks multiple branches as needing PR body update in a single atomic operation
-	BatchMarkNeedsPRBodyUpdate(ctx context.Context, branchNames []string) error
+	// MarkBranchesForPRBodyUpdate marks multiple branches as needing a PR body
+	// update in a single atomic operation.
+	MarkBranchesForPRBodyUpdate(ctx context.Context, branchNames []string) error
 	// ClearNeedsPRBodyUpdate clears the PR body update flag for a branch
 	ClearNeedsPRBodyUpdate(branchName string) error
 	// GetBranchesNeedingPRBodyUpdate returns all branches that need PR body updates

--- a/internal/engine/pr_body_update_test.go
+++ b/internal/engine/pr_body_update_test.go
@@ -25,7 +25,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		require.Empty(t, needsUpdate)
 
 		// Mark branch as needing update
-		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature"})
+		err := eng.MarkBranchesForPRBodyUpdate(context.Background(), []string{"feature"})
 		require.NoError(t, err)
 
 		// Now it should be in the list
@@ -43,7 +43,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark and then clear
-		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature"})
+		err := eng.MarkBranchesForPRBodyUpdate(context.Background(), []string{"feature"})
 		require.NoError(t, err)
 
 		err = eng.ClearNeedsPRBodyUpdate("feature")
@@ -78,7 +78,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark branch
-		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature"})
+		err := eng.MarkBranchesForPRBodyUpdate(context.Background(), []string{"feature"})
 		require.NoError(t, err)
 
 		// Rebuild engine to simulate fresh state
@@ -104,7 +104,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark only feature-a
-		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature-a"})
+		err := eng.MarkBranchesForPRBodyUpdate(context.Background(), []string{"feature-a"})
 		require.NoError(t, err)
 
 		needsUpdate := eng.GetBranchesNeedingPRBodyUpdate()
@@ -112,7 +112,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		require.NotContains(t, needsUpdate, "feature-b")
 
 		// Mark feature-b too
-		err = eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature-b"})
+		err = eng.MarkBranchesForPRBodyUpdate(context.Background(), []string{"feature-b"})
 		require.NoError(t, err)
 
 		needsUpdate = eng.GetBranchesNeedingPRBodyUpdate()
@@ -142,7 +142,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark both at once
-		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature-a", "feature-b"})
+		err := eng.MarkBranchesForPRBodyUpdate(context.Background(), []string{"feature-a", "feature-b"})
 		require.NoError(t, err)
 
 		needsUpdate := eng.GetBranchesNeedingPRBodyUpdate()
@@ -156,10 +156,10 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 
 		eng := s.Engine
 
-		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{})
+		err := eng.MarkBranchesForPRBodyUpdate(context.Background(), []string{})
 		require.NoError(t, err)
 
-		err = eng.BatchMarkNeedsPRBodyUpdate(context.Background(), nil)
+		err = eng.MarkBranchesForPRBodyUpdate(context.Background(), nil)
 		require.NoError(t, err)
 	})
 }

--- a/internal/engine/pr_flags.go
+++ b/internal/engine/pr_flags.go
@@ -7,11 +7,11 @@ import (
 	"github.com/getstackit/stackit/internal/git"
 )
 
-// BatchMarkNeedsPRBodyUpdate marks multiple branches as needing PR body update in a single atomic operation.
-// It batch-reads local metadata, sets the flag, writes all the blobs in one
-// `git hash-object` call via WriteLocalMetadataBlobsBatch, and atomically
-// updates all refs.
-func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(ctx context.Context, branchNames []string) error {
+// MarkBranchesForPRBodyUpdate marks multiple branches as needing a PR body update
+// in a single atomic operation. It batch-reads local metadata, sets the flag,
+// writes all the blobs in one `git hash-object` call via WriteLocalMetadataBlobsBatch,
+// and atomically updates all refs.
+func (e *engineImpl) MarkBranchesForPRBodyUpdate(ctx context.Context, branchNames []string) error {
 	if len(branchNames) == 0 {
 		return nil
 	}

--- a/internal/engine/rebase_validator.go
+++ b/internal/engine/rebase_validator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/getstackit/stackit/internal/git"
@@ -337,8 +338,32 @@ func (e *engineImpl) validateSingleSpec(
 	rebasedByName *sync.Map,
 	rebasedBySHA *sync.Map,
 ) validationResult {
-	// Create temporary worktree for this validation
-	// Use WorktreePruneSkip since ValidateRebasesParallel already prunes once before parallel execution
+	// Resolve NewParent to handle rebased parents: try branch name first, then SHA lookup.
+	resolvedParent := spec.NewParent
+	if val, ok := rebasedByName.Load(spec.NewParent); ok {
+		if str, ok := val.(string); ok {
+			resolvedParent = str
+		}
+	} else if val, ok := rebasedBySHA.Load(spec.NewParent); ok {
+		if str, ok := val.(string); ok {
+			resolvedParent = str
+		}
+	}
+
+	// Fast path: skip worktree creation for single-commit branches where the
+	// parent and branch changes touch disjoint file sets (conflict impossible).
+	if newSHA, ok := e.tryConflictFreeReplay(ctx, spec, resolvedParent); ok {
+		oldSHA, _ := e.git.GetRevision(spec.Branch)
+		return validationResult{
+			spec:    spec,
+			success: true,
+			newSHA:  newSHA,
+			oldSHA:  oldSHA,
+		}
+	}
+
+	// Slow path: dry-run the rebase inside a temporary worktree.
+	// Use WorktreePruneSkip since ValidateRebasesParallel already prunes once before parallel execution.
 	worktreePath, cleanup, err := e.CreateTemporaryWorktreeWithOptions(ctx, "HEAD", "stackit-validate-*", WorktreeCheckoutFull, WorktreePruneSkip)
 	if err != nil {
 		return validationResult{
@@ -352,33 +377,16 @@ func (e *engineImpl) validateSingleSpec(
 
 	wtGit := git.NewRunnerWithPath(worktreePath, nil)
 
-	// Resolve NewParent to handle rebased parents
-	newParent := spec.NewParent
-
-	// Check if NewParent refers to a branch we already rebased
-	// Try branch name first, then SHA lookup
-	if val, ok := rebasedByName.Load(spec.NewParent); ok {
-		if str, ok := val.(string); ok {
-			newParent = str
-		}
-	} else if val, ok := rebasedBySHA.Load(spec.NewParent); ok {
-		if str, ok := val.(string); ok {
-			newParent = str
-		}
-	}
-
-	// Get the branch's current SHA before rebasing (to track old SHA -> new SHA mapping)
+	// Get the branch's current SHA before rebasing (to track old SHA -> new SHA mapping).
 	oldBranchSHA, err := wtGit.GetRevision(spec.Branch)
 	if err != nil {
-		// Branch may not exist - this is not fatal, just means we can't track SHA mapping
-		// Log for debugging but continue validation
+		// Branch may not exist — not fatal, just means we can't track the SHA mapping.
 		oldBranchSHA = ""
 	}
 
 	// Perform dry-run rebase
-	rebaseResult, newSHA, conflictFiles, err := dryRunRebase(ctx, wtGit, spec.Branch, newParent, spec.OldUpstream)
+	rebaseResult, newSHA, conflictFiles, err := dryRunRebase(ctx, wtGit, spec.Branch, resolvedParent, spec.OldUpstream)
 	if err != nil || rebaseResult.Result == git.RebaseConflict {
-		// Build helpful error message with branch name
 		errorMsg := fmt.Sprintf("conflict rebasing %s onto %s", spec.Branch, spec.NewParent)
 		errorType := ValidationErrorConflict
 		if err != nil {
@@ -386,7 +394,6 @@ func (e *engineImpl) validateSingleSpec(
 			errorType = ValidationErrorSystem
 		}
 
-		// Abort the in-progress rebase if any
 		if wtGit.IsRebaseInProgress(ctx) {
 			_ = wtGit.RebaseAbort(ctx)
 		}
@@ -407,4 +414,105 @@ func (e *engineImpl) validateSingleSpec(
 		oldSHA:         oldBranchSHA,
 		rerereResolved: rebaseResult.RerereResolvedCount,
 	}
+}
+
+// tryConflictFreeReplay tries to produce the rebased SHA without a worktree for
+// single-commit branches where the parent's new changes and the branch's changes
+// touch completely disjoint file sets (a content conflict is therefore impossible).
+//
+// Returns (newSHA, true) on success; returns ("", false) to signal the caller to
+// fall back to the full worktree path.
+func (e *engineImpl) tryConflictFreeReplay(
+	ctx context.Context,
+	spec RebaseSpec,
+	resolvedParent string,
+) (string, bool) {
+	// Only handle single-commit branches — multi-commit replay requires iterating
+	// each commit individually and is deferred to the worktree path.
+	commits, err := e.git.GetCommitRangeSHAs(ctx, spec.OldUpstream, spec.Branch)
+	if err != nil || len(commits) != 1 {
+		return "", false
+	}
+
+	// Get the files changed by the parent's new commits (what we're rebasing onto).
+	parentFiles, err := e.git.GetChangedFiles(ctx, spec.OldUpstream, resolvedParent)
+	if err != nil || len(parentFiles) == 0 {
+		return "", false
+	}
+
+	// Get the files changed by our branch.
+	branchFiles, err := e.git.GetChangedFiles(ctx, spec.OldUpstream, spec.Branch)
+	if err != nil {
+		return "", false
+	}
+
+	// If any file appears in both change sets, a conflict is possible.
+	if rebaseFileOverlap(parentFiles, branchFiles) {
+		return "", false
+	}
+
+	// File sets are disjoint — compute the rebased tree via merge-tree.
+	// git merge-tree --write-tree <base> <ours> <theirs>
+	// OURS  = resolvedParent (the new base we're rebasing onto)
+	// THEIRS = spec.Branch  (carries our changes on top of OldUpstream)
+	treeSHARaw, err := e.git.RunGitCommandWithContext(ctx,
+		"merge-tree", "--write-tree", spec.OldUpstream, resolvedParent, spec.Branch)
+	if err != nil {
+		return "", false
+	}
+	// merge-tree --write-tree may emit additional lines (conflict markers) after
+	// the tree SHA on a conflict; a non-zero exit covers that, but trim just in case.
+	treeSHA := strings.TrimSpace(strings.SplitN(treeSHARaw, "\n", 2)[0])
+	if treeSHA == "" {
+		return "", false
+	}
+
+	// Preserve the original commit's author identity and message.
+	commitSHA := commits[0] // single commit, newest-first list
+	authorName, err := e.git.GetCommitLog(commitSHA, "%an")
+	if err != nil {
+		return "", false
+	}
+	authorEmail, err := e.git.GetCommitLog(commitSHA, "%ae")
+	if err != nil {
+		return "", false
+	}
+	authorDate, err := e.git.GetCommitLog(commitSHA, "%aI")
+	if err != nil {
+		return "", false
+	}
+	msg, err := e.git.GetCommitLog(commitSHA, "%B")
+	if err != nil {
+		return "", false
+	}
+
+	env := []string{
+		"GIT_AUTHOR_NAME=" + strings.TrimSpace(authorName),
+		"GIT_AUTHOR_EMAIL=" + strings.TrimSpace(authorEmail),
+		"GIT_AUTHOR_DATE=" + strings.TrimSpace(authorDate),
+	}
+
+	newSHARaw, err := e.git.RunGitCommandWithEnv(ctx, env,
+		"commit-tree", treeSHA, "-p", resolvedParent, "-m", strings.TrimSpace(msg))
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(newSHARaw), true
+}
+
+// rebaseFileOverlap reports whether two sorted file-path slices share any element.
+// Both slices must be sorted (GetChangedFiles guarantees this).
+func rebaseFileOverlap(a, b []string) bool {
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		switch {
+		case a[i] < b[j]:
+			i++
+		case a[i] > b[j]:
+			j++
+		default:
+			return true
+		}
+	}
+	return false
 }

--- a/internal/git/bench_test.go
+++ b/internal/git/bench_test.go
@@ -299,7 +299,7 @@ func BenchmarkCreateBlobs_Sequential(b *testing.B) {
 }
 
 // BenchmarkCreateBlobsBatch exercises the optimized batched path used by
-// BatchMarkNeedsPRBodyUpdate and transaction commits — temp-file staging
+// MarkBranchesForPRBodyUpdate and transaction commits — temp-file staging
 // plus a single `git hash-object -w --stdin-paths` invocation.
 func BenchmarkCreateBlobsBatch(b *testing.B) {
 	for _, n := range []int{1, 10, 50} {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

UntrackBranch called rebuild() once per branch in a loop, triggering K+1
full engine rebuilds to remove K descendants. Replace with a new
BatchUntrackBranches method that deletes all metadata refs in one
DeleteRefsBatch call and rebuilds the engine exactly once.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1086**
  * **PR #1087** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1111 by jonnii*