### PR TITLE
fix: avoid duplicate worktree create hooks

### DIFF
--- a/internal/cli/common/hookmiddleware.go
+++ b/internal/cli/common/hookmiddleware.go
@@ -61,6 +61,12 @@ func RunCommandHooks(ctx *app.Context, cmd *cobra.Command, phase PhasePrefix) er
 	}
 
 	phaseKey := CommandPhase(cmd, phase)
+	if phaseKey == config.PhasePostWorktreeCreate {
+		// post-worktree-create is the legacy worktree hook. Worktree create/attach
+		// run it explicitly inside the target worktree; the generic command
+		// lifecycle runner would run the same hook again from the original repo.
+		return nil
+	}
 	hookCmds := projectCfg.Hooks.For(phaseKey)
 	if len(hookCmds) == 0 {
 		return nil


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1123**
  * **PR #1124** 👈
    * **PR #1125**
      * **PR #1126**
        * **PR #1128**
          * **PR #1129**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1130 by jonnii*