### PR TITLE
fix: make sync --dry-run a true read-only preview

### DIFF
--- a/internal/cli/stack/sync.go
+++ b/internal/cli/stack/sync.go
@@ -12,6 +12,8 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/cli/common"
 	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
 
 // NewSyncCmd creates the sync command
@@ -39,15 +41,25 @@ If trunk cannot be fast-forwarded to match remote, overwrites trunk with the rem
 			}
 
 			return common.Run(cmd, func(ctx *app.Context) error {
-				// JSON output for dry-run mode
-				if jsonOutput && dryRun {
-					return syncDryRunJSON(ctx, sync.Options{
-						All:       all,
-						Force:     force,
-						Restack:   restack,
-						NoRestack: noRestack,
-						DryRun:    true,
-					})
+				opts := sync.Options{
+					All:       all,
+					Force:     force,
+					Restack:   restack,
+					NoRestack: noRestack,
+					DryRun:    dryRun,
+				}
+
+				// --dry-run is a read-only PREVIEW. Compute the plan from the
+				// current (remote-aware) state and render it without ever calling
+				// sync.Action, so nothing is fast-forwarded, deleted, restacked,
+				// or pushed to GitHub. This is the whole contract of --dry-run.
+				if dryRun {
+					result := computeSyncDryRun(ctx, opts)
+					if jsonOutput {
+						return renderSyncDryRunJSON(ctx.Output, result)
+					}
+					renderSyncDryRunText(ctx.Output, result, restack)
+					return nil
 				}
 
 				// Check for uncommitted changes BEFORE starting TUI to avoid
@@ -61,13 +73,7 @@ If trunk cannot be fast-forwarded to match remote, overwrites trunk with the rem
 				defer runner.Cleanup()
 
 				// Run sync action with handler
-				return sync.Action(ctx, sync.Options{
-					All:       all,
-					Force:     force,
-					Restack:   restack,
-					NoRestack: noRestack,
-					DryRun:    dryRun,
-				}, handler)
+				return sync.Action(ctx, opts, handler)
 			})
 		},
 	}
@@ -82,17 +88,13 @@ If trunk cannot be fast-forwarded to match remote, overwrites trunk with the rem
 	return cmd
 }
 
