### PR TITLE
perf(engine): batch child metadata writes in RenameBranch

### DIFF
--- a/internal/engine/branch_mutations.go
+++ b/internal/engine/branch_mutations.go
@@ -418,15 +418,24 @@ func (e *engineImpl) RenameBranch(ctx context.Context, oldBranch, newBranch Bran
 		}
 	}
 
-	// Update children to point to the new branch name
-	for _, child := range children {
-		childMeta, err := e.readMetadata(child)
-		if err != nil {
-			continue
-		}
-		childMeta = childMeta.WithParentBranchName(&newName)
-		if err := e.writeMetadata(child, childMeta); err != nil {
-			return fmt.Errorf("update parent metadata for child %s: %w", child, err)
+	// Update children to point to the new branch name. Batch the reads and
+	// stage every write in a single metadata transaction so a wide root costs
+	// one atomic ref update instead of two git processes per child.
+	if len(children) > 0 {
+		childMetas, _ := e.batchReadMetadata(children)
+		if err := e.withMetadataTx(ctx, fmt.Sprintf("rename %s to %s: reparent children", oldName, newName), func(tx *MetadataTx) error {
+			for _, child := range children {
+				childMeta := childMetas[child]
+				if childMeta == nil {
+					continue
+				}
+				if err := tx.UpdateMeta(child, childMeta.WithParentBranchName(&newName)); err != nil {
+					return fmt.Errorf("update parent metadata for child %s: %w", child, err)
+				}
+			}
+			return nil
+		}); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

RenameBranch updated each child branch with a separate readMetadata +
writeMetadata pair, spawning two git processes per child (git hash-object
+ git update-ref). For a wide stack root this is an O(N) N+1.

Batch the reads via batchReadMetadata and stage every reparent write in a
single withMetadataTx commit, collapsing the work to one cat-file batch
read plus one atomic git update-ref --stdin regardless of child count. The
transaction is also atomic, so a mid-loop failure no longer leaves some
children reparented and others not.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781486856`.


* **PR #1220** 👈
  * **PR #1221**
    * **PR #1222**
      * **PR #1223**
        * **PR #1224**
          * **PR #1225**
            * **PR #1228**
              * **PR #1230**
                * **PR #1231**
                  * **PR #1232**
                    * **PR #1233**
                      * **PR #1234**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1235 by jonnii*