### PR TITLE
perf: warm revision/stat caches before per-branch loops

### DIFF
--- a/internal/actions/debug.go
+++ b/internal/actions/debug.go
@@ -135,6 +135,7 @@ func DebugAction(ctx *app.Context, opts DebugOptions) error {
 
 	branchNames := allBranches.Names()
 	allMeta, _ := eng.BatchReadMetadataRaw(branchNames)
+	revisions, _ := eng.GetRevisions(branchNames)
 
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
 	branchInfos := make([]BranchInfo, 0, len(allBranches))
@@ -147,8 +148,7 @@ func DebugAction(ctx *app.Context, opts DebugOptions) error {
 		}
 
 		branchObj := eng.GetBranch(branchName)
-		sha, err := branchObj.GetRevision()
-		if err == nil {
+		if sha, ok := revisions[branchName]; ok {
 			branchInfo.SHA = sha
 		}
 

--- a/internal/actions/flatten/flatten.go
+++ b/internal/actions/flatten/flatten.go
@@ -449,6 +449,11 @@ func buildFlattenPlan(ctx *app.Context, eng engine.Engine, branches engine.Branc
 	// Starts with trunk, and grows as we process branches
 	potentialParents := []string{trunk.GetName()}
 
+	// Warm the revision and metadata caches once so the per-branch
+	// GetDivergencePoint and GetRevision calls below hit memory instead of
+	// spawning a git rev-parse each.
+	eng.PreloadBranchData()
+
 	for i, b := range branches {
 		bName := b.GetName()
 

--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -457,6 +457,17 @@ func BuildRebaseSpecs(eng engine.Engine, out output.Output, source, onto string,
 	// For descendants, each will be rebased onto its parent (which is part of the moving stack)
 	// Since these are topologically ordered, each parent will be rebased before its children
 	sortedDescendants := eng.SortBranchesTopologically(descendants)
+
+	// Prefetch every descendant's parent revision in one batch instead of a
+	// git rev-parse per descendant.
+	parentNames := make([]string, 0, len(sortedDescendants))
+	for _, d := range sortedDescendants {
+		if parent := d.GetParent(); parent != nil {
+			parentNames = append(parentNames, parent.GetName())
+		}
+	}
+	parentRevs, _ := eng.GetRevisions(parentNames)
+
 	for _, d := range sortedDescendants {
 		if d.GetName() == source {
 			continue // Already handled above
@@ -465,9 +476,9 @@ func BuildRebaseSpecs(eng engine.Engine, out output.Output, source, onto string,
 		if parent == nil {
 			continue
 		}
-		parentRev, revErr := eng.GetRevision(*parent)
-		if revErr != nil {
-			out.Debug("Failed to get revision for parent %s of %s: %v", parent.GetName(), d.GetName(), revErr)
+		parentRev, ok := parentRevs[parent.GetName()]
+		if !ok {
+			out.Debug("Failed to get revision for parent %s of %s", parent.GetName(), d.GetName())
 		}
 
 		// Get the old upstream (divergence point)

--- a/internal/tui/log_ui.go
+++ b/internal/tui/log_ui.go
@@ -308,8 +308,11 @@ func (m *LogModel) enrichData() tea.Cmd {
 		wtData := GetWorktreeData(eng)
 
 		// Pre-load metadata and revisions for all branches to eliminate per-branch
-		// cache misses during parallel annotation building.
+		// cache misses during parallel annotation building. PreloadBranchStats
+		// additionally warms the diff-stat and commit-count caches that
+		// BuildFullAnnotation reads, which PreloadBranchData does not cover.
 		eng.PreloadBranchData()
+		eng.PreloadBranchStats(allBranches)
 
 		// Collect full annotations
 		start := time.Now()


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Several hot loops read per-branch revisions or stats without first warming
the engine caches, so each iteration spawned a git rev-parse / git log:

- tui log: PreloadBranchData warms revisions+metadata but not the
  diff-stat/commit-count caches BuildFullAnnotation reads; add
  PreloadBranchStats so the parallel annotation build hits memory.
- debug snapshot: prefetch all branch revisions with one GetRevisions and
  look them up instead of GetRevision per branch.
- move: prefetch every descendant parent revision in one GetRevisions
  instead of a rev-parse per descendant when building rebase specs.
- flatten plan: PreloadBranchData before the planning loop so the
  per-branch GetDivergencePoint/GetRevision calls are cache hits.

No behavior change; these only populate caches / batch reads that the
loops already depended on.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781486856`.


* **PR #1220**
  * **PR #1221**
    * **PR #1222**
      * **PR #1223** 👈
        * **PR #1224**
          * **PR #1225**
            * **PR #1228**
              * **PR #1230**
                * **PR #1231**
                  * **PR #1232**
                    * **PR #1233**
                      * **PR #1234**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1235 by jonnii*