### PR TITLE
perf: compile branch-name and GraphQL-alias regexes once at package init

### DIFF
--- a/internal/github/status.go
+++ b/internal/github/status.go
@@ -38,6 +38,9 @@ const (
 	ReviewDecisionReviewRequired   = "REVIEW_REQUIRED"
 )
 
+// graphQLAliasRegex matches characters not valid in GraphQL alias identifiers
+var graphQLAliasRegex = regexp.MustCompile(`[^a-zA-Z0-9]`)
+
 // IsApproved returns true if the review decision indicates approval
 func (s *CheckStatus) IsApproved() bool {
 	return s.ReviewDecision == ReviewDecisionApproved
@@ -68,9 +71,8 @@ func BatchGetPRChecksStatusGraphQL(ctx context.Context, runner git.Runner, owner
 	// Sanitize branch names for GraphQL aliases
 	aliasMap := make(map[string]string)
 	aliasToBranch := make(map[string]string)
-	re := regexp.MustCompile(`[^a-zA-Z0-9]`)
 	for _, name := range branchNames {
-		alias := "b_" + re.ReplaceAllString(name, "_")
+		alias := "b_" + graphQLAliasRegex.ReplaceAllString(name, "_")
 		// Ensure unique aliases if multiple branches map to same sanitized name
 		baseAlias := alias
 		counter := 1

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -26,6 +26,12 @@ var (
 	// BranchNameIgnoreRegex matches trailing slashes and dots that should be removed
 	BranchNameIgnoreRegex = regexp.MustCompile(`[/.]*$`)
 
+	// branchNameHyphenRegex matches consecutive hyphens for collapsing
+	branchNameHyphenRegex = regexp.MustCompile(`-+`)
+
+	// conventionalCommitPrefixRegex matches conventional commit prefixes like "feat:", "fix(scope):", etc.
+	conventionalCommitPrefixRegex = regexp.MustCompile(`^(feat|fix|chore|docs|style|refactor|perf|test|build|ci)(\([^)]+\))?:\s*`)
+
 	// interactiveMode is accessed atomically to avoid data races
 	interactiveMode int32 = 1 // 1 = true, 0 = false
 )
@@ -39,8 +45,7 @@ func SanitizeBranchName(name string) string {
 	name = BranchNameReplaceRegex.ReplaceAllString(name, "-")
 
 	// Remove multiple consecutive hyphens
-	hyphenRegex := regexp.MustCompile(`-+`)
-	name = hyphenRegex.ReplaceAllString(name, "-")
+	name = branchNameHyphenRegex.ReplaceAllString(name, "-")
 
 	// Trim leading/trailing hyphens
 	name = strings.Trim(name, "-")
@@ -121,7 +126,7 @@ func GenerateBranchNameFromMessage(message string) string {
 	subject := strings.TrimSpace(lines[0])
 
 	// Remove common prefixes like "feat:", "fix:", etc. if present (with optional scope)
-	subject = regexp.MustCompile(`^(feat|fix|chore|docs|style|refactor|perf|test|build|ci)(\([^)]+\))?:\s*`).ReplaceAllString(subject, "")
+	subject = conventionalCommitPrefixRegex.ReplaceAllString(subject, "")
 
 	// Truncate to a reasonable length for branch names (before sanitization)
 	// Aim for ~50 characters to leave room for username/date prefixes


### PR DESCRIPTION
## Summary

- Three `regexp.MustCompile` calls were inside hot-path functions, paying the compile cost on every invocation instead of once at program startup
- `SanitizeBranchName` (called on every branch creation) compiled `-+` on each call
- `GenerateBranchNameFromMessage` compiled the conventional-commit prefix regex on each call
- `BatchGetPRChecksStatusGraphQL` compiled `[^a-zA-Z0-9]` on each batch CI status fetch
- Lifted all three to package-level `var` blocks alongside the existing package-level regex vars in each file

Zero behavior change — purely eliminates redundant work.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/utils/... ./internal/github/...` passes

https://claude.ai/code/session_01DHy6bvMCtvADnRZNdNS1xq

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHy6bvMCtvADnRZNdNS1xq)_