### PR TITLE
perf(submit): batch remote read in submit planning

### DIFF
--- a/internal/actions/submit/planning.go
+++ b/internal/actions/submit/planning.go
@@ -13,12 +13,17 @@ func prepareBranchesForSubmit(ctx *app.Context, branches engine.Branches, opts O
 	submissionInfos := make([]Info, 0, len(branches))
 	nav := ctx.Navigator()
 
+	// Read submission status for every branch at once. This reads remote status
+	// a single time for the whole stack instead of a full `git ls-remote` per
+	// branch inside the loop.
+	statuses, err := ctx.Engine.BatchGetPRSubmissionStatus(branches)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, branch := range branches {
 		branchName := branch.GetName()
-		status, err := branch.GetPRSubmissionStatus()
-		if err != nil {
-			return nil, err
-		}
+		status := statuses[branchName]
 
 		action := status.Action
 		prNumber := status.PRNumber

--- a/internal/engine/engine_pr.go
+++ b/internal/engine/engine_pr.go
@@ -112,6 +112,40 @@ func (e *engineImpl) UpsertPrInfo(ctx context.Context, branch Branch, prInfo *Pr
 
 // GetPRSubmissionStatus returns the submission status of a branch
 func (e *engineImpl) GetPRSubmissionStatus(branch Branch) (PRSubmissionStatus, error) {
+	remoteStatus := e.ReadBranchRemoteStatuses(context.Background(), BranchesOf(branch)).ForBranch(branch)
+	return e.prSubmissionStatus(branch, remoteStatus)
+}
+
+// BatchGetPRSubmissionStatus returns the submission status for every branch,
+// reading remote status once for the whole set instead of once per branch (a
+// full `git ls-remote` each time). Results are keyed by branch name.
+func (e *engineImpl) BatchGetPRSubmissionStatus(branches Branches) (map[string]PRSubmissionStatus, error) {
+	// Only branches with an existing PR consult remote status; creates return
+	// early without it. Read the remote a single time, and only if at least one
+	// branch needs it, so an all-creates stack stays fully offline here.
+	remoteStatuses := BranchRemoteStatuses{}
+	for _, branch := range branches {
+		prInfo, err := e.GetPrInfo(branch)
+		if err == nil && prInfo != nil && prInfo.Number() != nil {
+			remoteStatuses = e.ReadBranchRemoteStatuses(context.Background(), branches)
+			break
+		}
+	}
+
+	results := make(map[string]PRSubmissionStatus, len(branches))
+	for _, branch := range branches {
+		status, err := e.prSubmissionStatus(branch, remoteStatuses.ForBranch(branch))
+		if err != nil {
+			return nil, err
+		}
+		results[branch.GetName()] = status
+	}
+	return results, nil
+}
+
+// prSubmissionStatus computes a branch's submission status from a precomputed
+// remote status, so batched callers read the remote once.
+func (e *engineImpl) prSubmissionStatus(branch Branch, remoteStatus BranchRemoteStatus) (PRSubmissionStatus, error) {
 	prInfo, err := e.GetPrInfo(branch)
 	if err != nil {
 		return PRSubmissionStatus{}, err
@@ -135,8 +169,7 @@ func (e *engineImpl) GetPRSubmissionStatus(branch Branch) (PRSubmissionStatus, e
 
 	// It's an update
 	baseChanged := prInfo.Base() != parentBranchName
-	status := e.ReadBranchRemoteStatuses(context.Background(), BranchesOf(branch)).ForBranch(branch)
-	branchMatches := status.Matches()
+	branchMatches := remoteStatus.Matches()
 
 	// Check if PR title needs update due to scope changes
 	titleNeedsUpdate := e.prTitleNeedsUpdate(branch, prInfo)

--- a/internal/engine/engine_pr_batch_test.go
+++ b/internal/engine/engine_pr_batch_test.go
@@ -1,0 +1,92 @@
+package engine_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// countingFetchRunner wraps a git.Runner and counts FetchRemoteShas calls, so a
+// test can assert remote status is read once for a whole stack rather than once
+// per branch.
+type countingFetchRunner struct {
+	git.Runner
+	fetchRemoteShas atomic.Int64
+}
+
+func (c *countingFetchRunner) FetchRemoteShas(ctx context.Context, remote string) (map[string]string, error) {
+	c.fetchRemoteShas.Add(1)
+	return c.Runner.FetchRemoteShas(ctx, remote)
+}
+
+func newCountingEngine(t *testing.T, dir string) (engine.Engine, *countingFetchRunner) {
+	t.Helper()
+	counting := &countingFetchRunner{Runner: git.NewRunnerWithPath(dir, nil)}
+	eng, err := engine.NewEngine(engine.Options{
+		RepoRoot: dir,
+		Trunk:    "main",
+		Git:      counting,
+	})
+	require.NoError(t, err)
+	return eng, counting
+}
+
+func TestBatchGetPRSubmissionStatusReadsRemoteOnceForUpdates(t *testing.T) {
+	t.Parallel()
+
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"P": "main", "C1": "P", "C2": "C1"})
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+	for _, b := range []string{"main", "P", "C1", "C2"} {
+		require.NoError(t, s.Scene.Repo.PushBranch("origin", b))
+	}
+
+	eng, counting := newCountingEngine(t, s.Scene.Dir)
+
+	// Give each branch an existing PR so it is an update, not a create.
+	for i, name := range []string{"P", "C1", "C2"} {
+		require.NoError(t, eng.UpsertPrInfo(context.Background(), eng.GetBranch(name),
+			testhelpers.NewTestPrInfoWithTitle(100+i, "title")))
+	}
+
+	branches := engine.BranchesOf(eng.GetBranch("P"), eng.GetBranch("C1"), eng.GetBranch("C2"))
+
+	// Measure only the batched call, isolating it from any setup reads.
+	counting.fetchRemoteShas.Store(0)
+	statuses, err := eng.BatchGetPRSubmissionStatus(branches)
+	require.NoError(t, err)
+	require.Len(t, statuses, 3)
+
+	require.Equal(t, int64(1), counting.fetchRemoteShas.Load(),
+		"submission status for an update stack must read remote once, not per branch")
+}
+
+func TestBatchGetPRSubmissionStatusSkipsRemoteForCreates(t *testing.T) {
+	t.Parallel()
+
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"P": "main", "C1": "P", "C2": "C1"})
+
+	eng, counting := newCountingEngine(t, s.Scene.Dir)
+
+	branches := engine.BranchesOf(eng.GetBranch("P"), eng.GetBranch("C1"), eng.GetBranch("C2"))
+
+	counting.fetchRemoteShas.Store(0)
+	statuses, err := eng.BatchGetPRSubmissionStatus(branches)
+	require.NoError(t, err)
+	require.Len(t, statuses, 3)
+
+	require.Equal(t, int64(0), counting.fetchRemoteShas.Load(),
+		"an all-creates stack needs no remote read for submission status")
+	for name, st := range statuses {
+		require.Equal(t, "create", st.Action, "branch %s should be a create", name)
+	}
+}

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -55,6 +55,9 @@ type BranchStatus interface {
 	IsWorktreeAnchor(branch Branch) bool
 	GetBranchType(branch Branch) git.BranchType
 	GetPrInfo(branch Branch) (*PrInfo, error)
+	// BatchGetPRSubmissionStatus returns submission status for many branches,
+	// reading remote status once for the whole set instead of per branch.
+	BatchGetPRSubmissionStatus(branches Branches) (map[string]PRSubmissionStatus, error)
 	FindMostRecentTrackedAncestors(ctx context.Context, branchName string) ([]string, error)
 	GetRemote() string
 	GetRemoteURL(ctx context.Context) (string, error)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


submit planning called GetPRSubmissionStatus per branch, and for update
branches each call ran a full `git ls-remote`. An N-branch update stack
did N ls-remote calls during planning alone — separate from the push
pre-check already batched earlier in the stack.

Add engine.BatchGetPRSubmissionStatus, which reads remote status once
for the whole set and computes each branch's status from that snapshot.
It skips the remote read entirely when no branch needs it (an all-creates
stack returns early), preserving the prior offline behavior for new
stacks. Planning now calls it once instead of looping per branch.

Adds engine tests asserting one remote read for an update stack and zero
for an all-creates stack.

<hr/>

<!-- STACKIT-SECTION-START -->
**Eliminate submit N+1s: batch remote reads, pushes, and GitHub API calls**

Systematically removes the per-branch N+1 patterns from `stackit submit`, replacing serial per-branch operations with batched equivalents across every network boundary.

**Performance changes (each removes a per-branch serial operation):**
- **Batch remote ref read:** replace per-branch `git ls-remote` with a single `FetchRemoteShas` call shared across planning, force-with-lease guards, and the push
- **Batch push:** replace one `git push` per branch with a single batched `git push --porcelain` for the whole stack; partial failures surface per-branch via `--force-with-lease=<ref>:<sha>` guards
- **Batch PR-info sync:** replace one REST list call per branch with a single GraphQL query using aliased `ref.associatedPullRequests` lookups; REST fallback preserved for GraphQL failures
- **Batch PR-content reads (footer pass):** replace one `GetPullRequest` per branch with a single aliased GraphQL query when updating PR body footers
- **Batch remote read in planning:** `BatchGetPRSubmissionStatus` reads remote status once for the whole set, not once per branch; skips the read entirely for all-creates stacks
- **Overlap remote read with PR sync:** fire the single `ls-remote` concurrently with validation's GraphQL PR-info sync (independent round trips); skipped on dry runs
- **Batch empty-branch validation:** replace per-branch `git diff` with a single batched `rev-parse` resolving all branch and parent tree SHAs at once

**Refactors:**
- **Lazy TUI start:** fold `HasSubmitWork` (a pre-flight scope check) into `Action`; the TUI runner now starts on the first `StackDisplayEvent` instead of unconditionally, eliminating the startup/teardown flash when there is nothing to submit
- **Submit feedback:** dry-run create-only stacks skip the `ls-remote` entirely; GraphQL→REST fallback in `SyncPrInfo` ensures PR info syncs even when GraphQL fails

**Testing:** counting-runner assertions lock in the N+1 elimination (one remote read, one push per submit invocation); porcelain partial-failure test covers stale-lease isolation; GraphQL parse tests cover null refs, missing PRs, and error responses.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780885933`.


* **PR #1175**
  * **PR #1176**
    * **PR #1177**
      * **PR #1178**
        * **PR #1179** 👈
          * **PR #1180**
            * **PR #1181**
              * **PR #1182**
                * **PR #1183**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->