### PR TITLE
perf(submit): batch PR-content reads in the footer pass

### DIFF
--- a/internal/actions/pr_updates.go
+++ b/internal/actions/pr_updates.go
@@ -10,18 +10,55 @@ import (
 
 // UpdateStackPRMetadata updates PR titles and body footers for a list of branches
 func UpdateStackPRMetadata(ctx *app.Context, branches []string, repoOwner, repoName string) {
-	// Update PRs in parallel using a worker pool
 	if len(branches) == 0 {
 		return
 	}
 
+	// Fetch every PR's current title/body in one GraphQL query instead of one
+	// GetPullRequest per branch, then update each in parallel.
+	current := FetchPRContentForBranches(ctx, branches, repoOwner, repoName)
+
 	utils.Run(branches, func(name string) {
-		UpdateBranchPRMetadata(ctx, name, repoOwner, repoName)
+		UpdateBranchPRMetadataWithContent(ctx, name, repoOwner, repoName, current)
 	})
 }
 
-// UpdateBranchPRMetadata updates PR title and body footer for a single branch
+// FetchPRContentForBranches fetches the current title and body for the PRs of
+// the given branches in a single GraphQL query, keyed by PR number. Branches
+// without a known PR number are skipped. On failure it returns an empty map; the
+// per-branch update then falls back to a direct GetPullRequest.
+func FetchPRContentForBranches(ctx *app.Context, branches []string, repoOwner, repoName string) map[int]github.PRContent {
+	prNumbers := make([]int, 0, len(branches))
+	for _, name := range branches {
+		prInfo, err := ctx.Engine.GetBranch(name).GetPrInfo()
+		if err != nil || prInfo == nil || prInfo.Number() == nil {
+			continue
+		}
+		prNumbers = append(prNumbers, *prInfo.Number())
+	}
+	if len(prNumbers) == 0 {
+		return map[int]github.PRContent{}
+	}
+
+	content, err := github.BatchGetPRContentGraphQL(ctx.Context, ctx.Git(), repoOwner, repoName, prNumbers) //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
+	if err != nil {
+		ctx.Output.Debug("Failed to batch-fetch PR content: %v", err)
+		return map[int]github.PRContent{}
+	}
+	return content
+}
+
+// UpdateBranchPRMetadata updates PR title and body footer for a single branch.
 func UpdateBranchPRMetadata(ctx *app.Context, name string, repoOwner, repoName string) {
+	current := FetchPRContentForBranches(ctx, []string{name}, repoOwner, repoName)
+	UpdateBranchPRMetadataWithContent(ctx, name, repoOwner, repoName, current)
+}
+
+// UpdateBranchPRMetadataWithContent updates PR title and body footer for a single
+// branch, using PR content pre-fetched in bulk by FetchPRContentForBranches. If
+// the branch's PR is not present in current (a batch miss or fetch failure), it
+// falls back to a direct GetPullRequest so the freshness guarantee is preserved.
+func UpdateBranchPRMetadataWithContent(ctx *app.Context, name string, repoOwner, repoName string, current map[int]github.PRContent) {
 	branch := ctx.Engine.GetBranch(name)
 	prInfo, err := branch.GetPrInfo()
 	if err != nil || prInfo == nil || prInfo.Number() == nil {
@@ -31,17 +68,21 @@ func UpdateBranchPRMetadata(ctx *app.Context, name string, repoOwner, repoName s
 
 	prNumber := *prInfo.Number()
 
-	// 1. Fetch latest PR state from GitHub (Option 1)
-	latestPR, err := ctx.GitHub().GetPullRequest(ctx.Context, repoOwner, repoName, prNumber)
-	if err != nil {
-		ctx.Output.Debug("Failed to fetch PR #%d for %s: %v", prNumber, name, err)
-		return
+	// Use the bulk-fetched current state, falling back to a single GET on a miss.
+	content, ok := current[prNumber]
+	if !ok {
+		latestPR, err := ctx.GitHub().GetPullRequest(ctx.Context, repoOwner, repoName, prNumber)
+		if err != nil {
+			ctx.Output.Debug("Failed to fetch PR #%d for %s: %v", prNumber, name, err)
+			return
+		}
+		content = github.PRContent{Title: latestPR.Title, Body: latestPR.Body}
 	}
 
-	// 2. Calculate updates
+	// Calculate updates
 	scope := ctx.Engine.GetScope(branch)
-	currentTitle := latestPR.Title
-	currentBody := latestPR.Body
+	currentTitle := content.Title
+	currentBody := content.Body
 
 	updatedTitle := scope.ApplyToTitle(currentTitle)
 

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -324,14 +324,17 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return submitErr
 	}
 
-	// Update PR body footers with per-branch progress
+	// Update PR body footers with per-branch progress. Fetch every PR's current
+	// content in one GraphQL query up front (instead of a GET per branch), then
+	// apply each footer/title update in parallel.
 	if opts.SubmitFooter {
+		prContent := actions.FetchPRContentForBranches(ctx, branches, repoOwner, repoName)
 		utils.Run(branches, func(name string) {
 			handler.OnEvent(BranchProgressEvent{
 				BranchName: name,
 				Status:     StatusSyncing,
 			})
-			actions.UpdateBranchPRMetadata(ctx, name, repoOwner, repoName)
+			actions.UpdateBranchPRMetadataWithContent(ctx, name, repoOwner, repoName, prContent)
 			handler.OnEvent(BranchProgressEvent{
 				BranchName: name,
 				Status:     StatusDone,

--- a/internal/github/pr_content.go
+++ b/internal/github/pr_content.go
@@ -1,0 +1,100 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// PRContent is the current title and body of a pull request, fetched in bulk.
+type PRContent struct {
+	Title string
+	Body  string
+}
+
+// BatchGetPRContentGraphQL fetches the current title and body for multiple PR
+// numbers in a single GraphQL query, replacing one REST GetPullRequest call per
+// PR. PRs absent from the response (e.g. not found) are omitted from the map.
+func BatchGetPRContentGraphQL(ctx context.Context, runner GitCommandRunner, owner, repo string, prNumbers []int) (map[int]PRContent, error) {
+	if len(prNumbers) == 0 {
+		return make(map[int]PRContent), nil
+	}
+
+	seen := make(map[int]struct{}, len(prNumbers))
+	unique := make([]int, 0, len(prNumbers))
+	for _, n := range prNumbers {
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		unique = append(unique, n)
+	}
+
+	query := buildPRContentQuery(unique)
+	variables := map[string]any{
+		"owner": owner,
+		"repo":  repo,
+	}
+
+	body, err := executeGraphQLQuery(ctx, runner, query, variables)
+	if err != nil {
+		return nil, err
+	}
+
+	return parsePRContentResponse(body, unique)
+}
+
+// buildPRContentQuery builds a GraphQL query to fetch title and body for
+// multiple PRs by number.
+func buildPRContentQuery(prNumbers []int) string {
+	var b strings.Builder
+	b.WriteString("query($owner: String!, $repo: String!) {\n")
+	b.WriteString("  repository(owner: $owner, name: $repo) {\n")
+	for _, n := range prNumbers {
+		fmt.Fprintf(&b, "    pr_%d: pullRequest(number: %d) { title body }\n", n, n)
+	}
+	b.WriteString("  }\n")
+	b.WriteString("}\n")
+	return b.String()
+}
+
+// parsePRContentResponse parses the GraphQL response for PR content queries.
+func parsePRContentResponse(body []byte, prNumbers []int) (map[int]PRContent, error) {
+	var resp struct {
+		Data   map[string]any `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse GraphQL response: %w", err)
+	}
+
+	repository, ok := resp.Data["repository"].(map[string]any)
+	if !ok {
+		if len(resp.Errors) > 0 {
+			return nil, fmt.Errorf("graphql error: %s", resp.Errors[0].Message)
+		}
+		return nil, fmt.Errorf("invalid GraphQL response format: missing repository")
+	}
+
+	results := make(map[int]PRContent, len(prNumbers))
+	for _, n := range prNumbers {
+		alias := fmt.Sprintf("pr_%d", n)
+		data, ok := repository[alias].(map[string]any)
+		if !ok {
+			continue
+		}
+		content := PRContent{}
+		if title, ok := data["title"].(string); ok {
+			content.Title = title
+		}
+		if prBody, ok := data["body"].(string); ok {
+			content.Body = prBody
+		}
+		results[n] = content
+	}
+
+	return results, nil
+}

--- a/internal/github/pr_content_test.go
+++ b/internal/github/pr_content_test.go
@@ -1,0 +1,70 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPRContentQuery(t *testing.T) {
+	t.Parallel()
+
+	query := buildPRContentQuery([]int{42, 99})
+
+	require.Contains(t, query, "pr_42: pullRequest(number: 42) { title body }")
+	require.Contains(t, query, "pr_99: pullRequest(number: 99) { title body }")
+	require.Contains(t, query, "repository(owner: $owner, name: $repo)")
+}
+
+func TestParsePRContentResponse(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"data": {
+			"repository": {
+				"pr_42": {"title": "feat: auth", "body": "body 42"},
+				"pr_99": {"title": "fix: race", "body": ""}
+			}
+		}
+	}`)
+
+	content, err := parsePRContentResponse(body, []int{42, 99})
+	require.NoError(t, err)
+	require.Equal(t, map[int]PRContent{
+		42: {Title: "feat: auth", Body: "body 42"},
+		99: {Title: "fix: race", Body: ""},
+	}, content)
+}
+
+func TestParsePRContentResponse_NullEntry(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"data": {
+			"repository": {
+				"pr_42": {"title": "feat: auth", "body": "body 42"},
+				"pr_99": null
+			}
+		}
+	}`)
+
+	content, err := parsePRContentResponse(body, []int{42, 99})
+	require.NoError(t, err)
+	require.Equal(t, map[int]PRContent{42: {Title: "feat: auth", Body: "body 42"}}, content)
+}
+
+func TestParsePRContentResponse_MissingRepository(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"data": {}, "errors": [{"message": "Bad credentials"}]}`)
+	_, err := parsePRContentResponse(body, []int{42})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Bad credentials")
+}
+
+func TestParsePRContentResponse_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	_, err := parsePRContentResponse([]byte(`{bad`), []int{42})
+	require.Error(t, err)
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The PR footer/title pass (submit --footer, sync, lock) called
GetPullRequest once per branch to read the current title/body before
recomputing the navigation footer — N REST round trips per stack.

Add BatchGetPRContentGraphQL to fetch every PR's title/body in one
GraphQL query, and thread the pre-fetched content through
UpdateStackPRMetadata / UpdateBranchPRMetadataWithContent. A per-branch
GetPullRequest fallback runs only on a batch miss, so the freshness
guarantee (read current GitHub state before patching) is preserved.

The pass still scans every branch in the stack, not just the ones
submitted: footers carry stack-wide navigation, so an unchanged branch
still needs its footer refreshed when a sibling changes. Batching the
read makes that full scan one call, and the "nothing changed" case now
costs a single GraphQL read and zero PATCHes.

Adds unit tests for the content query builder and response parser.

<hr/>

<!-- STACKIT-SECTION-START -->
**Eliminate submit N+1s: batch remote reads, pushes, and GitHub API calls**

Systematically removes the per-branch N+1 patterns from `stackit submit`, replacing serial per-branch operations with batched equivalents across every network boundary.

**Performance changes (each removes a per-branch serial operation):**
- **Batch remote ref read:** replace per-branch `git ls-remote` with a single `FetchRemoteShas` call shared across planning, force-with-lease guards, and the push
- **Batch push:** replace one `git push` per branch with a single batched `git push --porcelain` for the whole stack; partial failures surface per-branch via `--force-with-lease=<ref>:<sha>` guards
- **Batch PR-info sync:** replace one REST list call per branch with a single GraphQL query using aliased `ref.associatedPullRequests` lookups; REST fallback preserved for GraphQL failures
- **Batch PR-content reads (footer pass):** replace one `GetPullRequest` per branch with a single aliased GraphQL query when updating PR body footers
- **Batch remote read in planning:** `BatchGetPRSubmissionStatus` reads remote status once for the whole set, not once per branch; skips the read entirely for all-creates stacks
- **Overlap remote read with PR sync:** fire the single `ls-remote` concurrently with validation's GraphQL PR-info sync (independent round trips); skipped on dry runs
- **Batch empty-branch validation:** replace per-branch `git diff` with a single batched `rev-parse` resolving all branch and parent tree SHAs at once

**Refactors:**
- **Lazy TUI start:** fold `HasSubmitWork` (a pre-flight scope check) into `Action`; the TUI runner now starts on the first `StackDisplayEvent` instead of unconditionally, eliminating the startup/teardown flash when there is nothing to submit
- **Submit feedback:** dry-run create-only stacks skip the `ls-remote` entirely; GraphQL→REST fallback in `SyncPrInfo` ensures PR info syncs even when GraphQL fails

**Testing:** counting-runner assertions lock in the N+1 elimination (one remote read, one push per submit invocation); porcelain partial-failure test covers stale-lease isolation; GraphQL parse tests cover null refs, missing PRs, and error responses.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780885933`.


* **PR #1175**
  * **PR #1176**
    * **PR #1177**
      * **PR #1178** 👈
        * **PR #1179**
          * **PR #1180**
            * **PR #1181**
              * **PR #1182**
                * **PR #1183**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1184 by jonnii*