### PR TITLE
fix: normalize hook commands to trimmed form before approval checks

### DIFF
--- a/internal/actions/hooks/resolve.go
+++ b/internal/actions/hooks/resolve.go
@@ -5,6 +5,7 @@ package hooks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -53,7 +54,7 @@ func ResolveApproved(req ResolveRequest) ([]string, error) {
 	filtered := make([]string, 0, len(req.Commands))
 	for _, hook := range req.Commands {
 		if trimmed := strings.TrimSpace(hook); trimmed != "" {
-			filtered = append(filtered, hook)
+			filtered = append(filtered, trimmed)
 		}
 	}
 	if len(filtered) == 0 {
@@ -103,7 +104,7 @@ func unapprovedRequiredHookError(phase, hook string, cause error) error {
 	if cause != nil {
 		return fmt.Errorf("%s: %w", msg, cause)
 	}
-	return fmt.Errorf("%s", msg)
+	return errors.New(msg)
 }
 
 // RunOptions controls how a list of resolved hooks is executed.

--- a/internal/actions/hooks/resolve_test.go
+++ b/internal/actions/hooks/resolve_test.go
@@ -131,3 +131,44 @@ func TestResolveApproved_RequiredHookFailsClosedOnDecline(t *testing.T) {
 	require.Contains(t, err.Error(), "hook \"scripts/check.sh\" at pre-modify is not approved")
 	require.Len(t, prompter.calls, 1)
 }
+
+func TestResolveApproved_WhitespaceNormalizedBeforeApproval(t *testing.T) {
+	t.Parallel()
+
+	// Commands configured with surrounding whitespace (e.g. from multi-line
+	// YAML or hand-edited git config) must be trimmed before being passed to
+	// IsHookApproved / AddApprovedHook, so that an approval stored for
+	// "scripts/ok.sh" matches a subsequent lookup for "  scripts/ok.sh  ".
+	scene := testhelpers.NewSceneParallel(t, nil)
+	cfg, err := config.LoadConfig(scene.Dir)
+	require.NoError(t, err)
+
+	prompter := &fakePrompter{answers: []bool{true}}
+
+	approved, err := hooks.ResolveApproved(hooks.ResolveRequest{
+		Phase:    "pre-modify",
+		Commands: []string{"  scripts/ok.sh  "},
+		Config:   cfg,
+		Prompter: prompter,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"scripts/ok.sh"}, approved, "returned command must be trimmed")
+	require.Len(t, prompter.calls, 1)
+
+	// Approval was stored under the trimmed key.
+	cfg2, err := config.LoadConfig(scene.Dir)
+	require.NoError(t, err)
+	require.True(t, cfg2.IsHookApproved("pre-modify", "scripts/ok.sh"))
+
+	// Re-running with the same padded command must not re-prompt.
+	prompter2 := &fakePrompter{}
+	approved2, err := hooks.ResolveApproved(hooks.ResolveRequest{
+		Phase:    "pre-modify",
+		Commands: []string{"  scripts/ok.sh  "},
+		Config:   cfg2,
+		Prompter: prompter2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"scripts/ok.sh"}, approved2)
+	require.Empty(t, prompter2.calls, "already-approved trimmed command must not re-prompt")
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

ResolveApproved filtered empty-after-trim entries but stored the original
un-trimmed command in filtered[], then passed it to IsHookApproved and
AddApprovedHook. A hook configured with surrounding whitespace was stored
under a different key than it was looked up, causing a re-approval prompt
on every invocation.

Also replace fmt.Errorf("%s", msg) with errors.New(msg) in
unapprovedRequiredHookError so errors.Is checks work correctly and go vet
no longer flags the call.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780366913`.


* **PR #1139**
  * **PR #1135**
    * **PR #1136** 👈
      * **PR #1137**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->