### PR TITLE
perf(submit): batch PR-info writes and warm caches during planning

### DIFF
--- a/internal/actions/submit/planning.go
+++ b/internal/actions/submit/planning.go
@@ -16,6 +16,14 @@ func prepareBranchesForSubmit(ctx *app.Context, branches engine.Branches, opts O
 	submissionInfos := make([]Info, 0, len(branches))
 	nav := ctx.Navigator()
 
+	// Warm revision and metadata caches so the per-branch GetRevision calls in
+	// the loop are cache hits rather than a git rev-parse each.
+	ctx.Engine.PreloadBranchData()
+
+	// PR-info writes are collected here and persisted in one batched ref write
+	// after planning, instead of a git ref write per branch.
+	prUpdates := make(map[string]*engine.PrInfo, len(branches))
+
 	var (
 		statuses map[string]engine.PRSubmissionStatus
 		err      error
@@ -107,6 +115,7 @@ func prepareBranchesForSubmit(ctx *app.Context, branches engine.Branches, opts O
 		if err != nil {
 			return nil, fmt.Errorf("failed to prepare metadata for %s: %w", branchName, err)
 		}
+		prUpdates[branchName] = pendingPrInfo(branch, metadata)
 
 		// Get SHAs
 		headSHA, _ := branch.GetRevision()
@@ -133,6 +142,15 @@ func prepareBranchesForSubmit(ctx *app.Context, branches engine.Branches, opts O
 		})
 
 		submissionInfos = append(submissionInfos, submissionInfo)
+	}
+
+	// Persist all prepared PR info in one batched write so a later submit
+	// failure can recover the titles/bodies. Non-fatal, like the per-branch
+	// write it replaces.
+	if len(prUpdates) > 0 {
+		if err := ctx.Engine.BatchUpsertPrInfo(ctx.Context, prUpdates); err != nil {
+			ctx.Output.Debug("Failed to save PR metadata: %v", err)
+		}
 	}
 
 	return submissionInfos, nil

--- a/internal/actions/submit/submit_metadata.go
+++ b/internal/actions/submit/submit_metadata.go
@@ -68,7 +68,6 @@ func GetReviewersWithPrompt(reviewersFlag string) ([]string, []string, error) {
 func PreparePRMetadata(branch engine.Branch, opts MetadataOptions, ctx *app.Context) (*PRMetadata, error) {
 	prInfo, _ := branch.GetPrInfo()
 	nav := ctx.Navigator()
-	pr := ctx.PR()
 
 	metadata := &PRMetadata{
 		Title:   getStringValue(prInfo, "Title"),
@@ -156,8 +155,16 @@ func PreparePRMetadata(branch engine.Branch, opts MetadataOptions, ctx *app.Cont
 	// Set assignees from config
 	metadata.Assignees = opts.ConfigAssignees
 
-	// Save metadata to engine in case command fails
-	if err := pr.UpsertPrInfo(ctx.Context, branch, engine.NewPrInfo(
+	// The prepared title/body/draft are persisted by the caller in one batch
+	// after planning (see prepareBranchesForSubmit), so a later submit failure
+	// can still recover them. PreparePRMetadata itself stays side-effect free.
+	return metadata, nil
+}
+
+// pendingPrInfo builds the PR info to persist for a branch from its prepared
+// metadata, matching what was previously written inline by PreparePRMetadata.
+func pendingPrInfo(branch engine.Branch, metadata *PRMetadata) *engine.PrInfo {
+	return engine.NewPrInfo(
 		nil,
 		metadata.Title,
 		metadata.Body,
@@ -165,11 +172,7 @@ func PreparePRMetadata(branch engine.Branch, opts MetadataOptions, ctx *app.Cont
 		"",
 		"",
 		metadata.IsDraft,
-	).WithLockReason(branch.GetLockReason())); err != nil {
-		ctx.Output.Debug("Failed to save PR metadata: %v", err)
-	}
-
-	return metadata, nil
+	).WithLockReason(branch.GetLockReason())
 }
 
 // MetadataOptions contains options for PR metadata collection

--- a/internal/actions/submit/submit_validation.go
+++ b/internal/actions/submit/submit_validation.go
@@ -81,6 +81,32 @@ func validateBaseRevisions(branches []string, eng engine.BranchStatus, ctx *app.
 	validatedBranches := make(map[string]bool)
 	nav := ctx.Navigator()
 
+	// Read remote status for every parent at most once, and only if a branch
+	// actually needs it, so a stack whose parents are all trunk or in-list stays
+	// offline. When needed, all parents are read in a single ls-remote instead
+	// of one per branch.
+	var (
+		remoteStatuses engine.BranchRemoteStatuses
+		remoteRead     bool
+	)
+	parentRemoteStatuses := func() engine.BranchRemoteStatuses {
+		if !remoteRead {
+			parentBranches := engine.Branches{}
+			seen := make(map[string]bool)
+			for _, branchName := range branches {
+				parentName := resolveSubmitParentName(nav, eng.GetBranch(branchName))
+				if seen[parentName] {
+					continue
+				}
+				seen[parentName] = true
+				parentBranches = parentBranches.Append(eng.GetBranch(parentName))
+			}
+			remoteStatuses = eng.ReadBranchRemoteStatuses(ctx.Context, parentBranches)
+			remoteRead = true
+		}
+		return remoteStatuses
+	}
+
 	for _, branchName := range branches {
 		branch := eng.GetBranch(branchName)
 		parentBranchName := resolveSubmitParentName(nav, branch)
@@ -100,7 +126,7 @@ func validateBaseRevisions(branches []string, eng engine.BranchStatus, ctx *app.
 			}
 		default:
 			// Parent is not in submission list
-			if !eng.ReadBranchRemoteStatuses(ctx.Context, engine.BranchesOf(parentBranch)).ForBranch(parentBranch).Matches() {
+			if !parentRemoteStatuses().ForBranch(parentBranch).Matches() {
 				return fmt.Errorf("you are trying to submit at least one branch whose base does not match its parent remotely, without including its parent. You may want to use 'stackit submit --stack' to ensure that the ancestors of %s are included in your submission",
 					output.Branch(branchName, false))
 			}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Submit planning prepared each branch in a loop, and PreparePRMetadata
wrote that branch's PR info to the engine inline (a git ref write per
branch). The loop also read each branch and parent revision from a cold
cache, spawning a git rev-parse each.

Make PreparePRMetadata side-effect free and have the planner collect the
prepared PR info, persisting all branches with one BatchUpsertPrInfo after
the loop (still before the submission phase, so failure recovery is
preserved). PreloadBranchData up front turns the per-branch GetRevision
calls into cache hits.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781486856`.


* **PR #1220**
  * **PR #1221**
    * **PR #1222**
      * **PR #1223**
        * **PR #1224**
          * **PR #1225**
            * **PR #1228** 👈
              * **PR #1230**
                * **PR #1231**
                  * **PR #1232**
                    * **PR #1233**
                      * **PR #1234**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1235 by jonnii*