### PR TITLE
refactor: route remaining domain git operations through the engine

### DIFF
--- a/internal/actions/merge/multistack_worktree.go
+++ b/internal/actions/merge/multistack_worktree.go
@@ -127,9 +127,8 @@ func (w *MultiStackWorktreeExecutor) tryGlobalOctopusMerge(ctx context.Context, 
 	})
 	if err != nil {
 		// Abort the merge if it's in progress
-		git := eng.Git()
-		if git.IsMergeInProgress(ctx) {
-			if abortErr := git.MergeAbort(ctx); abortErr != nil {
+		if eng.IsMergeInProgress(ctx) {
+			if abortErr := eng.MergeAbort(ctx); abortErr != nil {
 				w.output.Debug("Failed to abort merge: %v", abortErr)
 			}
 		}
@@ -153,9 +152,8 @@ func (w *MultiStackWorktreeExecutor) tryMergeStack(ctx context.Context, eng engi
 	})
 	if err != nil {
 		// Abort the merge if it's in progress
-		git := eng.Git()
-		if git.IsMergeInProgress(ctx) {
-			if abortErr := git.MergeAbort(ctx); abortErr != nil {
+		if eng.IsMergeInProgress(ctx) {
+			if abortErr := eng.MergeAbort(ctx); abortErr != nil {
 				w.output.Debug("Failed to abort merge: %v", abortErr)
 			}
 		}

--- a/internal/actions/state.go
+++ b/internal/actions/state.go
@@ -96,18 +96,17 @@ func BuildState(ctx *app.Context, _ StateOptions) StateResult {
 	}
 
 	// In-progress operation + conflicts.
-	g := eng.Git()
 	op := OperationStatus{Kind: "none", ConflictedFiles: []string{}}
 	switch {
-	case g.IsRebaseInProgress(ctx.Context):
+	case eng.IsRebaseInProgress(ctx.Context):
 		op.Kind = "rebase"
 		op.InProgress = true
-	case g.IsMergeInProgress(ctx.Context):
+	case eng.IsMergeInProgress(ctx.Context):
 		op.Kind = "merge"
 		op.InProgress = true
 	}
 	if op.InProgress {
-		files, err := g.GetUnmergedFiles(ctx.Context)
+		files, err := eng.GetUnmergedFiles(ctx.Context)
 		if err != nil {
 			ctx.Output.Debug("state: failed to list unmerged files: %v", err)
 		} else {

--- a/internal/cli/navigation/trunk.go
+++ b/internal/cli/navigation/trunk.go
@@ -59,10 +59,9 @@ Use --all to see all configured trunk branches, or --add to add an additional tr
 
 // handleAddTrunk adds a new trunk branch
 func handleAddTrunk(ctx *app.Context, trunkName string) error {
-	runner := ctx.Git()
 	repoRoot := ctx.RepoRoot
 	// Verify the branch exists
-	branches, err := runner.GetAllBranchNames(ctx)
+	branches, err := ctx.Engine.GetAllBranchNames(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get branches: %w", err)
 	}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Three sites grabbed the raw runner via eng.Git()/ctx.Git() into a local and
then performed domain operations the engine now exposes directly:

- state.go: IsRebaseInProgress / IsMergeInProgress / GetUnmergedFiles
- merge/multistack_worktree.go: IsMergeInProgress / MergeAbort (both abort paths)
- cli/navigation/trunk.go: GetAllBranchNames

Call the engine methods directly. After this, the only remaining production
.Git() uses pass the runner to integration/helper packages (github.*,
rerere) that need a command executor — a separate, more defensible concern.

<hr/>

<!-- STACKIT-SECTION-START -->
**Eliminate Engine.Git() escape-hatch: route ops through engine interfaces**

Removes all production uses of `Engine.Git()` — the raw git runner escape-hatch — and routes every git operation through typed engine interfaces instead. A final lint rule locks the door so new escape-hatch uses can't slip back in.

Key changes:
- **Read-only git queries** (#1149): Branch listing, status, and worktree queries in actions routed through new engine interface methods
- **Conflict recovery and staging** (#1150): Cherry-pick abort, stash, and staging operations promoted to engine-level methods
- **Metadata and remote operations** (#1151): Submit, merge, delete, and sync actions use `metadata_transport` and engine-level pull/push helpers
- **MetadataInspector** (#1153): Dedicated escape-hatch for diagnostic/debug commands that legitimately need raw metadata reads, keeping those paths clearly separated
- **Last production uses** (#1154): Sync and pull operations cleaned up
- **Validation package** (#1155): Takes a narrow `EngineState` interface instead of the raw git runner
- **Remaining domain ops** (#1156): Multistack worktree, state, and trunk navigation cleaned up
- **Rerere package** (#1157): Takes a narrow `GitConfigurer` interface instead of the raw git runner
- **Lint enforcement** (#1158): New `forbidigo` rule in `.golangci.yml` blocks any future `Engine.Git()` calls outside the engine package

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780617749`.


* **PR #1149**
  * **PR #1150**
    * **PR #1151**
      * **PR #1153**
        * **PR #1154**
          * **PR #1155**
            * **PR #1156** 👈
              * **PR #1157**
                * **PR #1158**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1159 by jonnii*