### PR TITLE
Batch git fetches and eliminate redundant remote lookups

### DIFF
--- a/internal/actions/checkout.go
+++ b/internal/actions/checkout.go
@@ -70,12 +70,6 @@ func CheckoutAction(ctx *app.Context, opts CheckoutOptions, handler CheckoutHand
 			return CheckoutResult{}, err
 		}
 	default:
-		// Only populate remote SHAs when entering interactive mode
-		// (the selector may need remote information for display)
-		if err := eng.PopulateRemoteShas(); err != nil {
-			return CheckoutResult{}, fmt.Errorf("failed to populate remote SHAs: %w", err)
-		}
-
 		branchName, err = handler.SelectBranch(ctx, opts)
 		if err != nil {
 			return CheckoutResult{}, err

--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -217,6 +217,7 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[
 	deleteStatuses := make(map[string]engine.DeletionStatus) // name -> status
 	utilityBranches := make(map[string]bool)                 // branches that are utility type
 	var skippedInWorktree []string
+	remoteStatuses := eng.ReadBranchRemoteStatuses(c, allTrackedBranches.WithoutTrunk())
 
 	for _, name := range candidateNames {
 		status := statuses[name]
@@ -233,8 +234,8 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[
 
 		// Check if local branch has unpushed changes relative to remote
 		branch := eng.GetBranch(name)
-		remoteStatus, err := eng.GetBranchRemoteStatus(branch)
-		if err == nil && (remoteStatus.Ahead() || remoteStatus.Diverged()) {
+		remoteStatus := remoteStatuses[name]
+		if remoteStatus.Ahead() || remoteStatus.Diverged() {
 			status.HasUnpushedChanges = true
 			ctx.Logger.Info("identifyBranchesToDelete branch has unpushed changes branch=%v ahead=%v diverged=%v", name, remoteStatus.Ahead(), remoteStatus.Diverged())
 		}

--- a/internal/actions/clean_branches_test.go
+++ b/internal/actions/clean_branches_test.go
@@ -221,10 +221,6 @@ func TestCleanBranches(t *testing.T) {
 		err = s.Engine.UpsertPrInfo(context.Background(), branch, prInfo)
 		require.NoError(t, err)
 
-		// Populate remote SHAs so GetBranchRemoteStatus works
-		err = s.Engine.PopulateRemoteShas()
-		require.NoError(t, err)
-
 		s.Checkout("main")
 
 		plan, err := actions.PlanBranchDeletions(s.Context, actions.CleanBranchesOptions{
@@ -255,10 +251,6 @@ func TestCleanBranches(t *testing.T) {
 		prInfo := testhelpers.NewTestPrInfoMerged(1, "main")
 		branch := s.Engine.GetBranch("branch1")
 		err = s.Engine.UpsertPrInfo(context.Background(), branch, prInfo)
-		require.NoError(t, err)
-
-		// Populate remote SHAs
-		err = s.Engine.PopulateRemoteShas()
 		require.NoError(t, err)
 
 		plan, err := actions.PlanBranchDeletions(s.Context, actions.CleanBranchesOptions{

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -149,19 +149,8 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		Type:  GetEventStarted,
 	})
 
-	// Fetch target branch from origin
 	remote := eng.GetRemote()
-	if err := eng.Fetch(gctx, remote, targetBranch); err != nil {
-		return fmt.Errorf("failed to fetch branch %s from %s: %w", targetBranch, remote, err)
-	}
-
-	// Emit trunk status (main/master)
 	trunkName := eng.Trunk().GetName()
-	handler.EmitEvent(GetEvent{
-		Phase:  GetPhaseFetch,
-		Type:   GetEventCompleted,
-		Branch: trunkName,
-	})
 
 	// Identify branches to sync (ancestors + descendants)
 	branchesToSync := []string{targetBranch}
@@ -205,6 +194,34 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		}
 	}
 
+	branchesToFetch := make([]string, 0, len(branchesToSync))
+	seenFetchBranch := make(map[string]bool, len(branchesToSync))
+	for _, branchName := range branchesToSync {
+		if branchName == trunkName && branchName != targetBranch {
+			continue
+		}
+		if seenFetchBranch[branchName] {
+			continue
+		}
+		seenFetchBranch[branchName] = true
+		branchesToFetch = append(branchesToFetch, branchName)
+	}
+
+	if err := eng.FetchRemote(gctx, engine.RemoteFetchRequest{
+		Remote:          remote,
+		Branches:        branchesToFetch,
+		IncludeMetadata: true,
+	}); err != nil {
+		return fmt.Errorf("failed to fetch branches from %s: %w", remote, err)
+	}
+
+	// Emit trunk status (main/master)
+	handler.EmitEvent(GetEvent{
+		Phase:  GetPhaseFetch,
+		Type:   GetEventCompleted,
+		Branch: trunkName,
+	})
+
 	// Emit sync phase started
 	handler.EmitEvent(GetEvent{
 		Phase: GetPhaseSync,
@@ -245,9 +262,6 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		if branchName == eng.Trunk().GetName() {
 			continue
 		}
-
-		// Fetch if not already fetched
-		_ = eng.Fetch(gctx, remote, branchName)
 
 		branch := eng.GetBranch(branchName)
 		isNew := !branch.IsTracked()
@@ -312,23 +326,19 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	}
 
 	// Fetch and apply remote metadata for all branches in the stack
-	if err := eng.FetchRemoteMetadata(ctx.Context); err != nil {
-		out.Debug("No remote metadata to fetch: %v", err)
+	// Configure refspec so future git fetch commands also fetch metadata
+	if err := eng.ConfigureRemoteMetadataSync(ctx.Context); err != nil {
+		out.Debug("Failed to configure metadata refspec: %v", err)
+	}
+	if err := eng.LoadRemoteMetadataCache(); err != nil {
+		out.Debug("Failed to load remote metadata cache: %v", err)
 	} else {
-		// Configure refspec so future git fetch commands also fetch metadata
-		if err := eng.ConfigureRemoteMetadataSync(ctx.Context); err != nil {
-			out.Debug("Failed to configure metadata refspec: %v", err)
-		}
-		if err := eng.LoadRemoteMetadataCache(); err != nil {
-			out.Debug("Failed to load remote metadata cache: %v", err)
-		} else {
-			for _, branchName := range branchesToSync {
-				if branchName == eng.Trunk().GetName() {
-					continue
-				}
-				if err := eng.ApplyRemoteMetadataIfExists(branchName); err != nil {
-					out.Debug("Failed to apply metadata for %s: %v", branchName, err)
-				}
+		for _, branchName := range branchesToSync {
+			if branchName == eng.Trunk().GetName() {
+				continue
+			}
+			if err := eng.ApplyRemoteMetadataIfExists(branchName); err != nil {
+				out.Debug("Failed to apply metadata for %s: %v", branchName, err)
 			}
 		}
 	}

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -330,33 +330,15 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		}
 	}
 
-	// Fetch and apply remote metadata for all branches in the stack
-	// Configure refspec so future git fetch commands also fetch metadata
-	if err := eng.ConfigureRemoteMetadataSync(ctx.Context); err != nil {
-		out.Debug("Failed to configure metadata refspec: %v", err)
-	}
-	if err := eng.LoadRemoteMetadataCache(); err != nil {
-		out.Debug("Failed to load remote metadata cache: %v", err)
-	} else {
-		for _, branchName := range branchesToSync {
-			if branchName == eng.Trunk().GetName() {
-				continue
-			}
-			if err := eng.ApplyRemoteMetadataIfExists(branchName); err != nil {
-				out.Debug("Failed to apply metadata for %s: %v", branchName, err)
-			}
-		}
+	// FetchRemote above already brought metadata refs local; apply any matching
+	// remote metadata to the branches we synced.
+	if err := eng.ApplyRemoteMetadataForBranches(ctx.Context, branchesToSync); err != nil {
+		out.Debug("Failed to apply remote metadata: %v", err)
 	}
 
 	// Checkout target branch
 	if err := eng.CheckoutBranch(gctx, eng.GetBranch(targetBranch)); err != nil {
 		return fmt.Errorf("failed to checkout target branch %s: %w", targetBranch, err)
-	}
-
-	// `get` may have created local branches via raw git fetch above; rebuild
-	// so engine's branch list includes those new branches before we proceed.
-	if err := eng.Rebuild(""); err != nil {
-		return fmt.Errorf("failed to refresh engine: %w", err)
 	}
 
 	// Restack if requested

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -155,6 +155,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	// Identify branches to sync (ancestors + descendants)
 	branchesToSync := []string{targetBranch}
 	parentMap := make(map[string]string)
+	branchPRInfo := make(map[string]*int) // branch -> PR number
 
 	// Crawl ancestors using GitHub PR info if possible
 	if ctx.GitHub() != nil {
@@ -165,6 +166,8 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 			if err != nil || pr == nil {
 				break
 			}
+			prNum := pr.Number
+			branchPRInfo[current] = &prNum
 
 			base := pr.Base
 			if base == "" || base == eng.Trunk().GetName() {
@@ -230,7 +233,6 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 
 	// Track statistics for summary
 	var branchesCreated, branchesUpdated int
-	branchPRInfo := make(map[string]*int)       // branch -> PR number
 	branchFrozenStatus := make(map[string]bool) // branch -> is frozen
 
 	// Fetch PR info for branches in parallel if possible
@@ -241,6 +243,9 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		// Filter out trunk before parallel fetch
 		branchesToFetch := make([]string, 0, len(branchesToSync))
 		for _, branchName := range branchesToSync {
+			if _, ok := branchPRInfo[branchName]; ok {
+				continue
+			}
 			if branchName != trunkName {
 				branchesToFetch = append(branchesToFetch, branchName)
 			}

--- a/internal/actions/get_test.go
+++ b/internal/actions/get_test.go
@@ -1,15 +1,45 @@
 package actions_test
 
 import (
+	"context"
+	"sync"
 	"testing"
 
 	"github.com/google/go-github/v67/github"
 	"github.com/stretchr/testify/require"
 
 	"github.com/getstackit/stackit/internal/actions"
+	stackitgithub "github.com/getstackit/stackit/internal/github"
 	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
+
+type countingGitHubClient struct {
+	stackitgithub.Client
+	mu          sync.Mutex
+	branchCalls map[string]int
+}
+
+func newCountingGitHubClient(client stackitgithub.Client) *countingGitHubClient {
+	return &countingGitHubClient{
+		Client:      client,
+		branchCalls: make(map[string]int),
+	}
+}
+
+func (c *countingGitHubClient) GetPullRequestByBranch(ctx context.Context, owner, repo, branchName string) (*stackitgithub.PullRequestInfo, error) {
+	c.mu.Lock()
+	c.branchCalls[branchName]++
+	c.mu.Unlock()
+
+	return c.Client.GetPullRequestByBranch(ctx, owner, repo, branchName)
+}
+
+func (c *countingGitHubClient) branchCallCount(branchName string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.branchCalls[branchName]
+}
 
 func TestGetAction(t *testing.T) {
 	t.Run("resolves PR number and fetches branches", func(t *testing.T) {
@@ -68,7 +98,8 @@ func TestGetAction(t *testing.T) {
 		ghConfig.PRs["feature-b"] = prB
 		ghConfig.PRs["feature-a"] = prA
 		ghClient, owner, repo := testhelpers.NewMockGitHubClient(t, ghConfig)
-		s.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(ghClient, owner, repo, ghConfig)
+		countingClient := newCountingGitHubClient(testhelpers.NewMockGitHubClientInterface(ghClient, owner, repo, ghConfig))
+		s.Context.GitHubClient = countingClient
 
 		// Create a bare repository to act as the remote
 		remoteDir := t.TempDir()
@@ -93,6 +124,8 @@ func TestGetAction(t *testing.T) {
 		require.True(t, s.Engine.GetBranch("feature-b").IsTracked())
 		require.Equal(t, "main", s.Engine.GetBranch("feature-a").GetParent().GetName())
 		require.Equal(t, "feature-a", s.Engine.GetBranch("feature-b").GetParent().GetName())
+		require.Equal(t, 1, countingClient.branchCallCount("feature-a"))
+		require.Equal(t, 1, countingClient.branchCallCount("feature-b"))
 	})
 
 	t.Run("identifies and syncs local descendants", func(t *testing.T) {

--- a/internal/actions/info.go
+++ b/internal/actions/info.go
@@ -84,15 +84,8 @@ func InfoAction(ctx *app.Context, opts InfoOptions) error {
 		// For remote branches, fetch metadata to show the latest info
 		if err := eng.FetchRemoteMetadata(ctx.Context); err != nil {
 			out.Debug("Failed to fetch remote metadata: %v", err)
-		} else {
-			if err := eng.LoadRemoteMetadataCache(); err != nil {
-				out.Debug("Failed to load remote metadata cache: %v", err)
-			} else {
-				// Apply remote metadata if available
-				if err := eng.ApplyRemoteMetadataIfExists(branchName); err != nil {
-					out.Debug("Failed to apply remote metadata for %s: %v", branchName, err)
-				}
-			}
+		} else if err := eng.ApplyRemoteMetadataForBranches(ctx.Context, []string{branchName}); err != nil {
+			out.Debug("Failed to apply remote metadata for %s: %v", branchName, err)
 		}
 	}
 

--- a/internal/actions/lock/lock.go
+++ b/internal/actions/lock/lock.go
@@ -41,16 +41,15 @@ func Action(ctx *app.Context, branchName string, handler Handler) error {
 
 	// Check for unpushed commits
 	unpushedBranches := []string{}
-	if err := eng.PopulateRemoteShas(); err == nil {
-		for _, b := range branches {
-			if b.IsTrunk() {
-				continue
-			}
-			status, err := eng.GetBranchRemoteStatus(b)
-			if err == nil && !status.Matches() {
-				if status.Ahead() || status.MissingRemote() || status.Diverged() {
-					unpushedBranches = append(unpushedBranches, b.GetName())
-				}
+	remoteStatuses := eng.ReadBranchRemoteStatuses(ctx.Context, branches)
+	for _, b := range branches {
+		if b.IsTrunk() {
+			continue
+		}
+		status := remoteStatuses[b.GetName()]
+		if !status.Matches() {
+			if status.Ahead() || status.MissingRemote() || status.Diverged() {
+				unpushedBranches = append(unpushedBranches, b.GetName())
 			}
 		}
 	}

--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -105,13 +105,6 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 		return err
 	}
 
-	// Populate remote SHAs if needed (only for FULL mode)
-	if opts.Style == LogStyleFull {
-		if err := ctx.Engine.PopulateRemoteShas(); err != nil {
-			ctx.Output.Debug("Failed to populate remote SHAs: %v", err)
-		}
-	}
-
 	// Detect worktrees (builds both empty and stack-root maps in one call)
 	wtData := tui.GetWorktreeData(ctx.Engine)
 

--- a/internal/actions/merge/multistack_validation_test.go
+++ b/internal/actions/merge/multistack_validation_test.go
@@ -20,9 +20,6 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 		require.NoError(t, s.Scene.Repo.PushBranch("origin", "feature1"))
 		s.Rebuild()
 
-		// Populate remote SHAs so GetBranchRemoteStatus works
-		require.NoError(t, s.Engine.PopulateRemoteShas())
-
 		stacks := []MultiStackInfo{
 			{RootBranch: "feature1", AllBranches: []string{"feature1"}},
 		}
@@ -45,9 +42,6 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 		// Make a local change (branch now differs from remote)
 		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("local-only-change", "file2"))
 		s.Rebuild()
-
-		// Populate remote SHAs
-		require.NoError(t, s.Engine.PopulateRemoteShas())
 
 		stacks := []MultiStackInfo{
 			{RootBranch: "feature1", AllBranches: []string{"feature1"}},
@@ -86,9 +80,6 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("local-change-2", "file4"))
 		s.Rebuild()
 
-		// Populate remote SHAs
-		require.NoError(t, s.Engine.PopulateRemoteShas())
-
 		stacks := []MultiStackInfo{
 			{RootBranch: "feature1", AllBranches: []string{"feature1", "feature2"}},
 		}
@@ -116,9 +107,6 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("s2-content", "s2file"))
 		require.NoError(t, s.Scene.Repo.PushBranch("origin", "stack2-b1"))
 		s.Rebuild()
-
-		// Populate remote SHAs
-		require.NoError(t, s.Engine.PopulateRemoteShas())
 
 		stacks := []MultiStackInfo{
 			{RootBranch: "stack1-b1", AllBranches: []string{"stack1-b1"}},
@@ -152,9 +140,6 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("local-change", "s2file2"))
 		s.Rebuild()
 
-		// Populate remote SHAs
-		require.NoError(t, s.Engine.PopulateRemoteShas())
-
 		stacks := []MultiStackInfo{
 			{RootBranch: "stack1-b1", AllBranches: []string{"stack1-b1"}},
 			{RootBranch: "stack2-b1", AllBranches: []string{"stack2-b1"}},
@@ -174,9 +159,6 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 			TrackBranch("feature1", s.Engine.Trunk().GetName())
 		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("feature1-content", "file1"))
 		s.Rebuild()
-
-		// Populate remote SHAs
-		require.NoError(t, s.Engine.PopulateRemoteShas())
 
 		stacks := []MultiStackInfo{
 			{RootBranch: "feature1", AllBranches: []string{"feature1"}},

--- a/internal/actions/merge/wizard.go
+++ b/internal/actions/merge/wizard.go
@@ -30,11 +30,6 @@ func RunWizard(ctx *app.Context, handler InteractiveHandler, opts WizardOptions)
 
 	out.Debug("merge wizard: starting with opts=%+v", opts)
 
-	// Populate remote SHAs so we can accurately check if branches match remote
-	if err := eng.PopulateRemoteShas(); err != nil {
-		out.Debug("merge wizard: failed to populate remote SHAs: %v", err)
-	}
-
 	// Determine what to merge if not pre-selected
 	scope := opts.Scope
 	targetBranch := opts.TargetBranch

--- a/internal/actions/merge/worktree.go
+++ b/internal/actions/merge/worktree.go
@@ -55,11 +55,6 @@ func ExecuteInWorktree(ctx *app.Context, eng mergeExecuteEngine, opts ExecuteOpt
 	worktreeCtx.RepoRoot = worktreePath
 
 	// 4. Pre-flight operations in the worktree
-	// Populate remote SHAs so we can accurately check if branches match remote
-	if err := worktreeEng.PopulateRemoteShas(); err != nil {
-		out.Debug("Failed to populate remote SHAs in worktree: %v", err)
-	}
-
 	// Pull trunk in the worktree to ensure we have latest changes
 	pullResult, err := worktreeEng.PullTrunk(ctx.Context)
 	if err != nil {

--- a/internal/actions/metadata.go
+++ b/internal/actions/metadata.go
@@ -1,16 +1,16 @@
 package actions
 
 import (
+	"context"
+
 	"github.com/getstackit/stackit/internal/app"
-	"github.com/getstackit/stackit/internal/git"
 )
 
 // MetadataPushEngine defines the engine capabilities needed for pushing metadata.
 type MetadataPushEngine interface {
 	BatchSetLastModifiedBy(branchNames []string) error
-	IsRemoteSyncEnabled() bool
-	SetRemoteSyncEnabled(enabled bool)
-	Git() git.Runner
+	PrepareRemoteMetadataPush(ctx context.Context) error
+	PushMetadataForBranches(ctx context.Context, branchNames []string) error
 }
 
 // PushMetadataOnly pushes metadata refs without updating GitHub PRs.
@@ -23,21 +23,13 @@ func PushMetadataOnly(ctx *app.Context, eng MetadataPushEngine, branchNames []st
 		out.Debug("Failed to update metadata: %v", err)
 	}
 
-	// Check if remote sync is enabled; if not, run compatibility test first
-	if !eng.IsRemoteSyncEnabled() {
-		if err := eng.Git().TestRemoteRefCompatibility(ctx.Context); err != nil {
-			out.Debug("Remote metadata sync not supported: %v", err)
-			return nil // Non-fatal
-		}
-		eng.SetRemoteSyncEnabled(true)
-		// Configure refspec so future git fetch commands also fetch metadata
-		if err := eng.Git().EnsureMetadataRefspecConfigured(); err != nil {
-			out.Debug("Failed to configure metadata refspec: %v", err)
-		}
+	if err := eng.PrepareRemoteMetadataPush(ctx.Context); err != nil {
+		out.Debug("Remote metadata sync not supported: %v", err)
+		return nil // Non-fatal
 	}
 
 	// Push metadata refs
-	if err := eng.Git().PushMetadataRefs(ctx.Context, branchNames); err != nil {
+	if err := eng.PushMetadataForBranches(ctx.Context, branchNames); err != nil {
 		out.Debug("Failed to push metadata refs: %v", err)
 		return err
 	}

--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -89,8 +89,11 @@ func Action(ctx *app.Context, opts Options, h Handler) error {
 	if err := eng.ReparentBranch(gctx, plan.sourceBranch, plan.ontoBranch); err != nil {
 		return fmt.Errorf("failed to set parent: %w", err)
 	}
-
-	updateStackIDsAfterMove(ctx, plan, plan.source, plan.sourceBranch)
+	if eng.IsTrunk(plan.ontoBranch) {
+		if _, err := eng.AssignBranchesToNewStack(gctx, plan.sourceBranch, plan.descendants); err != nil {
+			ctx.Output.Warn("Failed to update stack IDs: %v", err)
+		}
+	}
 
 	if err := restackAndMark(ctx, plan, plan.sourceBranch); err != nil {
 		return err
@@ -300,42 +303,6 @@ func maybeRename(ctx *app.Context, h Handler, opts Options, plan *movePlan) (boo
 	}
 
 	return false, source, sourceBranch
-}
-
-func updateStackIDsAfterMove(ctx *app.Context, plan *movePlan, source string, sourceBranch engine.Branch) {
-	eng := ctx.Engine
-	out := ctx.Output
-
-	if plan.oldParentName == plan.onto {
-		return
-	}
-
-	oldStackID := eng.GetStackID(sourceBranch)
-	if oldStackID == "" {
-		return
-	}
-
-	newStackID := eng.GetStackID(plan.ontoBranch)
-
-	var targetStackID string
-	switch {
-	case eng.IsTrunk(plan.ontoBranch):
-		targetStackID = eng.GenerateStackID(source)
-		if err := eng.CreateStackRef(targetStackID, nil); err != nil {
-			out.Warn("Failed to create stack ref: %v", err)
-		}
-	case newStackID != "" && newStackID != oldStackID:
-		targetStackID = newStackID
-	}
-
-	if targetStackID == "" {
-		return
-	}
-
-	if err := eng.SetStackID(ctx.Context, plan.descendants, targetStackID); err != nil {
-		out.Warn("Failed to update stack IDs: %v", err)
-	}
-	out.Info("Stack membership updated for %s", source)
 }
 
 func restackAndMark(ctx *app.Context, plan *movePlan, sourceBranch engine.Branch) error {

--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -204,33 +204,10 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		handler.OnStep(StepMovingSource, basehandler.StatusFailed, err.Error())
 		return fmt.Errorf("failed to set parent: %w", err)
 	}
-
-	// Update stack ID based on the pluck destination:
-	// 1. Plucking to trunk creates a new independent stack with a fresh ID
-	// 2. Plucking to a branch in a different stack inherits that stack's ID
-	// 3. Plucking within the same stack keeps the existing ID (no update needed)
-	oldStackID := eng.GetStackID(sourceBranch)
-	newStackID := eng.GetStackID(ontoBranch)
-
-	var targetStackID string
-	switch {
-	case eng.IsTrunk(ontoBranch):
-		// Plucking to trunk creates a new stack
-		targetStackID = eng.GenerateStackID(source)
-		if err := eng.CreateStackRef(targetStackID, nil); err != nil {
-			out.Warn("Failed to create stack ref: %v", err)
-		}
-	case newStackID != "" && newStackID != oldStackID:
-		// Plucking to a different stack - inherit that stack's ID
-		targetStackID = newStackID
-	}
-
-	// Update stack ID if needed (pluck only moves the source, not descendants)
-	if targetStackID != "" {
-		if err := eng.SetStackID(gctx, engine.BranchesOf(sourceBranch), targetStackID); err != nil {
+	if eng.IsTrunk(ontoBranch) {
+		if _, err := eng.AssignBranchesToNewStack(gctx, sourceBranch, engine.BranchesOf(sourceBranch)); err != nil {
 			out.Warn("Failed to update stack ID for %s: %v", source, err)
 		}
-		out.Info("Stack membership updated for %s", source)
 	}
 
 	out.Info("Plucked %s from %s to %s.",

--- a/internal/actions/pr_updates.go
+++ b/internal/actions/pr_updates.go
@@ -220,17 +220,9 @@ func PushMetadataAndSyncPRs(ctx *app.Context, branchNames []string) error {
 		out.Debug("Failed to update metadata: %v", err)
 	}
 
-	// Check if remote sync is enabled; if not, run compatibility test first
-	if !eng.IsRemoteSyncEnabled() {
-		if err := eng.TestRemoteMetadataCompatibility(ctx.Context); err != nil {
-			out.Debug("Remote metadata sync not supported: %v", err)
-			return nil // Non-fatal
-		}
-		eng.SetRemoteSyncEnabled(true)
-		// Configure refspec so future git fetch commands also fetch metadata
-		if err := eng.ConfigureRemoteMetadataSync(ctx.Context); err != nil {
-			out.Debug("Failed to configure metadata refspec: %v", err)
-		}
+	if err := eng.PrepareRemoteMetadataPush(ctx.Context); err != nil {
+		out.Debug("Remote metadata sync not supported: %v", err)
+		return nil // Non-fatal
 	}
 
 	// Push metadata refs

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -115,7 +115,6 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	nav := ctx.Navigator()
-	pr := ctx.PR()
 	eng := ctx.Engine
 
 	// Determine target branch (explicit --branch flag or current branch)
@@ -174,11 +173,6 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	currentBranchName := ""
 	if currentBranch != nil {
 		currentBranchName = currentBranch.GetName()
-	}
-
-	// Populate remote SHAs early for accurate display
-	if err := pr.PopulateRemoteShas(); err != nil {
-		ctx.Output.Debug("Failed to populate remote SHAs: %v", err)
 	}
 
 	// Build tree structure for display

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -633,16 +633,8 @@ func pushMetadataRefs(ctx *app.Context, branches engine.Branches) error {
 		return fmt.Errorf("failed to update metadata: %w", err)
 	}
 
-	// Check if remote sync is enabled; if not, run compatibility test first
-	if !rm.IsRemoteSyncEnabled() {
-		if err := rm.TestRemoteMetadataCompatibility(ctx.Context); err != nil {
-			return fmt.Errorf("remote does not support metadata refs (GitHub compatibility check failed): %w", err)
-		}
-		rm.SetRemoteSyncEnabled(true)
-		// Configure refspec so future git fetch commands also fetch metadata
-		if err := rm.ConfigureRemoteMetadataSync(ctx.Context); err != nil {
-			ctx.Output.Debug("Failed to configure metadata refspec: %v", err)
-		}
+	if err := rm.PrepareRemoteMetadataPush(ctx.Context); err != nil {
+		return fmt.Errorf("remote does not support metadata refs (GitHub compatibility check failed): %w", err)
 	}
 
 	// Push metadata refs

--- a/internal/actions/sync/branch_cleaning_test.go
+++ b/internal/actions/sync/branch_cleaning_test.go
@@ -82,8 +82,6 @@ func TestCleanBranchesInteractiveDoesNotAutoDeleteUnpushedUtilityBranch(t *testi
 	require.NoError(t, err)
 	err = s.Engine.UpsertPrInfo(context.Background(), s.Engine.GetBranch("util-branch"), testhelpers.NewTestPrInfoMerged(1, "main"))
 	require.NoError(t, err)
-	err = s.Engine.PopulateRemoteShas()
-	require.NoError(t, err)
 
 	s.Checkout("main")
 

--- a/internal/actions/sync/branch_sync.go
+++ b/internal/actions/sync/branch_sync.go
@@ -23,6 +23,7 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, handler H
 
 	// Get all tracked branches
 	allBranches := nav.AllBranches()
+	remoteStatuses := eng.ReadBranchRemoteStatuses(gctx, allBranches)
 
 	syncStart := time.Now()
 	var statusCheckTotalMs int64
@@ -68,13 +69,9 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, handler H
 
 		// Check if branch is behind remote
 		statusStart := time.Now()
-		status, err := eng.GetBranchRemoteStatus(branch)
+		status := remoteStatuses[branchName]
 		statusCheckTotalMs += time.Since(statusStart).Milliseconds()
 		statusCheckCount++
-		if err != nil {
-			// Can't determine status, skip
-			continue
-		}
 
 		// Skip if not behind remote
 		if !status.Behind() {

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -88,7 +88,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	handler.Start(totalOps)
 
 	// Phase 1: Parallel network operations
-	// Run trunk pull, metadata fetch, and GitHub PR info sync concurrently
+	// Fetch trunk and metadata refs, and sync GitHub PR info concurrently.
 	handler.EmitEvent(Event{Phase: PhaseTrunk, Type: EventStarted})
 	handler.EmitEvent(Event{Phase: PhaseGitHub, Type: EventStarted})
 
@@ -103,30 +103,24 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	g, _ := errgroup.WithContext(gctx)
 
-	// Goroutine 1: Pull trunk
+	// Goroutine 1: Fetch trunk and Stackit metadata refs in one network round trip.
 	g.Go(func() error {
-		ctx.Logger.Info("goroutine trunk started delayMs=%v", time.Since(parallelStart).Milliseconds())
-		trunkErr = syncTrunk(ctx, &opts, handler, &trunkSummary)
-		return nil // Don't fail the group, handle error after Wait
-	})
-
-	// Goroutine 2: Fetch remote metadata refs (network operation only)
-	g.Go(func() error {
-		ctx.Logger.Info("goroutine metadata started delayMs=%v", time.Since(parallelStart).Milliseconds())
+		ctx.Logger.Info("goroutine remote fetch started delayMs=%v", time.Since(parallelStart).Milliseconds())
 		fetchStart := time.Now()
-		metadataFetchErr = ctx.RemoteMetadata().FetchRemoteMetadata(gctx)
-		ctx.Logger.Info("fetch remote metadata refs completed durationMs=%v", time.Since(fetchStart).Milliseconds())
-
-		// Also fetch stack metadata refs (stack-level descriptions, etc.)
-		stackFetchStart := time.Now()
-		if err := ctx.Engine.FetchStackMetadata(gctx); err != nil {
-			ctx.Logger.Debug("fetch stack metadata refs failed (non-fatal) error=%v", err)
+		metadataFetchErr = eng.FetchRemote(gctx, engine.RemoteFetchRequest{
+			Remote:               eng.GetRemote(),
+			Branches:             []string{eng.Trunk().GetName()},
+			IncludeMetadata:      true,
+			IncludeStackMetadata: true,
+		})
+		ctx.Logger.Info("fetch trunk and metadata refs completed durationMs=%v", time.Since(fetchStart).Milliseconds())
+		if metadataFetchErr != nil {
+			ctx.Logger.Debug("fetch trunk and metadata refs failed (non-fatal) error=%v", metadataFetchErr)
 		}
-		ctx.Logger.Info("fetch stack metadata refs completed durationMs=%v", time.Since(stackFetchStart).Milliseconds())
 		return nil
 	})
 
-	// Goroutine 3: Sync PR info from GitHub (network operation only)
+	// Goroutine 2: Sync PR info from GitHub (network operation only)
 	g.Go(func() error {
 		ctx.Logger.Info("goroutine github started delayMs=%v", time.Since(parallelStart).Milliseconds())
 		var err error
@@ -138,7 +132,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	_ = g.Wait()
 	ctx.Logger.Info("parallel phase completed durationMs=%v", time.Since(parallelStart).Milliseconds())
 
-	// Handle errors from parallel operations
+	trunkErr = syncFetchedTrunk(ctx, &opts, handler, &trunkSummary)
 	if trunkErr != nil {
 		return trunkErr
 	}

--- a/internal/actions/sync/trunk_sync.go
+++ b/internal/actions/sync/trunk_sync.go
@@ -8,21 +8,27 @@ import (
 	"github.com/getstackit/stackit/internal/engine"
 )
 
-// syncTrunk handles pulling the trunk and resolving any conflicts
-func syncTrunk(ctx *app.Context, opts *Options, handler Handler, summary *Summary) error {
+func syncFetchedTrunk(ctx *app.Context, opts *Options, handler Handler, summary *Summary) error {
+	eng := ctx.Sync()
+	gctx := ctx.Context
+
+	updateStart := time.Now()
+	pullResult, err := eng.UpdateTrunkFromRemote(gctx)
+	ctx.Logger.Info("update trunk from remote completed durationMs=%d", time.Since(updateStart).Milliseconds())
+	if err != nil {
+		return fmt.Errorf("failed to update trunk from remote: %w", err)
+	}
+
+	return handleTrunkPullResult(ctx, opts, handler, summary, pullResult)
+}
+
+func handleTrunkPullResult(ctx *app.Context, opts *Options, handler Handler, summary *Summary, pullResult engine.PullResult) error {
 	eng := ctx.Sync()
 	nav := ctx.Navigator()
 	out := ctx.Output
 	gctx := ctx.Context
 	trunk := nav.Trunk()
 	trunkName := trunk.GetName()
-
-	pullStart := time.Now()
-	pullResult, err := eng.PullTrunk(gctx)
-	ctx.Logger.Info("pull trunk completed durationMs=%d", time.Since(pullStart).Milliseconds())
-	if err != nil {
-		return fmt.Errorf("failed to pull trunk: %w", err)
-	}
 
 	switch pullResult {
 	case engine.PullDone:

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -256,6 +256,10 @@ func (d *demoGitRunner) Fetch(_ context.Context, _, _ string) error {
 	return nil
 }
 
+func (d *demoGitRunner) FetchRefSpecs(_ context.Context, _ string, _ []string) error {
+	return nil
+}
+
 func (d *demoGitRunner) CreateBranch(_ context.Context, _, _ string) error {
 	return nil
 }

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -208,6 +208,10 @@ func (d *demoGitRunner) PullBranch(_ context.Context, _, _ string) (git.PullResu
 	return git.PullDone, nil
 }
 
+func (d *demoGitRunner) UpdateBranchFromRemote(_ context.Context, _, _ string) (git.PullResult, error) {
+	return git.PullDone, nil
+}
+
 func (d *demoGitRunner) PushBranch(_ context.Context, _, _ string, _ git.PushOptions) error {
 	return nil
 }

--- a/internal/engine/branch_mutations.go
+++ b/internal/engine/branch_mutations.go
@@ -11,7 +11,14 @@ import (
 
 // CreateBranch creates a new branch at the given start point
 func (e *engineImpl) CreateBranch(ctx context.Context, branchName string, startPoint string) error {
-	return e.git.CreateBranch(ctx, branchName, startPoint)
+	if err := e.git.CreateBranch(ctx, branchName, startPoint); err != nil {
+		return err
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.addKnownBranchLocked(branchName)
+	return nil
 }
 
 // ResetHard performs a hard reset to the given revision
@@ -345,12 +352,20 @@ func (e *engineImpl) CreateAndCheckoutBranch(ctx context.Context, branch Branch)
 	defer e.mu.Unlock()
 
 	e.currentBranch = branchName
-	// Add to branches list if not already there
-	if !slices.Contains(e.state.branches, branchName) {
-		e.state.setBranches(append(e.state.branches, branchName))
-	}
+	e.addKnownBranchLocked(branchName)
 
 	return nil
+}
+
+// addKnownBranchLocked records a branch ref that was created through the
+// engine. Callers must hold e.mu.
+func (e *engineImpl) addKnownBranchLocked(branchName string) {
+	if branchName == "" || slices.Contains(e.state.branches, branchName) {
+		return
+	}
+	branches := append(slices.Clone(e.state.branches), branchName)
+	slices.Sort(branches)
+	e.state.setBranches(branches)
 }
 
 // RenameBranch renames a branch and its metadata

--- a/internal/engine/branch_mutations.go
+++ b/internal/engine/branch_mutations.go
@@ -45,7 +45,44 @@ func (e *engineImpl) MergeMultiple(ctx context.Context, branches []string, opts 
 
 // Fetch fetches from a remote
 func (e *engineImpl) Fetch(ctx context.Context, remote string, branch string) error {
-	return e.git.Fetch(ctx, remote, branch)
+	return e.FetchRemote(ctx, RemoteFetchRequest{
+		Remote:   remote,
+		Branches: []string{branch},
+	})
+}
+
+// FetchRemote fetches branches and Stackit metadata refs from a remote in a
+// single git fetch invocation.
+func (e *engineImpl) FetchRemote(ctx context.Context, req RemoteFetchRequest) error {
+	remote := req.Remote
+	if remote == "" {
+		remote = e.GetRemote()
+	}
+
+	refspecs := make([]string, 0, len(req.Branches)+2)
+	seen := make(map[string]bool, len(req.Branches)+2)
+	add := func(refspec string) {
+		if refspec == "" || seen[refspec] {
+			return
+		}
+		seen[refspec] = true
+		refspecs = append(refspecs, refspec)
+	}
+
+	for _, branch := range req.Branches {
+		if branch == "" {
+			continue
+		}
+		add(fmt.Sprintf("refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch))
+	}
+	if req.IncludeMetadata {
+		add("+refs/stackit/metadata/*:refs/stackit/remote-metadata/*")
+	}
+	if req.IncludeStackMetadata {
+		add("+refs/stackit/stacks/*:refs/stackit/remote-stacks/*")
+	}
+
+	return e.git.FetchRefSpecs(ctx, remote, refspecs)
 }
 
 // InteractiveRebase starts an interactive rebase

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -37,6 +37,7 @@ type PRManager interface {
 type SyncManager interface {
 	// Sync operations
 	PullTrunk(ctx context.Context) (PullResult, error)
+	UpdateTrunkFromRemote(ctx context.Context) (PullResult, error)
 	ResetTrunkToRemote(ctx context.Context) error
 	PlanRestack(ctx context.Context, branches Branches) (*RestackPlan, error)
 	RestackBranches(ctx context.Context, branches Branches) (RestackBatchResult, error)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -24,7 +24,7 @@ import (
 type PRManager interface {
 	UpsertPrInfo(ctx context.Context, branch Branch, prInfo *PrInfo) error
 	GetBranchRemoteStatus(branch Branch) (BranchRemoteStatus, error)
-	PopulateRemoteShas() error
+	ReadBranchRemoteStatuses(ctx context.Context, branches Branches) map[string]BranchRemoteStatus
 	PushBranch(ctx context.Context, branch Branch, remote string, opts git.PushOptions) error
 	// Navigation comment ID caching (stored in local metadata)
 	GetNavigationCommentID(branch Branch) (int64, error)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -78,6 +78,7 @@ type RemoteMetadataManager interface {
 	BatchSetLastModifiedBy(branchNames []string) error
 	LoadRemoteMetadataCache() error
 	ApplyRemoteMetadataIfExists(branchName string) error
+	ApplyRemoteMetadataForBranches(ctx context.Context, branchNames []string) error
 	GetRemoteMetadataCache() RemoteMetadataView
 	ComputeMetadataDiff(branch string) (*MetadataDiff, error)
 	ComputeAllMetadataDiffs() ([]*MetadataDiff, error)
@@ -93,6 +94,9 @@ type RemoteMetadataManager interface {
 	// accepts the metadata-ref namespace. Adapter code should call this instead
 	// of reaching to the git runner directly.
 	TestRemoteMetadataCompatibility(ctx context.Context) error
+	// PrepareRemoteMetadataPush verifies remote metadata refs are supported and
+	// enables local metadata sync state before pushing metadata refs.
+	PrepareRemoteMetadataPush(ctx context.Context) error
 	// PushMetadataForBranches pushes the metadata refs for the given branch
 	// names to origin.
 	PushMetadataForBranches(ctx context.Context, branchNames []string) error

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -95,9 +95,9 @@ type RemoteMetadataManager interface {
 	// PushMetadataForBranches pushes the metadata refs for the given branch
 	// names to origin.
 	PushMetadataForBranches(ctx context.Context, branchNames []string) error
-	// ConfigureStackMetadataSync adds the stack-metadata refspec to origin.
+	// ConfigureStackMetadataSync adds the stack-metadata refspec to the configured remote.
 	ConfigureStackMetadataSync(ctx context.Context) error
-	// FetchStackMetadata fetches stack-metadata refs from origin.
+	// FetchStackMetadata fetches stack-metadata refs from the configured remote.
 	FetchStackMetadata(ctx context.Context) error
 	// ListStackMetadata returns a map of local stack IDs to their ref SHAs.
 	ListStackMetadata() (map[string]string, error)
@@ -108,6 +108,20 @@ type RemoteMetadataManager interface {
 	// GetStackIDsForBranches returns the unique stack IDs for the given branches.
 	// This is used to determine which stack refs need to be pushed to remote.
 	GetStackIDsForBranches(branches Branches) []string
+}
+
+// RemoteFetchRequest describes a single remote fetch that may update several
+// branch and Stackit metadata namespaces in one network round trip.
+type RemoteFetchRequest struct {
+	Remote               string
+	Branches             []string
+	IncludeMetadata      bool
+	IncludeStackMetadata bool
+}
+
+// RemoteFetcher provides batched remote fetch operations.
+type RemoteFetcher interface {
+	FetchRemote(ctx context.Context, req RemoteFetchRequest) error
 }
 
 // ApplySplitOptions contains options for applying a split
@@ -194,6 +208,7 @@ type Engine interface {
 	Absorber
 	UndoManager
 	RemoteMetadataManager
+	RemoteFetcher
 	WorktreeRegistry
 	Git() git.Runner
 

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -240,53 +240,62 @@ func (e *engineImpl) ReadBranchStatuses(branches Branches) BranchStatuses {
 	return newBranchStatuses(results)
 }
 
-// GetBranchRemoteStatus returns the relationship between a local branch and its remote
+// GetBranchRemoteStatus returns the relationship between a local branch and its remote.
 func (e *engineImpl) GetBranchRemoteStatus(branch Branch) (BranchRemoteStatus, error) {
-	branchName := branch.GetName()
-	e.mu.RLock()
-	state := e.readState(branch.GetName())
-	var remoteSha string
-	if state != nil {
-		remoteSha = state.RemoteSHA
-	}
-	e.mu.RUnlock()
+	return e.ReadBranchRemoteStatuses(context.Background(), BranchesOf(branch))[branch.GetName()], nil
+}
 
-	localSha, err := e.git.GetRevision(branchName)
-	if err != nil {
-		localSha = "" // Branch doesn't exist locally
+// ReadBranchRemoteStatuses returns the local/remote relationship for the
+// requested branches. It lists remote branch SHAs once and does not mutate
+// engine state.
+func (e *engineImpl) ReadBranchRemoteStatuses(ctx context.Context, branches Branches) map[string]BranchRemoteStatus {
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
-	if remoteSha == "" {
-		// Fall back to local remote tracking branch
-		remoteSha, err = e.git.GetRemoteRevision(branchName)
-		if err != nil {
-			remoteSha = "" // No remote tracking branch
-		}
+	results := make(map[string]BranchRemoteStatus, len(branches))
+	if len(branches) == 0 {
+		return results
 	}
 
-	status := BranchRemoteStatus{
-		LocalSha:  localSha,
-		RemoteSha: remoteSha,
-	}
+	branchNames := branches.Names()
+	localShas, _ := e.git.BatchGetRevisions(branchNames)
 
-	if localSha == "" || remoteSha == "" {
-		return status, nil
-	}
-
-	if localSha == remoteSha {
-		status.CommonAncestor = localSha
-		return status, nil
-	}
-
-	// They differ, compute common ancestor to determine relation
 	remote := e.git.GetRemote()
-	remoteBranchRef := "refs/remotes/" + remote + "/" + branchName
-	commonAncestor, err := e.git.GetMergeBaseByRef(context.Background(), branchName, remoteBranchRef)
-	if err == nil {
-		status.CommonAncestor = commonAncestor
+	remoteShas, err := e.git.FetchRemoteShas(ctx, remote)
+	if err != nil {
+		remoteShas = map[string]string{}
 	}
 
-	return status, nil
+	for _, branch := range branches {
+		branchName := branch.GetName()
+		localSha := localShas[branchName]
+		remoteSha := remoteShas[branchName]
+		if remoteSha == "" {
+			if sha, err := e.git.GetRemoteRevision(branchName); err == nil {
+				remoteSha = sha
+			}
+		}
+
+		status := BranchRemoteStatus{
+			LocalSha:  localSha,
+			RemoteSha: remoteSha,
+		}
+
+		switch {
+		case localSha == "" || remoteSha == "":
+		case localSha == remoteSha:
+			status.CommonAncestor = localSha
+		default:
+			if commonAncestor, err := e.git.GetMergeBaseByRef(ctx, localSha, remoteSha); err == nil {
+				status.CommonAncestor = commonAncestor
+			}
+		}
+
+		results[branchName] = status
+	}
+
+	return results
 }
 
 // GetMergedBranches returns a map of branches merged into the target branch

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -334,7 +334,8 @@ func (e *engineImpl) ensureLocalLoaded() {
 func (e *engineImpl) maybeAutoFetchRemoteMetadata() {
 	// Fast path: Check if refspec is already configured (most common case)
 	// This avoids expensive git config reads and network fetches for normal operations
-	refspecs, err := e.git.GetConfigAll("remote.origin.fetch")
+	remote := e.GetRemote()
+	refspecs, err := e.git.GetConfigAll(fmt.Sprintf("remote.%s.fetch", remote))
 	if err == nil {
 		metadataRefspec := "+refs/stackit/metadata/*:refs/stackit/remote-metadata/*"
 		if slices.Contains(refspecs, metadataRefspec) {
@@ -348,7 +349,10 @@ func (e *engineImpl) maybeAutoFetchRemoteMetadata() {
 	// Not configured yet - this might be a fresh clone
 	// Try to fetch metadata refs (this is a network operation, so it's slow)
 	// Only do this if refspec isn't configured to avoid slowing down every command
-	if err := e.git.FetchMetadataRefs(context.Background()); err != nil {
+	if err := e.FetchRemote(context.Background(), RemoteFetchRequest{
+		Remote:          remote,
+		IncludeMetadata: true,
+	}); err != nil {
 		// No remote metadata available, or error fetching - that's okay
 		return
 	}

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -413,30 +413,3 @@ func (e *engineImpl) Rebuild(newTrunkName string) error {
 
 	return e.rebuild()
 }
-
-// PopulateRemoteShas populates remote branch information by fetching SHAs from remote
-func (e *engineImpl) PopulateRemoteShas() error {
-	remote := e.git.GetRemote()
-	remoteShas, err := e.git.FetchRemoteShas(context.Background(), remote)
-
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	// Clear existing remote SHAs
-	for _, state := range e.state.branchState {
-		state.RemoteSHA = ""
-	}
-
-	if err != nil {
-		// Don't fail if we can't fetch remote SHAs (e.g., offline)
-		return nil
-	}
-
-	// Set RemoteSHA for tracked branches that have a remote
-	for branchName, sha := range remoteShas {
-		if state := e.readState(branchName); state != nil {
-			state.RemoteSHA = sha
-		}
-	}
-	return nil
-}

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -980,10 +980,6 @@ func TestGetBranchRemoteStatus(t *testing.T) {
 		require.NoError(t, err)
 		s.Checkout("main")
 
-		// Populate remote SHAs
-		err = s.Engine.PopulateRemoteShas()
-		require.NoError(t, err)
-
 		// Verify GetBranchRemoteStatus
 		status, err := s.Engine.GetBranchRemoteStatus(s.Engine.GetBranch("feature"))
 		require.NoError(t, err)
@@ -1015,10 +1011,6 @@ func TestGetBranchRemoteStatus(t *testing.T) {
 		s.Commit("local change").
 			Checkout("main")
 
-		// Populate remote SHAs
-		err = s.Engine.PopulateRemoteShas()
-		require.NoError(t, err)
-
 		// Verify GetBranchRemoteStatus
 		status, err := s.Engine.GetBranchRemoteStatus(s.Engine.GetBranch("feature"))
 		require.NoError(t, err)
@@ -1044,10 +1036,6 @@ func TestGetBranchRemoteStatus(t *testing.T) {
 		s.CreateBranch("feature").
 			Commit("feature change").
 			Checkout("main")
-
-		// Populate remote SHAs
-		err = s.Engine.PopulateRemoteShas()
-		require.NoError(t, err)
 
 		// Verify GetBranchRemoteStatus
 		status, err := s.Engine.GetBranchRemoteStatus(s.Engine.GetBranch("feature"))
@@ -1080,10 +1068,6 @@ func TestGetBranchRemoteStatus(t *testing.T) {
 
 		s.Checkout("main")
 
-		// Populate remote SHAs
-		err = s.Engine.PopulateRemoteShas()
-		require.NoError(t, err)
-
 		// Verify GetBranchRemoteStatus
 		status, err := s.Engine.GetBranchRemoteStatus(s.Engine.GetBranch("feature"))
 		require.NoError(t, err)
@@ -1094,9 +1078,9 @@ func TestGetBranchRemoteStatus(t *testing.T) {
 	})
 }
 
-func TestPopulateRemoteShas(t *testing.T) {
+func TestReadBranchRemoteStatuses(t *testing.T) {
 	t.Parallel()
-	t.Run("populates SHAs for all remote branches", func(t *testing.T) {
+	t.Run("reads statuses for all requested remote branches", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
@@ -1121,14 +1105,14 @@ func TestPopulateRemoteShas(t *testing.T) {
 		require.NoError(t, err)
 		s.Checkout("main")
 
-		// Populate remote SHAs
-		err = s.Engine.PopulateRemoteShas()
-		require.NoError(t, err)
-
-		// All branches should match remote
+		branches := engine.BranchesOf(
+			s.Engine.GetBranch("main"),
+			s.Engine.GetBranch("feature1"),
+			s.Engine.GetBranch("feature2"),
+		)
+		statuses := s.Engine.ReadBranchRemoteStatuses(context.Background(), branches)
 		for _, branchName := range []string{"main", "feature1", "feature2"} {
-			status, err := s.Engine.GetBranchRemoteStatus(s.Engine.GetBranch(branchName))
-			require.NoError(t, err)
+			status := statuses[branchName]
 			require.True(t, status.Matches(), "branch %s should match remote", branchName)
 		}
 	})
@@ -1139,10 +1123,6 @@ func TestPopulateRemoteShas(t *testing.T) {
 
 		// Create a bare remote but don't push anything
 		_, err := s.Scene.Repo.CreateBareRemote("origin")
-		require.NoError(t, err)
-
-		// Populate should not fail
-		err = s.Engine.PopulateRemoteShas()
 		require.NoError(t, err)
 
 		// Branches should not match (nothing on remote)

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -588,6 +588,29 @@ func TestRebuild(t *testing.T) {
 	})
 }
 
+func TestCreateBranchUpdatesBranchInventory(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+	s.CreateBranchQuiet("branch3").
+		Commit("branch3 change").
+		CheckoutQuiet("main")
+
+	require.NoError(t, s.Engine.CreateBranch(context.Background(), "branch2", "main"))
+
+	allBranches := s.Engine.AllBranches()
+	branchNames := make([]string, len(allBranches))
+	for i, b := range allBranches {
+		branchNames[i] = b.GetName()
+	}
+	require.Contains(t, branchNames, "branch2")
+	require.NotContains(t, branchNames, "branch3")
+
+	require.False(t, s.Engine.GetBranch("branch2").IsTracked())
+	require.NoError(t, s.Engine.TrackBranch(context.Background(), "branch2", "main"))
+	require.Equal(t, "main", s.Engine.GetBranch("branch2").GetParentOrTrunk())
+}
+
 func TestIsBranchTracked(t *testing.T) {
 	t.Parallel()
 	t.Run("returns true for tracked branch", func(t *testing.T) {

--- a/internal/engine/engine_remote_metadata_test.go
+++ b/internal/engine/engine_remote_metadata_test.go
@@ -169,6 +169,28 @@ func TestRemoteMetadataSync(t *testing.T) {
 		require.Empty(t, diffs, "expected no diffs for non-existent local branches")
 	})
 
+	t.Run("applies remote metadata for requested branches", func(t *testing.T) {
+		t.Parallel()
+		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		eng := sh.Engine
+
+		sh.CreateBranch("feature-e").
+			CommitChange("file-e", "content-e").
+			TrackBranch("feature-e", "main")
+
+		remoteMeta := git.NewMetaFrom(git.MetaFields{
+			LockReason: git.LockReasonUser,
+			Scope:      new("remote-scope"),
+		})
+		createRemoteMetadataRef(t, sh, "feature-e", remoteMeta)
+
+		require.NoError(t, eng.ApplyRemoteMetadataForBranches(context.Background(), []string{"main", "feature-e", "feature-e"}))
+
+		branch := eng.GetBranch("feature-e")
+		require.True(t, eng.IsLocked(branch))
+		require.Equal(t, "remote-scope", eng.GetScope(branch).String())
+	})
+
 	t.Run("identifies orphaned metadata when local branch is gone", func(t *testing.T) {
 		t.Parallel()
 		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -54,6 +54,7 @@ type BranchStatus interface {
 	GetRemoteURL(ctx context.Context) (string, error)
 	GetBranchRemoteDifference(branchName string) (string, error)
 	GetBranchRemoteStatus(branch Branch) (BranchRemoteStatus, error)
+	ReadBranchRemoteStatuses(ctx context.Context, branches Branches) map[string]BranchRemoteStatus
 	GetMergedBranches(ctx context.Context, target string) (map[string]bool, error)
 }
 

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -181,6 +181,9 @@ type BranchTracking interface {
 	EnsureStackID(ctx context.Context, branch Branch) (string, error)
 	// SetStackID sets the stack ID on multiple branches atomically in a single transaction.
 	SetStackID(ctx context.Context, branches Branches, stackID string) error
+	// AssignBranchesToNewStack creates a new stack metadata ref and assigns its
+	// ID to the provided branches atomically.
+	AssignBranchesToNewStack(ctx context.Context, root Branch, branches Branches) (string, error)
 	// CreateStackRef creates a new stack ref with the given metadata.
 	CreateStackRef(stackID string, meta *git.StackMeta) error
 	// GetStackMeta returns the stack metadata for a stack ID.

--- a/internal/engine/metadata_transport.go
+++ b/internal/engine/metadata_transport.go
@@ -13,6 +13,22 @@ func (e *engineImpl) TestRemoteMetadataCompatibility(ctx context.Context) error 
 	return e.git.TestRemoteRefCompatibility(ctx)
 }
 
+// PrepareRemoteMetadataPush verifies that the remote accepts metadata refs and
+// records that support locally. Fetch-refspec setup is best-effort because
+// metadata pushes can still succeed when local fetch configuration cannot be
+// updated.
+func (e *engineImpl) PrepareRemoteMetadataPush(ctx context.Context) error {
+	if e.IsRemoteSyncEnabled() {
+		return nil
+	}
+	if err := e.TestRemoteMetadataCompatibility(ctx); err != nil {
+		return err
+	}
+	e.SetRemoteSyncEnabled(true)
+	_ = e.ConfigureRemoteMetadataSync(ctx)
+	return nil
+}
+
 // PushMetadataForBranches pushes metadata refs for the given branch names to
 // origin. A no-op when the list is empty.
 func (e *engineImpl) PushMetadataForBranches(ctx context.Context, branchNames []string) error {

--- a/internal/engine/metadata_transport.go
+++ b/internal/engine/metadata_transport.go
@@ -19,16 +19,16 @@ func (e *engineImpl) PushMetadataForBranches(ctx context.Context, branchNames []
 	return e.git.PushMetadataRefs(ctx, branchNames)
 }
 
-// ConfigureStackMetadataSync adds the stack-metadata refspec to origin so
-// subsequent `git fetch origin` invocations pick up stack-ref changes.
+// ConfigureStackMetadataSync adds the stack-metadata refspec to the configured
+// remote so subsequent git fetches pick up stack-ref changes.
 func (e *engineImpl) ConfigureStackMetadataSync(_ context.Context) error {
 	return e.git.EnsureStackMetaRefspecConfigured()
 }
 
-// FetchStackMetadata fetches stack-metadata refs from origin into the
+// FetchStackMetadata fetches stack-metadata refs into the
 // remote-stacks namespace.
 func (e *engineImpl) FetchStackMetadata(ctx context.Context) error {
-	return e.git.FetchStackMetaRefs(ctx)
+	return e.FetchRemote(ctx, RemoteFetchRequest{IncludeStackMetadata: true})
 }
 
 // ListStackMetadata returns a map of local stack IDs to their ref SHAs. Used

--- a/internal/engine/persistence_locked_test.go
+++ b/internal/engine/persistence_locked_test.go
@@ -33,14 +33,9 @@ func TestPrInfoLockedPersistence(t *testing.T) {
 	err = eng.UpsertPrInfo(context.Background(), branch, prInfo)
 	require.NoError(t, err)
 
-	// Simulate push by updating remote SHA
+	// Simulate push by updating the local remote-tracking ref.
 	localSha, _ := eng.GetRevision(branch)
-	// We need a way to set remote SHA. Since we're using a real git repo in the scenario,
-	// we should probably just use PopulateRemoteShas after a real push or mock it.
-	// For this test, let's just mock the behavior by setting the remote ref.
 	s.RunGit("update-ref", "refs/remotes/origin/feature", localSha)
-	err = eng.PopulateRemoteShas()
-	require.NoError(t, err)
 
 	// 3. Verify it's saved in the PR info
 	gotPrInfo, err := branch.GetPrInfo()

--- a/internal/engine/pull.go
+++ b/internal/engine/pull.go
@@ -18,6 +18,26 @@ func (e *engineImpl) PullTrunk(ctx context.Context) (PullResult, error) {
 		return PullConflict, err
 	}
 
+	return e.finishTrunkPull(gitResult)
+}
+
+// UpdateTrunkFromRemote updates trunk from the already-fetched remote-tracking
+// branch. Callers that need to batch the network fetch with other refspecs can
+// use FetchRemote first, then call this local update step.
+func (e *engineImpl) UpdateTrunkFromRemote(ctx context.Context) (PullResult, error) {
+	remote := e.git.GetRemote()
+	e.mu.RLock()
+	trunk := e.trunk
+	e.mu.RUnlock()
+	gitResult, err := e.git.UpdateBranchFromRemote(ctx, remote, trunk)
+	if err != nil {
+		return PullConflict, err
+	}
+
+	return e.finishTrunkPull(gitResult)
+}
+
+func (e *engineImpl) finishTrunkPull(gitResult git.PullResult) (PullResult, error) {
 	// Convert git.PullResult to engine.PullResult
 	var result PullResult
 	switch gitResult {

--- a/internal/engine/remote_sync.go
+++ b/internal/engine/remote_sync.go
@@ -472,14 +472,14 @@ func (e *engineImpl) DeleteMetadata(ctx context.Context, branchName string) erro
 	})
 }
 
-// FetchRemoteMetadata fetches metadata refs from origin into the remote-metadata
+// FetchRemoteMetadata fetches metadata refs into the remote-metadata
 // namespace, so the cache loader sees the latest authored values.
 func (e *engineImpl) FetchRemoteMetadata(ctx context.Context) error {
-	return e.git.FetchMetadataRefs(ctx)
+	return e.FetchRemote(ctx, RemoteFetchRequest{IncludeMetadata: true})
 }
 
-// ConfigureRemoteMetadataSync adds the metadata refspec to origin so subsequent
-// `git fetch origin` invocations pick up metadata changes automatically.
+// ConfigureRemoteMetadataSync adds the metadata refspec to the configured
+// remote so subsequent git fetches pick up metadata changes automatically.
 func (e *engineImpl) ConfigureRemoteMetadataSync(_ context.Context) error {
 	return e.git.EnsureMetadataRefspecConfigured()
 }

--- a/internal/engine/remote_sync.go
+++ b/internal/engine/remote_sync.go
@@ -199,6 +199,40 @@ func (e *engineImpl) ApplyRemoteMetadataIfExists(branchName string) error {
 	return e.writeMetadata(branchName, local)
 }
 
+// ApplyRemoteMetadataForBranches applies the latest fetched remote metadata to
+// the requested local branches. It owns the cache/refspec setup so callers
+// don't need to sequence ConfigureRemoteMetadataSync, LoadRemoteMetadataCache,
+// and per-branch application themselves.
+func (e *engineImpl) ApplyRemoteMetadataForBranches(ctx context.Context, branchNames []string) error {
+	if len(branchNames) == 0 {
+		return nil
+	}
+
+	if err := e.ConfigureRemoteMetadataSync(ctx); err != nil {
+		return fmt.Errorf("configure metadata sync: %w", err)
+	}
+	if err := e.LoadRemoteMetadataCache(); err != nil {
+		return fmt.Errorf("load remote metadata cache: %w", err)
+	}
+
+	var firstErr error
+	seen := make(map[string]struct{}, len(branchNames))
+	trunkName := e.Trunk().GetName()
+	for _, branchName := range branchNames {
+		if branchName == "" || branchName == trunkName {
+			continue
+		}
+		if _, ok := seen[branchName]; ok {
+			continue
+		}
+		seen[branchName] = struct{}{}
+		if err := e.ApplyRemoteMetadataIfExists(branchName); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
 // GetRemoteMetadataCache returns a read-only view of the remote metadata cache.
 // Returns RemoteMetadataView instead of a raw map to prevent external mutation
 // and provide a stable snapshot even if the cache is reloaded concurrently.

--- a/internal/engine/stack_id.go
+++ b/internal/engine/stack_id.go
@@ -173,28 +173,15 @@ func (e *engineImpl) EnsureStackID(ctx context.Context, branch Branch) (string, 
 		return existingID, nil
 	}
 
-	// Need to create a new stack ID
-	// Find the stack root to generate the ID
+	// Need to create a new stack ID.
+	// Find the stack root to generate the ID.
 	rootName := e.GetStackRootForBranch(branch)
 	if rootName == "" {
 		return "", fmt.Errorf("cannot determine stack root for branch %s", branch.GetName())
 	}
 
-	// Generate new stack ID based on the root branch
 	stackID := e.GenerateStackID(rootName)
-
-	// Create the stack metadata ref
-	stackMeta := &git.StackMeta{
-		ID:        stackID,
-		CreatedAt: timeNow(),
-	}
-
-	// Try to get user name for CreatedBy
-	if userName, err := e.git.GetUserName(ctx); err == nil {
-		stackMeta.CreatedBy = userName
-	}
-
-	if err := e.git.WriteStackMeta(stackID, stackMeta); err != nil {
+	if err := e.writeNewStackMeta(ctx, stackID); err != nil {
 		return "", fmt.Errorf("failed to create stack ref: %w", err)
 	}
 
@@ -254,6 +241,36 @@ func (e *engineImpl) propagateStackID(ctx context.Context, branchName string, st
 	return e.batchSetStackID(ctx, e.collectSubtree(branchName), stackID)
 }
 
+func (e *engineImpl) writeNewStackMeta(ctx context.Context, stackID string) error {
+	stackMeta := &git.StackMeta{
+		ID:        stackID,
+		CreatedAt: timeNow(),
+	}
+	if userName, err := e.git.GetUserName(ctx); err == nil {
+		stackMeta.CreatedBy = userName
+	}
+	return e.git.WriteStackMeta(stackID, stackMeta)
+}
+
+// AssignBranchesToNewStack creates a new stack metadata ref and assigns its ID
+// to the provided branches. Use this for operations that intentionally extract
+// a branch or subtree into an independent stack; plain reparenting preserves
+// existing stack membership unless the new parent belongs to another stack.
+func (e *engineImpl) AssignBranchesToNewStack(ctx context.Context, root Branch, branches Branches) (string, error) {
+	if len(branches) == 0 {
+		return "", nil
+	}
+
+	stackID := e.GenerateStackID(root.GetName())
+	if err := e.writeNewStackMeta(ctx, stackID); err != nil {
+		return "", fmt.Errorf("failed to create stack ref: %w", err)
+	}
+	if err := e.SetStackID(ctx, branches, stackID); err != nil {
+		return "", fmt.Errorf("failed to assign stack ID: %w", err)
+	}
+	return stackID, nil
+}
+
 // SetStackID sets the stack ID on multiple branches atomically in a single transaction.
 func (e *engineImpl) SetStackID(ctx context.Context, branches Branches, stackID string) error {
 	names := make([]string, len(branches))
@@ -285,12 +302,11 @@ func (e *engineImpl) GetStackMeta(stackID string) (*git.StackMeta, error) {
 // exported because external callers should reparent via ReparentBranch instead
 // of poking the stack ID directly.
 //
-// Returns nil if the parent is trunk (keeps existing stack ID), the parent has
-// no stack ID (legacy branch), or the branch is already in sync.
+// Returns nil if the parent is trunk (keeps existing stack membership), the
+// parent has no stack ID (legacy branch), or the branch is already in sync.
 func (e *engineImpl) syncStackIDFromParent(ctx context.Context, branch Branch) error {
 	parent := branch.GetParent()
-	if parent == nil {
-		// Parent is trunk - keep existing stack ID
+	if parent == nil || e.IsTrunk(*parent) {
 		return nil
 	}
 

--- a/internal/engine/stack_id_test.go
+++ b/internal/engine/stack_id_test.go
@@ -238,6 +238,38 @@ func TestStackIDInheritance(t *testing.T) {
 		require.NotEmpty(t, id2)
 		require.NotEqual(t, id1, id2)
 	})
+
+	t.Run("assigning branches to a new stack creates a new stack ID", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit().
+			CreateBranch("root").
+			Commit("root commit").
+			TrackBranch("root", "main").
+			CreateBranch("child").
+			Commit("child commit").
+			TrackBranch("child", "root").
+			CreateBranch("grandchild").
+			Commit("grandchild commit").
+			TrackBranch("grandchild", "child")
+
+		root := s.Engine.GetBranch("root")
+		child := s.Engine.GetBranch("child")
+		rootID, err := s.Engine.EnsureStackID(context.Background(), root)
+		require.NoError(t, err)
+		require.Equal(t, rootID, s.Engine.GetStackID(child))
+
+		_, err = s.Engine.AssignBranchesToNewStack(context.Background(), child, engine.Branches{child, s.Engine.GetBranch("grandchild")})
+		require.NoError(t, err)
+
+		child = s.Engine.GetBranch("child")
+		grandchild := s.Engine.GetBranch("grandchild")
+		childID := s.Engine.GetStackID(child)
+		require.NotEmpty(t, childID)
+		require.NotEqual(t, rootID, childID)
+		require.Equal(t, childID, s.Engine.GetStackID(grandchild))
+		require.Equal(t, rootID, s.Engine.GetStackID(root))
+	})
 }
 
 func TestCreateStackRef(t *testing.T) {

--- a/internal/engine/state_core.go
+++ b/internal/engine/state_core.go
@@ -15,7 +15,6 @@ type BranchState struct {
 	LockReason           git.LockReason // Lock reason (empty if not locked)
 	Frozen               bool           // Whether branch is frozen (local-only state)
 	BranchType           git.BranchType // Branch type (worktree-anchor, utility, etc.)
-	RemoteSHA            string         // Remote SHA (populated by PopulateRemoteShas)
 	LocalModified        bool           // Has local metadata changes not yet pushed
 }
 

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -39,6 +39,7 @@ type RemoteOperations interface {
 	PushBranch(ctx context.Context, branchName, remote string, opts PushOptions) error
 	PullBranch(ctx context.Context, remote, branchName string) (PullResult, error)
 	Fetch(ctx context.Context, remote, branch string) error
+	FetchRefSpecs(ctx context.Context, remote string, refspecs []string) error
 	PushMetadataRefs(ctx context.Context, branches []string) error
 	FetchMetadataRefs(ctx context.Context) error
 	DeleteRemoteMetadataRef(ctx context.Context, branch string) error

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -38,6 +38,7 @@ type RemoteOperations interface {
 	FindRemoteBranch(ctx context.Context, remote string) (string, error)
 	PushBranch(ctx context.Context, branchName, remote string, opts PushOptions) error
 	PullBranch(ctx context.Context, remote, branchName string) (PullResult, error)
+	UpdateBranchFromRemote(ctx context.Context, remote, branchName string) (PullResult, error)
 	Fetch(ctx context.Context, remote, branch string) error
 	FetchRefSpecs(ctx context.Context, remote string, refspecs []string) error
 	PushMetadataRefs(ctx context.Context, branches []string) error

--- a/internal/git/pull.go
+++ b/internal/git/pull.go
@@ -114,3 +114,7 @@ func (r *runner) Fetch(ctx context.Context, remote, branch string) error {
 	}
 	return nil
 }
+
+func (r *runner) FetchRefSpecs(ctx context.Context, remote string, refspecs []string) error {
+	return r.fetchRemoteRefSpecs(ctx, remote, refspecs)
+}

--- a/internal/git/pull.go
+++ b/internal/git/pull.go
@@ -18,24 +18,20 @@ const (
 )
 
 func (r *runner) PullBranch(ctx context.Context, remote, branchName string) (PullResult, error) {
-	// Save current branch/detached HEAD
-	currentBranch, err := r.GetCurrentBranch()
-	var currentRev string
-	if err != nil {
-		currentBranch = ""
-		currentRev, _ = r.GetCurrentRevision(ctx)
-	}
+	// Fetch with explicit refspec to update the remote-tracking branch.
+	// This ensures refs/remotes/<remote>/<branch> is actually updated.
+	refspec := fmt.Sprintf("refs/heads/%s:refs/remotes/%s/%s", branchName, remote, branchName)
+	_ = r.fetchRemoteRefSpecs(ctx, remote, []string{refspec})
 
+	return r.UpdateBranchFromRemote(ctx, remote, branchName)
+}
+
+func (r *runner) UpdateBranchFromRemote(ctx context.Context, remote, branchName string) (PullResult, error) {
 	// Get the SHA of the local branch
 	oldRev, err := r.GetRevision(branchName)
 	if err != nil {
 		return PullConflict, fmt.Errorf("failed to get local revision for %s: %w", branchName, err)
 	}
-
-	// Fetch with explicit refspec to update the remote-tracking branch.
-	// This ensures refs/remotes/origin/<branch> is actually updated.
-	refspec := fmt.Sprintf("refs/heads/%s:refs/remotes/%s/%s", branchName, remote, branchName)
-	_ = r.fetchRemoteRefSpecs(ctx, remote, []string{refspec})
 
 	// Get the SHA of the remote branch
 	remoteRev, err := r.GetRemoteSha(remote, branchName)
@@ -51,6 +47,14 @@ func (r *runner) PullBranch(ctx context.Context, remote, branchName string) (Pul
 	// Check if it's a fast-forward (remote is ahead of local)
 	isRemoteAhead, err := r.IsAncestor(ctx, oldRev, remoteRev)
 	if err == nil && isRemoteAhead {
+		// Save current branch/detached HEAD immediately before mutating refs.
+		currentBranch, err := r.GetCurrentBranch()
+		var currentRev string
+		if err != nil {
+			currentBranch = ""
+			currentRev, _ = r.GetCurrentRevision(ctx)
+		}
+
 		// Before updating the ref, check if this branch is checked out in another worktree.
 		// update-ref is global and will affect all worktrees, so we need to sync any
 		// worktree that has this branch checked out to avoid corrupting its index/working tree.

--- a/internal/git/remote_metadata_test.go
+++ b/internal/git/remote_metadata_test.go
@@ -87,3 +87,49 @@ func TestBatchDeleteRemoteMetadataRefs(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestFetchRefSpecsFetchesBranchAndMetadataFromCustomRemote(t *testing.T) {
+	scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+
+	_, err := scene.Repo.CreateBareRemote("upstream")
+	require.NoError(t, err)
+
+	err = scene.Repo.RunGitCommand("checkout", "-b", "feature")
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand("commit", "--allow-empty", "-m", "feature")
+	require.NoError(t, err)
+	err = scene.Repo.PushBranch("upstream", "feature")
+	require.NoError(t, err)
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	metadataRef := "refs/stackit/metadata/feature"
+	sha, err := runner.CreateBlob(`{"branch":"feature"}`)
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand("update-ref", metadataRef, sha)
+	require.NoError(t, err)
+	err = scene.Repo.RunGitCommand("push", "upstream", metadataRef)
+	require.NoError(t, err)
+
+	err = scene.Repo.RunGitCommand("update-ref", "-d", "refs/remotes/upstream/feature")
+	require.NoError(t, err)
+
+	err = runner.FetchRefSpecs(context.Background(), "upstream", []string{
+		"refs/heads/feature:refs/remotes/upstream/feature",
+		"+refs/stackit/metadata/*:refs/stackit/remote-metadata/*",
+	})
+	require.NoError(t, err)
+
+	branchSHA, err := scene.Repo.RunGitCommandAndGetOutput("rev-parse", "--verify", "refs/remotes/upstream/feature")
+	require.NoError(t, err)
+	require.NotEmpty(t, branchSHA)
+
+	remoteMetadataSHA, err := scene.Repo.RunGitCommandAndGetOutput("rev-parse", "--verify", "refs/stackit/remote-metadata/feature")
+	require.NoError(t, err)
+	require.NotEmpty(t, remoteMetadataSHA)
+
+	err = runner.EnsureMetadataRefspecConfigured()
+	require.NoError(t, err)
+	upstreamRefspecs, err := runner.GetConfigAll("remote.upstream.fetch")
+	require.NoError(t, err)
+	require.Contains(t, upstreamRefspecs, "+refs/stackit/metadata/*:refs/stackit/remote-metadata/*")
+}

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -613,7 +613,8 @@ func (r *runner) GetUserName(ctx context.Context) (string, error) {
 func (r *runner) EnsureMetadataRefspecConfigured() error {
 	const metadataRefspec = "+refs/stackit/metadata/*:refs/stackit/remote-metadata/*"
 
-	refspecs, err := r.GetConfigAll("remote.origin.fetch")
+	fetchConfigKey := fmt.Sprintf("remote.%s.fetch", r.GetRemote())
+	refspecs, err := r.GetConfigAll(fetchConfigKey)
 	if err != nil {
 		return fmt.Errorf("failed to get fetch refspecs: %w", err)
 	}
@@ -624,13 +625,14 @@ func (r *runner) EnsureMetadataRefspecConfigured() error {
 	}
 
 	// Add refspec for metadata refs
-	return r.AddConfigValue("remote.origin.fetch", metadataRefspec)
+	return r.AddConfigValue(fetchConfigKey, metadataRefspec)
 }
 
 func (r *runner) EnsureStackMetaRefspecConfigured() error {
 	const stackMetaRefspec = "+refs/stackit/stacks/*:refs/stackit/remote-stacks/*"
 
-	refspecs, err := r.GetConfigAll("remote.origin.fetch")
+	fetchConfigKey := fmt.Sprintf("remote.%s.fetch", r.GetRemote())
+	refspecs, err := r.GetConfigAll(fetchConfigKey)
 	if err != nil {
 		return fmt.Errorf("failed to get fetch refspecs: %w", err)
 	}
@@ -641,7 +643,7 @@ func (r *runner) EnsureStackMetaRefspecConfigured() error {
 	}
 
 	// Add refspec for stack metadata refs
-	return r.AddConfigValue("remote.origin.fetch", stackMetaRefspec)
+	return r.AddConfigValue(fetchConfigKey, stackMetaRefspec)
 }
 
 func (r *runner) FindRemoteBranch(ctx context.Context, remote string) (string, error) {
@@ -1036,7 +1038,7 @@ func (r *runner) PushMetadataRefs(ctx context.Context, branches []string) error 
 }
 
 func (r *runner) FetchMetadataRefs(ctx context.Context) error {
-	return r.fetchRemoteRefSpecs(ctx, "origin", []string{
+	return r.fetchRemoteRefSpecs(ctx, r.GetRemote(), []string{
 		"+refs/stackit/metadata/*:refs/stackit/remote-metadata/*",
 	})
 }
@@ -1053,7 +1055,7 @@ func (r *runner) PushStackMetaRefs(ctx context.Context, stackIDs []string) error
 }
 
 func (r *runner) FetchStackMetaRefs(ctx context.Context) error {
-	return r.fetchRemoteRefSpecs(ctx, "origin", []string{
+	return r.fetchRemoteRefSpecs(ctx, r.GetRemote(), []string{
 		"+refs/stackit/stacks/*:refs/stackit/remote-stacks/*",
 	})
 }

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -183,6 +183,13 @@ func (t *tracingRunner) PullBranch(ctx context.Context, remote, branchName strin
 	return result, err
 }
 
+func (t *tracingRunner) UpdateBranchFromRemote(ctx context.Context, remote, branchName string) (PullResult, error) {
+	start := time.Now()
+	result, err := t.inner.UpdateBranchFromRemote(ctx, remote, branchName)
+	t.trace("UpdateBranchFromRemote", time.Since(start), err == nil, err, slog.String("remote", remote), slog.String("branch", branchName))
+	return result, err
+}
+
 func (t *tracingRunner) Fetch(ctx context.Context, remote, branch string) error {
 	start := time.Now()
 	err := t.inner.Fetch(ctx, remote, branch)

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -190,6 +190,13 @@ func (t *tracingRunner) Fetch(ctx context.Context, remote, branch string) error 
 	return err
 }
 
+func (t *tracingRunner) FetchRefSpecs(ctx context.Context, remote string, refspecs []string) error {
+	start := time.Now()
+	err := t.inner.FetchRefSpecs(ctx, remote, refspecs)
+	t.trace("FetchRefSpecs", time.Since(start), err == nil, err, slog.String("remote", remote), slog.Int("count", len(refspecs)))
+	return err
+}
+
 func (t *tracingRunner) PushMetadataRefs(ctx context.Context, branches []string) error {
 	start := time.Now()
 	err := t.inner.PushMetadataRefs(ctx, branches)

--- a/internal/integration/sync_test.go
+++ b/internal/integration/sync_test.go
@@ -612,10 +612,6 @@ func TestSyncDoesNotLeaveIndexState(t *testing.T) {
 		// Go back to main for sync
 		sh.Checkout("main")
 
-		// Populate remote SHAs so GetBranchRemoteStatus can detect ahead
-		err = eng.PopulateRemoteShas()
-		require.NoError(t, err)
-
 		// Run sync (non-interactive - should skip unpushed branches)
 		err = sync.Action(sh.Context, sync.Options{}, nil)
 		require.NoError(t, err)

--- a/internal/tui/log_ui.go
+++ b/internal/tui/log_ui.go
@@ -238,7 +238,7 @@ func (m *LogModel) log(msg string, args ...any) {
 }
 
 // enrichData returns a command that fetches full annotation data in the background.
-// This includes git operations and network calls (remote SHAs, CI status).
+// This includes git operations and CI status network calls.
 func (m *LogModel) enrichData() tea.Cmd {
 	// Capture values needed by the goroutine to avoid races on struct fields
 	ctx := m.context
@@ -271,27 +271,6 @@ func (m *LogModel) enrichData() tea.Cmd {
 			err      error
 		}
 		ciChan := make(chan ciResult, 1)
-		remoteShasDone := make(chan struct{}, 1)
-
-		// Run PopulateRemoteShas and BatchGetPRChecksStatus in parallel
-		if style == logStyleFull {
-			go func() {
-				defer func() {
-					if p := recover(); p != nil {
-						logError("PopulateRemoteShas panicked: %v", p)
-					}
-					remoteShasDone <- struct{}{}
-				}()
-				start := time.Now()
-				if err := eng.PopulateRemoteShas(); err != nil {
-					logError("PopulateRemoteShas failed: %v", err)
-				}
-				logDebug("PopulateRemoteShas completed in %v", time.Since(start))
-			}()
-		} else {
-			remoteShasDone <- struct{}{}
-		}
-
 		if style == logStyleFull && ghClient != nil {
 			branchNames := engine.Branches(allBranches).Select(engine.BranchFilter{ExcludeTrunk: true, RequirePR: true}).Names()
 			if len(branchNames) > 0 {
@@ -318,8 +297,7 @@ func (m *LogModel) enrichData() tea.Cmd {
 			ciChan <- ciResult{}
 		}
 
-		// Wait for both operations to complete
-		<-remoteShasDone
+		// Wait for CI status fetch to complete
 		ciRes := <-ciChan
 		if ciRes.err != nil {
 			logError("CI status fetch failed, skipping CI annotations: %v", ciRes.err)

--- a/internal/worktree/executor.go
+++ b/internal/worktree/executor.go
@@ -105,10 +105,6 @@ func (e *Executor) CreateSession(ctx context.Context, opts CreateSessionOptions)
 
 // pullTrunk updates trunk in the worktree to match remote.
 func (s *Session) pullTrunk(ctx context.Context) error {
-	if err := s.Engine.PopulateRemoteShas(); err != nil {
-		s.output.Debug("Failed to populate remote SHAs in worktree: %v", err)
-	}
-
 	pullResult, err := s.Engine.PullTrunk(ctx)
 	if err != nil {
 		return errors.FailedTo("update", "trunk in worktree", err)


### PR DESCRIPTION
**Batch git fetches and eliminate redundant remote lookups**

A series of performance improvements that replace per-branch sequential git fetch calls with batched equivalents, eliminating N+1 git process overhead across get, sync, and branch status operations.

Key changes:
- **Batch get fetches**: `GetAction` collects all branches upfront and issues a single `FetchRemote` call, replacing individual `eng.Fetch` calls per branch in the sync loop.
- **Batch sync fetches**: `SyncAction` and trunk sync consolidate fetch calls into a single batched operation.
- **Avoid duplicate PR branch lookups**: Deduplicates PR branch resolution during get to prevent redundant lookups.
- **Selective branch metadata refresh**: New `ApplyRemoteMetadataForBranches` engine method encapsulates the three-step configure/load/apply sequence and skips trunk and empty branches, simplifying callers across several actions.
- **Replace remote SHA cache warming**: `GetBranchRemoteStatus` is refactored into `ReadBranchRemoteStatuses`, which fetches all remote SHAs in one `FetchRemoteShas` call and removes the per-branch cache-warming pattern from the engine.

This PR merges the following changes:

1. **#1113** perf: batch get fetches
2. **#1114** perf: batch sync fetches
3. **#1115** fix: avoid duplicate PR branch lookups
4. **#1116** perf: refresh get branches selectively
5. **#1117** refactor: replace remote SHA cache warming

### Stack

```
main
  └─ jonnii/20260531122433/batch-get-fetches (#1113)
    └─ jonnii/20260531125059/batch-sync-fetches (#1114)
      └─ jonnii/20260531181805/avoid-duplicate-PR-branch-lookups (#1115)
        └─ jonnii/20260531204803/refresh-get-branches-selectively (#1116)
          └─ jonnii/20260601010634/replace-remote-SHA-cache-warming (#1117)
```

Stackit-Stack-Size: 5
Stackit-PRs: 1113,1114,1115,1116,1117
