### PR TITLE
feat(engine): add LoadMode with lazy shared/local metadata promotion

### DIFF
--- a/internal/engine/engine_loadmode_test.go
+++ b/internal/engine/engine_loadmode_test.go
@@ -158,54 +158,7 @@ func TestLoadMode_BranchesOnly_ReadsBranchListOnly(t *testing.T) {
 	require.Zero(t, stats.Misses, "BranchesOnly bootstrap must not read metadata refs")
 }
 
-func TestLoadMode_BranchesOnly_LazilyLoadsBranchChain(t *testing.T) {
-	t.Parallel()
-	s := makeStackForLoadModeTest(t)
-
-	gitRunner := git.NewRunnerWithPath(s.Scene.Dir, nil)
-	require.NoError(t, gitRunner.InitDefaultRepo())
-
-	eng, err := engine.NewEngine(engine.Options{
-		RepoRoot: s.Scene.Dir,
-		Trunk:    "main",
-		Git:      gitRunner,
-		LoadMode: engine.LoadModeBranchesOnly,
-	})
-	require.NoError(t, err)
-
-	root := eng.GetStackRootForBranch(eng.GetBranch("c"))
-	require.Equal(t, "a", root)
-	require.True(t, eng.IsTracked(eng.GetBranch("c")))
-
-	stats := gitRunner.MetadataCacheStats()
-	require.LessOrEqual(t, stats.Misses, uint64(3),
-		"lazy stack-root lookup should read only the target parent chain")
-}
-
-func TestLoadMode_BranchesOnly_GetScopeLazilyLoadsParentChain(t *testing.T) {
-	t.Parallel()
-	s := makeStackForLoadModeTest(t)
-	require.NoError(t, s.Engine.SetScope(context.Background(), s.Engine.GetBranch("b"), engine.NewScope("topic")))
-
-	gitRunner := git.NewRunnerWithPath(s.Scene.Dir, nil)
-	require.NoError(t, gitRunner.InitDefaultRepo())
-
-	eng, err := engine.NewEngine(engine.Options{
-		RepoRoot: s.Scene.Dir,
-		Trunk:    "main",
-		Git:      gitRunner,
-		LoadMode: engine.LoadModeBranchesOnly,
-	})
-	require.NoError(t, err)
-
-	scope := eng.GetScope(eng.GetBranch("c"))
-	require.Equal(t, "topic", scope.String())
-
-	stats := gitRunner.MetadataCacheStats()
-	require.LessOrEqual(t, stats.Misses, uint64(2),
-		"lazy scope lookup should read only the target branch and scoped parent")
-}
-
+=======
 
 // TestLoadMode_ConcurrentEnsureLoaded asserts that many concurrent accessors
 // against a LoadModeBranchesOnly engine all see the same fully-populated state


### PR DESCRIPTION

Introduce three engine load tiers, defaulting to LoadModeFull so today's
behavior is unchanged:

- LoadModeFull: read both shared and local metadata at construction.
- LoadModeShared: read shared metadata, defer local until first IsFrozen
  (or other local-only accessor) call.
- LoadModeBranchesOnly: read only the branch list; both metadata tiers
  defer until the first accessor that needs them.

The promotion is implemented as two sync.Once gates (sharedLoadOnce,
localLoadOnce) backed by atomic.Bool fast-path flags on engineImpl.
ensureSharedLoaded / ensureLocalLoaded snapshot the branches list under
read lock, do the batched git read without the lock, then apply state
under write lock. Atomic-set-true after the load so subsequent calls are
free.

Splits stateCore.rebuildFromMetadata into applySharedMetadata +
applyLocalMetadata so the gates can run each tier independently while
keeping the existing full-rebuild path single-sourced.

SnapshotForWorktree force-loads both tiers before copying, so worktree
consumers (restack, sync) always see fully-populated state regardless of
the parent engine's LoadMode. NewEngineForWorktree marks both gates open
since the snapshot is the source of truth.

IsFrozen gets ensureLocalLoaded() at entry — the only public accessor
that reads a local-only field today. ensureLocalLoaded is a no-op under
LoadModeFull (atomic check), so no behavior change.

Tests (engine_loadmode_test.go) cover: full-vs-shared equivalence
across IsTracked / IsLocked / GetScope / GetBranchType / GetParent /
IsFrozen; LoadModeShared not triggering local reads at bootstrap;
LoadModeBranchesOnly leaving metadataCache untouched; 32-goroutine
concurrent IsFrozen against LoadModeShared collapsing to a single
local promotion; SnapshotForWorktree force-loading a BranchesOnly
parent.

PR 5 will flip app.Context default to LoadModeShared; PR 6 will add
per-command LoadModeBranchesOnly opt-ins for parent/children/etc.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1119**
  * **PR #1120** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->