### PR TITLE
perf(create): batch child reparenting on insert via ReparentBranchesRecompute

### DIFF
--- a/internal/actions/create/insert.go
+++ b/internal/actions/create/insert.go
@@ -63,12 +63,14 @@ func handleInsert(ctx context.Context, newBranch, currentBranch string, runtimeC
 		toMove = siblings
 	}
 
-	// Update parent for each child to move
+	// Reparent every moving child onto the new branch in one batch, recomputing
+	// each child's divergence against it.
+	if err := runtimeCtx.Engine.ReparentBranchesRecompute(ctx, toMove, runtimeCtx.Engine.GetBranch(newBranch)); err != nil {
+		return fmt.Errorf("failed to update parents onto %s: %w", newBranch, err)
+	}
+
 	allToRestack := engine.NewBranchesBuilder(len(toMove) * 2)
 	for _, child := range toMove {
-		if err := runtimeCtx.Engine.TrackBranch(ctx, child, newBranch); err != nil {
-			return fmt.Errorf("failed to update parent for %s: %w", child, err)
-		}
 		childBranch := runtimeCtx.Engine.GetBranch(child)
 		allToRestack.Add(childBranch)
 

--- a/internal/engine/branch_tracking.go
+++ b/internal/engine/branch_tracking.go
@@ -323,6 +323,26 @@ func (e *engineImpl) ReparentBranchesToParents(ctx context.Context, moves []Bran
 	return nil
 }
 
+// ReparentBranchesRecompute reparents each branch onto the same new parent and
+// recomputes its divergence point against that parent (a fresh merge-base)
+// rather than preserving the existing one. Use when the branches are moving
+// under a newly created/inserted parent and should replay their own commits
+// onto it — the batch counterpart to SetParent(..., DivergenceRecompute).
+//
+// Automatically propagates the new parent's stack ID when a move crosses a
+// stack boundary.
+func (e *engineImpl) ReparentBranchesRecompute(ctx context.Context, branchNames []string, newParent Branch) error {
+	for _, name := range branchNames {
+		if err := e.SetParent(ctx, e.GetBranch(name), newParent, DivergenceRecompute); err != nil {
+			return fmt.Errorf("failed to reparent %s to %s: %w", name, newParent.GetName(), err)
+		}
+		if err := e.syncStackIDFromParent(ctx, e.GetBranch(name)); err != nil {
+			return fmt.Errorf("failed to sync stack ID for %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
 // updateParentRevision updates the parent revision in metadata using transaction API
 // with retry logic for concurrent modification resilience.
 func (e *engineImpl) updateParentRevision(ctx context.Context, branchName string, parentRev string) error {

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -165,6 +165,10 @@ type BranchTracking interface {
 	// parent (per-branch, unlike ReparentBranches) while preserving divergence
 	// points, all captured before any mutation begins.
 	ReparentBranchesToParents(ctx context.Context, moves []BranchParentMove) error
+	// ReparentBranchesRecompute reparents multiple branches onto the same new
+	// parent and recomputes each divergence point against it (fresh merge-base).
+	// Use when moving branches under a newly created parent.
+	ReparentBranchesRecompute(ctx context.Context, branchNames []string, newParent Branch) error
 	SetScope(ctx context.Context, branch Branch, scope Scope) error
 	// SetScopeAndMarkForUpdate sets the scope and marks the branch as needing a
 	// PR body update in one atomic transaction instead of two separate ref writes.


### PR DESCRIPTION

Inserting a branch moved each selected child onto the new branch with a
per-child TrackBranch call, recomputing divergence and writing metadata
one branch at a time.

Add engine.ReparentBranchesRecompute(branchNames, newParent) — the batch
counterpart to SetParent(..., DivergenceRecompute) — and use it to move
all children at once. The restack-target gathering stays in its own loop
since it walks each child's descendants. The children already exist in the
graph (new branch was created first), so no per-child existence revalidation
is needed.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1220**
  * **PR #1221**
    * **PR #1222**
      * **PR #1223**
        * **PR #1224**
          * **PR #1225**
            * **PR #1226** 👈
              * **PR #1227**
                * **PR #1228**
                  * **PR #1229**
                    * **PR #1230**
                      * **PR #1231**
                        * **PR #1232**
                          * **PR #1233**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->