### PR TITLE
refactor(actions): route remaining query and remote-metadata Git() calls through the engine

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -353,7 +353,7 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 			return
 		}
 		pushStart := time.Now()
-		err := eng.Git().BatchDeleteRemoteMetadataRefs(c, deletedBranchNames)
+		err := eng.DeleteRemoteMetadataForBranches(c, deletedBranchNames)
 		ctx.Logger.Info("delete remote metadata refs completed durationMs=%d branchCount=%d ok=%v",
 			time.Since(pushStart).Milliseconds(), len(deletedBranchNames), err == nil)
 		if err != nil {
@@ -614,7 +614,7 @@ func removeWorktreeIfCheckedOut(ctx context.Context, branchName string, worktree
 	}
 
 	// Don't remove main worktree (resolve symlinks for comparison, e.g., /var vs /private/var on macOS)
-	repoRoot := eng.Git().GetRepoRoot()
+	repoRoot := eng.GetRepoRoot()
 	resolvedWorktree, _ := filepath.EvalSymlinks(worktreePath)
 	resolvedRoot, _ := filepath.EvalSymlinks(repoRoot)
 	if resolvedWorktree == resolvedRoot {

--- a/internal/actions/delete/delete.go
+++ b/internal/actions/delete/delete.go
@@ -127,7 +127,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) (Result, error) {
 
 	// Batch delete remote metadata for deleted branches
 	branchNames := toDeleteNames
-	if err := eng.Git().BatchDeleteRemoteMetadataRefs(ctx.Context, branchNames); err != nil {
+	if err := eng.DeleteRemoteMetadataForBranches(ctx.Context, branchNames); err != nil {
 		out.Debug("Failed to batch delete remote metadata: %v", err)
 	}
 

--- a/internal/actions/merge/consolidate.go
+++ b/internal/actions/merge/consolidate.go
@@ -96,7 +96,7 @@ func (c *ConsolidateMergeExecutor) Execute(ctx context.Context, opts ExecuteOpti
 
 		// Store consolidation info for footer updates
 		c.consolidationPR = pr
-		if userName, err := c.ctx.Git().GetUserName(ctx); err == nil && userName != "" {
+		if userName, err := c.ctx.Engine.GetUserName(ctx); err == nil && userName != "" {
 			c.consolidationUser = userName
 		}
 

--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -404,7 +404,7 @@ func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecut
 			} else {
 				// Drop the remote metadata ref so it doesn't linger on origin and surface as
 				// a phantom conflict next time someone runs sync.
-				if err := eng.Git().BatchDeleteRemoteMetadataRefs(ctx.Context, []string{step.BranchName}); err != nil {
+				if err := eng.DeleteRemoteMetadataForBranches(ctx.Context, []string{step.BranchName}); err != nil {
 					out.Debug("Failed to delete remote metadata ref for %s: %v", step.BranchName, err)
 				}
 			}
@@ -456,7 +456,7 @@ func removeWorktreeForBranch(ctx context.Context, branchName string, worktrees g
 	}
 
 	// Don't remove main worktree (resolve symlinks for comparison, e.g., /var vs /private/var on macOS)
-	repoRoot := eng.Git().GetRepoRoot()
+	repoRoot := eng.GetRepoRoot()
 	resolvedWorktree, _ := filepath.EvalSymlinks(worktreePath)
 	resolvedRoot, _ := filepath.EvalSymlinks(repoRoot)
 	if resolvedWorktree == resolvedRoot {

--- a/internal/actions/merge/multistack.go
+++ b/internal/actions/merge/multistack.go
@@ -203,7 +203,7 @@ func ExecuteMultiStack(ctx *app.Context, opts MultiStackOptions) (*MultiStackRes
 			branchNames = append(branchNames, stack.AllBranches...)
 		}
 
-		userName, _ := eng.Git().GetUserName(ctx.Context)
+		userName, _ := eng.GetUserName(ctx.Context)
 		cleaner := NewPRCleaner(ctx, eng, PRCleanupConfig{
 			Source:                CleanupSourceMultiStack,
 			ConsolidationPRNumber: pr.Number,

--- a/internal/actions/merge/plan.go
+++ b/internal/actions/merge/plan.go
@@ -264,7 +264,7 @@ func CollectMergeBranches(ctx context.Context, eng mergePlanEngine, splog output
 	involvedBranches := append(append([]string{}, allBranches...), upstackBranches...)
 	allMeta, _ := eng.Git().BatchReadMetadata(involvedBranches)
 	// We don't strictly need allRevisions here yet, but it's good for cache
-	_, _ = eng.Git().BatchGetRevisions(involvedBranches)
+	_, _ = eng.GetRevisions(involvedBranches)
 
 	// Fetch CI statuses in batch if possible
 	var allCheckStatuses map[string]*github.CheckStatus

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -642,7 +642,7 @@ func pushMetadataRefs(ctx *app.Context, branches engine.Branches) error {
 	// Push stack metadata refs for any stacks that have branches being submitted
 	stackIDs := ctx.Engine.GetStackIDsForBranches(branches)
 	if len(stackIDs) > 0 {
-		if err := ctx.Git().PushStackMetaRefs(ctx.Context, stackIDs); err != nil {
+		if err := ctx.Engine.PushStackMetadata(ctx.Context, stackIDs); err != nil {
 			ctx.Output.Debug("Failed to push stack metadata refs: %v", err)
 			// Non-fatal: stack metadata push failure shouldn't fail the submit
 		}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -99,6 +99,12 @@ type RemoteMetadataManager interface {
 	// PushMetadataForBranches pushes the metadata refs for the given branch
 	// names to origin.
 	PushMetadataForBranches(ctx context.Context, branchNames []string) error
+	// DeleteRemoteMetadataForBranches pushes ref-deletions for the given
+	// branches' metadata refs to origin.
+	DeleteRemoteMetadataForBranches(ctx context.Context, branchNames []string) error
+	// PushStackMetadata pushes the stack-metadata refs for the given stack IDs
+	// to origin.
+	PushStackMetadata(ctx context.Context, stackIDs []string) error
 	// ConfigureStackMetadataSync adds the stack-metadata refspec to the configured remote.
 	ConfigureStackMetadataSync(ctx context.Context) error
 	// FetchStackMetadata fetches stack-metadata refs from the configured remote.

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -245,6 +245,16 @@ func (e *engineImpl) GetRepoInfo(ctx context.Context) (string, string, error) {
 	return e.git.GetRepoInfo(ctx)
 }
 
+// GetRepoRoot returns the absolute path to the repository root.
+func (e *engineImpl) GetRepoRoot() string {
+	return e.git.GetRepoRoot()
+}
+
+// GetUserName returns the configured git user.name.
+func (e *engineImpl) GetUserName(ctx context.Context) (string, error) {
+	return e.git.GetUserName(ctx)
+}
+
 // IsInsideRepo checks if the current directory is inside a git repository
 func (e *engineImpl) IsInsideRepo() bool {
 	return e.git.IsInsideRepo()

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -28,6 +28,8 @@ type StackNavigator interface {
 	GetScope(branch Branch) Scope
 	GetRemote() string
 	GetRepoInfo(ctx context.Context) (string, string, error)
+	GetRepoRoot() string
+	GetUserName(ctx context.Context) (string, error)
 	IsInsideRepo() bool
 }
 

--- a/internal/engine/metadata_transport.go
+++ b/internal/engine/metadata_transport.go
@@ -35,6 +35,19 @@ func (e *engineImpl) PushMetadataForBranches(ctx context.Context, branchNames []
 	return e.git.PushMetadataRefs(ctx, branchNames)
 }
 
+// DeleteRemoteMetadataForBranches pushes ref-deletions for the given branches'
+// metadata refs to origin. Best-effort: callers typically treat failure as
+// non-fatal because the remote refs may already be absent.
+func (e *engineImpl) DeleteRemoteMetadataForBranches(ctx context.Context, branchNames []string) error {
+	return e.git.BatchDeleteRemoteMetadataRefs(ctx, branchNames)
+}
+
+// PushStackMetadata pushes the stack-metadata refs for the given stack IDs to
+// origin. A no-op when the list is empty.
+func (e *engineImpl) PushStackMetadata(ctx context.Context, stackIDs []string) error {
+	return e.git.PushStackMetaRefs(ctx, stackIDs)
+}
+
 // ConfigureStackMetadataSync adds the stack-metadata refspec to the configured
 // remote so subsequent git fetches pick up stack-ref changes.
 func (e *engineImpl) ConfigureStackMetadataSync(_ context.Context) error {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Add thin engine forwarders for the operations actions still performed
against the raw git runner, and migrate the call sites:

- GetUserName, GetRepoRoot (StackNavigator).
- DeleteRemoteMetadataForBranches, PushStackMetadata (RemoteMetadataManager),
  matching the engine's existing ownership of the metadata-ref namespace.
- Swap BatchGetRevisions for the existing engine GetRevisions.

Remaining Git() users in actions are the diagnostic metadata reads
(debug, doctor), the hand-built stack-metadata GC ref deletion, the
per-branch PullBranch (needs a PullResult mapping decision), and a
string-based CheckoutBranch — all deferred to a metadata-ownership change.

<hr/>

<!-- STACKIT-SECTION-START -->
**Eliminate Engine.Git() escape-hatch: route ops through engine interfaces**

Removes all production uses of `Engine.Git()` — the raw git runner escape-hatch — and routes every git operation through typed engine interfaces instead. A final lint rule locks the door so new escape-hatch uses can't slip back in.

Key changes:
- **Read-only git queries** (#1149): Branch listing, status, and worktree queries in actions routed through new engine interface methods
- **Conflict recovery and staging** (#1150): Cherry-pick abort, stash, and staging operations promoted to engine-level methods
- **Metadata and remote operations** (#1151): Submit, merge, delete, and sync actions use `metadata_transport` and engine-level pull/push helpers
- **MetadataInspector** (#1153): Dedicated escape-hatch for diagnostic/debug commands that legitimately need raw metadata reads, keeping those paths clearly separated
- **Last production uses** (#1154): Sync and pull operations cleaned up
- **Validation package** (#1155): Takes a narrow `EngineState` interface instead of the raw git runner
- **Remaining domain ops** (#1156): Multistack worktree, state, and trunk navigation cleaned up
- **Rerere package** (#1157): Takes a narrow `GitConfigurer` interface instead of the raw git runner
- **Lint enforcement** (#1158): New `forbidigo` rule in `.golangci.yml` blocks any future `Engine.Git()` calls outside the engine package

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780617749`.


* **PR #1149**
  * **PR #1150**
    * **PR #1151** 👈
      * **PR #1153**
        * **PR #1154**
          * **PR #1155**
            * **PR #1156**
              * **PR #1157**
                * **PR #1158**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->