### PR TITLE
fix: don't report worktree as removed when anchor branch deletion fails

### DIFF
--- a/internal/actions/sync/worktree_cleanup.go
+++ b/internal/actions/sync/worktree_cleanup.go
@@ -108,6 +108,7 @@ func cleanOrphanedWorktrees(ctx *app.Context, dirtyAnchors map[string]bool) *Wor
 				result.Errors = append(result.Errors,
 					"failed to delete anchor branch "+wt.AnchorBranch+": "+deleteErr.Error())
 				ctx.Output.Debug("Failed to delete anchor branch %s: %v", wt.AnchorBranch, deleteErr)
+				continue
 			}
 		}
 		result.RemovedWorktrees = append(result.RemovedWorktrees, wt.AnchorBranch)


### PR DESCRIPTION
## Summary

During worktree auto-cleanup (`sync`), when deleting the anchor branch fails, the code was still appending to `RemovedWorktrees` — reporting the cleanup as successful even though the branch remains on disk.

Every other error path in the same loop uses `continue` to bail out before the success record:
- `RemoveWorktree` failure → `continue`
- `os.Stat` failure → `continue`  
- `UnregisterWorktree` failure → `continue`
- **`DeleteBranch` failure → ~~no continue~~ → fell through to `RemovedWorktrees` append** ← bug

The fix is a single `continue` to make `DeleteBranch` consistent with the rest of the loop.

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] Existing `TestSyncCleansOrphanedWorktrees` tests still pass
- [ ] The scenario "worktree physical path gone but branch deletion fails" no longer reports the worktree as removed

---
_Generated by [Claude Code](https://claude.ai/code/session_01EC1QKpZwGnM3GByTmw8Zr3)_