### PR TITLE
test: consolidate JSON output, lifecycle hooks, and frozen tests

### DIFF
--- a/internal/integration/frozen_integration_test.go
+++ b/internal/integration/frozen_integration_test.go
@@ -94,32 +94,21 @@ func TestFrozenIntegration(t *testing.T) {
 			OutputContains("cannot freeze trunk branch")
 	})
 
-	t.Run("freeze fails on untracked branch", func(t *testing.T) {
+	t.Run("freeze and unfreeze fail on untracked branch", func(t *testing.T) {
 		t.Parallel()
-		s := NewTestShellInProcess(t)
+		for _, cmd := range []string{"freeze", "unfreeze"} {
+			t.Run(cmd, func(t *testing.T) {
+				t.Parallel()
+				s := NewTestShellInProcess(t)
+				s.Git("checkout -b untracked").
+					WriteFile("file", "content").
+					Git("add file").
+					Git("commit -m 'untracked commit'")
 
-		// Create an untracked branch using git directly
-		s.Git("checkout -b untracked").
-			WriteFile("file", "content").
-			Git("add file").
-			Git("commit -m 'untracked commit'")
-
-		s.RunExpectError("freeze untracked").
-			OutputContains("not tracked by stackit")
-	})
-
-	t.Run("unfreeze fails on untracked branch", func(t *testing.T) {
-		t.Parallel()
-		s := NewTestShellInProcess(t)
-
-		// Create an untracked branch using git directly
-		s.Git("checkout -b untracked").
-			WriteFile("file", "content").
-			Git("add file").
-			Git("commit -m 'untracked commit'")
-
-		s.RunExpectError("unfreeze untracked").
-			OutputContains("not tracked by stackit")
+				s.RunExpectError(cmd+" untracked").
+					OutputContains("not tracked by stackit")
+			})
+		}
 	})
 
 	t.Run("frozen branch blocks rename", func(t *testing.T) {

--- a/internal/integration/frozen_integration_test.go
+++ b/internal/integration/frozen_integration_test.go
@@ -105,7 +105,7 @@ func TestFrozenIntegration(t *testing.T) {
 					Git("add file").
 					Git("commit -m 'untracked commit'")
 
-				s.RunExpectError(cmd+" untracked").
+				s.RunExpectError(cmd + " untracked").
 					OutputContains("not tracked by stackit")
 			})
 		}

--- a/internal/integration/json_output_test.go
+++ b/internal/integration/json_output_test.go
@@ -59,6 +59,9 @@ func TestJSONOutput(t *testing.T) {
 
 		// Verify summary
 		require.Equal(t, 2, result.Summary.TotalBranches, "should have 2 tracked branches")
+
+		// GitHub is never available in tests.
+		require.False(t, result.GitHubAvailable)
 	})
 
 	t.Run("log --json outputs valid JSON with recommendations", func(t *testing.T) {
@@ -101,24 +104,6 @@ func TestJSONOutput(t *testing.T) {
 		require.True(t, foundRestackNeeded, "feature-b should show NeedsRestack=true")
 	})
 
-	t.Run("log --json always emits status booleans even when false", func(t *testing.T) {
-		t.Parallel()
-		sh := NewTestShellInProcess(t)
-
-		// A healthy, unlocked branch: the status booleans are all false but must
-		// still appear, so `log --json` is a complete, self-describing status
-		// source (an explicit false is unambiguous; an omitted field is not).
-		sh.Write("feature_a", "content a").
-			Run("create feature-a -m 'Add feature A'")
-
-		sh.Run("log --json")
-		output := sh.Output()
-
-		require.Contains(t, output, "\"needs_restack\": false")
-		require.Contains(t, output, "\"is_locked\": false")
-		require.Contains(t, output, "\"is_frozen\": false")
-	})
-
 	t.Run("log --quiet outputs minimal when healthy", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)
@@ -138,59 +123,41 @@ func TestJSONOutput(t *testing.T) {
 
 	t.Run("restack --json outputs valid JSON", func(t *testing.T) {
 		t.Parallel()
-		sh := NewTestShellInProcess(t)
+		for _, tt := range []struct {
+			name          string
+			advanceParent bool
+			minTotal      int
+		}{
+			{"already up to date", false, 0},
+			{"reports branches that needed restacking", true, 1},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				sh := NewTestShellInProcess(t)
 
-		// Create a stack
-		sh.Write("feature_a", "content a").
-			Run("create feature-a -m 'Add feature A'").
-			OnBranch("feature-a")
+				sh.Write("feature_a", "content a").
+					Run("create feature-a -m 'Add feature A'").
+					OnBranch("feature-a")
 
-		sh.Write("feature_b", "content b").
-			Run("create feature-b -m 'Add feature B'").
-			OnBranch("feature-b")
+				sh.Write("feature_b", "content b").
+					Run("create feature-b -m 'Add feature B'").
+					OnBranch("feature-b")
 
-		// Get JSON output from restack (should report already up to date)
-		sh.Run("restack --json")
-		output := sh.Output()
+				if tt.advanceParent {
+					sh.Checkout("feature-a").Commit("extra", "extra content")
+				}
 
-		// Parse and verify JSON structure
-		var result handlers.RestackJSONResult
-		err := json.Unmarshal([]byte(output), &result)
-		require.NoError(t, err, "restack --json should produce valid JSON")
+				sh.Run("restack --json")
+				output := sh.Output()
 
-		require.Equal(t, handlers.RestackJSONStatusSuccess, result.Status, "status should be success")
-		require.Empty(t, result.Conflicts, "should have no conflicts")
-	})
-
-	t.Run("restack --json reports branches that needed restacking", func(t *testing.T) {
-		t.Parallel()
-		sh := NewTestShellInProcess(t)
-
-		// Create a stack
-		sh.Write("feature_a", "content a").
-			Run("create feature-a -m 'Add feature A'").
-			OnBranch("feature-a")
-
-		sh.Write("feature_b", "content b").
-			Run("create feature-b -m 'Add feature B'").
-			OnBranch("feature-b")
-
-		// Modify parent to make child need restack
-		sh.Checkout("feature-a").
-			Commit("extra", "extra content")
-
-		// Restack with JSON output
-		sh.Run("restack --json")
-		output := sh.Output()
-
-		// Parse and verify JSON structure
-		var result handlers.RestackJSONResult
-		err := json.Unmarshal([]byte(output), &result)
-		require.NoError(t, err, "restack --json should produce valid JSON")
-
-		require.Equal(t, handlers.RestackJSONStatusSuccess, result.Status, "status should be success")
-		// Either restacked or skipped, depending on whether it needed work
-		require.GreaterOrEqual(t, result.TotalCount, 1, "should have processed at least 1 branch")
+				var result handlers.RestackJSONResult
+				err := json.Unmarshal([]byte(output), &result)
+				require.NoError(t, err, "restack --json should produce valid JSON")
+				require.Equal(t, handlers.RestackJSONStatusSuccess, result.Status)
+				require.Empty(t, result.Conflicts)
+				require.GreaterOrEqual(t, result.TotalCount, tt.minTotal)
+			})
+		}
 	})
 
 	t.Run("sync --dry-run --json requires --dry-run", func(t *testing.T) {
@@ -258,24 +225,6 @@ func TestJSONOutput(t *testing.T) {
 		require.NotNil(t, result.WouldRestackStacks, "would_restack_stacks should be populated when branches need restack")
 		require.Equal(t, []string{"alpha-root"}, result.WouldRestackStacks,
 			"should deduplicate and sort restack roots; only alpha's stack has drift")
-	})
-
-	t.Run("log --json with no tracked branches outputs valid JSON", func(t *testing.T) {
-		t.Parallel()
-		sh := NewTestShellInProcess(t)
-
-		// Don't create any tracked branches - just run log on a fresh repo
-		sh.Run("log --json")
-		output := sh.Output()
-
-		// Parse and verify JSON structure
-		var result actions.LogJSONResult
-		err := json.Unmarshal([]byte(output), &result)
-		require.NoError(t, err, "log --json should produce valid JSON even with no tracked branches")
-
-		// With no tracked branches, should have trunk at minimum
-		require.NotNil(t, result.Branches, "branches should not be nil")
-		require.Equal(t, 0, result.Summary.TotalBranches, "summary total should be 0 with no tracked branches")
 	})
 
 	t.Run("log --json with mixed branch states", func(t *testing.T) {
@@ -357,33 +306,6 @@ func TestJSONOutput(t *testing.T) {
 				require.Len(t, b.Children, 2, "feature-a should have 2 children")
 				require.Contains(t, b.Children, "feature-a-1")
 				require.Contains(t, b.Children, "feature-a-2")
-			}
-		}
-	})
-
-	t.Run("log --json reports branches without GitHub available", func(t *testing.T) {
-		t.Parallel()
-		sh := NewTestShellInProcess(t)
-
-		// Create branches (no GitHub configured in test environment)
-		sh.Write("feature_a", "content a").
-			Run("create feature-a -m 'Add feature A'")
-
-		// Get JSON output
-		sh.Run("log --json")
-		output := sh.Output()
-
-		var result actions.LogJSONResult
-		err := json.Unmarshal([]byte(output), &result)
-		require.NoError(t, err)
-
-		// GitHubAvailable should be false in test environment
-		require.False(t, result.GitHubAvailable)
-
-		// CI status should be empty for all branches without PRs
-		for _, b := range result.Branches {
-			if b.PR != nil {
-				require.Equal(t, "", b.PR.CIStatus, "CI should be empty without GitHub")
 			}
 		}
 	})

--- a/internal/integration/lifecycle_hooks_test.go
+++ b/internal/integration/lifecycle_hooks_test.go
@@ -42,18 +42,6 @@ func TestLifecycleHooks_NoVerifyBypasses(t *testing.T) {
 	require.NotContains(t, sh.lastOutput, "Running hook:", "no hook should run with --no-verify")
 }
 
-func TestLifecycleHooks_ZeroCostWhenUnconfigured(t *testing.T) {
-	t.Parallel()
-	sh := NewTestShellInProcess(t)
-
-	// No .stackit.yaml hooks section at all.
-	sh.WriteFile("seed.txt", "seed").Run("create feature -m 'feat: seed'")
-	sh.WriteFile("seed.txt", "updated")
-	sh.Run("modify -a")
-
-	require.NotContains(t, sh.lastOutput, "Running hook:", "no hook lines should appear when nothing is configured")
-}
-
 func TestLifecycleHooks_PostHookFailureIsWarning(t *testing.T) {
 	t.Parallel()
 	sh := NewTestShellInProcess(t)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

json_output_test.go:
- Delete "log --json always emits status booleans even when false"
  (pure JSON serialization tag test, unit-level concern)
- Delete "log --json with no tracked branches outputs valid JSON"
  (trivial edge case covered by action layer)
- Delete "log --json reports branches without GitHub available"
  (GitHub always unavailable in tests; add require.False assertion
  to the first log --json test instead)
- Merge two restack --json subtests into one table-driven test
  (already-up-to-date vs needs-restack; shared 2-branch setup)

lifecycle_hooks_test.go:
- Delete TestLifecycleHooks_ZeroCostWhenUnconfigured, which duplicates
  TestResolveApproved_EmptyCommandsIsZeroCost in actions/hooks/resolve_test.go

frozen_integration_test.go:
- Merge "freeze fails on untracked branch" and "unfreeze fails on
  untracked branch" into one table-driven test (byte-for-byte identical
  except for the command string)

Estimated savings: ~600ms.

<hr/>

<!-- STACKIT-SECTION-START -->
**Clean up integration test suite and add --json to merge status**

Reduces the integration test suite by ~2,000 lines through systematic cleanup, and adds a --json flag to `stackit merge status`.

Test cleanup (PRs #1095–#1105):
- **Remove dead tests**: Delete permanently-skipped, wrong-location, and duplicate tests
- **Move to unit layer**: Pluck/move PR-update tests relocated to action unit tests; integration tests for describe, scope, and modify deleted where unit tests already provide coverage
- **Strip unnecessary overhead**: Remove unneeded `WithRemote()` calls from tests that don't exercise remote operations
- **Consolidate into table-driven tests**: JSON output, lifecycle hooks, frozen state, merge subcommands, flatten, and worktree tests rewritten as compact table-driven tests
- **Extract shared helpers**: Worktree setup, sync squash-merge, flatten, and track helpers extracted to reduce duplication

Feature (PR #1107):
- **`--json` flag for `merge status`**: Machine-readable output for the merge status command

#### Stack


* **PR #1095**
  * **PR #1096**
    * **PR #1097**
      * **PR #1098**
        * **PR #1099**
          * **PR #1100** 👈
            * **PR #1101**
              * **PR #1102**
                * **PR #1103**
                  * **PR #1104**
                    * **PR #1105**
                      * **PR #1107**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1108 by jonnii*