### PR TITLE
refactor: replace fmt.Sscanf("%d") with strconv.Atoi

### DIFF
--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -2,7 +2,7 @@ package engine
 
 import (
 	"context"
-	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -58,8 +58,7 @@ func (e *engineImpl) GetCommitCount(branch Branch) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	var count int
-	_, _ = fmt.Sscanf(strings.TrimSpace(out), "%d", &count)
+	count, _ := strconv.Atoi(strings.TrimSpace(out))
 	e.commitCountCache.Store(cacheKey, count)
 	return count, nil
 }
@@ -93,9 +92,8 @@ func (e *engineImpl) GetDiffStats(branch Branch) (int, int, error) {
 		}
 		fields := strings.Fields(line)
 		if len(fields) >= 2 {
-			var a, d int
-			_, _ = fmt.Sscanf(fields[0], "%d", &a)
-			_, _ = fmt.Sscanf(fields[1], "%d", &d)
+			a, _ := strconv.Atoi(fields[0])
+			d, _ := strconv.Atoi(fields[1])
 			added += a
 			deleted += d
 		}

--- a/internal/git/hunks.go
+++ b/internal/git/hunks.go
@@ -3,6 +3,7 @@ package git
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -179,11 +180,7 @@ func ParseDiffOutput(diffOutput string) ([]Hunk, error) {
 
 // parseInt parses a string to int, returns 0 if empty or invalid
 func parseInt(s string) int {
-	if s == "" {
-		return 0
-	}
-	var result int
-	_, _ = fmt.Sscanf(s, "%d", &result)
+	result, _ := strconv.Atoi(s)
 	return result
 }
 


### PR DESCRIPTION
## Summary

- Replace `fmt.Sscanf(s, "%d", &n)` with `strconv.Atoi(s)` in `engine_branch_info.go` and `git/hunks.go`
- Drop the now-unused `fmt` import from `engine_branch_info.go`
- Simplify `parseInt` in `hunks.go` by removing a redundant empty-string guard (`strconv.Atoi("")` already returns 0)

`strconv.Atoi` is the idiomatic Go way to parse an integer from a string. `fmt.Sscanf` with `"%d"` is heavier, less obvious at a glance, and requires declaring a variable before the call just to take its address. Both produce 0 for invalid or empty input, so behaviour is unchanged.

## Test plan

- [ ] `go vet ./internal/engine/... ./internal/git/...` passes
- [ ] `go build ./...` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEXrvXrK95CGfLrBgK7JB7)_