### PR TITLE
perf(merge): batch PR state/body fetch in consolidation cleanup

### DIFF
--- a/internal/actions/merge/cleanup.go
+++ b/internal/actions/merge/cleanup.go
@@ -89,6 +89,22 @@ func (c *PRCleaner) CleanupBranches(ctx context.Context, branchNames []string) P
 
 	affectedBranches := make([]string, 0, len(branchNames))
 
+	// Fetch every PR's state and body in one GraphQL query instead of a REST
+	// GetPullRequest per branch.
+	prNumbers := make([]int, 0, len(branchNames))
+	for _, branchName := range branchNames {
+		prInfo, err := c.engine.GetBranch(branchName).GetPrInfo()
+		if err != nil || prInfo == nil || prInfo.Number() == nil {
+			continue
+		}
+		prNumbers = append(prNumbers, *prInfo.Number())
+	}
+	prDetails, err := github.BatchGetPRStateBodyGraphQL(ctx, c.ctx.Git(), repoOwner, repoName, prNumbers) //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
+	if err != nil {
+		out.Debug("Failed to batch fetch PR details: %v", err)
+		prDetails = map[int]github.PRStateBody{}
+	}
+
 	for _, branchName := range branchNames {
 		branch := c.engine.GetBranch(branchName)
 		prInfo, err := branch.GetPrInfo()
@@ -98,10 +114,10 @@ func (c *PRCleaner) CleanupBranches(ctx context.Context, branchNames []string) P
 
 		prNumber := *prInfo.Number()
 
-		// Get current PR state from GitHub
-		existingPR, err := githubClient.GetPullRequest(ctx, repoOwner, repoName, prNumber)
-		if err != nil {
-			out.Debug("Failed to get PR #%d for %s: %v", prNumber, branchName, err)
+		// Get current PR state/body from the batched fetch
+		existingPR, ok := prDetails[prNumber]
+		if !ok {
+			out.Debug("Failed to get PR #%d for %s", prNumber, branchName)
 			continue
 		}
 

--- a/internal/github/pr_state_body.go
+++ b/internal/github/pr_state_body.go
@@ -1,0 +1,98 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// PRStateBody holds the subset of pull-request fields needed to append a
+// consolidation footer and decide whether a PR still needs closing.
+type PRStateBody struct {
+	State string
+	Body  string
+}
+
+// BatchGetPRStateBodyGraphQL fetches the state and body for multiple PR numbers
+// in a single GraphQL query, replacing one REST GetPullRequest call per number.
+// Numbers with no matching PR are absent from the returned map.
+func BatchGetPRStateBodyGraphQL(ctx context.Context, runner GitCommandRunner, owner, repo string, prNumbers []int) (map[int]PRStateBody, error) {
+	if len(prNumbers) == 0 {
+		return make(map[int]PRStateBody), nil
+	}
+
+	// Deduplicate PR numbers
+	seen := make(map[int]struct{}, len(prNumbers))
+	unique := make([]int, 0, len(prNumbers))
+	for _, n := range prNumbers {
+		if _, ok := seen[n]; !ok {
+			seen[n] = struct{}{}
+			unique = append(unique, n)
+		}
+	}
+
+	query := buildPRStateBodyQuery(unique)
+	variables := map[string]any{
+		"owner": owner,
+		"repo":  repo,
+	}
+
+	body, err := executeGraphQLQuery(ctx, runner, query, variables)
+	if err != nil {
+		return nil, err
+	}
+
+	return parsePRStateBodyResponse(body, unique)
+}
+
+// buildPRStateBodyQuery builds a GraphQL query to fetch state and body for multiple PRs by number.
+func buildPRStateBodyQuery(prNumbers []int) string {
+	var b strings.Builder
+	b.WriteString("query($owner: String!, $repo: String!) {\n")
+	b.WriteString("  repository(owner: $owner, name: $repo) {\n")
+	for _, n := range prNumbers {
+		fmt.Fprintf(&b, "    pr_%d: pullRequest(number: %d) { state body }\n", n, n)
+	}
+	b.WriteString("  }\n")
+	b.WriteString("}\n")
+	return b.String()
+}
+
+// parsePRStateBodyResponse parses the GraphQL response for PR state/body queries.
+func parsePRStateBodyResponse(body []byte, prNumbers []int) (map[int]PRStateBody, error) {
+	var graphqlResponse struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(body, &graphqlResponse); err != nil {
+		return nil, fmt.Errorf("failed to parse GraphQL response: %w", err)
+	}
+
+	repository, ok := graphqlResponse.Data["repository"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("invalid GraphQL response format: missing repository")
+	}
+
+	results := make(map[int]PRStateBody, len(prNumbers))
+	for _, n := range prNumbers {
+		alias := fmt.Sprintf("pr_%d", n)
+		data, ok := repository[alias]
+		if !ok || data == nil {
+			continue
+		}
+		prData, ok := data.(map[string]any)
+		if !ok {
+			continue
+		}
+		var entry PRStateBody
+		if state, ok := prData["state"].(string); ok {
+			entry.State = state
+		}
+		if prBody, ok := prData["body"].(string); ok {
+			entry.Body = prBody
+		}
+		results[n] = entry
+	}
+
+	return results, nil
+}

--- a/internal/github/pr_state_body_test.go
+++ b/internal/github/pr_state_body_test.go
@@ -1,0 +1,70 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPRStateBodyQuery(t *testing.T) {
+	t.Parallel()
+
+	query := buildPRStateBodyQuery([]int{42, 99})
+
+	require.Contains(t, query, "pr_42: pullRequest(number: 42) { state body }")
+	require.Contains(t, query, "pr_99: pullRequest(number: 99) { state body }")
+	require.Contains(t, query, "repository(owner: $owner, name: $repo)")
+}
+
+func TestParsePRStateBodyResponse(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"data": {
+			"repository": {
+				"pr_42": {"state": "OPEN", "body": "hello"},
+				"pr_99": {"state": "MERGED", "body": ""}
+			}
+		}
+	}`)
+
+	results, err := parsePRStateBodyResponse(body, []int{42, 99})
+	require.NoError(t, err)
+	require.Equal(t, map[int]PRStateBody{
+		42: {State: "OPEN", Body: "hello"},
+		99: {State: "MERGED", Body: ""},
+	}, results)
+}
+
+func TestParsePRStateBodyResponse_NullEntry(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"data": {
+			"repository": {
+				"pr_42": {"state": "OPEN", "body": "hello"},
+				"pr_99": null
+			}
+		}
+	}`)
+
+	results, err := parsePRStateBodyResponse(body, []int{42, 99})
+	require.NoError(t, err)
+	require.Equal(t, map[int]PRStateBody{42: {State: "OPEN", Body: "hello"}}, results)
+}
+
+func TestParsePRStateBodyResponse_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	_, err := parsePRStateBodyResponse([]byte(`{invalid`), []int{42})
+	require.Error(t, err)
+}
+
+func TestParsePRStateBodyResponse_MissingRepository(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"data": {}}`)
+	_, err := parsePRStateBodyResponse(body, []int{42})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing repository")
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

CleanupBranches fetched each PR's current state and body with a separate
REST GetPullRequest call before appending the consolidation footer and
closing it.

Add github.BatchGetPRStateBodyGraphQL (state + body by PR number in one
aliased GraphQL query) and prefetch all PRs once before the loop, so the
read side is a single round trip. The per-branch update and close calls
remain — REST has no bulk form — but the N read calls collapse to one.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781486856`.


* **PR #1220**
  * **PR #1221**
    * **PR #1222**
      * **PR #1223**
        * **PR #1224**
          * **PR #1225**
            * **PR #1228**
              * **PR #1230**
                * **PR #1231**
                  * **PR #1232**
                    * **PR #1233** 👈
                      * **PR #1234**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1235 by jonnii*