### PR TITLE
Merging 3 PRs

### DIFF
--- a/internal/actions/hooks/resolve.go
+++ b/internal/actions/hooks/resolve.go
@@ -5,6 +5,7 @@ package hooks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -53,7 +54,7 @@ func ResolveApproved(req ResolveRequest) ([]string, error) {
 	filtered := make([]string, 0, len(req.Commands))
 	for _, hook := range req.Commands {
 		if trimmed := strings.TrimSpace(hook); trimmed != "" {
-			filtered = append(filtered, hook)
+			filtered = append(filtered, trimmed)
 		}
 	}
 	if len(filtered) == 0 {
@@ -103,7 +104,7 @@ func unapprovedRequiredHookError(phase, hook string, cause error) error {
 	if cause != nil {
 		return fmt.Errorf("%s: %w", msg, cause)
 	}
-	return fmt.Errorf("%s", msg)
+	return errors.New(msg)
 }
 
 // RunOptions controls how a list of resolved hooks is executed.

--- a/internal/actions/hooks/resolve_test.go
+++ b/internal/actions/hooks/resolve_test.go
@@ -131,3 +131,44 @@ func TestResolveApproved_RequiredHookFailsClosedOnDecline(t *testing.T) {
 	require.Contains(t, err.Error(), "hook \"scripts/check.sh\" at pre-modify is not approved")
 	require.Len(t, prompter.calls, 1)
 }
+
+func TestResolveApproved_WhitespaceNormalizedBeforeApproval(t *testing.T) {
+	t.Parallel()
+
+	// Commands configured with surrounding whitespace (e.g. from multi-line
+	// YAML or hand-edited git config) must be trimmed before being passed to
+	// IsHookApproved / AddApprovedHook, so that an approval stored for
+	// "scripts/ok.sh" matches a subsequent lookup for "  scripts/ok.sh  ".
+	scene := testhelpers.NewSceneParallel(t, nil)
+	cfg, err := config.LoadConfig(scene.Dir)
+	require.NoError(t, err)
+
+	prompter := &fakePrompter{answers: []bool{true}}
+
+	approved, err := hooks.ResolveApproved(hooks.ResolveRequest{
+		Phase:    "pre-modify",
+		Commands: []string{"  scripts/ok.sh  "},
+		Config:   cfg,
+		Prompter: prompter,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"scripts/ok.sh"}, approved, "returned command must be trimmed")
+	require.Len(t, prompter.calls, 1)
+
+	// Approval was stored under the trimmed key.
+	cfg2, err := config.LoadConfig(scene.Dir)
+	require.NoError(t, err)
+	require.True(t, cfg2.IsHookApproved("pre-modify", "scripts/ok.sh"))
+
+	// Re-running with the same padded command must not re-prompt.
+	prompter2 := &fakePrompter{}
+	approved2, err := hooks.ResolveApproved(hooks.ResolveRequest{
+		Phase:    "pre-modify",
+		Commands: []string{"  scripts/ok.sh  "},
+		Config:   cfg2,
+		Prompter: prompter2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"scripts/ok.sh"}, approved2)
+	require.Empty(t, prompter2.calls, "already-approved trimmed command must not re-prompt")
+}

--- a/internal/cli/stack/merge/merge_test.go
+++ b/internal/cli/stack/merge/merge_test.go
@@ -541,3 +541,25 @@ func TestShipDefaultWait(t *testing.T) {
 		require.Equal(t, "false", waitFlag.DefValue)
 	})
 }
+
+func TestRunMultiStackShip_DryRunDoesNotRequireYes(t *testing.T) {
+	t.Parallel()
+
+	// runMultiStackShip with dryRun=true and no stacks specified should
+	// succeed without --yes, even in non-interactive mode. Before the fix,
+	// the --yes guard ran before the dry-run early-return, causing
+	//   "no stacks specified. Use --stacks ... or --yes ..."
+	// in non-interactive CI environments.
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{
+			"stack-a": "main",
+		})
+
+	// Context is non-interactive (scenario sets Interactive: false)
+	err := runMultiStackShip(s.Context, shipMultiStackOptions{
+		dryRun: true,
+		// stacks is nil: no specific stacks selected, meaning "all stacks"
+	})
+	require.NoError(t, err, "dry-run must not require --yes in non-interactive mode")
+	require.Contains(t, s.Output.String(), "Dry-run mode")
+}

