### PR TITLE
refactor: eliminate the last production Engine.Git() escape-hatch uses

### DIFF
--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -91,7 +91,7 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 	}
 
 	// Success - checkout the branch (rebase leaves us in detached HEAD)
-	if err := eng.Git().CheckoutBranch(ctx.Context, result.BranchName); err != nil {
+	if err := eng.CheckoutBranch(ctx.Context, eng.GetBranch(result.BranchName)); err != nil {
 		return fmt.Errorf("failed to checkout branch %s: %w", result.BranchName, err)
 	}
 

--- a/internal/actions/sync/branch_sync.go
+++ b/internal/actions/sync/branch_sync.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/getstackit/stackit/internal/app"
-	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // syncStackBranches pulls stack branches that are behind their remote counterparts.
@@ -80,7 +80,7 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, handler H
 
 		// Pull the branch
 		pullStart := time.Now()
-		result, err := ctx.Git().PullBranch(gctx, remote, branchName)
+		result, err := eng.PullBranch(gctx, remote, branchName)
 		ctx.Logger.Info("pull branch completed branch=%v durationMs=%v", branchName, time.Since(pullStart).Milliseconds())
 
 		if err != nil {
@@ -97,7 +97,7 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, handler H
 		}
 
 		switch result {
-		case git.PullDone:
+		case engine.PullDone:
 			// Get the new revision
 			rev, _ := branch.GetRevision()
 			revShort := rev
@@ -112,7 +112,7 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, handler H
 				NewRevision: revShort,
 			})
 
-		case git.PullUnneeded:
+		case engine.PullUnneeded:
 			// Already up to date (shouldn't happen since we checked Behind(), but handle it)
 			handler.EmitEvent(Event{
 				Phase:  PhaseBranches,
@@ -120,7 +120,7 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, handler H
 				Branch: branchName,
 			})
 
