### PR TITLE
Merging 2 PRs

### DIFF
--- a/internal/actions/submit/base_sha_stale_test.go
+++ b/internal/actions/submit/base_sha_stale_test.go
@@ -1,0 +1,100 @@
+package submit
+
+import (
+	"testing"
+
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBaseSHAIsStale(t *testing.T) {
+	t.Parallel()
+
+	prNumber := 42
+	makePrInfo := func(base, baseSHA string) *engine.PrInfo {
+		return engine.NewPrInfo(&prNumber, "title", "body", "OPEN", base, "https://example.com/pr/42", false).
+			WithBaseSHA(baseSHA)
+	}
+
+	tests := []struct {
+		name            string
+		prInfo          *engine.PrInfo
+		info            Info
+		trunkName       string
+		parentRewritten bool
+		expected        bool
+	}{
+		{
+			name:            "nil prInfo",
+			prInfo:          nil,
+			info:            Info{Base: "parent", BaseSHA: "sha-new"},
+			trunkName:       "main",
+			parentRewritten: true,
+			expected:        false,
+		},
+		{
+			name:            "empty stored BaseSHA",
+			prInfo:          makePrInfo("parent", ""),
+			info:            Info{Base: "parent", BaseSHA: "sha-new"},
+			trunkName:       "main",
+			parentRewritten: true,
+			expected:        false,
+		},
+		{
+			name:            "fast-forward of parent is not stale",
+			prInfo:          makePrInfo("parent", "sha-old"),
+			info:            Info{Base: "parent", BaseSHA: "sha-new"},
+			trunkName:       "main",
+			parentRewritten: false,
+			expected:        false,
+		},
+		{
+			name:            "genuine rewrite of parent is stale",
+			prInfo:          makePrInfo("parent", "sha-old"),
+			info:            Info{Base: "parent", BaseSHA: "sha-new", HeadSHA: "sha-head"},
+			trunkName:       "main",
+			parentRewritten: true,
+			expected:        true,
+		},
+		{
+			name:            "empty child with head at parent tip",
+			prInfo:          makePrInfo("parent", "sha-old"),
+			info:            Info{Base: "parent", BaseSHA: "sha-new", HeadSHA: "sha-new"},
+			trunkName:       "main",
+			parentRewritten: true,
+			expected:        false,
+		},
+		{
+			name:            "base is trunk",
+			prInfo:          makePrInfo("main", "sha-old"),
+			info:            Info{Base: "main", BaseSHA: "sha-new"},
+			trunkName:       "main",
+			parentRewritten: true,
+			expected:        false,
+		},
+		{
+			name:            "base branch name changed",
+			prInfo:          makePrInfo("old-parent", "sha-old"),
+			info:            Info{Base: "new-parent", BaseSHA: "sha-new"},
+			trunkName:       "main",
+			parentRewritten: true,
+			expected:        false,
+		},
+		{
+			name:            "unchanged parent tip is not stale",
+			prInfo:          makePrInfo("parent", "sha-same"),
+			info:            Info{Base: "parent", BaseSHA: "sha-same"},
+			trunkName:       "main",
+			parentRewritten: false,
+			expected:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := baseSHAIsStale(tt.prInfo, tt.info, tt.trunkName, tt.parentRewritten)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -534,16 +534,19 @@ func updatePullRequestQuiet(ctx *app.Context, submissionInfo Info, opts Options,
 	prInfo, _ := branch.GetPrInfo()
 	baseChanged := prInfo != nil && prInfo.Base() != submissionInfo.Base
 
-	// Detect stale base.sha: base branch name is the same but the parent was force-pushed.
-	// After a restack, GitHub retains the old parent tip SHA in base.sha, causing the child
-	// PR to show the parent's tip commit in its diff. Fix by temporarily changing the PR base
-	// to trunk before setting it back to the actual parent — this forces GitHub to recompute
-	// base.sha to the current parent tip.
-	baseSHAStale := !baseChanged &&
-		prInfo != nil &&
-		prInfo.BaseSHA() != "" &&
-		prInfo.BaseSHA() != submissionInfo.BaseSHA &&
-		submissionInfo.Base != ctx.Engine.Trunk().GetName()
+	// Detect stale base.sha: base branch name is the same but the parent was rewritten
+	// (rebased/force-pushed) since the last submit. GitHub retains the old parent tip SHA
+	// in base.sha, causing the child PR to show the parent's tip commit in its diff. A
+	// fast-forward of the parent does NOT make base.sha stale, so only treat it as stale
+	// when the stored BaseSHA is no longer an ancestor of the current parent tip. Fix by
+	// temporarily changing the PR base to trunk before setting it back to the actual
+	// parent — this forces GitHub to recompute base.sha to the current parent tip.
+	parentRewritten := false
+	if !baseChanged && prInfo != nil && prInfo.BaseSHA() != "" && prInfo.BaseSHA() != submissionInfo.BaseSHA {
+		isAncestor, err := ctx.Engine.IsAncestor(ctx.Context, prInfo.BaseSHA(), submissionInfo.BaseSHA)
+		parentRewritten = err == nil && !isAncestor
+	}
+	baseSHAStale := baseSHAIsStale(prInfo, submissionInfo, ctx.Engine.Trunk().GetName(), parentRewritten)
 
 	updateOpts := github.UpdatePROptions{
 		Title:           &submissionInfo.Metadata.Title,
@@ -591,9 +594,10 @@ func updatePullRequestQuiet(ctx *app.Context, submissionInfo Info, opts Options,
 		}
 	}
 
-	// When the parent was force-pushed (stale base.sha), temporarily retarget the PR
+	// When the parent was rewritten (stale base.sha), temporarily retarget the PR
 	// to trunk and then back to the actual parent. GitHub recomputes base.sha on each
 	// base change, so the second change sets it to the current parent tip.
+	retargetedToTrunk := false
 	if baseSHAStale {
 		trunkName := ctx.Engine.Trunk().GetName()
 		trunkOpts := github.UpdatePROptions{Base: &trunkName}
@@ -603,17 +607,34 @@ func updatePullRequestQuiet(ctx *app.Context, submissionInfo Info, opts Options,
 			// The main update below will set it back to the actual parent, causing GitHub
 			// to recompute base.sha to the current parent tip.
 			updateOpts.Base = &submissionInfo.Base
+			retargetedToTrunk = true
 		}
 	}
 
 	updateWarnings, err := ctx.GitHub().UpdatePullRequest(ctx.Context, repoOwner, repoName, *submissionInfo.PRNumber, updateOpts)
 	if err != nil {
+		if retargetedToTrunk {
+			// The PR is currently targeting trunk from the base.sha refresh above; restore
+			// the real parent so a failed update doesn't strand it showing the full stack diff.
+			rollbackOpts := github.UpdatePROptions{Base: &submissionInfo.Base}
+			if _, rollbackErr := ctx.GitHub().UpdatePullRequest(ctx.Context, repoOwner, repoName, *submissionInfo.PRNumber, rollbackOpts); rollbackErr != nil {
+				ctx.Output.Debug("Failed to restore PR base for %s after update error: %v", submissionInfo.BranchName, rollbackErr)
+			}
+		}
 		return "", fmt.Errorf("failed to update PR for %s: %w", submissionInfo.BranchName, err)
 	}
 
 	// Log any warnings from PR update (e.g., failed to add labels/assignees)
 	for _, warning := range updateWarnings {
 		ctx.Output.Warn("%s: %s", submissionInfo.BranchName, warning)
+	}
+
+	// If the base.sha refresh was needed but failed, keep the previously stored BaseSHA
+	// so the next submit detects the rewrite again and retries the refresh. Storing the
+	// current tip would make the stale diff permanent.
+	baseSHAToStore := submissionInfo.BaseSHA
+	if baseSHAStale && !retargetedToTrunk {
+		baseSHAToStore = prInfo.BaseSHA()
 	}
 
 	// Get PR URL
@@ -637,9 +658,36 @@ func updatePullRequestQuiet(ctx *app.Context, submissionInfo Info, opts Options,
 		baseToStore,
 		prURL,
 		submissionInfo.Metadata.IsDraft,
-	).WithLockReason(branch.GetLockReason()).WithBaseSHA(submissionInfo.BaseSHA))
+	).WithLockReason(branch.GetLockReason()).WithBaseSHA(baseSHAToStore))
 
 	return prURL, nil
+}
+
+// baseSHAIsStale reports whether GitHub's stored base.sha for an existing PR is stale
+// and needs the trunk-and-back retarget to be refreshed. It is stale only when the base
+// branch name is unchanged but the parent was rewritten (rebased/force-pushed) since the
+// last submit — a fast-forward of the parent keeps GitHub's base.sha valid.
+// parentRewritten is whether the stored BaseSHA is no longer an ancestor of the current
+// parent tip.
+func baseSHAIsStale(prInfo *engine.PrInfo, info Info, trunkName string, parentRewritten bool) bool {
+	if prInfo == nil || prInfo.BaseSHA() == "" {
+		return false
+	}
+	// A base branch name change is handled by the regular base update, which already
+	// makes GitHub recompute base.sha.
+	if prInfo.Base() != info.Base {
+		return false
+	}
+	if info.Base == trunkName {
+		return false
+	}
+	// An empty child (no commits between parent and head) can't be retargeted back to
+	// its parent — GitHub rejects base updates with no commits between base and head,
+	// which would strand the PR targeting trunk.
+	if info.BaseSHA == info.HeadSHA {
+		return false
+	}
+	return prInfo.BaseSHA() != info.BaseSHA && parentRewritten
 }
 
 // pushMetadataRefs pushes metadata refs for submitted branches to remote

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -161,6 +161,13 @@ func ToPullRequestInfo(pr *github.PullRequest) *PullRequestInfo {
 	if pr.State != nil {
 		info.State = strings.ToUpper(*pr.State)
 	}
+	// The REST API reports merged PRs as state "closed" with a separate merged
+	// indicator; normalize to MERGED so this path matches the GraphQL
+	// PullRequestState enum. List responses omit the `merged` boolean and only
+	// populate `merged_at`, so check both.
+	if pr.GetMerged() || pr.MergedAt != nil {
+		info.State = PRStateMerged
+	}
 	if pr.Draft != nil {
 		info.Draft = *pr.Draft
 	}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,0 +1,62 @@
+package github_test
+
+import (
+	"testing"
+	"time"
+
+	gogithub "github.com/google/go-github/v67/github"
+	"github.com/stretchr/testify/require"
+
+	githubpkg "github.com/getstackit/stackit/internal/github"
+)
+
+func TestToPullRequestInfoState(t *testing.T) {
+	t.Parallel()
+
+	mergedAt := gogithub.Timestamp{Time: time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)}
+
+	tests := []struct {
+		name     string
+		pr       *gogithub.PullRequest
+		expected string
+	}{
+		{
+			name:     "open PR",
+			pr:       &gogithub.PullRequest{State: new("open")},
+			expected: "OPEN",
+		},
+		{
+			name: "closed PR that was not merged",
+			pr: &gogithub.PullRequest{
+				State:  new("closed"),
+				Merged: new(false),
+			},
+			expected: "CLOSED",
+		},
+		{
+			name: "closed PR with merged flag",
+			pr: &gogithub.PullRequest{
+				State:  new("closed"),
+				Merged: new(true),
+			},
+			expected: "MERGED",
+		},
+		{
+			name: "closed PR with only merged_at populated (list response)",
+			pr: &gogithub.PullRequest{
+				State:    new("closed"),
+				MergedAt: &mergedAt,
+			},
+			expected: "MERGED",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			info := githubpkg.ToPullRequestInfo(tt.pr)
+			require.NotNil(t, info)
+			require.Equal(t, tt.expected, info.State)
+		})
+	}
+}


### PR DESCRIPTION
This PR merges the following changes:

1. **#1201** fix: record merged PRs as MERGED in the REST PR-info fallback
2. **#1200** fix: only refresh base.sha on a non-fast-forward parent rewrite

### Stack

```
main
  └─ jonnii/20260612060804/record-merged-PRs-as-MERGED-in-the-REST-PR-info (#1201)
  └─ jonnii/20260612060046/only-refresh-base.sha-on-a-non-fast-forward (#1200)
```

Stackit-Stack-Size: 2
Stackit-PRs: 1201,1200