--- a/internal/cli/stack/merge/ship.go
+++ b/internal/cli/stack/merge/ship.go
@@ -294,27 +294,8 @@ func runMultiStackShip(ctx *app.Context, opts shipMultiStackOptions) error {
 	}
 	out.Newline()
 
-	// If no stacks specified, confirm proceeding with all stacks
-	if len(opts.stacks) == 0 {
-		if !ctx.Interactive {
-			// Non-interactive mode requires explicit stack selection or --yes
-			if !opts.yes {
-				return fmt.Errorf("no stacks specified. Use --stacks to select stacks or --yes to combine all %d stacks", len(availableStacks))
-			}
-			out.Info("Combining all %d stacks (--yes specified)", len(availableStacks))
-		} else {
-			confirmed, err := tui.PromptConfirm(fmt.Sprintf("Combine all %d stacks?", len(availableStacks)), true)
-			if err != nil {
-				return err
-			}
-			if !confirmed {
-				out.Info("Canceled. Use --stacks to select specific stacks.")
-				return nil
-			}
-		}
-	}
-
-	// Dry-run mode: show the plan and exit without side effects
+	// Dry-run mode: show the plan and exit without side effects. Evaluated
+	// before the --yes check so it is usable non-interactively without flags.
 	if opts.dryRun {
 		selected := availableStacks
 		if len(opts.stacks) > 0 {
@@ -337,6 +318,26 @@ func runMultiStackShip(ctx *app.Context, opts shipMultiStackOptions) error {
 		}
 		out.Info("Dry-run mode: No changes were made.")
 		return nil
+	}
+
+	// If no stacks specified, confirm proceeding with all stacks
+	if len(opts.stacks) == 0 {
+		if !ctx.Interactive {
+			// Non-interactive mode requires explicit stack selection or --yes
+			if !opts.yes {
+				return fmt.Errorf("no stacks specified. Use --stacks to select stacks or --yes to combine all %d stacks", len(availableStacks))
+			}
+			out.Info("Combining all %d stacks (--yes specified)", len(availableStacks))
+		} else {
+			confirmed, err := tui.PromptConfirm(fmt.Sprintf("Combine all %d stacks?", len(availableStacks)), true)
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				out.Info("Canceled. Use --stacks to select specific stacks.")
+				return nil
+			}
+		}
 	}
 
 	// Execute multi-stack merge

--- a/internal/git/object_reader.go
+++ b/internal/git/object_reader.go
@@ -44,9 +44,11 @@ func (r *objectReader) start() error {
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
+		_ = stdin.Close()
 		return fmt.Errorf("object reader stdout pipe: %w", err)
 	}
 	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
 		return fmt.Errorf("object reader start: %w", err)
 	}
 	r.cmd = cmd
@@ -125,6 +127,9 @@ func (r *objectReader) ReadObjectsBatch(refs []string) (map[string]string, error
 	}
 	for _, ref := range refs {
 		if _, err := fmt.Fprintf(r.stdin, "%s\n", ref); err != nil {
+			// Process died; clear it so the next call restarts, mirroring ReadObject.
+			_ = r.cmd.Process.Kill()
+			r.cmd = nil
 			return nil, fmt.Errorf("object reader write: %w", err)
 		}
 	}
