### PR TITLE
fix: multi-stack dry-run bypasses --yes guard in non-interactive mode

### DIFF
--- a/internal/cli/stack/merge/merge_test.go
+++ b/internal/cli/stack/merge/merge_test.go
@@ -541,3 +541,25 @@ func TestShipDefaultWait(t *testing.T) {
 		require.Equal(t, "false", waitFlag.DefValue)
 	})
 }
+
+func TestRunMultiStackShip_DryRunDoesNotRequireYes(t *testing.T) {
+	t.Parallel()
+
+	// runMultiStackShip with dryRun=true and no stacks specified should
+	// succeed without --yes, even in non-interactive mode. Before the fix,
+	// the --yes guard ran before the dry-run early-return, causing
+	//   "no stacks specified. Use --stacks ... or --yes ..."
+	// in non-interactive CI environments.
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{
+			"stack-a": "main",
+		})
+
+	// Context is non-interactive (scenario sets Interactive: false)
+	err := runMultiStackShip(s.Context, shipMultiStackOptions{
+		dryRun: true,
+		// stacks is nil: no specific stacks selected, meaning "all stacks"
+	})
+	require.NoError(t, err, "dry-run must not require --yes in non-interactive mode")
+	require.Contains(t, s.Output.String(), "Dry-run mode")
+}

--- a/internal/cli/stack/merge/ship.go
+++ b/internal/cli/stack/merge/ship.go
@@ -294,27 +294,8 @@ func runMultiStackShip(ctx *app.Context, opts shipMultiStackOptions) error {
 	}
 	out.Newline()
 
-	// If no stacks specified, confirm proceeding with all stacks
-	if len(opts.stacks) == 0 {
-		if !ctx.Interactive {
-			// Non-interactive mode requires explicit stack selection or --yes
-			if !opts.yes {
-				return fmt.Errorf("no stacks specified. Use --stacks to select stacks or --yes to combine all %d stacks", len(availableStacks))
-			}
-			out.Info("Combining all %d stacks (--yes specified)", len(availableStacks))
-		} else {
-			confirmed, err := tui.PromptConfirm(fmt.Sprintf("Combine all %d stacks?", len(availableStacks)), true)
-			if err != nil {
-				return err
-			}
-			if !confirmed {
-				out.Info("Canceled. Use --stacks to select specific stacks.")
-				return nil
-			}
-		}
-	}
-
-	// Dry-run mode: show the plan and exit without side effects
+	// Dry-run mode: show the plan and exit without side effects. Evaluated
+	// before the --yes check so it is usable non-interactively without flags.
 	if opts.dryRun {
 		selected := availableStacks
 		if len(opts.stacks) > 0 {
@@ -337,6 +318,26 @@ func runMultiStackShip(ctx *app.Context, opts shipMultiStackOptions) error {
 		}
 		out.Info("Dry-run mode: No changes were made.")
 		return nil
+	}
+
+	// If no stacks specified, confirm proceeding with all stacks
+	if len(opts.stacks) == 0 {
+		if !ctx.Interactive {
+			// Non-interactive mode requires explicit stack selection or --yes
+			if !opts.yes {
+				return fmt.Errorf("no stacks specified. Use --stacks to select stacks or --yes to combine all %d stacks", len(availableStacks))
+			}
+			out.Info("Combining all %d stacks (--yes specified)", len(availableStacks))
+		} else {
+			confirmed, err := tui.PromptConfirm(fmt.Sprintf("Combine all %d stacks?", len(availableStacks)), true)
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				out.Info("Canceled. Use --stacks to select specific stacks.")
+				return nil
+			}
+		}
 	}
 
 	// Execute multi-stack merge


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

runMultiStackShip checked the --yes requirement before reaching the dryRun
early-return. In non-interactive mode without --stacks, callers received
"no stacks specified" instead of seeing the dry-run plan.

Move the dry-run block above the --yes guard, consistent with runMergeShip.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780366913`.


* **PR #1139**
  * **PR #1135**
    * **PR #1136**
      * **PR #1137** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1140 by jonnii*