### PR TITLE
refactor(flatten): plan from explicit revision/divergence values

### DIFF
--- a/internal/actions/flatten/flatten.go
+++ b/internal/actions/flatten/flatten.go
@@ -438,23 +438,25 @@ func buildFlattenPlan(ctx *app.Context, eng engine.Engine, branches engine.Branc
 		RebaseSpecs: make([]engine.RebaseSpec, 0),
 	}
 
-	// Track the current revision of each potential parent (including trunk)
-	// This is needed to build accurate rebase specs
-	parentRevisions := make(map[string]string)
-	trunkRev, err := trunk.GetRevision()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get trunk revision: %w", err)
+	// Resolve every branch and trunk revision, plus every divergence point, in
+	// batched reads up front (passed-around values, no engine-global cache). The
+	// revision map doubles as the parent-revision lookup the planning loop used
+	// to accumulate one entry at a time.
+	revNames := make([]string, 0, len(branches)+1)
+	revNames = append(revNames, trunk.GetName())
+	for _, b := range branches {
+		revNames = append(revNames, b.GetName())
 	}
-	parentRevisions[trunk.GetName()] = trunkRev
+	revisions, _ := eng.GetRevisions(revNames)
+	divergence := eng.BatchDivergencePoints(branches)
+
+	if revisions[trunk.GetName()] == "" {
+		return nil, fmt.Errorf("failed to get trunk revision")
+	}
 
 	// potentialParents tracks branches that can serve as parents for subsequent branches
 	// Starts with trunk, and grows as we process branches
 	potentialParents := []string{trunk.GetName()}
-
-	// Warm the revision and metadata caches once so the per-branch
-	// GetDivergencePoint and GetRevision calls below hit memory instead of
-	// spawning a git rev-parse each.
-	eng.PreloadBranchData()
 
 	for i, b := range branches {
 		bName := b.GetName()
@@ -467,21 +469,11 @@ func buildFlattenPlan(ctx *app.Context, eng engine.Engine, branches engine.Branc
 		// Get current parent info
 		origParentName := b.GetParentOrTrunk()
 
-		// Get the branch's base (divergence point from parent)
-		oldUpstream, err := eng.GetDivergencePoint(bName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get base for %s: %w", bName, err)
-		}
+		// The branch's base (divergence point from parent)
+		oldUpstream := divergence[bName]
 
 		// Try to find the best (closest to trunk) parent this branch can move to
-		newParent := findBestParent(ctx, eng, bName, oldUpstream, potentialParents, parentRevisions)
-
-		// Track this branch's revision for subsequent branches
-		bRev, err := b.GetRevision()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get revision for %s: %w", bName, err)
-		}
-		parentRevisions[bName] = bRev
+		newParent := findBestParent(ctx, eng, bName, oldUpstream, potentialParents, revisions)
 
 		// Add this branch as a potential parent for subsequent branches
 		potentialParents = append(potentialParents, bName)
@@ -495,7 +487,7 @@ func buildFlattenPlan(ctx *app.Context, eng engine.Engine, branches engine.Branc
 			})
 
 			// Add rebase spec for this move
-			newParentRev := parentRevisions[newParent]
+			newParentRev := revisions[newParent]
 			plan.RebaseSpecs = append(plan.RebaseSpecs, engine.RebaseSpec{
 				Branch:      bName,
 				NewParent:   newParentRev,

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -38,6 +38,38 @@ func (e *engineImpl) GetRevisions(branchNames []string) (map[string]string, []er
 	return e.git.BatchGetRevisions(branchNames)
 }
 
+// BatchDivergencePoints returns each branch's divergence point keyed by branch
+// name, matching GetDivergencePoint (the stored parent revision when present,
+// else the parent's current tip) but resolving the whole set with one batched
+// metadata read and one batched revision lookup instead of per-branch git.
+func (e *engineImpl) BatchDivergencePoints(branches Branches) map[string]string {
+	result := make(map[string]string, len(branches))
+	if len(branches) == 0 {
+		return result
+	}
+
+	names := make([]string, 0, len(branches))
+	parentNames := make([]string, 0, len(branches))
+	for _, b := range branches {
+		names = append(names, b.GetName())
+		parentNames = append(parentNames, b.GetParentOrTrunk())
+	}
+	metas, _ := e.batchReadMetadata(names)
+	parentRevs, _ := e.GetRevisions(parentNames)
+
+	for _, b := range branches {
+		name := b.GetName()
+		if m := metas[name]; m != nil {
+			if rev := m.GetParentBranchRevision(); rev != nil && *rev != "" {
+				result[name] = *rev
+				continue
+			}
+		}
+		result[name] = parentRevs[b.GetParentOrTrunk()]
+	}
+	return result
+}
+
 // GetCommitCount returns the number of commits for a branch.
 // Results are cached by (base, head) SHA pair and populated by PreloadBranchStats.
 func (e *engineImpl) GetCommitCount(branch Branch) (int, error) {

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -90,6 +90,9 @@ type BranchInfo interface {
 	// GetDivergencePoint returns the divergence point of a branch from its parent.
 	// Returns the ParentBranchRevision from metadata if valid, otherwise the parent's current revision.
 	GetDivergencePoint(branchName string) (string, error)
+	// BatchDivergencePoints returns the divergence point for every branch in one
+	// batched (git-free when metadata is cached) pass, keyed by branch name.
+	BatchDivergencePoints(branches Branches) map[string]string
 	// PreloadBranchData batch-loads metadata and revisions for all branches
 	// into their respective caches. Call before parallel annotation building
 	// to eliminate per-branch cache misses and mutex contention.


### PR DESCRIPTION

Second model slice, with different requirements than stack-info: a
mutating planning command that needs revisions + divergence points (no
commits or diffs).

buildFlattenPlan warmed the engine-global caches with PreloadBranchData,
then accumulated each branch revision into a parentRevisions map as it
went and called GetDivergencePoint per branch. Resolve all branch and
trunk revisions, plus all divergence points, up front as passed-around
value maps (GetRevisions + new engine.BatchDivergencePoints). The
revision map doubles as the parent-revision lookup, so the sequential
accumulation disappears and the loop reads values instead of spawning a
rev-parse per branch.

Unlike stack-info, this command shares only revisions with the other; its
narrow, disjoint needs are served cleanly by per-concern value maps rather
than a bundled BranchView.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1249**
  * **PR #1250** 👈
    * **PR #1251**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->