### PR TITLE
refactor: remove redundant GetBranch calls in debug action loop

### DIFF
--- a/internal/actions/debug.go
+++ b/internal/actions/debug.go
@@ -174,8 +174,7 @@ func DebugAction(ctx *app.Context, opts DebugOptions) error {
 				branchInfo.ParentRevision = *rev
 			}
 
-			branch := eng.GetBranch(branchName)
-			prInfo, err := branch.GetPrInfo()
+			prInfo, err := branchObj.GetPrInfo()
 			if err == nil && prInfo != nil {
 				branchInfo.PRInfo = prInfo
 			}
@@ -186,8 +185,7 @@ func DebugAction(ctx *app.Context, opts DebugOptions) error {
 		}
 
 		if !branchInfo.IsTrunk {
-			branch := eng.GetBranch(branchName)
-			branchInfo.IsFixed = branch.IsBranchUpToDate()
+			branchInfo.IsFixed = branchObj.IsBranchUpToDate()
 		} else {
 			branchInfo.IsFixed = true
 		}


### PR DESCRIPTION
## Summary

- Each loop iteration in the debug action's branch collection called `eng.GetBranch(branchName)` three times — once into `branchObj` (line 152), then twice more into a shadowing `branch` variable (lines 177, 189)
- All three calls return an identical `NewBranch(name, e)` wrapper, so the extra two are pure waste
- Reuse `branchObj` for both the PR info lookup and the `IsFixed` check, eliminating redundant allocations and variable shadowing per iteration

## Test plan

- [ ] `go vet ./internal/actions/...` passes (verified locally)
- [ ] `go build ./...` compiles cleanly
- [ ] `stackit debug` output is unchanged — this is a pure refactor with no behavior change

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDZ54otfZa2axgZ9CxspQq)_