### PR TITLE
refactor(submit): remove dead stack-tree rendering from submit TUI

### DIFF
--- a/internal/actions/submit/events.go
+++ b/internal/actions/submit/events.go
@@ -53,8 +53,7 @@ func (BranchPlanEvent) submitEvent() {}
 
 // SubmissionStartEvent indicates the submission phase is beginning.
 type SubmissionStartEvent struct {
-	Branches     []BranchInfo
-	IsSequential bool // Sequential submission mode (all creates) for PR ordering
+	Branches []BranchInfo
 }
 
 func (SubmissionStartEvent) submitEvent() {}

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -259,7 +259,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	// Start submission phase with a worker pool to avoid spawning too many goroutines
-	handler.OnEvent(SubmissionStartEvent{Branches: branchInfos, IsSequential: allCreates})
+	handler.OnEvent(SubmissionStartEvent{Branches: branchInfos})
 
 	githubClient, err := getGitHubClient(ctx)
 	if err != nil {

--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -6,30 +6,8 @@ import (
 	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/tui"
 	submitComponent "github.com/getstackit/stackit/internal/tui/components/submit"
-	"github.com/getstackit/stackit/internal/tui/components/tree"
 	"github.com/getstackit/stackit/internal/tui/style"
 )
-
-// snapshotToStackTree converts a submit stack snapshot into a tree.StackTree for
-// rendering by the handlers.
-func snapshotToStackTree(snapshot submit.StackSnapshot) *tree.StackTree {
-	childrenMap := make(map[string][]string, len(snapshot.Branches))
-	for _, branchName := range snapshot.Branches {
-		parentName := snapshot.ParentMap[branchName]
-		if parentName != "" {
-			childrenMap[parentName] = append(childrenMap[parentName], branchName)
-		}
-	}
-
-	return &tree.StackTree{
-		Branches:       snapshot.Branches,
-		CurrentBranchV: snapshot.CurrentBranch,
-		TrunkBranch:    snapshot.TrunkBranch,
-		ParentMap:      snapshot.ParentMap,
-		ChildrenMap:    childrenMap,
-		FixedMap:       snapshot.FixedMap,
-	}
-}
 
 // NewSubmitUI creates a runner and handler pair for submit operations.
 // The runner manages terminal state; the handler processes events.
@@ -79,11 +57,10 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 	switch ev := e.(type) {
 	case submit.StackDisplayEvent:
 		h.displayed = true
-		stackTree := snapshotToStackTree(ev.Stack)
 		h.Output.Info("Stack to submit:")
 		for _, branch := range ev.Stack.Branches {
 			marker := "  "
-			if branch == stackTree.CurrentBranch() {
+			if branch == ev.Stack.CurrentBranch {
 				marker = "● "
 			}
 			scope := ev.Stack.ScopeMap[branch]
@@ -240,8 +217,6 @@ type InteractiveSubmitHandler struct {
 	model         *submitComponent.Model
 	out           output.Output
 	inSubmitPhase bool
-	stack         *tree.StackTree
-	fixedMap      map[string]bool
 }
 
 // NewInteractiveSubmitHandler creates a new interactive submit handler
@@ -249,59 +224,16 @@ func NewInteractiveSubmitHandler(runner *tui.Runner, model *submitComponent.Mode
 	return &InteractiveSubmitHandler{runner: runner, model: model, out: out}
 }
 
-// findRootBranch finds the root branch of the stack (the one whose parent is trunk)
-func (h *InteractiveSubmitHandler) findRootBranch() string {
-	if h.stack == nil || len(h.stack.Branches) == 0 {
-		return ""
-	}
-
-	// If we're on the trunk branch, show everything from trunk down
-	if h.stack.CurrentBranch() == h.stack.TrunkBranch {
-		return h.stack.TrunkBranch
-	}
-
-	// The root is the branch whose parent is trunk
-	for _, branch := range h.stack.Branches {
-		parent := h.stack.ParentMap[branch]
-		if parent == h.stack.TrunkBranch {
-			return branch
-		}
-	}
-	// Fallback to first branch
-	return h.stack.Branches[0]
-}
-
 // OnEvent handles events from the submit action
 func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 	switch ev := e.(type) {
 	case submit.StackDisplayEvent:
-		h.stack = snapshotToStackTree(ev.Stack)
-		h.fixedMap = ev.Stack.FixedMap
-
-		// Build a tree renderer from the stack with custom fixed logic
-		renderer := h.stack.ToRendererWithFixed(func(branchName string) bool {
-			// Trunk is always "fixed" (never needs restack)
-			if branchName == h.stack.TrunkBranch {
-				return true
-			}
-			return h.fixedMap[branchName]
-		})
-
-		// Set scopes and other annotations
 		items := make([]submitComponent.Item, 0, len(ev.Stack.Branches))
 		for _, branchName := range ev.Stack.Branches {
 			// Skip trunk - we don't submit it
 			if branchName == ev.Stack.TrunkBranch {
 				continue
 			}
-
-			scope := ev.Stack.ScopeMap[branchName]
-			worktreePath := ev.Stack.WorktreeMap[branchName]
-			renderer.SetAnnotation(branchName, tree.BranchAnnotation{
-				Scope:         scope,
-				ExplicitScope: scope,
-				WorktreePath:  worktreePath,
-			})
 
 			items = append(items, submitComponent.Item{
 				BranchName: branchName,
@@ -310,10 +242,7 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 			})
 		}
 
-		// Update model with tree renderer and initial items
 		h.model.Items = items
-		h.model.Renderer = renderer
-		h.model.RootBranch = h.findRootBranch()
 
 		// Start the TUI now that there's a populated stack to show. Idempotent,
 		// so later events that arrive after this are safe.
@@ -360,11 +289,6 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 			if !found {
 				h.model.Items = append(h.model.Items, item)
 			}
-		}
-
-		// Set sequential mode if all PRs are being created (preserves PR number ordering)
-		if ev.IsSequential {
-			h.runner.Send(submitComponent.SetSequentialMsg{IsSequential: true})
 		}
 
 		h.runner.Send(submitComponent.GlobalMessageMsg("Submitting..."))

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -8,7 +8,6 @@ import (
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/getstackit/stackit/internal/tui/components/tree"
 	"github.com/getstackit/stackit/internal/tui/core"
 )
 
@@ -17,12 +16,9 @@ import (
 type Model struct {
 	core.BaseModel // Embedded for ReadySignaler interface
 	Items          []Item
-	Renderer       *tree.StackTreeRenderer
-	RootBranch     string
 	spinner        spinner.Model // lowercase for custom style
 	Styles         Styles
 	GlobalMessage  string
-	IsSequential   bool // Sequential submission mode for PR ordering
 }
 
 // ProgressUpdateMsg is sent to update the status of a specific branch submission
@@ -31,11 +27,6 @@ type ProgressUpdateMsg struct {
 	Status     string
 	URL        string
 	Err        error
-}
-
-// StartSubmitMsg is sent when the submission phase begins
-type StartSubmitMsg struct {
-	Items []Item
 }
 
 // PlanUpdateMsg is sent when a branch plan is updated
@@ -52,11 +43,6 @@ type GlobalMessageMsg string
 
 // ProgressCompleteMsg is sent when all submissions are finished
 type ProgressCompleteMsg struct{}
-
-// SetSequentialMsg indicates sequential submission mode for PR ordering
-type SetSequentialMsg struct {
-	IsSequential bool
-}
 
 // NewModel creates a new submit model
 func NewModel(items []Item) *Model {
@@ -93,29 +79,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg := msg.(type) {
-	case SetSequentialMsg:
-		m.IsSequential = msg.IsSequential
-		return m, nil
-
-	case StartSubmitMsg:
-		// Update status for items that are in msg.Items
-		for _, newItem := range msg.Items {
-			found := false
-			for i, item := range m.Items {
-				if item.BranchName == newItem.BranchName {
-					m.Items[i].Status = newItem.Status
-					m.Items[i].Action = newItem.Action
-					m.Items[i].PRNumber = newItem.PRNumber
-					found = true
-					break
-				}
-			}
-			if !found {
-				m.Items = append(m.Items, newItem)
-			}
-		}
-		return m, nil
-
 	case PlanUpdateMsg:
 		// Update existing item or add new one
 		found := false
@@ -181,48 +144,6 @@ func (m *Model) View() tea.View {
 	}
 
 	var b strings.Builder
-
-	if m.Renderer != nil {
-		// Update annotations based on items
-		for _, item := range m.Items {
-			ann := m.Renderer.Annotations[item.BranchName]
-
-			// Update PR action if known
-			if item.Action != "" {
-				ann.PRAction = item.Action
-			}
-
-			// Update custom label for status
-			if item.IsSkipped {
-				if item.SkipReason == SkipReasonNoChanges {
-					ann.PRAction = SkipReasonNoChanges
-					ann.CustomLabel = ""
-				} else {
-					ann.CustomLabel = m.Styles.DimStyle.Render("(skipped: " + item.SkipReason + ")")
-				}
-			} else {
-				switch item.Status {
-				case StatusSubmitting:
-					ann.CustomLabel = m.Styles.SpinnerStyle.Render(m.spinner.View() + " submitting...")
-				case StatusSyncing:
-					ann.CustomLabel = m.Styles.SpinnerStyle.Render(m.spinner.View() + " syncing...")
-				case StatusDone:
-					ann.PRAction = "" // Clear action since we're showing the result
-					ann.CustomLabel = m.Styles.DoneStyle.Render("✓")
-					if item.URL != "" {
-						ann.CustomLabel += " " + m.Styles.URLStyle.Render("→ "+item.URL)
-					}
-				case StatusError:
-					ann.PRAction = "" // Clear action since we're showing the result
-					ann.CustomLabel = m.Styles.ErrorStyle.Render("✗")
-					if item.Error != nil {
-						ann.CustomLabel += " " + m.Styles.ErrorStyle.Render(item.Error.Error())
-					}
-				}
-			}
-			m.Renderer.SetAnnotation(item.BranchName, ann)
-		}
-	}
 
 	header := m.header()
 	if header != "" {

--- a/internal/tui/components/submit/submit.go
+++ b/internal/tui/components/submit/submit.go
@@ -26,7 +26,6 @@ type Styles struct {
 	DoneStyle    lipgloss.Style
 	ErrorStyle   lipgloss.Style
 	BranchStyle  lipgloss.Style
-	URLStyle     lipgloss.Style
 	DimStyle     lipgloss.Style
 }
 
@@ -40,7 +39,6 @@ func DefaultStyles() Styles {
 		DoneStyle:    statusStyles.Done,
 		ErrorStyle:   statusStyles.Error,
 		BranchStyle:  commonStyles.Branch.Bold(true),
-		URLStyle:     commonStyles.URL,
 		DimStyle:     commonStyles.Subtle,
 	}
 }

--- a/internal/tui/stories.go
+++ b/internal/tui/stories.go
@@ -374,45 +374,13 @@ func registerTreeStories() {
 }
 
 func registerSubmitStories() {
-	mockData := &tree.MockTreeData{
-		CurrentVal: "feature-3",
-		TrunkVal:   "main",
-		ChildrenMap: map[string][]string{
-			"main":      {"feature-1"},
-			"feature-1": {"feature-2"},
-			"feature-2": {"feature-3"},
-			"feature-3": {},
-		},
-		ParentsMap: map[string]string{
-			"feature-1": "main",
-			"feature-2": "feature-1",
-			"feature-3": "feature-2",
-		},
-		FixedMap: map[string]bool{
-			"main":      true,
-			"feature-1": true,
-			"feature-2": true,
-			"feature-3": true,
-		},
-	}
-
-	createRenderer := func() *tree.StackTreeRenderer {
-		return tree.NewRenderer(mockData)
-	}
-
 	RegisterStory(Story{
 		Name:        "Full Submission",
 		Category:    "Submit",
 		Description: "A simulated full submission process with state transitions",
 		CreateModel: func() tea.Model {
-			m := submit.NewModel(nil)
-			m.Renderer = createRenderer()
-			m.Renderer.SetAnnotation("feature-1", tree.BranchAnnotation{Scope: "CORE", ExplicitScope: "CORE"})
-			m.Renderer.SetAnnotation("feature-2", tree.BranchAnnotation{Scope: "API", ExplicitScope: "API"})
-			m.Renderer.SetAnnotation("feature-3", tree.BranchAnnotation{Scope: "UI", ExplicitScope: "UI"})
-			m.RootBranch = mockData.TrunkVal
 			return &submitSimulationModel{
-				submitModel: m,
+				submitModel: submit.NewModel(nil),
 				startTime:   time.Now(),
 			}
 		},
@@ -428,13 +396,7 @@ func registerSubmitStories() {
 				{BranchName: "feature-2", Action: "update", Status: submit.StatusError, Error: fmt.Errorf("failed to push branch: remote rejected")},
 				{BranchName: "feature-3", Action: "create", Status: submit.StatusPending},
 			})
-			m.Renderer = createRenderer()
-			m.Renderer.SetAnnotation("feature-1", tree.BranchAnnotation{Scope: "CORE", ExplicitScope: "CORE"})
-			m.Renderer.SetAnnotation("feature-2", tree.BranchAnnotation{Scope: "API", ExplicitScope: "API"})
-			m.Renderer.SetAnnotation("feature-3", tree.BranchAnnotation{Scope: "UI", ExplicitScope: "UI"})
-			m.RootBranch = mockData.TrunkVal
 			m.GlobalMessage = "Submitting 3 branches..."
-			m.Done = true
 			return m
 		},
 	})
@@ -472,26 +434,6 @@ func (m *submitSimulationModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Reset simulation
 			m.step = 0
 			m.submitModel = submit.NewModel(nil)
-			m.submitModel.Renderer = tree.NewRenderer(&tree.StackTree{
-				Branches:       []string{"main", "feature-1", "feature-2", "feature-3"},
-				CurrentBranchV: "feature-3",
-				TrunkBranch:    "main",
-				ChildrenMap: map[string][]string{
-					"main":      {"feature-1"},
-					"feature-1": {"feature-2"},
-					"feature-2": {"feature-3"},
-					"feature-3": {},
-				},
-				ParentMap: map[string]string{
-					"feature-1": "main",
-					"feature-2": "feature-1",
-					"feature-3": "feature-2",
-				},
-			})
-			m.submitModel.Renderer.SetAnnotation("feature-1", tree.BranchAnnotation{Scope: "CORE", ExplicitScope: "CORE"})
-			m.submitModel.Renderer.SetAnnotation("feature-2", tree.BranchAnnotation{Scope: "API", ExplicitScope: "API"})
-			m.submitModel.Renderer.SetAnnotation("feature-3", tree.BranchAnnotation{Scope: "UI", ExplicitScope: "UI"})
-			m.submitModel.RootBranch = "main"
 			return m, m.nextTick()
 		}
 
@@ -519,8 +461,8 @@ func (m *submitSimulationModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			_, c := m.submitModel.Update(submit.ProgressUpdateMsg{BranchName: "feature-3", Status: submit.StatusDone, URL: "https://github.com/owner/repo/pull/103"})
 			cmds = append(cmds, c, m.nextTick())
 			m.submitModel.Update(submit.GlobalMessageMsg("✓ All branches submitted"))
-			// We don't send ProgressCompleteMsg because it would trigger tea.Quit
-			m.submitModel.Done = true
+			// We don't send ProgressCompleteMsg because it would trigger tea.Quit,
+			// and we don't set Done because the view blanks once Done is set.
 			cmds = append(cmds, tea.Tick(3*time.Second, func(_ time.Time) tea.Msg {
 				return simulationTickMsg(-1) // Signal reset
 			}))


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The compact progress view no longer calls RenderStack, so the tree renderer
path was dead weight: Model.Renderer/RootBranch and the annotation-mutation
block in View, the StartSubmitMsg/SetSequentialMsg messages, URLStyle, and
the handler code that built the renderer (snapshotToStackTree, findRootBranch,
stack/fixedMap fields). SubmissionStartEvent.IsSequential is dropped too —
its only consumer was the dead SetSequentialMsg; the action still submits
new stacks sequentially internally. The storyboard submit stories now match
the compact view, and StackSnapshot stays intact as the action-layer contract.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1783682845`.


* **PR #935**
  * **PR #1189**
    * **PR #1190** 👈
      * **PR #1194**
        * **PR #1195**
          * **PR #1196**
            * **PR #1197**
              * **PR #1270**
                * **PR #1271**
                  * **PR #1399**
                    * **PR #1400**
                      * **PR #1401**
                        * **PR #1402**
                          * **PR #1403**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1404 by jonnii*