### PR TITLE
fix: require --yes for non-interactive merge

### DIFF
--- a/internal/cli/stack/merge/confirm.go
+++ b/internal/cli/stack/merge/confirm.go
@@ -1,0 +1,14 @@
+package merge
+
+import (
+	"fmt"
+
+	"github.com/getstackit/stackit/internal/app"
+)
+
+func requireYesInNonInteractive(ctx *app.Context, command string, yes, dryRun bool) error {
+	if dryRun || yes || ctx.Interactive {
+		return nil
+	}
+	return fmt.Errorf("%s requires --yes in non-interactive mode", command)
+}

--- a/internal/cli/stack/merge/drain.go
+++ b/internal/cli/stack/merge/drain.go
@@ -142,6 +142,10 @@ func runMergeDrain(ctx *app.Context, opts mergeDrainOptions) error {
 		return nil
 	}
 
+	if err := requireYesInNonInteractive(ctx, "merge drain", opts.yes, opts.dryRun); err != nil {
+		return err
+	}
+
 	// Fail fast if no GitHub client
 	if _, err := ctx.RequireGitHub(); err != nil {
 		return err

--- a/internal/cli/stack/merge/merge_test.go
+++ b/internal/cli/stack/merge/merge_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	mergeAction "github.com/getstackit/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/github"
 	"github.com/getstackit/stackit/internal/tui"
@@ -151,6 +152,36 @@ func TestNewDrainCmd(t *testing.T) {
 		waitFlag := cmd.Flags().Lookup("wait")
 		require.Nil(t, waitFlag)
 	})
+}
+
+func TestRequireYesInNonInteractive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		interactive bool
+		yes         bool
+		dryRun      bool
+		wantErr     bool
+	}{
+		{name: "interactive prompts later", interactive: true},
+		{name: "non-interactive with yes", yes: true},
+		{name: "non-interactive dry run", dryRun: true},
+		{name: "non-interactive without yes", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := &app.Context{Interactive: tt.interactive}
+			err := requireYesInNonInteractive(ctx, "merge next", tt.yes, tt.dryRun)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "--yes")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestMergeNextUsesCreateMergePlan(t *testing.T) {

--- a/internal/cli/stack/merge/next.go
+++ b/internal/cli/stack/merge/next.go
@@ -116,6 +116,10 @@ func runMergeNext(ctx *app.Context, opts mergeNextOptions, postMergeHandler Post
 		return nil
 	}
 
+	if err := requireYesInNonInteractive(ctx, "merge next", opts.yes, opts.dryRun); err != nil {
+		return err
+	}
+
 	// Fail fast if no GitHub client
 	if _, err := ctx.RequireGitHub(); err != nil {
 		return err

--- a/internal/cli/stack/merge/ship.go
+++ b/internal/cli/stack/merge/ship.go
@@ -146,6 +146,10 @@ func runMergeShip(ctx *app.Context, opts mergeShipOptions, postMergeHandler Post
 		return nil
 	}
 
+	if err := requireYesInNonInteractive(ctx, "merge ship", opts.yes, opts.dryRun); err != nil {
+		return err
+	}
+
 	// Fail fast if no GitHub client
 	if _, err := ctx.RequireGitHub(); err != nil {
 		return err


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1123** 👈
  * **PR #1124**
    * **PR #1125**
      * **PR #1126**
        * **PR #1128**
          * **PR #1129**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1130 by jonnii*