### PR TITLE
feat(skill): harden /optimize-tests with parallel-hazard detection and union coverage guard

### DIFF
--- a/.claude/skills/optimize-tests/SKILL.md
+++ b/.claude/skills/optimize-tests/SKILL.md
@@ -106,12 +106,62 @@ are usually the biggest wall-time win:
 - 3+ hand-rolled `CreateAndCheckoutBranch` calls → a fixture
   (`CreateLinearStack3()`, `CreateDiamondStack()`).
 
-After this batch, run the affected packages green (`mise run test:pkg ./pkg`).
-No coverage re-check is needed for Tier A.
+After this batch, **validate parallelization with the race detector using the
+flags CI actually uses** (check `.github/workflows/` — here it's
+`go test -race -p=1 -parallel=2`). Do NOT trust a default-`GOMAXPROCS` run:
+default over-parallelism crashes subprocess-heavy tests under `-race` (git child
+processes segfault) in ways CI never reproduces, AND a plain run can pass a
+genuinely broken parallel test by luck of timing. Match CI, and re-run 2-3× —
+parallel/subprocess bugs are probabilistic.
 
-> Watch for shared mutable state when adding `t.Parallel()` — package-level vars,
-> `t.Setenv`, shared temp dirs. If a test mutates global state it can't be
-> parallel as written; leave a note rather than introduce a flake.
+> **Exclude global-state mutators — they cannot be parallel.** `scan-antipatterns.sh`
+> lists these under "⚠ PARALLEL HAZARDS". A test that touches process-global state
+> must stay serial (no `t.Parallel()` on it OR its parent, so it runs in the
+> sequential phase with nothing else live):
+> - `t.Setenv` / `os.Setenv` — panics under `t.Parallel`; env is process-wide.
+> - `os.Stdin` / `os.Stdout` / `os.Stderr` swap — a concurrent test's **child
+>   process inherits the wrong pipe and blocks forever** (this is the real cause
+>   of a parallel test suite hanging for minutes; it surfaced as a 660s timeout).
+> - `os.Chdir` — races the working directory across goroutines.
+>
+> Also watch for package-level vars and shared fixtures. When in doubt, leave it
+> serial and note it — a flake costs more than the saved second.
+
+#### Parallelization playbook
+
+In practice, adding `t.Parallel()` to serial-by-omission tests is the single
+biggest win (this suite's `internal/actions/*` tests were ~5× over-serial). Work
+in safe batches:
+
+1. **Know what's already safe.** In this repo `scenario.NewScenario` /
+   `NewRemoteScenario` are ALREADY parallel-safe (they use `NewSceneParallel` —
+   isolated temp dir, engine bound to `scene.Dir`, no `os.Chdir`). So most serial
+   action tests are serial only by omission. (The raw `testhelpers.NewScene` does
+   `os.Chdir` and is NOT safe.)
+
+2. **Screen each candidate file** before editing:
+   ```bash
+   # per file: subtests, existing parallel, scenario builds, hazards
+   rg -c 't\.Run\(' f_test.go; rg -c 't\.Parallel\(\)' f_test.go
+   rg -c 'scenario\.New' f_test.go
+   rg -n 't\.Setenv|os\.Setenv|os\.Chdir|os\.Std(in|out|err)' f_test.go   # exclude if any
+   rg -n '^\ts :?= scenario\.New' f_test.go   # 1-tab = scenario SHARED across subtests → race; skip
+   ```
+   A file is a clean candidate when subtests ≈ scenario builds (each subtest makes
+   its own), `t.Parallel` count is low, and there are no hazards or shared (1-tab)
+   scenarios.
+
+3. **Transform** (idempotent — won't double-add to already-parallel subtests):
+   ```bash
+   perl -0777 -pi -e 's/^(\t+)(t\.Run\([^\n]*func\(t \*testing\.T\) \{\n)(?!\s*t\.Parallel\(\))/$1$2$1\tt.Parallel()\n/gm' f_test.go
+   perl -0777 -pi -e 's/^(func Test\w+\(t \*testing\.T\) \{\n)(?!\s*t\.Parallel\(\))/$1\tt.Parallel()\n/gm' f_test.go
+   gofmt -w f_test.go && go vet ./pkg/...
+   ```
+
+4. **Validate with the race detector under CI's flags, 2–3×** (see the warning
+   above). If a package hangs/segfaults, bisect: revert the file with the hazard,
+   keep the rest. A 660s timeout almost always means an `os.Std*`/`t.Setenv`
+   mutator slipped through the screen.
 
 ### Step 3 — Analyze hotspots for consolidation (Tier B/C)
 
@@ -159,10 +209,17 @@ bash .claude/skills/optimize-tests/scripts/coverage-guard.sh "$D/before.cover" "
 - **Fail** → the guard names the lost blocks. Revert the edit that dropped them,
   or restore the assertion that exercised them, then re-run. Loop until green.
 
-> Flaky-coverage caveat: a 1–2 block "regression" on a timing-dependent
-> integration path can be nondeterministic. Re-run `after.cover` once; if it
-> clears, it wasn't a real loss. The guard fails closed (errs toward flagging) —
-> that's the safe direction; always look before dismissing.
+> Flaky-coverage caveat: a 1–2 block "regression" can be nondeterministic — e.g.
+> a sort comparator fed by Go's randomized map iteration, which is covered only on
+> some runs. Capture a second after-run and pass BOTH to the guard; it uses the
+> union, so a block covered in either run counts:
+> ```bash
+> bash .../measure-cover.sh "$SCOPE" "$D/after2.cover"
+> bash .../coverage-guard.sh "$D/before.cover" "$D/after.cover" "$D/after2.cover"
+> ```
+> A real regression is a block covered before that NO after-run covers. The guard
+> fails closed (errs toward flagging) — that's the safe direction; always look
+> before dismissing.
 
 ### Step 6 — Re-measure and report
 

--- a/.claude/skills/optimize-tests/scripts/coverage-guard.sh
+++ b/.claude/skills/optimize-tests/scripts/coverage-guard.sh
@@ -2,38 +2,51 @@
 # Coverage-preservation guardrail — the safety net for this whole skill.
 #
 # Fails (exit 1) if any statement block that was covered in BEFORE is no longer
-# covered in AFTER. Equal coverage PERCENTAGE is not enough: two suites can share
-# a number while covering different lines. This compares the actual covered-block
-# SETS, so deleting the only test that hit a line is caught even if the percent
-# barely moves.
+# covered in ANY of the AFTER runs. Equal coverage PERCENTAGE is not enough: two
+# suites can share a number while covering different lines. This compares the
+# actual covered-block SETS, so deleting the only test that hit a line is caught
+# even if the percent barely moves.
 #
-# Usage: coverage-guard.sh <before.cover> <after.cover>
+# Usage: coverage-guard.sh <before.cover> <after.cover> [after2.cover ...]
 #
-# Only edit *_test.go files between the two runs. Coverage blocks are keyed by
-# source position; editing non-test source shifts the keys and makes the
-# comparison meaningless.
+# Pass MULTIPLE after-runs to defuse flaky coverage: a block counts as still
+# covered if ANY after-run hits it (the union). Some blocks cover
+# nondeterministically across runs — e.g. a sort comparator fed by Go's
+# randomized map iteration — and a single after-run will intermittently flag
+# them. Two or three after-runs make the guard robust; the regression set is
+# then only blocks that NO after-run covered, which is a real loss.
+#
+# Only edit *_test.go files between the runs. Coverage blocks are keyed by source
+# position; editing non-test source shifts the keys and makes the comparison
+# meaningless.
 set -euo pipefail
 
-before="${1:?usage: coverage-guard.sh <before.cover> <after.cover>}"
-after="${2:?usage: coverage-guard.sh <before.cover> <after.cover>}"
+before="${1:?usage: coverage-guard.sh <before.cover> <after.cover> [after2.cover ...]}"
+shift
+[ "$#" -ge 1 ] || { echo "usage: coverage-guard.sh <before.cover> <after.cover> [after2.cover ...]" >&2; exit 2; }
 
 covered() {
   # Block key = field 1 = "import/path/file.go:startLine.col,endLine.col".
   # Covered when the trailing hit count (last field) > 0. Skip the mode header.
-  awk 'NR>1 && $NF+0 > 0 {print $1}' "$1" | LC_ALL=C sort -u
+  awk 'NR>1 && $NF+0 > 0 {print $1}' "$@" | LC_ALL=C sort -u
 }
 
-# Lines present in BEFORE-covered but absent from AFTER-covered = regressions.
-regressions="$(comm -23 <(covered "$before") <(covered "$after") || true)"
+# Union of covered blocks across every after-run (each "$@" is one after file).
+after_union="$(covered "$@")"
+
+# Lines covered BEFORE but in NONE of the after-runs = real regressions.
+regressions="$(comm -23 <(covered "$before") <(printf '%s\n' "$after_union") || true)"
 
 if [ -n "$regressions" ]; then
   count="$(printf '%s\n' "$regressions" | grep -c . || true)"
-  echo "❌ COVERAGE REGRESSION: ${count} block(s) covered before are NOT covered after:" >&2
+  echo "❌ COVERAGE REGRESSION: ${count} block(s) covered before are NOT covered in any after-run:" >&2
   printf '%s\n' "$regressions" | head -50 >&2
   [ "$count" -gt 50 ] && echo "  … and $((count - 50)) more" >&2
   echo >&2
   echo "Revert the edit that dropped these, or restore an assertion that exercises them." >&2
+  echo "(If you passed a single after-run and the block looks nondeterministic, re-run" >&2
+  echo " coverage and pass both files: coverage-guard.sh before.cover after1.cover after2.cover)" >&2
   exit 1
 fi
 
-echo "✅ no coverage regression — $(covered "$before" | grep -c .) covered blocks preserved"
+echo "✅ no coverage regression — $(covered "$before" | grep -c .) covered blocks preserved across $# after-run(s)"

--- a/.claude/skills/optimize-tests/scripts/scan-antipatterns.sh
+++ b/.claude/skills/optimize-tests/scripts/scan-antipatterns.sh
@@ -22,6 +22,23 @@ hr "Files with 3+ manual CreateAndCheckoutBranch calls — candidates for a fixt
 rg -c '\.CreateAndCheckoutBranch\(' -g '*_test.go' \
   | awk -F: '$2>=3 {printf "  %s (%d calls)\n", $1, $2}' || echo "  none"
 
+hr "⚠ PARALLEL HAZARDS — test files that mutate process-global state"
+# These mutate state shared by the whole process, so they CANNOT be made parallel
+# (and a concurrent test inheriting that state can hang or flake). t.Setenv panics
+# under t.Parallel; os.Stdin/out/err swaps let a concurrent test's child process
+# inherit the wrong pipe and block forever; os.Chdir/os.Setenv race the cwd/env.
+# EXCLUDE these files (or just the offending func) when parallelizing — same class
+# as the t.Setenv rule. Leave them serial.
+rg -ln 't\.Setenv\(|os\.Setenv\(|os\.Chdir\(|os\.Stdin\b|os\.Stdout\b|os\.Stderr\b' -g '*_test.go' \
+  | sed 's/^/  exclude: /' || echo "  none"
+
+hr "⚠ SHARED SCENARIO — one scenario built at func level, reused across subtests"
+# A scenario declared at the function body (1-tab indent), not inside each t.Run,
+# is shared mutable state: making the subtests parallel races on it. Either give
+# each subtest its own scenario or keep the func serial. (Stackit-specific to the
+# scenario.New* helpers; adapt the pattern to your fixture constructor.)
+rg -n '^\t[a-zA-Z_]+ :?= .*scenario\.New' -g '*_test.go' | sed 's/^/  review: /' || echo "  none"
+
 hr "Serial top-level Test funcs — no .Parallel() anywhere in the body"
 # Heuristic brace-depth scan: flag func TestX(... that never calls .Parallel().
 # Advisory only (braces inside strings can fool the depth counter) — the agent


### PR DESCRIPTION

Lessons from the first real passes, baked back into the skill:
- scan-antipatterns.sh now flags PARALLEL HAZARDS (t.Setenv/os.Setenv/os.Chdir and os.Stdin/out/err) — files that mutate process-global state and must stay serial. This is what would have pre-empted the os.Stdin hang.
- coverage-guard.sh accepts multiple after-runs and compares against their union, so nondeterministically-covered blocks (e.g. a map-iteration-randomized sort comparator) stop false-alarming. SKILL.md Step 2 now mandates validating parallelization with CI's race flags, not default GOMAXPROCS.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1209**
  * **PR #1210**
    * **PR #1211**
      * **PR #1212**
        * **PR #1213** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->