### PR TITLE
test: extract worktree helpers and consolidate worktree tests

### DIFF
--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -1071,3 +1071,35 @@ func (s *TestShell) ExpectStackIDsDiffer(branch1, branch2 string) *TestShell {
 		branch1, branch2, stackID1)
 	return s
 }
+
+// =============================================================================
+// Worktree Helpers
+// =============================================================================
+
+// AdvanceMain commits a new file on the main branch and pushes it to origin.
+// Requires the shell to have a remote (WithRemote).
+func AdvanceMain(sh *TestShell, filename string) {
+	sh.t.Helper()
+	sh.WriteFile(filename, "content from main").
+		Git("add " + filename).
+		Git("commit -m 'Advance main: " + filename + "'").
+		Git("push origin main")
+}
+
+// SimulateMerge fast-forward merges the branch into main, pushes, and marks its PR as MERGED.
+// Requires the shell to have a remote (WithRemote).
+func SimulateMerge(sh *TestShell, branchName string) {
+	sh.t.Helper()
+	sh.Git("checkout main").
+		Git("merge " + branchName + " --ff-only").
+		Git("push origin main")
+	sh.SetPrState(branchName, "MERGED")
+}
+
+// MakeWorktreeDirty writes an uncommitted file into a worktree directory.
+func MakeWorktreeDirty(t *testing.T, worktreePath string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(worktreePath, "uncommitted.txt"), []byte("uncommitted"), 0644); err != nil {
+		t.Fatalf("failed to make worktree dirty: %v", err)
+	}
+}

--- a/internal/integration/worktree_attach_detach_test.go
+++ b/internal/integration/worktree_attach_detach_test.go
@@ -246,53 +246,37 @@ func TestWorktreeDetach(t *testing.T) {
 		sh.ExpectBranchParent("feature", "main")
 	})
 
-	run("detach fails with uncommitted changes without force", func(t *testing.T, sh *TestShell) {
-		// Create a stack and attach
-		sh.WriteFile("feature.txt", "feature").
-			Run("create feature -m 'feature branch'")
-		sh.Run("worktree attach feature")
+	run("detach with dirty worktree requires --force", func(t *testing.T, sh *TestShell) {
+		for _, tt := range []struct {
+			name     string
+			cmd      string
+			wantGone bool
+		}{
+			{"fails without force", "worktree detach feature", false},
+			{"removes with force", "worktree detach feature --force", true},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				sh := sh.WithT(t)
+				sh.ResetRepo()
+				sh.WriteFile("feature.txt", "feature").Run("create feature -m 'feature branch'")
+				sh.Run("worktree attach feature")
+				worktreePath := sh.GetWorktreePath("feature")
+				MakeWorktreeDirty(t, worktreePath)
 
-		worktreePath := sh.GetWorktreePath("feature")
-
-		// Create uncommitted changes in worktree
-		uncommittedFile := worktreePath + "/uncommitted.txt"
-		if err := os.WriteFile(uncommittedFile, []byte("uncommitted"), 0644); err != nil {
-			t.Fatalf("Failed to write file: %v", err)
+				if tt.wantGone {
+					sh.Run(tt.cmd)
+					if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
+						t.Errorf("worktree directory should be removed at %s", worktreePath)
+					}
+					sh.HasBranches("main", "feature")
+				} else {
+					sh.RunExpectError(tt.cmd)
+					if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
+						t.Errorf("worktree should still exist at %s", worktreePath)
+					}
+				}
+			})
 		}
-
-		// Detach without force should fail
-		sh.RunExpectError("worktree detach feature")
-
-		// Worktree should still exist
-		if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
-			t.Errorf("Worktree should still exist")
-		}
-	})
-
-	run("detach with force removes worktree with uncommitted changes", func(t *testing.T, sh *TestShell) {
-		// Create a stack and attach
-		sh.WriteFile("feature.txt", "feature").
-			Run("create feature -m 'feature branch'")
-		sh.Run("worktree attach feature")
-
-		worktreePath := sh.GetWorktreePath("feature")
-
-		// Create uncommitted changes in worktree
-		uncommittedFile := worktreePath + "/uncommitted.txt"
-		if err := os.WriteFile(uncommittedFile, []byte("uncommitted"), 0644); err != nil {
-			t.Fatalf("Failed to write file: %v", err)
-		}
-
-		// Detach with force should succeed
-		sh.Run("worktree detach feature --force")
-
-		// Worktree should be removed
-		if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
-			t.Errorf("Worktree directory should be removed at %s", worktreePath)
-		}
-
-		// Branches should still exist
-		sh.HasBranches("main", "feature")
 	})
 
 	run("detach fails from inside worktree", func(_ *testing.T, sh *TestShell) {

--- a/internal/integration/worktree_comprehensive_test.go
+++ b/internal/integration/worktree_comprehensive_test.go
@@ -211,34 +211,26 @@ func TestWorktreeBasicOperations(t *testing.T) {
 			Run("create dirty-stack -w -m 'dirty stack branch'")
 
 		worktreePath := sh.GetWorktreePath("dirty-stack")
-		uncommittedFile := worktreePath + "/uncommitted.txt"
-		if err := os.WriteFile(uncommittedFile, []byte("uncommitted"), 0644); err != nil {
-			t.Fatalf("Failed to write file: %v", err)
-		}
+		MakeWorktreeDirty(t, worktreePath)
 
 		sh.RunExpectError("worktree remove dirty-stack")
 
 		if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
-			t.Errorf("Dirty worktree should still exist")
+			t.Errorf("dirty worktree should still exist at %s", worktreePath)
 		}
-
-		sh.Run("worktree list").
-			OutputContains("dirty-stack")
+		sh.Run("worktree list").OutputContains("dirty-stack")
 	})
 
 	run("worktree remove force discards dirty worktree", func(t *testing.T, sh *TestShell) {
 		sh.Run("worktree create force-stack")
 
 		worktreePath := sh.GetWorktreePath("force-stack")
-		uncommittedFile := worktreePath + "/uncommitted.txt"
-		if err := os.WriteFile(uncommittedFile, []byte("uncommitted"), 0644); err != nil {
-			t.Fatalf("Failed to write file: %v", err)
-		}
+		MakeWorktreeDirty(t, worktreePath)
 
 		sh.Run("worktree remove force-stack --force")
 
 		if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
-			t.Errorf("Worktree directory should be removed at %s", worktreePath)
+			t.Errorf("worktree directory should be removed at %s", worktreePath)
 		}
 	})
 }
