### PR TITLE
fix: refresh stale GitHub base.sha after restack force-push

### DIFF
--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -515,7 +515,7 @@ func createPullRequestQuiet(ctx *app.Context, submissionInfo Info, repoOwner, re
 		submissionInfo.Base,
 		prURL,
 		submissionInfo.Metadata.IsDraft,
-	).WithLockReason(branch.GetLockReason()))
+	).WithLockReason(branch.GetLockReason()).WithBaseSHA(submissionInfo.BaseSHA))
 
 	return prURL, nil
 }
@@ -529,6 +529,17 @@ func updatePullRequestQuiet(ctx *app.Context, submissionInfo Info, opts Options,
 	branch := nav.GetBranch(submissionInfo.BranchName)
 	prInfo, _ := branch.GetPrInfo()
 	baseChanged := prInfo != nil && prInfo.Base() != submissionInfo.Base
+
+	// Detect stale base.sha: base branch name is the same but the parent was force-pushed.
+	// After a restack, GitHub retains the old parent tip SHA in base.sha, causing the child
+	// PR to show the parent's tip commit in its diff. Fix by temporarily changing the PR base
+	// to trunk before setting it back to the actual parent — this forces GitHub to recompute
+	// base.sha to the current parent tip.
+	baseSHAStale := !baseChanged &&
+		prInfo != nil &&
+		prInfo.BaseSHA() != "" &&
+		prInfo.BaseSHA() != submissionInfo.BaseSHA &&
+		submissionInfo.Base != ctx.Engine.Trunk().GetName()
 
 	updateOpts := github.UpdatePROptions{
 		Title:           &submissionInfo.Metadata.Title,
@@ -576,6 +587,21 @@ func updatePullRequestQuiet(ctx *app.Context, submissionInfo Info, opts Options,
 		}
 	}
 
+	// When the parent was force-pushed (stale base.sha), temporarily retarget the PR
+	// to trunk and then back to the actual parent. GitHub recomputes base.sha on each
+	// base change, so the second change sets it to the current parent tip.
+	if baseSHAStale {
+		trunkName := ctx.Engine.Trunk().GetName()
+		trunkOpts := github.UpdatePROptions{Base: &trunkName}
+		if _, err := ctx.GitHub().UpdatePullRequest(ctx.Context, repoOwner, repoName, *submissionInfo.PRNumber, trunkOpts); err != nil {
+			ctx.Output.Debug("Failed to refresh stale base.sha for %s: %v", submissionInfo.BranchName, err)
+		} else {
+			// The main update below will set it back to the actual parent, causing GitHub
+			// to recompute base.sha to the current parent tip.
+			updateOpts.Base = &submissionInfo.Base
+		}
+	}
+
 	updateWarnings, err := ctx.GitHub().UpdatePullRequest(ctx.Context, repoOwner, repoName, *submissionInfo.PRNumber, updateOpts)
 	if err != nil {
 		return "", fmt.Errorf("failed to update PR for %s: %w", submissionInfo.BranchName, err)
@@ -607,7 +633,7 @@ func updatePullRequestQuiet(ctx *app.Context, submissionInfo Info, opts Options,
 		baseToStore,
 		prURL,
 		submissionInfo.Metadata.IsDraft,
-	).WithLockReason(branch.GetLockReason()))
+	).WithLockReason(branch.GetLockReason()).WithBaseSHA(submissionInfo.BaseSHA))
 
 	return prURL, nil
 }

--- a/internal/engine/engine_pr.go
+++ b/internal/engine/engine_pr.go
@@ -39,7 +39,7 @@ func NewPrInfoFromMeta(meta *git.Meta) *PrInfo {
 		getBoolValue(prInfo.IsDraft),
 		LockReason(lockReason),
 		getStringValue(prInfo.MergeBranch),
-	)
+	).WithBaseSHA(getStringValue(prInfo.BaseSHA))
 }
 
 // GetMergedDownstack returns the merged downstack history for a branch
