### PR TITLE
fix(submit): persist the plan view when nothing is submitted

### DIFF
--- a/internal/tui/components/submit/format_test.go
+++ b/internal/tui/components/submit/format_test.go
@@ -118,6 +118,39 @@ func TestModelPreservesURLAcrossFooterSyncDone(t *testing.T) {
 	require.Equal(t, "https://github.com/getstackit/stackit/pull/934", m.Items[0].URL)
 }
 
+func TestModelCompletionSummaryFallsBackToPlanView(t *testing.T) {
+	t.Parallel()
+
+	m := NewModel([]Item{
+		{BranchName: "feature-1", Action: ActionUpdate, Status: StatusPending, IsSkipped: true, SkipReason: "no changes"},
+		{BranchName: "feature-2", Action: ActionCreate, Status: StatusPending},
+	})
+	updated, _ := m.Update(GlobalMessageMsg("Dry run complete"))
+	m = updated.(*Model)
+
+	summary := stripANSIEscape(m.completionSummary())
+	require.Contains(t, summary, "Dry run complete")
+	require.Contains(t, summary, "feature-1")
+	require.Contains(t, summary, "no changes")
+	require.Contains(t, summary, "feature-2")
+	require.Contains(t, summary, "create")
+}
+
+func TestModelCompletionSummaryPrefersSubmissionResults(t *testing.T) {
+	t.Parallel()
+
+	m := NewModel([]Item{{
+		BranchName: "feature-1",
+		Action:     ActionUpdate,
+		Status:     StatusDone,
+		URL:        "https://github.com/getstackit/stackit/pull/934",
+	}})
+
+	summary := m.completionSummary()
+	require.Contains(t, summary, "Pull requests")
+	require.Contains(t, summary, "https://github.com/getstackit/stackit/pull/934")
+}
+
 func stripANSIEscape(s string) string {
 	return ansiPattern.ReplaceAllString(s, "")
 }

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -124,7 +124,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case ProgressCompleteMsg:
 		m.Done = true
-		summary := FormatCompletionSummary(m.Items)
+		summary := m.completionSummary()
 		if summary != "" {
 			return m, tea.Sequence(
 				tea.Printf("\n%s", summary),
@@ -142,7 +142,11 @@ func (m *Model) View() tea.View {
 	if m.Done {
 		return tea.NewView("")
 	}
+	return tea.NewView(m.content() + "\n")
+}
 
+// content renders the header and per-branch progress rows.
+func (m *Model) content() string {
 	var b strings.Builder
 
 	header := m.header()
@@ -162,8 +166,18 @@ func (m *Model) View() tea.View {
 		}
 	}
 
-	b.WriteString("\n")
-	return tea.NewView(b.String())
+	return b.String()
+}
+
+// completionSummary is the output persisted to the terminal when the TUI
+// exits. After a submission it lists PR URLs and failures; when nothing was
+// submitted (dry run, all up to date) it falls back to the final plan view,
+// which would otherwise be erased with the progress display.
+func (m *Model) completionSummary() string {
+	if summary := FormatCompletionSummary(m.Items); summary != "" {
+		return summary
+	}
+	return m.content()
 }
 
 func (m *Model) header() string {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

When a submit run ends without submitting anything (dry run, all PRs up to
date), the completion summary has no URLs or failures to print, so quitting
the TUI erased the plan and left the terminal blank. Fall back to persisting
the final header and plan rows so the outcome stays visible.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1783682845`.


* **PR #935**
  * **PR #1189**
    * **PR #1190**
      * **PR #1194** 👈
        * **PR #1195**
          * **PR #1196**
            * **PR #1197**
              * **PR #1270**
                * **PR #1271**
                  * **PR #1399**
                    * **PR #1400**
                      * **PR #1401**
                        * **PR #1402**
                          * **PR #1403**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1404 by jonnii*