### PR TITLE
feat: add --json flag to stackit merge status

### DIFF
--- a/internal/cli/stack/merge/status.go
+++ b/internal/cli/stack/merge/status.go
@@ -13,6 +13,7 @@ import (
 // This command displays the shippability status of stacks without entering the merge wizard.
 func NewStatusCmd() *cobra.Command {
 	var showAll bool
+	var jsonOutput bool
 
 	cmd := &cobra.Command{
 		Use:   "status",
@@ -22,8 +23,9 @@ func NewStatusCmd() *cobra.Command {
 By default, shows only your own stacks. Use --all to see the entire team's work.
 
 Examples:
-  stackit merge status        # Show your mergeable work
-  stackit merge status --all  # Show entire team's mergeable work`,
+  stackit merge status         # Show your mergeable work
+  stackit merge status --all   # Show entire team's mergeable work
+  stackit merge status --json  # Machine-readable JSON output`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
@@ -41,6 +43,10 @@ Examples:
 					}
 				}
 
+				if jsonOutput {
+					return PrintMergeStatusJSON(ctx.Output, analysisResult)
+				}
+
 				DisplayMergeStatus(ctx.Output, analysisResult)
 				return nil
 			})
@@ -48,6 +54,7 @@ Examples:
 	}
 
 	cmd.Flags().BoolVar(&showAll, "all", false, "Show all team members' stacks (default: your stacks only)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON for machine consumption")
 
 	return cmd
 }

--- a/internal/cli/stack/merge/status_json.go
+++ b/internal/cli/stack/merge/status_json.go
@@ -1,0 +1,80 @@
+package merge
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/shippable"
+)
+
+type statusJSONBlocking struct {
+	Branch   string                   `json:"branch"`
+	PRNumber int                      `json:"pr_number,omitempty"`
+	Reason   shippable.BlockingReason `json:"reason"`
+}
+
+type statusJSONStack struct {
+	RootBranch  string               `json:"root_branch"`
+	AllBranches []string             `json:"all_branches"`
+	PRCount     int                  `json:"pr_count"`
+	Scope       string               `json:"scope,omitempty"`
+	Status      shippable.Status     `json:"status"`
+	Author      string               `json:"author,omitempty"`
+	PRTitle     string               `json:"pr_title,omitempty"`
+	ApprovalOK  bool                 `json:"approval_ok"`
+	GitHubCIOK  bool                 `json:"github_ci_ok"`
+	LocalCIOK   *bool                `json:"local_ci_ok"`
+	BlockingPRs []statusJSONBlocking `json:"blocking_prs"`
+}
+
+type statusJSONResult struct {
+	Stacks          []statusJSONStack `json:"stacks"`
+	ShippableCount  int               `json:"shippable_count"`
+	PendingCount    int               `json:"pending_count"`
+	BlockedCount    int               `json:"blocked_count"`
+	IncompleteCount int               `json:"incomplete_count"`
+}
+
+// PrintMergeStatusJSON outputs the shippability analysis as JSON.
+func PrintMergeStatusJSON(out output.Output, result *shippable.AnalysisResult) error {
+	stacks := make([]statusJSONStack, len(result.Stacks))
+	for i, s := range result.Stacks {
+		blocking := make([]statusJSONBlocking, len(s.BlockingPRs))
+		for j, b := range s.BlockingPRs {
+			blocking[j] = statusJSONBlocking{
+				Branch:   b.Branch,
+				PRNumber: b.PRNumber,
+				Reason:   b.Reason,
+			}
+		}
+		stacks[i] = statusJSONStack{
+			RootBranch:  s.Stack.RootBranch,
+			AllBranches: s.Stack.AllBranches,
+			PRCount:     s.Stack.PRCount,
+			Scope:       s.Stack.Scope,
+			Status:      s.Status,
+			Author:      s.Author,
+			PRTitle:     s.PRTitle,
+			ApprovalOK:  s.ApprovalOK,
+			GitHubCIOK:  s.GitHubCIOK,
+			LocalCIOK:   s.LocalCIOK,
+			BlockingPRs: blocking,
+		}
+	}
+
+	view := statusJSONResult{
+		Stacks:          stacks,
+		ShippableCount:  result.ShippableCount,
+		PendingCount:    result.PendingCount,
+		BlockedCount:    result.BlockedCount,
+		IncompleteCount: result.IncompleteCount,
+	}
+
+	data, err := json.MarshalIndent(view, "", "  ")
+	if err != nil {
+		return fmt.Errorf("json marshal: %w", err)
+	}
+	out.Print(string(data) + "\n")
+	return nil
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Adds machine-readable JSON output to the merge status command so that
tooling (and the new stack-ship skill) can reliably parse stack
shippability data without scraping terminal-formatted text.

<hr/>

<!-- STACKIT-SECTION-START -->
**Clean up integration test suite and add --json to merge status**

Reduces the integration test suite by ~2,000 lines through systematic cleanup, and adds a --json flag to `stackit merge status`.

Test cleanup (PRs #1095–#1105):
- **Remove dead tests**: Delete permanently-skipped, wrong-location, and duplicate tests
- **Move to unit layer**: Pluck/move PR-update tests relocated to action unit tests; integration tests for describe, scope, and modify deleted where unit tests already provide coverage
- **Strip unnecessary overhead**: Remove unneeded `WithRemote()` calls from tests that don't exercise remote operations
- **Consolidate into table-driven tests**: JSON output, lifecycle hooks, frozen state, merge subcommands, flatten, and worktree tests rewritten as compact table-driven tests
- **Extract shared helpers**: Worktree setup, sync squash-merge, flatten, and track helpers extracted to reduce duplication

Feature (PR #1107):
- **`--json` flag for `merge status`**: Machine-readable output for the merge status command

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780197148`.


* **PR #1095**
  * **PR #1096**
    * **PR #1097**
      * **PR #1098**
        * **PR #1099**
          * **PR #1100**
            * **PR #1101**
              * **PR #1102**
                * **PR #1103**
                  * **PR #1104**
                    * **PR #1105**
                      * **PR #1107** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->