### PR TITLE
test: delete misc duplicate tests (undo stubs, move, stack ID)

### DIFF
--- a/internal/integration/move_noninteractive_test.go
+++ b/internal/integration/move_noninteractive_test.go
@@ -38,19 +38,6 @@ func TestMoveNonInteractive(t *testing.T) {
 			CommitCount("main", "b", 1)
 	})
 
-	t.Run("dry-run requires onto flag", func(t *testing.T) {
-		t.Parallel()
-		sh := NewTestShellInProcess(t)
-
-		// Create a stack: main → a → b
-		sh.CreateLinearStack3()
-		sh.Checkout("b")
-
-		// Running move with --dry-run but without --onto should fail
-		sh.RunExpectError("move --dry-run").
-			OutputContains("--onto flag is required when using --dry-run")
-	})
-
 	t.Run("dry-run works with onto flag", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)

--- a/internal/integration/move_stack_id_test.go
+++ b/internal/integration/move_stack_id_test.go
@@ -145,45 +145,6 @@ func TestMoveStackID(t *testing.T) {
 		sh.ExpectStackID("a", firstStackID)
 	})
 
-	t.Run("moving entire first-level branch to trunk creates new stack", func(t *testing.T) {
-		t.Parallel()
-		sh := NewTestShellInProcess(t)
-
-		// Create stack: main -> a -> b -> c
-		sh.CreateLinearStack3()
-
-		// Set a description to trigger stack ID creation
-		sh.Run("describe -m 'First stack'")
-
-		// Capture original stack ID
-		originalStackID := sh.GetStackID("a")
-		sh.ExpectStackIDsMatch("a", "b", "c")
-
-		// Move a to... well, it's already on trunk, so let's create a different scenario
-		// Create: main -> x -> a -> b -> c by moving a onto x
-		sh.Checkout("main").
-			Write("x.txt", "content for x").
-			Run("create x -m 'Add x'")
-
-		// Set a description to trigger stack ID creation for x
-		sh.Run("describe -m 'Second stack'")
-
-		secondStackID := sh.GetStackID("x")
-
-		// Move a onto x
-		sh.Checkout("a")
-		sh.Run("move --onto x --no-interactive --yes")
-
-		// Verify a, b, c all now have the second stack's ID
-		sh.ExpectStackIDsMatch("a", "b", "c")
-		sh.ExpectStackID("a", secondStackID)
-
-		// Verify original stack ID is no longer used (a, b, c should all have new ID)
-		if sh.GetStackID("a") == originalStackID {
-			t.Fatal("expected a to have a new stack ID after moving to x")
-		}
-	})
-
 	t.Run("moving within same stack does not change stack ID", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)

--- a/internal/integration/stack_id_test.go
+++ b/internal/integration/stack_id_test.go
@@ -78,52 +78,6 @@ func TestStackIDPreservation(t *testing.T) {
 		sh.ExpectStackID("a", originalStackID)
 	})
 
-	t.Run("pluck changes stack ID when moving to different stack", func(t *testing.T) {
-		t.Parallel()
-		sh := NewTestShellInProcess(t)
-
-		// Create first stack: main -> a -> b -> c
-		sh.Write("a.txt", "content for a").
-			Run("create a -m 'Add a'").
-			Write("b.txt", "content for b").
-			Run("create b -m 'Add b'").
-			Write("c.txt", "content for c").
-			Run("create c -m 'Add c'")
-
-		// Set a description to trigger stack ID creation
-		sh.Run("describe -m 'First stack'")
-
-		// Capture first stack's ID
-		firstStackID := sh.GetStackID("a")
-		sh.ExpectStackIDsMatch("a", "b", "c")
-
-		// Create second stack: main -> x
-		sh.Checkout("main").
-			Write("x.txt", "content for x").
-			Run("create x -m 'Add x'")
-
-		// Set a description to trigger stack ID creation for second stack
-		sh.Run("describe -m 'Second stack'")
-
-		// Capture second stack's ID
-		secondStackID := sh.GetStackID("x")
-		sh.ExpectStackIDsDiffer("a", "x")
-
-		// Pluck b onto x (unlike move, pluck doesn't bring descendants)
-		sh.Checkout("b")
-		sh.Run("pluck --onto x --yes")
-
-		// Verify b now has the second stack's ID
-		sh.ExpectStackID("b", secondStackID)
-
-		// Verify a still has the first stack ID
-		sh.ExpectStackID("a", firstStackID)
-
-		// Verify c is reparented to a and still has first stack ID
-		sh.ExpectBranchParent("c", "a")
-		sh.ExpectStackID("c", firstStackID)
-	})
-
 	t.Run("fold with siblings syncs stack IDs from new parent", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)

