### PR TITLE
perf(test): parallelize 10 action subpackages' scenario tests

### DIFF
--- a/internal/actions/absorb/absorb_test.go
+++ b/internal/actions/absorb/absorb_test.go
@@ -15,7 +15,9 @@ import (
 )
 
 func TestAbsorbScopeBoundaries(t *testing.T) {
+	t.Parallel()
 	t.Run("absorb stops at scope boundaries", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"scoped-a":   "main",
@@ -91,6 +93,7 @@ func TestAbsorbScopeBoundaries(t *testing.T) {
 	})
 
 	t.Run("absorb includes all branches when no scope set", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch-a": "main",
@@ -133,6 +136,7 @@ func TestAbsorbScopeBoundaries(t *testing.T) {
 	})
 
 	t.Run("absorb stops at first scope boundary encountered", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"scoped-a":    "main",
@@ -188,7 +192,9 @@ func TestAbsorbScopeBoundaries(t *testing.T) {
 }
 
 func TestAbsorbWithInterveningCommits(t *testing.T) {
+	t.Parallel()
 	t.Run("absorb handles changes when intervening commits modify same file", func(t *testing.T) {
+		t.Parallel()
 		// This test verifies that absorb can apply changes to an earlier commit
 		// even when later commits have modified the same file, using three-way merge.
 		// The key is having enough separation between sections so commutation check
@@ -415,6 +421,7 @@ func sectionB() {
 	})
 
 	t.Run("absorb cleans up on failure and restores original branch", func(t *testing.T) {
+		t.Parallel()
 		// This test verifies that when absorb fails, it cleans up properly
 		// and returns the user to their original branch without leaving
 		// the repository in a detached HEAD or unmerged state.
@@ -484,6 +491,7 @@ func example() {
 	})
 
 	t.Run("absorb with three-way merge when context lines differ", func(t *testing.T) {
+		t.Parallel()
 		// This test specifically verifies the --3way merge functionality:
 		// We create a scenario where the patch context doesn't match exactly
 		// because an intervening commit has modified lines far away in the same file.
@@ -704,7 +712,9 @@ func DefaultConfig() *Config {
 }
 
 func TestAbsorbConflictHandling(t *testing.T) {
+	t.Parallel()
 	t.Run("IsAbsorbInProgress returns false in normal state", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a branch with a commit
@@ -721,6 +731,7 @@ func TestAbsorbConflictHandling(t *testing.T) {
 	})
 
 	t.Run("IsAbsorbInProgress returns true in detached HEAD state", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a branch with a commit
@@ -740,6 +751,7 @@ func TestAbsorbConflictHandling(t *testing.T) {
 	})
 
 	t.Run("ShowConflict displays staged changes info", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a branch with a commit
@@ -762,6 +774,7 @@ func TestAbsorbConflictHandling(t *testing.T) {
 	})
 
 	t.Run("ShowConflict handles no staged changes", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a branch with a commit but no staged changes
@@ -779,6 +792,7 @@ func TestAbsorbConflictHandling(t *testing.T) {
 	})
 
 	t.Run("Abort handles normal state", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a branch with a commit
@@ -796,6 +810,7 @@ func TestAbsorbConflictHandling(t *testing.T) {
 	})
 
 	t.Run("Abort recovers from detached HEAD state", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a branch with a commit

--- a/internal/actions/absorb/plan_test.go
+++ b/internal/actions/absorb/plan_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestGeneratePlanJSON(t *testing.T) {
+	t.Parallel()
 	t.Run("generates valid JSON with absorbed and unabsorbable hunks", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch-a": "main",
@@ -112,6 +114,7 @@ func TestGeneratePlanJSON(t *testing.T) {
 	})
 
 	t.Run("handles empty inputs", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch-a": "main",
@@ -141,6 +144,7 @@ func TestGeneratePlanJSON(t *testing.T) {
 }
 
 func TestFormatLines(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		start    int
 		count    int

--- a/internal/actions/create/create_test.go
+++ b/internal/actions/create/create_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestCreateAction_Stdin(t *testing.T) {
+	// NOT parallel: this test swaps the process-global os.Stdin for a pipe. Under
+	// t.Parallel(), a concurrent test's git subprocess inherits that pipe as stdin
+	// and blocks forever (same global-state hazard class as t.Setenv).
 	t.Run("reads commit message from stdin in non-interactive mode", func(t *testing.T) {
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
@@ -50,7 +53,9 @@ func TestCreateAction_Stdin(t *testing.T) {
 }
 
 func TestCreateAction_Insert(t *testing.T) {
+	t.Parallel()
 	t.Run("inserts branch between parent and children", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -97,6 +102,7 @@ func TestCreateAction_Insert(t *testing.T) {
 	})
 
 	t.Run("inserts branch in the middle of a stack", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -147,6 +153,7 @@ func TestCreateAction_Insert(t *testing.T) {
 	})
 
 	t.Run("inserts branch into a branching stack (multiple children)", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -205,6 +212,7 @@ func TestCreateAction_Insert(t *testing.T) {
 	})
 
 	t.Run("restores original branch after insert", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -236,7 +244,9 @@ func TestCreateAction_Insert(t *testing.T) {
 }
 
 func TestCreateAction_Insert_Deep(t *testing.T) {
+	t.Parallel()
 	t.Run("restacks descendants deep into the stack", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -286,7 +296,9 @@ func TestCreateAction_Insert_Deep(t *testing.T) {
 }
 
 func TestCreateAction_Worktree(t *testing.T) {
+	t.Parallel()
 	t.Run("creates worktree when -w flag is used from trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -329,6 +341,7 @@ func TestCreateAction_Worktree(t *testing.T) {
 	})
 
 	t.Run("fails with -w flag when not on trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 

--- a/internal/actions/delete/delete_test.go
+++ b/internal/actions/delete/delete_test.go
@@ -12,7 +12,9 @@ import (
 )
 
 func TestDelete(t *testing.T) {
+	t.Parallel()
 	t.Run("deletes a single branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, nil).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -35,6 +37,7 @@ func TestDelete(t *testing.T) {
 	})
 
 	t.Run("deletes upstack", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, nil).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -56,6 +59,7 @@ func TestDelete(t *testing.T) {
 	})
 
 	t.Run("deletes downstack", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, nil).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -77,6 +81,7 @@ func TestDelete(t *testing.T) {
 	})
 
 	t.Run("fails without force if not merged", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, nil).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -95,6 +100,7 @@ func TestDelete(t *testing.T) {
 	})
 
 	t.Run("deletes current branch and switches to trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, nil).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -117,6 +123,7 @@ func TestDelete(t *testing.T) {
 	})
 
 	t.Run("deletes a branch in a branching stack", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, nil).
 			WithStack(map[string]string{
 				"parent": "main",
@@ -147,6 +154,7 @@ func TestDelete(t *testing.T) {
 	})
 
 	t.Run("preserves child commit boundaries when deleting squash-merged parent", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		s.CreateBranch("branch1").
@@ -185,7 +193,9 @@ func TestDelete(t *testing.T) {
 }
 
 func TestDeleteCleansUpWorktrees(t *testing.T) {
+	t.Parallel()
 	t.Run("cleans worktree when stack root is deleted", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a stack root branch
@@ -216,6 +226,7 @@ func TestDeleteCleansUpWorktrees(t *testing.T) {
 	})
 
 	t.Run("does not clean worktree when non-root branch is deleted", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a stack with two branches
@@ -248,6 +259,7 @@ func TestDeleteCleansUpWorktrees(t *testing.T) {
 	})
 
 	t.Run("cleans worktree when upstack deletes entire stack including root", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a stack with multiple branches

--- a/internal/actions/flatten/flatten_test.go
+++ b/internal/actions/flatten/flatten_test.go
@@ -19,7 +19,9 @@ func writeFile(t *testing.T, s *scenario.Scenario, name, content string) {
 }
 
 func TestFlattenAction(t *testing.T) {
+	t.Parallel()
 	t.Run("flattens linear independent stack to trunk", func(t *testing.T) {
+		t.Parallel()
 		// main -> A -> B -> C
 		// WithStack creates independent changes (separate files)
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
@@ -44,6 +46,7 @@ func TestFlattenAction(t *testing.T) {
 	})
 
 	t.Run("respects dependencies", func(t *testing.T) {
+		t.Parallel()
 		// main -> A -> B
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
@@ -74,6 +77,7 @@ func TestFlattenAction(t *testing.T) {
 	})
 
 	t.Run("partial flatten", func(t *testing.T) {
+		t.Parallel()
 		// main -> A -> B -> C
 		// A independent
 		// B depends on A
@@ -119,6 +123,7 @@ func TestFlattenAction(t *testing.T) {
 	})
 
 	t.Run("handles already flat stack", func(t *testing.T) {
+		t.Parallel()
 		// main -> A, main -> B (already flat)
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
@@ -140,6 +145,7 @@ func TestFlattenAction(t *testing.T) {
 	})
 
 	t.Run("uses current branch when none specified", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"A": "main",
@@ -163,6 +169,7 @@ func TestFlattenAction(t *testing.T) {
 	})
 
 	t.Run("returns error for untracked branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create an untracked branch
@@ -175,6 +182,7 @@ func TestFlattenAction(t *testing.T) {
 	})
 
 	t.Run("excludes move when descendant would conflict", func(t *testing.T) {
+		t.Parallel()
 		// This test verifies that flatten correctly validates descendant branches
 		// in a CHAINED manner and excludes moves that would cause conflicts.
 		//
@@ -239,6 +247,7 @@ func TestFlattenAction(t *testing.T) {
 	})
 
 	t.Run("fallback to parent revision when metadata missing", func(t *testing.T) {
+		t.Parallel()
 		// This test verifies the fix for the bug where getOldUpstream() was using
 		// GetMergeBase as a fallback, which could include parent commits when
 		// flattening. The fix uses the parent's current revision instead.

--- a/internal/actions/lock/lock_test.go
+++ b/internal/actions/lock/lock_test.go
@@ -43,7 +43,9 @@ func (h *testLockHandler) Cleanup()                         {}
 func (h *testLockHandler) IsInteractive() bool              { return h.isInteractive }
 
 func TestLockUnlockAction(t *testing.T) {
+	t.Parallel()
 	t.Run("LockAction locks branch and ancestors", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature-a").
@@ -63,6 +65,7 @@ func TestLockUnlockAction(t *testing.T) {
 	})
 
 	t.Run("LockAction indicates already locked branches", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature-a").
@@ -85,6 +88,7 @@ func TestLockUnlockAction(t *testing.T) {
 	})
 
 	t.Run("UnlockAction unlocks branch and descendants", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature-a").
@@ -108,6 +112,7 @@ func TestLockUnlockAction(t *testing.T) {
 	})
 
 	t.Run("UnlockAction indicates already unlocked branches", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature-a").
@@ -128,6 +133,7 @@ func TestLockUnlockAction(t *testing.T) {
 	})
 
 	t.Run("LockAction fails on untracked branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranchQuiet("untracked")
@@ -138,6 +144,7 @@ func TestLockUnlockAction(t *testing.T) {
 	})
 
 	t.Run("LockAction fails on trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -147,6 +154,7 @@ func TestLockUnlockAction(t *testing.T) {
 	})
 
 	t.Run("LockAction with unpushed commits in non-interactive mode", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature-a").
@@ -176,6 +184,7 @@ func TestLockUnlockAction(t *testing.T) {
 	})
 
 	t.Run("LockAction prompts for new branch not on remote", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("new-feature").
@@ -199,6 +208,7 @@ func TestLockUnlockAction(t *testing.T) {
 	})
 
 	t.Run("UnlockAction prompts for downstack and unlocks it if confirmed", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature-a").
@@ -232,6 +242,7 @@ func TestLockUnlockAction(t *testing.T) {
 	})
 
 	t.Run("UnlockAction prompts for downstack and does not unlock it if declined", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature-a").

--- a/internal/actions/scope/scope_test.go
+++ b/internal/actions/scope/scope_test.go
@@ -32,7 +32,9 @@ func (h *testScopeHandler) Cleanup() {}
 func (h *testScopeHandler) IsInteractive() bool { return h.isInteractive }
 
 func TestScopeAction(t *testing.T) {
+	t.Parallel()
 	t.Run("show scope when no args provided", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -46,6 +48,7 @@ func TestScopeAction(t *testing.T) {
 	})
 
 	t.Run("set scope on branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -62,6 +65,7 @@ func TestScopeAction(t *testing.T) {
 	})
 
 	t.Run("unset scope on branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -82,6 +86,7 @@ func TestScopeAction(t *testing.T) {
 	})
 
 	t.Run("cannot set scope on trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -93,6 +98,7 @@ func TestScopeAction(t *testing.T) {
 	})
 
 	t.Run("PromptConfirmRename is called when scope changes and branch name contains old scope", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("JIRA-100-feature").
@@ -120,6 +126,7 @@ func TestScopeAction(t *testing.T) {
 	})
 
 	t.Run("PromptConfirmRename is not called when branch name does not contain old scope", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -145,6 +152,7 @@ func TestScopeAction(t *testing.T) {
 	})
 
 	t.Run("non-interactive handler does not rename branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("JIRA-100-feature").

--- a/internal/actions/submit/submit_metadata_fetch_test.go
+++ b/internal/actions/submit/submit_metadata_fetch_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestPreparePRMetadata_FetchFromGitHub(t *testing.T) {
+	t.Parallel()
 	t.Run("fetches body from GitHub when local body is empty", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		branchName := featureBranch
 		prNumber := 123
@@ -55,6 +57,7 @@ func TestPreparePRMetadata_FetchFromGitHub(t *testing.T) {
 	})
 
 	t.Run("GetPRBody uses existingBody when not empty", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		branch := s.Engine.GetBranch("main") // just need a branch object
 

--- a/internal/actions/track/track_test.go
+++ b/internal/actions/track/track_test.go
@@ -40,7 +40,9 @@ func (h *testTrackHandler) Cleanup() {}
 func (h *testTrackHandler) IsInteractive() bool { return h.isInteractive }
 
 func TestTrackAction(t *testing.T) {
+	t.Parallel()
 	t.Run("track with --parent flag validates parent exists", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranchQuiet("feature")
@@ -54,6 +56,7 @@ func TestTrackAction(t *testing.T) {
 	})
 
 	t.Run("track with --parent flag validates parent is tracked", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranchQuiet("untracked-parent").
@@ -69,6 +72,7 @@ func TestTrackAction(t *testing.T) {
 	})
 
 	t.Run("track with --force succeeds using trunk as ancestor", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranchQuiet("feature")
@@ -84,6 +88,7 @@ func TestTrackAction(t *testing.T) {
 	})
 
 	t.Run("non-interactive mode requires --parent or --force", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranchQuiet("feature")
@@ -97,6 +102,7 @@ func TestTrackAction(t *testing.T) {
 	})
 
 	t.Run("interactive mode calls PromptSelectParent when auto-detection fails", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranchQuiet("feature")
@@ -114,6 +120,7 @@ func TestTrackAction(t *testing.T) {
 	})
 
 	t.Run("interactive mode handles user cancellation (empty parent)", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranchQuiet("feature")
@@ -132,6 +139,7 @@ func TestTrackAction(t *testing.T) {
 	})
 
 	t.Run("interactive mode auto-detects parent when unambiguous", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("base").
@@ -153,6 +161,7 @@ func TestTrackAction(t *testing.T) {
 	})
 
 	t.Run("PromptTrackChild is called for untracked children", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranchQuiet("feature").

--- a/internal/actions/undo/undo_test.go
+++ b/internal/actions/undo/undo_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func TestUndoAction(t *testing.T) {
+	t.Parallel()
 	t.Run("returns error when no snapshots exist", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -20,6 +22,7 @@ func TestUndoAction(t *testing.T) {
 	})
 
 	t.Run("restores to snapshot when only one exists", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -63,6 +66,7 @@ func TestUndoAction(t *testing.T) {
 	})
 
 	t.Run("returns error for invalid snapshot ID", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -78,6 +82,7 @@ func TestUndoAction(t *testing.T) {
 	})
 
 	t.Run("restores after multiple operations", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature1").
@@ -140,7 +145,9 @@ func TestUndoAction(t *testing.T) {
 }
 
 func TestUndoAfterCreate(t *testing.T) {
+	t.Parallel()
 	t.Run("undoes branch creation", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -186,7 +193,9 @@ func TestUndoAfterCreate(t *testing.T) {
 }
 
 func TestUndoAfterMove(t *testing.T) {
+	t.Parallel()
 	t.Run("undoes branch move operation", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature1").

--- a/internal/actions/untrack/untrack_test.go
+++ b/internal/actions/untrack/untrack_test.go
@@ -32,7 +32,9 @@ func (h *testUntrackHandler) Cleanup() {}
 func (h *testUntrackHandler) IsInteractive() bool { return h.isInteractive }
 
 func TestUntrackAction(t *testing.T) {
+	t.Parallel()
 	t.Run("fails for untracked branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranchQuiet("untracked")
@@ -45,6 +47,7 @@ func TestUntrackAction(t *testing.T) {
 	})
 
 	t.Run("succeeds for branch without descendants", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -61,6 +64,7 @@ func TestUntrackAction(t *testing.T) {
 	})
 
 	t.Run("force flag bypasses confirmation for descendants", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -90,6 +94,7 @@ func TestUntrackAction(t *testing.T) {
 	})
 
 	t.Run("prompts for confirmation when descendants exist", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -117,6 +122,7 @@ func TestUntrackAction(t *testing.T) {
 	})
 
 	t.Run("cancels when user declines confirmation", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -143,6 +149,7 @@ func TestUntrackAction(t *testing.T) {
 	})
 
 	t.Run("nil handler cancels when descendants exist", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -164,6 +171,7 @@ func TestUntrackAction(t *testing.T) {
 	})
 
 	t.Run("untracks multiple descendants", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").


### PR DESCRIPTION

Adds t.Parallel() to serial-by-omission subtests across absorb, create, delete, flatten, lock, scope, track, undo, untrack and submit (metadata-fetch). Each subtest already builds its own parallel-safe scenario, so this is a pure structural speedup: ~83s -> ~14s for these packages. Race-clean across all 10.

Coverage verified safe: a single sort-comparator block (engine/stack_graph.go:125) covers nondeterministically (map-iteration-randomized sort), so the guard's single-run compare flagged it; before-coverage is a subset of the union of after-runs, confirming no real loss.
Deliberately EXCLUDED: the root internal/actions package (parallelizing it hangs/times out at 600s under -race — a latent ordering/shared-state coupling to investigate separately), sync_diamond_test.go (t.Setenv), and the merge package (mock/worktree-heavy, deferred). Found via /optimize-tests.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1209**
  * **PR #1210**
    * **PR #1211** 👈
      * **PR #1212**
        * **PR #1213**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->