### PR TITLE
refactor: remove redundant PrInfo constructors

### DIFF
--- a/internal/engine/engine_merged_history_test.go
+++ b/internal/engine/engine_merged_history_test.go
@@ -63,7 +63,7 @@ func TestRestackBranch_CapturesMergedHistory(t *testing.T) {
 		// Set PR info on branch1
 		branch1 := s.Engine.GetBranch("branch1")
 		prNum := 99
-		prInfo := engine.NewPrInfoFull(&prNum, "Fix bug", "Body", prStateMerged, "main", "https://github.com/test/99", false, "", "")
+		prInfo := engine.NewPrInfo(&prNum, "Fix bug", "Body", prStateMerged, "main", "https://github.com/test/99", false)
 		err := s.Engine.UpsertPrInfo(context.Background(), branch1, prInfo)
 		require.NoError(t, err)
 

--- a/internal/engine/engine_pr.go
+++ b/internal/engine/engine_pr.go
@@ -29,7 +29,7 @@ func NewPrInfoFromMeta(meta *git.Meta) *PrInfo {
 		lockReason = string(*prInfo.LockReason)
 	}
 
-	return NewPrInfoFull(
+	return NewPrInfo(
 		prInfo.Number,
 		getStringValue(prInfo.Title),
 		getStringValue(prInfo.Body),
@@ -37,9 +37,9 @@ func NewPrInfoFromMeta(meta *git.Meta) *PrInfo {
 		getStringValue(prInfo.Base),
 		getStringValue(prInfo.URL),
 		getBoolValue(prInfo.IsDraft),
-		LockReason(lockReason),
-		getStringValue(prInfo.MergeBranch),
-	).WithBaseSHA(getStringValue(prInfo.BaseSHA))
+	).WithLockReason(LockReason(lockReason)).
+		WithMergeBranch(getStringValue(prInfo.MergeBranch)).
+		WithBaseSHA(getStringValue(prInfo.BaseSHA))
 }
 
 // GetMergedDownstack returns the merged downstack history for a branch

--- a/internal/engine/pr_info.go
+++ b/internal/engine/pr_info.go
@@ -30,35 +30,6 @@ func NewPrInfo(number *int, title, body, state, base, url string, isDraft bool) 
 	}
 }
 
-// NewPrInfoWithLockReason creates a new PrInfo instance including lock reason
-func NewPrInfoWithLockReason(number *int, title, body, state, base, url string, isDraft bool, lockReason LockReason) *PrInfo {
-	return &PrInfo{
-		number:     number,
-		title:      title,
-		body:       body,
-		isDraft:    isDraft,
-		state:      state,
-		base:       base,
-		url:        url,
-		lockReason: lockReason,
-	}
-}
-
-// NewPrInfoFull creates a new PrInfo instance with all fields
-func NewPrInfoFull(number *int, title, body, state, base, url string, isDraft bool, lockReason LockReason, mergeBranch string) *PrInfo {
-	return &PrInfo{
-		number:      number,
-		title:       title,
-		body:        body,
-		isDraft:     isDraft,
-		state:       state,
-		base:        base,
-		url:         url,
-		lockReason:  lockReason,
-		mergeBranch: mergeBranch,
-	}
-}
-
 // Number returns the PR number
 func (p *PrInfo) Number() *int {
 	return p.number


### PR DESCRIPTION
## Summary

- `NewPrInfoWithLockReason` was never called anywhere in the codebase — removed entirely.
- `NewPrInfoFull` was only called in two places and duplicated logic already covered by chaining the existing `With*` fluent methods. Both call sites now use `NewPrInfo(...).WithLockReason(...).WithMergeBranch(...).WithBaseSHA(...)`.

The result is a smaller public API surface with a single canonical construction pattern throughout the codebase. All existing `NewPrInfo(...).WithLockReason(...)` callers are unaffected.

## Test plan

- [x] `go build ./...` — compiles cleanly
- [x] `go test ./internal/pr/...` — all pass
- [x] `go test ./internal/engine/... -run TestPrInfo` — passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9rvZGiVeXb4z1o2mx2Y5s)_