### PR TITLE
fix: restore original branch after pre-commit hook failure in create

### DIFF
--- a/internal/actions/create/create.go
+++ b/internal/actions/create/create.go
@@ -194,7 +194,10 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 	if hasStaged {
 		h.OnStep(StepCommit, handler.StatusStarted, "Committing changes")
 		if err := eng.Commit(ctx.Context, commitMessage, opts.Verbose, !ctx.Verify); err != nil {
-			// Clean up branch on commit failure
+			// Restore the original branch before deleting the new one so that
+			// DeleteBranch doesn't fall back to trunk when cleaning up the
+			// currently-checked-out branch (e.g. a git pre-commit hook failure).
+			_ = eng.CheckoutBranch(ctx.Context, eng.GetBranch(currentBranch))
 			_ = eng.DeleteBranch(ctx.Context, branch)
 			h.OnStep(StepCommit, handler.StatusFailed, err.Error())
 			return Result{}, fmt.Errorf("failed to commit: %w", err)

--- a/internal/integration/create_precommit_hook_test.go
+++ b/internal/integration/create_precommit_hook_test.go
@@ -1,0 +1,60 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCreatePreCommitHookFailure verifies that when a git pre-commit hook
+// rejects the commit during `stackit create`, the user is left on the branch
+// they were on before the command ran, not on main/trunk.
+func TestCreatePreCommitHookFailure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns to original branch after pre-commit hook failure", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Build up a stack: main -> base
+		sh.Write("base.txt", "v1").
+			Run("create base -m 'feat: base'").
+			OnBranch("base")
+
+		// Install a git pre-commit hook that always fails.
+		hookPath := filepath.Join(sh.Dir(), ".git", "hooks", "pre-commit")
+		err := os.WriteFile(hookPath, []byte("#!/bin/sh\nexit 1\n"), 0o755)
+		if err != nil {
+			t.Fatalf("failed to write pre-commit hook: %v", err)
+		}
+
+		// Stage a change, then try to create a new branch. The pre-commit hook
+		// will fire and fail, causing the commit to be rejected.
+		sh.WriteFile("next.txt", "v1")
+		sh.RunExpectError("create next -m 'feat: next'")
+
+		// The user should be back on "base", not on "main" or "next".
+		sh.OnBranch("base")
+	})
+
+	t.Run("new branch is cleaned up after pre-commit hook failure", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("base.txt", "v1").
+			Run("create base -m 'feat: base'").
+			OnBranch("base")
+
+		hookPath := filepath.Join(sh.Dir(), ".git", "hooks", "pre-commit")
+		err := os.WriteFile(hookPath, []byte("#!/bin/sh\nexit 1\n"), 0o755)
+		if err != nil {
+			t.Fatalf("failed to write pre-commit hook: %v", err)
+		}
+
+		sh.WriteFile("next.txt", "v1")
+		sh.RunExpectError("create next -m 'feat: next'")
+
+		// The partially-created branch should not exist.
+		sh.HasBranches("base", "main")
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #1147

- When a git pre-commit hook rejected the commit during `stackit create`, the user was left on `main` instead of their original branch
- Root cause: `DeleteBranch` unconditionally switches to trunk when deleting the currently-checked-out branch; since cleanup happens while still on the new branch, the user lands on trunk
- Fix: checkout the original branch *before* calling `DeleteBranch` so the deletion no longer needs to move away from the current branch

## Root Cause

`internal/actions/create/create.go` called `eng.DeleteBranch(branch)` on failure while still checked out on the new branch. `DeleteBranch` (in `engine/branch_mutations.go:131`) detects it's deleting the current branch and switches to trunk first — leaving the user on `main` instead of their original branch.

## Fix

One-line addition in the commit-failure path:

```go
// Restore the original branch before deleting the new one so that
// DeleteBranch doesn't fall back to trunk when cleaning up the
// currently-checked-out branch (e.g. a git pre-commit hook failure).
_ = eng.CheckoutBranch(ctx.Context, eng.GetBranch(currentBranch))
_ = eng.DeleteBranch(ctx.Context, branch)
```

## Test plan

- [ ] New integration test `TestCreatePreCommitHookFailure` covers both scenarios: user is returned to original branch, and the partially-created branch is cleaned up
- [ ] `go build ./...` and `go vet` pass cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVk81gNTYq4wWBjS1PP1LL)_