### PR TITLE
refactor(actions): route conflict recovery and staging through the engine

### DIFF
--- a/internal/actions/abort/action.go
+++ b/internal/actions/abort/action.go
@@ -23,7 +23,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	out := ctx.Output
 
 	rebaseInProgress := eng.IsRebaseInProgress(ctx.Context)
-	mergeInProgress := eng.Git().IsMergeInProgress(ctx.Context)
+	mergeInProgress := eng.IsMergeInProgress(ctx.Context)
 
 	// Check for continuation state
 	hasContinuation := false
@@ -51,13 +51,13 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Abort Git operations
 	if rebaseInProgress {
 		out.Info("Aborting rebase...")
-		if err := eng.Git().RebaseAbort(ctx.Context); err != nil {
+		if err := eng.RebaseAbort(ctx.Context); err != nil {
 			return fmt.Errorf("failed to abort rebase: %w", err)
 		}
 	}
 	if mergeInProgress {
 		out.Info("Aborting merge...")
-		if err := eng.Git().MergeAbort(ctx.Context); err != nil {
+		if err := eng.MergeAbort(ctx.Context); err != nil {
 			return fmt.Errorf("failed to abort merge: %w", err)
 		}
 	}

--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -70,7 +70,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		All:   opts.All,
 		Patch: opts.Patch,
 	}
-	if err := ctx.Git().StageChanges(ctx.Context, stagingOpts); err != nil {
+	if err := ctx.Engine.StageChanges(ctx.Context, stagingOpts); err != nil {
 		return err
 	}
 

--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -208,7 +208,7 @@ func restackBranchesWithPlan(ctx *app.Context, branches engine.Branches, prePlan
 			}
 
 			ctx.Logger.Warn("unexpected rebase state after sync restack; aborting branch=%v", conflictBranch)
-			if abortErr := ctx.Engine.Git().RebaseAbort(ctx.Context); abortErr != nil {
+			if abortErr := ctx.Engine.RebaseAbort(ctx.Context); abortErr != nil {
 				return fmt.Errorf("unexpected restack conflict on %s: failed to abort rebase: %w", conflictBranch, abortErr)
 			}
 
@@ -218,7 +218,7 @@ func restackBranchesWithPlan(ctx *app.Context, branches engine.Branches, prePlan
 						conflictBranch, originalBranch.GetName(), checkoutErr)
 				}
 			} else if originalRev != "" {
-				if detachErr := ctx.Engine.Git().CheckoutDetached(ctx.Context, originalRev); detachErr != nil {
+				if detachErr := ctx.Engine.Detach(ctx.Context, originalRev); detachErr != nil {
 					return fmt.Errorf("unexpected restack conflict on %s: aborted rebase but failed to restore detached HEAD %s: %w",
 						conflictBranch, originalRev, detachErr)
 				}
@@ -436,7 +436,7 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 		if revErr != nil {
 			return fmt.Errorf("failed to read HEAD before conflict workflow: %w", revErr)
 		}
-		if detachErr := ctx.Engine.Git().CheckoutDetached(ctx.Context, currentRev); detachErr != nil {
+		if detachErr := ctx.Engine.Detach(ctx.Context, currentRev); detachErr != nil {
 			return fmt.Errorf("failed to detach HEAD before conflict workflow: %w", detachErr)
 		}
 	}

--- a/internal/actions/create/create.go
+++ b/internal/actions/create/create.go
@@ -92,7 +92,7 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 			Update: opts.Update,
 			Patch:  opts.Patch,
 		}
-		if err := ctx.Git().StageChanges(ctx.Context, stagingOpts); err != nil {
+		if err := ctx.Engine.StageChanges(ctx.Context, stagingOpts); err != nil {
 			h.OnStep(StepStaging, handler.StatusFailed, err.Error())
 			return Result{}, err
 		}

--- a/internal/actions/modify.go
+++ b/internal/actions/modify.go
@@ -72,7 +72,7 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) error {
 		Update: opts.Update,
 		Patch:  opts.Patch,
 	}
-	if err := ctx.Git().StageChanges(gctx, stagingOpts); err != nil {
+	if err := ctx.Engine.StageChanges(gctx, stagingOpts); err != nil {
 		return err
 	}
 

--- a/internal/actions/pop.go
+++ b/internal/actions/pop.go
@@ -43,7 +43,7 @@ func PopAction(ctx *app.Context, _ PopOptions) error {
 
 	// Soft reset to parent - this uncommits the current branch's changes
 	// and stages them, keeping the working tree unchanged
-	if err := eng.Git().SoftReset(ctx.Context, parentRev); err != nil {
+	if err := eng.SoftReset(ctx.Context, parentRev); err != nil {
 		return fmt.Errorf("failed to reset to parent: %w", err)
 	}
 

--- a/internal/actions/undo/undo.go
+++ b/internal/actions/undo/undo.go
@@ -126,14 +126,14 @@ func Action(ctx *app.Context, opts Options, h Handler) error {
 	// Abort any in-progress Git operations that might interfere with restoration
 	if eng.IsRebaseInProgress(ctx.Context) {
 		h.OnStep("Aborting in-progress rebase before undo...", handler.StatusStarted)
-		if err := eng.Git().RebaseAbort(ctx.Context); err != nil {
+		if err := eng.RebaseAbort(ctx.Context); err != nil {
 			return fmt.Errorf("failed to abort rebase: %w", err)
 		}
 		h.OnStep("Aborted in-progress rebase", handler.StatusCompleted)
 	}
-	if eng.Git().IsMergeInProgress(ctx.Context) {
+	if eng.IsMergeInProgress(ctx.Context) {
 		h.OnStep("Aborting in-progress merge before undo...", handler.StatusStarted)
-		if err := eng.Git().MergeAbort(ctx.Context); err != nil {
+		if err := eng.MergeAbort(ctx.Context); err != nil {
 			return fmt.Errorf("failed to abort merge: %w", err)
 		}
 		h.OnStep("Aborted in-progress merge", handler.StatusCompleted)

--- a/internal/engine/branch_mutations.go
+++ b/internal/engine/branch_mutations.go
@@ -31,6 +31,22 @@ func (e *engineImpl) ResetMerge(ctx context.Context, revision string) error {
 	return e.git.ResetMerge(ctx, revision)
 }
 
+// SoftReset moves HEAD to the given revision, keeping the index and working
+// tree intact (git reset --soft).
+func (e *engineImpl) SoftReset(ctx context.Context, revision string) error {
+	return e.git.SoftReset(ctx, revision)
+}
+
+// RebaseAbort aborts an in-progress rebase, restoring the pre-rebase HEAD.
+func (e *engineImpl) RebaseAbort(ctx context.Context) error {
+	return e.git.RebaseAbort(ctx)
+}
+
+// MergeAbort aborts an in-progress merge, restoring the pre-merge state.
+func (e *engineImpl) MergeAbort(ctx context.Context) error {
+	return e.git.MergeAbort(ctx)
+}
+
 // Merge merges a revision into the current branch
 func (e *engineImpl) Merge(ctx context.Context, revision string, opts MergeOptions) error {
 	return e.git.Merge(ctx, revision, git.MergeOptions{

--- a/internal/engine/commit_ops.go
+++ b/internal/engine/commit_ops.go
@@ -35,6 +35,11 @@ func (e *engineImpl) StageHunks(ctx context.Context, hunks []git.Hunk) error {
 	return e.git.StageHunks(ctx, hunks)
 }
 
+// StageChanges stages changes according to the given staging options.
+func (e *engineImpl) StageChanges(ctx context.Context, opts git.StagingOptions) error {
+	return e.git.StageChanges(ctx, opts)
+}
+
 // StashPush pushes current changes to the stash
 func (e *engineImpl) StashPush(ctx context.Context, message string) (string, error) {
 	return e.git.StashPush(ctx, message)

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -225,6 +225,11 @@ func (e *engineImpl) IsRebaseInProgress(ctx context.Context) bool {
 	return e.git.IsRebaseInProgress(ctx)
 }
 
+// IsMergeInProgress checks if a merge is in progress
+func (e *engineImpl) IsMergeInProgress(ctx context.Context) bool {
+	return e.git.IsMergeInProgress(ctx)
+}
+
 // GetRebaseHead returns the current rebase head
 func (e *engineImpl) GetRebaseHead() (string, error) {
 	return e.git.GetRebaseHead()

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -114,6 +114,7 @@ type WorkingTree interface {
 	ParseStagedHunks(ctx context.Context) ([]git.Hunk, error)
 	ListWorktrees(ctx context.Context) (git.WorktreeList, error)
 	IsRebaseInProgress(ctx context.Context) bool
+	IsMergeInProgress(ctx context.Context) bool
 	GetRebaseHead() (string, error)
 	HasUncommittedChanges(ctx context.Context) bool
 	CheckoutPaths(ctx context.Context, branch string, pathspecs []string) error
@@ -202,10 +203,13 @@ type BranchMutations interface {
 	CreateBranch(ctx context.Context, branchName string, startPoint string) error
 	ResetHard(ctx context.Context, revision string) error
 	ResetMerge(ctx context.Context, revision string) error
+	SoftReset(ctx context.Context, revision string) error
 	Merge(ctx context.Context, revision string, opts MergeOptions) error
 	MergeMultiple(ctx context.Context, branches []string, opts MergeOptions) error
 	Fetch(ctx context.Context, remote string, branch string) error
 	InteractiveRebase(ctx context.Context, onto string) error
+	RebaseAbort(ctx context.Context) error
+	MergeAbort(ctx context.Context) error
 }
 
 // CommitOperations handles staging and committing
@@ -215,6 +219,7 @@ type CommitOperations interface {
 	StageAll(ctx context.Context) error
 	StagePatch(ctx context.Context) error
 	StageHunks(ctx context.Context, hunks []git.Hunk) error
+	StageChanges(ctx context.Context, opts git.StagingOptions) error
 	StashPush(ctx context.Context, message string) (string, error)
 	StashPushStaged(ctx context.Context, message string) (string, error)
 	StashPop(ctx context.Context) error


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Continue removing the Engine.Git() escape hatch by giving the engine
first-class methods for the stateful operations actions were performing
against the raw git runner:

- Add thin engine forwarders: RebaseAbort, MergeAbort, IsMergeInProgress,
  SoftReset, StageChanges. These mirror the existing ResetHard/ResetMerge
  forwarders and keep conflict-state operations in the domain layer.
- Replace raw CheckoutDetached calls in the sync conflict-recovery path
  with the existing engine Detach(), which also clears the cached current
  branch. Detaching via the raw runner left engine.currentBranch stale.

Migrates abort, undo, pop, create, modify, absorb, and the restack
conflict handler in common.go. Metadata/remote ref operations are the
remaining Git() users and follow in a later change.

<hr/>

<!-- STACKIT-SECTION-START -->
**Eliminate Engine.Git() escape-hatch: route ops through engine interfaces**

Removes all production uses of `Engine.Git()` — the raw git runner escape-hatch — and routes every git operation through typed engine interfaces instead. A final lint rule locks the door so new escape-hatch uses can't slip back in.

Key changes:
- **Read-only git queries** (#1149): Branch listing, status, and worktree queries in actions routed through new engine interface methods
- **Conflict recovery and staging** (#1150): Cherry-pick abort, stash, and staging operations promoted to engine-level methods
- **Metadata and remote operations** (#1151): Submit, merge, delete, and sync actions use `metadata_transport` and engine-level pull/push helpers
- **MetadataInspector** (#1153): Dedicated escape-hatch for diagnostic/debug commands that legitimately need raw metadata reads, keeping those paths clearly separated
- **Last production uses** (#1154): Sync and pull operations cleaned up
- **Validation package** (#1155): Takes a narrow `EngineState` interface instead of the raw git runner
- **Remaining domain ops** (#1156): Multistack worktree, state, and trunk navigation cleaned up
- **Rerere package** (#1157): Takes a narrow `GitConfigurer` interface instead of the raw git runner
- **Lint enforcement** (#1158): New `forbidigo` rule in `.golangci.yml` blocks any future `Engine.Git()` calls outside the engine package

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780617749`.


* **PR #1149**
  * **PR #1150** 👈
    * **PR #1151**
      * **PR #1153**
        * **PR #1154**
          * **PR #1155**
            * **PR #1156**
              * **PR #1157**
                * **PR #1158**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1159 by jonnii*