### PR TITLE
refactor(config): branch patterns need a username, not the whole git runner

### DIFF
--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -79,6 +79,13 @@ func (c *Context) Git() git.Runner {
 	return c.Engine.Git()
 }
 
+// GetUserName returns the configured git user name. Forwards to the engine so
+// callers that only need the username (e.g. branch-name patterns) can depend on
+// this instead of the full git runner.
+func (c *Context) GetUserName(ctx context.Context) (string, error) {
+	return c.Engine.GetUserName(ctx)
+}
+
 // GitHub returns the GitHub client, lazily initializing it on first access.
 // If GitHubClient was set directly (e.g. in tests), it is returned immediately.
 // Returns nil if initialization failed; use GitHubError() to get the reason.

--- a/internal/config/branch_pattern.go
+++ b/internal/config/branch_pattern.go
@@ -58,11 +58,12 @@ func (p BranchPattern) WithDefault() BranchPattern {
 	return p
 }
 
-// GitContext is a minimal interface that provides a git runner and context.
-// This matches app.Context but avoids a circular dependency.
+// GitContext is a minimal interface that provides the git user name and a
+// context. This matches app.Context but avoids a circular dependency and keeps
+// branch-name generation from depending on the full git runner.
 type GitContext interface {
 	context.Context
-	Git() git.Runner
+	GetUserName(ctx context.Context) (string, error)
 }
 
 // GetBranchName generates a branch name from the pattern using the provided commit message and optional scope.
@@ -81,7 +82,7 @@ func (p BranchPattern) GetBranchName(ctx GitContext, commitMessage string, scope
 	// Define all available placeholder replacement functions
 	placeholderFuncs := map[string]func() string{
 		"{username}": func() string {
-			username, err := ctx.Git().GetUserName(ctx)
+			username, err := ctx.GetUserName(ctx)
 			if err != nil {
 				// If we can't get username, use empty string (will be sanitized)
 				return ""


### PR DESCRIPTION

config's GitContext required Git() git.Runner but used it only to read the
git user name for the {username} placeholder. Narrow GitContext to require
GetUserName(ctx) instead, and add a GetUserName forwarder to app.Context (it
delegates to the engine, same as the old ctx.Git().GetUserName path — so
behavior is unchanged).

config no longer references git.Runner. Together with the github change, the
only remaining git.Runner consumers are the engine (which genuinely needs the
broad surface) and the cli adapters (which the architecture permits).