### PR TITLE
perf(engine): add GetWorkingTreeStatus to replace three sequential git calls

### DIFF
--- a/internal/actions/state.go
+++ b/internal/actions/state.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -81,18 +80,12 @@ func BuildState(ctx *app.Context, _ StateOptions) StateResult {
 		result.Detached = true
 	}
 
-	// Working-tree state. A failed check is non-fatal for a read-only snapshot;
-	// log it and fall back to the safe default (false).
-	check := func(name string, fn func(context.Context) (bool, error)) bool {
-		v, err := fn(ctx.Context)
-		if err != nil {
-			ctx.Output.Debug("state: %s check failed: %v", name, err)
-		}
-		return v
+	// Working-tree state via a single git status --porcelain call.
+	// A failed check is non-fatal; log and fall back to the safe default (false).
+	staged, unstaged, untracked, statusErr := eng.GetWorkingTreeStatus(ctx.Context)
+	if statusErr != nil {
+		ctx.Output.Debug("state: working-tree status check failed: %v", statusErr)
 	}
-	staged := check("staged", eng.HasStagedChanges)
-	unstaged := check("unstaged", eng.HasUnstagedChanges)
-	untracked := check("untracked", eng.HasUntrackedFiles)
 	result.WorkingTree = WorkingTreeStatus{
 		Staged:    staged,
 		Unstaged:  unstaged,

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -72,6 +72,34 @@ func (e *engineImpl) HasUntrackedFiles(ctx context.Context) (bool, error) {
 	return e.git.HasUntrackedFiles(ctx)
 }
 
+// GetWorkingTreeStatus returns staged, unstaged, and untracked status in a
+// single git status --porcelain call instead of three separate subprocesses.
+func (e *engineImpl) GetWorkingTreeStatus(ctx context.Context) (staged, unstaged, untracked bool, err error) {
+	output, err := e.git.GetStatusPorcelain(ctx)
+	if err != nil {
+		return false, false, false, err
+	}
+	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+		if len(line) < 2 {
+			continue
+		}
+		x, y := line[0], line[1]
+		if x != ' ' && x != '?' {
+			staged = true
+		}
+		if y != ' ' && (x != '?' || y != '?') {
+			unstaged = true
+		}
+		if x == '?' && y == '?' {
+			untracked = true
+		}
+		if staged && unstaged && untracked {
+			break
+		}
+	}
+	return staged, unstaged, untracked, nil
+}
+
 // GetUntrackedFileHunks returns synthetic hunks for all untracked files.
 // This allows new files to be included in hunk-based operations like split.
 func (e *engineImpl) GetUntrackedFileHunks(ctx context.Context) ([]git.Hunk, error) {


### PR DESCRIPTION

state.go called HasStagedChanges, HasUnstagedChanges, and HasUntrackedFiles
as three separate git subprocesses. Add GetWorkingTreeStatus(ctx) that
parses git status --porcelain once and returns all three flags, then update
state.go to use it.

Also adds GetWorkingTreeStatus to the WorkingTree engine interface.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1086**
  * **PR #1087**
    * **PR #1088**
      * **PR #1089**
        * **PR #1090**
          * **PR #1091** 👈
            * **PR #1092**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->