### PR TITLE
perf: batch PR info writes during sync and submit validation

### DIFF
--- a/internal/actions/submit/submit_validation.go
+++ b/internal/actions/submit/submit_validation.go
@@ -3,6 +3,7 @@ package submit
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/app"
@@ -22,16 +23,20 @@ func ValidateBranchesToSubmit(ctx *app.Context, branches []string) error {
 		return err
 	}
 	if repoOwner != "" && repoName != "" {
+		// Collect updates from the callback (which may be called concurrently in the
+		// REST fallback) then write all PR info in one atomic batch.
+		var mu sync.Mutex
+		updates := make(map[string]*engine.PrInfo)
 		if err := github.SyncPrInfo(ctx.Context, ctx.Git(), branches, repoOwner, repoName, func(name string, prInfo *github.PullRequestInfo) { //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
 			branch := nav.GetBranch(name)
 
-			// Preserve existing locked status
 			lockReason := engine.LockReasonNone
 			if existing, err := branch.GetPrInfo(); err == nil && existing != nil {
 				lockReason = existing.LockReason()
 			}
 
-			_ = pr.UpsertPrInfo(ctx.Context, branch, engine.NewPrInfo(
+			mu.Lock()
+			updates[name] = engine.NewPrInfo(
 				&prInfo.Number,
 				prInfo.Title,
 				prInfo.Body,
@@ -39,10 +44,14 @@ func ValidateBranchesToSubmit(ctx *app.Context, branches []string) error {
 				prInfo.Base,
 				prInfo.HTMLURL,
 				prInfo.Draft,
-			).WithLockReason(lockReason))
+			).WithLockReason(lockReason)
+			mu.Unlock()
 		}); err != nil {
 			// Non-fatal, continue
 			ctx.Output.Debug("Failed to sync PR info: %v", err)
+		}
+		if err := pr.BatchUpsertPrInfo(ctx.Context, updates); err != nil {
+			ctx.Output.Debug("Failed to update PR info: %v", err)
 		}
 	}
 

--- a/internal/actions/sync/github_sync.go
+++ b/internal/actions/sync/github_sync.go
@@ -72,19 +72,18 @@ func processGitHubSyncResult(ctx *app.Context, result *GitHubSyncResult, dirtyAn
 	nav := ctx.Navigator()
 	out := ctx.Output
 
-	prsUpdated := 0
-
-	// Update local PR info from GitHub results
+	// Update local PR info from GitHub results, preserving lock reasons.
+	// Collect into a map first so we can write all updates in one atomic batch.
+	updates := make(map[string]*engine.PrInfo, len(result.PRInfos))
 	for name, prInfo := range result.PRInfos {
 		branch := nav.GetBranch(name)
 
-		// Try to preserve existing locked status
 		lockReason := engine.LockReasonNone
 		if existing, err := branch.GetPrInfo(); err == nil && existing != nil {
 			lockReason = existing.LockReason()
 		}
 
-		_ = eng.UpsertPrInfo(ctx.Context, branch, engine.NewPrInfo(
+		updates[name] = engine.NewPrInfo(
 			&prInfo.Number,
 			prInfo.Title,
 			prInfo.Body,
@@ -92,9 +91,13 @@ func processGitHubSyncResult(ctx *app.Context, result *GitHubSyncResult, dirtyAn
 			prInfo.Base,
 			prInfo.HTMLURL,
 			prInfo.Draft,
-		).WithLockReason(lockReason))
-		prsUpdated++
+		).WithLockReason(lockReason)
 	}
+
+	if err := eng.BatchUpsertPrInfo(ctx.Context, updates); err != nil {
+		out.Debug("Failed to update PR info: %v", err)
+	}
+	prsUpdated := len(updates)
 
 	// Emit completion event with count
 	if prsUpdated > 0 {


### PR DESCRIPTION
## Summary

- Replace per-branch `UpsertPrInfo` calls in a loop with a single `BatchUpsertPrInfo` call in both `github_sync.go` and `submit_validation.go`
- Errors from the batch write are now surfaced via `out.Debug` instead of being silently swallowed with `_ =`
- In `submit_validation.go`, collect updates with a mutex since the `SyncPrInfo` callback can be called concurrently via the REST fallback path

## Why this matters

Both sites were writing PR info for N branches by calling `UpsertPrInfo` N times in a loop. Each call runs its own `git update-ref` transaction. `BatchUpsertPrInfo` collapses all N writes into one atomic transaction — the same pattern already used in `consolidate.go` and `multistack.go`.

For a stack with 10 branches, sync was doing 10 serial metadata writes where 1 would do.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/actions/sync/... ./internal/actions/submit/...` passes
- [x] `go vet` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkwT9qHdo7RtVpZuzJ8hTm)_