### PR TITLE
perf(test): parallelize sync action subtests

### DIFF
--- a/internal/actions/sync/metadata_cleanup_test.go
+++ b/internal/actions/sync/metadata_cleanup_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestMetadataCleanup(t *testing.T) {
+	t.Parallel()
 	t.Run("silently cleans up metadata for deleted local branches", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// 1. Create a branch and metadata
@@ -50,6 +52,7 @@ func TestMetadataCleanup(t *testing.T) {
 	})
 
 	t.Run("does not prompt for remote metadata on non-existent branches", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// 1. Simulate remote metadata for a branch that doesn't exist locally

--- a/internal/actions/sync/sync_test.go
+++ b/internal/actions/sync/sync_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestSyncAction(t *testing.T) {
+	t.Parallel()
 	t.Run("syncs when trunk is up to date", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t)
 
 		err := Action(s.Context, Options{
@@ -26,6 +28,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("fails when required trunk fetch fails", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		err := Action(s.Context, Options{}, nil)
@@ -37,6 +40,7 @@ func TestSyncAction(t *testing.T) {
 	// before TUI initialization. Tested in internal/cli/stack/sync_test.go.
 
 	t.Run("syncs with restack flag", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -52,6 +56,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("restacks branches in topological order (parents before children)", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -69,6 +74,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("restacks branching stacks in topological order", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"stackA":        "main",
@@ -97,6 +103,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("restacks multiple deep subtrees correctly", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"P":   "main",
@@ -128,6 +135,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("partial success in branching restack (one child succeeds, one fails)", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t)
 
 		// Create: main -> P -> [0-Success, 1-Failure]
@@ -177,6 +185,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("sync mode aborts unexpected runtime restack conflict and restores branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"branch1": "main",

--- a/internal/actions/sync/worktree_cleanup_test.go
+++ b/internal/actions/sync/worktree_cleanup_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestSyncCleansOrphanedWorktrees(t *testing.T) {
+	t.Parallel()
 	t.Run("cleans worktree when stack root branch is deleted", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t)
 
 		// Create a branch that will become a stack root
@@ -46,6 +48,7 @@ func TestSyncCleansOrphanedWorktrees(t *testing.T) {
 	})
 
 	t.Run("preserves worktree when stack root branch still exists", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t)
 
 		// Create and track a branch
@@ -69,6 +72,7 @@ func TestSyncCleansOrphanedWorktrees(t *testing.T) {
 	})
 
 	t.Run("preserves registration when worktree removal fails", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t)
 
 		worktreePath := filepath.Join(t.TempDir(), "not-a-git-worktree")


### PR DESCRIPTION

sync_test/metadata_cleanup_test/worktree_cleanup_test ran their subtests serially though each creates its own parallel-safe scenario (NewScenario/NewRemoteScenario). Adding t.Parallel() drops the sync package from ~48s to ~6s. Deliberately EXCLUDES sync_diamond_test.go, which calls t.Setenv(GITHUB_TOKEN) — incompatible with t.Parallel (process-global env leak). Race-clean; coverage-guard preserved all 1903 blocks (19.1%).

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1209**
  * **PR #1210** 👈
    * **PR #1211**
      * **PR #1212**
        * **PR #1213**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->