### PR TITLE
refactor(stack-info): read per-branch data via an explicit BranchView

### DIFF
--- a/internal/actions/stack_info.go
+++ b/internal/actions/stack_info.go
@@ -62,56 +62,39 @@ func StackInfoAction(ctx *app.Context, opts StackInfoOptions) error {
 	})
 	result := make([]StackBranchInfo, 0, len(stackBranches))
 
-	// Warm the revision/metadata and diff-stat caches once, and read PR
-	// submission status for the whole stack in a single batch, so the loop
-	// below does not spawn a git rev-parse, git diff, and (most costly) a
-	// git ls-remote per branch.
-	eng.PreloadBranchData()
-	eng.PreloadBranchStats(stackBranches)
+	// Read all per-branch data the loop needs as explicit, passed-around values:
+	// a BranchView (revisions, commits, diff summary) built in batched/parallel
+	// git reads, plus PR submission status read in a single batch. Nothing here
+	// warms an engine-global cache.
+	view := eng.ViewBranches(ctx.Context, stackBranches, engine.CommitFormatReadable)
 	prStatuses, _ := eng.BatchGetPRSubmissionStatus(stackBranches)
 
 	for _, branch := range stackBranches {
 		if branch.IsTrunk() {
 			continue
 		}
+		name := branch.GetName()
 
+		diff := view.Diff(name)
 		info := StackBranchInfo{
-			Name:           branch.GetName(),
+			Name:           name,
 			Parent:         branch.GetParentOrTrunk(),
 			IsLocked:       branch.IsLocked(),
 			IsFrozen:       branch.IsFrozen(),
 			Scope:          branch.GetScope().String(),
-			CommitMessages: []string{},
+			CommitMessages: view.Commits(name),
+			DiffStats: DiffStats{
+				Additions:    diff.Additions,
+				Deletions:    diff.Deletions,
+				FilesChanged: diff.FilesChanged,
+			},
 		}
-
-		// Commit messages
-		commits, err := branch.GetAllCommits(engine.CommitFormatReadable)
-		if err == nil {
-			info.CommitMessages = commits
-		}
-
-		// Diff stats
-		added, deleted, err := branch.GetDiffStats()
-		if err == nil {
-			info.DiffStats.Additions = added
-			info.DiffStats.Deletions = deleted
-		}
-
-		// Files changed
-		parentName := branch.GetParentOrTrunk()
-		parentRev, err := eng.GetRevision(eng.GetBranch(parentName))
-		if err == nil {
-			branchRev, err := branch.GetRevision()
-			if err == nil {
-				files, err := eng.GetChangedFiles(ctx.Context, parentRev, branchRev)
-				if err == nil {
-					info.DiffStats.FilesChanged = len(files)
-				}
-			}
+		if info.CommitMessages == nil {
+			info.CommitMessages = []string{}
 		}
 
 		// PR info
-		prStatus := prStatuses[branch.GetName()]
+		prStatus := prStatuses[name]
 		if prStatus.PRNumber != nil {
 			info.PRNumber = prStatus.PRNumber
 			if prStatus.PRInfo != nil {

--- a/internal/engine/branch_view.go
+++ b/internal/engine/branch_view.go
@@ -1,0 +1,131 @@
+package engine
+
+import (
+	"context"
+	"sync"
+)
+
+// DiffSummary is a branch's additions/deletions/files-changed relative to its
+// parent, captured at the moment a BranchView is built.
+type DiffSummary struct {
+	Additions    int
+	Deletions    int
+	FilesChanged int
+}
+
+// BranchView is an immutable, point-in-time snapshot of per-branch read data,
+// materialized in batched and parallel git reads when it is built. Consumers
+// read plain values from it — there is no engine callback or global cache
+// behind a lookup, so the data cannot go stale behind a caller's back the way
+// an ambient cache can. Build a fresh view after a mutation rather than reusing
+// an old one.
+type BranchView struct {
+	revisions map[string]string
+	commits   map[string][]string
+	diffs     map[string]DiffSummary
+}
+
+// Revision returns the branch tip SHA captured when the view was built.
+func (v *BranchView) Revision(branch string) string { return v.revisions[branch] }
+
+// Commits returns the formatted commit list captured for the branch.
+func (v *BranchView) Commits(branch string) []string { return v.commits[branch] }
+
+// Diff returns the diff summary captured for the branch.
+func (v *BranchView) Diff(branch string) DiffSummary { return v.diffs[branch] }
+
+// ViewBranches builds a BranchView for the given branches. Every branch and
+// parent revision is resolved in one batched call and every branch's metadata is
+// read in one batched (cached) call; each branch's commits and diff summary are
+// then computed in parallel from those pre-resolved values. The view does not
+// warm or read any engine-global revision cache — no PreloadBranchData /
+// PreloadBranchStats needed — and no per-branch git rev-parse is spawned.
+func (e *engineImpl) ViewBranches(ctx context.Context, branches Branches, format CommitFormat) *BranchView {
+	view := &BranchView{
+		revisions: make(map[string]string, len(branches)),
+		commits:   make(map[string][]string, len(branches)),
+		diffs:     make(map[string]DiffSummary, len(branches)),
+	}
+	if len(branches) == 0 {
+		return view
+	}
+
+	// Resolve every branch and parent revision in one batched call, and read all
+	// branch metadata in one batched (cache-backed) call, so the per-branch work
+	// below derives its base/head SHAs from these maps without any git of its own.
+	branchNames := make([]string, 0, len(branches))
+	revNames := make([]string, 0, len(branches)*2)
+	for _, b := range branches {
+		branchNames = append(branchNames, b.GetName())
+		revNames = append(revNames, b.GetName(), b.GetParentOrTrunk())
+	}
+	revs, _ := e.GetRevisions(revNames)
+	metas, _ := e.batchReadMetadata(branchNames)
+	for _, b := range branches {
+		view.revisions[b.GetName()] = revs[b.GetName()]
+	}
+
+	// Compute commits and the diff summary for each branch concurrently, into a
+	// positional slice so the goroutines never share a map.
+	type entry struct {
+		name    string
+		commits []string
+		diff    DiffSummary
+	}
+	entries := make([]entry, len(branches))
+	var wg sync.WaitGroup
+	for i, b := range branches {
+		if e.IsTrunk(b) {
+			continue
+		}
+		wg.Add(1)
+		go func(i int, b Branch) {
+			defer wg.Done()
+			name := b.GetName()
+			head := revs[name]
+			parentRev := revs[b.GetParentOrTrunk()]
+
+			// Stored divergence point, mirroring how the deep accessors pick a base.
+			storedBase := ""
+			if m := metas[name]; m != nil {
+				if rev := m.GetParentBranchRevision(); rev != nil {
+					storedBase = *rev
+				}
+			}
+
+			en := entry{name: name}
+			// Commits: GetAllCommits compares against the stored base (empty if unset).
+			if commits, err := e.commitsBetween(storedBase, head, format); err == nil {
+				en.commits = commits
+			}
+			// Additions/deletions: GetDiffStats compares against the stored base,
+			// falling back to the parent's current tip when none is stored.
+			diffBase := storedBase
+			if diffBase == "" {
+				diffBase = parentRev
+			}
+			if added, deleted, err := e.diffStatsBetween(diffBase, head); err == nil {
+				en.diff.Additions = added
+				en.diff.Deletions = deleted
+			}
+			// Files changed: matches the original, which diffs against the parent's
+			// current tip rather than the stored divergence point.
+			if parentRev != "" && head != "" {
+				if files, err := e.GetChangedFiles(ctx, parentRev, head); err == nil {
+					en.diff.FilesChanged = len(files)
+				}
+			}
+			entries[i] = en
+		}(i, b)
+	}
+	wg.Wait()
+
+	for _, en := range entries {
+		if en.name == "" {
+			continue
+		}
+		view.commits[en.name] = en.commits
+		view.diffs[en.name] = en.diff
+	}
+	return view
+}

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -70,17 +70,24 @@ func (e *engineImpl) GetDiffStats(branch Branch) (int, int, error) {
 	if err != nil {
 		return 0, 0, err
 	}
-	if branchRev == base {
+	return e.diffStatsBetween(base, branchRev)
+}
+
+// diffStatsBetween returns the additions/deletions between two revisions, using
+// the (base, head)-keyed cache. It takes pre-resolved revisions so batched
+// callers (e.g. ViewBranches) need not re-resolve a branch's head.
+func (e *engineImpl) diffStatsBetween(base, head string) (int, int, error) {
+	if head == base {
 		return 0, 0, nil
 	}
 
-	cacheKey := base + ":" + branchRev
+	cacheKey := base + ":" + head
 	if v, ok := e.diffStatsCache.Load(cacheKey); ok {
 		stats := v.([2]int)
 		return stats[0], stats[1], nil
 	}
 
-	output, err := e.git.GetDiffNumstat(base, branchRev)
+	output, err := e.git.GetDiffNumstat(base, head)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -214,7 +221,12 @@ func (e *engineImpl) GetAllCommits(branch Branch, format CommitFormat) ([]string
 		baseRevision = *rev
 	}
 
-	// Use GetCommitRange directly to handle formatting in-process via go-git,
-	// avoiding per-commit git process spawns.
-	return e.git.GetCommitRange(context.Background(), baseRevision, branchRevision, string(format))
+	return e.commitsBetween(baseRevision, branchRevision, format)
+}
+
+// commitsBetween returns the formatted commits in (base, head]. It handles
+// formatting in-process via go-git, avoiding per-commit git process spawns, and
+// takes pre-resolved revisions so batched callers need not re-resolve the head.
+func (e *engineImpl) commitsBetween(base, head string, format CommitFormat) ([]string, error) {
+	return e.git.GetCommitRange(context.Background(), base, head, string(format))
 }

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -98,6 +98,10 @@ type BranchInfo interface {
 	// given branches in parallel. Call before utils.Run iteration so subsequent
 	// GetDiffStats / GetCommitCount calls are instant cache hits.
 	PreloadBranchStats(branches []Branch)
+	// ViewBranches builds an explicit, immutable BranchView of per-branch read
+	// data (revisions, commits, diff summary) in batched/parallel reads, instead
+	// of warming engine-global caches with PreloadBranchData/PreloadBranchStats.
+	ViewBranches(ctx context.Context, branches Branches, format CommitFormat) *BranchView
 }
 
 // GitDiffer handles diff and merge operations


### PR DESCRIPTION

Prototype slice exploring an explicit, passed-around read-model instead of
warming engine-global caches. StackInfoAction previously called
PreloadBranchData + PreloadBranchStats to warm the global revision/stat
caches, then read per-branch revisions, commits, and diff stats through
the deep engine accessors (which read those globals).

Introduce engine.BranchView: an immutable snapshot of per-branch revisions,
commits, and diff summary, built in one batched revision resolve plus
parallel per-branch reads. The command builds the view, reads plain values
from it in the loop, and no longer touches PreloadBranch*. PR submission
status stays a separate batched value (network-touching, not git read-data).

Exploration only: the global revision cache and PreloadBranch* remain for
other callers; this is one slice to evaluate the model.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1249** 👈
  * **PR #1250**
    * **PR #1251**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->