### PR TITLE
fix(submit): tidy non-TTY submit output

### DIFF
--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -24,27 +24,71 @@ func NewSubmitUI(out output.Output, logger output.Logger) (*tui.Runner, submit.H
 	return nil, NewSimpleSubmitHandler(out)
 }
 
+// planPrinter prints the stack and per-branch plan as a single merged list,
+// shared by both submit handlers.
+type planPrinter struct {
+	out         output.Output
+	scopes      map[string]string
+	worktrees   map[string]string
+	headerShown bool
+}
+
+// SetStack stashes the stack annotations so plan lines can include them.
+func (p *planPrinter) SetStack(stack submit.StackSnapshot) {
+	p.scopes = stack.ScopeMap
+	p.worktrees = stack.WorktreeMap
+}
+
+// PrintLine prints one branch of the plan, with the stack header before the
+// first line.
+func (p *planPrinter) PrintLine(ev submit.BranchPlanEvent) {
+	if !p.headerShown {
+		p.headerShown = true
+		p.out.Info("Stack to submit:")
+	}
+
+	marker := "  "
+	if ev.IsCurrent {
+		marker = "● "
+	}
+	name := submitComponent.DisplayBranchName(ev.BranchName)
+	if scope := p.scopes[ev.BranchName]; scope != "" {
+		name += " [" + scope + "]"
+	}
+	if p.worktrees[ev.BranchName] != "" {
+		name += " 📂 worktree"
+	}
+
+	if ev.Skipped {
+		p.out.Info("%s%s %s", marker, style.ColorDim(name), style.ColorDim("— "+ev.SkipReason))
+	} else {
+		p.out.Info("%s%s → %s", marker, name, ev.Action)
+	}
+}
+
 // SimpleSubmitHandler implements submit.Handler with line-by-line output
 type SimpleSubmitHandler struct {
 	common.BaseHandler
-	items     map[string]*branchItem
-	order     []string
-	displayed bool
+	plan  planPrinter
+	items map[string]*branchItem
+	order []string
 }
 
 type branchItem struct {
-	name     string
-	action   string
-	prNumber *int
-	url      string
-	status   string
-	err      error
+	name         string
+	action       string
+	prNumber     *int
+	url          string
+	status       string
+	err          error
+	reportedDone bool
 }
 
 // NewSimpleSubmitHandler creates a new simple submit handler
 func NewSimpleSubmitHandler(out output.Output) *SimpleSubmitHandler {
 	return &SimpleSubmitHandler{
 		BaseHandler: common.NewBaseHandler(out),
+		plan:        planPrinter{out: out},
 		items:       make(map[string]*branchItem),
 	}
 }
@@ -56,28 +100,8 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 
 	switch ev := e.(type) {
 	case submit.StackDisplayEvent:
-		h.displayed = true
-		h.Output.Info("Stack to submit:")
-		for _, branch := range ev.Stack.Branches {
-			marker := "  "
-			if branch == ev.Stack.CurrentBranch {
-				marker = "● "
-			}
-			scope := ev.Stack.ScopeMap[branch]
-			worktree := ev.Stack.WorktreeMap[branch]
-
-			var line string
-			if scope != "" {
-				line = marker + submitComponent.DisplayBranchName(branch) + " [" + scope + "]"
-			} else {
-				line = marker + submitComponent.DisplayBranchName(branch)
-			}
-			if worktree != "" {
-				line += " 📂 worktree"
-			}
-			h.Output.Info("%s", line)
-		}
-		h.Output.Newline()
+		// The stack and plan print as one merged list once plan events arrive.
+		h.plan.SetStack(ev.Stack)
 
 	case submit.RestackEvent:
 		if ev.Started {
@@ -89,15 +113,7 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 		// Skip - we'll show progress during actual submission
 
 	case submit.BranchPlanEvent:
-		displayName := submitComponent.DisplayBranchName(ev.BranchName)
-		if ev.IsCurrent {
-			displayName += " (current)"
-		}
-		if ev.Skipped {
-			h.Output.Info("  ▸ %s %s", style.ColorDim(displayName), style.ColorDim("— "+ev.SkipReason))
-		} else {
-			h.Output.Info("  ▸ %s → %s", displayName, ev.Action)
-		}
+		h.plan.PrintLine(ev)
 
 	case submit.SubmissionStartEvent:
 		h.order = h.order[:0]
@@ -135,9 +151,15 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 			h.Output.Info("  ⋯ %s %s...", submitComponent.DisplayBranchName(ev.BranchName), action)
 
 		case submit.StatusSyncing:
-			h.Output.Info("  ⋯ %s syncing...", submitComponent.DisplayBranchName(ev.BranchName))
+			// Quiet: the metadata footer sync carries no new information; the
+			// branch result was already reported when it first reached done.
 
 		case submit.StatusDone:
+			// The footer sync re-emits done; only report a branch once.
+			if item.reportedDone {
+				return
+			}
+			item.reportedDone = true
 			actionDone := "created"
 			if item.action == "update" {
 				actionDone = "updated"
@@ -162,11 +184,9 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 				h.Output.Newline()
 				h.Output.Info("%s", summary)
 			}
-		case ev.Success && !h.displayed && ev.Message != "":
-			// No stack was ever displayed (empty scope / nothing to submit).
-			// Surface the outcome that the CLI used to print before delegating
-			// work-detection to Action. Cases that show a stack first (dry run,
-			// all up to date) already convey the outcome via the plan lines.
+		case ev.Success && ev.Message != "":
+			// Dry run, all up to date, nothing to submit: print the outcome so
+			// the run doesn't end silently.
 			h.Output.Info("%s", ev.Message)
 		}
 	}

