### PR TITLE
perf(absorb): batch commit-to-branch lookups via FindBranchesForCommits

### DIFF
--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -152,13 +152,12 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		})
 	}
 
-	// Group hunks by branch, then by commit
+	// Group hunks by branch, then by commit. Resolve every target commit's
+	// owning branch in one batched scan instead of a git-log sweep per hunk.
+	commitBranches := eng.FindBranchesForCommits(targetCommitSHAs(hunkTargets))
 	hunksByBranch := make(map[string]map[string][]git.Hunk)
 	for _, target := range hunkTargets {
-		branchName, err := eng.FindBranchForCommit(target.CommitSHA)
-		if err != nil {
-			continue
-		}
+		branchName := commitBranches[target.CommitSHA]
 		if hunksByBranch[branchName] == nil {
 			hunksByBranch[branchName] = make(map[string][]git.Hunk)
 		}

--- a/internal/actions/absorb/output.go
+++ b/internal/actions/absorb/output.go
@@ -11,10 +11,11 @@ func printDryRunOutput(hunksByCommit map[string][]git.Hunk, unabsorbedHunks []gi
 	splog.Info("Would absorb the following changes:")
 	splog.Newline()
 
-	// Get commit info for display
+	// Get commit info for display. Resolve owning branches in one batched scan.
+	commitBranches := eng.FindBranchesForCommits(commitSHAKeys(hunksByCommit))
 	for commitSHA, hunks := range hunksByCommit {
-		branchName, err := eng.FindBranchForCommit(commitSHA)
-		if err != nil {
+		branchName := commitBranches[commitSHA]
+		if branchName == "" {
 			branchName = unknown
 		}
 
@@ -42,14 +43,25 @@ func printDryRunOutput(hunksByCommit map[string][]git.Hunk, unabsorbedHunks []gi
 	}
 }
 
+// commitSHAKeys returns the commit SHAs keying the hunks-by-commit map, for a
+// single batched branch lookup instead of one resolution per commit.
+func commitSHAKeys(hunksByCommit map[string][]git.Hunk) []string {
+	shas := make([]string, 0, len(hunksByCommit))
+	for sha := range hunksByCommit {
+		shas = append(shas, sha)
+	}
+	return shas
+}
+
 // printAbsorbPlan prints the plan for absorbing changes
 func printAbsorbPlan(hunksByCommit map[string][]git.Hunk, unabsorbedHunks []git.Hunk, eng engine.Engine, splog output.Output) {
 	splog.Info("Will absorb the following changes:")
 	splog.Newline()
 
+	commitBranches := eng.FindBranchesForCommits(commitSHAKeys(hunksByCommit))
 	for commitSHA, hunks := range hunksByCommit {
-		branchName, err := eng.FindBranchForCommit(commitSHA)
-		if err != nil {
+		branchName := commitBranches[commitSHA]
+		if branchName == "" {
 			branchName = unknown
 		}
 

--- a/internal/actions/absorb/plan.go
+++ b/internal/actions/absorb/plan.go
@@ -59,10 +59,11 @@ func GeneratePlanJSON(
 		Stack:         buildStackNodes(eng, currentBranch),
 	}
 
-	// Convert absorbed hunks
+	// Convert absorbed hunks. Resolve all target branches in one batched scan.
+	commitBranches := eng.FindBranchesForCommits(targetCommitSHAs(hunkTargets))
 	for _, target := range hunkTargets {
-		branchName, err := eng.FindBranchForCommit(target.CommitSHA)
-		if err != nil {
+		branchName := commitBranches[target.CommitSHA]
+		if branchName == "" {
 			branchName = "unknown"
 		}
 
@@ -132,6 +133,21 @@ func buildStackNodes(eng engine.Engine, currentBranch string) []StackNode {
 	}
 
 	return nodes
+}
+
+// targetCommitSHAs returns the unique commit SHAs referenced by the hunk
+// targets, preserving first-seen order, for a single batched branch lookup.
+func targetCommitSHAs(targets []git.HunkTarget) []string {
+	seen := make(map[string]struct{}, len(targets))
+	shas := make([]string, 0, len(targets))
+	for _, t := range targets {
+		if _, ok := seen[t.CommitSHA]; ok {
+			continue
+		}
+		seen[t.CommitSHA] = struct{}{}
+		shas = append(shas, t.CommitSHA)
+	}
+	return shas
 }
 
 // formatLines formats line range as "start-end" or just "start" for single lines

--- a/internal/engine/engine_reader.go
+++ b/internal/engine/engine_reader.go
@@ -181,25 +181,47 @@ func (e *engineImpl) FindMostRecentTrackedAncestors(ctx context.Context, branchN
 	return nil, nil
 }
 
-// FindBranchForCommit finds which branch a commit belongs to
-func (e *engineImpl) FindBranchForCommit(commitSHA string) (string, error) {
+// FindBranchesForCommits maps each requested commit SHA to the tracked branch
+// that owns it (the branch whose parent..tip range contains the commit). It
+// scans each branch at most once, so the cost is O(branches) git-log
+// invocations regardless of how many SHAs are requested — the batch counterpart
+// to looking up commits one at a time. Commits not owned by any branch are
+// simply absent from the returned map.
+func (e *engineImpl) FindBranchesForCommits(commitSHAs []string) map[string]string {
+	result := make(map[string]string, len(commitSHAs))
+	if len(commitSHAs) == 0 {
+		return result
+	}
+
+	want := make(map[string]struct{}, len(commitSHAs))
+	for _, sha := range commitSHAs {
+		want[sha] = struct{}{}
+	}
+
 	e.mu.RLock()
 	branches := make([]string, len(e.state.branches))
 	copy(branches, e.state.branches)
 	e.mu.RUnlock()
 
 	for _, branchName := range branches {
+		if len(result) == len(want) {
+			break
+		}
 		commits, err := e.GetAllCommits(NewBranch(branchName, e), CommitFormatSHA)
 		if err != nil {
 			continue
 		}
-
-		if slices.Contains(commits, commitSHA) {
-			return branchName, nil
+		for _, sha := range commits {
+			if _, ok := want[sha]; !ok {
+				continue
+			}
+			if _, mapped := result[sha]; !mapped {
+				result[sha] = branchName
+			}
 		}
 	}
 
-	return "", nil
+	return result
 }
 
 // SortBranchesTopologically sorts branches so parents come before children.

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -18,7 +18,7 @@ type StackNavigator interface {
 	Graph(strategy SortStrategy) *StackGraph
 	BranchesDepthFirst(startBranch Branch) iter.Seq2[Branch, int]
 	SortBranchesTopologically(branches Branches) Branches
-	FindBranchForCommit(commitSHA string) (string, error)
+	FindBranchesForCommits(commitSHAs []string) map[string]string
 	// GetAllBranchNames returns the names of all local branches, including ones
 	// not tracked by stackit. Used by diagnostics that must see untracked or
 	// orphaned branches.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

absorb resolved each hunk target to its owning branch with a separate
FindBranchForCommit call, and that method scans every tracked branch with
a git log. Across H hunk targets and B branches this is O(H*B) git-log
invocations, repeated for the same commit when multiple hunks share it.

Replace the per-item FindBranchForCommit with a single engine batch:
FindBranchesForCommits scans each branch at most once and returns a
commit->branch map, making the cost O(B) regardless of hunk count. All
four absorb call sites (group, dry-run, plan print, plan JSON) now share
one batched lookup. The old per-item method is removed from the engine
interface since nothing else used it.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781486856`.


* **PR #1220**
  * **PR #1221** 👈
    * **PR #1222**
      * **PR #1223**
        * **PR #1224**
          * **PR #1225**
            * **PR #1228**
              * **PR #1230**
                * **PR #1231**
                  * **PR #1232**
                    * **PR #1233**
                      * **PR #1234**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1235 by jonnii*