### PR TITLE
refactor(actions): render colors via the output layer, not tui/style

### DIFF
--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -11,7 +11,7 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 const (
@@ -279,7 +279,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 		for commitSHA := range branchHunks {
 			handler.OnApply(branch.GetName(), commitSHA[:8])
-			out.Info("Absorbed changes into commit %s in %s", commitSHA[:8], style.ColorBranchName(branch.GetName(), false))
+			out.Info("Absorbed changes into commit %s in %s", commitSHA[:8], output.Branch(branch.GetName(), false))
 		}
 	}
 

--- a/internal/actions/absorb/output.go
+++ b/internal/actions/absorb/output.go
@@ -4,7 +4,6 @@ import (
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/output"
-	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // printDryRunOutput prints what would be absorbed in dry-run mode
@@ -23,10 +22,10 @@ func printDryRunOutput(hunksByCommit map[string][]git.Hunk, unabsorbedHunks []gi
 		branch := eng.GetBranch(branchName)
 		commits, err := branch.GetAllCommits(engine.CommitFormatReadable)
 		if err == nil && len(commits) > 0 {
-			splog.Info("  %s in %s:", commitSHA[:8], style.ColorBranchName(branchName, false))
+			splog.Info("  %s in %s:", commitSHA[:8], output.Branch(branchName, false))
 			splog.Info("    %s", commits[0])
 		} else {
-			splog.Info("  %s in %s:", commitSHA[:8], style.ColorBranchName(branchName, false))
+			splog.Info("  %s in %s:", commitSHA[:8], output.Branch(branchName, false))
 		}
 
 		for _, hunk := range hunks {
@@ -54,7 +53,7 @@ func printAbsorbPlan(hunksByCommit map[string][]git.Hunk, unabsorbedHunks []git.
 			branchName = unknown
 		}
 
-		splog.Info("  Commit %s in %s:", commitSHA[:8], style.ColorBranchName(branchName, false))
+		splog.Info("  Commit %s in %s:", commitSHA[:8], output.Branch(branchName, false))
 		for _, hunk := range hunks {
 			splog.Info("    - %s (lines %d-%d)", hunk.File, hunk.NewStart, hunk.NewStart+hunk.NewCount-1)
 		}

--- a/internal/actions/checkout.go
+++ b/internal/actions/checkout.go
@@ -11,7 +11,6 @@ import (
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/output"
-	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // CheckoutOptions contains options for the checkout command
@@ -81,7 +80,7 @@ func CheckoutAction(ctx *app.Context, opts CheckoutOptions, handler CheckoutHand
 			if currentBranch != nil {
 				currentBranchName = currentBranch.GetName()
 			}
-			out.Info("No branch selected; staying on %s.", style.ColorBranchName(currentBranchName, true))
+			out.Info("No branch selected; staying on %s.", output.Branch(currentBranchName, true))
 			return CheckoutResult{}, nil
 		}
 	}
@@ -89,7 +88,7 @@ func CheckoutAction(ctx *app.Context, opts CheckoutOptions, handler CheckoutHand
 	currentBranch := eng.CurrentBranch()
 	if currentBranch != nil && branchName == currentBranch.GetName() {
 		if !ctx.Quiet {
-			out.Info("Already on %s.", style.ColorBranchName(branchName, true))
+			out.Info("Already on %s.", output.Branch(branchName, true))
 		}
 		return CheckoutResult{}, nil
 	}
@@ -132,7 +131,7 @@ func CheckoutAction(ctx *app.Context, opts CheckoutOptions, handler CheckoutHand
 	}
 	ctx.Logger.Info("branch changed from=%v to=%v", previousBranch, branchName)
 
-	out.Info("Checked out %s.", style.ColorBranchName(branchName, false))
+	out.Info("Checked out %s.", output.Branch(branchName, false))
 
 	// Skip branch info in quiet mode for faster checkout
 	if !ctx.Quiet {
@@ -170,8 +169,8 @@ func printBranchInfo(ctx *app.Context, branch engine.Branch) {
 	if !statuses.IsUpToDate(branch) {
 		parent := branch.GetParentOrTrunk()
 		ctx.Output.Info("This branch has fallen behind %s - you may want to %s.",
-			style.ColorBranchName(parent, false),
-			style.ColorCyan("stackit upstack restack"))
+			output.Branch(parent, false),
+			output.Cyan("stackit upstack restack"))
 		return
 	}
 
@@ -180,9 +179,9 @@ func printBranchInfo(ctx *app.Context, branch engine.Branch) {
 		if !statuses.IsUpToDate(ancestor) {
 			parent := ancestor.GetParentOrTrunk()
 			ctx.Output.Info("The downstack branch %s has fallen behind %s - you may want to %s.",
-				style.ColorBranchName(ancestor.GetName(), false),
-				style.ColorBranchName(parent, false),
-				style.ColorCyan("stackit stack restack"))
+				output.Branch(ancestor.GetName(), false),
+				output.Branch(parent, false),
+				output.Cyan("stackit stack restack"))
 			return
 		}
 	}
@@ -218,7 +217,7 @@ func getWorktreeSwitchInfo(ctx *app.Context, branch engine.Branch, branchName st
 
 		if switchTarget != "" {
 			if targetStack != "" {
-				ctx.Output.Info("Switching to worktree for stack %s.", style.ColorBranchName(targetStack, false))
+				ctx.Output.Info("Switching to worktree for stack %s.", output.Branch(targetStack, false))
 			} else {
 				ctx.Output.Info("Switching to main repository.")
 			}
@@ -240,12 +239,12 @@ func getWorktreeSwitchInfo(ctx *app.Context, branch engine.Branch, branchName st
 
 	if _, err := os.Stat(targetWorktree.Path); os.IsNotExist(err) {
 		ctx.Output.Warn("Worktree for stack %s is registered but path does not exist: %s",
-			style.ColorBranchName(targetStackRoot, false), targetWorktree.Path)
+			output.Branch(targetStackRoot, false), targetWorktree.Path)
 		ctx.Output.Tip("stackit worktree remove %s", targetStackRoot)
 		return "", nil, nil
 	}
 
-	ctx.Output.Info("Switching to worktree for stack %s.", style.ColorBranchName(targetStackRoot, false))
+	ctx.Output.Info("Switching to worktree for stack %s.", output.Branch(targetStackRoot, false))
 	fallbackTips := []string{
 		fmt.Sprintf("cd %s && stackit co %s", targetWorktree.Path, branchName),
 		"For automatic worktree switching, enable shell integration: eval \"$(stackit shell zsh)\"",
@@ -273,7 +272,7 @@ func resolveBranchName(eng engine.Engine, out output.Output, input string) (stri
 	if len(scopeBranches) > 0 {
 		sorted := eng.SortBranchesTopologically(scopeBranches)
 		topmost := sorted[len(sorted)-1].GetName()
-		out.Info("Matched scope %s.", style.ColorDim(input))
+		out.Info("Matched scope %s.", output.Dim(input))
 		return topmost, nil
 	}
 
@@ -281,7 +280,7 @@ func resolveBranchName(eng engine.Engine, out output.Output, input string) (stri
 	names := branchNames.Names()
 	matches := fuzzy.Find(input, names)
 	if len(matches) == 1 {
-		out.Info("Fuzzy matched to %s.", style.ColorBranchName(matches[0].Str, false))
+		out.Info("Fuzzy matched to %s.", output.Branch(matches[0].Str, false))
 		return matches[0].Str, nil
 	} else if len(matches) > 1 {
 		// Multiple matches - return error with suggestions

--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -12,7 +12,6 @@ import (
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/output"
-	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // CleanBranchesOptions contains options for cleaning branches
@@ -453,7 +452,7 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 
 		// Cleanup plan and update parent blockers
 		for _, name := range batchNames {
-			out.Info("Deleted branch %s", style.ColorBranchName(name, false))
+			out.Info("Deleted branch %s", output.Branch(name, false))
 			delete(plan.branches, name)
 
 			parentName := parents[name]
@@ -552,8 +551,8 @@ func reparentBranchIfNecessary(ctx context.Context, branch engine.Branch, plan *
 			return "", fmt.Errorf("failed to set parent for %s: %w", branchName, err)
 		}
 		out.Info("Set parent of %s to %s.",
-			style.ColorBranchName(branchName, false),
-			style.ColorBranchName(newParentName, false))
+			output.Branch(branchName, false),
+			output.Branch(newParentName, false))
 
 		// Remove this branch as a blocker for its old parent in the plan
 		plan.removeBlocker(parentName, branchName)

--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -25,7 +25,7 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/engine"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 var pluralizeClient = pluralize.NewClient()
@@ -383,9 +383,9 @@ func reportRestackResult(ctx *app.Context, branch engine.Branch, result engine.R
 	if result.Reparented {
 		isCurrent := branchName == currentBranchName
 		ctx.Output.Info("Reparented %s from %s to %s (parent was merged/deleted).",
-			style.ColorBranchName(branchName, isCurrent),
-			style.ColorBranchName(result.OldParent, false),
-			style.ColorBranchName(result.NewParent, false))
+			output.Branch(branchName, isCurrent),
+			output.Branch(result.OldParent, false),
+			output.Branch(result.NewParent, false))
 	}
 
 	switch result.Result {
@@ -393,28 +393,28 @@ func reportRestackResult(ctx *app.Context, branch engine.Branch, result engine.R
 		parentName := branch.GetParentOrTrunk()
 		isCurrent := branchName == currentBranchName
 		ctx.Output.Info("Restacked %s on %s.",
-			style.ColorBranchName(branchName, isCurrent),
-			style.ColorBranchName(parentName, false))
+			output.Branch(branchName, isCurrent),
+			output.Branch(parentName, false))
 		if result.RerereResolvedCount > 0 {
 			printRerereResolved(ctx, result.RerereResolvedCount)
 		}
 	case engine.RestackUnneeded:
 		switch {
 		case result.LockReason.IsLocked():
-			ctx.Output.Info("%s locked: %s", style.ColorBranchName(branchName, branchName == currentBranchName), result.LockReason)
+			ctx.Output.Info("%s locked: %s", output.Branch(branchName, branchName == currentBranchName), result.LockReason)
 		case result.Frozen:
-			ctx.Output.Info("%s frozen", style.ColorBranchName(branchName, branchName == currentBranchName))
+			ctx.Output.Info("%s frozen", output.Branch(branchName, branchName == currentBranchName))
 		case !branch.CanModify():
 			if branch.IsLocked() {
-				ctx.Output.Info("%s locked: %s", style.ColorBranchName(branchName, branchName == currentBranchName), branch.GetLockReason())
+				ctx.Output.Info("%s locked: %s", output.Branch(branchName, branchName == currentBranchName), branch.GetLockReason())
 			} else {
-				ctx.Output.Info("%s frozen", style.ColorBranchName(branchName, branchName == currentBranchName))
+				ctx.Output.Info("%s frozen", output.Branch(branchName, branchName == currentBranchName))
 			}
 		case branch.IsTrunk():
-			ctx.Output.Info("%s up to date", style.ColorBranchName(branchName, false))
+			ctx.Output.Info("%s up to date", output.Branch(branchName, false))
 		default:
 			isCurrent := branchName == currentBranchName
-			ctx.Output.Info("%s up to date", style.ColorBranchName(branchName, isCurrent))
+			ctx.Output.Info("%s up to date", output.Branch(branchName, isCurrent))
 		}
 	}
 }
@@ -618,23 +618,23 @@ func PrintConflictStatus(ctx *app.Context, branchName string) error {
 	reader := ctx.Reader()
 	out := ctx.Output
 
-	msg := style.ColorRed(fmt.Sprintf("Hit conflict restacking %s", branchName))
+	msg := output.Red(fmt.Sprintf("Hit conflict restacking %s", branchName))
 	out.Info("%s", msg)
 	out.Newline()
 
 	// Get unmerged files
 	unmergedFiles, err := reader.GetUnmergedFiles(ctx.Context)
 	if err == nil && len(unmergedFiles) > 0 {
-		out.Info("%s", style.ColorYellow("Conflicted files:"))
+		out.Info("%s", output.Yellow("Conflicted files:"))
 		for _, file := range unmergedFiles {
 			sections, sectionErr := conflictMarkerSectionsForFile(ctx.RepoRoot, file)
 			if sectionErr != nil || len(sections) == 0 {
-				out.Info("  %s", style.ColorRed(file))
+				out.Info("  %s", output.Red(file))
 				continue
 			}
 			for _, section := range sections {
 				out.Info("  %s (lines %d-%d)",
-					style.ColorRed(file),
+					output.Red(file),
 					section.StartLine,
 					section.EndLine,
 				)
@@ -650,7 +650,7 @@ func PrintConflictStatus(ctx *app.Context, branchName string) error {
 		if len(rebaseHead) > 7 {
 			rebaseHeadShort = rebaseHead[:7]
 		}
-		msg := style.ColorYellow(fmt.Sprintf("You are here (resolving %s):", rebaseHeadShort))
+		msg := output.Yellow(fmt.Sprintf("You are here (resolving %s):", rebaseHeadShort))
 		out.Info("%s", msg)
 		// Could show log here if needed
 		out.Newline()
@@ -661,15 +661,15 @@ func PrintConflictStatus(ctx *app.Context, branchName string) error {
 		parentBranch = branch.GetParentOrTrunk()
 	}
 
-	out.Info("%s", style.ColorYellow("To resolve:"))
+	out.Info("%s", output.Yellow("To resolve:"))
 	out.Info("  1. Open each conflicted file and remove conflict markers:")
-	out.Info("     %s  (incoming changes from %s)", style.ColorCyan("<<<<<<< HEAD"), parentBranch)
-	out.Info("     %s", style.ColorCyan("======="))
-	out.Info("     %s  (changes from %s)", style.ColorCyan(">>>>>>>"), branchName)
-	out.Info("  2. Stage resolved files: %s", style.ColorCyan("stackit add <file>"))
-	out.Info("  3. Continue the previous Stackit command: %s", style.ColorCyan("stackit continue"))
-	out.Info("  4. Abort and restore the pre-command snapshot: %s", style.ColorCyan("stackit abort"))
-	out.Info("Tip: %s stages all resolved files before continuing.", style.ColorCyan("stackit continue --all"))
+	out.Info("     %s  (incoming changes from %s)", output.Cyan("<<<<<<< HEAD"), parentBranch)
+	out.Info("     %s", output.Cyan("======="))
+	out.Info("     %s  (changes from %s)", output.Cyan(">>>>>>>"), branchName)
+	out.Info("  2. Stage resolved files: %s", output.Cyan("stackit add <file>"))
+	out.Info("  3. Continue the previous Stackit command: %s", output.Cyan("stackit continue"))
+	out.Info("  4. Abort and restore the pre-command snapshot: %s", output.Cyan("stackit abort"))
+	out.Info("Tip: %s stages all resolved files before continuing.", output.Cyan("stackit continue --all"))
 
 	return nil
 }

--- a/internal/actions/config.go
+++ b/internal/actions/config.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/output"
-	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 const valueNotSet = "(not set)"
@@ -41,7 +40,7 @@ func ConfigListAction(repoRoot string, writer io.Writer) error {
 
 	// Format and print
 	var lines []string
-	lines = append(lines, fmt.Sprintf("%s: %s", style.ColorCyan("trunk"), trunk))
+	lines = append(lines, fmt.Sprintf("%s: %s", output.Cyan("trunk"), trunk))
 
 	if len(trunks) > 1 {
 		additionalTrunks := []string{}
@@ -51,39 +50,39 @@ func ConfigListAction(repoRoot string, writer io.Writer) error {
 			}
 		}
 		if len(additionalTrunks) > 0 {
-			lines = append(lines, fmt.Sprintf("%s: %s", style.ColorCyan("trunks"), strings.Join(additionalTrunks, ", ")))
+			lines = append(lines, fmt.Sprintf("%s: %s", output.Cyan("trunks"), strings.Join(additionalTrunks, ", ")))
 		}
 	}
 
-	lines = append(lines, fmt.Sprintf("%s: %s", style.ColorCyan("branch.pattern"), branchPattern))
-	lines = append(lines, fmt.Sprintf("%s: %v", style.ColorCyan("submit.footer"), submitFooter))
-	lines = append(lines, fmt.Sprintf("%s: %s", style.ColorCyan("merge.method"), mergeMethod))
+	lines = append(lines, fmt.Sprintf("%s: %s", output.Cyan("branch.pattern"), branchPattern))
+	lines = append(lines, fmt.Sprintf("%s: %v", output.Cyan("submit.footer"), submitFooter))
+	lines = append(lines, fmt.Sprintf("%s: %s", output.Cyan("merge.method"), mergeMethod))
 
 	// CI settings
 	ciCommand := cfg.CICommand()
 	if ciCommand == "" {
 		ciCommand = valueNotSet
 	}
-	lines = append(lines, fmt.Sprintf("%s: %s", style.ColorCyan("ci.command"), ciCommand))
-	lines = append(lines, fmt.Sprintf("%s: %d", style.ColorCyan("ci.timeout"), cfg.CITimeout()))
+	lines = append(lines, fmt.Sprintf("%s: %s", output.Cyan("ci.command"), ciCommand))
+	lines = append(lines, fmt.Sprintf("%s: %d", output.Cyan("ci.timeout"), cfg.CITimeout()))
 
 	// Undo settings
-	lines = append(lines, fmt.Sprintf("%s: %d", style.ColorCyan("undo.depth"), cfg.UndoStackDepth()))
-	lines = append(lines, fmt.Sprintf("%s: %v", style.ColorCyan("undo.enabled"), cfg.UndoEnabled()))
+	lines = append(lines, fmt.Sprintf("%s: %d", output.Cyan("undo.depth"), cfg.UndoStackDepth()))
+	lines = append(lines, fmt.Sprintf("%s: %v", output.Cyan("undo.enabled"), cfg.UndoEnabled()))
 
 	// Worktree settings
 	worktreeBasePath := cfg.WorktreeBasePath()
 	if worktreeBasePath == "" {
 		worktreeBasePath = valueNotSet
 	}
-	lines = append(lines, fmt.Sprintf("%s: %s", style.ColorCyan("worktree.basePath"), worktreeBasePath))
-	lines = append(lines, fmt.Sprintf("%s: %v", style.ColorCyan("worktree.autoClean"), cfg.WorktreeAutoClean()))
+	lines = append(lines, fmt.Sprintf("%s: %s", output.Cyan("worktree.basePath"), worktreeBasePath))
+	lines = append(lines, fmt.Sprintf("%s: %v", output.Cyan("worktree.autoClean"), cfg.WorktreeAutoClean()))
 
 	// Split settings
-	lines = append(lines, fmt.Sprintf("%s: %s", style.ColorCyan("split.hunkSelector"), cfg.SplitHunkSelector()))
+	lines = append(lines, fmt.Sprintf("%s: %s", output.Cyan("split.hunkSelector"), cfg.SplitHunkSelector()))
 
 	// Concurrency settings
-	lines = append(lines, fmt.Sprintf("%s: %d", style.ColorCyan("maxConcurrency"), cfg.MaxConcurrency()))
+	lines = append(lines, fmt.Sprintf("%s: %d", output.Cyan("maxConcurrency"), cfg.MaxConcurrency()))
 
 	out.Print(strings.Join(lines, "\n"))
 	out.Newline()

--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -8,7 +8,7 @@ import (
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/errors"
 	"github.com/getstackit/stackit/internal/git"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // ContinueOptions contains options for the continue command
@@ -95,7 +95,7 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 		return fmt.Errorf("failed to checkout branch %s: %w", result.BranchName, err)
 	}
 
-	out.Info("Resolved rebase conflict for %s.", style.ColorBranchName(result.BranchName, true))
+	out.Info("Resolved rebase conflict for %s.", output.Branch(result.BranchName, true))
 	if result.RerereResolvedCount > 0 {
 		printRerereResolved(ctx, result.RerereResolvedCount)
 	}

--- a/internal/actions/delete/delete.go
+++ b/internal/actions/delete/delete.go
@@ -9,7 +9,7 @@ import (
 	"github.com/getstackit/stackit/internal/actions/validation"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // Options contains options for deleting branches
@@ -133,7 +133,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) (Result, error) {
 
 	for _, name := range branchNames {
 		handler.OnBranch(name, StatusDeleted, nil)
-		out.Info("Deleted branch %s", style.ColorBranchName(name, false))
+		out.Info("Deleted branch %s", output.Branch(name, false))
 	}
 
 	// Identify stack roots that were deleted (branches whose parent is trunk)
@@ -262,7 +262,7 @@ func cleanupWorktreesForDeletedStacks(ctx *app.Context, deletedStackRoots []stri
 			mainRepoDir = wt.MainRepoDir
 		}
 
-		ctx.Output.Info("Removing worktree for deleted stack %s", style.ColorBranchName(stackRoot, false))
+		ctx.Output.Info("Removing worktree for deleted stack %s", output.Branch(stackRoot, false))
 
 		// Remove worktree directory if it exists
 		if _, statErr := os.Stat(wt.Path); statErr == nil {

--- a/internal/actions/describe/describe.go
+++ b/internal/actions/describe/describe.go
@@ -9,8 +9,8 @@ import (
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/errors"
 	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/tui"
-	"github.com/getstackit/stackit/internal/tui/style"
 	"github.com/getstackit/stackit/internal/utils"
 )
 
@@ -64,7 +64,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		if err := eng.ClearStackDescription(ctx.Context, *currentBranch); err != nil {
 			return fmt.Errorf("failed to clear stack description: %w", err)
 		}
-		out.Info("Cleared stack description for stack rooted at %s.", style.ColorBranchName(stackRoot, false))
+		out.Info("Cleared stack description for stack rooted at %s.", output.Branch(stackRoot, false))
 
 		// Mark stack for PR updates and push metadata
 		if err := markStackAndPushMetadata(ctx, eng, stackRoot); err != nil {
@@ -118,10 +118,10 @@ func applyStackDescription(ctx *app.Context, branch engine.Branch, stackRoot str
 		return fmt.Errorf("failed to set stack description: %w", err)
 	}
 
-	out.Info("Set stack description for stack rooted at %s:", style.ColorBranchName(stackRoot, false))
-	out.Info("  Title: %s", style.ColorDim(desc.Title))
+	out.Info("Set stack description for stack rooted at %s:", output.Branch(stackRoot, false))
+	out.Info("  Title: %s", output.Dim(desc.Title))
 	if displayDesc != "" {
-		out.Info("  Description: %s", style.ColorDim(displayDesc))
+		out.Info("  Description: %s", output.Dim(displayDesc))
 	}
 
 	if err := markStackAndPushMetadata(ctx, eng, stackRoot); err != nil {
@@ -153,11 +153,11 @@ func showDescription(ctx *app.Context, branch engine.Branch, stackRoot string) e
 	desc := ctx.Engine.GetStackDescription(branch)
 
 	if desc == nil || desc.IsEmpty() {
-		out.Info("Stack rooted at %s has no description set.", style.ColorBranchName(stackRoot, false))
+		out.Info("Stack rooted at %s has no description set.", output.Branch(stackRoot, false))
 		return nil
 	}
 
-	out.Info("Stack description for %s:", style.ColorBranchName(stackRoot, false))
+	out.Info("Stack description for %s:", output.Branch(stackRoot, false))
 	out.Info("")
 	out.Info("  Title: %s", desc.Title)
 	if desc.Description != "" {

--- a/internal/actions/flatten/flatten.go
+++ b/internal/actions/flatten/flatten.go
@@ -8,7 +8,7 @@ import (
 	basehandler "github.com/getstackit/stackit/internal/actions/handler"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // Options contains options for the flatten command
@@ -227,9 +227,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 		handler.OnBranchMoved(move.Branch, move.OldParent, move.NewParent)
 		out.Info("  %s: %s -> %s",
-			style.ColorBranchName(move.Branch, false),
-			style.ColorDim(move.OldParent),
-			style.ColorBranchName(move.NewParent, false))
+			output.Branch(move.Branch, false),
+			output.Dim(move.OldParent),
+			output.Branch(move.NewParent, false))
 	}
 
 	handler.OnStep(StepFlattening, basehandler.StatusCompleted, "Parent pointers updated")

--- a/internal/actions/fold/fold.go
+++ b/internal/actions/fold/fold.go
@@ -8,7 +8,7 @@ import (
 	"github.com/getstackit/stackit/internal/actions/validation"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // Options contains options for the fold command
@@ -22,19 +22,19 @@ func showDryRun(ctx *app.Context, current, parent engine.Branch) {
 	eng := ctx.Engine
 	out := ctx.Output
 
-	out.Info("%s", style.ColorYellow("Dry Run: Folding plan"))
-	out.Info("  Fold branch: %s", style.ColorBranchName(current.GetName(), true))
-	out.Info("  Into parent: %s", style.ColorBranchName(parent.GetName(), false))
+	out.Info("%s", output.Yellow("Dry Run: Folding plan"))
+	out.Info("  Fold branch: %s", output.Branch(current.GetName(), true))
+	out.Info("  Into parent: %s", output.Branch(parent.GetName(), false))
 	out.Newline()
 
 	// Show combined commit messages
-	out.Info("%s", style.ColorCyan("Proposed Commit History:"))
+	out.Info("%s", output.Cyan("Proposed Commit History:"))
 	parentCommits, err := parent.GetAllCommits(engine.CommitFormatReadable)
 	if err != nil {
 		out.Debug("Failed to get parent commits for %s: %v", parent.GetName(), err)
 	}
 	for _, commit := range parentCommits {
-		out.Info("  %s", style.ColorDim(commit))
+		out.Info("  %s", output.Dim(commit))
 	}
 
 	currentCommits, err := current.GetAllCommits(engine.CommitFormatReadable)
@@ -47,7 +47,7 @@ func showDryRun(ctx *app.Context, current, parent engine.Branch) {
 	out.Newline()
 
 	// Show combined diff stat
-	out.Info("%s", style.ColorCyan("Combined Diff Stat:"))
+	out.Info("%s", output.Cyan("Combined Diff Stat:"))
 	// Base is parent's parent (or trunk)
 	grandparentName := parent.GetParentOrTrunk()
 	baseRev, err := eng.GetRevision(eng.GetBranch(grandparentName))
@@ -76,7 +76,7 @@ func showDryRun(ctx *app.Context, current, parent engine.Branch) {
 	}
 
 	out.Newline()
-	out.Info("%s", style.ColorDim("No changes were applied."))
+	out.Info("%s", output.Dim("No changes were applied."))
 }
 
 // Action performs the fold operation

--- a/internal/actions/fold/fold_keep.go
+++ b/internal/actions/fold/fold_keep.go
@@ -8,7 +8,6 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/output"
-	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 func foldWithKeep(gctx context.Context, ctx *app.Context, currentBranch, parentBranch engine.Branch, eng engine.Engine, splog output.Output, _ Options) error {
@@ -67,9 +66,9 @@ func foldWithKeep(gctx context.Context, ctx *app.Context, currentBranch, parentB
 	}
 
 	splog.Info("Folded %s into %s (kept %s).",
-		style.ColorBranchName(parentBranch.GetName(), true),
-		style.ColorBranchName(currentBranch.GetName(), false),
-		style.ColorBranchName(currentBranch.GetName(), false))
+		output.Branch(parentBranch.GetName(), true),
+		output.Branch(currentBranch.GetName(), false),
+		output.Branch(currentBranch.GetName(), false))
 
 	// Rebuild graph with fresh engine state after deletion
 	graph = eng.Graph(engine.SortStrategyAlphabetical)

--- a/internal/actions/fold/fold_normal.go
+++ b/internal/actions/fold/fold_normal.go
@@ -8,7 +8,6 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/output"
-	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 func foldNormal(gctx context.Context, ctx *app.Context, currentBranch, parentBranch engine.Branch, eng engine.Engine, splog output.Output, _ Options) error {
@@ -43,8 +42,8 @@ func foldNormal(gctx context.Context, ctx *app.Context, currentBranch, parentBra
 	}
 
 	splog.Info("Folded %s into %s.",
-		style.ColorBranchName(currentBranch.GetName(), true),
-		style.ColorBranchName(parentBranch.GetName(), false))
+		output.Branch(currentBranch.GetName(), true),
+		output.Branch(parentBranch.GetName(), false))
 
 	// Restack all descendants of the parent
 	if len(descendants) > 0 {

--- a/internal/actions/freeze.go
+++ b/internal/actions/freeze.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // FreezeAction freezes the specified branch and all branches downstack of it (recursive parents)
@@ -49,7 +49,7 @@ func FreezeAction(ctx *app.Context, branchName string) error {
 		}
 
 		for _, name := range res.AffectedBranches {
-			out.Info("Frozen %s locally.", style.ColorBranchName(name, name == branchName))
+			out.Info("Frozen %s locally.", output.Branch(name, name == branchName))
 		}
 	}
 

--- a/internal/actions/info.go
+++ b/internal/actions/info.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // SingleBranchInfo represents JSON-serializable info for a single branch (used by info --json)
@@ -104,21 +104,21 @@ func InfoAction(ctx *app.Context, opts InfoOptions) error {
 	isCurrent := branchName == currentBranch.GetName()
 	isTrunk := branch.IsTrunk()
 
-	coloredBranchName := style.ColorBranchNameWithTrunk(branchName, isCurrent, isTrunk)
+	coloredBranchName := output.BranchWithTrunk(branchName, isCurrent, isTrunk)
 
 	if branch.IsLocked() {
-		coloredBranchName += " " + style.IconLocked() + " " + style.ColorDim("(locked)")
+		coloredBranchName += " " + output.IconLocked() + " " + output.Dim("(locked)")
 	}
 	if branch.IsFrozen() {
-		coloredBranchName += " " + style.IconFrozen() + " " + style.ColorDim("(frozen)")
+		coloredBranchName += " " + output.IconFrozen() + " " + output.Dim("(frozen)")
 	}
 
 	if !isTrunk && !branch.IsBranchUpToDate() {
-		coloredBranchName += " " + style.ColorNeedsRestack("(needs restack)")
+		coloredBranchName += " " + output.NeedsRestack("(needs restack)")
 	}
 
 	if scope := branch.GetScope(); !scope.IsNone() {
-		coloredBranchName += " " + style.ColorScope(scope.String())
+		coloredBranchName += " " + output.Scope(scope.String())
 	}
 
 	outputLines = append(outputLines, coloredBranchName)
@@ -134,14 +134,14 @@ func InfoAction(ctx *app.Context, opts InfoOptions) error {
 		} else {
 			markdown = "# " + stackDesc.Title
 		}
-		rendered := style.RenderMarkdown(markdown)
+		rendered := output.RenderMarkdown(markdown)
 		outputLines = append(outputLines, rendered)
 	}
 
 	commitDate, err := branch.GetCommitDate()
 	if err == nil {
 		dateStr := commitDate.Format(time.RFC3339)
-		outputLines = append(outputLines, style.ColorDim(dateStr))
+		outputLines = append(outputLines, output.Dim(dateStr))
 	}
 
 	var prInfo *engine.PrInfo
@@ -155,7 +155,7 @@ func InfoAction(ctx *app.Context, opts InfoOptions) error {
 				outputLines = append(outputLines, prTitleLine)
 			}
 			if prInfo.URL() != "" {
-				outputLines = append(outputLines, style.ColorMagenta(prInfo.URL()))
+				outputLines = append(outputLines, output.Magenta(prInfo.URL()))
 			}
 		}
 	}
@@ -164,15 +164,15 @@ func InfoAction(ctx *app.Context, opts InfoOptions) error {
 	parentBranch := branchObj.GetParent()
 	if parentBranch != nil {
 		outputLines = append(outputLines, "")
-		outputLines = append(outputLines, fmt.Sprintf("%s: %s", style.ColorCyan("Parent"), style.ColorBranchNameWithTrunk(parentBranch.GetName(), false, parentBranch.IsTrunk())))
+		outputLines = append(outputLines, fmt.Sprintf("%s: %s", output.Cyan("Parent"), output.BranchWithTrunk(parentBranch.GetName(), false, parentBranch.IsTrunk())))
 	}
 
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
 	children := graph.ChildBranches(branchObj)
 	if len(children) > 0 {
-		outputLines = append(outputLines, fmt.Sprintf("%s:", style.ColorCyan("Children")))
+		outputLines = append(outputLines, fmt.Sprintf("%s:", output.Cyan("Children")))
 		for _, child := range children {
-			outputLines = append(outputLines, fmt.Sprintf("▸ %s", style.ColorBranchNameWithTrunk(child.GetName(), false, child.IsTrunk())))
+			outputLines = append(outputLines, fmt.Sprintf("▸ %s", output.BranchWithTrunk(child.GetName(), false, child.IsTrunk())))
 		}
 	}
 
@@ -204,7 +204,7 @@ func InfoAction(ctx *app.Context, opts InfoOptions) error {
 		commits, err := branch.GetAllCommits(engine.CommitFormatReadable)
 		if err == nil {
 			for _, commit := range commits {
-				outputLines = append(outputLines, style.ColorDim(commit))
+				outputLines = append(outputLines, output.Dim(commit))
 			}
 		}
 	}
@@ -245,7 +245,7 @@ func InfoAction(ctx *app.Context, opts InfoOptions) error {
 	)
 	if prInfo != nil && (prInfo.State() == prStateMerged || prInfo.State() == prStateClosed) {
 		for i := range outputLines {
-			outputLines[i] = style.ColorDim(outputLines[i])
+			outputLines[i] = output.Dim(outputLines[i])
 		}
 	}
 
@@ -267,15 +267,15 @@ func getPRTitleLine(prInfo *engine.PrInfo) string {
 		prStateClosed = "CLOSED"
 	)
 
-	prNumber := style.ColorPRNumber(*prInfo.Number())
+	prNumber := output.PRNumber(*prInfo.Number())
 
 	switch state {
 	case prStateMerged:
 		return fmt.Sprintf("%s (Merged) %s", prNumber, prInfo.Title())
 	case prStateClosed:
-		return fmt.Sprintf("%s (Abandoned) %s", prNumber, style.ColorDim(prInfo.Title()))
+		return fmt.Sprintf("%s (Abandoned) %s", prNumber, output.Dim(prInfo.Title()))
 	default:
-		prState := style.ColorPRState(state, prInfo.IsDraft())
+		prState := output.PRState(state, prInfo.IsDraft())
 		return fmt.Sprintf("%s %s %s", prNumber, prState, prInfo.Title())
 	}
 }

--- a/internal/actions/lock/lock.go
+++ b/internal/actions/lock/lock.go
@@ -8,7 +8,7 @@ import (
 	"github.com/getstackit/stackit/internal/actions/submit"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // Action locks the specified branch and all branches downstack of it
@@ -80,7 +80,7 @@ func Action(ctx *app.Context, branchName string, handler Handler) error {
 			continue
 		}
 		if b.IsLocked() {
-			out.Info("Branch %s is already locked.", style.ColorBranchName(b.GetName(), b.GetName() == branchName))
+			out.Info("Branch %s is already locked.", output.Branch(b.GetName(), b.GetName() == branchName))
 			continue
 		}
 		branchesToLock = branchesToLock.Append(b)
@@ -97,7 +97,7 @@ func Action(ctx *app.Context, branchName string, handler Handler) error {
 		}
 
 		for _, name := range res.AffectedBranches {
-			out.Info("Locked %s.", style.ColorBranchName(name, name == branchName))
+			out.Info("Locked %s.", output.Branch(name, name == branchName))
 			affectedBranches = append(affectedBranches, name)
 		}
 	}
@@ -163,7 +163,7 @@ func Unlock(ctx *app.Context, branchName string, handler Handler) error {
 			continue
 		}
 		if !b.IsLocked() {
-			out.Info("Branch %s is already unlocked.", style.ColorBranchName(b.GetName(), b.GetName() == branchName))
+			out.Info("Branch %s is already unlocked.", output.Branch(b.GetName(), b.GetName() == branchName))
 			continue
 		}
 		branchesToUnlock = branchesToUnlock.Append(b)
@@ -180,7 +180,7 @@ func Unlock(ctx *app.Context, branchName string, handler Handler) error {
 		}
 
 		for _, name := range res.AffectedBranches {
-			out.Info("Unlocked %s.", style.ColorBranchName(name, name == branchName))
+			out.Info("Unlocked %s.", output.Branch(name, name == branchName))
 			affectedBranches = append(affectedBranches, name)
 		}
 	}

--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -12,9 +12,9 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/tui"
 	"github.com/getstackit/stackit/internal/tui/components/tree"
-	"github.com/getstackit/stackit/internal/tui/style"
 	"github.com/getstackit/stackit/internal/utils"
 )
 
@@ -205,7 +205,7 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 			summaryParts = append(summaryParts, fmt.Sprintf("%d in review", inReviewCount))
 		}
 		stackLines = append(stackLines, "")
-		stackLines = append(stackLines, style.ColorDim(strings.Join(summaryParts, " · ")))
+		stackLines = append(stackLines, output.Dim(strings.Join(summaryParts, " · ")))
 	}
 
 	// Add untracked branches if requested

--- a/internal/actions/modify.go
+++ b/internal/actions/modify.go
@@ -7,7 +7,7 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/utils"
 )
 
@@ -121,9 +121,9 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) error {
 
 	// Log success
 	if opts.CreateCommit {
-		out.Info("Created new commit in %s.", style.ColorBranchName(currentBranch, true))
+		out.Info("Created new commit in %s.", output.Branch(currentBranch, true))
 	} else {
-		out.Info("Amended commit in %s.", style.ColorBranchName(currentBranch, true))
+		out.Info("Amended commit in %s.", output.Branch(currentBranch, true))
 	}
 
 	// Restack upstack branches
@@ -158,8 +158,8 @@ func interactiveRebaseAction(ctx *app.Context, _ ModifyOptions) error {
 	}
 
 	out.Info("Starting interactive rebase for %s onto %s...",
-		style.ColorBranchName(currentBranch.GetName(), true),
-		style.ColorBranchName(parentName, false))
+		output.Branch(currentBranch.GetName(), true),
+		output.Branch(parentName, false))
 
 	// Run interactive rebase
 	if err := eng.InteractiveRebase(gctx, parentName); err != nil {

--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -11,7 +11,6 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/output"
-	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // Options contains options for the move command
@@ -294,7 +293,7 @@ func maybeRename(ctx *app.Context, h Handler, opts Options, plan *movePlan) (boo
 				out.Info("Warning: failed to rename branch: %v", err)
 			} else {
 				h.OnRename(source, newName)
-				out.Info("Renamed branch %s to %s.", style.ColorBranchName(source, false), style.ColorBranchName(newName, true))
+				out.Info("Renamed branch %s to %s.", output.Branch(source, false), output.Branch(newName, true))
 				source = newName
 				sourceBranch = eng.GetBranch(source)
 				return true, source, sourceBranch
@@ -312,9 +311,9 @@ func restackAndMark(ctx *app.Context, plan *movePlan, sourceBranch engine.Branch
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
 
 	out.Info("Moved %s from %s to %s.",
-		style.ColorBranchName(plan.source, true),
-		style.ColorBranchName(plan.oldParentName, false),
-		style.ColorBranchName(plan.onto, false))
+		output.Branch(plan.source, true),
+		output.Branch(plan.oldParentName, false),
+		output.Branch(plan.onto, false))
 
 	branchesToRestack := graph.Range(sourceBranch, engine.StackRange{
 		RecursiveChildren: true,
@@ -370,9 +369,9 @@ func dryRun(ctx *app.Context, source, oldParentName, onto string, sourceBranch e
 	out.Info("Dry-run: showing what would happen without making changes\n")
 
 	// Print move summary
-	out.Info("Move: %s", style.ColorBranchName(source, true))
-	out.Info("  From: %s", style.ColorBranchName(oldParentName, false))
-	out.Info("  To:   %s", style.ColorBranchName(onto, false))
+	out.Info("Move: %s", output.Branch(source, true))
+	out.Info("  From: %s", output.Branch(oldParentName, false))
+	out.Info("  To:   %s", output.Branch(onto, false))
 
 	// Print commits that would be moved
 	if len(commits) > 0 {
@@ -388,21 +387,21 @@ func dryRun(ctx *app.Context, source, oldParentName, onto string, sourceBranch e
 	if len(descNames) > 0 {
 		out.Info("\nDescendant branches to restack (%d):", len(descNames))
 		for _, name := range descNames {
-			out.Info("  • %s", style.ColorBranchName(name, false))
+			out.Info("  • %s", output.Branch(name, false))
 		}
 	}
 
 	// Print validation result
 	out.Info("")
 	if validationErr != nil {
-		out.Info("Validation: %s", style.ColorRed("failed"))
+		out.Info("Validation: %s", output.Red("failed"))
 		out.Info("  Error: %s", validationErr.Error())
 		return fmt.Errorf("validation failed: %w", validationErr)
 	}
 
 	if !validation.Success {
-		out.Info("Validation: %s", style.ColorRed("conflicts detected"))
-		out.Info("  Branch: %s", style.ColorBranchName(validation.FailedBranch, false))
+		out.Info("Validation: %s", output.Red("conflicts detected"))
+		out.Info("  Branch: %s", output.Branch(validation.FailedBranch, false))
 		out.Info("  Error: %s", validation.ErrorMessage)
 		if len(validation.ConflictingFiles) > 0 {
 			out.Info("  Conflicting files:")
@@ -413,7 +412,7 @@ func dryRun(ctx *app.Context, source, oldParentName, onto string, sourceBranch e
 		return fmt.Errorf("move would cause conflicts: %s on branch %s", validation.ErrorMessage, validation.FailedBranch)
 	}
 
-	out.Info("Validation: %s", style.ColorGreen("passed"))
+	out.Info("Validation: %s", output.Green("passed"))
 	out.Info("\nRun without --dry-run to execute the move.")
 	return nil
 }

--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -9,7 +9,7 @@ import (
 	"github.com/getstackit/stackit/internal/actions/validation"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // Options contains options for the pluck command
@@ -188,9 +188,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 			handler.OnChildReparented(child.GetName(), source, grandparentBranch.GetName())
 			reparentedChildren = append(reparentedChildren, child.GetName())
 			out.Info("Reparented %s from %s to %s.",
-				style.ColorBranchName(child.GetName(), false),
-				style.ColorBranchName(source, false),
-				style.ColorBranchName(grandparentBranch.GetName(), false))
+				output.Branch(child.GetName(), false),
+				output.Branch(source, false),
+				output.Branch(grandparentBranch.GetName(), false))
 		}
 
 		handler.OnStep(StepReparentingChild, basehandler.StatusCompleted, "Children reparented")
@@ -211,9 +211,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	out.Info("Plucked %s from %s to %s.",
-		style.ColorBranchName(source, true),
-		style.ColorBranchName(oldParentName, false),
-		style.ColorBranchName(onto, false))
+		output.Branch(source, true),
+		output.Branch(oldParentName, false),
+		output.Branch(onto, false))
 	handler.OnStep(StepMovingSource, basehandler.StatusCompleted, "Source branch moved")
 
 	// Step 3: Restack all affected branches

--- a/internal/actions/pop.go
+++ b/internal/actions/pop.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/actions/validation"
 	"github.com/getstackit/stackit/internal/app"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // PopOptions contains options for the pop command
@@ -61,12 +61,12 @@ func PopAction(ctx *app.Context, _ PopOptions) error {
 	hasStaged, err := eng.HasStagedChanges(ctx.Context)
 	if err == nil && hasStaged {
 		out.Info("Popped branch %s. Changes are now staged on %s.",
-			style.ColorBranchName(currentBranch, false),
-			style.ColorBranchName(parentName, false))
+			output.Branch(currentBranch, false),
+			output.Branch(parentName, false))
 	} else {
 		out.Info("Popped branch %s. Switched to %s.",
-			style.ColorBranchName(currentBranch, false),
-			style.ColorBranchName(parentName, false))
+			output.Branch(currentBranch, false),
+			output.Branch(parentName, false))
 	}
 
 	return nil

--- a/internal/actions/rename.go
+++ b/internal/actions/rename.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/getstackit/stackit/internal/actions/validation"
 	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/tui"
-	"github.com/getstackit/stackit/internal/tui/style"
 	"github.com/getstackit/stackit/internal/utils"
 )
 
@@ -82,7 +82,7 @@ func RenameAction(ctx *app.Context, opts RenameOptions) error {
 		return fmt.Errorf("failed to rename branch: %w", err)
 	}
 
-	out.Info("Renamed %s to %s.", style.ColorBranchName(currentBranch, false), style.ColorBranchName(newName, true))
+	out.Info("Renamed %s to %s.", output.Branch(currentBranch, false), output.Branch(newName, true))
 
 	return nil
 }

--- a/internal/actions/scope/action.go
+++ b/internal/actions/scope/action.go
@@ -8,7 +8,7 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/errors"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // Options contains options for the scope command
@@ -47,14 +47,14 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		switch {
 		case !explicitScope.IsEmpty():
 			if explicitScope.IsNone() {
-				out.Info("Branch %s has scope inheritance DISABLED (explicitly set to '%s').", style.ColorBranchName(currentBranch, false), explicitScope.String())
+				out.Info("Branch %s has scope inheritance DISABLED (explicitly set to '%s').", output.Branch(currentBranch, false), explicitScope.String())
 			} else {
-				out.Info("Branch %s has explicit scope: %s", style.ColorBranchName(currentBranch, false), style.ColorDim(explicitScope.String()))
+				out.Info("Branch %s has explicit scope: %s", output.Branch(currentBranch, false), output.Dim(explicitScope.String()))
 			}
 		case !resolvedScope.IsEmpty():
-			out.Info("Branch %s inherits scope: %s", style.ColorBranchName(currentBranch, false), style.ColorDim(resolvedScope.String()))
+			out.Info("Branch %s inherits scope: %s", output.Branch(currentBranch, false), output.Dim(resolvedScope.String()))
 		default:
-			out.Info("Branch %s has no scope set.", style.ColorBranchName(currentBranch, false))
+			out.Info("Branch %s has no scope set.", output.Branch(currentBranch, false))
 		}
 		return nil
 	}
@@ -67,7 +67,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		if err := eng.SetScopeAndMarkForUpdate(ctx.Context, eng.GetBranch(currentBranch), engine.Empty()); err != nil {
 			return fmt.Errorf("failed to unset scope: %w", err)
 		}
-		out.Info("Unset explicit scope for branch %s. It will now inherit from its parent.", style.ColorBranchName(currentBranch, false))
+		out.Info("Unset explicit scope for branch %s. It will now inherit from its parent.", output.Branch(currentBranch, false))
 		// PR body update flag already set atomically inside SetScopeAndMarkForUpdate.
 		if err := actions.PushMetadataOnly(ctx, eng, []string{currentBranch}); err != nil {
 			out.Debug("Failed to push metadata changes: %v", err)
@@ -94,9 +94,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	if newScope.IsNone() {
-		out.Info("Disabled scope for branch %s (breaks inheritance).", style.ColorBranchName(currentBranch, false))
+		out.Info("Disabled scope for branch %s (breaks inheritance).", output.Branch(currentBranch, false))
 	} else {
-		out.Info("Set scope for branch %s to: %s", style.ColorBranchName(currentBranch, false), style.ColorDim(opts.Scope))
+		out.Info("Set scope for branch %s to: %s", output.Branch(currentBranch, false), output.Dim(opts.Scope))
 
 		// Rename prompt - only if scope changed and branch name contains old scope
 		if oldScope.IsDefined() && !oldScope.Equal(newScope) && strings.Contains(currentBranch, oldScope.String()) {
@@ -106,7 +106,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 				if err := eng.RenameBranch(ctx.Context, eng.GetBranch(currentBranch), eng.GetBranch(newName)); err != nil {
 					out.Info("Warning: failed to rename branch: %v", err)
 				} else {
-					out.Info("Renamed branch %s to %s.", style.ColorBranchName(currentBranch, false), style.ColorBranchName(newName, true))
+					out.Info("Renamed branch %s to %s.", output.Branch(currentBranch, false), output.Branch(newName, true))
 				}
 			}
 		}

--- a/internal/actions/split/split_commit.go
+++ b/internal/actions/split/split_commit.go
@@ -9,7 +9,6 @@ import (
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/tui"
-	"github.com/getstackit/stackit/internal/tui/style"
 	"github.com/getstackit/stackit/internal/utils"
 )
 
@@ -57,12 +56,12 @@ func splitByCommit(ctx *app.Context, branchToSplit string, eng splitByCommitEngi
 	}
 
 	// Show initial info
-	splog.Info("Splitting the commits of %s into multiple branches.", style.ColorBranchName(branchToSplit, true))
+	splog.Info("Splitting the commits of %s into multiple branches.", output.Branch(branchToSplit, true))
 	branch := eng.GetBranch(branchToSplit)
 	prInfo, _ := branch.GetPrInfo()
 	if prInfo != nil && prInfo.Number() != nil {
 		splog.Info("If any of the new branches keeps the name %s, it will be linked to PR #%d.",
-			style.ColorBranchName(branchToSplit, true), *prInfo.Number())
+			output.Branch(branchToSplit, true), *prInfo.Number())
 	}
 	splog.Info("")
 
@@ -173,7 +172,7 @@ func selectSplitPoint(readableCommits []string, branchToSplit string) (int, erro
 		// Skip commit lines - they're not selectable options
 	}
 
-	title := fmt.Sprintf("Select where to split %s (commits above the line stay):", style.ColorBranchName(branchToSplit, true))
+	title := fmt.Sprintf("Select where to split %s (commits above the line stay):", output.Branch(branchToSplit, true))
 	selected, err := tui.PromptSelect(title, options, 0)
 	if err != nil {
 		return 0, err
@@ -220,7 +219,7 @@ func groupRemainingCommits(
 			}
 			existingNames = append(existingNames, name)
 
-			splog.Info("New branch: %s", style.ColorBranchName(name, false))
+			splog.Info("New branch: %s", output.Branch(name, false))
 			splog.Info("  %s", remaining[0])
 			splog.Info("")
 
@@ -262,7 +261,7 @@ func groupRemainingCommits(
 			existingNames = append(existingNames, name)
 
 			if groupSize == 1 {
-				splog.Info("New branch: %s", style.ColorBranchName(name, false))
+				splog.Info("New branch: %s", output.Branch(name, false))
 				splog.Info("  %s", groupReadable[0])
 				splog.Info("")
 			}

--- a/internal/actions/split/split_file.go
+++ b/internal/actions/split/split_file.go
@@ -11,7 +11,6 @@ import (
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/tui"
-	"github.com/getstackit/stackit/internal/tui/style"
 	"github.com/getstackit/stackit/internal/utils"
 )
 
@@ -657,17 +656,17 @@ func promptForFiles(ctx context.Context, branchToSplit engine.Branch, eng splitB
 	}
 
 	// Show instructions based on mode
-	splog.Info("Splitting %s by file.", style.ColorBranchName(branchToSplit.GetName(), true))
+	splog.Info("Splitting %s by file.", output.Branch(branchToSplit.GetName(), true))
 	switch {
 	case asSibling:
 		splog.Info("Select the files to extract to a new sibling branch.")
 		splog.Info("The original branch will remain unchanged.")
 	case direction == DirectionAbove:
 		splog.Info("Select the files to extract to a new child branch.")
-		splog.Info("The remaining files will stay on %s.", style.ColorBranchName(branchToSplit.GetName(), true))
+		splog.Info("The remaining files will stay on %s.", output.Branch(branchToSplit.GetName(), true))
 	default:
 		splog.Info("Select the files to extract to a new parent branch.")
-		splog.Info("The remaining files will stay on %s.", style.ColorBranchName(branchToSplit.GetName(), true))
+		splog.Info("The remaining files will stay on %s.", output.Branch(branchToSplit.GetName(), true))
 	}
 	splog.Info("")
 

--- a/internal/actions/split/split_hunk.go
+++ b/internal/actions/split/split_hunk.go
@@ -15,7 +15,6 @@ import (
 	sterrors "github.com/getstackit/stackit/internal/errors"
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/output"
-	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // hunkOptions contains options for hunk-based splitting
@@ -80,12 +79,12 @@ func splitByHunkWithHandler(ctx *app.Context, branchToSplit engine.Branch, eng s
 	defaultCommitMessage := strings.Join(commitMessages, "\n\n")
 
 	// Show instructions
-	splog.Info("Splitting %s into multiple single-commit branches.", style.ColorBranchName(branchToSplit.GetName(), true))
+	splog.Info("Splitting %s into multiple single-commit branches.", output.Branch(branchToSplit.GetName(), true))
 	branch := eng.GetBranch(branchToSplit.GetName())
 	prInfo, _ := branch.GetPrInfo()
 	if prInfo != nil && prInfo.Number() != nil {
 		splog.Info("If any of the new branches keeps the name %s, it will be linked to PR #%d.",
-			style.ColorBranchName(branchToSplit.GetName(), true), *prInfo.Number())
+			output.Branch(branchToSplit.GetName(), true), *prInfo.Number())
 	}
 	splog.Info("")
 	splog.Info("For each branch you'd like to create:")
@@ -499,7 +498,7 @@ func splitByHunkBelowWithPatch(ctx *app.Context, branchToSplit engine.Branch, en
 		return fmt.Errorf("failed to checkout original branch: %w", err)
 	}
 
-	splog.Info("Created branch %s as parent of %s", style.ColorBranchName(newParentName, true), style.ColorBranchName(branchToSplit.GetName(), true))
+	splog.Info("Created branch %s as parent of %s", output.Branch(newParentName, true), output.Branch(branchToSplit.GetName(), true))
 
 	return nil
 }
@@ -543,10 +542,10 @@ func splitByHunkAbove(ctx *app.Context, branchToSplit engine.Branch, eng splitBy
 
 	// Show instructions (only for interactive mode)
 	if handler != nil {
-		splog.Info("Splitting %s - extracting changes to a new child branch.", style.ColorBranchName(branchToSplit.GetName(), true))
+		splog.Info("Splitting %s - extracting changes to a new child branch.", output.Branch(branchToSplit.GetName(), true))
 		splog.Info("")
 		splog.Info("Stage the changes you want to EXTRACT to the new child branch.")
-		splog.Info("The remaining changes will stay on %s.", style.ColorBranchName(branchToSplit.GetName(), true))
+		splog.Info("The remaining changes will stay on %s.", output.Branch(branchToSplit.GetName(), true))
 		splog.Info("")
 		handler.OnStep(StepStagingHunks, handlerBase.StatusStarted, "Stage changes to extract")
 	}
@@ -834,7 +833,7 @@ func splitByHunkAbove(ctx *app.Context, branchToSplit engine.Branch, eng splitBy
 		})
 	} else {
 		// Non-interactive mode (patch file): print completion message
-		splog.Info("Created branch %s as child of %s", style.ColorBranchName(childBranchName, true), style.ColorBranchName(branchToSplit.GetName(), true))
+		splog.Info("Created branch %s as child of %s", output.Branch(childBranchName, true), output.Branch(branchToSplit.GetName(), true))
 	}
 
 	return nil

--- a/internal/actions/squash.go
+++ b/internal/actions/squash.go
@@ -6,7 +6,7 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/errors"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // SquashOptions contains options for the squash command
@@ -50,7 +50,7 @@ func SquashAction(ctx *app.Context, opts SquashOptions) error {
 		return fmt.Errorf("failed to squash branch: %w", err)
 	}
 
-	out.Info("Squashed commits in %s.", style.ColorBranchName(currentBranch.GetName(), true))
+	out.Info("Squashed commits in %s.", output.Branch(currentBranch.GetName(), true))
 	ctx.Logger.Info("squash completed branch=%v", currentBranch.GetName())
 
 	// Get upstack branches (recursive children only, excluding current branch)

--- a/internal/actions/stack_info.go
+++ b/internal/actions/stack_info.go
@@ -8,8 +8,8 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/tui/components/tree"
-	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // StackBranchInfo represents JSON-serializable info for a single branch in a stack
@@ -139,7 +139,7 @@ func StackInfoAction(ctx *app.Context, opts StackInfoOptions) error {
 			} else {
 				markdown = "# " + stackDesc.Title
 			}
-			rendered := style.RenderMarkdown(markdown)
+			rendered := output.RenderMarkdown(markdown)
 			ctx.Output.Info("%s", rendered)
 			ctx.Output.Info("")
 			ctx.Output.Info(strings.Repeat("─", 40))

--- a/internal/actions/submit/submit_validation.go
+++ b/internal/actions/submit/submit_validation.go
@@ -9,7 +9,7 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/github"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // ValidateBranchesToSubmit validates that branches are ready to submit
@@ -82,19 +82,19 @@ func validateBaseRevisions(branches []string, eng engine.BranchStatus, ctx *app.
 		case parentBranch.IsTrunk():
 			if !branch.IsBranchUpToDate() {
 				ctx.Output.Info("Note that %s has fallen behind trunk. You may encounter conflicts if you attempt to merge it.",
-					style.ColorBranchName(branchName, false))
+					output.Branch(branchName, false))
 			}
 		case validatedBranches[parentBranchName]:
 			// Parent is in the submission list
 			if !branch.IsBranchUpToDate() {
 				return fmt.Errorf("you are trying to submit at least one branch that has not been restacked on its parent. To resolve this, check out %s and run 'stackit restack'",
-					style.ColorBranchName(branchName, false))
+					output.Branch(branchName, false))
 			}
 		default:
 			// Parent is not in submission list
 			if !eng.ReadBranchRemoteStatuses(ctx.Context, engine.BranchesOf(parentBranch)).ForBranch(parentBranch).Matches() {
 				return fmt.Errorf("you are trying to submit at least one branch whose base does not match its parent remotely, without including its parent. You may want to use 'stackit submit --stack' to ensure that the ancestors of %s are included in your submission",
-					style.ColorBranchName(branchName, false))
+					output.Branch(branchName, false))
 			}
 		}
 

--- a/internal/actions/sync/branch_cleaning.go
+++ b/internal/actions/sync/branch_cleaning.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/app"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // cleanBranches handles cleaning merged/closed branches
@@ -91,7 +91,7 @@ func cleanBranches(ctx *app.Context, opts *Options, dirtyAnchors map[string]bool
 				// Utility branch with no unpushed local changes - auto-confirm without prompting.
 				branchesToDelete[name] = true
 				ctx.Output.Info("Auto-deleting utility branch %s (%s)",
-					style.ColorBranchName(name, false), reason)
+					output.Branch(name, false), reason)
 			} else {
 				// Regular branch - add to prompt list
 				branchesToPrompt[name] = reason
@@ -143,13 +143,13 @@ func cleanBranches(ctx *app.Context, opts *Options, dirtyAnchors map[string]bool
 	// Warn about branches that couldn't be deleted from worktree
 	for _, name := range result.SkippedInWorktree {
 		ctx.Output.Warn("Cannot delete %s from worktree. Run sync from the main repository to clean up.",
-			style.ColorBranchName(name, true))
+			output.Branch(name, true))
 	}
 
 	// Warn about branches skipped due to unpushed changes
 	for _, name := range result.SkippedUnpushed {
 		ctx.Output.Warn("Skipped %s — has unpushed local changes. Push first or delete manually with 'git branch -D %s'.",
-			style.ColorBranchName(name, false), name)
+			output.Branch(name, false), name)
 	}
 
 	return result, nil

--- a/internal/actions/sync/github_sync.go
+++ b/internal/actions/sync/github_sync.go
@@ -9,7 +9,7 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/github"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/utils"
 )
 
@@ -229,9 +229,9 @@ func PushParentsToGitHub(ctx *app.Context, result *GitHubSyncResult, dirtyAnchor
 		}
 
 		out.Info("Updated PR base for %s: %s → %s",
-			style.ColorBranchName(u.branchName, false),
-			style.ColorDim(u.oldBase),
-			style.ColorBranchName(u.localParentName, false))
+			output.Branch(u.branchName, false),
+			output.Dim(u.oldBase),
+			output.Branch(u.localParentName, false))
 
 		mu.Lock()
 		updated = append(updated, u.branchName)

--- a/internal/actions/sync/metadata_sync.go
+++ b/internal/actions/sync/metadata_sync.go
@@ -8,7 +8,7 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/errors"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // syncRemoteMetadata fetches and processes remote metadata.
@@ -109,11 +109,11 @@ func handleOrphanedMetadata(ctx *app.Context, opts *Options, handler Handler) er
 		for _, info := range orphaned {
 			switch {
 			case !info.ExistsLocally:
-				out.Info("  %s: local branch gone, would delete metadata", style.ColorBranchName(info.BranchName, false))
+				out.Info("  %s: local branch gone, would delete metadata", output.Branch(info.BranchName, false))
 			case info.HasLocalChanges:
-				out.Info("  %s: has local changes, would prompt", style.ColorBranchName(info.BranchName, false))
+				out.Info("  %s: has local changes, would prompt", output.Branch(info.BranchName, false))
 			default:
-				out.Info("  %s: no local changes, would delete sync state", style.ColorBranchName(info.BranchName, false))
+				out.Info("  %s: no local changes, would delete sync state", output.Branch(info.BranchName, false))
 			}
 		}
 		return nil
@@ -162,7 +162,7 @@ func resolveOrphanedMetadata(ctx *app.Context, info engine.OrphanedMetadataInfo,
 		if err := actions.PushMetadataAndSyncPRs(ctx, []string{info.BranchName}); err != nil {
 			out.Debug("Failed to push metadata: %v", err)
 		} else {
-			out.Info("Pushed metadata for %s", style.ColorBranchName(info.BranchName, false))
+			out.Info("Pushed metadata for %s", output.Branch(info.BranchName, false))
 		}
 	} else {
 		// Accept deletion - remove sync state
@@ -178,7 +178,7 @@ func resolveOrphanedMetadata(ctx *app.Context, info engine.OrphanedMetadataInfo,
 func printMetadataDiffs(diffs []*engine.MetadataDiff, splog interface{ Info(string, ...any) }) {
 	splog.Info("\n=== Metadata changes (dry run) ===")
 	for _, diff := range diffs {
-		splog.Info("\nBranch: %s", style.ColorBranchName(diff.Branch, false))
+		splog.Info("\nBranch: %s", output.Branch(diff.Branch, false))
 		for _, fd := range diff.Differences {
 			splog.Info("  %s: %v → %v", fd.Field, fd.LocalValue, fd.RemoteValue)
 		}

--- a/internal/actions/track/action.go
+++ b/internal/actions/track/action.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/getstackit/stackit/internal/app"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // Options contains options for the track command
@@ -67,7 +67,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 			return fmt.Errorf("failed to track branch: %w", err)
 		}
 
-		ctx.Output.Info("Tracked %s with parent %s.", style.ColorBranchName(branchName, false), style.ColorBranchName(parent, false))
+		ctx.Output.Info("Tracked %s with parent %s.", output.Branch(branchName, false), output.Branch(parent, false))
 		return nil
 	}
 
@@ -86,7 +86,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 			return fmt.Errorf("failed to track branch: %w", err)
 		}
 
-		ctx.Output.Info("Tracked %s with parent %s.", style.ColorBranchName(branchName, false), style.ColorBranchName(parentBranch, false))
+		ctx.Output.Info("Tracked %s with parent %s.", output.Branch(branchName, false), output.Branch(parentBranch, false))
 		return nil
 	}
 
@@ -106,7 +106,7 @@ func trackBranchRecursively(ctx *app.Context, branchName string, handler Handler
 	// Check if branch is already tracked
 	branch := eng.GetBranch(branchName)
 	if branch.IsTracked() {
-		ctx.Output.Info("%s is already tracked.", style.ColorBranchName(branchName, false))
+		ctx.Output.Info("%s is already tracked.", output.Branch(branchName, false))
 		// Still ask if user wants to track descendants
 	} else {
 		// Try auto-detection (single unambiguous non-trunk tracked ancestor)
@@ -118,7 +118,7 @@ func trackBranchRecursively(ctx *app.Context, branchName string, handler Handler
 			// Skip worktree anchors for auto-detection
 			if !candidateBranch.IsWorktreeAnchor() {
 				parentBranch = candidate
-				ctx.Output.Info("Auto-detected parent %s for %s.", style.ColorBranchName(parentBranch, false), style.ColorBranchName(branchName, false))
+				ctx.Output.Info("Auto-detected parent %s for %s.", output.Branch(parentBranch, false), output.Branch(branchName, false))
 			}
 		}
 
@@ -152,7 +152,7 @@ func trackBranchRecursively(ctx *app.Context, branchName string, handler Handler
 			return fmt.Errorf("failed to track branch: %w", err)
 		}
 
-		ctx.Output.Info("Tracked %s with parent %s.", style.ColorBranchName(branchName, false), style.ColorBranchName(parentBranch, false))
+		ctx.Output.Info("Tracked %s with parent %s.", output.Branch(branchName, false), output.Branch(parentBranch, false))
 	}
 
 	// Find untracked children and ask to track them

--- a/internal/actions/unfreeze.go
+++ b/internal/actions/unfreeze.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // UnfreezeAction unfreezes the specified branch and all branches upstack of it (recursive children)
@@ -45,7 +45,7 @@ func UnfreezeAction(ctx *app.Context, branchName string) error {
 		}
 
 		for _, name := range res.AffectedBranches {
-			out.Info("Unfrozen %s locally.", style.ColorBranchName(name, name == branchName))
+			out.Info("Unfrozen %s locally.", output.Branch(name, name == branchName))
 		}
 	}
 

--- a/internal/actions/untrack/action.go
+++ b/internal/actions/untrack/action.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // Options contains options for the untrack command
@@ -60,7 +60,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	for _, name := range allNames {
-		ctx.Output.Info("Stopped tracking %s.", style.ColorBranchName(name, false))
+		ctx.Output.Info("Stopped tracking %s.", output.Branch(name, false))
 	}
 
 	return nil

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -13,7 +13,6 @@ import (
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/output"
-	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 type worktreeSnapshot struct {
@@ -121,13 +120,13 @@ func RemoveAction(ctx *app.Context, opts RemoveOptions) error {
 		return err
 	}
 	if entry.NeedsRepair && (entry.RegistrationState != RegistrationStateInvalid || entry.Exists) {
-		return fmt.Errorf("managed worktree %s cannot be removed because %s; %s", style.ColorBranchName(entry.displayName(), false), style.ColorDim(entry.StatusMessage), repairHint(entry))
+		return fmt.Errorf("managed worktree %s cannot be removed because %s; %s", output.Branch(entry.displayName(), false), output.Dim(entry.StatusMessage), repairHint(entry))
 	}
 	if entry.IsCurrent {
 		return fmt.Errorf("cannot remove the current worktree; cd to the main repo first")
 	}
 	if len(entry.RootBranches) > 0 {
-		return fmt.Errorf("worktree %s has %d branch(es); use 'stackit worktree detach %s' to remove the worktree while keeping branches", style.ColorBranchName(entry.displayName(), false), entry.StackSize, entry.displayName())
+		return fmt.Errorf("worktree %s has %d branch(es); use 'stackit worktree detach %s' to remove the worktree while keeping branches", output.Branch(entry.displayName(), false), entry.StackSize, entry.displayName())
 	}
 	if entry.Exists && entry.IsDirty && !opts.Force {
 		return fmt.Errorf("worktree has uncommitted changes; use --force to discard them")
@@ -188,7 +187,7 @@ func RemoveAction(ctx *app.Context, opts RemoveOptions) error {
 		out.Debug("Deleted anchor branch %s", snapshot.Info.AnchorBranch)
 	}
 
-	out.Success("Removed worktree for stack %s", style.ColorBranchName(snapshot.Info.AnchorBranch, false))
+	out.Success("Removed worktree for stack %s", output.Branch(snapshot.Info.AnchorBranch, false))
 	return nil
 }
 
@@ -305,11 +304,11 @@ func CreateAction(ctx *app.Context, opts CreateOptions) (*CreateResult, error) {
 		return nil, err
 	}
 
-	out.Success("Created worktree %s", style.ColorBranchName(opts.Name, false))
-	out.Info("  Anchor branch: %s", style.ColorBranchName(created.AnchorBranch, false))
-	out.Info("  Path: %s", style.ColorDim(created.Path))
+	out.Success("Created worktree %s", output.Branch(opts.Name, false))
+	out.Info("  Anchor branch: %s", output.Branch(created.AnchorBranch, false))
+	out.Info("  Path: %s", output.Dim(created.Path))
 	if opts.Scope != "" {
-		out.Info("  Scope: %s", style.ColorDim(opts.Scope))
+		out.Info("  Scope: %s", output.Dim(opts.Scope))
 	}
 	out.Newline()
 
@@ -664,15 +663,15 @@ func AttachAction(ctx *app.Context, opts AttachOptions) (*AttachResult, error) {
 	if !branch.IsTracked() {
 		// Check if the branch exists at all
 		if _, err := eng.GetRevision(branch); err != nil {
-			return nil, fmt.Errorf("branch %s does not exist", style.ColorBranchName(opts.Branch, false))
+			return nil, fmt.Errorf("branch %s does not exist", output.Branch(opts.Branch, false))
 		}
-		return nil, fmt.Errorf("branch %s is not tracked by stackit", style.ColorBranchName(opts.Branch, false))
+		return nil, fmt.Errorf("branch %s is not tracked by stackit", output.Branch(opts.Branch, false))
 	}
 
 	// Find the stack root
 	stackRootName := eng.GetStackRootForBranch(branch)
 	if stackRootName == "" {
-		return nil, fmt.Errorf("branch %s is not part of a stack (its parent must be trunk)", style.ColorBranchName(opts.Branch, false))
+		return nil, fmt.Errorf("branch %s is not part of a stack (its parent must be trunk)", output.Branch(opts.Branch, false))
 	}
 	stackRoot := eng.GetBranch(stackRootName)
 	originalParent := eng.Trunk().GetName()
@@ -682,7 +681,7 @@ func AttachAction(ctx *app.Context, opts AttachOptions) (*AttachResult, error) {
 
 	// Validate: stack root is not already a worktree anchor
 	if eng.IsWorktreeAnchor(stackRoot) {
-		return nil, fmt.Errorf("branch %s is already a worktree anchor", style.ColorBranchName(stackRootName, false))
+		return nil, fmt.Errorf("branch %s is already a worktree anchor", output.Branch(stackRootName, false))
 	}
 
 	// Validate: stack root doesn't already have a worktree
@@ -751,10 +750,10 @@ func AttachAction(ctx *app.Context, opts AttachOptions) (*AttachResult, error) {
 		return nil, err
 	}
 
-	out.Success("Attached stack %s to worktree", style.ColorBranchName(stackRootName, false))
-	out.Info("  Name: %s", style.ColorBranchName(name, false))
-	out.Info("  Anchor branch: %s", style.ColorBranchName(created.AnchorBranch, false))
-	out.Info("  Path: %s", style.ColorDim(created.Path))
+	out.Success("Attached stack %s to worktree", output.Branch(stackRootName, false))
+	out.Info("  Name: %s", output.Branch(name, false))
+	out.Info("  Anchor branch: %s", output.Branch(created.AnchorBranch, false))
+	out.Info("  Path: %s", output.Dim(created.Path))
 	out.Newline()
 
 	// Run post-create hooks
@@ -784,7 +783,7 @@ func DetachAction(ctx *app.Context, opts DetachOptions) error {
 		return err
 	}
 	if entry.NeedsRepair {
-		return fmt.Errorf("managed worktree %s cannot be detached because %s; %s", style.ColorBranchName(entry.displayName(), false), style.ColorDim(entry.StatusMessage), repairHint(entry))
+		return fmt.Errorf("managed worktree %s cannot be detached because %s; %s", output.Branch(entry.displayName(), false), output.Dim(entry.StatusMessage), repairHint(entry))
 	}
 
 	// Check if we're currently in this worktree
@@ -872,7 +871,7 @@ func DetachAction(ctx *app.Context, opts DetachOptions) error {
 	}
 	unregistered = true
 
-	out.Success("Detached worktree %s", style.ColorBranchName(snapshot.Info.Name, false))
+	out.Success("Detached worktree %s", output.Branch(snapshot.Info.Name, false))
 	return nil
 }
 func removeWorktreePath(ctx *app.Context, path string, force bool) error {

--- a/internal/actions/worktree/entry.go
+++ b/internal/actions/worktree/entry.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 // ListOptions contains options for the list action
@@ -209,7 +209,7 @@ func findWorktreeByNameOrBranch(ctx *app.Context, nameOrBranch string) (*engine.
 		}
 	}
 
-	return nil, fmt.Errorf("no worktree found for %s", style.ColorBranchName(nameOrBranch, false))
+	return nil, fmt.Errorf("no worktree found for %s", output.Branch(nameOrBranch, false))
 }
 
 func getWorktreeEntry(ctx *app.Context, nameOrBranch string) (*Entry, error) {
@@ -218,7 +218,7 @@ func getWorktreeEntry(ctx *app.Context, nameOrBranch string) (*Entry, error) {
 		return nil, err
 	}
 	if len(result.Worktrees) == 0 {
-		return nil, fmt.Errorf("no worktree found for %s", style.ColorBranchName(nameOrBranch, false))
+		return nil, fmt.Errorf("no worktree found for %s", output.Branch(nameOrBranch, false))
 	}
 	entry := result.Worktrees[0]
 	return &entry, nil

--- a/internal/actions/worktree/repair.go
+++ b/internal/actions/worktree/repair.go
@@ -6,7 +6,7 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
-	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/output"
 )
 
 type RepairOptions struct {
@@ -30,7 +30,7 @@ func RepairAction(ctx *app.Context, opts RepairOptions) (*RepairResult, error) {
 		return nil, err
 	}
 	if opts.NameOrBranch != "" && len(listResult.Worktrees) == 0 {
-		return nil, fmt.Errorf("no worktree found for %s", style.ColorBranchName(opts.NameOrBranch, false))
+		return nil, fmt.Errorf("no worktree found for %s", output.Branch(opts.NameOrBranch, false))
 	}
 
 	result := &RepairResult{
@@ -95,12 +95,12 @@ func repairEntry(ctx *app.Context, entry Entry) (RepairEntry, error) {
 		}
 
 		if entry.CurrentBranch == "" {
-			return RepairEntry{}, fmt.Errorf("cannot repair %s automatically because the worktree has no branch checked out", style.ColorBranchName(entry.displayName(), false))
+			return RepairEntry{}, fmt.Errorf("cannot repair %s automatically because the worktree has no branch checked out", output.Branch(entry.displayName(), false))
 		}
 
 		currentBranch := ctx.Engine.GetBranch(entry.CurrentBranch)
 		if !currentBranch.IsTracked() {
-			return RepairEntry{}, fmt.Errorf("cannot repair %s automatically because %s is not tracked by stackit", style.ColorBranchName(entry.displayName(), false), style.ColorBranchName(entry.CurrentBranch, false))
+			return RepairEntry{}, fmt.Errorf("cannot repair %s automatically because %s is not tracked by stackit", output.Branch(entry.displayName(), false), output.Branch(entry.CurrentBranch, false))
 		}
 
 		stackRootName := ctx.Engine.GetStackRootForBranch(currentBranch)
@@ -109,7 +109,7 @@ func repairEntry(ctx *app.Context, entry Entry) (RepairEntry, error) {
 		}
 		stackRoot := ctx.Engine.GetBranch(stackRootName)
 		if !stackRoot.IsTracked() {
-			return RepairEntry{}, fmt.Errorf("cannot repair %s automatically because no tracked stack root could be determined", style.ColorBranchName(entry.displayName(), false))
+			return RepairEntry{}, fmt.Errorf("cannot repair %s automatically because no tracked stack root could be determined", output.Branch(entry.displayName(), false))
 		}
 
 		if ctx.Engine.IsWorktreeAnchor(stackRoot) {
@@ -118,14 +118,14 @@ func repairEntry(ctx *app.Context, entry Entry) (RepairEntry, error) {
 				return RepairEntry{}, fmt.Errorf("failed to inspect anchor registration: %w", err)
 			}
 			if existing != nil && existing.Path != wtInfo.Path {
-				return RepairEntry{}, fmt.Errorf("cannot repair %s automatically because anchor %s is already registered to %s", style.ColorBranchName(entry.displayName(), false), style.ColorBranchName(stackRootName, false), existing.Path)
+				return RepairEntry{}, fmt.Errorf("cannot repair %s automatically because anchor %s is already registered to %s", output.Branch(entry.displayName(), false), output.Branch(stackRootName, false), existing.Path)
 			}
 			if err := ctx.Engine.RegisterWorktreeWithName(stackRootName, wtInfo.Path, wtInfo.Name); err != nil {
 				return RepairEntry{}, fmt.Errorf("failed to register worktree under anchor %s: %w", stackRootName, err)
 			}
 			if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
 				_ = ctx.Engine.UnregisterWorktree(ctx.Context, stackRootName)
-				return RepairEntry{}, fmt.Errorf("failed to remove stale registration %s: %w", style.ColorBranchName(wtInfo.AnchorBranch, false), err)
+				return RepairEntry{}, fmt.Errorf("failed to remove stale registration %s: %w", output.Branch(wtInfo.AnchorBranch, false), err)
 			}
 			return RepairEntry{
 				Name:         entry.displayName(),
@@ -151,7 +151,7 @@ func repairEntry(ctx *app.Context, entry Entry) (RepairEntry, error) {
 func convertLegacyRegistration(ctx *app.Context, wtInfo engine.WorktreeInfo, rootBranchName string) (string, error) {
 	rootBranch := ctx.Engine.GetBranch(rootBranchName)
 	if !rootBranch.IsTracked() {
-		return "", fmt.Errorf("branch %s is not tracked by stackit", style.ColorBranchName(rootBranchName, false))
+		return "", fmt.Errorf("branch %s is not tracked by stackit", output.Branch(rootBranchName, false))
 	}
 
 	originalParent := ctx.Engine.Trunk().GetName()
@@ -169,16 +169,16 @@ func convertLegacyRegistration(ctx *app.Context, wtInfo engine.WorktreeInfo, roo
 		return "", err
 	}
 	if ctx.Engine.BranchNames().Contains(anchorBranchName) {
-		return "", fmt.Errorf("generated anchor branch %s already exists", style.ColorBranchName(anchorBranchName, false))
+		return "", fmt.Errorf("generated anchor branch %s already exists", output.Branch(anchorBranchName, false))
 	}
 
 	parentBranch := ctx.Engine.GetBranch(originalParent)
 	parentSHA, err := parentBranch.GetRevision()
 	if err != nil {
-		return "", fmt.Errorf("failed to get parent revision for %s: %w", style.ColorBranchName(originalParent, false), err)
+		return "", fmt.Errorf("failed to get parent revision for %s: %w", output.Branch(originalParent, false), err)
 	}
 	if err := ctx.Engine.CreateBranch(ctx.Context, anchorBranchName, parentSHA); err != nil {
-		return "", fmt.Errorf("failed to create anchor branch %s: %w", style.ColorBranchName(anchorBranchName, false), err)
+		return "", fmt.Errorf("failed to create anchor branch %s: %w", output.Branch(anchorBranchName, false), err)
 	}
 
 	anchorBranch := ctx.Engine.GetBranch(anchorBranchName)
@@ -199,31 +199,31 @@ func convertLegacyRegistration(ctx *app.Context, wtInfo engine.WorktreeInfo, roo
 
 	if err := ctx.Engine.SetParent(ctx.Context, anchorBranch, parentBranch, engine.DivergenceRecompute); err != nil {
 		cleanup()
-		return "", fmt.Errorf("failed to set parent on anchor branch %s: %w", style.ColorBranchName(anchorBranchName, false), err)
+		return "", fmt.Errorf("failed to set parent on anchor branch %s: %w", output.Branch(anchorBranchName, false), err)
 	}
 	if err := ctx.Engine.SetBranchType(anchorBranch, git.BranchTypeWorktreeAnchor); err != nil {
 		cleanup()
-		return "", fmt.Errorf("failed to mark %s as a worktree anchor: %w", style.ColorBranchName(anchorBranchName, false), err)
+		return "", fmt.Errorf("failed to mark %s as a worktree anchor: %w", output.Branch(anchorBranchName, false), err)
 	}
 	if scope != "" {
 		if err := ctx.Engine.SetScope(ctx.Context, anchorBranch, engine.NewScope(scope)); err != nil {
 			cleanup()
-			return "", fmt.Errorf("failed to set scope on anchor branch %s: %w", style.ColorBranchName(anchorBranchName, false), err)
+			return "", fmt.Errorf("failed to set scope on anchor branch %s: %w", output.Branch(anchorBranchName, false), err)
 		}
 	}
 	if err := ctx.Engine.ReparentBranch(ctx.Context, ctx.Engine.GetBranch(rootBranchName), anchorBranch); err != nil {
 		cleanup()
-		return "", fmt.Errorf("failed to reparent %s under anchor %s: %w", style.ColorBranchName(rootBranchName, false), style.ColorBranchName(anchorBranchName, false), err)
+		return "", fmt.Errorf("failed to reparent %s under anchor %s: %w", output.Branch(rootBranchName, false), output.Branch(anchorBranchName, false), err)
 	}
 	rootReparented = true
 	if err := ctx.Engine.RegisterWorktreeWithName(anchorBranchName, wtInfo.Path, wtInfo.Name); err != nil {
 		cleanup()
-		return "", fmt.Errorf("failed to register worktree under anchor %s: %w", style.ColorBranchName(anchorBranchName, false), err)
+		return "", fmt.Errorf("failed to register worktree under anchor %s: %w", output.Branch(anchorBranchName, false), err)
 	}
 	registered = true
 	if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
 		cleanup()
-		return "", fmt.Errorf("failed to remove legacy registration %s: %w", style.ColorBranchName(wtInfo.AnchorBranch, false), err)
+		return "", fmt.Errorf("failed to remove legacy registration %s: %w", output.Branch(wtInfo.AnchorBranch, false), err)
 	}
 	return anchorBranchName, nil
 }

--- a/internal/output/style.go
+++ b/internal/output/style.go
@@ -1,0 +1,57 @@
+package output
+
+import "github.com/getstackit/stackit/internal/tui/style"
+
+// Styling helpers for composing user-facing messages. These live in the output
+// (presentation) layer so business-logic actions can render colored fragments
+// without importing internal/tui. They delegate to internal/tui/style, which
+// remains the single source of the actual lipgloss rendering.
+
+// Branch renders a branch name, colored, with a "(current)" marker when isCurrent.
+func Branch(name string, isCurrent bool) string {
+	return style.ColorBranchName(name, isCurrent)
+}
+
+// BranchWithTrunk is like Branch but renders the trunk branch in a distinct color.
+func BranchWithTrunk(name string, isCurrent, isTrunk bool) string {
+	return style.ColorBranchNameWithTrunk(name, isCurrent, isTrunk)
+}
+
+// Dim renders text in a dim/gray style.
+func Dim(text string) string { return style.ColorDim(text) }
+
+// Cyan renders text in cyan.
+func Cyan(text string) string { return style.ColorCyan(text) }
+
+// Red renders text in red.
+func Red(text string) string { return style.ColorRed(text) }
+
+// Yellow renders text in yellow.
+func Yellow(text string) string { return style.ColorYellow(text) }
+
+// Green renders text in green.
+func Green(text string) string { return style.ColorGreen(text) }
+
+// Magenta renders text in magenta.
+func Magenta(text string) string { return style.ColorMagenta(text) }
+
+// Scope renders a scope label.
+func Scope(scope string) string { return style.ColorScope(scope) }
+
+// NeedsRestack renders a "needs restack" hint.
+func NeedsRestack(text string) string { return style.ColorNeedsRestack(text) }
+
+// PRNumber renders a pull-request number.
+func PRNumber(prNumber int) string { return style.ColorPRNumber(prNumber) }
+
+// PRState renders a pull-request state label.
+func PRState(state string, isDraft bool) string { return style.ColorPRState(state, isDraft) }
+
+// RenderMarkdown renders markdown content for the terminal.
+func RenderMarkdown(content string) string { return style.RenderMarkdown(content) }
+
+// IconLocked returns the lock status icon.
+func IconLocked() string { return style.IconLocked() }
+
+// IconFrozen returns the freeze status icon.
+func IconFrozen() string { return style.IconFrozen() }


### PR DESCRIPTION

Business-logic actions imported internal/tui/style directly to colorize
branch names and other fragments — a presentation decision the architecture
assigns to the adapter/output layer.

Add delegating styling helpers to internal/output (Branch, Dim, Cyan, Red,
Yellow, Green, Magenta, BranchWithTrunk, Scope, NeedsRestack, PRNumber,
PRState, RenderMarkdown, IconLocked, IconFrozen) that forward to
internal/tui/style — which remains the single source of the lipgloss
rendering, so output is byte-identical. Then migrate all 38 action files
(217 call sites) from style.X to output.X and drop their tui/style imports.

Package-level functions (not Output methods) so string-building helpers that
have no Output value in scope migrate the same way. No action file imports
internal/tui/style anymore. Behavior unchanged; verified by build, lint, and
the actions (560) + integration (494) suites.