### PR TITLE
test: extract flatten and track shared setup helpers

### DIFF
--- a/internal/integration/flatten_test.go
+++ b/internal/integration/flatten_test.go
@@ -171,11 +171,7 @@ func TestFlattenUndo(t *testing.T) {
 		sh := NewTestShellInProcess(t)
 
 		// Create a stack
-		sh.Write("file-a", "content a").
-			Run("create branch-a -m 'Add file A'")
-
-		sh.Write("file-b", "content b").
-			Run("create branch-b -m 'Add file B'")
+		sh.CreateIndependentStack2()
 
 		// Verify initial structure
 		sh.ExpectStackStructure(map[string]string{
@@ -215,11 +211,7 @@ func TestFlattenCommitIntegrity(t *testing.T) {
 
 		sh := NewTestShellInProcess(t)
 
-		sh.Write("file-a", "content a").
-			Run("create branch-a -m 'Add file A'")
-
-		sh.Write("file-b", "content b").
-			Run("create branch-b -m 'Add file B'")
+		sh.CreateIndependentStack2()
 
 		sh.Write("file-c", "content c").
 			Run("create branch-c -m 'Add file C'")
@@ -246,11 +238,7 @@ func TestFlattenCommitIntegrity(t *testing.T) {
 
 		sh := NewTestShellInProcess(t)
 
-		sh.Write("file-a", "content a").
-			Run("create branch-a -m 'Add file A'")
-
-		sh.Write("file-b", "content b").
-			Run("create branch-b -m 'Add file B'")
+		sh.CreateIndependentStack2()
 
 		// Advance main (simulating a local pull or direct commit)
 		sh.Checkout("main").
@@ -313,11 +301,7 @@ func TestFlattenCommitIntegrity(t *testing.T) {
 
 		sh := NewTestShellInProcess(t)
 
-		sh.Write("file-a", "content a").
-			Run("create branch-a -m 'Add file A'")
-
-		sh.Write("file-b", "content b").
-			Run("create branch-b -m 'Add file B'")
+		sh.CreateIndependentStack2()
 
 		// Advance main
 		sh.Checkout("main").
@@ -350,11 +334,7 @@ func TestFlattenCommitIntegrity(t *testing.T) {
 
 		sh := NewTestShellInProcess(t)
 
-		sh.Write("file-a", "content a").
-			Run("create branch-a -m 'Add file A'")
-
-		sh.Write("file-b", "content b").
-			Run("create branch-b -m 'Add file B'")
+		sh.CreateIndependentStack2()
 
 		sh.Write("file-c", "content c").
 			Run("create branch-c -m 'Add file C'")

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -1103,3 +1103,14 @@ func MakeWorktreeDirty(t *testing.T, worktreePath string) {
 		t.Fatalf("failed to make worktree dirty: %v", err)
 	}
 }
+
+// CreateIndependentStack2 creates main->branch-a->branch-b where each branch
+// touches a different file (no file dependencies between branches).
+// Used by flatten tests to verify file-independence detection.
+func (s *TestShell) CreateIndependentStack2() *TestShell {
+	s.t.Helper()
+	return s.Write("file-a", "content a").
+		Run("create branch-a -m 'Add file A'").
+		Write("file-b", "content b").
+		Run("create branch-b -m 'Add file B'")
+}

--- a/internal/integration/track_test.go
+++ b/internal/integration/track_test.go
@@ -153,29 +153,42 @@ func TestTrackIntegration(t *testing.T) {
 			OutputContains("feature-b")
 	})
 
-	t.Run("track with force finds most recent ancestor in complex stack", func(t *testing.T) {
+	t.Run("track with force finds most recent tracked ancestor", func(t *testing.T) {
 		t.Parallel()
-		shell := NewTestShellInProcess(t)
-
-		// Create a complex stack
-		shell.Write("a.go", "package main").
-			Run("create feature-a -m 'Add feature A'").
-			Write("b.go", "package main").
-			Run("create feature-b -m 'Add feature B'").
-			Write("c.go", "package main").
-			Run("create feature-c -m 'Add feature C'")
-
-		// Create an untracked branch from feature-c
-		shell.Git("checkout -b feature-d").
-			Write("d.go", "package main").
-			Commit("d.go", "Add feature D")
-
-		// Track with --force should find feature-c as most recent ancestor
-		shell.Run("track feature-d --force")
-
-		// Verify it found the correct parent
-		shell.Run("parent").
-			OutputContains("feature-c")
+		for _, tt := range []struct {
+			name  string
+			setup func(*TestShell) // builds the tracked branches; feature-d is always untracked
+		}{
+			{
+				"linear stack — finds direct parent",
+				func(sh *TestShell) {
+					sh.Write("a.go", "package main").Run("create feature-a -m 'Add feature A'").
+						Write("b.go", "package main").Run("create feature-b -m 'Add feature B'").
+						Write("c.go", "package main").Run("create feature-c -m 'Add feature C'")
+					sh.Git("checkout -b feature-d").Write("d.go", "package main").Commit("d.go", "Add feature D")
+				},
+			},
+			{
+				"diamond topology — finds correct parent among siblings",
+				func(sh *TestShell) {
+					sh.Write("a.go", "package main").Run("create feature-a -m 'Add feature A'").
+						Checkout("main").
+						Write("b.go", "package main").Run("create feature-b -m 'Add feature B'").
+						Checkout("feature-a").
+						Write("c.go", "package main").Run("create feature-c -m 'Add feature C'")
+					sh.Checkout("feature-c").Git("checkout -b feature-d").
+						Write("d.go", "package main").Commit("d.go", "Add feature D")
+				},
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				shell := NewTestShellInProcess(t)
+				tt.setup(shell)
+				shell.Run("track feature-d --force")
+				shell.Run("parent").OutputContains("feature-c")
+			})
+		}
 	})
 
 	t.Run("track branches after split operation", func(t *testing.T) {
@@ -291,35 +304,6 @@ func TestTrackIntegration(t *testing.T) {
 		// Verify relationship restored
 		shell.Run("parent").
 			OutputContains("feature-a")
-	})
-
-	t.Run("track with force handles multiple potential ancestors correctly", func(t *testing.T) {
-		t.Parallel()
-		shell := NewTestShellInProcess(t)
-
-		// Create a complex branching structure
-		shell.Write("a.go", "package main").
-			Run("create feature-a -m 'Add feature A'").
-			Checkout("main").
-			Write("b.go", "package main").
-			Run("create feature-b -m 'Add feature B'").
-			Checkout("feature-a").
-			Write("c.go", "package main").
-			Run("create feature-c -m 'Add feature C'")
-
-		// Create a branch that could be based on either feature-a or feature-b
-		// But it's actually based on feature-c (most recent)
-		shell.Checkout("feature-c").
-			Git("checkout -b feature-d").
-			Write("d.go", "package main").
-			Commit("d.go", "Add feature D")
-
-		// Track with --force should find feature-c (most recent tracked ancestor)
-		shell.Run("track feature-d --force")
-
-		// Verify it found the correct parent
-		shell.Run("parent").
-			OutputContains("feature-c")
 	})
 
 	t.Run("track can recover entire corrupted stack", func(t *testing.T) {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Adds CreateIndependentStack2() to TestShell in helpers_test.go.
The pattern of creating main->branch-a->branch-b where each branch
touches a different file appeared verbatim 5 times across flatten_test.go.
Replaced with a single helper call each.

Collapses TestTrackIntegration/"track with force finds most recent
ancestor" and "track with force handles multiple potential ancestors"
into one table-driven test with two topology variants (linear stack
and diamond). Both end with the same assertion: track feature-d --force
finds feature-c as the most recent tracked ancestor.

<hr/>

<!-- STACKIT-SECTION-START -->
**Clean up integration test suite and add --json to merge status**

Reduces the integration test suite by ~2,000 lines through systematic cleanup, and adds a --json flag to `stackit merge status`.

Test cleanup (PRs #1095–#1105):
- **Remove dead tests**: Delete permanently-skipped, wrong-location, and duplicate tests
- **Move to unit layer**: Pluck/move PR-update tests relocated to action unit tests; integration tests for describe, scope, and modify deleted where unit tests already provide coverage
- **Strip unnecessary overhead**: Remove unneeded `WithRemote()` calls from tests that don't exercise remote operations
- **Consolidate into table-driven tests**: JSON output, lifecycle hooks, frozen state, merge subcommands, flatten, and worktree tests rewritten as compact table-driven tests
- **Extract shared helpers**: Worktree setup, sync squash-merge, flatten, and track helpers extracted to reduce duplication

Feature (PR #1107):
- **`--json` flag for `merge status`**: Machine-readable output for the merge status command

#### Stack


* **PR #1095**
  * **PR #1096**
    * **PR #1097**
      * **PR #1098**
        * **PR #1099**
          * **PR #1100**
            * **PR #1101**
              * **PR #1102**
                * **PR #1103**
                  * **PR #1104**
                    * **PR #1105** 👈
                      * **PR #1107**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1108 by jonnii*