### PR TITLE
perf(reorder,flatten): reparent via per-branch ReparentBranchesToParents

### DIFF
--- a/internal/actions/create/insert.go
+++ b/internal/actions/create/insert.go
@@ -63,12 +63,14 @@ func handleInsert(ctx context.Context, newBranch, currentBranch string, runtimeC
 		toMove = siblings
 	}
 
-	// Update parent for each child to move
+	// Reparent every moving child onto the new branch in one batch, recomputing
+	// each child's divergence against it.
+	if err := runtimeCtx.Engine.ReparentBranchesRecompute(ctx, toMove, runtimeCtx.Engine.GetBranch(newBranch)); err != nil {
+		return fmt.Errorf("failed to update parents onto %s: %w", newBranch, err)
+	}
+
 	allToRestack := engine.NewBranchesBuilder(len(toMove) * 2)
 	for _, child := range toMove {
-		if err := runtimeCtx.Engine.TrackBranch(ctx, child, newBranch); err != nil {
-			return fmt.Errorf("failed to update parent for %s: %w", child, err)
-		}
 		childBranch := runtimeCtx.Engine.GetBranch(child)
 		allToRestack.Add(childBranch)
 

--- a/internal/actions/delete/delete.go
+++ b/internal/actions/delete/delete.go
@@ -180,6 +180,7 @@ func preReparentChildrenWithPreservedDivergence(ctx *app.Context, toDelete engin
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
 	reparentedChildren := make([]string, 0)
 	reparentedSet := make(map[string]bool)
+	var moves []engine.BranchParentMove
 
 	for _, deleted := range toDelete {
 		deletedName := deleted.GetName()
@@ -199,14 +200,20 @@ func preReparentChildrenWithPreservedDivergence(ctx *app.Context, toDelete engin
 				continue
 			}
 
-			if err := eng.ReparentBranch(gctx, child, eng.GetBranch(targetParentName)); err != nil {
-				return nil, fmt.Errorf("failed to reparent %s to %s: %w", childName, targetParentName, err)
-			}
-			out.Debug("Pre-reparented %s to %s while preserving divergence", childName, targetParentName)
+			moves = append(moves, engine.BranchParentMove{Branch: childName, NewParent: targetParentName})
+			out.Debug("Will pre-reparent %s to %s while preserving divergence", childName, targetParentName)
 			if !reparentedSet[childName] {
 				reparentedSet[childName] = true
 				reparentedChildren = append(reparentedChildren, childName)
 			}
+		}
+	}
+
+	// Apply every pre-reparent in one batch; divergence points are captured
+	// before any mutation.
+	if len(moves) > 0 {
+		if err := eng.ReparentBranchesToParents(gctx, moves); err != nil {
+			return nil, fmt.Errorf("failed to pre-reparent children: %w", err)
 		}
 	}
 

--- a/internal/actions/flatten/flatten.go
+++ b/internal/actions/flatten/flatten.go
@@ -215,16 +215,18 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Execute the flatten
 	handler.OnStep(StepFlattening, basehandler.StatusStarted, "Moving branches...")
 
-	// Update parent pointers for all planned moves
+	// Update parent pointers for all planned moves in one batch. Each branch
+	// moves to a different parent, so use the per-branch reparent batch; it
+	// captures every divergence point before mutating.
+	moves := make([]engine.BranchParentMove, len(filteredPlan.Moves))
+	for i, move := range filteredPlan.Moves {
+		moves[i] = engine.BranchParentMove{Branch: move.Branch, NewParent: move.NewParent}
+	}
+	if err := eng.ReparentBranchesToParents(gctx, moves); err != nil {
+		handler.OnStep(StepFlattening, basehandler.StatusFailed, err.Error())
+		return fmt.Errorf("failed to update flattened parent relationships: %w", err)
+	}
 	for _, move := range filteredPlan.Moves {
-		moveBranch := eng.GetBranch(move.Branch)
-		newParentBranch := eng.GetBranch(move.NewParent)
-
-		if err := eng.ReparentBranch(gctx, moveBranch, newParentBranch); err != nil {
-			handler.OnStep(StepFlattening, basehandler.StatusFailed, err.Error())
-			return fmt.Errorf("failed to set parent for %s to %s: %w", move.Branch, move.NewParent, err)
-		}
-
 		handler.OnBranchMoved(move.Branch, move.OldParent, move.NewParent)
 		out.Info("  %s: %s -> %s",
 			output.Branch(move.Branch, false),

--- a/internal/actions/reorder.go
+++ b/internal/actions/reorder.go
@@ -256,20 +256,19 @@ func updateParentRelationships(ctx context.Context, eng reorderUpdateEngine, new
 	trunk := eng.Trunk()
 	out.Debug("reorder: updateParentRelationships: trunk is %s", trunk.GetName())
 
+	moves := make([]engine.BranchParentMove, len(newOrder))
 	for i, branchName := range newOrder {
-		branch := eng.GetBranch(branchName)
-		var parent engine.Branch
-		if i == 0 {
-			parent = trunk
-		} else {
-			parent = eng.GetBranch(newOrder[i-1])
+		parentName := trunk.GetName()
+		if i > 0 {
+			parentName = newOrder[i-1]
 		}
-
 		out.Debug("reorder: updateParentRelationships: setting parent of %s to %s",
-			branchName, parent.GetName())
-		if err := eng.ReparentBranch(ctx, branch, parent); err != nil {
-			return fmt.Errorf("failed to set parent of %s to %s: %w", branchName, parent.GetName(), err)
-		}
+			branchName, parentName)
+		moves[i] = engine.BranchParentMove{Branch: branchName, NewParent: parentName}
+	}
+
+	if err := eng.ReparentBranchesToParents(ctx, moves); err != nil {
+		return fmt.Errorf("failed to update reordered parent relationships: %w", err)
 	}
 
 	out.Debug("reorder: updateParentRelationships: all parent relationships updated")

--- a/internal/engine/branch_tracking.go
+++ b/internal/engine/branch_tracking.go
@@ -271,6 +271,13 @@ func (e *engineImpl) ReparentBranch(ctx context.Context, branch Branch, newParen
 	return e.syncStackIDFromParent(ctx, e.GetBranch(branch.GetName()))
 }
 
+// BranchParentMove pairs a branch with the name of the new parent it should
+// adopt. It is the unit of work for ReparentBranchesToParents.
+type BranchParentMove struct {
+	Branch    string
+	NewParent string
+}
+
 // ReparentBranches changes multiple branches to the same new parent while
 // preserving each branch's divergence point. Divergence points are captured
 // for all branches before any reparenting begins, ensuring correctness when
@@ -279,21 +286,38 @@ func (e *engineImpl) ReparentBranch(ctx context.Context, branch Branch, newParen
 // Automatically propagates the new parent's stack ID to each branch when the
 // move crosses a stack boundary.
 func (e *engineImpl) ReparentBranches(ctx context.Context, branchNames []string, newParent Branch) error {
-	divPoints := make(map[string]string, len(branchNames))
-	for _, name := range branchNames {
-		div, err := e.GetDivergencePoint(name)
+	moves := make([]BranchParentMove, len(branchNames))
+	for i, name := range branchNames {
+		moves[i] = BranchParentMove{Branch: name, NewParent: newParent.GetName()}
+	}
+	return e.ReparentBranchesToParents(ctx, moves)
+}
+
+// ReparentBranchesToParents reparents each branch onto its own designated parent
+// while preserving every branch's divergence point. Like ReparentBranches, all
+// divergence points are captured before any mutation so related branches in the
+// set stay correct; unlike it, each branch may move to a different parent — the
+// shape needed by whole-stack rewrites such as reorder and flatten.
+//
+// Automatically propagates each new parent's stack ID when a move crosses a
+// stack boundary.
+func (e *engineImpl) ReparentBranchesToParents(ctx context.Context, moves []BranchParentMove) error {
+	divPoints := make(map[string]string, len(moves))
+	for _, m := range moves {
+		div, err := e.GetDivergencePoint(m.Branch)
 		if err != nil {
-			return fmt.Errorf("failed to determine divergence point for %s: %w", name, err)
+			return fmt.Errorf("failed to determine divergence point for %s: %w", m.Branch, err)
 		}
-		divPoints[name] = div
+		divPoints[m.Branch] = div
 	}
 
-	for _, name := range branchNames {
-		if err := e.setParentPreservingDivergence(ctx, e.GetBranch(name), newParent, divPoints[name]); err != nil {
-			return fmt.Errorf("failed to reparent %s to %s: %w", name, newParent.GetName(), err)
+	for _, m := range moves {
+		newParent := e.GetBranch(m.NewParent)
+		if err := e.setParentPreservingDivergence(ctx, e.GetBranch(m.Branch), newParent, divPoints[m.Branch]); err != nil {
+			return fmt.Errorf("failed to reparent %s to %s: %w", m.Branch, m.NewParent, err)
 		}
-		if err := e.syncStackIDFromParent(ctx, e.GetBranch(name)); err != nil {
-			return fmt.Errorf("failed to sync stack ID for %s: %w", name, err)
+		if err := e.syncStackIDFromParent(ctx, e.GetBranch(m.Branch)); err != nil {
+			return fmt.Errorf("failed to sync stack ID for %s: %w", m.Branch, err)
 		}
 	}
 	return nil

--- a/internal/engine/branch_tracking.go
+++ b/internal/engine/branch_tracking.go
@@ -323,6 +323,26 @@ func (e *engineImpl) ReparentBranchesToParents(ctx context.Context, moves []Bran
 	return nil
 }
 
+// ReparentBranchesRecompute reparents each branch onto the same new parent and
+// recomputes its divergence point against that parent (a fresh merge-base)
+// rather than preserving the existing one. Use when the branches are moving
+// under a newly created/inserted parent and should replay their own commits
+// onto it — the batch counterpart to SetParent(..., DivergenceRecompute).
+//
+// Automatically propagates the new parent's stack ID when a move crosses a
+// stack boundary.
+func (e *engineImpl) ReparentBranchesRecompute(ctx context.Context, branchNames []string, newParent Branch) error {
+	for _, name := range branchNames {
+		if err := e.SetParent(ctx, e.GetBranch(name), newParent, DivergenceRecompute); err != nil {
+			return fmt.Errorf("failed to reparent %s to %s: %w", name, newParent.GetName(), err)
+		}
+		if err := e.syncStackIDFromParent(ctx, e.GetBranch(name)); err != nil {
+			return fmt.Errorf("failed to sync stack ID for %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
 // updateParentRevision updates the parent revision in metadata using transaction API
 // with retry logic for concurrent modification resilience.
 func (e *engineImpl) updateParentRevision(ctx context.Context, branchName string, parentRev string) error {

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -161,6 +161,10 @@ type BranchTracking interface {
 	// preserving divergence points. All divergence points are captured before
 	// any reparenting begins.
 	ReparentBranches(ctx context.Context, branchNames []string, newParent Branch) error
+	// ReparentBranchesToParents reparents each branch onto its own designated
+	// parent (per-branch, unlike ReparentBranches) while preserving divergence
+	// points, all captured before any mutation begins.
+	ReparentBranchesToParents(ctx context.Context, moves []BranchParentMove) error
 	SetScope(ctx context.Context, branch Branch, scope Scope) error
 	// SetScopeAndMarkForUpdate sets the scope and marks the branch as needing a
 	// PR body update in one atomic transaction instead of two separate ref writes.

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -165,6 +165,10 @@ type BranchTracking interface {
 	// parent (per-branch, unlike ReparentBranches) while preserving divergence
 	// points, all captured before any mutation begins.
 	ReparentBranchesToParents(ctx context.Context, moves []BranchParentMove) error
+	// ReparentBranchesRecompute reparents multiple branches onto the same new
+	// parent and recomputes each divergence point against it (fresh merge-base).
+	// Use when moving branches under a newly created parent.
+	ReparentBranchesRecompute(ctx context.Context, branchNames []string, newParent Branch) error
 	SetScope(ctx context.Context, branch Branch, scope Scope) error
 	// SetScopeAndMarkForUpdate sets the scope and marks the branch as needing a
 	// PR body update in one atomic transaction instead of two separate ref writes.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

reorder and flatten each rewrote a whole stack by calling ReparentBranch
in a loop, one branch at a time. ReparentBranch recaptures the divergence
point and writes metadata per call, and capturing divergence mid-loop is
fragile when the branches being moved are related.

Add engine.ReparentBranchesToParents(moves), the per-branch-parent
counterpart to ReparentBranches: it captures every divergence point
before any mutation, then applies each move. ReparentBranches is now a
thin wrapper over it (same-parent is just every move sharing a parent).
reorder builds a chain of moves and flatten builds its planned moves, so
neither calls the per-item ReparentBranch in a loop anymore.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781486856`.


* **PR #1220**
  * **PR #1221**
    * **PR #1222**
      * **PR #1223**
        * **PR #1224**
          * **PR #1225** 👈
            * **PR #1228**
              * **PR #1230**
                * **PR #1231**
                  * **PR #1232**
                    * **PR #1233**
                      * **PR #1234**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1235 by jonnii*