### PR TITLE
test: strip unneeded WithRemote() and remove non-existent code path test

### DIFF
--- a/internal/integration/untracked_branch_test.go
+++ b/internal/integration/untracked_branch_test.go
@@ -9,40 +9,13 @@ func TestSubmitUntrackedBranch(t *testing.T) {
 
 	t.Run("submit on untracked branch shows tracking suggestion in non-interactive mode", func(t *testing.T) {
 		t.Parallel()
-		sh := NewTestShellInProcess(t, WithRemote())
+		sh := NewTestShellInProcess(t)
 
-		// Create an untracked branch using raw git (not stackit)
 		sh.Git("checkout -b untracked-feature")
 		sh.Write("feature.txt", "some content")
 		sh.Git("add .")
 		sh.Git("commit -m 'add feature'")
 
-		// Run ss with --dry-run - in non-interactive mode, should inform user to track
-		sh.Run("ss --dry-run").
-			OutputContains("not tracked").
-			OutputContains("stackit track")
-	})
-
-	t.Run("submit on untracked branch behind main shows tracking suggestion", func(t *testing.T) {
-		t.Parallel()
-		sh := NewTestShellInProcess(t, WithRemote())
-
-		// Create an untracked branch
-		sh.Git("checkout -b untracked-feature")
-		sh.Write("feature.txt", "some content")
-		sh.Git("add .")
-		sh.Git("commit -m 'add feature'")
-
-		// Go back to main and advance it with new commits
-		sh.Checkout("main")
-		sh.Write("main-update.txt", "main content")
-		sh.Git("add .")
-		sh.Git("commit -m 'advance main'")
-
-		// Go back to the untracked branch (now behind main)
-		sh.Checkout("untracked-feature")
-
-		// Run ss with --dry-run - should show tracking suggestion
 		sh.Run("ss --dry-run").
 			OutputContains("not tracked").
 			OutputContains("stackit track")
@@ -50,19 +23,15 @@ func TestSubmitUntrackedBranch(t *testing.T) {
 
 	t.Run("submit with --branch flag on untracked branch shows tracking suggestion", func(t *testing.T) {
 		t.Parallel()
-		sh := NewTestShellInProcess(t, WithRemote())
+		sh := NewTestShellInProcess(t)
 
-		// Create an untracked branch using raw git
 		sh.Git("checkout -b untracked-feature")
 		sh.Write("feature.txt", "some content")
 		sh.Git("add .")
 		sh.Git("commit -m 'add feature'")
 
-		// Go back to main
 		sh.Checkout("main")
 
-		// Run ss with --branch flag pointing to untracked branch
-		// Should still detect the untracked branch and show suggestion
 		sh.Run("ss --dry-run --branch untracked-feature").
 			OutputContains("not tracked").
 			OutputContains("stackit track")
@@ -70,13 +39,11 @@ func TestSubmitUntrackedBranch(t *testing.T) {
 
 	t.Run("submit on tracked branch works normally", func(t *testing.T) {
 		t.Parallel()
-		sh := NewTestShellInProcess(t, WithRemote())
+		sh := NewTestShellInProcess(t)
 
-		// Create a tracked branch using stackit
 		sh.Write("feature.txt", "some content")
 		sh.Run("create feature -m 'add feature'")
 
-		// Run ss with --dry-run - should show the branch in submission plan
 		sh.Run("ss --dry-run").
 			OutputContains("feature").
 			OutputContains("create")
@@ -84,16 +51,13 @@ func TestSubmitUntrackedBranch(t *testing.T) {
 
 	t.Run("submit with --branch flag on tracked branch works normally", func(t *testing.T) {
 		t.Parallel()
-		sh := NewTestShellInProcess(t, WithRemote())
+		sh := NewTestShellInProcess(t)
 
-		// Create a tracked branch using stackit
 		sh.Write("feature.txt", "some content")
 		sh.Run("create feature -m 'add feature'")
 
-		// Go back to main
 		sh.Checkout("main")
 
-		// Run ss with --branch flag - should work normally
 		sh.Run("ss --dry-run --branch feature").
 			OutputContains("feature").
 			OutputContains("create")

--- a/internal/integration/worktree_sync_test.go
+++ b/internal/integration/worktree_sync_test.go
@@ -326,62 +326,6 @@ func TestSyncWithMultipleWorktrees(t *testing.T) {
 		sh.ExpectBranchParent("branchD", "branchC")
 	})
 
-	run("sync from dirty worktree skips own stack", func(t *testing.T, sh *TestShell) {
-		// Test scenario:
-		// 1. Create a worktree with a stack
-		// 2. Add uncommitted changes to the worktree
-		// 3. Run sync FROM that dirty worktree
-		// Expected:
-		// - Sync should complete without error
-		// - The worktree's stack should be skipped
-
-		// Create a stack with worktree
-		sh.Log("Creating stack with worktree...")
-		sh.WriteFile("feature.txt", "feature content").
-			Run("create feature -w -m 'feature branch'").
-			OnBranch("main")
-
-		worktree := sh.GetWorktreePath("feature")
-		shW := sh.InWorktree(worktree)
-		shW.OnBranch("feature")
-
-		// Record SHA before sync
-		sh.Git("rev-parse feature")
-		featureBefore := sh.Output()
-
-		// Add uncommitted changes to the worktree
-		sh.Log("Adding uncommitted changes to worktree...")
-		shW.WriteFile("dirty.txt", "uncommitted content")
-		// Don't commit - this makes it dirty
-
-		// Advance main
-		sh.Log("Advancing main...")
-		sh.WriteFile("main-update.txt", "main change").
-			Git("add main-update.txt").
-			Git("commit -m 'Main advanced'").
-			Git("push origin main")
-
-		// Run sync from the dirty worktree
-		sh.Log("Running sync from dirty worktree...")
-		shW.Run("sync")
-
-		// Sync should complete without error
-		shW.OutputContains("Skipping stack")
-
-		// Feature branch should NOT be restacked (we're in it with uncommitted changes)
-		sh.Git("rev-parse feature")
-		featureAfter := sh.Output()
-		if featureBefore != featureAfter {
-			t.Errorf("Feature branch should NOT have been restacked (dirty), but SHA changed from %s to %s", featureBefore, featureAfter)
-		}
-
-		// Uncommitted changes should still be present
-		shW.Git("status --porcelain")
-		if shW.Output() == "" {
-			t.Error("Worktree should still have uncommitted changes")
-		}
-	})
-
 	run("sync skips dirty worktree stack and syncs clean stack", func(t *testing.T, sh *TestShell) {
 		// Test scenario:
 		// 1. Create two worktrees with separate stacks


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Removes WithRemote() from all 5 TestSubmitUntrackedBranch tests. The
untracked early-exit guard and the submit --dry-run path both return
before any network operation, so the remote setup was pure overhead
(~200ms × 5 = ~1s).

Deletes the "behind main" subtest (submit_on_untracked_branch_behind_main)
because the submit untracked guard fires before any trunk-comparison
logic; the "behind main" state cannot influence the output. The first
"untracked" subtest already covers this guard identically.

Deletes "sync from dirty worktree skips own stack" from worktree_sync_test.go.
All its assertions are a strict subset of the more comprehensive
"sync skips dirty worktree stack and syncs clean stack" test, which
also verifies the clean peer stack continues to be synced normally.

Estimated savings: ~1,600ms.

<hr/>

<!-- STACKIT-SECTION-START -->
**Clean up integration test suite and add --json to merge status**

Reduces the integration test suite by ~2,000 lines through systematic cleanup, and adds a --json flag to `stackit merge status`.

Test cleanup (PRs #1095–#1105):
- **Remove dead tests**: Delete permanently-skipped, wrong-location, and duplicate tests
- **Move to unit layer**: Pluck/move PR-update tests relocated to action unit tests; integration tests for describe, scope, and modify deleted where unit tests already provide coverage
- **Strip unnecessary overhead**: Remove unneeded `WithRemote()` calls from tests that don't exercise remote operations
- **Consolidate into table-driven tests**: JSON output, lifecycle hooks, frozen state, merge subcommands, flatten, and worktree tests rewritten as compact table-driven tests
- **Extract shared helpers**: Worktree setup, sync squash-merge, flatten, and track helpers extracted to reduce duplication

Feature (PR #1107):
- **`--json` flag for `merge status`**: Machine-readable output for the merge status command

#### Stack


* **PR #1095**
  * **PR #1096**
    * **PR #1097** 👈
      * **PR #1098**
        * **PR #1099**
          * **PR #1100**
            * **PR #1101**
              * **PR #1102**
                * **PR #1103**
                  * **PR #1104**
                    * **PR #1105**
                      * **PR #1107**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1108 by jonnii*