### PR TITLE
refactor(github): depend on a 2-method GitCommandRunner, not the whole git.Runner

### DIFF
--- a/internal/github/client_real.go
+++ b/internal/github/client_real.go
@@ -7,20 +7,18 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v67/github"
-
-	"github.com/getstackit/stackit/internal/git"
 )
 
 // StackitGitHubClient implements Client using the real GitHub API
 type StackitGitHubClient struct {
 	client *github.Client
-	runner git.Runner
+	runner GitCommandRunner
 	owner  string
 	repo   string
 }
 
 // NewGitHubClient creates a new RealGitHubClient
-func NewGitHubClient(ctx context.Context, runner git.Runner) (*StackitGitHubClient, error) {
+func NewGitHubClient(ctx context.Context, runner GitCommandRunner) (*StackitGitHubClient, error) {
 	token, err := getGitHubToken(runner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get GitHub token: %w", err)

--- a/internal/github/git_runner.go
+++ b/internal/github/git_runner.go
@@ -1,0 +1,13 @@
+package github
+
+import "context"
+
+// GitCommandRunner is the minimal git surface the GitHub integration needs: it
+// reads git config (to resolve the host and token) and executes gh CLI
+// commands. The full git.Runner satisfies it, so callers pass their existing
+// runner; the GitHub package depends only on these two methods rather than the
+// whole git surface.
+type GitCommandRunner interface {
+	GetConfig(key string) (string, error)
+	RunGHCommandWithContext(ctx context.Context, args ...string) (string, error)
+}

--- a/internal/github/pr_info.go
+++ b/internal/github/pr_info.go
@@ -11,12 +11,11 @@ import (
 	"github.com/google/go-github/v67/github"
 	"golang.org/x/oauth2"
 
-	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/utils"
 )
 
 // SyncPrInfo syncs PR information for branches from GitHub
-func SyncPrInfo(ctx context.Context, runner git.Runner, branchNames []string, repoOwner, repoName string, onUpdate func(string, *PullRequestInfo)) error {
+func SyncPrInfo(ctx context.Context, runner GitCommandRunner, branchNames []string, repoOwner, repoName string, onUpdate func(string, *PullRequestInfo)) error {
 	// Get GitHub token
 	token, err := getGitHubToken(runner)
 	if err != nil {
@@ -122,7 +121,7 @@ func createGitHubClient(ctx context.Context, hostname, token string) (*github.Cl
 }
 
 // getGitHubToken gets GitHub token from environment or gh CLI
-func getGitHubToken(runner git.Runner) (string, error) {
+func getGitHubToken(runner GitCommandRunner) (string, error) {
 	// Try environment variable first
 	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
 		// Trim whitespace to handle cases where secrets might have leading/trailing spaces
@@ -229,7 +228,7 @@ func ParseGitHubRemoteURL(remoteURL string) (*RepoInfo, error) {
 }
 
 // getRepoInfoWithHostname gets repository hostname, owner, and name from git remote
-func getRepoInfoWithHostname(_ context.Context, runner git.Runner) (*RepoInfo, error) {
+func getRepoInfoWithHostname(_ context.Context, runner GitCommandRunner) (*RepoInfo, error) {
 	// Get remote URL
 	remoteURL, err := runner.GetConfig("remote.origin.url")
 	if err != nil {

--- a/internal/github/pr_operations.go
+++ b/internal/github/pr_operations.go
@@ -14,8 +14,6 @@ import (
 
 	"github.com/google/go-github/v67/github"
 	"golang.org/x/oauth2"
-
-	"github.com/getstackit/stackit/internal/git"
 )
 
 var (
@@ -108,7 +106,7 @@ func CreatePullRequest(ctx context.Context, client *github.Client, owner, repo s
 
 // UpdatePullRequest updates an existing pull request
 // Returns warnings (non-fatal issues like failed label/assignee additions) and error
-func UpdatePullRequest(ctx context.Context, client *github.Client, runner git.Runner, owner, repo string, prNumber int, opts UpdatePROptions) ([]string, error) {
+func UpdatePullRequest(ctx context.Context, client *github.Client, runner GitCommandRunner, owner, repo string, prNumber int, opts UpdatePROptions) ([]string, error) {
 	var warnings []string
 
 	// Handle draft status changes separately using GraphQL API, as the REST API
@@ -239,7 +237,7 @@ func GetPullRequestByBranch(ctx context.Context, client *github.Client, owner, r
 }
 
 // GetGitHubClient creates a GitHub client with authentication
-func GetGitHubClient(ctx context.Context, runner git.Runner) (*github.Client, string, string, error) {
+func GetGitHubClient(ctx context.Context, runner GitCommandRunner) (*github.Client, string, string, error) {
 	token, err := getGitHubToken(runner)
 	if err != nil {
 		return nil, "", "", fmt.Errorf("failed to get GitHub token: %w", err)
@@ -313,7 +311,7 @@ func MergePullRequest(ctx context.Context, client *github.Client, owner, repo, b
 }
 
 // executeGraphQLQuery executes a GraphQL query and returns the response body
-func executeGraphQLQuery(ctx context.Context, runner git.Runner, query string, variables map[string]any) ([]byte, error) {
+func executeGraphQLQuery(ctx context.Context, runner GitCommandRunner, query string, variables map[string]any) ([]byte, error) {
 	// Get GitHub token
 	token, err := getGitHubToken(runner)
 	if err != nil {
@@ -411,7 +409,7 @@ type EnableAutoMergeOptions struct {
 
 // EnableAutoMerge enables GitHub's auto-merge feature on a PR.
 // This requires the repository to have auto-merge enabled in settings.
-func EnableAutoMerge(ctx context.Context, runner git.Runner, prNodeID string, opts EnableAutoMergeOptions) error {
+func EnableAutoMerge(ctx context.Context, runner GitCommandRunner, prNodeID string, opts EnableAutoMergeOptions) error {
 	// We use two separate mutations because GitHub's GraphQL API treats
 	// `commitBody: null` differently from omitting commitBody entirely.
 	// When omitted, GitHub uses its default commit message (e.g., PR body).
@@ -487,7 +485,7 @@ func EnableAutoMerge(ctx context.Context, runner git.Runner, prNodeID string, op
 }
 
 // DisableAutoMerge disables GitHub's auto-merge feature on a PR.
-func DisableAutoMerge(ctx context.Context, runner git.Runner, prNodeID string) error {
+func DisableAutoMerge(ctx context.Context, runner GitCommandRunner, prNodeID string) error {
 	mutation := `mutation DisableAutoMerge($pullRequestId: ID!) {
 		disablePullRequestAutoMerge(input: {
 			pullRequestId: $pullRequestId
@@ -511,7 +509,7 @@ func DisableAutoMerge(ctx context.Context, runner git.Runner, prNodeID string) e
 }
 
 // GetAutoMergeStatus checks if auto-merge is enabled on a PR and returns its status.
-func GetAutoMergeStatus(ctx context.Context, runner git.Runner, prNodeID string) (*AutoMergeStatus, error) {
+func GetAutoMergeStatus(ctx context.Context, runner GitCommandRunner, prNodeID string) (*AutoMergeStatus, error) {
 	query := `query GetAutoMergeStatus($nodeId: ID!) {
 		node(id: $nodeId) {
 			... on PullRequest {
@@ -606,7 +604,7 @@ func mergeableToMergeStateText(mergeable string) string {
 }
 
 // GetPRMergeableState checks if a PR has merge conflicts.
-func GetPRMergeableState(ctx context.Context, runner git.Runner, prNodeID string) (*PRMergeableState, error) {
+func GetPRMergeableState(ctx context.Context, runner GitCommandRunner, prNodeID string) (*PRMergeableState, error) {
 	query := `query GetPRMergeableState($nodeId: ID!) {
 		node(id: $nodeId) {
 			... on PullRequest {
@@ -652,7 +650,7 @@ func GetPRMergeableState(ctx context.Context, runner git.Runner, prNodeID string
 
 // getPRMergeableStateBasic fetches PR mergeable state without the mergeStateStatus field,
 // used as a fallback for GitHub Enterprise instances that don't support that field.
-func getPRMergeableStateBasic(ctx context.Context, runner git.Runner, prNodeID string) (*PRMergeableState, error) {
+func getPRMergeableStateBasic(ctx context.Context, runner GitCommandRunner, prNodeID string) (*PRMergeableState, error) {
 	query := `query GetPRMergeableState($nodeId: ID!) {
 		node(id: $nodeId) {
 			... on PullRequest {
@@ -693,7 +691,7 @@ func getPRMergeableStateBasic(ctx context.Context, runner git.Runner, prNodeID s
 
 // BatchGetPRMergeableStates checks mergeable state for multiple PRs in a single GraphQL query.
 // Returns a map from node ID to PRMergeableState. If a PR fails to fetch, it won't be in the map.
-func BatchGetPRMergeableStates(ctx context.Context, runner git.Runner, prNodeIDs []string) (map[string]*PRMergeableState, error) {
+func BatchGetPRMergeableStates(ctx context.Context, runner GitCommandRunner, prNodeIDs []string) (map[string]*PRMergeableState, error) {
 	if len(prNodeIDs) == 0 {
 		return make(map[string]*PRMergeableState), nil
 	}
@@ -765,7 +763,7 @@ func BatchGetPRMergeableStates(ctx context.Context, runner git.Runner, prNodeIDs
 
 // batchGetPRMergeableStatesBasic fetches PR mergeable states without the mergeStateStatus field,
 // used as a fallback for GitHub Enterprise instances that don't support that field.
-func batchGetPRMergeableStatesBasic(ctx context.Context, runner git.Runner, prNodeIDs []string) (map[string]*PRMergeableState, error) {
+func batchGetPRMergeableStatesBasic(ctx context.Context, runner GitCommandRunner, prNodeIDs []string) (map[string]*PRMergeableState, error) {
 	queryParts := make([]string, 0, len(prNodeIDs))
 	variables := make(map[string]any, len(prNodeIDs))
 	for i, nodeID := range prNodeIDs {
@@ -824,7 +822,7 @@ func batchGetPRMergeableStatesBasic(ctx context.Context, runner git.Runner, prNo
 
 // WaitForPRMerge polls until a PR is merged or times out.
 // Returns nil if the PR is merged, error otherwise.
-func WaitForPRMerge(ctx context.Context, runner git.Runner, prNodeID string, timeout time.Duration, pollInterval time.Duration) error {
+func WaitForPRMerge(ctx context.Context, runner GitCommandRunner, prNodeID string, timeout time.Duration, pollInterval time.Duration) error {
 	deadline := time.Now().Add(timeout)
 
 	for time.Now().Before(deadline) {
@@ -873,7 +871,7 @@ func WaitForPRMerge(ctx context.Context, runner git.Runner, prNodeID string, tim
 // Returns the final PRMergeableState when ready.
 // Returns ErrPRAlreadyMerged if the PR is merged during polling.
 // Returns an error if the PR is CLOSED, DIRTY (conflicts), times out, or the context is canceled.
-func WaitForMergeable(ctx context.Context, runner git.Runner, prNodeID string, timeout time.Duration, pollInterval time.Duration) (*PRMergeableState, error) {
+func WaitForMergeable(ctx context.Context, runner GitCommandRunner, prNodeID string, timeout time.Duration, pollInterval time.Duration) (*PRMergeableState, error) {
 	deadline := time.Now().Add(timeout)
 
 	for time.Now().Before(deadline) {
@@ -910,7 +908,7 @@ func WaitForMergeable(ctx context.Context, runner git.Runner, prNodeID string, t
 }
 
 // updatePRDraftStatus updates the draft status of a PR using GitHub's GraphQL API
-func updatePRDraftStatus(ctx context.Context, runner git.Runner, pullRequestID string, isDraft bool) error {
+func updatePRDraftStatus(ctx context.Context, runner GitCommandRunner, pullRequestID string, isDraft bool) error {
 	// Determine which mutation to use
 	var mutation string
 	var mutationName string

--- a/internal/github/pr_titles.go
+++ b/internal/github/pr_titles.go
@@ -5,12 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-
-	"github.com/getstackit/stackit/internal/git"
 )
 
 // BatchGetPRTitlesGraphQL fetches PR titles for multiple PR numbers using a single GraphQL query.
-func BatchGetPRTitlesGraphQL(ctx context.Context, runner git.Runner, owner, repo string, prNumbers []int) (map[int]string, error) {
+func BatchGetPRTitlesGraphQL(ctx context.Context, runner GitCommandRunner, owner, repo string, prNumbers []int) (map[int]string, error) {
 	if len(prNumbers) == 0 {
 		return make(map[int]string), nil
 	}

--- a/internal/github/status.go
+++ b/internal/github/status.go
@@ -8,8 +8,6 @@ import (
 	"regexp"
 	"strings"
 	"time"
-
-	"github.com/getstackit/stackit/internal/git"
 )
 
 // Status check constants
@@ -63,7 +61,7 @@ func (s *CheckStatus) IsReady() bool {
 
 // BatchGetPRChecksStatusGraphQL returns the check status for multiple branches using a single GraphQL query.
 // This function fetches both CI check status and PR review decisions in a single request for efficiency.
-func BatchGetPRChecksStatusGraphQL(ctx context.Context, runner git.Runner, owner, repo string, branchNames []string) (map[string]*CheckStatus, error) {
+func BatchGetPRChecksStatusGraphQL(ctx context.Context, runner GitCommandRunner, owner, repo string, branchNames []string) (map[string]*CheckStatus, error) {
 	if len(branchNames) == 0 {
 		return make(map[string]*CheckStatus), nil
 	}


### PR DESCRIPTION

The GitHub integration took the entire ~120-method git.Runner across ~20
functions and the client struct, but only ever calls two methods: GetConfig
(to resolve host/token) and RunGHCommandWithContext (to run gh).

Introduce a local GitCommandRunner interface with exactly those two methods
and use it everywhere the package previously took git.Runner. git.Runner
still satisfies it, so every caller is unchanged and the github package no
longer imports internal/git at all — it's now honest about (and testable
against) its tiny git dependency.

First of several "narrow the shallow git.Runner consumers" changes. The
engine keeps the broad Runner at its own seam, where it genuinely needs it.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1161** 👈
  * **PR #1162**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->