### PR TITLE
perf(fold,pluck): reparent same-parent children via ReparentBranches

### DIFF
--- a/internal/actions/fold/fold_keep.go
+++ b/internal/actions/fold/fold_keep.go
@@ -57,11 +57,12 @@ func foldWithKeep(gctx context.Context, ctx *app.Context, currentBranch, parentB
 		}
 	}
 
-	// Reparent each sibling onto the current branch. Stack ID is propagated
-	// automatically by ReparentBranch.
-	for _, sibling := range siblings {
-		if err := eng.ReparentBranch(gctx, sibling, refreshedCurrent); err != nil {
-			return fmt.Errorf("failed to reparent %s to %s: %w", sibling.GetName(), currentBranch.GetName(), err)
+	// Reparent all siblings onto the current branch in one batch. Stack ID is
+	// propagated automatically, and capturing divergence points up front keeps
+	// related siblings correct.
+	if len(siblings) > 0 {
+		if err := eng.ReparentBranches(gctx, siblings.Names(), refreshedCurrent); err != nil {
+			return fmt.Errorf("failed to reparent siblings to %s: %w", currentBranch.GetName(), err)
 		}
 	}
 

--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -180,11 +180,13 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	if len(children) > 0 {
 		handler.OnStep(StepReparentingChild, basehandler.StatusStarted, "Reparenting children...")
 
+		// All children move to the same grandparent, so reparent them in one
+		// batch instead of a per-child engine call.
+		if err := eng.ReparentBranches(gctx, children.Names(), grandparentBranch); err != nil {
+			handler.OnStep(StepReparentingChild, basehandler.StatusFailed, err.Error())
+			return fmt.Errorf("failed to reparent children to %s: %w", grandparentBranch.GetName(), err)
+		}
 		for _, child := range children {
-			if err := eng.ReparentBranch(gctx, child, grandparentBranch); err != nil {
-				handler.OnStep(StepReparentingChild, basehandler.StatusFailed, err.Error())
-				return fmt.Errorf("failed to reparent %s to %s: %w", child.GetName(), grandparentBranch.GetName(), err)
-			}
 			handler.OnChildReparented(child.GetName(), source, grandparentBranch.GetName())
 			reparentedChildren = append(reparentedChildren, child.GetName())
 			out.Info("Reparented %s from %s to %s.",


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

fold (keep) and pluck reparented their siblings/children one at a time in
a loop with eng.ReparentBranch. Each call captures a divergence point and
writes metadata independently, so a fan of N children cost N separate
reparent passes.

Both loops move every branch to the same new parent, which is exactly the
case the existing ReparentBranches batch handles. It captures all
divergence points before any mutation, so related children stay correct.
Pluck keeps its per-child handler callbacks and logging in a second pass
so the reparentedChildren result is unchanged.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781486856`.


* **PR #1220**
  * **PR #1221**
    * **PR #1222** 👈
      * **PR #1223**
        * **PR #1224**
          * **PR #1225**
            * **PR #1228**
              * **PR #1230**
                * **PR #1231**
                  * **PR #1232**
                    * **PR #1233**
                      * **PR #1234**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1235 by jonnii*