### PR TITLE
refactor: extract reusable golden helper and sync prompt-description helpers

### DIFF
--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -2,6 +2,7 @@ package stack
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	stdsync "sync"
 
@@ -660,25 +661,47 @@ func (h *InteractiveSyncHandler) Pause() { h.runner.Pause() }
 // Resume restores the TUI after Pause. Implements rerere.Pauser.
 func (h *InteractiveSyncHandler) Resume() { h.runner.Resume() }
 
+// describeMetadataConflict writes the human-readable details of a metadata
+// conflict to out. Shared by the interactive handler and the golden transcript
+// harness so both render identical text.
+func describeMetadataConflict(out output.Output, diff *engine.MetadataDiff) {
+	out.Info("\nMetadata differs for branch '%s':", style.ColorBranchName(diff.Branch, false))
+	for _, fd := range diff.Differences {
+		out.Info("  %s: %v (local) → %v (remote)", fd.Field, fd.LocalValue, fd.RemoteValue)
+	}
+	if diff.RemoteMeta != nil {
+		if modBy := diff.RemoteMeta.GetLastModifiedBy(); modBy != nil {
+			out.Info("  Last modified by: %s <%s>",
+				modBy.GitName,
+				modBy.GitEmail)
+		}
+	}
+}
+
 // PromptMetadataConflict implements Handler. Pauses TUI, displays conflict, prompts user.
 func (h *InteractiveSyncHandler) PromptMetadataConflict(diff *engine.MetadataDiff) (bool, error) {
 	h.runner.Pause()
 	defer h.runner.Resume()
 
-	// Display the conflict details
-	h.output.Info("\nMetadata differs for branch '%s':", style.ColorBranchName(diff.Branch, false))
-	for _, fd := range diff.Differences {
-		h.output.Info("  %s: %v (local) → %v (remote)", fd.Field, fd.LocalValue, fd.RemoteValue)
-	}
-	if diff.RemoteMeta != nil {
-		if modBy := diff.RemoteMeta.GetLastModifiedBy(); modBy != nil {
-			h.output.Info("  Last modified by: %s <%s>",
-				modBy.GitName,
-				modBy.GitEmail)
-		}
-	}
+	describeMetadataConflict(h.output, diff)
 
 	return tui.PromptConfirm("Accept remote metadata?", false)
+}
+
+// describeOrphanedMetadata writes the human-readable details of orphaned local
+// metadata to out. Shared by the interactive handler and the golden transcript
+// harness so both render identical text.
+func describeOrphanedMetadata(out output.Output, info engine.OrphanedMetadataInfo) {
+	out.Info("\nRemote metadata for '%s' was deleted, but you have local changes:",
+		style.ColorBranchName(info.BranchName, false))
+	if info.LocalMeta != nil {
+		if info.LocalMeta.GetLockReason().IsLocked() {
+			out.Info("  lockReason: %s", info.LocalMeta.GetLockReason())
+		}
+		if info.LocalMeta.GetScope() != nil {
+			out.Info("  scope: %s", *info.LocalMeta.GetScope())
+		}
+	}
 }
 
 // PromptOrphanedMetadata implements Handler. Pauses TUI, displays info, prompts user.
@@ -686,18 +709,25 @@ func (h *InteractiveSyncHandler) PromptOrphanedMetadata(info engine.OrphanedMeta
 	h.runner.Pause()
 	defer h.runner.Resume()
 
-	h.output.Info("\nRemote metadata for '%s' was deleted, but you have local changes:",
-		style.ColorBranchName(info.BranchName, false))
-	if info.LocalMeta != nil {
-		if info.LocalMeta.GetLockReason().IsLocked() {
-			h.output.Info("  lockReason: %s", info.LocalMeta.GetLockReason())
-		}
-		if info.LocalMeta.GetScope() != nil {
-			h.output.Info("  scope: %s", *info.LocalMeta.GetScope())
-		}
-	}
+	describeOrphanedMetadata(h.output, info)
 
 	return tui.PromptConfirm("Push your local metadata to remote?", false)
+}
+
+// describeRestackConflicts writes the human-readable summary of restack
+// conflicts to out. Shared by the interactive handler and the golden transcript
+// harness so both render identical text.
+func describeRestackConflicts(out output.Output, conflictBranches []string) {
+	out.Newline()
+	out.Warn("⚠️  Found conflicts in %d %s during restack:",
+		len(conflictBranches),
+		map[bool]string{true: "branch", false: "branches"}[len(conflictBranches) == 1])
+	for _, name := range conflictBranches {
+		out.Warn("  • %s", style.ColorBranchName(name, false))
+	}
+	out.Newline()
+	out.Info("Branches that could be restacked cleanly have been restacked.")
+	out.Newline()
 }
 
 // PromptResolveConflicts implements Handler. Pauses TUI, displays conflicts, prompts user.
