### PR TITLE
fix(lock): defer GitHub PR updates to sync

### DIFF
--- a/internal/actions/lock/lock.go
+++ b/internal/actions/lock/lock.go
@@ -102,8 +102,11 @@ func Action(ctx *app.Context, branchName string, handler Handler) error {
 		}
 	}
 
-	// Push metadata changes to remote and update PRs to trigger CI re-evaluation
-	if err := actions.PushMetadataAndSyncPRs(ctx, affectedBranches); err != nil {
+	// Mark branches for PR body update; sync will handle the GitHub API calls
+	if err := eng.MarkBranchesForPRBodyUpdate(ctx.Context, affectedBranches); err != nil {
+		out.Debug("Failed to mark branches for PR body update: %v", err)
+	}
+	if err := actions.PushMetadataOnly(ctx, eng, affectedBranches); err != nil {
 		out.Debug("Failed to push metadata changes: %v", err)
 	}
 
@@ -185,8 +188,11 @@ func Unlock(ctx *app.Context, branchName string, handler Handler) error {
 		}
 	}
 
-	// Push metadata changes to remote and update PRs to trigger CI re-evaluation
-	if err := actions.PushMetadataAndSyncPRs(ctx, affectedBranches); err != nil {
+	// Mark branches for PR body update; sync will handle the GitHub API calls
+	if err := eng.MarkBranchesForPRBodyUpdate(ctx.Context, affectedBranches); err != nil {
+		out.Debug("Failed to mark branches for PR body update: %v", err)
+	}
+	if err := actions.PushMetadataOnly(ctx, eng, affectedBranches); err != nil {
 		out.Debug("Failed to push metadata changes: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

- `lock` and `unlock` were calling `PushMetadataAndSyncPRs`, which hits the GitHub API immediately to update PR bodies
- This violates the pattern documented in `safety-invariants.md`: commands should mark branches for update and let `sync` handle the network call
- Switch both functions to `MarkBranchesForPRBodyUpdate` + `PushMetadataOnly`, matching how `describe` already works

## Why this matters

`PushMetadataAndSyncPRs` does two things: pushes metadata refs (fast git op) **and** calls `UpdateStackPRMetadata` (slow GitHub API call). The lock command doesn't need to update PR bodies synchronously — it just needs to persist the lock flag. Deferring to sync means:

- `lock`/`unlock` are faster (one fewer GitHub round-trip)
- They work without a GitHub connection
- PR body updates are consistent with how every other metadata-only command works

This was explicitly marked `❌ TODO` in `safety-invariants.md`.

## Test plan

- [x] `go test ./internal/actions/lock/...` passes
- [x] Existing lock/unlock behavior preserved (locking still works, metadata still pushed to remote)
- [x] PR bodies updated on next `stackit sync` (deferred, not lost)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoguxeCUx88XfRVnU6Z7w5)_