### PR TITLE
perf(git): read stack metadata in one cat-file lookup

### DIFF
--- a/internal/git/stack_metadata.go
+++ b/internal/git/stack_metadata.go
@@ -58,18 +58,14 @@ const (
 func (r *runner) ReadStackMeta(stackID string) (*StackMeta, error) {
 	refName := StackMetaRefName(stackID)
 
-	sha, err := r.GetRef(refName)
+	// Resolve the ref and read its blob in a single cat-file --batch lookup
+	// (which accepts ref names) instead of a rev-parse followed by a blob read.
+	content, found, err := r.objects.ReadObject(refName)
 	if err != nil {
-		// If ref doesn't exist, it's not an error, just means no metadata
-		return nil, nil //nolint:nilerr
+		return nil, fmt.Errorf("failed to read stack metadata for %s: %w", stackID, err)
 	}
-
-	content, err := r.ReadBlob(sha)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read stack metadata blob %s: %w", sha, err)
-	}
-
-	if content == "" {
+	if !found || content == "" {
+		// Ref doesn't exist or is empty: no metadata, not an error.
 		return nil, nil
 	}
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

ReadStackMeta resolved the stack-meta ref with GetRef (a git rev-parse)
and then read the blob separately. The dashboard reads stack metadata for
every stack on each refresh and on a 30s timer, so the extra rev-parse per
stack added up.

Read the ref directly through the shared cat-file --batch object reader,
which resolves ref names to their blob content in one lookup. A missing
ref reports not-found (no metadata), matching the previous behavior.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781486856`.


* **PR #1220**
  * **PR #1221**
    * **PR #1222**
      * **PR #1223**
        * **PR #1224**
          * **PR #1225**
            * **PR #1228**
              * **PR #1230**
                * **PR #1231**
                  * **PR #1232** 👈
                    * **PR #1233**
                      * **PR #1234**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1235 by jonnii*