### PR TITLE
fix: skip restacking branches whose PR is already merged

### DIFF
--- a/internal/engine/branch_tracking.go
+++ b/internal/engine/branch_tracking.go
@@ -172,8 +172,15 @@ func (e *engineImpl) setParentRecomputingDivergence(ctx context.Context, branch 
 		if oldParent != "" && oldParent != parentBranchName && meta.GetParentBranchRevision() != nil && *meta.GetParentBranchRevision() != "" {
 			// Check if existing revision is still a valid ancestor of the branch
 			if isAncestor, _ := e.git.IsAncestor(ctx, *meta.GetParentBranchRevision(), branchName); isAncestor {
-				// Check if the old parent was merged into the new parent (the "merge" case)
-				if merged, _ := e.git.IsMerged(ctx, oldParent, parentBranchName); merged {
+				// Check if the old parent was merged into the new parent (the
+				// "merge" case). The PR state is checked first: patch-id
+				// detection (git cherry inside IsMerged) cannot recognize a
+				// multi-commit squash merge, and errors when the old parent
+				// ref is already deleted — clobbering the divergence point
+				// would make the next restack replay the merged commits.
+				if e.prStateIsMerged(oldParent) {
+					shouldUpdateRevision = false
+				} else if merged, _ := e.git.IsMerged(ctx, oldParent, parentBranchName); merged {
 					shouldUpdateRevision = false
 				}
 			}

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -443,10 +443,7 @@ func (e *engineImpl) evaluateDeletionStatus(ctx context.Context, branchName stri
 	if meta != nil {
 		prInfo := NewPrInfoFromMeta(meta)
 		if prInfo != nil {
-			const (
-				prStateClosed = "CLOSED"
-				prStateMerged = "MERGED"
-			)
+			const prStateClosed = "CLOSED"
 			if prInfo.State() == prStateClosed {
 				return DeletionStatus{SafeToDelete: true, Reason: "closed on GitHub", Kind: DeletionReasonClosedPR}
 			}

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -1362,6 +1362,51 @@ func TestDetachAndResetBranchChanges(t *testing.T) {
 
 func TestSetParentScenarios(t *testing.T) {
 	t.Parallel()
+	t.Run("preserves divergence point when multi-commit parent was squash-merged", func(t *testing.T) {
+		t.Parallel()
+		// Scenario: main -> branch1 (3 commits) -> branch2. GitHub
+		// squash-merges branch1, so no individual commit patch-matches the
+		// squashed result and patch-id detection (git cherry) cannot see the
+		// merge. Only the MERGED PR state in metadata can.
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		s.CreateBranch("branch1").
+			CommitChange("file1.txt", "v1").
+			CommitChange("file1.txt", "v1\nv2").
+			CommitChange("file1.txt", "v1\nv2\nv3").
+			TrackBranch("branch1", "main")
+
+		branch1SHA, _ := s.Engine.GetBranch("branch1").GetRevision()
+
+		s.CreateBranch("branch2").
+			CommitChange("file2.txt", "feat: branch2").
+			TrackBranch("branch2", "branch1")
+
+		// Squash commit lands on main; record the MERGED PR state.
+		s.Checkout("main").
+			CommitChange("file1.txt", "v1\nv2\nv3")
+
+		meta, err := s.Engine.Git().ReadMetadata("branch1")
+		require.NoError(t, err)
+		prNumber := 1
+		state := prStateMerged
+		base := "main"
+		meta = meta.WithPrInfo(&git.PrInfoPersistence{Number: &prNumber, State: &state, Base: &base})
+		require.NoError(t, s.Engine.Git().WriteMetadata("branch1", meta))
+		s.Rebuild()
+
+		// Reparent branch2 to main (what restack/sync do after the merge).
+		err = s.Engine.SetParent(context.Background(), s.Engine.GetBranch("branch2"), s.Engine.GetBranch("main"), engine.DivergenceRecompute)
+		require.NoError(t, err)
+
+		// The divergence point must stay at branch1's pre-merge tip so a
+		// restack replays only branch2's own commits, not branch1's.
+		meta2, err := s.Engine.Git().ReadMetadata("branch2")
+		require.NoError(t, err)
+		require.Equal(t, branch1SHA, *meta2.GetParentBranchRevision(),
+			"divergence point should be preserved for a squash-merged parent")
+	})
+
 	t.Run("preserves divergence point when parent is rebased and merged into trunk", func(t *testing.T) {
 		t.Parallel()
 		// Scenario: main -> branch1 -> branch2

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -79,6 +79,14 @@ func (e *engineImpl) rebuild() error {
 // prStateMerged is the GitHub PR state recorded in metadata once a PR merges.
 const prStateMerged = "MERGED"
 
+// prStateIsMerged reports whether a branch's PR was recorded as merged in
+// metadata. Works even when the branch ref itself no longer exists, since
+// PR info lives on the metadata ref.
+func (e *engineImpl) prStateIsMerged(branchName string) bool {
+	prInfo, err := e.GetPrInfo(e.GetBranch(branchName))
+	return err == nil && prInfo != nil && prInfo.State() == prStateMerged
+}
+
 // shouldReparentBranch checks if a parent branch should be reparented
 // Returns true if the parent branch:
 // - No longer exists locally
@@ -121,13 +129,7 @@ func (e *engineImpl) shouldReparentBranch(ctx context.Context, parentBranchName 
 	}
 
 	// Fall back to engine cache/disk if not in metaMap or state unknown
-	parentBranch := e.GetBranch(parentBranchName)
-	prInfo, err := e.GetPrInfo(parentBranch)
-	if err == nil && prInfo != nil && prInfo.State() == prStateMerged {
-		return true
-	}
-
-	return false
+	return e.prStateIsMerged(parentBranchName)
 }
 
 // findNearestValidAncestor finds the nearest ancestor that hasn't been merged/deleted

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -76,6 +76,9 @@ func (e *engineImpl) rebuild() error {
 	return nil
 }
 
+// prStateMerged is the GitHub PR state recorded in metadata once a PR merges.
+const prStateMerged = "MERGED"
+
 // shouldReparentBranch checks if a parent branch should be reparented
 // Returns true if the parent branch:
 // - No longer exists locally
@@ -109,7 +112,7 @@ func (e *engineImpl) shouldReparentBranch(ctx context.Context, parentBranchName 
 	if metaMap != nil {
 		if meta, ok := metaMap[parentBranchName]; ok && meta != nil {
 			prInfo := meta.GetPrInfo()
-			if prInfo != nil && prInfo.State != nil && *prInfo.State == "MERGED" {
+			if prInfo != nil && prInfo.State != nil && *prInfo.State == prStateMerged {
 				return true
 			}
 			// If metadata exists but state isn't MERGED, we don't need to check further
@@ -120,7 +123,7 @@ func (e *engineImpl) shouldReparentBranch(ctx context.Context, parentBranchName 
 	// Fall back to engine cache/disk if not in metaMap or state unknown
 	parentBranch := e.GetBranch(parentBranchName)
 	prInfo, err := e.GetPrInfo(parentBranch)
-	if err == nil && prInfo != nil && prInfo.State() == "MERGED" {
+	if err == nil && prInfo != nil && prInfo.State() == prStateMerged {
 		return true
 	}
 

--- a/internal/engine/restack_plan.go
+++ b/internal/engine/restack_plan.go
@@ -62,6 +62,17 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 		return item, true
 	}
 
+	// A branch whose PR was already merged is awaiting sync cleanup. Rebasing
+	// it onto trunk would replay commits the merge already applied — for a
+	// multi-commit squash merge that conflicts on every commit, since no
+	// individual commit patch-matches the squashed result. Skip it;
+	// descendants still reparent past it via shouldReparentBranch.
+	if prInfo, err := e.GetPrInfo(branch); err == nil && prInfo != nil && prInfo.State() == prStateMerged {
+		item.Skip = true
+		item.SkipResult = RestackBranchResult{Result: RestackUnneeded}
+		return item, true
+	}
+
 	parent := branch.GetParent()
 	parentName := e.trunk
 	e.mu.RLock()

--- a/internal/integration/restack_squash_merge_test.go
+++ b/internal/integration/restack_squash_merge_test.go
@@ -1,0 +1,152 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/actions/sync"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/handlers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// TestSquashMergeMultiCommitParent reproduces the case where a parent branch
+// with MULTIPLE commits is squash-merged on GitHub. The squash commit's
+// patch-id matches none of the parent's individual commits, so patch-id
+// based merge detection (git cherry) cannot see the parent as merged.
+// The child must still restack onto trunk replaying only its own commit.
+func TestSquashMergeMultiCommitParent(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	// Parent: 3 commits evolving the same file (diffs build on each other,
+	// so replaying them onto the squashed result conflicts).
+	sh.CreateBranch("parent").
+		CommitChange("file-p", "v1").
+		CommitChange("file-p", "v1\nv2").
+		CommitChange("file-p", "v1\nv2\nv3").
+		TrackBranch("parent", "main")
+
+	// Child: 1 unique commit on top.
+	sh.CreateBranch("child").
+		CommitChange("file-c", "c").
+		TrackBranch("child", "parent")
+
+	// GitHub squash-merges parent's PR: one combined commit lands on main.
+	mainName := sh.Engine.Trunk().GetName()
+	sh.Checkout("main")
+	sh.CommitChange("file-p", "v1\nv2\nv3")
+	markPrMerged(t, sh, "parent", 1, mainName)
+
+	require.NoError(t, sync.Action(sh.Context, sync.Options{Restack: true}, nil))
+
+	branches, err := sh.Scene.Repo.GetLocalBranches()
+	require.NoError(t, err)
+	require.NotContains(t, branches, "parent", "squash-merged parent should be deleted")
+	require.Contains(t, branches, "child")
+
+	require.Equal(t, mainName, sh.Engine.GetBranch("child").GetParent().GetName())
+
+	// Child must keep ONLY its own commit — parent's 3 commits must not replay.
+	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("child"))
+	require.NoError(t, err)
+	require.Equal(t, 1, cCount, "child should not inherit parent's squashed commits")
+
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestRestackAfterMultiCommitSquashParentDeleted covers the case where the
+// squash-merged parent branch is already gone locally (deleted outside
+// stackit's sync cleanup) and the child is restacked. Reparenting happens in
+// restack itself; with the parent ref gone, the divergence-preservation check
+// in setParentRecomputingDivergence cannot run and the child's divergence
+// point falls back to the fork point, replaying the parent's commits.
+func TestRestackAfterMultiCommitSquashParentDeleted(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("parent").
+		CommitChange("file-p", "v1").
+		CommitChange("file-p", "v1\nv2").
+		CommitChange("file-p", "v1\nv2\nv3").
+		TrackBranch("parent", "main")
+
+	sh.CreateBranch("child").
+		CommitChange("file-c", "c").
+		TrackBranch("child", "parent")
+
+	mainName := sh.Engine.Trunk().GetName()
+	sh.Checkout("main")
+	sh.CommitChange("file-p", "v1\nv2\nv3")
+
+	// Parent branch deleted locally (e.g. user cleanup after GitHub merge).
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("branch", "-D", "parent"))
+	sh.Rebuild()
+
+	sh.Checkout("child")
+	plan, err := actions.PlanRestack(sh.Context, actions.RestackOptions{
+		BranchName: "child",
+		Scope:      engine.StackRangeFull(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, actions.RestackAction(sh.Context, plan, &handlers.NullRestackHandler{}))
+
+	sh.Rebuild()
+	require.Equal(t, mainName, sh.Engine.GetBranch("child").GetParent().GetName())
+
+	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("child"))
+	require.NoError(t, err)
+	require.Equal(t, 1, cCount, "child should not inherit parent's squashed commits")
+
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestRestackAfterMultiCommitSquashWithoutSync covers running `stackit restack`
+// BEFORE sync has cleaned up the squash-merged parent. The parent branch still
+// exists locally with a MERGED PR state; restack itself does the reparenting
+// (restack_impl.go shouldReparentBranch path), not sync's clean_branches path.
+func TestRestackAfterMultiCommitSquashWithoutSync(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("parent").
+		CommitChange("file-p", "v1").
+		CommitChange("file-p", "v1\nv2").
+		CommitChange("file-p", "v1\nv2\nv3").
+		TrackBranch("parent", "main")
+
+	sh.CreateBranch("child").
+		CommitChange("file-c", "c").
+		TrackBranch("child", "parent")
+
+	// GitHub squash-merges parent's PR: one combined commit lands on main.
+	mainName := sh.Engine.Trunk().GetName()
+	sh.Checkout("main")
+	sh.CommitChange("file-p", "v1\nv2\nv3")
+	markPrMerged(t, sh, "parent", 1, mainName)
+
+	// User runs `stackit restack` from the child without syncing first.
+	sh.Checkout("child")
+	plan, err := actions.PlanRestack(sh.Context, actions.RestackOptions{
+		BranchName: "child",
+		Scope:      engine.StackRangeFull(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, actions.RestackAction(sh.Context, plan, &handlers.NullRestackHandler{}))
+
+	sh.Rebuild()
+	require.Equal(t, mainName, sh.Engine.GetBranch("child").GetParent().GetName(),
+		"child should reparent to main past the merged parent")
+
+	// Child must keep ONLY its own commit — parent's 3 commits must not replay.
+	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("child"))
+	require.NoError(t, err)
+	require.Equal(t, 1, cCount, "child should not inherit parent's squashed commits")
+
+	requireCleanWorkingTree(t, sh)
+}


### PR DESCRIPTION

Restack planned a rebase for branches with a MERGED PR state. For a
multi-commit squash merge, replaying those commits onto trunk conflicts
on every one of them, since no individual commit patch-matches the
squashed result — the restack stops on spurious conflicts. Skip such
branches during planning; they are awaiting sync cleanup, and their
descendants still reparent past them.