### PR TITLE
perf(test): parallelize action-package tests and harden /optimize-tests skill

### DIFF
--- a/.claude/skills/optimize-tests/SKILL.md
+++ b/.claude/skills/optimize-tests/SKILL.md
@@ -106,12 +106,62 @@ are usually the biggest wall-time win:
 - 3+ hand-rolled `CreateAndCheckoutBranch` calls → a fixture
   (`CreateLinearStack3()`, `CreateDiamondStack()`).
 
-After this batch, run the affected packages green (`mise run test:pkg ./pkg`).
-No coverage re-check is needed for Tier A.
+After this batch, **validate parallelization with the race detector using the
+flags CI actually uses** (check `.github/workflows/` — here it's
+`go test -race -p=1 -parallel=2`). Do NOT trust a default-`GOMAXPROCS` run:
+default over-parallelism crashes subprocess-heavy tests under `-race` (git child
+processes segfault) in ways CI never reproduces, AND a plain run can pass a
+genuinely broken parallel test by luck of timing. Match CI, and re-run 2-3× —
+parallel/subprocess bugs are probabilistic.
 
-> Watch for shared mutable state when adding `t.Parallel()` — package-level vars,
-> `t.Setenv`, shared temp dirs. If a test mutates global state it can't be
-> parallel as written; leave a note rather than introduce a flake.
+> **Exclude global-state mutators — they cannot be parallel.** `scan-antipatterns.sh`
+> lists these under "⚠ PARALLEL HAZARDS". A test that touches process-global state
+> must stay serial (no `t.Parallel()` on it OR its parent, so it runs in the
+> sequential phase with nothing else live):
+> - `t.Setenv` / `os.Setenv` — panics under `t.Parallel`; env is process-wide.
+> - `os.Stdin` / `os.Stdout` / `os.Stderr` swap — a concurrent test's **child
+>   process inherits the wrong pipe and blocks forever** (this is the real cause
+>   of a parallel test suite hanging for minutes; it surfaced as a 660s timeout).
+> - `os.Chdir` — races the working directory across goroutines.
+>
+> Also watch for package-level vars and shared fixtures. When in doubt, leave it
+> serial and note it — a flake costs more than the saved second.
+
+#### Parallelization playbook
+
+In practice, adding `t.Parallel()` to serial-by-omission tests is the single
+biggest win (this suite's `internal/actions/*` tests were ~5× over-serial). Work
+in safe batches:
+
+1. **Know what's already safe.** In this repo `scenario.NewScenario` /
+   `NewRemoteScenario` are ALREADY parallel-safe (they use `NewSceneParallel` —
+   isolated temp dir, engine bound to `scene.Dir`, no `os.Chdir`). So most serial
+   action tests are serial only by omission. (The raw `testhelpers.NewScene` does
+   `os.Chdir` and is NOT safe.)
+
+2. **Screen each candidate file** before editing:
+   ```bash
+   # per file: subtests, existing parallel, scenario builds, hazards
+   rg -c 't\.Run\(' f_test.go; rg -c 't\.Parallel\(\)' f_test.go
+   rg -c 'scenario\.New' f_test.go
+   rg -n 't\.Setenv|os\.Setenv|os\.Chdir|os\.Std(in|out|err)' f_test.go   # exclude if any
+   rg -n '^\ts :?= scenario\.New' f_test.go   # 1-tab = scenario SHARED across subtests → race; skip
+   ```
+   A file is a clean candidate when subtests ≈ scenario builds (each subtest makes
+   its own), `t.Parallel` count is low, and there are no hazards or shared (1-tab)
+   scenarios.
+
+3. **Transform** (idempotent — won't double-add to already-parallel subtests):
+   ```bash
+   perl -0777 -pi -e 's/^(\t+)(t\.Run\([^\n]*func\(t \*testing\.T\) \{\n)(?!\s*t\.Parallel\(\))/$1$2$1\tt.Parallel()\n/gm' f_test.go
+   perl -0777 -pi -e 's/^(func Test\w+\(t \*testing\.T\) \{\n)(?!\s*t\.Parallel\(\))/$1\tt.Parallel()\n/gm' f_test.go
+   gofmt -w f_test.go && go vet ./pkg/...
+   ```
+
+4. **Validate with the race detector under CI's flags, 2–3×** (see the warning
+   above). If a package hangs/segfaults, bisect: revert the file with the hazard,
+   keep the rest. A 660s timeout almost always means an `os.Std*`/`t.Setenv`
+   mutator slipped through the screen.
 
 ### Step 3 — Analyze hotspots for consolidation (Tier B/C)
 
@@ -159,10 +209,17 @@ bash .claude/skills/optimize-tests/scripts/coverage-guard.sh "$D/before.cover" "
 - **Fail** → the guard names the lost blocks. Revert the edit that dropped them,
   or restore the assertion that exercised them, then re-run. Loop until green.
 
-> Flaky-coverage caveat: a 1–2 block "regression" on a timing-dependent
-> integration path can be nondeterministic. Re-run `after.cover` once; if it
-> clears, it wasn't a real loss. The guard fails closed (errs toward flagging) —
-> that's the safe direction; always look before dismissing.
+> Flaky-coverage caveat: a 1–2 block "regression" can be nondeterministic — e.g.
+> a sort comparator fed by Go's randomized map iteration, which is covered only on
+> some runs. Capture a second after-run and pass BOTH to the guard; it uses the
+> union, so a block covered in either run counts:
+> ```bash
+> bash .../measure-cover.sh "$SCOPE" "$D/after2.cover"
+> bash .../coverage-guard.sh "$D/before.cover" "$D/after.cover" "$D/after2.cover"
+> ```
+> A real regression is a block covered before that NO after-run covers. The guard
+> fails closed (errs toward flagging) — that's the safe direction; always look
+> before dismissing.
 
 ### Step 6 — Re-measure and report
 

--- a/.claude/skills/optimize-tests/scripts/coverage-guard.sh
+++ b/.claude/skills/optimize-tests/scripts/coverage-guard.sh
@@ -2,38 +2,51 @@
 # Coverage-preservation guardrail — the safety net for this whole skill.
 #
 # Fails (exit 1) if any statement block that was covered in BEFORE is no longer
-# covered in AFTER. Equal coverage PERCENTAGE is not enough: two suites can share
-# a number while covering different lines. This compares the actual covered-block
-# SETS, so deleting the only test that hit a line is caught even if the percent
-# barely moves.
+# covered in ANY of the AFTER runs. Equal coverage PERCENTAGE is not enough: two
+# suites can share a number while covering different lines. This compares the
+# actual covered-block SETS, so deleting the only test that hit a line is caught
+# even if the percent barely moves.
 #
-# Usage: coverage-guard.sh <before.cover> <after.cover>
+# Usage: coverage-guard.sh <before.cover> <after.cover> [after2.cover ...]
 #
-# Only edit *_test.go files between the two runs. Coverage blocks are keyed by
-# source position; editing non-test source shifts the keys and makes the
-# comparison meaningless.
+# Pass MULTIPLE after-runs to defuse flaky coverage: a block counts as still
+# covered if ANY after-run hits it (the union). Some blocks cover
+# nondeterministically across runs — e.g. a sort comparator fed by Go's
+# randomized map iteration — and a single after-run will intermittently flag
+# them. Two or three after-runs make the guard robust; the regression set is
+# then only blocks that NO after-run covered, which is a real loss.
+#
+# Only edit *_test.go files between the runs. Coverage blocks are keyed by source
+# position; editing non-test source shifts the keys and makes the comparison
+# meaningless.
 set -euo pipefail
 
-before="${1:?usage: coverage-guard.sh <before.cover> <after.cover>}"
-after="${2:?usage: coverage-guard.sh <before.cover> <after.cover>}"
+before="${1:?usage: coverage-guard.sh <before.cover> <after.cover> [after2.cover ...]}"
+shift
+[ "$#" -ge 1 ] || { echo "usage: coverage-guard.sh <before.cover> <after.cover> [after2.cover ...]" >&2; exit 2; }
 
 covered() {
   # Block key = field 1 = "import/path/file.go:startLine.col,endLine.col".
   # Covered when the trailing hit count (last field) > 0. Skip the mode header.
-  awk 'NR>1 && $NF+0 > 0 {print $1}' "$1" | LC_ALL=C sort -u
+  awk 'NR>1 && $NF+0 > 0 {print $1}' "$@" | LC_ALL=C sort -u
 }
 
-# Lines present in BEFORE-covered but absent from AFTER-covered = regressions.
-regressions="$(comm -23 <(covered "$before") <(covered "$after") || true)"
+# Union of covered blocks across every after-run (each "$@" is one after file).
+after_union="$(covered "$@")"
+
+# Lines covered BEFORE but in NONE of the after-runs = real regressions.
+regressions="$(comm -23 <(covered "$before") <(printf '%s\n' "$after_union") || true)"
 
 if [ -n "$regressions" ]; then
   count="$(printf '%s\n' "$regressions" | grep -c . || true)"
-  echo "❌ COVERAGE REGRESSION: ${count} block(s) covered before are NOT covered after:" >&2
+  echo "❌ COVERAGE REGRESSION: ${count} block(s) covered before are NOT covered in any after-run:" >&2
   printf '%s\n' "$regressions" | head -50 >&2
   [ "$count" -gt 50 ] && echo "  … and $((count - 50)) more" >&2
   echo >&2
   echo "Revert the edit that dropped these, or restore an assertion that exercises them." >&2
+  echo "(If you passed a single after-run and the block looks nondeterministic, re-run" >&2
+  echo " coverage and pass both files: coverage-guard.sh before.cover after1.cover after2.cover)" >&2
   exit 1
 fi
 
-echo "✅ no coverage regression — $(covered "$before" | grep -c .) covered blocks preserved"
+echo "✅ no coverage regression — $(covered "$before" | grep -c .) covered blocks preserved across $# after-run(s)"

--- a/.claude/skills/optimize-tests/scripts/scan-antipatterns.sh
+++ b/.claude/skills/optimize-tests/scripts/scan-antipatterns.sh
@@ -22,6 +22,23 @@ hr "Files with 3+ manual CreateAndCheckoutBranch calls — candidates for a fixt
 rg -c '\.CreateAndCheckoutBranch\(' -g '*_test.go' \
   | awk -F: '$2>=3 {printf "  %s (%d calls)\n", $1, $2}' || echo "  none"
 
+hr "⚠ PARALLEL HAZARDS — test files that mutate process-global state"
+# These mutate state shared by the whole process, so they CANNOT be made parallel
+# (and a concurrent test inheriting that state can hang or flake). t.Setenv panics
+# under t.Parallel; os.Stdin/out/err swaps let a concurrent test's child process
+# inherit the wrong pipe and block forever; os.Chdir/os.Setenv race the cwd/env.
+# EXCLUDE these files (or just the offending func) when parallelizing — same class
+# as the t.Setenv rule. Leave them serial.
+rg -ln 't\.Setenv\(|os\.Setenv\(|os\.Chdir\(|os\.Stdin\b|os\.Stdout\b|os\.Stderr\b' -g '*_test.go' \
+  | sed 's/^/  exclude: /' || echo "  none"
+
+hr "⚠ SHARED SCENARIO — one scenario built at func level, reused across subtests"
+# A scenario declared at the function body (1-tab indent), not inside each t.Run,
+# is shared mutable state: making the subtests parallel races on it. Either give
+# each subtest its own scenario or keep the func serial. (Stackit-specific to the
+# scenario.New* helpers; adapt the pattern to your fixture constructor.)
+rg -n '^\t[a-zA-Z_]+ :?= .*scenario\.New' -g '*_test.go' | sed 's/^/  review: /' || echo "  none"
+
 hr "Serial top-level Test funcs — no .Parallel() anywhere in the body"
 # Heuristic brace-depth scan: flag func TestX(... that never calls .Parallel().
 # Advisory only (braces inside strings can fool the depth counter) — the agent

--- a/internal/actions/abort_test.go
+++ b/internal/actions/abort_test.go
@@ -31,7 +31,9 @@ func (h *testAbortHandler) Cleanup() {}
 func (h *testAbortHandler) IsInteractive() bool { return h.isInteractive }
 
 func TestAbortAction(t *testing.T) {
+	t.Parallel()
 	t.Run("reports when no operation is in progress", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -40,6 +42,7 @@ func TestAbortAction(t *testing.T) {
 	})
 
 	t.Run("aborts when continuation state exists", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -79,6 +82,7 @@ func TestAbortAction(t *testing.T) {
 	})
 
 	t.Run("non-interactive handler without force does not abort", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -106,6 +110,7 @@ func TestAbortAction(t *testing.T) {
 	})
 
 	t.Run("interactive handler with confirmation proceeds with abort", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -140,6 +145,7 @@ func TestAbortAction(t *testing.T) {
 	})
 
 	t.Run("interactive handler with decline cancels abort", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -167,6 +173,7 @@ func TestAbortAction(t *testing.T) {
 	})
 
 	t.Run("force flag bypasses handler prompt", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").

--- a/internal/actions/absorb/absorb_test.go
+++ b/internal/actions/absorb/absorb_test.go
@@ -15,7 +15,9 @@ import (
 )
 
 func TestAbsorbScopeBoundaries(t *testing.T) {
+	t.Parallel()
 	t.Run("absorb stops at scope boundaries", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"scoped-a":   "main",
@@ -91,6 +93,7 @@ func TestAbsorbScopeBoundaries(t *testing.T) {
 	})
 
 	t.Run("absorb includes all branches when no scope set", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch-a": "main",
@@ -133,6 +136,7 @@ func TestAbsorbScopeBoundaries(t *testing.T) {
 	})
 
 	t.Run("absorb stops at first scope boundary encountered", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"scoped-a":    "main",
@@ -188,7 +192,9 @@ func TestAbsorbScopeBoundaries(t *testing.T) {
 }
 
 func TestAbsorbWithInterveningCommits(t *testing.T) {
+	t.Parallel()
 	t.Run("absorb handles changes when intervening commits modify same file", func(t *testing.T) {
+		t.Parallel()
 		// This test verifies that absorb can apply changes to an earlier commit
 		// even when later commits have modified the same file, using three-way merge.
 		// The key is having enough separation between sections so commutation check
@@ -415,6 +421,7 @@ func sectionB() {
 	})
 
 	t.Run("absorb cleans up on failure and restores original branch", func(t *testing.T) {
+		t.Parallel()
 		// This test verifies that when absorb fails, it cleans up properly
 		// and returns the user to their original branch without leaving
 		// the repository in a detached HEAD or unmerged state.
@@ -484,6 +491,7 @@ func example() {
 	})
 
 	t.Run("absorb with three-way merge when context lines differ", func(t *testing.T) {
+		t.Parallel()
 		// This test specifically verifies the --3way merge functionality:
 		// We create a scenario where the patch context doesn't match exactly
 		// because an intervening commit has modified lines far away in the same file.
@@ -704,7 +712,9 @@ func DefaultConfig() *Config {
 }
 
 func TestAbsorbConflictHandling(t *testing.T) {
+	t.Parallel()
 	t.Run("IsAbsorbInProgress returns false in normal state", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a branch with a commit
@@ -721,6 +731,7 @@ func TestAbsorbConflictHandling(t *testing.T) {
 	})
 
 	t.Run("IsAbsorbInProgress returns true in detached HEAD state", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a branch with a commit
@@ -740,6 +751,7 @@ func TestAbsorbConflictHandling(t *testing.T) {
 	})
 
 	t.Run("ShowConflict displays staged changes info", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a branch with a commit
@@ -762,6 +774,7 @@ func TestAbsorbConflictHandling(t *testing.T) {
 	})
 
 	t.Run("ShowConflict handles no staged changes", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a branch with a commit but no staged changes
@@ -779,6 +792,7 @@ func TestAbsorbConflictHandling(t *testing.T) {
 	})
 
 	t.Run("Abort handles normal state", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a branch with a commit
@@ -796,6 +810,7 @@ func TestAbsorbConflictHandling(t *testing.T) {
 	})
 
 	t.Run("Abort recovers from detached HEAD state", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a branch with a commit

--- a/internal/actions/absorb/plan_test.go
+++ b/internal/actions/absorb/plan_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestGeneratePlanJSON(t *testing.T) {
+	t.Parallel()
 	t.Run("generates valid JSON with absorbed and unabsorbable hunks", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch-a": "main",
@@ -112,6 +114,7 @@ func TestGeneratePlanJSON(t *testing.T) {
 	})
 
 	t.Run("handles empty inputs", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch-a": "main",
@@ -141,6 +144,7 @@ func TestGeneratePlanJSON(t *testing.T) {
 }
 
 func TestFormatLines(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		start    int
 		count    int

--- a/internal/actions/clean_branches_test.go
+++ b/internal/actions/clean_branches_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestCleanBranches(t *testing.T) {
+	t.Parallel()
 	t.Run("deletes merged branch and updates children", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -51,6 +53,7 @@ func TestCleanBranches(t *testing.T) {
 	})
 
 	t.Run("handles multiple children when parent is deleted", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -91,6 +94,7 @@ func TestCleanBranches(t *testing.T) {
 	})
 
 	t.Run("does not delete branch without PR when not merged", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -107,6 +111,7 @@ func TestCleanBranches(t *testing.T) {
 	})
 
 	t.Run("deletes locked branch when merged", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -142,6 +147,7 @@ func TestCleanBranches(t *testing.T) {
 	})
 
 	t.Run("never considers trunk for deletion", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -174,6 +180,7 @@ func TestCleanBranches(t *testing.T) {
 	})
 
 	t.Run("deletes merged child even if parent is NOT merged", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -198,6 +205,7 @@ func TestCleanBranches(t *testing.T) {
 	})
 
 	t.Run("marks branch with unpushed changes when merged", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -234,6 +242,7 @@ func TestCleanBranches(t *testing.T) {
 	})
 
 	t.Run("does not mark branch without unpushed changes as unpushed", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -264,6 +273,7 @@ func TestCleanBranches(t *testing.T) {
 	})
 
 	t.Run("preserves divergence when reparenting after squash-merged parent deletion", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create main -> branch1 (2 commits) -> branch2.

--- a/internal/actions/create/create_test.go
+++ b/internal/actions/create/create_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestCreateAction_Stdin(t *testing.T) {
+	// NOT parallel: this test swaps the process-global os.Stdin for a pipe. Under
+	// t.Parallel(), a concurrent test's git subprocess inherits that pipe as stdin
+	// and blocks forever (same global-state hazard class as t.Setenv).
 	t.Run("reads commit message from stdin in non-interactive mode", func(t *testing.T) {
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
@@ -50,7 +53,9 @@ func TestCreateAction_Stdin(t *testing.T) {
 }
 
 func TestCreateAction_Insert(t *testing.T) {
+	t.Parallel()
 	t.Run("inserts branch between parent and children", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -97,6 +102,7 @@ func TestCreateAction_Insert(t *testing.T) {
 	})
 
 	t.Run("inserts branch in the middle of a stack", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -147,6 +153,7 @@ func TestCreateAction_Insert(t *testing.T) {
 	})
 
 	t.Run("inserts branch into a branching stack (multiple children)", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -205,6 +212,7 @@ func TestCreateAction_Insert(t *testing.T) {
 	})
 
 	t.Run("restores original branch after insert", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -236,7 +244,9 @@ func TestCreateAction_Insert(t *testing.T) {
 }
 
 func TestCreateAction_Insert_Deep(t *testing.T) {
+	t.Parallel()
 	t.Run("restacks descendants deep into the stack", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -286,7 +296,9 @@ func TestCreateAction_Insert_Deep(t *testing.T) {
 }
 
 func TestCreateAction_Worktree(t *testing.T) {
+	t.Parallel()
 	t.Run("creates worktree when -w flag is used from trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -329,6 +341,7 @@ func TestCreateAction_Worktree(t *testing.T) {
 	})
 
 	t.Run("fails with -w flag when not on trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 

--- a/internal/actions/delete/delete_test.go
+++ b/internal/actions/delete/delete_test.go
@@ -12,7 +12,9 @@ import (
 )
 
 func TestDelete(t *testing.T) {
+	t.Parallel()
 	t.Run("deletes a single branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, nil).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -35,6 +37,7 @@ func TestDelete(t *testing.T) {
 	})
 
 	t.Run("deletes upstack", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, nil).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -56,6 +59,7 @@ func TestDelete(t *testing.T) {
 	})
 
 	t.Run("deletes downstack", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, nil).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -77,6 +81,7 @@ func TestDelete(t *testing.T) {
 	})
 
 	t.Run("fails without force if not merged", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, nil).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -95,6 +100,7 @@ func TestDelete(t *testing.T) {
 	})
 
 	t.Run("deletes current branch and switches to trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, nil).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -117,6 +123,7 @@ func TestDelete(t *testing.T) {
 	})
 
 	t.Run("deletes a branch in a branching stack", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, nil).
 			WithStack(map[string]string{
 				"parent": "main",
@@ -147,6 +154,7 @@ func TestDelete(t *testing.T) {
 	})
 
 	t.Run("preserves child commit boundaries when deleting squash-merged parent", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		s.CreateBranch("branch1").
@@ -185,7 +193,9 @@ func TestDelete(t *testing.T) {
 }
 
 func TestDeleteCleansUpWorktrees(t *testing.T) {
+	t.Parallel()
 	t.Run("cleans worktree when stack root is deleted", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a stack root branch
@@ -216,6 +226,7 @@ func TestDeleteCleansUpWorktrees(t *testing.T) {
 	})
 
 	t.Run("does not clean worktree when non-root branch is deleted", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a stack with two branches
@@ -248,6 +259,7 @@ func TestDeleteCleansUpWorktrees(t *testing.T) {
 	})
 
 	t.Run("cleans worktree when upstack deletes entire stack including root", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a stack with multiple branches

--- a/internal/actions/flatten/flatten_test.go
+++ b/internal/actions/flatten/flatten_test.go
@@ -19,7 +19,9 @@ func writeFile(t *testing.T, s *scenario.Scenario, name, content string) {
 }
 
 func TestFlattenAction(t *testing.T) {
+	t.Parallel()
 	t.Run("flattens linear independent stack to trunk", func(t *testing.T) {
+		t.Parallel()
 		// main -> A -> B -> C
 		// WithStack creates independent changes (separate files)
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
@@ -44,6 +46,7 @@ func TestFlattenAction(t *testing.T) {
 	})
 
 	t.Run("respects dependencies", func(t *testing.T) {
+		t.Parallel()
 		// main -> A -> B
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
@@ -74,6 +77,7 @@ func TestFlattenAction(t *testing.T) {
 	})
 
 	t.Run("partial flatten", func(t *testing.T) {
+		t.Parallel()
 		// main -> A -> B -> C
 		// A independent
 		// B depends on A
@@ -119,6 +123,7 @@ func TestFlattenAction(t *testing.T) {
 	})
 
 	t.Run("handles already flat stack", func(t *testing.T) {
+		t.Parallel()
 		// main -> A, main -> B (already flat)
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
@@ -140,6 +145,7 @@ func TestFlattenAction(t *testing.T) {
 	})
 
 	t.Run("uses current branch when none specified", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"A": "main",
@@ -163,6 +169,7 @@ func TestFlattenAction(t *testing.T) {
 	})
 
 	t.Run("returns error for untracked branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create an untracked branch
@@ -175,6 +182,7 @@ func TestFlattenAction(t *testing.T) {
 	})
 
 	t.Run("excludes move when descendant would conflict", func(t *testing.T) {
+		t.Parallel()
 		// This test verifies that flatten correctly validates descendant branches
 		// in a CHAINED manner and excludes moves that would cause conflicts.
 		//
@@ -239,6 +247,7 @@ func TestFlattenAction(t *testing.T) {
 	})
 
 	t.Run("fallback to parent revision when metadata missing", func(t *testing.T) {
+		t.Parallel()
 		// This test verifies the fix for the bug where getOldUpstream() was using
 		// GetMergeBase as a fallback, which could include parent commits when
 		// flattening. The fix uses the parent's current revision instead.

--- a/internal/actions/fold/fold_test.go
+++ b/internal/actions/fold/fold_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestFoldAction(t *testing.T) {
+	t.Parallel()
 	t.Run("folds branch into parent", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -46,6 +48,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("reparents children when folding branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -73,6 +76,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("folds with --keep flag", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -110,6 +114,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("folds with --keep and reparents siblings", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -143,6 +148,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when trying to fold trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Try to fold trunk (main)
@@ -152,6 +158,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when trying to fold untracked branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			CreateBranch("untracked")
 
@@ -162,6 +169,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when trying to fold into trunk with --keep", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -174,6 +182,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when there are uncommitted changes", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -187,6 +196,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("returns clear error message on merge conflict", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, nil)
 
 		// Create conflicting changes manually
@@ -216,6 +226,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("restacks descendants after folding", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -251,6 +262,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("folding middle branch preserves all commits when folded branch has multiple commits", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -296,6 +308,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("folding middle branch moves no-op descendants to new parent tip", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Build main -> branch1 -> branch2 -> branch3, and create branch4 from branch3 with no unique commits.
@@ -335,6 +348,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("folding middle branch preserves folded commits for descendants that diverged earlier", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Build main -> branch1 -> branch2 -> branch3.
@@ -371,6 +385,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when rebase is in progress", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -390,6 +405,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("folds branch with no unique commits", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -409,6 +425,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("takes snapshot before folding", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -427,6 +444,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("takes snapshot with --keep flag", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -446,6 +464,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when folding into trunk without --allow-trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -458,6 +477,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("folds bottom branch into trunk with --allow-trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -481,6 +501,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when folding branches with different scopes", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -505,6 +526,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when current branch is locked", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -522,6 +544,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when parent branch is locked", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -539,6 +562,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("fails when branch is frozen", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -556,6 +580,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("dry-run does not modify repository", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -584,6 +609,7 @@ func TestFoldAction(t *testing.T) {
 	})
 
 	t.Run("dry-run fails if branch is locked", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",

--- a/internal/actions/get_test.go
+++ b/internal/actions/get_test.go
@@ -42,7 +42,9 @@ func (c *countingGitHubClient) branchCallCount(branchName string) int {
 }
 
 func TestGetAction(t *testing.T) {
+	t.Parallel()
 	t.Run("resolves PR number and fetches branches", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -80,6 +82,7 @@ func TestGetAction(t *testing.T) {
 	})
 
 	t.Run("crawls ancestors via GitHub PRs", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -129,6 +132,7 @@ func TestGetAction(t *testing.T) {
 	})
 
 	t.Run("identifies and syncs local descendants", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature-a").
@@ -159,6 +163,7 @@ func TestGetAction(t *testing.T) {
 	})
 
 	t.Run("fails if uncommitted changes exist", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			WithUncommittedChange("dirty.txt")

--- a/internal/actions/lock/lock_test.go
+++ b/internal/actions/lock/lock_test.go
@@ -43,7 +43,9 @@ func (h *testLockHandler) Cleanup()                         {}
 func (h *testLockHandler) IsInteractive() bool              { return h.isInteractive }
 
 func TestLockUnlockAction(t *testing.T) {
+	t.Parallel()
 	t.Run("LockAction locks branch and ancestors", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature-a").
@@ -63,6 +65,7 @@ func TestLockUnlockAction(t *testing.T) {
 	})
 
 	t.Run("LockAction indicates already locked branches", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature-a").
@@ -85,6 +88,7 @@ func TestLockUnlockAction(t *testing.T) {
 	})
 
 	t.Run("UnlockAction unlocks branch and descendants", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature-a").
@@ -108,6 +112,7 @@ func TestLockUnlockAction(t *testing.T) {
 	})
 
 	t.Run("UnlockAction indicates already unlocked branches", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature-a").
@@ -128,6 +133,7 @@ func TestLockUnlockAction(t *testing.T) {
 	})
 
 	t.Run("LockAction fails on untracked branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranchQuiet("untracked")
@@ -138,6 +144,7 @@ func TestLockUnlockAction(t *testing.T) {
 	})
 
 	t.Run("LockAction fails on trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -147,6 +154,7 @@ func TestLockUnlockAction(t *testing.T) {
 	})
 
 	t.Run("LockAction with unpushed commits in non-interactive mode", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature-a").
@@ -176,6 +184,7 @@ func TestLockUnlockAction(t *testing.T) {
 	})
 
 	t.Run("LockAction prompts for new branch not on remote", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("new-feature").
@@ -199,6 +208,7 @@ func TestLockUnlockAction(t *testing.T) {
 	})
 
 	t.Run("UnlockAction prompts for downstack and unlocks it if confirmed", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature-a").
@@ -232,6 +242,7 @@ func TestLockUnlockAction(t *testing.T) {
 	})
 
 	t.Run("UnlockAction prompts for downstack and does not unlock it if declined", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature-a").

--- a/internal/actions/move/move_test.go
+++ b/internal/actions/move/move_test.go
@@ -45,7 +45,9 @@ func writeAndCommit(t *testing.T, s *scenario.Scenario, file, content, message s
 }
 
 func TestMoveAction(t *testing.T) {
+	t.Parallel()
 	t.Run("moves branch downstack and restacks descendants", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -89,6 +91,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("moves branch upstack and restacks descendants", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branchA":  "main",
@@ -122,6 +125,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("moves branch across different stack trees", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branchA1": "main",
@@ -150,6 +154,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("defaults source to current branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -174,6 +179,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("prevents moving trunk branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		err := Action(s.Context, Options{
@@ -185,6 +191,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("prevents moving onto itself", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -199,6 +206,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("prevents moving onto descendant (cycle detection)", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -217,6 +225,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("fails when source branch is not tracked", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			CreateBranch("untracked").
 			Checkout("main")
@@ -230,6 +239,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("fails when onto branch does not exist", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -244,6 +254,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("fails when not on branch and no source specified", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Detach HEAD
@@ -263,6 +274,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("allows moving onto untracked branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -285,6 +297,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("restacks all descendants after move", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -325,6 +338,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("fails when onto is not specified", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -339,6 +353,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("moves branch downstack without pulling along intermediate commits", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a clean stack: main -> branch1 -> branch2
@@ -372,6 +387,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("preserves PR information after move", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -402,6 +418,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("moves branch after it has been amended", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -426,6 +443,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("moves branch across stacks without pulling old parent's commits", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Stack 1: main -> branchA1 -> branchA2
@@ -462,6 +480,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("moving middle branch to trunk does not affect downstack branches", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a linear stack: main -> A -> B -> C
@@ -511,6 +530,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("interactive cancel does not move", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -532,6 +552,7 @@ func TestMoveAction(t *testing.T) {
 	})
 
 	t.Run("interactive proceed on conflict enters conflict workflow", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).WithInitialCommit()
 
 		// Restack invokes git commit without stripping global config, so any

--- a/internal/actions/pluck/pluck_test.go
+++ b/internal/actions/pluck/pluck_test.go
@@ -105,7 +105,9 @@ func TestPluckStackID(t *testing.T) {
 }
 
 func TestPluckAction(t *testing.T) {
+	t.Parallel()
 	t.Run("plucks branch to new parent and reparents children to grandparent", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -135,6 +137,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("plucks branch with no children", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -162,6 +165,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("plucks branch with multiple children", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -207,6 +211,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("defaults source to current branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -231,6 +236,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("prevents plucking trunk branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		err := Action(s.Context, Options{
@@ -242,6 +248,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("prevents plucking onto itself", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -256,6 +263,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("prevents plucking onto descendant (cycle detection)", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -274,6 +282,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("fails when source branch is not tracked", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			CreateBranch("untracked").
 			Checkout("main")
@@ -287,6 +296,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("fails when onto branch does not exist", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -301,6 +311,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("fails when onto is not specified", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -315,6 +326,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("fails when not on branch and no source specified", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Detach HEAD
@@ -332,6 +344,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("restacks all affected branches after pluck", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -356,6 +369,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("preserves commits on plucked branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create branch1 with a commit
@@ -381,6 +395,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("preserves PR information after pluck", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -411,6 +426,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("pluck differs from move by not bringing descendants", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -443,6 +459,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("allows plucking onto untracked branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -465,6 +482,7 @@ func TestPluckAction(t *testing.T) {
 	})
 
 	t.Run("plucks from middle of stack correctly", func(t *testing.T) {
+		t.Parallel()
 		// main -> A -> B -> C -> D
 		// Pluck B to main
 		// Result: B is on main, C is on A (not B!)

--- a/internal/actions/pop_test.go
+++ b/internal/actions/pop_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestPopAction(t *testing.T) {
+	t.Parallel()
 	t.Run("pops branch and retains changes as staged", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -44,6 +46,7 @@ func TestPopAction(t *testing.T) {
 	})
 
 	t.Run("reparents children when popping branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -70,6 +73,7 @@ func TestPopAction(t *testing.T) {
 	})
 
 	t.Run("fails when trying to pop trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Try to pop trunk (main)
@@ -79,6 +83,7 @@ func TestPopAction(t *testing.T) {
 	})
 
 	t.Run("fails when trying to pop untracked branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			CreateBranch("untracked")
 
@@ -89,6 +94,7 @@ func TestPopAction(t *testing.T) {
 	})
 
 	t.Run("fails when rebase is in progress", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -109,6 +115,7 @@ func TestPopAction(t *testing.T) {
 	})
 
 	t.Run("fails when there are uncommitted changes", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",

--- a/internal/actions/restack_test.go
+++ b/internal/actions/restack_test.go
@@ -29,7 +29,9 @@ func (h *promptRestackHandler) PromptResolveConflicts(conflictBranches []string)
 }
 
 func TestRestackAction(t *testing.T) {
+	t.Parallel()
 	t.Run("planning from trunk excludes trunk branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		plan, err := PlanRestack(s.Context, RestackOptions{
@@ -42,6 +44,7 @@ func TestRestackAction(t *testing.T) {
 	})
 
 	t.Run("planning from trunk keeps descendants but not trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"feature":       "main",
@@ -67,6 +70,7 @@ func TestRestackAction(t *testing.T) {
 	})
 
 	t.Run("parallel multi-stack restack returns worker errors", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"alpha-root":  "main",
@@ -110,6 +114,7 @@ func TestRestackAction(t *testing.T) {
 	})
 
 	t.Run("interactive restack prompts before entering conflict workflow", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		s.Checkout("main")

--- a/internal/actions/scope/scope_test.go
+++ b/internal/actions/scope/scope_test.go
@@ -32,7 +32,9 @@ func (h *testScopeHandler) Cleanup() {}
 func (h *testScopeHandler) IsInteractive() bool { return h.isInteractive }
 
 func TestScopeAction(t *testing.T) {
+	t.Parallel()
 	t.Run("show scope when no args provided", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -46,6 +48,7 @@ func TestScopeAction(t *testing.T) {
 	})
 
 	t.Run("set scope on branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -62,6 +65,7 @@ func TestScopeAction(t *testing.T) {
 	})
 
 	t.Run("unset scope on branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -82,6 +86,7 @@ func TestScopeAction(t *testing.T) {
 	})
 
 	t.Run("cannot set scope on trunk", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -93,6 +98,7 @@ func TestScopeAction(t *testing.T) {
 	})
 
 	t.Run("PromptConfirmRename is called when scope changes and branch name contains old scope", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("JIRA-100-feature").
@@ -120,6 +126,7 @@ func TestScopeAction(t *testing.T) {
 	})
 
 	t.Run("PromptConfirmRename is not called when branch name does not contain old scope", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -145,6 +152,7 @@ func TestScopeAction(t *testing.T) {
 	})
 
 	t.Run("non-interactive handler does not rename branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("JIRA-100-feature").

--- a/internal/actions/stack_info_test.go
+++ b/internal/actions/stack_info_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestStackInfoAction(t *testing.T) {
+	t.Parallel()
 	t.Run("returns JSON info for the current stack", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -60,6 +62,7 @@ func TestStackInfoAction(t *testing.T) {
 	})
 
 	t.Run("fails when not on a branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		// Detach HEAD
 		s.RunGit("checkout", "--detach", "main")
@@ -70,6 +73,7 @@ func TestStackInfoAction(t *testing.T) {
 	})
 
 	t.Run("returns tree view with commit messages when JSON flag is false", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -89,6 +93,7 @@ func TestStackInfoAction(t *testing.T) {
 	})
 
 	t.Run("includes lock and frozen state", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",

--- a/internal/actions/submit/submit_metadata_fetch_test.go
+++ b/internal/actions/submit/submit_metadata_fetch_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestPreparePRMetadata_FetchFromGitHub(t *testing.T) {
+	t.Parallel()
 	t.Run("fetches body from GitHub when local body is empty", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		branchName := featureBranch
 		prNumber := 123
@@ -55,6 +57,7 @@ func TestPreparePRMetadata_FetchFromGitHub(t *testing.T) {
 	})
 
 	t.Run("GetPRBody uses existingBody when not empty", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		branch := s.Engine.GetBranch("main") // just need a branch object
 

--- a/internal/actions/sync/metadata_cleanup_test.go
+++ b/internal/actions/sync/metadata_cleanup_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestMetadataCleanup(t *testing.T) {
+	t.Parallel()
 	t.Run("silently cleans up metadata for deleted local branches", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// 1. Create a branch and metadata
@@ -50,6 +52,7 @@ func TestMetadataCleanup(t *testing.T) {
 	})
 
 	t.Run("does not prompt for remote metadata on non-existent branches", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// 1. Simulate remote metadata for a branch that doesn't exist locally

--- a/internal/actions/sync/sync_test.go
+++ b/internal/actions/sync/sync_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestSyncAction(t *testing.T) {
+	t.Parallel()
 	t.Run("syncs when trunk is up to date", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t)
 
 		err := Action(s.Context, Options{
@@ -26,6 +28,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("fails when required trunk fetch fails", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		err := Action(s.Context, Options{}, nil)
@@ -37,6 +40,7 @@ func TestSyncAction(t *testing.T) {
 	// before TUI initialization. Tested in internal/cli/stack/sync_test.go.
 
 	t.Run("syncs with restack flag", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -52,6 +56,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("restacks branches in topological order (parents before children)", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -69,6 +74,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("restacks branching stacks in topological order", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"stackA":        "main",
@@ -97,6 +103,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("restacks multiple deep subtrees correctly", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"P":   "main",
@@ -128,6 +135,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("partial success in branching restack (one child succeeds, one fails)", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t)
 
 		// Create: main -> P -> [0-Success, 1-Failure]
@@ -177,6 +185,7 @@ func TestSyncAction(t *testing.T) {
 	})
 
 	t.Run("sync mode aborts unexpected runtime restack conflict and restores branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"branch1": "main",

--- a/internal/actions/sync/worktree_cleanup_test.go
+++ b/internal/actions/sync/worktree_cleanup_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestSyncCleansOrphanedWorktrees(t *testing.T) {
+	t.Parallel()
 	t.Run("cleans worktree when stack root branch is deleted", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t)
 
 		// Create a branch that will become a stack root
@@ -46,6 +48,7 @@ func TestSyncCleansOrphanedWorktrees(t *testing.T) {
 	})
 
 	t.Run("preserves worktree when stack root branch still exists", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t)
 
 		// Create and track a branch
@@ -69,6 +72,7 @@ func TestSyncCleansOrphanedWorktrees(t *testing.T) {
 	})
 
 	t.Run("preserves registration when worktree removal fails", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t)
 
 		worktreePath := filepath.Join(t.TempDir(), "not-a-git-worktree")

--- a/internal/actions/track/track_test.go
+++ b/internal/actions/track/track_test.go
@@ -40,7 +40,9 @@ func (h *testTrackHandler) Cleanup() {}
 func (h *testTrackHandler) IsInteractive() bool { return h.isInteractive }
 
 func TestTrackAction(t *testing.T) {
+	t.Parallel()
 	t.Run("track with --parent flag validates parent exists", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranchQuiet("feature")
@@ -54,6 +56,7 @@ func TestTrackAction(t *testing.T) {
 	})
 
 	t.Run("track with --parent flag validates parent is tracked", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranchQuiet("untracked-parent").
@@ -69,6 +72,7 @@ func TestTrackAction(t *testing.T) {
 	})
 
 	t.Run("track with --force succeeds using trunk as ancestor", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranchQuiet("feature")
@@ -84,6 +88,7 @@ func TestTrackAction(t *testing.T) {
 	})
 
 	t.Run("non-interactive mode requires --parent or --force", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranchQuiet("feature")
@@ -97,6 +102,7 @@ func TestTrackAction(t *testing.T) {
 	})
 
 	t.Run("interactive mode calls PromptSelectParent when auto-detection fails", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranchQuiet("feature")
@@ -114,6 +120,7 @@ func TestTrackAction(t *testing.T) {
 	})
 
 	t.Run("interactive mode handles user cancellation (empty parent)", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranchQuiet("feature")
@@ -132,6 +139,7 @@ func TestTrackAction(t *testing.T) {
 	})
 
 	t.Run("interactive mode auto-detects parent when unambiguous", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("base").
@@ -153,6 +161,7 @@ func TestTrackAction(t *testing.T) {
 	})
 
 	t.Run("PromptTrackChild is called for untracked children", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranchQuiet("feature").

--- a/internal/actions/undo/undo_test.go
+++ b/internal/actions/undo/undo_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func TestUndoAction(t *testing.T) {
+	t.Parallel()
 	t.Run("returns error when no snapshots exist", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -20,6 +22,7 @@ func TestUndoAction(t *testing.T) {
 	})
 
 	t.Run("restores to snapshot when only one exists", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -63,6 +66,7 @@ func TestUndoAction(t *testing.T) {
 	})
 
 	t.Run("returns error for invalid snapshot ID", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -78,6 +82,7 @@ func TestUndoAction(t *testing.T) {
 	})
 
 	t.Run("restores after multiple operations", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature1").
@@ -140,7 +145,9 @@ func TestUndoAction(t *testing.T) {
 }
 
 func TestUndoAfterCreate(t *testing.T) {
+	t.Parallel()
 	t.Run("undoes branch creation", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -186,7 +193,9 @@ func TestUndoAfterCreate(t *testing.T) {
 }
 
 func TestUndoAfterMove(t *testing.T) {
+	t.Parallel()
 	t.Run("undoes branch move operation", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature1").

--- a/internal/actions/untrack/untrack_test.go
+++ b/internal/actions/untrack/untrack_test.go
@@ -32,7 +32,9 @@ func (h *testUntrackHandler) Cleanup() {}
 func (h *testUntrackHandler) IsInteractive() bool { return h.isInteractive }
 
 func TestUntrackAction(t *testing.T) {
+	t.Parallel()
 	t.Run("fails for untracked branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranchQuiet("untracked")
@@ -45,6 +47,7 @@ func TestUntrackAction(t *testing.T) {
 	})
 
 	t.Run("succeeds for branch without descendants", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -61,6 +64,7 @@ func TestUntrackAction(t *testing.T) {
 	})
 
 	t.Run("force flag bypasses confirmation for descendants", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -90,6 +94,7 @@ func TestUntrackAction(t *testing.T) {
 	})
 
 	t.Run("prompts for confirmation when descendants exist", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -117,6 +122,7 @@ func TestUntrackAction(t *testing.T) {
 	})
 
 	t.Run("cancels when user declines confirmation", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -143,6 +149,7 @@ func TestUntrackAction(t *testing.T) {
 	})
 
 	t.Run("nil handler cancels when descendants exist", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -164,6 +171,7 @@ func TestUntrackAction(t *testing.T) {
 	})
 
 	t.Run("untracks multiple descendants", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").


### PR DESCRIPTION
Consolidates the 5-PR test-parallelization stack (#1209–#1213) into a single atomic merge via `stackit merge ship`.

All changes are test-only parallelization speedups plus hardening of the `/optimize-tests` skill — no production code paths change.

### Consolidated PRs

- **#1209** perf(test): parallelize fold/move/pluck action subtests (~113s → ~10s)
- **#1210** perf(test): parallelize sync action subtests (~48s → ~6s; excludes `sync_diamond_test.go` which uses `t.Setenv`)
- **#1211** perf(test): parallelize 10 action subpackages' scenario tests (~83s → ~14s)
- **#1212** perf(test): parallelize root actions package tests (~30s → ~13s under race; keeps `TestModifyAction_Stdin` serial — it swaps process-global `os.Stdin`)
- **#1213** feat(skill): harden `/optimize-tests` with parallel-hazard detection and union coverage guard

### Safety

- Each parallelized subtest already builds its own isolated, parallel-safe scenario — these are pure structural `t.Parallel()` additions.
- Coverage-guarded: every covered block preserved across the stack.
- Race-clean; process-global-state tests (`t.Setenv`, `os.Stdin`/`os.Chdir`) deliberately left serial.

<sub>Consolidation of the stack rooted at #1209.</sub>

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJc5UH9BkP1JAdhwRuBtxc)_