### PR TITLE
test: consolidate flatten_test.go and delete split undo duplicate

### DIFF
--- a/internal/integration/flatten_test.go
+++ b/internal/integration/flatten_test.go
@@ -14,43 +14,6 @@ import (
 func TestFlattenWorkflow(t *testing.T) {
 	t.Parallel()
 
-	t.Run("flattens linear independent stack to trunk", func(t *testing.T) {
-		t.Parallel()
-
-		// Scenario:
-		// Before: main -> A -> B -> C (each with independent changes)
-		// After:  main -> A, main -> B, main -> C (all parallel)
-
-		sh := NewTestShellInProcess(t)
-
-		// Create a stack of independent branches (each touches a different file)
-		sh.Write("file-a", "content a").
-			Run("create branch-a -m 'Add file A'")
-
-		sh.Write("file-b", "content b").
-			Run("create branch-b -m 'Add file B'")
-
-		sh.Write("file-c", "content c").
-			Run("create branch-c -m 'Add file C'")
-
-		// Verify initial stack structure
-		sh.ExpectStackStructure(map[string]string{
-			"branch-a": "main",
-			"branch-b": "branch-a",
-			"branch-c": "branch-b",
-		})
-
-		// Run flatten with --yes to skip confirmation
-		sh.Run("flatten --yes")
-
-		// After flatten, all branches should be on main since they're independent
-		sh.ExpectStackStructure(map[string]string{
-			"branch-a": "main",
-			"branch-b": "main",
-			"branch-c": "main",
-		})
-	})
-
 	t.Run("respects dependencies and keeps branch in place", func(t *testing.T) {
 		t.Parallel()
 
@@ -151,50 +114,37 @@ func TestFlattenWorkflow(t *testing.T) {
 		})
 	})
 
-	t.Run("uses current branch when none specified", func(t *testing.T) {
+	t.Run("accepts current branch or positional branch argument", func(t *testing.T) {
 		t.Parallel()
-
-		sh := NewTestShellInProcess(t)
-
-		// Create a simple stack
-		sh.Write("file-a", "content a").
-			Run("create branch-a -m 'Add file A'")
-
-		sh.Write("file-b", "content b").
-			Run("create branch-b -m 'Add file B'")
-
-		// Stay on branch-b and run flatten without specifying branch
-		sh.OnBranch("branch-b").
-			Run("flatten --yes")
-
-		// Both should now be on main
-		sh.ExpectStackStructure(map[string]string{
-			"branch-a": "main",
-			"branch-b": "main",
-		})
-	})
-
-	t.Run("flatten with positional branch argument", func(t *testing.T) {
-		t.Parallel()
-
-		sh := NewTestShellInProcess(t)
-
-		// Create a stack
-		sh.Write("file-a", "content a").
-			Run("create branch-a -m 'Add file A'")
-
-		sh.Write("file-b", "content b").
-			Run("create branch-b -m 'Add file B'")
-
-		// Go to main and flatten from branch-b
-		sh.Checkout("main").
-			Run("flatten branch-b --yes")
-
-		// Both should be on main
-		sh.ExpectStackStructure(map[string]string{
-			"branch-a": "main",
-			"branch-b": "main",
-		})
+		for _, tt := range []struct {
+			name string
+			prep func(*TestShell)
+			cmd  string
+		}{
+			{
+				"uses current branch when none specified",
+				func(sh *TestShell) { sh.OnBranch("branch-b") },
+				"flatten --yes",
+			},
+			{
+				"positional branch argument",
+				func(sh *TestShell) { sh.Checkout("main") },
+				"flatten branch-b --yes",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				sh := NewTestShellInProcess(t)
+				sh.Write("file-a", "content a").Run("create branch-a -m 'Add file A'")
+				sh.Write("file-b", "content b").Run("create branch-b -m 'Add file B'")
+				tt.prep(sh)
+				sh.Run(tt.cmd)
+				sh.ExpectStackStructure(map[string]string{
+					"branch-a": "main",
+					"branch-b": "main",
+				})
+			})
+		}
 	})
 
 	t.Run("error on untracked branch", func(t *testing.T) {
@@ -353,40 +303,6 @@ func TestFlattenCommitIntegrity(t *testing.T) {
 		// A should have 2 commits, B should have only 1
 		sh.CommitCount("main", "branch-a", 2).
 			CommitCount("main", "branch-b", 1)
-	})
-
-	t.Run("flatten after parent amended without restacking child", func(t *testing.T) {
-		t.Parallel()
-
-		// Scenario: A is created, B is created on top, then A is amended
-		// B is NOT restacked before flatten
-		// After flatten: B should only contain its own commit
-
-		sh := NewTestShellInProcess(t)
-
-		sh.Write("file-a", "content a").
-			Run("create branch-a -m 'Add file A'")
-
-		sh.Write("file-b", "content b").
-			Run("create branch-b -m 'Add file B'")
-
-		// Go back to A and amend it (add more content)
-		sh.Checkout("branch-a").
-			Amend("file-a-extra", "extra content for A")
-
-		// Do NOT restack branch-b — it's now based on old A
-
-		// Go to B and flatten
-		sh.Checkout("branch-b").
-			Run("flatten --yes")
-
-		sh.ExpectStackStructure(map[string]string{
-			"branch-a": "main",
-			"branch-b": "main",
-		})
-
-		// B should have exactly 1 commit relative to main
-		sh.CommitCount("main", "branch-b", 1)
 	})
 
 	t.Run("flatten with main advanced and parent amended", func(t *testing.T) {

--- a/internal/integration/split_test.go
+++ b/internal/integration/split_test.go
@@ -1156,33 +1156,6 @@ func TestSplitEdgeCases(t *testing.T) {
 			OutputContains("modified keep")
 	})
 
-	run("split creates snapshot for undo recovery", func(t *testing.T, sh *TestShell) {
-		sh.Write("file1", "content1").
-			Write("file2", "content2").
-			Run("create feature -m 'Add files'")
-
-		// Verify initial state
-		sh.HasBranches("main", "feature")
-
-		// Successful split should create snapshot
-		sh.Run("split --by-file file1_test.txt")
-
-		// Verify split happened
-		sh.HasBranches("main", "feature", "feature_split")
-
-		// Verify we can undo using the snapshot
-		sh.UndoLatest()
-
-		// Should be back on original feature with both files
-		sh.OnBranch("feature")
-
-		// Split branch should be removed
-		sh.HasBranches("main", "feature")
-
-		// Verify both files exist in the tree
-		verifyFilesExist(t, sh, []string{"file1_test.txt", "file2_test.txt"})
-	})
-
 	run("by-file with special characters in filename", func(_ *testing.T, sh *TestShell) {
 		sh.Write("normal", "normal content").
 			Run("create setup -m 'Setup'")


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

flatten_test.go:
- Delete "flattens linear independent stack to trunk" — its only
  assertion (ExpectStackStructure) is a strict subset of
  TestFlattenCommitIntegrity/"flattened branch only contains its own
  commits" which additionally verifies CommitCounts.
- Delete "flatten after parent amended without restacking child" — its
  assertions are a strict subset of the more comprehensive "flatten
  with main advanced and parent amended" which adds an extra main-advance
  step before the same assertions.
- Collapse "uses current branch when none specified" and "flatten with
  positional branch argument" into one table-driven test: both create
  the same 2-branch stack and assert the same final structure; the only
  difference is whether the user is on branch-b or passes it as an arg.

split_test.go:
- Delete TestSplitEdgeCases/"split creates snapshot for undo recovery":
  it is a strict superset of TestSplitUndo/"undo split --by-file
  restores original branch" — both write the same two files, split,
  undo, and verify HasBranches + verifyFilesExist. The edge-cases version
  only adds an intermediate HasBranches check before the split.
  The test uses a shared-shell pattern so the per-deletion savings are
  modest but the duplicate is clear.

Estimated savings: ~700ms.

<hr/>

<!-- STACKIT-SECTION-START -->
**Clean up integration test suite and add --json to merge status**

Reduces the integration test suite by ~2,000 lines through systematic cleanup, and adds a --json flag to `stackit merge status`.

Test cleanup (PRs #1095–#1105):
- **Remove dead tests**: Delete permanently-skipped, wrong-location, and duplicate tests
- **Move to unit layer**: Pluck/move PR-update tests relocated to action unit tests; integration tests for describe, scope, and modify deleted where unit tests already provide coverage
- **Strip unnecessary overhead**: Remove unneeded `WithRemote()` calls from tests that don't exercise remote operations
- **Consolidate into table-driven tests**: JSON output, lifecycle hooks, frozen state, merge subcommands, flatten, and worktree tests rewritten as compact table-driven tests
- **Extract shared helpers**: Worktree setup, sync squash-merge, flatten, and track helpers extracted to reduce duplication

Feature (PR #1107):
- **`--json` flag for `merge status`**: Machine-readable output for the merge status command

#### Stack


* **PR #1095**
  * **PR #1096**
    * **PR #1097**
      * **PR #1098**
        * **PR #1099**
          * **PR #1100**
            * **PR #1101**
              * **PR #1102** 👈
                * **PR #1103**
                  * **PR #1104**
                    * **PR #1105**
                      * **PR #1107**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1108 by jonnii*