### PR TITLE
ignore claude local

### DIFF
--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -364,6 +364,7 @@ func NewContextAutoWithWriter(ctx context.Context, repoRoot string, opts GlobalO
 		loadMode = *opts.EngineLoadMode
 	}
 
+
 	// Create real engine with configured runner. LoadModeShared skips
 	// BatchReadLocalMetadata at bootstrap — local metadata (Frozen, etc.)
 	// loads on first accessor call. For commands that never read local-only

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -304,6 +304,7 @@ func (e *engineImpl) ensureBranchSharedLoaded(branchName string) {
 	e.mu.Unlock()
 }
 
+
 // ensureLocalLoaded reads local metadata for all known branches and applies
 // the Frozen flag to state. Same locking contract as ensureSharedLoaded.
 //

--- a/internal/engine/engine_loadmode_test.go
+++ b/internal/engine/engine_loadmode_test.go
@@ -206,6 +206,7 @@ func TestLoadMode_BranchesOnly_GetScopeLazilyLoadsParentChain(t *testing.T) {
 		"lazy scope lookup should read only the target branch and scoped parent")
 }
 
+
 // TestLoadMode_ConcurrentEnsureLoaded asserts that many concurrent accessors
 // against a LoadModeBranchesOnly engine all see the same fully-populated state
 // after the gate fires, regardless of which goroutine triggers it. This is


### PR DESCRIPTION
- ignore claude local
- feat(engine): add LoadMode with lazy shared/local metadata promotion

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1119** 👈
  * **PR #1120**

**Previously based on:**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->