### PR TITLE
Eliminate Engine.Git() escape-hatch: route ops through engine interfaces

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,7 +39,16 @@ linters:
     - errorlint
     - copyloopvar
     - tparallel
+    - forbidigo
   settings:
+    forbidigo:
+      forbid:
+        - pattern: '\.Git\(\)'
+          msg: >-
+            Do not reach through Engine.Git()/Context.Git() to the raw git
+            runner. Add or use an engine method for domain operations. The only
+            allowed uses are passing the runner to integration helpers (github,
+            etc.), which must be annotated with //nolint:forbidigo and a reason.
     misspell:
       locale: US
     gosec:
@@ -63,6 +72,16 @@ linters:
       - path: _test\.go
         linters:
           - lll
+      # Tests use Engine.Git() freely for setup/assertions.
+      - path: _test\.go
+        linters:
+          - forbidigo
+      # Bootstrap and core own the git runner: app/config wire it, engine
+      # implements and returns it. The escape-hatch guard targets the
+      # action/adapter/business layers.
+      - path: internal/(app|config|engine)/
+        linters:
+          - forbidigo
 
 issues:
   max-issues-per-linter: 0

--- a/internal/actions/abort/action.go
+++ b/internal/actions/abort/action.go
@@ -23,7 +23,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	out := ctx.Output
 
 	rebaseInProgress := eng.IsRebaseInProgress(ctx.Context)
-	mergeInProgress := eng.Git().IsMergeInProgress(ctx.Context)
+	mergeInProgress := eng.IsMergeInProgress(ctx.Context)
 
 	// Check for continuation state
 	hasContinuation := false
