### PR TITLE
perf: batch PR info writes during consolidation merge

### DIFF
--- a/internal/actions/merge/consolidate.go
+++ b/internal/actions/merge/consolidate.go
@@ -318,12 +318,16 @@ func (c *ConsolidateMergeExecutor) lockAndNotifyIndividualPRs(_ context.Context,
 		}
 	}
 
+	prUpdates := make(map[string]*engine.PrInfo, len(branchesToLock))
 	for _, b := range branchesToLock {
 		prInfo, _ := b.GetPrInfo()
 		if prInfo != nil {
-			if err := c.engine.UpsertPrInfo(c.ctx.Context, b, prInfo.WithMergeBranch(consolidationBranch)); err != nil {
-				splog.Debug("Failed to upsert PR info for %s: %v", b.GetName(), err)
-			}
+			prUpdates[b.GetName()] = prInfo.WithMergeBranch(consolidationBranch)
+		}
+	}
+	if len(prUpdates) > 0 {
+		if err := c.engine.BatchUpsertPrInfo(c.ctx.Context, prUpdates); err != nil {
+			splog.Debug("Failed to batch upsert PR info: %v", err)
 		}
 	}
 

--- a/internal/actions/merge/multistack.go
+++ b/internal/actions/merge/multistack.go
@@ -284,12 +284,16 @@ func lockAndNotifyMultiStackPRs(ctx *app.Context, eng engine.Engine, includedSta
 	}
 
 	// Update PR info with consolidation branch
