### PR TITLE
refactor(validation): take engine state interface instead of the raw git runner

### DIFF
--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -42,7 +42,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	handler.Start(opts.DryRun)
 
 	// Validate preconditions
-	if err := validation.AbsorbChain(ctx.Context, eng, ctx.Git(), "absorb into").Validate(); err != nil {
+	if err := validation.AbsorbChain(ctx.Context, eng, "absorb into").Validate(); err != nil {
 		return err
 	}
 	currentBranch := eng.CurrentBranch()

--- a/internal/actions/fold/fold.go
+++ b/internal/actions/fold/fold.go
@@ -92,7 +92,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	defer handler.Cleanup()
 
 	// Validate preconditions
-	if err := validation.GitOperationChain(gctx, eng, ctx.Git(), "fold").Validate(); err != nil {
+	if err := validation.GitOperationChain(gctx, eng, "fold").Validate(); err != nil {
 		return err
 	}
 	currentBranch := eng.CurrentBranch().GetName()

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -110,7 +110,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	out := ctx.Output
 	gctx := ctx.Context
 
-	if err := validation.MustNotHaveUncommittedChanges(gctx, ctx.Git()).Validate(); err != nil {
+	if err := validation.MustNotHaveUncommittedChanges(gctx, eng).Validate(); err != nil {
 		return err
 	}
 

--- a/internal/actions/modify.go
+++ b/internal/actions/modify.go
@@ -49,7 +49,7 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) error {
 	}
 
 	// Check if rebase is in progress (only for non-interactive mode)
-	if err := validation.MustNotHaveRebaseInProgress(gctx, ctx.Git()).Validate(); err != nil {
+	if err := validation.MustNotHaveRebaseInProgress(gctx, eng).Validate(); err != nil {
 		return err
 	}
 

--- a/internal/actions/pop.go
+++ b/internal/actions/pop.go
@@ -23,8 +23,8 @@ func PopAction(ctx *app.Context, _ PopOptions) error {
 		validation.MustBeOnBranch(eng),
 		validation.CurrentBranchMustNotBeTrunk(eng, "pop"),
 		validation.CurrentBranchMustBeTracked(eng),
-		validation.MustNotHaveRebaseInProgress(ctx.Context, ctx.Git()),
-		validation.MustNotHaveUncommittedChanges(ctx.Context, ctx.Git()),
+		validation.MustNotHaveRebaseInProgress(ctx.Context, eng),
+		validation.MustNotHaveUncommittedChanges(ctx.Context, eng),
 	}).Validate(); err != nil {
 		return err
 	}

--- a/internal/actions/reorder.go
+++ b/internal/actions/reorder.go
@@ -24,8 +24,8 @@ func ReorderAction(ctx *app.Context) error {
 	// Pre-checks using validation chain
 	if err := (validation.Chain{
 		validation.MustBeOnBranch(eng),
-		validation.MustNotHaveRebaseInProgress(gctx, ctx.Git()),
-		validation.MustNotHaveUncommittedChanges(gctx, ctx.Git()),
+		validation.MustNotHaveRebaseInProgress(gctx, eng),
+		validation.MustNotHaveUncommittedChanges(gctx, eng),
 		validation.CurrentBranchMustNotBeTrunk(eng, "reorder"),
 	}).Validate(); err != nil {
 		out.Debug("reorder: validation failed: %v", err)

--- a/internal/actions/validation/chains.go
+++ b/internal/actions/validation/chains.go
@@ -2,9 +2,15 @@ package validation
 
 import (
 	"context"
-
-	"github.com/getstackit/stackit/internal/git"
 )
+
+// GitOperationEngine is the engine contract needed by the git-state chains:
+// branch validation plus git-state reads. engine.Engine satisfies it, so
+// callers pass the engine rather than the raw git runner.
+type GitOperationEngine interface {
+	BranchValidationEngine
+	GitStateReader
+}
 
 // ModifyBranchChain validates for simple branch modifications (rename, scope).
 // Checks: on branch, not trunk, modifiable.
@@ -18,24 +24,24 @@ func ModifyBranchChain(eng BranchValidationEngine, operation string) Chain {
 
 // GitOperationChain validates for git history modifications (fold, pop, reorder).
 // Checks: on branch, not trunk, tracked, no rebase in progress, no uncommitted changes, modifiable.
-func GitOperationChain(ctx context.Context, eng BranchValidationEngine, g git.Runner, operation string) Chain {
+func GitOperationChain(ctx context.Context, eng GitOperationEngine, operation string) Chain {
 	return Chain{
 		MustBeOnBranch(eng),
 		CurrentBranchMustNotBeTrunk(eng, operation),
 		CurrentBranchMustBeTracked(eng),
-		MustNotHaveRebaseInProgress(ctx, g),
-		MustNotHaveUncommittedChanges(ctx, g),
+		MustNotHaveRebaseInProgress(ctx, eng),
+		MustNotHaveUncommittedChanges(ctx, eng),
 		CurrentBranchMustBeModifiable(eng),
 	}
 }
 
 // AbsorbChain validates for absorb operations (works with staged changes).
 // Checks: on branch, not trunk, modifiable, no rebase in progress.
-func AbsorbChain(ctx context.Context, eng BranchValidationEngine, g git.Runner, operation string) Chain {
+func AbsorbChain(ctx context.Context, eng GitOperationEngine, operation string) Chain {
 	return Chain{
 		MustBeOnBranch(eng),
 		CurrentBranchMustNotBeTrunk(eng, operation),
 		CurrentBranchMustBeModifiable(eng),
-		MustNotHaveRebaseInProgress(ctx, g),
+		MustNotHaveRebaseInProgress(ctx, eng),
 	}
 }

--- a/internal/actions/validation/chains_test.go
+++ b/internal/actions/validation/chains_test.go
@@ -43,7 +43,7 @@ func TestGitOperationChain(t *testing.T) {
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithLinearStack3().Checkout("b")
 
-		chain := validation.GitOperationChain(s.Context.Context, s.Engine, s.Context.Git(), "fold")
+		chain := validation.GitOperationChain(s.Context.Context, s.Engine, "fold")
 		err := chain.Validate()
 		require.NoError(t, err)
 	})
@@ -53,7 +53,7 @@ func TestGitOperationChain(t *testing.T) {
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithLinearStack3().Checkout("main")
 
-		chain := validation.GitOperationChain(s.Context.Context, s.Engine, s.Context.Git(), "fold")
+		chain := validation.GitOperationChain(s.Context.Context, s.Engine, "fold")
 		err := chain.Validate()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "trunk")
@@ -64,7 +64,7 @@ func TestGitOperationChain(t *testing.T) {
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithLinearStack3().Checkout("b").WithUncommittedChange("dirty")
 
-		chain := validation.GitOperationChain(s.Context.Context, s.Engine, s.Context.Git(), "fold")
+		chain := validation.GitOperationChain(s.Context.Context, s.Engine, "fold")
 		err := chain.Validate()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "uncommitted")
@@ -79,7 +79,7 @@ func TestAbsorbChain(t *testing.T) {
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithLinearStack3().Checkout("b")
 
-		chain := validation.AbsorbChain(s.Context.Context, s.Engine, s.Context.Git(), "absorb into")
+		chain := validation.AbsorbChain(s.Context.Context, s.Engine, "absorb into")
 		err := chain.Validate()
 		require.NoError(t, err)
 	})
@@ -89,7 +89,7 @@ func TestAbsorbChain(t *testing.T) {
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithLinearStack3().Checkout("main")
 
-		chain := validation.AbsorbChain(s.Context.Context, s.Engine, s.Context.Git(), "absorb into")
+		chain := validation.AbsorbChain(s.Context.Context, s.Engine, "absorb into")
 		err := chain.Validate()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "trunk")

--- a/internal/actions/validation/validators.go
+++ b/internal/actions/validation/validators.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/errors"
-	"github.com/getstackit/stackit/internal/git"
 )
 
 // Validator validates a single precondition.
@@ -55,6 +54,17 @@ type BranchValidationEngine interface {
 	AllBranches() engine.Branches
 }
 
+// GitStateReader is the minimal git-state contract the git-aware validators
+// need. engine.Engine satisfies it, so callers pass the engine instead of the
+// raw git runner — keeping validation in the domain layer rather than reaching
+// through Engine.Git().
+type GitStateReader interface {
+	IsRebaseInProgress(ctx context.Context) bool
+	HasUncommittedChanges(ctx context.Context) bool
+	HasStagedChanges(ctx context.Context) (bool, error)
+	GetRevisionForName(branchName string) (string, error)
+}
+
 // MustBeOnBranch validates that HEAD is on a branch (not detached).
 // Returns a Validator that checks the engine's current branch state.
 func MustBeOnBranch(eng BranchValidationEngine) Validator {
@@ -65,14 +75,17 @@ func MustBeOnBranch(eng BranchValidationEngine) Validator {
 }
 
 // MustNotHaveRebaseInProgress validates that no rebase operation is in progress.
-func MustNotHaveRebaseInProgress(ctx context.Context, g git.Runner) Validator {
+func MustNotHaveRebaseInProgress(ctx context.Context, g GitStateReader) Validator {
 	return ValidatorFunc(func() error {
-		return g.CheckRebaseInProgress(ctx)
+		if g.IsRebaseInProgress(ctx) {
+			return fmt.Errorf("a rebase is already in progress. Please finish or abort it first")
+		}
+		return nil
 	})
 }
 
 // MustNotHaveUncommittedChanges validates that there are no uncommitted changes.
-func MustNotHaveUncommittedChanges(ctx context.Context, g git.Runner) Validator {
+func MustNotHaveUncommittedChanges(ctx context.Context, g GitStateReader) Validator {
 	return ValidatorFunc(func() error {
 		if g.HasUncommittedChanges(ctx) {
 			return fmt.Errorf("cannot perform operation with uncommitted changes; please commit or stash them first")
@@ -82,7 +95,7 @@ func MustNotHaveUncommittedChanges(ctx context.Context, g git.Runner) Validator 
 }
 
 // MustHaveStagedChanges validates that there are staged changes ready to commit.
-func MustHaveStagedChanges(ctx context.Context, g git.Runner) Validator {
+func MustHaveStagedChanges(ctx context.Context, g GitStateReader) Validator {
 	return ValidatorFunc(func() error {
 		hasStagedChanges, err := g.HasStagedChanges(ctx)
 		if err != nil {
@@ -96,10 +109,10 @@ func MustHaveStagedChanges(ctx context.Context, g git.Runner) Validator {
 }
 
 // BranchMustExist validates that a branch exists in git.
-// Uses git.Runner to check if the branch ref exists.
-func BranchMustExist(g git.Runner, branchName string) Validator {
+// Checks that the branch ref resolves to a revision.
+func BranchMustExist(g GitStateReader, branchName string) Validator {
 	return ValidatorFunc(func() error {
-		_, err := g.GetRevision(branchName)
+		_, err := g.GetRevisionForName(branchName)
 		if err != nil {
 			return fmt.Errorf("branch %s does not exist", branchName)
 		}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The git-aware validators (MustNotHaveRebaseInProgress,
MustNotHaveUncommittedChanges, MustHaveStagedChanges, BranchMustExist) and
the GitOperationChain / AbsorbChain took a git.Runner, so callers reached
through ctx.Git() to the raw runner just to validate preconditions.

Introduce a narrow GitStateReader interface (IsRebaseInProgress,
HasUncommittedChanges, HasStagedChanges, GetRevisionForName) that
engine.Engine satisfies, and a GitOperationEngine that composes it with
BranchValidationEngine. Validators and chains now take the engine, so
absorb, fold, pop, get, reorder, and modify pass `eng` instead of ctx.Git().

This was found by a forbidigo experiment: a `.Git()` grep on method-call
form alone missed these argument-position uses. Behaviour is unchanged
(the rebase-in-progress error message is preserved verbatim).

<hr/>

<!-- STACKIT-SECTION-START -->
**Eliminate Engine.Git() escape-hatch: route ops through engine interfaces**

Removes all production uses of `Engine.Git()` — the raw git runner escape-hatch — and routes every git operation through typed engine interfaces instead. A final lint rule locks the door so new escape-hatch uses can't slip back in.

Key changes:
- **Read-only git queries** (#1149): Branch listing, status, and worktree queries in actions routed through new engine interface methods
- **Conflict recovery and staging** (#1150): Cherry-pick abort, stash, and staging operations promoted to engine-level methods
- **Metadata and remote operations** (#1151): Submit, merge, delete, and sync actions use `metadata_transport` and engine-level pull/push helpers
- **MetadataInspector** (#1153): Dedicated escape-hatch for diagnostic/debug commands that legitimately need raw metadata reads, keeping those paths clearly separated
- **Last production uses** (#1154): Sync and pull operations cleaned up
- **Validation package** (#1155): Takes a narrow `EngineState` interface instead of the raw git runner
- **Remaining domain ops** (#1156): Multistack worktree, state, and trunk navigation cleaned up
- **Rerere package** (#1157): Takes a narrow `GitConfigurer` interface instead of the raw git runner
- **Lint enforcement** (#1158): New `forbidigo` rule in `.golangci.yml` blocks any future `Engine.Git()` calls outside the engine package

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780617749`.


* **PR #1149**
  * **PR #1150**
    * **PR #1151**
      * **PR #1153**
        * **PR #1154**
          * **PR #1155** 👈
            * **PR #1156**
              * **PR #1157**
                * **PR #1158**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1159 by jonnii*