### PR TITLE
fix: prevent merge next from leaving user in detached HEAD state

### DIFF
--- a/internal/cli/stack/merge.go
+++ b/internal/cli/stack/merge.go
@@ -46,13 +46,32 @@ func handlePostMergeAction(ctx *app.Context, action mergeAction.PostMergeAction)
 		runner, handler := NewSyncUI(ctx.Output, ctx.Logger)
 		defer runner.Cleanup()
 
+		// Wrap the handler to prevent entering the conflict resolution workflow.
+		// EnterConflictWorkflow detaches HEAD, which violates the safety invariant
+		// that merge next must never leave the user in detached HEAD state.
+		// Conflicts are reported in the sync summary with instructions to run
+		// 'stackit restack' manually.
 		return sync.Action(ctx, sync.Options{
 			Restack: true,
-		}, handler)
+		}, &postMergeSyncHandler{Handler: handler})
 
 	case mergeAction.PostMergeDone:
 		return nil
 	}
 
 	return nil
+}
+
+// postMergeSyncHandler wraps a sync handler to prevent entering the conflict
+// resolution workflow after merge next. EnterConflictWorkflow detaches HEAD,
+// which would leave the user in an unexpected state after a merge operation.
+type postMergeSyncHandler struct {
+	sync.Handler
+}
+
+// PromptResolveConflicts always returns false to skip entering the conflict
+// workflow. Conflicts are shown in the summary with instructions to run
+// 'stackit restack' manually.
+func (h *postMergeSyncHandler) PromptResolveConflicts(_ []string) (bool, error) {
+	return false, nil
 }

--- a/internal/cli/stack/merge_test.go
+++ b/internal/cli/stack/merge_test.go
@@ -1,0 +1,54 @@
+package stack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	syncAction "github.com/getstackit/stackit/internal/actions/sync"
+)
+
+// conflictResolvingHandler is a fake sync handler that simulates an interactive
+// handler which would enter the conflict resolution workflow. It embeds
+// NullHandler and overrides only IsInteractive and PromptResolveConflicts.
+//
+// Without the postMergeSyncHandler wrapper, sync.Action would call
+// PromptResolveConflicts on this handler, get true, and invoke
+// EnterConflictWorkflow — which detaches HEAD. The merge next post-merge flow
+// must never reach that path, so the wrapper has to override the prompt
+// regardless of what the underlying handler would have answered.
+type conflictResolvingHandler struct {
+	syncAction.NullHandler
+}
+
+func (h *conflictResolvingHandler) IsInteractive() bool { return true }
+
+func (h *conflictResolvingHandler) PromptResolveConflicts(_ []string) (bool, error) {
+	return true, nil
+}
+
+func TestPostMergeSyncHandler_SkipsConflictWorkflow(t *testing.T) {
+	t.Parallel()
+
+	// Wrap a handler that would otherwise enter the conflict workflow.
+	wrapped := &postMergeSyncHandler{Handler: &conflictResolvingHandler{}}
+
+	// The wrapper must override the prompt to skip the conflict workflow,
+	// even though the underlying handler answers "yes". Returning true here
+	// would route sync.Action into EnterConflictWorkflow, which detaches HEAD
+	// and violates the safety invariant for merge next.
+	resolve, err := wrapped.PromptResolveConflicts([]string{"branch-a"})
+	require.NoError(t, err)
+	require.False(t, resolve, "post-merge sync must never enter the conflict workflow")
+}
+
+func TestPostMergeSyncHandler_DelegatesIsInteractive(t *testing.T) {
+	t.Parallel()
+
+	// IsInteractive must delegate to the wrapped handler so that other
+	// interactive prompts (metadata conflicts, branch deletions) keep working.
+	// sync.Action only reaches the conflict prompt when IsInteractive is true,
+	// so the wrapper must not flip it to false to "fix" the detached HEAD.
+	wrapped := &postMergeSyncHandler{Handler: &conflictResolvingHandler{}}
+	require.True(t, wrapped.IsInteractive(), "wrapper must delegate IsInteractive to the underlying handler")
+}


### PR DESCRIPTION
## Summary

Fixes #1145 — `st merge next` could leave the user in a detached HEAD state after a successful merge.

- **Root cause**: When `merge next --wait` completed and triggered post-merge sync+restack, restack conflicts caused the interactive `InteractiveSyncHandler` to prompt "Resolve conflicts now?". If confirmed, `EnterConflictWorkflow` was called — which **intentionally detaches HEAD** to protect branch refs during a long-lived rebase. This violated the safety invariant that `merge next` must never leave the user in detached HEAD.
- **Fix**: Wrap the sync handler in `handlePostMergeAction` with `postMergeSyncHandler`, which overrides `PromptResolveConflicts` to always return `false`. This prevents the conflict resolution workflow from being entered. Conflicts are still reported in the sync summary with instructions to run `stackit restack` manually.
- The `merge drain` command already handled this correctly via `drainSyncHandler` (embeds `NullHandler`). This fix applies the same principle to `merge next`.

## Test plan

- [ ] Run `merge next --wait` when post-merge restack would have conflicts — verify you end up on trunk (not detached HEAD), and the summary shows conflict branches with instructions
- [ ] Run `merge next --wait` with no conflicts — verify normal sync + restack behavior is unchanged
- [ ] Run `stackit sync --restack` with conflicts — verify conflict workflow still works as expected (unaffected)

https://claude.ai/code/session_01JtSzYG5RraHmREz2mSz1BU

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtSzYG5RraHmREz2mSz1BU)_