### PR TITLE
fix: record merged PRs as MERGED in the REST PR-info fallback

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -161,6 +161,13 @@ func ToPullRequestInfo(pr *github.PullRequest) *PullRequestInfo {
 	if pr.State != nil {
 		info.State = strings.ToUpper(*pr.State)
 	}
+	// The REST API reports merged PRs as state "closed" with a separate merged
+	// indicator; normalize to MERGED so this path matches the GraphQL
+	// PullRequestState enum. List responses omit the `merged` boolean and only
+	// populate `merged_at`, so check both.
+	if pr.GetMerged() || pr.MergedAt != nil {
+		info.State = PRStateMerged
+	}
 	if pr.Draft != nil {
 		info.Draft = *pr.Draft
 	}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,0 +1,62 @@
+package github_test
+
+import (
+	"testing"
+	"time"
+
+	gogithub "github.com/google/go-github/v67/github"
+	"github.com/stretchr/testify/require"
+
+	githubpkg "github.com/getstackit/stackit/internal/github"
+)
+
+func TestToPullRequestInfoState(t *testing.T) {
+	t.Parallel()
+
+	mergedAt := gogithub.Timestamp{Time: time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)}
+
+	tests := []struct {
+		name     string
+		pr       *gogithub.PullRequest
+		expected string
+	}{
+		{
+			name:     "open PR",
+			pr:       &gogithub.PullRequest{State: new("open")},
+			expected: "OPEN",
+		},
+		{
+			name: "closed PR that was not merged",
+			pr: &gogithub.PullRequest{
+				State:  new("closed"),
+				Merged: new(false),
+			},
+			expected: "CLOSED",
+		},
+		{
+			name: "closed PR with merged flag",
+			pr: &gogithub.PullRequest{
+				State:  new("closed"),
+				Merged: new(true),
+			},
+			expected: "MERGED",
+		},
+		{
+			name: "closed PR with only merged_at populated (list response)",
+			pr: &gogithub.PullRequest{
+				State:    new("closed"),
+				MergedAt: &mergedAt,
+			},
+			expected: "MERGED",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			info := githubpkg.ToPullRequestInfo(tt.pr)
+			require.NotNil(t, info)
+			require.Equal(t, tt.expected, info.State)
+		})
+	}
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->


The GraphQL PR-info path reports merged PRs as MERGED via the
PullRequestState enum, but the per-branch REST fallback mapped state
directly from the REST state field, which is only open/closed. Merged
PRs were recorded as CLOSED on that path, so the merged-PR restack-skip
and squash-merge reparent detection silently never fired. Normalize to
MERGED when the PR reports it was merged, checking both the merged flag
and merged_at since list responses omit the boolean.