### PR TITLE
perf(config): add undo.enabled opt-out to skip snapshot overhead

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -62,6 +62,7 @@ git config --local --add stackit.trunks develop
 | `stackit.submit.reviewers` | string[] | `[]` | Default reviewers for PRs |
 | `stackit.submit.assignees` | string[] | `[]` | Default assignees for PRs |
 | `stackit.undo.depth` | int | `10` | Max undo snapshots to retain |
+| `stackit.undo.enabled` | bool | `true` | Take undo snapshots before mutations (set `false` to eliminate snapshot overhead for users who never run `stackit undo`) |
 | `stackit.worktree.basePath` | string | `""` | Base directory for worktrees |
 | `stackit.worktree.autoClean` | bool | `true` | Auto-remove clean, empty managed worktrees during sync |
 | `stackit.merge.method` | string | `""` | Merge strategy (squash/merge/rebase) |
@@ -228,6 +229,7 @@ The table below shows all options available in `.stackit.yaml`. The "Team Fallba
 | `ci.command` | string | `""` | CI validation command | Yes |
 | `ci.timeout` | int | `600` | CI timeout in seconds | Yes |
 | `undo.depth` | int | `10` | Max undo snapshots to retain | Yes |
+| `undo.enabled` | bool | `true` | Take undo snapshots before mutations | Yes |
 | `worktree.basePath` | string | `""` | Base directory for worktrees | Yes |
 | `worktree.autoClean` | bool | `true` | Auto-remove clean, empty managed worktrees during sync | Yes |
 | `split.hunkSelector` | string | `tui` | Hunk selector mode (tui/git) | Yes |

--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -41,8 +41,11 @@ func printRerereResolved(ctx *app.Context, count int) {
 }
 
 // TakeBestEffortSnapshot records an undo snapshot and logs failures without
-// aborting the action.
+// aborting the action. It is a no-op when undo.enabled is false in config.
 func TakeBestEffortSnapshot(ctx *app.Context, opts engine.SnapshotOptions) {
+	if ctx.Config != nil && !ctx.Config.UndoEnabled() {
+		return
+	}
 	if err := ctx.Undo().TakeSnapshot(opts); err != nil {
 		ctx.Output.Debug("Failed to take snapshot: %v", err)
 	}

--- a/internal/config/config_git.go
+++ b/internal/config/config_git.go
@@ -249,6 +249,19 @@ func (c *GitConfig) UndoStackDepth() int {
 	return DefaultUndoDepth
 }
 
+// UndoEnabled reports whether undo snapshots should be taken.
+// When false, TakeBestEffortSnapshot is a no-op, eliminating snapshot overhead
+// for users who never run `stackit undo`.
+func (c *GitConfig) UndoEnabled() bool {
+	if c.store.Exists(KeyUndoEnabled) {
+		return c.store.GetBoolWithDefault(KeyUndoEnabled, DefaultUndoEnabled)
+	}
+	if c.project != nil && c.project.Undo.Enabled != nil {
+		return *c.project.Undo.Enabled
+	}
+	return DefaultUndoEnabled
+}
+
 // SetUndoStackDepth sets the max undo depth.
 func (c *GitConfig) SetUndoStackDepth(depth int) error {
 	if depth < 1 {

--- a/internal/config/interface.go
+++ b/internal/config/interface.go
@@ -20,6 +20,7 @@ type Configurer interface {
 
 	// Undo settings
 	UndoStackDepth() int
+	UndoEnabled() bool
 
 	// Worktree settings
 	WorktreeBasePath() string

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -13,6 +13,9 @@ const (
 	KeySubmitFooter = "stackit.submit.footer"
 	// KeyUndoDepth is the maximum number of undo snapshots to keep.
 	KeyUndoDepth = "stackit.undo.depth"
+	// KeyUndoEnabled controls whether undo snapshots are taken at all.
+	// Set to false to skip snapshot overhead for users who never run `stackit undo`.
+	KeyUndoEnabled = "stackit.undo.enabled"
 	// KeyWorktreeBasePath is the base path for worktrees.
 	KeyWorktreeBasePath = "stackit.worktree.basePath"
 	// KeyWorktreeAutoClean controls automatic worktree cleanup during sync.
@@ -63,6 +66,8 @@ const (
 	DefaultSubmitFooter = true
 	// DefaultUndoDepth is the default number of undo snapshots to keep.
 	DefaultUndoDepth = 10
+	// DefaultUndoEnabled is whether undo snapshots are taken by default.
+	DefaultUndoEnabled = true
 	// DefaultWorktreeAutoClean is whether to auto-clean worktrees by default.
 	DefaultWorktreeAutoClean = true
 	// DefaultCITimeout is the default CI timeout in seconds (10 minutes).

--- a/internal/config/metadata.go
+++ b/internal/config/metadata.go
@@ -157,6 +157,13 @@ var Options = []Option{
 		Default:     DefaultUndoDepth,
 		Section:     "undo",
 	},
+	{
+		YAMLPath:    "undo.enabled",
+		GitKey:      KeyUndoEnabled,
+		Description: "Take snapshots before mutations (set false to skip undo overhead)",
+		Default:     DefaultUndoEnabled,
+		Section:     "undo",
+	},
 
 	// Worktree section
 	{

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -42,7 +42,8 @@ type CIConfig struct {
 
 // UndoConfig contains undo settings
 type UndoConfig struct {
-	Depth int `yaml:"depth,omitempty"`
+	Depth   int   `yaml:"depth,omitempty"`
+	Enabled *bool `yaml:"enabled,omitempty"`
 }
 
 // WorktreeConfig contains worktree settings

--- a/internal/config/testdata/config_template.golden
+++ b/internal/config/testdata/config_template.golden
@@ -35,6 +35,7 @@
 # Undo history
 # undo:
 #   depth: 10 # Max snapshots
+#   enabled: true # Take snapshots before mutations (set false to skip undo overhead)
 
 # Worktree settings
 # worktree:


### PR DESCRIPTION

TakeBestEffortSnapshot is called before every mutating command. Users who
never run 'stackit undo' pay snapshot overhead unconditionally.

Add stackit.undo.enabled (default true). When set to false,
TakeBestEffortSnapshot is a no-op. Also supports the undo.enabled key in
.stackit.yaml for team-level opt-out.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1086**
  * **PR #1087**
    * **PR #1088**
      * **PR #1089**
        * **PR #1090** 👈
          * **PR #1091**
            * **PR #1092**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->