### PR TITLE
perf(delete): batch pre-reparent of children via ReparentBranchesToParents

### DIFF
--- a/internal/actions/delete/delete.go
+++ b/internal/actions/delete/delete.go
@@ -180,6 +180,7 @@ func preReparentChildrenWithPreservedDivergence(ctx *app.Context, toDelete engin
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
 	reparentedChildren := make([]string, 0)
 	reparentedSet := make(map[string]bool)
+	var moves []engine.BranchParentMove
 
 	for _, deleted := range toDelete {
 		deletedName := deleted.GetName()
@@ -199,14 +200,20 @@ func preReparentChildrenWithPreservedDivergence(ctx *app.Context, toDelete engin
 				continue
 			}
 
-			if err := eng.ReparentBranch(gctx, child, eng.GetBranch(targetParentName)); err != nil {
-				return nil, fmt.Errorf("failed to reparent %s to %s: %w", childName, targetParentName, err)
-			}
-			out.Debug("Pre-reparented %s to %s while preserving divergence", childName, targetParentName)
+			moves = append(moves, engine.BranchParentMove{Branch: childName, NewParent: targetParentName})
+			out.Debug("Will pre-reparent %s to %s while preserving divergence", childName, targetParentName)
 			if !reparentedSet[childName] {
 				reparentedSet[childName] = true
 				reparentedChildren = append(reparentedChildren, childName)
 			}
+		}
+	}
+
+	// Apply every pre-reparent in one batch; divergence points are captured
+	// before any mutation.
+	if len(moves) > 0 {
+		if err := eng.ReparentBranchesToParents(gctx, moves); err != nil {
+			return nil, fmt.Errorf("failed to pre-reparent children: %w", err)
 		}
 	}
 


### PR DESCRIPTION

When deleting branches, preReparentChildrenWithPreservedDivergence moved
each surviving child onto its deleted parent's nearest non-excluded
ancestor with a per-child ReparentBranch call, nested in the per-deleted
outer loop.

Collect all (child -> target ancestor) moves across both loops and apply
them in a single ReparentBranchesToParents call. Each child has exactly
one parent so there are no duplicate moves, and divergence is preserved as
before (now captured for the whole set up front).

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1220**
  * **PR #1221**
    * **PR #1222**
      * **PR #1223**
        * **PR #1224**
          * **PR #1225**
            * **PR #1226**
              * **PR #1227** 👈
                * **PR #1228**
                  * **PR #1229**
                    * **PR #1230**
                      * **PR #1231**
                        * **PR #1232**
                          * **PR #1233**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->