### PR TITLE
Merging 4 PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ api/openapi/       API contract source of truth
 
 - `docs/config.md` - Configuration system, keys, layered config
 - `docs/hooks.md` - Lifecycle hook configuration, env vars, approval flow, recipes
+- `docs/performance.md` - Remote-operation tuning (SSH reuse), diagnosing slow commands with the tracer
 - `docs/recipes.md` - Step-by-step file lists for cross-cutting changes
 - `docs/shipping.md` - Merge strategies, consolidation, multi-stack shipping
 - `docs/tui.md` - TUI patterns, BaseModel, styling, components

--- a/README.md
+++ b/README.md
@@ -573,6 +573,8 @@ The `hooks.post-worktree-create` option allows you to run commands automatically
 
 Stackit uses parallel validation for rebase operations, providing 2-3x speedup for wide stacks with many sibling branches. Branches at the same depth are validated concurrently, with automatic early exit on first conflict to save resources.
 
+For tuning remote operations (SSH connection reuse) and diagnosing a slow command with the built-in tracer, see [docs/performance.md](docs/performance.md).
+
 ---
 
 ## Troubleshooting

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,76 @@
+# Performance
+
+Most stackit commands are fast and local. When a command feels slow, the cost is almost
+always **network round-trips to GitHub** — the `git fetch` over SSH, plus any GitHub API
+calls. This guide covers the biggest levers and how to diagnose a slow run.
+
+## Reuse the SSH connection (biggest lever on slow links)
+
+Every `git fetch` stackit runs opens a fresh SSH connection to GitHub, and the SSH
+handshake is several round-trips. On a fast network that's ~0.5s; on a high-latency link
+(VPN, far from GitHub's servers, flaky Wi-Fi) it can be several seconds — paid on *every*
+fetch, by every stackit command that touches the remote.
+
+Enabling SSH connection multiplexing keeps one connection alive and reuses it, eliminating
+the per-fetch handshake. Add this to `~/.ssh/config`:
+
+```sshconfig
+Host github.com
+    ControlMaster auto
+    ControlPath ~/.ssh/control-%r@%h:%p
+    ControlPersist 5m
+```
+
+The first connection in a 5-minute window pays the handshake; subsequent fetches reuse it.
+This speeds up `get`, `sync`, `submit`, and every other remote operation — not just one
+command.
+
+## Why `get` is fast
+
+`stackit get` discovers a branch's stack (its parent chain) from the **metadata** that the
+fetch already brings down (`refs/stackit/metadata/*`), rather than making a serial GitHub
+API call per ancestor. For a branch submitted via stackit, this means:
+
+- A single branch whose parent is trunk: one fetch, zero GitHub calls.
+- A deeper stack: two fetches total (target + metadata, then ancestor heads) regardless of
+  depth.
+
+stackit only falls back to a GitHub lookup when a branch has no stackit metadata (for
+example a branch that was never submitted via stackit), and even then PR-number lookups
+run in parallel rather than blocking the fetch.
+
+## Diagnosing a slow command
+
+stackit traces every git operation with a microsecond duration. Enable debug-level logging
+to a file, run the slow command, then read the trace:
+
+```bash
+STACKIT_LOG_LEVEL=debug STACKIT_LOG_FILE=/tmp/st-trace.log stackit get <branch>
+```
+
+Each git operation is logged as an `[st-trace]` line with `op=` (operation) and `dur_us=`
+(microseconds). To see which operation dominates:
+
+```bash
+python3 -c '
+import re
+rows = []
+for line in open("/tmp/st-trace.log"):
+    if "st-trace" not in line: continue
+    o = re.search(r"op=(\S+)", line); d = re.search(r"dur_us=(\d+)", line)
+    if o and d: rows.append((int(d.group(1)), o.group(1)))
+rows.sort(reverse=True)
+print(f"git ops: {len(rows)}, summed git time: {sum(d for d,_ in rows)/1e6:.2f}s")
+[print(f"  {d/1000:8.1f} ms  {o}") for d, o in rows[:15]]
+'
+```
+
+Interpreting the result:
+
+- **`FetchRefSpecs` dominates** → the cost is the `git fetch` / SSH handshake. Enable SSH
+  connection reuse (above).
+- **A large gap between the summed git time and the wall-clock time** → the remaining time
+  is GitHub API latency or shell `precmd` hooks (e.g. `mise`, `direnv`) firing around the
+  command in your interactive shell.
+
+> Note: logging is disabled when `STACKIT_NO_LOGGING` is set. Unset it to capture traces.

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -157,8 +157,30 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	parentMap := make(map[string]string)
 	branchPRInfo := make(map[string]*int) // branch -> PR number
 
-	// Crawl ancestors using GitHub PR info if possible
-	branchesToSync = crawlAncestorsViaGitHub(ctx, targetBranch, branchesToSync, parentMap, branchPRInfo)
+	// First fetch: the target's head plus all stack metadata. The metadata refspec is a
+	// wildcard independent of which branch heads we request, so this single round trip
+	// brings down the entire stack's parent chain — letting us discover ancestors from
+	// local metadata instead of a serial, blocking GitHub crawl.
+	if err := eng.FetchRemote(gctx, engine.RemoteFetchRequest{
+		Remote:          remote,
+		Branches:        []string{targetBranch},
+		IncludeMetadata: true,
+	}); err != nil {
+		return fmt.Errorf("failed to fetch %s from %s: %w", targetBranch, remote, err)
+	}
+
+	// Discover ancestors. Prefer the fetched metadata (no network); fall back to a GitHub
+	// crawl only when the target has no stackit metadata (e.g. a branch never submitted
+	// via stackit, or when the metadata cache fails to load).
+	usedMetadata := false
+	if err := eng.LoadRemoteMetadataCache(); err != nil {
+		out.Debug("failed to load remote metadata cache: %v", err)
+	} else {
+		branchesToSync, usedMetadata = crawlAncestorsViaMetadata(eng, targetBranch, branchesToSync, parentMap, branchPRInfo)
+	}
+	if !usedMetadata {
+		branchesToSync = crawlAncestorsViaGitHub(ctx, targetBranch, branchesToSync, parentMap, branchPRInfo)
+	}
 
 	// If target branch exists locally, identify local descendants
 	targetBranchObj := eng.GetBranch(targetBranch)
@@ -172,8 +194,12 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		}
 	}
 