@@ -705,18 +735,34 @@ func (h *InteractiveSyncHandler) PromptResolveConflicts(conflictBranches []strin
 	h.runner.Pause()
 	defer h.runner.Resume()
 
-	h.output.Newline()
-	h.output.Warn("⚠️  Found conflicts in %d %s during restack:",
-		len(conflictBranches),
-		map[bool]string{true: "branch", false: "branches"}[len(conflictBranches) == 1])
-	for _, name := range conflictBranches {
-		h.output.Warn("  • %s", style.ColorBranchName(name, false))
-	}
-	h.output.Newline()
-	h.output.Info("Branches that could be restacked cleanly have been restacked.")
-	h.output.Newline()
+	describeRestackConflicts(h.output, conflictBranches)
 
 	return tui.PromptConfirm("Resolve conflicts now?", false)
+}
+
+// buildDeletionOptions returns the alphabetically sorted branch names alongside
+// the parallel multi-select option labels (branch name + reason, with an
+// "unpushed changes" note) and their default pre-selection state (unpushed
+// branches are not pre-selected). Shared by the interactive handler and the
+// golden transcript harness so both render identical option labels.
+func buildDeletionOptions(branches map[string]string, unpushedBranches map[string]bool) (names, options []string, preSelected []bool) {
+	names = make([]string, 0, len(branches))
+	for name := range branches {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	options = make([]string, len(names))
+	preSelected = make([]bool, len(names))
+	for i, name := range names {
+		reason := branches[name]
+		if unpushedBranches[name] {
+			reason += " — has unpushed changes"
+		}
+		options[i] = fmt.Sprintf("%s (%s)", style.ColorBranchName(name, false), style.ColorDim(reason))
+		preSelected[i] = !unpushedBranches[name] // Don't pre-select branches with unpushed changes
+	}
+	return names, options, preSelected
 }
 
 // PromptBranchDeletions implements Handler. Pauses TUI, displays planned deletions, prompts for each.
@@ -730,31 +776,7 @@ func (h *InteractiveSyncHandler) PromptBranchDeletions(branches map[string]strin
 		return confirmed, nil
 	}
 
-	// Sort branch names for consistent ordering
-	names := make([]string, 0, len(branches))
-	for name := range branches {
-		names = append(names, name)
-	}
-	// Sort alphabetically
-	for i := 0; i < len(names)-1; i++ {
-		for j := i + 1; j < len(names); j++ {
-			if names[i] > names[j] {
-				names[i], names[j] = names[j], names[i]
-			}
-		}
-	}
-
-	// Build options for multi-select with branch name and reason
-	options := make([]string, len(names))
-	preSelected := make([]bool, len(names))
-	for i, name := range names {
-		reason := branches[name]
-		if unpushedBranches[name] {
-			reason += " — has unpushed changes"
-		}
-		options[i] = fmt.Sprintf("%s (%s)", style.ColorBranchName(name, false), style.ColorDim(reason))
-		preSelected[i] = !unpushedBranches[name] // Don't pre-select branches with unpushed changes
-	}
+	names, options, preSelected := buildDeletionOptions(branches, unpushedBranches)
 
 	h.output.Newline()
 	selected, err := tui.PromptMultiSelectWithDefaults("Select branches to delete:", options, preSelected)

--- a/testhelpers/golden/golden.go
+++ b/testhelpers/golden/golden.go
@@ -1,0 +1,90 @@
+// Package golden provides shared helpers for golden-file (snapshot) tests.
+//
+// A golden test captures rendered output as a checked-in .golden file so the
+// output is reviewable as a diff in PRs and regenerated on demand with -update.
+// This package holds the generic machinery (the -update flag, ANSI stripping,
+// file compare with a readable diff) so any command can golden its output by
+// supplying only its own scenarios. See internal/cli/stack/sync_golden_test.go
+// for a worked example.
+package golden
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Update reports whether golden files should be regenerated. Enable it with
+// `go test ./... -update`. Go compiles each package's tests into a separate
+// binary, so this flag is registered independently per test binary and does
+// not collide with -update flags defined in other packages.
+var Update = flag.Bool("update", false, "update golden files")
+
+// ansiRegex matches ANSI color escape sequences.
+var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// StripANSI removes ANSI color escape sequences so golden files stay readable
+// and stable regardless of terminal color settings.
+func StripANSI(s string) string {
+	return ansiRegex.ReplaceAllString(s, "")
+}
+
+// Assert compares actual against the golden file at path. With -update it
+// (re)writes the file (creating parent directories) instead of comparing. On a
+// mismatch it fails the test with a line-by-line diff; on a missing file it
+// hints to run with -update.
+func Assert(t *testing.T, path, actual string) {
+	t.Helper()
+
+	if *Update {
+		if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+			t.Fatalf("golden: create dir for %s: %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(actual), 0o600); err != nil {
+			t.Fatalf("golden: update %s: %v", path, err)
+		}
+		t.Logf("golden: updated %s", path)
+		return
+	}
+
+	want, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Fatalf("golden: %s does not exist; run with -update to create it.\n\nActual output:\n%s", path, actual)
+		}
+		t.Fatalf("golden: read %s: %v", path, err)
+	}
+
+	if actual != string(want) {
+		t.Errorf("golden mismatch for %s (run with -update to accept)\n\nGot:\n%s\n\nWant:\n%s\n\nDiff:\n%s",
+			path, actual, string(want), lineDiff(string(want), actual))
+	}
+}
+
+// lineDiff renders a simple line-by-line diff for debugging mismatches.
+func lineDiff(want, got string) string {
+	wantLines := strings.Split(want, "\n")
+	gotLines := strings.Split(got, "\n")
+
+	var b strings.Builder
+	for i := range max(len(wantLines), len(gotLines)) {
+		var w, g string
+		if i < len(wantLines) {
+			w = wantLines[i]
+		}
+		if i < len(gotLines) {
+			g = gotLines[i]
+		}
+		if w != g {
+			b.WriteString("- ")
+			b.WriteString(w)
+			b.WriteString("\n+ ")
+			b.WriteString(g)
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Add a generic testhelpers/golden package (the -update flag, ANSI stripping,
and file compare with a line diff) so any command can golden its output.

Extract sync's interactive prompt-description rendering into shared helpers
(describeMetadataConflict, describeOrphanedMetadata, buildDeletionOptions,
describeRestackConflicts) so the same text can be reused outside the bubbletea
InteractiveSyncHandler. Pure extraction; no behavior change.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781442517`.


* **PR #1217** 👈
  * **PR #1218**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1219 by jonnii*