### PR TITLE
fix: avoid duplicate PR branch lookups

### DIFF
--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -155,6 +155,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	// Identify branches to sync (ancestors + descendants)
 	branchesToSync := []string{targetBranch}
 	parentMap := make(map[string]string)
+	branchPRInfo := make(map[string]*int) // branch -> PR number
 
 	// Crawl ancestors using GitHub PR info if possible
 	if ctx.GitHub() != nil {
@@ -165,6 +166,8 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 			if err != nil || pr == nil {
 				break
 			}
+			prNum := pr.Number
+			branchPRInfo[current] = &prNum
 
 			base := pr.Base
 			if base == "" || base == eng.Trunk().GetName() {
@@ -230,7 +233,6 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 
 	// Track statistics for summary
 	var branchesCreated, branchesUpdated int
-	branchPRInfo := make(map[string]*int)       // branch -> PR number
 	branchFrozenStatus := make(map[string]bool) // branch -> is frozen
 
 	// Fetch PR info for branches in parallel if possible
@@ -241,6 +243,9 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		// Filter out trunk before parallel fetch
 		branchesToFetch := make([]string, 0, len(branchesToSync))
 		for _, branchName := range branchesToSync {
+			if _, ok := branchPRInfo[branchName]; ok {
+				continue
+			}
 			if branchName != trunkName {
 				branchesToFetch = append(branchesToFetch, branchName)
 			}

--- a/internal/actions/get_test.go
+++ b/internal/actions/get_test.go
@@ -1,15 +1,45 @@
 package actions_test
 
 import (
+	"context"
+	"sync"
 	"testing"
 
 	"github.com/google/go-github/v67/github"
 	"github.com/stretchr/testify/require"
 
 	"github.com/getstackit/stackit/internal/actions"
+	stackitgithub "github.com/getstackit/stackit/internal/github"
 	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
+
+type countingGitHubClient struct {
+	stackitgithub.Client
+	mu          sync.Mutex
+	branchCalls map[string]int
+}
+
+func newCountingGitHubClient(client stackitgithub.Client) *countingGitHubClient {
+	return &countingGitHubClient{
+		Client:      client,
+		branchCalls: make(map[string]int),
+	}
+}
+
+func (c *countingGitHubClient) GetPullRequestByBranch(ctx context.Context, owner, repo, branchName string) (*stackitgithub.PullRequestInfo, error) {
+	c.mu.Lock()
+	c.branchCalls[branchName]++
+	c.mu.Unlock()
+
+	return c.Client.GetPullRequestByBranch(ctx, owner, repo, branchName)
+}
+
+func (c *countingGitHubClient) branchCallCount(branchName string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.branchCalls[branchName]
+}
 
 func TestGetAction(t *testing.T) {
 	t.Run("resolves PR number and fetches branches", func(t *testing.T) {
@@ -68,7 +98,8 @@ func TestGetAction(t *testing.T) {
 		ghConfig.PRs["feature-b"] = prB
 		ghConfig.PRs["feature-a"] = prA
 		ghClient, owner, repo := testhelpers.NewMockGitHubClient(t, ghConfig)
-		s.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(ghClient, owner, repo, ghConfig)
+		countingClient := newCountingGitHubClient(testhelpers.NewMockGitHubClientInterface(ghClient, owner, repo, ghConfig))
+		s.Context.GitHubClient = countingClient
 
 		// Create a bare repository to act as the remote
 		remoteDir := t.TempDir()
@@ -93,6 +124,8 @@ func TestGetAction(t *testing.T) {
 		require.True(t, s.Engine.GetBranch("feature-b").IsTracked())
 		require.Equal(t, "main", s.Engine.GetBranch("feature-a").GetParent().GetName())
 		require.Equal(t, "feature-a", s.Engine.GetBranch("feature-b").GetParent().GetName())
+		require.Equal(t, 1, countingClient.branchCallCount("feature-a"))
+		require.Equal(t, 1, countingClient.branchCallCount("feature-b"))
 	})
 
 	t.Run("identifies and syncs local descendants", func(t *testing.T) {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Batch git fetches and eliminate redundant remote lookups**

A series of performance improvements that replace per-branch sequential git fetch calls with batched equivalents, eliminating N+1 git process overhead across get, sync, and branch status operations.

Key changes:
- **Batch get fetches**: `GetAction` collects all branches upfront and issues a single `FetchRemote` call, replacing individual `eng.Fetch` calls per branch in the sync loop.
- **Batch sync fetches**: `SyncAction` and trunk sync consolidate fetch calls into a single batched operation.
- **Avoid duplicate PR branch lookups**: Deduplicates PR branch resolution during get to prevent redundant lookups.
- **Selective branch metadata refresh**: New `ApplyRemoteMetadataForBranches` engine method encapsulates the three-step configure/load/apply sequence and skips trunk and empty branches, simplifying callers across several actions.
- **Replace remote SHA cache warming**: `GetBranchRemoteStatus` is refactored into `ReadBranchRemoteStatuses`, which fetches all remote SHAs in one `FetchRemoteShas` call and removes the per-branch cache-warming pattern from the engine.

#### Stack


* **PR #1113**
  * **PR #1114**
    * **PR #1115** 👈
      * **PR #1116**
        * **PR #1117**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1118 by jonnii*