### PR TITLE
refactor: introduce BranchRemoteStatuses type and remove GetBranchRemoteStatus

### DIFF
--- a/internal/actions/merge/multistack.go
+++ b/internal/actions/merge/multistack.go
@@ -1,6 +1,7 @@
 package merge
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -53,7 +54,7 @@ func ExecuteMultiStack(ctx *app.Context, opts MultiStackOptions) (*MultiStackRes
 	// This is critical: if branches differ from remote, the octopus merge uses local SHAs
 	// but PRs track remote SHAs, so GitHub won't auto-close individual PRs
 	out.Debug("multistack: validating branches match remote")
-	if err := validateBranchesMatchRemote(eng, stacks, out); err != nil {
+	if err := validateBranchesMatchRemote(ctx.Context, eng, stacks, out); err != nil {
 		out.Debug("multistack: branch validation failed: %v", err)
 		return nil, err
 	}
@@ -228,18 +229,13 @@ func ExecuteMultiStack(ctx *app.Context, opts MultiStackOptions) (*MultiStackRes
 // validateBranchesMatchRemote checks that all branches in the stacks match their remote.
 // This is critical for shipping: if local differs from remote, the octopus merge
 // will use local SHAs but PRs track remote SHAs, so GitHub won't auto-close them.
-func validateBranchesMatchRemote(eng engine.Engine, stacks []MultiStackInfo, out interface{ Warn(string, ...any) }) error {
+func validateBranchesMatchRemote(ctx context.Context, eng engine.Engine, stacks []MultiStackInfo, out interface{ Warn(string, ...any) }) error {
 	var mismatchedBranches []string
 
 	for _, stack := range stacks {
 		for _, branchName := range stack.AllBranches {
 			branch := eng.GetBranch(branchName)
-			status, err := eng.GetBranchRemoteStatus(branch)
-			if err != nil {
-				continue // Skip branches we can't check
-			}
-
-			if !status.Matches() {
+			if !eng.ReadBranchRemoteStatuses(ctx, engine.BranchesOf(branch)).ForBranch(branch).Matches() {
 				mismatchedBranches = append(mismatchedBranches, branchName)
 			}
 		}

--- a/internal/actions/merge/multistack_validation_test.go
+++ b/internal/actions/merge/multistack_validation_test.go
@@ -1,6 +1,7 @@
 package merge
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,7 +26,7 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 		}
 
 		// Should pass - branch matches remote
-		err := validateBranchesMatchRemote(s.Engine, stacks, s.Context.Output)
+		err := validateBranchesMatchRemote(context.Background(), s.Engine, stacks, s.Context.Output)
 		assert.NoError(t, err)
 	})
 
@@ -48,7 +49,7 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 		}
 
 		// Should fail - branch differs from remote
-		err := validateBranchesMatchRemote(s.Engine, stacks, s.Context.Output)
+		err := validateBranchesMatchRemote(context.Background(), s.Engine, stacks, s.Context.Output)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot ship")
 		assert.Contains(t, err.Error(), "differ from remote")
@@ -85,7 +86,7 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 		}
 
 		// Should fail with count of 2
-		err := validateBranchesMatchRemote(s.Engine, stacks, s.Context.Output)
+		err := validateBranchesMatchRemote(context.Background(), s.Engine, stacks, s.Context.Output)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "2 branch")
 	})
@@ -114,7 +115,7 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 		}
 
 		// Should pass - all branches match remote
-		err := validateBranchesMatchRemote(s.Engine, stacks, s.Context.Output)
+		err := validateBranchesMatchRemote(context.Background(), s.Engine, stacks, s.Context.Output)
 		assert.NoError(t, err)
 	})
 
@@ -146,7 +147,7 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 		}
 
 		// Should fail - stack2 branch differs from remote
-		err := validateBranchesMatchRemote(s.Engine, stacks, s.Context.Output)
+		err := validateBranchesMatchRemote(context.Background(), s.Engine, stacks, s.Context.Output)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "1 branch")
 	})
@@ -165,7 +166,7 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 		}
 
 		// Should fail - branch doesn't exist on remote (doesn't match)
-		err := validateBranchesMatchRemote(s.Engine, stacks, s.Context.Output)
+		err := validateBranchesMatchRemote(context.Background(), s.Engine, stacks, s.Context.Output)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "differ from remote")
 	})

