### PR TITLE
fix: surface metadata write errors in RenameBranch

### DIFF
--- a/internal/engine/branch_mutations.go
+++ b/internal/engine/branch_mutations.go
@@ -404,7 +404,7 @@ func (e *engineImpl) RenameBranch(ctx context.Context, oldBranch, newBranch Bran
 		}
 		childMeta = childMeta.WithParentBranchName(&newName)
 		if err := e.writeMetadata(child, childMeta); err != nil {
-			continue
+			return fmt.Errorf("update parent metadata for child %s: %w", child, err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- When `RenameBranch` updates children's `parentBranchName` metadata after a git rename, a failed `writeMetadata` call was silently swallowed with `continue`
- This left children still pointing to the old (now non-existent) branch name; after `rebuild()` re-reads metadata from disk, those children lose their stack relationship
- Now returns a descriptive error naming the child branch, consistent with how other write failures are handled in the engine

## Test plan

- [ ] Existing `TestRenameWithChildren` integration test verifies the happy path (child's parent is updated correctly after rename)
- [ ] The write-failure path is a defensive fix for an edge case (disk I/O errors); normal test runs are unaffected since `writeMetadata` succeeds in tests
- [ ] `go vet ./internal/engine/...` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaqHEhXsPBVERF3xErY5sH)_