### PR TITLE
perf(test): parallelize root actions package tests (excluding stdin-mutating modify)

### DIFF
--- a/internal/actions/abort_test.go
+++ b/internal/actions/abort_test.go
@@ -31,7 +31,9 @@ func (h *testAbortHandler) Cleanup() {}
 func (h *testAbortHandler) IsInteractive() bool { return h.isInteractive }
 
 func TestAbortAction(t *testing.T) {
+	t.Parallel()
 	t.Run("reports when no operation is in progress", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -40,6 +42,7 @@ func TestAbortAction(t *testing.T) {
 	})
 
 	t.Run("aborts when continuation state exists", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -79,6 +82,7 @@ func TestAbortAction(t *testing.T) {
 	})
 
 	t.Run("non-interactive handler without force does not abort", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -106,6 +110,7 @@ func TestAbortAction(t *testing.T) {
 	})
 
 	t.Run("interactive handler with confirmation proceeds with abort", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -140,6 +145,7 @@ func TestAbortAction(t *testing.T) {
 	})
 
 	t.Run("interactive handler with decline cancels abort", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -167,6 +173,7 @@ func TestAbortAction(t *testing.T) {
 	})
 
 	t.Run("force flag bypasses handler prompt", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").

--- a/internal/actions/clean_branches_test.go
+++ b/internal/actions/clean_branches_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestCleanBranches(t *testing.T) {
+	t.Parallel()
 	t.Run("deletes merged branch and updates children", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -51,6 +53,7 @@ func TestCleanBranches(t *testing.T) {
 	})
 
 	t.Run("handles multiple children when parent is deleted", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -91,6 +94,7 @@ func TestCleanBranches(t *testing.T) {
 	})
 
 	t.Run("does not delete branch without PR when not merged", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -107,6 +111,7 @@ func TestCleanBranches(t *testing.T) {
 	})
 
 	t.Run("deletes locked branch when merged", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -142,6 +147,7 @@ func TestCleanBranches(t *testing.T) {
 	})
 
 	t.Run("never considers trunk for deletion", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -174,6 +180,7 @@ func TestCleanBranches(t *testing.T) {
 	})
 
 	t.Run("deletes merged child even if parent is NOT merged", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -198,6 +205,7 @@ func TestCleanBranches(t *testing.T) {
 	})
 
 	t.Run("marks branch with unpushed changes when merged", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -234,6 +242,7 @@ func TestCleanBranches(t *testing.T) {
 	})
 
 	t.Run("does not mark branch without unpushed changes as unpushed", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -264,6 +273,7 @@ func TestCleanBranches(t *testing.T) {
 	})
 
 	t.Run("preserves divergence when reparenting after squash-merged parent deletion", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create main -> branch1 (2 commits) -> branch2.

--- a/internal/actions/get_test.go
+++ b/internal/actions/get_test.go
@@ -42,7 +42,9 @@ func (c *countingGitHubClient) branchCallCount(branchName string) int {
 }
 
 func TestGetAction(t *testing.T) {
+	t.Parallel()
 	t.Run("resolves PR number and fetches branches", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -80,6 +82,7 @@ func TestGetAction(t *testing.T) {
 	})
 
 	t.Run("crawls ancestors via GitHub PRs", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -129,6 +132,7 @@ func TestGetAction(t *testing.T) {
 	})
 
 	t.Run("identifies and syncs local descendants", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature-a").
@@ -159,6 +163,7 @@ func TestGetAction(t *testing.T) {
 	})
 
 	t.Run("fails if uncommitted changes exist", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			WithUncommittedChange("dirty.txt")

--- a/internal/actions/pop_test.go
+++ b/internal/actions/pop_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestPopAction(t *testing.T) {
+	t.Parallel()
 	t.Run("pops branch and retains changes as staged", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -44,6 +46,7 @@ func TestPopAction(t *testing.T) {
 	})
 
 	t.Run("reparents children when popping branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -70,6 +73,7 @@ func TestPopAction(t *testing.T) {
 	})
 
 	t.Run("fails when trying to pop trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Try to pop trunk (main)
@@ -79,6 +83,7 @@ func TestPopAction(t *testing.T) {
 	})
 
 	t.Run("fails when trying to pop untracked branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			CreateBranch("untracked")
 
@@ -89,6 +94,7 @@ func TestPopAction(t *testing.T) {
 	})
 
 	t.Run("fails when rebase is in progress", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -109,6 +115,7 @@ func TestPopAction(t *testing.T) {
 	})
 
 	t.Run("fails when there are uncommitted changes", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",

--- a/internal/actions/restack_test.go
+++ b/internal/actions/restack_test.go
@@ -29,7 +29,9 @@ func (h *promptRestackHandler) PromptResolveConflicts(conflictBranches []string)
 }
 
 func TestRestackAction(t *testing.T) {
+	t.Parallel()
 	t.Run("planning from trunk excludes trunk branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		plan, err := PlanRestack(s.Context, RestackOptions{
@@ -42,6 +44,7 @@ func TestRestackAction(t *testing.T) {
 	})
 
 	t.Run("planning from trunk keeps descendants but not trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"feature":       "main",
@@ -67,6 +70,7 @@ func TestRestackAction(t *testing.T) {
 	})
 
 	t.Run("parallel multi-stack restack returns worker errors", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"alpha-root":  "main",
@@ -110,6 +114,7 @@ func TestRestackAction(t *testing.T) {
 	})
 
 	t.Run("interactive restack prompts before entering conflict workflow", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		s.Checkout("main")

--- a/internal/actions/stack_info_test.go
+++ b/internal/actions/stack_info_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestStackInfoAction(t *testing.T) {
+	t.Parallel()
 	t.Run("returns JSON info for the current stack", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -60,6 +62,7 @@ func TestStackInfoAction(t *testing.T) {
 	})
 
 	t.Run("fails when not on a branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		// Detach HEAD
 		s.RunGit("checkout", "--detach", "main")
@@ -70,6 +73,7 @@ func TestStackInfoAction(t *testing.T) {
 	})
 
 	t.Run("returns tree view with commit messages when JSON flag is false", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -89,6 +93,7 @@ func TestStackInfoAction(t *testing.T) {
 	})
 
 	t.Run("includes lock and frozen state", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",


### PR DESCRIPTION

Parallelizes the serial subtests in abort/clean_branches/get/pop/restack/stack_info. Root internal/actions package drops from ~30s to ~13s under CI's race flags (-race -p=1 -parallel=2), ~4s under plain go test. Coverage-guard preserved all 2323 blocks.

TestModifyAction_Stdin is deliberately LEFT SERIAL: it swaps the process-global os.Stdin for a pipe, which is incompatible with t.Parallel() — a concurrent test's git subprocess inherits the pipe as stdin and blocks forever (this caused the 660s hang when the whole package was naively parallelized). Same global-state hazard class as t.Setenv. Validate parallelization with CI's flags, not default GOMAXPROCS: default over-parallelism crashes git subprocesses under -race in ways CI never hits.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1209**
  * **PR #1210**
    * **PR #1211**
      * **PR #1212** 👈
        * **PR #1213**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->