### PR TITLE
feat(submit): defer the submit TUI until the submission phase begins

### DIFF
--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -16,9 +16,10 @@ func NewSubmitUI(out output.Output, logger output.Logger) (*tui.Runner, submit.H
 	if tui.IsTTY() {
 		model := submitComponent.NewModel(nil)
 		runner := tui.NewRunner(model, out, logger)
-		// Start lazily on the first stack-display event rather than here, so a
-		// submit that turns out to have nothing to do never flashes the bubbletea
-		// startup/teardown sequence. See InteractiveSubmitHandler.OnEvent.
+		// Start lazily when the submission phase begins rather than here: the
+		// stack and plan print as plain lines, so a submit that turns out to
+		// have nothing to do never flashes the bubbletea startup/teardown
+		// sequence. See InteractiveSubmitHandler.OnEvent.
 		return runner, NewInteractiveSubmitHandler(runner, model, out)
 	}
 	return nil, NewSimpleSubmitHandler(out)
@@ -236,81 +237,53 @@ type InteractiveSubmitHandler struct {
 	runner        *tui.Runner
 	model         *submitComponent.Model
 	out           output.Output
+	plan          planPrinter
 	inSubmitPhase bool
 }
 
 // NewInteractiveSubmitHandler creates a new interactive submit handler
 func NewInteractiveSubmitHandler(runner *tui.Runner, model *submitComponent.Model, out output.Output) *InteractiveSubmitHandler {
-	return &InteractiveSubmitHandler{runner: runner, model: model, out: out}
+	return &InteractiveSubmitHandler{runner: runner, model: model, out: out, plan: planPrinter{out: out}}
 }
 
 // OnEvent handles events from the submit action
 func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 	switch ev := e.(type) {
 	case submit.StackDisplayEvent:
-		items := make([]submitComponent.Item, 0, len(ev.Stack.Branches))
-		for _, branchName := range ev.Stack.Branches {
-			// Skip trunk - we don't submit it
-			if branchName == ev.Stack.TrunkBranch {
-				continue
-			}
-
-			items = append(items, submitComponent.Item{
-				BranchName: branchName,
-				Action:     "thinking...",
-				Status:     submitComponent.StatusPending,
-			})
-		}
-
-		h.model.Items = items
-
-		// Start the TUI now that there's a populated stack to show. Idempotent,
-		// so later events that arrive after this are safe.
-		h.runner.Start()
+		// The stack and plan print as plain lines (see planPrinter); the TUI
+		// only starts once there are branches to submit, so runs with no work
+		// to do never flash the bubbletea startup/teardown sequence.
+		h.plan.SetStack(ev.Stack)
 
 	case submit.RestackEvent:
 		if ev.Started {
-			h.runner.Send(submitComponent.GlobalMessageMsg("Restacking branches..."))
-		} else if ev.Completed {
-			h.runner.Send(submitComponent.GlobalMessageMsg(""))
+			h.out.Info("Restacking branches before submitting...")
 		}
+		// No output for completion
 
 	case submit.PreparingEvent:
-		h.runner.Send(submitComponent.GlobalMessageMsg("Preparing branches..."))
+		// Quiet - the plan lines follow immediately
 
 	case submit.BranchPlanEvent:
-		h.runner.Send(submitComponent.PlanUpdateMsg{
-			BranchName: ev.BranchName,
-			Action:     ev.Action,
-			IsCurrent:  ev.IsCurrent,
-			Skip:       ev.Skipped,
-			SkipReason: ev.SkipReason,
-		})
+		h.plan.PrintLine(ev)
 
 	case submit.SubmissionStartEvent:
 		h.inSubmitPhase = true
 
-		// Update items in the model
-		for _, branch := range ev.Branches {
-			item := submitComponent.Item{
+		items := make([]submitComponent.Item, len(ev.Branches))
+		for i, branch := range ev.Branches {
+			items[i] = submitComponent.Item{
 				BranchName: branch.Name,
 				Action:     branch.Action,
 				PRNumber:   branch.PRNumber,
-				Status:     "pending",
-			}
-			found := false
-			for i, existing := range h.model.Items {
-				if existing.BranchName == branch.Name {
-					h.model.Items[i] = item
-					found = true
-					break
-				}
-			}
-			if !found {
-				h.model.Items = append(h.model.Items, item)
+				Status:     submitComponent.StatusPending,
 			}
 		}
+		h.model.Items = items
 
+		// Start the TUI now that there's real submission work to animate.
+		// Idempotent, so later events that arrive after this are safe.
+		h.runner.Start()
 		h.runner.Send(submitComponent.GlobalMessageMsg("Submitting..."))
 
 	case submit.BranchProgressEvent:

--- a/internal/cli/stack/submit_handlers_test.go
+++ b/internal/cli/stack/submit_handlers_test.go
@@ -8,6 +8,7 @@ import (
 
 	submitAction "github.com/getstackit/stackit/internal/actions/submit"
 	"github.com/getstackit/stackit/internal/output"
+	submitComponent "github.com/getstackit/stackit/internal/tui/components/submit"
 )
 
 func TestSimpleSubmitHandlerPrintsFinalURLSummary(t *testing.T) {
@@ -104,6 +105,35 @@ func TestSimpleSubmitHandlerMergesPlanIntoStackList(t *testing.T) {
 	require.Contains(t, got, "skipped-branch")
 	require.Contains(t, got, "— no changes")
 	require.Equal(t, 1, strings.Count(got, "current-branch"), "stack and plan must print as one merged list")
+}
+
+func TestInteractiveSubmitHandlerPrintsPlanWithoutStartingTUI(t *testing.T) {
+	t.Parallel()
+
+	out := output.NewTestOutput()
+	// A nil runner stands in for a TUI that was never started; every runner
+	// method is nil-safe. Plan output must not depend on the TUI running.
+	handler := NewInteractiveSubmitHandler(nil, submitComponent.NewModel(nil), out)
+	branch := "jonnii/20260511011552/up-to-date-branch"
+
+	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+		Branches:      []string{branch},
+		CurrentBranch: branch,
+		TrunkBranch:   "main",
+	}})
+	handler.OnEvent(submitAction.BranchPlanEvent{
+		BranchName: branch,
+		Skipped:    true,
+		SkipReason: "no changes",
+		IsCurrent:  true,
+	})
+	handler.OnEvent(submitAction.CompletionEvent{Success: true, Message: "All PRs up to date"})
+
+	got := out.String()
+	require.Contains(t, got, "Stack to submit:")
+	require.Contains(t, got, "up-to-date-branch")
+	require.Contains(t, got, "— no changes")
+	require.Contains(t, got, "All PRs up to date")
 }
 
 func TestSimpleSubmitHandlerPrintsOutcomeWhenNothingSubmitted(t *testing.T) {

--- a/internal/tui/components/submit/format.go
+++ b/internal/tui/components/submit/format.go
@@ -155,8 +155,6 @@ func actionLabel(action string) string {
 		return "create"
 	case ActionUpdate:
 		return "update"
-	case "thinking...":
-		return "planning"
 	default:
 		return action
 	}

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -29,15 +29,6 @@ type ProgressUpdateMsg struct {
 	Err        error
 }
 
-// PlanUpdateMsg is sent when a branch plan is updated
-type PlanUpdateMsg struct {
-	BranchName string
-	Action     string
-	IsCurrent  bool
-	Skip       bool
-	SkipReason string
-}
-
 // GlobalMessageMsg is sent to display a global message (e.g., "Submitting...")
 type GlobalMessageMsg string
 
@@ -79,29 +70,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg := msg.(type) {
-	case PlanUpdateMsg:
-		// Update existing item or add new one
-		found := false
-		for i, item := range m.Items {
-			if item.BranchName == msg.BranchName {
-				m.Items[i].Action = msg.Action
-				m.Items[i].IsSkipped = msg.Skip
-				m.Items[i].SkipReason = msg.SkipReason
-				found = true
-				break
-			}
-		}
-		if !found {
-			m.Items = append(m.Items, Item{
-				BranchName: msg.BranchName,
-				Action:     msg.Action,
-				IsSkipped:  msg.Skip,
-				SkipReason: msg.SkipReason,
-				Status:     StatusPending,
-			})
-		}
-		return m, nil
-
 	case GlobalMessageMsg:
 		m.GlobalMessage = string(msg)
 		return m, nil
@@ -190,16 +158,10 @@ func (m *Model) header() string {
 		return fmt.Sprintf("Submit %d %s", count, pluralBranch(count))
 	}
 
-	switch strings.TrimSuffix(message, "...") {
-	case "Submitting":
+	if strings.TrimSuffix(message, "...") == "Submitting" {
 		return fmt.Sprintf("Submitting %d %s", count, pluralBranch(count))
-	case "Preparing branches":
-		return fmt.Sprintf("Preparing %d %s", count, pluralBranch(count))
-	case "Restacking branches":
-		return fmt.Sprintf("Restacking %d %s", count, pluralBranch(count))
-	default:
-		return message
 	}
+	return message
 }
 
 func pluralBranch(count int) string {

--- a/internal/tui/stories.go
+++ b/internal/tui/stories.go
@@ -373,6 +373,15 @@ func registerTreeStories() {
 	})
 }
 
+// newSimulationSubmitModel builds the submit model as it looks when the TUI
+// starts: the submission set is known and every branch is pending.
+func newSimulationSubmitModel() *submit.Model {
+	return submit.NewModel([]submit.Item{
+		{BranchName: "feature-2", Action: submit.ActionUpdate, Status: submit.StatusPending},
+		{BranchName: "feature-3", Action: submit.ActionCreate, Status: submit.StatusPending},
+	})
+}
+
 func registerSubmitStories() {
 	RegisterStory(Story{
 		Name:        "Full Submission",
@@ -380,7 +389,7 @@ func registerSubmitStories() {
 		Description: "A simulated full submission process with state transitions",
 		CreateModel: func() tea.Model {
 			return &submitSimulationModel{
-				submitModel: submit.NewModel(nil),
+				submitModel: newSimulationSubmitModel(),
 				startTime:   time.Now(),
 			}
 		},
@@ -433,7 +442,7 @@ func (m *submitSimulationModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if int(msg) == -1 {
 			// Reset simulation
 			m.step = 0
-			m.submitModel = submit.NewModel(nil)
+			m.submitModel = newSimulationSubmitModel()
 			return m, m.nextTick()
 		}
 
@@ -442,22 +451,18 @@ func (m *submitSimulationModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		switch m.step {
 		case 1:
-			_, c := m.submitModel.Update(submit.GlobalMessageMsg("Preparing branches..."))
+			// The TUI only exists during the submission phase; the stack and
+			// plan print as plain lines before it starts.
+			_, c := m.submitModel.Update(submit.GlobalMessageMsg("Submitting..."))
 			cmds = append(cmds, c, m.nextTick())
 		case 2:
-			m.submitModel.Update(submit.PlanUpdateMsg{BranchName: "feature-1", Action: "update", Skip: true, SkipReason: "already up to date"})
-			m.submitModel.Update(submit.PlanUpdateMsg{BranchName: "feature-2", Action: "update"})
-			_, c := m.submitModel.Update(submit.PlanUpdateMsg{BranchName: "feature-3", Action: "create"})
-			cmds = append(cmds, c, m.nextTick())
-		case 3:
-			m.submitModel.Update(submit.GlobalMessageMsg("Submitting..."))
 			_, c := m.submitModel.Update(submit.ProgressUpdateMsg{BranchName: "feature-2", Status: submit.StatusSubmitting})
 			cmds = append(cmds, c, m.nextTick())
-		case 4:
+		case 3:
 			m.submitModel.Update(submit.ProgressUpdateMsg{BranchName: "feature-2", Status: submit.StatusDone, URL: "https://github.com/owner/repo/pull/102"})
 			_, c := m.submitModel.Update(submit.ProgressUpdateMsg{BranchName: "feature-3", Status: submit.StatusSubmitting})
 			cmds = append(cmds, c, m.nextTick())
-		case 5:
+		case 4:
 			_, c := m.submitModel.Update(submit.ProgressUpdateMsg{BranchName: "feature-3", Status: submit.StatusDone, URL: "https://github.com/owner/repo/pull/103"})
 			cmds = append(cmds, c, m.nextTick())
 			m.submitModel.Update(submit.GlobalMessageMsg("✓ All branches submitted"))
@@ -484,6 +489,6 @@ func (m *submitSimulationModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m *submitSimulationModel) View() tea.View {
 	helpStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241")).MarginTop(1)
 	return tea.NewView(fmt.Sprint(m.submitModel.View().Content) + "\n" +
-		helpStyle.Render(fmt.Sprintf("Simulation step: %d/6", m.step)) + "\n" +
+		helpStyle.Render(fmt.Sprintf("Simulation step: %d/4", m.step)) + "\n" +
 		helpStyle.Render("q: back"))
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The interactive handler started bubbletea on the first stack-display event,
so runs with nothing to do (dry run, all up to date) flashed the TUI
startup/teardown sequence and routed plain-text outcomes through a renderer
that immediately quit. The stack and plan now print as plain lines via the
planPrinter shared with the non-TTY handler, and the TUI starts only when
there are branches to actually submit. This also makes the "Submitting N
branches" header count only submitted branches rather than the whole stack,
and lets the plan-phase machinery in the model (PlanUpdateMsg, the
planning/restacking header variants) be removed. The storyboard simulation
now models the TUI lifecycle from the submission phase.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1783682845`.


* **PR #935**
  * **PR #1189**
    * **PR #1190**
      * **PR #1194**
        * **PR #1195**
          * **PR #1196** 👈
            * **PR #1197**
              * **PR #1270**
                * **PR #1271**
                  * **PR #1399**
                    * **PR #1400**
                      * **PR #1401**
                        * **PR #1402**
                          * **PR #1403**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1404 by jonnii*