### PR TITLE
fix: harden CLI sync and worktree status

### DIFF
--- a/internal/actions/state.go
+++ b/internal/actions/state.go
@@ -81,16 +81,18 @@ func BuildState(ctx *app.Context, _ StateOptions) StateResult {
 	}
 
 	// Working-tree state via a single git status --porcelain call.
-	// A failed check is non-fatal; log and fall back to the safe default (false).
+	// A failed check is non-fatal; log and avoid reporting a clean tree.
 	staged, unstaged, untracked, statusErr := eng.GetWorkingTreeStatus(ctx.Context)
+	clean := !staged && !unstaged && !untracked
 	if statusErr != nil {
 		ctx.Output.Debug("state: working-tree status check failed: %v", statusErr)
+		clean = false
 	}
 	result.WorkingTree = WorkingTreeStatus{
 		Staged:    staged,
 		Unstaged:  unstaged,
 		Untracked: untracked,
-		Clean:     !staged && !unstaged && !untracked,
+		Clean:     clean,
 	}
 
 	// In-progress operation + conflicts.

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -95,6 +95,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	var trunkSummary Summary
 	var githubSyncResult *GitHubSyncResult
 	var metadataFetchErr error
+	var trunkFetchErr error
 	var trunkErr error
 	var githubErr error
 
@@ -103,19 +104,30 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	g, _ := errgroup.WithContext(gctx)
 
-	// Goroutine 1: Fetch trunk and Stackit metadata refs in one network round trip.
+	// Goroutine 1: Fetch trunk as a required operation, then refresh Stackit
+	// metadata refs on a best-effort basis.
 	g.Go(func() error {
 		ctx.Logger.Info("goroutine remote fetch started delayMs=%v", time.Since(parallelStart).Milliseconds())
 		fetchStart := time.Now()
+		trunkFetchErr = eng.FetchRemote(gctx, engine.RemoteFetchRequest{
+			Remote:   eng.GetRemote(),
+			Branches: []string{eng.Trunk().GetName()},
+		})
+		ctx.Logger.Info("fetch trunk completed durationMs=%v", time.Since(fetchStart).Milliseconds())
+		if trunkFetchErr != nil {
+			ctx.Logger.Debug("fetch trunk failed error=%v", trunkFetchErr)
+			return trunkFetchErr
+		}
+
+		metadataFetchStart := time.Now()
 		metadataFetchErr = eng.FetchRemote(gctx, engine.RemoteFetchRequest{
 			Remote:               eng.GetRemote(),
-			Branches:             []string{eng.Trunk().GetName()},
 			IncludeMetadata:      true,
 			IncludeStackMetadata: true,
 		})
-		ctx.Logger.Info("fetch trunk and metadata refs completed durationMs=%v", time.Since(fetchStart).Milliseconds())
+		ctx.Logger.Info("fetch metadata refs completed durationMs=%v", time.Since(metadataFetchStart).Milliseconds())
 		if metadataFetchErr != nil {
-			ctx.Logger.Debug("fetch trunk and metadata refs failed (non-fatal) error=%v", metadataFetchErr)
+			ctx.Logger.Debug("fetch metadata refs failed (non-fatal) error=%v", metadataFetchErr)
 		}
 		return nil
 	})
@@ -129,8 +141,15 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return nil
 	})
 
-	_ = g.Wait()
+	parallelErr := g.Wait()
 	ctx.Logger.Info("parallel phase completed durationMs=%v", time.Since(parallelStart).Milliseconds())
