### PR TITLE
Eliminate submit N+1s: batch remote reads, pushes, and GitHub API calls

### DIFF
--- a/internal/actions/pr_updates.go
+++ b/internal/actions/pr_updates.go
@@ -10,18 +10,55 @@ import (
 
 // UpdateStackPRMetadata updates PR titles and body footers for a list of branches
 func UpdateStackPRMetadata(ctx *app.Context, branches []string, repoOwner, repoName string) {
-	// Update PRs in parallel using a worker pool
 	if len(branches) == 0 {
 		return
 	}
 
+	// Fetch every PR's current title/body in one GraphQL query instead of one
+	// GetPullRequest per branch, then update each in parallel.
+	current := FetchPRContentForBranches(ctx, branches, repoOwner, repoName)
+
 	utils.Run(branches, func(name string) {
-		UpdateBranchPRMetadata(ctx, name, repoOwner, repoName)
+		UpdateBranchPRMetadataWithContent(ctx, name, repoOwner, repoName, current)
 	})
 }
 
-// UpdateBranchPRMetadata updates PR title and body footer for a single branch
+// FetchPRContentForBranches fetches the current title and body for the PRs of
+// the given branches in a single GraphQL query, keyed by PR number. Branches
+// without a known PR number are skipped. On failure it returns an empty map; the
+// per-branch update then falls back to a direct GetPullRequest.
+func FetchPRContentForBranches(ctx *app.Context, branches []string, repoOwner, repoName string) map[int]github.PRContent {
+	prNumbers := make([]int, 0, len(branches))
+	for _, name := range branches {
+		prInfo, err := ctx.Engine.GetBranch(name).GetPrInfo()
+		if err != nil || prInfo == nil || prInfo.Number() == nil {
+			continue
+		}
+		prNumbers = append(prNumbers, *prInfo.Number())
+	}
+	if len(prNumbers) == 0 {
+		return map[int]github.PRContent{}
+	}
+
+	content, err := github.BatchGetPRContentGraphQL(ctx.Context, ctx.Git(), repoOwner, repoName, prNumbers) //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
+	if err != nil {
+		ctx.Output.Debug("Failed to batch-fetch PR content: %v", err)
+		return map[int]github.PRContent{}
+	}
+	return content
+}
+
+// UpdateBranchPRMetadata updates PR title and body footer for a single branch.
 func UpdateBranchPRMetadata(ctx *app.Context, name string, repoOwner, repoName string) {
+	current := FetchPRContentForBranches(ctx, []string{name}, repoOwner, repoName)
+	UpdateBranchPRMetadataWithContent(ctx, name, repoOwner, repoName, current)
+}
+
+// UpdateBranchPRMetadataWithContent updates PR title and body footer for a single
+// branch, using PR content pre-fetched in bulk by FetchPRContentForBranches. If
+// the branch's PR is not present in current (a batch miss or fetch failure), it
+// falls back to a direct GetPullRequest so the freshness guarantee is preserved.
+func UpdateBranchPRMetadataWithContent(ctx *app.Context, name string, repoOwner, repoName string, current map[int]github.PRContent) {
 	branch := ctx.Engine.GetBranch(name)
 	prInfo, err := branch.GetPrInfo()
 	if err != nil || prInfo == nil || prInfo.Number() == nil {
@@ -31,17 +68,21 @@ func UpdateBranchPRMetadata(ctx *app.Context, name string, repoOwner, repoName s
 
 	prNumber := *prInfo.Number()
 
-	// 1. Fetch latest PR state from GitHub (Option 1)
-	latestPR, err := ctx.GitHub().GetPullRequest(ctx.Context, repoOwner, repoName, prNumber)
-	if err != nil {
-		ctx.Output.Debug("Failed to fetch PR #%d for %s: %v", prNumber, name, err)
-		return
+	// Use the bulk-fetched current state, falling back to a single GET on a miss.
+	content, ok := current[prNumber]
+	if !ok {
+		latestPR, err := ctx.GitHub().GetPullRequest(ctx.Context, repoOwner, repoName, prNumber)
+		if err != nil {
+			ctx.Output.Debug("Failed to fetch PR #%d for %s: %v", prNumber, name, err)
+			return
+		}
+		content = github.PRContent{Title: latestPR.Title, Body: latestPR.Body}
 	}
 
-	// 2. Calculate updates
+	// Calculate updates
 	scope := ctx.Engine.GetScope(branch)
-	currentTitle := latestPR.Title
-	currentBody := latestPR.Body
+	currentTitle := content.Title
+	currentBody := content.Body
 
 	updatedTitle := scope.ApplyToTitle(currentTitle)
 

--- a/internal/actions/submit/planning.go
+++ b/internal/actions/submit/planning.go
@@ -8,15 +8,15 @@ import (
 	"github.com/getstackit/stackit/internal/errors"
 )
 
-// prepareBranchesForSubmit prepares submission info for each branch, emitting events via handler
-func prepareBranchesForSubmit(ctx *app.Context, branches engine.Branches, opts Options, currentBranch string, handler Handler) ([]Info, error) {
+// prepareBranchesForSubmit prepares submission info for each branch, emitting
+// events via handler. remoteStatuses is the snapshot prefetched once in Action,
+// so this reads no remote state per branch.
+func prepareBranchesForSubmit(ctx *app.Context, branches engine.Branches, opts Options, currentBranch string, remoteStatuses engine.BranchRemoteStatuses, handler Handler) ([]Info, error) {
 	submissionInfos := make([]Info, 0, len(branches))
 	nav := ctx.Navigator()
 
-	// Read submission status for every branch at once. This reads remote status
-	// a single time for the whole stack instead of a full `git ls-remote` per
-	// branch inside the loop.
-	statuses, err := ctx.Engine.BatchGetPRSubmissionStatus(branches)
+	// Compute submission status for every branch from the shared remote snapshot.
+	statuses, err := ctx.Engine.BatchGetPRSubmissionStatusWithRemote(branches, remoteStatuses)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/actions/submit/planning.go
+++ b/internal/actions/submit/planning.go
@@ -13,12 +13,17 @@ func prepareBranchesForSubmit(ctx *app.Context, branches engine.Branches, opts O
 	submissionInfos := make([]Info, 0, len(branches))
 	nav := ctx.Navigator()
 
+	// Read submission status for every branch at once. This reads remote status
+	// a single time for the whole stack instead of a full `git ls-remote` per
+	// branch inside the loop.
+	statuses, err := ctx.Engine.BatchGetPRSubmissionStatus(branches)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, branch := range branches {
 		branchName := branch.GetName()
-		status, err := branch.GetPRSubmissionStatus()
-		if err != nil {
-			return nil, err
-		}
+		status := statuses[branchName]
 
 		action := status.Action
 		prNumber := status.PRNumber

--- a/internal/actions/submit/planning.go
+++ b/internal/actions/submit/planning.go
@@ -9,14 +9,22 @@ import (
 )
 
 // prepareBranchesForSubmit prepares submission info for each branch, emitting
-// events via handler. remoteStatuses is the snapshot prefetched once in Action,
-// so this reads no remote state per branch.
+// events via handler. When remoteStatuses is provided, planning reuses that
+// snapshot; otherwise it asks the engine for lazily batched status so create-only
+// dry runs do not read remote state.
 func prepareBranchesForSubmit(ctx *app.Context, branches engine.Branches, opts Options, currentBranch string, remoteStatuses engine.BranchRemoteStatuses, handler Handler) ([]Info, error) {
 	submissionInfos := make([]Info, 0, len(branches))
 	nav := ctx.Navigator()
 
-	// Compute submission status for every branch from the shared remote snapshot.
-	statuses, err := ctx.Engine.BatchGetPRSubmissionStatusWithRemote(branches, remoteStatuses)
+	var (
+		statuses map[string]engine.PRSubmissionStatus
+		err      error
+	)
+	if remoteStatuses == nil {
+		statuses, err = ctx.Engine.BatchGetPRSubmissionStatus(branches)
+	} else {
+		statuses, err = ctx.Engine.BatchGetPRSubmissionStatusWithRemote(branches, remoteStatuses)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -219,12 +219,26 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Validate and prepare branches
 	handler.OnEvent(PreparingEvent{})
 
+	// Read remote branch status (one `git ls-remote`) concurrently with
+	// validation's PR-info sync (one GraphQL query). Both are independent network
+	// round trips, and overlapping them roughly halves the latency of a no-op
+	// submit, where these two reads dominate. The snapshot reflects post-restack
+	// local SHAs and is reused by planning and the push below, so the whole
+	// submit reads the remote ref list exactly once. The channel is buffered so
+	// the goroutine never blocks even if validation returns early.
+	remoteStatusCh := make(chan engine.BranchRemoteStatuses, 1)
+	go func() {
+		remoteStatusCh <- eng.ReadBranchRemoteStatuses(ctx.Context, branchObjs)
+	}()
+
 	if err := ValidateBranchesToSubmit(ctx, branches); err != nil {
 		return fmt.Errorf("validation failed: %w", err)
 	}
 
+	remoteStatuses := <-remoteStatusCh
+
 	// Prepare branches for submit (show planning phase with current indicator)
-	submissionInfos, err := prepareBranchesForSubmit(ctx, branchObjs, opts, currentBranchName, handler)
+	submissionInfos, err := prepareBranchesForSubmit(ctx, branchObjs, opts, currentBranchName, remoteStatuses, handler)
 	if err != nil {
 		return fmt.Errorf("failed to prepare branches: %w", err)
 	}
@@ -278,16 +292,12 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	remote := nav.GetRemote()
 
-	// Read remote status for every branch once, up front. The force-with-lease
-	// guards below need each branch's remote SHA; reading per branch would run a
-	// full `git ls-remote` over the entire remote N times. One batched read does
-	// a single ls-remote and indexes every branch from it.
-	remoteStatuses := ctx.PR().ReadBranchRemoteStatuses(ctx.Context, branchObjs)
-
 	// Push every branch that needs it in a single git invocation instead of one
-	// `git push` per branch (N network round trips). The push runs before the
-	// create/update loop so every ref exists on the remote before its PR is
-	// created; the per-branch result is consumed by submitBranch below.
+	// `git push` per branch (N network round trips). The force-with-lease guards
+	// reuse remoteStatuses prefetched above, so no further `git ls-remote` runs.
+	// The push runs before the create/update loop so every ref exists on the
+	// remote before its PR is created; the per-branch result is consumed by
+	// submitBranch below.
 	pushResults := pushSubmittedBranches(ctx, opts, submissionInfos, remote, remoteStatuses)
 
 	var submitErr error

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -279,12 +279,16 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	remote := nav.GetRemote()
 
 	// Read remote status for every branch once, up front. The force-with-lease
-	// pre-check in pushBranchIfNeeded needs each branch's remote SHA, and reading
-	// it per branch would run a full `git ls-remote` for the entire remote N
-	// times. A single batched read does one ls-remote and indexes every branch
-	// from it. Branches push to independent refs, so this snapshot stays valid
-	// across the parallel update path.
+	// guards below need each branch's remote SHA; reading per branch would run a
+	// full `git ls-remote` over the entire remote N times. One batched read does
+	// a single ls-remote and indexes every branch from it.
 	remoteStatuses := ctx.PR().ReadBranchRemoteStatuses(ctx.Context, branchObjs)
+
+	// Push every branch that needs it in a single git invocation instead of one
+	// `git push` per branch (N network round trips). The push runs before the
+	// create/update loop so every ref exists on the remote before its PR is
+	// created; the per-branch result is consumed by submitBranch below.
+	pushResults := pushSubmittedBranches(ctx, opts, submissionInfos, remote, remoteStatuses)
 
 	var submitErr error
 	var errMu sync.Mutex
@@ -293,7 +297,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		if allCreates {
 			// Sequential submission for new stacks - ensures sequential PR numbers
 			for _, info := range submissionInfos {
-				if err := submitBranch(ctx, info, opts, handler, repoOwner, repoName, remote, remoteStatuses); err != nil {
+				if err := submitBranch(ctx, info, opts, handler, repoOwner, repoName, pushResults); err != nil {
 					errMu.Lock()
 					if submitErr == nil {
 						submitErr = err
@@ -304,7 +308,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		} else {
 			// Parallel submission for updates (faster when PRs already exist)
 			utils.Run(submissionInfos, func(info Info) {
-				if err := submitBranch(ctx, info, opts, handler, repoOwner, repoName, remote, remoteStatuses); err != nil {
+				if err := submitBranch(ctx, info, opts, handler, repoOwner, repoName, pushResults); err != nil {
 					errMu.Lock()
 					if submitErr == nil {
 						submitErr = err
@@ -366,14 +370,19 @@ func normalizeDisplayTreeParents(nav engine.StackNavigator, stackTree *tree.Stac
 	stackTree.ChildrenMap = childrenMap
 }
 
-// submitBranch submits a single branch
-func submitBranch(ctx *app.Context, info Info, opts Options, handler Handler, repoOwner, repoName, remote string, remoteStatuses engine.BranchRemoteStatuses) error {
+// submitBranch creates or updates the PR for a single branch. The branch has
+// already been pushed as part of the batched push in Action; pushResults carries
+// that branch's push outcome.
+func submitBranch(ctx *app.Context, info Info, opts Options, handler Handler, repoOwner, repoName string, pushResults map[string]error) error {
 	handler.OnEvent(BranchProgressEvent{
 		BranchName: info.BranchName,
 		Status:     StatusSubmitting,
 	})
 
-	if err := pushBranchIfNeeded(ctx, info, opts, remote, remoteStatuses); err != nil {
+	if err := pushResults[info.BranchName]; err != nil {
+		if errors.Is(err, git.ErrStaleRemoteInfo) {
+			err = fmt.Errorf("force-with-lease push of %s failed due to external changes to the remote branch. If you are collaborating on this stack, try 'stackit sync' to pull in changes. Alternatively, use the --force option to bypass the stale info warning", info.BranchName)
+		}
 		handler.OnEvent(BranchProgressEvent{
 			BranchName: info.BranchName,
 			Status:     StatusError,
@@ -442,39 +451,38 @@ func getGitHubClient(ctx *app.Context) (github.Client, error) {
 	return nil, fmt.Errorf("no GitHub client available - check your GITHUB_TOKEN")
 }
 
-// pushBranchIfNeeded pushes a branch to remote if needed. remoteStatuses is the
-// batched snapshot read once in Action, so this does not hit the network per
-// branch.
-func pushBranchIfNeeded(ctx *app.Context, submissionInfo Info, opts Options, remote string, remoteStatuses engine.BranchRemoteStatuses) error {
-	// Skip if dry run
-	if opts.DryRun {
-		return nil
+// pushSubmittedBranches pushes every branch that needs it in a single git
+// invocation and returns a per-branch result map (nil entry = success). A branch
+// already in sync with the remote is skipped (unless --force) to avoid a
+// spurious "cannot lock ref: reference already exists" rejection, and is absent
+// from the map — callers treat a missing entry as success. remoteStatuses is the
+// batched snapshot read once in Action, so building the push specs hits no
+// network per branch.
+func pushSubmittedBranches(ctx *app.Context, opts Options, infos []Info, remote string, remoteStatuses engine.BranchRemoteStatuses) map[string]error {
+	nav := ctx.Navigator()
+	forceWithLease := !opts.Force
+
+	specs := make([]git.PushSpec, 0, len(infos))
+	for _, info := range infos {
+		branch := nav.GetBranch(info.BranchName)
+		status := remoteStatuses.ForBranch(branch)
+		if forceWithLease && status.Matches() {
+			continue
+		}
+		specs = append(specs, git.PushSpec{
+			BranchName:        info.BranchName,
+			ExpectedRemoteSHA: status.RemoteSha,
+		})
 	}
 
-	forceWithLease := !opts.Force
-	branch := ctx.Navigator().GetBranch(submissionInfo.BranchName)
-	leaseExpectedSHA := ""
-	if forceWithLease {
-		status := remoteStatuses.ForBranch(branch)
-		// Remote already has this exact SHA — skip the push to avoid a spurious
-		// "cannot lock ref: reference already exists" rejection from the server.
-		if status.Matches() {
-			return nil
-		}
-		leaseExpectedSHA = status.RemoteSha
+	if len(specs) == 0 {
+		return map[string]error{}
 	}
-	if err := ctx.PR().PushBranch(ctx.Context, branch, remote, git.PushOptions{
-		Force:                     opts.Force,
-		ForceWithLease:            forceWithLease,
-		ForceWithLeaseExpectedSHA: leaseExpectedSHA,
-		NoVerify:                  !ctx.Verify,
-	}); err != nil {
-		if errors.Is(err, git.ErrStaleRemoteInfo) {
-			return fmt.Errorf("force-with-lease push of %s failed due to external changes to the remote branch. If you are collaborating on this stack, try 'stackit sync' to pull in changes. Alternatively, use the --force option to bypass the stale info warning", submissionInfo.BranchName)
-		}
-		return fmt.Errorf("failed to push branch %s: %w", submissionInfo.BranchName, err)
-	}
-	return nil
+
+	return ctx.PR().PushBranches(ctx.Context, remote, specs, git.PushOptions{
+		Force:    opts.Force,
+		NoVerify: !ctx.Verify,
+	})
 }
 
 // createPullRequestQuiet creates a new pull request without logging

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -277,6 +277,15 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	repoOwner, repoName := githubClient.GetOwnerRepo()
 
 	remote := nav.GetRemote()
+
+	// Read remote status for every branch once, up front. The force-with-lease
+	// pre-check in pushBranchIfNeeded needs each branch's remote SHA, and reading
+	// it per branch would run a full `git ls-remote` for the entire remote N
+	// times. A single batched read does one ls-remote and indexes every branch
+	// from it. Branches push to independent refs, so this snapshot stays valid
+	// across the parallel update path.
+	remoteStatuses := ctx.PR().ReadBranchRemoteStatuses(ctx.Context, branchObjs)
+
 	var submitErr error
 	var errMu sync.Mutex
 
@@ -284,7 +293,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		if allCreates {
 			// Sequential submission for new stacks - ensures sequential PR numbers
 			for _, info := range submissionInfos {
-				if err := submitBranch(ctx, info, opts, handler, repoOwner, repoName, remote); err != nil {
+				if err := submitBranch(ctx, info, opts, handler, repoOwner, repoName, remote, remoteStatuses); err != nil {
 					errMu.Lock()
 					if submitErr == nil {
 						submitErr = err
@@ -295,7 +304,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		} else {
 			// Parallel submission for updates (faster when PRs already exist)
 			utils.Run(submissionInfos, func(info Info) {
-				if err := submitBranch(ctx, info, opts, handler, repoOwner, repoName, remote); err != nil {
+				if err := submitBranch(ctx, info, opts, handler, repoOwner, repoName, remote, remoteStatuses); err != nil {
 					errMu.Lock()
 					if submitErr == nil {
 						submitErr = err
@@ -358,13 +367,13 @@ func normalizeDisplayTreeParents(nav engine.StackNavigator, stackTree *tree.Stac
 }
 
 // submitBranch submits a single branch
-func submitBranch(ctx *app.Context, info Info, opts Options, handler Handler, repoOwner, repoName, remote string) error {
+func submitBranch(ctx *app.Context, info Info, opts Options, handler Handler, repoOwner, repoName, remote string, remoteStatuses engine.BranchRemoteStatuses) error {
 	handler.OnEvent(BranchProgressEvent{
 		BranchName: info.BranchName,
 		Status:     StatusSubmitting,
 	})
 
-	if err := pushBranchIfNeeded(ctx, info, opts, remote); err != nil {
+	if err := pushBranchIfNeeded(ctx, info, opts, remote, remoteStatuses); err != nil {
 		handler.OnEvent(BranchProgressEvent{
 			BranchName: info.BranchName,
 			Status:     StatusError,
@@ -433,8 +442,10 @@ func getGitHubClient(ctx *app.Context) (github.Client, error) {
 	return nil, fmt.Errorf("no GitHub client available - check your GITHUB_TOKEN")
 }
 
-// pushBranchIfNeeded pushes a branch to remote if needed
-func pushBranchIfNeeded(ctx *app.Context, submissionInfo Info, opts Options, remote string) error {
+// pushBranchIfNeeded pushes a branch to remote if needed. remoteStatuses is the
+// batched snapshot read once in Action, so this does not hit the network per
+// branch.
+func pushBranchIfNeeded(ctx *app.Context, submissionInfo Info, opts Options, remote string, remoteStatuses engine.BranchRemoteStatuses) error {
 	// Skip if dry run
 	if opts.DryRun {
 		return nil
@@ -444,7 +455,7 @@ func pushBranchIfNeeded(ctx *app.Context, submissionInfo Info, opts Options, rem
 	branch := ctx.Navigator().GetBranch(submissionInfo.BranchName)
 	leaseExpectedSHA := ""
 	if forceWithLease {
-		status := ctx.PR().ReadBranchRemoteStatuses(ctx.Context, engine.BranchesOf(branch)).ForBranch(branch)
+		status := remoteStatuses.ForBranch(branch)
 		// Remote already has this exact SHA — skip the push to avoid a spurious
 		// "cannot lock ref: reference already exists" rejection from the server.
 		if status.Matches() {

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -324,14 +324,17 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return submitErr
 	}
 
-	// Update PR body footers with per-branch progress
+	// Update PR body footers with per-branch progress. Fetch every PR's current
+	// content in one GraphQL query up front (instead of a GET per branch), then
+	// apply each footer/title update in parallel.
 	if opts.SubmitFooter {
+		prContent := actions.FetchPRContentForBranches(ctx, branches, repoOwner, repoName)
 		utils.Run(branches, func(name string) {
 			handler.OnEvent(BranchProgressEvent{
 				BranchName: name,
 				Status:     StatusSyncing,
 			})
-			actions.UpdateBranchPRMetadata(ctx, name, repoOwner, repoName)
+			actions.UpdateBranchPRMetadataWithContent(ctx, name, repoOwner, repoName, prContent)
 			handler.OnEvent(BranchProgressEvent{
 				BranchName: name,
 				Status:     StatusDone,

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -73,40 +73,6 @@ type Info struct {
 	Metadata   *PRMetadata
 }
 
-// HasSubmitWork reports whether Action might do anything worth showing a
-// progress TUI for. Use this from the CLI to gate TUI initialization — when
-// the answer is no, starting the bubbletea runner only flashes its
-// startup/teardown escape codes and races with the deferred Cleanup before
-// the "no branches to submit" message can render.
-//
-// Returns true if the target branch is untracked (Action will prompt or
-// print a tracking hint, both of which need the TUI lifecycle to behave),
-// or if there is at least one branch in the resolved scope. Returns false
-// only when the scope is verifiably empty for a tracked target.
-func HasSubmitWork(ctx *app.Context, opts Options) (bool, error) {
-	nav := ctx.Navigator()
-	var targetBranch engine.Branch
-	switch {
-	case opts.Branch != "":
-		targetBranch = nav.GetBranch(opts.Branch)
-	default:
-		if cb := nav.CurrentBranch(); cb != nil {
-			targetBranch = *cb
-		}
-	}
-	// Untracked non-trunk targets reach the prompt/hint path inside Action;
-	// keep the TUI alive so the interactive flow works as designed.
-	if targetBranch.GetName() != "" && !targetBranch.IsTracked() && !targetBranch.IsTrunk() {
-		return true, nil
-	}
-
-	branches, err := getBranchesToSubmit(ctx, opts)
-	if err != nil {
-		return false, err
-	}
-	return len(branches) > 0, nil
-}
-
 // Action performs the submit operation with an event handler for progress feedback.
 func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Validate flags

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -186,22 +186,28 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	handler.OnEvent(PreparingEvent{})
 
 	// Read remote branch status (one `git ls-remote`) concurrently with
-	// validation's PR-info sync (one GraphQL query). Both are independent network
-	// round trips, and overlapping them roughly halves the latency of a no-op
-	// submit, where these two reads dominate. The snapshot reflects post-restack
-	// local SHAs and is reused by planning and the push below, so the whole
-	// submit reads the remote ref list exactly once. The channel is buffered so
-	// the goroutine never blocks even if validation returns early.
-	remoteStatusCh := make(chan engine.BranchRemoteStatuses, 1)
-	go func() {
-		remoteStatusCh <- eng.ReadBranchRemoteStatuses(ctx.Context, branchObjs)
-	}()
+	// validation's PR-info sync (one GraphQL query) for real submits. Dry runs use
+	// the engine's lazy batched status path below so create-only stacks stay
+	// offline. The snapshot reflects post-restack local SHAs and is reused by
+	// planning and the push below, so a real submit reads the remote ref list
+	// exactly once. The channel is buffered so the goroutine never blocks even if
+	// validation returns early.
+	var remoteStatusCh chan engine.BranchRemoteStatuses
+	if !opts.DryRun {
+		remoteStatusCh = make(chan engine.BranchRemoteStatuses, 1)
+		go func() {
+			remoteStatusCh <- eng.ReadBranchRemoteStatuses(ctx.Context, branchObjs)
+		}()
+	}
 
 	if err := ValidateBranchesToSubmit(ctx, branches); err != nil {
 		return fmt.Errorf("validation failed: %w", err)
 	}
 
-	remoteStatuses := <-remoteStatusCh
+	var remoteStatuses engine.BranchRemoteStatuses
+	if remoteStatusCh != nil {
+		remoteStatuses = <-remoteStatusCh
+	}
 
 	// Prepare branches for submit (show planning phase with current indicator)
 	submissionInfos, err := prepareBranchesForSubmit(ctx, branchObjs, opts, currentBranchName, remoteStatuses, handler)

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -1,17 +1,33 @@
 package submit_test
 
 import (
+	"bytes"
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/getstackit/stackit/internal/actions/submit"
+	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
+
+// countingRunner wraps a git.Runner and counts FetchRemoteShas calls. It lets
+// tests assert that submit reads the remote ref list once for the whole stack
+// rather than once per branch (a full `git ls-remote` each time).
+type countingRunner struct {
+	git.Runner
+	fetchRemoteShas atomic.Int64
+}
+
+func (c *countingRunner) FetchRemoteShas(ctx context.Context, remote string) (map[string]string, error) {
+	c.fetchRemoteShas.Add(1)
+	return c.Runner.FetchRemoteShas(ctx, remote)
+}
 
 // noopHandler is a test handler that ignores all events
 type noopHandler struct{}
@@ -297,6 +313,57 @@ func TestActionWithMockedGitHub(t *testing.T) {
 		err = submit.Action(s.Context, opts, &noopHandler{})
 		require.NoError(t, err, "submit should succeed when branch is already in sync with remote")
 	})
+}
+
+func TestSubmitReadsRemoteStatusOnceForStack(t *testing.T) {
+	t.Parallel()
+	// Regression test for the per-branch ls-remote N+1: submitting a stack must
+	// read remote ref status once for the whole stack, not once per branch.
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{
+			"P":  "main",
+			"C1": "P",
+			"C2": "C1",
+		})
+
+	s.Checkout("P")
+
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	// Build a second engine over the same repo with a runner that counts
+	// FetchRemoteShas, then drive submit through it.
+	counting := &countingRunner{Runner: git.NewRunnerWithPath(s.Scene.Dir, nil)}
+	eng, err := engine.NewEngine(engine.Options{
+		RepoRoot: s.Scene.Dir,
+		Trunk:    "main",
+		Git:      counting,
+	})
+	require.NoError(t, err)
+
+	config := testhelpers.NewMockGitHubServerConfig()
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, config)
+	githubClient := testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, config)
+
+	ctx := app.NewContext(eng,
+		app.WithRepoRoot(s.Scene.Dir),
+		app.WithWriter(&bytes.Buffer{}),
+		app.WithGlobalOptions(app.GlobalOptions{Verify: true}),
+	)
+	ctx.GitHubClient = githubClient
+
+	opts := submit.Options{
+		StackRange: engine.StackRangeFull(),
+		NoEdit:     true,
+		Draft:      true,
+	}
+
+	err = submit.Action(ctx, opts, &noopHandler{})
+	require.NoError(t, err)
+	require.Equal(t, 3, len(config.CreatedPRs), "should create a PR for each of P, C1, C2")
+
+	require.Equal(t, int64(1), counting.fetchRemoteShas.Load(),
+		"submit must read remote status once for the whole stack, not once per branch")
 }
 
 func TestSubmitPreservesLockStatus(t *testing.T) {

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -16,17 +16,30 @@ import (
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
-// countingRunner wraps a git.Runner and counts FetchRemoteShas calls. It lets
-// tests assert that submit reads the remote ref list once for the whole stack
-// rather than once per branch (a full `git ls-remote` each time).
+// countingRunner wraps a git.Runner and counts the network-bound operations
+// submit fans out over a stack. It lets tests assert that submit reads the
+// remote ref list once (not once per branch) and pushes the whole stack in a
+// single batched invocation rather than one `git push` per branch.
 type countingRunner struct {
 	git.Runner
 	fetchRemoteShas atomic.Int64
+	pushBranches    atomic.Int64
+	pushBranch      atomic.Int64
 }
 
 func (c *countingRunner) FetchRemoteShas(ctx context.Context, remote string) (map[string]string, error) {
 	c.fetchRemoteShas.Add(1)
 	return c.Runner.FetchRemoteShas(ctx, remote)
+}
+
+func (c *countingRunner) PushBranches(ctx context.Context, remote string, specs []git.PushSpec, opts git.PushOptions) map[string]error {
+	c.pushBranches.Add(1)
+	return c.Runner.PushBranches(ctx, remote, specs, opts)
+}
+
+func (c *countingRunner) PushBranch(ctx context.Context, branchName, remote string, opts git.PushOptions) error {
+	c.pushBranch.Add(1)
+	return c.Runner.PushBranch(ctx, branchName, remote, opts)
 }
 
 // noopHandler is a test handler that ignores all events
@@ -364,6 +377,63 @@ func TestSubmitReadsRemoteStatusOnceForStack(t *testing.T) {
 
 	require.Equal(t, int64(1), counting.fetchRemoteShas.Load(),
 		"submit must read remote status once for the whole stack, not once per branch")
+}
+
+func TestSubmitPushesStackInSingleBatch(t *testing.T) {
+	t.Parallel()
+	// Regression test for the per-branch push N+1: submitting a stack must push
+	// every branch in one `git push` invocation, not one push per branch.
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{
+			"P":  "main",
+			"C1": "P",
+			"C2": "C1",
+		})
+
+	s.Checkout("P")
+
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	counting := &countingRunner{Runner: git.NewRunnerWithPath(s.Scene.Dir, nil)}
+	eng, err := engine.NewEngine(engine.Options{
+		RepoRoot: s.Scene.Dir,
+		Trunk:    "main",
+		Git:      counting,
+	})
+	require.NoError(t, err)
+
+	config := testhelpers.NewMockGitHubServerConfig()
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, config)
+	githubClient := testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, config)
+
+	ctx := app.NewContext(eng,
+		app.WithRepoRoot(s.Scene.Dir),
+		app.WithWriter(&bytes.Buffer{}),
+		app.WithGlobalOptions(app.GlobalOptions{Verify: true}),
+	)
+	ctx.GitHubClient = githubClient
+
+	opts := submit.Options{
+		StackRange: engine.StackRangeFull(),
+		NoEdit:     true,
+		Draft:      true,
+	}
+
+	err = submit.Action(ctx, opts, &noopHandler{})
+	require.NoError(t, err)
+	require.Equal(t, 3, len(config.CreatedPRs), "should create a PR for each of P, C1, C2")
+
+	require.Equal(t, int64(1), counting.pushBranches.Load(),
+		"submit must push the whole stack in a single batched push")
+	require.Equal(t, int64(0), counting.pushBranch.Load(),
+		"submit must not fall back to per-branch pushes")
+
+	// Every branch landed on the remote.
+	for _, branch := range []string{"P", "C1", "C2"} {
+		require.NoError(t, s.Scene.Repo.RunGitCommand("rev-parse", "--verify", "refs/remotes/origin/"+branch),
+			"branch %s should be pushed to origin", branch)
+	}
 }
 
 func TestSubmitPreservesLockStatus(t *testing.T) {

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -436,6 +436,62 @@ func TestSubmitPushesStackInSingleBatch(t *testing.T) {
 	}
 }
 
+func TestSubmitNoOpReadsRemoteOnceAndSkipsPush(t *testing.T) {
+	t.Parallel()
+	// A second submit of an unchanged, in-sync stack must do no pushes and read
+	// the remote ref list exactly once (the shared prefetch), not per branch.
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{
+			"P":  "main",
+			"C1": "P",
+			"C2": "C1",
+		})
+
+	s.Checkout("P")
+
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	counting := &countingRunner{Runner: git.NewRunnerWithPath(s.Scene.Dir, nil)}
+	eng, err := engine.NewEngine(engine.Options{
+		RepoRoot: s.Scene.Dir,
+		Trunk:    "main",
+		Git:      counting,
+	})
+	require.NoError(t, err)
+
+	config := testhelpers.NewMockGitHubServerConfig()
+	rawClient, owner, repo := testhelpers.NewMockGitHubClient(t, config)
+	githubClient := testhelpers.NewMockGitHubClientInterface(rawClient, owner, repo, config)
+
+	ctx := app.NewContext(eng,
+		app.WithRepoRoot(s.Scene.Dir),
+		app.WithWriter(&bytes.Buffer{}),
+		app.WithGlobalOptions(app.GlobalOptions{Verify: true}),
+	)
+	ctx.GitHubClient = githubClient
+
+	// First submit: creates the PRs and pushes the branches. Use non-draft so a
+	// subsequent submit with the same options has genuinely nothing to do.
+	firstOpts := submit.Options{StackRange: engine.StackRangeFull(), NoEdit: true}
+	require.NoError(t, submit.Action(ctx, firstOpts, &noopHandler{}))
+	require.Equal(t, 3, len(config.CreatedPRs))
+
+	// Second submit: nothing changed, so it should be a no-op.
+	counting.fetchRemoteShas.Store(0)
+	counting.pushBranches.Store(0)
+	counting.pushBranch.Store(0)
+	createdBefore := len(config.CreatedPRs)
+
+	require.NoError(t, submit.Action(ctx, firstOpts, &noopHandler{}))
+
+	require.Equal(t, createdBefore, len(config.CreatedPRs), "no-op submit must not create PRs")
+	require.Equal(t, int64(0), counting.pushBranches.Load(), "no-op submit must not push")
+	require.Equal(t, int64(0), counting.pushBranch.Load(), "no-op submit must not push")
+	require.Equal(t, int64(1), counting.fetchRemoteShas.Load(),
+		"no-op submit must read the remote ref list exactly once")
+}
+
 func TestSubmitPreservesLockStatus(t *testing.T) {
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 		WithStack(map[string]string{

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -379,6 +379,49 @@ func TestSubmitReadsRemoteStatusOnceForStack(t *testing.T) {
 		"submit must read remote status once for the whole stack, not once per branch")
 }
 
+func TestSubmitDryRunCreateOnlySkipsRemoteStatusRead(t *testing.T) {
+	t.Parallel()
+	// A create-only dry run can compute every action locally; it should not pay a
+	// remote ls-remote round trip when no push will happen.
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{
+			"P":  "main",
+			"C1": "P",
+			"C2": "C1",
+		})
+
+	s.Checkout("P")
+
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+
+	counting := &countingRunner{Runner: git.NewRunnerWithPath(s.Scene.Dir, nil)}
+	eng, err := engine.NewEngine(engine.Options{
+		RepoRoot: s.Scene.Dir,
+		Trunk:    "main",
+		Git:      counting,
+	})
+	require.NoError(t, err)
+
+	ctx := app.NewContext(eng,
+		app.WithRepoRoot(s.Scene.Dir),
+		app.WithWriter(&bytes.Buffer{}),
+		app.WithGlobalOptions(app.GlobalOptions{Verify: true}),
+	)
+
+	opts := submit.Options{
+		StackRange: engine.StackRangeFull(),
+		NoEdit:     true,
+		DryRun:     true,
+	}
+
+	require.NoError(t, submit.Action(ctx, opts, &noopHandler{}))
+	require.Equal(t, int64(0), counting.fetchRemoteShas.Load(),
+		"create-only dry runs must not read remote status")
+	require.Equal(t, int64(0), counting.pushBranches.Load(), "dry runs must not push")
+	require.Equal(t, int64(0), counting.pushBranch.Load(), "dry runs must not push")
+}
+
 func TestSubmitPushesStackInSingleBatch(t *testing.T) {
 	t.Parallel()
 	// Regression test for the per-branch push N+1: submitting a stack must push

--- a/internal/actions/submit/submit_validation.go
+++ b/internal/actions/submit/submit_validation.go
@@ -2,7 +2,6 @@
 package submit
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/getstackit/stackit/internal/actions"
@@ -53,7 +52,7 @@ func ValidateBranchesToSubmit(ctx *app.Context, branches []string) error {
 	}
 
 	// Validate no empty branches
-	if err := validateNoEmptyBranches(ctx.Context, branches, ctx.Navigator(), ctx); err != nil {
+	if err := validateNoEmptyBranches(branches, ctx); err != nil {
 		return err
 	}
 
@@ -105,14 +104,13 @@ func validateBaseRevisions(branches []string, eng engine.BranchStatus, ctx *app.
 }
 
 // validateNoEmptyBranches checks for empty branches and prompts user if found
-func validateNoEmptyBranches(ctx context.Context, branches []string, nav engine.StackNavigator, runtimeCtx *app.Context) error {
+func validateNoEmptyBranches(branches []string, runtimeCtx *app.Context) error {
+	// Resolve emptiness for the whole set in one batched rev-parse rather than a
+	// diff per branch.
+	empty := runtimeCtx.Engine.BatchIsBranchEmpty(branches)
 	emptyBranches := []string{}
 	for _, branchName := range branches {
-		isEmpty, err := nav.IsBranchEmpty(ctx, branchName)
-		if err != nil {
-			continue
-		}
-		if isEmpty {
+		if empty[branchName] {
 			emptyBranches = append(emptyBranches, branchName)
 		}
 	}

--- a/internal/cli/stack/submit.go
+++ b/internal/cli/stack/submit.go
@@ -141,20 +141,9 @@ func executeSubmit(cmd *cobra.Command, f *submitFlags) error {
 			ConfigAssignees: configAssignees,
 		}
 
-		// Pre-flight: skip the TUI when there's no submittable scope. The
-		// runner sets output to quiet, so without this check the
-		// "No branches to submit" CompletionEvent races with the deferred
-		// Cleanup and the user only sees bubbletea startup/teardown codes.
-		hasWork, err := submit.HasSubmitWork(ctx, opts)
-		if err != nil {
-			return err
-		}
-		if !hasWork {
-			ctx.Output.Info("No branches to submit.")
-			return nil
-		}
-
-		// Create runner (manages terminal state) and handler (processes events)
+		// Action is the single source of truth for what to submit. The runner
+		// starts lazily (on the first stack-display event), so calling Action
+		// unconditionally no longer flashes the TUI when there's nothing to do.
 		runner, handler := NewSubmitUI(ctx.Output, ctx.Logger)
 		defer runner.Cleanup()
 		return submit.Action(ctx, opts, handler)
@@ -210,19 +199,22 @@ func NewSubmitUI(out output.Output, logger output.Logger) (*tui.Runner, submit.H
 	if tui.IsTTY() {
 		model := submitComponent.NewModel(nil)
 		runner := tui.NewRunner(model, out, logger)
-		runner.Start()
-		return runner, NewInteractiveSubmitHandler(runner, model)
+		// Start lazily on the first stack-display event rather than here, so a
+		// submit that turns out to have nothing to do never flashes the bubbletea
+		// startup/teardown sequence. See InteractiveSubmitHandler.OnEvent.
+		return runner, NewInteractiveSubmitHandler(runner, model, out)
 	}
 	return nil, NewSimpleSubmitHandler(out)
 }
 
 // SimpleSubmitHandler implements submit.Handler with line-by-line output
 type SimpleSubmitHandler struct {
-	splog   output.Output
-	out     io.Writer
-	items   map[string]*branchItem
-	mu      sync.Mutex
-	started bool
+	splog     output.Output
+	out       io.Writer
+	items     map[string]*branchItem
+	mu        sync.Mutex
+	started   bool
+	displayed bool
 }
 
 type branchItem struct {
@@ -246,6 +238,7 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 
 	switch ev := e.(type) {
 	case submit.StackDisplayEvent:
+		h.displayed = true
 		h.splog.Info("Stack to submit:")
 		for _, branch := range ev.Stack.Branches {
 			marker := "  "
@@ -328,7 +321,14 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 		}
 
 	case submit.CompletionEvent:
-		if !ev.Success && ev.Message != "" {
+		switch {
+		case !ev.Success && ev.Message != "":
+			h.splog.Info("%s", ev.Message)
+		case ev.Success && !h.displayed && ev.Message != "":
+			// No stack was ever displayed (empty scope / nothing to submit).
+			// Surface the outcome that the CLI used to print before delegating
+			// work-detection to Action. Cases that show a stack first (dry run,
+			// all up to date) already convey the outcome via the plan lines.
 			h.splog.Info("%s", ev.Message)
 		}
 	}
@@ -349,14 +349,15 @@ func (h *SimpleSubmitHandler) IsInteractive() bool {
 type InteractiveSubmitHandler struct {
 	runner        *tui.Runner
 	model         *submitComponent.Model
+	out           output.Output
 	inSubmitPhase bool
 	stack         *tree.StackTree
 	fixedMap      map[string]bool
 }
 
 // NewInteractiveSubmitHandler creates a new interactive submit handler
-func NewInteractiveSubmitHandler(runner *tui.Runner, model *submitComponent.Model) *InteractiveSubmitHandler {
-	return &InteractiveSubmitHandler{runner: runner, model: model}
+func NewInteractiveSubmitHandler(runner *tui.Runner, model *submitComponent.Model, out output.Output) *InteractiveSubmitHandler {
+	return &InteractiveSubmitHandler{runner: runner, model: model, out: out}
 }
 
 // findRootBranch finds the root branch of the stack (the one whose parent is trunk)
@@ -425,6 +426,10 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 		h.model.Renderer = renderer
 		h.model.RootBranch = h.findRootBranch()
 
+		// Start the TUI now that there's a populated stack to show. Idempotent,
+		// so later events that arrive after this are safe.
+		h.runner.Start()
+
 	case submit.RestackEvent:
 		if ev.Started {
 			h.runner.Send(submitComponent.GlobalMessageMsg("Restacking branches..."))
@@ -488,6 +493,15 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 		})
 
 	case submit.CompletionEvent:
+		// If no stack was ever displayed (e.g. nothing to submit), the TUI was
+		// never started — print the outcome plainly instead of routing it
+		// through a runner that isn't running.
+		if !h.runner.IsRunning() {
+			if ev.Message != "" {
+				h.out.Info("%s", ev.Message)
+			}
+			return
+		}
 		if ev.Message != "" && ev.Message != "Submit complete" {
 			h.runner.Send(submitComponent.GlobalMessageMsg(ev.Message))
 		} else {

--- a/internal/cli/stack/submit_test.go
+++ b/internal/cli/stack/submit_test.go
@@ -68,4 +68,21 @@ Stack to submit:
 		output = runCliCommandSuccess(t, binaryPath, scene.Dir, "ss", "--dry-run", "--no-edit", "--draft", "--no-interactive")
 		require.Equal(t, expectedStack, testhelpers.NormalizeOutput(output), "ss alias should behave like submit --stack")
 	})
+
+	t.Run("no branches to submit reports cleanly", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+			if err := testhelpers.InitialCommitSceneSetup(s); err != nil {
+				return err
+			}
+			runCliCommand(binaryPath, s.Dir, "init")
+			return nil
+		})
+
+		// On trunk with no stacked branches there is nothing to submit. Action
+		// is the single source of truth now (HasSubmitWork was folded in), so it
+		// must still surface the outcome.
+		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--no-edit", "--no-interactive")
+		require.Contains(t, testhelpers.NormalizeOutput(output), "No branches to submit")
+	})
 }

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -216,6 +216,14 @@ func (d *demoGitRunner) PushBranch(_ context.Context, _, _ string, _ git.PushOpt
 	return nil
 }
 
+func (d *demoGitRunner) PushBranches(_ context.Context, _ string, specs []git.PushSpec, _ git.PushOptions) map[string]error {
+	results := make(map[string]error, len(specs))
+	for _, s := range specs {
+		results[s.BranchName] = nil
+	}
+	return results
+}
+
 func (d *demoGitRunner) Rebase(_ context.Context, _, _, _ string) (git.RebaseOutcome, error) {
 	return git.RebaseOutcome{Result: git.RebaseDone}, nil
 }

--- a/internal/engine/branch_mutations.go
+++ b/internal/engine/branch_mutations.go
@@ -118,6 +118,12 @@ func (e *engineImpl) PushBranch(ctx context.Context, branch Branch, remote strin
 	return e.git.PushBranch(ctx, branch.GetName(), remote, opts)
 }
 
+// PushBranches pushes multiple branches to the remote in a single git
+// invocation, returning a per-branch result map (nil entry = success).
+func (e *engineImpl) PushBranches(ctx context.Context, remote string, specs []git.PushSpec, opts git.PushOptions) map[string]error {
+	return e.git.PushBranches(ctx, remote, specs, opts)
+}
+
 // DeleteBranch deletes a branch and its metadata
 func (e *engineImpl) DeleteBranch(ctx context.Context, branch Branch) error {
 	branchName := branch.GetName()

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -25,6 +25,7 @@ type PRManager interface {
 	UpsertPrInfo(ctx context.Context, branch Branch, prInfo *PrInfo) error
 	ReadBranchRemoteStatuses(ctx context.Context, branches Branches) BranchRemoteStatuses
 	PushBranch(ctx context.Context, branch Branch, remote string, opts git.PushOptions) error
+	PushBranches(ctx context.Context, remote string, specs []git.PushSpec, opts git.PushOptions) map[string]error
 	// Navigation comment ID caching (stored in local metadata)
 	GetNavigationCommentID(branch Branch) (int64, error)
 	SetNavigationCommentID(branch Branch, commentID int64) error

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -327,6 +327,59 @@ func (e *engineImpl) IsBranchEmpty(ctx context.Context, branchName string) (bool
 	return e.git.IsDiffEmpty(ctx, branchName, parentRev)
 }
 
+// BatchIsBranchEmpty reports, for each branch, whether it has no changes against
+// its parent. A branch is empty iff its tree matches its parent's tree (trees
+// are content-addressed, so equal SHA ⇔ no diff). All branch and parent tree
+// SHAs are resolved in a single batched rev-parse rather than a `git diff` per
+// branch. Branches whose trees cannot be resolved are omitted from the result.
+func (e *engineImpl) BatchIsBranchEmpty(branchNames []string) map[string]bool {
+	result := make(map[string]bool, len(branchNames))
+	if len(branchNames) == 0 {
+		return result
+	}
+
+	e.mu.RLock()
+	trunk := e.trunk
+	parents := make(map[string]string, len(branchNames))
+	for _, name := range branchNames {
+		parent := trunk
+		if state := e.readState(name); state != nil {
+			parent = state.Parent
+		}
+		parents[name] = parent
+	}
+	e.mu.RUnlock()
+
+	// Collect each distinct ref's tree spec for one batched rev-parse.
+	treeRefs := make([]string, 0, len(branchNames)*2)
+	seen := make(map[string]struct{}, len(branchNames)*2)
+	addRef := func(ref string) {
+		spec := ref + "^{tree}"
+		if _, ok := seen[spec]; ok {
+			return
+		}
+		seen[spec] = struct{}{}
+		treeRefs = append(treeRefs, spec)
+	}
+	for _, name := range branchNames {
+		addRef(name)
+		addRef(parents[name])
+	}
+
+	trees, _ := e.git.BatchGetRevisions(treeRefs)
+
+	for _, name := range branchNames {
+		branchTree, ok1 := trees[name+"^{tree}"]
+		parentTree, ok2 := trees[parents[name]+"^{tree}"]
+		if !ok1 || !ok2 {
+			continue
+		}
+		result[name] = branchTree == parentTree
+	}
+
+	return result
+}
+
 // GetDeletionStatuses checks deletion status for multiple branches in a single batch.
 // It batch-fetches metadata, revisions, and merged status, then evaluates the canonical
 // deletion policy for each branch.

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -896,6 +896,25 @@ func TestIsBranchEmpty(t *testing.T) {
 	})
 }
 
+func TestBatchIsBranchEmpty(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		CreateBranch("withchanges").
+		CommitChange("file1", "real change").
+		Checkout("main").
+		CreateBranch("emptycommit").
+		Commit("empty commit"). // --allow-empty: tree matches parent
+		Checkout("main").
+		CreateBranch("nochanges"). // no commit at all: tree matches parent
+		Checkout("main")
+
+	result := s.Engine.BatchIsBranchEmpty([]string{"withchanges", "emptycommit", "nochanges"})
+
+	require.False(t, result["withchanges"], "branch with real changes is not empty")
+	require.True(t, result["emptycommit"], "branch with an empty commit is empty")
+	require.True(t, result["nochanges"], "branch with no commits is empty")
+}
+
 func TestUpsertPrInfo(t *testing.T) {
 	t.Parallel()
 	t.Run("creates PR info for branch", func(t *testing.T) {

--- a/internal/engine/engine_pr.go
+++ b/internal/engine/engine_pr.go
@@ -132,6 +132,14 @@ func (e *engineImpl) BatchGetPRSubmissionStatus(branches Branches) (map[string]P
 		}
 	}
 
+	return e.BatchGetPRSubmissionStatusWithRemote(branches, remoteStatuses)
+}
+
+// BatchGetPRSubmissionStatusWithRemote is like BatchGetPRSubmissionStatus but
+// uses a caller-supplied remote-status snapshot. This lets a caller read the
+// remote once and reuse it — e.g. concurrently with other network work, or
+// across planning and the later push — instead of reading it again here.
+func (e *engineImpl) BatchGetPRSubmissionStatusWithRemote(branches Branches, remoteStatuses BranchRemoteStatuses) (map[string]PRSubmissionStatus, error) {
 	results := make(map[string]PRSubmissionStatus, len(branches))
 	for _, branch := range branches {
 		status, err := e.prSubmissionStatus(branch, remoteStatuses.ForBranch(branch))

--- a/internal/engine/engine_pr.go
+++ b/internal/engine/engine_pr.go
@@ -112,6 +112,40 @@ func (e *engineImpl) UpsertPrInfo(ctx context.Context, branch Branch, prInfo *Pr
 
 // GetPRSubmissionStatus returns the submission status of a branch
 func (e *engineImpl) GetPRSubmissionStatus(branch Branch) (PRSubmissionStatus, error) {
+	remoteStatus := e.ReadBranchRemoteStatuses(context.Background(), BranchesOf(branch)).ForBranch(branch)
+	return e.prSubmissionStatus(branch, remoteStatus)
+}
+
+// BatchGetPRSubmissionStatus returns the submission status for every branch,
+// reading remote status once for the whole set instead of once per branch (a
+// full `git ls-remote` each time). Results are keyed by branch name.
+func (e *engineImpl) BatchGetPRSubmissionStatus(branches Branches) (map[string]PRSubmissionStatus, error) {
+	// Only branches with an existing PR consult remote status; creates return
+	// early without it. Read the remote a single time, and only if at least one
+	// branch needs it, so an all-creates stack stays fully offline here.
+	remoteStatuses := BranchRemoteStatuses{}
+	for _, branch := range branches {
+		prInfo, err := e.GetPrInfo(branch)
+		if err == nil && prInfo != nil && prInfo.Number() != nil {
+			remoteStatuses = e.ReadBranchRemoteStatuses(context.Background(), branches)
+			break
+		}
+	}
+
+	results := make(map[string]PRSubmissionStatus, len(branches))
+	for _, branch := range branches {
+		status, err := e.prSubmissionStatus(branch, remoteStatuses.ForBranch(branch))
+		if err != nil {
+			return nil, err
+		}
+		results[branch.GetName()] = status
+	}
+	return results, nil
+}
+
+// prSubmissionStatus computes a branch's submission status from a precomputed
+// remote status, so batched callers read the remote once.
+func (e *engineImpl) prSubmissionStatus(branch Branch, remoteStatus BranchRemoteStatus) (PRSubmissionStatus, error) {
 	prInfo, err := e.GetPrInfo(branch)
 	if err != nil {
 		return PRSubmissionStatus{}, err
@@ -135,8 +169,7 @@ func (e *engineImpl) GetPRSubmissionStatus(branch Branch) (PRSubmissionStatus, e
 
 	// It's an update
 	baseChanged := prInfo.Base() != parentBranchName
-	status := e.ReadBranchRemoteStatuses(context.Background(), BranchesOf(branch)).ForBranch(branch)
-	branchMatches := status.Matches()
+	branchMatches := remoteStatus.Matches()
 
 	// Check if PR title needs update due to scope changes
 	titleNeedsUpdate := e.prTitleNeedsUpdate(branch, prInfo)

--- a/internal/engine/engine_pr_batch_test.go
+++ b/internal/engine/engine_pr_batch_test.go
@@ -1,0 +1,92 @@
+package engine_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// countingFetchRunner wraps a git.Runner and counts FetchRemoteShas calls, so a
+// test can assert remote status is read once for a whole stack rather than once
+// per branch.
+type countingFetchRunner struct {
+	git.Runner
+	fetchRemoteShas atomic.Int64
+}
+
+func (c *countingFetchRunner) FetchRemoteShas(ctx context.Context, remote string) (map[string]string, error) {
+	c.fetchRemoteShas.Add(1)
+	return c.Runner.FetchRemoteShas(ctx, remote)
+}
+
+func newCountingEngine(t *testing.T, dir string) (engine.Engine, *countingFetchRunner) {
+	t.Helper()
+	counting := &countingFetchRunner{Runner: git.NewRunnerWithPath(dir, nil)}
+	eng, err := engine.NewEngine(engine.Options{
+		RepoRoot: dir,
+		Trunk:    "main",
+		Git:      counting,
+	})
+	require.NoError(t, err)
+	return eng, counting
+}
+
+func TestBatchGetPRSubmissionStatusReadsRemoteOnceForUpdates(t *testing.T) {
+	t.Parallel()
+
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"P": "main", "C1": "P", "C2": "C1"})
+	_, err := s.Scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+	for _, b := range []string{"main", "P", "C1", "C2"} {
+		require.NoError(t, s.Scene.Repo.PushBranch("origin", b))
+	}
+
+	eng, counting := newCountingEngine(t, s.Scene.Dir)
+
+	// Give each branch an existing PR so it is an update, not a create.
+	for i, name := range []string{"P", "C1", "C2"} {
+		require.NoError(t, eng.UpsertPrInfo(context.Background(), eng.GetBranch(name),
+			testhelpers.NewTestPrInfoWithTitle(100+i, "title")))
+	}
+
+	branches := engine.BranchesOf(eng.GetBranch("P"), eng.GetBranch("C1"), eng.GetBranch("C2"))
+
+	// Measure only the batched call, isolating it from any setup reads.
+	counting.fetchRemoteShas.Store(0)
+	statuses, err := eng.BatchGetPRSubmissionStatus(branches)
+	require.NoError(t, err)
+	require.Len(t, statuses, 3)
+
+	require.Equal(t, int64(1), counting.fetchRemoteShas.Load(),
+		"submission status for an update stack must read remote once, not per branch")
+}
+
+func TestBatchGetPRSubmissionStatusSkipsRemoteForCreates(t *testing.T) {
+	t.Parallel()
+
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"P": "main", "C1": "P", "C2": "C1"})
+
+	eng, counting := newCountingEngine(t, s.Scene.Dir)
+
+	branches := engine.BranchesOf(eng.GetBranch("P"), eng.GetBranch("C1"), eng.GetBranch("C2"))
+
+	counting.fetchRemoteShas.Store(0)
+	statuses, err := eng.BatchGetPRSubmissionStatus(branches)
+	require.NoError(t, err)
+	require.Len(t, statuses, 3)
+
+	require.Equal(t, int64(0), counting.fetchRemoteShas.Load(),
+		"an all-creates stack needs no remote read for submission status")
+	for name, st := range statuses {
+		require.Equal(t, "create", st.Action, "branch %s should be a create", name)
+	}
+}

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -55,6 +55,9 @@ type BranchStatus interface {
 	IsWorktreeAnchor(branch Branch) bool
 	GetBranchType(branch Branch) git.BranchType
 	GetPrInfo(branch Branch) (*PrInfo, error)
+	// BatchGetPRSubmissionStatus returns submission status for many branches,
+	// reading remote status once for the whole set instead of per branch.
+	BatchGetPRSubmissionStatus(branches Branches) (map[string]PRSubmissionStatus, error)
 	FindMostRecentTrackedAncestors(ctx context.Context, branchName string) ([]string, error)
 	GetRemote() string
 	GetRemoteURL(ctx context.Context) (string, error)

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -46,6 +46,9 @@ type BranchStatus interface {
 	ReadBranchStatuses(branches Branches) BranchStatuses
 	IsMergedIntoTrunk(ctx context.Context, branchName string) (bool, error)
 	IsBranchEmpty(ctx context.Context, branchName string) (bool, error)
+	// BatchIsBranchEmpty reports emptiness for many branches, resolving all tree
+	// SHAs in one batched rev-parse instead of a diff per branch.
+	BatchIsBranchEmpty(branchNames []string) map[string]bool
 	GetDeletionStatuses(ctx context.Context, branchNames []string) (map[string]DeletionStatus, error)
 	GetScope(branch Branch) Scope
 	GetStackDescription(branch Branch) *git.StackDescription

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -58,6 +58,9 @@ type BranchStatus interface {
 	// BatchGetPRSubmissionStatus returns submission status for many branches,
 	// reading remote status once for the whole set instead of per branch.
 	BatchGetPRSubmissionStatus(branches Branches) (map[string]PRSubmissionStatus, error)
+	// BatchGetPRSubmissionStatusWithRemote is BatchGetPRSubmissionStatus with a
+	// caller-supplied remote-status snapshot, so the remote read can be shared.
+	BatchGetPRSubmissionStatusWithRemote(branches Branches, remoteStatuses BranchRemoteStatuses) (map[string]PRSubmissionStatus, error)
 	FindMostRecentTrackedAncestors(ctx context.Context, branchName string) ([]string, error)
 	GetRemote() string
 	GetRemoteURL(ctx context.Context) (string, error)

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -37,6 +37,7 @@ type RemoteOperations interface {
 	GetRemoteRevision(branchName string) (string, error)
 	FindRemoteBranch(ctx context.Context, remote string) (string, error)
 	PushBranch(ctx context.Context, branchName, remote string, opts PushOptions) error
+	PushBranches(ctx context.Context, remote string, specs []PushSpec, opts PushOptions) map[string]error
 	PullBranch(ctx context.Context, remote, branchName string) (PullResult, error)
 	UpdateBranchFromRemote(ctx context.Context, remote, branchName string) (PullResult, error)
 	Fetch(ctx context.Context, remote, branch string) error

--- a/internal/git/push.go
+++ b/internal/git/push.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -12,6 +13,16 @@ type PushOptions struct {
 	ForceWithLease            bool
 	ForceWithLeaseExpectedSHA string
 	NoVerify                  bool
+}
+
+// PushSpec describes a single branch to push as part of a batched PushBranches
+// call.
+type PushSpec struct {
+	BranchName string
+	// ExpectedRemoteSHA is the SHA the remote ref is expected to be at, used for
+	// force-with-lease. An empty value means the branch is not expected to exist
+	// on the remote yet (a create); the lease then asserts the ref is absent.
+	ExpectedRemoteSHA string
 }
 
 func (r *runner) PushBranch(ctx context.Context, branchName, remote string, opts PushOptions) error {
@@ -41,4 +52,97 @@ func (r *runner) PushBranch(ctx context.Context, branchName, remote string, opts
 	}
 
 	return nil
+}
+
+// PushBranches pushes multiple branches to a remote in a single git invocation,
+// replacing N separate `git push` round trips with one. It returns a per-branch
+// result map: a nil entry means that branch pushed successfully. Push is
+// non-atomic, so a force-with-lease rejection on one branch does not block the
+// others — matching the prior one-push-per-branch behavior where each branch
+// succeeded or failed independently.
+//
+// When opts.Force is set, every branch is pushed with --force and the per-branch
+// ExpectedRemoteSHA is ignored. Otherwise each branch is pushed with an explicit
+// --force-with-lease guarding its expected remote SHA.
+func (r *runner) PushBranches(ctx context.Context, remote string, specs []PushSpec, opts PushOptions) map[string]error {
+	results := make(map[string]error, len(specs))
+	if len(specs) == 0 {
+		return results
+	}
+
+	args := []string{"push", "--porcelain", "-u", remote}
+	if opts.Force {
+		args = append(args, "--force")
+	} else {
+		for _, s := range specs {
+			args = append(args, fmt.Sprintf("--force-with-lease=refs/heads/%s:%s", s.BranchName, s.ExpectedRemoteSHA))
+		}
+	}
+	if opts.NoVerify {
+		args = append(args, "--no-verify")
+	}
+	for _, s := range specs {
+		args = append(args, s.BranchName)
+	}
+
+	out, err := r.RunGitCommandWithContext(ctx, args...)
+	if err != nil {
+		// `--porcelain` writes its per-ref status to stdout even when the push
+		// exits non-zero (some refs rejected); recover it from the error.
+		var ce *CommandError
+		if errors.As(err, &ce) {
+			out = ce.Stdout
+		}
+	}
+
+	parsePushPorcelain(out, results)
+
+	// Any branch not reported by porcelain (e.g. a connection/auth failure that
+	// produced no per-ref lines) inherits the command error so nothing is
+	// silently treated as a success.
+	for _, s := range specs {
+		if _, ok := results[s.BranchName]; ok {
+			continue
+		}
+		if err != nil {
+			results[s.BranchName] = fmt.Errorf("failed to push branch %s: %w", s.BranchName, err)
+		} else {
+			results[s.BranchName] = nil
+		}
+	}
+
+	return results
+}
+
+// parsePushPorcelain parses `git push --porcelain` output into per-branch
+// results, writing into the provided map. Each ref line has the form
+// "<flag>\t<from>:<to>\t<summary>"; only "!" indicates a rejected ref.
+func parsePushPorcelain(out string, results map[string]error) {
+	for line := range strings.SplitSeq(out, "\n") {
+		if line == "" || strings.HasPrefix(line, "To ") || line == "Done" {
+			continue
+		}
+		flag, rest, ok := strings.Cut(line, "\t")
+		if !ok {
+			continue
+		}
+		refs, summary, _ := strings.Cut(rest, "\t")
+		_, to, ok := strings.Cut(refs, ":")
+		if !ok {
+			continue
+		}
+		branch, ok := strings.CutPrefix(to, "refs/heads/")
+		if !ok {
+			continue
+		}
+		if flag == "!" {
+			if strings.Contains(summary, "stale info") || strings.Contains(summary, "forced update") {
+				results[branch] = fmt.Errorf("%w: force-with-lease push of %s failed due to external changes to the remote branch", ErrStaleRemoteInfo, branch)
+			} else {
+				results[branch] = fmt.Errorf("failed to push branch %s: %s", branch, strings.TrimSpace(summary))
+			}
+			continue
+		}
+		results[branch] = nil
+	}
 }

--- a/internal/git/push_test.go
+++ b/internal/git/push_test.go
@@ -61,3 +61,83 @@ func TestPushBranchWithExplicitForceWithLease(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, localSHA, remoteAfterPush["feature"])
 }
+
+func TestPushBranchesCreatesMultipleBranchesInOnePush(t *testing.T) {
+	t.Parallel()
+
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+	_, err := scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+	require.NoError(t, scene.Repo.PushBranch("origin", "main"))
+
+	require.NoError(t, scene.Repo.CreateAndCheckoutBranch("f1"))
+	require.NoError(t, scene.Repo.CreateChangeAndCommit("f1 v1", "f1"))
+	require.NoError(t, scene.Repo.CreateAndCheckoutBranch("f2"))
+	require.NoError(t, scene.Repo.CreateChangeAndCommit("f2 v1", "f2"))
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	// Empty ExpectedRemoteSHA means "expect absent" — the create case.
+	results := runner.PushBranches(context.Background(), "origin", []git.PushSpec{
+		{BranchName: "f1"},
+		{BranchName: "f2"},
+	}, git.PushOptions{})
+
+	require.NoError(t, results["f1"])
+	require.NoError(t, results["f2"])
+
+	remote, err := runner.FetchRemoteShas(context.Background(), "origin")
+	require.NoError(t, err)
+	require.Contains(t, remote, "f1")
+	require.Contains(t, remote, "f2")
+}
+
+func TestPushBranchesPartialSuccessOnStaleLease(t *testing.T) {
+	t.Parallel()
+
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+	remotePath, err := scene.Repo.CreateBareRemote("origin")
+	require.NoError(t, err)
+	require.NoError(t, scene.Repo.PushBranch("origin", "main"))
+
+	// Two branches, both already on the remote.
+	require.NoError(t, scene.Repo.CreateAndCheckoutBranch("f1"))
+	require.NoError(t, scene.Repo.CreateChangeAndCommit("f1 v1", "f1"))
+	require.NoError(t, scene.Repo.PushBranch("origin", "f1"))
+	require.NoError(t, scene.Repo.CheckoutBranch("main"))
+	require.NoError(t, scene.Repo.CreateAndCheckoutBranch("f2"))
+	require.NoError(t, scene.Repo.CreateChangeAndCommit("f2 v1", "f2"))
+	require.NoError(t, scene.Repo.PushBranch("origin", "f2"))
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	before, err := runner.FetchRemoteShas(context.Background(), "origin")
+	require.NoError(t, err)
+
+	// Advance f1 on the remote out-of-band so the recorded lease goes stale.
+	otherDir := filepath.Join(t.TempDir(), "other")
+	otherRepo, err := testhelpers.NewGitRepoFromURL(otherDir, remotePath)
+	require.NoError(t, err)
+	require.NoError(t, otherRepo.RunGitCommand("checkout", "-b", "f1", "origin/f1"))
+	require.NoError(t, otherRepo.CreateChangeAndCommit("f1 external", "f1ext"))
+	require.NoError(t, otherRepo.PushBranch("origin", "f1"))
+
+	// Advance both branches locally so each has something to push.
+	require.NoError(t, scene.Repo.CheckoutBranch("f1"))
+	require.NoError(t, scene.Repo.CreateChangeAndCommit("f1 v2", "f1local"))
+	require.NoError(t, scene.Repo.CheckoutBranch("f2"))
+	require.NoError(t, scene.Repo.CreateChangeAndCommit("f2 v2", "f2local"))
+
+	results := runner.PushBranches(context.Background(), "origin", []git.PushSpec{
+		{BranchName: "f1", ExpectedRemoteSHA: before["f1"]}, // stale: remote moved
+		{BranchName: "f2", ExpectedRemoteSHA: before["f2"]}, // current
+	}, git.PushOptions{})
+
+	require.ErrorIs(t, results["f1"], git.ErrStaleRemoteInfo, "stale lease must surface ErrStaleRemoteInfo")
+	require.NoError(t, results["f2"], "the in-sync branch must still push despite f1's rejection")
+
+	// f2 advanced on the remote, f1 did not.
+	after, err := runner.FetchRemoteShas(context.Background(), "origin")
+	require.NoError(t, err)
+	f2SHA, err := scene.Repo.RunGitCommandAndGetOutput("rev-parse", "f2")
+	require.NoError(t, err)
+	require.Equal(t, f2SHA, after["f2"])
+}

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -176,6 +176,19 @@ func (t *tracingRunner) PushBranch(ctx context.Context, branchName, remote strin
 	return err
 }
 
+func (t *tracingRunner) PushBranches(ctx context.Context, remote string, specs []PushSpec, opts PushOptions) map[string]error {
+	start := time.Now()
+	results := t.inner.PushBranches(ctx, remote, specs, opts)
+	failed := 0
+	for _, err := range results {
+		if err != nil {
+			failed++
+		}
+	}
+	t.trace("PushBranches", time.Since(start), failed == 0, nil, slog.String("remote", remote), slog.Int("branches", len(specs)), slog.Int("failed", failed))
+	return results
+}
+
 func (t *tracingRunner) PullBranch(ctx context.Context, remote, branchName string) (PullResult, error) {
 	start := time.Now()
 	result, err := t.inner.PullBranch(ctx, remote, branchName)

--- a/internal/github/pr_content.go
+++ b/internal/github/pr_content.go
@@ -1,0 +1,100 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// PRContent is the current title and body of a pull request, fetched in bulk.
+type PRContent struct {
+	Title string
+	Body  string
+}
+
+// BatchGetPRContentGraphQL fetches the current title and body for multiple PR
+// numbers in a single GraphQL query, replacing one REST GetPullRequest call per
+// PR. PRs absent from the response (e.g. not found) are omitted from the map.
+func BatchGetPRContentGraphQL(ctx context.Context, runner GitCommandRunner, owner, repo string, prNumbers []int) (map[int]PRContent, error) {
+	if len(prNumbers) == 0 {
+		return make(map[int]PRContent), nil
+	}
+
+	seen := make(map[int]struct{}, len(prNumbers))
+	unique := make([]int, 0, len(prNumbers))
+	for _, n := range prNumbers {
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		unique = append(unique, n)
+	}
+
+	query := buildPRContentQuery(unique)
+	variables := map[string]any{
+		"owner": owner,
+		"repo":  repo,
+	}
+
+	body, err := executeGraphQLQuery(ctx, runner, query, variables)
+	if err != nil {
+		return nil, err
+	}
+
+	return parsePRContentResponse(body, unique)
+}
+
+// buildPRContentQuery builds a GraphQL query to fetch title and body for
+// multiple PRs by number.
+func buildPRContentQuery(prNumbers []int) string {
+	var b strings.Builder
+	b.WriteString("query($owner: String!, $repo: String!) {\n")
+	b.WriteString("  repository(owner: $owner, name: $repo) {\n")
+	for _, n := range prNumbers {
+		fmt.Fprintf(&b, "    pr_%d: pullRequest(number: %d) { title body }\n", n, n)
+	}
+	b.WriteString("  }\n")
+	b.WriteString("}\n")
+	return b.String()
+}
+
+// parsePRContentResponse parses the GraphQL response for PR content queries.
+func parsePRContentResponse(body []byte, prNumbers []int) (map[int]PRContent, error) {
+	var resp struct {
+		Data   map[string]any `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse GraphQL response: %w", err)
+	}
+
+	repository, ok := resp.Data["repository"].(map[string]any)
+	if !ok {
+		if len(resp.Errors) > 0 {
+			return nil, fmt.Errorf("graphql error: %s", resp.Errors[0].Message)
+		}
+		return nil, fmt.Errorf("invalid GraphQL response format: missing repository")
+	}
+
+	results := make(map[int]PRContent, len(prNumbers))
+	for _, n := range prNumbers {
+		alias := fmt.Sprintf("pr_%d", n)
+		data, ok := repository[alias].(map[string]any)
+		if !ok {
+			continue
+		}
+		content := PRContent{}
+		if title, ok := data["title"].(string); ok {
+			content.Title = title
+		}
+		if prBody, ok := data["body"].(string); ok {
+			content.Body = prBody
+		}
+		results[n] = content
+	}
+
+	return results, nil
+}

--- a/internal/github/pr_content_test.go
+++ b/internal/github/pr_content_test.go
@@ -1,0 +1,70 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPRContentQuery(t *testing.T) {
+	t.Parallel()
+
+	query := buildPRContentQuery([]int{42, 99})
+
+	require.Contains(t, query, "pr_42: pullRequest(number: 42) { title body }")
+	require.Contains(t, query, "pr_99: pullRequest(number: 99) { title body }")
+	require.Contains(t, query, "repository(owner: $owner, name: $repo)")
+}
+
+func TestParsePRContentResponse(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"data": {
+			"repository": {
+				"pr_42": {"title": "feat: auth", "body": "body 42"},
+				"pr_99": {"title": "fix: race", "body": ""}
+			}
+		}
+	}`)
+
+	content, err := parsePRContentResponse(body, []int{42, 99})
+	require.NoError(t, err)
+	require.Equal(t, map[int]PRContent{
+		42: {Title: "feat: auth", Body: "body 42"},
+		99: {Title: "fix: race", Body: ""},
+	}, content)
+}
+
+func TestParsePRContentResponse_NullEntry(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"data": {
+			"repository": {
+				"pr_42": {"title": "feat: auth", "body": "body 42"},
+				"pr_99": null
+			}
+		}
+	}`)
+
+	content, err := parsePRContentResponse(body, []int{42, 99})
+	require.NoError(t, err)
+	require.Equal(t, map[int]PRContent{42: {Title: "feat: auth", Body: "body 42"}}, content)
+}
+
+func TestParsePRContentResponse_MissingRepository(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"data": {}, "errors": [{"message": "Bad credentials"}]}`)
+	_, err := parsePRContentResponse(body, []int{42})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Bad credentials")
+}
+
+func TestParsePRContentResponse_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	_, err := parsePRContentResponse([]byte(`{bad`), []int{42})
+	require.Error(t, err)
+}

--- a/internal/github/pr_info.go
+++ b/internal/github/pr_info.go
@@ -10,83 +10,45 @@ import (
 
 	"github.com/google/go-github/v67/github"
 	"golang.org/x/oauth2"
-
-	"github.com/getstackit/stackit/internal/utils"
 )
 
-// SyncPrInfo syncs PR information for branches from GitHub
+// SyncPrInfo syncs PR information for branches from GitHub. It fetches every
+// branch's PR in a single GraphQL query rather than one REST call per branch.
 func SyncPrInfo(ctx context.Context, runner GitCommandRunner, branchNames []string, repoOwner, repoName string, onUpdate func(string, *PullRequestInfo)) error {
-	// Get GitHub token
-	token, err := getGitHubToken(runner)
-	if err != nil {
-		// If no token, skip PR syncing (non-fatal)
+	if len(branchNames) == 0 {
+		return nil
+	}
+
+	// If no token, skip PR syncing (non-fatal).
+	if _, err := getGitHubToken(runner); err != nil {
 		return nil //nolint:nilerr
 	}
 
-	// Get repository info if not provided
-	var repoInfo *RepoInfo
+	// Resolve repository info if not provided.
 	if repoOwner == "" || repoName == "" {
-		repoInfo, err = getRepoInfoWithHostname(ctx, runner)
+		repoInfo, err := getRepoInfoWithHostname(ctx, runner)
 		if err != nil {
 			return nil //nolint:nilerr // Skip if can't determine repo
 		}
 		repoOwner = repoInfo.Owner
 		repoName = repoInfo.Repo
-	} else {
-		// Still need hostname for client configuration
-		repoInfo, err = getRepoInfoWithHostname(ctx, runner)
-		if err != nil {
-			return nil //nolint:nilerr // Skip if can't determine repo
-		}
 	}
 
-	// Create GitHub client with Enterprise support
-	client, err := createGitHubClient(ctx, repoInfo.Hostname, token)
+	infos, err := batchGetPRInfoByBranchGraphQL(ctx, runner, repoOwner, repoName, branchNames)
 	if err != nil {
-		return nil //nolint:nilerr // Skip if can't create client
+		return err
 	}
 
-	// Fetch PR info for each branch in parallel using a worker pool
-	if len(branchNames) == 0 {
+	if onUpdate == nil {
 		return nil
 	}
-
-	utils.Run(branchNames, func(name string) {
-		pr, err := getPRInfoForBranch(ctx, client, repoOwner, repoName, name)
-		if err != nil {
-			return
+	for name, info := range infos {
+		if info != nil {
+			onUpdate(name, info)
 		}
-
-		if pr != nil {
-			info := ToPullRequestInfo(pr)
-			if onUpdate != nil {
-				onUpdate(name, info)
-			}
-		}
-	})
+	}
 
 	return nil
-}
-
-// getPRInfoForBranch gets PR info for a branch
-func getPRInfoForBranch(ctx context.Context, client *github.Client, owner, repo, branchName string) (*github.PullRequest, error) {
-	// List PRs for this branch
-	prs, _, err := client.PullRequests.List(ctx, owner, repo, &github.PullRequestListOptions{
-		Head:  fmt.Sprintf("%s:%s", owner, branchName),
-		State: "all",
-		ListOptions: github.ListOptions{
-			PerPage: 1,
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	if len(prs) == 0 {
-		return nil, nil
-	}
-
-	return prs[0], nil
 }
 
 // createGitHubClient creates a GitHub client configured for the given hostname

--- a/internal/github/pr_info.go
+++ b/internal/github/pr_info.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/google/go-github/v67/github"
 	"golang.org/x/oauth2"
+
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // SyncPrInfo syncs PR information for branches from GitHub. It fetches every
@@ -20,35 +22,65 @@ func SyncPrInfo(ctx context.Context, runner GitCommandRunner, branchNames []stri
 	}
 
 	// If no token, skip PR syncing (non-fatal).
-	if _, err := getGitHubToken(runner); err != nil {
+	token, err := getGitHubToken(runner)
+	if err != nil {
 		return nil //nolint:nilerr
 	}
 
-	// Resolve repository info if not provided.
+	// Resolve repository info. Even when owner/repo are provided, the hostname is
+	// needed for the REST fallback on GitHub Enterprise.
+	repoInfo, err := getRepoInfoWithHostname(ctx, runner)
+	if err != nil {
+		return nil //nolint:nilerr // Skip if can't determine repo
+	}
 	if repoOwner == "" || repoName == "" {
-		repoInfo, err := getRepoInfoWithHostname(ctx, runner)
-		if err != nil {
-			return nil //nolint:nilerr // Skip if can't determine repo
-		}
 		repoOwner = repoInfo.Owner
 		repoName = repoInfo.Repo
 	}
 
 	infos, err := batchGetPRInfoByBranchGraphQL(ctx, runner, repoOwner, repoName, branchNames)
-	if err != nil {
-		return err
-	}
-
-	if onUpdate == nil {
+	if err == nil {
+		for name, info := range infos {
+			if info != nil && onUpdate != nil {
+				onUpdate(name, info)
+			}
+		}
 		return nil
 	}
-	for name, info := range infos {
-		if info != nil {
-			onUpdate(name, info)
-		}
+
+	client, err := createGitHubClient(ctx, repoInfo.Hostname, token)
+	if err != nil {
+		return nil //nolint:nilerr // Preserve best-effort PR sync behavior.
 	}
 
+	utils.Run(branchNames, func(name string) {
+		pr, err := getPRInfoForBranch(ctx, client, repoOwner, repoName, name)
+		if err != nil || pr == nil || onUpdate == nil {
+			return
+		}
+		onUpdate(name, ToPullRequestInfo(pr))
+	})
+
 	return nil
+}
+
+// getPRInfoForBranch gets PR info for a branch using the REST API. This is the
+// compatibility fallback when the batched GraphQL sync fails.
+func getPRInfoForBranch(ctx context.Context, client *github.Client, owner, repo, branchName string) (*github.PullRequest, error) {
+	prs, _, err := client.PullRequests.List(ctx, owner, repo, &github.PullRequestListOptions{
+		Head:  fmt.Sprintf("%s:%s", owner, branchName),
+		State: "all",
+		ListOptions: github.ListOptions{
+			PerPage: 1,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(prs) == 0 {
+		return nil, nil
+	}
+	return prs[0], nil
 }
 
 // createGitHubClient creates a GitHub client configured for the given hostname

--- a/internal/github/pr_info_graphql.go
+++ b/internal/github/pr_info_graphql.go
@@ -1,0 +1,151 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// batchGetPRInfoByBranchGraphQL fetches the most recent pull request associated
+// (as head ref) with each branch in a single GraphQL query, replacing one REST
+// list call per branch. Branches with no associated PR are absent from the
+// returned map.
+func batchGetPRInfoByBranchGraphQL(ctx context.Context, runner GitCommandRunner, owner, repo string, branchNames []string) (map[string]*PullRequestInfo, error) {
+	results := make(map[string]*PullRequestInfo, len(branchNames))
+	if len(branchNames) == 0 {
+		return results, nil
+	}
+
+	// Deduplicate while keeping a stable order for alias assignment.
+	seen := make(map[string]struct{}, len(branchNames))
+	unique := make([]string, 0, len(branchNames))
+	for _, n := range branchNames {
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		unique = append(unique, n)
+	}
+
+	query, variables := buildPRInfoByBranchQuery(owner, repo, unique)
+	body, err := executeGraphQLQuery(ctx, runner, query, variables)
+	if err != nil {
+		return nil, err
+	}
+	return parsePRInfoByBranchResponse(body, unique)
+}
+
+// buildPRInfoByBranchQuery builds a GraphQL query that resolves each branch's
+// head PR under a b<index> alias. Branch names are passed as variables so names
+// containing slashes or other characters need no escaping.
+func buildPRInfoByBranchQuery(owner, repo string, branches []string) (string, map[string]any) {
+	var b strings.Builder
+	b.WriteString("query($owner: String!, $repo: String!")
+	for i := range branches {
+		fmt.Fprintf(&b, ", $b%d: String!", i)
+	}
+	b.WriteString(") {\n")
+	b.WriteString("  repository(owner: $owner, name: $repo) {\n")
+	for i := range branches {
+		fmt.Fprintf(&b, "    b%d: ref(qualifiedName: $b%d) {\n", i, i)
+		b.WriteString("      associatedPullRequests(first: 1, orderBy: {field: CREATED_AT, direction: DESC}) {\n")
+		b.WriteString("        nodes { number title body state url isDraft baseRefName headRefName }\n")
+		b.WriteString("      }\n")
+		b.WriteString("    }\n")
+	}
+	b.WriteString("  }\n")
+	b.WriteString("}\n")
+
+	variables := map[string]any{
+		"owner": owner,
+		"repo":  repo,
+	}
+	for i, name := range branches {
+		variables[fmt.Sprintf("b%d", i)] = "refs/heads/" + name
+	}
+	return b.String(), variables
+}
+
+// parsePRInfoByBranchResponse maps each b<index> alias back to its branch name.
+// A missing ref or a ref with no associated PR is skipped (left out of the map),
+// matching the prior per-branch behavior where such branches kept their existing
+// local PR info.
+func parsePRInfoByBranchResponse(body []byte, branches []string) (map[string]*PullRequestInfo, error) {
+	var resp struct {
+		Data   map[string]any `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse GraphQL response: %w", err)
+	}
+
+	repository, ok := resp.Data["repository"].(map[string]any)
+	if !ok {
+		// No repository payload at all is a hard failure (bad repo, auth, etc.).
+		// Per-ref nulls do not land here — ref() simply returns null for a
+		// missing branch without producing a top-level error.
+		if len(resp.Errors) > 0 {
+			return nil, fmt.Errorf("graphql error: %s", resp.Errors[0].Message)
+		}
+		return nil, fmt.Errorf("invalid GraphQL response format: missing repository")
+	}
+
+	results := make(map[string]*PullRequestInfo, len(branches))
+	for i, name := range branches {
+		alias := fmt.Sprintf("b%d", i)
+		refData, ok := repository[alias].(map[string]any)
+		if !ok {
+			continue
+		}
+		assoc, ok := refData["associatedPullRequests"].(map[string]any)
+		if !ok {
+			continue
+		}
+		nodes, ok := assoc["nodes"].([]any)
+		if !ok || len(nodes) == 0 {
+			continue
+		}
+		node, ok := nodes[0].(map[string]any)
+		if !ok {
+			continue
+		}
+		results[name] = pullRequestInfoFromGraphQLNode(node)
+	}
+	return results, nil
+}
+
+// pullRequestInfoFromGraphQLNode converts a single associatedPullRequests node
+// into a PullRequestInfo. State is normalized to upper case to match the REST
+// path (ToPullRequestInfo); the GraphQL PullRequestState enum is already upper
+// case (OPEN/CLOSED/MERGED).
+func pullRequestInfoFromGraphQLNode(node map[string]any) *PullRequestInfo {
+	info := &PullRequestInfo{}
+	if v, ok := node["number"].(float64); ok {
+		info.Number = int(v)
+	}
+	if v, ok := node["title"].(string); ok {
+		info.Title = v
+	}
+	if v, ok := node["body"].(string); ok {
+		info.Body = v
+	}
+	if v, ok := node["state"].(string); ok {
+		info.State = strings.ToUpper(v)
+	}
+	if v, ok := node["url"].(string); ok {
+		info.HTMLURL = v
+	}
+	if v, ok := node["isDraft"].(bool); ok {
+		info.Draft = v
+	}
+	if v, ok := node["baseRefName"].(string); ok {
+		info.Base = v
+	}
+	if v, ok := node["headRefName"].(string); ok {
+		info.Head = v
+	}
+	return info
+}

--- a/internal/github/pr_info_graphql_test.go
+++ b/internal/github/pr_info_graphql_test.go
@@ -1,0 +1,101 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPRInfoByBranchQuery(t *testing.T) {
+	t.Parallel()
+
+	query, variables := buildPRInfoByBranchQuery("octo", "repo", []string{"feature", "jonnii/long/branch-name"})
+
+	require.Contains(t, query, "repository(owner: $owner, name: $repo)")
+	require.Contains(t, query, "b0: ref(qualifiedName: $b0)")
+	require.Contains(t, query, "b1: ref(qualifiedName: $b1)")
+	require.Contains(t, query, "associatedPullRequests(first: 1, orderBy: {field: CREATED_AT, direction: DESC})")
+	require.Contains(t, query, "number title body state url isDraft baseRefName headRefName")
+
+	require.Equal(t, "octo", variables["owner"])
+	require.Equal(t, "repo", variables["repo"])
+	// Branch names are passed as variables (qualified) so slashes need no escaping.
+	require.Equal(t, "refs/heads/feature", variables["b0"])
+	require.Equal(t, "refs/heads/jonnii/long/branch-name", variables["b1"])
+}
+
+func TestParsePRInfoByBranchResponse(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"data": {
+			"repository": {
+				"b0": {
+					"associatedPullRequests": {
+						"nodes": [
+							{"number": 42, "title": "feat: auth", "body": "do auth", "state": "OPEN", "url": "https://gh/pr/42", "isDraft": true, "baseRefName": "main", "headRefName": "feature"}
+						]
+					}
+				},
+				"b1": {
+					"associatedPullRequests": {
+						"nodes": [
+							{"number": 7, "title": "fix: merged", "body": "", "state": "MERGED", "url": "https://gh/pr/7", "isDraft": false, "baseRefName": "feature", "headRefName": "child"}
+						]
+					}
+				}
+			}
+		}
+	}`)
+
+	infos, err := parsePRInfoByBranchResponse(body, []string{"feature", "child"})
+	require.NoError(t, err)
+	require.Len(t, infos, 2)
+
+	feature := infos["feature"]
+	require.NotNil(t, feature)
+	require.Equal(t, 42, feature.Number)
+	require.Equal(t, "feat: auth", feature.Title)
+	require.Equal(t, "do auth", feature.Body)
+	require.Equal(t, "OPEN", feature.State)
+	require.Equal(t, "https://gh/pr/42", feature.HTMLURL)
+	require.True(t, feature.Draft)
+	require.Equal(t, "main", feature.Base)
+	require.Equal(t, "feature", feature.Head)
+
+	require.Equal(t, "MERGED", infos["child"].State)
+}
+
+func TestParsePRInfoByBranchResponse_NullRefAndNoPR(t *testing.T) {
+	t.Parallel()
+
+	// b0 ref does not exist (null); b1 exists but has no associated PR.
+	body := []byte(`{
+		"data": {
+			"repository": {
+				"b0": null,
+				"b1": {"associatedPullRequests": {"nodes": []}}
+			}
+		}
+	}`)
+
+	infos, err := parsePRInfoByBranchResponse(body, []string{"gone", "no-pr"})
+	require.NoError(t, err)
+	require.Empty(t, infos, "branches without an associated PR are skipped")
+}
+
+func TestParsePRInfoByBranchResponse_MissingRepository(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"data": {}, "errors": [{"message": "Could not resolve to a Repository"}]}`)
+	_, err := parsePRInfoByBranchResponse(body, []string{"feature"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Could not resolve to a Repository")
+}
+
+func TestParsePRInfoByBranchResponse_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	_, err := parsePRInfoByBranchResponse([]byte(`{invalid`), []string{"feature"})
+	require.Error(t, err)
+}


### PR DESCRIPTION
**Eliminate submit N+1s: batch remote reads, pushes, and GitHub API calls**

Systematically removes the per-branch N+1 patterns from `stackit submit`, replacing serial per-branch operations with batched equivalents across every network boundary.

**Performance changes (each removes a per-branch serial operation):**
- **Batch remote ref read:** replace per-branch `git ls-remote` with a single `FetchRemoteShas` call shared across planning, force-with-lease guards, and the push
- **Batch push:** replace one `git push` per branch with a single batched `git push --porcelain` for the whole stack; partial failures surface per-branch via `--force-with-lease=<ref>:<sha>` guards
- **Batch PR-info sync:** replace one REST list call per branch with a single GraphQL query using aliased `ref.associatedPullRequests` lookups; REST fallback preserved for GraphQL failures
- **Batch PR-content reads (footer pass):** replace one `GetPullRequest` per branch with a single aliased GraphQL query when updating PR body footers
- **Batch remote read in planning:** `BatchGetPRSubmissionStatus` reads remote status once for the whole set, not once per branch; skips the read entirely for all-creates stacks
- **Overlap remote read with PR sync:** fire the single `ls-remote` concurrently with validation's GraphQL PR-info sync (independent round trips); skipped on dry runs
- **Batch empty-branch validation:** replace per-branch `git diff` with a single batched `rev-parse` resolving all branch and parent tree SHAs at once

**Refactors:**
- **Lazy TUI start:** fold `HasSubmitWork` (a pre-flight scope check) into `Action`; the TUI runner now starts on the first `StackDisplayEvent` instead of unconditionally, eliminating the startup/teardown flash when there is nothing to submit
- **Submit feedback:** dry-run create-only stacks skip the `ls-remote` entirely; GraphQL→REST fallback in `SyncPrInfo` ensures PR info syncs even when GraphQL fails

**Testing:** counting-runner assertions lock in the N+1 elimination (one remote read, one push per submit invocation); porcelain partial-failure test covers stale-lease isolation; GraphQL parse tests cover null refs, missing PRs, and error responses.

This PR merges the following changes:

1. **#1175** perf(submit): batch remote ref read for stack submit
2. **#1176** perf(submit): push entire stack in a single git push
3. **#1177** perf(submit): fetch stack PR info in one GraphQL query
4. **#1178** perf(submit): batch PR-content reads in the footer pass
5. **#1179** perf(submit): batch remote read in submit planning
6. **#1180** perf(submit): overlap remote read with PR sync, share one ls-remote
7. **#1181** perf(submit): batch the empty-branch validation check
8. **#1182** refactor(submit): fold HasSubmitWork into Action with lazy TUI start
9. **#1183** refactor: submit feedback

### Stack

```
main
  └─ jonnii/20260608002343/batch-remote-ref-read-for-stack-submit (#1175)
    └─ jonnii/20260608003658/push-entire-stack-in-a-single-git-push (#1176)
      └─ jonnii/20260608004252/fetch-stack-PR-info-in-one-GraphQL-query (#1177)
        └─ jonnii/20260608004713/batch-PR-content-reads-in-the-footer-pass (#1178)
          └─ jonnii/20260608005903/batch-remote-read-in-submit-planning (#1179)
            └─ jonnii/20260608011207/overlap-remote-read-with-PR-sync-share-one (#1180)
              └─ jonnii/20260608012454/batch-the-empty-branch-validation-check (#1181)
                └─ jonnii/20260608013333/fold-HasSubmitWork-into-Action-with-lazy-TUI-start (#1182)
                  └─ jonnii/20260608022254/submit-feedback (#1183)
```

Stackit-Stack-Size: 9
Stackit-PRs: 1175,1176,1177,1178,1179,1180,1181,1182,1183
