### PR TITLE
chore(lint): guard against new Engine.Git() escape-hatch use

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,7 +39,16 @@ linters:
     - errorlint
     - copyloopvar
     - tparallel
+    - forbidigo
   settings:
+    forbidigo:
+      forbid:
+        - pattern: '\.Git\(\)'
+          msg: >-
+            Do not reach through Engine.Git()/Context.Git() to the raw git
+            runner. Add or use an engine method for domain operations. The only
+            allowed uses are passing the runner to integration helpers (github,
+            etc.), which must be annotated with //nolint:forbidigo and a reason.
     misspell:
       locale: US
     gosec:
@@ -63,6 +72,16 @@ linters:
       - path: _test\.go
         linters:
           - lll
+      # Tests use Engine.Git() freely for setup/assertions.
+      - path: _test\.go
+        linters:
+          - forbidigo
+      # Bootstrap and core own the git runner: app/config wire it, engine
+      # implements and returns it. The escape-hatch guard targets the
+      # action/adapter/business layers.
+      - path: internal/(app|config|engine)/
+        linters:
+          - forbidigo
 
 issues:
   max-issues-per-linter: 0

--- a/internal/actions/doctor/doctor.go
+++ b/internal/actions/doctor/doctor.go
@@ -29,7 +29,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	// Environment checks
 	handler.OnCategory(CategoryEnvironment)
-	warningCount, errorCount = checkEnvironment(ctx.Git(), handler, warningCount, errorCount)
+	warningCount, errorCount = checkEnvironment(ctx.Git(), handler, warningCount, errorCount) //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
 
 	// Repository checks
 	handler.OnCategory(CategoryRepository)

--- a/internal/actions/merge/consolidate.go
+++ b/internal/actions/merge/consolidate.go
@@ -110,7 +110,7 @@ func (c *ConsolidateMergeExecutor) Execute(ctx context.Context, opts ExecuteOpti
 			return nil, fmt.Errorf("failed to get merge method: %w", err)
 		}
 		metadata := c.buildStackMetadata()