-		case git.PullConflict:
+		case engine.PullConflict:
 			// Branches have diverged
 			summary.ConflictBranches = append(summary.ConflictBranches, branchName)
 			handler.EmitEvent(Event{

--- a/internal/actions/sync/stack_metadata_gc.go
+++ b/internal/actions/sync/stack_metadata_gc.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"github.com/getstackit/stackit/internal/app"
-	"github.com/getstackit/stackit/internal/git"
 )
 
 // StackMetadataGCResult contains the results of stack metadata garbage collection.
@@ -59,12 +58,9 @@ func gcOrphanedStackMetadata(ctx *app.Context) *StackMetadataGCResult {
 	// per-orphan DeleteStackMeta loop spawned 2 git subprocesses per ref
 	// (update-ref -d + show-ref --verify) — same N+1 pattern fixed for branch
 	// deletion. If the atomic batch fails, fall back to per-ref so partial
-	// progress is still reported.
-	refs := make([]string, 0, len(orphaned))
-	for _, stackID := range orphaned {
-		refs = append(refs, git.StackMetaRefName(stackID))
-	}
-	if err := ctx.Git().DeleteRefsBatch(ctx.Context, refs); err != nil {
+	// progress is still reported. The engine owns the stack-ref name format, so
+	// we pass stack IDs rather than building ref names here.
+	if err := ctx.Engine.DeleteStackMetadataBatch(ctx.Context, orphaned); err != nil {
 		ctx.Logger.Debug("batch delete of local stack refs failed, falling back per-ref error=%v", err)
 		for _, stackID := range orphaned {
 			if perRefErr := ctx.Engine.DeleteStackMetadata(ctx.Context, stackID); perRefErr != nil {

--- a/internal/cli/stack/sync.go
+++ b/internal/cli/stack/sync.go
@@ -154,7 +154,7 @@ func syncDryRunJSON(ctx *app.Context, opts sync.Options) error {
 	managedWorktrees, err := eng.ListManagedWorktrees()
 	if err == nil {
 		for _, wt := range managedWorktrees {
-			if hasChanges, _ := eng.Git().WorktreeHasUncommittedChanges(ctx.Context, wt.Path); hasChanges {
+			if hasChanges, _ := eng.WorktreeHasUncommittedChanges(ctx.Context, wt.Path); hasChanges {
 				result.SkippedStacks = append(result.SkippedStacks, wt.AnchorBranch)
 			}
 		}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -36,6 +36,7 @@ type PRManager interface {
 type SyncManager interface {
 	// Sync operations
 	PullTrunk(ctx context.Context) (PullResult, error)
+	PullBranch(ctx context.Context, remote, branchName string) (PullResult, error)
 	UpdateTrunkFromRemote(ctx context.Context) (PullResult, error)
 	ResetTrunkToRemote(ctx context.Context) error
 	PlanRestack(ctx context.Context, branches Branches) (*RestackPlan, error)
@@ -113,6 +114,9 @@ type RemoteMetadataManager interface {
 	ListStackMetadata() (map[string]string, error)
 	// DeleteStackMetadata removes a single local stack-metadata ref.
 	DeleteStackMetadata(ctx context.Context, stackID string) error
+	// DeleteStackMetadataBatch removes the local stack-metadata refs for the
+	// given stack IDs in a single batched ref update.
+	DeleteStackMetadataBatch(ctx context.Context, stackIDs []string) error
 	// DeleteRemoteStackMetadata pushes ref-deletions for the given stack IDs.
 	DeleteRemoteStackMetadata(ctx context.Context, stackIDs []string) error
 	// GetStackIDsForBranches returns the unique stack IDs for the given branches.

--- a/internal/engine/metadata_transport.go
+++ b/internal/engine/metadata_transport.go
@@ -1,6 +1,10 @@
 package engine
 
-import "context"
+import (
+	"context"
+
+	"github.com/getstackit/stackit/internal/git"
+)
 
 // Metadata transport methods. Engine owns the metadata-ref namespace
 // (refs/stackit/metadata/* and refs/stackit/stacks/*) and is the single point
@@ -70,6 +74,17 @@ func (e *engineImpl) ListStackMetadata() (map[string]string, error) {
 // per-ref fallback in the GC path when the batched ref-update fails.
 func (e *engineImpl) DeleteStackMetadata(ctx context.Context, stackID string) error {
 	return e.git.DeleteStackMeta(ctx, stackID)
+}
+
+// DeleteStackMetadataBatch removes the local stack-metadata refs for the given
+// stack IDs in a single update-ref --stdin batch. The engine owns the
+// stack-ref name format, so callers pass stack IDs rather than raw ref names.
+func (e *engineImpl) DeleteStackMetadataBatch(ctx context.Context, stackIDs []string) error {
+	refs := make([]string, 0, len(stackIDs))
+	for _, stackID := range stackIDs {
+		refs = append(refs, git.StackMetaRefName(stackID))
+	}
+	return e.git.DeleteRefsBatch(ctx, refs)
 }
 
 // DeleteRemoteStackMetadata pushes ref-deletions for the given stack IDs to

--- a/internal/engine/pull.go
+++ b/internal/engine/pull.go
@@ -37,19 +37,20 @@ func (e *engineImpl) UpdateTrunkFromRemote(ctx context.Context) (PullResult, err
 	return e.finishTrunkPull(gitResult)
 }
 
-func (e *engineImpl) finishTrunkPull(gitResult git.PullResult) (PullResult, error) {
-	// Convert git.PullResult to engine.PullResult
-	var result PullResult
-	switch gitResult {
-	case git.PullDone:
-		result = PullDone
-	case git.PullUnneeded:
-		result = PullUnneeded
-	case git.PullConflict:
-		result = PullConflict
-	default:
-		result = PullConflict
+// PullBranch fast-forwards a single branch from its remote counterpart. Unlike
+// PullTrunk it does not rebuild engine state, so it is safe to call in a loop;
+// callers should rebuild once after the batch if downstream reads need the
+// refreshed revisions.
+func (e *engineImpl) PullBranch(ctx context.Context, remote, branchName string) (PullResult, error) {
+	gitResult, err := e.git.PullBranch(ctx, remote, branchName)
+	if err != nil {
+		return PullConflict, err
 	}
+	return pullResultFromGit(gitResult), nil
+}
+
+func (e *engineImpl) finishTrunkPull(gitResult git.PullResult) (PullResult, error) {
+	result := pullResultFromGit(gitResult)
 
 	// Rebuild to refresh branch cache
 	if err := e.rebuild(); err != nil {
@@ -57,6 +58,20 @@ func (e *engineImpl) finishTrunkPull(gitResult git.PullResult) (PullResult, erro
 	}
 
 	return result, nil
+}
+
+// pullResultFromGit maps a git.PullResult onto the engine's PullResult.
+func pullResultFromGit(gitResult git.PullResult) PullResult {
+	switch gitResult {
+	case git.PullDone:
+		return PullDone
+	case git.PullUnneeded:
+		return PullUnneeded
+	case git.PullConflict:
+		return PullConflict
+	default:
+		return PullConflict
+	}
 }
 
 // ResetTrunkToRemote resets trunk to match remote


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Close out the remaining direct git.Runner access in non-test code, bringing
production .Git() usage to zero:

- Add engine PullBranch (non-rebuilding, safe in a loop) and route the
  per-branch sync through it; branch_sync drops its git import and switches
  on engine.PullResult instead of git.PullResult.
- Add engine DeleteStackMetadataBatch so the stack-metadata GC passes stack
  IDs instead of hand-building refs/stackit/stacks/* names; stack_metadata_gc
  drops its git import.
- continue: check out the resolved branch via the state-maintaining engine
  CheckoutBranch (keeps cached currentBranch correct) instead of raw git.
- cli sync: use the engine WorktreeHasUncommittedChanges forwarder.

Tests still use Engine.Git() for setup/assertions, which is fine; a lint
guard against new non-test usage follows.

<hr/>

<!-- STACKIT-SECTION-START -->
**Eliminate Engine.Git() escape-hatch: route ops through engine interfaces**

Removes all production uses of `Engine.Git()` — the raw git runner escape-hatch — and routes every git operation through typed engine interfaces instead. A final lint rule locks the door so new escape-hatch uses can't slip back in.

Key changes:
- **Read-only git queries** (#1149): Branch listing, status, and worktree queries in actions routed through new engine interface methods
- **Conflict recovery and staging** (#1150): Cherry-pick abort, stash, and staging operations promoted to engine-level methods
- **Metadata and remote operations** (#1151): Submit, merge, delete, and sync actions use `metadata_transport` and engine-level pull/push helpers
- **MetadataInspector** (#1153): Dedicated escape-hatch for diagnostic/debug commands that legitimately need raw metadata reads, keeping those paths clearly separated
- **Last production uses** (#1154): Sync and pull operations cleaned up
- **Validation package** (#1155): Takes a narrow `EngineState` interface instead of the raw git runner
- **Remaining domain ops** (#1156): Multistack worktree, state, and trunk navigation cleaned up
- **Rerere package** (#1157): Takes a narrow `GitConfigurer` interface instead of the raw git runner
- **Lint enforcement** (#1158): New `forbidigo` rule in `.golangci.yml` blocks any future `Engine.Git()` calls outside the engine package

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780617749`.


* **PR #1149**
  * **PR #1150**
    * **PR #1151**
      * **PR #1153**
        * **PR #1154** 👈
          * **PR #1155**
            * **PR #1156**
              * **PR #1157**
                * **PR #1158**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->