### PR TITLE
perf(test): parallelize fold/move/pluck action subtests

### DIFF
--- a/internal/actions/fold/fold_test.go
+++ b/internal/actions/fold/fold_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestFoldAction(t *testing.T) {
+	t.Parallel()
 	t.Run("folds branch into parent", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -46,6 +48,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("reparents children when folding branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -73,6 +76,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("folds with --keep flag", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -110,6 +114,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("folds with --keep and reparents siblings", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -143,6 +148,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when trying to fold trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Try to fold trunk (main)
@@ -152,6 +158,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when trying to fold untracked branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			CreateBranch("untracked")
 
@@ -162,6 +169,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when trying to fold into trunk with --keep", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -174,6 +182,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when there are uncommitted changes", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -187,6 +196,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("returns clear error message on merge conflict", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, nil)
 
 		// Create conflicting changes manually
@@ -216,6 +226,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("restacks descendants after folding", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -251,6 +262,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("folding middle branch preserves all commits when folded branch has multiple commits", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -296,6 +308,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("folding middle branch moves no-op descendants to new parent tip", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Build main -> branch1 -> branch2 -> branch3, and create branch4 from branch3 with no unique commits.
@@ -335,6 +348,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("folding middle branch preserves folded commits for descendants that diverged earlier", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Build main -> branch1 -> branch2 -> branch3.
@@ -371,6 +385,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when rebase is in progress", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -390,6 +405,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("folds branch with no unique commits", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -409,6 +425,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("takes snapshot before folding", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -427,6 +444,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("takes snapshot with --keep flag", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -446,6 +464,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when folding into trunk without --allow-trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -458,6 +477,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("folds bottom branch into trunk with --allow-trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -481,6 +501,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when folding branches with different scopes", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -505,6 +526,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when current branch is locked", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -522,6 +544,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when parent branch is locked", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -539,6 +562,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when branch is frozen", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -556,6 +580,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("dry-run does not modify repository", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -584,6 +609,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("dry-run fails if branch is locked", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",

--- a/internal/actions/move/move_test.go
+++ b/internal/actions/move/move_test.go
@@ -45,7 +45,9 @@ func writeAndCommit(t *testing.T, s *scenario.Scenario, file, content, message s
 }
 
 func TestMoveAction(t *testing.T) {
+	t.Parallel()
 	t.Run("moves branch downstack and restacks descendants", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -89,6 +91,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("moves branch upstack and restacks descendants", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branchA":  "main",
@@ -122,6 +125,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("moves branch across different stack trees", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branchA1": "main",
@@ -150,6 +154,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("defaults source to current branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -174,6 +179,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("prevents moving trunk branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		err := Action(s.Context, Options{
@@ -185,6 +191,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("prevents moving onto itself", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -199,6 +206,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("prevents moving onto descendant (cycle detection)", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -217,6 +225,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("fails when source branch is not tracked", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			CreateBranch("untracked").
 			Checkout("main")
@@ -230,6 +239,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("fails when onto branch does not exist", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -244,6 +254,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("fails when not on branch and no source specified", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Detach HEAD
@@ -263,6 +274,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("allows moving onto untracked branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -285,6 +297,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("restacks all descendants after move", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -325,6 +338,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("fails when onto is not specified", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -339,6 +353,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("moves branch downstack without pulling along intermediate commits", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a clean stack: main -> branch1 -> branch2
@@ -372,6 +387,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("preserves PR information after move", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -402,6 +418,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("moves branch after it has been amended", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -426,6 +443,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("moves branch across stacks without pulling old parent's commits", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Stack 1: main -> branchA1 -> branchA2
@@ -462,6 +480,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("moving middle branch to trunk does not affect downstack branches", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a linear stack: main -> A -> B -> C
@@ -511,6 +530,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("interactive cancel does not move", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -532,6 +552,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("interactive proceed on conflict enters conflict workflow", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).WithInitialCommit()
 
 		// Restack invokes git commit without stripping global config, so any

--- a/internal/actions/pluck/pluck_test.go
+++ b/internal/actions/pluck/pluck_test.go
@@ -105,7 +105,9 @@ func TestPluckStackID(t *testing.T) {
 }
 
 func TestPluckAction(t *testing.T) {
+	t.Parallel()
 	t.Run("plucks branch to new parent and reparents children to grandparent", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -135,6 +137,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("plucks branch with no children", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -162,6 +165,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("plucks branch with multiple children", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -207,6 +211,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("defaults source to current branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -231,6 +236,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("prevents plucking trunk branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		err := Action(s.Context, Options{
@@ -242,6 +248,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("prevents plucking onto itself", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -256,6 +263,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("prevents plucking onto descendant (cycle detection)", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -274,6 +282,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("fails when source branch is not tracked", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			CreateBranch("untracked").
 			Checkout("main")
@@ -287,6 +296,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("fails when onto branch does not exist", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -301,6 +311,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("fails when onto is not specified", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -315,6 +326,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("fails when not on branch and no source specified", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Detach HEAD
@@ -332,6 +344,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("restacks all affected branches after pluck", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -356,6 +369,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("preserves commits on plucked branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create branch1 with a commit
@@ -381,6 +395,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("preserves PR information after pluck", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -411,6 +426,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("pluck differs from move by not bringing descendants", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -443,6 +459,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("allows plucking onto untracked branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -465,6 +482,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("plucks from middle of stack correctly", func(t *testing.T) {
+		t.Parallel()
 		// main -> A -> B -> C -> D
 		// Pluck B to main
 		// Result: B is on main, C is on A (not B!)


### PR DESCRIPTION

These three action-test functions ran 25/23/21 subtests serially despite scenario.NewScenario already being parallel-safe (it uses NewSceneParallel — fully isolated temp dirs, engine bound to scene.Dir, no os.Chdir). Adding t.Parallel() to each subtest and parent cuts their combined wall time from ~113s (37+40+36) to ~10s. Race-clean; coverage-guard confirms all 1885 covered blocks preserved (identical 18.6%). Found via the /optimize-tests skill.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1209** 👈
  * **PR #1210**
    * **PR #1211**
      * **PR #1212**
        * **PR #1213**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->