+	prUpdates := make(map[string]*engine.PrInfo, len(branchesToLock))
 	for _, b := range branchesToLock {
 		prInfo, _ := b.GetPrInfo()
 		if prInfo != nil {
-			if err := eng.UpsertPrInfo(ctx.Context, b, prInfo.WithMergeBranch(consolidationBranch)); err != nil {
-				out.Debug("Failed to upsert PR info for %s: %v", b.GetName(), err)
-			}
+			prUpdates[b.GetName()] = prInfo.WithMergeBranch(consolidationBranch)
+		}
+	}
+	if len(prUpdates) > 0 {
+		if err := eng.BatchUpsertPrInfo(ctx.Context, prUpdates); err != nil {
+			out.Debug("Failed to batch upsert PR info: %v", err)
 		}
 	}
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -23,6 +23,10 @@ import (
 // Thread-safe: All methods are safe for concurrent use
 type PRManager interface {
 	UpsertPrInfo(ctx context.Context, branch Branch, prInfo *PrInfo) error
+	// BatchUpsertPrInfo updates PR information for multiple branches atomically,
+	// replacing N serial git ref writes with one transaction. The updates map is
+	// keyed by branch name.
+	BatchUpsertPrInfo(ctx context.Context, updates map[string]*PrInfo) error
 	ReadBranchRemoteStatuses(ctx context.Context, branches Branches) BranchRemoteStatuses
 	PushBranch(ctx context.Context, branch Branch, remote string, opts git.PushOptions) error
 	PushBranches(ctx context.Context, remote string, specs []git.PushSpec, opts git.PushOptions) map[string]error

--- a/internal/engine/engine_pr.go
+++ b/internal/engine/engine_pr.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/getstackit/stackit/internal/git"
 )
@@ -57,61 +58,99 @@ func (e *engineImpl) UpsertPrInfo(ctx context.Context, branch Branch, prInfo *Pr
 	branchName := branch.GetName()
 
 	return e.WithRetry(ctx, func() error {
-		// Read existing metadata (outside lock for performance)
 		meta, err := e.readMetadata(branchName)
 		if err != nil {
 			meta = git.NewMeta()
 		}
-
-		if prInfo == nil {
-			meta = meta.WithPrInfo(nil)
-		} else {
-			existing := meta.GetPrInfo()
-			if existing == nil {
-				existing = &git.PrInfoPersistence{}
-			}
-
-			// Update PR info fields
-			if prInfo.Number() != nil {
-				existing.Number = prInfo.Number()
-			}
-			if prInfo.Title() != "" {
-				title := prInfo.Title()
-				existing.Title = &title
-			}
-			if prInfo.Body() != "" {
-				body := prInfo.Body()
-				existing.Body = &body
-			}
-			isDraft := prInfo.IsDraft()
-			existing.IsDraft = &isDraft
-			if prInfo.State() != "" {
-				state := prInfo.State()
-				existing.State = &state
-			}
-			if prInfo.Base() != "" {
-				base := prInfo.Base()
-				existing.Base = &base
-			}
-			if prInfo.BaseSHA() != "" {
-				baseSHA := prInfo.BaseSHA()
-				existing.BaseSHA = &baseSHA
-			}
-			if prInfo.URL() != "" {
-				url := prInfo.URL()
-				existing.URL = &url
-			}
-			lr := prInfo.LockReason()
-			existing.LockReason = &lr
-			mergeBranch := prInfo.MergeBranch()
-			existing.MergeBranch = &mergeBranch
-			meta = meta.WithPrInfo(existing)
-		}
-
+		meta = mergePrInfoIntoMeta(meta, prInfo)
 		return e.withMetadataTx(ctx, fmt.Sprintf("upsert PR info: %s", branchName), func(tx *MetadataTx) error {
 			return tx.UpdateMeta(branchName, meta)
 		})
 	})
+}
+
+// BatchUpsertPrInfo updates PR information for multiple branches in one atomic
+// transaction, replacing N serial git ref writes with a single batched write.
+// The updates map is keyed by branch name; nil PrInfo clears the PR info.
+func (e *engineImpl) BatchUpsertPrInfo(ctx context.Context, updates map[string]*PrInfo) error {
+	if len(updates) == 0 {
+		return nil
+	}
+
+	branchNames := make([]string, 0, len(updates))
+	for name := range updates {
+		branchNames = append(branchNames, name)
+	}
+	slices.Sort(branchNames)
+
+	return e.WithRetry(ctx, func() error {
+		metas, _ := e.batchReadMetadata(branchNames)
+
+		tx := e.BeginTx(fmt.Sprintf("batch upsert PR info: %d branches", len(updates)))
+
+		for _, name := range branchNames {
+			meta, ok := metas[name]
+			if !ok || meta == nil {
+				meta = git.NewMeta()
+			}
+			meta = mergePrInfoIntoMeta(meta, updates[name])
+			if err := tx.UpdateMeta(name, meta); err != nil {
+				tx.Rollback()
+				return err
+			}
+		}
+
+		return tx.Commit(ctx)
+	})
+}
+
+// mergePrInfoIntoMeta applies prInfo fields to meta's stored PR info and
+// returns the updated meta. Non-zero fields in prInfo overwrite existing values.
+func mergePrInfoIntoMeta(meta *git.Meta, prInfo *PrInfo) *git.Meta {
+	if prInfo == nil {
+		return meta.WithPrInfo(nil)
+	}
+
+	existing := meta.GetPrInfo()
+	if existing == nil {
+		existing = &git.PrInfoPersistence{}
+	}
+
+	if prInfo.Number() != nil {
+		existing.Number = prInfo.Number()
+	}
+	if prInfo.Title() != "" {
+		title := prInfo.Title()
+		existing.Title = &title
+	}
+	if prInfo.Body() != "" {
+		body := prInfo.Body()
+		existing.Body = &body
+	}
+	isDraft := prInfo.IsDraft()
+	existing.IsDraft = &isDraft
+	if prInfo.State() != "" {
+		state := prInfo.State()
+		existing.State = &state
+	}
+	if prInfo.Base() != "" {
+		base := prInfo.Base()
+		existing.Base = &base
+	}
+	if prInfo.BaseSHA() != "" {
+		baseSHA := prInfo.BaseSHA()
+		existing.BaseSHA = &baseSHA
+	}
+	if prInfo.URL() != "" {
+		url := prInfo.URL()
+		existing.URL = &url
+	}
+	lr := prInfo.LockReason()
+	existing.LockReason = &lr
+	mergeBranch := prInfo.MergeBranch()
+	existing.MergeBranch = &mergeBranch
+
+	return meta.WithPrInfo(existing)
 }
 
 // GetPRSubmissionStatus returns the submission status of a branch

--- a/internal/engine/engine_pr_batch_test.go
+++ b/internal/engine/engine_pr_batch_test.go
@@ -69,6 +69,71 @@ func TestBatchGetPRSubmissionStatusReadsRemoteOnceForUpdates(t *testing.T) {
 		"submission status for an update stack must read remote once, not per branch")
 }
 
