### PR TITLE
fix: preserve merge branch in PR info updates

### DIFF
--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -885,7 +885,8 @@ func TestUpsertPrInfo(t *testing.T) {
 				"branch1": "main",
 			})
 
-		prInfo := testhelpers.NewTestPrInfoWithTitle(123, "Original Title")
+		prInfo := testhelpers.NewTestPrInfoWithTitle(123, "Original Title").
+			WithMergeBranch("stackit-merge-branch")
 
 		branch := s.Engine.GetBranch("branch1")
 		err := s.Engine.UpsertPrInfo(context.Background(), branch, prInfo)
@@ -902,6 +903,7 @@ func TestUpsertPrInfo(t *testing.T) {
 		require.NotNil(t, retrieved)
 		require.Equal(t, "Updated Title", retrieved.Title())
 		require.Equal(t, "Updated body", retrieved.Body())
+		require.Equal(t, "stackit-merge-branch", retrieved.MergeBranch())
 	})
 }
 

--- a/internal/engine/pr_info.go
+++ b/internal/engine/pr_info.go
@@ -137,42 +137,45 @@ func (p *PrInfo) MarshalJSON() ([]byte, error) {
 // WithNumber returns a new PrInfo with the number field updated
 func (p *PrInfo) WithNumber(number *int) *PrInfo {
 	return &PrInfo{
-		number:     number,
-		title:      p.title,
-		body:       p.body,
-		isDraft:    p.isDraft,
-		state:      p.state,
-		base:       p.base,
-		url:        p.url,
-		lockReason: p.lockReason,
+		number:      number,
+		title:       p.title,
+		body:        p.body,
+		isDraft:     p.isDraft,
+		state:       p.state,
+		base:        p.base,
+		url:         p.url,
+		lockReason:  p.lockReason,
+		mergeBranch: p.mergeBranch,
 	}
 }
 
 // WithTitle returns a new PrInfo with the title field updated
 func (p *PrInfo) WithTitle(title string) *PrInfo {
 	return &PrInfo{
-		number:     p.number,
-		title:      title,
-		body:       p.body,
-		isDraft:    p.isDraft,
-		state:      p.state,
-		base:       p.base,
-		url:        p.url,
-		lockReason: p.lockReason,
+		number:      p.number,
+		title:       title,
+		body:        p.body,
+		isDraft:     p.isDraft,
+		state:       p.state,
+		base:        p.base,
+		url:         p.url,
+		lockReason:  p.lockReason,
+		mergeBranch: p.mergeBranch,
 	}
 }
 
 // WithBody returns a new PrInfo with the body field updated
 func (p *PrInfo) WithBody(body string) *PrInfo {
 	return &PrInfo{
-		number:     p.number,
-		title:      p.title,
-		body:       body,
-		isDraft:    p.isDraft,
-		state:      p.state,
-		base:       p.base,
-		url:        p.url,
-		lockReason: p.lockReason,
+		number:      p.number,
+		title:       p.title,
+		body:        body,
+		isDraft:     p.isDraft,
+		state:       p.state,
+		base:        p.base,
+		url:         p.url,
+		lockReason:  p.lockReason,
+		mergeBranch: p.mergeBranch,
 	}
 }
 
@@ -180,70 +183,75 @@ func (p *PrInfo) WithBody(body string) *PrInfo {
 // This is more efficient than chaining WithTitle().WithBody() as it only creates one copy
 func (p *PrInfo) WithTitleAndBody(title, body string) *PrInfo {
 	return &PrInfo{
-		number:     p.number,
-		title:      title,
-		body:       body,
-		isDraft:    p.isDraft,
-		state:      p.state,
-		base:       p.base,
-		url:        p.url,
-		lockReason: p.lockReason,
+		number:      p.number,
+		title:       title,
+		body:        body,
+		isDraft:     p.isDraft,
+		state:       p.state,
+		base:        p.base,
+		url:         p.url,
+		lockReason:  p.lockReason,
+		mergeBranch: p.mergeBranch,
 	}
 }
 
 // WithIsDraft returns a new PrInfo with the isDraft field updated
 func (p *PrInfo) WithIsDraft(isDraft bool) *PrInfo {
 	return &PrInfo{
-		number:     p.number,
-		title:      p.title,
-		body:       p.body,
-		isDraft:    isDraft,
-		state:      p.state,
-		base:       p.base,
-		url:        p.url,
-		lockReason: p.lockReason,
+		number:      p.number,
+		title:       p.title,
+		body:        p.body,
+		isDraft:     isDraft,
+		state:       p.state,
+		base:        p.base,
+		url:         p.url,
+		lockReason:  p.lockReason,
+		mergeBranch: p.mergeBranch,
 	}
 }
 
 // WithState returns a new PrInfo with the state field updated
 func (p *PrInfo) WithState(state string) *PrInfo {
 	return &PrInfo{
-		number:     p.number,
-		title:      p.title,
-		body:       p.body,
-		isDraft:    p.isDraft,
-		state:      state,
-		base:       p.base,
-		url:        p.url,
-		lockReason: p.lockReason,
+		number:      p.number,
+		title:       p.title,
+		body:        p.body,
+		isDraft:     p.isDraft,
+		state:       state,
+		base:        p.base,
+		url:         p.url,
+		lockReason:  p.lockReason,
+		mergeBranch: p.mergeBranch,
 	}
 }
 
 // WithBase returns a new PrInfo with the base field updated
 func (p *PrInfo) WithBase(base string) *PrInfo {
 	return &PrInfo{
-		number:     p.number,
-		title:      p.title,
-		body:       p.body,
-		isDraft:    p.isDraft,
-		state:      p.state,
-		base:       base,
-		url:        p.url,
-		lockReason: p.lockReason,
+		number:      p.number,
+		title:       p.title,
+		body:        p.body,
+		isDraft:     p.isDraft,
+		state:       p.state,
+		base:        base,
+		url:         p.url,
+		lockReason:  p.lockReason,
+		mergeBranch: p.mergeBranch,
 	}
 }
 
 // WithURL returns a new PrInfo with the url field updated
 func (p *PrInfo) WithURL(url string) *PrInfo {
 	return &PrInfo{
-		number:     p.number,
-		title:      p.title,
-		body:       p.body,
-		isDraft:    p.isDraft,
-		state:      p.state,
-		base:       p.base,
-		url:        url,
-		lockReason: p.lockReason,
+		number:      p.number,
+		title:       p.title,
+		body:        p.body,
+		isDraft:     p.isDraft,
+		state:       p.state,
+		base:        p.base,
+		url:         url,
+		lockReason:  p.lockReason,
+		mergeBranch: p.mergeBranch,
 	}
 }
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780336490`.


* **PR #1123**
  * **PR #1124**
    * **PR #1125** 👈
      * **PR #1126**
        * **PR #1128**
          * **PR #1129**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->