### PR TITLE
refactor(split): consolidate cleanup in splitByFileSibling with defer

### DIFF
--- a/internal/actions/split/split_file.go
+++ b/internal/actions/split/split_file.go
@@ -553,23 +553,26 @@ func splitByFileSibling(ctx context.Context, branchToSplit engine.Branch, parent
 		return nil, fmt.Errorf("failed to create branch: %w", err)
 	}
 
+	// On any subsequent failure, delete the partially-created branch and restore the original.
+	var succeeded bool
+	defer func() {
+		if !succeeded {
+			_ = eng.DeleteBranch(ctx, newBranch)
+			_ = eng.CheckoutBranch(ctx, branchToSplit)
+		}
+	}()
+
 	// Stage the hunks directly
 	if err := eng.StageHunks(ctx, hunks); err != nil {
-		_ = eng.DeleteBranch(ctx, newBranch)
-		_ = eng.CheckoutBranch(ctx, branchToSplit)
 		return nil, fmt.Errorf("failed to stage hunks: %w", err)
 	}
 
 	// Check if anything was staged
 	hasStaged, err := eng.HasStagedChanges(ctx)
 	if err != nil {
-		_ = eng.DeleteBranch(ctx, newBranch)
-		_ = eng.CheckoutBranch(ctx, branchToSplit)
 		return nil, fmt.Errorf("failed to check staged changes: %w", err)
 	}
 	if !hasStaged {
-		_ = eng.DeleteBranch(ctx, newBranch)
-		_ = eng.CheckoutBranch(ctx, branchToSplit)
 		return nil, fmt.Errorf("no changes staged")
 	}
 
@@ -578,28 +581,22 @@ func splitByFileSibling(ctx context.Context, branchToSplit engine.Branch, parent
 		Message:  commitMessage,
 		NoVerify: true,
 	}); err != nil {
-		_ = eng.DeleteBranch(ctx, newBranch)
-		_ = eng.CheckoutBranch(ctx, branchToSplit)
 		return nil, fmt.Errorf("failed to commit: %w", err)
 	}
 
 	// Track the new branch
 	if err := eng.TrackBranch(ctx, newBranchName, parentBranch.GetName()); err != nil {
-		_ = eng.DeleteBranch(ctx, newBranch)
-		_ = eng.CheckoutBranch(ctx, branchToSplit)
 		return nil, fmt.Errorf("failed to track branch: %w", err)
 	}
 
 	// Preserve stack ID from original branch
 	if originalStackID != "" {
 		if err := eng.SetStackID(ctx, engine.BranchesOf(newBranch), originalStackID); err != nil {
-			_ = eng.DeleteBranch(ctx, newBranch)
-			_ = eng.CheckoutBranch(ctx, branchToSplit)
 			return nil, fmt.Errorf("failed to preserve stack ID: %w", err)
 		}
 	}
 
-	// Return to original branch
+	succeeded = true
 	if err := eng.CheckoutBranch(ctx, branchToSplit); err != nil {
 		return nil, fmt.Errorf("failed to checkout original branch: %w", err)
 	}


### PR DESCRIPTION
## Summary

- `splitByFileSibling` had five identical two-line cleanup pairs (`DeleteBranch` + `CheckoutBranch`) scattered across every error path
- Replaced them with a single `defer` guarded by a `succeeded` flag
- No behavior change — cleanup is identical; the `succeeded = true` path preserves the explicit error-checked checkout on success

## Before / After

**Before:** every new error path required manually remembering to add both cleanup calls
```go
if err := eng.StageHunks(...); err != nil {
    _ = eng.DeleteBranch(ctx, newBranch)       // repeated
    _ = eng.CheckoutBranch(ctx, branchToSplit) // repeated
    return nil, fmt.Errorf(...)
}
// × 5 more times
```

**After:** one deferred closure covers all error paths
```go
var succeeded bool
defer func() {
    if !succeeded {
        _ = eng.DeleteBranch(ctx, newBranch)
        _ = eng.CheckoutBranch(ctx, branchToSplit)
    }
}()
// all error returns automatically trigger cleanup
```

## Test plan

- [ ] `go test ./internal/actions/split/...` passes
- [ ] `go test ./internal/integration/ -run TestSplit` passes

https://claude.ai/code/session_01BmyMFA95UjbwKzBdSttVuR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmyMFA95UjbwKzBdSttVuR)_