+
+	if trunkFetchErr != nil {
+		return fmt.Errorf("failed to fetch trunk from %s: %w", eng.GetRemote(), trunkFetchErr)
+	}
+	if parallelErr != nil {
+		return parallelErr
+	}
 
 	trunkErr = syncFetchedTrunk(ctx, &opts, handler, &trunkSummary)
 	if trunkErr != nil {

--- a/internal/actions/sync/sync_test.go
+++ b/internal/actions/sync/sync_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestSyncAction(t *testing.T) {
 	t.Run("syncs when trunk is up to date", func(t *testing.T) {
-		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s := scenario.NewRemoteScenario(t)
 
 		err := Action(s.Context, Options{
 			All:     false,
@@ -25,11 +25,19 @@ func TestSyncAction(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("fails when required trunk fetch fails", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		err := Action(s.Context, Options{}, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to fetch trunk from")
+	})
+
 	// Note: uncommitted changes check moved to CLI layer (sync.go) to run
 	// before TUI initialization. Tested in internal/cli/stack/sync_test.go.
 
 	t.Run("syncs with restack flag", func(t *testing.T) {
-		s := scenario.NewScenario(t, nil).
+		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"branch1": "main",
 			})
@@ -44,7 +52,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("restacks branches in topological order (parents before children)", func(t *testing.T) {
-		s := scenario.NewScenario(t, nil).
+		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"branch1": "main",
 				"branch2": "branch1",
@@ -61,7 +69,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("restacks branching stacks in topological order", func(t *testing.T) {
-		s := scenario.NewScenario(t, nil).
+		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"stackA":        "main",
 				"stackA-child1": "stackA",
@@ -89,7 +97,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("restacks multiple deep subtrees correctly", func(t *testing.T) {
-		s := scenario.NewScenario(t, nil).
+		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"P":   "main",
 				"C1":  "P",
@@ -120,7 +128,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("partial success in branching restack (one child succeeds, one fails)", func(t *testing.T) {
-		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s := scenario.NewRemoteScenario(t)
 
 		// Create: main -> P -> [0-Success, 1-Failure]
 		// We use these names because siblings are sorted ascending by name by default,
@@ -169,7 +177,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("sync mode aborts unexpected runtime restack conflict and restores branch", func(t *testing.T) {
-		s := scenario.NewScenario(t, nil).
+		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"branch1": "main",
 			})

--- a/internal/actions/sync/worktree_cleanup_test.go
+++ b/internal/actions/sync/worktree_cleanup_test.go
@@ -9,14 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/getstackit/stackit/internal/actions/sync"
-	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestSyncCleansOrphanedWorktrees(t *testing.T) {
 	t.Run("cleans worktree when stack root branch is deleted", func(t *testing.T) {
-		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
-		s.WithInitialCommit()
+		s := scenario.NewRemoteScenario(t)
 
 		// Create a branch that will become a stack root
 		s.CreateBranch("feature-branch").Commit("feature change")
@@ -48,8 +46,7 @@ func TestSyncCleansOrphanedWorktrees(t *testing.T) {
 	})
 
 	t.Run("preserves worktree when stack root branch still exists", func(t *testing.T) {
-		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
-		s.WithInitialCommit()
+		s := scenario.NewRemoteScenario(t)
 
 		// Create and track a branch
 		s.CreateBranch("feature-branch").Commit("feature change")
@@ -72,8 +69,7 @@ func TestSyncCleansOrphanedWorktrees(t *testing.T) {
 	})
 
 	t.Run("preserves registration when worktree removal fails", func(t *testing.T) {
-		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
-		s.WithInitialCommit()
+		s := scenario.NewRemoteScenario(t)
 
 		worktreePath := filepath.Join(t.TempDir(), "not-a-git-worktree")
 		require.NoError(t, os.MkdirAll(worktreePath, 0o755))

--- a/internal/cli/stack/merge/ship.go
+++ b/internal/cli/stack/merge/ship.go
@@ -155,12 +155,6 @@ func runMergeShip(ctx *app.Context, opts mergeShipOptions, postMergeHandler Post
 		return err
 	}
 
-	// Prompt for a stack description on multi-PR stacks that have none set.
-	// Best-effort: a failure here never blocks the ship.
-	if len(plan.BranchesToMerge) > 1 {
-		promptForShipDescription(ctx, plan.BranchesToMerge, opts.yes)
-	}
-
 	// Confirm unless --yes
 	if !opts.yes && ctx.Interactive {
 		confirmed, err := tui.PromptConfirm("Proceed with ship merge?", false)
@@ -171,6 +165,12 @@ func runMergeShip(ctx *app.Context, opts mergeShipOptions, postMergeHandler Post
 			out.Info("Merge canceled")
 			return nil
 		}
+	}
+
+	// Prompt for a stack description on multi-PR stacks that have none set.
+	// Best-effort: a failure here never blocks the ship.
+	if len(plan.BranchesToMerge) > 1 {
+		promptForShipDescription(ctx, plan.BranchesToMerge, opts.yes)
 	}
 
 	// Get config values

--- a/internal/cli/stack/sync_test.go
+++ b/internal/cli/stack/sync_test.go
@@ -26,6 +26,8 @@ func TestSyncCommand(t *testing.T) {
 		// Create a remote to avoid sync errors related to missing remote
 		_, err := s.Scene.Repo.CreateBareRemote("origin")
 		require.NoError(t, err)
+		err = s.Scene.Repo.PushBranch("origin", "main")
+		require.NoError(t, err)
 
 		s.RunCli("init")
 		s.RunCli("create", "branch1", "-m", "branch1")
@@ -84,6 +86,8 @@ func TestSyncCommand(t *testing.T) {
 
 		// Create a remote to avoid sync errors related to missing remote
 		_, err := s.Scene.Repo.CreateBareRemote("origin")
+		require.NoError(t, err)
+		err = s.Scene.Repo.PushBranch("origin", "main")
 		require.NoError(t, err)
 
 		s.RunCli("init")

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -18,7 +18,7 @@ func (e *engineImpl) GetPendingChanges(ctx context.Context) ([]PendingChange, er
 	}
 
 	var changes []PendingChange
-	lines := strings.SplitSeq(strings.TrimSpace(output), "\n")
+	lines := strings.SplitSeq(strings.TrimSuffix(output, "\n"), "\n")
 	for line := range lines {
 		if len(line) < 4 {
 			continue
@@ -79,7 +79,7 @@ func (e *engineImpl) GetWorkingTreeStatus(ctx context.Context) (staged, unstaged
 	if err != nil {
 		return false, false, false, err
 	}
-	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSuffix(output, "\n"), "\n") {
 		if len(line) < 2 {
 			continue
 		}

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -100,6 +100,57 @@ func TestTrackBranch(t *testing.T) {
 	})
 }
 
+func TestGetWorkingTreeStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("clean repo", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		staged, unstaged, untracked, err := s.Engine.GetWorkingTreeStatus(context.Background())
+		require.NoError(t, err)
+		require.False(t, staged)
+		require.False(t, unstaged)
+		require.False(t, untracked)
+	})
+
+	t.Run("unstaged tracked change", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		require.NoError(t, s.Scene.Repo.CreateChange("2", "1", true))
+
+		staged, unstaged, untracked, err := s.Engine.GetWorkingTreeStatus(context.Background())
+		require.NoError(t, err)
+		require.False(t, staged)
+		require.True(t, unstaged)
+		require.False(t, untracked)
+	})
+
+	t.Run("staged tracked change", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		require.NoError(t, s.Scene.Repo.CreateChange("2", "1", false))
+
+		staged, unstaged, untracked, err := s.Engine.GetWorkingTreeStatus(context.Background())
+		require.NoError(t, err)
+		require.True(t, staged)
+		require.False(t, unstaged)
+		require.False(t, untracked)
+	})
+
+	t.Run("untracked file", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		require.NoError(t, s.Scene.Repo.CreateChange("new", "untracked", true))
+
+		staged, unstaged, untracked, err := s.Engine.GetWorkingTreeStatus(context.Background())
+		require.NoError(t, err)
+		require.False(t, staged)
+		require.False(t, unstaged)
+		require.True(t, untracked)
+	})
+}
+
 func TestSetParent(t *testing.T) {
 	t.Parallel()
 	t.Run("updates parent relationship", func(t *testing.T) {

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -858,7 +858,7 @@ func (r *runner) GetCommitLog(sha, format string) (string, error) {
 }
 
 func (r *runner) GetStatusPorcelain(ctx context.Context) (string, error) {
-	return r.RunGitCommandWithContext(ctx, "status", "--porcelain")
+	return r.RunGitCommandRawWithContext(ctx, "status", "--porcelain")
 }
 
 func (r *runner) GetCommitTemplate(ctx context.Context) (string, error) {

--- a/internal/integration/scope_integration_test.go
+++ b/internal/integration/scope_integration_test.go
@@ -77,7 +77,7 @@ func TestScopeRequiredInPattern(t *testing.T) {
 
 func TestScopeSubmitSyncFlow(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 
 	// 1. Create a branch
 	sh.CreateBranch("feature").
@@ -91,30 +91,26 @@ func TestScopeSubmitSyncFlow(t *testing.T) {
 	require.NoError(t, eng.SetScope(context.Background(), branch, engine.NewScope("JIRA-123")))
 	require.Equal(t, "JIRA-123", eng.GetScope(branch).String())
 
-	// 3. Setup a local remote to simulate "origin"
-	_, err := sh.Scene.Repo.CreateBareRemote("origin")
-	require.NoError(t, err)
-
-	// 4. Setup mocked GitHub client for submit
+	// 3. Setup mocked GitHub client for submit
 	config := testhelpers.NewMockGitHubServerConfig()
 	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, config)
 	githubClient := testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, config)
 	sh.Context.GitHubClient = githubClient
 
-	// 5. Submit the branch (this should push the metadata ref)
+	// 4. Submit the branch (this should push the metadata ref)
 	opts := submit.Options{
 		NoEdit: true,
 		Draft:  true,
 	}
-	err = submit.Action(sh.Context, opts, &noopHandler{})
+	err := submit.Action(sh.Context, opts, &noopHandler{})
 	require.NoError(t, err)
 
-	// 6. Run sync to fetch remote metadata
+	// 5. Run sync to fetch remote metadata
 	// This will fetch refs/stackit/metadata/*:refs/stackit/remote-metadata/*
 	err = sync.Action(sh.Context, sync.Options{}, nil)
 	require.NoError(t, err)
 
-	// 7. Verify the scope is now in the remote metadata cache
+	// 6. Verify the scope is now in the remote metadata cache
 	err = eng.LoadRemoteMetadataCache()
 	require.NoError(t, err)
 

--- a/internal/integration/stack_metadata_gc_test.go
+++ b/internal/integration/stack_metadata_gc_test.go
@@ -14,7 +14,7 @@ func TestStackMetadataGC(t *testing.T) {
 
 	t.Run("orphaned stack ref is cleaned after all branches deleted", func(t *testing.T) {
 		t.Parallel()
-		sh := NewTestShellInProcess(t)
+		sh := NewTestShellInProcess(t, WithRemote())
 
 		// Create a stack: main -> a -> b
 		sh.CreateLinearStack("a", "b")
@@ -42,7 +42,7 @@ func TestStackMetadataGC(t *testing.T) {
 
 	t.Run("active stack refs are NOT deleted", func(t *testing.T) {
 		t.Parallel()
-		sh := NewTestShellInProcess(t)
+		sh := NewTestShellInProcess(t, WithRemote())
 
 		// Create a stack: main -> a -> b -> c
 		sh.CreateLinearStack3()
@@ -67,7 +67,7 @@ func TestStackMetadataGC(t *testing.T) {
 
 	t.Run("stack ref survives when some branches remain after partial deletion", func(t *testing.T) {
 		t.Parallel()
-		sh := NewTestShellInProcess(t)
+		sh := NewTestShellInProcess(t, WithRemote())
 
 		// Create a stack: main -> a -> b -> c
 		sh.CreateLinearStack3()
@@ -100,7 +100,7 @@ func TestStackMetadataGC(t *testing.T) {
 
 	t.Run("multiple orphaned stacks are cleaned in one sync", func(t *testing.T) {
 		t.Parallel()
-		sh := NewTestShellInProcess(t)
+		sh := NewTestShellInProcess(t, WithRemote())
 
 		// Create first stack: main -> a
 		sh.Write("a.txt", "content for a").

--- a/internal/integration/sync_test.go
+++ b/internal/integration/sync_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/getstackit/stackit/internal/actions/sync"
 	"github.com/getstackit/stackit/internal/git"
-	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
@@ -18,7 +17,7 @@ func TestSync(t *testing.T) {
 	t.Parallel()
 	t.Run("local parent is authoritative over GitHub PR base", func(t *testing.T) {
 		t.Parallel()
-		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		sh := scenario.NewRemoteScenario(t)
 
 		// 1. Create a diamond-like structure:
 		// main -> feature-a -> feature-b
@@ -68,7 +67,7 @@ func TestSync(t *testing.T) {
 
 	t.Run("handles consolidation and deletion of merged branches", func(t *testing.T) {
 		t.Parallel()
-		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		sh := scenario.NewRemoteScenario(t)
 
 		// 1. Create a chain of branches: main -> branch-a -> branch-b -> branch-c
 		branchNames := []string{"branch-a", "branch-b", "branch-c"}
@@ -145,7 +144,7 @@ func TestSync(t *testing.T) {
 
 	t.Run("handles diamond dependency during sync", func(t *testing.T) {
 		t.Parallel()
-		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		sh := scenario.NewRemoteScenario(t)
 
 		// Create: main -> a -> b
 		//                \-> c
@@ -200,7 +199,7 @@ func TestSync(t *testing.T) {
 
 func TestSyncDraftPRs(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 
 	// Create branch-a on main
 	sh.CreateBranch("branch-a").
@@ -245,7 +244,7 @@ func TestSyncDraftPRs(t *testing.T) {
 
 func TestSyncCleanupDiamond(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 
 	// Create: main -> a -> b
 	//                \-> c
@@ -299,7 +298,7 @@ func TestSyncStaleDraftCleanup(t *testing.T) {
 	t.Parallel()
 	// Tests the fix for the "stale draft" bug where empty branches
 	// weren't being cleaned up if they were ancestors of other branches.
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 
 	// Create: main -> a -> b
 	sh.CreateBranch("a").CommitChange("a", "a").TrackBranch("a", "main")
@@ -343,7 +342,7 @@ func TestSyncStaleDraftCleanup(t *testing.T) {
 
 func TestSyncSquashMergedRootPreservesChildCommitBoundaries(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 
 	// Create stack: main -> A(2 commits) -> B -> C
 	sh.CreateBranch("branch-a").
@@ -414,7 +413,7 @@ func TestSyncDoesNotLeaveIndexState(t *testing.T) {
 	t.Parallel()
 	t.Run("sync from main does not leave staged changes after cleanup and restack", func(t *testing.T) {
 		t.Parallel()
-		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		sh := scenario.NewRemoteScenario(t)
 
 		// 1. Create a chain: main -> branch-a -> branch-b
 		sh.CreateBranch("branch-a").
@@ -471,7 +470,7 @@ func TestSyncDoesNotLeaveIndexState(t *testing.T) {
 
 	t.Run("sync from detached HEAD does not leave staged changes", func(t *testing.T) {
 		t.Parallel()
-		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		sh := scenario.NewRemoteScenario(t)
 
 		// Create a simple stack
 		sh.CreateBranch("feature").
@@ -513,7 +512,7 @@ func TestSyncDoesNotLeaveIndexState(t *testing.T) {
 		t.Parallel()
 		// This test creates a scenario where the rebase actually moves commits,
 		// which is more likely to trigger index state issues.
-		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		sh := scenario.NewRemoteScenario(t)
 
 		// 1. Create initial stack: main -> feature -> child
 		sh.CreateBranch("feature").
@@ -572,7 +571,7 @@ func TestSyncDoesNotLeaveIndexState(t *testing.T) {
 
 	t.Run("sync skips deletion of branch with unpushed commits", func(t *testing.T) {
 		t.Parallel()
-		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		sh := scenario.NewRemoteScenario(t)
 
 		// Create a branch and track it
 		sh.CreateBranch("feature").
@@ -582,14 +581,9 @@ func TestSyncDoesNotLeaveIndexState(t *testing.T) {
 		eng := sh.Engine
 		mainBranchName := eng.Trunk().GetName()
 
-		// Set up remote and push everything
-		_, err := sh.Scene.Repo.CreateBareRemote("origin")
-		require.NoError(t, err)
-		sh.Checkout("main")
-		err = sh.Scene.Repo.PushBranch("origin", "main")
-		require.NoError(t, err)
+		// Push the branch once so the extra commit below is detected as unpushed.
 		sh.Checkout("feature")
-		err = sh.Scene.Repo.PushBranch("origin", "feature")
+		err := sh.Scene.Repo.PushBranch("origin", "feature")
 		require.NoError(t, err)
 
 		// Add an unpushed local commit
@@ -687,7 +681,7 @@ func markPrMerged(t *testing.T, sh *scenario.Scenario, branch string, prNumber i
 // not skip over to trunk.
 func TestSquashMergeMiddleOfStack(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	// main -> A -> B -> C
@@ -731,7 +725,7 @@ func TestSquashMergeMiddleOfStack(t *testing.T) {
 // deletions to main in a single pass.
 func TestSquashMergeMultipleAdjacentMergedInOneSync(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	sh.CreateBranch("branch-a").
@@ -777,7 +771,7 @@ func TestSquashMergeMultipleAdjacentMergedInOneSync(t *testing.T) {
 // should be cleaned up; A is unaffected.
 func TestSquashMergeDiamondAllChildrenMerged(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	// main -> A -> {B, C}
@@ -817,7 +811,7 @@ func TestSquashMergeDiamondAllChildrenMerged(t *testing.T) {
 // Per .claude/rules/safety-invariants.md "No Detached HEAD State".
 func TestSquashMergeSyncWhileOnMergedBranch(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	setupTwoBranchSquashScenario(t, sh)
@@ -845,7 +839,7 @@ func TestSquashMergeSyncWhileOnMergedBranch(t *testing.T) {
 // onto trunk.
 func TestSquashMergeSyncWhileOnChildOfMergedBranch(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	mainName := setupTwoBranchSquashScenario(t, sh)
@@ -880,7 +874,7 @@ func TestSquashMergeSyncWhileOnChildOfMergedBranch(t *testing.T) {
 // only cleanup.
 func TestSquashMergeNoRestackLeavesGitRefsUntouched(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	mainName := setupTwoBranchSquashScenario(t, sh)
@@ -914,7 +908,7 @@ func TestSquashMergeNoRestackLeavesGitRefsUntouched(t *testing.T) {
 // for B.
 func TestSquashMergeChildBecomesEmpty(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	// A introduces shared=v1; B advances it to v2.
@@ -958,7 +952,7 @@ func TestSquashMergeChildBecomesEmpty(t *testing.T) {
 // recover gracefully and reparent the child rather than crash.
 func TestUserDeletedMergedBranchBeforeSync(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	mainName := setupTwoBranchSquashScenario(t, sh)
@@ -1006,7 +1000,7 @@ func TestUserDeletedMergedBranchBeforeSync(t *testing.T) {
 // either to a clearer error message or to graceful auto-recovery.
 func TestUserManuallyRebasedChildBeforeSync(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	mainName := setupTwoBranchSquashScenario(t, sh)
@@ -1044,7 +1038,7 @@ func TestUserManuallyRebasedChildBeforeSync(t *testing.T) {
 // cleanup runs cleanly.
 func TestMergeCommitNotSquash(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	sh.CreateBranch("branch-a").
@@ -1085,7 +1079,7 @@ func TestMergeCommitNotSquash(t *testing.T) {
 // double-application or restack churn on the surviving child.
 func TestUserLocallyAdvancedTrunkBeforeSync(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	sh.CreateBranch("branch-a").

--- a/internal/integration/sync_ui_test.go
+++ b/internal/integration/sync_ui_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/getstackit/stackit/internal/engine"
-	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
@@ -15,12 +14,11 @@ func TestSyncUIReporting(t *testing.T) {
 	t.Parallel()
 	t.Run("reports locked and frozen branches during sync", func(t *testing.T) {
 		t.Parallel()
-		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		sh := scenario.NewRemoteScenario(t).
 			WithInProcess(true)
 
 		// Create a stack: main -> feature-a -> feature-b -> feature-c
-		sh.WithInitialCommit().
-			CreateBranch("feature-a").Commit("a1").TrackBranch("feature-a", "main").
+		sh.CreateBranch("feature-a").Commit("a1").TrackBranch("feature-a", "main").
 			CreateBranch("feature-b").Commit("b1").TrackBranch("feature-b", "feature-a").
 			CreateBranch("feature-c").Commit("c1").TrackBranch("feature-c", "feature-b")
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1123**
  * **PR #1124**
    * **PR #1125**
      * **PR #1126**
        * **PR #1128** 👈
          * **PR #1129**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1130 by jonnii*