@@ -343,72 +335,52 @@ func TestWorktreeSyncOperations(t *testing.T) {
 		})
 	}
 
-	run("sync from main updates worktree branches", func(t *testing.T, sh *TestShell) {
-		// Create a stack in worktree
-		sh.WriteFile("feature.txt", "feature").
-			Run("create feature -w -m 'feature branch'")
+	run("sync from main or worktree context restacks the stack", func(t *testing.T, sh *TestShell) {
+		for _, tt := range []struct {
+			name             string
+			syncFromWorktree bool
+		}{
+			{"sync from main repo", false},
+			{"sync from worktree context", true},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				sh := sh.WithT(t)
+				sh.ResetRepo()
 
-		worktreePath := sh.GetWorktreePath("feature")
-		shW := sh.InWorktree(worktreePath)
+				sh.WriteFile("feature.txt", "feature").
+					Run("create feature -w -m 'feature branch'")
+				worktreePath := sh.GetWorktreePath("feature")
+				shW := sh.InWorktree(worktreePath)
 
-		// Add child branch in worktree
-		shW.WriteFile("child.txt", "child").
-			Run("create feature-child -m 'child branch'")
+				shW.WriteFile("child.txt", "child").
+					Run("create feature-child -m 'child branch'")
 
-		// Advance main in main repo
-		sh.WriteFile("main-update.txt", "main update").
-			Git("add main-update.txt").
-			Git("commit -m 'Main advanced'").
-			Git("push origin main")
+				AdvanceMain(sh, "main-update.txt")
 
-		// Sync from main with full restack
-		sh.Run("sync --restack")
+				if tt.syncFromWorktree {
+					shW.Run("sync --restack")
+				} else {
+					sh.Run("sync --restack")
+				}
 
-		// Verify stack is restacked
-		sh.ExpectStackStructure(map[string]string{
-			"feature":       "main",
-			"feature-child": "feature",
-		})
+				sh.ExpectStackStructure(map[string]string{
+					"feature":       "main",
+					"feature-child": "feature",
+				})
 
-		// Verify worktree working directory is clean
-		shW.Git("status --porcelain")
-		if output := shW.Output(); output != "" {
-			t.Errorf("Worktree should be clean after sync, but has:\n%s", output)
+				if !tt.syncFromWorktree {
+					// Verify worktree working directory is clean after sync from main.
+					shW.Git("status --porcelain")
+					if output := shW.Output(); output != "" {
+						t.Errorf("worktree should be clean after sync, but has:\n%s", output)
+					}
+					shW.Git("ls-files main-update.txt")
+					if shW.Output() == "" {
+						t.Error("main-update.txt should exist in worktree after sync")
+					}
+				}
+			})
 		}
-
-		// Verify new file from main exists in worktree
-		shW.Git("ls-files main-update.txt")
-		if shW.Output() == "" {
-			t.Error("main-update.txt should exist in worktree after sync")
-		}
-	})
-
-	run("sync from worktree updates main repo branches", func(_ *testing.T, sh *TestShell) {
-		// Create a stack in worktree
-		sh.WriteFile("feature.txt", "feature").
-			Run("create feature -w -m 'feature branch'")
-
-		worktreePath := sh.GetWorktreePath("feature")
-		shW := sh.InWorktree(worktreePath)
-
-		// Add child in worktree
-		shW.WriteFile("child.txt", "child").
-			Run("create feature-child -m 'child branch'")
-
-		// Advance main in main repo
-		sh.WriteFile("main-update.txt", "main update").
-			Git("add main-update.txt").
-			Git("commit -m 'Main advanced'").
-			Git("push origin main")
-
-		// Sync from worktree with full restack
-		shW.Run("sync --restack")
-
-		// Verify stack is restacked
-		sh.ExpectStackStructure(map[string]string{
-			"feature":       "main",
-			"feature-child": "feature",
-		})
 	})
 
 	run("sync cleans orphaned worktrees when branches deleted", func(t *testing.T, sh *TestShell) {
@@ -419,13 +391,7 @@ func TestWorktreeSyncOperations(t *testing.T) {
 		worktreePath := sh.GetWorktreePath("feature")
 		shW := sh.InWorktree(worktreePath)
 
-		// Simulate the branch being merged (fast-forward main to include it)
-		sh.Git("checkout main").
-			Git("merge feature --ff-only").
-			Git("push origin main")
-
-		// Mark PR as merged
-		sh.SetPrState("feature", "MERGED")
+		SimulateMerge(sh, "feature")
 
 		// Checkout main in worktree first (so feature isn't the active branch)
 		// Note: In a real scenario, the worktree would need to be removed manually first
@@ -456,10 +422,7 @@ func TestWorktreeSyncOperations(t *testing.T) {
 		worktreePath := sh.GetWorktreePath("feature")
 		shW := sh.InWorktree(worktreePath)
 
-		sh.Git("checkout main").
-			Git("merge feature --ff-only").
-			Git("push origin main")
-		sh.SetPrState("feature", "MERGED")
+		SimulateMerge(sh, "feature")
 
 		shW.Git("checkout --detach HEAD")
 		shW.Run("sync")
@@ -737,25 +700,18 @@ func TestWorktreeEdgeCases(t *testing.T) {
 		worktreePath := sh.GetWorktreePath("feature")
 		shW := sh.InWorktree(worktreePath)
 
-		// Create child
 		shW.WriteFile("child.txt", "child").Run("create child -m 'child branch'")
 
-		// Make uncommitted change in worktree (on child branch)
-		filePath := filepath.Join(worktreePath, "uncommitted.txt")
-		err := os.WriteFile(filePath, []byte("uncommitted"), 0644)
-		if err != nil {
-			t.Fatalf("Failed to write file: %v", err)
-		}
+		MakeWorktreeDirty(t, worktreePath)
 
-		// Modify parent and trigger restack from main
 		sh.Checkout("feature").
 			WriteFile("feature-update.txt", "update").
 			Run("modify -n").
 			Checkout("main")
 
-		// The uncommitted file should still be in the worktree
-		if _, err := os.Stat(filePath); os.IsNotExist(err) {
-			t.Error("Uncommitted file should still exist in worktree after restack")
+		dirtyFile := filepath.Join(worktreePath, "uncommitted.txt")
+		if _, err := os.Stat(dirtyFile); os.IsNotExist(err) {
+			t.Error("uncommitted file should still exist in worktree after restack")
 		}
 	})
 
@@ -766,11 +722,7 @@ func TestWorktreeEdgeCases(t *testing.T) {
 		sh.WriteFile("stack2.txt", "stack2").
 			Run("create stack2 -w -m 'stack 2'")
 
-		// Advance main
-		sh.WriteFile("main-update.txt", "update").
-			Git("add main-update.txt").
-			Git("commit -m 'Main advanced'").
-			Git("push origin main")
+		AdvanceMain(sh, "main-update.txt")
 
 		// Sync should update both stacks
 		sh.Run("sync --restack")
@@ -790,22 +742,6 @@ func TestWorktreeEdgeCases(t *testing.T) {
 		shW2.Git("ls-files main-update.txt")
 		if shW2.Output() == "" {
 			t.Error("stack2 worktree should have main-update.txt")
-		}
-	})
-
-	run("worktree uses default stacks directory", func(t *testing.T, sh *TestShell) {
-		// Create worktree
-		sh.WriteFile("feature.txt", "feature").
-			Run("create feature -w -m 'feature branch'")
-
-		// Worktree should be created (verify via list)
-		sh.Run("worktree list").
-			OutputContains("feature")
-
-		// Worktree path should exist
-		worktreePath := sh.GetWorktreePath("feature")
-		if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
-			t.Errorf("Worktree directory should exist at %s", worktreePath)
 		}
 	})
 
@@ -1007,11 +943,7 @@ func TestWorktreeComplexScenarios(t *testing.T) {
 		shA.WriteFile("a-grandchild.txt", "a-gc").Run("create a-grandchild -m 'a grandchild'")
 		shB.WriteFile("b-grandchild.txt", "b-gc").Run("create b-grandchild -m 'b grandchild'")
 
-		// Advance main
-		sh.WriteFile("main-update.txt", "main").
-			Git("add main-update.txt").
-			Git("commit -m 'Main advanced'").
-			Git("push origin main")
+		AdvanceMain(sh, "main-update.txt")
 
 		// Sync from main with full restack
 		sh.Run("sync --restack")
@@ -1048,11 +980,7 @@ func TestWorktreeComplexScenarios(t *testing.T) {
 		shMerged := sh.InWorktree(wtMerged)
 		shActive := sh.InWorktree(wtActive)
 
-		// Simulate merged stack being merged
-		sh.Git("checkout main").
-			Git("merge to-be-merged --ff-only").
-			Git("push origin main")
-		sh.SetPrState("to-be-merged", "MERGED")
+		SimulateMerge(sh, "to-be-merged")
 
 		// Detach head in merged worktree so the branch can be deleted
 		shMerged.Git("checkout --detach HEAD")
@@ -1128,11 +1056,8 @@ func TestWorktreeErrorHandling(t *testing.T) {
 		})
 	}
 
-	run("worktree open with non-existent stack fails gracefully", func(_ *testing.T, sh *TestShell) {
+	run("worktree open and remove with non-existent stack fail gracefully", func(_ *testing.T, sh *TestShell) {
 		sh.RunExpectError("worktree open nonexistent")
-	})
-
-	run("worktree remove with non-existent stack fails gracefully", func(_ *testing.T, sh *TestShell) {
 		sh.RunExpectError("worktree remove nonexistent")
 	})
 
@@ -1211,51 +1136,25 @@ func TestWorktreeAnchorBranchCleanup(t *testing.T) {
 		sh.HasBranches("main", "feature", "child")
 	})
 
-	run("worktree prune cleans up missing directories", func(t *testing.T, sh *TestShell) {
-		// Create empty anchored worktree.
+	run("worktree prune dry-run then actual prune clean up missing directories", func(t *testing.T, sh *TestShell) {
 		sh.Run("worktree create test-wt")
-
-		sh.HasBranches("main")
-
 		worktreePath := sh.GetWorktreePath("test-wt")
 
-		// Manually delete the worktree directory (simulating external deletion)
 		if err := os.RemoveAll(worktreePath); err != nil {
-			t.Fatalf("Failed to remove worktree directory: %v", err)
+			t.Fatalf("failed to remove worktree directory: %v", err)
 		}
 
-		// Worktree list should show missing worktree
-		sh.Run("worktree list").
-			OutputContains("missing")
+		sh.Run("worktree list").OutputContains("missing")
 
-		// Prune should clean up the missing worktree
-		sh.Run("worktree prune")
-
-		// Worktree list should be empty
-		sh.Run("worktree list").
-			OutputContains("No managed worktrees")
-
-		// Anchor branch should be deleted
-		sh.HasBranches("main")
-	})
-
-	run("worktree prune dry-run shows what would be cleaned", func(t *testing.T, sh *TestShell) {
-		// Create empty anchored worktree.
-		sh.Run("worktree create test-wt")
-
-		worktreePath := sh.GetWorktreePath("test-wt")
-
-		// Manually delete the worktree directory
-		if err := os.RemoveAll(worktreePath); err != nil {
-			t.Fatalf("Failed to remove worktree directory: %v", err)
-		}
-
-		// Prune with dry-run should show what would be cleaned
+		// Dry-run shows what would be pruned but makes no changes.
 		sh.Run("worktree prune --dry-run").
 			OutputContains("Would prune").
 			OutputContains("test-wt")
+		sh.HasBranches("main") // anchor still exists after dry-run
 
-		// But nothing should actually be deleted
+		// Actual prune removes the missing worktree.
+		sh.Run("worktree prune")
+		sh.Run("worktree list").OutputContains("No managed worktrees")
 		sh.HasBranches("main")
 	})
 

--- a/internal/integration/worktree_sync_test.go
+++ b/internal/integration/worktree_sync_test.go
@@ -31,12 +31,9 @@ func TestWorktreeWorkingDirAfterRestack(t *testing.T) {
 		shW := sh.InWorktree(worktreePath)
 		shW.OnBranch("feature")
 
-		// Advance main with a change to a file that the worktree will see after restack
+		// Advance main with a change that the worktree will see after restack
 		sh.Log("Advancing main with new file...")
-		sh.WriteFile("new-from-main.txt", "content from main").
-			Git("add new-from-main.txt").
-			Git("commit -m 'Add new file from main'").
-			Git("push origin main")
+		AdvanceMain(sh, "new-from-main.txt")
 
 		// Run sync from main repo - this will restack feature onto new main
 		sh.Log("Running sync from main repo...")
@@ -126,13 +123,7 @@ func TestSyncWithMultipleWorktrees(t *testing.T) {
 		// === Simulate: Stack A gets merged on GitHub ===
 		sh.Log("Simulating Stack A merge on GitHub...")
 
-		// Fast-forward main to include stackA (simulating GitHub squash/merge)
-		sh.Git("checkout main").
-			Git("merge stackA --ff-only").
-			Git("push origin main")
-
-		// Mark stackA PR as merged in metadata
-		sh.SetPrState("stackA", "MERGED")
+		SimulateMerge(sh, "stackA")
 
 		// === Action: Run sync from main repo ===
 		sh.Log("Running sync from main repo...")
@@ -190,10 +181,7 @@ func TestSyncWithMultipleWorktrees(t *testing.T) {
 
 		// Advance main in the main repo
 		sh.Log("Advancing main...")
-		sh.WriteFile("main-update.txt", "main change").
-			Git("add main-update.txt").
-			Git("commit -m 'Main advanced'").
-			Git("push origin main")
+		AdvanceMain(sh, "main-update.txt")
 
 		// Sync from main - should restack entire worktree stack
 		sh.Log("Running sync from main repo...")
@@ -230,10 +218,7 @@ func TestSyncWithMultipleWorktrees(t *testing.T) {
 
 		// Advance main in the main repo
 		sh.Log("Advancing main...")
-		sh.WriteFile("main-update.txt", "main change").
-			Git("add main-update.txt").
-			Git("commit -m 'Main advanced'").
-			Git("push origin main")
+		AdvanceMain(sh, "main-update.txt")
 
 		// Sync from the worktree context with full restack
 		sh.Log("Running sync from worktree...")
@@ -285,12 +270,7 @@ func TestSyncWithMultipleWorktrees(t *testing.T) {
 
 		// Simulate A getting merged on GitHub
 		sh.Log("Simulating branchA merge on GitHub...")
-		sh.Git("checkout main").
-			Git("merge branchA --ff-only").
-			Git("push origin main")
-
-		// Mark branchA PR as merged
-		sh.SetPrState("branchA", "MERGED")
+		SimulateMerge(sh, "branchA")
 
 		// Run sync from main repo
 		sh.Log("Running sync from main repo...")
@@ -369,10 +349,7 @@ func TestSyncWithMultipleWorktrees(t *testing.T) {
 
 		// Advance main
 		sh.Log("Advancing main...")
-		sh.WriteFile("main-update.txt", "main change").
-			Git("add main-update.txt").
-			Git("commit -m 'Main advanced'").
-			Git("push origin main")
+		AdvanceMain(sh, "main-update.txt")
 
 		// Run sync from main repo
 		sh.Log("Running sync from main repo...")
@@ -441,12 +418,7 @@ func TestSyncWithMultipleWorktrees(t *testing.T) {
 
 		// Simulate A getting merged on GitHub
 		sh.Log("Simulating branchA merge on GitHub...")
-		sh.Git("checkout main").
-			Git("merge branchA --ff-only").
-			Git("push origin main")
-
-		// Mark branchA PR as merged
-		sh.SetPrState("branchA", "MERGED")
+		SimulateMerge(sh, "branchA")
 
 		// Run sync from main repo
 		sh.Log("Running sync from main repo...")


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Adds three shared helpers to helpers_test.go:
- AdvanceMain(sh, filename): WriteFile + git add/commit/push on main.
  Replaces a 4-line inline pattern repeated 8 times across worktree tests.
- SimulateMerge(sh, branchName): ff-only merge + push + SetPrState MERGED.
  Replaces a 4-line inline pattern repeated 7 times.
- MakeWorktreeDirty(t, path): writes an uncommitted file into a worktree.
  Replaces a 5-line os.WriteFile + error check repeated 6 times.

Applies helpers throughout worktree_sync_test.go and
worktree_comprehensive_test.go.

Consolidations:
- Merge "sync from main" and "sync from worktree" into one table-driven
  test in TestWorktreeSyncOperations (shared setup, parameterised on
  which shell runs sync).
- Merge "detach fails without force" and "detach with force" into one
  table-driven test in TestWorktreeDetach.
- Delete "worktree uses default stacks directory" — a strict subset of
  "create branch with worktree flag".
- Merge two error-path tests (open/remove non-existent) into one run()
  entry.
- Merge "prune cleans up missing" and "prune dry-run shows" into one
  sequential test (dry-run first, then actual prune).

<hr/>

<!-- STACKIT-SECTION-START -->
**Clean up integration test suite and add --json to merge status**

Reduces the integration test suite by ~2,000 lines through systematic cleanup, and adds a --json flag to `stackit merge status`.

Test cleanup (PRs #1095–#1105):
- **Remove dead tests**: Delete permanently-skipped, wrong-location, and duplicate tests
- **Move to unit layer**: Pluck/move PR-update tests relocated to action unit tests; integration tests for describe, scope, and modify deleted where unit tests already provide coverage
- **Strip unnecessary overhead**: Remove unneeded `WithRemote()` calls from tests that don't exercise remote operations
- **Consolidate into table-driven tests**: JSON output, lifecycle hooks, frozen state, merge subcommands, flatten, and worktree tests rewritten as compact table-driven tests
- **Extract shared helpers**: Worktree setup, sync squash-merge, flatten, and track helpers extracted to reduce duplication

Feature (PR #1107):
- **`--json` flag for `merge status`**: Machine-readable output for the merge status command

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780197148`.


* **PR #1095**
  * **PR #1096**
    * **PR #1097**
      * **PR #1098**
        * **PR #1099**
          * **PR #1100**
            * **PR #1101**
              * **PR #1102**
                * **PR #1103** 👈
                  * **PR #1104**
                    * **PR #1105**
                      * **PR #1107**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->