### PR TITLE
perf: batch ref deletions in DeleteBranch to match DeleteBranches

### DIFF
--- a/internal/engine/branch_mutations.go
+++ b/internal/engine/branch_mutations.go
@@ -162,18 +162,16 @@ func (e *engineImpl) DeleteBranch(ctx context.Context, branch Branch) error {
 	}
 	e.mu.Unlock()
 
-	// Delete git branch (no lock needed for git operations)
-	if err := e.git.DeleteBranch(ctx, branch.GetName()); err != nil {
-		if !git.IsBranchNotFoundError(err) {
-			return fmt.Errorf("failed to delete branch: %w", err)
-		}
+	// Delete the head ref and both metadata refs atomically in one git invocation.
+	// update-ref --stdin tolerates missing refs, so this is safe even if the
+	// branch or its metadata refs were already absent.
+	if err := e.git.DeleteRefsBatch(ctx, []string{
+		"refs/heads/" + branchName,
+		git.MetadataRefPrefix + branchName,
+		git.LocalMetadataRefPrefix + branchName,
+	}); err != nil {
+		return fmt.Errorf("failed to delete branch refs: %w", err)
 	}
-
-	// Best-effort metadata cleanup. The branch ref is already gone, so any
-	// remaining metadata refs are orphans that `sync` reconciles later — no
-	// user-actionable signal here.
-	_ = e.git.DeleteMetadata(ctx, branchName)
-	_ = e.git.DeleteRef(ctx, fmt.Sprintf("%s%s", git.LocalMetadataRefPrefix, branchName))
 
 	// Reparent children to grandparent, preserving divergence points so
 	// children don't carry the deleted branch's commits after restacking.


### PR DESCRIPTION
## Summary

`engine.DeleteBranch` was spawning three separate git subprocesses where one would do:

- `git.DeleteBranch` → `git update-ref -d refs/heads/<name>`
- `git.DeleteMetadata` → deletes the metadata ref (error silently ignored with `_ =`)
- `git.DeleteRef` → deletes the local-metadata ref (also `_ =`)

`engine.DeleteBranches` already does this correctly: all three refs are deleted atomically in a single `git update-ref --stdin` call. This PR aligns the single-branch path with the batch path.

**Changes:**
- Replace 3 separate git subprocess calls with one `DeleteRefsBatch` call
- Deletion of head ref + metadata ref + local-metadata ref is now atomic
- `update-ref --stdin` tolerates missing refs, so the previous `IsBranchNotFoundError` carve-out is no longer needed
- Metadata cleanup errors are no longer silently swallowed with `_ =`

The fix mirrors exactly what `DeleteBranches` already does, making the two code paths consistent.

## Test plan

- [x] `TestDeleteBranch/deletes_branch_and_updates_children` — passes
- [x] `TestDeleteBranch/deletes_branch_with_multiple_siblings_and_children` — passes
- [x] `TestDeleteBranch/returns_error_when_child_cannot_be_reparented` — passes
- [x] `TestDeleteBranch/fails_when_trying_to_delete_trunk` — passes

https://claude.ai/code/session_01HmhjEpywAiMTPMjYTT9WAi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmhjEpywAiMTPMjYTT9WAi)_