### PR TITLE
perf(sync): batch orphaned-metadata cleanup in one transaction

### DIFF
--- a/internal/actions/sync/metadata_sync.go
+++ b/internal/actions/sync/metadata_sync.go
@@ -119,15 +119,16 @@ func handleOrphanedMetadata(ctx *app.Context, opts *Options, handler Handler) er
 		return nil
 	}
 
+	// Collect the auto-delete actions so they apply in one batched transaction;
+	// branches with local changes still prompt per-branch.
+	var deleteRefs, clearLocalHash []string
 	for _, info := range orphaned {
 		if info.Action == engine.OrphanedActionDelete {
 			// No local changes - silently remove sync state or delete ref if branch is gone
 			if !info.ExistsLocally {
-				if err := eng.DeleteMetadata(ctx.Context, info.BranchName); err != nil {
-					out.Debug("Failed to delete orphaned metadata ref for %s: %v", info.BranchName, err)
-				}
-			} else if err := eng.DeleteLocalMetadataHash(info.BranchName); err != nil {
-				out.Debug("Failed to delete metadata hash for %s: %v", info.BranchName, err)
+				deleteRefs = append(deleteRefs, info.BranchName)
+			} else {
+				clearLocalHash = append(clearLocalHash, info.BranchName)
 			}
 		} else {
 			// Has local changes - prompt user via handler
@@ -135,6 +136,10 @@ func handleOrphanedMetadata(ctx *app.Context, opts *Options, handler Handler) er
 				return err
 			}
 		}
+	}
+
+	if err := eng.CleanOrphanedMetadata(ctx.Context, deleteRefs, clearLocalHash); err != nil {
+		out.Debug("Failed to clean orphaned metadata: %v", err)
 	}
 
 	return nil

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -94,6 +94,10 @@ type RemoteMetadataManager interface {
 	FindOrphanedLocalMetadata() ([]OrphanedMetadataInfo, error)
 	DeleteLocalMetadataHash(branchName string) error
 	DeleteMetadata(ctx context.Context, branchName string) error
+	// CleanOrphanedMetadata deletes metadata refs for branches whose local
+	// branch is gone (deleteRefs) and clears the local-only hash for branches
+	// that remain (clearLocalHash), in a single transaction.
+	CleanOrphanedMetadata(ctx context.Context, deleteRefs []string, clearLocalHash []string) error
 	FetchRemoteMetadata(ctx context.Context) error
 	ConfigureRemoteMetadataSync(ctx context.Context) error
 	// TestRemoteMetadataCompatibility probes the configured remote to verify it

--- a/internal/engine/remote_sync.go
+++ b/internal/engine/remote_sync.go
@@ -506,6 +506,40 @@ func (e *engineImpl) DeleteMetadata(ctx context.Context, branchName string) erro
 	})
 }
 
+// CleanOrphanedMetadata reconciles branches whose remote metadata was deleted in
+// a single transaction: it deletes the metadata ref entirely for branches whose
+// local branch is also gone (deleteRefs) and clears just the local-only hash for
+// branches that still exist locally (clearLocalHash). This replaces one git ref
+// write per orphaned branch with a single batched write.
+func (e *engineImpl) CleanOrphanedMetadata(ctx context.Context, deleteRefs []string, clearLocalHash []string) error {
+	if len(deleteRefs) == 0 && len(clearLocalHash) == 0 {
+		return nil
+	}
+
+	return e.WithRetry(ctx, func() error {
+		metas, _ := e.batchReadMetadata(clearLocalHash)
+
+		tx := e.BeginTx(fmt.Sprintf("clean orphaned metadata: %d deleted, %d cleared", len(deleteRefs), len(clearLocalHash)))
+		for _, name := range deleteRefs {
+			if err := tx.DeleteMeta(name); err != nil {
+				tx.Rollback()
+				return err
+			}
+		}
+		for _, name := range clearLocalHash {
+			meta := metas[name]
+			if meta == nil {
+				continue
+			}
+			if err := tx.UpdateMeta(name, meta.WithLocalOnlyHash(nil)); err != nil {
+				tx.Rollback()
+				return err
+			}
+		}
+		return tx.Commit(ctx)
+	})
+}
+
 // FetchRemoteMetadata fetches metadata refs into the remote-metadata
 // namespace, so the cache loader sees the latest authored values.
 func (e *engineImpl) FetchRemoteMetadata(ctx context.Context) error {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

When reconciling branches whose remote metadata was deleted, sync looped
over the orphans and issued a DeleteMetadata or DeleteLocalMetadataHash
per branch — one git ref write each.

Add engine.CleanOrphanedMetadata(deleteRefs, clearLocalHash), which stages
all ref deletions and local-hash clears in a single metadata transaction.
Sync now collects the auto-delete actions and applies them in one batched
write; branches with local changes still prompt per-branch.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781486856`.


* **PR #1220**
  * **PR #1221**
    * **PR #1222**
      * **PR #1223**
        * **PR #1224**
          * **PR #1225**
            * **PR #1228**
              * **PR #1230** 👈
                * **PR #1231**
                  * **PR #1232**
                    * **PR #1233**
                      * **PR #1234**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1235 by jonnii*