### PR TITLE
docs: add performance guide (SSH reuse + tracing)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ api/openapi/       API contract source of truth
 
 - `docs/config.md` - Configuration system, keys, layered config
 - `docs/hooks.md` - Lifecycle hook configuration, env vars, approval flow, recipes
+- `docs/performance.md` - Remote-operation tuning (SSH reuse), diagnosing slow commands with the tracer
 - `docs/recipes.md` - Step-by-step file lists for cross-cutting changes
 - `docs/shipping.md` - Merge strategies, consolidation, multi-stack shipping
 - `docs/tui.md` - TUI patterns, BaseModel, styling, components

--- a/README.md
+++ b/README.md
@@ -573,6 +573,8 @@ The `hooks.post-worktree-create` option allows you to run commands automatically
 
 Stackit uses parallel validation for rebase operations, providing 2-3x speedup for wide stacks with many sibling branches. Branches at the same depth are validated concurrently, with automatic early exit on first conflict to save resources.
 
+For tuning remote operations (SSH connection reuse) and diagnosing a slow command with the built-in tracer, see [docs/performance.md](docs/performance.md).
+
 ---
 
 ## Troubleshooting

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,76 @@
+# Performance
+
+Most stackit commands are fast and local. When a command feels slow, the cost is almost
+always **network round-trips to GitHub** — the `git fetch` over SSH, plus any GitHub API
+calls. This guide covers the biggest levers and how to diagnose a slow run.
+
+## Reuse the SSH connection (biggest lever on slow links)
+
+Every `git fetch` stackit runs opens a fresh SSH connection to GitHub, and the SSH
+handshake is several round-trips. On a fast network that's ~0.5s; on a high-latency link
+(VPN, far from GitHub's servers, flaky Wi-Fi) it can be several seconds — paid on *every*
+fetch, by every stackit command that touches the remote.
+
+Enabling SSH connection multiplexing keeps one connection alive and reuses it, eliminating
+the per-fetch handshake. Add this to `~/.ssh/config`:
+
+```sshconfig
+Host github.com
+    ControlMaster auto
+    ControlPath ~/.ssh/control-%r@%h:%p
+    ControlPersist 5m
+```
+
+The first connection in a 5-minute window pays the handshake; subsequent fetches reuse it.
+This speeds up `get`, `sync`, `submit`, and every other remote operation — not just one
+command.
+
+## Why `get` is fast
+
+`stackit get` discovers a branch's stack (its parent chain) from the **metadata** that the
+fetch already brings down (`refs/stackit/metadata/*`), rather than making a serial GitHub
+API call per ancestor. For a branch submitted via stackit, this means:
+
+- A single branch whose parent is trunk: one fetch, zero GitHub calls.
+- A deeper stack: two fetches total (target + metadata, then ancestor heads) regardless of
+  depth.
+
+stackit only falls back to a GitHub lookup when a branch has no stackit metadata (for
+example a branch that was never submitted via stackit), and even then PR-number lookups
+run in parallel rather than blocking the fetch.
+
+## Diagnosing a slow command
+
+stackit traces every git operation with a microsecond duration. Enable debug-level logging
+to a file, run the slow command, then read the trace:
+
+```bash
+STACKIT_LOG_LEVEL=debug STACKIT_LOG_FILE=/tmp/st-trace.log stackit get <branch>
+```
+
+Each git operation is logged as an `[st-trace]` line with `op=` (operation) and `dur_us=`
+(microseconds). To see which operation dominates:
+
+```bash
+python3 -c '
+import re
+rows = []
+for line in open("/tmp/st-trace.log"):
+    if "st-trace" not in line: continue
+    o = re.search(r"op=(\S+)", line); d = re.search(r"dur_us=(\d+)", line)
+    if o and d: rows.append((int(d.group(1)), o.group(1)))
+rows.sort(reverse=True)
+print(f"git ops: {len(rows)}, summed git time: {sum(d for d,_ in rows)/1e6:.2f}s")
+[print(f"  {d/1000:8.1f} ms  {o}") for d, o in rows[:15]]
+'
+```
+
+Interpreting the result:
+
+- **`FetchRefSpecs` dominates** → the cost is the `git fetch` / SSH handshake. Enable SSH
+  connection reuse (above).
+- **A large gap between the summed git time and the wall-clock time** → the remaining time
+  is GitHub API latency or shell `precmd` hooks (e.g. `mise`, `direnv`) firing around the
+  command in your interactive shell.
+
+> Note: logging is disabled when `STACKIT_NO_LOGGING` is set. Unset it to capture traces.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


Document the biggest lever for slow remote operations (SSH ControlMaster/
ControlPersist connection reuse) and how to diagnose a slow command with
the built-in STACKIT_LOG_LEVEL=debug git-operation tracer. Explain why get
resolves stacks from fetched metadata rather than serial GitHub calls.

Linked from the README performance section and the docs index in AGENTS.md.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780876321`.


* **PR #1169**
  * **PR #1170**
    * **PR #1171**
      * **PR #1172** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->