### PR TITLE
perf(sync): prefetch remote branch statuses in Phase 1 parallel block

### DIFF
--- a/internal/actions/sync/branch_sync.go
+++ b/internal/actions/sync/branch_sync.go
@@ -12,7 +12,7 @@ import (
 // It skips branches that are trunk, locked, frozen, or in a dirty stack.
 // This allows the sync command to fast-forward branches when someone else pushes
 // commits to a stack branch from another machine.
-func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, handler Handler, summary *Summary) error {
+func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, remoteStatuses engine.BranchRemoteStatuses, handler Handler, summary *Summary) error {
 	eng := ctx.Engine
 	nav := ctx.Navigator()
 	gctx := ctx.Context
@@ -23,7 +23,12 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, handler H
 
 	// Get all tracked branches
 	allBranches := nav.AllBranches()
-	remoteStatuses := eng.ReadBranchRemoteStatuses(gctx, allBranches)
+	// Remote statuses are normally prefetched in sync's parallel phase so the
+	// ls-remote overlaps the trunk fetch and GitHub call. Fall back to computing
+	// them here when the caller didn't supply them.
+	if remoteStatuses == nil {
+		remoteStatuses = eng.ReadBranchRemoteStatuses(gctx, allBranches)
+	}
 
 	syncStart := time.Now()
 	var statusCheckTotalMs int64

--- a/internal/actions/sync/branch_sync_test.go
+++ b/internal/actions/sync/branch_sync_test.go
@@ -47,7 +47,8 @@ func TestSyncStackBranchesBatchFastForward(t *testing.T) {
 	s.Checkout("main")
 
 	summary := &Summary{}
-	require.NoError(t, syncStackBranches(s.Context, nil, &NullHandler{}, summary))
+	// Pass nil statuses to exercise the on-demand fallback path.
+	require.NoError(t, syncStackBranches(s.Context, nil, nil, &NullHandler{}, summary))
 
 	require.Equal(t, 3, summary.BranchesSynced, "all three behind branches should be synced")
 	require.Empty(t, summary.ConflictBranches, "no branch should conflict")
@@ -81,7 +82,8 @@ func TestSyncStackBranchesSkipsDiverged(t *testing.T) {
 	s.Rebuild()
 
 	summary := &Summary{}
-	require.NoError(t, syncStackBranches(s.Context, nil, &NullHandler{}, summary))
+	// Pass nil statuses to exercise the on-demand fallback path.
+	require.NoError(t, syncStackBranches(s.Context, nil, nil, &NullHandler{}, summary))
 
 	require.Equal(t, 0, summary.BranchesSynced, "diverged branch should not be synced")
 	require.NotContains(t, summary.ConflictBranches, "d", "diverged branch is skipped, not flagged as conflict")

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -98,6 +98,12 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	var trunkFetchErr error
 	var trunkErr error
 	var githubErr error
+	var remoteStatuses engine.BranchRemoteStatuses
+
+	// Snapshot the branch set for the remote-status probe below. The set is
+	// stable through the parallel phase (no branches are created or deleted
+	// until later), so reading it once here is safe.
+	branchesForStatus := ctx.Navigator().AllBranches()
 
 	parallelStart := time.Now()
 	ctx.Logger.Info("starting parallel phase")
@@ -138,6 +144,17 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		var err error
 		githubSyncResult, err = syncGitHubPRInfo(ctx)
 		githubErr = err
+		return nil
+	})
+
+	// Goroutine 3: Probe remote branch statuses (a single ls-remote) so this
+	// network round trip overlaps the trunk fetch and GitHub call instead of
+	// running serially later in syncStackBranches.
+	g.Go(func() error {
+		ctx.Logger.Info("goroutine remote statuses started delayMs=%v", time.Since(parallelStart).Milliseconds())
+		statusStart := time.Now()
+		remoteStatuses = eng.ReadBranchRemoteStatuses(gctx, branchesForStatus)
+		ctx.Logger.Info("prefetch remote branch statuses completed durationMs=%v branchCount=%v", time.Since(statusStart).Milliseconds(), len(remoteStatuses))
 		return nil
 	})
 
@@ -188,7 +205,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	// Phase 2.5: Sync stack branches from remote
-	if err := syncStackBranches(ctx, dirtyAnchors, handler, summary); err != nil {
+	if err := syncStackBranches(ctx, dirtyAnchors, remoteStatuses, handler, summary); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

syncStackBranches computed branch remote statuses via a serial ls-remote
that ran after sync's parallel phase, adding a network round trip to every
sync. Move the probe into the existing errgroup as a third goroutine so it
overlaps the trunk fetch and the GitHub PR-info call, then thread the result
into syncStackBranches (which keeps an on-demand fallback when not supplied).

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781374494`.


* **PR #1206**
  * **PR #1207** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1215 by jonnii*