### PR TITLE
refactor: submit feedback

### DIFF
--- a/internal/actions/submit/planning.go
+++ b/internal/actions/submit/planning.go
@@ -9,14 +9,22 @@ import (
 )
 
 // prepareBranchesForSubmit prepares submission info for each branch, emitting
-// events via handler. remoteStatuses is the snapshot prefetched once in Action,
-// so this reads no remote state per branch.
+// events via handler. When remoteStatuses is provided, planning reuses that
+// snapshot; otherwise it asks the engine for lazily batched status so create-only
+// dry runs do not read remote state.
 func prepareBranchesForSubmit(ctx *app.Context, branches engine.Branches, opts Options, currentBranch string, remoteStatuses engine.BranchRemoteStatuses, handler Handler) ([]Info, error) {
 	submissionInfos := make([]Info, 0, len(branches))
 	nav := ctx.Navigator()
 
-	// Compute submission status for every branch from the shared remote snapshot.
-	statuses, err := ctx.Engine.BatchGetPRSubmissionStatusWithRemote(branches, remoteStatuses)
+	var (
+		statuses map[string]engine.PRSubmissionStatus
+		err      error
+	)
+	if remoteStatuses == nil {
+		statuses, err = ctx.Engine.BatchGetPRSubmissionStatus(branches)
+	} else {
+		statuses, err = ctx.Engine.BatchGetPRSubmissionStatusWithRemote(branches, remoteStatuses)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -186,22 +186,28 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	handler.OnEvent(PreparingEvent{})
 
 	// Read remote branch status (one `git ls-remote`) concurrently with
-	// validation's PR-info sync (one GraphQL query). Both are independent network
-	// round trips, and overlapping them roughly halves the latency of a no-op
-	// submit, where these two reads dominate. The snapshot reflects post-restack
-	// local SHAs and is reused by planning and the push below, so the whole
-	// submit reads the remote ref list exactly once. The channel is buffered so
-	// the goroutine never blocks even if validation returns early.
-	remoteStatusCh := make(chan engine.BranchRemoteStatuses, 1)
-	go func() {
-		remoteStatusCh <- eng.ReadBranchRemoteStatuses(ctx.Context, branchObjs)
-	}()
+	// validation's PR-info sync (one GraphQL query) for real submits. Dry runs use
+	// the engine's lazy batched status path below so create-only stacks stay
+	// offline. The snapshot reflects post-restack local SHAs and is reused by
+	// planning and the push below, so a real submit reads the remote ref list
+	// exactly once. The channel is buffered so the goroutine never blocks even if
+	// validation returns early.
+	var remoteStatusCh chan engine.BranchRemoteStatuses
+	if !opts.DryRun {
+		remoteStatusCh = make(chan engine.BranchRemoteStatuses, 1)
+		go func() {
+			remoteStatusCh <- eng.ReadBranchRemoteStatuses(ctx.Context, branchObjs)
+		}()
+	}
 
 	if err := ValidateBranchesToSubmit(ctx, branches); err != nil {
 		return fmt.Errorf("validation failed: %w", err)
 	}
 
-	remoteStatuses := <-remoteStatusCh
+	var remoteStatuses engine.BranchRemoteStatuses
+	if remoteStatusCh != nil {
+		remoteStatuses = <-remoteStatusCh
+	}
 
 	// Prepare branches for submit (show planning phase with current indicator)
 	submissionInfos, err := prepareBranchesForSubmit(ctx, branchObjs, opts, currentBranchName, remoteStatuses, handler)

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -379,6 +379,49 @@ func TestSubmitReadsRemoteStatusOnceForStack(t *testing.T) {
 		"submit must read remote status once for the whole stack, not once per branch")
 }
 
+func TestSubmitDryRunCreateOnlySkipsRemoteStatusRead(t *testing.T) {
+	t.Parallel()
+	// A create-only dry run can compute every action locally; it should not pay a
+	// remote ls-remote round trip when no push will happen.
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{
+			"P":  "main",
+			"C1": "P",
+			"C2": "C1",
+		})
+
+	s.Checkout("P")
+
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	counting := &countingRunner{Runner: git.NewRunnerWithPath(s.Scene.Dir, nil)}
+	eng, err := engine.NewEngine(engine.Options{
+		RepoRoot: s.Scene.Dir,
+		Trunk:    "main",
+		Git:      counting,
+	})
+	require.NoError(t, err)
+
+	ctx := app.NewContext(eng,
+		app.WithRepoRoot(s.Scene.Dir),
+		app.WithWriter(&bytes.Buffer{}),
+		app.WithGlobalOptions(app.GlobalOptions{Verify: true}),
+	)
+
+	opts := submit.Options{
+		StackRange: engine.StackRangeFull(),
+		NoEdit:     true,
+		DryRun:     true,
+	}
+
+	require.NoError(t, submit.Action(ctx, opts, &noopHandler{}))
+	require.Equal(t, int64(0), counting.fetchRemoteShas.Load(),
+		"create-only dry runs must not read remote status")
+	require.Equal(t, int64(0), counting.pushBranches.Load(), "dry runs must not push")
+	require.Equal(t, int64(0), counting.pushBranch.Load(), "dry runs must not push")
+}
+
 func TestSubmitPushesStackInSingleBatch(t *testing.T) {
 	t.Parallel()
 	// Regression test for the per-branch push N+1: submitting a stack must push

--- a/internal/github/pr_info.go
+++ b/internal/github/pr_info.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/google/go-github/v67/github"
 	"golang.org/x/oauth2"
+
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // SyncPrInfo syncs PR information for branches from GitHub. It fetches every
@@ -20,35 +22,65 @@ func SyncPrInfo(ctx context.Context, runner GitCommandRunner, branchNames []stri
 	}
 
 	// If no token, skip PR syncing (non-fatal).
-	if _, err := getGitHubToken(runner); err != nil {
+	token, err := getGitHubToken(runner)
+	if err != nil {
 		return nil //nolint:nilerr
 	}
 
-	// Resolve repository info if not provided.
+	// Resolve repository info. Even when owner/repo are provided, the hostname is
+	// needed for the REST fallback on GitHub Enterprise.
+	repoInfo, err := getRepoInfoWithHostname(ctx, runner)
+	if err != nil {
+		return nil //nolint:nilerr // Skip if can't determine repo
+	}
 	if repoOwner == "" || repoName == "" {
-		repoInfo, err := getRepoInfoWithHostname(ctx, runner)
-		if err != nil {
-			return nil //nolint:nilerr // Skip if can't determine repo
-		}
 		repoOwner = repoInfo.Owner
 		repoName = repoInfo.Repo
 	}
 
 	infos, err := batchGetPRInfoByBranchGraphQL(ctx, runner, repoOwner, repoName, branchNames)
-	if err != nil {
-		return err
-	}
-
-	if onUpdate == nil {
+	if err == nil {
+		for name, info := range infos {
+			if info != nil && onUpdate != nil {
+				onUpdate(name, info)
+			}
+		}
 		return nil
 	}
-	for name, info := range infos {
-		if info != nil {
-			onUpdate(name, info)
-		}
+
+	client, err := createGitHubClient(ctx, repoInfo.Hostname, token)
+	if err != nil {
+		return nil //nolint:nilerr // Preserve best-effort PR sync behavior.
 	}
 
+	utils.Run(branchNames, func(name string) {
+		pr, err := getPRInfoForBranch(ctx, client, repoOwner, repoName, name)
+		if err != nil || pr == nil || onUpdate == nil {
+			return
+		}
+		onUpdate(name, ToPullRequestInfo(pr))
+	})
+
 	return nil
+}
+
+// getPRInfoForBranch gets PR info for a branch using the REST API. This is the
+// compatibility fallback when the batched GraphQL sync fails.
+func getPRInfoForBranch(ctx context.Context, client *github.Client, owner, repo, branchName string) (*github.PullRequest, error) {
+	prs, _, err := client.PullRequests.List(ctx, owner, repo, &github.PullRequestListOptions{
+		Head:  fmt.Sprintf("%s:%s", owner, branchName),
+		State: "all",
+		ListOptions: github.ListOptions{
+			PerPage: 1,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(prs) == 0 {
+		return nil, nil
+	}
+	return prs[0], nil
 }
 
 // createGitHubClient creates a GitHub client configured for the given hostname


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Eliminate submit N+1s: batch remote reads, pushes, and GitHub API calls**

Systematically removes the per-branch N+1 patterns from `stackit submit`, replacing serial per-branch operations with batched equivalents across every network boundary.

**Performance changes (each removes a per-branch serial operation):**
- **Batch remote ref read:** replace per-branch `git ls-remote` with a single `FetchRemoteShas` call shared across planning, force-with-lease guards, and the push
- **Batch push:** replace one `git push` per branch with a single batched `git push --porcelain` for the whole stack; partial failures surface per-branch via `--force-with-lease=<ref>:<sha>` guards
- **Batch PR-info sync:** replace one REST list call per branch with a single GraphQL query using aliased `ref.associatedPullRequests` lookups; REST fallback preserved for GraphQL failures
- **Batch PR-content reads (footer pass):** replace one `GetPullRequest` per branch with a single aliased GraphQL query when updating PR body footers
- **Batch remote read in planning:** `BatchGetPRSubmissionStatus` reads remote status once for the whole set, not once per branch; skips the read entirely for all-creates stacks
- **Overlap remote read with PR sync:** fire the single `ls-remote` concurrently with validation's GraphQL PR-info sync (independent round trips); skipped on dry runs
- **Batch empty-branch validation:** replace per-branch `git diff` with a single batched `rev-parse` resolving all branch and parent tree SHAs at once

**Refactors:**
- **Lazy TUI start:** fold `HasSubmitWork` (a pre-flight scope check) into `Action`; the TUI runner now starts on the first `StackDisplayEvent` instead of unconditionally, eliminating the startup/teardown flash when there is nothing to submit
- **Submit feedback:** dry-run create-only stacks skip the `ls-remote` entirely; GraphQL→REST fallback in `SyncPrInfo` ensures PR info syncs even when GraphQL fails

**Testing:** counting-runner assertions lock in the N+1 elimination (one remote read, one push per submit invocation); porcelain partial-failure test covers stale-lease isolation; GraphQL parse tests cover null refs, missing PRs, and error responses.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1780885933`.


* **PR #1175**
  * **PR #1176**
    * **PR #1177**
      * **PR #1178**
        * **PR #1179**
          * **PR #1180**
            * **PR #1181**
              * **PR #1182**
                * **PR #1183** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->