### PR TITLE
refactor: extract applyPRMetadata helper to eliminate duplication

### DIFF
--- a/internal/github/pr_operations.go
+++ b/internal/github/pr_operations.go
@@ -113,8 +113,6 @@ func CreatePullRequest(ctx context.Context, client *github.Client, owner, repo s
 // UpdatePullRequest updates an existing pull request
 // Returns warnings (non-fatal issues like failed label/assignee additions) and error
 func UpdatePullRequest(ctx context.Context, client *github.Client, runner GitCommandRunner, owner, repo string, prNumber int, opts UpdatePROptions) ([]string, error) {
-	var warnings []string
-
 	// Handle draft status changes separately using GraphQL API, as the REST API
 	// doesn't support updating draft status. We need to use GraphQL mutation
 	// markPullRequestReadyForReview or convertPullRequestToDraft.
@@ -161,8 +159,8 @@ func UpdatePullRequest(ctx context.Context, client *github.Client, runner GitCom
 		return nil, fmt.Errorf("failed to update pull request: %w", err)
 	}
 
-	warnings = append(warnings, applyPRMetadata(ctx, client, owner, repo, prNumber,
-		opts.Reviewers, opts.TeamReviewers, opts.Labels, opts.Assignees)...)
+	warnings := applyPRMetadata(ctx, client, owner, repo, prNumber,
+		opts.Reviewers, opts.TeamReviewers, opts.Labels, opts.Assignees)
 
 	// Rerequest review if specified
 	if opts.RerequestReview {

--- a/internal/github/pr_operations.go
+++ b/internal/github/pr_operations.go
@@ -52,6 +52,38 @@ type UpdatePROptions struct {
 	RerequestReview bool
 }
 
+// applyPRMetadata applies reviewers, labels, and assignees to an existing PR.
+// Failures are non-fatal and returned as warning strings rather than errors.
+func applyPRMetadata(ctx context.Context, client *github.Client, owner, repo string, prNumber int, reviewers, teamReviewers, labels, assignees []string) []string {
+	var warnings []string
+
+	if len(reviewers) > 0 || len(teamReviewers) > 0 {
+		_, _, err := client.PullRequests.RequestReviewers(ctx, owner, repo, prNumber, github.ReviewersRequest{
+			Reviewers:     reviewers,
+			TeamReviewers: teamReviewers,
+		})
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("failed to add reviewers: %v", err))
+		}
+	}
+
+	if len(labels) > 0 {
+		_, _, err := client.Issues.AddLabelsToIssue(ctx, owner, repo, prNumber, labels)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("failed to add labels: %v", err))
+		}
+	}
+
+	if len(assignees) > 0 {
+		_, _, err := client.Issues.AddAssignees(ctx, owner, repo, prNumber, assignees)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("failed to add assignees: %v", err))
+		}
+	}
+
+	return warnings
+}
+
 // CreatePullRequest creates a new pull request.
 // Returns warnings (non-fatal issues like failed label/assignee additions) and error,
 // matching the same contract as UpdatePullRequest.
@@ -72,34 +104,8 @@ func CreatePullRequest(ctx context.Context, client *github.Client, owner, repo s
 		return nil, nil, fmt.Errorf("failed to create pull request: %w", err)
 	}
 
-	var warnings []string
-
-	// Add reviewers if specified
-	if len(opts.Reviewers) > 0 || len(opts.TeamReviewers) > 0 {
-		_, _, err := client.PullRequests.RequestReviewers(ctx, owner, repo, *createdPR.Number, github.ReviewersRequest{
-			Reviewers:     opts.Reviewers,
-			TeamReviewers: opts.TeamReviewers,
-		})
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to add reviewers: %v", err))
-		}
-	}
-
-	// Add labels if specified
-	if len(opts.Labels) > 0 {
-		_, _, err := client.Issues.AddLabelsToIssue(ctx, owner, repo, *createdPR.Number, opts.Labels)
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to add labels: %v", err))
-		}
-	}
-
-	// Add assignees if specified
-	if len(opts.Assignees) > 0 {
-		_, _, err := client.Issues.AddAssignees(ctx, owner, repo, *createdPR.Number, opts.Assignees)
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to add assignees: %v", err))
-		}
-	}
+	warnings := applyPRMetadata(ctx, client, owner, repo, *createdPR.Number,
+		opts.Reviewers, opts.TeamReviewers, opts.Labels, opts.Assignees)
 
 	return warnings, createdPR, nil
 }
@@ -155,32 +161,8 @@ func UpdatePullRequest(ctx context.Context, client *github.Client, runner GitCom
 		return nil, fmt.Errorf("failed to update pull request: %w", err)
 	}
 
-	// Update reviewers if specified
-	if len(opts.Reviewers) > 0 || len(opts.TeamReviewers) > 0 {
-		_, _, err := client.PullRequests.RequestReviewers(ctx, owner, repo, prNumber, github.ReviewersRequest{
-			Reviewers:     opts.Reviewers,
-			TeamReviewers: opts.TeamReviewers,
-		})
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to add reviewers: %v", err))
-		}
-	}
-
-	// Add labels if specified
-	if len(opts.Labels) > 0 {
-		_, _, err := client.Issues.AddLabelsToIssue(ctx, owner, repo, prNumber, opts.Labels)
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to add labels: %v", err))
-		}
-	}
-
-	// Add assignees if specified
-	if len(opts.Assignees) > 0 {
-		_, _, err := client.Issues.AddAssignees(ctx, owner, repo, prNumber, opts.Assignees)
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to add assignees: %v", err))
-		}
-	}
+	warnings = append(warnings, applyPRMetadata(ctx, client, owner, repo, prNumber,
+		opts.Reviewers, opts.TeamReviewers, opts.Labels, opts.Assignees)...)
 
 	// Rerequest review if specified
 	if opts.RerequestReview {


### PR DESCRIPTION
## Summary

`CreatePullRequest` and `UpdatePullRequest` in `internal/github/pr_operations.go` contained identical 20-line blocks for applying reviewers, labels, and assignees to a PR — each failure producing a warning string rather than a hard error.

Extract that logic into a private `applyPRMetadata` helper, replacing both copies.

- No behaviour change: same API calls, same warning message strings, same non-fatal contract
- Warning format ("failed to add reviewers/labels/assignees") now lives in one place
- Both callers collapse to a single line, making the main functions easier to follow

## Test plan

- `go vet ./internal/github/...` passes
- `go build ./...` passes
- Logic is identical to the pre-refactor code — no new branches to test

---
_Generated by [Claude Code](https://claude.ai/code/session_013oBSeKRD6NEqeCohoJVTQQ)_