### PR TITLE
perf(submit): batch the empty-branch validation check

### DIFF
--- a/internal/actions/submit/submit_validation.go
+++ b/internal/actions/submit/submit_validation.go
@@ -2,7 +2,6 @@
 package submit
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/getstackit/stackit/internal/actions"
@@ -53,7 +52,7 @@ func ValidateBranchesToSubmit(ctx *app.Context, branches []string) error {
 	}
 
 	// Validate no empty branches
-	if err := validateNoEmptyBranches(ctx.Context, branches, ctx.Navigator(), ctx); err != nil {
+	if err := validateNoEmptyBranches(branches, ctx); err != nil {
 		return err
 	}
 
@@ -105,14 +104,13 @@ func validateBaseRevisions(branches []string, eng engine.BranchStatus, ctx *app.
 }
 
 // validateNoEmptyBranches checks for empty branches and prompts user if found
-func validateNoEmptyBranches(ctx context.Context, branches []string, nav engine.StackNavigator, runtimeCtx *app.Context) error {
+func validateNoEmptyBranches(branches []string, runtimeCtx *app.Context) error {
+	// Resolve emptiness for the whole set in one batched rev-parse rather than a
+	// diff per branch.
+	empty := runtimeCtx.Engine.BatchIsBranchEmpty(branches)
 	emptyBranches := []string{}
 	for _, branchName := range branches {
-		isEmpty, err := nav.IsBranchEmpty(ctx, branchName)
-		if err != nil {
-			continue
-		}
-		if isEmpty {
+		if empty[branchName] {
 			emptyBranches = append(emptyBranches, branchName)
 		}
 	}

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -327,6 +327,59 @@ func (e *engineImpl) IsBranchEmpty(ctx context.Context, branchName string) (bool
 	return e.git.IsDiffEmpty(ctx, branchName, parentRev)
 }
 
+// BatchIsBranchEmpty reports, for each branch, whether it has no changes against
+// its parent. A branch is empty iff its tree matches its parent's tree (trees
+// are content-addressed, so equal SHA ⇔ no diff). All branch and parent tree
+// SHAs are resolved in a single batched rev-parse rather than a `git diff` per
+// branch. Branches whose trees cannot be resolved are omitted from the result.
+func (e *engineImpl) BatchIsBranchEmpty(branchNames []string) map[string]bool {
+	result := make(map[string]bool, len(branchNames))
+	if len(branchNames) == 0 {
+		return result
+	}
+
+	e.mu.RLock()
+	trunk := e.trunk
+	parents := make(map[string]string, len(branchNames))
+	for _, name := range branchNames {
+		parent := trunk
+		if state := e.readState(name); state != nil {
+			parent = state.Parent
+		}
+		parents[name] = parent
+	}
+	e.mu.RUnlock()
+
+	// Collect each distinct ref's tree spec for one batched rev-parse.
+	treeRefs := make([]string, 0, len(branchNames)*2)
+	seen := make(map[string]struct{}, len(branchNames)*2)
+	addRef := func(ref string) {
+		spec := ref + "^{tree}"
+		if _, ok := seen[spec]; ok {
+			return
+		}
+		seen[spec] = struct{}{}
+		treeRefs = append(treeRefs, spec)
+	}
+	for _, name := range branchNames {
+		addRef(name)
+		addRef(parents[name])
+	}
+
+	trees, _ := e.git.BatchGetRevisions(treeRefs)
+
+	for _, name := range branchNames {
+		branchTree, ok1 := trees[name+"^{tree}"]
+		parentTree, ok2 := trees[parents[name]+"^{tree}"]
+		if !ok1 || !ok2 {
+			continue
+		}
+		result[name] = branchTree == parentTree
+	}
+
+	return result
+}
+
 // GetDeletionStatuses checks deletion status for multiple branches in a single batch.
 // It batch-fetches metadata, revisions, and merged status, then evaluates the canonical
 // deletion policy for each branch.

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -896,6 +896,25 @@ func TestIsBranchEmpty(t *testing.T) {
 	})
 }
 
+func TestBatchIsBranchEmpty(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		CreateBranch("withchanges").
+		CommitChange("file1", "real change").
+		Checkout("main").
+		CreateBranch("emptycommit").
+		Commit("empty commit"). // --allow-empty: tree matches parent
+		Checkout("main").
+		CreateBranch("nochanges"). // no commit at all: tree matches parent
+		Checkout("main")
+
+	result := s.Engine.BatchIsBranchEmpty([]string{"withchanges", "emptycommit", "nochanges"})
+
+	require.False(t, result["withchanges"], "branch with real changes is not empty")
+	require.True(t, result["emptycommit"], "branch with an empty commit is empty")
+	require.True(t, result["nochanges"], "branch with no commits is empty")
+}
+
 func TestUpsertPrInfo(t *testing.T) {
 	t.Parallel()
 	t.Run("creates PR info for branch", func(t *testing.T) {

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -46,6 +46,9 @@ type BranchStatus interface {
 	ReadBranchStatuses(branches Branches) BranchStatuses
 	IsMergedIntoTrunk(ctx context.Context, branchName string) (bool, error)
 	IsBranchEmpty(ctx context.Context, branchName string) (bool, error)
+	// BatchIsBranchEmpty reports emptiness for many branches, resolving all tree
+	// SHAs in one batched rev-parse instead of a diff per branch.
+	BatchIsBranchEmpty(branchNames []string) map[string]bool
 	GetDeletionStatuses(ctx context.Context, branchNames []string) (map[string]DeletionStatus, error)
 	GetScope(branch Branch) Scope
 	GetStackDescription(branch Branch) *git.StackDescription


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


validateNoEmptyBranches called IsBranchEmpty per branch, each running a
handful of rev-parse spawns (branch rev, parent rev, two tree SHAs) — for
an N-branch stack that is ~4N git processes just to emit warnings.

Add engine.BatchIsBranchEmpty, which resolves every branch and parent
tree SHA in a single batched rev-parse (a branch is empty iff its tree
matches its parent's — trees are content-addressed). Submit validation
now makes one batched call instead of a diff per branch.

Adds an engine test covering branches with real changes, an empty
commit, and no commits.

<hr/>

<!-- STACKIT-SECTION-START -->
**Eliminate submit N+1s: batch remote reads, pushes, and GitHub API calls**

Systematically removes the per-branch N+1 patterns from `stackit submit`, replacing serial per-branch operations with batched equivalents across every network boundary.

**Performance changes (each removes a per-branch serial operation):**
- **Batch remote ref read:** replace per-branch `git ls-remote` with a single `FetchRemoteShas` call shared across planning, force-with-lease guards, and the push
- **Batch push:** replace one `git push` per branch with a single batched `git push --porcelain` for the whole stack; partial failures surface per-branch via `--force-with-lease=<ref>:<sha>` guards
- **Batch PR-info sync:** replace one REST list call per branch with a single GraphQL query using aliased `ref.associatedPullRequests` lookups; REST fallback preserved for GraphQL failures
- **Batch PR-content reads (footer pass):** replace one `GetPullRequest` per branch with a single aliased GraphQL query when updating PR body footers
- **Batch remote read in planning:** `BatchGetPRSubmissionStatus` reads remote status once for the whole set, not once per branch; skips the read entirely for all-creates stacks
- **Overlap remote read with PR sync:** fire the single `ls-remote` concurrently with validation's GraphQL PR-info sync (independent round trips); skipped on dry runs
- **Batch empty-branch validation:** replace per-branch `git diff` with a single batched `rev-parse` resolving all branch and parent tree SHAs at once

**Refactors:**
- **Lazy TUI start:** fold `HasSubmitWork` (a pre-flight scope check) into `Action`; the TUI runner now starts on the first `StackDisplayEvent` instead of unconditionally, eliminating the startup/teardown flash when there is nothing to submit
- **Submit feedback:** dry-run create-only stacks skip the `ls-remote` entirely; GraphQL→REST fallback in `SyncPrInfo` ensures PR info syncs even when GraphQL fails

**Testing:** counting-runner assertions lock in the N+1 elimination (one remote read, one push per submit invocation); porcelain partial-failure test covers stale-lease isolation; GraphQL parse tests cover null refs, missing PRs, and error responses.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780885933`.


* **PR #1175**
  * **PR #1176**
    * **PR #1177**
      * **PR #1178**
        * **PR #1179**
          * **PR #1180**
            * **PR #1181** 👈
              * **PR #1182**
                * **PR #1183**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->