### PR TITLE
perf(stack-info): batch PR status and warm caches for the stack

### DIFF
--- a/internal/actions/stack_info.go
+++ b/internal/actions/stack_info.go
@@ -62,6 +62,14 @@ func StackInfoAction(ctx *app.Context, opts StackInfoOptions) error {
 	})
 	result := make([]StackBranchInfo, 0, len(stackBranches))
 
+	// Warm the revision/metadata and diff-stat caches once, and read PR
+	// submission status for the whole stack in a single batch, so the loop
+	// below does not spawn a git rev-parse, git diff, and (most costly) a
+	// git ls-remote per branch.
+	eng.PreloadBranchData()
+	eng.PreloadBranchStats(stackBranches)
+	prStatuses, _ := eng.BatchGetPRSubmissionStatus(stackBranches)
+
 	for _, branch := range stackBranches {
 		if branch.IsTrunk() {
 			continue
@@ -103,8 +111,8 @@ func StackInfoAction(ctx *app.Context, opts StackInfoOptions) error {
 		}
 
 		// PR info
-		prStatus, err := branch.GetPRSubmissionStatus()
-		if err == nil && prStatus.PRNumber != nil {
+		prStatus := prStatuses[branch.GetName()]
+		if prStatus.PRNumber != nil {
 			info.PRNumber = prStatus.PRNumber
 			if prStatus.PRInfo != nil {
 				info.PRURL = prStatus.PRInfo.URL()


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

StackInfoAction looped over every branch in the stack with no preloading,
so each iteration paid for a cold revision/diff-stat cache and — worst of
all — a per-branch git ls-remote via GetPRSubmissionStatus.

Warm the revision/metadata and diff-stat caches once (PreloadBranchData +
PreloadBranchStats) and read submission status for the whole stack with a
single BatchGetPRSubmissionStatus, which reads the remote at most once.
The loop now does map lookups for PR status instead of N network round
trips.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781486856`.


* **PR #1220**
  * **PR #1221**
    * **PR #1222**
      * **PR #1223**
        * **PR #1224** 👈
          * **PR #1225**
            * **PR #1228**
              * **PR #1230**
                * **PR #1231**
                  * **PR #1232**
                    * **PR #1233**
                      * **PR #1234**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1235 by jonnii*