### PR TITLE
perf(sync): batch behind-branch pulls

### DIFF
--- a/internal/actions/sync/branch_sync.go
+++ b/internal/actions/sync/branch_sync.go
@@ -34,6 +34,9 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, handler H
 			time.Since(syncStart).Milliseconds(), len(allBranches), branchesSynced, statusCheckTotalMs, statusCheckCount)
 	}()
 
+	// Pass 1: collect branches that are behind their remote, applying the same
+	// skip rules as before (trunk / untracked / locked / frozen / dirty stack).
+	var behind engine.Branches
 	for _, branch := range allBranches {
 		// Check for context cancellation
 		if err := gctx.Err(); err != nil {
@@ -78,60 +81,114 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, handler H
 			continue
 		}
 
-		// Pull the branch
-		pullStart := time.Now()
-		result, err := eng.PullBranch(gctx, remote, branchName)
-		ctx.Logger.Info("pull branch completed branch=%v durationMs=%v", branchName, time.Since(pullStart).Milliseconds())
+		behind = append(behind, branch)
+	}
 
-		if err != nil {
-			// Treat errors as conflicts - warn and continue
-			summary.ConflictBranches = append(summary.ConflictBranches, branchName)
-			handler.EmitEvent(Event{
-				Phase:    PhaseBranches,
-				Type:     EventSkipped,
-				Branch:   branchName,
-				Conflict: true,
-				Message:  err.Error(),
-			})
-			continue
+	if len(behind) == 0 {
+		summary.BranchesSynced = 0
+		return nil
+	}
+
+	// Fetch every behind branch in a single git fetch, replacing the previous
+	// N per-branch fetches (one network round trip instead of N).
+	behindNames := behind.Names()
+	fetchStart := time.Now()
+	fetchErr := eng.FetchRemote(gctx, engine.RemoteFetchRequest{
+		Remote:   remote,
+		Branches: behindNames,
+	})
+	ctx.Logger.Info("batch fetch stack branches completed durationMs=%d branchCount=%d fetchErr=%v",
+		time.Since(fetchStart).Milliseconds(), len(behindNames), fetchErr)
+
+	// Pass 2: apply the fast-forward for each branch. When the batch fetch
+	// succeeded, UpdateBranchFromRemote does the local-only update (no network).
+	// If the batch fetch failed, fall back to the per-branch PullBranch, which
+	// re-fetches individually — preserving sync's warn-and-continue behavior
+	// rather than failing the whole sync.
+	for _, branch := range behind {
+		// Check for context cancellation
+		if err := gctx.Err(); err != nil {
+			return context.Cause(gctx)
 		}
 
-		switch result {
-		case engine.PullDone:
-			// Get the new revision
-			rev, _ := branch.GetRevision()
-			revShort := rev
-			if len(rev) > 7 {
-				revShort = rev[:7]
-			}
+		branchName := branch.GetName()
+
+		pullStart := time.Now()
+		var result engine.PullResult
+		var err error
+		if fetchErr != nil {
+			result, err = eng.PullBranch(gctx, remote, branchName)
+		} else {
+			result, err = eng.UpdateBranchFromRemote(gctx, remote, branchName)
+		}
+		ctx.Logger.Info("update branch from remote completed branch=%v durationMs=%v", branchName, time.Since(pullStart).Milliseconds())
+
+		if applyBranchSyncResult(branch, result, err, handler, summary) {
 			branchesSynced++
-			handler.EmitEvent(Event{
-				Phase:       PhaseBranches,
-				Type:        EventCompleted,
-				Branch:      branchName,
-				NewRevision: revShort,
-			})
-
-		case engine.PullUnneeded:
-			// Already up to date (shouldn't happen since we checked Behind(), but handle it)
-			handler.EmitEvent(Event{
-				Phase:  PhaseBranches,
-				Type:   EventCompleted,
-				Branch: branchName,
-			})
-
-		case engine.PullConflict:
-			// Branches have diverged
-			summary.ConflictBranches = append(summary.ConflictBranches, branchName)
-			handler.EmitEvent(Event{
-				Phase:    PhaseBranches,
-				Type:     EventSkipped,
-				Branch:   branchName,
-				Conflict: true,
-			})
 		}
 	}
 
 	summary.BranchesSynced = branchesSynced
 	return nil
+}
+
+// applyBranchSyncResult emits the PhaseBranches event for a single branch's
+// pull/update result and reports whether the branch was fast-forwarded. It is
+// shared by the batched local-update path and the per-branch fetch fallback so
+// both behave identically.
+func applyBranchSyncResult(branch engine.Branch, result engine.PullResult, err error, handler Handler, summary *Summary) (synced bool) {
+	branchName := branch.GetName()
+
+	if err != nil {
+		// Treat errors as conflicts - warn and continue
+		summary.ConflictBranches = append(summary.ConflictBranches, branchName)
+		handler.EmitEvent(Event{
+			Phase:    PhaseBranches,
+			Type:     EventSkipped,
+			Branch:   branchName,
+			Conflict: true,
+			Message:  err.Error(),
+		})
+		return false
+	}
+
+	switch result {
+	case engine.PullDone:
+		// Get the new revision (GetRevision reads live git, so it reflects the
+		// just-applied fast-forward without an engine rebuild).
+		rev, _ := branch.GetRevision()
+		revShort := rev
+		if len(rev) > 7 {
+			revShort = rev[:7]
+		}
+		handler.EmitEvent(Event{
+			Phase:       PhaseBranches,
+			Type:        EventCompleted,
+			Branch:      branchName,
+			NewRevision: revShort,
+		})
+		return true
+
+	case engine.PullUnneeded:
+		// Already up to date (shouldn't happen since we checked Behind(), but handle it)
+		handler.EmitEvent(Event{
+			Phase:  PhaseBranches,
+			Type:   EventCompleted,
+			Branch: branchName,
+		})
+		return false
+
+	case engine.PullConflict:
+		// Branches have diverged
+		summary.ConflictBranches = append(summary.ConflictBranches, branchName)
+		handler.EmitEvent(Event{
+			Phase:    PhaseBranches,
+			Type:     EventSkipped,
+			Branch:   branchName,
+			Conflict: true,
+		})
+		return false
+	}
+
+	return false
 }

--- a/internal/actions/sync/branch_sync_test.go
+++ b/internal/actions/sync/branch_sync_test.go
@@ -1,0 +1,116 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// setupBehindBranch pushes branch to origin, adds one more commit, pushes that,
+// then resets the local branch one commit back. The local branch is left BEHIND
+// its remote by exactly one (fast-forwardable) commit. Returns the origin SHA the
+// branch should fast-forward to. The branch must already exist and be checked
+// out-able.
+func setupBehindBranch(t *testing.T, s *scenario.Scenario, branch string) string {
+	t.Helper()
+	s.Checkout(branch)
+	require.NoError(t, s.Scene.Repo.PushBranch("origin", branch))
+	s.CommitChange(branch+"-advance", "advance "+branch)
+	want, err := s.Scene.Repo.GetRevision(branch)
+	require.NoError(t, err)
+	require.NoError(t, s.Scene.Repo.PushBranch("origin", branch))
+	require.NoError(t, s.Scene.Repo.RunGitCommand("reset", "--hard", "HEAD~1"))
+	return want
+}
+
+// TestSyncStackBranchesBatchFastForward verifies that several branches that are
+// behind their remote are all fast-forwarded by syncStackBranches using a single
+// batched fetch (the per-branch fetch N+1 was removed).
+func TestSyncStackBranchesBatchFastForward(t *testing.T) {
+	s := scenario.NewRemoteScenario(t)
+
+	// Linear stack: main -> a -> b -> c, each tracked.
+	s.CreateBranch("a").CommitChange("a-1", "a one").TrackBranch("a", "main")
+	s.CreateBranch("b").CommitChange("b-1", "b one").TrackBranch("b", "a")
+	s.CreateBranch("c").CommitChange("c-1", "c one").TrackBranch("c", "b")
+
+	// Make each branch one commit behind its remote.
+	want := map[string]string{
+		"a": setupBehindBranch(t, s, "a"),
+		"b": setupBehindBranch(t, s, "b"),
+		"c": setupBehindBranch(t, s, "c"),
+	}
+
+	// Move off the stack so the fast-forwards are pure ref updates.
+	s.Checkout("main")
+
+	summary := &Summary{}
+	require.NoError(t, syncStackBranches(s.Context, nil, &NullHandler{}, summary))
+
+	require.Equal(t, 3, summary.BranchesSynced, "all three behind branches should be synced")
+	require.Empty(t, summary.ConflictBranches, "no branch should conflict")
+
+	for branch, wantSha := range want {
+		got, err := s.Scene.Repo.GetRevision(branch)
+		require.NoError(t, err)
+		require.Equal(t, wantSha, got, "branch %s should be fast-forwarded to its remote tip", branch)
+	}
+}
+
+// TestSyncStackBranchesSkipsDiverged verifies that a branch that has diverged
+// from its remote (both sides have unique commits) is left untouched: it fails
+// the Behind() gate, so it is neither fast-forwarded nor reported as a conflict.
+func TestSyncStackBranchesSkipsDiverged(t *testing.T) {
+	s := scenario.NewRemoteScenario(t)
+
+	s.CreateBranch("d").CommitChange("d-1", "d one").TrackBranch("d", "main")
+	s.Checkout("d")
+	require.NoError(t, s.Scene.Repo.PushBranch("origin", "d"))
+
+	// Remote advances with one commit...
+	s.CommitChange("d-remote", "remote change")
+	require.NoError(t, s.Scene.Repo.PushBranch("origin", "d"))
+	require.NoError(t, s.Scene.Repo.RunGitCommand("reset", "--hard", "HEAD~1"))
+
+	// ...and local advances with a different commit -> diverged.
+	s.CommitChange("d-local", "local change")
+	localSha, err := s.Scene.Repo.GetRevision("d")
+	require.NoError(t, err)
+	s.Rebuild()
+
+	summary := &Summary{}
+	require.NoError(t, syncStackBranches(s.Context, nil, &NullHandler{}, summary))
+
+	require.Equal(t, 0, summary.BranchesSynced, "diverged branch should not be synced")
+	require.NotContains(t, summary.ConflictBranches, "d", "diverged branch is skipped, not flagged as conflict")
+
+	got, err := s.Scene.Repo.GetRevision("d")
+	require.NoError(t, err)
+	require.Equal(t, localSha, got, "diverged branch should be left untouched")
+}
+
+// TestSyncActionFastForwardsBehindBranches verifies the full sync.Action
+// pipeline fast-forwards behind branches end-to-end. Uses independent branches
+// off main so no restack is triggered, isolating the branch-sync behavior.
+func TestSyncActionFastForwardsBehindBranches(t *testing.T) {
+	s := scenario.NewRemoteScenario(t)
+
+	want := map[string]string{}
+	for _, name := range []string{"x", "y", "z"} {
+		s.Checkout("main")
+		s.CreateBranch(name).CommitChange(name+"-1", name+" one").TrackBranch(name, "main")
+		want[name] = setupBehindBranch(t, s, name)
+	}
+
+	s.Checkout("main")
+
+	require.NoError(t, Action(s.Context, Options{}, nil))
+
+	for branch, wantSha := range want {
+		got, err := s.Scene.Repo.GetRevision(branch)
+		require.NoError(t, err)
+		require.Equal(t, wantSha, got, "branch %s should be fast-forwarded by sync.Action", branch)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -43,6 +43,7 @@ type SyncManager interface {
 	PullTrunk(ctx context.Context) (PullResult, error)
 	PullBranch(ctx context.Context, remote, branchName string) (PullResult, error)
 	UpdateTrunkFromRemote(ctx context.Context) (PullResult, error)
+	UpdateBranchFromRemote(ctx context.Context, remote, branchName string) (PullResult, error)
 	ResetTrunkToRemote(ctx context.Context) error
 	PlanRestack(ctx context.Context, branches Branches) (*RestackPlan, error)
 	RestackBranches(ctx context.Context, branches Branches) (RestackBatchResult, error)

--- a/internal/engine/pull.go
+++ b/internal/engine/pull.go
@@ -37,6 +37,20 @@ func (e *engineImpl) UpdateTrunkFromRemote(ctx context.Context) (PullResult, err
 	return e.finishTrunkPull(gitResult)
 }
 
+// UpdateBranchFromRemote fast-forwards a single branch from its already-fetched
+// remote-tracking ref. Unlike PullBranch it performs no network fetch — callers
+// batch the fetch via FetchRemote first, then call this per branch. Like
+// PullBranch it does not rebuild engine state, so it is safe to call in a loop;
+// callers should rebuild once after the batch if downstream reads need the
+// refreshed revisions.
+func (e *engineImpl) UpdateBranchFromRemote(ctx context.Context, remote, branchName string) (PullResult, error) {
+	gitResult, err := e.git.UpdateBranchFromRemote(ctx, remote, branchName)
+	if err != nil {
+		return PullConflict, err
+	}
+	return pullResultFromGit(gitResult), nil
+}
+
 // PullBranch fast-forwards a single branch from its remote counterpart. Unlike
 // PullTrunk it does not rebuild engine state, so it is safe to call in a loop;
 // callers should rebuild once after the batch if downstream reads need the


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

syncStackBranches pulled each behind branch one at a time, and each
eng.PullBranch ran its own single-branch `git fetch` before the local
fast-forward — N behind branches meant N sequential network round trips.

Collect the behind branches first, fetch them all in one FetchRemote, then
apply the fast-forward locally per branch via the new
engine.UpdateBranchFromRemote (no network). Fall back to the per-branch
PullBranch if the batched fetch fails, preserving sync's warn-and-continue
behavior. Event emission and skip rules are unchanged.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781374494`.


* **PR #1206** 👈
  * **PR #1207**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1215 by jonnii*