### PR TITLE
fix: clear cat-file process on batch I/O failure

### DIFF
--- a/internal/git/object_reader.go
+++ b/internal/git/object_reader.go
@@ -44,9 +44,11 @@ func (r *objectReader) start() error {
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
+		_ = stdin.Close()
 		return fmt.Errorf("object reader stdout pipe: %w", err)
 	}
 	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
 		return fmt.Errorf("object reader start: %w", err)
 	}
 	r.cmd = cmd
@@ -125,6 +127,9 @@ func (r *objectReader) ReadObjectsBatch(refs []string) (map[string]string, error
 	}
 	for _, ref := range refs {
 		if _, err := fmt.Fprintf(r.stdin, "%s\n", ref); err != nil {
+			// Process died; clear it so the next call restarts, mirroring ReadObject.
+			_ = r.cmd.Process.Kill()
+			r.cmd = nil
 			return nil, fmt.Errorf("object reader write: %w", err)
 		}
 	}
@@ -132,6 +137,9 @@ func (r *objectReader) ReadObjectsBatch(refs []string) (map[string]string, error
 	for _, ref := range refs {
 		content, found, err := r.readResponse(ref)
 		if err != nil {
+			// Stdout stream is broken; discard the process so the next call restarts.
+			_ = r.cmd.Process.Kill()
+			r.cmd = nil
 			return nil, err
 		}
 		if found {

--- a/internal/git/object_reader_internal_test.go
+++ b/internal/git/object_reader_internal_test.go
@@ -1,0 +1,104 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// initTestRepo creates a minimal git repo in a temp dir and returns its path.
+func initTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Test",
+			"GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=Test",
+			"GIT_COMMITTER_EMAIL=test@example.com",
+			"GIT_CONFIG_NOSYSTEM=1",
+			"HOME="+t.TempDir(),
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+
+	run("init", "-b", "main")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("hello"), 0o644))
+	run("add", ".")
+	run("commit", "-m", "init")
+	return dir
+}
+
+// TestReadObjectsBatch_ClearsCmdOnWriteError verifies that ReadObjectsBatch
+// clears r.cmd when stdin becomes unwritable, so the next call restarts a
+// fresh process instead of failing forever on the dead handle.
+func TestReadObjectsBatch_ClearsCmdOnWriteError(t *testing.T) {
+	t.Parallel()
+
+	dir := initTestRepo(t)
+	reader := newObjectReader(func() (string, error) { return dir, nil })
+
+	// Warm up the process with a successful call.
+	results, err := reader.ReadObjectsBatch([]string{"HEAD"})
+	require.NoError(t, err)
+	require.NotNil(t, results)
+	require.NotNil(t, reader.cmd, "process should be running after a successful call")
+
+	// Close stdin to simulate the pipe becoming unwritable (e.g. process died).
+	// The next write to r.stdin will fail with "io: read/write on closed pipe".
+	_ = reader.stdin.Close()
+
+	// First call after stdin closes: must fail AND clear r.cmd.
+	_, err = reader.ReadObjectsBatch([]string{"HEAD"})
+	require.Error(t, err, "ReadObjectsBatch must return an error when stdin is closed")
+	require.Nil(t, reader.cmd, "r.cmd must be nil after write failure so the next call can restart")
+
+	// Second call must restart the process and succeed.
+	results2, err := reader.ReadObjectsBatch([]string{"HEAD"})
+	require.NoError(t, err, "ReadObjectsBatch must succeed after restarting the process")
+	require.NotEmpty(t, results2)
+}
+
+// TestReadObjectsBatch_ClearsCmdOnReadError verifies that a broken stdout
+// stream also clears r.cmd so subsequent calls recover correctly.
+func TestReadObjectsBatch_ClearsCmdOnReadError(t *testing.T) {
+	t.Parallel()
+
+	dir := initTestRepo(t)
+
+	// Get a real commit SHA for use in assertions.
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	require.NoError(t, err)
+	headSHA := strings.TrimSpace(string(out))
+
+	reader := newObjectReader(func() (string, error) { return dir, nil })
+
+	// Warm up.
+	results, err := reader.ReadObjectsBatch([]string{headSHA})
+	require.NoError(t, err)
+	require.Contains(t, results, headSHA)
+
+	// Kill the process so that reading stdout returns an error (EOF or broken pipe).
+	_ = reader.cmd.Process.Kill()
+	_ = reader.cmd.Wait()
+
+	// The batch call may partially write refs before the read fails; either
+	// path (write failure or read failure) must clear r.cmd.
+	//nolint:errcheck // result intentionally discarded — we only care that cmd is cleared
+	reader.ReadObjectsBatch([]string{headSHA, headSHA})
+	require.Nil(t, reader.cmd, "r.cmd must be nil after stdout read failure")
+
+	// Recovery: the next call restarts cleanly.
+	results2, err := reader.ReadObjectsBatch([]string{headSHA})
+	require.NoError(t, err, "ReadObjectsBatch must recover after clearing the dead process")
+	require.Contains(t, results2, headSHA)
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

ReadObjectsBatch left r.cmd pointing to a dead process on any I/O error.
The next call would skip start() and write to dead stdin, producing the same
error forever. Mirrors the restart logic already present in ReadObject.

Also close stdin on StdoutPipe/Start failure in start() to avoid a small
pipe handle leak when process startup fails mid-way.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780366913`.


* **PR #1139**
  * **PR #1135** 👈
    * **PR #1136**
      * **PR #1137**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1140 by jonnii*