### PR TITLE
perf(submit): read external parent remote status in one batch

### DIFF
--- a/internal/actions/submit/submit_validation.go
+++ b/internal/actions/submit/submit_validation.go
@@ -81,6 +81,32 @@ func validateBaseRevisions(branches []string, eng engine.BranchStatus, ctx *app.
 	validatedBranches := make(map[string]bool)
 	nav := ctx.Navigator()
 
+	// Read remote status for every parent at most once, and only if a branch
+	// actually needs it, so a stack whose parents are all trunk or in-list stays
+	// offline. When needed, all parents are read in a single ls-remote instead
+	// of one per branch.
+	var (
+		remoteStatuses engine.BranchRemoteStatuses
+		remoteRead     bool
+	)
+	parentRemoteStatuses := func() engine.BranchRemoteStatuses {
+		if !remoteRead {
+			parentBranches := engine.Branches{}
+			seen := make(map[string]bool)
+			for _, branchName := range branches {
+				parentName := resolveSubmitParentName(nav, eng.GetBranch(branchName))
+				if seen[parentName] {
+					continue
+				}
+				seen[parentName] = true
+				parentBranches = parentBranches.Append(eng.GetBranch(parentName))
+			}
+			remoteStatuses = eng.ReadBranchRemoteStatuses(ctx.Context, parentBranches)
+			remoteRead = true
+		}
+		return remoteStatuses
+	}
+
 	for _, branchName := range branches {
 		branch := eng.GetBranch(branchName)
 		parentBranchName := resolveSubmitParentName(nav, branch)
@@ -100,7 +126,7 @@ func validateBaseRevisions(branches []string, eng engine.BranchStatus, ctx *app.
 			}
 		default:
 			// Parent is not in submission list
-			if !eng.ReadBranchRemoteStatuses(ctx.Context, engine.BranchesOf(parentBranch)).ForBranch(parentBranch).Matches() {
+			if !parentRemoteStatuses().ForBranch(parentBranch).Matches() {
 				return fmt.Errorf("you are trying to submit at least one branch whose base does not match its parent remotely, without including its parent. You may want to use 'stackit submit --stack' to ensure that the ancestors of %s are included in your submission",
 					output.Branch(branchName, false))
 			}


### PR DESCRIPTION

validateBaseRevisions checked, for every branch whose parent is outside
the submission set, whether the parent matched its remote — each check
ran a separate git ls-remote.

Read remote status for all parents in a single lazy batched call: the
first branch that needs it triggers one ReadBranchRemoteStatuses over
every parent, and the rest reuse that snapshot. A stack whose parents are
all trunk or in the submission set never touches the network, preserving
the offline path.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1220**
  * **PR #1221**
    * **PR #1222**
      * **PR #1223**
        * **PR #1224**
          * **PR #1225**
            * **PR #1226**
              * **PR #1227**
                * **PR #1228**
                  * **PR #1229** 👈
                    * **PR #1230**
                      * **PR #1231**
                        * **PR #1232**
                          * **PR #1233**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->