### PR TITLE
refactor: extract applyPRMetadata helper to remove duplication

### DIFF
--- a/internal/github/pr_operations.go
+++ b/internal/github/pr_operations.go
@@ -52,6 +52,39 @@ type UpdatePROptions struct {
 	RerequestReview bool
 }
 
+// applyPRMetadata requests reviewers, adds labels, and adds assignees on an existing PR.
+// Failures are collected as warnings rather than hard errors, matching the non-fatal
+// contract used by both CreatePullRequest and UpdatePullRequest.
+func applyPRMetadata(ctx context.Context, client *github.Client, owner, repo string, prNumber int, reviewers, teamReviewers, labels, assignees []string) []string {
+	var warnings []string
+
+	if len(reviewers) > 0 || len(teamReviewers) > 0 {
+		_, _, err := client.PullRequests.RequestReviewers(ctx, owner, repo, prNumber, github.ReviewersRequest{
+			Reviewers:     reviewers,
+			TeamReviewers: teamReviewers,
+		})
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("failed to add reviewers: %v", err))
+		}
+	}
+
+	if len(labels) > 0 {
+		_, _, err := client.Issues.AddLabelsToIssue(ctx, owner, repo, prNumber, labels)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("failed to add labels: %v", err))
+		}
+	}
+
+	if len(assignees) > 0 {
+		_, _, err := client.Issues.AddAssignees(ctx, owner, repo, prNumber, assignees)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("failed to add assignees: %v", err))
+		}
+	}
+
+	return warnings
+}
+
 // CreatePullRequest creates a new pull request.
 // Returns warnings (non-fatal issues like failed label/assignee additions) and error,
 // matching the same contract as UpdatePullRequest.
@@ -72,35 +105,7 @@ func CreatePullRequest(ctx context.Context, client *github.Client, owner, repo s
 		return nil, nil, fmt.Errorf("failed to create pull request: %w", err)
 	}
 
-	var warnings []string
-
-	// Add reviewers if specified
-	if len(opts.Reviewers) > 0 || len(opts.TeamReviewers) > 0 {
-		_, _, err := client.PullRequests.RequestReviewers(ctx, owner, repo, *createdPR.Number, github.ReviewersRequest{
-			Reviewers:     opts.Reviewers,
-			TeamReviewers: opts.TeamReviewers,
-		})
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to add reviewers: %v", err))
-		}
-	}
-
-	// Add labels if specified
-	if len(opts.Labels) > 0 {
-		_, _, err := client.Issues.AddLabelsToIssue(ctx, owner, repo, *createdPR.Number, opts.Labels)
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to add labels: %v", err))
-		}
-	}
-
-	// Add assignees if specified
-	if len(opts.Assignees) > 0 {
-		_, _, err := client.Issues.AddAssignees(ctx, owner, repo, *createdPR.Number, opts.Assignees)
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to add assignees: %v", err))
-		}
-	}
-
+	warnings := applyPRMetadata(ctx, client, owner, repo, *createdPR.Number, opts.Reviewers, opts.TeamReviewers, opts.Labels, opts.Assignees)
 	return warnings, createdPR, nil
 }
 
@@ -155,32 +160,7 @@ func UpdatePullRequest(ctx context.Context, client *github.Client, runner GitCom
 		return nil, fmt.Errorf("failed to update pull request: %w", err)
 	}
 
-	// Update reviewers if specified
-	if len(opts.Reviewers) > 0 || len(opts.TeamReviewers) > 0 {
-		_, _, err := client.PullRequests.RequestReviewers(ctx, owner, repo, prNumber, github.ReviewersRequest{
-			Reviewers:     opts.Reviewers,
-			TeamReviewers: opts.TeamReviewers,
-		})
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to add reviewers: %v", err))
-		}
-	}
-
-	// Add labels if specified
-	if len(opts.Labels) > 0 {
-		_, _, err := client.Issues.AddLabelsToIssue(ctx, owner, repo, prNumber, opts.Labels)
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to add labels: %v", err))
-		}
-	}
-
-	// Add assignees if specified
-	if len(opts.Assignees) > 0 {
-		_, _, err := client.Issues.AddAssignees(ctx, owner, repo, prNumber, opts.Assignees)
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to add assignees: %v", err))
-		}
-	}
+	warnings = append(warnings, applyPRMetadata(ctx, client, owner, repo, prNumber, opts.Reviewers, opts.TeamReviewers, opts.Labels, opts.Assignees)...)
 
 	// Rerequest review if specified
 	if opts.RerequestReview {

--- a/internal/github/pr_operations.go
+++ b/internal/github/pr_operations.go
@@ -112,8 +112,6 @@ func CreatePullRequest(ctx context.Context, client *github.Client, owner, repo s
 // UpdatePullRequest updates an existing pull request
 // Returns warnings (non-fatal issues like failed label/assignee additions) and error
 func UpdatePullRequest(ctx context.Context, client *github.Client, runner GitCommandRunner, owner, repo string, prNumber int, opts UpdatePROptions) ([]string, error) {
-	var warnings []string
-
 	// Handle draft status changes separately using GraphQL API, as the REST API
 	// doesn't support updating draft status. We need to use GraphQL mutation
 	// markPullRequestReadyForReview or convertPullRequestToDraft.
@@ -160,7 +158,7 @@ func UpdatePullRequest(ctx context.Context, client *github.Client, runner GitCom
 		return nil, fmt.Errorf("failed to update pull request: %w", err)
 	}
 
-	warnings = append(warnings, applyPRMetadata(ctx, client, owner, repo, prNumber, opts.Reviewers, opts.TeamReviewers, opts.Labels, opts.Assignees)...)
+	warnings := applyPRMetadata(ctx, client, owner, repo, prNumber, opts.Reviewers, opts.TeamReviewers, opts.Labels, opts.Assignees)
 
 	// Rerequest review if specified
 	if opts.RerequestReview {


### PR DESCRIPTION
## Summary

- `CreatePullRequest` and `UpdatePullRequest` contained identical 18-line blocks for requesting reviewers, adding labels, and adding assignees
- Extracts a private `applyPRMetadata` helper that both callers now share
- Net: -20 lines, zero behavior change

## Why this matters

Any future change to the non-fatal metadata application logic (adding a new metadata type, changing error message format, adding a retry) would previously require two edits in lockstep. With the helper, there is one place to change.

## Test plan

- [ ] `go test ./internal/github/...` passes (verified locally — all existing tests green)
- [ ] No behavior change: reviewers/labels/assignees still applied as non-fatal warnings in both create and update paths

---
_Generated by [Claude Code](https://claude.ai/code/session_014Hpy8BXs7BQSMSSwf8GmaR)_