### PR TITLE
docs(lock): document that lock/unlock sync GitHub immediately by design

### DIFF
--- a/.claude/rules/safety-invariants.md
+++ b/.claude/rules/safety-invariants.md
@@ -87,7 +87,9 @@ session.Engine.PushBranch(ctx, tempBranch, remote, opts)
 
 **Commands must NOT directly update GitHub PRs. Instead, mark branches for update and let `sync` handle it.**
 
-This applies to: describe, scope, lock, and any command that changes metadata affecting PR display.
+This applies to: describe, scope, and any command that changes metadata affecting PR display.
+
+**Exception:** `lock`/`unlock` deliberately do NOT follow this pattern — see the Exceptions section below.
 
 ### Why This Matters
 
@@ -101,6 +103,7 @@ This applies to: describe, scope, lock, and any command that changes metadata af
 1. **Read-only for display**: `log` showing CI status, `get` showing PR info
 2. **Primary purpose is GitHub**: `submit` creating/updating PRs, `merge` creating consolidation PRs
 3. **During sync**: All PR body/title updates should happen here
+4. **Lock/unlock**: `lock` and `unlock` call GitHub directly (`PushMetadataAndSyncPRs`), on purpose. A lock is a shared state change: it must reflect for other collaborators and re-evaluate PR CI **immediately**, not on the locking user's next `sync`. Deferring it would let others keep merging a branch the user just locked. The performance/offline tradeoffs above are outweighed by the need for an immediate, visible effect. Do not migrate `lock`/`unlock` to the mark-and-sync pattern.
 
 ### Implementation Pattern
 
@@ -137,4 +140,4 @@ if len(flaggedBranches) > 0 {
 |---------|-----------------|------------------------------|
 | `describe` | Stack description in footer | ✅ Fixed |
 | `scope` | PR title prefix | ❌ TODO |
-| `lock` | Lock section in PR body | ❌ TODO |
+| `lock` | Lock section in PR body | ⛔ Exception — syncs immediately (see Exceptions above) |

--- a/internal/actions/lock/lock.go
+++ b/internal/actions/lock/lock.go
@@ -102,7 +102,11 @@ func Action(ctx *app.Context, branchName string, handler Handler) error {
 		}
 	}
 
-	// Push metadata changes to remote and update PRs to trigger CI re-evaluation
+	// Lock/unlock intentionally sync GitHub PRs immediately instead of using the
+	// mark-and-sync pattern (see .claude/rules/safety-invariants.md, "GitHub Writes
+	// Only During Sync"). A lock is shared state: it must reflect for other
+	// collaborators and re-trigger PR CI right away, not on this user's next sync.
+	// Do not convert this to MarkBranchesForPRBodyUpdate + PushMetadataOnly.
 	if err := actions.PushMetadataAndSyncPRs(ctx, affectedBranches); err != nil {
 		out.Debug("Failed to push metadata changes: %v", err)
 	}
@@ -185,7 +189,11 @@ func Unlock(ctx *app.Context, branchName string, handler Handler) error {
 		}
 	}
 
-	// Push metadata changes to remote and update PRs to trigger CI re-evaluation
+	// Lock/unlock intentionally sync GitHub PRs immediately instead of using the
+	// mark-and-sync pattern (see .claude/rules/safety-invariants.md, "GitHub Writes
+	// Only During Sync"). A lock is shared state: it must reflect for other
+	// collaborators and re-trigger PR CI right away, not on this user's next sync.
+	// Do not convert this to MarkBranchesForPRBodyUpdate + PushMetadataOnly.
 	if err := actions.PushMetadataAndSyncPRs(ctx, affectedBranches); err != nil {
 		out.Debug("Failed to push metadata changes: %v", err)
 	}


### PR DESCRIPTION
## Summary

Documents that `lock`/`unlock` calling GitHub directly (`PushMetadataAndSyncPRs`) is **intentional**, not a violation of the "GitHub Writes Only During Sync" rule.

## Why

`safety-invariants.md` listed `lock` as a `❌ TODO` to migrate to the mark-and-sync pattern. That invited a "fix" (#1165) that deferred lock's PR update to the next `sync`. But a lock is **shared state**:

- It must reflect for **other collaborators immediately** — not on the locking user's next `sync`.
- It must **re-trigger PR CI right away** so a locked branch is visibly protected.
- Deferring it would let others keep merging a branch the user just locked.

The performance/offline benefits of mark-and-sync don't apply here — immediate, visible effect is the whole point of locking.

## Changes

- `.claude/rules/safety-invariants.md`: move `lock`/`unlock` out of the "should mark, not call GitHub" list and into the **Exceptions** section, with the rationale. Updates the tracking table accordingly.
- `internal/actions/lock/lock.go`: add a comment at both call sites (lock + unlock) explaining why the immediate sync is deliberate, so the next reader doesn't try to "fix" it.

No behavior change — `main` already syncs immediately; this makes the intent explicit.

## Closes

Supersedes and closes #1165, which incorrectly treated this design as a bug.
