### PR TITLE
perf(merge): resolve PR node IDs in one GraphQL query

### DIFF
--- a/internal/actions/merge/plan.go
+++ b/internal/actions/merge/plan.go
@@ -771,24 +771,27 @@ func CanMergeIndividually(ctx context.Context, gitRunner git.Runner, githubClien
 	}
 
 	// Check 2: All PRs must have MERGEABLE state
-	// First, collect all PR NodeIDs (still requires N API calls)
+	// Resolve all PR node IDs in a single GraphQL query instead of one REST call per PR.
 	owner, repo := githubClient.GetOwnerRepo()
+	prNumbers := make([]int, 0, len(branches))
+	for _, branchInfo := range branches {
+		prNumbers = append(prNumbers, branchInfo.PRNumber)
+	}
+	nodeIDByNumber, err := github.BatchGetPRNodeIDsGraphQL(ctx, gitRunner, owner, repo, prNumbers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to batch get PR node IDs: %w", err)
+	}
+
 	nodeIDToBranch := make(map[string]string, len(branches))
 	nodeIDs := make([]string, 0, len(branches))
-
 	for _, branchInfo := range branches {
-		prInfo, err := githubClient.GetPullRequest(ctx, owner, repo, branchInfo.PRNumber)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get PR #%d for %s: %w", branchInfo.PRNumber, branchInfo.BranchName, err)
-		}
-
-		if prInfo == nil || prInfo.NodeID == "" {
+		nodeID := nodeIDByNumber[branchInfo.PRNumber]
+		if nodeID == "" {
 			status.BlockingReason = fmt.Sprintf("branch %s has no PR node ID", branchInfo.BranchName)
 			return status, nil
 		}
-
-		nodeIDToBranch[prInfo.NodeID] = branchInfo.BranchName
-		nodeIDs = append(nodeIDs, prInfo.NodeID)
+		nodeIDToBranch[nodeID] = branchInfo.BranchName
+		nodeIDs = append(nodeIDs, nodeID)
 	}
 
 	// Batch fetch all mergeable states in a single GraphQL query

--- a/internal/github/pr_node_ids.go
+++ b/internal/github/pr_node_ids.go
@@ -1,0 +1,86 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// BatchGetPRNodeIDsGraphQL fetches PR node IDs for multiple PR numbers using a
+// single GraphQL query, replacing one REST GetPullRequest call per number.
+// Numbers with no matching PR are simply absent from the returned map.
+func BatchGetPRNodeIDsGraphQL(ctx context.Context, runner GitCommandRunner, owner, repo string, prNumbers []int) (map[int]string, error) {
+	if len(prNumbers) == 0 {
+		return make(map[int]string), nil
+	}
+
+	// Deduplicate PR numbers
+	seen := make(map[int]struct{}, len(prNumbers))
+	unique := make([]int, 0, len(prNumbers))
+	for _, n := range prNumbers {
+		if _, ok := seen[n]; !ok {
+			seen[n] = struct{}{}
+			unique = append(unique, n)
+		}
+	}
+
+	query := buildPRNodeIDsQuery(unique)
+	variables := map[string]any{
+		"owner": owner,
+		"repo":  repo,
+	}
+
+	body, err := executeGraphQLQuery(ctx, runner, query, variables)
+	if err != nil {
+		return nil, err
+	}
+
+	return parsePRNodeIDsResponse(body, unique)
+}
+
+// buildPRNodeIDsQuery builds a GraphQL query to fetch node IDs for multiple PRs by number.
+func buildPRNodeIDsQuery(prNumbers []int) string {
+	var b strings.Builder
+	b.WriteString("query($owner: String!, $repo: String!) {\n")
+	b.WriteString("  repository(owner: $owner, name: $repo) {\n")
+	for _, n := range prNumbers {
+		fmt.Fprintf(&b, "    pr_%d: pullRequest(number: %d) { id }\n", n, n)
+	}
+	b.WriteString("  }\n")
+	b.WriteString("}\n")
+	return b.String()
+}
+
+// parsePRNodeIDsResponse parses the GraphQL response for PR node ID queries.
+func parsePRNodeIDsResponse(body []byte, prNumbers []int) (map[int]string, error) {
+	var graphqlResponse struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(body, &graphqlResponse); err != nil {
+		return nil, fmt.Errorf("failed to parse GraphQL response: %w", err)
+	}
+
+	repository, ok := graphqlResponse.Data["repository"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("invalid GraphQL response format: missing repository")
+	}
+
+	results := make(map[int]string, len(prNumbers))
+	for _, n := range prNumbers {
+		alias := fmt.Sprintf("pr_%d", n)
+		data, ok := repository[alias]
+		if !ok || data == nil {
+			continue
+		}
+		prData, ok := data.(map[string]any)
+		if !ok {
+			continue
+		}
+		if id, ok := prData["id"].(string); ok {
+			results[n] = id
+		}
+	}
+
+	return results, nil
+}