-// syncDryRunJSON generates JSON output for sync --dry-run.
-//
-// This function intentionally duplicates some logic from sync.Action rather than
-// calling the action with a special handler. This is because:
-//  1. sync.Action has complex interactive behavior (prompts, confirmations) that
-//     doesn't make sense for a pure dry-run query
-//  2. The dry-run JSON output needs to be a simple snapshot of current state,
-//     not a simulation of the full sync process
-//  3. Keeping this separate makes it easier to extend the JSON output without
-//     affecting the main sync action's behavior
-func syncDryRunJSON(ctx *app.Context, opts sync.Options) error {
+// computeSyncDryRun builds a read-only snapshot of what a sync WOULD do from the
+// current (remote-aware) state. It never mutates: it probes remote status and
+// reads PR/deletion state, but performs no fetch-and-merge, deletion, restack,
+// or GitHub write. It intentionally reimplements a slice of sync.Action's
+// planning rather than running the action with a special handler, because a
+// dry-run is a query, not a simulation of the full interactive process.
+func computeSyncDryRun(ctx *app.Context, opts sync.Options) sync.DryRunResult {
 	eng := ctx.Engine
 
 	result := sync.DryRunResult{
@@ -160,12 +162,58 @@ func syncDryRunJSON(ctx *app.Context, opts sync.Options) error {
 		}
 	}
 
-	// Output JSON
+	return result
+}
+
+// renderSyncDryRunJSON prints the dry-run snapshot as indented JSON. The shape
+// is a stable contract for scripting, so keep it byte-compatible.
+func renderSyncDryRunJSON(out output.Output, result sync.DryRunResult) error {
 	data, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
-	ctx.Output.Info("%s", string(data))
-
+	out.Info("%s", string(data))
 	return nil
+}
+
+// renderSyncDryRunText prints a human-readable preview of what a sync would do.
+// restackRequested mirrors the --restack flag so we can hint that restacking is
+// only previewed when explicitly requested (WouldRestack is empty otherwise).
+func renderSyncDryRunText(out output.Output, result sync.DryRunResult, restackRequested bool) {
+	out.Info("🔍 Dry run — no changes will be made.")
+
+	printed := false
+	section := func(title string, items []string) {
+		if len(items) == 0 {
+			return
+		}
+		out.Newline()
+		out.Info("%s", title)
+		for _, name := range items {
+			out.Info("  %s", style.ColorBranchName(name, false))
+		}
+		printed = true
+	}
+
+	if result.WouldPull != "" {
+		out.Newline()
+		out.Info("Would pull from remote:")
+		out.Info("  %s", style.ColorBranchName(result.WouldPull, false))
+		printed = true
+	}
+	section("Would delete (merged or closed PRs):", result.WouldClean)
+	section("Would restack:", result.WouldRestack)
+	section("Skipped (worktree has uncommitted changes):", result.SkippedStacks)
+
+	if !printed {
+		out.Newline()
+		out.Info("Everything is up to date — sync would make no changes.")
+		return
+	}
+
+	out.Newline()
+	if !restackRequested {
+		out.Info("%s", style.ColorDim("Restacking is previewed only with --restack."))
+	}
+	out.Info("Run %s to apply.", style.ColorCyan("stackit sync"))
 }

--- a/internal/cli/stack/sync_dryrun_golden_test.go
+++ b/internal/cli/stack/sync_dryrun_golden_test.go
@@ -1,0 +1,66 @@
+package stack
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	syncAction "github.com/getstackit/stackit/internal/actions/sync"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/testhelpers/golden"
+)
+
+// Golden coverage for the human-readable `sync --dry-run` preview. The dry-run
+// is a read-only query, so its renderer takes a plain DryRunResult — no engine,
+// no repository. See sync.go:computeSyncDryRun for where the result is built.
+
+type syncDryRunGoldenCase struct {
+	name             string
+	result           syncAction.DryRunResult
+	restackRequested bool
+}
+
+func syncDryRunGoldenCases() []syncDryRunGoldenCase {
+	return []syncDryRunGoldenCase{
+		{
+			name:   "nothing_to_do",
+			result: syncAction.DryRunResult{},
+		},
+		{
+			name: "pull_and_clean",
+			result: syncAction.DryRunResult{
+				WouldPull:  "main",
+				WouldClean: []string{"feat-login", "feat-old"},
+			},
+		},
+		{
+			name:             "restack_requested",
+			restackRequested: true,
+			result: syncAction.DryRunResult{
+				WouldRestack: []string{"feat-api", "feat-ui"},
+			},
+		},
+		{
+			name:             "full",
+			restackRequested: true,
+			result: syncAction.DryRunResult{
+				WouldPull:     "main",
+				WouldClean:    []string{"feat-old"},
+				WouldRestack:  []string{"feat-api", "feat-ui"},
+				SkippedStacks: []string{"feat-wip"},
+			},
+		},
+	}
+}
+
+func TestSyncDryRunGolden(t *testing.T) {
+	t.Parallel()
+	for _, c := range syncDryRunGoldenCases() {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			buf := &bytes.Buffer{}
+			renderSyncDryRunText(output.NewConsoleOutput(buf, false), c.result, c.restackRequested)
+			golden.Assert(t, filepath.Join("testdata", "sync", "dryrun", c.name+".golden"), golden.StripANSI(buf.String()))
+		})
+	}
+}

