### PR TITLE
perf: use O(1) BranchNames lookup in ValidateTargetBranch

### DIFF
--- a/internal/actions/validation/validators.go
+++ b/internal/actions/validation/validators.go
@@ -51,7 +51,7 @@ type BranchValidationEngine interface {
 	ValidateOnBranch() (string, error)
 	GetBranch(branchName string) engine.Branch
 	CurrentBranch() *engine.Branch
-	AllBranches() engine.Branches
+	BranchNames() *engine.BranchSet
 }
 
 // GitStateReader is the minimal git-state contract the git-aware validators
@@ -262,18 +262,8 @@ func ValidateTargetBranch(eng BranchValidationEngine, sourceName, targetName, op
 	targetBranch := eng.GetBranch(targetName)
 
 	// Target must exist - check if it's trunk, tracked, or at least a git branch
-	if !targetBranch.IsTrunk() && !targetBranch.IsTracked() {
-		allBranches := eng.AllBranches()
-		found := false
-		for _, branch := range allBranches {
-			if branch.GetName() == targetName {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("branch %s does not exist", targetName)
-		}
+	if !targetBranch.IsTrunk() && !targetBranch.IsTracked() && !eng.BranchNames().Contains(targetName) {
+		return fmt.Errorf("branch %s does not exist", targetName)
 	}
 
 	if targetBranch.IsWorktreeAnchor() {


### PR DESCRIPTION
## Summary

- `ValidateTargetBranch` was calling `AllBranches()` and doing a linear O(N) scan to check if a branch name existed in git
- The engine already exposes `BranchNames()` — a lazily-built, cached `BranchSet` backed by a map — which gives O(1) lookups
- Replace `AllBranches() engine.Branches` in the `BranchValidationEngine` interface with `BranchNames() *engine.BranchSet`, and collapse the 10-line loop to a single `Contains` call

This affects `move` and `pluck` operations, which both call `ValidateTargetBranch` on every invocation.

## Test plan

- [ ] `go test ./internal/actions/validation/...` passes
- [ ] `go build ./...` passes
- [ ] No behavior change — purely a performance/clarity improvement

---
_Generated by [Claude Code](https://claude.ai/code/session_011YVtDrPBqKU8sBz3vfh7Qg)_