### PR TITLE
perf(submit): batch remote ref read for stack submit

### DIFF
--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -277,6 +277,15 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	repoOwner, repoName := githubClient.GetOwnerRepo()
 
 	remote := nav.GetRemote()
+
+	// Read remote status for every branch once, up front. The force-with-lease
+	// pre-check in pushBranchIfNeeded needs each branch's remote SHA, and reading
+	// it per branch would run a full `git ls-remote` for the entire remote N
+	// times. A single batched read does one ls-remote and indexes every branch
+	// from it. Branches push to independent refs, so this snapshot stays valid
+	// across the parallel update path.
+	remoteStatuses := ctx.PR().ReadBranchRemoteStatuses(ctx.Context, branchObjs)
+
 	var submitErr error
 	var errMu sync.Mutex
 
@@ -284,7 +293,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		if allCreates {
 			// Sequential submission for new stacks - ensures sequential PR numbers
 			for _, info := range submissionInfos {
-				if err := submitBranch(ctx, info, opts, handler, repoOwner, repoName, remote); err != nil {
+				if err := submitBranch(ctx, info, opts, handler, repoOwner, repoName, remote, remoteStatuses); err != nil {
 					errMu.Lock()
 					if submitErr == nil {
 						submitErr = err
@@ -295,7 +304,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		} else {
 			// Parallel submission for updates (faster when PRs already exist)
 			utils.Run(submissionInfos, func(info Info) {
-				if err := submitBranch(ctx, info, opts, handler, repoOwner, repoName, remote); err != nil {
+				if err := submitBranch(ctx, info, opts, handler, repoOwner, repoName, remote, remoteStatuses); err != nil {
 					errMu.Lock()
 					if submitErr == nil {
 						submitErr = err
@@ -358,13 +367,13 @@ func normalizeDisplayTreeParents(nav engine.StackNavigator, stackTree *tree.Stac
 }
 
 // submitBranch submits a single branch
-func submitBranch(ctx *app.Context, info Info, opts Options, handler Handler, repoOwner, repoName, remote string) error {
+func submitBranch(ctx *app.Context, info Info, opts Options, handler Handler, repoOwner, repoName, remote string, remoteStatuses engine.BranchRemoteStatuses) error {
 	handler.OnEvent(BranchProgressEvent{
 		BranchName: info.BranchName,
 		Status:     StatusSubmitting,
 	})
 
-	if err := pushBranchIfNeeded(ctx, info, opts, remote); err != nil {
+	if err := pushBranchIfNeeded(ctx, info, opts, remote, remoteStatuses); err != nil {
 		handler.OnEvent(BranchProgressEvent{
 			BranchName: info.BranchName,
 			Status:     StatusError,
@@ -433,8 +442,10 @@ func getGitHubClient(ctx *app.Context) (github.Client, error) {
 	return nil, fmt.Errorf("no GitHub client available - check your GITHUB_TOKEN")
 }
 
-// pushBranchIfNeeded pushes a branch to remote if needed
-func pushBranchIfNeeded(ctx *app.Context, submissionInfo Info, opts Options, remote string) error {
+// pushBranchIfNeeded pushes a branch to remote if needed. remoteStatuses is the
+// batched snapshot read once in Action, so this does not hit the network per
+// branch.
+func pushBranchIfNeeded(ctx *app.Context, submissionInfo Info, opts Options, remote string, remoteStatuses engine.BranchRemoteStatuses) error {
 	// Skip if dry run
 	if opts.DryRun {
 		return nil
@@ -444,7 +455,7 @@ func pushBranchIfNeeded(ctx *app.Context, submissionInfo Info, opts Options, rem
 	branch := ctx.Navigator().GetBranch(submissionInfo.BranchName)
 	leaseExpectedSHA := ""
 	if forceWithLease {
-		status := ctx.PR().ReadBranchRemoteStatuses(ctx.Context, engine.BranchesOf(branch)).ForBranch(branch)
+		status := remoteStatuses.ForBranch(branch)
 		// Remote already has this exact SHA — skip the push to avoid a spurious
 		// "cannot lock ref: reference already exists" rejection from the server.
 		if status.Matches() {

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -1,17 +1,33 @@
 package submit_test
 
 import (
+	"bytes"
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/getstackit/stackit/internal/actions/submit"
+	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
+
+// countingRunner wraps a git.Runner and counts FetchRemoteShas calls. It lets
+// tests assert that submit reads the remote ref list once for the whole stack
+// rather than once per branch (a full `git ls-remote` each time).
+type countingRunner struct {
+	git.Runner
+	fetchRemoteShas atomic.Int64
+}
+
+func (c *countingRunner) FetchRemoteShas(ctx context.Context, remote string) (map[string]string, error) {
+	c.fetchRemoteShas.Add(1)
+	return c.Runner.FetchRemoteShas(ctx, remote)
+}
 
 // noopHandler is a test handler that ignores all events
 type noopHandler struct{}
@@ -297,6 +313,57 @@ func TestActionWithMockedGitHub(t *testing.T) {
 		err = submit.Action(s.Context, opts, &noopHandler{})
 		require.NoError(t, err, "submit should succeed when branch is already in sync with remote")
 	})
+}
+
+func TestSubmitReadsRemoteStatusOnceForStack(t *testing.T) {
+	t.Parallel()
+	// Regression test for the per-branch ls-remote N+1: submitting a stack must
+	// read remote ref status once for the whole stack, not once per branch.
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{
+			"P":  "main",
+			"C1": "P",
+			"C2": "C1",
+		})
+
+	s.Checkout("P")
+
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	// Build a second engine over the same repo with a runner that counts
+	// FetchRemoteShas, then drive submit through it.
+	counting := &countingRunner{Runner: git.NewRunnerWithPath(s.Scene.Dir, nil)}
+	eng, err := engine.NewEngine(engine.Options{
+		RepoRoot: s.Scene.Dir,
+		Trunk:    "main",
+		Git:      counting,
+	})
+	require.NoError(t, err)
+
+	config := testhelpers.NewMockGitHubServerConfig()
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, config)
+	githubClient := testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, config)
+
+	ctx := app.NewContext(eng,
+		app.WithRepoRoot(s.Scene.Dir),
+		app.WithWriter(&bytes.Buffer{}),
+		app.WithGlobalOptions(app.GlobalOptions{Verify: true}),
+	)
+	ctx.GitHubClient = githubClient
+
+	opts := submit.Options{
+		StackRange: engine.StackRangeFull(),
+		NoEdit:     true,
+		Draft:      true,
+	}
+
+	err = submit.Action(ctx, opts, &noopHandler{})
+	require.NoError(t, err)
+	require.Equal(t, 3, len(config.CreatedPRs), "should create a PR for each of P, C1, C2")
+
+	require.Equal(t, int64(1), counting.fetchRemoteShas.Load(),
+		"submit must read remote status once for the whole stack, not once per branch")
 }
 
 func TestSubmitPreservesLockStatus(t *testing.T) {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

submit --stack read remote ref status once per branch inside the push
loop, and each read runs a full `git ls-remote` over the entire remote.
For an N-branch stack that is N full remote listings.

Hoist a single ReadBranchRemoteStatuses over all branches before the
submit loop and thread the snapshot into pushBranchIfNeeded. Branches
push to independent refs, so the snapshot stays valid across the
parallel update path and the sequential create path (new branches are
absent from the remote either way). One ls-remote instead of N.

Adds a counting git runner test asserting a single FetchRemoteShas for
a three-branch stack submit.

<hr/>

<!-- STACKIT-SECTION-START -->
**Eliminate submit N+1s: batch remote reads, pushes, and GitHub API calls**

Systematically removes the per-branch N+1 patterns from `stackit submit`, replacing serial per-branch operations with batched equivalents across every network boundary.

**Performance changes (each removes a per-branch serial operation):**
- **Batch remote ref read:** replace per-branch `git ls-remote` with a single `FetchRemoteShas` call shared across planning, force-with-lease guards, and the push
- **Batch push:** replace one `git push` per branch with a single batched `git push --porcelain` for the whole stack; partial failures surface per-branch via `--force-with-lease=<ref>:<sha>` guards
- **Batch PR-info sync:** replace one REST list call per branch with a single GraphQL query using aliased `ref.associatedPullRequests` lookups; REST fallback preserved for GraphQL failures
- **Batch PR-content reads (footer pass):** replace one `GetPullRequest` per branch with a single aliased GraphQL query when updating PR body footers
- **Batch remote read in planning:** `BatchGetPRSubmissionStatus` reads remote status once for the whole set, not once per branch; skips the read entirely for all-creates stacks
- **Overlap remote read with PR sync:** fire the single `ls-remote` concurrently with validation's GraphQL PR-info sync (independent round trips); skipped on dry runs
- **Batch empty-branch validation:** replace per-branch `git diff` with a single batched `rev-parse` resolving all branch and parent tree SHAs at once

**Refactors:**
- **Lazy TUI start:** fold `HasSubmitWork` (a pre-flight scope check) into `Action`; the TUI runner now starts on the first `StackDisplayEvent` instead of unconditionally, eliminating the startup/teardown flash when there is nothing to submit
- **Submit feedback:** dry-run create-only stacks skip the `ls-remote` entirely; GraphQL→REST fallback in `SyncPrInfo` ensures PR info syncs even when GraphQL fails

**Testing:** counting-runner assertions lock in the N+1 elimination (one remote read, one push per submit invocation); porcelain partial-failure test covers stale-lease isolation; GraphQL parse tests cover null refs, missing PRs, and error responses.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780885933`.


* **PR #1175** 👈
  * **PR #1176**
    * **PR #1177**
      * **PR #1178**
        * **PR #1179**
          * **PR #1180**
            * **PR #1181**
              * **PR #1182**
                * **PR #1183**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1184 by jonnii*