### PR TITLE
perf(submit): overlap remote read with PR sync, share one ls-remote

### DIFF
--- a/internal/actions/submit/planning.go
+++ b/internal/actions/submit/planning.go
@@ -8,15 +8,15 @@ import (
 	"github.com/getstackit/stackit/internal/errors"
 )
 
-// prepareBranchesForSubmit prepares submission info for each branch, emitting events via handler
-func prepareBranchesForSubmit(ctx *app.Context, branches engine.Branches, opts Options, currentBranch string, handler Handler) ([]Info, error) {
+// prepareBranchesForSubmit prepares submission info for each branch, emitting
+// events via handler. remoteStatuses is the snapshot prefetched once in Action,
+// so this reads no remote state per branch.
+func prepareBranchesForSubmit(ctx *app.Context, branches engine.Branches, opts Options, currentBranch string, remoteStatuses engine.BranchRemoteStatuses, handler Handler) ([]Info, error) {
 	submissionInfos := make([]Info, 0, len(branches))
 	nav := ctx.Navigator()
 
-	// Read submission status for every branch at once. This reads remote status
-	// a single time for the whole stack instead of a full `git ls-remote` per
-	// branch inside the loop.
-	statuses, err := ctx.Engine.BatchGetPRSubmissionStatus(branches)
+	// Compute submission status for every branch from the shared remote snapshot.
+	statuses, err := ctx.Engine.BatchGetPRSubmissionStatusWithRemote(branches, remoteStatuses)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -219,12 +219,26 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Validate and prepare branches
 	handler.OnEvent(PreparingEvent{})
 
+	// Read remote branch status (one `git ls-remote`) concurrently with
+	// validation's PR-info sync (one GraphQL query). Both are independent network
+	// round trips, and overlapping them roughly halves the latency of a no-op
+	// submit, where these two reads dominate. The snapshot reflects post-restack
+	// local SHAs and is reused by planning and the push below, so the whole
+	// submit reads the remote ref list exactly once. The channel is buffered so
+	// the goroutine never blocks even if validation returns early.
+	remoteStatusCh := make(chan engine.BranchRemoteStatuses, 1)
+	go func() {
+		remoteStatusCh <- eng.ReadBranchRemoteStatuses(ctx.Context, branchObjs)
+	}()
+
 	if err := ValidateBranchesToSubmit(ctx, branches); err != nil {
 		return fmt.Errorf("validation failed: %w", err)
 	}
 
+	remoteStatuses := <-remoteStatusCh
+
 	// Prepare branches for submit (show planning phase with current indicator)
-	submissionInfos, err := prepareBranchesForSubmit(ctx, branchObjs, opts, currentBranchName, handler)
+	submissionInfos, err := prepareBranchesForSubmit(ctx, branchObjs, opts, currentBranchName, remoteStatuses, handler)
 	if err != nil {
 		return fmt.Errorf("failed to prepare branches: %w", err)
 	}
@@ -278,16 +292,12 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	remote := nav.GetRemote()
 
-	// Read remote status for every branch once, up front. The force-with-lease
-	// guards below need each branch's remote SHA; reading per branch would run a
-	// full `git ls-remote` over the entire remote N times. One batched read does
-	// a single ls-remote and indexes every branch from it.
-	remoteStatuses := ctx.PR().ReadBranchRemoteStatuses(ctx.Context, branchObjs)
-
 	// Push every branch that needs it in a single git invocation instead of one
-	// `git push` per branch (N network round trips). The push runs before the
-	// create/update loop so every ref exists on the remote before its PR is
-	// created; the per-branch result is consumed by submitBranch below.
+	// `git push` per branch (N network round trips). The force-with-lease guards
+	// reuse remoteStatuses prefetched above, so no further `git ls-remote` runs.
+	// The push runs before the create/update loop so every ref exists on the
+	// remote before its PR is created; the per-branch result is consumed by
+	// submitBranch below.
 	pushResults := pushSubmittedBranches(ctx, opts, submissionInfos, remote, remoteStatuses)
 
 	var submitErr error

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -436,6 +436,62 @@ func TestSubmitPushesStackInSingleBatch(t *testing.T) {
 	}
 }
 
+func TestSubmitNoOpReadsRemoteOnceAndSkipsPush(t *testing.T) {
+	t.Parallel()
+	// A second submit of an unchanged, in-sync stack must do no pushes and read
+	// the remote ref list exactly once (the shared prefetch), not per branch.
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{
+			"P":  "main",
+			"C1": "P",
+			"C2": "C1",
+		})
+
+	s.Checkout("P")
+
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	counting := &countingRunner{Runner: git.NewRunnerWithPath(s.Scene.Dir, nil)}
+	eng, err := engine.NewEngine(engine.Options{
+		RepoRoot: s.Scene.Dir,
+		Trunk:    "main",
+		Git:      counting,
+	})
+	require.NoError(t, err)
+
+	config := testhelpers.NewMockGitHubServerConfig()
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, config)
+	githubClient := testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, config)
+
+	ctx := app.NewContext(eng,
+		app.WithRepoRoot(s.Scene.Dir),
+		app.WithWriter(&bytes.Buffer{}),
+		app.WithGlobalOptions(app.GlobalOptions{Verify: true}),
+	)
+	ctx.GitHubClient = githubClient
+
+	// First submit: creates the PRs and pushes the branches. Use non-draft so a
+	// subsequent submit with the same options has genuinely nothing to do.
+	firstOpts := submit.Options{StackRange: engine.StackRangeFull(), NoEdit: true}
+	require.NoError(t, submit.Action(ctx, firstOpts, &noopHandler{}))
+	require.Equal(t, 3, len(config.CreatedPRs))
+
+	// Second submit: nothing changed, so it should be a no-op.
+	counting.fetchRemoteShas.Store(0)
+	counting.pushBranches.Store(0)
+	counting.pushBranch.Store(0)
+	createdBefore := len(config.CreatedPRs)
+
+	require.NoError(t, submit.Action(ctx, firstOpts, &noopHandler{}))
+
+	require.Equal(t, createdBefore, len(config.CreatedPRs), "no-op submit must not create PRs")
+	require.Equal(t, int64(0), counting.pushBranches.Load(), "no-op submit must not push")
+	require.Equal(t, int64(0), counting.pushBranch.Load(), "no-op submit must not push")
+	require.Equal(t, int64(1), counting.fetchRemoteShas.Load(),
+		"no-op submit must read the remote ref list exactly once")
+}
+
 func TestSubmitPreservesLockStatus(t *testing.T) {
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 		WithStack(map[string]string{

--- a/internal/engine/engine_pr.go
+++ b/internal/engine/engine_pr.go
@@ -132,6 +132,14 @@ func (e *engineImpl) BatchGetPRSubmissionStatus(branches Branches) (map[string]P
 		}
 	}
 
+	return e.BatchGetPRSubmissionStatusWithRemote(branches, remoteStatuses)
+}
+
+// BatchGetPRSubmissionStatusWithRemote is like BatchGetPRSubmissionStatus but
+// uses a caller-supplied remote-status snapshot. This lets a caller read the
+// remote once and reuse it — e.g. concurrently with other network work, or
+// across planning and the later push — instead of reading it again here.
+func (e *engineImpl) BatchGetPRSubmissionStatusWithRemote(branches Branches, remoteStatuses BranchRemoteStatuses) (map[string]PRSubmissionStatus, error) {
 	results := make(map[string]PRSubmissionStatus, len(branches))
 	for _, branch := range branches {
 		status, err := e.prSubmissionStatus(branch, remoteStatuses.ForBranch(branch))

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -58,6 +58,9 @@ type BranchStatus interface {
 	// BatchGetPRSubmissionStatus returns submission status for many branches,
 	// reading remote status once for the whole set instead of per branch.
 	BatchGetPRSubmissionStatus(branches Branches) (map[string]PRSubmissionStatus, error)
+	// BatchGetPRSubmissionStatusWithRemote is BatchGetPRSubmissionStatus with a
+	// caller-supplied remote-status snapshot, so the remote read can be shared.
+	BatchGetPRSubmissionStatusWithRemote(branches Branches, remoteStatuses BranchRemoteStatuses) (map[string]PRSubmissionStatus, error)
 	FindMostRecentTrackedAncestors(ctx context.Context, branchName string) ([]string, error)
 	GetRemote() string
 	GetRemoteURL(ctx context.Context) (string, error)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

A no-op submit (nothing to push or update) was dominated by two
sequential network round trips: validation's PR-info GraphQL sync and
planning's `git ls-remote`. They are independent, so run the ls-remote
concurrently with validation and reuse the snapshot in planning and the
push pre-check.

Effect: the remote ref list is now read exactly once per submit (the
working path previously read it twice — once in planning, once before the
push), and for a no-op the read overlaps the GraphQL sync, roughly
halving its latency.

Adds engine.BatchGetPRSubmissionStatusWithRemote so planning can compute
status from the shared snapshot, and a test asserting a no-op submit
pushes nothing and reads the remote exactly once.

<hr/>

<!-- STACKIT-SECTION-START -->
**Eliminate submit N+1s: batch remote reads, pushes, and GitHub API calls**

Systematically removes the per-branch N+1 patterns from `stackit submit`, replacing serial per-branch operations with batched equivalents across every network boundary.

**Performance changes (each removes a per-branch serial operation):**
- **Batch remote ref read:** replace per-branch `git ls-remote` with a single `FetchRemoteShas` call shared across planning, force-with-lease guards, and the push
- **Batch push:** replace one `git push` per branch with a single batched `git push --porcelain` for the whole stack; partial failures surface per-branch via `--force-with-lease=<ref>:<sha>` guards
- **Batch PR-info sync:** replace one REST list call per branch with a single GraphQL query using aliased `ref.associatedPullRequests` lookups; REST fallback preserved for GraphQL failures
- **Batch PR-content reads (footer pass):** replace one `GetPullRequest` per branch with a single aliased GraphQL query when updating PR body footers
- **Batch remote read in planning:** `BatchGetPRSubmissionStatus` reads remote status once for the whole set, not once per branch; skips the read entirely for all-creates stacks
- **Overlap remote read with PR sync:** fire the single `ls-remote` concurrently with validation's GraphQL PR-info sync (independent round trips); skipped on dry runs
- **Batch empty-branch validation:** replace per-branch `git diff` with a single batched `rev-parse` resolving all branch and parent tree SHAs at once

**Refactors:**
- **Lazy TUI start:** fold `HasSubmitWork` (a pre-flight scope check) into `Action`; the TUI runner now starts on the first `StackDisplayEvent` instead of unconditionally, eliminating the startup/teardown flash when there is nothing to submit
- **Submit feedback:** dry-run create-only stacks skip the `ls-remote` entirely; GraphQL→REST fallback in `SyncPrInfo` ensures PR info syncs even when GraphQL fails

**Testing:** counting-runner assertions lock in the N+1 elimination (one remote read, one push per submit invocation); porcelain partial-failure test covers stale-lease isolation; GraphQL parse tests cover null refs, missing PRs, and error responses.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780885933`.


* **PR #1175**
  * **PR #1176**
    * **PR #1177**
      * **PR #1178**
        * **PR #1179**
          * **PR #1180** 👈
            * **PR #1181**
              * **PR #1182**
                * **PR #1183**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1184 by jonnii*