### PR TITLE
refactor: replace remote SHA cache warming

### DIFF
--- a/internal/actions/checkout.go
+++ b/internal/actions/checkout.go
@@ -70,12 +70,6 @@ func CheckoutAction(ctx *app.Context, opts CheckoutOptions, handler CheckoutHand
 			return CheckoutResult{}, err
 		}
 	default:
-		// Only populate remote SHAs when entering interactive mode
-		// (the selector may need remote information for display)
-		if err := eng.PopulateRemoteShas(); err != nil {
-			return CheckoutResult{}, fmt.Errorf("failed to populate remote SHAs: %w", err)
-		}
-
 		branchName, err = handler.SelectBranch(ctx, opts)
 		if err != nil {
 			return CheckoutResult{}, err

--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -217,6 +217,7 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[
 	deleteStatuses := make(map[string]engine.DeletionStatus) // name -> status
 	utilityBranches := make(map[string]bool)                 // branches that are utility type
 	var skippedInWorktree []string
+	remoteStatuses := eng.ReadBranchRemoteStatuses(c, allTrackedBranches.WithoutTrunk())
 
 	for _, name := range candidateNames {
 		status := statuses[name]
@@ -233,8 +234,8 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[
 
 		// Check if local branch has unpushed changes relative to remote
 		branch := eng.GetBranch(name)
-		remoteStatus, err := eng.GetBranchRemoteStatus(branch)
-		if err == nil && (remoteStatus.Ahead() || remoteStatus.Diverged()) {
+		remoteStatus := remoteStatuses[name]
+		if remoteStatus.Ahead() || remoteStatus.Diverged() {
 			status.HasUnpushedChanges = true
 			ctx.Logger.Info("identifyBranchesToDelete branch has unpushed changes branch=%v ahead=%v diverged=%v", name, remoteStatus.Ahead(), remoteStatus.Diverged())
 		}

--- a/internal/actions/clean_branches_test.go
+++ b/internal/actions/clean_branches_test.go
@@ -221,10 +221,6 @@ func TestCleanBranches(t *testing.T) {
 		err = s.Engine.UpsertPrInfo(context.Background(), branch, prInfo)
 		require.NoError(t, err)
 
-		// Populate remote SHAs so GetBranchRemoteStatus works
-		err = s.Engine.PopulateRemoteShas()
-		require.NoError(t, err)
-
 		s.Checkout("main")
 
 		plan, err := actions.PlanBranchDeletions(s.Context, actions.CleanBranchesOptions{
@@ -255,10 +251,6 @@ func TestCleanBranches(t *testing.T) {
 		prInfo := testhelpers.NewTestPrInfoMerged(1, "main")
 		branch := s.Engine.GetBranch("branch1")
 		err = s.Engine.UpsertPrInfo(context.Background(), branch, prInfo)
-		require.NoError(t, err)
-
-		// Populate remote SHAs
-		err = s.Engine.PopulateRemoteShas()
 		require.NoError(t, err)
 
 		plan, err := actions.PlanBranchDeletions(s.Context, actions.CleanBranchesOptions{

--- a/internal/actions/lock/lock.go
+++ b/internal/actions/lock/lock.go
@@ -41,16 +41,15 @@ func Action(ctx *app.Context, branchName string, handler Handler) error {
 
 	// Check for unpushed commits
 	unpushedBranches := []string{}
-	if err := eng.PopulateRemoteShas(); err == nil {
-		for _, b := range branches {
-			if b.IsTrunk() {
-				continue
-			}
-			status, err := eng.GetBranchRemoteStatus(b)
-			if err == nil && !status.Matches() {
-				if status.Ahead() || status.MissingRemote() || status.Diverged() {
-					unpushedBranches = append(unpushedBranches, b.GetName())
-				}
+	remoteStatuses := eng.ReadBranchRemoteStatuses(ctx.Context, branches)
+	for _, b := range branches {
+		if b.IsTrunk() {
+			continue
+		}
+		status := remoteStatuses[b.GetName()]
+		if !status.Matches() {
+			if status.Ahead() || status.MissingRemote() || status.Diverged() {
+				unpushedBranches = append(unpushedBranches, b.GetName())
 			}
 		}
 	}

--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -105,13 +105,6 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 		return err
 	}
 
-	// Populate remote SHAs if needed (only for FULL mode)
-	if opts.Style == LogStyleFull {
-		if err := ctx.Engine.PopulateRemoteShas(); err != nil {
-			ctx.Output.Debug("Failed to populate remote SHAs: %v", err)
-		}
-	}
-
 	// Detect worktrees (builds both empty and stack-root maps in one call)
 	wtData := tui.GetWorktreeData(ctx.Engine)
 

--- a/internal/actions/merge/multistack_validation_test.go
+++ b/internal/actions/merge/multistack_validation_test.go
@@ -20,9 +20,6 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 		require.NoError(t, s.Scene.Repo.PushBranch("origin", "feature1"))
 		s.Rebuild()
 
-		// Populate remote SHAs so GetBranchRemoteStatus works
-		require.NoError(t, s.Engine.PopulateRemoteShas())
-
 		stacks := []MultiStackInfo{
 			{RootBranch: "feature1", AllBranches: []string{"feature1"}},
 		}
@@ -45,9 +42,6 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 		// Make a local change (branch now differs from remote)
 		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("local-only-change", "file2"))
 		s.Rebuild()
-
-		// Populate remote SHAs
-		require.NoError(t, s.Engine.PopulateRemoteShas())
 
 		stacks := []MultiStackInfo{
 			{RootBranch: "feature1", AllBranches: []string{"feature1"}},
@@ -86,9 +80,6 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("local-change-2", "file4"))
 		s.Rebuild()
 
-		// Populate remote SHAs
-		require.NoError(t, s.Engine.PopulateRemoteShas())
-
 		stacks := []MultiStackInfo{
 			{RootBranch: "feature1", AllBranches: []string{"feature1", "feature2"}},
 		}
@@ -116,9 +107,6 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("s2-content", "s2file"))
 		require.NoError(t, s.Scene.Repo.PushBranch("origin", "stack2-b1"))
 		s.Rebuild()
-
-		// Populate remote SHAs
-		require.NoError(t, s.Engine.PopulateRemoteShas())
 
 		stacks := []MultiStackInfo{
 			{RootBranch: "stack1-b1", AllBranches: []string{"stack1-b1"}},
@@ -152,9 +140,6 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("local-change", "s2file2"))
 		s.Rebuild()
 
-		// Populate remote SHAs
-		require.NoError(t, s.Engine.PopulateRemoteShas())
-
 		stacks := []MultiStackInfo{
 			{RootBranch: "stack1-b1", AllBranches: []string{"stack1-b1"}},
 			{RootBranch: "stack2-b1", AllBranches: []string{"stack2-b1"}},
@@ -174,9 +159,6 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 			TrackBranch("feature1", s.Engine.Trunk().GetName())
 		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("feature1-content", "file1"))
 		s.Rebuild()
-
-		// Populate remote SHAs
-		require.NoError(t, s.Engine.PopulateRemoteShas())
 
 		stacks := []MultiStackInfo{
 			{RootBranch: "feature1", AllBranches: []string{"feature1"}},

--- a/internal/actions/merge/wizard.go
+++ b/internal/actions/merge/wizard.go
@@ -30,11 +30,6 @@ func RunWizard(ctx *app.Context, handler InteractiveHandler, opts WizardOptions)
 
 	out.Debug("merge wizard: starting with opts=%+v", opts)
 
-	// Populate remote SHAs so we can accurately check if branches match remote
-	if err := eng.PopulateRemoteShas(); err != nil {
-		out.Debug("merge wizard: failed to populate remote SHAs: %v", err)
-	}
-
 	// Determine what to merge if not pre-selected
 	scope := opts.Scope
 	targetBranch := opts.TargetBranch

--- a/internal/actions/merge/worktree.go
+++ b/internal/actions/merge/worktree.go
@@ -55,11 +55,6 @@ func ExecuteInWorktree(ctx *app.Context, eng mergeExecuteEngine, opts ExecuteOpt
 	worktreeCtx.RepoRoot = worktreePath
 
 	// 4. Pre-flight operations in the worktree
-	// Populate remote SHAs so we can accurately check if branches match remote
-	if err := worktreeEng.PopulateRemoteShas(); err != nil {
-		out.Debug("Failed to populate remote SHAs in worktree: %v", err)
-	}
-
 	// Pull trunk in the worktree to ensure we have latest changes
 	pullResult, err := worktreeEng.PullTrunk(ctx.Context)
 	if err != nil {

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -115,7 +115,6 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	nav := ctx.Navigator()
-	pr := ctx.PR()
 	eng := ctx.Engine
 
 	// Determine target branch (explicit --branch flag or current branch)
@@ -174,11 +173,6 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	currentBranchName := ""
 	if currentBranch != nil {
 		currentBranchName = currentBranch.GetName()
-	}
-
-	// Populate remote SHAs early for accurate display
-	if err := pr.PopulateRemoteShas(); err != nil {
-		ctx.Output.Debug("Failed to populate remote SHAs: %v", err)
 	}
 
 	// Build tree structure for display

--- a/internal/actions/sync/branch_cleaning_test.go
+++ b/internal/actions/sync/branch_cleaning_test.go
@@ -82,8 +82,6 @@ func TestCleanBranchesInteractiveDoesNotAutoDeleteUnpushedUtilityBranch(t *testi
 	require.NoError(t, err)
 	err = s.Engine.UpsertPrInfo(context.Background(), s.Engine.GetBranch("util-branch"), testhelpers.NewTestPrInfoMerged(1, "main"))
 	require.NoError(t, err)
-	err = s.Engine.PopulateRemoteShas()
-	require.NoError(t, err)
 
 	s.Checkout("main")
 

--- a/internal/actions/sync/branch_sync.go
+++ b/internal/actions/sync/branch_sync.go
@@ -23,6 +23,7 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, handler H
 
 	// Get all tracked branches
 	allBranches := nav.AllBranches()
+	remoteStatuses := eng.ReadBranchRemoteStatuses(gctx, allBranches)
 
 	syncStart := time.Now()
 	var statusCheckTotalMs int64
@@ -68,13 +69,9 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, handler H
 
 		// Check if branch is behind remote
 		statusStart := time.Now()
-		status, err := eng.GetBranchRemoteStatus(branch)
+		status := remoteStatuses[branchName]
 		statusCheckTotalMs += time.Since(statusStart).Milliseconds()
 		statusCheckCount++
-		if err != nil {
-			// Can't determine status, skip
-			continue
-		}
 
 		// Skip if not behind remote
 		if !status.Behind() {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -24,7 +24,7 @@ import (
 type PRManager interface {
 	UpsertPrInfo(ctx context.Context, branch Branch, prInfo *PrInfo) error
 	GetBranchRemoteStatus(branch Branch) (BranchRemoteStatus, error)
-	PopulateRemoteShas() error
+	ReadBranchRemoteStatuses(ctx context.Context, branches Branches) map[string]BranchRemoteStatus
 	PushBranch(ctx context.Context, branch Branch, remote string, opts git.PushOptions) error
 	// Navigation comment ID caching (stored in local metadata)
 	GetNavigationCommentID(branch Branch) (int64, error)

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -240,53 +240,62 @@ func (e *engineImpl) ReadBranchStatuses(branches Branches) BranchStatuses {
 	return newBranchStatuses(results)
 }
 
-// GetBranchRemoteStatus returns the relationship between a local branch and its remote
+// GetBranchRemoteStatus returns the relationship between a local branch and its remote.
 func (e *engineImpl) GetBranchRemoteStatus(branch Branch) (BranchRemoteStatus, error) {
-	branchName := branch.GetName()
-	e.mu.RLock()
-	state := e.readState(branch.GetName())
-	var remoteSha string
-	if state != nil {
-		remoteSha = state.RemoteSHA
-	}
-	e.mu.RUnlock()
+	return e.ReadBranchRemoteStatuses(context.Background(), BranchesOf(branch))[branch.GetName()], nil
+}
 
-	localSha, err := e.git.GetRevision(branchName)
-	if err != nil {
-		localSha = "" // Branch doesn't exist locally
+// ReadBranchRemoteStatuses returns the local/remote relationship for the
+// requested branches. It lists remote branch SHAs once and does not mutate
+// engine state.
+func (e *engineImpl) ReadBranchRemoteStatuses(ctx context.Context, branches Branches) map[string]BranchRemoteStatus {
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
-	if remoteSha == "" {
-		// Fall back to local remote tracking branch
-		remoteSha, err = e.git.GetRemoteRevision(branchName)
-		if err != nil {
-			remoteSha = "" // No remote tracking branch
-		}
+	results := make(map[string]BranchRemoteStatus, len(branches))
+	if len(branches) == 0 {
+		return results
 	}
 
-	status := BranchRemoteStatus{
-		LocalSha:  localSha,
-		RemoteSha: remoteSha,
-	}
+	branchNames := branches.Names()
+	localShas, _ := e.git.BatchGetRevisions(branchNames)
 
-	if localSha == "" || remoteSha == "" {
-		return status, nil
-	}
-
-	if localSha == remoteSha {
-		status.CommonAncestor = localSha
-		return status, nil
-	}
-
-	// They differ, compute common ancestor to determine relation
 	remote := e.git.GetRemote()
-	remoteBranchRef := "refs/remotes/" + remote + "/" + branchName
-	commonAncestor, err := e.git.GetMergeBaseByRef(context.Background(), branchName, remoteBranchRef)
-	if err == nil {
-		status.CommonAncestor = commonAncestor
+	remoteShas, err := e.git.FetchRemoteShas(ctx, remote)
+	if err != nil {
+		remoteShas = map[string]string{}
 	}
 
-	return status, nil
+	for _, branch := range branches {
+		branchName := branch.GetName()
+		localSha := localShas[branchName]
+		remoteSha := remoteShas[branchName]
+		if remoteSha == "" {
+			if sha, err := e.git.GetRemoteRevision(branchName); err == nil {
+				remoteSha = sha
+			}
+		}
+
+		status := BranchRemoteStatus{
+			LocalSha:  localSha,
+			RemoteSha: remoteSha,
+		}
+
+		switch {
+		case localSha == "" || remoteSha == "":
+		case localSha == remoteSha:
+			status.CommonAncestor = localSha
+		default:
+			if commonAncestor, err := e.git.GetMergeBaseByRef(ctx, localSha, remoteSha); err == nil {
+				status.CommonAncestor = commonAncestor
+			}
+		}
+
+		results[branchName] = status
+	}
+
+	return results
 }
 
 // GetMergedBranches returns a map of branches merged into the target branch

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -413,30 +413,3 @@ func (e *engineImpl) Rebuild(newTrunkName string) error {
 
 	return e.rebuild()
 }
-
-// PopulateRemoteShas populates remote branch information by fetching SHAs from remote
-func (e *engineImpl) PopulateRemoteShas() error {
-	remote := e.git.GetRemote()
-	remoteShas, err := e.git.FetchRemoteShas(context.Background(), remote)
-
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	// Clear existing remote SHAs
-	for _, state := range e.state.branchState {
-		state.RemoteSHA = ""
-	}
-
-	if err != nil {
-		// Don't fail if we can't fetch remote SHAs (e.g., offline)
-		return nil
-	}
-
-	// Set RemoteSHA for tracked branches that have a remote
-	for branchName, sha := range remoteShas {
-		if state := e.readState(branchName); state != nil {
-			state.RemoteSHA = sha
-		}
-	}
-	return nil
-}

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -980,10 +980,6 @@ func TestGetBranchRemoteStatus(t *testing.T) {
 		require.NoError(t, err)
 		s.Checkout("main")
 
-		// Populate remote SHAs
-		err = s.Engine.PopulateRemoteShas()
-		require.NoError(t, err)
-
 		// Verify GetBranchRemoteStatus
 		status, err := s.Engine.GetBranchRemoteStatus(s.Engine.GetBranch("feature"))
 		require.NoError(t, err)
@@ -1015,10 +1011,6 @@ func TestGetBranchRemoteStatus(t *testing.T) {
 		s.Commit("local change").
 			Checkout("main")
 
-		// Populate remote SHAs
-		err = s.Engine.PopulateRemoteShas()
-		require.NoError(t, err)
-
 		// Verify GetBranchRemoteStatus
 		status, err := s.Engine.GetBranchRemoteStatus(s.Engine.GetBranch("feature"))
 		require.NoError(t, err)
@@ -1044,10 +1036,6 @@ func TestGetBranchRemoteStatus(t *testing.T) {
 		s.CreateBranch("feature").
 			Commit("feature change").
 			Checkout("main")
-
-		// Populate remote SHAs
-		err = s.Engine.PopulateRemoteShas()
-		require.NoError(t, err)
 
 		// Verify GetBranchRemoteStatus
 		status, err := s.Engine.GetBranchRemoteStatus(s.Engine.GetBranch("feature"))
@@ -1080,10 +1068,6 @@ func TestGetBranchRemoteStatus(t *testing.T) {
 
 		s.Checkout("main")
 
-		// Populate remote SHAs
-		err = s.Engine.PopulateRemoteShas()
-		require.NoError(t, err)
-
 		// Verify GetBranchRemoteStatus
 		status, err := s.Engine.GetBranchRemoteStatus(s.Engine.GetBranch("feature"))
 		require.NoError(t, err)
@@ -1094,9 +1078,9 @@ func TestGetBranchRemoteStatus(t *testing.T) {
 	})
 }
 
-func TestPopulateRemoteShas(t *testing.T) {
+func TestReadBranchRemoteStatuses(t *testing.T) {
 	t.Parallel()
-	t.Run("populates SHAs for all remote branches", func(t *testing.T) {
+	t.Run("reads statuses for all requested remote branches", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
@@ -1121,14 +1105,14 @@ func TestPopulateRemoteShas(t *testing.T) {
 		require.NoError(t, err)
 		s.Checkout("main")
 
-		// Populate remote SHAs
-		err = s.Engine.PopulateRemoteShas()
-		require.NoError(t, err)
-
-		// All branches should match remote
+		branches := engine.BranchesOf(
+			s.Engine.GetBranch("main"),
+			s.Engine.GetBranch("feature1"),
+			s.Engine.GetBranch("feature2"),
+		)
+		statuses := s.Engine.ReadBranchRemoteStatuses(context.Background(), branches)
 		for _, branchName := range []string{"main", "feature1", "feature2"} {
-			status, err := s.Engine.GetBranchRemoteStatus(s.Engine.GetBranch(branchName))
-			require.NoError(t, err)
+			status := statuses[branchName]
 			require.True(t, status.Matches(), "branch %s should match remote", branchName)
 		}
 	})
@@ -1139,10 +1123,6 @@ func TestPopulateRemoteShas(t *testing.T) {
 
 		// Create a bare remote but don't push anything
 		_, err := s.Scene.Repo.CreateBareRemote("origin")
-		require.NoError(t, err)
-
-		// Populate should not fail
-		err = s.Engine.PopulateRemoteShas()
 		require.NoError(t, err)
 
 		// Branches should not match (nothing on remote)

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -54,6 +54,7 @@ type BranchStatus interface {
 	GetRemoteURL(ctx context.Context) (string, error)
 	GetBranchRemoteDifference(branchName string) (string, error)
 	GetBranchRemoteStatus(branch Branch) (BranchRemoteStatus, error)
+	ReadBranchRemoteStatuses(ctx context.Context, branches Branches) map[string]BranchRemoteStatus
 	GetMergedBranches(ctx context.Context, target string) (map[string]bool, error)
 }
 

--- a/internal/engine/persistence_locked_test.go
+++ b/internal/engine/persistence_locked_test.go
@@ -33,14 +33,9 @@ func TestPrInfoLockedPersistence(t *testing.T) {
 	err = eng.UpsertPrInfo(context.Background(), branch, prInfo)
 	require.NoError(t, err)
 
-	// Simulate push by updating remote SHA
+	// Simulate push by updating the local remote-tracking ref.
 	localSha, _ := eng.GetRevision(branch)
-	// We need a way to set remote SHA. Since we're using a real git repo in the scenario,
-	// we should probably just use PopulateRemoteShas after a real push or mock it.
-	// For this test, let's just mock the behavior by setting the remote ref.
 	s.RunGit("update-ref", "refs/remotes/origin/feature", localSha)
-	err = eng.PopulateRemoteShas()
-	require.NoError(t, err)
 
 	// 3. Verify it's saved in the PR info
 	gotPrInfo, err := branch.GetPrInfo()

--- a/internal/engine/state_core.go
+++ b/internal/engine/state_core.go
@@ -15,7 +15,6 @@ type BranchState struct {
 	LockReason           git.LockReason // Lock reason (empty if not locked)
 	Frozen               bool           // Whether branch is frozen (local-only state)
 	BranchType           git.BranchType // Branch type (worktree-anchor, utility, etc.)
-	RemoteSHA            string         // Remote SHA (populated by PopulateRemoteShas)
 	LocalModified        bool           // Has local metadata changes not yet pushed
 }
 

--- a/internal/integration/sync_test.go
+++ b/internal/integration/sync_test.go
@@ -612,10 +612,6 @@ func TestSyncDoesNotLeaveIndexState(t *testing.T) {
 		// Go back to main for sync
 		sh.Checkout("main")
 
-		// Populate remote SHAs so GetBranchRemoteStatus can detect ahead
-		err = eng.PopulateRemoteShas()
-		require.NoError(t, err)
-
 		// Run sync (non-interactive - should skip unpushed branches)
 		err = sync.Action(sh.Context, sync.Options{}, nil)
 		require.NoError(t, err)

--- a/internal/tui/log_ui.go
+++ b/internal/tui/log_ui.go
@@ -238,7 +238,7 @@ func (m *LogModel) log(msg string, args ...any) {
 }
 
 // enrichData returns a command that fetches full annotation data in the background.
-// This includes git operations and network calls (remote SHAs, CI status).
+// This includes git operations and CI status network calls.
 func (m *LogModel) enrichData() tea.Cmd {
 	// Capture values needed by the goroutine to avoid races on struct fields
 	ctx := m.context
@@ -271,27 +271,6 @@ func (m *LogModel) enrichData() tea.Cmd {
 			err      error
 		}
 		ciChan := make(chan ciResult, 1)
-		remoteShasDone := make(chan struct{}, 1)
-
-		// Run PopulateRemoteShas and BatchGetPRChecksStatus in parallel
-		if style == logStyleFull {
-			go func() {
-				defer func() {
-					if p := recover(); p != nil {
-						logError("PopulateRemoteShas panicked: %v", p)
-					}
-					remoteShasDone <- struct{}{}
-				}()
-				start := time.Now()
-				if err := eng.PopulateRemoteShas(); err != nil {
-					logError("PopulateRemoteShas failed: %v", err)
-				}
-				logDebug("PopulateRemoteShas completed in %v", time.Since(start))
-			}()
-		} else {
-			remoteShasDone <- struct{}{}
-		}
-
 		if style == logStyleFull && ghClient != nil {
 			branchNames := engine.Branches(allBranches).Select(engine.BranchFilter{ExcludeTrunk: true, RequirePR: true}).Names()
 			if len(branchNames) > 0 {
@@ -318,8 +297,7 @@ func (m *LogModel) enrichData() tea.Cmd {
 			ciChan <- ciResult{}
 		}
 
-		// Wait for both operations to complete
-		<-remoteShasDone
+		// Wait for CI status fetch to complete
 		ciRes := <-ciChan
 		if ciRes.err != nil {
 			logError("CI status fetch failed, skipping CI annotations: %v", ciRes.err)

--- a/internal/worktree/executor.go
+++ b/internal/worktree/executor.go
@@ -105,10 +105,6 @@ func (e *Executor) CreateSession(ctx context.Context, opts CreateSessionOptions)
 
 // pullTrunk updates trunk in the worktree to match remote.
 func (s *Session) pullTrunk(ctx context.Context) error {
-	if err := s.Engine.PopulateRemoteShas(); err != nil {
-		s.output.Debug("Failed to populate remote SHAs in worktree: %v", err)
-	}
-
 	pullResult, err := s.Engine.PullTrunk(ctx)
 	if err != nil {
 		return errors.FailedTo("update", "trunk in worktree", err)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Batch git fetches and eliminate redundant remote lookups**

A series of performance improvements that replace per-branch sequential git fetch calls with batched equivalents, eliminating N+1 git process overhead across get, sync, and branch status operations.

Key changes:
- **Batch get fetches**: `GetAction` collects all branches upfront and issues a single `FetchRemote` call, replacing individual `eng.Fetch` calls per branch in the sync loop.
- **Batch sync fetches**: `SyncAction` and trunk sync consolidate fetch calls into a single batched operation.
- **Avoid duplicate PR branch lookups**: Deduplicates PR branch resolution during get to prevent redundant lookups.
- **Selective branch metadata refresh**: New `ApplyRemoteMetadataForBranches` engine method encapsulates the three-step configure/load/apply sequence and skips trunk and empty branches, simplifying callers across several actions.
- **Replace remote SHA cache warming**: `GetBranchRemoteStatus` is refactored into `ReadBranchRemoteStatuses`, which fetches all remote SHAs in one `FetchRemoteShas` call and removes the per-branch cache-warming pattern from the engine.

#### Stack


* **PR #1113**
  * **PR #1114**
    * **PR #1115**
      * **PR #1116**
        * **PR #1117** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1118 by jonnii*