### PR TITLE
refactor(git): collapse the 23 dead sub-interfaces into a single Runner

### DIFF
--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -5,8 +5,16 @@ import (
 	"time"
 )
 
-// RepositoryReader provides read access to repository configuration and state.
-type RepositoryReader interface {
+// Runner defines the interface for git operations used by the engine.
+// This allows the engine to be used with both real git and mock implementations.
+//
+// Runner is a single, monolithic surface: every consumer takes the whole
+// Runner, so the methods are grouped here by section comment rather than split
+// into separate named sub-interfaces (which would imply a narrow-dependency
+// decoupling that nothing actually uses). Consumers that only need a slice of
+// git behavior should define their own narrow interface at the call site.
+type Runner interface {
+	// --- Repository access and configuration ---
 	GetRemote() string
 	GetConfig(key string) (string, error)
 	GetConfigAll(key string) ([]string, error)
@@ -19,19 +27,13 @@ type RepositoryReader interface {
 	IsInsideRepo() bool
 	GetUserName(ctx context.Context) (string, error)
 	GetRepoInfo(ctx context.Context) (string, string, error)
-}
-
-// RepositoryWriter provides write access to repository configuration.
-type RepositoryWriter interface {
 	InitDefaultRepo() error
 	SetConfig(key, value string) error
 	AddConfigValue(key, value string) error
 	EnsureMetadataRefspecConfigured() error
 	EnsureStackMetaRefspecConfigured() error
-}
 
-// RemoteOperations handles interaction with remote repositories.
-type RemoteOperations interface {
+	// --- Remote operations ---
 	FetchRemoteShas(ctx context.Context, remote string) (map[string]string, error)
 	GetRemoteSha(remote, branchName string) (string, error)
 	GetRemoteRevision(branchName string) (string, error)
@@ -49,17 +51,13 @@ type RemoteOperations interface {
 	PushStackMetaRefs(ctx context.Context, stackIDs []string) error
 	FetchStackMetaRefs(ctx context.Context) error
 	DeleteRemoteStackMetaRefs(ctx context.Context, stackIDs []string) error
-}
 
-// BranchReader provides read access to branch information.
-type BranchReader interface {
+	// --- Branch read ---
 	GetCurrentBranch() (string, error)
 	GetAllBranchNames(ctx context.Context) ([]string, error)
 	GetCurrentBranchOrSHA(ctx context.Context) (string, error)
-}
 
-// BranchWriter handles branch lifecycle operations.
-type BranchWriter interface {
+	// --- Branch write ---
 	CheckoutBranch(ctx context.Context, branchName string) error
 	CheckoutBranchForce(ctx context.Context, branchName string) error
 	CheckoutDetached(ctx context.Context, revision string) error
@@ -69,10 +67,8 @@ type BranchWriter interface {
 	DeleteBranch(ctx context.Context, branchName string) error
 	RenameBranch(ctx context.Context, oldName, newName string) error
 	UpdateBranchRef(ctx context.Context, branchName, revision string) error
-}
 
-// CommitReader provides read access to commit and revision information.
-type CommitReader interface {
+	// --- Commit and revision access ---
 	GetRevision(branchName string) (string, error)
 	GetCurrentRevision(ctx context.Context) (string, error)
 	BatchGetRevisions(branchNames []string) (map[string]string, []error)
@@ -90,10 +86,8 @@ type CommitReader interface {
 	GetRecentCommits(ctx context.Context, branchName string, count int) ([]RecentCommit, error)
 	GetCommitTemplate(ctx context.Context) (string, error)
 	GetParentCommitSHA(commitSHA string) (string, error)
-}
 
-// DiffOperations provides access to diff and comparison operations.
-type DiffOperations interface {
+	// --- Diff and comparison ---
 	GetMergeBase(ctx context.Context, rev1, rev2 string) (string, error)
 	GetMergeBaseByRef(ctx context.Context, ref1, ref2 string) (string, error)
 	IsAncestor(ctx context.Context, ancestor, descendant string) (bool, error)
@@ -109,10 +103,8 @@ type DiffOperations interface {
 	// GetDiffBetween returns the raw diff between two refs, without color codes.
 	// This is suitable for parsing into hunks.
 	GetDiffBetween(ctx context.Context, base, head string, files ...string) (string, error)
-}
 
-// StagingOperations handles staging area operations.
-type StagingOperations interface {
+	// --- Staging area ---
 	StageAll(ctx context.Context) error
 	StagePatch(ctx context.Context) error
 	StageTracked(ctx context.Context) error
@@ -125,17 +117,13 @@ type StagingOperations interface {
 	ParseStagedHunks(ctx context.Context) ([]Hunk, error)
 	StageHunks(ctx context.Context, hunks []Hunk) error
 	UnstageAll(ctx context.Context) error
-}
 
-// CommitWriter handles commit creation and modification.
-type CommitWriter interface {
+	// --- Commit creation ---
 	Commit(message string, verbose int, noVerify bool) error
 	CommitWithOptions(opts CommitOptions) error
 	CommitAmendNoEdit(ctx context.Context) error
-}
 
-// RebaseOperations handles rebase operations.
-type RebaseOperations interface {
+	// --- Rebase ---
 	Rebase(ctx context.Context, branchName, upstream, oldUpstream string) (RebaseOutcome, error)
 	RebaseContinue(ctx context.Context) (RebaseOutcome, error)
 	RebaseContinueNoEdit(ctx context.Context) (RebaseOutcome, error)
@@ -144,54 +132,40 @@ type RebaseOperations interface {
 	IsRebaseInProgress(ctx context.Context) bool
 	GetRebaseHead() (string, error)
 	CheckRebaseInProgress(ctx context.Context) error
-}
 
-// MergeOperations handles merge operations.
-type MergeOperations interface {
+	// --- Merge ---
 	Merge(ctx context.Context, branchName string, opts MergeOptions) error
 	MergeMultiple(ctx context.Context, branches []string, opts MergeOptions) error
 	IsMergeInProgress(ctx context.Context) bool
 	MergeAbort(ctx context.Context) error
 	GetUnmergedFiles(ctx context.Context) ([]string, error)
-}
 
-// CherryPickOperations handles cherry-pick operations.
-type CherryPickOperations interface {
+	// --- Cherry-pick ---
 	CherryPick(ctx context.Context, commitSHA, onto string) (string, error)
 	CherryPickSimple(ctx context.Context, commitSHA string) error
 	CherryPickAbort(ctx context.Context) error
-}
 
-// StashOperations handles stash operations.
-type StashOperations interface {
+	// --- Stash ---
 	StashPush(ctx context.Context, message string) (string, error)
 	StashPushStaged(ctx context.Context, message string) (string, error)
 	StashPop(ctx context.Context) error
 	ListStash(ctx context.Context) (string, error)
-}
 
-// ResetOperations handles reset operations.
-type ResetOperations interface {
+	// --- Reset ---
 	HardReset(ctx context.Context, revision string) error
 	ResetMerge(ctx context.Context, revision string) error
 	SoftReset(ctx context.Context, revision string) error
 	MixedReset(ctx context.Context, revision string) error
-}
 
-// PathOperations handles file path operations.
-type PathOperations interface {
+	// --- File paths ---
 	CheckoutPaths(ctx context.Context, branch string, paths []string) error
 	RemovePaths(ctx context.Context, paths []string) error
-}
 
-// PatchOperations handles patch operations.
-type PatchOperations interface {
+	// --- Patches ---
 	ApplyPatch(ctx context.Context, patchFile string, threeWay bool) error
 	CheckCommutation(hunk Hunk, commitSHA, parentSHA string) (bool, error)
-}
 
-// WorktreeOperations handles worktree management.
-type WorktreeOperations interface {
+	// --- Worktree management ---
 	AddWorktree(ctx context.Context, path string, branch string, detach bool) error
 	AddWorktreeWithOptions(ctx context.Context, path string, branch string, detach bool, noCheckout bool) error
 	RemoveWorktree(ctx context.Context, path string) error
@@ -202,25 +176,19 @@ type WorktreeOperations interface {
 	GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error)
 	ResetWorktreeWorkingDir(ctx context.Context, worktreePath string) error
 	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)
-}
 
-// WorktreeRegistryOperations handles stackit-managed worktree tracking (local-only refs).
-type WorktreeRegistryOperations interface {
+	// --- Worktree registry (stackit-managed worktree tracking, local-only refs) ---
 	ReadWorktreeMeta(stackRoot string) (*WorktreeMeta, error)
 	WriteWorktreeMeta(stackRoot string, meta *WorktreeMeta) error
 	DeleteWorktreeMeta(ctx context.Context, stackRoot string) error
 	ListWorktreeMetas() (map[string]*WorktreeMeta, error)
-}
 
-// StatusOperations provides repository status information.
-type StatusOperations interface {
+	// --- Repository status ---
 	GetStatusPorcelain(ctx context.Context) (string, error)
 	GetReflog(ctx context.Context, count int, format string) (string, error)
 	HasUncommittedChanges(ctx context.Context) bool
-}
 
-// RefOperations provides low-level reference operations.
-type RefOperations interface {
+	// --- Low-level references ---
 	GetRef(name string) (string, error)
 	UpdateRef(name, sha string) error
 	UpdateRefWithLog(ctx context.Context, refName, sha, message string) error
@@ -230,10 +198,8 @@ type RefOperations interface {
 	VerifyRef(ctx context.Context, refName string) error
 	DeleteRef(ctx context.Context, name string) error
 	ListRefs(prefix string) (map[string]string, error)
-}
 
-// ObjectOperations provides low-level Git object operations.
-type ObjectOperations interface {
+	// --- Low-level objects ---
 	CreateBlob(content string) (string, error)
 	// CreateBlobsBatch writes N blobs in a single `git hash-object` invocation.
 	// Returns SHAs in input order. For small N (<3) callers should still use
@@ -243,10 +209,8 @@ type ObjectOperations interface {
 	CreateBlobsBatch(ctx context.Context, contents []string) ([]string, error)
 	ReadBlob(sha string) (string, error)
 	CatFile(sha string) (string, error)
-}
 
-// MetadataOperations handles stackit metadata persistence.
-type MetadataOperations interface {
+	// --- Stackit branch metadata persistence ---
 	ReadMetadata(branchName string) (*Meta, error)
 	BatchReadMetadata(branchNames []string) (map[string]*Meta, map[string]error)
 	WriteMetadata(branchName string, meta *Meta) error
@@ -256,33 +220,34 @@ type MetadataOperations interface {
 	ReadLocalMetadata(branchName string) (*LocalMeta, error)
 	BatchReadLocalMetadata(branchNames []string) map[string]*LocalMeta
 	WriteLocalMetadata(branchName string, meta *LocalMeta) error
-
-	// Transaction support methods. The batch forms marshal each entry and
-	// forward to CreateBlobsBatch — call them with len(metas) >= 1 from
-	// engine_writer.go and transaction.go's commit path. ctx is honored for
-	// the underlying git hash-object invocation.
+	// WriteMetadataBlobsBatch and WriteLocalMetadataBlobsBatch marshal each entry
+	// and forward to CreateBlobsBatch — call them with len(metas) >= 1 from
+	// engine_writer.go and transaction.go's commit path. ctx is honored for the
+	// underlying git hash-object invocation.
 	WriteMetadataBlobsBatch(ctx context.Context, metas []*Meta) ([]string, error)
 	WriteLocalMetadataBlobsBatch(ctx context.Context, metas []*LocalMeta) ([]string, error)
 	GetMetadataRefSHA(branchName string) string
 	GetLocalMetadataRefSHA(branchName string) string
-
-	// Cache management
 	ClearMetadataCache()
-
 	// MetadataCacheStats returns cumulative cache hit/miss counts since process start.
 	// Used by tests and instrumentation to verify lazy-load behavior.
 	MetadataCacheStats() MetadataCacheSummary
-}
 
-// StackMetadataOperations handles stack-level metadata persistence.
-// Stack metadata is stored separately from branch metadata and survives branch operations.
-type StackMetadataOperations interface {
+	// --- Stack-level metadata persistence (separate from branch metadata; survives branch operations) ---
 	ReadStackMeta(stackID string) (*StackMeta, error)
 	WriteStackMeta(stackID string, meta *StackMeta) error
 	DeleteStackMeta(ctx context.Context, stackID string) error
 	ListStackMetas() (map[string]string, error)
-
-	// Transaction support methods
 	WriteStackMetaBlob(meta *StackMeta) (string, error)
 	GetStackMetaRefSHA(stackID string) string
+
+	// --- Raw command execution ---
+	RunGitCommandWithContext(ctx context.Context, args ...string) (string, error)
+	RunGitCommandRawWithContext(ctx context.Context, args ...string) (string, error)
+	RunGitCommandWithEnv(ctx context.Context, env []string, args ...string) (string, error)
+	RunGitCommandInteractive(args ...string) error
+	RunGHCommandWithContext(ctx context.Context, args ...string) (string, error)
+
+	// --- Logging ---
+	SetLogger(logger DebugLogger)
 }

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -328,69 +328,6 @@ type MergeOptions struct {
 	Message string
 }
 
-// Runner defines the interface for git operations used by the engine.
-// This allows the engine to be used with both real git and mock implementations.
-//
-// Runner is a composite interface that embeds smaller, focused interfaces for better
-// modularity and testability. Each embedded interface represents a logical grouping
-// of related git operations.
-type Runner interface {
-	// Repository access and configuration
-	RepositoryReader
-	RepositoryWriter
-
-	// Remote operations
-	RemoteOperations
-
-	// Branch operations
-	BranchReader
-	BranchWriter
-
-	// Commit and revision access
-	CommitReader
-
-	// Diff and comparison
-	DiffOperations
-
-	// Staging area
-	StagingOperations
-
-	// Commit creation
-	CommitWriter
-
-	// Advanced git operations
-	RebaseOperations
-	MergeOperations
-	CherryPickOperations
-	StashOperations
-	ResetOperations
-	PathOperations
-	PatchOperations
-
-	// Worktree management
-	WorktreeOperations
-	WorktreeRegistryOperations
-
-	// Repository status
-	StatusOperations
-
-	// Low-level operations
-	RefOperations
-	ObjectOperations
-	MetadataOperations
-	StackMetadataOperations
-
-	// Raw command execution
-	RunGitCommandWithContext(ctx context.Context, args ...string) (string, error)
-	RunGitCommandRawWithContext(ctx context.Context, args ...string) (string, error)
-	RunGitCommandWithEnv(ctx context.Context, env []string, args ...string) (string, error)
-	RunGitCommandInteractive(args ...string) error
-	RunGHCommandWithContext(ctx context.Context, args ...string) (string, error)
-
-	// Logging
-	SetLogger(logger DebugLogger)
-}
-
 // NewRunner returns a standard implementation of Runner that uses the current
 // working directory as its repository root.
 func NewRunner(logger DebugLogger) Runner {


### PR DESCRIPTION

internal/git defined 23 fine-grained interfaces (RepositoryReader,
RebaseOperations, RefOperations, ...) that were referenced zero times as
standalone types — every consumer takes the whole git.Runner. They implied a
narrow-dependency decoupling that nothing uses, and three of them
(BranchReader, BranchWriter, WorktreeOperations) collided by name with
distinct engine interfaces.

Inline all of them into a single Runner interface, grouped by section comment
(the same grouping tracing_runner.go already uses). No method signatures
change, so every implementation and consumer is unaffected; the three
git/engine name collisions are gone.

Consumers that genuinely need a slice of git behavior should define their own
narrow interface at the call site (as validation, rerere, and mergePlanEngine
now do) rather than reviving speculative fine-grained interfaces here.