+func TestBatchUpsertPrInfo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes all branches in one transaction", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{"P": "main", "C1": "P", "C2": "C1"})
+
+		eng := s.Engine
+
+		updates := map[string]*engine.PrInfo{
+			"P":  testhelpers.NewTestPrInfoWithTitle(101, "PR for P").WithMergeBranch("consolidation"),
+			"C1": testhelpers.NewTestPrInfoWithTitle(102, "PR for C1").WithMergeBranch("consolidation"),
+			"C2": testhelpers.NewTestPrInfoWithTitle(103, "PR for C2").WithMergeBranch("consolidation"),
+		}
+
+		require.NoError(t, eng.BatchUpsertPrInfo(context.Background(), updates))
+
+		for name, want := range updates {
+			got, err := eng.GetBranch(name).GetPrInfo()
+			require.NoError(t, err)
+			require.NotNil(t, got, "branch %s should have PR info", name)
+			require.Equal(t, want.Title(), got.Title(), "branch %s title", name)
+			require.Equal(t, want.MergeBranch(), got.MergeBranch(), "branch %s merge branch", name)
+		}
+	})
+
+	t.Run("preserves existing fields when merging", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{"A": "main"})
+
+		eng := s.Engine
+		branch := eng.GetBranch("A")
+
+		// Set initial PR info with a title and state
+		require.NoError(t, eng.UpsertPrInfo(context.Background(), branch,
+			testhelpers.NewTestPrInfoFull(200, "original title", "body", "OPEN", "main", "https://example.com", false)))
+
+		// Batch upsert only updates MergeBranch; other fields should be preserved
+		prInfo, err := branch.GetPrInfo()
+		require.NoError(t, err)
+		require.NoError(t, eng.BatchUpsertPrInfo(context.Background(), map[string]*engine.PrInfo{
+			"A": prInfo.WithMergeBranch("my-consolidation"),
+		}))
+
+		got, err := branch.GetPrInfo()
+		require.NoError(t, err)
+		require.Equal(t, "original title", got.Title())
+		require.Equal(t, "my-consolidation", got.MergeBranch())
+	})
+
+	t.Run("no-op on empty map", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{"A": "main"})
+
+		require.NoError(t, s.Engine.BatchUpsertPrInfo(context.Background(), nil))
+		require.NoError(t, s.Engine.BatchUpsertPrInfo(context.Background(), map[string]*engine.PrInfo{}))
+	})
+}
+
 func TestBatchGetPRSubmissionStatusSkipsRemoteForCreates(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- `lockAndNotifyIndividualPRs` (consolidate.go) and `lockAndNotifyMultiStackPRs` (multistack.go) both looped over branches calling `UpsertPrInfo` one at a time — N separate `git update-ref` transactions for N branches
- Added `BatchUpsertPrInfo` to the `PRManager` interface and engine, which batch-reads all metadata once and commits all PR info updates in a single atomic transaction
- Extracted the per-branch field-merge logic from `UpsertPrInfo` into a private `mergePrInfoIntoMeta` helper, shared by both the single and batch paths

## Test plan

- [ ] `go test ./internal/engine/... -run "TestBatchUpsertPrInfo|TestUpsertPrInfo"` — new tests covering: writes all branches in one transaction, preserves existing fields when merging, no-op on empty map
- [ ] `go build ./...` — compiles clean

https://claude.ai/code/session_014wqxU8v6mtotvQXP4J4nxK

---
_Generated by [Claude Code](https://claude.ai/code/session_014wqxU8v6mtotvQXP4J4nxK)_