-		if err := github.EnableAutoMerge(ctx, c.engine.Git(), pr.NodeID, github.EnableAutoMergeOptions{
+		if err := github.EnableAutoMerge(ctx, c.engine.Git(), pr.NodeID, github.EnableAutoMergeOptions{ //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
 			MergeMethod: mergeMethod,
 			CommitBody:  metadata.ToTrailers(),
 		}); err != nil {

--- a/internal/actions/merge/multistack_pr.go
+++ b/internal/actions/merge/multistack_pr.go
@@ -126,7 +126,7 @@ func (p *MultiStackPRCreator) EnableAutoMerge(ctx context.Context, pr *github.Pu
 		return fmt.Errorf("failed to get merge method: %w", err)
 	}
 
-	return github.EnableAutoMerge(ctx, p.ctx.Git(), pr.NodeID, github.EnableAutoMergeOptions{
+	return github.EnableAutoMerge(ctx, p.ctx.Git(), pr.NodeID, github.EnableAutoMergeOptions{ //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
 		MergeMethod: mergeMethod,
 		CommitBody:  commitBody,
 	})

--- a/internal/actions/submit/submit_validation.go
+++ b/internal/actions/submit/submit_validation.go
@@ -23,7 +23,7 @@ func ValidateBranchesToSubmit(ctx *app.Context, branches []string) error {
 		return err
 	}
 	if repoOwner != "" && repoName != "" {
-		if err := github.SyncPrInfo(ctx.Context, ctx.Git(), branches, repoOwner, repoName, func(name string, prInfo *github.PullRequestInfo) {
+		if err := github.SyncPrInfo(ctx.Context, ctx.Git(), branches, repoOwner, repoName, func(name string, prInfo *github.PullRequestInfo) { //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
 			branch := nav.GetBranch(name)
 
 			// Preserve existing locked status

--- a/internal/actions/sync/github_sync.go
+++ b/internal/actions/sync/github_sync.go
@@ -54,7 +54,7 @@ func syncGitHubPRInfo(ctx *app.Context) (*GitHubSyncResult, error) {
 
 	// Sync PR info from GitHub (this is already parallelized internally)
 	syncPrStart := time.Now()
-	if err := github.SyncPrInfo(gctx, ctx.Git(), branchNames, repoOwner, repoName, func(name string, prInfo *github.PullRequestInfo) {
+	if err := github.SyncPrInfo(gctx, ctx.Git(), branchNames, repoOwner, repoName, func(name string, prInfo *github.PullRequestInfo) { //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
 		result.mu.Lock()
 		result.PRInfos[name] = prInfo
 		result.mu.Unlock()

--- a/internal/cli/stack/merge/orchestrate.go
+++ b/internal/cli/stack/merge/orchestrate.go
@@ -83,7 +83,7 @@ func (d *defaultPRMergeAPI) mergePR(ctx context.Context, branchName string, meth
 //     - "not enabled on repo" + no wait → error with --wait suggestion.
 func orchestrateMerge(ctx *app.Context, opts orchestrateMergeOptions) (Outcome, error) {
 	api := &defaultPRMergeAPI{client: ctx.GitHub()}
-	return doOrchestrateMerge(ctx.Context, ctx.Output, ctx.Engine.Git(), api, opts)
+	return doOrchestrateMerge(ctx.Context, ctx.Output, ctx.Engine.Git(), api, opts) //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
 }
 
 // doOrchestrateMerge contains the core merge orchestration logic, accepting a prMergeAPI

--- a/internal/cli/stack/merge/ship.go
+++ b/internal/cli/stack/merge/ship.go
@@ -371,7 +371,7 @@ func runMultiStackShip(ctx *app.Context, opts shipMultiStackOptions) error {
 				out.Warn("Could not determine merge method: %v", methodErr)
 				out.Tip("Enable automerge manually on the PR: %s", result.PRURL)
 			} else {
-				if err := github.EnableAutoMerge(ctx.Context, ctx.Engine.Git(), prNodeID, github.EnableAutoMergeOptions{MergeMethod: mergeMethod}); err != nil {
+				if err := github.EnableAutoMerge(ctx.Context, ctx.Engine.Git(), prNodeID, github.EnableAutoMergeOptions{MergeMethod: mergeMethod}); err != nil { //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
 					out.Warn("Could not enable automerge: %v", err)
 					out.Tip("Enable automerge manually on the PR: %s", result.PRURL)
 				} else {

--- a/internal/shippable/combiner.go
+++ b/internal/shippable/combiner.go
@@ -271,9 +271,8 @@ func (c *Combiner) tryMergeStacks(
 
 		if err != nil {
 			// Abort merge if in progress
-			git := session.Engine.Git()
-			if git.IsMergeInProgress(ctx) {
-				_ = git.MergeAbort(ctx)
+			if session.Engine.IsMergeInProgress(ctx) {
+				_ = session.Engine.MergeAbort(ctx)
 			}
 
 			// Reset to baseline


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Add a forbidigo rule that forbids `.Git()` so no new code can reach through
Engine.Git()/Context.Git() to the raw git runner for domain operations. It
runs in CI automatically via the existing golangci-lint step.

Exceptions, all explicit:
- tests (use the runner freely for setup/assertions) and bootstrap/core
  (internal/app, internal/config, internal/engine own or wire the runner)
  are excluded by path.
- the seven sites that hand the runner to the GitHub integration
  (EnableAutoMerge / SyncPrInfo / gh-token + client) carry a
  //nolint:forbidigo with a reason — they need a command runner, not a
  domain method.

Also fixes the last domain-op straggler the guard surfaced:
shippable/combiner.go used eng.Git().IsMergeInProgress/MergeAbort; it now
calls the engine methods directly.

<hr/>

<!-- STACKIT-SECTION-START -->
**Eliminate Engine.Git() escape-hatch: route ops through engine interfaces**

Removes all production uses of `Engine.Git()` — the raw git runner escape-hatch — and routes every git operation through typed engine interfaces instead. A final lint rule locks the door so new escape-hatch uses can't slip back in.

Key changes:
- **Read-only git queries** (#1149): Branch listing, status, and worktree queries in actions routed through new engine interface methods
- **Conflict recovery and staging** (#1150): Cherry-pick abort, stash, and staging operations promoted to engine-level methods
- **Metadata and remote operations** (#1151): Submit, merge, delete, and sync actions use `metadata_transport` and engine-level pull/push helpers
- **MetadataInspector** (#1153): Dedicated escape-hatch for diagnostic/debug commands that legitimately need raw metadata reads, keeping those paths clearly separated
- **Last production uses** (#1154): Sync and pull operations cleaned up
- **Validation package** (#1155): Takes a narrow `EngineState` interface instead of the raw git runner
- **Remaining domain ops** (#1156): Multistack worktree, state, and trunk navigation cleaned up
- **Rerere package** (#1157): Takes a narrow `GitConfigurer` interface instead of the raw git runner
- **Lint enforcement** (#1158): New `forbidigo` rule in `.golangci.yml` blocks any future `Engine.Git()` calls outside the engine package

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780617749`.


* **PR #1149**
  * **PR #1150**
    * **PR #1151**
      * **PR #1153**
        * **PR #1154**
          * **PR #1155**
            * **PR #1156**
              * **PR #1157**
                * **PR #1158** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1159 by jonnii*