### PR TITLE
Merging 6 PRs

### DIFF
--- a/internal/actions/config.go
+++ b/internal/actions/config.go
@@ -69,6 +69,7 @@ func ConfigListAction(repoRoot string, writer io.Writer) error {
 
 	// Undo settings
 	lines = append(lines, fmt.Sprintf("%s: %d", style.ColorCyan("undo.depth"), cfg.UndoStackDepth()))
+	lines = append(lines, fmt.Sprintf("%s: %v", style.ColorCyan("undo.enabled"), cfg.UndoEnabled()))
 
 	// Worktree settings
 	worktreeBasePath := cfg.WorktreeBasePath()

--- a/internal/actions/state.go
+++ b/internal/actions/state.go
@@ -81,16 +81,18 @@ func BuildState(ctx *app.Context, _ StateOptions) StateResult {
 	}
 
 	// Working-tree state via a single git status --porcelain call.
-	// A failed check is non-fatal; log and fall back to the safe default (false).
+	// A failed check is non-fatal; log and avoid reporting a clean tree.
 	staged, unstaged, untracked, statusErr := eng.GetWorkingTreeStatus(ctx.Context)
+	clean := !staged && !unstaged && !untracked
 	if statusErr != nil {
 		ctx.Output.Debug("state: working-tree status check failed: %v", statusErr)
+		clean = false
 	}
 	result.WorkingTree = WorkingTreeStatus{
 		Staged:    staged,
 		Unstaged:  unstaged,
 		Untracked: untracked,
-		Clean:     !staged && !unstaged && !untracked,
+		Clean:     clean,
 	}
 
 	// In-progress operation + conflicts.

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -95,6 +95,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	var trunkSummary Summary
 	var githubSyncResult *GitHubSyncResult
 	var metadataFetchErr error
+	var trunkFetchErr error
 	var trunkErr error
 	var githubErr error
 
@@ -103,19 +104,30 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	g, _ := errgroup.WithContext(gctx)
 
-	// Goroutine 1: Fetch trunk and Stackit metadata refs in one network round trip.
+	// Goroutine 1: Fetch trunk as a required operation, then refresh Stackit
+	// metadata refs on a best-effort basis.
 	g.Go(func() error {
 		ctx.Logger.Info("goroutine remote fetch started delayMs=%v", time.Since(parallelStart).Milliseconds())
 		fetchStart := time.Now()
+		trunkFetchErr = eng.FetchRemote(gctx, engine.RemoteFetchRequest{
+			Remote:   eng.GetRemote(),
+			Branches: []string{eng.Trunk().GetName()},
+		})
+		ctx.Logger.Info("fetch trunk completed durationMs=%v", time.Since(fetchStart).Milliseconds())
+		if trunkFetchErr != nil {
+			ctx.Logger.Debug("fetch trunk failed error=%v", trunkFetchErr)
+			return trunkFetchErr
+		}
+
+		metadataFetchStart := time.Now()
 		metadataFetchErr = eng.FetchRemote(gctx, engine.RemoteFetchRequest{
 			Remote:               eng.GetRemote(),
-			Branches:             []string{eng.Trunk().GetName()},
 			IncludeMetadata:      true,
 			IncludeStackMetadata: true,
 		})
-		ctx.Logger.Info("fetch trunk and metadata refs completed durationMs=%v", time.Since(fetchStart).Milliseconds())
+		ctx.Logger.Info("fetch metadata refs completed durationMs=%v", time.Since(metadataFetchStart).Milliseconds())
 		if metadataFetchErr != nil {
-			ctx.Logger.Debug("fetch trunk and metadata refs failed (non-fatal) error=%v", metadataFetchErr)
+			ctx.Logger.Debug("fetch metadata refs failed (non-fatal) error=%v", metadataFetchErr)
 		}
 		return nil
 	})
@@ -129,8 +141,15 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return nil
 	})
 
-	_ = g.Wait()
+	parallelErr := g.Wait()
 	ctx.Logger.Info("parallel phase completed durationMs=%v", time.Since(parallelStart).Milliseconds())
