### PR TITLE
fix: fall back to mergeable field when mergeStateStatus unavailable on GitHub Enterprise

### DIFF
--- a/internal/github/pr_operations.go
+++ b/internal/github/pr_operations.go
@@ -581,6 +581,25 @@ type PRMergeableState struct {
 	State          string // OPEN, CLOSED, MERGED
 }
 
+// isMergeStateStatusUnsupported returns true when the error indicates the mergeStateStatus
+// field is not available on the GitHub instance (e.g. older GitHub Enterprise versions).
+func isMergeStateStatusUnsupported(err error) bool {
+	return strings.Contains(err.Error(), "mergeStateStatus")
+}
+
+// mergeableToMergeStateText maps GitHub's mergeable field to an equivalent MergeStateStatus
+// value. Used on GitHub Enterprise instances that don't support mergeStateStatus.
+func mergeableToMergeStateText(mergeable string) string {
+	switch mergeable {
+	case "MERGEABLE":
+		return "CLEAN"
+	case "CONFLICTING":
+		return "DIRTY"
+	default:
+		return "UNKNOWN"
+	}
+}
+
 // GetPRMergeableState checks if a PR has merge conflicts.
 func GetPRMergeableState(ctx context.Context, runner git.Runner, prNodeID string) (*PRMergeableState, error) {
 	query := `query GetPRMergeableState($nodeId: ID!) {
@@ -599,6 +618,9 @@ func GetPRMergeableState(ctx context.Context, runner git.Runner, prNodeID string
 
 	body, err := executeGraphQLQuery(ctx, runner, query, variables)
 	if err != nil {
+		if isMergeStateStatusUnsupported(err) {
+			return getPRMergeableStateBasic(ctx, runner, prNodeID)
+		}
 		return nil, fmt.Errorf("failed to get PR mergeable state: %w", err)
 	}
 
@@ -619,6 +641,47 @@ func GetPRMergeableState(ctx context.Context, runner git.Runner, prNodeID string
 	return &PRMergeableState{
 		Mergeable:      response.Data.Node.Mergeable == "MERGEABLE",
 		MergeStateText: response.Data.Node.MergeStateStatus,
+		State:          response.Data.Node.State,
+	}, nil
+}
+
+// getPRMergeableStateBasic fetches PR mergeable state without the mergeStateStatus field,
+// used as a fallback for GitHub Enterprise instances that don't support that field.
+func getPRMergeableStateBasic(ctx context.Context, runner git.Runner, prNodeID string) (*PRMergeableState, error) {
+	query := `query GetPRMergeableState($nodeId: ID!) {
+		node(id: $nodeId) {
+			... on PullRequest {
+				mergeable
+				state
+			}
+		}
+	}`
+
+	variables := map[string]any{
+		"nodeId": prNodeID,
+	}
+
+	body, err := executeGraphQLQuery(ctx, runner, query, variables)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get PR mergeable state: %w", err)
+	}
+
+	var response struct {
+		Data struct {
+			Node struct {
+				Mergeable string `json:"mergeable"`
+				State     string `json:"state"`
+			} `json:"node"`
+		} `json:"data"`
+	}
+
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse PR mergeable state response: %w", err)
+	}
+
+	return &PRMergeableState{
+		Mergeable:      response.Data.Node.Mergeable == "MERGEABLE",
+		MergeStateText: mergeableToMergeStateText(response.Data.Node.Mergeable),
 		State:          response.Data.Node.State,
 	}, nil
 }
@@ -659,6 +722,9 @@ func BatchGetPRMergeableStates(ctx context.Context, runner git.Runner, prNodeIDs
 
 	body, err := executeGraphQLQuery(ctx, runner, query, variables)
 	if err != nil {
+		if isMergeStateStatusUnsupported(err) {
+			return batchGetPRMergeableStatesBasic(ctx, runner, prNodeIDs)
+		}
 		return nil, fmt.Errorf("failed to batch get PR mergeable states: %w", err)
 	}
 
@@ -685,6 +751,65 @@ func BatchGetPRMergeableStates(ctx context.Context, runner git.Runner, prNodeIDs
 		result[prData.ID] = &PRMergeableState{
 			Mergeable:      prData.Mergeable == "MERGEABLE",
 			MergeStateText: prData.MergeStateStatus,
+			State:          prData.State,
+		}
+	}
+
+	return result, nil
+}
+
+// batchGetPRMergeableStatesBasic fetches PR mergeable states without the mergeStateStatus field,
+// used as a fallback for GitHub Enterprise instances that don't support that field.
+func batchGetPRMergeableStatesBasic(ctx context.Context, runner git.Runner, prNodeIDs []string) (map[string]*PRMergeableState, error) {
+	queryParts := make([]string, 0, len(prNodeIDs))
+	variables := make(map[string]any, len(prNodeIDs))
+	for i, nodeID := range prNodeIDs {
+		alias := fmt.Sprintf("pr%d", i)
+		varName := fmt.Sprintf("nodeId%d", i)
+		queryParts = append(queryParts, fmt.Sprintf(`%s: node(id: $%s) {
+			... on PullRequest {
+				id
+				mergeable
+				state
+			}
+		}`, alias, varName))
+		variables[varName] = nodeID
+	}
+
+	varDecls := make([]string, 0, len(prNodeIDs))
+	for i := range prNodeIDs {
+		varDecls = append(varDecls, fmt.Sprintf("$nodeId%d: ID!", i))
+	}
+
+	query := fmt.Sprintf("query BatchGetPRMergeableStates(%s) { %s }",
+		strings.Join(varDecls, ", "),
+		strings.Join(queryParts, " "))
+
+	body, err := executeGraphQLQuery(ctx, runner, query, variables)
+	if err != nil {
+		return nil, fmt.Errorf("failed to batch get PR mergeable states: %w", err)
+	}
+
+	var response struct {
+		Data map[string]struct {
+			ID        string `json:"id"`
+			Mergeable string `json:"mergeable"`
+			State     string `json:"state"`
+		} `json:"data"`
+	}
+
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse batch PR mergeable state response: %w", err)
+	}
+
+	result := make(map[string]*PRMergeableState, len(prNodeIDs))
+	for _, prData := range response.Data {
+		if prData.ID == "" {
+			continue
+		}
+		result[prData.ID] = &PRMergeableState{
+			Mergeable:      prData.Mergeable == "MERGEABLE",
+			MergeStateText: mergeableToMergeStateText(prData.Mergeable),
 			State:          prData.State,
 		}
 	}

--- a/internal/github/pr_operations.go
+++ b/internal/github/pr_operations.go
@@ -574,10 +574,15 @@ const (
 	PRStateClosed = "CLOSED"
 )
 
+// mergeableMergeable is the GraphQL `mergeable` field value indicating a PR can
+// be merged without conflicts. The field's possible values are MERGEABLE,
+// CONFLICTING, and UNKNOWN.
+const mergeableMergeable = "MERGEABLE"
+
 // PRMergeableState represents the mergeable state of a PR
 type PRMergeableState struct {
 	Mergeable      bool   // True if PR can be merged without conflicts
-	MergeStateText string // MERGEABLE, CONFLICTING, UNKNOWN
+	MergeStateText string // mergeStateStatus value: CLEAN, DIRTY, BLOCKED, UNKNOWN, etc.
 	State          string // OPEN, CLOSED, MERGED
 }
 
@@ -591,7 +596,7 @@ func isMergeStateStatusUnsupported(err error) bool {
 // value. Used on GitHub Enterprise instances that don't support mergeStateStatus.
 func mergeableToMergeStateText(mergeable string) string {
 	switch mergeable {
-	case "MERGEABLE":
+	case mergeableMergeable:
 		return "CLEAN"
 	case "CONFLICTING":
 		return "DIRTY"
@@ -639,7 +644,7 @@ func GetPRMergeableState(ctx context.Context, runner git.Runner, prNodeID string
 	}
 
 	return &PRMergeableState{
-		Mergeable:      response.Data.Node.Mergeable == "MERGEABLE",
+		Mergeable:      response.Data.Node.Mergeable == mergeableMergeable,
 		MergeStateText: response.Data.Node.MergeStateStatus,
 		State:          response.Data.Node.State,
 	}, nil
@@ -680,7 +685,7 @@ func getPRMergeableStateBasic(ctx context.Context, runner git.Runner, prNodeID s
 	}
 
 	return &PRMergeableState{
-		Mergeable:      response.Data.Node.Mergeable == "MERGEABLE",
+		Mergeable:      response.Data.Node.Mergeable == mergeableMergeable,
 		MergeStateText: mergeableToMergeStateText(response.Data.Node.Mergeable),
 		State:          response.Data.Node.State,
 	}, nil
@@ -749,7 +754,7 @@ func BatchGetPRMergeableStates(ctx context.Context, runner git.Runner, prNodeIDs
 			continue // Skip null nodes
 		}
 		result[prData.ID] = &PRMergeableState{
-			Mergeable:      prData.Mergeable == "MERGEABLE",
+			Mergeable:      prData.Mergeable == mergeableMergeable,
 			MergeStateText: prData.MergeStateStatus,
 			State:          prData.State,
 		}
@@ -808,7 +813,7 @@ func batchGetPRMergeableStatesBasic(ctx context.Context, runner git.Runner, prNo
 			continue
 		}
 		result[prData.ID] = &PRMergeableState{
-			Mergeable:      prData.Mergeable == "MERGEABLE",
+			Mergeable:      prData.Mergeable == mergeableMergeable,
 			MergeStateText: mergeableToMergeStateText(prData.Mergeable),
 			State:          prData.State,
 		}

--- a/internal/github/pr_operations_internal_test.go
+++ b/internal/github/pr_operations_internal_test.go
@@ -1,0 +1,89 @@
+package github
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsMergeStateStatusUnsupported(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "GitHub Enterprise field-missing error",
+			err:  errors.New("GraphQL error: Field 'mergeStateStatus' doesn't exist on type 'PullRequest'"),
+			want: true,
+		},
+		{
+			name: "wrapped error mentioning the field",
+			err:  errors.New("failed to get PR mergeable state: GraphQL error: field mergeStateStatus doesn't exist"),
+			want: true,
+		},
+		{
+			name: "unrelated GraphQL error",
+			err:  errors.New("GraphQL error: Could not resolve to a node with the global id"),
+			want: false,
+		},
+		{
+			name: "network error",
+			err:  errors.New("failed to execute GraphQL request: connection refused"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, isMergeStateStatusUnsupported(tt.err))
+		})
+	}
+}
+
+func TestMergeableToMergeStateText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		mergeable string
+		want      string
+	}{
+		{
+			name:      "MERGEABLE maps to CLEAN",
+			mergeable: "MERGEABLE",
+			want:      "CLEAN",
+		},
+		{
+			name:      "CONFLICTING maps to DIRTY",
+			mergeable: "CONFLICTING",
+			want:      "DIRTY",
+		},
+		{
+			name:      "UNKNOWN maps to UNKNOWN",
+			mergeable: "UNKNOWN",
+			want:      "UNKNOWN",
+		},
+		{
+			name:      "empty maps to UNKNOWN",
+			mergeable: "",
+			want:      "UNKNOWN",
+		},
+		{
+			name:      "unexpected value maps to UNKNOWN",
+			mergeable: "SOMETHING_ELSE",
+			want:      "UNKNOWN",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, mergeableToMergeStateText(tt.mergeable))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1143 — `stackit merge next` fails on GitHub Enterprise with `GraphQL error - field mergeStateStatus doesn't exist on type PullRequest`.

- `mergeStateStatus` is a GitHub.com-only GraphQL field not supported on all GitHub Enterprise versions
- When the query fails with that error, we now retry using only the `mergeable` field (universally supported)
- Map `mergeable` values to equivalent states: `MERGEABLE→CLEAN`, `CONFLICTING→DIRTY`, otherwise `UNKNOWN`
- Applied to both `GetPRMergeableState` and `BatchGetPRMergeableStates`

## Test plan

- [ ] Existing `internal/github` and `internal/cli/stack/merge` tests pass
- [ ] On a GitHub Enterprise instance, `stackit merge next` no longer fails with the mergeStateStatus GraphQL error
- [ ] On github.com, merge behavior is unchanged (full `mergeStateStatus` path still used)

https://claude.ai/code/session_01DGMiFTALf3p74xiswZuCnb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGMiFTALf3p74xiswZuCnb)_