+	// Second fetch: heads of any ancestors/descendants not already fetched. The metadata
+	// wildcard already came down in the first fetch, so this only needs branch heads. The
+	// target was fetched above, so it is pre-seeded as seen and skipped here. For a single
+	// branch whose parent is trunk this list is empty, leaving exactly one fetch total.
 	branchesToFetch := make([]string, 0, len(branchesToSync))
-	seenFetchBranch := make(map[string]bool, len(branchesToSync))
+	seenFetchBranch := map[string]bool{targetBranch: true}
 	for _, branchName := range branchesToSync {
 		if branchName == trunkName && branchName != targetBranch {
 			continue
@@ -185,12 +211,13 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		branchesToFetch = append(branchesToFetch, branchName)
 	}
 
-	if err := eng.FetchRemote(gctx, engine.RemoteFetchRequest{
-		Remote:          remote,
-		Branches:        branchesToFetch,
-		IncludeMetadata: true,
-	}); err != nil {
-		return fmt.Errorf("failed to fetch branches from %s: %w", remote, err)
+	if len(branchesToFetch) > 0 {
+		if err := eng.FetchRemote(gctx, engine.RemoteFetchRequest{
+			Remote:   remote,
+			Branches: branchesToFetch,
+		}); err != nil {
+			return fmt.Errorf("failed to fetch branches from %s: %w", remote, err)
+		}
 	}
 
 	// Emit trunk status (main/master)
@@ -337,7 +364,13 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 			handler.OnRestackStart(len(sorted))
 
 			if err := RestackBranchesWithHandler(ctx, sorted, func(p RestackProgress) {
-				prNumber := getPRNumber(eng, p.Branch)
+				// Prefer the PR number discovered during sync (which may have come
+				// from remote metadata not copied into local metadata); fall back to
+				// local metadata otherwise.
+				prNumber := branchPRInfo[p.Branch]
+				if prNumber == nil {
+					prNumber = getPRNumber(eng, p.Branch)
+				}
 
 				parentName := ""
 				br := eng.GetBranch(p.Branch)
@@ -383,6 +416,60 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	})
 
 	return nil
+}
+
+// crawlAncestorsViaMetadata walks the parent chain of targetBranch using the fetched
+// remote metadata cache (refs/stackit/remote-metadata/*), avoiding GitHub calls. It
+// prepends discovered ancestors to branchesToSync (trunk-first) and records each branch's
+// parent in parentMap and any known PR number in branchPRInfo. The second return value
+// reports whether the target had usable metadata; when false the caller should fall back
+// to a GitHub crawl. Callers must have populated the cache via LoadRemoteMetadataCache.
+func crawlAncestorsViaMetadata(eng engine.Engine, targetBranch string, branchesToSync []string, parentMap map[string]string, branchPRInfo map[string]*int) ([]string, bool) {
+	view := eng.GetRemoteMetadataCache()
+	trunkName := eng.Trunk().GetName()
+
+	// No usable metadata for the target: signal a fallback to the GitHub crawl.
+	if meta := view.Get(targetBranch); meta == nil || meta.GetParentBranchName() == nil {
+		return branchesToSync, false
+	}
+
+	discoveredBranches := slices.Clone(branchesToSync)
+	discoveredParents := make(map[string]string)
+	discoveredPRs := make(map[string]*int)
+
+	current := targetBranch
+	for {
+		meta := view.Get(current)
+		if meta == nil {
+			// A partial metadata chain is not safe to use: falling back lets GitHub
+			// recover the full ancestry instead of syncing only part of the stack.
+			return branchesToSync, false
+		}
+		if pr := meta.GetPrInfo(); pr != nil && pr.Number != nil {
+			discoveredPRs[current] = pr.Number
+		}
+
+		parent := meta.GetParentBranchName()
+		if parent == nil || *parent == "" || *parent == trunkName {
+			discoveredParents[current] = trunkName
+			break
+		}
+
+		discoveredParents[current] = *parent
+		if slices.Contains(discoveredBranches, *parent) {
+			break // Avoid cycles
+		}
+		discoveredBranches = append([]string{*parent}, discoveredBranches...)
+		current = *parent
+	}
+
+	for branch, parent := range discoveredParents {
+		parentMap[branch] = parent
+	}
+	for branch, prNumber := range discoveredPRs {
+		branchPRInfo[branch] = prNumber
+	}
+	return discoveredBranches, true
 }
 
 // crawlAncestorsViaGitHub walks the parent chain of targetBranch using GitHub PR

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -158,32 +158,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	branchPRInfo := make(map[string]*int) // branch -> PR number
 
 	// Crawl ancestors using GitHub PR info if possible
-	if ctx.GitHub() != nil {
-		current := targetBranch
-		owner, repo := ctx.GitHub().GetOwnerRepo()
-		for {
-			pr, err := ctx.GitHub().GetPullRequestByBranch(gctx, owner, repo, current)
-			if err != nil || pr == nil {
-				break
-			}
-			prNum := pr.Number
-			branchPRInfo[current] = &prNum
-
-			base := pr.Base
-			if base == "" || base == eng.Trunk().GetName() {
-				parentMap[current] = eng.Trunk().GetName()
-				break
-			}
-
-			parentMap[current] = base
-			if !slices.Contains(branchesToSync, base) {
-				branchesToSync = append([]string{base}, branchesToSync...)
-				current = base
-			} else {
-				break // Avoid cycles
-			}
-		}
-	}
+	branchesToSync = crawlAncestorsViaGitHub(ctx, targetBranch, branchesToSync, parentMap, branchPRInfo)
 
 	// If target branch exists locally, identify local descendants
 	targetBranchObj := eng.GetBranch(targetBranch)
@@ -408,6 +383,44 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	})
 
 	return nil