--- a/internal/actions/merge/plan.go
+++ b/internal/actions/merge/plan.go
@@ -325,13 +325,8 @@ func CollectMergeBranches(ctx context.Context, eng mergePlanEngine, splog output
 		}
 
 		// Check if local matches remote
-		status, err := eng.GetBranchRemoteStatus(eng.GetBranch(name))
-		matchesRemote := true
-		if err != nil {
-			splog.Debug("Failed to get branch remote status: %v", err)
-		} else {
-			matchesRemote = status.Matches()
-		}
+		branchObj := eng.GetBranch(name)
+		matchesRemote := eng.ReadBranchRemoteStatuses(ctx, engine.BranchesOf(branchObj)).ForBranch(branchObj).Matches()
 
 		if !matchesRemote {
 			// Get detailed difference information
@@ -385,7 +380,7 @@ func CollectMergeBranches(ctx context.Context, eng mergePlanEngine, splog output
 
 	// Pre-flight check: Check if trunk is in sync with remote
 	trunk := eng.Trunk()
-	if status, err := eng.GetBranchRemoteStatus(trunk); err == nil && status.Diverged() {
+	if eng.ReadBranchRemoteStatuses(ctx, engine.BranchesOf(trunk)).ForBranch(trunk).Diverged() {
 		validation.Warnings = append(validation.Warnings, fmt.Sprintf("Trunk branch %s has diverged from remote. You may need to sync it manually or use --force during merge.", trunk.GetName()))
 	}
 

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -444,14 +444,13 @@ func pushBranchIfNeeded(ctx *app.Context, submissionInfo Info, opts Options, rem
 	branch := ctx.Navigator().GetBranch(submissionInfo.BranchName)
 	leaseExpectedSHA := ""
 	if forceWithLease {
-		if status, err := ctx.PR().GetBranchRemoteStatus(branch); err == nil {
-			// Remote already has this exact SHA — skip the push to avoid a spurious
-			// "cannot lock ref: reference already exists" rejection from the server.
-			if status.Matches() {
-				return nil
-			}
-			leaseExpectedSHA = status.RemoteSha
+		status := ctx.PR().ReadBranchRemoteStatuses(ctx.Context, engine.BranchesOf(branch)).ForBranch(branch)
+		// Remote already has this exact SHA — skip the push to avoid a spurious
+		// "cannot lock ref: reference already exists" rejection from the server.
+		if status.Matches() {
+			return nil
 		}
+		leaseExpectedSHA = status.RemoteSha
 	}
 	if err := ctx.PR().PushBranch(ctx.Context, branch, remote, git.PushOptions{
 		Force:                     opts.Force,

--- a/internal/actions/submit/submit_validation.go
+++ b/internal/actions/submit/submit_validation.go
@@ -92,11 +92,7 @@ func validateBaseRevisions(branches []string, eng engine.BranchStatus, ctx *app.
 			}
 		default:
 			// Parent is not in submission list
-			status, err := eng.GetBranchRemoteStatus(parentBranch)
-			if err != nil {
-				return fmt.Errorf("failed to check if parent branch matches remote: %w", err)
-			}
-			if !status.Matches() {
+			if !eng.ReadBranchRemoteStatuses(ctx.Context, engine.BranchesOf(parentBranch)).ForBranch(parentBranch).Matches() {
 				return fmt.Errorf("you are trying to submit at least one branch whose base does not match its parent remotely, without including its parent. You may want to use 'stackit submit --stack' to ensure that the ancestors of %s are included in your submission",
 					style.ColorBranchName(branchName, false))
 			}

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -263,7 +263,7 @@ func CreateAction(ctx *app.Context, opts CreateOptions) (*CreateResult, error) {
 	trunk := eng.Trunk()
 
 	// Check if trunk is behind remote and warn
-	if status, err := eng.GetBranchRemoteStatus(trunk); err == nil && status.Behind() {
+	if eng.ReadBranchRemoteStatuses(ctx.Context, engine.BranchesOf(trunk)).ForBranch(trunk).Behind() {
 		out.Warn("Local %s is behind remote. Consider running 'st sync' first.", trunk.GetName())
 	}
 

--- a/internal/cli/stack/sync.go
+++ b/internal/cli/stack/sync.go
@@ -11,6 +11,7 @@ import (
 	"github.com/getstackit/stackit/internal/actions/sync"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // NewSyncCmd creates the sync command
@@ -101,8 +102,8 @@ func syncDryRunJSON(ctx *app.Context, opts sync.Options) error {
 
 	// Check if trunk needs to be pulled from remote
 	trunk := eng.Trunk()
-	remoteStatus, err := eng.GetBranchRemoteStatus(trunk)
-	if err == nil && remoteStatus.Behind() {
+	remoteStatus := eng.ReadBranchRemoteStatuses(ctx.Context, engine.BranchesOf(trunk)).ForBranch(trunk)
+	if remoteStatus.Behind() {
 		result.WouldPull = trunk.GetName()
 	}
 

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -1,6 +1,7 @@
 package httpcontract
 
 import (
+	"context"
 	"slices"
 	"strings"
 	"time"
@@ -71,13 +72,12 @@ func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.Stack
 	}
 
 	// Map remote status
-	if remoteStatus, err := eng.GetBranchRemoteStatus(branch); err == nil {
-		resp.RemoteStatus = &RemoteStatus{
-			Ahead:         remoteStatus.Ahead(),
-			Behind:        remoteStatus.Behind(),
-			Diverged:      remoteStatus.Diverged(),
-			MissingRemote: remoteStatus.MissingRemote(),
-		}
+	remoteStatus := eng.ReadBranchRemoteStatuses(context.Background(), engine.BranchesOf(branch)).ForBranch(branch)
+	resp.RemoteStatus = &RemoteStatus{
+		Ahead:         remoteStatus.Ahead(),
+		Behind:        remoteStatus.Behind(),
+		Diverged:      remoteStatus.Diverged(),
+		MissingRemote: remoteStatus.MissingRemote(),
 	}
 
 	return resp

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -23,8 +23,7 @@ import (
 // Thread-safe: All methods are safe for concurrent use
 type PRManager interface {
 	UpsertPrInfo(ctx context.Context, branch Branch, prInfo *PrInfo) error
-	GetBranchRemoteStatus(branch Branch) (BranchRemoteStatus, error)
-	ReadBranchRemoteStatuses(ctx context.Context, branches Branches) map[string]BranchRemoteStatus
+	ReadBranchRemoteStatuses(ctx context.Context, branches Branches) BranchRemoteStatuses
 	PushBranch(ctx context.Context, branch Branch, remote string, opts git.PushOptions) error
 	// Navigation comment ID caching (stored in local metadata)
 	GetNavigationCommentID(branch Branch) (int64, error)

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -240,15 +240,10 @@ func (e *engineImpl) ReadBranchStatuses(branches Branches) BranchStatuses {
 	return newBranchStatuses(results)
 }
 
-// GetBranchRemoteStatus returns the relationship between a local branch and its remote.
-func (e *engineImpl) GetBranchRemoteStatus(branch Branch) (BranchRemoteStatus, error) {
-	return e.ReadBranchRemoteStatuses(context.Background(), BranchesOf(branch))[branch.GetName()], nil
-}
-
 // ReadBranchRemoteStatuses returns the local/remote relationship for the
 // requested branches. It lists remote branch SHAs once and does not mutate
 // engine state.
-func (e *engineImpl) ReadBranchRemoteStatuses(ctx context.Context, branches Branches) map[string]BranchRemoteStatus {
+func (e *engineImpl) ReadBranchRemoteStatuses(ctx context.Context, branches Branches) BranchRemoteStatuses {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -468,10 +463,7 @@ func (e *engineImpl) GetRemote() string {
 // GetBranchRemoteDifference returns a string describing the difference between local and remote branch
 func (e *engineImpl) GetBranchRemoteDifference(branchName string) (string, error) {
 	branch := e.GetBranch(branchName)
-	status, err := e.GetBranchRemoteStatus(branch)
-	if err != nil {
-		return "", err
-	}
+	status := e.ReadBranchRemoteStatuses(context.Background(), BranchesOf(branch)).ForBranch(branch)
 
 	if status.LocalSha == "" {
 		return "(branch not found locally)", nil

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -959,30 +959,29 @@ func TestConcurrentAccess(t *testing.T) {
 	})
 }
 
-func TestGetBranchRemoteStatus(t *testing.T) {
+func TestBranchRemoteStatuses(t *testing.T) {
 	t.Parallel()
+
+	getBranchStatus := func(s *scenario.Scenario, name string) engine.BranchRemoteStatus {
+		branch := s.Engine.GetBranch(name)
+		return s.Engine.ReadBranchRemoteStatuses(context.Background(), engine.BranchesOf(branch)).ForBranch(branch)
+	}
+
 	t.Run("returns true when branch matches remote", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
-		// Create a bare remote
 		_, err := s.Scene.Repo.CreateBareRemote("origin")
 		require.NoError(t, err)
-
-		// Push main first
 		err = s.Scene.Repo.PushBranch("origin", "main")
 		require.NoError(t, err)
 
-		// Create and push a branch
-		s.CreateBranch("feature").
-			Commit("feature change")
+		s.CreateBranch("feature").Commit("feature change")
 		err = s.Scene.Repo.PushBranch("origin", "feature")
 		require.NoError(t, err)
 		s.Checkout("main")
 
-		// Verify GetBranchRemoteStatus
-		status, err := s.Engine.GetBranchRemoteStatus(s.Engine.GetBranch("feature"))
-		require.NoError(t, err)
+		status := getBranchStatus(s, "feature")
 		require.True(t, status.Matches(), "branch should match remote after push")
 		require.False(t, status.Ahead())
 		require.False(t, status.Behind())
@@ -993,27 +992,17 @@ func TestGetBranchRemoteStatus(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
-		// Create a bare remote
 		_, err := s.Scene.Repo.CreateBareRemote("origin")
 		require.NoError(t, err)
-
-		// Push main first
 		err = s.Scene.Repo.PushBranch("origin", "main")
 		require.NoError(t, err)
 
-		// Create and push a branch
-		s.CreateBranch("feature").
-			Commit("feature change")
+		s.CreateBranch("feature").Commit("feature change")
 		err = s.Scene.Repo.PushBranch("origin", "feature")
 		require.NoError(t, err)
+		s.Commit("local change").Checkout("main")
 
-		// Make local change (not pushed)
-		s.Commit("local change").
-			Checkout("main")
-
-		// Verify GetBranchRemoteStatus
-		status, err := s.Engine.GetBranchRemoteStatus(s.Engine.GetBranch("feature"))
-		require.NoError(t, err)
+		status := getBranchStatus(s, "feature")
 		require.False(t, status.Matches(), "branch should not match remote with local changes")
 		require.True(t, status.Ahead())
 		require.False(t, status.Behind())
@@ -1024,22 +1013,14 @@ func TestGetBranchRemoteStatus(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
-		// Create a bare remote
 		_, err := s.Scene.Repo.CreateBareRemote("origin")
 		require.NoError(t, err)
-
-		// Push main (but not feature)
 		err = s.Scene.Repo.PushBranch("origin", "main")
 		require.NoError(t, err)
 
-		// Create a branch locally but don't push it
-		s.CreateBranch("feature").
-			Commit("feature change").
-			Checkout("main")
+		s.CreateBranch("feature").Commit("feature change").Checkout("main")
 
-		// Verify GetBranchRemoteStatus
-		status, err := s.Engine.GetBranchRemoteStatus(s.Engine.GetBranch("feature"))
-		require.NoError(t, err)
+		status := getBranchStatus(s, "feature")
 		require.False(t, status.Matches(), "branch should not match when it doesn't exist on remote")
 		require.True(t, status.MissingRemote())
 	})
@@ -1048,29 +1029,20 @@ func TestGetBranchRemoteStatus(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
-		// Create a bare remote
 		_, err := s.Scene.Repo.CreateBareRemote("origin")
 		require.NoError(t, err)
-
-		// Push main first
 		err = s.Scene.Repo.PushBranch("origin", "main")
 		require.NoError(t, err)
 
-		// Create and push a branch
-		s.CreateBranch("feature").
-			Commit("feature change")
+		s.CreateBranch("feature").Commit("feature change")
 		err = s.Scene.Repo.PushBranch("origin", "feature")
 		require.NoError(t, err)
 
-		// Amend the commit locally (simulates squash or rebase)
 		err = s.Scene.Repo.CreateChangeAndAmend("amended change", "amended")
 		require.NoError(t, err)
-
 		s.Checkout("main")
 
-		// Verify GetBranchRemoteStatus
-		status, err := s.Engine.GetBranchRemoteStatus(s.Engine.GetBranch("feature"))
-		require.NoError(t, err)
+		status := getBranchStatus(s, "feature")
 		require.False(t, status.Matches(), "branch should not match remote after amend")
 		require.True(t, status.Diverged())
 		require.False(t, status.Ahead())
@@ -1126,8 +1098,8 @@ func TestReadBranchRemoteStatuses(t *testing.T) {
 		require.NoError(t, err)
 
 		// Branches should not match (nothing on remote)
-		status, err := s.Engine.GetBranchRemoteStatus(s.Engine.GetBranch("main"))
-		require.NoError(t, err)
+		main := s.Engine.GetBranch("main")
+		status := s.Engine.ReadBranchRemoteStatuses(context.Background(), engine.BranchesOf(main)).ForBranch(main)
 		require.False(t, status.Matches(), "main should not match empty remote")
 	})
 }

--- a/internal/engine/engine_pr.go
+++ b/internal/engine/engine_pr.go
@@ -135,7 +135,7 @@ func (e *engineImpl) GetPRSubmissionStatus(branch Branch) (PRSubmissionStatus, e
 
 	// It's an update
 	baseChanged := prInfo.Base() != parentBranchName
-	status, _ := e.GetBranchRemoteStatus(branch)
+	status := e.ReadBranchRemoteStatuses(context.Background(), BranchesOf(branch)).ForBranch(branch)
 	branchMatches := status.Matches()
 
 	// Check if PR title needs update due to scope changes

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -53,8 +53,7 @@ type BranchStatus interface {
 	GetRemote() string
 	GetRemoteURL(ctx context.Context) (string, error)
 	GetBranchRemoteDifference(branchName string) (string, error)
-	GetBranchRemoteStatus(branch Branch) (BranchRemoteStatus, error)
-	ReadBranchRemoteStatuses(ctx context.Context, branches Branches) map[string]BranchRemoteStatus
+	ReadBranchRemoteStatuses(ctx context.Context, branches Branches) BranchRemoteStatuses
 	GetMergedBranches(ctx context.Context, target string) (map[string]bool, error)
 }
 

--- a/internal/engine/persistence_locked_test.go
+++ b/internal/engine/persistence_locked_test.go
@@ -64,7 +64,7 @@ func TestPrInfoLockedPersistence(t *testing.T) {
 		prInfo, _ := branch.GetPrInfo()
 		parentBranch := eng.Trunk().GetName()
 		baseChanged := prInfo.Base() != parentBranch
-		remoteStatus, _ := eng.GetBranchRemoteStatus(branch)
+		remoteStatus := eng.ReadBranchRemoteStatuses(context.Background(), engine.BranchesOf(branch)).ForBranch(branch)
 		branchChanged := !remoteStatus.Matches()
 		t.Logf("baseChanged: %v, branchChanged: %v, prInfo.IsLocked: %v, branch.IsLocked: %v", baseChanged, branchChanged, prInfo.IsLocked(), branch.IsLocked())
 	}

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -227,6 +227,14 @@ func (s BranchRemoteStatus) MissingRemote() bool {
 	return s.RemoteSha == ""
 }
 
+// BranchRemoteStatuses maps branch names to their remote sync status.
+type BranchRemoteStatuses map[string]BranchRemoteStatus
+
+// ForBranch returns the remote status for the given branch.
+func (s BranchRemoteStatuses) ForBranch(branch Branch) BranchRemoteStatus {
+	return s[branch.GetName()]
+}
+
 // ValidationResult represents the validation state of a branch
 type ValidationResult int
 

--- a/internal/shippable/analyzer.go
+++ b/internal/shippable/analyzer.go
@@ -181,8 +181,7 @@ func (a *Analyzer) analyzeBranch(branchName string, statusMap map[string]*github
 	// Check if local branch matches remote
 	// This is critical for shipping: if local differs from remote, the octopus merge
 	// will use local SHAs but PRs track remote SHAs, so GitHub won't auto-close them
-	remoteStatus, err := a.eng.GetBranchRemoteStatus(branch)
-	if err == nil && !remoteStatus.Matches() {
+	if !a.eng.ReadBranchRemoteStatuses(context.Background(), engine.BranchesOf(branch)).ForBranch(branch).Matches() {
 		return &BlockingPR{
 			Branch:   branchName,
 			PRNumber: prNumber,


### PR DESCRIPTION

Replace map[string]BranchRemoteStatus with a named BranchRemoteStatuses type that
carries a ForBranch method, eliminating the GetBranchRemoteStatus convenience wrapper
and its always-nil error return. All callers now go through ReadBranchRemoteStatuses
directly.