### PR TITLE
refactor(engine): add MetadataInspector for diagnostic raw metadata reads

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -512,7 +512,7 @@ func appendStrandedRoots(eng engine.Engine, graph *engine.StackGraph, deleteStat
 			}
 			kind := engine.DeletionReasonGhost
 			reason := "branch no longer exists locally"
-			if meta, err := eng.Git().ReadMetadata(ghostName); err == nil && meta != nil {
+			if meta, err := eng.ReadMetadataRaw(ghostName); err == nil && meta != nil {
 				if pr := meta.GetPrInfo(); pr != nil && pr.State != nil && *pr.State == "MERGED" {
 					kind = engine.DeletionReasonMergedPR
 					reason = "branch deleted locally; PR was merged"

--- a/internal/actions/debug.go
+++ b/internal/actions/debug.go
@@ -128,7 +128,7 @@ func DebugAction(ctx *app.Context, opts DebugOptions) error {
 	currentBranch := eng.CurrentBranch()
 	allBranches := eng.AllBranches()
 
-	metadataRefs, err := eng.Git().ListMetadata()
+	metadataRefs, err := eng.ListMetadataRefs()
 	if err != nil {
 		metadataRefs = make(map[string]string)
 	}
@@ -137,7 +137,7 @@ func DebugAction(ctx *app.Context, opts DebugOptions) error {
 	for i, b := range allBranches {
 		branchNames[i] = b.GetName()
 	}
-	allMeta, _ := eng.Git().BatchReadMetadata(branchNames)
+	allMeta, _ := eng.BatchReadMetadataRaw(branchNames)
 
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
 	branchInfos := make([]BranchInfo, 0, len(allBranches))

--- a/internal/actions/doctor/stack_state.go
+++ b/internal/actions/doctor/stack_state.go
@@ -11,7 +11,7 @@ import (
 // checkStackState performs stack state and metadata integrity checks
 func checkStackState(ctx context.Context, eng engine.Engine, handler Handler, warnings int, errors int, fix bool) (int, int) {
 	// Get all branches
-	allBranches, err := eng.Git().GetAllBranchNames(ctx)
+	allBranches, err := eng.GetAllBranchNames(ctx)
 	if err != nil {
 		errors++
 		handler.OnCheck("branch_list", CheckError, fmt.Sprintf("failed to get branch names: %v", err))
@@ -19,7 +19,7 @@ func checkStackState(ctx context.Context, eng engine.Engine, handler Handler, wa
 	}
 
 	// Get all metadata refs
-	metadataRefs, err := eng.Git().ListMetadata()
+	metadataRefs, err := eng.ListMetadataRefs()
 	if err != nil {
 		errors++
 		handler.OnCheck("metadata_list", CheckError, fmt.Sprintf("failed to get metadata refs: %v", err))
@@ -38,7 +38,7 @@ func checkStackState(ctx context.Context, eng engine.Engine, handler Handler, wa
 		if !branchSet[branchName] {
 			orphanedCount++
 			if fix {
-				if err := eng.Git().DeleteMetadata(ctx, branchName); err != nil {
+				if err := eng.DeleteMetadataRef(ctx, branchName); err != nil {
 					warnings++
 					handler.OnCheck("orphaned_metadata", CheckWarning, fmt.Sprintf("orphaned metadata for '%s' (fix failed: %v)", branchName, err))
 				} else {
@@ -70,7 +70,7 @@ func checkStackState(ctx context.Context, eng engine.Engine, handler Handler, wa
 	for branchName := range metadataRefs {
 		metadataRefNames = append(metadataRefNames, branchName)
 	}
-	allMeta, allMetaErrs := eng.Git().BatchReadMetadata(metadataRefNames)
+	allMeta, allMetaErrs := eng.BatchReadMetadataRaw(metadataRefNames)
 
 	corruptedCount := 0
 	for _, branchName := range metadataRefNames {

--- a/internal/actions/merge/plan.go
+++ b/internal/actions/merge/plan.go
@@ -147,7 +147,7 @@ type mergePlanEngine interface {
 	engine.BranchReader
 	engine.PRManager
 	engine.SyncManager
-	Git() git.Runner
+	engine.MetadataInspector
 }
 
 // CreateMergePlan analyzes the current state and builds a merge plan.
@@ -262,7 +262,7 @@ func CollectMergeBranches(ctx context.Context, eng mergePlanEngine, splog output
 
 	// 4. Batch fetch metadata and revisions for all involved branches
 	involvedBranches := append(append([]string{}, allBranches...), upstackBranches...)
-	allMeta, _ := eng.Git().BatchReadMetadata(involvedBranches)
+	allMeta, _ := eng.BatchReadMetadataRaw(involvedBranches)
 	// We don't strictly need allRevisions here yet, but it's good for cache
 	_, _ = eng.GetRevisions(involvedBranches)
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -220,6 +220,7 @@ type Engine interface {
 	RemoteMetadataManager
 	RemoteFetcher
 	WorktreeRegistry
+	MetadataInspector
 	Git() git.Runner
 
 	// SnapshotForWorktree creates a deep copy of engine state for initializing

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -255,6 +255,37 @@ func (e *engineImpl) GetUserName(ctx context.Context) (string, error) {
 	return e.git.GetUserName(ctx)
 }
 
+// GetAllBranchNames returns the names of all local branches, including ones not
+// tracked by stackit.
+func (e *engineImpl) GetAllBranchNames(ctx context.Context) ([]string, error) {
+	return e.git.GetAllBranchNames(ctx)
+}
+
+// ListMetadataRefs returns a map of branch name to metadata-ref SHA for every
+// stackit metadata ref, including refs whose branches no longer exist.
+func (e *engineImpl) ListMetadataRefs() (map[string]string, error) {
+	return e.git.ListMetadata()
+}
+
+// ReadMetadataRaw reads a single branch's metadata directly from its ref,
+// bypassing the engine's tracked-branch cache.
+func (e *engineImpl) ReadMetadataRaw(branchName string) (*git.Meta, error) {
+	return e.git.ReadMetadata(branchName)
+}
+
+// BatchReadMetadataRaw reads raw metadata for many branches in one pass,
+// returning per-branch errors so callers can detect corrupted refs.
+func (e *engineImpl) BatchReadMetadataRaw(branchNames []string) (map[string]*git.Meta, map[string]error) {
+	return e.git.BatchReadMetadata(branchNames)
+}
+
+// DeleteMetadataRef deletes a single branch's metadata ref directly, without
+// the transactional rebuild performed by DeleteMetadata. Intended for pruning
+// orphaned refs whose branches no longer exist.
+func (e *engineImpl) DeleteMetadataRef(ctx context.Context, branchName string) error {
+	return e.git.DeleteMetadata(ctx, branchName)
+}
+
 // IsInsideRepo checks if the current directory is inside a git repository
 func (e *engineImpl) IsInsideRepo() bool {
 	return e.git.IsInsideRepo()

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -19,6 +19,10 @@ type StackNavigator interface {
 	BranchesDepthFirst(startBranch Branch) iter.Seq2[Branch, int]
 	SortBranchesTopologically(branches Branches) Branches
 	FindBranchForCommit(commitSHA string) (string, error)
+	// GetAllBranchNames returns the names of all local branches, including ones
+	// not tracked by stackit. Used by diagnostics that must see untracked or
+	// orphaned branches.
+	GetAllBranchNames(ctx context.Context) ([]string, error)
 	// FindNearestNonExcludedAncestor walks the parent chain from startParent
 	// and returns the first ancestor for which isExcluded returns false. Falls
 	// back to trunk if every ancestor up the chain is excluded.
@@ -284,6 +288,28 @@ type BranchWriter interface {
 	CommitOperations
 	WorktreeOperations
 	Initializer
+}
+
+// MetadataInspector exposes raw, below-abstraction reads of the stackit branch
+// metadata-ref store. It is the low-level escape valve for diagnostic and
+// repair commands (doctor, debug) that must observe metadata the engine's
+// tracked-branch view cannot see — orphaned, corrupted, or untracked-branch
+// refs. Prefer the higher-level branch accessors for normal flows; reach for
+// this only when raw ref access is genuinely required.
+type MetadataInspector interface {
+	// ListMetadataRefs returns a map of branch name to metadata-ref SHA for
+	// every stackit metadata ref, including refs whose branches no longer exist.
+	ListMetadataRefs() (map[string]string, error)
+	// ReadMetadataRaw reads a single branch's metadata directly from its ref,
+	// bypassing the engine's tracked-branch cache.
+	ReadMetadataRaw(branchName string) (*git.Meta, error)
+	// BatchReadMetadataRaw reads raw metadata for many branches in one pass,
+	// returning per-branch errors so callers can detect corrupted refs.
+	BatchReadMetadataRaw(branchNames []string) (map[string]*git.Meta, map[string]error)
+	// DeleteMetadataRef deletes a single branch's metadata ref directly, without
+	// the transactional rebuild performed by DeleteMetadata. Intended for
+	// pruning orphaned refs whose branches no longer exist.
+	DeleteMetadataRef(ctx context.Context, branchName string) error
 }
 
 // Absorber applies staged hunks to appropriate commits


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

doctor and debug must inspect the raw metadata-ref store below the engine's
tracked-branch abstraction — to find orphaned refs (metadata for branches
that no longer exist) and corrupted entries the normal branch view cannot
see. They did this through the broad Engine.Git() git.Runner escape hatch.

Replace that with a narrow, documented MetadataInspector capability on the
engine:

- ListMetadataRefs, ReadMetadataRaw, BatchReadMetadataRaw, DeleteMetadataRef
  (named to distinguish raw ref access from the transactional DeleteMetadata).
- GetAllBranchNames on StackNavigator (all local branches, incl. untracked).

Migrate doctor, debug, clean_branches (ghost-branch read), and merge/plan.
merge's mergePlanEngine now composes MetadataInspector and no longer needs
the Git() escape hatch at all, so it is dropped from that interface.

<hr/>

<!-- STACKIT-SECTION-START -->
**Eliminate Engine.Git() escape-hatch: route ops through engine interfaces**

Removes all production uses of `Engine.Git()` — the raw git runner escape-hatch — and routes every git operation through typed engine interfaces instead. A final lint rule locks the door so new escape-hatch uses can't slip back in.

Key changes:
- **Read-only git queries** (#1149): Branch listing, status, and worktree queries in actions routed through new engine interface methods
- **Conflict recovery and staging** (#1150): Cherry-pick abort, stash, and staging operations promoted to engine-level methods
- **Metadata and remote operations** (#1151): Submit, merge, delete, and sync actions use `metadata_transport` and engine-level pull/push helpers
- **MetadataInspector** (#1153): Dedicated escape-hatch for diagnostic/debug commands that legitimately need raw metadata reads, keeping those paths clearly separated
- **Last production uses** (#1154): Sync and pull operations cleaned up
- **Validation package** (#1155): Takes a narrow `EngineState` interface instead of the raw git runner
- **Remaining domain ops** (#1156): Multistack worktree, state, and trunk navigation cleaned up
- **Rerere package** (#1157): Takes a narrow `GitConfigurer` interface instead of the raw git runner
- **Lint enforcement** (#1158): New `forbidigo` rule in `.golangci.yml` blocks any future `Engine.Git()` calls outside the engine package

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780617749`.


* **PR #1149**
  * **PR #1150**
    * **PR #1151**
      * **PR #1153** 👈
        * **PR #1154**
          * **PR #1155**
            * **PR #1156**
              * **PR #1157**
                * **PR #1158**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1159 by jonnii*