### PR TITLE
refactor: use err.Error() in isCIFailure and avoid alloc in split prompt

### DIFF
--- a/internal/actions/merge/helpers.go
+++ b/internal/actions/merge/helpers.go
@@ -2,7 +2,6 @@ package merge
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -76,6 +75,6 @@ func isCIFailure(err error) bool {
 	if err == nil {
 		return false
 	}
-	errStr := fmt.Sprintf("%v", err)
-	return strings.Contains(errStr, "CI checks failed") || strings.Contains(errStr, "failing CI checks") || strings.Contains(errStr, "pending CI checks")
+	msg := err.Error()
+	return strings.Contains(msg, "CI checks failed") || strings.Contains(msg, "failing CI checks") || strings.Contains(msg, "pending CI checks")
 }

--- a/internal/actions/split/split_prompts.go
+++ b/internal/actions/split/split_prompts.go
@@ -42,13 +42,10 @@ func promptBranchName(existingNames []string, originalBranchName string, branchN
 	// Allow reusing the original branch name being split (it will be replaced)
 	// but don't allow other existing branch names
 	if branchName != originalBranchName {
-		allBranches := eng.AllBranches()
-		branchNames := make([]string, len(allBranches))
-		for i, b := range allBranches {
-			branchNames[i] = b.GetName()
-		}
-		if slices.Contains(branchNames, branchName) {
-			return "", fmt.Errorf("branch name %s is already in use", branchName)
+		for _, b := range eng.AllBranches() {
+			if b.GetName() == branchName {
+				return "", fmt.Errorf("branch name %s is already in use", branchName)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- **`isCIFailure`** was using `fmt.Sprintf("%v", err)` while its sibling `isConflictError` already uses `err.Error()` — inconsistent and allocates unnecessarily via `fmt`. Aligned them and dropped the now-unused `fmt` import.
- **`promptBranchName`** was copying `AllBranches()` into a `[]string` just to call `slices.Contains` once. Replaced with a direct range loop that short-circuits on first match, eliminating the intermediate allocation.

## Test plan

- [ ] `go build ./internal/actions/...` passes (verified locally)
- [ ] `mise run check` — no behavior change, lint clean

---
_Generated by [Claude Code](https://claude.ai/code/session_011w2RG1TFu8eBcweCTK7Jru)_