### PR TITLE
fix(submit): persist per-branch failures after the submit TUI exits

### DIFF
--- a/internal/tui/components/submit/format.go
+++ b/internal/tui/components/submit/format.go
@@ -219,3 +219,37 @@ func FormatURLSummary(items []Item) string {
 	}
 	return "Pull requests\n\n" + strings.Join(rows, "\n")
 }
+
+// FormatFailureSummary renders failed branches with their errors. The progress
+// view is cleared when the TUI exits, so failures must be re-emitted as
+// persistent output or they vanish from the terminal.
+func FormatFailureSummary(items []Item) string {
+	rows := make([]string, 0, len(items))
+	for _, item := range items {
+		if item.Status != StatusError {
+			continue
+		}
+		detail := "failed"
+		if item.Error != nil {
+			detail = item.Error.Error()
+		}
+		rows = append(rows, fmt.Sprintf("✗ %s — %s", DisplayBranchName(item.BranchName), detail))
+	}
+	if len(rows) == 0 {
+		return ""
+	}
+	return strings.Join(rows, "\n")
+}
+
+// FormatCompletionSummary renders the persistent post-submit output: PR URLs
+// for submitted branches followed by errors for failed ones.
+func FormatCompletionSummary(items []Item) string {
+	sections := make([]string, 0, 2)
+	if urls := FormatURLSummary(items); urls != "" {
+		sections = append(sections, urls)
+	}
+	if failures := FormatFailureSummary(items); failures != "" {
+		sections = append(sections, failures)
+	}
+	return strings.Join(sections, "\n\n")
+}

--- a/internal/tui/components/submit/format_test.go
+++ b/internal/tui/components/submit/format_test.go
@@ -1,6 +1,7 @@
 package submit
 
 import (
+	"errors"
 	"regexp"
 	"testing"
 
@@ -51,6 +52,46 @@ func TestFormatURLSummaryRendersClickableRows(t *testing.T) {
 
 #934 guard-runner.repoRoot-reads-with-repoMu-to-fix
      https://github.com/getstackit/stackit/pull/934`, summary)
+}
+
+func TestFormatCompletionSummaryIncludesFailures(t *testing.T) {
+	t.Parallel()
+
+	summary := FormatCompletionSummary([]Item{
+		{
+			BranchName: "jonnii/20260511011552/add-feature",
+			Action:     ActionCreate,
+			Status:     StatusDone,
+			URL:        "https://github.com/getstackit/stackit/pull/935",
+		},
+		{
+			BranchName: "jonnii/20260511011552/fix-bug",
+			Action:     ActionUpdate,
+			Status:     StatusError,
+			Error:      errors.New("failed to push branch: remote rejected"),
+		},
+	})
+
+	require.Equal(t, `Pull requests
+
+#935 add-feature
+     https://github.com/getstackit/stackit/pull/935
+
+✗ fix-bug — failed to push branch: remote rejected`, summary)
+}
+
+func TestFormatCompletionSummaryFailuresWithoutURLs(t *testing.T) {
+	t.Parallel()
+
+	summary := FormatCompletionSummary([]Item{
+		{
+			BranchName: "jonnii/20260511011552/fix-bug",
+			Action:     ActionUpdate,
+			Status:     StatusError,
+		},
+	})
+
+	require.Equal(t, "✗ fix-bug — failed", summary)
 }
 
 func TestModelPreservesURLAcrossFooterSyncDone(t *testing.T) {

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -161,7 +161,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case ProgressCompleteMsg:
 		m.Done = true
-		summary := FormatURLSummary(m.Items)
+		summary := FormatCompletionSummary(m.Items)
 		if summary != "" {
 			return m, tea.Sequence(
 				tea.Printf("\n%s", summary),


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The submit progress view is cleared when the TUI quits, and the persistent
summary printed on completion only listed PR URLs. Failed branches have no
URL, so their error rows flashed and vanished, leaving only the generic
top-level error. Extend the completion summary to re-emit a ✗ line with the
error for each failed branch so failures survive the screen clear.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1783682845`.


* **PR #935**
  * **PR #1189** 👈
    * **PR #1190**
      * **PR #1194**
        * **PR #1195**
          * **PR #1196**
            * **PR #1197**
              * **PR #1270**
                * **PR #1271**
                  * **PR #1399**
                    * **PR #1400**
                      * **PR #1401**
                        * **PR #1402**
                          * **PR #1403**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1404 by jonnii*