### PR TITLE
perf: refresh get branches selectively

### DIFF
--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -330,33 +330,15 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		}
 	}
 
-	// Fetch and apply remote metadata for all branches in the stack
-	// Configure refspec so future git fetch commands also fetch metadata
-	if err := eng.ConfigureRemoteMetadataSync(ctx.Context); err != nil {
-		out.Debug("Failed to configure metadata refspec: %v", err)
-	}
-	if err := eng.LoadRemoteMetadataCache(); err != nil {
-		out.Debug("Failed to load remote metadata cache: %v", err)
-	} else {
-		for _, branchName := range branchesToSync {
-			if branchName == eng.Trunk().GetName() {
-				continue
-			}
-			if err := eng.ApplyRemoteMetadataIfExists(branchName); err != nil {
-				out.Debug("Failed to apply metadata for %s: %v", branchName, err)
-			}
-		}
+	// FetchRemote above already brought metadata refs local; apply any matching
+	// remote metadata to the branches we synced.
+	if err := eng.ApplyRemoteMetadataForBranches(ctx.Context, branchesToSync); err != nil {
+		out.Debug("Failed to apply remote metadata: %v", err)
 	}
 
 	// Checkout target branch
 	if err := eng.CheckoutBranch(gctx, eng.GetBranch(targetBranch)); err != nil {
 		return fmt.Errorf("failed to checkout target branch %s: %w", targetBranch, err)
-	}
-
-	// `get` may have created local branches via raw git fetch above; rebuild
-	// so engine's branch list includes those new branches before we proceed.
-	if err := eng.Rebuild(""); err != nil {
-		return fmt.Errorf("failed to refresh engine: %w", err)
 	}
 
 	// Restack if requested

--- a/internal/actions/info.go
+++ b/internal/actions/info.go
@@ -84,15 +84,8 @@ func InfoAction(ctx *app.Context, opts InfoOptions) error {
 		// For remote branches, fetch metadata to show the latest info
 		if err := eng.FetchRemoteMetadata(ctx.Context); err != nil {
 			out.Debug("Failed to fetch remote metadata: %v", err)
-		} else {
-			if err := eng.LoadRemoteMetadataCache(); err != nil {
-				out.Debug("Failed to load remote metadata cache: %v", err)
-			} else {
-				// Apply remote metadata if available
-				if err := eng.ApplyRemoteMetadataIfExists(branchName); err != nil {
-					out.Debug("Failed to apply remote metadata for %s: %v", branchName, err)
-				}
-			}
+		} else if err := eng.ApplyRemoteMetadataForBranches(ctx.Context, []string{branchName}); err != nil {
+			out.Debug("Failed to apply remote metadata for %s: %v", branchName, err)
 		}
 	}
 

--- a/internal/actions/metadata.go
+++ b/internal/actions/metadata.go
@@ -1,16 +1,16 @@
 package actions
 
 import (
+	"context"
+
 	"github.com/getstackit/stackit/internal/app"
-	"github.com/getstackit/stackit/internal/git"
 )
 
 // MetadataPushEngine defines the engine capabilities needed for pushing metadata.
 type MetadataPushEngine interface {
 	BatchSetLastModifiedBy(branchNames []string) error
-	IsRemoteSyncEnabled() bool
-	SetRemoteSyncEnabled(enabled bool)
-	Git() git.Runner
+	PrepareRemoteMetadataPush(ctx context.Context) error
+	PushMetadataForBranches(ctx context.Context, branchNames []string) error
 }
 
 // PushMetadataOnly pushes metadata refs without updating GitHub PRs.
@@ -23,21 +23,13 @@ func PushMetadataOnly(ctx *app.Context, eng MetadataPushEngine, branchNames []st
 		out.Debug("Failed to update metadata: %v", err)
 	}
 
-	// Check if remote sync is enabled; if not, run compatibility test first
-	if !eng.IsRemoteSyncEnabled() {
-		if err := eng.Git().TestRemoteRefCompatibility(ctx.Context); err != nil {
-			out.Debug("Remote metadata sync not supported: %v", err)
-			return nil // Non-fatal
-		}
-		eng.SetRemoteSyncEnabled(true)
-		// Configure refspec so future git fetch commands also fetch metadata
-		if err := eng.Git().EnsureMetadataRefspecConfigured(); err != nil {
-			out.Debug("Failed to configure metadata refspec: %v", err)
-		}
+	if err := eng.PrepareRemoteMetadataPush(ctx.Context); err != nil {
+		out.Debug("Remote metadata sync not supported: %v", err)
+		return nil // Non-fatal
 	}
 
 	// Push metadata refs
-	if err := eng.Git().PushMetadataRefs(ctx.Context, branchNames); err != nil {
+	if err := eng.PushMetadataForBranches(ctx.Context, branchNames); err != nil {
 		out.Debug("Failed to push metadata refs: %v", err)
 		return err
 	}

--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -89,8 +89,11 @@ func Action(ctx *app.Context, opts Options, h Handler) error {
 	if err := eng.ReparentBranch(gctx, plan.sourceBranch, plan.ontoBranch); err != nil {
 		return fmt.Errorf("failed to set parent: %w", err)
 	}
-
-	updateStackIDsAfterMove(ctx, plan, plan.source, plan.sourceBranch)
+	if eng.IsTrunk(plan.ontoBranch) {
+		if _, err := eng.AssignBranchesToNewStack(gctx, plan.sourceBranch, plan.descendants); err != nil {
+			ctx.Output.Warn("Failed to update stack IDs: %v", err)
+		}
+	}
 
 	if err := restackAndMark(ctx, plan, plan.sourceBranch); err != nil {
 		return err
@@ -300,42 +303,6 @@ func maybeRename(ctx *app.Context, h Handler, opts Options, plan *movePlan) (boo
 	}
 
 	return false, source, sourceBranch
-}
-
-func updateStackIDsAfterMove(ctx *app.Context, plan *movePlan, source string, sourceBranch engine.Branch) {
-	eng := ctx.Engine
-	out := ctx.Output
-
-	if plan.oldParentName == plan.onto {
-		return
-	}
-
-	oldStackID := eng.GetStackID(sourceBranch)
-	if oldStackID == "" {
-		return
-	}
-
-	newStackID := eng.GetStackID(plan.ontoBranch)
-
-	var targetStackID string
-	switch {
-	case eng.IsTrunk(plan.ontoBranch):
-		targetStackID = eng.GenerateStackID(source)
-		if err := eng.CreateStackRef(targetStackID, nil); err != nil {
-			out.Warn("Failed to create stack ref: %v", err)
-		}
-	case newStackID != "" && newStackID != oldStackID:
-		targetStackID = newStackID
-	}
-
-	if targetStackID == "" {
-		return
-	}
-
-	if err := eng.SetStackID(ctx.Context, plan.descendants, targetStackID); err != nil {
-		out.Warn("Failed to update stack IDs: %v", err)
-	}
-	out.Info("Stack membership updated for %s", source)
 }
 
 func restackAndMark(ctx *app.Context, plan *movePlan, sourceBranch engine.Branch) error {

--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -204,33 +204,10 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		handler.OnStep(StepMovingSource, basehandler.StatusFailed, err.Error())
 		return fmt.Errorf("failed to set parent: %w", err)
 	}
-
-	// Update stack ID based on the pluck destination:
-	// 1. Plucking to trunk creates a new independent stack with a fresh ID
-	// 2. Plucking to a branch in a different stack inherits that stack's ID
-	// 3. Plucking within the same stack keeps the existing ID (no update needed)
-	oldStackID := eng.GetStackID(sourceBranch)
-	newStackID := eng.GetStackID(ontoBranch)
-
-	var targetStackID string
-	switch {
-	case eng.IsTrunk(ontoBranch):
-		// Plucking to trunk creates a new stack
-		targetStackID = eng.GenerateStackID(source)
-		if err := eng.CreateStackRef(targetStackID, nil); err != nil {
-			out.Warn("Failed to create stack ref: %v", err)
-		}
-	case newStackID != "" && newStackID != oldStackID:
-		// Plucking to a different stack - inherit that stack's ID
-		targetStackID = newStackID
-	}
-
-	// Update stack ID if needed (pluck only moves the source, not descendants)
-	if targetStackID != "" {
-		if err := eng.SetStackID(gctx, engine.BranchesOf(sourceBranch), targetStackID); err != nil {
+	if eng.IsTrunk(ontoBranch) {
+		if _, err := eng.AssignBranchesToNewStack(gctx, sourceBranch, engine.BranchesOf(sourceBranch)); err != nil {
 			out.Warn("Failed to update stack ID for %s: %v", source, err)
 		}
-		out.Info("Stack membership updated for %s", source)
 	}
 
 	out.Info("Plucked %s from %s to %s.",

--- a/internal/actions/pr_updates.go
+++ b/internal/actions/pr_updates.go
@@ -220,17 +220,9 @@ func PushMetadataAndSyncPRs(ctx *app.Context, branchNames []string) error {
 		out.Debug("Failed to update metadata: %v", err)
 	}
 
-	// Check if remote sync is enabled; if not, run compatibility test first
-	if !eng.IsRemoteSyncEnabled() {
-		if err := eng.TestRemoteMetadataCompatibility(ctx.Context); err != nil {
-			out.Debug("Remote metadata sync not supported: %v", err)
-			return nil // Non-fatal
-		}
-		eng.SetRemoteSyncEnabled(true)
-		// Configure refspec so future git fetch commands also fetch metadata
-		if err := eng.ConfigureRemoteMetadataSync(ctx.Context); err != nil {
-			out.Debug("Failed to configure metadata refspec: %v", err)
-		}
+	if err := eng.PrepareRemoteMetadataPush(ctx.Context); err != nil {
+		out.Debug("Remote metadata sync not supported: %v", err)
+		return nil // Non-fatal
 	}
 
 	// Push metadata refs

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -633,16 +633,8 @@ func pushMetadataRefs(ctx *app.Context, branches engine.Branches) error {
 		return fmt.Errorf("failed to update metadata: %w", err)
 	}
 
-	// Check if remote sync is enabled; if not, run compatibility test first
-	if !rm.IsRemoteSyncEnabled() {
-		if err := rm.TestRemoteMetadataCompatibility(ctx.Context); err != nil {
-			return fmt.Errorf("remote does not support metadata refs (GitHub compatibility check failed): %w", err)
-		}
-		rm.SetRemoteSyncEnabled(true)
-		// Configure refspec so future git fetch commands also fetch metadata
-		if err := rm.ConfigureRemoteMetadataSync(ctx.Context); err != nil {
-			ctx.Output.Debug("Failed to configure metadata refspec: %v", err)
-		}
+	if err := rm.PrepareRemoteMetadataPush(ctx.Context); err != nil {
+		return fmt.Errorf("remote does not support metadata refs (GitHub compatibility check failed): %w", err)
 	}
 
 	// Push metadata refs

--- a/internal/engine/branch_mutations.go
+++ b/internal/engine/branch_mutations.go
@@ -11,7 +11,14 @@ import (
 
 // CreateBranch creates a new branch at the given start point
 func (e *engineImpl) CreateBranch(ctx context.Context, branchName string, startPoint string) error {
-	return e.git.CreateBranch(ctx, branchName, startPoint)
+	if err := e.git.CreateBranch(ctx, branchName, startPoint); err != nil {
+		return err
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.addKnownBranchLocked(branchName)
+	return nil
 }
 
 // ResetHard performs a hard reset to the given revision
@@ -345,12 +352,20 @@ func (e *engineImpl) CreateAndCheckoutBranch(ctx context.Context, branch Branch)
 	defer e.mu.Unlock()
 
 	e.currentBranch = branchName
-	// Add to branches list if not already there
-	if !slices.Contains(e.state.branches, branchName) {
-		e.state.setBranches(append(e.state.branches, branchName))
-	}
+	e.addKnownBranchLocked(branchName)
 
 	return nil
+}
+
+// addKnownBranchLocked records a branch ref that was created through the
+// engine. Callers must hold e.mu.
+func (e *engineImpl) addKnownBranchLocked(branchName string) {
+	if branchName == "" || slices.Contains(e.state.branches, branchName) {
+		return
+	}
+	branches := append(slices.Clone(e.state.branches), branchName)
+	slices.Sort(branches)
+	e.state.setBranches(branches)
 }
 
 // RenameBranch renames a branch and its metadata

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -78,6 +78,7 @@ type RemoteMetadataManager interface {
 	BatchSetLastModifiedBy(branchNames []string) error
 	LoadRemoteMetadataCache() error
 	ApplyRemoteMetadataIfExists(branchName string) error
+	ApplyRemoteMetadataForBranches(ctx context.Context, branchNames []string) error
 	GetRemoteMetadataCache() RemoteMetadataView
 	ComputeMetadataDiff(branch string) (*MetadataDiff, error)
 	ComputeAllMetadataDiffs() ([]*MetadataDiff, error)
@@ -93,6 +94,9 @@ type RemoteMetadataManager interface {
 	// accepts the metadata-ref namespace. Adapter code should call this instead
 	// of reaching to the git runner directly.
 	TestRemoteMetadataCompatibility(ctx context.Context) error
+	// PrepareRemoteMetadataPush verifies remote metadata refs are supported and
+	// enables local metadata sync state before pushing metadata refs.
+	PrepareRemoteMetadataPush(ctx context.Context) error
 	// PushMetadataForBranches pushes the metadata refs for the given branch
 	// names to origin.
 	PushMetadataForBranches(ctx context.Context, branchNames []string) error

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -588,6 +588,29 @@ func TestRebuild(t *testing.T) {
 	})
 }
 
+func TestCreateBranchUpdatesBranchInventory(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+	s.CreateBranchQuiet("branch3").
+		Commit("branch3 change").
+		CheckoutQuiet("main")
+
+	require.NoError(t, s.Engine.CreateBranch(context.Background(), "branch2", "main"))
+
+	allBranches := s.Engine.AllBranches()
+	branchNames := make([]string, len(allBranches))
+	for i, b := range allBranches {
+		branchNames[i] = b.GetName()
+	}
+	require.Contains(t, branchNames, "branch2")
+	require.NotContains(t, branchNames, "branch3")
+
+	require.False(t, s.Engine.GetBranch("branch2").IsTracked())
+	require.NoError(t, s.Engine.TrackBranch(context.Background(), "branch2", "main"))
+	require.Equal(t, "main", s.Engine.GetBranch("branch2").GetParentOrTrunk())
+}
+
 func TestIsBranchTracked(t *testing.T) {
 	t.Parallel()
 	t.Run("returns true for tracked branch", func(t *testing.T) {

--- a/internal/engine/engine_remote_metadata_test.go
+++ b/internal/engine/engine_remote_metadata_test.go
@@ -169,6 +169,28 @@ func TestRemoteMetadataSync(t *testing.T) {
 		require.Empty(t, diffs, "expected no diffs for non-existent local branches")
 	})
 
+	t.Run("applies remote metadata for requested branches", func(t *testing.T) {
+		t.Parallel()
+		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		eng := sh.Engine
+
+		sh.CreateBranch("feature-e").
+			CommitChange("file-e", "content-e").
+			TrackBranch("feature-e", "main")
+
+		remoteMeta := git.NewMetaFrom(git.MetaFields{
+			LockReason: git.LockReasonUser,
+			Scope:      new("remote-scope"),
+		})
+		createRemoteMetadataRef(t, sh, "feature-e", remoteMeta)
+
+		require.NoError(t, eng.ApplyRemoteMetadataForBranches(context.Background(), []string{"main", "feature-e", "feature-e"}))
+
+		branch := eng.GetBranch("feature-e")
+		require.True(t, eng.IsLocked(branch))
+		require.Equal(t, "remote-scope", eng.GetScope(branch).String())
+	})
+
 	t.Run("identifies orphaned metadata when local branch is gone", func(t *testing.T) {
 		t.Parallel()
 		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -181,6 +181,9 @@ type BranchTracking interface {
 	EnsureStackID(ctx context.Context, branch Branch) (string, error)
 	// SetStackID sets the stack ID on multiple branches atomically in a single transaction.
 	SetStackID(ctx context.Context, branches Branches, stackID string) error
+	// AssignBranchesToNewStack creates a new stack metadata ref and assigns its
+	// ID to the provided branches atomically.
+	AssignBranchesToNewStack(ctx context.Context, root Branch, branches Branches) (string, error)
 	// CreateStackRef creates a new stack ref with the given metadata.
 	CreateStackRef(stackID string, meta *git.StackMeta) error
 	// GetStackMeta returns the stack metadata for a stack ID.

--- a/internal/engine/metadata_transport.go
+++ b/internal/engine/metadata_transport.go
@@ -13,6 +13,22 @@ func (e *engineImpl) TestRemoteMetadataCompatibility(ctx context.Context) error 
 	return e.git.TestRemoteRefCompatibility(ctx)
 }
 
+// PrepareRemoteMetadataPush verifies that the remote accepts metadata refs and
+// records that support locally. Fetch-refspec setup is best-effort because
+// metadata pushes can still succeed when local fetch configuration cannot be
+// updated.
+func (e *engineImpl) PrepareRemoteMetadataPush(ctx context.Context) error {
+	if e.IsRemoteSyncEnabled() {
+		return nil
+	}
+	if err := e.TestRemoteMetadataCompatibility(ctx); err != nil {
+		return err
+	}
+	e.SetRemoteSyncEnabled(true)
+	_ = e.ConfigureRemoteMetadataSync(ctx)
+	return nil
+}
+
 // PushMetadataForBranches pushes metadata refs for the given branch names to
 // origin. A no-op when the list is empty.
 func (e *engineImpl) PushMetadataForBranches(ctx context.Context, branchNames []string) error {

--- a/internal/engine/remote_sync.go
+++ b/internal/engine/remote_sync.go
@@ -199,6 +199,40 @@ func (e *engineImpl) ApplyRemoteMetadataIfExists(branchName string) error {
 	return e.writeMetadata(branchName, local)
 }
 
+// ApplyRemoteMetadataForBranches applies the latest fetched remote metadata to
+// the requested local branches. It owns the cache/refspec setup so callers
+// don't need to sequence ConfigureRemoteMetadataSync, LoadRemoteMetadataCache,
+// and per-branch application themselves.
+func (e *engineImpl) ApplyRemoteMetadataForBranches(ctx context.Context, branchNames []string) error {
+	if len(branchNames) == 0 {
+		return nil
+	}
+
+	if err := e.ConfigureRemoteMetadataSync(ctx); err != nil {
+		return fmt.Errorf("configure metadata sync: %w", err)
+	}
+	if err := e.LoadRemoteMetadataCache(); err != nil {
+		return fmt.Errorf("load remote metadata cache: %w", err)
+	}
+
+	var firstErr error
+	seen := make(map[string]struct{}, len(branchNames))
+	trunkName := e.Trunk().GetName()
+	for _, branchName := range branchNames {
+		if branchName == "" || branchName == trunkName {
+			continue
+		}
+		if _, ok := seen[branchName]; ok {
+			continue
+		}
+		seen[branchName] = struct{}{}
+		if err := e.ApplyRemoteMetadataIfExists(branchName); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
 // GetRemoteMetadataCache returns a read-only view of the remote metadata cache.
 // Returns RemoteMetadataView instead of a raw map to prevent external mutation
 // and provide a stable snapshot even if the cache is reloaded concurrently.

--- a/internal/engine/stack_id.go
+++ b/internal/engine/stack_id.go
@@ -173,28 +173,15 @@ func (e *engineImpl) EnsureStackID(ctx context.Context, branch Branch) (string, 
 		return existingID, nil
 	}
 
-	// Need to create a new stack ID
-	// Find the stack root to generate the ID
+	// Need to create a new stack ID.
+	// Find the stack root to generate the ID.
 	rootName := e.GetStackRootForBranch(branch)
 	if rootName == "" {
 		return "", fmt.Errorf("cannot determine stack root for branch %s", branch.GetName())
 	}
 
-	// Generate new stack ID based on the root branch
 	stackID := e.GenerateStackID(rootName)
-
-	// Create the stack metadata ref
-	stackMeta := &git.StackMeta{
-		ID:        stackID,
-		CreatedAt: timeNow(),
-	}
-
-	// Try to get user name for CreatedBy
-	if userName, err := e.git.GetUserName(ctx); err == nil {
-		stackMeta.CreatedBy = userName
-	}
-
-	if err := e.git.WriteStackMeta(stackID, stackMeta); err != nil {
+	if err := e.writeNewStackMeta(ctx, stackID); err != nil {
 		return "", fmt.Errorf("failed to create stack ref: %w", err)
 	}
 
@@ -254,6 +241,36 @@ func (e *engineImpl) propagateStackID(ctx context.Context, branchName string, st
 	return e.batchSetStackID(ctx, e.collectSubtree(branchName), stackID)
 }
 
+func (e *engineImpl) writeNewStackMeta(ctx context.Context, stackID string) error {
+	stackMeta := &git.StackMeta{
+		ID:        stackID,
+		CreatedAt: timeNow(),
+	}
+	if userName, err := e.git.GetUserName(ctx); err == nil {
+		stackMeta.CreatedBy = userName
+	}
+	return e.git.WriteStackMeta(stackID, stackMeta)
+}
+
+// AssignBranchesToNewStack creates a new stack metadata ref and assigns its ID
+// to the provided branches. Use this for operations that intentionally extract
+// a branch or subtree into an independent stack; plain reparenting preserves
+// existing stack membership unless the new parent belongs to another stack.
+func (e *engineImpl) AssignBranchesToNewStack(ctx context.Context, root Branch, branches Branches) (string, error) {
+	if len(branches) == 0 {
+		return "", nil
+	}
+
+	stackID := e.GenerateStackID(root.GetName())
+	if err := e.writeNewStackMeta(ctx, stackID); err != nil {
+		return "", fmt.Errorf("failed to create stack ref: %w", err)
+	}
+	if err := e.SetStackID(ctx, branches, stackID); err != nil {
+		return "", fmt.Errorf("failed to assign stack ID: %w", err)
+	}
+	return stackID, nil
+}
+
 // SetStackID sets the stack ID on multiple branches atomically in a single transaction.
 func (e *engineImpl) SetStackID(ctx context.Context, branches Branches, stackID string) error {
 	names := make([]string, len(branches))
@@ -285,12 +302,11 @@ func (e *engineImpl) GetStackMeta(stackID string) (*git.StackMeta, error) {
 // exported because external callers should reparent via ReparentBranch instead
 // of poking the stack ID directly.
 //
-// Returns nil if the parent is trunk (keeps existing stack ID), the parent has
-// no stack ID (legacy branch), or the branch is already in sync.
+// Returns nil if the parent is trunk (keeps existing stack membership), the
+// parent has no stack ID (legacy branch), or the branch is already in sync.
 func (e *engineImpl) syncStackIDFromParent(ctx context.Context, branch Branch) error {
 	parent := branch.GetParent()
-	if parent == nil {
-		// Parent is trunk - keep existing stack ID
+	if parent == nil || e.IsTrunk(*parent) {
 		return nil
 	}
 

--- a/internal/engine/stack_id_test.go
+++ b/internal/engine/stack_id_test.go
@@ -238,6 +238,38 @@ func TestStackIDInheritance(t *testing.T) {
 		require.NotEmpty(t, id2)
 		require.NotEqual(t, id1, id2)
 	})
+
+	t.Run("assigning branches to a new stack creates a new stack ID", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit().
+			CreateBranch("root").
+			Commit("root commit").
+			TrackBranch("root", "main").
+			CreateBranch("child").
+			Commit("child commit").
+			TrackBranch("child", "root").
+			CreateBranch("grandchild").
+			Commit("grandchild commit").
+			TrackBranch("grandchild", "child")
+
+		root := s.Engine.GetBranch("root")
+		child := s.Engine.GetBranch("child")
+		rootID, err := s.Engine.EnsureStackID(context.Background(), root)
+		require.NoError(t, err)
+		require.Equal(t, rootID, s.Engine.GetStackID(child))
+
+		_, err = s.Engine.AssignBranchesToNewStack(context.Background(), child, engine.Branches{child, s.Engine.GetBranch("grandchild")})
+		require.NoError(t, err)
+
+		child = s.Engine.GetBranch("child")
+		grandchild := s.Engine.GetBranch("grandchild")
+		childID := s.Engine.GetStackID(child)
+		require.NotEmpty(t, childID)
+		require.NotEqual(t, rootID, childID)
+		require.Equal(t, childID, s.Engine.GetStackID(grandchild))
+		require.Equal(t, rootID, s.Engine.GetStackID(root))
+	})
 }
 
 func TestCreateStackRef(t *testing.T) {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Batch git fetches and eliminate redundant remote lookups**

A series of performance improvements that replace per-branch sequential git fetch calls with batched equivalents, eliminating N+1 git process overhead across get, sync, and branch status operations.

Key changes:
- **Batch get fetches**: `GetAction` collects all branches upfront and issues a single `FetchRemote` call, replacing individual `eng.Fetch` calls per branch in the sync loop.
- **Batch sync fetches**: `SyncAction` and trunk sync consolidate fetch calls into a single batched operation.
- **Avoid duplicate PR branch lookups**: Deduplicates PR branch resolution during get to prevent redundant lookups.
- **Selective branch metadata refresh**: New `ApplyRemoteMetadataForBranches` engine method encapsulates the three-step configure/load/apply sequence and skips trunk and empty branches, simplifying callers across several actions.
- **Replace remote SHA cache warming**: `GetBranchRemoteStatus` is refactored into `ReadBranchRemoteStatuses`, which fetches all remote SHAs in one `FetchRemoteShas` call and removes the per-branch cache-warming pattern from the engine.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780276457`.


* **PR #1113**
  * **PR #1114**
    * **PR #1115**
      * **PR #1116** 👈
        * **PR #1117**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->