### PR TITLE
refactor(rerere): take a narrow GitConfigurer instead of the raw git runner

### DIFF
--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -159,7 +159,7 @@ func RestackAction(ctx *app.Context, plan *RestackPlan, handler handlers.Restack
 		interactiveRererePrompt = false
 	}
 	pauser, _ := handler.(rerere.Pauser)
-	if _, err := rerere.EnsureEnabled(ctx.Context, ctx.Git(), interactiveRererePrompt, pauser); err != nil {
+	if _, err := rerere.EnsureEnabled(ctx.Context, ctx.Engine, interactiveRererePrompt, pauser); err != nil {
 		out.Warn("Failed to enable git rerere: %v", err)
 	}
 

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -260,7 +260,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	pauser, _ := handler.(rerere.Pauser)
-	if _, err := rerere.EnsureEnabled(gctx, ctx.Git(), ctx.Interactive && !ctx.Quiet && handler.IsInteractive(), pauser); err != nil {
+	if _, err := rerere.EnsureEnabled(gctx, ctx.Engine, ctx.Interactive && !ctx.Quiet && handler.IsInteractive(), pauser); err != nil {
 		out.Warn("Failed to enable git rerere: %v", err)
 	}
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -225,6 +225,7 @@ type Engine interface {
 	RemoteFetcher
 	WorktreeRegistry
 	MetadataInspector
+	GitConfig
 	Git() git.Runner
 
 	// SnapshotForWorktree creates a deep copy of engine state for initializing

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -255,6 +255,16 @@ func (e *engineImpl) GetUserName(ctx context.Context) (string, error) {
 	return e.git.GetUserName(ctx)
 }
 
+// GetConfig reads a git configuration value.
+func (e *engineImpl) GetConfig(key string) (string, error) {
+	return e.git.GetConfig(key)
+}
+
+// SetConfig writes a git configuration value.
+func (e *engineImpl) SetConfig(key, value string) error {
+	return e.git.SetConfig(key, value)
+}
+
 // GetAllBranchNames returns the names of all local branches, including ones not
 // tracked by stackit.
 func (e *engineImpl) GetAllBranchNames(ctx context.Context) ([]string, error) {

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -312,6 +312,14 @@ type MetadataInspector interface {
 	DeleteMetadataRef(ctx context.Context, branchName string) error
 }
 
+// GitConfig provides access to git configuration values. Exposed so helpers
+// that only need config access (e.g. rerere setup) can take the engine instead
+// of the raw git runner.
+type GitConfig interface {
+	GetConfig(key string) (string, error)
+	SetConfig(key, value string) error
+}
+
 // Absorber applies staged hunks to appropriate commits
 type Absorber interface {
 	ApplyHunksToBranch(ctx context.Context, branch Branch, hunksByCommit map[string][]git.Hunk) error

--- a/internal/rerere/rerere.go
+++ b/internal/rerere/rerere.go
@@ -4,11 +4,18 @@ import (
 	"context"
 	"strings"
 
-	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/tui"
 )
 
 const declinedKey = "stackit.rerere.declined"
+
+// GitConfigurer reads and writes git configuration values. Both git.Runner and
+// engine.Engine satisfy it, so callers can pass the engine rather than reaching
+// for the raw git runner.
+type GitConfigurer interface {
+	GetConfig(key string) (string, error)
+	SetConfig(key, value string) error
+}
 
 // ConfirmFunc prompts the user for a yes/no answer. Matches the signature
 // of tui.PromptConfirm.
@@ -31,21 +38,21 @@ type Pauser interface {
 //
 // If pauser is non-nil, it is paused around the confirmation prompt so a
 // surrounding TUI does not contend for stdin/stdout.
-func EnsureEnabled(ctx context.Context, runner git.Runner, interactive bool, pauser Pauser) (bool, error) {
-	return ensureEnabled(ctx, runner, interactive, pauser, tui.PromptConfirm)
+func EnsureEnabled(ctx context.Context, cfg GitConfigurer, interactive bool, pauser Pauser) (bool, error) {
+	return ensureEnabled(ctx, cfg, interactive, pauser, tui.PromptConfirm)
 }
 
-func ensureEnabled(_ context.Context, runner git.Runner, interactive bool, pauser Pauser, confirm ConfirmFunc) (bool, error) {
-	if configBool(runner, "rerere.enabled") {
-		if !configBool(runner, "rerere.autoupdate") {
-			if err := runner.SetConfig("rerere.autoupdate", "true"); err != nil {
+func ensureEnabled(_ context.Context, cfg GitConfigurer, interactive bool, pauser Pauser, confirm ConfirmFunc) (bool, error) {
+	if configBool(cfg, "rerere.enabled") {
+		if !configBool(cfg, "rerere.autoupdate") {
+			if err := cfg.SetConfig("rerere.autoupdate", "true"); err != nil {
 				return false, err
 			}
 		}
 		return false, nil
 	}
 
-	if configBool(runner, declinedKey) || !interactive {
+	if configBool(cfg, declinedKey) || !interactive {
 		return false, nil
 	}
 
@@ -54,14 +61,14 @@ func ensureEnabled(_ context.Context, runner git.Runner, interactive bool, pause
 		return false, nil //nolint:nilerr // prompt cancel (Ctrl+C) should not error — treat as decline without persisting
 	}
 	if !ok {
-		_ = runner.SetConfig(declinedKey, "true")
+		_ = cfg.SetConfig(declinedKey, "true")
 		return false, nil
 	}
 
-	if err := runner.SetConfig("rerere.enabled", "true"); err != nil {
+	if err := cfg.SetConfig("rerere.enabled", "true"); err != nil {
 		return false, err
 	}
-	if err := runner.SetConfig("rerere.autoupdate", "true"); err != nil {
+	if err := cfg.SetConfig("rerere.autoupdate", "true"); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -75,8 +82,8 @@ func promptWithPause(pauser Pauser, confirm ConfirmFunc, prompt string, defaultV
 	return confirm(prompt, defaultValue)
 }
 
-func configBool(runner git.Runner, key string) bool {
-	value, err := runner.GetConfig(key)
+func configBool(cfg GitConfigurer, key string) bool {
+	value, err := cfg.GetConfig(key)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


rerere.EnsureEnabled only reads and writes git config, but took a full
git.Runner — so sync and restack reached through ctx.Git() to call it.

Give rerere a narrow GitConfigurer interface (GetConfig/SetConfig). Add the
matching GitConfig forwarder pair to the engine and compose it into the
Engine interface, so callers pass ctx.Engine. The engine can't wrap rerere
directly (rerere imports tui, and core must not), but this decouples rerere
from git.Runner and removes the escape hatch at the call sites.

git.Runner still satisfies GitConfigurer, so rerere's own tests are unchanged.
After this, the only production .Git() uses left pass the runner to the GitHub
integration (EnableAutoMerge / SyncPrInfo / gh-token + client construction).

<hr/>

<!-- STACKIT-SECTION-START -->
**Eliminate Engine.Git() escape-hatch: route ops through engine interfaces**

Removes all production uses of `Engine.Git()` — the raw git runner escape-hatch — and routes every git operation through typed engine interfaces instead. A final lint rule locks the door so new escape-hatch uses can't slip back in.

Key changes:
- **Read-only git queries** (#1149): Branch listing, status, and worktree queries in actions routed through new engine interface methods
- **Conflict recovery and staging** (#1150): Cherry-pick abort, stash, and staging operations promoted to engine-level methods
- **Metadata and remote operations** (#1151): Submit, merge, delete, and sync actions use `metadata_transport` and engine-level pull/push helpers
- **MetadataInspector** (#1153): Dedicated escape-hatch for diagnostic/debug commands that legitimately need raw metadata reads, keeping those paths clearly separated
- **Last production uses** (#1154): Sync and pull operations cleaned up
- **Validation package** (#1155): Takes a narrow `EngineState` interface instead of the raw git runner
- **Remaining domain ops** (#1156): Multistack worktree, state, and trunk navigation cleaned up
- **Rerere package** (#1157): Takes a narrow `GitConfigurer` interface instead of the raw git runner
- **Lint enforcement** (#1158): New `forbidigo` rule in `.golangci.yml` blocks any future `Engine.Git()` calls outside the engine package

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780617749`.


* **PR #1149**
  * **PR #1150**
    * **PR #1151**
      * **PR #1153**
        * **PR #1154**
          * **PR #1155**
            * **PR #1156**
              * **PR #1157** 👈
                * **PR #1158**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->