### PR TITLE
fix: escape Slack mrkdwn special chars in share output

### DIFF
--- a/internal/actions/share.go
+++ b/internal/actions/share.go
@@ -123,10 +123,21 @@ func shareLabel(name string, prNumber *int, prTitle, prURL string) string {
 
 	text := fmt.Sprintf("#%d", *prNumber)
 	if prTitle != "" {
-		text = fmt.Sprintf("#%d %s", *prNumber, prTitle)
+		text = fmt.Sprintf("#%d %s", *prNumber, sanitizeSlackText(prTitle))
 	}
 	if prURL == "" {
 		return text
 	}
 	return fmt.Sprintf("<%s|%s>", prURL, text)
+}
+
+// sanitizeSlackText escapes characters that have special meaning in Slack's
+// mrkdwn format so that PR titles containing angle brackets or ampersands don't
+// produce malformed links (e.g. "<url|#1 Add <T> support>" would break the
+// link because the inner "<T>" looks like a nested mrkdwn element).
+func sanitizeSlackText(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	return s
 }

--- a/internal/actions/share_internal_test.go
+++ b/internal/actions/share_internal_test.go
@@ -52,6 +52,30 @@ func TestShareLabel(t *testing.T) {
 			prNumber: ptr(9),
 			want:     "#9",
 		},
+		{
+			name:     "angle brackets in title are escaped",
+			branch:   "feature-x",
+			prNumber: ptr(42),
+			prTitle:  "Add <T> generic support",
+			prURL:    "https://github.com/o/r/pull/42",
+			want:     "<https://github.com/o/r/pull/42|#42 Add &lt;T&gt; generic support>",
+		},
+		{
+			name:     "ampersand in title is escaped",
+			branch:   "feature-x",
+			prNumber: ptr(43),
+			prTitle:  "Fix auth & session handling",
+			prURL:    "https://github.com/o/r/pull/43",
+			want:     "<https://github.com/o/r/pull/43|#43 Fix auth &amp; session handling>",
+		},
+		{
+			name:     "multiple special chars in title are all escaped",
+			branch:   "feature-x",
+			prNumber: ptr(44),
+			prTitle:  "Support <A> & <B> types",
+			prURL:    "https://github.com/o/r/pull/44",
+			want:     "<https://github.com/o/r/pull/44|#44 Support &lt;A&gt; &amp; &lt;B&gt; types>",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Fixes #1245

- PR titles with `<`, `>`, or `&` produce malformed Slack mrkdwn links in the `<url|text>` format. For example `"Add <T> support"` generates `<url|#1 Add <T> support>` where the inner `<T>` is parsed as a nested mrkdwn element, breaking the link.
- Add `sanitizeSlackText()` helper that replaces `&`, `<`, `>` with their HTML entities (`&amp;`, `&lt;`, `&gt;`) before embedding a PR title inside a link.
- Add test cases covering angle brackets, ampersands, and combinations thereof.

## Test plan

- [ ] `go test -run TestShareLabel ./internal/actions/` passes (all 8 cases including the 3 new ones)
- [ ] Verify that a PR with title like `"Add <T> support"` produces a valid Slack link when using `stackit share`

---
_Generated by [Claude Code](https://claude.ai/code/session_0175YXyo3UGcxRt3rsLHvdag)_