+
+	if trunkFetchErr != nil {
+		return fmt.Errorf("failed to fetch trunk from %s: %w", eng.GetRemote(), trunkFetchErr)
+	}
+	if parallelErr != nil {
+		return parallelErr
+	}
 
 	trunkErr = syncFetchedTrunk(ctx, &opts, handler, &trunkSummary)
 	if trunkErr != nil {

--- a/internal/actions/sync/sync_test.go
+++ b/internal/actions/sync/sync_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestSyncAction(t *testing.T) {
 	t.Run("syncs when trunk is up to date", func(t *testing.T) {
-		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s := scenario.NewRemoteScenario(t)
 
 		err := Action(s.Context, Options{
 			All:     false,
@@ -25,11 +25,19 @@ func TestSyncAction(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("fails when required trunk fetch fails", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		err := Action(s.Context, Options{}, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to fetch trunk from")
+	})
+
 	// Note: uncommitted changes check moved to CLI layer (sync.go) to run
 	// before TUI initialization. Tested in internal/cli/stack/sync_test.go.
 
 	t.Run("syncs with restack flag", func(t *testing.T) {
-		s := scenario.NewScenario(t, nil).
+		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"branch1": "main",
 			})
@@ -44,7 +52,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("restacks branches in topological order (parents before children)", func(t *testing.T) {
-		s := scenario.NewScenario(t, nil).
+		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"branch1": "main",
 				"branch2": "branch1",
@@ -61,7 +69,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("restacks branching stacks in topological order", func(t *testing.T) {
-		s := scenario.NewScenario(t, nil).
+		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"stackA":        "main",
 				"stackA-child1": "stackA",
@@ -89,7 +97,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("restacks multiple deep subtrees correctly", func(t *testing.T) {
-		s := scenario.NewScenario(t, nil).
+		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"P":   "main",
 				"C1":  "P",
@@ -120,7 +128,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("partial success in branching restack (one child succeeds, one fails)", func(t *testing.T) {
-		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s := scenario.NewRemoteScenario(t)
 
 		// Create: main -> P -> [0-Success, 1-Failure]
 		// We use these names because siblings are sorted ascending by name by default,
@@ -169,7 +177,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("sync mode aborts unexpected runtime restack conflict and restores branch", func(t *testing.T) {
-		s := scenario.NewScenario(t, nil).
+		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"branch1": "main",
 			})

--- a/internal/actions/sync/worktree_cleanup_test.go
+++ b/internal/actions/sync/worktree_cleanup_test.go
@@ -9,14 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/getstackit/stackit/internal/actions/sync"
-	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
 func TestSyncCleansOrphanedWorktrees(t *testing.T) {
 	t.Run("cleans worktree when stack root branch is deleted", func(t *testing.T) {
-		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
-		s.WithInitialCommit()
+		s := scenario.NewRemoteScenario(t)
 
 		// Create a branch that will become a stack root
 		s.CreateBranch("feature-branch").Commit("feature change")
@@ -48,8 +46,7 @@ func TestSyncCleansOrphanedWorktrees(t *testing.T) {
 	})
 
 	t.Run("preserves worktree when stack root branch still exists", func(t *testing.T) {
-		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
-		s.WithInitialCommit()
+		s := scenario.NewRemoteScenario(t)
 
 		// Create and track a branch
 		s.CreateBranch("feature-branch").Commit("feature change")
@@ -72,8 +69,7 @@ func TestSyncCleansOrphanedWorktrees(t *testing.T) {
 	})
 
 	t.Run("preserves registration when worktree removal fails", func(t *testing.T) {
-		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
-		s.WithInitialCommit()
+		s := scenario.NewRemoteScenario(t)
 
 		worktreePath := filepath.Join(t.TempDir(), "not-a-git-worktree")
 		require.NoError(t, os.MkdirAll(worktreePath, 0o755))

--- a/internal/actions/worktree/hooks.go
+++ b/internal/actions/worktree/hooks.go
@@ -25,7 +25,7 @@ func ResolveApprovedHooks(ctx *app.Context) ([]string, error) {
 	}
 	return hooks.ResolveApproved(hooks.ResolveRequest{
 		Phase:    config.PhasePostWorktreeCreate,
-		Commands: projectCfg.Hooks.PostWorktreeCreate,
+		Commands: projectCfg.Hooks.For(config.PhasePostWorktreeCreate),
 		Config:   ctx.Config,
 		Prompter: worktreePrompter{},
 		Output:   ctx.Output,

--- a/internal/cli/common/hookmiddleware.go
+++ b/internal/cli/common/hookmiddleware.go
@@ -61,6 +61,12 @@ func RunCommandHooks(ctx *app.Context, cmd *cobra.Command, phase PhasePrefix) er
 	}
 
 	phaseKey := CommandPhase(cmd, phase)
+	if phaseKey == config.PhasePostWorktreeCreate {
+		// post-worktree-create is the legacy worktree hook. Worktree create/attach
+		// run it explicitly inside the target worktree; the generic command
+		// lifecycle runner would run the same hook again from the original repo.
+		return nil
+	}
 	hookCmds := projectCfg.Hooks.For(phaseKey)
 	if len(hookCmds) == 0 {
 		return nil

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -44,6 +44,7 @@ const (
 	keyWorktreeAutoClean    = "worktree.autoClean"
 	keySplitHunkSelector    = "split.hunkSelector"
 	keyUndoDepth            = "undo.depth"
+	keyUndoEnabled          = "undo.enabled"
 	keyCICommand            = "ci.command"
 	keyCITimeout            = "ci.timeout"
 	keyMaxConcurrency       = "maxConcurrency"
@@ -191,6 +192,8 @@ func newConfigGetCmd() *cobra.Command {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), cfg.SplitHunkSelector())
 			case keyUndoDepth:
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), cfg.UndoStackDepth())
+			case keyUndoEnabled:
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), cfg.UndoEnabled())
 			case keyCICommand:
 				ciCmd := cfg.CICommand()
 				if ciCmd == "" {
@@ -361,6 +364,15 @@ func newConfigSetCmd() *cobra.Command {
 					return fmt.Errorf("failed to set %s: %w", keyUndoDepth, err)
 				}
 				splog.Info("Set %s to: %d", keyUndoDepth, depth)
+			case keyUndoEnabled:
+				enabled, err := strconv.ParseBool(value)
+				if err != nil {
+					return fmt.Errorf("invalid value for %s: %s (must be 'true' or 'false')", keyUndoEnabled, value)
+				}
+				if err := cfg.SetUndoEnabled(enabled); err != nil {
+					return fmt.Errorf("failed to set %s: %w", keyUndoEnabled, err)
+				}
+				splog.Info("Set %s to: %v", keyUndoEnabled, enabled)
 			case keyCICommand:
 				if err := cfg.SetCICommand(value); err != nil {
 					return fmt.Errorf("failed to set %s: %w", keyCICommand, err)
@@ -543,6 +555,11 @@ Examples:
 					return fmt.Errorf("failed to unset %s: %w", keyUndoDepth, err)
 				}
 				splog.Info("Unset %s (now using: %d)", keyUndoDepth, cfg.UndoStackDepth())
+			case keyUndoEnabled:
+				if err := cfg.UnsetUndoEnabled(); err != nil {
+					return fmt.Errorf("failed to unset %s: %w", keyUndoEnabled, err)
+				}
+				splog.Info("Unset %s (now using: %v)", keyUndoEnabled, cfg.UndoEnabled())
 			case keyCICommand:
 				if err := cfg.UnsetCICommand(); err != nil {
 					return fmt.Errorf("failed to unset %s: %w", keyCICommand, err)
@@ -914,6 +931,10 @@ func showConfigWithSources(repoRoot string, w io.Writer) error {
 	// undo.depth
 	undoSource := getIntSource(config.KeyUndoDepth, projectCfg != nil && projectCfg.HasUndoDepth())
 	formatLine("undo.depth", fmt.Sprintf("%d", cfg.UndoStackDepth()), undoSource)
+
+	// undo.enabled
+	undoEnabledSource := getBoolSource(config.KeyUndoEnabled, projectCfg != nil && projectCfg.HasUndoEnabled())
+	formatLine("undo.enabled", strconv.FormatBool(cfg.UndoEnabled()), undoEnabledSource)
 
 	// worktree.basePath
 	basePath := cfg.WorktreeBasePath()

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -173,4 +173,39 @@ func TestConfigCommand(t *testing.T) {
 		require.NoError(t, err, "config get command failed: %s", output)
 		require.Equal(t, "true", strings.TrimSpace(output))
 	})
+
+	t.Run("config set get and unset undo.enabled", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).WithInProcess(true)
+
+		output, err := s.RunCliAndGetOutput("config", "get", "undo.enabled")
+		require.NoError(t, err, "config get command failed: %s", output)
+		require.Equal(t, "true", strings.TrimSpace(output))
+
+		output, err = s.RunCliAndGetOutput("config", "set", "undo.enabled", "false")
+		require.NoError(t, err, "config set command failed: %s", output)
+		require.Contains(t, output, "Set undo.enabled to: false")
+
+		output, err = s.RunCliAndGetOutput("config", "get", "undo.enabled")
+		require.NoError(t, err, "config get command failed: %s", output)
+		require.Equal(t, "false", strings.TrimSpace(output))
+
+		output, err = s.RunCliAndGetOutput("config", "unset", "undo.enabled")
+		require.NoError(t, err, "config unset command failed: %s", output)
+		require.Contains(t, output, "Unset undo.enabled")
+
+		output, err = s.RunCliAndGetOutput("config", "get", "undo.enabled")
+		require.NoError(t, err, "config get command failed: %s", output)
+		require.Equal(t, "true", strings.TrimSpace(output))
+	})
+
+	t.Run("config list includes undo.enabled", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).WithInProcess(true)
+
+		output, err := s.RunCliAndGetOutput("config", "list")
+		require.NoError(t, err, "config list command failed: %s", output)
+		require.Contains(t, output, "undo.enabled")
+		require.Contains(t, output, "true")
+	})
 }

--- a/internal/cli/stack/merge/confirm.go
+++ b/internal/cli/stack/merge/confirm.go
@@ -1,0 +1,14 @@
+package merge
+
+import (
+	"fmt"
+
+	"github.com/getstackit/stackit/internal/app"
+)
+
+func requireYesInNonInteractive(ctx *app.Context, command string, yes, dryRun bool) error {
+	if dryRun || yes || ctx.Interactive {
+		return nil
+	}
+	return fmt.Errorf("%s requires --yes in non-interactive mode", command)
+}

--- a/internal/cli/stack/merge/drain.go
+++ b/internal/cli/stack/merge/drain.go
@@ -142,6 +142,10 @@ func runMergeDrain(ctx *app.Context, opts mergeDrainOptions) error {
 		return nil
 	}
 
+	if err := requireYesInNonInteractive(ctx, "merge drain", opts.yes, opts.dryRun); err != nil {
+		return err
+	}
+
 	// Fail fast if no GitHub client
 	if _, err := ctx.RequireGitHub(); err != nil {
 		return err

--- a/internal/cli/stack/merge/merge_test.go
+++ b/internal/cli/stack/merge/merge_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	mergeAction "github.com/getstackit/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/github"
 	"github.com/getstackit/stackit/internal/tui"
@@ -151,6 +152,36 @@ func TestNewDrainCmd(t *testing.T) {
 		waitFlag := cmd.Flags().Lookup("wait")
 		require.Nil(t, waitFlag)
 	})
+}
+
+func TestRequireYesInNonInteractive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		interactive bool
+		yes         bool
+		dryRun      bool
+		wantErr     bool
+	}{
+		{name: "interactive prompts later", interactive: true},
+		{name: "non-interactive with yes", yes: true},
+		{name: "non-interactive dry run", dryRun: true},
+		{name: "non-interactive without yes", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := &app.Context{Interactive: tt.interactive}
+			err := requireYesInNonInteractive(ctx, "merge next", tt.yes, tt.dryRun)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "--yes")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestMergeNextUsesCreateMergePlan(t *testing.T) {

--- a/internal/cli/stack/merge/next.go
+++ b/internal/cli/stack/merge/next.go
@@ -116,6 +116,10 @@ func runMergeNext(ctx *app.Context, opts mergeNextOptions, postMergeHandler Post
 		return nil
 	}
 
+	if err := requireYesInNonInteractive(ctx, "merge next", opts.yes, opts.dryRun); err != nil {
+		return err
+	}
+
 	// Fail fast if no GitHub client
 	if _, err := ctx.RequireGitHub(); err != nil {
 		return err

--- a/internal/cli/stack/merge/ship.go
+++ b/internal/cli/stack/merge/ship.go
@@ -155,12 +155,6 @@ func runMergeShip(ctx *app.Context, opts mergeShipOptions, postMergeHandler Post
 		return err
 	}
 
-	// Prompt for a stack description on multi-PR stacks that have none set.
-	// Best-effort: a failure here never blocks the ship.
-	if len(plan.BranchesToMerge) > 1 {
-		promptForShipDescription(ctx, plan.BranchesToMerge, opts.yes)
-	}
-
 	// Confirm unless --yes
 	if !opts.yes && ctx.Interactive {
 		confirmed, err := tui.PromptConfirm("Proceed with ship merge?", false)
@@ -171,6 +165,12 @@ func runMergeShip(ctx *app.Context, opts mergeShipOptions, postMergeHandler Post
 			out.Info("Merge canceled")
 			return nil
 		}
+	}
+
+	// Prompt for a stack description on multi-PR stacks that have none set.
+	// Best-effort: a failure here never blocks the ship.
+	if len(plan.BranchesToMerge) > 1 {
+		promptForShipDescription(ctx, plan.BranchesToMerge, opts.yes)
 	}
 
 	// Get config values

--- a/internal/cli/stack/merge/ship.go
+++ b/internal/cli/stack/merge/ship.go
@@ -146,6 +146,10 @@ func runMergeShip(ctx *app.Context, opts mergeShipOptions, postMergeHandler Post
 		return nil
 	}
 
+	if err := requireYesInNonInteractive(ctx, "merge ship", opts.yes, opts.dryRun); err != nil {
+		return err
+	}
+
 	// Fail fast if no GitHub client
 	if _, err := ctx.RequireGitHub(); err != nil {
 		return err

--- a/internal/cli/stack/sync_test.go
+++ b/internal/cli/stack/sync_test.go
@@ -26,6 +26,8 @@ func TestSyncCommand(t *testing.T) {
 		// Create a remote to avoid sync errors related to missing remote
 		_, err := s.Scene.Repo.CreateBareRemote("origin")
 		require.NoError(t, err)
+		err = s.Scene.Repo.PushBranch("origin", "main")
+		require.NoError(t, err)
 
 		s.RunCli("init")
 		s.RunCli("create", "branch1", "-m", "branch1")
@@ -84,6 +86,8 @@ func TestSyncCommand(t *testing.T) {
 
 		// Create a remote to avoid sync errors related to missing remote
 		_, err := s.Scene.Repo.CreateBareRemote("origin")
+		require.NoError(t, err)
+		err = s.Scene.Repo.PushBranch("origin", "main")
 		require.NoError(t, err)
 
 		s.RunCli("init")

--- a/internal/config/config_git.go
+++ b/internal/config/config_git.go
@@ -270,6 +270,11 @@ func (c *GitConfig) SetUndoStackDepth(depth int) error {
 	return c.store.SetInt(KeyUndoDepth, depth)
 }
 
+// SetUndoEnabled sets whether undo snapshots are taken before mutations.
+func (c *GitConfig) SetUndoEnabled(enabled bool) error {
+	return c.store.SetBool(KeyUndoEnabled, enabled)
+}
+
 // WorktreeBasePath returns the worktree base path.
 // Priority: personal git config > team project config > empty (not set).
 func (c *GitConfig) WorktreeBasePath() string {
@@ -913,6 +918,11 @@ func (c *GitConfig) UnsetSplitHunkSelector() error {
 // UnsetUndoStackDepth removes the personal undo stack depth setting, reverting to project/default.
 func (c *GitConfig) UnsetUndoStackDepth() error {
 	return c.store.Unset(KeyUndoDepth)
+}
+
+// UnsetUndoEnabled removes the personal undo enabled setting, reverting to project/default.
+func (c *GitConfig) UnsetUndoEnabled() error {
+	return c.store.Unset(KeyUndoEnabled)
 }
 
 // UnsetCICommand removes the personal CI command setting, reverting to project/default.

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -84,27 +84,15 @@ type ProjectConfig struct {
 	Navigation     NavigationConfig `yaml:"navigation,omitempty"`
 }
 
-// HooksConfig contains hook configurations.
-//
-// PostWorktreeCreate keeps its dedicated field for the legacy worktree-create
-// integration. All other phases (pre-modify, post-submit, ...) flow through
-// the inline Phases map and are matched by their kebab-case phase name.
-type HooksConfig struct {
-	// PostWorktreeCreate contains commands to run after creating a worktree.
-	PostWorktreeCreate []string `yaml:"post-worktree-create,omitempty"`
-	// Phases captures every other hook phase under hooks: in .stackit.yaml.
-	// Keys are phase names like "pre-modify"; values are shell command lists.
-	Phases map[string][]string `yaml:",inline"`
-}
+// HooksConfig contains hook configurations keyed by lifecycle phase.
+// Keys are phase names like "pre-modify" or "post-worktree-create"; values
+// are shell command lists.
+type HooksConfig map[string][]string
 
-// For returns the hook command list configured for the given phase, looking
-// up both the explicit field for PostWorktreeCreate and the inline Phases map.
+// For returns the hook command list configured for the given phase.
 // Returns nil for an unknown phase.
 func (h HooksConfig) For(phase string) []string {
-	if phase == PhasePostWorktreeCreate {
-		return h.PostWorktreeCreate
-	}
-	return h.Phases[phase]
+	return h[phase]
 }
 
 // knownTopLevelKeys contains all valid top-level keys in .stackit.yaml
@@ -162,7 +150,7 @@ func LoadProjectConfig(repoRoot string) (*ProjectConfig, error) {
 
 // HasPostWorktreeCreateHooks returns true if there are any post-worktree-create hooks configured
 func (c *ProjectConfig) HasPostWorktreeCreateHooks() bool {
-	return len(c.Hooks.PostWorktreeCreate) > 0
+	return len(c.Hooks.For(PhasePostWorktreeCreate)) > 0
 }
 
 // HasTrunk returns true if a trunk branch is configured

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -246,6 +246,11 @@ func (c *ProjectConfig) HasUndoDepth() bool {
 	return c.Undo.Depth > 0
 }
 
+// HasUndoEnabled returns true if undo enabled is configured
+func (c *ProjectConfig) HasUndoEnabled() bool {
+	return c.Undo.Enabled != nil
+}
+
 // HasWorktreeBasePath returns true if worktree base path is configured
 func (c *ProjectConfig) HasWorktreeBasePath() bool {
 	return c.Worktree.BasePath != ""

--- a/internal/config/project_config_test.go
+++ b/internal/config/project_config_test.go
@@ -23,7 +23,7 @@ func TestLoadProjectConfig(t *testing.T) {
 
 		cfg, err := LoadProjectConfig(tmpDir)
 		require.NoError(t, err)
-		assert.Equal(t, []string{"mise trust", "npm install"}, cfg.Hooks.PostWorktreeCreate)
+		assert.Equal(t, []string{"mise trust", "npm install"}, cfg.Hooks.For(PhasePostWorktreeCreate))
 	})
 
 	t.Run("returns empty config when file does not exist", func(t *testing.T) {
@@ -31,7 +31,7 @@ func TestLoadProjectConfig(t *testing.T) {
 
 		cfg, err := LoadProjectConfig(tmpDir)
 		require.NoError(t, err)
-		assert.Empty(t, cfg.Hooks.PostWorktreeCreate)
+		assert.Empty(t, cfg.Hooks.For(PhasePostWorktreeCreate))
 	})
 
 	t.Run("returns error for malformed YAML", func(t *testing.T) {
@@ -59,7 +59,7 @@ func TestLoadProjectConfig(t *testing.T) {
 
 		cfg, err := LoadProjectConfig(tmpDir)
 		require.NoError(t, err)
-		assert.Empty(t, cfg.Hooks.PostWorktreeCreate)
+		assert.Empty(t, cfg.Hooks.For(PhasePostWorktreeCreate))
 	})
 
 	t.Run("handles empty config file", func(t *testing.T) {
@@ -70,7 +70,7 @@ func TestLoadProjectConfig(t *testing.T) {
 
 		cfg, err := LoadProjectConfig(tmpDir)
 		require.NoError(t, err)
-		assert.Empty(t, cfg.Hooks.PostWorktreeCreate)
+		assert.Empty(t, cfg.Hooks.For(PhasePostWorktreeCreate))
 	})
 
 	t.Run("rejects config with unknown top-level keys", func(t *testing.T) {
@@ -89,10 +89,10 @@ func TestLoadProjectConfig(t *testing.T) {
 	})
 }
 
-func TestHooksConfigInlinePhases(t *testing.T) {
+func TestHooksConfigPhases(t *testing.T) {
 	t.Parallel()
 
-	t.Run("inline phase keys parse alongside explicit worktree field", func(t *testing.T) {
+	t.Run("phase keys parse into one map", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
 
@@ -110,17 +110,17 @@ func TestHooksConfigInlinePhases(t *testing.T) {
 		cfg, err := LoadProjectConfig(tmpDir)
 		require.NoError(t, err)
 
-		assert.Equal(t, []string{"mise trust"}, cfg.Hooks.PostWorktreeCreate)
-		assert.Equal(t, []string{"scripts/check-review.sh"}, cfg.Hooks.Phases["pre-modify"])
-		assert.Equal(t, []string{"scripts/notify.sh"}, cfg.Hooks.Phases["post-submit"])
+		assert.Equal(t, []string{"mise trust"}, cfg.Hooks.For(PhasePostWorktreeCreate))
+		assert.Equal(t, []string{"scripts/check-review.sh"}, cfg.Hooks.For("pre-modify"))
+		assert.Equal(t, []string{"scripts/notify.sh"}, cfg.Hooks.For("post-submit"))
 
-		// For() abstracts the lookup so callers don't care which field a phase lives in.
+		// For() abstracts the lookup so callers do not reach into the map directly.
 		assert.Equal(t, []string{"mise trust"}, cfg.Hooks.For(PhasePostWorktreeCreate))
 		assert.Equal(t, []string{"scripts/check-review.sh"}, cfg.Hooks.For("pre-modify"))
 		assert.Nil(t, cfg.Hooks.For("never-configured"))
 	})
 
-	t.Run("worktree-create does not leak into inline map", func(t *testing.T) {
+	t.Run("worktree-create uses the same phase map", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
 
@@ -134,18 +134,15 @@ func TestHooksConfigInlinePhases(t *testing.T) {
 		cfg, err := LoadProjectConfig(tmpDir)
 		require.NoError(t, err)
 
-		assert.Equal(t, []string{"mise trust"}, cfg.Hooks.PostWorktreeCreate)
-		_, present := cfg.Hooks.Phases["post-worktree-create"]
-		assert.False(t, present, "explicit field should consume the key, not the inline map")
+		assert.Equal(t, []string{"mise trust"}, cfg.Hooks.For(PhasePostWorktreeCreate))
+		assert.Equal(t, []string{"mise trust"}, cfg.Hooks[PhasePostWorktreeCreate])
 	})
 }
 
 func TestHasPostWorktreeCreateHooks(t *testing.T) {
 	t.Run("returns true when hooks exist", func(t *testing.T) {
 		cfg := &ProjectConfig{
-			Hooks: HooksConfig{
-				PostWorktreeCreate: []string{"mise trust"},
-			},
+			Hooks: HooksConfig{PhasePostWorktreeCreate: []string{"mise trust"}},
 		}
 		assert.True(t, cfg.HasPostWorktreeCreateHooks())
 	})
@@ -157,9 +154,7 @@ func TestHasPostWorktreeCreateHooks(t *testing.T) {
 
 	t.Run("returns false when hooks list is empty", func(t *testing.T) {
 		cfg := &ProjectConfig{
-			Hooks: HooksConfig{
-				PostWorktreeCreate: []string{},
-			},
+			Hooks: HooksConfig{PhasePostWorktreeCreate: []string{}},
 		}
 		assert.False(t, cfg.HasPostWorktreeCreateHooks())
 	})
@@ -204,7 +199,7 @@ hooks:
 		assert.Equal(t, "squash", cfg.Merge.Method)
 		assert.Equal(t, "make test", cfg.CI.Command)
 		assert.Equal(t, 300, cfg.CI.Timeout)
-		assert.Equal(t, []string{"npm install"}, cfg.Hooks.PostWorktreeCreate)
+		assert.Equal(t, []string{"npm install"}, cfg.Hooks.For(PhasePostWorktreeCreate))
 	})
 
 	t.Run("loads partial config", func(t *testing.T) {

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -18,7 +18,7 @@ func (e *engineImpl) GetPendingChanges(ctx context.Context) ([]PendingChange, er
 	}
 
 	var changes []PendingChange
-	lines := strings.SplitSeq(strings.TrimSpace(output), "\n")
+	lines := strings.SplitSeq(strings.TrimSuffix(output, "\n"), "\n")
 	for line := range lines {
 		if len(line) < 4 {
 			continue
@@ -79,7 +79,7 @@ func (e *engineImpl) GetWorkingTreeStatus(ctx context.Context) (staged, unstaged
 	if err != nil {
 		return false, false, false, err
 	}
-	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSuffix(output, "\n"), "\n") {
 		if len(line) < 2 {
 			continue
 		}

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -885,7 +885,8 @@ func TestUpsertPrInfo(t *testing.T) {
 				"branch1": "main",
 			})
 
-		prInfo := testhelpers.NewTestPrInfoWithTitle(123, "Original Title")
+		prInfo := testhelpers.NewTestPrInfoWithTitle(123, "Original Title").
+			WithMergeBranch("stackit-merge-branch")
 
 		branch := s.Engine.GetBranch("branch1")
 		err := s.Engine.UpsertPrInfo(context.Background(), branch, prInfo)
@@ -902,6 +903,7 @@ func TestUpsertPrInfo(t *testing.T) {
 		require.NotNil(t, retrieved)
 		require.Equal(t, "Updated Title", retrieved.Title())
 		require.Equal(t, "Updated body", retrieved.Body())
+		require.Equal(t, "stackit-merge-branch", retrieved.MergeBranch())
 	})
 }
 

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -100,6 +100,57 @@ func TestTrackBranch(t *testing.T) {
 	})
 }
 
+func TestGetWorkingTreeStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("clean repo", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		staged, unstaged, untracked, err := s.Engine.GetWorkingTreeStatus(context.Background())
+		require.NoError(t, err)
+		require.False(t, staged)
+		require.False(t, unstaged)
+		require.False(t, untracked)
+	})
+
+	t.Run("unstaged tracked change", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		require.NoError(t, s.Scene.Repo.CreateChange("2", "1", true))
+
+		staged, unstaged, untracked, err := s.Engine.GetWorkingTreeStatus(context.Background())
+		require.NoError(t, err)
+		require.False(t, staged)
+		require.True(t, unstaged)
+		require.False(t, untracked)
+	})
+
+	t.Run("staged tracked change", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		require.NoError(t, s.Scene.Repo.CreateChange("2", "1", false))
+
+		staged, unstaged, untracked, err := s.Engine.GetWorkingTreeStatus(context.Background())
+		require.NoError(t, err)
+		require.True(t, staged)
+		require.False(t, unstaged)
+		require.False(t, untracked)
+	})
+
+	t.Run("untracked file", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		require.NoError(t, s.Scene.Repo.CreateChange("new", "untracked", true))
+
+		staged, unstaged, untracked, err := s.Engine.GetWorkingTreeStatus(context.Background())
+		require.NoError(t, err)
+		require.False(t, staged)
+		require.False(t, unstaged)
+		require.True(t, untracked)
+	})
+}
+
 func TestSetParent(t *testing.T) {
 	t.Parallel()
 	t.Run("updates parent relationship", func(t *testing.T) {

--- a/internal/engine/pr_info.go
+++ b/internal/engine/pr_info.go
@@ -137,42 +137,45 @@ func (p *PrInfo) MarshalJSON() ([]byte, error) {
 // WithNumber returns a new PrInfo with the number field updated
 func (p *PrInfo) WithNumber(number *int) *PrInfo {
 	return &PrInfo{
-		number:     number,
-		title:      p.title,
-		body:       p.body,
-		isDraft:    p.isDraft,
-		state:      p.state,
-		base:       p.base,
-		url:        p.url,
-		lockReason: p.lockReason,
+		number:      number,
+		title:       p.title,
+		body:        p.body,
+		isDraft:     p.isDraft,
+		state:       p.state,
+		base:        p.base,
+		url:         p.url,
+		lockReason:  p.lockReason,
+		mergeBranch: p.mergeBranch,
 	}
 }
 
 // WithTitle returns a new PrInfo with the title field updated
 func (p *PrInfo) WithTitle(title string) *PrInfo {
 	return &PrInfo{
-		number:     p.number,
-		title:      title,
-		body:       p.body,
-		isDraft:    p.isDraft,
-		state:      p.state,
-		base:       p.base,
-		url:        p.url,
-		lockReason: p.lockReason,
+		number:      p.number,
+		title:       title,
+		body:        p.body,
+		isDraft:     p.isDraft,
+		state:       p.state,
+		base:        p.base,
+		url:         p.url,
+		lockReason:  p.lockReason,
+		mergeBranch: p.mergeBranch,
 	}
 }
 
 // WithBody returns a new PrInfo with the body field updated
 func (p *PrInfo) WithBody(body string) *PrInfo {
 	return &PrInfo{
-		number:     p.number,
-		title:      p.title,
-		body:       body,
-		isDraft:    p.isDraft,
-		state:      p.state,
-		base:       p.base,
-		url:        p.url,
-		lockReason: p.lockReason,
+		number:      p.number,
+		title:       p.title,
+		body:        body,
+		isDraft:     p.isDraft,
+		state:       p.state,
+		base:        p.base,
+		url:         p.url,
+		lockReason:  p.lockReason,
+		mergeBranch: p.mergeBranch,
 	}
 }
 
@@ -180,70 +183,75 @@ func (p *PrInfo) WithBody(body string) *PrInfo {
 // This is more efficient than chaining WithTitle().WithBody() as it only creates one copy
 func (p *PrInfo) WithTitleAndBody(title, body string) *PrInfo {
 	return &PrInfo{
-		number:     p.number,
-		title:      title,
-		body:       body,
-		isDraft:    p.isDraft,
-		state:      p.state,
-		base:       p.base,
-		url:        p.url,
-		lockReason: p.lockReason,
+		number:      p.number,
+		title:       title,
+		body:        body,
+		isDraft:     p.isDraft,
+		state:       p.state,
+		base:        p.base,
+		url:         p.url,
+		lockReason:  p.lockReason,
+		mergeBranch: p.mergeBranch,
 	}
 }
 
 // WithIsDraft returns a new PrInfo with the isDraft field updated
 func (p *PrInfo) WithIsDraft(isDraft bool) *PrInfo {
 	return &PrInfo{
-		number:     p.number,
-		title:      p.title,
-		body:       p.body,
-		isDraft:    isDraft,
-		state:      p.state,
-		base:       p.base,
-		url:        p.url,
-		lockReason: p.lockReason,
+		number:      p.number,
+		title:       p.title,
+		body:        p.body,
+		isDraft:     isDraft,
+		state:       p.state,
+		base:        p.base,
+		url:         p.url,
+		lockReason:  p.lockReason,
+		mergeBranch: p.mergeBranch,
 	}
 }
 
 // WithState returns a new PrInfo with the state field updated
 func (p *PrInfo) WithState(state string) *PrInfo {
 	return &PrInfo{
-		number:     p.number,
-		title:      p.title,
-		body:       p.body,
-		isDraft:    p.isDraft,
-		state:      state,
-		base:       p.base,
-		url:        p.url,
-		lockReason: p.lockReason,
+		number:      p.number,
+		title:       p.title,
+		body:        p.body,
+		isDraft:     p.isDraft,
+		state:       state,
+		base:        p.base,
+		url:         p.url,
+		lockReason:  p.lockReason,
+		mergeBranch: p.mergeBranch,
 	}
 }
 
 // WithBase returns a new PrInfo with the base field updated
 func (p *PrInfo) WithBase(base string) *PrInfo {
 	return &PrInfo{
-		number:     p.number,
-		title:      p.title,
-		body:       p.body,
-		isDraft:    p.isDraft,
-		state:      p.state,
-		base:       base,
-		url:        p.url,
-		lockReason: p.lockReason,
+		number:      p.number,
+		title:       p.title,
+		body:        p.body,
+		isDraft:     p.isDraft,
+		state:       p.state,
+		base:        base,
+		url:         p.url,
+		lockReason:  p.lockReason,
+		mergeBranch: p.mergeBranch,
 	}
 }
 
 // WithURL returns a new PrInfo with the url field updated
 func (p *PrInfo) WithURL(url string) *PrInfo {
 	return &PrInfo{
-		number:     p.number,
-		title:      p.title,
-		body:       p.body,
-		isDraft:    p.isDraft,
-		state:      p.state,
-		base:       p.base,
-		url:        url,
-		lockReason: p.lockReason,
+		number:      p.number,
+		title:       p.title,
+		body:        p.body,
+		isDraft:     p.isDraft,
+		state:       p.state,
+		base:        p.base,
+		url:         url,
+		lockReason:  p.lockReason,
+		mergeBranch: p.mergeBranch,
 	}
 }
 

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -858,7 +858,7 @@ func (r *runner) GetCommitLog(sha, format string) (string, error) {
 }
 
 func (r *runner) GetStatusPorcelain(ctx context.Context) (string, error) {
-	return r.RunGitCommandWithContext(ctx, "status", "--porcelain")
+	return r.RunGitCommandRawWithContext(ctx, "status", "--porcelain")
 }
 
 func (r *runner) GetCommitTemplate(ctx context.Context) (string, error) {

--- a/internal/integration/scope_integration_test.go
+++ b/internal/integration/scope_integration_test.go
@@ -77,7 +77,7 @@ func TestScopeRequiredInPattern(t *testing.T) {
 
 func TestScopeSubmitSyncFlow(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 
 	// 1. Create a branch
 	sh.CreateBranch("feature").
@@ -91,30 +91,26 @@ func TestScopeSubmitSyncFlow(t *testing.T) {
 	require.NoError(t, eng.SetScope(context.Background(), branch, engine.NewScope("JIRA-123")))
 	require.Equal(t, "JIRA-123", eng.GetScope(branch).String())
 
-	// 3. Setup a local remote to simulate "origin"
-	_, err := sh.Scene.Repo.CreateBareRemote("origin")
-	require.NoError(t, err)
-
-	// 4. Setup mocked GitHub client for submit
+	// 3. Setup mocked GitHub client for submit
 	config := testhelpers.NewMockGitHubServerConfig()
 	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, config)
 	githubClient := testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, config)
 	sh.Context.GitHubClient = githubClient
 
-	// 5. Submit the branch (this should push the metadata ref)
+	// 4. Submit the branch (this should push the metadata ref)
 	opts := submit.Options{
 		NoEdit: true,
 		Draft:  true,
 	}
-	err = submit.Action(sh.Context, opts, &noopHandler{})
+	err := submit.Action(sh.Context, opts, &noopHandler{})
 	require.NoError(t, err)
 
-	// 6. Run sync to fetch remote metadata
+	// 5. Run sync to fetch remote metadata
 	// This will fetch refs/stackit/metadata/*:refs/stackit/remote-metadata/*
 	err = sync.Action(sh.Context, sync.Options{}, nil)
 	require.NoError(t, err)
 
-	// 7. Verify the scope is now in the remote metadata cache
+	// 6. Verify the scope is now in the remote metadata cache
 	err = eng.LoadRemoteMetadataCache()
 	require.NoError(t, err)
 

--- a/internal/integration/stack_metadata_gc_test.go
+++ b/internal/integration/stack_metadata_gc_test.go
@@ -14,7 +14,7 @@ func TestStackMetadataGC(t *testing.T) {
 
 	t.Run("orphaned stack ref is cleaned after all branches deleted", func(t *testing.T) {
 		t.Parallel()
-		sh := NewTestShellInProcess(t)
+		sh := NewTestShellInProcess(t, WithRemote())
 
 		// Create a stack: main -> a -> b
 		sh.CreateLinearStack("a", "b")
@@ -42,7 +42,7 @@ func TestStackMetadataGC(t *testing.T) {
 
 	t.Run("active stack refs are NOT deleted", func(t *testing.T) {
 		t.Parallel()
-		sh := NewTestShellInProcess(t)
+		sh := NewTestShellInProcess(t, WithRemote())
 
 		// Create a stack: main -> a -> b -> c
 		sh.CreateLinearStack3()
@@ -67,7 +67,7 @@ func TestStackMetadataGC(t *testing.T) {
 
 	t.Run("stack ref survives when some branches remain after partial deletion", func(t *testing.T) {
 		t.Parallel()
-		sh := NewTestShellInProcess(t)
+		sh := NewTestShellInProcess(t, WithRemote())
 
 		// Create a stack: main -> a -> b -> c
 		sh.CreateLinearStack3()
@@ -100,7 +100,7 @@ func TestStackMetadataGC(t *testing.T) {
 
 	t.Run("multiple orphaned stacks are cleaned in one sync", func(t *testing.T) {
 		t.Parallel()
-		sh := NewTestShellInProcess(t)
+		sh := NewTestShellInProcess(t, WithRemote())
 
 		// Create first stack: main -> a
 		sh.Write("a.txt", "content for a").

--- a/internal/integration/sync_test.go
+++ b/internal/integration/sync_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/getstackit/stackit/internal/actions/sync"
 	"github.com/getstackit/stackit/internal/git"
-	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
@@ -18,7 +17,7 @@ func TestSync(t *testing.T) {
 	t.Parallel()
 	t.Run("local parent is authoritative over GitHub PR base", func(t *testing.T) {
 		t.Parallel()
-		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		sh := scenario.NewRemoteScenario(t)
 
 		// 1. Create a diamond-like structure:
 		// main -> feature-a -> feature-b
@@ -68,7 +67,7 @@ func TestSync(t *testing.T) {
 
 	t.Run("handles consolidation and deletion of merged branches", func(t *testing.T) {
 		t.Parallel()
-		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		sh := scenario.NewRemoteScenario(t)
 
 		// 1. Create a chain of branches: main -> branch-a -> branch-b -> branch-c
 		branchNames := []string{"branch-a", "branch-b", "branch-c"}
@@ -145,7 +144,7 @@ func TestSync(t *testing.T) {
 
 	t.Run("handles diamond dependency during sync", func(t *testing.T) {
 		t.Parallel()
-		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		sh := scenario.NewRemoteScenario(t)
 
 		// Create: main -> a -> b
 		//                \-> c
@@ -200,7 +199,7 @@ func TestSync(t *testing.T) {
 
 func TestSyncDraftPRs(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 
 	// Create branch-a on main
 	sh.CreateBranch("branch-a").
@@ -245,7 +244,7 @@ func TestSyncDraftPRs(t *testing.T) {
 
 func TestSyncCleanupDiamond(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 
 	// Create: main -> a -> b
 	//                \-> c
@@ -299,7 +298,7 @@ func TestSyncStaleDraftCleanup(t *testing.T) {
 	t.Parallel()
 	// Tests the fix for the "stale draft" bug where empty branches
 	// weren't being cleaned up if they were ancestors of other branches.
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 
 	// Create: main -> a -> b
 	sh.CreateBranch("a").CommitChange("a", "a").TrackBranch("a", "main")
@@ -343,7 +342,7 @@ func TestSyncStaleDraftCleanup(t *testing.T) {
 
 func TestSyncSquashMergedRootPreservesChildCommitBoundaries(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 
 	// Create stack: main -> A(2 commits) -> B -> C
 	sh.CreateBranch("branch-a").
@@ -414,7 +413,7 @@ func TestSyncDoesNotLeaveIndexState(t *testing.T) {
 	t.Parallel()
 	t.Run("sync from main does not leave staged changes after cleanup and restack", func(t *testing.T) {
 		t.Parallel()
-		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		sh := scenario.NewRemoteScenario(t)
 
 		// 1. Create a chain: main -> branch-a -> branch-b
 		sh.CreateBranch("branch-a").
@@ -471,7 +470,7 @@ func TestSyncDoesNotLeaveIndexState(t *testing.T) {
 
 	t.Run("sync from detached HEAD does not leave staged changes", func(t *testing.T) {
 		t.Parallel()
-		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		sh := scenario.NewRemoteScenario(t)
 
 		// Create a simple stack
 		sh.CreateBranch("feature").
@@ -513,7 +512,7 @@ func TestSyncDoesNotLeaveIndexState(t *testing.T) {
 		t.Parallel()
 		// This test creates a scenario where the rebase actually moves commits,
 		// which is more likely to trigger index state issues.
-		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		sh := scenario.NewRemoteScenario(t)
 
 		// 1. Create initial stack: main -> feature -> child
 		sh.CreateBranch("feature").
@@ -572,7 +571,7 @@ func TestSyncDoesNotLeaveIndexState(t *testing.T) {
 
 	t.Run("sync skips deletion of branch with unpushed commits", func(t *testing.T) {
 		t.Parallel()
-		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		sh := scenario.NewRemoteScenario(t)
 
 		// Create a branch and track it
 		sh.CreateBranch("feature").
@@ -582,14 +581,9 @@ func TestSyncDoesNotLeaveIndexState(t *testing.T) {
 		eng := sh.Engine
 		mainBranchName := eng.Trunk().GetName()
 
-		// Set up remote and push everything
-		_, err := sh.Scene.Repo.CreateBareRemote("origin")
-		require.NoError(t, err)
-		sh.Checkout("main")
-		err = sh.Scene.Repo.PushBranch("origin", "main")
-		require.NoError(t, err)
+		// Push the branch once so the extra commit below is detected as unpushed.
 		sh.Checkout("feature")
-		err = sh.Scene.Repo.PushBranch("origin", "feature")
+		err := sh.Scene.Repo.PushBranch("origin", "feature")
 		require.NoError(t, err)
 
 		// Add an unpushed local commit
@@ -687,7 +681,7 @@ func markPrMerged(t *testing.T, sh *scenario.Scenario, branch string, prNumber i
 // not skip over to trunk.
 func TestSquashMergeMiddleOfStack(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	// main -> A -> B -> C
@@ -731,7 +725,7 @@ func TestSquashMergeMiddleOfStack(t *testing.T) {
 // deletions to main in a single pass.
 func TestSquashMergeMultipleAdjacentMergedInOneSync(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	sh.CreateBranch("branch-a").
@@ -777,7 +771,7 @@ func TestSquashMergeMultipleAdjacentMergedInOneSync(t *testing.T) {
 // should be cleaned up; A is unaffected.
 func TestSquashMergeDiamondAllChildrenMerged(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	// main -> A -> {B, C}
@@ -817,7 +811,7 @@ func TestSquashMergeDiamondAllChildrenMerged(t *testing.T) {
 // Per .claude/rules/safety-invariants.md "No Detached HEAD State".
 func TestSquashMergeSyncWhileOnMergedBranch(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	setupTwoBranchSquashScenario(t, sh)
@@ -845,7 +839,7 @@ func TestSquashMergeSyncWhileOnMergedBranch(t *testing.T) {
 // onto trunk.
 func TestSquashMergeSyncWhileOnChildOfMergedBranch(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	mainName := setupTwoBranchSquashScenario(t, sh)
@@ -880,7 +874,7 @@ func TestSquashMergeSyncWhileOnChildOfMergedBranch(t *testing.T) {
 // only cleanup.
 func TestSquashMergeNoRestackLeavesGitRefsUntouched(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	mainName := setupTwoBranchSquashScenario(t, sh)
@@ -914,7 +908,7 @@ func TestSquashMergeNoRestackLeavesGitRefsUntouched(t *testing.T) {
 // for B.
 func TestSquashMergeChildBecomesEmpty(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	// A introduces shared=v1; B advances it to v2.
@@ -958,7 +952,7 @@ func TestSquashMergeChildBecomesEmpty(t *testing.T) {
 // recover gracefully and reparent the child rather than crash.
 func TestUserDeletedMergedBranchBeforeSync(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	mainName := setupTwoBranchSquashScenario(t, sh)
@@ -1006,7 +1000,7 @@ func TestUserDeletedMergedBranchBeforeSync(t *testing.T) {
 // either to a clearer error message or to graceful auto-recovery.
 func TestUserManuallyRebasedChildBeforeSync(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	mainName := setupTwoBranchSquashScenario(t, sh)
@@ -1044,7 +1038,7 @@ func TestUserManuallyRebasedChildBeforeSync(t *testing.T) {
 // cleanup runs cleanly.
 func TestMergeCommitNotSquash(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	sh.CreateBranch("branch-a").
@@ -1085,7 +1079,7 @@ func TestMergeCommitNotSquash(t *testing.T) {
 // double-application or restack churn on the surviving child.
 func TestUserLocallyAdvancedTrunkBeforeSync(t *testing.T) {
 	t.Parallel()
-	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
 
 	sh.CreateBranch("branch-a").

--- a/internal/integration/sync_ui_test.go
+++ b/internal/integration/sync_ui_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/getstackit/stackit/internal/engine"
-	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
@@ -15,12 +14,11 @@ func TestSyncUIReporting(t *testing.T) {
 	t.Parallel()
 	t.Run("reports locked and frozen branches during sync", func(t *testing.T) {
 		t.Parallel()
-		sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		sh := scenario.NewRemoteScenario(t).
 			WithInProcess(true)
 
 		// Create a stack: main -> feature-a -> feature-b -> feature-c
-		sh.WithInitialCommit().
-			CreateBranch("feature-a").Commit("a1").TrackBranch("feature-a", "main").
+		sh.CreateBranch("feature-a").Commit("a1").TrackBranch("feature-a", "main").
 			CreateBranch("feature-b").Commit("b1").TrackBranch("feature-b", "feature-a").
 			CreateBranch("feature-c").Commit("c1").TrackBranch("feature-c", "feature-b")
 


### PR DESCRIPTION
This PR merges the following changes:

1. **#1123** fix: require --yes for non-interactive merge
2. **#1124** fix: avoid duplicate worktree create hooks
3. **#1125** fix: preserve merge branch in PR info updates
4. **#1126** fix: expose undo enabled in config CLI
5. **#1128** fix: harden CLI sync and worktree status
6. **#1129** refactor: normalize hook phase config

### Stack

```
main
  └─ jonnii/20260601113758/require-yes-for-non-interactive-merge (#1123)
    └─ jonnii/20260601113815/avoid-duplicate-worktree-create-hooks (#1124)
      └─ jonnii/20260601113828/preserve-merge-branch-in-PR-info-updates (#1125)
        └─ jonnii/20260601113849/expose-undo-enabled-in-config-CLI (#1126)
          └─ jonnii/20260601153626/harden-CLI-sync-and-worktree-status (#1128)
            └─ jonnii/20260601175129/normalize-hook-phase-config (#1129)
```

Stackit-Stack-Size: 6
Stackit-PRs: 1123,1124,1125,1126,1128,1129