--- a/internal/integration/sync_test.go
+++ b/internal/integration/sync_test.go
@@ -1,17 +1,12 @@
 package integration
 
 import (
-	"context"
-	"encoding/json"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/getstackit/stackit/internal/actions/sync"
-	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
@@ -346,81 +341,6 @@ func TestSyncStaleDraftCleanup(t *testing.T) {
 	require.Equal(t, "main", eng.GetBranch("b").GetParent().GetName())
 }
 
-func TestSyncRemoteMetadata(t *testing.T) {
-	t.Parallel()
-	t.Run("loads remote metadata cache", func(t *testing.T) {
-		t.Parallel()
-		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
-
-		// Create a branch
-		sh.CreateBranch("feature-a").
-			CommitChange("file-a", "content-a").
-			TrackBranch("feature-a", "main")
-
-		eng := sh.Engine
-
-		// Set local metadata
-		branch := eng.GetBranch("feature-a")
-		_, err := eng.SetLocked(context.Background(), engine.BranchesOf(branch), engine.LockReasonNone)
-		require.NoError(t, err)
-
-		// Create remote metadata refs (simulating a successful fetch)
-		remoteMeta := git.NewMetaFrom(git.MetaFields{
-			LockReason: git.LockReasonUser,
-			Scope:      new("remote-scope"),
-		})
-		createRemoteMetadataRefForSync(t, sh, "feature-a", remoteMeta)
-
-		// Load remote metadata cache (this is what sync does after fetching)
-		err = eng.LoadRemoteMetadataCache()
-		require.NoError(t, err)
-
-		// Verify remote metadata cache was loaded
-		cache := eng.GetRemoteMetadataCache()
-		cachedMeta := cache.Get("feature-a")
-		require.NotNil(t, cachedMeta, "Remote metadata should be in cache")
-		require.Equal(t, git.LockReasonUser, cachedMeta.GetLockReason(), "Remote metadata should show lock reason")
-		require.Equal(t, "remote-scope", *cachedMeta.GetScope(), "Remote metadata should have scope")
-	})
-
-	t.Run("detects metadata conflicts", func(t *testing.T) {
-		t.Parallel()
-		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
-
-		sh.CreateBranch("feature-b").
-			CommitChange("file-b", "content-b").
-			TrackBranch("feature-b", "main")
-
-		eng := sh.Engine
-
-		// Set local metadata: locked=false
-		branch := eng.GetBranch("feature-b")
-		_, err := eng.SetLocked(context.Background(), engine.BranchesOf(branch), engine.LockReasonNone)
-		require.NoError(t, err)
-
-		// Create remote metadata refs: locked=true (conflict)
-		remoteMeta := git.NewMetaFrom(git.MetaFields{
-			LockReason: git.LockReasonUser,
-		})
-		createRemoteMetadataRefForSync(t, sh, "feature-b", remoteMeta)
-
-		// Load remote metadata cache
-		err = eng.LoadRemoteMetadataCache()
-		require.NoError(t, err)
-
-		// Compute diff to verify conflict detection
-		diff, err := eng.ComputeMetadataDiff("feature-b")
-		require.NoError(t, err)
-		require.NotNil(t, diff)
-		require.True(t, diff.HasConflict, "Should detect conflict between local and remote metadata")
-
-		// Verify the specific field that differs
-		require.Len(t, diff.Differences, 1)
-		require.Equal(t, "lockReason", diff.Differences[0].Field)
-		require.Equal(t, git.LockReasonNone, diff.Differences[0].LocalValue)
-		require.Equal(t, git.LockReasonUser, diff.Differences[0].RemoteValue)
-	})
-}
 
 func TestSyncSquashMergedRootPreservesChildCommitBoundaries(t *testing.T) {
 	t.Parallel()
@@ -487,30 +407,6 @@ func TestSyncSquashMergedRootPreservesChildCommitBoundaries(t *testing.T) {
 		ExpectBranchFixed("branch-c")
 }
 
-// createRemoteMetadataRefForSync creates a ref at refs/stackit/remote-metadata/<branch>
-func createRemoteMetadataRefForSync(t *testing.T, sh *scenario.Scenario, branchName string, meta *git.Meta) {
-	t.Helper()
-
-	data, err := json.Marshal(meta)
-	require.NoError(t, err)
-
-	tmpFile := filepath.Join(sh.Scene.Dir, ".git", "tmp-meta-"+branchName)
-	err = os.WriteFile(tmpFile, data, 0600)
-	require.NoError(t, err)
-	defer os.Remove(tmpFile)
-
-	blobSha, err := sh.Scene.Repo.RunGitCommandAndGetOutput("hash-object", "-w", tmpFile)
-	require.NoError(t, err)
-
-	// Remove trailing newline
-	if len(blobSha) > 0 && blobSha[len(blobSha)-1] == '\n' {
-		blobSha = blobSha[:len(blobSha)-1]
-	}
-
-	refName := "refs/stackit/remote-metadata/" + branchName
-	err = sh.Scene.Repo.RunGitCommand("update-ref", refName, blobSha)
-	require.NoError(t, err)
-}
 
 // TestSyncDoesNotLeaveIndexState verifies that after sync cleans up merged branches
 // and restacks remaining branches, the working directory is left in a clean state

--- a/internal/integration/sync_test.go
+++ b/internal/integration/sync_test.go
@@ -341,7 +341,6 @@ func TestSyncStaleDraftCleanup(t *testing.T) {
 	require.Equal(t, "main", eng.GetBranch("b").GetParent().GetName())
 }
 
-
 func TestSyncSquashMergedRootPreservesChildCommitBoundaries(t *testing.T) {
 	t.Parallel()
 	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
@@ -406,7 +405,6 @@ func TestSyncSquashMergedRootPreservesChildCommitBoundaries(t *testing.T) {
 	sh.ExpectBranchFixed("branch-b").
 		ExpectBranchFixed("branch-c")
 }
-
 
 // TestSyncDoesNotLeaveIndexState verifies that after sync cleans up merged branches
 // and restacks remaining branches, the working directory is left in a clean state

--- a/internal/integration/undo_test.go
+++ b/internal/integration/undo_test.go
@@ -4,47 +4,8 @@ import (
 	"testing"
 )
 
-// =============================================================================
-// Undo Integration Tests
-//
-// These tests cover end-to-end undo functionality through the CLI.
-// =============================================================================
-
 func TestUndoCommand(t *testing.T) {
 	t.Parallel()
-
-	t.Run("undo after create command", func(t *testing.T) {
-		t.Parallel()
-		sh := NewTestShellInProcess(t)
-
-		// Create initial commit
-		sh.Log("Setting up repository...")
-		sh.Write("file1", "content1").
-			Commit("file1", "initial commit")
-
-		// Create a branch (this should create a snapshot)
-		sh.Log("Creating branch...")
-		sh.Write("file2", "content2").
-			Run("create feature -m 'Add feature'").
-			OnBranch("feature")
-
-		// Verify branch exists
-		sh.Run("log --stack").
-			OutputContains("feature")
-
-		// Undo the create operation
-		sh.Log("Undoing create operation...")
-		// Use --snapshot flag to avoid interactive prompt in tests
-		// First get the snapshot ID (we'll need to parse it or use a workaround)
-		// For now, test that undo command exists and doesn't crash
-		sh.Run("undo --help").
-			OutputContains("Restore the repository to a previous state")
-
-		// Note: Full undo test would require either:
-		// 1. Mocking the interactive prompt
-		// 2. Using a known snapshot ID
-		// 3. Setting up a test that can handle the interactive flow
-	})
 
 	t.Run("undo shows no history message when empty", func(t *testing.T) {
 		t.Parallel()
@@ -53,40 +14,7 @@ func TestUndoCommand(t *testing.T) {
 		sh.Write("file1", "content1").
 			Commit("file1", "initial commit")
 
-		// Run undo with no history
 		sh.Run("undo").
 			OutputContains("No undo history available")
-	})
-
-	t.Run("undo after move command", func(t *testing.T) {
-		t.Parallel()
-		sh := NewTestShellInProcess(t)
-
-		// Set up stack
-		sh.Log("Setting up stack...")
-		sh.Write("file1", "content1").
-			Commit("file1", "initial commit").
-			Write("file2", "content2").
-			Run("create feature1 -m 'Add feature1'").
-			Write("file3", "content3").
-			Run("create feature2 -m 'Add feature2'").
-			OnBranch("feature2")
-
-		// Get initial state
-		sh.Log("Getting initial branch structure...")
-		sh.Run("log --stack").
-			OutputContains("feature1").
-			OutputContains("feature2")
-
-		// Move feature2 onto main (this creates a snapshot)
-		sh.Log("Moving feature2 onto main...")
-		sh.Run("move feature2 --onto main")
-
-		// Verify move happened
-		sh.Run("info").
-			OutputContains("feature2")
-
-		// Note: Full undo test would require snapshot ID or interactive handling
-		// This test verifies the command structure works
 	})
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Undo: removes two stub subtests that comment they cannot complete the
round-trip (undo_after_create only runs --help, undo_after_move only
moves and never undoes). The action tests TestUndoAfterCreate and
TestUndoAfterMove already cover these paths. Keeps "no history" which
verifies the specific CLI output message.

Move: deletes TestMoveNonInteractive/dry-run_requires_onto_flag,
already covered by cli/stack/move_test.go "dry-run requires --onto
flag" (same assertion, same error message).

MoveStackID: deletes "moving entire first-level branch to trunk creates
new stack" — its assertions are subsumed by "moving branch and
descendants updates all stack IDs".

StackIDPreservation: deletes "pluck changes stack ID when moving to
different stack" — equivalent coverage now lives in
actions/pluck/pluck_test.go as a scenario test (added in previous
branch).

SyncRemoteMetadata: removes TestSyncRemoteMetadata (loads_remote and
detects_conflicts) from sync_test.go. Both tests use scenario.NewScenario
with no CLI invocations; they are now covered by the engine-level tests
added in engine_remote_metadata_test.go. Removes the
createRemoteMetadataRefForSync helper (no longer needed).

Estimated savings: ~1,100ms.

<hr/>

<!-- STACKIT-SECTION-START -->
**Clean up integration test suite and add --json to merge status**

Reduces the integration test suite by ~2,000 lines through systematic cleanup, and adds a --json flag to `stackit merge status`.

Test cleanup (PRs #1095–#1105):
- **Remove dead tests**: Delete permanently-skipped, wrong-location, and duplicate tests
- **Move to unit layer**: Pluck/move PR-update tests relocated to action unit tests; integration tests for describe, scope, and modify deleted where unit tests already provide coverage
- **Strip unnecessary overhead**: Remove unneeded `WithRemote()` calls from tests that don't exercise remote operations
- **Consolidate into table-driven tests**: JSON output, lifecycle hooks, frozen state, merge subcommands, flatten, and worktree tests rewritten as compact table-driven tests
- **Extract shared helpers**: Worktree setup, sync squash-merge, flatten, and track helpers extracted to reduce duplication

Feature (PR #1107):
- **`--json` flag for `merge status`**: Machine-readable output for the merge status command

#### Stack


* **PR #1095**
  * **PR #1096**
    * **PR #1097**
      * **PR #1098**
        * **PR #1099** 👈
          * **PR #1100**
            * **PR #1101**
              * **PR #1102**
                * **PR #1103**
                  * **PR #1104**
                    * **PR #1105**
                      * **PR #1107**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1108 by jonnii*