### PR TITLE
perf(submit): fetch stack PR info in one GraphQL query

### DIFF
--- a/internal/github/pr_info.go
+++ b/internal/github/pr_info.go
@@ -10,83 +10,45 @@ import (
 
 	"github.com/google/go-github/v67/github"
 	"golang.org/x/oauth2"
-
-	"github.com/getstackit/stackit/internal/utils"
 )
 
-// SyncPrInfo syncs PR information for branches from GitHub
+// SyncPrInfo syncs PR information for branches from GitHub. It fetches every
+// branch's PR in a single GraphQL query rather than one REST call per branch.
 func SyncPrInfo(ctx context.Context, runner GitCommandRunner, branchNames []string, repoOwner, repoName string, onUpdate func(string, *PullRequestInfo)) error {
-	// Get GitHub token
-	token, err := getGitHubToken(runner)
-	if err != nil {
-		// If no token, skip PR syncing (non-fatal)
+	if len(branchNames) == 0 {
+		return nil
+	}
+
+	// If no token, skip PR syncing (non-fatal).
+	if _, err := getGitHubToken(runner); err != nil {
 		return nil //nolint:nilerr
 	}
 
-	// Get repository info if not provided
-	var repoInfo *RepoInfo
+	// Resolve repository info if not provided.
 	if repoOwner == "" || repoName == "" {
-		repoInfo, err = getRepoInfoWithHostname(ctx, runner)
+		repoInfo, err := getRepoInfoWithHostname(ctx, runner)
 		if err != nil {
 			return nil //nolint:nilerr // Skip if can't determine repo
 		}
 		repoOwner = repoInfo.Owner
 		repoName = repoInfo.Repo
-	} else {
-		// Still need hostname for client configuration
-		repoInfo, err = getRepoInfoWithHostname(ctx, runner)
-		if err != nil {
-			return nil //nolint:nilerr // Skip if can't determine repo
-		}
 	}
 
-	// Create GitHub client with Enterprise support
-	client, err := createGitHubClient(ctx, repoInfo.Hostname, token)
+	infos, err := batchGetPRInfoByBranchGraphQL(ctx, runner, repoOwner, repoName, branchNames)
 	if err != nil {
-		return nil //nolint:nilerr // Skip if can't create client
+		return err
 	}
 
-	// Fetch PR info for each branch in parallel using a worker pool
-	if len(branchNames) == 0 {
+	if onUpdate == nil {
 		return nil
 	}
-
-	utils.Run(branchNames, func(name string) {
-		pr, err := getPRInfoForBranch(ctx, client, repoOwner, repoName, name)
-		if err != nil {
-			return
+	for name, info := range infos {
+		if info != nil {
+			onUpdate(name, info)
 		}
-
-		if pr != nil {
-			info := ToPullRequestInfo(pr)
-			if onUpdate != nil {
-				onUpdate(name, info)
-			}
-		}
-	})
+	}
 
 	return nil
-}
-
-// getPRInfoForBranch gets PR info for a branch
-func getPRInfoForBranch(ctx context.Context, client *github.Client, owner, repo, branchName string) (*github.PullRequest, error) {
-	// List PRs for this branch
-	prs, _, err := client.PullRequests.List(ctx, owner, repo, &github.PullRequestListOptions{
-		Head:  fmt.Sprintf("%s:%s", owner, branchName),
-		State: "all",
-		ListOptions: github.ListOptions{
-			PerPage: 1,
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	if len(prs) == 0 {
-		return nil, nil
-	}
-
-	return prs[0], nil
 }
 
 // createGitHubClient creates a GitHub client configured for the given hostname

--- a/internal/github/pr_info_graphql.go
+++ b/internal/github/pr_info_graphql.go
@@ -1,0 +1,151 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// batchGetPRInfoByBranchGraphQL fetches the most recent pull request associated
+// (as head ref) with each branch in a single GraphQL query, replacing one REST
+// list call per branch. Branches with no associated PR are absent from the
+// returned map.
+func batchGetPRInfoByBranchGraphQL(ctx context.Context, runner GitCommandRunner, owner, repo string, branchNames []string) (map[string]*PullRequestInfo, error) {
+	results := make(map[string]*PullRequestInfo, len(branchNames))
+	if len(branchNames) == 0 {
+		return results, nil
+	}
+
+	// Deduplicate while keeping a stable order for alias assignment.
+	seen := make(map[string]struct{}, len(branchNames))
+	unique := make([]string, 0, len(branchNames))
+	for _, n := range branchNames {
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		unique = append(unique, n)
+	}
+
+	query, variables := buildPRInfoByBranchQuery(owner, repo, unique)
+	body, err := executeGraphQLQuery(ctx, runner, query, variables)
+	if err != nil {
+		return nil, err
+	}
+	return parsePRInfoByBranchResponse(body, unique)
+}
+
+// buildPRInfoByBranchQuery builds a GraphQL query that resolves each branch's
+// head PR under a b<index> alias. Branch names are passed as variables so names
+// containing slashes or other characters need no escaping.
+func buildPRInfoByBranchQuery(owner, repo string, branches []string) (string, map[string]any) {
+	var b strings.Builder
+	b.WriteString("query($owner: String!, $repo: String!")
+	for i := range branches {
+		fmt.Fprintf(&b, ", $b%d: String!", i)
+	}
+	b.WriteString(") {\n")
+	b.WriteString("  repository(owner: $owner, name: $repo) {\n")
+	for i := range branches {
+		fmt.Fprintf(&b, "    b%d: ref(qualifiedName: $b%d) {\n", i, i)
+		b.WriteString("      associatedPullRequests(first: 1, orderBy: {field: CREATED_AT, direction: DESC}) {\n")
+		b.WriteString("        nodes { number title body state url isDraft baseRefName headRefName }\n")
+		b.WriteString("      }\n")
+		b.WriteString("    }\n")
+	}
+	b.WriteString("  }\n")
+	b.WriteString("}\n")
+
+	variables := map[string]any{
+		"owner": owner,
+		"repo":  repo,
+	}
+	for i, name := range branches {
+		variables[fmt.Sprintf("b%d", i)] = "refs/heads/" + name
+	}
+	return b.String(), variables
+}
+
+// parsePRInfoByBranchResponse maps each b<index> alias back to its branch name.
+// A missing ref or a ref with no associated PR is skipped (left out of the map),
+// matching the prior per-branch behavior where such branches kept their existing
+// local PR info.
+func parsePRInfoByBranchResponse(body []byte, branches []string) (map[string]*PullRequestInfo, error) {
+	var resp struct {
+		Data   map[string]any `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse GraphQL response: %w", err)
+	}
+
+	repository, ok := resp.Data["repository"].(map[string]any)
+	if !ok {
+		// No repository payload at all is a hard failure (bad repo, auth, etc.).
+		// Per-ref nulls do not land here — ref() simply returns null for a
+		// missing branch without producing a top-level error.
+		if len(resp.Errors) > 0 {
+			return nil, fmt.Errorf("graphql error: %s", resp.Errors[0].Message)
+		}
+		return nil, fmt.Errorf("invalid GraphQL response format: missing repository")
+	}
+
+	results := make(map[string]*PullRequestInfo, len(branches))
+	for i, name := range branches {
+		alias := fmt.Sprintf("b%d", i)
+		refData, ok := repository[alias].(map[string]any)
+		if !ok {
+			continue
+		}
+		assoc, ok := refData["associatedPullRequests"].(map[string]any)
+		if !ok {
+			continue
+		}
+		nodes, ok := assoc["nodes"].([]any)
+		if !ok || len(nodes) == 0 {
+			continue
+		}
+		node, ok := nodes[0].(map[string]any)
+		if !ok {
+			continue
+		}
+		results[name] = pullRequestInfoFromGraphQLNode(node)
+	}
+	return results, nil
+}
+
+// pullRequestInfoFromGraphQLNode converts a single associatedPullRequests node
+// into a PullRequestInfo. State is normalized to upper case to match the REST
+// path (ToPullRequestInfo); the GraphQL PullRequestState enum is already upper
+// case (OPEN/CLOSED/MERGED).
+func pullRequestInfoFromGraphQLNode(node map[string]any) *PullRequestInfo {
+	info := &PullRequestInfo{}
+	if v, ok := node["number"].(float64); ok {
+		info.Number = int(v)
+	}
+	if v, ok := node["title"].(string); ok {
+		info.Title = v
+	}
+	if v, ok := node["body"].(string); ok {
+		info.Body = v
+	}
+	if v, ok := node["state"].(string); ok {
+		info.State = strings.ToUpper(v)
+	}
+	if v, ok := node["url"].(string); ok {
+		info.HTMLURL = v
+	}
+	if v, ok := node["isDraft"].(bool); ok {
+		info.Draft = v
+	}
+	if v, ok := node["baseRefName"].(string); ok {
+		info.Base = v
+	}
+	if v, ok := node["headRefName"].(string); ok {
+		info.Head = v
+	}
+	return info
+}

--- a/internal/github/pr_info_graphql_test.go
+++ b/internal/github/pr_info_graphql_test.go
@@ -1,0 +1,101 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPRInfoByBranchQuery(t *testing.T) {
+	t.Parallel()
+
+	query, variables := buildPRInfoByBranchQuery("octo", "repo", []string{"feature", "jonnii/long/branch-name"})
+
+	require.Contains(t, query, "repository(owner: $owner, name: $repo)")
+	require.Contains(t, query, "b0: ref(qualifiedName: $b0)")
+	require.Contains(t, query, "b1: ref(qualifiedName: $b1)")
+	require.Contains(t, query, "associatedPullRequests(first: 1, orderBy: {field: CREATED_AT, direction: DESC})")
+	require.Contains(t, query, "number title body state url isDraft baseRefName headRefName")
+
+	require.Equal(t, "octo", variables["owner"])
+	require.Equal(t, "repo", variables["repo"])
+	// Branch names are passed as variables (qualified) so slashes need no escaping.
+	require.Equal(t, "refs/heads/feature", variables["b0"])
+	require.Equal(t, "refs/heads/jonnii/long/branch-name", variables["b1"])
+}
+
+func TestParsePRInfoByBranchResponse(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"data": {
+			"repository": {
+				"b0": {
+					"associatedPullRequests": {
+						"nodes": [
+							{"number": 42, "title": "feat: auth", "body": "do auth", "state": "OPEN", "url": "https://gh/pr/42", "isDraft": true, "baseRefName": "main", "headRefName": "feature"}
+						]
+					}
+				},
+				"b1": {
+					"associatedPullRequests": {
+						"nodes": [
+							{"number": 7, "title": "fix: merged", "body": "", "state": "MERGED", "url": "https://gh/pr/7", "isDraft": false, "baseRefName": "feature", "headRefName": "child"}
+						]
+					}
+				}
+			}
+		}
+	}`)
+
+	infos, err := parsePRInfoByBranchResponse(body, []string{"feature", "child"})
+	require.NoError(t, err)
+	require.Len(t, infos, 2)
+
+	feature := infos["feature"]
+	require.NotNil(t, feature)
+	require.Equal(t, 42, feature.Number)
+	require.Equal(t, "feat: auth", feature.Title)
+	require.Equal(t, "do auth", feature.Body)
+	require.Equal(t, "OPEN", feature.State)
+	require.Equal(t, "https://gh/pr/42", feature.HTMLURL)
+	require.True(t, feature.Draft)
+	require.Equal(t, "main", feature.Base)
+	require.Equal(t, "feature", feature.Head)
+
+	require.Equal(t, "MERGED", infos["child"].State)
+}
+
+func TestParsePRInfoByBranchResponse_NullRefAndNoPR(t *testing.T) {
+	t.Parallel()
+
+	// b0 ref does not exist (null); b1 exists but has no associated PR.
+	body := []byte(`{
+		"data": {
+			"repository": {
+				"b0": null,
+				"b1": {"associatedPullRequests": {"nodes": []}}
+			}
+		}
+	}`)
+
+	infos, err := parsePRInfoByBranchResponse(body, []string{"gone", "no-pr"})
+	require.NoError(t, err)
+	require.Empty(t, infos, "branches without an associated PR are skipped")
+}
+
+func TestParsePRInfoByBranchResponse_MissingRepository(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"data": {}, "errors": [{"message": "Could not resolve to a Repository"}]}`)
+	_, err := parsePRInfoByBranchResponse(body, []string{"feature"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Could not resolve to a Repository")
+}
+
+func TestParsePRInfoByBranchResponse_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	_, err := parsePRInfoByBranchResponse([]byte(`{invalid`), []string{"feature"})
+	require.Error(t, err)
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


SyncPrInfo (run by submit validation and sync) listed PRs one REST call
per branch — N round trips for an N-branch stack.

Replace the per-branch loop with a single GraphQL query that resolves
each branch's head PR under a b<index> alias, passing branch names as
variables so slashes need no escaping. Reuses the existing
executeGraphQLQuery helper, mirroring BatchGetPRTitlesGraphQL.

Behavior is preserved: no token still skips silently, branches without
an associated PR keep their existing local info, and state is normalized
to upper case. GraphQL reports merged PRs as MERGED (REST reported them
CLOSED), which downstream already treats identically.

Adds unit tests for the query builder and response parser, including the
null-ref/no-PR and missing-repository cases.

<hr/>

<!-- STACKIT-SECTION-START -->
**Eliminate submit N+1s: batch remote reads, pushes, and GitHub API calls**

Systematically removes the per-branch N+1 patterns from `stackit submit`, replacing serial per-branch operations with batched equivalents across every network boundary.

**Performance changes (each removes a per-branch serial operation):**
- **Batch remote ref read:** replace per-branch `git ls-remote` with a single `FetchRemoteShas` call shared across planning, force-with-lease guards, and the push
- **Batch push:** replace one `git push` per branch with a single batched `git push --porcelain` for the whole stack; partial failures surface per-branch via `--force-with-lease=<ref>:<sha>` guards
- **Batch PR-info sync:** replace one REST list call per branch with a single GraphQL query using aliased `ref.associatedPullRequests` lookups; REST fallback preserved for GraphQL failures
- **Batch PR-content reads (footer pass):** replace one `GetPullRequest` per branch with a single aliased GraphQL query when updating PR body footers
- **Batch remote read in planning:** `BatchGetPRSubmissionStatus` reads remote status once for the whole set, not once per branch; skips the read entirely for all-creates stacks
- **Overlap remote read with PR sync:** fire the single `ls-remote` concurrently with validation's GraphQL PR-info sync (independent round trips); skipped on dry runs
- **Batch empty-branch validation:** replace per-branch `git diff` with a single batched `rev-parse` resolving all branch and parent tree SHAs at once

**Refactors:**
- **Lazy TUI start:** fold `HasSubmitWork` (a pre-flight scope check) into `Action`; the TUI runner now starts on the first `StackDisplayEvent` instead of unconditionally, eliminating the startup/teardown flash when there is nothing to submit
- **Submit feedback:** dry-run create-only stacks skip the `ls-remote` entirely; GraphQL→REST fallback in `SyncPrInfo` ensures PR info syncs even when GraphQL fails

**Testing:** counting-runner assertions lock in the N+1 elimination (one remote read, one push per submit invocation); porcelain partial-failure test covers stale-lease isolation; GraphQL parse tests cover null refs, missing PRs, and error responses.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780885933`.


* **PR #1175**
  * **PR #1176**
    * **PR #1177** 👈
      * **PR #1178**
        * **PR #1179**
          * **PR #1180**
            * **PR #1181**
              * **PR #1182**
                * **PR #1183**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->