+}
+
+// crawlAncestorsViaGitHub walks the parent chain of targetBranch using GitHub PR
+// information. It prepends discovered ancestors to branchesToSync (trunk-first) and
+// records each branch's parent in parentMap and PR number in branchPRInfo. It is a
+// no-op when no GitHub client is configured. The (possibly grown) branchesToSync slice
+// is returned because ancestors are prepended.
+func crawlAncestorsViaGitHub(ctx *app.Context, targetBranch string, branchesToSync []string, parentMap map[string]string, branchPRInfo map[string]*int) []string {
+	if ctx.GitHub() == nil {
+		return branchesToSync
+	}
+	eng := ctx.Engine
+	gctx := ctx.Context
+	owner, repo := ctx.GitHub().GetOwnerRepo()
+	current := targetBranch
+	for {
+		pr, err := ctx.GitHub().GetPullRequestByBranch(gctx, owner, repo, current)
+		if err != nil || pr == nil {
+			break
+		}
+		prNum := pr.Number
+		branchPRInfo[current] = &prNum
+
+		base := pr.Base
+		if base == "" || base == eng.Trunk().GetName() {
+			parentMap[current] = eng.Trunk().GetName()
+			break
+		}
+
+		parentMap[current] = base
+		if !slices.Contains(branchesToSync, base) {
+			branchesToSync = append([]string{base}, branchesToSync...)
+			current = base
+		} else {
+			break // Avoid cycles
+		}
+	}
+	return branchesToSync
 }
 
 // getPRNumber returns the PR number for a branch, or nil if not available

