### PR TITLE
fix: expose undo enabled in config CLI

### DIFF
--- a/internal/actions/config.go
+++ b/internal/actions/config.go
@@ -69,6 +69,7 @@ func ConfigListAction(repoRoot string, writer io.Writer) error {
 
 	// Undo settings
 	lines = append(lines, fmt.Sprintf("%s: %d", style.ColorCyan("undo.depth"), cfg.UndoStackDepth()))
+	lines = append(lines, fmt.Sprintf("%s: %v", style.ColorCyan("undo.enabled"), cfg.UndoEnabled()))
 
 	// Worktree settings
 	worktreeBasePath := cfg.WorktreeBasePath()

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -44,6 +44,7 @@ const (
 	keyWorktreeAutoClean    = "worktree.autoClean"
 	keySplitHunkSelector    = "split.hunkSelector"
 	keyUndoDepth            = "undo.depth"
+	keyUndoEnabled          = "undo.enabled"
 	keyCICommand            = "ci.command"
 	keyCITimeout            = "ci.timeout"
 	keyMaxConcurrency       = "maxConcurrency"
@@ -191,6 +192,8 @@ func newConfigGetCmd() *cobra.Command {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), cfg.SplitHunkSelector())
 			case keyUndoDepth:
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), cfg.UndoStackDepth())
+			case keyUndoEnabled:
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), cfg.UndoEnabled())
 			case keyCICommand:
 				ciCmd := cfg.CICommand()
 				if ciCmd == "" {
@@ -361,6 +364,15 @@ func newConfigSetCmd() *cobra.Command {
 					return fmt.Errorf("failed to set %s: %w", keyUndoDepth, err)
 				}
 				splog.Info("Set %s to: %d", keyUndoDepth, depth)
+			case keyUndoEnabled:
+				enabled, err := strconv.ParseBool(value)
+				if err != nil {
+					return fmt.Errorf("invalid value for %s: %s (must be 'true' or 'false')", keyUndoEnabled, value)
+				}
+				if err := cfg.SetUndoEnabled(enabled); err != nil {
+					return fmt.Errorf("failed to set %s: %w", keyUndoEnabled, err)
+				}
+				splog.Info("Set %s to: %v", keyUndoEnabled, enabled)
 			case keyCICommand:
 				if err := cfg.SetCICommand(value); err != nil {
 					return fmt.Errorf("failed to set %s: %w", keyCICommand, err)
@@ -543,6 +555,11 @@ Examples:
 					return fmt.Errorf("failed to unset %s: %w", keyUndoDepth, err)
 				}
 				splog.Info("Unset %s (now using: %d)", keyUndoDepth, cfg.UndoStackDepth())
+			case keyUndoEnabled:
+				if err := cfg.UnsetUndoEnabled(); err != nil {
+					return fmt.Errorf("failed to unset %s: %w", keyUndoEnabled, err)
+				}
+				splog.Info("Unset %s (now using: %v)", keyUndoEnabled, cfg.UndoEnabled())
 			case keyCICommand:
 				if err := cfg.UnsetCICommand(); err != nil {
 					return fmt.Errorf("failed to unset %s: %w", keyCICommand, err)
@@ -914,6 +931,10 @@ func showConfigWithSources(repoRoot string, w io.Writer) error {
 	// undo.depth
 	undoSource := getIntSource(config.KeyUndoDepth, projectCfg != nil && projectCfg.HasUndoDepth())
 	formatLine("undo.depth", fmt.Sprintf("%d", cfg.UndoStackDepth()), undoSource)
+
+	// undo.enabled
+	undoEnabledSource := getBoolSource(config.KeyUndoEnabled, projectCfg != nil && projectCfg.HasUndoEnabled())
+	formatLine("undo.enabled", strconv.FormatBool(cfg.UndoEnabled()), undoEnabledSource)
 
 	// worktree.basePath
 	basePath := cfg.WorktreeBasePath()

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -173,4 +173,39 @@ func TestConfigCommand(t *testing.T) {
 		require.NoError(t, err, "config get command failed: %s", output)
 		require.Equal(t, "true", strings.TrimSpace(output))
 	})
+
+	t.Run("config set get and unset undo.enabled", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).WithInProcess(true)
+
+		output, err := s.RunCliAndGetOutput("config", "get", "undo.enabled")
+		require.NoError(t, err, "config get command failed: %s", output)
+		require.Equal(t, "true", strings.TrimSpace(output))
+
+		output, err = s.RunCliAndGetOutput("config", "set", "undo.enabled", "false")
+		require.NoError(t, err, "config set command failed: %s", output)
+		require.Contains(t, output, "Set undo.enabled to: false")
+
+		output, err = s.RunCliAndGetOutput("config", "get", "undo.enabled")
+		require.NoError(t, err, "config get command failed: %s", output)
+		require.Equal(t, "false", strings.TrimSpace(output))
+
+		output, err = s.RunCliAndGetOutput("config", "unset", "undo.enabled")
+		require.NoError(t, err, "config unset command failed: %s", output)
+		require.Contains(t, output, "Unset undo.enabled")
+
+		output, err = s.RunCliAndGetOutput("config", "get", "undo.enabled")
+		require.NoError(t, err, "config get command failed: %s", output)
+		require.Equal(t, "true", strings.TrimSpace(output))
+	})
+
+	t.Run("config list includes undo.enabled", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).WithInProcess(true)
+
+		output, err := s.RunCliAndGetOutput("config", "list")
+		require.NoError(t, err, "config list command failed: %s", output)
+		require.Contains(t, output, "undo.enabled")
+		require.Contains(t, output, "true")
+	})
 }

--- a/internal/config/config_git.go
+++ b/internal/config/config_git.go
@@ -270,6 +270,11 @@ func (c *GitConfig) SetUndoStackDepth(depth int) error {
 	return c.store.SetInt(KeyUndoDepth, depth)
 }
 
+// SetUndoEnabled sets whether undo snapshots are taken before mutations.
+func (c *GitConfig) SetUndoEnabled(enabled bool) error {
+	return c.store.SetBool(KeyUndoEnabled, enabled)
+}
+
 // WorktreeBasePath returns the worktree base path.
 // Priority: personal git config > team project config > empty (not set).
 func (c *GitConfig) WorktreeBasePath() string {
@@ -913,6 +918,11 @@ func (c *GitConfig) UnsetSplitHunkSelector() error {
 // UnsetUndoStackDepth removes the personal undo stack depth setting, reverting to project/default.
 func (c *GitConfig) UnsetUndoStackDepth() error {
 	return c.store.Unset(KeyUndoDepth)
+}
+
+// UnsetUndoEnabled removes the personal undo enabled setting, reverting to project/default.
+func (c *GitConfig) UnsetUndoEnabled() error {
+	return c.store.Unset(KeyUndoEnabled)
 }
 
 // UnsetCICommand removes the personal CI command setting, reverting to project/default.

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -246,6 +246,11 @@ func (c *ProjectConfig) HasUndoDepth() bool {
 	return c.Undo.Depth > 0
 }
 
+// HasUndoEnabled returns true if undo enabled is configured
+func (c *ProjectConfig) HasUndoEnabled() bool {
+	return c.Undo.Enabled != nil
+}
+
 // HasWorktreeBasePath returns true if worktree base path is configured
 func (c *ProjectConfig) HasWorktreeBasePath() bool {
 	return c.Worktree.BasePath != ""


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1123**
  * **PR #1124**
    * **PR #1125**
      * **PR #1126** 👈
        * **PR #1128**
          * **PR #1129**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1130 by jonnii*