### PR TITLE
perf(engine): cache and preload diff stats + commit counts for log

### DIFF
--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -140,6 +140,9 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 	// views are faster with lazy lookups than with a repo-wide preload.
 	if shouldPreloadLogBranchData(opts, len(visibleBranches), len(allBranches)) {
 		ctx.Engine.PreloadBranchData()
+		// Also warm diff-stats and commit-count caches so annotation goroutines
+		// get instant cache hits instead of spawning per-branch subprocesses.
+		ctx.Engine.PreloadBranchStats(visibleBranches.All())
 	}
 
 	// Collect annotations only for branches that will be rendered.
@@ -368,6 +371,10 @@ func BuildLogJSON(ctx *app.Context, opts LogOptions) LogJSONResult {
 	}
 	processableBranches := processable.Build()
 
+	// Warm the diff-stats and commit-count caches in parallel before the main
+	// annotation loop so that GetDiffStats / GetCommitCount are instant cache hits.
+	ctx.Engine.PreloadBranchStats(processableBranches.All())
+
 	if len(processableBranches) > 0 {
 		utils.Run(processableBranches.All(), func(branch engine.Branch) {
 			branchName := branch.GetName()
@@ -399,11 +406,11 @@ func BuildLogJSON(ctx *app.Context, opts LogOptions) LogJSONResult {
 				}
 			}
 
-			// Commits and diff stats
+			// Commits and diff stats (cache hits from PreloadBranchStats above)
 			if !branch.IsTrunk() {
-				commits, err := branch.GetAllCommits(engine.CommitFormatSHA)
+				count, err := branch.GetCommitCount()
 				if err == nil {
-					info.Commits = len(commits)
+					info.Commits = count
 				}
 
 				added, deleted, err := branch.GetDiffStats()

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/getstackit/stackit/internal/git"
@@ -37,47 +38,56 @@ func (e *engineImpl) BatchGetRevisions(branchNames []string) (map[string]string,
 	return e.git.BatchGetRevisions(branchNames)
 }
 
-// GetCommitCount returns the number of commits for a branch
+// GetCommitCount returns the number of commits for a branch.
+// Results are cached by (base, head) SHA pair and populated by PreloadBranchStats.
 func (e *engineImpl) GetCommitCount(branch Branch) (int, error) {
 	base, branchRev, err := e.resolveBranchComparisonRevisions(branch.GetName())
 	if err != nil {
 		return 0, err
 	}
-
-	// If revisions are same, count is 0
 	if branchRev == base {
 		return 0, nil
 	}
 
-	// For real git, we'd use a git helper. I'll use git.GetCommitRange count.
-	commits, err := e.GetAllCommits(branch, CommitFormatSHA)
+	cacheKey := base + ":" + branchRev
+	if v, ok := e.commitCountCache.Load(cacheKey); ok {
+		return v.(int), nil
+	}
+
+	out, err := e.git.RunGitCommandWithContext(context.Background(), "rev-list", "--count", base+".."+branchRev)
 	if err != nil {
 		return 0, err
 	}
-	return len(commits), nil
+	var count int
+	_, _ = fmt.Sscanf(strings.TrimSpace(out), "%d", &count)
+	e.commitCountCache.Store(cacheKey, count)
+	return count, nil
 }
 
-// GetDiffStats returns diff stats for a branch
+// GetDiffStats returns diff stats for a branch.
+// Results are cached by (base, head) SHA pair and populated by PreloadBranchStats.
 func (e *engineImpl) GetDiffStats(branch Branch) (int, int, error) {
 	base, branchRev, err := e.resolveBranchComparisonRevisions(branch.GetName())
 	if err != nil {
 		return 0, 0, err
 	}
-
-	// If revisions are same, stats are 0
 	if branchRev == base {
 		return 0, 0, nil
 	}
 
-	// Use git diff --numstat
+	cacheKey := base + ":" + branchRev
+	if v, ok := e.diffStatsCache.Load(cacheKey); ok {
+		stats := v.([2]int)
+		return stats[0], stats[1], nil
+	}
+
 	output, err := e.git.GetDiffNumstat(base, branchRev)
 	if err != nil {
 		return 0, 0, err
 	}
 
 	added, deleted := 0, 0
-	lines := strings.SplitSeq(strings.TrimSpace(output), "\n")
-	for line := range lines {
+	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
 		if line == "" {
 			continue
 		}
@@ -91,7 +101,27 @@ func (e *engineImpl) GetDiffStats(branch Branch) (int, int, error) {
 		}
 	}
 
+	e.diffStatsCache.Store(cacheKey, [2]int{added, deleted})
 	return added, deleted, nil
+}
+
+// PreloadBranchStats warms the diff-stats and commit-count caches for all given
+// branches in parallel. Call this before iterating branches in utils.Run so
+// subsequent GetDiffStats / GetCommitCount calls are instant cache hits.
+func (e *engineImpl) PreloadBranchStats(branches []Branch) {
+	var wg sync.WaitGroup
+	for _, b := range branches {
+		if b.IsTrunk() || b.IsWorktreeAnchor() {
+			continue
+		}
+		wg.Add(1)
+		go func(branch Branch) {
+			defer wg.Done()
+			_, _, _ = e.GetDiffStats(branch)
+			_, _ = e.GetCommitCount(branch)
+		}(b)
+	}
+	wg.Wait()
 }
 
 func (e *engineImpl) resolveBranchComparisonRevisions(branchName string) (base, branchRev string, err error) {

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -42,6 +42,11 @@ type engineImpl struct {
 	// Temporary worktree cleanup tracking.
 	tempWorktreeNeedsPrune bool
 	tempWorktreePrunedOnce bool
+
+	// Per-request caches for expensive git operations.
+	// Key: "base:head" (both are resolved SHAs); value type noted inline.
+	diffStatsCache   sync.Map // value: [2]int{added, deleted}
+	commitCountCache sync.Map // value: int
 }
 
 // WorktreeSnapshot holds a deep copy of engine state for initializing worktree engines.


### PR DESCRIPTION

GetDiffStats and GetCommitCount previously spawned one git subprocess per
branch with no caching. Add diffStatsCache and commitCountCache (sync.Map)
to engineImpl, then add PreloadBranchStats(branches) that warms both caches
in parallel before the annotation loop.

In log, call PreloadBranchStats before utils.Run so subsequent
GetDiffStats / GetCommitCount calls are instant cache hits instead of
blocking on subprocesses. Also switch from GetAllCommits+len() to
GetCommitCount (which uses git rev-list --count instead of fetching
all SHAs).

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1086**
  * **PR #1087**
    * **PR #1088**
      * **PR #1089** 👈
        * **PR #1090**
          * **PR #1091**
            * **PR #1092**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->