### PR TITLE
perf(submit): push entire stack in a single git push

### DIFF
--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -279,12 +279,16 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	remote := nav.GetRemote()
 
 	// Read remote status for every branch once, up front. The force-with-lease
-	// pre-check in pushBranchIfNeeded needs each branch's remote SHA, and reading
-	// it per branch would run a full `git ls-remote` for the entire remote N
-	// times. A single batched read does one ls-remote and indexes every branch
-	// from it. Branches push to independent refs, so this snapshot stays valid
-	// across the parallel update path.
+	// guards below need each branch's remote SHA; reading per branch would run a
+	// full `git ls-remote` over the entire remote N times. One batched read does
+	// a single ls-remote and indexes every branch from it.
 	remoteStatuses := ctx.PR().ReadBranchRemoteStatuses(ctx.Context, branchObjs)
+
+	// Push every branch that needs it in a single git invocation instead of one
+	// `git push` per branch (N network round trips). The push runs before the
+	// create/update loop so every ref exists on the remote before its PR is
+	// created; the per-branch result is consumed by submitBranch below.
+	pushResults := pushSubmittedBranches(ctx, opts, submissionInfos, remote, remoteStatuses)
 
 	var submitErr error
 	var errMu sync.Mutex
@@ -293,7 +297,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		if allCreates {
 			// Sequential submission for new stacks - ensures sequential PR numbers
 			for _, info := range submissionInfos {
-				if err := submitBranch(ctx, info, opts, handler, repoOwner, repoName, remote, remoteStatuses); err != nil {
+				if err := submitBranch(ctx, info, opts, handler, repoOwner, repoName, pushResults); err != nil {
 					errMu.Lock()
 					if submitErr == nil {
 						submitErr = err
@@ -304,7 +308,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		} else {
 			// Parallel submission for updates (faster when PRs already exist)
 			utils.Run(submissionInfos, func(info Info) {
-				if err := submitBranch(ctx, info, opts, handler, repoOwner, repoName, remote, remoteStatuses); err != nil {
+				if err := submitBranch(ctx, info, opts, handler, repoOwner, repoName, pushResults); err != nil {
 					errMu.Lock()
 					if submitErr == nil {
 						submitErr = err
@@ -366,14 +370,19 @@ func normalizeDisplayTreeParents(nav engine.StackNavigator, stackTree *tree.Stac
 	stackTree.ChildrenMap = childrenMap
 }
 
-// submitBranch submits a single branch
-func submitBranch(ctx *app.Context, info Info, opts Options, handler Handler, repoOwner, repoName, remote string, remoteStatuses engine.BranchRemoteStatuses) error {
+// submitBranch creates or updates the PR for a single branch. The branch has
+// already been pushed as part of the batched push in Action; pushResults carries
+// that branch's push outcome.
+func submitBranch(ctx *app.Context, info Info, opts Options, handler Handler, repoOwner, repoName string, pushResults map[string]error) error {
 	handler.OnEvent(BranchProgressEvent{
 		BranchName: info.BranchName,
 		Status:     StatusSubmitting,
 	})
 
-	if err := pushBranchIfNeeded(ctx, info, opts, remote, remoteStatuses); err != nil {
+	if err := pushResults[info.BranchName]; err != nil {
+		if errors.Is(err, git.ErrStaleRemoteInfo) {
+			err = fmt.Errorf("force-with-lease push of %s failed due to external changes to the remote branch. If you are collaborating on this stack, try 'stackit sync' to pull in changes. Alternatively, use the --force option to bypass the stale info warning", info.BranchName)
+		}
 		handler.OnEvent(BranchProgressEvent{
 			BranchName: info.BranchName,
 			Status:     StatusError,
@@ -442,39 +451,38 @@ func getGitHubClient(ctx *app.Context) (github.Client, error) {
 	return nil, fmt.Errorf("no GitHub client available - check your GITHUB_TOKEN")
 }
 
-// pushBranchIfNeeded pushes a branch to remote if needed. remoteStatuses is the
-// batched snapshot read once in Action, so this does not hit the network per
-// branch.
-func pushBranchIfNeeded(ctx *app.Context, submissionInfo Info, opts Options, remote string, remoteStatuses engine.BranchRemoteStatuses) error {
-	// Skip if dry run
-	if opts.DryRun {
-		return nil
+// pushSubmittedBranches pushes every branch that needs it in a single git
+// invocation and returns a per-branch result map (nil entry = success). A branch
+// already in sync with the remote is skipped (unless --force) to avoid a
+// spurious "cannot lock ref: reference already exists" rejection, and is absent
+// from the map — callers treat a missing entry as success. remoteStatuses is the
+// batched snapshot read once in Action, so building the push specs hits no
+// network per branch.
+func pushSubmittedBranches(ctx *app.Context, opts Options, infos []Info, remote string, remoteStatuses engine.BranchRemoteStatuses) map[string]error {
+	nav := ctx.Navigator()
+	forceWithLease := !opts.Force
+
+	specs := make([]git.PushSpec, 0, len(infos))
+	for _, info := range infos {
+		branch := nav.GetBranch(info.BranchName)
+		status := remoteStatuses.ForBranch(branch)
+		if forceWithLease && status.Matches() {
+			continue
+		}
+		specs = append(specs, git.PushSpec{
+			BranchName:        info.BranchName,
+			ExpectedRemoteSHA: status.RemoteSha,
+		})
 	}
 
-	forceWithLease := !opts.Force
-	branch := ctx.Navigator().GetBranch(submissionInfo.BranchName)
-	leaseExpectedSHA := ""
-	if forceWithLease {
-		status := remoteStatuses.ForBranch(branch)
-		// Remote already has this exact SHA — skip the push to avoid a spurious
-		// "cannot lock ref: reference already exists" rejection from the server.
-		if status.Matches() {
-			return nil
-		}
-		leaseExpectedSHA = status.RemoteSha
+	if len(specs) == 0 {
+		return map[string]error{}
 	}
-	if err := ctx.PR().PushBranch(ctx.Context, branch, remote, git.PushOptions{
-		Force:                     opts.Force,
-		ForceWithLease:            forceWithLease,
-		ForceWithLeaseExpectedSHA: leaseExpectedSHA,
-		NoVerify:                  !ctx.Verify,
-	}); err != nil {
-		if errors.Is(err, git.ErrStaleRemoteInfo) {
-			return fmt.Errorf("force-with-lease push of %s failed due to external changes to the remote branch. If you are collaborating on this stack, try 'stackit sync' to pull in changes. Alternatively, use the --force option to bypass the stale info warning", submissionInfo.BranchName)
-		}
-		return fmt.Errorf("failed to push branch %s: %w", submissionInfo.BranchName, err)
-	}
-	return nil
+
+	return ctx.PR().PushBranches(ctx.Context, remote, specs, git.PushOptions{
+		Force:    opts.Force,
+		NoVerify: !ctx.Verify,
+	})
 }
 
 // createPullRequestQuiet creates a new pull request without logging

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -16,17 +16,30 @@ import (
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
-// countingRunner wraps a git.Runner and counts FetchRemoteShas calls. It lets
-// tests assert that submit reads the remote ref list once for the whole stack
-// rather than once per branch (a full `git ls-remote` each time).
+// countingRunner wraps a git.Runner and counts the network-bound operations
+// submit fans out over a stack. It lets tests assert that submit reads the
+// remote ref list once (not once per branch) and pushes the whole stack in a
+// single batched invocation rather than one `git push` per branch.
 type countingRunner struct {
 	git.Runner
 	fetchRemoteShas atomic.Int64
+	pushBranches    atomic.Int64
+	pushBranch      atomic.Int64
 }
 
 func (c *countingRunner) FetchRemoteShas(ctx context.Context, remote string) (map[string]string, error) {
 	c.fetchRemoteShas.Add(1)
 	return c.Runner.FetchRemoteShas(ctx, remote)
+}
+
+func (c *countingRunner) PushBranches(ctx context.Context, remote string, specs []git.PushSpec, opts git.PushOptions) map[string]error {
+	c.pushBranches.Add(1)
+	return c.Runner.PushBranches(ctx, remote, specs, opts)
+}
+
+func (c *countingRunner) PushBranch(ctx context.Context, branchName, remote string, opts git.PushOptions) error {
+	c.pushBranch.Add(1)
+	return c.Runner.PushBranch(ctx, branchName, remote, opts)
 }
 
 // noopHandler is a test handler that ignores all events
@@ -364,6 +377,63 @@ func TestSubmitReadsRemoteStatusOnceForStack(t *testing.T) {
 
 	require.Equal(t, int64(1), counting.fetchRemoteShas.Load(),
 		"submit must read remote status once for the whole stack, not once per branch")
+}
+
+func TestSubmitPushesStackInSingleBatch(t *testing.T) {
+	t.Parallel()
+	// Regression test for the per-branch push N+1: submitting a stack must push
+	// every branch in one `git push` invocation, not one push per branch.
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{
+			"P":  "main",
+			"C1": "P",
+			"C2": "C1",
+		})
+
+	s.Checkout("P")
+
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	counting := &countingRunner{Runner: git.NewRunnerWithPath(s.Scene.Dir, nil)}
+	eng, err := engine.NewEngine(engine.Options{
+		RepoRoot: s.Scene.Dir,
+		Trunk:    "main",
+		Git:      counting,
+	})
+	require.NoError(t, err)
+
+	config := testhelpers.NewMockGitHubServerConfig()
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, config)
+	githubClient := testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, config)
+
+	ctx := app.NewContext(eng,
+		app.WithRepoRoot(s.Scene.Dir),
+		app.WithWriter(&bytes.Buffer{}),
+		app.WithGlobalOptions(app.GlobalOptions{Verify: true}),
+	)
+	ctx.GitHubClient = githubClient
+
+	opts := submit.Options{
+		StackRange: engine.StackRangeFull(),
+		NoEdit:     true,
+		Draft:      true,
+	}
+
+	err = submit.Action(ctx, opts, &noopHandler{})
+	require.NoError(t, err)
+	require.Equal(t, 3, len(config.CreatedPRs), "should create a PR for each of P, C1, C2")
+
+	require.Equal(t, int64(1), counting.pushBranches.Load(),
+		"submit must push the whole stack in a single batched push")
+	require.Equal(t, int64(0), counting.pushBranch.Load(),
+		"submit must not fall back to per-branch pushes")
+
+	// Every branch landed on the remote.
+	for _, branch := range []string{"P", "C1", "C2"} {
+		require.NoError(t, s.Scene.Repo.RunGitCommand("rev-parse", "--verify", "refs/remotes/origin/"+branch),
+			"branch %s should be pushed to origin", branch)
+	}
 }
 
 func TestSubmitPreservesLockStatus(t *testing.T) {

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -216,6 +216,14 @@ func (d *demoGitRunner) PushBranch(_ context.Context, _, _ string, _ git.PushOpt
 	return nil
 }
 
+func (d *demoGitRunner) PushBranches(_ context.Context, _ string, specs []git.PushSpec, _ git.PushOptions) map[string]error {
+	results := make(map[string]error, len(specs))
+	for _, s := range specs {
+		results[s.BranchName] = nil
+	}
+	return results
+}
+
 func (d *demoGitRunner) Rebase(_ context.Context, _, _, _ string) (git.RebaseOutcome, error) {
 	return git.RebaseOutcome{Result: git.RebaseDone}, nil
 }

--- a/internal/engine/branch_mutations.go
+++ b/internal/engine/branch_mutations.go
@@ -118,6 +118,12 @@ func (e *engineImpl) PushBranch(ctx context.Context, branch Branch, remote strin
 	return e.git.PushBranch(ctx, branch.GetName(), remote, opts)
 }
 
+// PushBranches pushes multiple branches to the remote in a single git
+// invocation, returning a per-branch result map (nil entry = success).
+func (e *engineImpl) PushBranches(ctx context.Context, remote string, specs []git.PushSpec, opts git.PushOptions) map[string]error {
+	return e.git.PushBranches(ctx, remote, specs, opts)
+}
+
 // DeleteBranch deletes a branch and its metadata
 func (e *engineImpl) DeleteBranch(ctx context.Context, branch Branch) error {
 	branchName := branch.GetName()

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -25,6 +25,7 @@ type PRManager interface {
 	UpsertPrInfo(ctx context.Context, branch Branch, prInfo *PrInfo) error
 	ReadBranchRemoteStatuses(ctx context.Context, branches Branches) BranchRemoteStatuses
 	PushBranch(ctx context.Context, branch Branch, remote string, opts git.PushOptions) error
+	PushBranches(ctx context.Context, remote string, specs []git.PushSpec, opts git.PushOptions) map[string]error
 	// Navigation comment ID caching (stored in local metadata)
 	GetNavigationCommentID(branch Branch) (int64, error)
 	SetNavigationCommentID(branch Branch, commentID int64) error

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -37,6 +37,7 @@ type RemoteOperations interface {
 	GetRemoteRevision(branchName string) (string, error)
 	FindRemoteBranch(ctx context.Context, remote string) (string, error)
 	PushBranch(ctx context.Context, branchName, remote string, opts PushOptions) error
+	PushBranches(ctx context.Context, remote string, specs []PushSpec, opts PushOptions) map[string]error
 	PullBranch(ctx context.Context, remote, branchName string) (PullResult, error)
 	UpdateBranchFromRemote(ctx context.Context, remote, branchName string) (PullResult, error)
 	Fetch(ctx context.Context, remote, branch string) error

--- a/internal/git/push.go
+++ b/internal/git/push.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -12,6 +13,16 @@ type PushOptions struct {
 	ForceWithLease            bool
 	ForceWithLeaseExpectedSHA string
 	NoVerify                  bool
+}
+
+// PushSpec describes a single branch to push as part of a batched PushBranches
+// call.
+type PushSpec struct {
+	BranchName string
+	// ExpectedRemoteSHA is the SHA the remote ref is expected to be at, used for
+	// force-with-lease. An empty value means the branch is not expected to exist
+	// on the remote yet (a create); the lease then asserts the ref is absent.
+	ExpectedRemoteSHA string
 }
 
 func (r *runner) PushBranch(ctx context.Context, branchName, remote string, opts PushOptions) error {
@@ -41,4 +52,97 @@ func (r *runner) PushBranch(ctx context.Context, branchName, remote string, opts
 	}
 
 	return nil
+}
+
+// PushBranches pushes multiple branches to a remote in a single git invocation,
+// replacing N separate `git push` round trips with one. It returns a per-branch
+// result map: a nil entry means that branch pushed successfully. Push is
+// non-atomic, so a force-with-lease rejection on one branch does not block the
+// others — matching the prior one-push-per-branch behavior where each branch
+// succeeded or failed independently.
+//
+// When opts.Force is set, every branch is pushed with --force and the per-branch
+// ExpectedRemoteSHA is ignored. Otherwise each branch is pushed with an explicit
+// --force-with-lease guarding its expected remote SHA.
+func (r *runner) PushBranches(ctx context.Context, remote string, specs []PushSpec, opts PushOptions) map[string]error {
+	results := make(map[string]error, len(specs))
+	if len(specs) == 0 {
+		return results
+	}
+
+	args := []string{"push", "--porcelain", "-u", remote}
+	if opts.Force {
+		args = append(args, "--force")
+	} else {
+		for _, s := range specs {
+			args = append(args, fmt.Sprintf("--force-with-lease=refs/heads/%s:%s", s.BranchName, s.ExpectedRemoteSHA))
+		}
+	}
+	if opts.NoVerify {
+		args = append(args, "--no-verify")
+	}
+	for _, s := range specs {
+		args = append(args, s.BranchName)
+	}
+
+	out, err := r.RunGitCommandWithContext(ctx, args...)
+	if err != nil {
+		// `--porcelain` writes its per-ref status to stdout even when the push
+		// exits non-zero (some refs rejected); recover it from the error.
+		var ce *CommandError
+		if errors.As(err, &ce) {
+			out = ce.Stdout
+		}
+	}
+
+	parsePushPorcelain(out, results)
+
+	// Any branch not reported by porcelain (e.g. a connection/auth failure that
+	// produced no per-ref lines) inherits the command error so nothing is
+	// silently treated as a success.
+	for _, s := range specs {
+		if _, ok := results[s.BranchName]; ok {
+			continue
+		}
+		if err != nil {
+			results[s.BranchName] = fmt.Errorf("failed to push branch %s: %w", s.BranchName, err)
+		} else {
+			results[s.BranchName] = nil
+		}
+	}
+
+	return results
+}
+
+// parsePushPorcelain parses `git push --porcelain` output into per-branch
+// results, writing into the provided map. Each ref line has the form
+// "<flag>\t<from>:<to>\t<summary>"; only "!" indicates a rejected ref.
+func parsePushPorcelain(out string, results map[string]error) {
+	for line := range strings.SplitSeq(out, "\n") {
+		if line == "" || strings.HasPrefix(line, "To ") || line == "Done" {
+			continue
+		}
+		flag, rest, ok := strings.Cut(line, "\t")
+		if !ok {
+			continue
+		}
+		refs, summary, _ := strings.Cut(rest, "\t")
+		_, to, ok := strings.Cut(refs, ":")
+		if !ok {
+			continue
+		}
+		branch, ok := strings.CutPrefix(to, "refs/heads/")
+		if !ok {
+			continue
+		}
+		if flag == "!" {
+			if strings.Contains(summary, "stale info") || strings.Contains(summary, "forced update") {
+				results[branch] = fmt.Errorf("%w: force-with-lease push of %s failed due to external changes to the remote branch", ErrStaleRemoteInfo, branch)
+			} else {
+				results[branch] = fmt.Errorf("failed to push branch %s: %s", branch, strings.TrimSpace(summary))
+			}
+			continue
+		}
+		results[branch] = nil
+	}
 }

--- a/internal/git/push_test.go
+++ b/internal/git/push_test.go
@@ -61,3 +61,83 @@ func TestPushBranchWithExplicitForceWithLease(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, localSHA, remoteAfterPush["feature"])
 }
+
+func TestPushBranchesCreatesMultipleBranchesInOnePush(t *testing.T) {
+	t.Parallel()
+
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+	_, err := scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+	require.NoError(t, scene.Repo.PushBranch("origin", "main"))
+
+	require.NoError(t, scene.Repo.CreateAndCheckoutBranch("f1"))
+	require.NoError(t, scene.Repo.CreateChangeAndCommit("f1 v1", "f1"))
+	require.NoError(t, scene.Repo.CreateAndCheckoutBranch("f2"))
+	require.NoError(t, scene.Repo.CreateChangeAndCommit("f2 v1", "f2"))
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	// Empty ExpectedRemoteSHA means "expect absent" — the create case.
+	results := runner.PushBranches(context.Background(), "origin", []git.PushSpec{
+		{BranchName: "f1"},
+		{BranchName: "f2"},
+	}, git.PushOptions{})
+
+	require.NoError(t, results["f1"])
+	require.NoError(t, results["f2"])
+
+	remote, err := runner.FetchRemoteShas(context.Background(), "origin")
+	require.NoError(t, err)
+	require.Contains(t, remote, "f1")
+	require.Contains(t, remote, "f2")
+}
+
+func TestPushBranchesPartialSuccessOnStaleLease(t *testing.T) {
+	t.Parallel()
+
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+	remotePath, err := scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+	require.NoError(t, scene.Repo.PushBranch("origin", "main"))
+
+	// Two branches, both already on the remote.
+	require.NoError(t, scene.Repo.CreateAndCheckoutBranch("f1"))
+	require.NoError(t, scene.Repo.CreateChangeAndCommit("f1 v1", "f1"))
+	require.NoError(t, scene.Repo.PushBranch("origin", "f1"))
+	require.NoError(t, scene.Repo.CheckoutBranch("main"))
+	require.NoError(t, scene.Repo.CreateAndCheckoutBranch("f2"))
+	require.NoError(t, scene.Repo.CreateChangeAndCommit("f2 v1", "f2"))
+	require.NoError(t, scene.Repo.PushBranch("origin", "f2"))
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	before, err := runner.FetchRemoteShas(context.Background(), "origin")
+	require.NoError(t, err)
+
+	// Advance f1 on the remote out-of-band so the recorded lease goes stale.
+	otherDir := filepath.Join(t.TempDir(), "other")
+	otherRepo, err := testhelpers.NewGitRepoFromURL(otherDir, remotePath)
+	require.NoError(t, err)
+	require.NoError(t, otherRepo.RunGitCommand("checkout", "-b", "f1", "origin/f1"))
+	require.NoError(t, otherRepo.CreateChangeAndCommit("f1 external", "f1ext"))
+	require.NoError(t, otherRepo.PushBranch("origin", "f1"))
+
+	// Advance both branches locally so each has something to push.
+	require.NoError(t, scene.Repo.CheckoutBranch("f1"))
+	require.NoError(t, scene.Repo.CreateChangeAndCommit("f1 v2", "f1local"))
+	require.NoError(t, scene.Repo.CheckoutBranch("f2"))
+	require.NoError(t, scene.Repo.CreateChangeAndCommit("f2 v2", "f2local"))
+
+	results := runner.PushBranches(context.Background(), "origin", []git.PushSpec{
+		{BranchName: "f1", ExpectedRemoteSHA: before["f1"]}, // stale: remote moved
+		{BranchName: "f2", ExpectedRemoteSHA: before["f2"]}, // current
+	}, git.PushOptions{})
+
+	require.ErrorIs(t, results["f1"], git.ErrStaleRemoteInfo, "stale lease must surface ErrStaleRemoteInfo")
+	require.NoError(t, results["f2"], "the in-sync branch must still push despite f1's rejection")
+
+	// f2 advanced on the remote, f1 did not.
+	after, err := runner.FetchRemoteShas(context.Background(), "origin")
+	require.NoError(t, err)
+	f2SHA, err := scene.Repo.RunGitCommandAndGetOutput("rev-parse", "f2")
+	require.NoError(t, err)
+	require.Equal(t, f2SHA, after["f2"])
+}

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -176,6 +176,19 @@ func (t *tracingRunner) PushBranch(ctx context.Context, branchName, remote strin
 	return err
 }
 
+func (t *tracingRunner) PushBranches(ctx context.Context, remote string, specs []PushSpec, opts PushOptions) map[string]error {
+	start := time.Now()
+	results := t.inner.PushBranches(ctx, remote, specs, opts)
+	failed := 0
+	for _, err := range results {
+		if err != nil {
+			failed++
+		}
+	}
+	t.trace("PushBranches", time.Since(start), failed == 0, nil, slog.String("remote", remote), slog.Int("branches", len(specs)), slog.Int("failed", failed))
+	return results
+}
+
 func (t *tracingRunner) PullBranch(ctx context.Context, remote, branchName string) (PullResult, error) {
 	start := time.Now()
 	result, err := t.inner.PullBranch(ctx, remote, branchName)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

submit pushed one branch per `git push` invocation — N network round
trips and N pre-push hook runs for an N-branch stack.

Add a batched git.Runner.PushBranches that pushes every branch in one
invocation, using per-ref --force-with-lease (explicit expected SHA for
updates, empty "expect absent" for creates) and parsing --porcelain
output into per-branch results. The push is non-atomic, so a stale-lease
rejection on one branch surfaces against that branch while the rest
still push — preserving the prior independent per-branch semantics.

submit now reads remote status once (from the existing batched snapshot),
builds push specs for branches that are not already in sync, and runs a
single push before the create/update loop. The loop consumes each
branch's push result instead of pushing itself.

Tests cover batched creates, partial-success on a stale lease at the git
layer, and an N-branch submit issuing exactly one PushBranches call.

<hr/>

<!-- STACKIT-SECTION-START -->
**Eliminate submit N+1s: batch remote reads, pushes, and GitHub API calls**

Systematically removes the per-branch N+1 patterns from `stackit submit`, replacing serial per-branch operations with batched equivalents across every network boundary.

**Performance changes (each removes a per-branch serial operation):**
- **Batch remote ref read:** replace per-branch `git ls-remote` with a single `FetchRemoteShas` call shared across planning, force-with-lease guards, and the push
- **Batch push:** replace one `git push` per branch with a single batched `git push --porcelain` for the whole stack; partial failures surface per-branch via `--force-with-lease=<ref>:<sha>` guards
- **Batch PR-info sync:** replace one REST list call per branch with a single GraphQL query using aliased `ref.associatedPullRequests` lookups; REST fallback preserved for GraphQL failures
- **Batch PR-content reads (footer pass):** replace one `GetPullRequest` per branch with a single aliased GraphQL query when updating PR body footers
- **Batch remote read in planning:** `BatchGetPRSubmissionStatus` reads remote status once for the whole set, not once per branch; skips the read entirely for all-creates stacks
- **Overlap remote read with PR sync:** fire the single `ls-remote` concurrently with validation's GraphQL PR-info sync (independent round trips); skipped on dry runs
- **Batch empty-branch validation:** replace per-branch `git diff` with a single batched `rev-parse` resolving all branch and parent tree SHAs at once

**Refactors:**
- **Lazy TUI start:** fold `HasSubmitWork` (a pre-flight scope check) into `Action`; the TUI runner now starts on the first `StackDisplayEvent` instead of unconditionally, eliminating the startup/teardown flash when there is nothing to submit
- **Submit feedback:** dry-run create-only stacks skip the `ls-remote` entirely; GraphQL→REST fallback in `SyncPrInfo` ensures PR info syncs even when GraphQL fails

**Testing:** counting-runner assertions lock in the N+1 elimination (one remote read, one push per submit invocation); porcelain partial-failure test covers stale-lease isolation; GraphQL parse tests cover null refs, missing PRs, and error responses.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780885933`.


* **PR #1175**
  * **PR #1176** 👈
    * **PR #1177**
      * **PR #1178**
        * **PR #1179**
          * **PR #1180**
            * **PR #1181**
              * **PR #1182**
                * **PR #1183**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1184 by jonnii*