@@ -51,13 +51,13 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Abort Git operations
 	if rebaseInProgress {
 		out.Info("Aborting rebase...")
-		if err := eng.Git().RebaseAbort(ctx.Context); err != nil {
+		if err := eng.RebaseAbort(ctx.Context); err != nil {
 			return fmt.Errorf("failed to abort rebase: %w", err)
 		}
 	}
 	if mergeInProgress {
 		out.Info("Aborting merge...")
-		if err := eng.Git().MergeAbort(ctx.Context); err != nil {
+		if err := eng.MergeAbort(ctx.Context); err != nil {
 			return fmt.Errorf("failed to abort merge: %w", err)
 		}
 	}

--- a/internal/actions/abort/action.go
+++ b/internal/actions/abort/action.go
@@ -22,7 +22,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	eng := ctx.Engine
 	out := ctx.Output
 
-	rebaseInProgress := eng.Git().IsRebaseInProgress(ctx.Context)
+	rebaseInProgress := eng.IsRebaseInProgress(ctx.Context)
 	mergeInProgress := eng.Git().IsMergeInProgress(ctx.Context)
 
 	// Check for continuation state

--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -42,7 +42,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	handler.Start(opts.DryRun)
 
 	// Validate preconditions
-	if err := validation.AbsorbChain(ctx.Context, eng, ctx.Git(), "absorb into").Validate(); err != nil {
+	if err := validation.AbsorbChain(ctx.Context, eng, "absorb into").Validate(); err != nil {
 		return err
 	}
 	currentBranch := eng.CurrentBranch()

--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -70,7 +70,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		All:   opts.All,
 		Patch: opts.Patch,
 	}
-	if err := ctx.Git().StageChanges(ctx.Context, stagingOpts); err != nil {
+	if err := ctx.Engine.StageChanges(ctx.Context, stagingOpts); err != nil {
 		return err
 	}
 

--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -197,7 +197,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 		// Output JSON if requested (works with dry-run for preview)
 		if opts.JSON {
-			newFiles, err := ctx.Git().GetUntrackedFiles(ctx.Context)
+			newFiles, err := ctx.Engine.GetUntrackedFiles(ctx.Context)
 			if err != nil {
 				out.Debug("Failed to get untracked files: %v", err)
 			}
@@ -320,7 +320,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	// Output JSON summary if requested
 	if opts.JSON {
-		newFiles, err := ctx.Git().GetUntrackedFiles(ctx.Context)
+		newFiles, err := ctx.Engine.GetUntrackedFiles(ctx.Context)
 		if err != nil {
 			out.Debug("Failed to get untracked files: %v", err)
 		}

--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -512,7 +512,7 @@ func appendStrandedRoots(eng engine.Engine, graph *engine.StackGraph, deleteStat
 			}
 			kind := engine.DeletionReasonGhost
 			reason := "branch no longer exists locally"
-			if meta, err := eng.Git().ReadMetadata(ghostName); err == nil && meta != nil {
+			if meta, err := eng.ReadMetadataRaw(ghostName); err == nil && meta != nil {
 				if pr := meta.GetPrInfo(); pr != nil && pr.State != nil && *pr.State == "MERGED" {
 					kind = engine.DeletionReasonMergedPR
 					reason = "branch deleted locally; PR was merged"

--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -353,7 +353,7 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 			return
 		}
 		pushStart := time.Now()
-		err := eng.Git().BatchDeleteRemoteMetadataRefs(c, deletedBranchNames)
+		err := eng.DeleteRemoteMetadataForBranches(c, deletedBranchNames)
 		ctx.Logger.Info("delete remote metadata refs completed durationMs=%d branchCount=%d ok=%v",
 			time.Since(pushStart).Milliseconds(), len(deletedBranchNames), err == nil)
 		if err != nil {
@@ -614,7 +614,7 @@ func removeWorktreeIfCheckedOut(ctx context.Context, branchName string, worktree
 	}
 
 	// Don't remove main worktree (resolve symlinks for comparison, e.g., /var vs /private/var on macOS)
-	repoRoot := eng.Git().GetRepoRoot()
+	repoRoot := eng.GetRepoRoot()
 	resolvedWorktree, _ := filepath.EvalSymlinks(worktreePath)
 	resolvedRoot, _ := filepath.EvalSymlinks(repoRoot)
 	if resolvedWorktree == resolvedRoot {

--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -382,7 +382,7 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 		// Snapshot the worktree list once for this batch instead of
 		// re-running `git worktree list --porcelain` per branch.
 		listStart := time.Now()
-		worktrees, err := eng.Git().ListWorktrees(c)
+		worktrees, err := eng.ListWorktrees(c)
 		ctx.Logger.Info("list worktrees for cleanup batch completed durationMs=%d batch=%d worktreeCount=%d",
 			time.Since(listStart).Milliseconds(), batchIdx, len(worktrees))
 		if err != nil {
@@ -624,7 +624,7 @@ func removeWorktreeIfCheckedOut(ctx context.Context, branchName string, worktree
 
 	out.Debug("Removing worktree at %s for branch %s", worktreePath, branchName)
 
-	if err := eng.Git().RemoveWorktree(ctx, worktreePath); err != nil {
+	if err := eng.RemoveWorktree(ctx, worktreePath); err != nil {
 		return worktreePath, fmt.Errorf("failed to remove worktree at %s for branch %s: %w", worktreePath, branchName, err)
 	}
 

--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -208,7 +208,7 @@ func restackBranchesWithPlan(ctx *app.Context, branches engine.Branches, prePlan
 			}
 
 			ctx.Logger.Warn("unexpected rebase state after sync restack; aborting branch=%v", conflictBranch)
-			if abortErr := ctx.Engine.Git().RebaseAbort(ctx.Context); abortErr != nil {
+			if abortErr := ctx.Engine.RebaseAbort(ctx.Context); abortErr != nil {
 				return fmt.Errorf("unexpected restack conflict on %s: failed to abort rebase: %w", conflictBranch, abortErr)
 			}
 
@@ -218,7 +218,7 @@ func restackBranchesWithPlan(ctx *app.Context, branches engine.Branches, prePlan
 						conflictBranch, originalBranch.GetName(), checkoutErr)
 				}
 			} else if originalRev != "" {
-				if detachErr := ctx.Engine.Git().CheckoutDetached(ctx.Context, originalRev); detachErr != nil {
+				if detachErr := ctx.Engine.Detach(ctx.Context, originalRev); detachErr != nil {
 					return fmt.Errorf("unexpected restack conflict on %s: aborted rebase but failed to restore detached HEAD %s: %w",
 						conflictBranch, originalRev, detachErr)
 				}
@@ -436,7 +436,7 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 		if revErr != nil {
 			return fmt.Errorf("failed to read HEAD before conflict workflow: %w", revErr)
 		}
-		if detachErr := ctx.Engine.Git().CheckoutDetached(ctx.Context, currentRev); detachErr != nil {
+		if detachErr := ctx.Engine.Detach(ctx.Context, currentRev); detachErr != nil {
 			return fmt.Errorf("failed to detach HEAD before conflict workflow: %w", detachErr)
 		}
 	}

--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -188,7 +188,7 @@ func restackBranchesWithPlan(ctx *app.Context, branches engine.Branches, prePlan
 		originalBranch := ctx.Engine.CurrentBranch()
 		originalRev := ""
 		if originalBranch == nil {
-			originalRev, _ = ctx.Engine.Git().GetCurrentRevision(ctx.Context)
+			originalRev, _ = ctx.Engine.GetCurrentRevision(ctx.Context)
 		}
 
 		currentBranchName := getCurrentBranchName(ctx.Engine)
@@ -201,7 +201,7 @@ func restackBranchesWithPlan(ctx *app.Context, branches engine.Branches, prePlan
 
 		// Sync mode should never leave the repo in a conflict workflow unless explicitly requested.
 		// If a runtime conflict occurred despite validation, clean it up and restore checkout state.
-		if mode == ConflictModeContinue && ctx.Engine.Git().IsRebaseInProgress(ctx.Context) {
+		if mode == ConflictModeContinue && ctx.Engine.IsRebaseInProgress(ctx.Context) {
 			conflictBranch := batchResult.ConflictBranch
 			if conflictBranch == "" {
 				conflictBranch = "unknown"
@@ -432,7 +432,7 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 	// abort can only touch HEAD, never a branch ref. `st continue` already
 	// re-attaches to the conflict branch on success.
 	if currentBranch := ctx.Engine.CurrentBranch(); currentBranch != nil {
-		currentRev, revErr := ctx.Engine.Git().GetCurrentRevision(ctx.Context)
+		currentRev, revErr := ctx.Engine.GetCurrentRevision(ctx.Context)
 		if revErr != nil {
 			return fmt.Errorf("failed to read HEAD before conflict workflow: %w", revErr)
 		}
@@ -449,7 +449,7 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 	}
 
 	// Verify we're actually in conflict state
-	if !ctx.Engine.Git().IsRebaseInProgress(ctx.Context) {
+	if !ctx.Engine.IsRebaseInProgress(ctx.Context) {
 		return fmt.Errorf("expected conflict on %s but rebase completed successfully", firstConflict)
 	}
 
@@ -523,7 +523,7 @@ func validateBranchAncestry(ctx *app.Context, branches engine.Branches) error {
 			}
 
 			// Parent exists - verify they have a common ancestor
-			_, err = ctx.Engine.Git().GetMergeBase(ctx.Context, parentRev, branchRev)
+			_, err = ctx.Engine.GetMergeBase(ctx.Context, parentRev, branchRev)
 			if err != nil {
 				return fmt.Errorf("branch %s and parent %s have no common ancestor: %w",
 					branchName, parentName, err)

--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -91,7 +91,7 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 	}
 
 	// Success - checkout the branch (rebase leaves us in detached HEAD)
-	if err := eng.Git().CheckoutBranch(ctx.Context, result.BranchName); err != nil {
+	if err := eng.CheckoutBranch(ctx.Context, eng.GetBranch(result.BranchName)); err != nil {
 		return fmt.Errorf("failed to checkout branch %s: %w", result.BranchName, err)
 	}
 

--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -22,7 +22,7 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 	out := ctx.Output
 
 	// Check if rebase is in progress
-	if !eng.Git().IsRebaseInProgress(ctx.Context) {
+	if !eng.IsRebaseInProgress(ctx.Context) {
 		// Clear any stale continuation state
 		_ = config.ClearContinuationState(ctx.RepoRoot)
 		return fmt.Errorf("no rebase in progress. Nothing to continue")
@@ -55,7 +55,7 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 
 	// Stage all changes if --all flag is set
 	if opts.AddAll {
-		if err := eng.Git().StageAll(ctx.Context); err != nil {
+		if err := eng.StageAll(ctx.Context); err != nil {
 			return fmt.Errorf("failed to stage changes: %w", err)
 		}
 	}

--- a/internal/actions/create/create.go
+++ b/internal/actions/create/create.go
@@ -92,7 +92,7 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 			Update: opts.Update,
 			Patch:  opts.Patch,
 		}
-		if err := ctx.Git().StageChanges(ctx.Context, stagingOpts); err != nil {
+		if err := ctx.Engine.StageChanges(ctx.Context, stagingOpts); err != nil {
 			h.OnStep(StepStaging, handler.StatusFailed, err.Error())
 			return Result{}, err
 		}

--- a/internal/actions/debug.go
+++ b/internal/actions/debug.go
@@ -128,7 +128,7 @@ func DebugAction(ctx *app.Context, opts DebugOptions) error {
 	currentBranch := eng.CurrentBranch()
 	allBranches := eng.AllBranches()
 
-	metadataRefs, err := eng.Git().ListMetadata()
+	metadataRefs, err := eng.ListMetadataRefs()
 	if err != nil {
 		metadataRefs = make(map[string]string)
 	}
@@ -137,7 +137,7 @@ func DebugAction(ctx *app.Context, opts DebugOptions) error {
 	for i, b := range allBranches {
 		branchNames[i] = b.GetName()
 	}
-	allMeta, _ := eng.Git().BatchReadMetadata(branchNames)
+	allMeta, _ := eng.BatchReadMetadataRaw(branchNames)
 
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
 	branchInfos := make([]BranchInfo, 0, len(allBranches))

--- a/internal/actions/delete/delete.go
+++ b/internal/actions/delete/delete.go
@@ -127,7 +127,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) (Result, error) {
 
 	// Batch delete remote metadata for deleted branches
 	branchNames := toDeleteNames
-	if err := eng.Git().BatchDeleteRemoteMetadataRefs(ctx.Context, branchNames); err != nil {
+	if err := eng.DeleteRemoteMetadataForBranches(ctx.Context, branchNames); err != nil {
 		out.Debug("Failed to batch delete remote metadata: %v", err)
 	}
 

--- a/internal/actions/doctor/doctor.go
+++ b/internal/actions/doctor/doctor.go
@@ -29,7 +29,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	// Environment checks
 	handler.OnCategory(CategoryEnvironment)
-	warningCount, errorCount = checkEnvironment(ctx.Git(), handler, warningCount, errorCount)
+	warningCount, errorCount = checkEnvironment(ctx.Git(), handler, warningCount, errorCount) //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
 
 	// Repository checks
 	handler.OnCategory(CategoryRepository)

--- a/internal/actions/doctor/repository.go
+++ b/internal/actions/doctor/repository.go
@@ -11,7 +11,7 @@ import (
 func checkRepository(ctx *app.Context, handler Handler, warnings int, errors int, trunk string) (int, int) {
 	// Check if we're in a git repository
 	if ctx.RepoRoot == "" {
-		if !ctx.Engine.Git().IsInsideRepo() {
+		if !ctx.Engine.IsInsideRepo() {
 			errors++
 			handler.OnCheck("git_repo", CheckError, "not in a git repository")
 			return warnings, errors

--- a/internal/actions/doctor/stack_state.go
+++ b/internal/actions/doctor/stack_state.go
@@ -11,7 +11,7 @@ import (
 // checkStackState performs stack state and metadata integrity checks
 func checkStackState(ctx context.Context, eng engine.Engine, handler Handler, warnings int, errors int, fix bool) (int, int) {
 	// Get all branches
-	allBranches, err := eng.Git().GetAllBranchNames(ctx)
+	allBranches, err := eng.GetAllBranchNames(ctx)
 	if err != nil {
 		errors++
 		handler.OnCheck("branch_list", CheckError, fmt.Sprintf("failed to get branch names: %v", err))
@@ -19,7 +19,7 @@ func checkStackState(ctx context.Context, eng engine.Engine, handler Handler, wa
 	}
 
 	// Get all metadata refs
-	metadataRefs, err := eng.Git().ListMetadata()
+	metadataRefs, err := eng.ListMetadataRefs()
 	if err != nil {
 		errors++
 		handler.OnCheck("metadata_list", CheckError, fmt.Sprintf("failed to get metadata refs: %v", err))
@@ -38,7 +38,7 @@ func checkStackState(ctx context.Context, eng engine.Engine, handler Handler, wa
 		if !branchSet[branchName] {
 			orphanedCount++
 			if fix {
-				if err := eng.Git().DeleteMetadata(ctx, branchName); err != nil {
+				if err := eng.DeleteMetadataRef(ctx, branchName); err != nil {
 					warnings++
 					handler.OnCheck("orphaned_metadata", CheckWarning, fmt.Sprintf("orphaned metadata for '%s' (fix failed: %v)", branchName, err))
 				} else {
@@ -70,7 +70,7 @@ func checkStackState(ctx context.Context, eng engine.Engine, handler Handler, wa
 	for branchName := range metadataRefs {
 		metadataRefNames = append(metadataRefNames, branchName)
 	}
-	allMeta, allMetaErrs := eng.Git().BatchReadMetadata(metadataRefNames)
+	allMeta, allMetaErrs := eng.BatchReadMetadataRaw(metadataRefNames)
 
 	corruptedCount := 0
 	for _, branchName := range metadataRefNames {

--- a/internal/actions/fold/fold.go
+++ b/internal/actions/fold/fold.go
@@ -92,7 +92,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	defer handler.Cleanup()
 
 	// Validate preconditions
-	if err := validation.GitOperationChain(gctx, eng, ctx.Git(), "fold").Validate(); err != nil {
+	if err := validation.GitOperationChain(gctx, eng, "fold").Validate(); err != nil {
 		return err
 	}
 	currentBranch := eng.CurrentBranch().GetName()

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -110,7 +110,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	out := ctx.Output
 	gctx := ctx.Context
 
-	if err := validation.MustNotHaveUncommittedChanges(gctx, ctx.Git()).Validate(); err != nil {
+	if err := validation.MustNotHaveUncommittedChanges(gctx, eng).Validate(); err != nil {
 		return err
 	}
 

--- a/internal/actions/merge/consolidate.go
+++ b/internal/actions/merge/consolidate.go
@@ -96,7 +96,7 @@ func (c *ConsolidateMergeExecutor) Execute(ctx context.Context, opts ExecuteOpti
 
 		// Store consolidation info for footer updates
 		c.consolidationPR = pr
-		if userName, err := c.ctx.Git().GetUserName(ctx); err == nil && userName != "" {
+		if userName, err := c.ctx.Engine.GetUserName(ctx); err == nil && userName != "" {
 			c.consolidationUser = userName
 		}
 

--- a/internal/actions/merge/consolidate.go
+++ b/internal/actions/merge/consolidate.go
@@ -110,7 +110,7 @@ func (c *ConsolidateMergeExecutor) Execute(ctx context.Context, opts ExecuteOpti
 			return nil, fmt.Errorf("failed to get merge method: %w", err)
 		}
 		metadata := c.buildStackMetadata()
-		if err := github.EnableAutoMerge(ctx, c.engine.Git(), pr.NodeID, github.EnableAutoMergeOptions{
+		if err := github.EnableAutoMerge(ctx, c.engine.Git(), pr.NodeID, github.EnableAutoMergeOptions{ //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
 			MergeMethod: mergeMethod,
 			CommitBody:  metadata.ToTrailers(),
 		}); err != nil {

--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -202,7 +202,7 @@ func executeSteps(ctx *app.Context, eng mergeExecuteEngine, opts ExecuteOptions)
 	// list` per step via removeWorktreeForBranch; the snapshot covers every
 	// step in this run. Safe to reuse: deleting a branch can only invalidate
 	// its own entry, and we only ever read each entry once.
-	worktrees, err := eng.Git().ListWorktrees(ctx.Context)
+	worktrees, err := eng.ListWorktrees(ctx.Context)
 	if err != nil {
 		ctx.Output.Debug("Failed to list worktrees for merge plan: %v", err)
 		worktrees = git.WorktreeList{}
@@ -466,7 +466,7 @@ func removeWorktreeForBranch(ctx context.Context, branchName string, worktrees g
 
 	out.Debug("Removing worktree at %s for branch %s", worktreePath, branchName)
 
-	if err := eng.Git().RemoveWorktree(ctx, worktreePath); err != nil {
+	if err := eng.RemoveWorktree(ctx, worktreePath); err != nil {
 		return fmt.Errorf("failed to remove worktree at %s for branch %s: %w", worktreePath, branchName, err)
 	}
 

--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -404,7 +404,7 @@ func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecut
 			} else {
 				// Drop the remote metadata ref so it doesn't linger on origin and surface as
 				// a phantom conflict next time someone runs sync.
-				if err := eng.Git().BatchDeleteRemoteMetadataRefs(ctx.Context, []string{step.BranchName}); err != nil {
+				if err := eng.DeleteRemoteMetadataForBranches(ctx.Context, []string{step.BranchName}); err != nil {
 					out.Debug("Failed to delete remote metadata ref for %s: %v", step.BranchName, err)
 				}
 			}
@@ -456,7 +456,7 @@ func removeWorktreeForBranch(ctx context.Context, branchName string, worktrees g
 	}
 
 	// Don't remove main worktree (resolve symlinks for comparison, e.g., /var vs /private/var on macOS)
-	repoRoot := eng.Git().GetRepoRoot()
+	repoRoot := eng.GetRepoRoot()
 	resolvedWorktree, _ := filepath.EvalSymlinks(worktreePath)
 	resolvedRoot, _ := filepath.EvalSymlinks(repoRoot)
 	if resolvedWorktree == resolvedRoot {

--- a/internal/actions/merge/multistack.go
+++ b/internal/actions/merge/multistack.go
@@ -203,7 +203,7 @@ func ExecuteMultiStack(ctx *app.Context, opts MultiStackOptions) (*MultiStackRes
 			branchNames = append(branchNames, stack.AllBranches...)
 		}
 
-		userName, _ := eng.Git().GetUserName(ctx.Context)
+		userName, _ := eng.GetUserName(ctx.Context)
 		cleaner := NewPRCleaner(ctx, eng, PRCleanupConfig{
 			Source:                CleanupSourceMultiStack,
 			ConsolidationPRNumber: pr.Number,

--- a/internal/actions/merge/multistack_pr.go
+++ b/internal/actions/merge/multistack_pr.go
@@ -126,7 +126,7 @@ func (p *MultiStackPRCreator) EnableAutoMerge(ctx context.Context, pr *github.Pu
 		return fmt.Errorf("failed to get merge method: %w", err)
 	}
 
-	return github.EnableAutoMerge(ctx, p.ctx.Git(), pr.NodeID, github.EnableAutoMergeOptions{
+	return github.EnableAutoMerge(ctx, p.ctx.Git(), pr.NodeID, github.EnableAutoMergeOptions{ //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
 		MergeMethod: mergeMethod,
 		CommitBody:  commitBody,
 	})

--- a/internal/actions/merge/multistack_worktree.go
+++ b/internal/actions/merge/multistack_worktree.go
@@ -127,9 +127,8 @@ func (w *MultiStackWorktreeExecutor) tryGlobalOctopusMerge(ctx context.Context, 
 	})
 	if err != nil {
 		// Abort the merge if it's in progress
-		git := eng.Git()
-		if git.IsMergeInProgress(ctx) {
-			if abortErr := git.MergeAbort(ctx); abortErr != nil {
+		if eng.IsMergeInProgress(ctx) {
+			if abortErr := eng.MergeAbort(ctx); abortErr != nil {
 				w.output.Debug("Failed to abort merge: %v", abortErr)
 			}
 		}
@@ -153,9 +152,8 @@ func (w *MultiStackWorktreeExecutor) tryMergeStack(ctx context.Context, eng engi
 	})
 	if err != nil {
 		// Abort the merge if it's in progress
-		git := eng.Git()
-		if git.IsMergeInProgress(ctx) {
-			if abortErr := git.MergeAbort(ctx); abortErr != nil {
+		if eng.IsMergeInProgress(ctx) {
+			if abortErr := eng.MergeAbort(ctx); abortErr != nil {
 				w.output.Debug("Failed to abort merge: %v", abortErr)
 			}
 		}

--- a/internal/actions/merge/plan.go
+++ b/internal/actions/merge/plan.go
@@ -147,7 +147,7 @@ type mergePlanEngine interface {
 	engine.BranchReader
 	engine.PRManager
 	engine.SyncManager
-	Git() git.Runner
+	engine.MetadataInspector
 }
 
 // CreateMergePlan analyzes the current state and builds a merge plan.
@@ -262,7 +262,7 @@ func CollectMergeBranches(ctx context.Context, eng mergePlanEngine, splog output
 
 	// 4. Batch fetch metadata and revisions for all involved branches
 	involvedBranches := append(append([]string{}, allBranches...), upstackBranches...)
-	allMeta, _ := eng.Git().BatchReadMetadata(involvedBranches)
+	allMeta, _ := eng.BatchReadMetadataRaw(involvedBranches)
 	// We don't strictly need allRevisions here yet, but it's good for cache
 	_, _ = eng.GetRevisions(involvedBranches)
 

--- a/internal/actions/merge/plan.go
+++ b/internal/actions/merge/plan.go
@@ -264,7 +264,7 @@ func CollectMergeBranches(ctx context.Context, eng mergePlanEngine, splog output
 	involvedBranches := append(append([]string{}, allBranches...), upstackBranches...)
 	allMeta, _ := eng.Git().BatchReadMetadata(involvedBranches)
 	// We don't strictly need allRevisions here yet, but it's good for cache
-	_, _ = eng.Git().BatchGetRevisions(involvedBranches)
+	_, _ = eng.GetRevisions(involvedBranches)
 
 	// Fetch CI statuses in batch if possible
 	var allCheckStatuses map[string]*github.CheckStatus

--- a/internal/actions/modify.go
+++ b/internal/actions/modify.go
@@ -49,7 +49,7 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) error {
 	}
 
 	// Check if rebase is in progress (only for non-interactive mode)
-	if err := validation.MustNotHaveRebaseInProgress(gctx, ctx.Git()).Validate(); err != nil {
+	if err := validation.MustNotHaveRebaseInProgress(gctx, eng).Validate(); err != nil {
 		return err
 	}
 

--- a/internal/actions/modify.go
+++ b/internal/actions/modify.go
@@ -72,7 +72,7 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) error {
 		Update: opts.Update,
 		Patch:  opts.Patch,
 	}
-	if err := ctx.Git().StageChanges(gctx, stagingOpts); err != nil {
+	if err := ctx.Engine.StageChanges(gctx, stagingOpts); err != nil {
 		return err
 	}
 

--- a/internal/actions/pop.go
+++ b/internal/actions/pop.go
@@ -58,7 +58,7 @@ func PopAction(ctx *app.Context, _ PopOptions) error {
 	}
 
 	// Check how many changes are staged
-	hasStaged, err := eng.Git().HasStagedChanges(ctx.Context)
+	hasStaged, err := eng.HasStagedChanges(ctx.Context)
 	if err == nil && hasStaged {
 		out.Info("Popped branch %s. Changes are now staged on %s.",
 			style.ColorBranchName(currentBranch, false),

--- a/internal/actions/pop.go
+++ b/internal/actions/pop.go
@@ -43,7 +43,7 @@ func PopAction(ctx *app.Context, _ PopOptions) error {
 
 	// Soft reset to parent - this uncommits the current branch's changes
 	// and stages them, keeping the working tree unchanged
-	if err := eng.Git().SoftReset(ctx.Context, parentRev); err != nil {
+	if err := eng.SoftReset(ctx.Context, parentRev); err != nil {
 		return fmt.Errorf("failed to reset to parent: %w", err)
 	}
 

--- a/internal/actions/pop.go
+++ b/internal/actions/pop.go
@@ -23,8 +23,8 @@ func PopAction(ctx *app.Context, _ PopOptions) error {
 		validation.MustBeOnBranch(eng),
 		validation.CurrentBranchMustNotBeTrunk(eng, "pop"),
 		validation.CurrentBranchMustBeTracked(eng),
-		validation.MustNotHaveRebaseInProgress(ctx.Context, ctx.Git()),
-		validation.MustNotHaveUncommittedChanges(ctx.Context, ctx.Git()),
+		validation.MustNotHaveRebaseInProgress(ctx.Context, eng),
+		validation.MustNotHaveUncommittedChanges(ctx.Context, eng),
 	}).Validate(); err != nil {
 		return err
 	}

--- a/internal/actions/reorder.go
+++ b/internal/actions/reorder.go
@@ -24,8 +24,8 @@ func ReorderAction(ctx *app.Context) error {
 	// Pre-checks using validation chain
 	if err := (validation.Chain{
 		validation.MustBeOnBranch(eng),
-		validation.MustNotHaveRebaseInProgress(gctx, ctx.Git()),
-		validation.MustNotHaveUncommittedChanges(gctx, ctx.Git()),
+		validation.MustNotHaveRebaseInProgress(gctx, eng),
+		validation.MustNotHaveUncommittedChanges(gctx, eng),
 		validation.CurrentBranchMustNotBeTrunk(eng, "reorder"),
 	}).Validate(); err != nil {
 		out.Debug("reorder: validation failed: %v", err)

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -159,7 +159,7 @@ func RestackAction(ctx *app.Context, plan *RestackPlan, handler handlers.Restack
 		interactiveRererePrompt = false
 	}
 	pauser, _ := handler.(rerere.Pauser)
-	if _, err := rerere.EnsureEnabled(ctx.Context, ctx.Git(), interactiveRererePrompt, pauser); err != nil {
+	if _, err := rerere.EnsureEnabled(ctx.Context, ctx.Engine, interactiveRererePrompt, pauser); err != nil {
 		out.Warn("Failed to enable git rerere: %v", err)
 	}
 

--- a/internal/actions/state.go
+++ b/internal/actions/state.go
@@ -96,18 +96,17 @@ func BuildState(ctx *app.Context, _ StateOptions) StateResult {
 	}
 
 	// In-progress operation + conflicts.
-	g := eng.Git()
 	op := OperationStatus{Kind: "none", ConflictedFiles: []string{}}
 	switch {
-	case g.IsRebaseInProgress(ctx.Context):
+	case eng.IsRebaseInProgress(ctx.Context):
 		op.Kind = "rebase"
 		op.InProgress = true
-	case g.IsMergeInProgress(ctx.Context):
+	case eng.IsMergeInProgress(ctx.Context):
 		op.Kind = "merge"
 		op.InProgress = true
 	}
 	if op.InProgress {
-		files, err := g.GetUnmergedFiles(ctx.Context)
+		files, err := eng.GetUnmergedFiles(ctx.Context)
 		if err != nil {
 			ctx.Output.Debug("state: failed to list unmerged files: %v", err)
 		} else {

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -642,7 +642,7 @@ func pushMetadataRefs(ctx *app.Context, branches engine.Branches) error {
 	// Push stack metadata refs for any stacks that have branches being submitted
 	stackIDs := ctx.Engine.GetStackIDsForBranches(branches)
 	if len(stackIDs) > 0 {
-		if err := ctx.Git().PushStackMetaRefs(ctx.Context, stackIDs); err != nil {
+		if err := ctx.Engine.PushStackMetadata(ctx.Context, stackIDs); err != nil {
 			ctx.Output.Debug("Failed to push stack metadata refs: %v", err)
 			// Non-fatal: stack metadata push failure shouldn't fail the submit
 		}

--- a/internal/actions/submit/submit_validation.go
+++ b/internal/actions/submit/submit_validation.go
@@ -18,7 +18,7 @@ func ValidateBranchesToSubmit(ctx *app.Context, branches []string) error {
 	nav := ctx.Navigator()
 
 	// Sync PR info first
-	repoOwner, repoName, err := ctx.Git().GetRepoInfo(ctx.Context)
+	repoOwner, repoName, err := ctx.Engine.GetRepoInfo(ctx.Context)
 	if err != nil {
 		return err
 	}

--- a/internal/actions/submit/submit_validation.go
+++ b/internal/actions/submit/submit_validation.go
@@ -23,7 +23,7 @@ func ValidateBranchesToSubmit(ctx *app.Context, branches []string) error {
 		return err
 	}
 	if repoOwner != "" && repoName != "" {
-		if err := github.SyncPrInfo(ctx.Context, ctx.Git(), branches, repoOwner, repoName, func(name string, prInfo *github.PullRequestInfo) {
+		if err := github.SyncPrInfo(ctx.Context, ctx.Git(), branches, repoOwner, repoName, func(name string, prInfo *github.PullRequestInfo) { //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
 			branch := nav.GetBranch(name)
 
 			// Preserve existing locked status

--- a/internal/actions/sync/branch_sync.go
+++ b/internal/actions/sync/branch_sync.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/getstackit/stackit/internal/app"
-	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // syncStackBranches pulls stack branches that are behind their remote counterparts.
@@ -80,7 +80,7 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, handler H
 
 		// Pull the branch
 		pullStart := time.Now()
-		result, err := ctx.Git().PullBranch(gctx, remote, branchName)
+		result, err := eng.PullBranch(gctx, remote, branchName)
 		ctx.Logger.Info("pull branch completed branch=%v durationMs=%v", branchName, time.Since(pullStart).Milliseconds())
 
 		if err != nil {
@@ -97,7 +97,7 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, handler H
 		}
 
 		switch result {
-		case git.PullDone:
+		case engine.PullDone:
 			// Get the new revision
 			rev, _ := branch.GetRevision()
 			revShort := rev
@@ -112,7 +112,7 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, handler H
 				NewRevision: revShort,
 			})
 
-		case git.PullUnneeded:
+		case engine.PullUnneeded:
 			// Already up to date (shouldn't happen since we checked Behind(), but handle it)
 			handler.EmitEvent(Event{
 				Phase:  PhaseBranches,
@@ -120,7 +120,7 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, handler H
 				Branch: branchName,
 			})
 
-		case git.PullConflict:
+		case engine.PullConflict:
 			// Branches have diverged
 			summary.ConflictBranches = append(summary.ConflictBranches, branchName)
 			handler.EmitEvent(Event{

--- a/internal/actions/sync/github_sync.go
+++ b/internal/actions/sync/github_sync.go
@@ -54,7 +54,7 @@ func syncGitHubPRInfo(ctx *app.Context) (*GitHubSyncResult, error) {
 
 	// Sync PR info from GitHub (this is already parallelized internally)
 	syncPrStart := time.Now()
-	if err := github.SyncPrInfo(gctx, ctx.Git(), branchNames, repoOwner, repoName, func(name string, prInfo *github.PullRequestInfo) {
+	if err := github.SyncPrInfo(gctx, ctx.Git(), branchNames, repoOwner, repoName, func(name string, prInfo *github.PullRequestInfo) { //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
 		result.mu.Lock()
 		result.PRInfos[name] = prInfo
 		result.mu.Unlock()

--- a/internal/actions/sync/stack_metadata_gc.go
+++ b/internal/actions/sync/stack_metadata_gc.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"github.com/getstackit/stackit/internal/app"
-	"github.com/getstackit/stackit/internal/git"
 )
 
 // StackMetadataGCResult contains the results of stack metadata garbage collection.
@@ -59,12 +58,9 @@ func gcOrphanedStackMetadata(ctx *app.Context) *StackMetadataGCResult {
 	// per-orphan DeleteStackMeta loop spawned 2 git subprocesses per ref
 	// (update-ref -d + show-ref --verify) — same N+1 pattern fixed for branch
 	// deletion. If the atomic batch fails, fall back to per-ref so partial
-	// progress is still reported.
-	refs := make([]string, 0, len(orphaned))
-	for _, stackID := range orphaned {
-		refs = append(refs, git.StackMetaRefName(stackID))
-	}
-	if err := ctx.Git().DeleteRefsBatch(ctx.Context, refs); err != nil {
+	// progress is still reported. The engine owns the stack-ref name format, so
+	// we pass stack IDs rather than building ref names here.
+	if err := ctx.Engine.DeleteStackMetadataBatch(ctx.Context, orphaned); err != nil {
 		ctx.Logger.Debug("batch delete of local stack refs failed, falling back per-ref error=%v", err)
 		for _, stackID := range orphaned {
 			if perRefErr := ctx.Engine.DeleteStackMetadata(ctx.Context, stackID); perRefErr != nil {

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -260,7 +260,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	pauser, _ := handler.(rerere.Pauser)
-	if _, err := rerere.EnsureEnabled(gctx, ctx.Git(), ctx.Interactive && !ctx.Quiet && handler.IsInteractive(), pauser); err != nil {
+	if _, err := rerere.EnsureEnabled(gctx, ctx.Engine, ctx.Interactive && !ctx.Quiet && handler.IsInteractive(), pauser); err != nil {
 		out.Warn("Failed to enable git rerere: %v", err)
 	}
 

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -66,7 +66,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	managedWorktrees, err := eng.ListManagedWorktrees()
 	if err == nil {
 		for _, wt := range managedWorktrees {
-			if hasChanges, _ := eng.Git().WorktreeHasUncommittedChanges(gctx, wt.Path); hasChanges {
+			if hasChanges, _ := eng.WorktreeHasUncommittedChanges(gctx, wt.Path); hasChanges {
 				if dirtyAnchors == nil {
 					dirtyAnchors = make(map[string]bool)
 				}

--- a/internal/actions/undo/undo.go
+++ b/internal/actions/undo/undo.go
@@ -126,14 +126,14 @@ func Action(ctx *app.Context, opts Options, h Handler) error {
 	// Abort any in-progress Git operations that might interfere with restoration
 	if eng.IsRebaseInProgress(ctx.Context) {
 		h.OnStep("Aborting in-progress rebase before undo...", handler.StatusStarted)
-		if err := eng.Git().RebaseAbort(ctx.Context); err != nil {
+		if err := eng.RebaseAbort(ctx.Context); err != nil {
 			return fmt.Errorf("failed to abort rebase: %w", err)
 		}
 		h.OnStep("Aborted in-progress rebase", handler.StatusCompleted)
 	}
-	if eng.Git().IsMergeInProgress(ctx.Context) {
+	if eng.IsMergeInProgress(ctx.Context) {
 		h.OnStep("Aborting in-progress merge before undo...", handler.StatusStarted)
-		if err := eng.Git().MergeAbort(ctx.Context); err != nil {
+		if err := eng.MergeAbort(ctx.Context); err != nil {
 			return fmt.Errorf("failed to abort merge: %w", err)
 		}
 		h.OnStep("Aborted in-progress merge", handler.StatusCompleted)

--- a/internal/actions/undo/undo.go
+++ b/internal/actions/undo/undo.go
@@ -124,7 +124,7 @@ func Action(ctx *app.Context, opts Options, h Handler) error {
 	}
 
 	// Abort any in-progress Git operations that might interfere with restoration
-	if eng.Git().IsRebaseInProgress(ctx.Context) {
+	if eng.IsRebaseInProgress(ctx.Context) {
 		h.OnStep("Aborting in-progress rebase before undo...", handler.StatusStarted)
 		if err := eng.Git().RebaseAbort(ctx.Context); err != nil {
 			return fmt.Errorf("failed to abort rebase: %w", err)

--- a/internal/actions/validation/chains.go
+++ b/internal/actions/validation/chains.go
@@ -2,9 +2,15 @@ package validation
 
 import (
 	"context"
-
-	"github.com/getstackit/stackit/internal/git"
 )
+
+// GitOperationEngine is the engine contract needed by the git-state chains:
+// branch validation plus git-state reads. engine.Engine satisfies it, so
+// callers pass the engine rather than the raw git runner.
+type GitOperationEngine interface {
+	BranchValidationEngine
+	GitStateReader
+}
 
 // ModifyBranchChain validates for simple branch modifications (rename, scope).
 // Checks: on branch, not trunk, modifiable.
@@ -18,24 +24,24 @@ func ModifyBranchChain(eng BranchValidationEngine, operation string) Chain {
 
 // GitOperationChain validates for git history modifications (fold, pop, reorder).
 // Checks: on branch, not trunk, tracked, no rebase in progress, no uncommitted changes, modifiable.
-func GitOperationChain(ctx context.Context, eng BranchValidationEngine, g git.Runner, operation string) Chain {
+func GitOperationChain(ctx context.Context, eng GitOperationEngine, operation string) Chain {
 	return Chain{
 		MustBeOnBranch(eng),
 		CurrentBranchMustNotBeTrunk(eng, operation),
 		CurrentBranchMustBeTracked(eng),
-		MustNotHaveRebaseInProgress(ctx, g),
-		MustNotHaveUncommittedChanges(ctx, g),
+		MustNotHaveRebaseInProgress(ctx, eng),
+		MustNotHaveUncommittedChanges(ctx, eng),
 		CurrentBranchMustBeModifiable(eng),
 	}
 }
 
 // AbsorbChain validates for absorb operations (works with staged changes).
 // Checks: on branch, not trunk, modifiable, no rebase in progress.
-func AbsorbChain(ctx context.Context, eng BranchValidationEngine, g git.Runner, operation string) Chain {
+func AbsorbChain(ctx context.Context, eng GitOperationEngine, operation string) Chain {
 	return Chain{
 		MustBeOnBranch(eng),
 		CurrentBranchMustNotBeTrunk(eng, operation),
 		CurrentBranchMustBeModifiable(eng),
-		MustNotHaveRebaseInProgress(ctx, g),
+		MustNotHaveRebaseInProgress(ctx, eng),
 	}
 }

--- a/internal/actions/validation/chains_test.go
+++ b/internal/actions/validation/chains_test.go
@@ -43,7 +43,7 @@ func TestGitOperationChain(t *testing.T) {
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithLinearStack3().Checkout("b")
 
-		chain := validation.GitOperationChain(s.Context.Context, s.Engine, s.Context.Git(), "fold")
+		chain := validation.GitOperationChain(s.Context.Context, s.Engine, "fold")
 		err := chain.Validate()
 		require.NoError(t, err)
 	})
@@ -53,7 +53,7 @@ func TestGitOperationChain(t *testing.T) {
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithLinearStack3().Checkout("main")
 
-		chain := validation.GitOperationChain(s.Context.Context, s.Engine, s.Context.Git(), "fold")
+		chain := validation.GitOperationChain(s.Context.Context, s.Engine, "fold")
 		err := chain.Validate()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "trunk")
@@ -64,7 +64,7 @@ func TestGitOperationChain(t *testing.T) {
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithLinearStack3().Checkout("b").WithUncommittedChange("dirty")
 
-		chain := validation.GitOperationChain(s.Context.Context, s.Engine, s.Context.Git(), "fold")
+		chain := validation.GitOperationChain(s.Context.Context, s.Engine, "fold")
 		err := chain.Validate()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "uncommitted")
@@ -79,7 +79,7 @@ func TestAbsorbChain(t *testing.T) {
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithLinearStack3().Checkout("b")
 
-		chain := validation.AbsorbChain(s.Context.Context, s.Engine, s.Context.Git(), "absorb into")
+		chain := validation.AbsorbChain(s.Context.Context, s.Engine, "absorb into")
 		err := chain.Validate()
 		require.NoError(t, err)
 	})
@@ -89,7 +89,7 @@ func TestAbsorbChain(t *testing.T) {
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithLinearStack3().Checkout("main")
 
-		chain := validation.AbsorbChain(s.Context.Context, s.Engine, s.Context.Git(), "absorb into")
+		chain := validation.AbsorbChain(s.Context.Context, s.Engine, "absorb into")
 		err := chain.Validate()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "trunk")

--- a/internal/actions/validation/validators.go
+++ b/internal/actions/validation/validators.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/errors"
-	"github.com/getstackit/stackit/internal/git"
 )
 
 // Validator validates a single precondition.
@@ -55,6 +54,17 @@ type BranchValidationEngine interface {
 	AllBranches() engine.Branches
 }
 
+// GitStateReader is the minimal git-state contract the git-aware validators
+// need. engine.Engine satisfies it, so callers pass the engine instead of the
+// raw git runner — keeping validation in the domain layer rather than reaching
+// through Engine.Git().
+type GitStateReader interface {
+	IsRebaseInProgress(ctx context.Context) bool
+	HasUncommittedChanges(ctx context.Context) bool
+	HasStagedChanges(ctx context.Context) (bool, error)
+	GetRevisionForName(branchName string) (string, error)
+}
+
 // MustBeOnBranch validates that HEAD is on a branch (not detached).
 // Returns a Validator that checks the engine's current branch state.
 func MustBeOnBranch(eng BranchValidationEngine) Validator {
@@ -65,14 +75,17 @@ func MustBeOnBranch(eng BranchValidationEngine) Validator {
 }
 
 // MustNotHaveRebaseInProgress validates that no rebase operation is in progress.
-func MustNotHaveRebaseInProgress(ctx context.Context, g git.Runner) Validator {
+func MustNotHaveRebaseInProgress(ctx context.Context, g GitStateReader) Validator {
 	return ValidatorFunc(func() error {
-		return g.CheckRebaseInProgress(ctx)
+		if g.IsRebaseInProgress(ctx) {
+			return fmt.Errorf("a rebase is already in progress. Please finish or abort it first")
+		}
+		return nil
 	})
 }
 
 // MustNotHaveUncommittedChanges validates that there are no uncommitted changes.
-func MustNotHaveUncommittedChanges(ctx context.Context, g git.Runner) Validator {
+func MustNotHaveUncommittedChanges(ctx context.Context, g GitStateReader) Validator {
 	return ValidatorFunc(func() error {
 		if g.HasUncommittedChanges(ctx) {
 			return fmt.Errorf("cannot perform operation with uncommitted changes; please commit or stash them first")
@@ -82,7 +95,7 @@ func MustNotHaveUncommittedChanges(ctx context.Context, g git.Runner) Validator 
 }
 
 // MustHaveStagedChanges validates that there are staged changes ready to commit.
-func MustHaveStagedChanges(ctx context.Context, g git.Runner) Validator {
+func MustHaveStagedChanges(ctx context.Context, g GitStateReader) Validator {
 	return ValidatorFunc(func() error {
 		hasStagedChanges, err := g.HasStagedChanges(ctx)
 		if err != nil {
@@ -96,10 +109,10 @@ func MustHaveStagedChanges(ctx context.Context, g git.Runner) Validator {
 }
 
 // BranchMustExist validates that a branch exists in git.
-// Uses git.Runner to check if the branch ref exists.
-func BranchMustExist(g git.Runner, branchName string) Validator {
+// Checks that the branch ref resolves to a revision.
+func BranchMustExist(g GitStateReader, branchName string) Validator {
 	return ValidatorFunc(func() error {
-		_, err := g.GetRevision(branchName)
+		_, err := g.GetRevisionForName(branchName)
 		if err != nil {
 			return fmt.Errorf("branch %s does not exist", branchName)
 		}

--- a/internal/actions/worktree/entry.go
+++ b/internal/actions/worktree/entry.go
@@ -76,12 +76,12 @@ func inspectWorktreeEntry(ctx *app.Context, wt engine.WorktreeInfo, graph *engin
 	}
 
 	if entry.Exists {
-		currentBranch, err := ctx.Git().GetWorktreeCurrentBranch(ctx.Context, wt.Path)
+		currentBranch, err := ctx.Engine.GetWorktreeCurrentBranch(ctx.Context, wt.Path)
 		if err == nil && currentBranch != "" {
 			entry.CurrentBranch = currentBranch
 		}
 
-		isDirty, err := ctx.Git().WorktreeHasUncommittedChanges(ctx.Context, wt.Path)
+		isDirty, err := ctx.Engine.WorktreeHasUncommittedChanges(ctx.Context, wt.Path)
 		if err == nil {
 			entry.IsDirty = isDirty
 		}

--- a/internal/cli/navigation/trunk.go
+++ b/internal/cli/navigation/trunk.go
@@ -59,10 +59,9 @@ Use --all to see all configured trunk branches, or --add to add an additional tr
 
 // handleAddTrunk adds a new trunk branch
 func handleAddTrunk(ctx *app.Context, trunkName string) error {
-	runner := ctx.Git()
 	repoRoot := ctx.RepoRoot
 	// Verify the branch exists
-	branches, err := runner.GetAllBranchNames(ctx)
+	branches, err := ctx.Engine.GetAllBranchNames(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get branches: %w", err)
 	}

--- a/internal/cli/stack/merge/orchestrate.go
+++ b/internal/cli/stack/merge/orchestrate.go
@@ -83,7 +83,7 @@ func (d *defaultPRMergeAPI) mergePR(ctx context.Context, branchName string, meth
 //     - "not enabled on repo" + no wait → error with --wait suggestion.
 func orchestrateMerge(ctx *app.Context, opts orchestrateMergeOptions) (Outcome, error) {
 	api := &defaultPRMergeAPI{client: ctx.GitHub()}
-	return doOrchestrateMerge(ctx.Context, ctx.Output, ctx.Engine.Git(), api, opts)
+	return doOrchestrateMerge(ctx.Context, ctx.Output, ctx.Engine.Git(), api, opts) //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
 }
 
 // doOrchestrateMerge contains the core merge orchestration logic, accepting a prMergeAPI

--- a/internal/cli/stack/merge/ship.go
+++ b/internal/cli/stack/merge/ship.go
@@ -371,7 +371,7 @@ func runMultiStackShip(ctx *app.Context, opts shipMultiStackOptions) error {
 				out.Warn("Could not determine merge method: %v", methodErr)
 				out.Tip("Enable automerge manually on the PR: %s", result.PRURL)
 			} else {
-				if err := github.EnableAutoMerge(ctx.Context, ctx.Engine.Git(), prNodeID, github.EnableAutoMergeOptions{MergeMethod: mergeMethod}); err != nil {
+				if err := github.EnableAutoMerge(ctx.Context, ctx.Engine.Git(), prNodeID, github.EnableAutoMergeOptions{MergeMethod: mergeMethod}); err != nil { //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
 					out.Warn("Could not enable automerge: %v", err)
 					out.Tip("Enable automerge manually on the PR: %s", result.PRURL)
 				} else {

--- a/internal/cli/stack/sync.go
+++ b/internal/cli/stack/sync.go
@@ -154,7 +154,7 @@ func syncDryRunJSON(ctx *app.Context, opts sync.Options) error {
 	managedWorktrees, err := eng.ListManagedWorktrees()
 	if err == nil {
 		for _, wt := range managedWorktrees {
-			if hasChanges, _ := eng.Git().WorktreeHasUncommittedChanges(ctx.Context, wt.Path); hasChanges {
+			if hasChanges, _ := eng.WorktreeHasUncommittedChanges(ctx.Context, wt.Path); hasChanges {
 				result.SkippedStacks = append(result.SkippedStacks, wt.AnchorBranch)
 			}
 		}

--- a/internal/engine/branch_mutations.go
+++ b/internal/engine/branch_mutations.go
@@ -31,6 +31,22 @@ func (e *engineImpl) ResetMerge(ctx context.Context, revision string) error {
 	return e.git.ResetMerge(ctx, revision)
 }
 
+// SoftReset moves HEAD to the given revision, keeping the index and working
+// tree intact (git reset --soft).
+func (e *engineImpl) SoftReset(ctx context.Context, revision string) error {
+	return e.git.SoftReset(ctx, revision)
+}
+
+// RebaseAbort aborts an in-progress rebase, restoring the pre-rebase HEAD.
+func (e *engineImpl) RebaseAbort(ctx context.Context) error {
+	return e.git.RebaseAbort(ctx)
+}
+
+// MergeAbort aborts an in-progress merge, restoring the pre-merge state.
+func (e *engineImpl) MergeAbort(ctx context.Context) error {
+	return e.git.MergeAbort(ctx)
+}
+
 // Merge merges a revision into the current branch
 func (e *engineImpl) Merge(ctx context.Context, revision string, opts MergeOptions) error {
 	return e.git.Merge(ctx, revision, git.MergeOptions{

--- a/internal/engine/commit_ops.go
+++ b/internal/engine/commit_ops.go
@@ -35,6 +35,11 @@ func (e *engineImpl) StageHunks(ctx context.Context, hunks []git.Hunk) error {
 	return e.git.StageHunks(ctx, hunks)
 }
 
+// StageChanges stages changes according to the given staging options.
+func (e *engineImpl) StageChanges(ctx context.Context, opts git.StagingOptions) error {
+	return e.git.StageChanges(ctx, opts)
+}
+
 // StashPush pushes current changes to the stash
 func (e *engineImpl) StashPush(ctx context.Context, message string) (string, error) {
 	return e.git.StashPush(ctx, message)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -225,6 +225,7 @@ type Engine interface {
 	RemoteFetcher
 	WorktreeRegistry
 	MetadataInspector
+	GitConfig
 	Git() git.Runner
 
 	// SnapshotForWorktree creates a deep copy of engine state for initializing

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -220,6 +220,7 @@ type Engine interface {
 	RemoteMetadataManager
 	RemoteFetcher
 	WorktreeRegistry
+	MetadataInspector
 	Git() git.Runner
 
 	// SnapshotForWorktree creates a deep copy of engine state for initializing

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -99,6 +99,12 @@ type RemoteMetadataManager interface {
 	// PushMetadataForBranches pushes the metadata refs for the given branch
 	// names to origin.
 	PushMetadataForBranches(ctx context.Context, branchNames []string) error
+	// DeleteRemoteMetadataForBranches pushes ref-deletions for the given
+	// branches' metadata refs to origin.
+	DeleteRemoteMetadataForBranches(ctx context.Context, branchNames []string) error
+	// PushStackMetadata pushes the stack-metadata refs for the given stack IDs
+	// to origin.
+	PushStackMetadata(ctx context.Context, stackIDs []string) error
 	// ConfigureStackMetadataSync adds the stack-metadata refspec to the configured remote.
 	ConfigureStackMetadataSync(ctx context.Context) error
 	// FetchStackMetadata fetches stack-metadata refs from the configured remote.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -36,6 +36,7 @@ type PRManager interface {
 type SyncManager interface {
 	// Sync operations
 	PullTrunk(ctx context.Context) (PullResult, error)
+	PullBranch(ctx context.Context, remote, branchName string) (PullResult, error)
 	UpdateTrunkFromRemote(ctx context.Context) (PullResult, error)
 	ResetTrunkToRemote(ctx context.Context) error
 	PlanRestack(ctx context.Context, branches Branches) (*RestackPlan, error)
@@ -113,6 +114,9 @@ type RemoteMetadataManager interface {
 	ListStackMetadata() (map[string]string, error)
 	// DeleteStackMetadata removes a single local stack-metadata ref.
 	DeleteStackMetadata(ctx context.Context, stackID string) error
+	// DeleteStackMetadataBatch removes the local stack-metadata refs for the
+	// given stack IDs in a single batched ref update.
+	DeleteStackMetadataBatch(ctx context.Context, stackIDs []string) error
 	// DeleteRemoteStackMetadata pushes ref-deletions for the given stack IDs.
 	DeleteRemoteStackMetadata(ctx context.Context, stackIDs []string) error
 	// GetStackIDsForBranches returns the unique stack IDs for the given branches.

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -255,6 +255,16 @@ func (e *engineImpl) GetUserName(ctx context.Context) (string, error) {
 	return e.git.GetUserName(ctx)
 }
 
+// GetConfig reads a git configuration value.
+func (e *engineImpl) GetConfig(key string) (string, error) {
+	return e.git.GetConfig(key)
+}
+
+// SetConfig writes a git configuration value.
+func (e *engineImpl) SetConfig(key, value string) error {
+	return e.git.SetConfig(key, value)
+}
+
 // GetAllBranchNames returns the names of all local branches, including ones not
 // tracked by stackit.
 func (e *engineImpl) GetAllBranchNames(ctx context.Context) ([]string, error) {

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -245,6 +245,16 @@ func (e *engineImpl) GetRepoInfo(ctx context.Context) (string, string, error) {
 	return e.git.GetRepoInfo(ctx)
 }
 
+// GetRepoRoot returns the absolute path to the repository root.
+func (e *engineImpl) GetRepoRoot() string {
+	return e.git.GetRepoRoot()
+}
+
+// GetUserName returns the configured git user.name.
+func (e *engineImpl) GetUserName(ctx context.Context) (string, error) {
+	return e.git.GetUserName(ctx)
+}
+
 // IsInsideRepo checks if the current directory is inside a git repository
 func (e *engineImpl) IsInsideRepo() bool {
 	return e.git.IsInsideRepo()

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -225,6 +225,11 @@ func (e *engineImpl) IsRebaseInProgress(ctx context.Context) bool {
 	return e.git.IsRebaseInProgress(ctx)
 }
 
+// IsMergeInProgress checks if a merge is in progress
+func (e *engineImpl) IsMergeInProgress(ctx context.Context) bool {
+	return e.git.IsMergeInProgress(ctx)
+}
+
 // GetRebaseHead returns the current rebase head
 func (e *engineImpl) GetRebaseHead() (string, error) {
 	return e.git.GetRebaseHead()

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -72,6 +72,11 @@ func (e *engineImpl) HasUntrackedFiles(ctx context.Context) (bool, error) {
 	return e.git.HasUntrackedFiles(ctx)
 }
 
+// GetUntrackedFiles returns the paths of untracked files in the working tree.
+func (e *engineImpl) GetUntrackedFiles(ctx context.Context) ([]string, error) {
+	return e.git.GetUntrackedFiles(ctx)
+}
+
 // GetWorkingTreeStatus returns staged, unstaged, and untracked status in a
 // single git status --porcelain call instead of three separate subprocesses.
 func (e *engineImpl) GetWorkingTreeStatus(ctx context.Context) (staged, unstaged, untracked bool, err error) {

--- a/internal/engine/engine_git_ops.go
+++ b/internal/engine/engine_git_ops.go
@@ -255,6 +255,37 @@ func (e *engineImpl) GetUserName(ctx context.Context) (string, error) {
 	return e.git.GetUserName(ctx)
 }
 
+// GetAllBranchNames returns the names of all local branches, including ones not
+// tracked by stackit.
+func (e *engineImpl) GetAllBranchNames(ctx context.Context) ([]string, error) {
+	return e.git.GetAllBranchNames(ctx)
+}
+
+// ListMetadataRefs returns a map of branch name to metadata-ref SHA for every
+// stackit metadata ref, including refs whose branches no longer exist.
+func (e *engineImpl) ListMetadataRefs() (map[string]string, error) {
+	return e.git.ListMetadata()
+}
+
+// ReadMetadataRaw reads a single branch's metadata directly from its ref,
+// bypassing the engine's tracked-branch cache.
+func (e *engineImpl) ReadMetadataRaw(branchName string) (*git.Meta, error) {
+	return e.git.ReadMetadata(branchName)
+}
+
+// BatchReadMetadataRaw reads raw metadata for many branches in one pass,
+// returning per-branch errors so callers can detect corrupted refs.
+func (e *engineImpl) BatchReadMetadataRaw(branchNames []string) (map[string]*git.Meta, map[string]error) {
+	return e.git.BatchReadMetadata(branchNames)
+}
+
+// DeleteMetadataRef deletes a single branch's metadata ref directly, without
+// the transactional rebuild performed by DeleteMetadata. Intended for pruning
+// orphaned refs whose branches no longer exist.
+func (e *engineImpl) DeleteMetadataRef(ctx context.Context, branchName string) error {
+	return e.git.DeleteMetadata(ctx, branchName)
+}
+
 // IsInsideRepo checks if the current directory is inside a git repository
 func (e *engineImpl) IsInsideRepo() bool {
 	return e.git.IsInsideRepo()

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -47,6 +47,18 @@ func (e *engineImpl) ForceRemoveWorktree(ctx context.Context, path string) error
 	return e.git.ForceRemoveWorktree(ctx, path)
 }
 
+// GetWorktreeCurrentBranch returns the branch currently checked out in the
+// worktree at worktreePath.
+func (e *engineImpl) GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error) {
+	return e.git.GetWorktreeCurrentBranch(ctx, worktreePath)
+}
+
+// WorktreeHasUncommittedChanges reports whether the worktree at worktreePath has
+// staged, unstaged, or untracked changes.
+func (e *engineImpl) WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error) {
+	return e.git.WorktreeHasUncommittedChanges(ctx, worktreePath)
+}
+
 // PruneWorktrees removes stale worktree entries from .git/worktrees.
 // This cleans up worktree information for worktrees whose working directory
 // has been deleted or is otherwise unavailable.

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -19,6 +19,10 @@ type StackNavigator interface {
 	BranchesDepthFirst(startBranch Branch) iter.Seq2[Branch, int]
 	SortBranchesTopologically(branches Branches) Branches
 	FindBranchForCommit(commitSHA string) (string, error)
+	// GetAllBranchNames returns the names of all local branches, including ones
+	// not tracked by stackit. Used by diagnostics that must see untracked or
+	// orphaned branches.
+	GetAllBranchNames(ctx context.Context) ([]string, error)
 	// FindNearestNonExcludedAncestor walks the parent chain from startParent
 	// and returns the first ancestor for which isExcluded returns false. Falls
 	// back to trunk if every ancestor up the chain is excluded.
@@ -284,6 +288,28 @@ type BranchWriter interface {
 	CommitOperations
 	WorktreeOperations
 	Initializer
+}
+
+// MetadataInspector exposes raw, below-abstraction reads of the stackit branch
+// metadata-ref store. It is the low-level escape valve for diagnostic and
+// repair commands (doctor, debug) that must observe metadata the engine's
+// tracked-branch view cannot see — orphaned, corrupted, or untracked-branch
+// refs. Prefer the higher-level branch accessors for normal flows; reach for
+// this only when raw ref access is genuinely required.
+type MetadataInspector interface {
+	// ListMetadataRefs returns a map of branch name to metadata-ref SHA for
+	// every stackit metadata ref, including refs whose branches no longer exist.
+	ListMetadataRefs() (map[string]string, error)
+	// ReadMetadataRaw reads a single branch's metadata directly from its ref,
+	// bypassing the engine's tracked-branch cache.
+	ReadMetadataRaw(branchName string) (*git.Meta, error)
+	// BatchReadMetadataRaw reads raw metadata for many branches in one pass,
+	// returning per-branch errors so callers can detect corrupted refs.
+	BatchReadMetadataRaw(branchNames []string) (map[string]*git.Meta, map[string]error)
+	// DeleteMetadataRef deletes a single branch's metadata ref directly, without
+	// the transactional rebuild performed by DeleteMetadata. Intended for
+	// pruning orphaned refs whose branches no longer exist.
+	DeleteMetadataRef(ctx context.Context, branchName string) error
 }
 
 // Absorber applies staged hunks to appropriate commits

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -28,6 +28,8 @@ type StackNavigator interface {
 	GetScope(branch Branch) Scope
 	GetRemote() string
 	GetRepoInfo(ctx context.Context) (string, string, error)
+	GetRepoRoot() string
+	GetUserName(ctx context.Context) (string, error)
 	IsInsideRepo() bool
 }
 

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -102,6 +102,7 @@ type WorkingTree interface {
 	HasStagedChanges(ctx context.Context) (bool, error)
 	HasUnstagedChanges(ctx context.Context) (bool, error)
 	HasUntrackedFiles(ctx context.Context) (bool, error)
+	GetUntrackedFiles(ctx context.Context) ([]string, error)
 	// GetWorkingTreeStatus returns all three working-tree flags in one git call.
 	// Prefer this over calling Has* individually when multiple flags are needed.
 	GetWorkingTreeStatus(ctx context.Context) (staged, unstaged, untracked bool, err error)
@@ -224,6 +225,8 @@ type WorktreeOperations interface {
 	AddWorktree(ctx context.Context, path string, branch string, detach bool) error
 	RemoveWorktree(ctx context.Context, path string) error
 	ForceRemoveWorktree(ctx context.Context, path string) error
+	GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error)
+	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)
 	CreateTemporaryWorktree(ctx context.Context, branch string, prefix string) (path string, cleanup func(), err error)
 	// CreateTemporaryWorktreeSkipPrune is like CreateTemporaryWorktree but skips the automatic
 	// PruneWorktrees() call. Use this when creating multiple worktrees in parallel after

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -312,6 +312,14 @@ type MetadataInspector interface {
 	DeleteMetadataRef(ctx context.Context, branchName string) error
 }
 
+// GitConfig provides access to git configuration values. Exposed so helpers
+// that only need config access (e.g. rerere setup) can take the engine instead
+// of the raw git runner.
+type GitConfig interface {
+	GetConfig(key string) (string, error)
+	SetConfig(key, value string) error
+}
+
 // Absorber applies staged hunks to appropriate commits
 type Absorber interface {
 	ApplyHunksToBranch(ctx context.Context, branch Branch, hunksByCommit map[string][]git.Hunk) error

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -114,6 +114,7 @@ type WorkingTree interface {
 	ParseStagedHunks(ctx context.Context) ([]git.Hunk, error)
 	ListWorktrees(ctx context.Context) (git.WorktreeList, error)
 	IsRebaseInProgress(ctx context.Context) bool
+	IsMergeInProgress(ctx context.Context) bool
 	GetRebaseHead() (string, error)
 	HasUncommittedChanges(ctx context.Context) bool
 	CheckoutPaths(ctx context.Context, branch string, pathspecs []string) error
@@ -202,10 +203,13 @@ type BranchMutations interface {
 	CreateBranch(ctx context.Context, branchName string, startPoint string) error
 	ResetHard(ctx context.Context, revision string) error
 	ResetMerge(ctx context.Context, revision string) error
+	SoftReset(ctx context.Context, revision string) error
 	Merge(ctx context.Context, revision string, opts MergeOptions) error
 	MergeMultiple(ctx context.Context, branches []string, opts MergeOptions) error
 	Fetch(ctx context.Context, remote string, branch string) error
 	InteractiveRebase(ctx context.Context, onto string) error
+	RebaseAbort(ctx context.Context) error
+	MergeAbort(ctx context.Context) error
 }
 
 // CommitOperations handles staging and committing
@@ -215,6 +219,7 @@ type CommitOperations interface {
 	StageAll(ctx context.Context) error
 	StagePatch(ctx context.Context) error
 	StageHunks(ctx context.Context, hunks []git.Hunk) error
+	StageChanges(ctx context.Context, opts git.StagingOptions) error
 	StashPush(ctx context.Context, message string) (string, error)
 	StashPushStaged(ctx context.Context, message string) (string, error)
 	StashPop(ctx context.Context) error

--- a/internal/engine/metadata_transport.go
+++ b/internal/engine/metadata_transport.go
@@ -1,6 +1,10 @@
 package engine
 
-import "context"
+import (
+	"context"
+
+	"github.com/getstackit/stackit/internal/git"
+)
 
 // Metadata transport methods. Engine owns the metadata-ref namespace
 // (refs/stackit/metadata/* and refs/stackit/stacks/*) and is the single point
@@ -70,6 +74,17 @@ func (e *engineImpl) ListStackMetadata() (map[string]string, error) {
 // per-ref fallback in the GC path when the batched ref-update fails.
 func (e *engineImpl) DeleteStackMetadata(ctx context.Context, stackID string) error {
 	return e.git.DeleteStackMeta(ctx, stackID)
+}
+
+// DeleteStackMetadataBatch removes the local stack-metadata refs for the given
+// stack IDs in a single update-ref --stdin batch. The engine owns the
+// stack-ref name format, so callers pass stack IDs rather than raw ref names.
+func (e *engineImpl) DeleteStackMetadataBatch(ctx context.Context, stackIDs []string) error {
+	refs := make([]string, 0, len(stackIDs))
+	for _, stackID := range stackIDs {
+		refs = append(refs, git.StackMetaRefName(stackID))
+	}
+	return e.git.DeleteRefsBatch(ctx, refs)
 }
 
 // DeleteRemoteStackMetadata pushes ref-deletions for the given stack IDs to

--- a/internal/engine/metadata_transport.go
+++ b/internal/engine/metadata_transport.go
@@ -35,6 +35,19 @@ func (e *engineImpl) PushMetadataForBranches(ctx context.Context, branchNames []
 	return e.git.PushMetadataRefs(ctx, branchNames)
 }
 
+// DeleteRemoteMetadataForBranches pushes ref-deletions for the given branches'
+// metadata refs to origin. Best-effort: callers typically treat failure as
+// non-fatal because the remote refs may already be absent.
+func (e *engineImpl) DeleteRemoteMetadataForBranches(ctx context.Context, branchNames []string) error {
+	return e.git.BatchDeleteRemoteMetadataRefs(ctx, branchNames)
+}
+
+// PushStackMetadata pushes the stack-metadata refs for the given stack IDs to
+// origin. A no-op when the list is empty.
+func (e *engineImpl) PushStackMetadata(ctx context.Context, stackIDs []string) error {
+	return e.git.PushStackMetaRefs(ctx, stackIDs)
+}
+
 // ConfigureStackMetadataSync adds the stack-metadata refspec to the configured
 // remote so subsequent git fetches pick up stack-ref changes.
 func (e *engineImpl) ConfigureStackMetadataSync(_ context.Context) error {

--- a/internal/engine/pull.go
+++ b/internal/engine/pull.go
@@ -37,19 +37,20 @@ func (e *engineImpl) UpdateTrunkFromRemote(ctx context.Context) (PullResult, err
 	return e.finishTrunkPull(gitResult)
 }
 
-func (e *engineImpl) finishTrunkPull(gitResult git.PullResult) (PullResult, error) {
-	// Convert git.PullResult to engine.PullResult
-	var result PullResult
-	switch gitResult {
-	case git.PullDone:
-		result = PullDone
-	case git.PullUnneeded:
-		result = PullUnneeded
-	case git.PullConflict:
-		result = PullConflict
-	default:
-		result = PullConflict
+// PullBranch fast-forwards a single branch from its remote counterpart. Unlike
+// PullTrunk it does not rebuild engine state, so it is safe to call in a loop;
+// callers should rebuild once after the batch if downstream reads need the
+// refreshed revisions.
+func (e *engineImpl) PullBranch(ctx context.Context, remote, branchName string) (PullResult, error) {
+	gitResult, err := e.git.PullBranch(ctx, remote, branchName)
+	if err != nil {
+		return PullConflict, err
 	}
+	return pullResultFromGit(gitResult), nil
+}
+
+func (e *engineImpl) finishTrunkPull(gitResult git.PullResult) (PullResult, error) {
+	result := pullResultFromGit(gitResult)
 
 	// Rebuild to refresh branch cache
 	if err := e.rebuild(); err != nil {
@@ -57,6 +58,20 @@ func (e *engineImpl) finishTrunkPull(gitResult git.PullResult) (PullResult, erro
 	}
 
 	return result, nil
+}
+
+// pullResultFromGit maps a git.PullResult onto the engine's PullResult.
+func pullResultFromGit(gitResult git.PullResult) PullResult {
+	switch gitResult {
+	case git.PullDone:
+		return PullDone
+	case git.PullUnneeded:
+		return PullUnneeded
+	case git.PullConflict:
+		return PullConflict
+	default:
+		return PullConflict
+	}
 }
 
 // ResetTrunkToRemote resets trunk to match remote

--- a/internal/rerere/rerere.go
+++ b/internal/rerere/rerere.go
@@ -4,11 +4,18 @@ import (
 	"context"
 	"strings"
 
-	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/tui"
 )
 
 const declinedKey = "stackit.rerere.declined"
+
+// GitConfigurer reads and writes git configuration values. Both git.Runner and
+// engine.Engine satisfy it, so callers can pass the engine rather than reaching
+// for the raw git runner.
+type GitConfigurer interface {
+	GetConfig(key string) (string, error)
+	SetConfig(key, value string) error
+}
 
 // ConfirmFunc prompts the user for a yes/no answer. Matches the signature
 // of tui.PromptConfirm.
@@ -31,21 +38,21 @@ type Pauser interface {
 //
 // If pauser is non-nil, it is paused around the confirmation prompt so a
 // surrounding TUI does not contend for stdin/stdout.
-func EnsureEnabled(ctx context.Context, runner git.Runner, interactive bool, pauser Pauser) (bool, error) {
-	return ensureEnabled(ctx, runner, interactive, pauser, tui.PromptConfirm)
+func EnsureEnabled(ctx context.Context, cfg GitConfigurer, interactive bool, pauser Pauser) (bool, error) {
+	return ensureEnabled(ctx, cfg, interactive, pauser, tui.PromptConfirm)
 }
 
-func ensureEnabled(_ context.Context, runner git.Runner, interactive bool, pauser Pauser, confirm ConfirmFunc) (bool, error) {
-	if configBool(runner, "rerere.enabled") {
-		if !configBool(runner, "rerere.autoupdate") {
-			if err := runner.SetConfig("rerere.autoupdate", "true"); err != nil {
+func ensureEnabled(_ context.Context, cfg GitConfigurer, interactive bool, pauser Pauser, confirm ConfirmFunc) (bool, error) {
+	if configBool(cfg, "rerere.enabled") {
+		if !configBool(cfg, "rerere.autoupdate") {
+			if err := cfg.SetConfig("rerere.autoupdate", "true"); err != nil {
 				return false, err
 			}
 		}
 		return false, nil
 	}
 
-	if configBool(runner, declinedKey) || !interactive {
+	if configBool(cfg, declinedKey) || !interactive {
 		return false, nil
 	}
 
@@ -54,14 +61,14 @@ func ensureEnabled(_ context.Context, runner git.Runner, interactive bool, pause
 		return false, nil //nolint:nilerr // prompt cancel (Ctrl+C) should not error — treat as decline without persisting
 	}
 	if !ok {
-		_ = runner.SetConfig(declinedKey, "true")
+		_ = cfg.SetConfig(declinedKey, "true")
 		return false, nil
 	}
 
-	if err := runner.SetConfig("rerere.enabled", "true"); err != nil {
+	if err := cfg.SetConfig("rerere.enabled", "true"); err != nil {
 		return false, err
 	}
-	if err := runner.SetConfig("rerere.autoupdate", "true"); err != nil {
+	if err := cfg.SetConfig("rerere.autoupdate", "true"); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -75,8 +82,8 @@ func promptWithPause(pauser Pauser, confirm ConfirmFunc, prompt string, defaultV
 	return confirm(prompt, defaultValue)
 }
 
-func configBool(runner git.Runner, key string) bool {
-	value, err := runner.GetConfig(key)
+func configBool(cfg GitConfigurer, key string) bool {
+	value, err := cfg.GetConfig(key)
 	if err != nil {
 		return false
 	}

--- a/internal/shippable/combiner.go
+++ b/internal/shippable/combiner.go
@@ -271,9 +271,8 @@ func (c *Combiner) tryMergeStacks(
 
 		if err != nil {
 			// Abort merge if in progress
-			git := session.Engine.Git()
-			if git.IsMergeInProgress(ctx) {
-				_ = git.MergeAbort(ctx)
+			if session.Engine.IsMergeInProgress(ctx) {
+				_ = session.Engine.MergeAbort(ctx)
 			}
 
 			// Reset to baseline


### PR DESCRIPTION
**Eliminate Engine.Git() escape-hatch: route ops through engine interfaces**

Removes all production uses of `Engine.Git()` — the raw git runner escape-hatch — and routes every git operation through typed engine interfaces instead. A final lint rule locks the door so new escape-hatch uses can't slip back in.

Key changes:
- **Read-only git queries** (#1149): Branch listing, status, and worktree queries in actions routed through new engine interface methods
- **Conflict recovery and staging** (#1150): Cherry-pick abort, stash, and staging operations promoted to engine-level methods
- **Metadata and remote operations** (#1151): Submit, merge, delete, and sync actions use `metadata_transport` and engine-level pull/push helpers
- **MetadataInspector** (#1153): Dedicated escape-hatch for diagnostic/debug commands that legitimately need raw metadata reads, keeping those paths clearly separated
- **Last production uses** (#1154): Sync and pull operations cleaned up
- **Validation package** (#1155): Takes a narrow `EngineState` interface instead of the raw git runner
- **Remaining domain ops** (#1156): Multistack worktree, state, and trunk navigation cleaned up
- **Rerere package** (#1157): Takes a narrow `GitConfigurer` interface instead of the raw git runner
- **Lint enforcement** (#1158): New `forbidigo` rule in `.golangci.yml` blocks any future `Engine.Git()` calls outside the engine package

This PR merges the following changes:

1. **#1149** refactor(actions): route read-only git queries through the engine
2. **#1150** refactor(actions): route conflict recovery and staging through the engine
3. **#1151** refactor(actions): route remaining query and remote-metadata Git() calls through the engine
4. **#1153** refactor(engine): add MetadataInspector for diagnostic raw metadata reads
5. **#1154** refactor: eliminate the last production Engine.Git() escape-hatch uses
6. **#1155** refactor(validation): take engine state interface instead of the raw git runner
7. **#1156** refactor: route remaining domain git operations through the engine
8. **#1157** refactor(rerere): take a narrow GitConfigurer instead of the raw git runner
9. **#1158** chore(lint): guard against new Engine.Git() escape-hatch use

### Stack

```
main
  └─ jonnii/20260604001138/route-read-only-git-queries-through-the-engine (#1149)
    └─ jonnii/20260604001845/route-conflict-recovery-and-staging-through-the (#1150)
      └─ jonnii/20260604002444/route-remaining-query-and-remote-metadata-Git (#1151)
        └─ jonnii/20260604005057/add-MetadataInspector-for-diagnostic-raw-metadata (#1153)
          └─ jonnii/20260604005853/eliminate-the-last-production-Engine.Git (#1154)
            └─ jonnii/20260604083750/take-engine-state-interface-instead-of-the-raw (#1155)
              └─ jonnii/20260604084155/route-remaining-domain-git-operations-through-the (#1156)
                └─ jonnii/20260604234750/take-a-narrow-GitConfigurer-instead-of-the-raw (#1157)
                  └─ jonnii/20260604235205/guard-against-new-Engine.Git-escape-hatch-use (#1158)
```

Stackit-Stack-Size: 9
Stackit-PRs: 1149,1150,1151,1153,1154,1155,1156,1157,1158
