### PR TITLE
fix: replay rerere in rebase auto-continue error path

### DIFF
--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -92,17 +92,9 @@ func AutoContinueRerereRebase(ctx context.Context, r Runner, originalErr error) 
 			return outcome, nil, nil
 		}
 
-		unmergedFiles, err := r.GetUnmergedFiles(ctx)
+		unmergedFiles, err := applyRerereToUnmerged(ctx, r)
 		if err != nil {
 			return outcome, nil, originalErr
-		}
-		if len(unmergedFiles) > 0 {
-			if _, rerereErr := r.RunGitCommandWithContext(ctx, "rerere"); rerereErr == nil {
-				unmergedFiles, err = r.GetUnmergedFiles(ctx)
-				if err != nil {
-					return outcome, nil, originalErr
-				}
-			}
 		}
 		if len(unmergedFiles) > 0 {
 			return outcome, unmergedFiles, nil
@@ -121,7 +113,12 @@ func AutoContinueRerereRebase(ctx context.Context, r Runner, originalErr error) 
 				}
 			}
 			if r.IsRebaseInProgress(ctx) {
-				unmergedFiles, filesErr := r.GetUnmergedFiles(ctx)
+				// rerere.autoupdate may not have staged the replayed
+				// resolution by the time `rebase --continue` returns, so give
+				// rerere the same explicit chance to apply (and, with
+				// autoupdate, stage) a known resolution as the top of the loop
+				// before treating this as an unresolved conflict.
+				unmergedFiles, filesErr := applyRerereToUnmerged(ctx, r)
 				if filesErr == nil {
 					if len(unmergedFiles) > 0 {
 						return outcome, unmergedFiles, nil
@@ -140,6 +137,32 @@ func AutoContinueRerereRebase(ctx context.Context, r Runner, originalErr error) 
 	}
 
 	return outcome, nil, fmt.Errorf("rerere auto-continue exceeded %d iterations: %w", MaxRerereContinueIterations, originalErr)
+}
+
+// applyRerereToUnmerged replays any recorded rerere resolutions for the
+// currently-conflicted paths (staging them when rerere.autoupdate is on) and
+// returns the paths that remain unmerged afterwards. It is a no-op when nothing
+// is unmerged. Callers use the returned slice to decide whether a conflict is
+// genuinely unresolved: a non-empty result means rerere had no resolution to
+// apply (or one that did not fully clear the conflict).
+func applyRerereToUnmerged(ctx context.Context, r Runner) ([]string, error) {
+	unmerged, err := r.GetUnmergedFiles(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(unmerged) == 0 {
+		return unmerged, nil
+	}
+	// A failed `git rerere` simply means no resolution was applied; keep the
+	// current unmerged set so the caller treats it as a genuine conflict.
+	if _, rerereErr := r.RunGitCommandWithContext(ctx, "rerere"); rerereErr == nil {
+		refreshed, refreshErr := r.GetUnmergedFiles(ctx)
+		if refreshErr != nil {
+			return nil, refreshErr
+		}
+		unmerged = refreshed
+	}
+	return unmerged, nil
 }
 
 func isRebaseContinueStagedChangesError(err error) bool {

--- a/internal/git/rebase_test.go
+++ b/internal/git/rebase_test.go
@@ -2,6 +2,8 @@ package git_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -468,4 +470,75 @@ func TestGetRebaseHead(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, rebaseHead)
 	})
+}
+
+// rerereLagRunner simulates the timing-dependent git behavior behind the flaky
+// TestRebase failure: when `git rebase --continue` replays a commit that hits a
+// conflict rerere can resolve, rerere.autoupdate writes the resolution to the
+// working tree but does not always stage it before the command returns.
+// GetUnmergedFiles therefore still reports the path as conflicted until an
+// explicit `git rerere` stages the resolution. The bug was that the error path
+// after `rebase --continue` bailed on that transient unmerged state without
+// giving rerere the chance to stage it (which the top of the loop already did).
+type rerereLagRunner struct {
+	git.Runner // embedded: only the methods AutoContinueRerereRebase uses are implemented
+
+	inProgress    bool
+	unmerged      []string
+	continueCalls int
+	rerereCalls   int
+}
+
+func (r *rerereLagRunner) IsRebaseInProgress(context.Context) bool {
+	return r.inProgress
+}
+
+func (r *rerereLagRunner) GetUnmergedFiles(context.Context) ([]string, error) {
+	return append([]string(nil), r.unmerged...), nil
+}
+
+func (r *rerereLagRunner) RunGitCommandWithContext(_ context.Context, args ...string) (string, error) {
+	if len(args) > 0 && args[0] == "rerere" {
+		r.rerereCalls++
+		// Explicit rerere applies the recorded resolution and, with autoupdate
+		// on, stages it -- clearing the conflict from the index.
+		r.unmerged = nil
+		return "", nil
+	}
+	return "", fmt.Errorf("unexpected git command: %v", args)
+}
+
+func (r *rerereLagRunner) RunGitCommandWithEnv(_ context.Context, _ []string, args ...string) (string, error) {
+	if len(args) == 2 && args[0] == "rebase" && args[1] == "--continue" {
+		r.continueCalls++
+		if r.continueCalls == 1 {
+			// Applying the next commit hits a conflict rerere can resolve, but
+			// autoupdate has not staged it by the time the command returns.
+			r.unmerged = []string{"fileB_test.txt"}
+			return "", errors.New("CONFLICT (content): merge conflict in fileB_test.txt")
+		}
+		// No commits remain; the rebase completes.
+		r.inProgress = false
+		r.unmerged = nil
+		return "", nil
+	}
+	return "", fmt.Errorf("unexpected git command: %v", args)
+}
+
+// TestAutoContinueRerereRebaseRecoversFromAutoupdateLag is the deterministic
+// regression test for the flaky "continues after rebase continue advances into
+// rerere-staged conflict" case. It pins the fix: when `rebase --continue`
+// returns an unmerged path that rerere can resolve, auto-continue must replay
+// rerere and keep going rather than reporting a spurious conflict.
+func TestAutoContinueRerereRebaseRecoversFromAutoupdateLag(t *testing.T) {
+	t.Parallel()
+
+	r := &rerereLagRunner{inProgress: true}
+	outcome, unmerged, err := git.AutoContinueRerereRebase(context.Background(), r, nil)
+
+	require.NoError(t, err)
+	require.Empty(t, unmerged)
+	require.Equal(t, git.RebaseDone, outcome.Result)
+	require.GreaterOrEqual(t, outcome.RerereResolvedCount, 1)
+	require.Equal(t, 1, r.rerereCalls, "auto-continue should replay rerere to stage the lagged resolution before bailing")
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

AutoContinueRerereRebase runs `git rerere` before treating unmerged files
as a conflict at the top of its loop, but the error path after
`git rebase --continue` checked for unmerged files directly and bailed.
When rerere.autoupdate replayed a recorded resolution into the working
tree but had not yet staged it by the time `rebase --continue` returned,
that path reported a spurious conflict -- the flaky TestRebase "continues
after rebase continue advances into rerere-staged conflict" failure.

Factor the rerere-replay-and-recheck into a shared helper and use it on
both paths so a known resolution is always applied before declaring an
unresolved conflict. Genuinely unresolvable conflicts still bail.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780366913`.


* **PR #1139** 👈
  * **PR #1135**
    * **PR #1136**
      * **PR #1137**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1140 by jonnii*