--- a/internal/cli/stack/sync_test.go
+++ b/internal/cli/stack/sync_test.go
@@ -116,4 +116,36 @@ Error: you have uncommitted changes. Please commit or stash them before syncing
 ✨ Everything is up to date!
 `), testhelpers.NormalizeOutput(output))
 	})
+
+	t.Run("dry-run previews without mutating", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+
+		_, err := s.Scene.Repo.CreateBareRemote("origin")
+		require.NoError(t, err)
+		require.NoError(t, s.Scene.Repo.PushBranch("origin", "main"))
+
+		s.RunCli("init")
+		s.RunCli("create", "branch1", "-m", "branch1")
+		s.RunGit("commit", "--allow-empty", "-m", "work on branch1")
+
+		// Make branch1 need a restack by advancing main behind it.
+		s.RunGit("checkout", "main")
+		s.Scene.Repo.CreateChangeAndCommit("main update", "main-file")
+		s.RunCli("checkout", "branch1")
+
+		// --dry-run must PREVIEW the restack, not perform it.
+		output, err := s.RunCliAndGetOutput("sync", "--dry-run", "--restack")
+		require.NoError(t, err, "sync --dry-run failed: %s", output)
+		normalized := testhelpers.NormalizeOutput(output)
+		require.Contains(t, normalized, "Dry run")
+		require.Contains(t, normalized, "Would restack")
+		require.Contains(t, normalized, "branch1")
+
+		// Proof it didn't mutate: the real sync still has the restack to do.
+		// (If dry-run had restacked, this would report "up to date" instead.)
+		output, err = s.RunCliAndGetOutput("sync", "--restack")
+		require.NoError(t, err, "sync --restack failed: %s", output)
+		require.Contains(t, testhelpers.NormalizeOutput(output), "Restacked branch1")
+	})
 }

--- a/internal/cli/stack/testdata/sync/dryrun/full.golden
+++ b/internal/cli/stack/testdata/sync/dryrun/full.golden
@@ -1,0 +1,16 @@
+🔍 Dry run — no changes will be made.
+
+Would pull from remote:
+  main
+
+Would delete (merged or closed PRs):
+  feat-old
+
+Would restack:
+  feat-api
+  feat-ui
+
+Skipped (worktree has uncommitted changes):
+  feat-wip
+
+Run stackit sync to apply.

--- a/internal/cli/stack/testdata/sync/dryrun/nothing_to_do.golden
+++ b/internal/cli/stack/testdata/sync/dryrun/nothing_to_do.golden
@@ -1,0 +1,3 @@
+🔍 Dry run — no changes will be made.
+
+Everything is up to date — sync would make no changes.

--- a/internal/cli/stack/testdata/sync/dryrun/pull_and_clean.golden
+++ b/internal/cli/stack/testdata/sync/dryrun/pull_and_clean.golden
@@ -1,0 +1,11 @@
+🔍 Dry run — no changes will be made.
+
+Would pull from remote:
+  main
+
+Would delete (merged or closed PRs):
+  feat-login
+  feat-old
+
+Restacking is previewed only with --restack.
+Run stackit sync to apply.

--- a/internal/cli/stack/testdata/sync/dryrun/restack_requested.golden
+++ b/internal/cli/stack/testdata/sync/dryrun/restack_requested.golden
@@ -1,0 +1,7 @@
+🔍 Dry run — no changes will be made.
+
+Would restack:
+  feat-api
+  feat-ui
+
+Run stackit sync to apply.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Previously `stackit sync --dry-run` (without --json) fell through to the real
sync.Action, which only honored DryRun for metadata. It would fast-forward
branches, DELETE merged/closed branches, restack the stack, and write PR
bodies/bases to GitHub — while printing "(dry run)" for metadata. The flag
name promises a preview but applied almost everything.

Route all --dry-run through a read-only compute + render that never calls
sync.Action: it probes remote status and reads PR/deletion state but performs
no fetch-and-merge, deletion, restack, or GitHub write. Add a human-readable
preview (previously --dry-run only spoke JSON); the JSON shape is unchanged.

Locked by a CLI test proving a restack stays pending after --dry-run, plus
golden coverage of the preview output.

<hr/>

<!-- STACKIT-SECTION-START -->
**Sync output quality**

Makes `stackit sync` output trustworthy and clean across all three surfaces
(JSON, non-TTY streaming, and the interactive TUI).

- Make `--dry-run` a true read-only preview instead of silently applying
  fast-forwards, deletions, restacks, and GitHub writes.
- Declutter the streaming output: lazy phase headers, fix doubled ⚠️, add
  ✓/→ item markers.
- Suppress empty phase headers in the interactive TUI to match.
- Polish: one shared single-width status-marker vocabulary, an enriched
  dry-run preview that mirrors the live run, and a deduped lazy-header rule.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781901935`.


* **PR #1236** 👈
  * **PR #1237**
    * **PR #1238**
      * **PR #1268**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1269 by jonnii*