### PR TITLE
refactor(engine): drop Batch prefix from interface methods, remove UntrackBranch

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -207,8 +207,8 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[
 
 	// Single batch call to engine for deletion statuses
 	batchStart := time.Now()
-	statuses, err := eng.BatchGetDeletionStatuses(c, candidateNames)
-	ctx.Logger.Info("BatchGetDeletionStatuses completed durationMs=%d candidateCount=%d ok=%v",
+	statuses, err := eng.GetDeletionStatuses(c, candidateNames)
+	ctx.Logger.Info("GetDeletionStatuses completed durationMs=%d candidateCount=%d ok=%v",
 		time.Since(batchStart).Milliseconds(), len(candidateNames), err == nil)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get deletion statuses: %w", err)

--- a/internal/actions/delete/delete.go
+++ b/internal/actions/delete/delete.go
@@ -79,7 +79,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) (Result, error) {
 
 	// Precompute deletion statuses once (used for confirmation and divergence-preserving reparenting).
 	toDeleteNames := toDelete.Names()
-	statuses, err := eng.BatchGetDeletionStatuses(ctx.Context, toDeleteNames)
+	statuses, err := eng.GetDeletionStatuses(ctx.Context, toDeleteNames)
 	if err != nil {
 		return Result{}, fmt.Errorf("failed to check deletion statuses: %w", err)
 	}

--- a/internal/actions/describe/describe.go
+++ b/internal/actions/describe/describe.go
@@ -139,7 +139,7 @@ func markStackAndPushMetadata(ctx *app.Context, eng engine.Engine, stackRoot str
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
 	root := eng.GetBranch(stackRoot)
 	if root.IsTracked() {
-		if err := eng.BatchMarkNeedsPRBodyUpdate(ctx, graph.CollectBranches(root).Names()); err != nil {
+		if err := eng.MarkBranchesForPRBodyUpdate(ctx, graph.CollectBranches(root).Names()); err != nil {
 			out.Debug("Failed to mark branches for PR body update: %v", err)
 		}
 	}

--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -365,7 +365,7 @@ func restackAndMark(ctx *app.Context, plan *movePlan, sourceBranch engine.Branch
 	if plan.oldParentName != eng.Trunk().GetName() {
 		affectedBranches = append(affectedBranches, plan.oldParentName)
 	}
-	if err := eng.BatchMarkNeedsPRBodyUpdate(ctx, affectedBranches); err != nil {
+	if err := eng.MarkBranchesForPRBodyUpdate(ctx, affectedBranches); err != nil {
 		out.Debug("Failed to mark branches for PR body update: %v", err)
 	}
 

--- a/internal/actions/untrack/action.go
+++ b/internal/actions/untrack/action.go
@@ -55,7 +55,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	allNames = append(allNames, branchName)
 
 	// Delete all metadata refs in one batch and rebuild the engine once.
-	if err := eng.BatchUntrackBranches(ctx.Context, allNames); err != nil {
+	if err := eng.UntrackBranches(ctx.Context, allNames); err != nil {
 		return fmt.Errorf("failed to untrack branches: %w", err)
 	}
 

--- a/internal/cli/stack/sync.go
+++ b/internal/cli/stack/sync.go
@@ -139,7 +139,7 @@ func syncDryRunJSON(ctx *app.Context, opts sync.Options) error {
 
 	// Batch-check deletion status for all candidates
 	if len(candidateNames) > 0 {
-		statuses, err := eng.BatchGetDeletionStatuses(ctx.Context, candidateNames)
+		statuses, err := eng.GetDeletionStatuses(ctx.Context, candidateNames)
 		if err == nil {
 			for _, name := range candidateNames {
 				if status, ok := statuses[name]; ok && status.SafeToDelete {

--- a/internal/engine/branch_tracking.go
+++ b/internal/engine/branch_tracking.go
@@ -77,9 +77,9 @@ func (e *engineImpl) UntrackBranch(ctx context.Context, branchName string) error
 	return e.rebuild()
 }
 
-// BatchUntrackBranches untracks multiple branches with a single metadata deletion
+// UntrackBranches stops tracking multiple branches with a single metadata deletion
 // and a single engine rebuild, rather than one rebuild per branch.
-func (e *engineImpl) BatchUntrackBranches(ctx context.Context, branchNames []string) error {
+func (e *engineImpl) UntrackBranches(ctx context.Context, branchNames []string) error {
 	if len(branchNames) == 0 {
 		return nil
 	}
@@ -343,7 +343,7 @@ func (e *engineImpl) SetScope(ctx context.Context, branch Branch, scope Scope) e
 
 // SetScopeAndMarkForUpdate sets the scope and marks the branch as needing a PR
 // body update in a single atomic transaction, saving one git ref write compared
-// to calling SetScope + BatchMarkNeedsPRBodyUpdate separately.
+// to calling SetScope + MarkBranchesForPRBodyUpdate separately.
 func (e *engineImpl) SetScopeAndMarkForUpdate(ctx context.Context, branch Branch, scope Scope) error {
 	branchName := branch.GetName()
 

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -33,8 +33,8 @@ func (e *engineImpl) GetRevisionForName(branchName string) (string, error) {
 	return e.git.GetRevision(branchName)
 }
 
-// BatchGetRevisions returns the SHAs for multiple branches
-func (e *engineImpl) BatchGetRevisions(branchNames []string) (map[string]string, []error) {
+// GetRevisions returns the SHAs for multiple branches.
+func (e *engineImpl) GetRevisions(branchNames []string) (map[string]string, []error) {
 	return e.git.BatchGetRevisions(branchNames)
 }
 

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -324,9 +324,9 @@ func (e *engineImpl) IsBranchEmpty(ctx context.Context, branchName string) (bool
 }
 
 // GetDeletionStatus checks if a branch should be deleted.
-// Thin wrapper around BatchGetDeletionStatuses for a single branch.
+// Thin wrapper around GetDeletionStatuses for a single branch.
 func (e *engineImpl) GetDeletionStatus(ctx context.Context, branchName string) (DeletionStatus, error) {
-	statuses, err := e.BatchGetDeletionStatuses(ctx, []string{branchName})
+	statuses, err := e.GetDeletionStatuses(ctx, []string{branchName})
 	if err != nil {
 		return DeletionStatus{}, err
 	}
@@ -336,10 +336,10 @@ func (e *engineImpl) GetDeletionStatus(ctx context.Context, branchName string) (
 	return DeletionStatus{SafeToDelete: false, Reason: "", Kind: DeletionReasonNone}, nil
 }
 
-// BatchGetDeletionStatuses checks deletion status for multiple branches in a single batch.
+// GetDeletionStatuses checks deletion status for multiple branches in a single batch.
 // It batch-fetches metadata, revisions, and merged status, then evaluates the canonical
 // deletion policy for each branch.
-func (e *engineImpl) BatchGetDeletionStatuses(ctx context.Context, branchNames []string) (map[string]DeletionStatus, error) {
+func (e *engineImpl) GetDeletionStatuses(ctx context.Context, branchNames []string) (map[string]DeletionStatus, error) {
 	results := make(map[string]DeletionStatus, len(branchNames))
 	if len(branchNames) == 0 {
 		return results, nil

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -726,14 +726,14 @@ func TestGetDeletionStatus(t *testing.T) {
 	})
 }
 
-func TestBatchGetDeletionStatuses(t *testing.T) {
+func TestGetDeletionStatuses(t *testing.T) {
 	t.Parallel()
 
 	t.Run("empty list returns empty map", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
-		statuses, err := s.Engine.BatchGetDeletionStatuses(context.Background(), []string{})
+		statuses, err := s.Engine.GetDeletionStatuses(context.Background(), []string{})
 		require.NoError(t, err)
 		require.Empty(t, statuses)
 	})
@@ -753,7 +753,7 @@ func TestBatchGetDeletionStatuses(t *testing.T) {
 		err := s.Engine.Rebuild("main")
 		require.NoError(t, err)
 
-		statuses, err := s.Engine.BatchGetDeletionStatuses(context.Background(), []string{"main", "branch1", "branch2"})
+		statuses, err := s.Engine.GetDeletionStatuses(context.Background(), []string{"main", "branch1", "branch2"})
 		require.NoError(t, err)
 		require.Len(t, statuses, 3)
 
@@ -787,7 +787,7 @@ func TestBatchGetDeletionStatuses(t *testing.T) {
 		err = s.Engine.SetBranchType(branch, git.BranchTypeWorktreeAnchor)
 		require.NoError(t, err)
 
-		statuses, err := s.Engine.BatchGetDeletionStatuses(context.Background(), []string{"branch1"})
+		statuses, err := s.Engine.GetDeletionStatuses(context.Background(), []string{"branch1"})
 		require.NoError(t, err)
 		require.False(t, statuses["branch1"].SafeToDelete)
 	})

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -41,7 +41,7 @@ type BranchStatus interface {
 	IsMergedIntoTrunk(ctx context.Context, branchName string) (bool, error)
 	IsBranchEmpty(ctx context.Context, branchName string) (bool, error)
 	GetDeletionStatus(ctx context.Context, branchName string) (DeletionStatus, error)
-	BatchGetDeletionStatuses(ctx context.Context, branchNames []string) (map[string]DeletionStatus, error)
+	GetDeletionStatuses(ctx context.Context, branchNames []string) (map[string]DeletionStatus, error)
 	GetScope(branch Branch) Scope
 	GetStackDescription(branch Branch) *git.StackDescription
 	IsLocked(branch Branch) bool
@@ -69,7 +69,7 @@ type BranchInfo interface {
 	GetParentCommitSHA(commitSHA string) (string, error)
 	GetCommitSHA(branchName string, offset int) (string, error)
 	GetRevisionForName(branchName string) (string, error)
-	BatchGetRevisions(branchNames []string) (map[string]string, []error)
+	GetRevisions(branchNames []string) (map[string]string, []error)
 	GetCurrentRevision(ctx context.Context) (string, error)
 	GetRecentTrunkCommits(count int) ([]git.RecentCommit, error)
 	GetReflog(ctx context.Context, count int, format string) (string, error)
@@ -134,10 +134,9 @@ type BranchReader interface {
 // BranchTracking handles branch tracking operations
 type BranchTracking interface {
 	TrackBranch(ctx context.Context, branchName string, parentBranchName string) error
-	UntrackBranch(ctx context.Context, branchName string) error
-	// BatchUntrackBranches untracks multiple branches in a single operation,
-	// triggering only one engine rebuild instead of one per branch.
-	BatchUntrackBranches(ctx context.Context, branchNames []string) error
+	// UntrackBranches stops tracking multiple branches, deleting their metadata
+	// and triggering a single engine rebuild.
+	UntrackBranches(ctx context.Context, branchNames []string) error
 	SetParent(ctx context.Context, branch Branch, parentBranch Branch, mode DivergenceMode) error
 	// ReparentBranch changes a branch's parent while automatically preserving
 	// its divergence point. Preferred over SetParent for existing branches.
@@ -154,8 +153,9 @@ type BranchTracking interface {
 	SetLocked(ctx context.Context, branches Branches, reason LockReason) (BatchLockResult, error)
 	SetFrozen(ctx context.Context, branches Branches, frozen bool) (BatchFreezeResult, error)
 
-	// BatchMarkNeedsPRBodyUpdate marks multiple branches as needing PR body update in a single atomic operation
-	BatchMarkNeedsPRBodyUpdate(ctx context.Context, branchNames []string) error
+	// MarkBranchesForPRBodyUpdate marks multiple branches as needing a PR body
+	// update in a single atomic operation.
+	MarkBranchesForPRBodyUpdate(ctx context.Context, branchNames []string) error
 	// ClearNeedsPRBodyUpdate clears the PR body update flag for a branch
 	ClearNeedsPRBodyUpdate(branchName string) error
 	// GetBranchesNeedingPRBodyUpdate returns all branches that need PR body updates

--- a/internal/engine/pr_body_update_test.go
+++ b/internal/engine/pr_body_update_test.go
@@ -25,7 +25,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		require.Empty(t, needsUpdate)
 
 		// Mark branch as needing update
-		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature"})
+		err := eng.MarkBranchesForPRBodyUpdate(context.Background(), []string{"feature"})
 		require.NoError(t, err)
 
 		// Now it should be in the list
@@ -43,7 +43,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark and then clear
-		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature"})
+		err := eng.MarkBranchesForPRBodyUpdate(context.Background(), []string{"feature"})
 		require.NoError(t, err)
 
 		err = eng.ClearNeedsPRBodyUpdate("feature")
@@ -78,7 +78,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark branch
-		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature"})
+		err := eng.MarkBranchesForPRBodyUpdate(context.Background(), []string{"feature"})
 		require.NoError(t, err)
 
 		// Rebuild engine to simulate fresh state
@@ -104,7 +104,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark only feature-a
-		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature-a"})
+		err := eng.MarkBranchesForPRBodyUpdate(context.Background(), []string{"feature-a"})
 		require.NoError(t, err)
 
 		needsUpdate := eng.GetBranchesNeedingPRBodyUpdate()
@@ -112,7 +112,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		require.NotContains(t, needsUpdate, "feature-b")
 
 		// Mark feature-b too
-		err = eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature-b"})
+		err = eng.MarkBranchesForPRBodyUpdate(context.Background(), []string{"feature-b"})
 		require.NoError(t, err)
 
 		needsUpdate = eng.GetBranchesNeedingPRBodyUpdate()
@@ -142,7 +142,7 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 		eng := s.Engine
 
 		// Mark both at once
-		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{"feature-a", "feature-b"})
+		err := eng.MarkBranchesForPRBodyUpdate(context.Background(), []string{"feature-a", "feature-b"})
 		require.NoError(t, err)
 
 		needsUpdate := eng.GetBranchesNeedingPRBodyUpdate()
@@ -156,10 +156,10 @@ func TestPRBodyUpdateTracking(t *testing.T) {
 
 		eng := s.Engine
 
-		err := eng.BatchMarkNeedsPRBodyUpdate(context.Background(), []string{})
+		err := eng.MarkBranchesForPRBodyUpdate(context.Background(), []string{})
 		require.NoError(t, err)
 
-		err = eng.BatchMarkNeedsPRBodyUpdate(context.Background(), nil)
+		err = eng.MarkBranchesForPRBodyUpdate(context.Background(), nil)
 		require.NoError(t, err)
 	})
 }

--- a/internal/engine/pr_flags.go
+++ b/internal/engine/pr_flags.go
@@ -7,11 +7,11 @@ import (
 	"github.com/getstackit/stackit/internal/git"
 )
 
-// BatchMarkNeedsPRBodyUpdate marks multiple branches as needing PR body update in a single atomic operation.
-// It batch-reads local metadata, sets the flag, writes all the blobs in one
-// `git hash-object` call via WriteLocalMetadataBlobsBatch, and atomically
-// updates all refs.
-func (e *engineImpl) BatchMarkNeedsPRBodyUpdate(ctx context.Context, branchNames []string) error {
+// MarkBranchesForPRBodyUpdate marks multiple branches as needing a PR body update
+// in a single atomic operation. It batch-reads local metadata, sets the flag,
+// writes all the blobs in one `git hash-object` call via WriteLocalMetadataBlobsBatch,
+// and atomically updates all refs.
+func (e *engineImpl) MarkBranchesForPRBodyUpdate(ctx context.Context, branchNames []string) error {
 	if len(branchNames) == 0 {
 		return nil
 	}

--- a/internal/git/bench_test.go
+++ b/internal/git/bench_test.go
@@ -299,7 +299,7 @@ func BenchmarkCreateBlobs_Sequential(b *testing.B) {
 }
 
 // BenchmarkCreateBlobsBatch exercises the optimized batched path used by
-// BatchMarkNeedsPRBodyUpdate and transaction commits — temp-file staging
+// MarkBranchesForPRBodyUpdate and transaction commits — temp-file staging
 // plus a single `git hash-object -w --stdin-paths` invocation.
 func BenchmarkCreateBlobsBatch(b *testing.B) {
 	for _, n := range []int{1, 10, 50} {


### PR DESCRIPTION

Remove UntrackBranch from BranchTracking (UntrackBranches handles the
single-item case via its len==1 fast path). Rename the remaining Batch*
engine-interface methods to use plural nouns instead:

  BatchUntrackBranches      → UntrackBranches
  BatchMarkNeedsPRBodyUpdate → MarkBranchesForPRBodyUpdate
  BatchGetDeletionStatuses   → GetDeletionStatuses
  BatchGetRevisions          → GetRevisions (engine level only)

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1086**
  * **PR #1087**
    * **PR #1110** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->