### PR TITLE
refactor(submit): fold HasSubmitWork into Action with lazy TUI start

### DIFF
--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -73,40 +73,6 @@ type Info struct {
 	Metadata   *PRMetadata
 }
 
-// HasSubmitWork reports whether Action might do anything worth showing a
-// progress TUI for. Use this from the CLI to gate TUI initialization — when
-// the answer is no, starting the bubbletea runner only flashes its
-// startup/teardown escape codes and races with the deferred Cleanup before
-// the "no branches to submit" message can render.
-//
-// Returns true if the target branch is untracked (Action will prompt or
-// print a tracking hint, both of which need the TUI lifecycle to behave),
-// or if there is at least one branch in the resolved scope. Returns false
-// only when the scope is verifiably empty for a tracked target.
-func HasSubmitWork(ctx *app.Context, opts Options) (bool, error) {
-	nav := ctx.Navigator()
-	var targetBranch engine.Branch
-	switch {
-	case opts.Branch != "":
-		targetBranch = nav.GetBranch(opts.Branch)
-	default:
-		if cb := nav.CurrentBranch(); cb != nil {
-			targetBranch = *cb
-		}
-	}
-	// Untracked non-trunk targets reach the prompt/hint path inside Action;
-	// keep the TUI alive so the interactive flow works as designed.
-	if targetBranch.GetName() != "" && !targetBranch.IsTracked() && !targetBranch.IsTrunk() {
-		return true, nil
-	}
-
-	branches, err := getBranchesToSubmit(ctx, opts)
-	if err != nil {
-		return false, err
-	}
-	return len(branches) > 0, nil
-}
-
 // Action performs the submit operation with an event handler for progress feedback.
 func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Validate flags

--- a/internal/cli/stack/submit.go
+++ b/internal/cli/stack/submit.go
@@ -141,20 +141,9 @@ func executeSubmit(cmd *cobra.Command, f *submitFlags) error {
 			ConfigAssignees: configAssignees,
 		}
 
-		// Pre-flight: skip the TUI when there's no submittable scope. The
-		// runner sets output to quiet, so without this check the
-		// "No branches to submit" CompletionEvent races with the deferred
-		// Cleanup and the user only sees bubbletea startup/teardown codes.
-		hasWork, err := submit.HasSubmitWork(ctx, opts)
-		if err != nil {
-			return err
-		}
-		if !hasWork {
-			ctx.Output.Info("No branches to submit.")
-			return nil
-		}
-
-		// Create runner (manages terminal state) and handler (processes events)
+		// Action is the single source of truth for what to submit. The runner
+		// starts lazily (on the first stack-display event), so calling Action
+		// unconditionally no longer flashes the TUI when there's nothing to do.
 		runner, handler := NewSubmitUI(ctx.Output, ctx.Logger)
 		defer runner.Cleanup()
 		return submit.Action(ctx, opts, handler)
@@ -210,19 +199,22 @@ func NewSubmitUI(out output.Output, logger output.Logger) (*tui.Runner, submit.H
 	if tui.IsTTY() {
 		model := submitComponent.NewModel(nil)
 		runner := tui.NewRunner(model, out, logger)
-		runner.Start()
-		return runner, NewInteractiveSubmitHandler(runner, model)
+		// Start lazily on the first stack-display event rather than here, so a
+		// submit that turns out to have nothing to do never flashes the bubbletea
+		// startup/teardown sequence. See InteractiveSubmitHandler.OnEvent.
+		return runner, NewInteractiveSubmitHandler(runner, model, out)
 	}
 	return nil, NewSimpleSubmitHandler(out)
 }
 
 // SimpleSubmitHandler implements submit.Handler with line-by-line output
 type SimpleSubmitHandler struct {
-	splog   output.Output
-	out     io.Writer
-	items   map[string]*branchItem
-	mu      sync.Mutex
-	started bool
+	splog     output.Output
+	out       io.Writer
+	items     map[string]*branchItem
+	mu        sync.Mutex
+	started   bool
+	displayed bool
 }
 
 type branchItem struct {
@@ -246,6 +238,7 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 
 	switch ev := e.(type) {
 	case submit.StackDisplayEvent:
+		h.displayed = true
 		h.splog.Info("Stack to submit:")
 		for _, branch := range ev.Stack.Branches {
 			marker := "  "
@@ -328,7 +321,14 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 		}
 
 	case submit.CompletionEvent:
-		if !ev.Success && ev.Message != "" {
+		switch {
+		case !ev.Success && ev.Message != "":
+			h.splog.Info("%s", ev.Message)
+		case ev.Success && !h.displayed && ev.Message != "":
+			// No stack was ever displayed (empty scope / nothing to submit).
+			// Surface the outcome that the CLI used to print before delegating
+			// work-detection to Action. Cases that show a stack first (dry run,
+			// all up to date) already convey the outcome via the plan lines.
 			h.splog.Info("%s", ev.Message)
 		}
 	}
@@ -349,14 +349,15 @@ func (h *SimpleSubmitHandler) IsInteractive() bool {
 type InteractiveSubmitHandler struct {
 	runner        *tui.Runner
 	model         *submitComponent.Model
+	out           output.Output
 	inSubmitPhase bool
 	stack         *tree.StackTree
 	fixedMap      map[string]bool
 }
 
 // NewInteractiveSubmitHandler creates a new interactive submit handler
-func NewInteractiveSubmitHandler(runner *tui.Runner, model *submitComponent.Model) *InteractiveSubmitHandler {
-	return &InteractiveSubmitHandler{runner: runner, model: model}
+func NewInteractiveSubmitHandler(runner *tui.Runner, model *submitComponent.Model, out output.Output) *InteractiveSubmitHandler {
+	return &InteractiveSubmitHandler{runner: runner, model: model, out: out}
 }
 
 // findRootBranch finds the root branch of the stack (the one whose parent is trunk)
@@ -425,6 +426,10 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 		h.model.Renderer = renderer
 		h.model.RootBranch = h.findRootBranch()
 
+		// Start the TUI now that there's a populated stack to show. Idempotent,
+		// so later events that arrive after this are safe.
+		h.runner.Start()
+
 	case submit.RestackEvent:
 		if ev.Started {
 			h.runner.Send(submitComponent.GlobalMessageMsg("Restacking branches..."))
@@ -488,6 +493,15 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 		})
 
 	case submit.CompletionEvent:
+		// If no stack was ever displayed (e.g. nothing to submit), the TUI was
+		// never started — print the outcome plainly instead of routing it
+		// through a runner that isn't running.
+		if !h.runner.IsRunning() {
+			if ev.Message != "" {
+				h.out.Info("%s", ev.Message)
+			}
+			return
+		}
 		if ev.Message != "" && ev.Message != "Submit complete" {
 			h.runner.Send(submitComponent.GlobalMessageMsg(ev.Message))
 		} else {

--- a/internal/cli/stack/submit_test.go
+++ b/internal/cli/stack/submit_test.go
@@ -68,4 +68,21 @@ Stack to submit:
 		output = runCliCommandSuccess(t, binaryPath, scene.Dir, "ss", "--dry-run", "--no-edit", "--draft", "--no-interactive")
 		require.Equal(t, expectedStack, testhelpers.NormalizeOutput(output), "ss alias should behave like submit --stack")
 	})
+
+	t.Run("no branches to submit reports cleanly", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+			if err := testhelpers.InitialCommitSceneSetup(s); err != nil {
+				return err
+			}
+			runCliCommand(binaryPath, s.Dir, "init")
+			return nil
+		})
+
+		// On trunk with no stacked branches there is nothing to submit. Action
+		// is the single source of truth now (HasSubmitWork was folded in), so it
+		// must still surface the outcome.
+		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--no-edit", "--no-interactive")
+		require.Contains(t, testhelpers.NormalizeOutput(output), "No branches to submit")
+	})
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The CLI ran submit.HasSubmitWork before Action purely to decide whether
to start the progress TUI — starting it with nothing to submit only
flashed bubbletea startup/teardown codes. That duplicated the scope
resolution (getBranchesToSubmit ran in both HasSubmitWork and Action).