--- a/internal/cli/stack/submit_handlers_test.go
+++ b/internal/cli/stack/submit_handlers_test.go
@@ -1,6 +1,7 @@
 package stack
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -66,5 +67,63 @@ func TestSimpleSubmitHandlerPreservesURLAcrossFooterSync(t *testing.T) {
 	})
 	handler.OnEvent(submitAction.CompletionEvent{Success: true, Message: "Submit complete"})
 
-	require.Contains(t, out.String(), "https://github.com/getstackit/stackit/pull/934")
+	got := out.String()
+	require.Contains(t, got, "https://github.com/getstackit/stackit/pull/934")
+	require.NotContains(t, got, "syncing")
+	require.Equal(t, 1, strings.Count(got, "✓"), "footer sync must not re-report a finished branch")
+}
+
+func TestSimpleSubmitHandlerMergesPlanIntoStackList(t *testing.T) {
+	t.Parallel()
+
+	out := output.NewTestOutput()
+	handler := NewSimpleSubmitHandler(out)
+	current := "jonnii/20260511011552/current-branch"
+	skipped := "jonnii/20260511011552/skipped-branch"
+
+	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+		Branches:      []string{skipped, current},
+		CurrentBranch: current,
+		TrunkBranch:   "main",
+		ScopeMap:      map[string]string{current: "CORE"},
+	}})
+	handler.OnEvent(submitAction.BranchPlanEvent{
+		BranchName: skipped,
+		Skipped:    true,
+		SkipReason: "no changes",
+	})
+	handler.OnEvent(submitAction.BranchPlanEvent{
+		BranchName: current,
+		Action:     "create",
+		IsCurrent:  true,
+	})
+
+	got := out.String()
+	require.Equal(t, 1, strings.Count(got, "Stack to submit:"))
+	require.Contains(t, got, "● current-branch [CORE] → create")
+	require.Contains(t, got, "skipped-branch")
+	require.Contains(t, got, "— no changes")
+	require.Equal(t, 1, strings.Count(got, "current-branch"), "stack and plan must print as one merged list")
+}
+
+func TestSimpleSubmitHandlerPrintsOutcomeWhenNothingSubmitted(t *testing.T) {
+	t.Parallel()
+
+	out := output.NewTestOutput()
+	handler := NewSimpleSubmitHandler(out)
+	branch := "jonnii/20260511011552/up-to-date-branch"
+
+	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+		Branches:      []string{branch},
+		CurrentBranch: branch,
+		TrunkBranch:   "main",
+	}})
+	handler.OnEvent(submitAction.BranchPlanEvent{
+		BranchName: branch,
+		Skipped:    true,
+		SkipReason: "no changes",
+	})
+	handler.OnEvent(submitAction.CompletionEvent{Success: true, Message: "All PRs up to date"})
+
+	require.Contains(t, out.String(), "All PRs up to date")
 }

--- a/internal/cli/stack/submit_test.go
+++ b/internal/cli/stack/submit_test.go
@@ -34,33 +34,30 @@ func TestSubmitCommand(t *testing.T) {
 		// 1. Basic submit (downstack)
 		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--dry-run", "--no-edit", "--draft", "--no-interactive")
 		expected := testhelpers.NormalizeOutput(`
-Stack to submit:
-  branch-a
-● branch-b
 ⚠️  The following branches have no changes:
 ⚠️  ▸ branch-a
 ⚠️  ▸ branch-b
 ⚠️  Are you sure you want to submit them?
-  ▸ branch-a → create
-  ▸ branch-b (current) → create
+Stack to submit:
+  branch-a → create
+● branch-b → create
+Dry run complete
 `)
 		require.Equal(t, expected, testhelpers.NormalizeOutput(output))
 
 		// 2. Submit --stack (full stack)
 		output = runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--stack", "--dry-run", "--no-edit", "--draft", "--no-interactive")
 		expectedStack := testhelpers.NormalizeOutput(`
-Stack to submit:
-  branch-a
-● branch-b
-  branch-c
 ⚠️  The following branches have no changes:
 ⚠️  ▸ branch-a
 ⚠️  ▸ branch-b
 ⚠️  ▸ branch-c
 ⚠️  Are you sure you want to submit them?
-  ▸ branch-a → create
-  ▸ branch-b (current) → create
-  ▸ branch-c → create
+Stack to submit:
+  branch-a → create
+● branch-b → create
+  branch-c → create
+Dry run complete
 `)
 		require.Equal(t, expectedStack, testhelpers.NormalizeOutput(output))
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Three cleanups to the line-by-line handler:

- Merge the "Stack to submit" list and the plan lines into one list (the
  stack printed twice: once bare, then again with planned actions). The
  current-branch marker replaces the "(current)" suffix, and scope/worktree
  annotations carry over to the merged lines via a planPrinter shared with
  the interactive handler in a follow-up.
- Report each branch done only once: the metadata footer sync re-emits
  done after syncing, which printed a duplicate ✓ line per branch. The
  syncing transition itself is quiet now too.
- Print the success outcome ("All PRs up to date", "Dry run complete")
  even when a stack was displayed, so runs that submit nothing don't end in
  silence.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1783682845`.


* **PR #935**
  * **PR #1189**
    * **PR #1190**
      * **PR #1194**
        * **PR #1195** 👈
          * **PR #1196**
            * **PR #1197**
              * **PR #1270**
                * **PR #1271**
                  * **PR #1399**
                    * **PR #1400**
                      * **PR #1401**
                        * **PR #1402**
                          * **PR #1403**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1404 by jonnii*