### PR TITLE
test: add t.Parallel() to all TUI tests

### DIFF
--- a/internal/tui/base_model_test.go
+++ b/internal/tui/base_model_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func TestBaseModel_SignalReady(t *testing.T) {
+	t.Parallel()
 	t.Run("closes channel on first call", func(t *testing.T) {
+		t.Parallel()
 		b := &BaseModel{}
 		ch := make(chan struct{})
 		b.SetReadyChan(ch)
@@ -31,7 +33,8 @@ func TestBaseModel_SignalReady(t *testing.T) {
 		}
 	})
 
-	t.Run("is idempotent - second call is no-op", func(_ *testing.T) {
+	t.Run("is idempotent - second call is no-op", func(t *testing.T) {
+		t.Parallel()
 		b := &BaseModel{}
 		ch := make(chan struct{})
 		b.SetReadyChan(ch)
@@ -41,7 +44,8 @@ func TestBaseModel_SignalReady(t *testing.T) {
 		b.SignalReady()
 	})
 
-	t.Run("handles nil channel gracefully", func(_ *testing.T) {
+	t.Run("handles nil channel gracefully", func(t *testing.T) {
+		t.Parallel()
 		b := &BaseModel{}
 		// Should not panic
 		b.SignalReady()
@@ -49,6 +53,7 @@ func TestBaseModel_SignalReady(t *testing.T) {
 }
 
 func TestBaseModel_HandleCommonMsg_KeyMsg(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		msg         tea.Msg
@@ -63,6 +68,7 @@ func TestBaseModel_HandleCommonMsg_KeyMsg(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			b := &BaseModel{}
 
 			handled, cmd := b.HandleCommonMsg(tt.msg)
@@ -81,6 +87,7 @@ func TestBaseModel_HandleCommonMsg_KeyMsg(t *testing.T) {
 }
 
 func TestBaseModel_HandleCommonMsg_WindowSizeMsg(t *testing.T) {
+	t.Parallel()
 	b := &BaseModel{}
 	msg := tea.WindowSizeMsg{Width: 100, Height: 50}
 
@@ -102,6 +109,7 @@ func TestBaseModel_HandleCommonMsg_WindowSizeMsg(t *testing.T) {
 }
 
 func TestBaseModel_HandleCommonMsg_SpinnerTickMsg(t *testing.T) {
+	t.Parallel()
 	b := &BaseModel{}
 	// Initialize spinner first
 	b.InitSpinner()
@@ -118,6 +126,7 @@ func TestBaseModel_HandleCommonMsg_SpinnerTickMsg(t *testing.T) {
 }
 
 func TestBaseModel_HandleCommonMsg_UnknownMsg(t *testing.T) {
+	t.Parallel()
 	b := &BaseModel{}
 	msg := struct{ custom string }{custom: "test"}
 
@@ -132,6 +141,7 @@ func TestBaseModel_HandleCommonMsg_UnknownMsg(t *testing.T) {
 }
 
 func TestBaseModel_DoneState(t *testing.T) {
+	t.Parallel()
 	b := &BaseModel{}
 
 	if b.IsDone() {
@@ -151,6 +161,7 @@ func TestBaseModel_DoneState(t *testing.T) {
 }
 
 func TestBaseModel_InitSpinner(t *testing.T) {
+	t.Parallel()
 	b := &BaseModel{}
 	cmd := b.InitSpinner()
 
@@ -166,6 +177,7 @@ func TestBaseModel_InitSpinner(t *testing.T) {
 }
 
 func TestBaseModel_SetReadyChan(t *testing.T) {
+	t.Parallel()
 	b := &BaseModel{}
 	ch := make(chan struct{})
 

--- a/internal/tui/components/merge/model_test.go
+++ b/internal/tui/components/merge/model_test.go
@@ -15,7 +15,9 @@ func viewString(v tea.View) string {
 }
 
 func TestModel_EmptyPlan(t *testing.T) {
+	t.Parallel()
 	t.Run("empty plan shows initializing message", func(t *testing.T) {
+		t.Parallel()
 		model := NewModel()
 
 		// Before any plan is loaded, groups is empty
@@ -34,6 +36,7 @@ func TestModel_EmptyPlan(t *testing.T) {
 	})
 
 	t.Run("empty plan with done shows complete", func(t *testing.T) {
+		t.Parallel()
 		model := NewModel()
 		model.Done = true
 
@@ -46,6 +49,7 @@ func TestModel_EmptyPlan(t *testing.T) {
 	})
 
 	t.Run("empty plan with summary shows summary", func(t *testing.T) {
+		t.Parallel()
 		model := NewModel()
 		model.Done = true
 		model.Summary = "Created PR #123"
@@ -57,7 +61,9 @@ func TestModel_EmptyPlan(t *testing.T) {
 }
 
 func TestModel_PlanLoadedMsg(t *testing.T) {
+	t.Parallel()
 	t.Run("loads plan with groups", func(t *testing.T) {
+		t.Parallel()
 		model := NewModel()
 
 		msg := PlanLoadedMsg{
@@ -78,6 +84,7 @@ func TestModel_PlanLoadedMsg(t *testing.T) {
 	})
 
 	t.Run("creates default groups when none provided", func(t *testing.T) {
+		t.Parallel()
 		model := NewModel()
 
 		msg := PlanLoadedMsg{
@@ -98,7 +105,9 @@ func TestModel_PlanLoadedMsg(t *testing.T) {
 }
 
 func TestModel_View_ProgressIndicator(t *testing.T) {
+	t.Parallel()
 	t.Run("shows correct progress", func(t *testing.T) {
+		t.Parallel()
 		model := NewModel()
 
 		// Load a plan with 3 groups
@@ -138,7 +147,9 @@ func TestModel_View_ProgressIndicator(t *testing.T) {
 }
 
 func TestModel_View_StepStatuses(t *testing.T) {
+	t.Parallel()
 	t.Run("shows running step with spinner", func(t *testing.T) {
+		t.Parallel()
 		model := NewModel()
 
 		loadMsg := PlanLoadedMsg{
@@ -161,6 +172,7 @@ func TestModel_View_StepStatuses(t *testing.T) {
 	})
 
 	t.Run("shows completed step with checkmark", func(t *testing.T) {
+		t.Parallel()
 		model := NewModel()
 
 		loadMsg := PlanLoadedMsg{
@@ -182,6 +194,7 @@ func TestModel_View_StepStatuses(t *testing.T) {
 	})
 
 	t.Run("shows failed step with error mark", func(t *testing.T) {
+		t.Parallel()
 		model := NewModel()
 
 		loadMsg := PlanLoadedMsg{
@@ -204,7 +217,9 @@ func TestModel_View_StepStatuses(t *testing.T) {
 }
 
 func TestModel_Quitting(t *testing.T) {
+	t.Parallel()
 	t.Run("returns empty view when quitting", func(t *testing.T) {
+		t.Parallel()
 		model := NewModel()
 		model.Quitting = true
 

--- a/internal/tui/components/sync/model_test.go
+++ b/internal/tui/components/sync/model_test.go
@@ -17,6 +17,7 @@ func viewString(v tea.View) string {
 }
 
 func TestNewModel(t *testing.T) {
+	t.Parallel()
 	model := NewModel(10)
 
 	assert.Equal(t, 10, model.TotalOps)
@@ -26,6 +27,7 @@ func TestNewModel(t *testing.T) {
 }
 
 func TestModel_Init(t *testing.T) {
+	t.Parallel()
 	model := NewModel(0)
 
 	// Set up ready channel to capture signal
@@ -47,6 +49,7 @@ func TestModel_Init(t *testing.T) {
 }
 
 func TestModel_Update_PhaseStartMsg(t *testing.T) {
+	t.Parallel()
 	model := NewModel(10)
 	model.Init()
 
@@ -60,6 +63,7 @@ func TestModel_Update_PhaseStartMsg(t *testing.T) {
 }
 
 func TestModel_Update_PhaseTransition(t *testing.T) {
+	t.Parallel()
 	model := NewModel(10)
 	model.Init()
 
@@ -75,6 +79,7 @@ func TestModel_Update_PhaseTransition(t *testing.T) {
 }
 
 func TestModel_Update_PhaseDetailMsg(t *testing.T) {
+	t.Parallel()
 	model := NewModel(10)
 	model.Init()
 
@@ -94,6 +99,7 @@ func TestModel_Update_PhaseDetailMsg(t *testing.T) {
 }
 
 func TestModel_Update_PhaseDetailMsg_WithWarn(t *testing.T) {
+	t.Parallel()
 	model := NewModel(10)
 	model.Init()
 
@@ -110,6 +116,7 @@ func TestModel_Update_PhaseDetailMsg_WithWarn(t *testing.T) {
 }
 
 func TestModel_Update_ProgressTickMsg(t *testing.T) {
+	t.Parallel()
 	model := NewModel(10)
 	model.Init()
 
@@ -126,6 +133,7 @@ func TestModel_Update_ProgressTickMsg(t *testing.T) {
 }
 
 func TestModel_Update_CompleteMsg(t *testing.T) {
+	t.Parallel()
 	model := NewModel(10)
 	model.Init()
 
@@ -143,6 +151,7 @@ func TestModel_Update_CompleteMsg(t *testing.T) {
 }
 
 func TestModel_Update_KeyMsg_Quit(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		msg  tea.Msg
@@ -153,6 +162,7 @@ func TestModel_Update_KeyMsg_Quit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			model := NewModel(10)
 			model.Init()
 
@@ -164,6 +174,7 @@ func TestModel_Update_KeyMsg_Quit(t *testing.T) {
 }
 
 func TestModel_Update_WindowSizeMsg(t *testing.T) {
+	t.Parallel()
 	model := NewModel(10)
 	model.Init()
 
@@ -177,6 +188,7 @@ func TestModel_Update_WindowSizeMsg(t *testing.T) {
 }
 
 func TestModel_Update_WindowSizeMsg_NarrowTerminal(t *testing.T) {
+	t.Parallel()
 	model := NewModel(10)
 	model.Init()
 
@@ -190,6 +202,7 @@ func TestModel_Update_WindowSizeMsg_NarrowTerminal(t *testing.T) {
 }
 
 func TestModel_View_InProgress(t *testing.T) {
+	t.Parallel()
 	model := NewModel(10)
 	model.Init()
 
@@ -210,6 +223,7 @@ func TestModel_View_InProgress(t *testing.T) {
 }
 
 func TestModel_View_Completed(t *testing.T) {
+	t.Parallel()
 	model := NewModel(10)
 	model.Init()
 
@@ -224,6 +238,7 @@ func TestModel_View_Completed(t *testing.T) {
 }
 
 func TestModel_Update_SpinnerTickMsg(t *testing.T) {
+	t.Parallel()
 	model := NewModel(10)
 	model.Init()
 
@@ -237,6 +252,7 @@ func TestModel_Update_SpinnerTickMsg(t *testing.T) {
 // TestMessageRecorder_Usage demonstrates how MessageRecorder can be used
 // to test message flow in more complex scenarios
 func TestMessageRecorder_Usage(t *testing.T) {
+	t.Parallel()
 	recorder := tui.NewMessageRecorder()
 
 	// Record some messages
@@ -265,6 +281,7 @@ func TestMessageRecorder_Usage(t *testing.T) {
 }
 
 func TestModel_GetStatusText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		phase    Phase
@@ -280,6 +297,7 @@ func TestModel_GetStatusText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			model := NewModel(10)
 			model.CurrentPhase = tt.phase
 			text := model.getStatusText()

--- a/internal/tui/components/tree/tree_golden_test.go
+++ b/internal/tui/components/tree/tree_golden_test.go
@@ -454,10 +454,12 @@ func buildGoldenTests() []goldenTest {
 }
 
 func TestStackTreeRenderer_Golden(t *testing.T) {
+	t.Parallel()
 	tests := buildGoldenTests()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			renderer := NewRenderer(tt.mock)
 
 			// Apply annotations if provided
@@ -532,6 +534,7 @@ func diffStrings(expected, actual string) string {
 // TestStackTreeRenderer_GoldenWithColors tests that colors are applied correctly
 // This test verifies ANSI codes are present without checking exact sequences
 func TestStackTreeRenderer_GoldenWithColors(t *testing.T) {
+	t.Parallel()
 	mock := NewMockTreeData()
 	renderer := NewRenderer(mock)
 

--- a/internal/tui/components/tree/tree_test.go
+++ b/internal/tui/components/tree/tree_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestStackTreeRenderer_RenderStack_LinearStack(t *testing.T) {
+	t.Parallel()
 	mock := NewMockTreeData()
 	renderer := NewRenderer(mock)
 
@@ -32,6 +33,7 @@ func TestStackTreeRenderer_RenderStack_LinearStack(t *testing.T) {
 }
 
 func TestStackTreeRenderer_RenderStack_WithAnnotations(t *testing.T) {
+	t.Parallel()
 	mock := NewMockTreeData()
 	renderer := NewRenderer(mock)
 
@@ -53,6 +55,7 @@ func TestStackTreeRenderer_RenderStack_WithAnnotations(t *testing.T) {
 }
 
 func TestStackTreeRenderer_RenderStack_BranchingStack(t *testing.T) {
+	t.Parallel()
 	mock := &MockTreeData{
 		CurrentVal: "feature-1a",
 		TrunkVal:   "main",
@@ -91,6 +94,7 @@ func TestStackTreeRenderer_RenderStack_BranchingStack(t *testing.T) {
 }
 
 func TestStackTreeRenderer_RenderStack_FullFormat(t *testing.T) {
+	t.Parallel()
 	mock := NewMockTreeData()
 	renderer := NewRenderer(mock)
 
@@ -111,6 +115,7 @@ func TestStackTreeRenderer_RenderStack_FullFormat(t *testing.T) {
 }
 
 func TestStackTreeRenderer_RenderBranchList(t *testing.T) {
+	t.Parallel()
 	mock := NewMockTreeData()
 	renderer := NewRenderer(mock)
 
@@ -132,6 +137,7 @@ func TestStackTreeRenderer_RenderBranchList(t *testing.T) {
 }
 
 func TestStackTreeRenderer_NeedsRestack(t *testing.T) {
+	t.Parallel()
 	mock := &MockTreeData{
 		CurrentVal: "feature-1",
 		TrunkVal:   "main",
@@ -161,6 +167,7 @@ func TestStackTreeRenderer_NeedsRestack(t *testing.T) {
 }
 
 func TestBranchAnnotation_CheckStatus(t *testing.T) {
+	t.Parallel()
 	mock := NewMockTreeData()
 	renderer := NewRenderer(mock)
 
@@ -186,6 +193,7 @@ func TestBranchAnnotation_CheckStatus(t *testing.T) {
 }
 
 func TestStackTreeRenderer_ScopeColoring(t *testing.T) {
+	t.Parallel()
 	mock := &MockTreeData{
 		CurrentVal: "feature-login",
 		TrunkVal:   "main",
@@ -241,6 +249,7 @@ func TestStackTreeRenderer_ScopeColoring(t *testing.T) {
 }
 
 func TestStackTreeRenderer_InheritedScopeColoring(t *testing.T) {
+	t.Parallel()
 	mock := &MockTreeData{
 		CurrentVal: "feature-login",
 		TrunkVal:   "main",
@@ -314,6 +323,7 @@ func TestStackTreeRenderer_InheritedScopeColoring(t *testing.T) {
 }
 
 func TestStackTreeRenderer_BranchingScopeColoring(t *testing.T) {
+	t.Parallel()
 	mock := &MockTreeData{
 		CurrentVal: "feature-1a",
 		TrunkVal:   "main",
@@ -356,6 +366,7 @@ func TestStackTreeRenderer_BranchingScopeColoring(t *testing.T) {
 }
 
 func TestStackTreeRenderer_ScopeColoringBoundaries(t *testing.T) {
+	t.Parallel()
 	// Setup a branching structure where one branch has a scope
 	// main
 	//   └─ base (A)
@@ -449,6 +460,7 @@ func TestStackTreeRenderer_ScopeColoringBoundaries(t *testing.T) {
 // Edge case tests
 
 func TestStackTreeRenderer_EmptyTree(t *testing.T) {
+	t.Parallel()
 	// A tree with just the trunk and no children
 	mock := &MockTreeData{
 		CurrentVal: "main",
@@ -476,6 +488,7 @@ func TestStackTreeRenderer_EmptyTree(t *testing.T) {
 }
 
 func TestStackTreeRenderer_SingleBranch(t *testing.T) {
+	t.Parallel()
 	// A tree with trunk -> one branch
 	mock := &MockTreeData{
 		CurrentVal: "feature",
@@ -508,6 +521,7 @@ func TestStackTreeRenderer_SingleBranch(t *testing.T) {
 }
 
 func TestStackTreeRenderer_DeeplyNested(t *testing.T) {
+	t.Parallel()
 	// A deeply nested linear tree with 15 levels
 	depth := 15
 	childrenMap := make(map[string][]string)
@@ -554,6 +568,7 @@ func TestStackTreeRenderer_DeeplyNested(t *testing.T) {
 }
 
 func TestStackTreeRenderer_CollapsedBranch(t *testing.T) {
+	t.Parallel()
 	mock := &MockTreeData{
 		CurrentVal: "feature-1",
 		TrunkVal:   "main",
@@ -612,6 +627,7 @@ func TestStackTreeRenderer_CollapsedBranch(t *testing.T) {
 }
 
 func TestStackTreeRenderer_WideBranching(t *testing.T) {
+	t.Parallel()
 	// A tree where main has 5 direct children
 	mock := &MockTreeData{
 		CurrentVal: "branch-1",
@@ -665,6 +681,7 @@ func TestStackTreeRenderer_WideBranching(t *testing.T) {
 }
 
 func TestStackTreeRenderer_RenderFromMiddleBranch(t *testing.T) {
+	t.Parallel()
 	// Test rendering from a branch in the middle of the stack
 	mock := &MockTreeData{
 		CurrentVal: "feature-2",
@@ -710,6 +727,7 @@ func TestStackTreeRenderer_RenderFromMiddleBranch(t *testing.T) {
 }
 
 func TestStackTreeRenderer_CacheIsCleared(t *testing.T) {
+	t.Parallel()
 	// Test that cache is properly cleared between renders
 	mock := &MockTreeData{
 		CurrentVal: "feature-1",

--- a/internal/tui/shippable_stories_test.go
+++ b/internal/tui/shippable_stories_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestShippableStoriesRegistered(t *testing.T) {
+	t.Parallel()
 	// Verify shippable stories are registered
 	shippableCount := 0
 	mergeFlowCount := 0
@@ -25,6 +26,7 @@ func TestShippableStoriesRegistered(t *testing.T) {
 }
 
 func TestShippableStoryModelCreation(t *testing.T) {
+	t.Parallel()
 	// Verify each scenario creates a valid model
 	for _, scenario := range shippableScenarios {
 		model := newShippableStoryModel(scenario)
@@ -37,6 +39,7 @@ func TestShippableStoryModelCreation(t *testing.T) {
 }
 
 func TestMergeProgressSimulationCreation(t *testing.T) {
+	t.Parallel()
 	scenarios := []mergeScenarioType{
 		mergeScenarioHappyPath,
 		mergeScenarioWaitingCI,

--- a/internal/tui/testing_test.go
+++ b/internal/tui/testing_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestMockRunner(t *testing.T) {
+	t.Parallel()
 	t.Run("tracks started and stopped state", func(t *testing.T) {
+		t.Parallel()
 		runner := NewMockRunner()
 		assert.False(t, runner.IsHealthy())
 
@@ -21,6 +23,7 @@ func TestMockRunner(t *testing.T) {
 	})
 
 	t.Run("records messages", func(t *testing.T) {
+		t.Parallel()
 		runner := NewMockRunner()
 		runner.Start()
 
@@ -35,6 +38,7 @@ func TestMockRunner(t *testing.T) {
 	})
 
 	t.Run("reset clears state", func(t *testing.T) {
+		t.Parallel()
 		runner := NewMockRunner()
 		runner.Start()
 		runner.Send(tea.KeyPressMsg{Code: tea.KeyEnter})
@@ -46,6 +50,7 @@ func TestMockRunner(t *testing.T) {
 	})
 
 	t.Run("is thread-safe", func(t *testing.T) {
+		t.Parallel()
 		runner := NewMockRunner()
 		runner.Start()
 
@@ -64,7 +69,9 @@ func TestMockRunner(t *testing.T) {
 }
 
 func TestMessageRecorder(t *testing.T) {
+	t.Parallel()
 	t.Run("records messages", func(t *testing.T) {
+		t.Parallel()
 		recorder := NewMessageRecorder()
 
 		type testMsg struct{ id string }
@@ -75,6 +82,7 @@ func TestMessageRecorder(t *testing.T) {
 	})
 
 	t.Run("HasMessage finds matching messages", func(t *testing.T) {
+		t.Parallel()
 		recorder := NewMessageRecorder()
 
 		type testMsg struct{ id string }
@@ -99,6 +107,7 @@ func TestMessageRecorder(t *testing.T) {
 	})
 
 	t.Run("reset clears messages", func(t *testing.T) {
+		t.Parallel()
 		recorder := NewMessageRecorder()
 		recorder.Record(tea.KeyPressMsg{Code: tea.KeyEnter})
 
@@ -107,6 +116,7 @@ func TestMessageRecorder(t *testing.T) {
 	})
 
 	t.Run("is thread-safe", func(t *testing.T) {
+		t.Parallel()
 		recorder := NewMessageRecorder()
 
 		var wg sync.WaitGroup


### PR DESCRIPTION
## Summary

- 54 of 57 test functions in `internal/tui/` were missing `t.Parallel()`, causing the entire TUI test suite to run serially
- All affected tests are pure unit tests (BubbleTea model state, message handling, tree rendering) with no shared global state — parallelism is safe
- Covers `base_model`, `shippable_stories`, `testing`, `sync/model`, `merge/model`, `tree/tree`, and `tree/tree_golden` test files

## Why this matters

Per the project's testing standards (`t.Parallel()` is non-negotiable), serial tests waste CPU cores and slow feedback loops. Going from 3 → 82 parallel declarations means all 57 TUI test functions now run concurrently, reducing wall-clock time for `go test ./internal/tui/...`.

## Test plan

- [x] `go test ./internal/tui/...` passes — all packages green
- [x] No shared mutable state in any of the affected tests (verified by inspection: each test constructs local structs, no `os.Chdir`, no global vars mutated)
- [x] Golden tests read from per-test-named files — safe to parallelize

---
_Generated by [Claude Code](https://claude.ai/code/session_012PirrK7fsn4Gh3ERLD8igm)_