@@ -132,6 +137,9 @@ func (r *objectReader) ReadObjectsBatch(refs []string) (map[string]string, error
 	for _, ref := range refs {
 		content, found, err := r.readResponse(ref)
 		if err != nil {
+			// Stdout stream is broken; discard the process so the next call restarts.
+			_ = r.cmd.Process.Kill()
+			r.cmd = nil
 			return nil, err
 		}
 		if found {

--- a/internal/git/object_reader_internal_test.go
+++ b/internal/git/object_reader_internal_test.go
@@ -1,0 +1,104 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// initTestRepo creates a minimal git repo in a temp dir and returns its path.
+func initTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Test",
+			"GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=Test",
+			"GIT_COMMITTER_EMAIL=test@example.com",
+			"GIT_CONFIG_NOSYSTEM=1",
+			"HOME="+t.TempDir(),
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+
+	run("init", "-b", "main")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("hello"), 0o644))
+	run("add", ".")
+	run("commit", "-m", "init")
+	return dir
+}
+
+// TestReadObjectsBatch_ClearsCmdOnWriteError verifies that ReadObjectsBatch
+// clears r.cmd when stdin becomes unwritable, so the next call restarts a
+// fresh process instead of failing forever on the dead handle.
+func TestReadObjectsBatch_ClearsCmdOnWriteError(t *testing.T) {
+	t.Parallel()
+
+	dir := initTestRepo(t)
+	reader := newObjectReader(func() (string, error) { return dir, nil })
+
+	// Warm up the process with a successful call.
+	results, err := reader.ReadObjectsBatch([]string{"HEAD"})
+	require.NoError(t, err)
+	require.NotNil(t, results)
+	require.NotNil(t, reader.cmd, "process should be running after a successful call")
+
+	// Close stdin to simulate the pipe becoming unwritable (e.g. process died).
+	// The next write to r.stdin will fail with "io: read/write on closed pipe".
+	_ = reader.stdin.Close()
+
+	// First call after stdin closes: must fail AND clear r.cmd.
+	_, err = reader.ReadObjectsBatch([]string{"HEAD"})
+	require.Error(t, err, "ReadObjectsBatch must return an error when stdin is closed")
+	require.Nil(t, reader.cmd, "r.cmd must be nil after write failure so the next call can restart")
+
+	// Second call must restart the process and succeed.
+	results2, err := reader.ReadObjectsBatch([]string{"HEAD"})
+	require.NoError(t, err, "ReadObjectsBatch must succeed after restarting the process")
+	require.NotEmpty(t, results2)
+}
+
+// TestReadObjectsBatch_ClearsCmdOnReadError verifies that a broken stdout
+// stream also clears r.cmd so subsequent calls recover correctly.
+func TestReadObjectsBatch_ClearsCmdOnReadError(t *testing.T) {
+	t.Parallel()
+
+	dir := initTestRepo(t)
+
+	// Get a real commit SHA for use in assertions.
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	require.NoError(t, err)
+	headSHA := strings.TrimSpace(string(out))
+
+	reader := newObjectReader(func() (string, error) { return dir, nil })
+
+	// Warm up.
+	results, err := reader.ReadObjectsBatch([]string{headSHA})
+	require.NoError(t, err)
+	require.Contains(t, results, headSHA)
+
+	// Kill the process so that reading stdout returns an error (EOF or broken pipe).
+	_ = reader.cmd.Process.Kill()
+	_ = reader.cmd.Wait()
+
+	// The batch call may partially write refs before the read fails; either
+	// path (write failure or read failure) must clear r.cmd.
+	//nolint:errcheck // result intentionally discarded — we only care that cmd is cleared
+	reader.ReadObjectsBatch([]string{headSHA, headSHA})
+	require.Nil(t, reader.cmd, "r.cmd must be nil after stdout read failure")
+
+	// Recovery: the next call restarts cleanly.
+	results2, err := reader.ReadObjectsBatch([]string{headSHA})
+	require.NoError(t, err, "ReadObjectsBatch must recover after clearing the dead process")
+	require.Contains(t, results2, headSHA)
+}


### PR DESCRIPTION
This PR merges the following changes:

1. **#1135** fix: clear cat-file process on batch I/O failure
2. **#1136** fix: normalize hook commands to trimmed form before approval checks
3. **#1137** fix: multi-stack dry-run bypasses --yes guard in non-interactive mode

### Stack

```
main
  └─ jonnii/20260601234005/clear-cat-file-process-on-batch-I/O-failure (#1135)
    └─ jonnii/20260601234130/normalize-hook-commands-to-trimmed-form-before (#1136)
      └─ jonnii/20260601235339/multi-stack-dry-run-bypasses-yes-guard-in (#1137)
```

Stackit-Stack-Size: 3
Stackit-PRs: 1135,1136,1137
