### PR TITLE
refactor: add Plan.BranchNames() to eliminate repeated branch-name extraction loops

### DIFF
--- a/internal/actions/merge/consolidate.go
+++ b/internal/actions/merge/consolidate.go
@@ -187,10 +187,7 @@ func (c *ConsolidateMergeExecutor) createMergeBranch(ctx context.Context) (strin
 	}
 
 	// Collect branch names for octopus merge
-	branches := make([]string, len(c.plan.BranchesToMerge))
-	for i, branchInfo := range c.plan.BranchesToMerge {
-		branches[i] = branchInfo.BranchName
-	}
+	branches := c.plan.BranchNames()
 
 	// Build commit message listing all branches
 	commitMsg := fmt.Sprintf("Consolidate stack [%s]", scope)
@@ -281,12 +278,6 @@ func (c *ConsolidateMergeExecutor) updateIndividualPRs() {
 		return
 	}
 
-	// Collect branch names
-	branchNames := make([]string, len(c.plan.BranchesToMerge))
-	for i, b := range c.plan.BranchesToMerge {
-		branchNames[i] = b.BranchName
-	}
-
 	// Use shared PR cleaner
 	cleaner := NewPRCleaner(c.ctx, c.engine, PRCleanupConfig{
 		Source:                CleanupSourceConsolidate,
@@ -294,7 +285,7 @@ func (c *ConsolidateMergeExecutor) updateIndividualPRs() {
 		UserName:              c.consolidationUser,
 	})
 
-	result := cleaner.CleanupBranches(c.ctx.Context, branchNames)
+	result := cleaner.CleanupBranches(c.ctx.Context, c.plan.BranchNames())
 	cleaner.LogResult(result)
 }
 
@@ -303,14 +294,13 @@ func (c *ConsolidateMergeExecutor) lockAndNotifyIndividualPRs(_ context.Context,
 	splog.Info("🔒 Locking individual PRs and updating status...")
 
 	branchesToLock := engine.Branches{}
-	branchNames := make([]string, 0, len(c.plan.BranchesToMerge))
 	for _, b := range c.plan.BranchesToMerge {
 		branch := c.engine.GetBranch(b.BranchName)
 		if !branch.IsLocked() {
 			branchesToLock = branchesToLock.Append(branch)
 		}
-		branchNames = append(branchNames, b.BranchName)
 	}
+	branchNames := c.plan.BranchNames()
 
 	if len(branchesToLock) > 0 {
 		if _, err := c.engine.SetLocked(c.ctx, branchesToLock, engine.LockReasonConsolidating); err != nil {

--- a/internal/actions/merge/helpers.go
+++ b/internal/actions/merge/helpers.go
@@ -27,12 +27,7 @@ func getMergeMethodWithPause(ctx *app.Context, githubClient github.Client, handl
 
 // calculateBaselineEstimate tries to find a branch with successful CI and use its timing as a baseline
 func calculateBaselineEstimate(ctx context.Context, plan *Plan, client github.Client, splog output.Output) time.Duration {
-	branchNames := make([]string, len(plan.BranchesToMerge))
-	for i, b := range plan.BranchesToMerge {
-		branchNames[i] = b.BranchName
-	}
-
-	statuses, err := client.BatchGetPRChecksStatus(ctx, branchNames)
+	statuses, err := client.BatchGetPRChecksStatus(ctx, plan.BranchNames())
 	if err != nil {
 		return 0
 	}

--- a/internal/actions/merge/plan.go
+++ b/internal/actions/merge/plan.go
@@ -104,6 +104,15 @@ func AnyPRHasChecks(branches []BranchMergeInfo) bool {
 	return false
 }
 
+// BranchNames returns the names of all branches to be merged, in order.
+func (p *Plan) BranchNames() []string {
+	names := make([]string, len(p.BranchesToMerge))
+	for i, b := range p.BranchesToMerge {
+		names[i] = b.BranchName
+	}
+	return names
+}
+
 // Plan is the complete plan for a merge operation
 type Plan struct {
 	Strategy        Strategy


### PR DESCRIPTION
## Summary

- The pattern of building a `[]string` of branch names from `plan.BranchesToMerge` was copy-pasted in four places across `consolidate.go` and `helpers.go`
- Added `Plan.BranchNames()` method to `plan.go` to centralise this into a single, named operation
- Each call site is now a one-liner (`c.plan.BranchNames()`) instead of a 4-line make+for loop
- In `lockAndNotifyIndividualPRs`, the dual-purpose loop (building both `branchesToLock` and `branchNames`) was split into two single-purpose loops, making each concern clearer

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/actions/merge/...` shows no new failures (3 pre-existing `TestMultiStackWorktreeExecutor_*` failures are unrelated)

https://claude.ai/code/session_01FiSBipfUh73s585QbMrrLf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiSBipfUh73s585QbMrrLf)_