Make Action the single source of truth and start the TUI lazily instead:

- NewSubmitUI no longer starts the runner eagerly. The interactive
  handler starts it on the first StackDisplayEvent (a populated stack to
  show), so a submit with nothing to do never starts the TUI.
- On a CompletionEvent that arrives before any stack was displayed, both
  handlers print the outcome plainly: the interactive handler prints
  directly when the runner is not running; the simple handler prints the
  success message when no stack was displayed (preserving the "No
  branches to submit" line the CLI used to print).
- The CLI now calls Action unconditionally; HasSubmitWork is removed.

Adds a CLI test for the no-branches path.

<hr/>

<!-- STACKIT-SECTION-START -->
**Eliminate submit N+1s: batch remote reads, pushes, and GitHub API calls**

Systematically removes the per-branch N+1 patterns from `stackit submit`, replacing serial per-branch operations with batched equivalents across every network boundary.

**Performance changes (each removes a per-branch serial operation):**
- **Batch remote ref read:** replace per-branch `git ls-remote` with a single `FetchRemoteShas` call shared across planning, force-with-lease guards, and the push
- **Batch push:** replace one `git push` per branch with a single batched `git push --porcelain` for the whole stack; partial failures surface per-branch via `--force-with-lease=<ref>:<sha>` guards
- **Batch PR-info sync:** replace one REST list call per branch with a single GraphQL query using aliased `ref.associatedPullRequests` lookups; REST fallback preserved for GraphQL failures
- **Batch PR-content reads (footer pass):** replace one `GetPullRequest` per branch with a single aliased GraphQL query when updating PR body footers
- **Batch remote read in planning:** `BatchGetPRSubmissionStatus` reads remote status once for the whole set, not once per branch; skips the read entirely for all-creates stacks
- **Overlap remote read with PR sync:** fire the single `ls-remote` concurrently with validation's GraphQL PR-info sync (independent round trips); skipped on dry runs
- **Batch empty-branch validation:** replace per-branch `git diff` with a single batched `rev-parse` resolving all branch and parent tree SHAs at once

**Refactors:**
- **Lazy TUI start:** fold `HasSubmitWork` (a pre-flight scope check) into `Action`; the TUI runner now starts on the first `StackDisplayEvent` instead of unconditionally, eliminating the startup/teardown flash when there is nothing to submit
- **Submit feedback:** dry-run create-only stacks skip the `ls-remote` entirely; GraphQL→REST fallback in `SyncPrInfo` ensures PR info syncs even when GraphQL fails

**Testing:** counting-runner assertions lock in the N+1 elimination (one remote read, one push per submit invocation); porcelain partial-failure test covers stale-lease isolation; GraphQL parse tests cover null refs, missing PRs, and error responses.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780885933`.


* **PR #1175**
  * **PR #1176**
    * **PR #1177**
      * **PR #1178**
        * **PR #1179**
          * **PR #1180**
            * **PR #1181**
              * **PR #1182** 👈
                * **PR #1183**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1184 by jonnii*