--- a/internal/github/pr_node_ids_test.go
+++ b/internal/github/pr_node_ids_test.go
@@ -1,0 +1,93 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPRNodeIDsQuery(t *testing.T) {
+	t.Parallel()
+
+	query := buildPRNodeIDsQuery([]int{42, 99})
+
+	require.Contains(t, query, "pr_42: pullRequest(number: 42) { id }")
+	require.Contains(t, query, "pr_99: pullRequest(number: 99) { id }")
+	require.Contains(t, query, "repository(owner: $owner, name: $repo)")
+}
+
+func TestBuildPRNodeIDsQuery_Empty(t *testing.T) {
+	t.Parallel()
+
+	query := buildPRNodeIDsQuery(nil)
+
+	require.Contains(t, query, "repository(owner: $owner, name: $repo)")
+	require.NotContains(t, query, "pullRequest")
+}
+
+func TestParsePRNodeIDsResponse(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"data": {
+			"repository": {
+				"pr_42": {"id": "PR_kwAAA42"},
+				"pr_99": {"id": "PR_kwAAA99"}
+			}
+		}
+	}`)
+
+	ids, err := parsePRNodeIDsResponse(body, []int{42, 99})
+	require.NoError(t, err)
+	require.Equal(t, map[int]string{
+		42: "PR_kwAAA42",
+		99: "PR_kwAAA99",
+	}, ids)
+}
+
+func TestParsePRNodeIDsResponse_NullEntry(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"data": {
+			"repository": {
+				"pr_42": {"id": "PR_kwAAA42"},
+				"pr_99": null
+			}
+		}
+	}`)
+
+	ids, err := parsePRNodeIDsResponse(body, []int{42, 99})
+	require.NoError(t, err)
+	require.Equal(t, map[int]string{42: "PR_kwAAA42"}, ids)
+}
+
+func TestParsePRNodeIDsResponse_Empty(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"data": {
+			"repository": {}
+		}
+	}`)
+
+	ids, err := parsePRNodeIDsResponse(body, []int{42})
+	require.NoError(t, err)
+	require.Empty(t, ids)
+}
+
+func TestParsePRNodeIDsResponse_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	_, err := parsePRNodeIDsResponse([]byte(`{invalid`), []int{42})
+	require.Error(t, err)
+}
+
+func TestParsePRNodeIDsResponse_MissingRepository(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"data": {}}`)
+	_, err := parsePRNodeIDsResponse(body, []int{42})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing repository")
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

CanMergeIndividually resolved each leaf PR's node ID with a separate REST
GetPullRequest call before batch-fetching mergeable states — the code even
noted it "still requires N API calls".

Add github.BatchGetPRNodeIDsGraphQL (mirroring BatchGetPRTitlesGraphQL),
which fetches every PR's node ID by number in a single aliased GraphQL
query, and use it so node-ID resolution is one round trip regardless of
branch count. A number with no matching PR is absent from the map and
still yields the existing "no PR node ID" blocking reason.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781486856`.


* **PR #1220**
  * **PR #1221**
    * **PR #1222**
      * **PR #1223**
        * **PR #1224**
          * **PR #1225**
            * **PR #1228**
              * **PR #1230**
                * **PR #1231** 👈
                  * **PR #1232**
                    * **PR #1233**
                      * **PR #1234**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1235 by jonnii*