### PR TITLE
refactor(actions): route read-only git queries through the engine

### DIFF
--- a/internal/actions/abort/action.go
+++ b/internal/actions/abort/action.go
@@ -22,7 +22,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	eng := ctx.Engine
 	out := ctx.Output
 
-	rebaseInProgress := eng.Git().IsRebaseInProgress(ctx.Context)
+	rebaseInProgress := eng.IsRebaseInProgress(ctx.Context)
 	mergeInProgress := eng.Git().IsMergeInProgress(ctx.Context)
 
 	// Check for continuation state

--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -197,7 +197,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 		// Output JSON if requested (works with dry-run for preview)
 		if opts.JSON {
-			newFiles, err := ctx.Git().GetUntrackedFiles(ctx.Context)
+			newFiles, err := ctx.Engine.GetUntrackedFiles(ctx.Context)
 			if err != nil {
 				out.Debug("Failed to get untracked files: %v", err)
 			}
@@ -320,7 +320,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	// Output JSON summary if requested
 	if opts.JSON {
-		newFiles, err := ctx.Git().GetUntrackedFiles(ctx.Context)
+		newFiles, err := ctx.Engine.GetUntrackedFiles(ctx.Context)
 		if err != nil {
 			out.Debug("Failed to get untracked files: %v", err)
 		}

--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -382,7 +382,7 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 		// Snapshot the worktree list once for this batch instead of
 		// re-running `git worktree list --porcelain` per branch.
 		listStart := time.Now()
-		worktrees, err := eng.Git().ListWorktrees(c)
+		worktrees, err := eng.ListWorktrees(c)
 		ctx.Logger.Info("list worktrees for cleanup batch completed durationMs=%d batch=%d worktreeCount=%d",
 			time.Since(listStart).Milliseconds(), batchIdx, len(worktrees))
 		if err != nil {
@@ -624,7 +624,7 @@ func removeWorktreeIfCheckedOut(ctx context.Context, branchName string, worktree
 
 	out.Debug("Removing worktree at %s for branch %s", worktreePath, branchName)
 
-	if err := eng.Git().RemoveWorktree(ctx, worktreePath); err != nil {
+	if err := eng.RemoveWorktree(ctx, worktreePath); err != nil {
 		return worktreePath, fmt.Errorf("failed to remove worktree at %s for branch %s: %w", worktreePath, branchName, err)
 	}
 

--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -188,7 +188,7 @@ func restackBranchesWithPlan(ctx *app.Context, branches engine.Branches, prePlan
 		originalBranch := ctx.Engine.CurrentBranch()
 		originalRev := ""
 		if originalBranch == nil {
-			originalRev, _ = ctx.Engine.Git().GetCurrentRevision(ctx.Context)
+			originalRev, _ = ctx.Engine.GetCurrentRevision(ctx.Context)
 		}
 
 		currentBranchName := getCurrentBranchName(ctx.Engine)
@@ -201,7 +201,7 @@ func restackBranchesWithPlan(ctx *app.Context, branches engine.Branches, prePlan
 
 		// Sync mode should never leave the repo in a conflict workflow unless explicitly requested.
 		// If a runtime conflict occurred despite validation, clean it up and restore checkout state.
-		if mode == ConflictModeContinue && ctx.Engine.Git().IsRebaseInProgress(ctx.Context) {
+		if mode == ConflictModeContinue && ctx.Engine.IsRebaseInProgress(ctx.Context) {
 			conflictBranch := batchResult.ConflictBranch
 			if conflictBranch == "" {
 				conflictBranch = "unknown"
@@ -432,7 +432,7 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 	// abort can only touch HEAD, never a branch ref. `st continue` already
 	// re-attaches to the conflict branch on success.
 	if currentBranch := ctx.Engine.CurrentBranch(); currentBranch != nil {
-		currentRev, revErr := ctx.Engine.Git().GetCurrentRevision(ctx.Context)
+		currentRev, revErr := ctx.Engine.GetCurrentRevision(ctx.Context)
 		if revErr != nil {
 			return fmt.Errorf("failed to read HEAD before conflict workflow: %w", revErr)
 		}
@@ -449,7 +449,7 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 	}
 
 	// Verify we're actually in conflict state
-	if !ctx.Engine.Git().IsRebaseInProgress(ctx.Context) {
+	if !ctx.Engine.IsRebaseInProgress(ctx.Context) {
 		return fmt.Errorf("expected conflict on %s but rebase completed successfully", firstConflict)
 	}
 
@@ -523,7 +523,7 @@ func validateBranchAncestry(ctx *app.Context, branches engine.Branches) error {
 			}
 
 			// Parent exists - verify they have a common ancestor
-			_, err = ctx.Engine.Git().GetMergeBase(ctx.Context, parentRev, branchRev)
+			_, err = ctx.Engine.GetMergeBase(ctx.Context, parentRev, branchRev)
 			if err != nil {
 				return fmt.Errorf("branch %s and parent %s have no common ancestor: %w",
 					branchName, parentName, err)

--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -22,7 +22,7 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 	out := ctx.Output
 
 	// Check if rebase is in progress
-	if !eng.Git().IsRebaseInProgress(ctx.Context) {
+	if !eng.IsRebaseInProgress(ctx.Context) {
 		// Clear any stale continuation state
 		_ = config.ClearContinuationState(ctx.RepoRoot)
 		return fmt.Errorf("no rebase in progress. Nothing to continue")
@@ -55,7 +55,7 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 
 	// Stage all changes if --all flag is set
 	if opts.AddAll {
-		if err := eng.Git().StageAll(ctx.Context); err != nil {
+		if err := eng.StageAll(ctx.Context); err != nil {
 			return fmt.Errorf("failed to stage changes: %w", err)
 		}
 	}

--- a/internal/actions/doctor/repository.go
+++ b/internal/actions/doctor/repository.go
@@ -11,7 +11,7 @@ import (
 func checkRepository(ctx *app.Context, handler Handler, warnings int, errors int, trunk string) (int, int) {
 	// Check if we're in a git repository
 	if ctx.RepoRoot == "" {
-		if !ctx.Engine.Git().IsInsideRepo() {
+		if !ctx.Engine.IsInsideRepo() {
 			errors++
 			handler.OnCheck("git_repo", CheckError, "not in a git repository")
 			return warnings, errors

--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -202,7 +202,7 @@ func executeSteps(ctx *app.Context, eng mergeExecuteEngine, opts ExecuteOptions)
 	// list` per step via removeWorktreeForBranch; the snapshot covers every
 	// step in this run. Safe to reuse: deleting a branch can only invalidate
 	// its own entry, and we only ever read each entry once.
-	worktrees, err := eng.Git().ListWorktrees(ctx.Context)
+	worktrees, err := eng.ListWorktrees(ctx.Context)
 	if err != nil {
 		ctx.Output.Debug("Failed to list worktrees for merge plan: %v", err)
 		worktrees = git.WorktreeList{}
@@ -466,7 +466,7 @@ func removeWorktreeForBranch(ctx context.Context, branchName string, worktrees g
 
 	out.Debug("Removing worktree at %s for branch %s", worktreePath, branchName)
 
-	if err := eng.Git().RemoveWorktree(ctx, worktreePath); err != nil {
+	if err := eng.RemoveWorktree(ctx, worktreePath); err != nil {
 		return fmt.Errorf("failed to remove worktree at %s for branch %s: %w", worktreePath, branchName, err)
 	}
 

--- a/internal/actions/pop.go
+++ b/internal/actions/pop.go
@@ -58,7 +58,7 @@ func PopAction(ctx *app.Context, _ PopOptions) error {
 	}
 
 	// Check how many changes are staged
-	hasStaged, err := eng.Git().HasStagedChanges(ctx.Context)
+	hasStaged, err := eng.HasStagedChanges(ctx.Context)
 	if err == nil && hasStaged {
 		out.Info("Popped branch %s. Changes are now staged on %s.",
 			style.ColorBranchName(currentBranch, false),

--- a/internal/actions/submit/submit_validation.go
+++ b/internal/actions/submit/submit_validation.go
@@ -18,7 +18,7 @@ func ValidateBranchesToSubmit(ctx *app.Context, branches []string) error {
 	nav := ctx.Navigator()
 
 	// Sync PR info first
-	repoOwner, repoName, err := ctx.Git().GetRepoInfo(ctx.Context)
+	repoOwner, repoName, err := ctx.Engine.GetRepoInfo(ctx.Context)
 	if err != nil {
 		return err
 	}

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -66,7 +66,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	managedWorktrees, err := eng.ListManagedWorktrees()
 	if err == nil {
 		for _, wt := range managedWorktrees {
-			if hasChanges, _ := eng.Git().WorktreeHasUncommittedChanges(gctx, wt.Path); hasChanges {
+			if hasChanges, _ := eng.WorktreeHasUncommittedChanges(gctx, wt.Path); hasChanges {
 				if dirtyAnchors == nil {
 					dirtyAnchors = make(map[string]bool)
 				}

--- a/internal/actions/undo/undo.go
+++ b/internal/actions/undo/undo.go
@@ -124,7 +124,7 @@ func Action(ctx *app.Context, opts Options, h Handler) error {
 	}
 
 	// Abort any in-progress Git operations that might interfere with restoration
-	if eng.Git().IsRebaseInProgress(ctx.Context) {
+	if eng.IsRebaseInProgress(ctx.Context) {
 		h.OnStep("Aborting in-progress rebase before undo...", handler.StatusStarted)
 		if err := eng.Git().RebaseAbort(ctx.Context); err != nil {
 			return fmt.Errorf("failed to abort rebase: %w", err)

--- a/internal/actions/worktree/entry.go
+++ b/internal/actions/worktree/entry.go
@@ -76,12 +76,12 @@ func inspectWorktreeEntry(ctx *app.Context, wt engine.WorktreeInfo, graph *engin
 	}
 
 	if entry.Exists {
-		currentBranch, err := ctx.Git().GetWorktreeCurrentBranch(ctx.Context, wt.Path)
+		currentBranch, err := ctx.Engine.GetWorktreeCurrentBranch(ctx.Context, wt.Path)
 		if err == nil && currentBranch != "" {
 			entry.CurrentBranch = currentBranch
 		}
 
-		isDirty, err := ctx.Git().WorktreeHasUncommittedChanges(ctx.Context, wt.Path)
+		isDirty, err := ctx.Engine.WorktreeHasUncommittedChanges(ctx.Context, wt.Path)
 		if err == nil {
 			entry.IsDirty = isDirty
 		}

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -72,6 +72,11 @@ func (e *engineImpl) HasUntrackedFiles(ctx context.Context) (bool, error) {
 	return e.git.HasUntrackedFiles(ctx)
 }
 
+// GetUntrackedFiles returns the paths of untracked files in the working tree.
+func (e *engineImpl) GetUntrackedFiles(ctx context.Context) ([]string, error) {
+	return e.git.GetUntrackedFiles(ctx)
+}
+
 // GetWorkingTreeStatus returns staged, unstaged, and untracked status in a
 // single git status --porcelain call instead of three separate subprocesses.
 func (e *engineImpl) GetWorkingTreeStatus(ctx context.Context) (staged, unstaged, untracked bool, err error) {

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -47,6 +47,18 @@ func (e *engineImpl) ForceRemoveWorktree(ctx context.Context, path string) error
 	return e.git.ForceRemoveWorktree(ctx, path)
 }
 
+// GetWorktreeCurrentBranch returns the branch currently checked out in the
+// worktree at worktreePath.
+func (e *engineImpl) GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error) {
+	return e.git.GetWorktreeCurrentBranch(ctx, worktreePath)
+}
+
+// WorktreeHasUncommittedChanges reports whether the worktree at worktreePath has
+// staged, unstaged, or untracked changes.
+func (e *engineImpl) WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error) {
+	return e.git.WorktreeHasUncommittedChanges(ctx, worktreePath)
+}
+
 // PruneWorktrees removes stale worktree entries from .git/worktrees.
 // This cleans up worktree information for worktrees whose working directory
 // has been deleted or is otherwise unavailable.

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -102,6 +102,7 @@ type WorkingTree interface {
 	HasStagedChanges(ctx context.Context) (bool, error)
 	HasUnstagedChanges(ctx context.Context) (bool, error)
 	HasUntrackedFiles(ctx context.Context) (bool, error)
+	GetUntrackedFiles(ctx context.Context) ([]string, error)
 	// GetWorkingTreeStatus returns all three working-tree flags in one git call.
 	// Prefer this over calling Has* individually when multiple flags are needed.
 	GetWorkingTreeStatus(ctx context.Context) (staged, unstaged, untracked bool, err error)
@@ -224,6 +225,8 @@ type WorktreeOperations interface {
 	AddWorktree(ctx context.Context, path string, branch string, detach bool) error
 	RemoveWorktree(ctx context.Context, path string) error
 	ForceRemoveWorktree(ctx context.Context, path string) error
+	GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error)
+	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)
 	CreateTemporaryWorktree(ctx context.Context, branch string, prefix string) (path string, cleanup func(), err error)
 	// CreateTemporaryWorktreeSkipPrune is like CreateTemporaryWorktree but skips the automatic
 	// PruneWorktrees() call. Use this when creating multiple worktrees in parallel after


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Actions reached through the Engine.Git() escape hatch to call git.Runner
directly for read-only working-tree and worktree queries, bypassing the
domain layer. Route them through the engine instead:

- Swap calls the engine already forwards: IsRebaseInProgress,
  HasStagedChanges, StageAll, ListWorktrees, RemoveWorktree,
  GetCurrentRevision, GetMergeBase, GetRepoInfo, IsInsideRepo.
- Add thin engine forwarders for the missing read queries
  (GetUntrackedFiles, GetWorktreeCurrentBranch,
  WorktreeHasUncommittedChanges) and migrate their call sites.

First step toward removing the Engine.Git() accessor. Stateful recovery
operations (abort/reset/detach) still use it and follow in a later change.

<hr/>

<!-- STACKIT-SECTION-START -->
**Eliminate Engine.Git() escape-hatch: route ops through engine interfaces**

Removes all production uses of `Engine.Git()` — the raw git runner escape-hatch — and routes every git operation through typed engine interfaces instead. A final lint rule locks the door so new escape-hatch uses can't slip back in.

Key changes:
- **Read-only git queries** (#1149): Branch listing, status, and worktree queries in actions routed through new engine interface methods
- **Conflict recovery and staging** (#1150): Cherry-pick abort, stash, and staging operations promoted to engine-level methods
- **Metadata and remote operations** (#1151): Submit, merge, delete, and sync actions use `metadata_transport` and engine-level pull/push helpers
- **MetadataInspector** (#1153): Dedicated escape-hatch for diagnostic/debug commands that legitimately need raw metadata reads, keeping those paths clearly separated
- **Last production uses** (#1154): Sync and pull operations cleaned up
- **Validation package** (#1155): Takes a narrow `EngineState` interface instead of the raw git runner
- **Remaining domain ops** (#1156): Multistack worktree, state, and trunk navigation cleaned up
- **Rerere package** (#1157): Takes a narrow `GitConfigurer` interface instead of the raw git runner
- **Lint enforcement** (#1158): New `forbidigo` rule in `.golangci.yml` blocks any future `Engine.Git()` calls outside the engine package

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780617749`.


* **PR #1149** 👈
  * **PR #1150**
    * **PR #1151**
      * **PR #1153**
        * **PR #1154**
          * **PR #1155**
            * **PR #1156**
              * **PR #1157**
                * **PR #1158**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1159 by jonnii*