### PR TITLE
perf: batch sync fetches

### DIFF
--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -88,7 +88,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	handler.Start(totalOps)
 
 	// Phase 1: Parallel network operations
-	// Run trunk pull, metadata fetch, and GitHub PR info sync concurrently
+	// Fetch trunk and metadata refs, and sync GitHub PR info concurrently.
 	handler.EmitEvent(Event{Phase: PhaseTrunk, Type: EventStarted})
 	handler.EmitEvent(Event{Phase: PhaseGitHub, Type: EventStarted})
 
@@ -103,30 +103,24 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	g, _ := errgroup.WithContext(gctx)
 
-	// Goroutine 1: Pull trunk
+	// Goroutine 1: Fetch trunk and Stackit metadata refs in one network round trip.
 	g.Go(func() error {
-		ctx.Logger.Info("goroutine trunk started delayMs=%v", time.Since(parallelStart).Milliseconds())
-		trunkErr = syncTrunk(ctx, &opts, handler, &trunkSummary)
-		return nil // Don't fail the group, handle error after Wait
-	})
-
-	// Goroutine 2: Fetch remote metadata refs (network operation only)
-	g.Go(func() error {
-		ctx.Logger.Info("goroutine metadata started delayMs=%v", time.Since(parallelStart).Milliseconds())
+		ctx.Logger.Info("goroutine remote fetch started delayMs=%v", time.Since(parallelStart).Milliseconds())
 		fetchStart := time.Now()
-		metadataFetchErr = ctx.RemoteMetadata().FetchRemoteMetadata(gctx)
-		ctx.Logger.Info("fetch remote metadata refs completed durationMs=%v", time.Since(fetchStart).Milliseconds())
-
-		// Also fetch stack metadata refs (stack-level descriptions, etc.)
-		stackFetchStart := time.Now()
-		if err := ctx.Engine.FetchStackMetadata(gctx); err != nil {
-			ctx.Logger.Debug("fetch stack metadata refs failed (non-fatal) error=%v", err)
+		metadataFetchErr = eng.FetchRemote(gctx, engine.RemoteFetchRequest{
+			Remote:               eng.GetRemote(),
+			Branches:             []string{eng.Trunk().GetName()},
+			IncludeMetadata:      true,
+			IncludeStackMetadata: true,
+		})
+		ctx.Logger.Info("fetch trunk and metadata refs completed durationMs=%v", time.Since(fetchStart).Milliseconds())
+		if metadataFetchErr != nil {
+			ctx.Logger.Debug("fetch trunk and metadata refs failed (non-fatal) error=%v", metadataFetchErr)
 		}
-		ctx.Logger.Info("fetch stack metadata refs completed durationMs=%v", time.Since(stackFetchStart).Milliseconds())
 		return nil
 	})
 
-	// Goroutine 3: Sync PR info from GitHub (network operation only)
+	// Goroutine 2: Sync PR info from GitHub (network operation only)
 	g.Go(func() error {
 		ctx.Logger.Info("goroutine github started delayMs=%v", time.Since(parallelStart).Milliseconds())
 		var err error
@@ -138,7 +132,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	_ = g.Wait()
 	ctx.Logger.Info("parallel phase completed durationMs=%v", time.Since(parallelStart).Milliseconds())
 
-	// Handle errors from parallel operations
+	trunkErr = syncFetchedTrunk(ctx, &opts, handler, &trunkSummary)
 	if trunkErr != nil {
 		return trunkErr
 	}

--- a/internal/actions/sync/trunk_sync.go
+++ b/internal/actions/sync/trunk_sync.go
@@ -8,21 +8,27 @@ import (
 	"github.com/getstackit/stackit/internal/engine"
 )
 
-// syncTrunk handles pulling the trunk and resolving any conflicts
-func syncTrunk(ctx *app.Context, opts *Options, handler Handler, summary *Summary) error {
+func syncFetchedTrunk(ctx *app.Context, opts *Options, handler Handler, summary *Summary) error {
+	eng := ctx.Sync()
+	gctx := ctx.Context
+
+	updateStart := time.Now()
+	pullResult, err := eng.UpdateTrunkFromRemote(gctx)
+	ctx.Logger.Info("update trunk from remote completed durationMs=%d", time.Since(updateStart).Milliseconds())
+	if err != nil {
+		return fmt.Errorf("failed to update trunk from remote: %w", err)
+	}
+
+	return handleTrunkPullResult(ctx, opts, handler, summary, pullResult)
+}
+
+func handleTrunkPullResult(ctx *app.Context, opts *Options, handler Handler, summary *Summary, pullResult engine.PullResult) error {
 	eng := ctx.Sync()
 	nav := ctx.Navigator()
 	out := ctx.Output
 	gctx := ctx.Context
 	trunk := nav.Trunk()
 	trunkName := trunk.GetName()
-
-	pullStart := time.Now()
-	pullResult, err := eng.PullTrunk(gctx)
-	ctx.Logger.Info("pull trunk completed durationMs=%d", time.Since(pullStart).Milliseconds())
-	if err != nil {
-		return fmt.Errorf("failed to pull trunk: %w", err)
-	}
 
 	switch pullResult {
 	case engine.PullDone:

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -208,6 +208,10 @@ func (d *demoGitRunner) PullBranch(_ context.Context, _, _ string) (git.PullResu
 	return git.PullDone, nil
 }
 
+func (d *demoGitRunner) UpdateBranchFromRemote(_ context.Context, _, _ string) (git.PullResult, error) {
+	return git.PullDone, nil
+}
+
 func (d *demoGitRunner) PushBranch(_ context.Context, _, _ string, _ git.PushOptions) error {
 	return nil
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -37,6 +37,7 @@ type PRManager interface {
 type SyncManager interface {
 	// Sync operations
 	PullTrunk(ctx context.Context) (PullResult, error)
+	UpdateTrunkFromRemote(ctx context.Context) (PullResult, error)
 	ResetTrunkToRemote(ctx context.Context) error
 	PlanRestack(ctx context.Context, branches Branches) (*RestackPlan, error)
 	RestackBranches(ctx context.Context, branches Branches) (RestackBatchResult, error)

--- a/internal/engine/pull.go
+++ b/internal/engine/pull.go
@@ -18,6 +18,26 @@ func (e *engineImpl) PullTrunk(ctx context.Context) (PullResult, error) {
 		return PullConflict, err
 	}
 
+	return e.finishTrunkPull(gitResult)
+}
+
+// UpdateTrunkFromRemote updates trunk from the already-fetched remote-tracking
+// branch. Callers that need to batch the network fetch with other refspecs can
+// use FetchRemote first, then call this local update step.
+func (e *engineImpl) UpdateTrunkFromRemote(ctx context.Context) (PullResult, error) {
+	remote := e.git.GetRemote()
+	e.mu.RLock()
+	trunk := e.trunk
+	e.mu.RUnlock()
+	gitResult, err := e.git.UpdateBranchFromRemote(ctx, remote, trunk)
+	if err != nil {
+		return PullConflict, err
+	}
+
+	return e.finishTrunkPull(gitResult)
+}
+
+func (e *engineImpl) finishTrunkPull(gitResult git.PullResult) (PullResult, error) {
 	// Convert git.PullResult to engine.PullResult
 	var result PullResult
 	switch gitResult {

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -38,6 +38,7 @@ type RemoteOperations interface {
 	FindRemoteBranch(ctx context.Context, remote string) (string, error)
 	PushBranch(ctx context.Context, branchName, remote string, opts PushOptions) error
 	PullBranch(ctx context.Context, remote, branchName string) (PullResult, error)
+	UpdateBranchFromRemote(ctx context.Context, remote, branchName string) (PullResult, error)
 	Fetch(ctx context.Context, remote, branch string) error
 	FetchRefSpecs(ctx context.Context, remote string, refspecs []string) error
 	PushMetadataRefs(ctx context.Context, branches []string) error

--- a/internal/git/pull.go
+++ b/internal/git/pull.go
@@ -18,24 +18,20 @@ const (
 )
 
 func (r *runner) PullBranch(ctx context.Context, remote, branchName string) (PullResult, error) {
-	// Save current branch/detached HEAD
-	currentBranch, err := r.GetCurrentBranch()
-	var currentRev string
-	if err != nil {
-		currentBranch = ""
-		currentRev, _ = r.GetCurrentRevision(ctx)
-	}
+	// Fetch with explicit refspec to update the remote-tracking branch.
+	// This ensures refs/remotes/<remote>/<branch> is actually updated.
+	refspec := fmt.Sprintf("refs/heads/%s:refs/remotes/%s/%s", branchName, remote, branchName)
+	_ = r.fetchRemoteRefSpecs(ctx, remote, []string{refspec})
 
+	return r.UpdateBranchFromRemote(ctx, remote, branchName)
+}
+
+func (r *runner) UpdateBranchFromRemote(ctx context.Context, remote, branchName string) (PullResult, error) {
 	// Get the SHA of the local branch
 	oldRev, err := r.GetRevision(branchName)
 	if err != nil {
 		return PullConflict, fmt.Errorf("failed to get local revision for %s: %w", branchName, err)
 	}
-
-	// Fetch with explicit refspec to update the remote-tracking branch.
-	// This ensures refs/remotes/origin/<branch> is actually updated.
-	refspec := fmt.Sprintf("refs/heads/%s:refs/remotes/%s/%s", branchName, remote, branchName)
-	_ = r.fetchRemoteRefSpecs(ctx, remote, []string{refspec})
 
 	// Get the SHA of the remote branch
 	remoteRev, err := r.GetRemoteSha(remote, branchName)
@@ -51,6 +47,14 @@ func (r *runner) PullBranch(ctx context.Context, remote, branchName string) (Pul
 	// Check if it's a fast-forward (remote is ahead of local)
 	isRemoteAhead, err := r.IsAncestor(ctx, oldRev, remoteRev)
 	if err == nil && isRemoteAhead {
+		// Save current branch/detached HEAD immediately before mutating refs.
+		currentBranch, err := r.GetCurrentBranch()
+		var currentRev string
+		if err != nil {
+			currentBranch = ""
+			currentRev, _ = r.GetCurrentRevision(ctx)
+		}
+
 		// Before updating the ref, check if this branch is checked out in another worktree.
 		// update-ref is global and will affect all worktrees, so we need to sync any
 		// worktree that has this branch checked out to avoid corrupting its index/working tree.

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -183,6 +183,13 @@ func (t *tracingRunner) PullBranch(ctx context.Context, remote, branchName strin
 	return result, err
 }
 
+func (t *tracingRunner) UpdateBranchFromRemote(ctx context.Context, remote, branchName string) (PullResult, error) {
+	start := time.Now()
+	result, err := t.inner.UpdateBranchFromRemote(ctx, remote, branchName)
+	t.trace("UpdateBranchFromRemote", time.Since(start), err == nil, err, slog.String("remote", remote), slog.String("branch", branchName))
+	return result, err
+}
+
 func (t *tracingRunner) Fetch(ctx context.Context, remote, branch string) error {
 	start := time.Now()
 	err := t.inner.Fetch(ctx, remote, branch)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Batch git fetches and eliminate redundant remote lookups**

A series of performance improvements that replace per-branch sequential git fetch calls with batched equivalents, eliminating N+1 git process overhead across get, sync, and branch status operations.

Key changes:
- **Batch get fetches**: `GetAction` collects all branches upfront and issues a single `FetchRemote` call, replacing individual `eng.Fetch` calls per branch in the sync loop.
- **Batch sync fetches**: `SyncAction` and trunk sync consolidate fetch calls into a single batched operation.
- **Avoid duplicate PR branch lookups**: Deduplicates PR branch resolution during get to prevent redundant lookups.
- **Selective branch metadata refresh**: New `ApplyRemoteMetadataForBranches` engine method encapsulates the three-step configure/load/apply sequence and skips trunk and empty branches, simplifying callers across several actions.
- **Replace remote SHA cache warming**: `GetBranchRemoteStatus` is refactored into `ReadBranchRemoteStatuses`, which fetches all remote SHAs in one `FetchRemoteShas` call and removes the per-branch cache-warming pattern from the engine.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780276457`.


* **PR #1113**
  * **PR #1114** 👈
    * **PR #1115**
      * **PR #1116**
        * **PR #1117**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->