### PR TITLE
fix: suppress empty phase headers in the interactive sync TUI

### DIFF
--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -644,7 +644,7 @@ func (h *InteractiveSyncHandler) formatRestackDetail(branch string, result syncA
 		if parent != "" {
 			msg += fmt.Sprintf(" on %s", parent)
 		}
-		msg += fmt.Sprintf(" -> %s", newRev)
+		msg += fmt.Sprintf(" → %s", newRev)
 		if rerereResolvedCount > 0 {
 			msg += " " + actions.FormatRerereResolved(rerereResolvedCount)
 		}

--- a/internal/tui/components/sync/model.go
+++ b/internal/tui/components/sync/model.go
@@ -43,6 +43,14 @@ type Model struct {
 	Progress       progress.Model
 	spinner        spinner.Model
 	Summary        string
+
+	// Phase headers commit to scrollback lazily: only when a phase emits its
+	// first detail. Phases that do nothing (nothing to sync/clean/restack) never
+	// print an empty header. CurrentPhase still updates eagerly so the live
+	// spinner reflects what's happening during slow phases.
+	phaseHeaders       map[Phase]string
+	committedPhases    map[Phase]bool
+	anyHeaderCommitted bool
 }
 
 // PhaseStartMsg indicates a phase has started
@@ -88,9 +96,11 @@ func NewModel(totalOps int) *Model {
 	s.Style = commonStyles.Spinner
 
 	m := &Model{
-		TotalOps: totalOps,
-		Progress: p,
-		spinner:  s,
+		TotalOps:        totalOps,
+		Progress:        p,
+		spinner:         s,
+		phaseHeaders:    make(map[Phase]string),
+		committedPhases: make(map[Phase]bool),
 	}
 	m.Width = 80 // Set BaseModel's Width
 	return m
@@ -130,10 +140,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case PhaseStartMsg:
-		// Print the phase header above the TUI
+		// Mark the phase active (drives the live spinner) and remember its
+		// header, but don't commit it to scrollback yet — the header prints
+		// lazily when the phase emits its first detail, so empty phases stay
+		// silent.
 		m.CurrentPhase = msg.Phase
 		m.CurrentDetail = ""
-		return m, tea.Printf("%s", msg.Message)
+		m.phaseHeaders[msg.Phase] = msg.Message
+		return m, nil
 
 	case PhaseCompleteMsg:
 		// Phase completed - nothing to do, next phase will start
@@ -146,7 +160,23 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.IsWarn {
 			mark = warnMark.String()
 		}
-		return m, tea.Printf("  %s %s", mark, msg.Message)
+		detail := tea.Printf("  %s %s", mark, msg.Message)
+
+		// Commit the phase header the first time the phase produces a detail,
+		// separated from the previous phase group by a blank line. A detail for
+		// a phase that was never started (e.g. standalone restack) just prints
+		// without a header.
+		if header, started := m.phaseHeaders[msg.Phase]; started && !m.committedPhases[msg.Phase] {
+			m.committedPhases[msg.Phase] = true
+			var cmds []tea.Cmd
+			if m.anyHeaderCommitted {
+				cmds = append(cmds, tea.Printf(""))
+			}
+			m.anyHeaderCommitted = true
+			cmds = append(cmds, tea.Printf("%s", header), detail)
+			return m, tea.Sequence(cmds...)
+		}
+		return m, detail
 
 	case ProgressTickMsg:
 		m.CompletedOps = msg.Completed

--- a/internal/tui/components/sync/model_test.go
+++ b/internal/tui/components/sync/model_test.go
@@ -53,13 +53,31 @@ func TestModel_Update_PhaseStartMsg(t *testing.T) {
 	model := NewModel(10)
 	model.Init()
 
-	// Start trunk phase - returns a tea.Printf command
+	// Start trunk phase - the header is deferred (committed lazily on the first
+	// detail), so no command is returned yet.
 	newModel, cmd := model.Update(PhaseStartMsg{Phase: PhaseTrunk, Message: "📥 Pulling from remote..."})
 	m := newModel.(*Model)
 
 	assert.Equal(t, PhaseTrunk, m.CurrentPhase)
 	assert.Equal(t, "", m.CurrentDetail) // Detail cleared on phase start
-	assert.NotNil(t, cmd, "should return print command")
+	assert.Nil(t, cmd, "phase start should defer its header until the first detail")
+	assert.False(t, m.committedPhases[PhaseTrunk], "header should not be committed before any detail")
+}
+
+func TestModel_Update_EmptyPhaseSuppressed(t *testing.T) {
+	t.Parallel()
+	model := NewModel(10)
+	model.Init()
+
+	// A phase that starts but never emits a detail must not commit a header.
+	newModel, _ := model.Update(PhaseStartMsg{Phase: PhaseBranches, Message: "📥 Syncing stack branches..."})
+	m := newModel.(*Model)
+	newModel, _ = m.Update(PhaseStartMsg{Phase: PhaseClean, Message: "🧹 Cleaning branches..."})
+	m = newModel.(*Model)
+
+	assert.False(t, m.committedPhases[PhaseBranches], "empty branches phase should not commit a header")
+	assert.False(t, m.committedPhases[PhaseClean], "empty clean phase should not commit a header")
+	assert.False(t, m.anyHeaderCommitted, "no headers should have been committed")
 }
 
 func TestModel_Update_PhaseTransition(t *testing.T) {
@@ -96,6 +114,7 @@ func TestModel_Update_PhaseDetailMsg(t *testing.T) {
 
 	assert.Equal(t, "main fast-forwarded to abc1234", m.CurrentDetail)
 	assert.NotNil(t, cmd, "should return print command")
+	assert.True(t, m.committedPhases[PhaseTrunk], "first detail should commit the phase header")
 }
 
 func TestModel_Update_PhaseDetailMsg_WithWarn(t *testing.T) {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The earlier sync output cleanup only touched SimpleSyncHandler (the non-TTY
streaming path). Running `stackit sync` in a terminal uses the bubbletea sync
component instead, which still committed a phase header to scrollback eagerly
on every PhaseStartMsg — so empty phases printed bare "Syncing stack
branches..." / "Cleaning branches..." headers with nothing under them.

Defer the header commit in the model: PhaseStartMsg now records the active
phase (so the live spinner still reflects slow phases) and stores its header,
but the header only prints to scrollback when the phase emits its first
detail, separated from the previous group by a blank line. Phases that do
nothing stay silent. Also align the interactive restack arrow (-> to →) with
the streaming output.

<hr/>

<!-- STACKIT-SECTION-START -->
**Sync output quality**

Makes `stackit sync` output trustworthy and clean across all three surfaces
(JSON, non-TTY streaming, and the interactive TUI).

- Make `--dry-run` a true read-only preview instead of silently applying
  fast-forwards, deletions, restacks, and GitHub writes.
- Declutter the streaming output: lazy phase headers, fix doubled ⚠️, add
  ✓/→ item markers.
- Suppress empty phase headers in the interactive TUI to match.
- Polish: one shared single-width status-marker vocabulary, an enriched
  dry-run preview that mirrors the live run, and a deduped lazy-header rule.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781901935`.


* **PR #1236**
  * **PR #1237**
    * **PR #1238** 👈
      * **PR #1268**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1269 by jonnii*