@@ -92,6 +92,10 @@ func (e *engineImpl) UpsertPrInfo(ctx context.Context, branch Branch, prInfo *Pr
 			if prInfo.Base() != "" {
 				base := prInfo.Base()
 				existing.Base = &base
+			}
+			if prInfo.BaseSHA() != "" {
+				baseSHA := prInfo.BaseSHA()
+				existing.BaseSHA = &baseSHA
 			}
 			if prInfo.URL() != "" {
 				url := prInfo.URL()

--- a/internal/engine/pr_info.go
+++ b/internal/engine/pr_info.go
@@ -11,6 +11,7 @@ type PrInfo struct {
 	isDraft     bool
 	state       string     // MERGED, CLOSED, OPEN
 	base        string     // Base branch name
+	baseSHA     string     // Tip SHA of base branch at last submit (used to detect stale base.sha on GitHub)
 	url         string     // PR URL
 	lockReason  LockReason // Why the PR is locked (empty if not locked)
 	mergeBranch string     // Name of the merge branch this PR is part of
@@ -88,6 +89,13 @@ func (p *PrInfo) Base() string {
 	return p.base
 }
 
+// BaseSHA returns the tip SHA of the base branch at the time of the last submit.
+// Used to detect when a parent branch has been force-pushed, making GitHub's
+// stored base.sha stale.
+func (p *PrInfo) BaseSHA() string {
+	return p.baseSHA
+}
+
 // URL returns the PR URL
 func (p *PrInfo) URL() string {
 	return p.url
@@ -143,6 +151,7 @@ func (p *PrInfo) WithNumber(number *int) *PrInfo {
 		isDraft:     p.isDraft,
 		state:       p.state,
 		base:        p.base,
+		baseSHA:     p.baseSHA,
 		url:         p.url,
 		lockReason:  p.lockReason,
 		mergeBranch: p.mergeBranch,
@@ -158,6 +167,7 @@ func (p *PrInfo) WithTitle(title string) *PrInfo {
 		isDraft:     p.isDraft,
 		state:       p.state,
 		base:        p.base,
+		baseSHA:     p.baseSHA,
 		url:         p.url,
 		lockReason:  p.lockReason,
 		mergeBranch: p.mergeBranch,
@@ -173,6 +183,7 @@ func (p *PrInfo) WithBody(body string) *PrInfo {
 		isDraft:     p.isDraft,
 		state:       p.state,
 		base:        p.base,
+		baseSHA:     p.baseSHA,
 		url:         p.url,
 		lockReason:  p.lockReason,
 		mergeBranch: p.mergeBranch,
@@ -189,6 +200,7 @@ func (p *PrInfo) WithTitleAndBody(title, body string) *PrInfo {
 		isDraft:     p.isDraft,
 		state:       p.state,
 		base:        p.base,
+		baseSHA:     p.baseSHA,
 		url:         p.url,
 		lockReason:  p.lockReason,
 		mergeBranch: p.mergeBranch,
@@ -204,6 +216,7 @@ func (p *PrInfo) WithIsDraft(isDraft bool) *PrInfo {
 		isDraft:     isDraft,
 		state:       p.state,
 		base:        p.base,
+		baseSHA:     p.baseSHA,
 		url:         p.url,
 		lockReason:  p.lockReason,
 		mergeBranch: p.mergeBranch,
@@ -219,6 +232,7 @@ func (p *PrInfo) WithState(state string) *PrInfo {
 		isDraft:     p.isDraft,
 		state:       state,
 		base:        p.base,
+		baseSHA:     p.baseSHA,
 		url:         p.url,
 		lockReason:  p.lockReason,
 		mergeBranch: p.mergeBranch,
@@ -234,6 +248,23 @@ func (p *PrInfo) WithBase(base string) *PrInfo {
 		isDraft:     p.isDraft,
 		state:       p.state,
 		base:        base,
+		baseSHA:     p.baseSHA,
+		url:         p.url,
+		lockReason:  p.lockReason,
+		mergeBranch: p.mergeBranch,
+	}
+}
+
+// WithBaseSHA returns a new PrInfo with the baseSHA field updated
+func (p *PrInfo) WithBaseSHA(sha string) *PrInfo {
+	return &PrInfo{
+		number:      p.number,
+		title:       p.title,
+		body:        p.body,
+		isDraft:     p.isDraft,
+		state:       p.state,
+		base:        p.base,
+		baseSHA:     sha,
 		url:         p.url,
 		lockReason:  p.lockReason,
 		mergeBranch: p.mergeBranch,
@@ -249,6 +280,7 @@ func (p *PrInfo) WithURL(url string) *PrInfo {
 		isDraft:     p.isDraft,
 		state:       p.state,
 		base:        p.base,
+		baseSHA:     p.baseSHA,
 		url:         url,
 		lockReason:  p.lockReason,
 		mergeBranch: p.mergeBranch,
@@ -264,6 +296,7 @@ func (p *PrInfo) WithLockReason(reason LockReason) *PrInfo {
 		isDraft:     p.isDraft,
 		state:       p.state,
 		base:        p.base,
+		baseSHA:     p.baseSHA,
 		url:         p.url,
 		lockReason:  reason,
 		mergeBranch: p.mergeBranch,
@@ -279,6 +312,7 @@ func (p *PrInfo) WithMergeBranch(branch string) *PrInfo {
 		isDraft:     p.isDraft,
 		state:       p.state,
 		base:        p.base,
+		baseSHA:     p.baseSHA,
 		url:         p.url,
 		lockReason:  p.lockReason,
 		mergeBranch: branch,

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -99,6 +99,7 @@ type ModifiedBy struct {
 type PrInfoPersistence struct {
 	Number      *int        `json:"number,omitempty"`
 	Base        *string     `json:"base,omitempty"`
+	BaseSHA     *string     `json:"baseSHA,omitempty"`
 	URL         *string     `json:"url,omitempty"`
 	Title       *string     `json:"title,omitempty"`
 	Body        *string     `json:"body,omitempty"`


### PR DESCRIPTION
## Summary

Fixes #1192

After `stackit restack` force-pushes a parent branch, GitHub retains the old parent tip SHA as `base.sha` for the child PR. This causes the child PR's "Commits" tab and diff to show the parent's tip commit as part of the child's changes, even though `git log parent..child` is correct locally.

**Root cause:** GitHub does not update a PR's stored `base.sha` when the base branch is force-pushed. The only way to refresh it is to change the PR's base branch (which triggers recomputation).

**Fix:** Track the parent branch tip SHA (`BaseSHA`) in local PR metadata after each `stackit submit`. On the next submit, if the cached `BaseSHA` differs from the current parent tip, the parent was force-pushed since last submit. We then do a "double-update": temporarily set the PR base to trunk, then back to the actual parent. GitHub recomputes `base.sha` on each base change, so the second update sets it to the current parent tip.

This is the same mechanism as the manual workaround (`gh pr edit --base main && gh pr edit --base <parent>`) but automated during submit.

## Changes

- `internal/git/metadata.go` — Add `BaseSHA` field to `PrInfoPersistence`
- `internal/engine/pr_info.go` — Add `baseSHA` field, `BaseSHA()` getter, and `WithBaseSHA()` method to `PrInfo`; propagate through all `With*` copy methods
- `internal/engine/engine_pr.go` — Read/write `BaseSHA` in metadata persistence
- `internal/actions/submit/submit.go` — Detect stale `base.sha` in `updatePullRequestQuiet` and perform double-update; store `BaseSHA` after create and update

## Test plan

- [ ] Stack: `main → parent → child`, both PRs open
- [ ] Amend a commit on `parent`, run `stackit restack --upstack`, then `stackit submit`
- [ ] Verify child PR no longer shows parent's tip commit in its diff/commits tab
- [ ] Verify normal submit (no restack) doesn't trigger unnecessary double-updates
- [ ] Verify that first submit after deploying stores `BaseSHA` correctly for future detections

https://claude.ai/code/session_01Y7ogKSwLNrnW13P9McFvoK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7ogKSwLNrnW13P9McFvoK)_