### PR TITLE
fix: force-update remote-tracking refs on explicit branch fetch

### DIFF
--- a/internal/engine/branch_mutations.go
+++ b/internal/engine/branch_mutations.go
@@ -80,7 +80,7 @@ func (e *engineImpl) FetchRemote(ctx context.Context, req RemoteFetchRequest) er
 		if branch == "" {
 			continue
 		}
-		add(fmt.Sprintf("refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch))
+		add(git.BranchFetchRefspec(remote, branch))
 	}
 	if req.IncludeMetadata {
 		add("+refs/stackit/metadata/*:refs/stackit/remote-metadata/*")

--- a/internal/git/pull.go
+++ b/internal/git/pull.go
@@ -17,10 +17,20 @@ const (
 	PullConflict
 )
 
+// BranchFetchRefspec builds the refspec used to fetch a remote branch into its
+// remote-tracking ref. The leading '+' forces the update so a force-pushed
+// remote branch (whose new tip is not a descendant of the previously fetched
+// tip) still updates refs/remotes/<remote>/<branch>, instead of failing the
+// fetch as a non-fast-forward update. This mirrors the '+' in Git's default
+// "+refs/heads/*:refs/remotes/origin/*" fetch refspec.
+func BranchFetchRefspec(remote, branch string) string {
+	return fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
+}
+
 func (r *runner) PullBranch(ctx context.Context, remote, branchName string) (PullResult, error) {
 	// Fetch with explicit refspec to update the remote-tracking branch.
 	// This ensures refs/remotes/<remote>/<branch> is actually updated.
-	refspec := fmt.Sprintf("refs/heads/%s:refs/remotes/%s/%s", branchName, remote, branchName)
+	refspec := BranchFetchRefspec(remote, branchName)
 	_ = r.fetchRemoteRefSpecs(ctx, remote, []string{refspec})
 
 	return r.UpdateBranchFromRemote(ctx, remote, branchName)
@@ -112,7 +122,7 @@ func (r *runner) UpdateBranchFromRemote(ctx context.Context, remote, branchName 
 }
 
 func (r *runner) Fetch(ctx context.Context, remote, branch string) error {
-	refspec := fmt.Sprintf("refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
+	refspec := BranchFetchRefspec(remote, branch)
 	if err := r.fetchRemoteRefSpecs(ctx, remote, []string{refspec}); err != nil {
 		return fmt.Errorf("failed to fetch %s from %s: %w", branch, remote, err)
 	}

--- a/internal/git/pull_test.go
+++ b/internal/git/pull_test.go
@@ -85,6 +85,82 @@ func TestPullBranch_Reproduction(t *testing.T) {
 	require.Equal(t, newRemoteSha, localSha, "Local branch should match remote after pull")
 }
 
+func TestBranchFetchRefspec_ForcesUpdate(t *testing.T) {
+	// The refspec must carry a leading '+' so that force-pushed (non-fast-forward)
+	// remote branches still update the remote-tracking ref. A missing '+' is the
+	// difference between a successful fetch and a non-fast-forward rejection.
+	require.Equal(t,
+		"+refs/heads/feature:refs/remotes/origin/feature",
+		git.BranchFetchRefspec("origin", "feature"),
+	)
+}
+
+func TestFetch_ForceUpdatedRemoteBranch(t *testing.T) {
+	// Regression: fetching an explicit branch refspec must tolerate a remote
+	// branch that was force-pushed to a divergent history after the local
+	// remote-tracking ref already saw the previous tip. Without the '+' force
+	// prefix, `git fetch origin refs/heads/feature:refs/remotes/origin/feature`
+	// exits non-zero as a non-fast-forward update.
+
+	// 1. Setup a "remote" repository
+	remoteScene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+	remotePath, err := remoteScene.Repo.CreateBareRemote("upstream")
+	require.NoError(t, err)
+	err = remoteScene.Repo.PushBranch("upstream", "main")
+	require.NoError(t, err)
+
+	// 2. Push an initial feature branch (commit A) to the remote
+	err = remoteScene.Repo.CreateAndCheckoutBranch("feature")
+	require.NoError(t, err)
+	err = remoteScene.Repo.CreateChangeAndCommit("feature change A", "feature")
+	require.NoError(t, err)
+	err = remoteScene.Repo.PushBranch("upstream", "feature")
+	require.NoError(t, err)
+	shaA, err := remoteScene.Repo.GetRevision("feature")
+	require.NoError(t, err)
+
+	// 3. Clone locally and prime the remote-tracking ref at commit A
+	localDir, err := os.MkdirTemp("", "stackit-test-local-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(localDir) })
+
+	cmd := exec.Command("git", "clone", "--branch", "main", remotePath, localDir)
+	err = cmd.Run()
+	require.NoError(t, err)
+
+	runner := git.NewRunnerWithPath(localDir, nil)
+	err = runner.InitDefaultRepo()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	err = runner.Fetch(ctx, "origin", "feature")
+	require.NoError(t, err)
+	trackedA, err := runner.RunGitCommandWithContext(ctx, "rev-parse", "refs/remotes/origin/feature")
+	require.NoError(t, err)
+	require.Equal(t, shaA, trackedA, "remote-tracking ref should point at commit A after first fetch")
+
+	// 4. Force-push a divergent rewrite (commit B) over feature on the remote.
+	// Resetting to main before committing makes B share a parent with A but be
+	// neither ancestor nor descendant — a true non-fast-forward update.
+	err = remoteScene.Repo.RunGitCommand("reset", "--hard", "main")
+	require.NoError(t, err)
+	err = remoteScene.Repo.CreateChangeAndCommit("feature change B", "feature")
+	require.NoError(t, err)
+	err = remoteScene.Repo.ForcePushBranch("upstream", "feature")
+	require.NoError(t, err)
+	shaB, err := remoteScene.Repo.GetRevision("feature")
+	require.NoError(t, err)
+	require.NotEqual(t, shaA, shaB, "force push should have rewritten feature to a new tip")
+
+	// 5. Fetch again — with the '+' force prefix this succeeds and advances the
+	// remote-tracking ref to B instead of failing as non-fast-forward.
+	err = runner.Fetch(ctx, "origin", "feature")
+	require.NoError(t, err, "fetch should tolerate force-updated remote branch")
+	trackedB, err := runner.RunGitCommandWithContext(ctx, "rev-parse", "refs/remotes/origin/feature")
+	require.NoError(t, err)
+	require.Equal(t, shaB, trackedB, "remote-tracking ref should update to force-pushed commit B")
+}
+
 func TestReloadRepository(t *testing.T) {
 	// Test that the runner can resolve commits created externally — the
 	// revision cache must invalidate / pass through to git for unknown SHAs.


### PR DESCRIPTION

Explicit branch fetch refspecs omitted the leading "+", so git applied
fast-forward semantics to refs/remotes/<remote>/<branch>. When a remote
branch (origin/main or a PR branch) was force-pushed after the local
remote-tracking ref already saw the previous tip, the fetch exited
non-zero as a non-fast-forward update, breaking sync and get.

Centralize branch refspec construction in git.BranchFetchRefspec, which
carries the "+" force prefix (mirroring Git's default fetch refspec and
the existing metadata refspecs), and route the engine batched fetch path,
PullBranch, and Fetch through it. Add a regression test that force-pushes
a divergent remote branch and asserts the fetch still updates the
remote-tracking ref.