--- a/internal/integration/get_metadata_test.go
+++ b/internal/integration/get_metadata_test.go
@@ -1,0 +1,206 @@
+package integration
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/go-github/v67/github"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/actions/submit"
+	syncaction "github.com/getstackit/stackit/internal/actions/sync"
+	githubpkg "github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// countingGitHubClient wraps a github.Client and counts GetPullRequestByBranch
+// calls, so tests can assert whether get fell back to the GitHub ancestry crawl.
+type countingGitHubClient struct {
+	githubpkg.Client
+	prByBranch atomic.Int64
+}
+
+func (c *countingGitHubClient) GetPullRequestByBranch(ctx context.Context, owner, repo, branch string) (*githubpkg.PullRequestInfo, error) {
+	c.prByBranch.Add(1)
+	return c.Client.GetPullRequestByBranch(ctx, owner, repo, branch)
+}
+
+// recordingGetHandler captures the PR number surfaced for each branch. EmitEvent is
+// only called from sequential phases (sync loop, restack callback), so no locking.
+type recordingGetHandler struct {
+	actions.GetNullHandler
+	prByBranch map[string]int
+}
+
+func (h *recordingGetHandler) EmitEvent(e actions.GetEvent) {
+	if e.Branch == "" || e.PRNumber == nil {
+		return
+	}
+	if h.prByBranch == nil {
+		h.prByBranch = map[string]int{}
+	}
+	h.prByBranch[e.Branch] = *e.PRNumber
+}
+
+// dropLocalBranch removes a branch and its metadata locally, simulating a branch the
+// user does not have (forcing get's recreate path). The remote copy is untouched.
+func dropLocalBranch(t *testing.T, sh *scenario.Scenario, branch string) {
+	t.Helper()
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("branch", "-D", branch))
+	_ = sh.Scene.Repo.RunGitCommand("update-ref", "-d", "refs/stackit/metadata/"+branch)
+	_ = sh.Scene.Repo.RunGitCommand("update-ref", "-d", "refs/stackit/local-metadata/"+branch)
+}
+
+// dropRemoteMetadata removes the pushed metadata ref and the local fetched cache for
+// a branch, simulating a partial remote metadata chain.
+func dropRemoteMetadata(t *testing.T, sh *scenario.Scenario, branch string) {
+	t.Helper()
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("push", "origin", ":refs/stackit/metadata/"+branch))
+	_ = sh.Scene.Repo.RunGitCommand("update-ref", "-d", "refs/stackit/remote-metadata/"+branch)
+}
+
+func newCountingGitHubClient(t *testing.T, config *testhelpers.MockGitHubServerConfig) *countingGitHubClient {
+	t.Helper()
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, config)
+	return &countingGitHubClient{Client: testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, config)}
+}
+
+func TestGetMetadataDiscovery(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resolves parents and PR numbers from metadata without a GitHub crawl", func(t *testing.T) {
+		t.Parallel()
+		sh := scenario.NewRemoteScenario(t)
+
+		// Build main -> a -> b as a stackit stack.
+		sh.CreateBranch("a").CommitChange("a.txt", "a").TrackBranch("a", "main")
+		sh.CreateBranch("b").CommitChange("b.txt", "b").TrackBranch("b", "a")
+
+		config := testhelpers.NewMockGitHubServerConfig()
+		gh := newCountingGitHubClient(t, config)
+		sh.Context.GitHubClient = gh
+
+		// Submit + sync so parent and PR info land in the pushed metadata.
+		require.NoError(t, submit.Action(sh.Context, submit.Options{NoEdit: true, Draft: true}, &noopHandler{}))
+		require.NoError(t, syncaction.Action(sh.Context, syncaction.Options{}, nil))
+
+		// Precondition: the remote metadata carries the PR number, so get has no reason
+		// to call GitHub for display either.
+		require.NoError(t, sh.Engine.LoadRemoteMetadataCache())
+		cache := sh.Engine.GetRemoteMetadataCache()
+		require.NotNil(t, cache.Get("b"), "remote metadata for b should exist")
+		require.NotNil(t, cache.Get("b").GetParentBranchName(), "remote metadata for b should record its parent")
+		bPR := cache.Get("b").GetPrInfo()
+		require.NotNil(t, bPR, "remote metadata for b should carry PR info")
+		require.NotNil(t, bPR.Number, "remote metadata for b should carry a PR number")
+
+		// Forget the branches locally so get must recreate them from the remote.
+		sh.Checkout("main")
+		dropLocalBranch(t, sh, "b")
+		dropLocalBranch(t, sh, "a")
+		sh.Rebuild()
+
+		// Now measure: get should resolve everything from metadata, zero GitHub crawl.
+		gh.prByBranch.Store(0)
+		handler := &recordingGetHandler{}
+		require.NoError(t, actions.GetAction(sh.Context, "b", actions.GetOptions{Restack: true}, handler))
+		sh.Rebuild()
+
+		sh.ExpectStackStructure(map[string]string{"b": "a", "a": "main"})
+		require.Equal(t, int64(0), gh.prByBranch.Load(),
+			"get should resolve parents and PR numbers from metadata without any GitHub PR-by-branch calls")
+		require.Equal(t, *bPR.Number, handler.prByBranch["b"], "get should surface the PR number from metadata")
+	})
+
+	t.Run("falls back to GitHub when remote metadata is absent", func(t *testing.T) {
+		t.Parallel()
+		sh := scenario.NewRemoteScenario(t)
+
+		// A raw git branch pushed to origin with NO stackit metadata.
+		sh.CreateBranchQuiet("feature-x")
+		sh.CommitChange("fx.txt", "feature x")
+		require.NoError(t, sh.Scene.Repo.RunGitCommand("push", "-u", "origin", "feature-x"))
+		sh.CheckoutQuiet("main")
+		require.NoError(t, sh.Scene.Repo.RunGitCommand("branch", "-D", "feature-x"))
+		sh.Rebuild()
+
+		// GitHub knows about the PR (base main); metadata does not.
+		config := testhelpers.NewMockGitHubServerConfig()
+		config.PRs["feature-x"] = &github.PullRequest{
+			Number: new(42),
+			Head:   &github.PullRequestBranch{Ref: new("feature-x")},
+			Base:   &github.PullRequestBranch{Ref: new("main")},
+			State:  new("open"),
+		}
+		gh := newCountingGitHubClient(t, config)
+		sh.Context.GitHubClient = gh
+
+		require.NoError(t, actions.GetAction(sh.Context, "feature-x", actions.GetOptions{Restack: true}, &actions.GetNullHandler{}))
+		sh.Rebuild()
+
+		sh.ExpectStackStructure(map[string]string{"feature-x": "main"})
+		require.GreaterOrEqual(t, gh.prByBranch.Load(), int64(1),
+			"get should fall back to the GitHub crawl when metadata is absent")
+	})
+
+	t.Run("falls back to GitHub when ancestor metadata is missing", func(t *testing.T) {
+		t.Parallel()
+		sh := scenario.NewRemoteScenario(t)
+
+		sh.CreateBranch("a").CommitChange("a.txt", "a").TrackBranch("a", "main")
+		sh.CreateBranch("b").CommitChange("b.txt", "b").TrackBranch("b", "a")
+
+		config := testhelpers.NewMockGitHubServerConfig()
+		gh := newCountingGitHubClient(t, config)
+		sh.Context.GitHubClient = gh
+
+		require.NoError(t, submit.Action(sh.Context, submit.Options{NoEdit: true, Draft: true}, &noopHandler{}))
+		require.NoError(t, syncaction.Action(sh.Context, syncaction.Options{}, nil))
+
+		// Keep b's metadata pointing to a, but remove a's metadata. Metadata discovery
+		// should not accept this partial chain; GitHub can still provide a -> main.
+		dropRemoteMetadata(t, sh, "a")
+
+		sh.Checkout("main")
+		dropLocalBranch(t, sh, "b")
+		dropLocalBranch(t, sh, "a")
+		sh.Rebuild()
+
+		gh.prByBranch.Store(0)
+		require.NoError(t, actions.GetAction(sh.Context, "b", actions.GetOptions{Restack: true}, &actions.GetNullHandler{}))
+		sh.Rebuild()
+
+		sh.ExpectStackStructure(map[string]string{"b": "a", "a": "main"})
+		require.GreaterOrEqual(t, gh.prByBranch.Load(), int64(2),
+			"get should crawl GitHub for the target and missing ancestor when metadata is partial")
+	})
+
+	t.Run("single branch resolves from metadata without a GitHub crawl", func(t *testing.T) {
+		t.Parallel()
+		sh := scenario.NewRemoteScenario(t)
+
+		sh.CreateBranch("feature").CommitChange("f.txt", "f").TrackBranch("feature", "main")
+
+		config := testhelpers.NewMockGitHubServerConfig()
+		gh := newCountingGitHubClient(t, config)
+		sh.Context.GitHubClient = gh
+
+		require.NoError(t, submit.Action(sh.Context, submit.Options{NoEdit: true, Draft: true}, &noopHandler{}))
+		require.NoError(t, syncaction.Action(sh.Context, syncaction.Options{}, nil))
+
+		sh.Checkout("main")
+		dropLocalBranch(t, sh, "feature")
+		sh.Rebuild()
+
+		gh.prByBranch.Store(0)
+		require.NoError(t, actions.GetAction(sh.Context, "feature", actions.GetOptions{Restack: true}, &actions.GetNullHandler{}))
+		sh.Rebuild()
+
+		sh.ExpectStackStructure(map[string]string{"feature": "main"})
+		require.Equal(t, int64(0), gh.prByBranch.Load(),
+			"single-branch get should resolve from metadata without any GitHub PR-by-branch calls")
+	})
+}


### PR DESCRIPTION
This PR merges the following changes:

1. **#1169** refactor(get): extract crawlAncestorsViaGitHub helper
2. **#1170** perf(get): derive parents from fetched metadata, not a serial GitHub crawl
3. **#1171** test(get): cover metadata-driven discovery and GitHub fallback
4. **#1172** docs: add performance guide (SSH reuse + tracing)

### Stack

```
main
  └─ jonnii/20260607155725/extract-crawlAncestorsViaGitHub-helper (#1169)
    └─ jonnii/20260607160345/derive-parents-from-fetched-metadata-not-a (#1170)
      └─ jonnii/20260607161202/cover-metadata-driven-discovery-and-GitHub (#1171)
        └─ jonnii/20260607161325/add-performance-guide-SSH-reuse-tracing (#1172)
```

Stackit-Stack-Size: 4
Stackit-PRs: 1169,1170,1171,1172
