### PR TITLE
perf: batch get fetches

### DIFF
--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -149,19 +149,8 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		Type:  GetEventStarted,
 	})
 
-	// Fetch target branch from origin
 	remote := eng.GetRemote()
-	if err := eng.Fetch(gctx, remote, targetBranch); err != nil {
-		return fmt.Errorf("failed to fetch branch %s from %s: %w", targetBranch, remote, err)
-	}
-
-	// Emit trunk status (main/master)
 	trunkName := eng.Trunk().GetName()
-	handler.EmitEvent(GetEvent{
-		Phase:  GetPhaseFetch,
-		Type:   GetEventCompleted,
-		Branch: trunkName,
-	})
 
 	// Identify branches to sync (ancestors + descendants)
 	branchesToSync := []string{targetBranch}
@@ -205,6 +194,34 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		}
 	}
 
+	branchesToFetch := make([]string, 0, len(branchesToSync))
+	seenFetchBranch := make(map[string]bool, len(branchesToSync))
+	for _, branchName := range branchesToSync {
+		if branchName == trunkName && branchName != targetBranch {
+			continue
+		}
+		if seenFetchBranch[branchName] {
+			continue
+		}
+		seenFetchBranch[branchName] = true
+		branchesToFetch = append(branchesToFetch, branchName)
+	}
+
+	if err := eng.FetchRemote(gctx, engine.RemoteFetchRequest{
+		Remote:          remote,
+		Branches:        branchesToFetch,
+		IncludeMetadata: true,
+	}); err != nil {
+		return fmt.Errorf("failed to fetch branches from %s: %w", remote, err)
+	}
+
+	// Emit trunk status (main/master)
+	handler.EmitEvent(GetEvent{
+		Phase:  GetPhaseFetch,
+		Type:   GetEventCompleted,
+		Branch: trunkName,
+	})
+
 	// Emit sync phase started
 	handler.EmitEvent(GetEvent{
 		Phase: GetPhaseSync,
@@ -245,9 +262,6 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		if branchName == eng.Trunk().GetName() {
 			continue
 		}
-
-		// Fetch if not already fetched
-		_ = eng.Fetch(gctx, remote, branchName)
 
 		branch := eng.GetBranch(branchName)
 		isNew := !branch.IsTracked()
@@ -312,23 +326,19 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	}
 
 	// Fetch and apply remote metadata for all branches in the stack
-	if err := eng.FetchRemoteMetadata(ctx.Context); err != nil {
-		out.Debug("No remote metadata to fetch: %v", err)
+	// Configure refspec so future git fetch commands also fetch metadata
+	if err := eng.ConfigureRemoteMetadataSync(ctx.Context); err != nil {
+		out.Debug("Failed to configure metadata refspec: %v", err)
+	}
+	if err := eng.LoadRemoteMetadataCache(); err != nil {
+		out.Debug("Failed to load remote metadata cache: %v", err)
 	} else {
-		// Configure refspec so future git fetch commands also fetch metadata
-		if err := eng.ConfigureRemoteMetadataSync(ctx.Context); err != nil {
-			out.Debug("Failed to configure metadata refspec: %v", err)
-		}
-		if err := eng.LoadRemoteMetadataCache(); err != nil {
-			out.Debug("Failed to load remote metadata cache: %v", err)
-		} else {
-			for _, branchName := range branchesToSync {
-				if branchName == eng.Trunk().GetName() {
-					continue
-				}
-				if err := eng.ApplyRemoteMetadataIfExists(branchName); err != nil {
-					out.Debug("Failed to apply metadata for %s: %v", branchName, err)
-				}
+		for _, branchName := range branchesToSync {
+			if branchName == eng.Trunk().GetName() {
+				continue
+			}
+			if err := eng.ApplyRemoteMetadataIfExists(branchName); err != nil {
+				out.Debug("Failed to apply metadata for %s: %v", branchName, err)
 			}
 		}
 	}

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -256,6 +256,10 @@ func (d *demoGitRunner) Fetch(_ context.Context, _, _ string) error {
 	return nil
 }
 
+func (d *demoGitRunner) FetchRefSpecs(_ context.Context, _ string, _ []string) error {
+	return nil
+}
+
 func (d *demoGitRunner) CreateBranch(_ context.Context, _, _ string) error {
 	return nil
 }

--- a/internal/engine/branch_mutations.go
+++ b/internal/engine/branch_mutations.go
@@ -45,7 +45,44 @@ func (e *engineImpl) MergeMultiple(ctx context.Context, branches []string, opts 
 
 // Fetch fetches from a remote
 func (e *engineImpl) Fetch(ctx context.Context, remote string, branch string) error {
-	return e.git.Fetch(ctx, remote, branch)
+	return e.FetchRemote(ctx, RemoteFetchRequest{
+		Remote:   remote,
+		Branches: []string{branch},
+	})
+}
+
+// FetchRemote fetches branches and Stackit metadata refs from a remote in a
+// single git fetch invocation.
+func (e *engineImpl) FetchRemote(ctx context.Context, req RemoteFetchRequest) error {
+	remote := req.Remote
+	if remote == "" {
+		remote = e.GetRemote()
+	}
+
+	refspecs := make([]string, 0, len(req.Branches)+2)
+	seen := make(map[string]bool, len(req.Branches)+2)
+	add := func(refspec string) {
+		if refspec == "" || seen[refspec] {
+			return
+		}
+		seen[refspec] = true
+		refspecs = append(refspecs, refspec)
+	}
+
+	for _, branch := range req.Branches {
+		if branch == "" {
+			continue
+		}
+		add(fmt.Sprintf("refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch))
+	}
+	if req.IncludeMetadata {
+		add("+refs/stackit/metadata/*:refs/stackit/remote-metadata/*")
+	}
+	if req.IncludeStackMetadata {
+		add("+refs/stackit/stacks/*:refs/stackit/remote-stacks/*")
+	}
+
+	return e.git.FetchRefSpecs(ctx, remote, refspecs)
 }
 
 // InteractiveRebase starts an interactive rebase

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -95,9 +95,9 @@ type RemoteMetadataManager interface {
 	// PushMetadataForBranches pushes the metadata refs for the given branch
 	// names to origin.
 	PushMetadataForBranches(ctx context.Context, branchNames []string) error
-	// ConfigureStackMetadataSync adds the stack-metadata refspec to origin.
+	// ConfigureStackMetadataSync adds the stack-metadata refspec to the configured remote.
 	ConfigureStackMetadataSync(ctx context.Context) error
-	// FetchStackMetadata fetches stack-metadata refs from origin.
+	// FetchStackMetadata fetches stack-metadata refs from the configured remote.
 	FetchStackMetadata(ctx context.Context) error
 	// ListStackMetadata returns a map of local stack IDs to their ref SHAs.
 	ListStackMetadata() (map[string]string, error)
@@ -108,6 +108,20 @@ type RemoteMetadataManager interface {
 	// GetStackIDsForBranches returns the unique stack IDs for the given branches.
 	// This is used to determine which stack refs need to be pushed to remote.
 	GetStackIDsForBranches(branches Branches) []string
+}
+
+// RemoteFetchRequest describes a single remote fetch that may update several
+// branch and Stackit metadata namespaces in one network round trip.
+type RemoteFetchRequest struct {
+	Remote               string
+	Branches             []string
+	IncludeMetadata      bool
+	IncludeStackMetadata bool
+}
+
+// RemoteFetcher provides batched remote fetch operations.
+type RemoteFetcher interface {
+	FetchRemote(ctx context.Context, req RemoteFetchRequest) error
 }
 
 // ApplySplitOptions contains options for applying a split
@@ -194,6 +208,7 @@ type Engine interface {
 	Absorber
 	UndoManager
 	RemoteMetadataManager
+	RemoteFetcher
 	WorktreeRegistry
 	Git() git.Runner
 

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -334,7 +334,8 @@ func (e *engineImpl) ensureLocalLoaded() {
 func (e *engineImpl) maybeAutoFetchRemoteMetadata() {
 	// Fast path: Check if refspec is already configured (most common case)
 	// This avoids expensive git config reads and network fetches for normal operations
-	refspecs, err := e.git.GetConfigAll("remote.origin.fetch")
+	remote := e.GetRemote()
+	refspecs, err := e.git.GetConfigAll(fmt.Sprintf("remote.%s.fetch", remote))
 	if err == nil {
 		metadataRefspec := "+refs/stackit/metadata/*:refs/stackit/remote-metadata/*"
 		if slices.Contains(refspecs, metadataRefspec) {
@@ -348,7 +349,10 @@ func (e *engineImpl) maybeAutoFetchRemoteMetadata() {
 	// Not configured yet - this might be a fresh clone
 	// Try to fetch metadata refs (this is a network operation, so it's slow)
 	// Only do this if refspec isn't configured to avoid slowing down every command
-	if err := e.git.FetchMetadataRefs(context.Background()); err != nil {
+	if err := e.FetchRemote(context.Background(), RemoteFetchRequest{
+		Remote:          remote,
+		IncludeMetadata: true,
+	}); err != nil {
 		// No remote metadata available, or error fetching - that's okay
 		return
 	}

--- a/internal/engine/metadata_transport.go
+++ b/internal/engine/metadata_transport.go
@@ -19,16 +19,16 @@ func (e *engineImpl) PushMetadataForBranches(ctx context.Context, branchNames []
 	return e.git.PushMetadataRefs(ctx, branchNames)
 }
 
-// ConfigureStackMetadataSync adds the stack-metadata refspec to origin so
-// subsequent `git fetch origin` invocations pick up stack-ref changes.
+// ConfigureStackMetadataSync adds the stack-metadata refspec to the configured
+// remote so subsequent git fetches pick up stack-ref changes.
 func (e *engineImpl) ConfigureStackMetadataSync(_ context.Context) error {
 	return e.git.EnsureStackMetaRefspecConfigured()
 }
 
-// FetchStackMetadata fetches stack-metadata refs from origin into the
+// FetchStackMetadata fetches stack-metadata refs into the
 // remote-stacks namespace.
 func (e *engineImpl) FetchStackMetadata(ctx context.Context) error {
-	return e.git.FetchStackMetaRefs(ctx)
+	return e.FetchRemote(ctx, RemoteFetchRequest{IncludeStackMetadata: true})
 }
 
 // ListStackMetadata returns a map of local stack IDs to their ref SHAs. Used

--- a/internal/engine/remote_sync.go
+++ b/internal/engine/remote_sync.go
@@ -472,14 +472,14 @@ func (e *engineImpl) DeleteMetadata(ctx context.Context, branchName string) erro
 	})
 }
 
-// FetchRemoteMetadata fetches metadata refs from origin into the remote-metadata
+// FetchRemoteMetadata fetches metadata refs into the remote-metadata
 // namespace, so the cache loader sees the latest authored values.
 func (e *engineImpl) FetchRemoteMetadata(ctx context.Context) error {
-	return e.git.FetchMetadataRefs(ctx)
+	return e.FetchRemote(ctx, RemoteFetchRequest{IncludeMetadata: true})
 }
 
-// ConfigureRemoteMetadataSync adds the metadata refspec to origin so subsequent
-// `git fetch origin` invocations pick up metadata changes automatically.
+// ConfigureRemoteMetadataSync adds the metadata refspec to the configured
+// remote so subsequent git fetches pick up metadata changes automatically.
 func (e *engineImpl) ConfigureRemoteMetadataSync(_ context.Context) error {
 	return e.git.EnsureMetadataRefspecConfigured()
 }

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -39,6 +39,7 @@ type RemoteOperations interface {
 	PushBranch(ctx context.Context, branchName, remote string, opts PushOptions) error
 	PullBranch(ctx context.Context, remote, branchName string) (PullResult, error)
 	Fetch(ctx context.Context, remote, branch string) error
+	FetchRefSpecs(ctx context.Context, remote string, refspecs []string) error
 	PushMetadataRefs(ctx context.Context, branches []string) error
 	FetchMetadataRefs(ctx context.Context) error
 	DeleteRemoteMetadataRef(ctx context.Context, branch string) error

--- a/internal/git/pull.go
+++ b/internal/git/pull.go
@@ -114,3 +114,7 @@ func (r *runner) Fetch(ctx context.Context, remote, branch string) error {
 	}
 	return nil
 }
+
+func (r *runner) FetchRefSpecs(ctx context.Context, remote string, refspecs []string) error {
+	return r.fetchRemoteRefSpecs(ctx, remote, refspecs)
+}

--- a/internal/git/remote_metadata_test.go
+++ b/internal/git/remote_metadata_test.go
@@ -87,3 +87,49 @@ func TestBatchDeleteRemoteMetadataRefs(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestFetchRefSpecsFetchesBranchAndMetadataFromCustomRemote(t *testing.T) {
+	scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+
+	_, err := scene.Repo.CreateBareRemote("upstream")
+	require.NoError(t, err)
+
+	err = scene.Repo.RunGitCommand("checkout", "-b", "feature")
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand("commit", "--allow-empty", "-m", "feature")
+	require.NoError(t, err)
+	err = scene.Repo.PushBranch("upstream", "feature")
+	require.NoError(t, err)
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	metadataRef := "refs/stackit/metadata/feature"
+	sha, err := runner.CreateBlob(`{"branch":"feature"}`)
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand("update-ref", metadataRef, sha)
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand("push", "upstream", metadataRef)
+	require.NoError(t, err)
+
+	err = scene.Repo.RunGitCommand("update-ref", "-d", "refs/remotes/upstream/feature")
+	require.NoError(t, err)
+
+	err = runner.FetchRefSpecs(context.Background(), "upstream", []string{
+		"refs/heads/feature:refs/remotes/upstream/feature",
+		"+refs/stackit/metadata/*:refs/stackit/remote-metadata/*",
+	})
+	require.NoError(t, err)
+
+	branchSHA, err := scene.Repo.RunGitCommandAndGetOutput("rev-parse", "--verify", "refs/remotes/upstream/feature")
+	require.NoError(t, err)
+	require.NotEmpty(t, branchSHA)
+
+	remoteMetadataSHA, err := scene.Repo.RunGitCommandAndGetOutput("rev-parse", "--verify", "refs/stackit/remote-metadata/feature")
+	require.NoError(t, err)
+	require.NotEmpty(t, remoteMetadataSHA)
+
+	err = runner.EnsureMetadataRefspecConfigured()
+	require.NoError(t, err)
+	upstreamRefspecs, err := runner.GetConfigAll("remote.upstream.fetch")
+	require.NoError(t, err)
+	require.Contains(t, upstreamRefspecs, "+refs/stackit/metadata/*:refs/stackit/remote-metadata/*")
+}

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -613,7 +613,8 @@ func (r *runner) GetUserName(ctx context.Context) (string, error) {
 func (r *runner) EnsureMetadataRefspecConfigured() error {
 	const metadataRefspec = "+refs/stackit/metadata/*:refs/stackit/remote-metadata/*"
 
-	refspecs, err := r.GetConfigAll("remote.origin.fetch")
+	fetchConfigKey := fmt.Sprintf("remote.%s.fetch", r.GetRemote())
+	refspecs, err := r.GetConfigAll(fetchConfigKey)
 	if err != nil {
 		return fmt.Errorf("failed to get fetch refspecs: %w", err)
 	}
@@ -624,13 +625,14 @@ func (r *runner) EnsureMetadataRefspecConfigured() error {
 	}
 
 	// Add refspec for metadata refs
-	return r.AddConfigValue("remote.origin.fetch", metadataRefspec)
+	return r.AddConfigValue(fetchConfigKey, metadataRefspec)
 }
 
 func (r *runner) EnsureStackMetaRefspecConfigured() error {
 	const stackMetaRefspec = "+refs/stackit/stacks/*:refs/stackit/remote-stacks/*"
 
-	refspecs, err := r.GetConfigAll("remote.origin.fetch")
+	fetchConfigKey := fmt.Sprintf("remote.%s.fetch", r.GetRemote())
+	refspecs, err := r.GetConfigAll(fetchConfigKey)
 	if err != nil {
 		return fmt.Errorf("failed to get fetch refspecs: %w", err)
 	}
@@ -641,7 +643,7 @@ func (r *runner) EnsureStackMetaRefspecConfigured() error {
 	}
 
 	// Add refspec for stack metadata refs
-	return r.AddConfigValue("remote.origin.fetch", stackMetaRefspec)
+	return r.AddConfigValue(fetchConfigKey, stackMetaRefspec)
 }
 
 func (r *runner) FindRemoteBranch(ctx context.Context, remote string) (string, error) {
@@ -1036,7 +1038,7 @@ func (r *runner) PushMetadataRefs(ctx context.Context, branches []string) error 
 }
 
 func (r *runner) FetchMetadataRefs(ctx context.Context) error {
-	return r.fetchRemoteRefSpecs(ctx, "origin", []string{
+	return r.fetchRemoteRefSpecs(ctx, r.GetRemote(), []string{
 		"+refs/stackit/metadata/*:refs/stackit/remote-metadata/*",
 	})
 }
@@ -1053,7 +1055,7 @@ func (r *runner) PushStackMetaRefs(ctx context.Context, stackIDs []string) error
 }
 
 func (r *runner) FetchStackMetaRefs(ctx context.Context) error {
-	return r.fetchRemoteRefSpecs(ctx, "origin", []string{
+	return r.fetchRemoteRefSpecs(ctx, r.GetRemote(), []string{
 		"+refs/stackit/stacks/*:refs/stackit/remote-stacks/*",
 	})
 }

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -190,6 +190,13 @@ func (t *tracingRunner) Fetch(ctx context.Context, remote, branch string) error 
 	return err
 }
 
+func (t *tracingRunner) FetchRefSpecs(ctx context.Context, remote string, refspecs []string) error {
+	start := time.Now()
+	err := t.inner.FetchRefSpecs(ctx, remote, refspecs)
+	t.trace("FetchRefSpecs", time.Since(start), err == nil, err, slog.String("remote", remote), slog.Int("count", len(refspecs)))
+	return err
+}
+
 func (t *tracingRunner) PushMetadataRefs(ctx context.Context, branches []string) error {
 	start := time.Now()
 	err := t.inner.PushMetadataRefs(ctx, branches)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Batch git fetches and eliminate redundant remote lookups**

A series of performance improvements that replace per-branch sequential git fetch calls with batched equivalents, eliminating N+1 git process overhead across get, sync, and branch status operations.

Key changes:
- **Batch get fetches**: `GetAction` collects all branches upfront and issues a single `FetchRemote` call, replacing individual `eng.Fetch` calls per branch in the sync loop.
- **Batch sync fetches**: `SyncAction` and trunk sync consolidate fetch calls into a single batched operation.
- **Avoid duplicate PR branch lookups**: Deduplicates PR branch resolution during get to prevent redundant lookups.
- **Selective branch metadata refresh**: New `ApplyRemoteMetadataForBranches` engine method encapsulates the three-step configure/load/apply sequence and skips trunk and empty branches, simplifying callers across several actions.
- **Replace remote SHA cache warming**: `GetBranchRemoteStatus` is refactored into `ReadBranchRemoteStatuses`, which fetches all remote SHAs in one `FetchRemoteShas` call and removes the per-branch cache-warming pattern from the engine.

#### Stack


* **PR #1113** 👈
  * **PR #1114**
    * **PR #1115**
      * **PR #1116**
        * **PR #1117**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1118 by jonnii*