### PR TITLE
refactor(log): annotate from batched BranchStat + separate forge status

### DIFF
--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -264,7 +264,7 @@ func buildLogAnnotation(
 	enrichment *tui.AnnotationEnrichment,
 ) tree.BranchAnnotation {
 	if opts.Style != LogStyleShort {
-		return tui.BuildFullAnnotation(eng, branch, enrichment, tui.AnnotationOptions{
+		return tui.BuildFullAnnotation(eng, branch, nil, enrichment, tui.AnnotationOptions{
 			SkipCommitMessages: true,
 		})
 	}

--- a/internal/cli/dashboard/shippable_model.go
+++ b/internal/cli/dashboard/shippable_model.go
@@ -423,7 +423,7 @@ func (m *shippableModel) rebuildCache() {
 		for _, branchName := range stack.Stack.AllBranches {
 			branch := m.engine.GetBranch(branchName)
 			if branch.GetName() != "" {
-				ann := tui.GetBranchAnnotation(m.engine, branch, tui.AnnotationOptions{})
+				ann := tui.GetBranchAnnotation(m.engine, branch, nil, tui.AnnotationOptions{})
 				m.cache.branchAnnotations[branchName] = ann
 			}
 		}

--- a/internal/engine/branch_view.go
+++ b/internal/engine/branch_view.go
@@ -13,6 +13,83 @@ type DiffSummary struct {
 	FilesChanged int
 }
 
+// BranchStat holds the git-computed fields a branch annotation needs (short SHA,
+// commit count, additions/deletions), resolved in batch so annotation builders
+// do no per-branch git.
+type BranchStat struct {
+	ShortSHA     string
+	CommitCount  int
+	LinesAdded   int
+	LinesDeleted int
+}
+
+// BatchBranchStats resolves the annotation stats for every branch in batched
+// reads (one revision resolve + one cached metadata read, then parallel
+// per-branch count and diff), keyed by branch name. It is the branch-state
+// counterpart that lets annotation builders drop PreloadBranchData /
+// PreloadBranchStats; forge status (CI, reviews) is a separate concern joined at
+// render time, not part of this.
+func (e *engineImpl) BatchBranchStats(branches Branches) map[string]BranchStat {
+	result := make(map[string]BranchStat, len(branches))
+	if len(branches) == 0 {
+		return result
+	}
+
+	branchNames := make([]string, 0, len(branches))
+	revNames := make([]string, 0, len(branches)*2)
+	for _, b := range branches {
+		branchNames = append(branchNames, b.GetName())
+		revNames = append(revNames, b.GetName(), b.GetParentOrTrunk())
+	}
+	revs, _ := e.GetRevisions(revNames)
+	metas, _ := e.batchReadMetadata(branchNames)
+
+	type entry struct {
+		name string
+		stat BranchStat
+	}
+	entries := make([]entry, len(branches))
+	var wg sync.WaitGroup
+	for i, b := range branches {
+		wg.Add(1)
+		go func(i int, b Branch) {
+			defer wg.Done()
+			name := b.GetName()
+			head := revs[name]
+			st := BranchStat{}
+			if len(head) >= 7 {
+				st.ShortSHA = head[:7]
+			}
+			// Trunk has no parent comparison; only its short SHA is meaningful.
+			if !e.IsTrunk(b) {
+				base := ""
+				if m := metas[name]; m != nil {
+					if rev := m.GetParentBranchRevision(); rev != nil && *rev != "" {
+						base = *rev
+					}
+				}
+				if base == "" {
+					base = revs[b.GetParentOrTrunk()]
+				}
+				if c, err := e.commitCountBetween(base, head); err == nil {
+					st.CommitCount = c
+				}
+				if a, d, err := e.diffStatsBetween(base, head); err == nil {
+					st.LinesAdded = a
+					st.LinesDeleted = d
+				}
+			}
+			entries[i] = entry{name: name, stat: st}
+		}(i, b)
+	}
+	wg.Wait()
+
+	for _, en := range entries {
+		result[en.name] = en.stat
+	}
+	return result
+}
+
 // BranchView is an immutable, point-in-time snapshot of per-branch read data,
 // materialized in batched and parallel git reads when it is built. Consumers
 // read plain values from it — there is no engine callback or global cache

--- a/internal/engine/branch_view_test.go
+++ b/internal/engine/branch_view_test.go
@@ -1,0 +1,46 @@
+package engine_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// TestBatchBranchStats asserts the batched stats match the per-branch accessors
+// they replace, so annotation builders can read from the batch instead of
+// warming the engine-global caches.
+func TestBatchBranchStats(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithLinearStack3()
+
+	branches := s.Engine.AllBranches()
+	stats := s.Engine.BatchBranchStats(branches)
+
+	for _, b := range branches {
+		name := b.GetName()
+		stat, ok := stats[name]
+		require.True(t, ok, "missing stat for %s", name)
+
+		// Short SHA matches GetRevision for every branch, including trunk.
+		if rev, err := s.Engine.GetRevision(b); err == nil && len(rev) >= 7 {
+			require.Equal(t, rev[:7], stat.ShortSHA, "ShortSHA for %s", name)
+		}
+
+		if b.IsTrunk() {
+			continue
+		}
+
+		wantCount, err := s.Engine.GetCommitCount(b)
+		require.NoError(t, err)
+		require.Equal(t, wantCount, stat.CommitCount, "CommitCount for %s", name)
+
+		wantAdded, wantDeleted, err := s.Engine.GetDiffStats(b)
+		require.NoError(t, err)
+		require.Equal(t, wantAdded, stat.LinesAdded, "LinesAdded for %s", name)
+		require.Equal(t, wantDeleted, stat.LinesDeleted, "LinesDeleted for %s", name)
+	}
+}

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -77,16 +77,23 @@ func (e *engineImpl) GetCommitCount(branch Branch) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	if branchRev == base {
+	return e.commitCountBetween(base, branchRev)
+}
+
+// commitCountBetween returns the commit count in (base, head], using the
+// (base, head)-keyed cache. It takes pre-resolved revisions so batched callers
+// need not re-resolve a branch's head.
+func (e *engineImpl) commitCountBetween(base, head string) (int, error) {
+	if head == base {
 		return 0, nil
 	}
 
-	cacheKey := base + ":" + branchRev
+	cacheKey := base + ":" + head
 	if v, ok := e.commitCountCache.Load(cacheKey); ok {
 		return v.(int), nil
 	}
 
-	out, err := e.git.RunGitCommandWithContext(context.Background(), "rev-list", "--count", base+".."+branchRev)
+	out, err := e.git.RunGitCommandWithContext(context.Background(), "rev-list", "--count", base+".."+head)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -105,6 +105,10 @@ type BranchInfo interface {
 	// data (revisions, commits, diff summary) in batched/parallel reads, instead
 	// of warming engine-global caches with PreloadBranchData/PreloadBranchStats.
 	ViewBranches(ctx context.Context, branches Branches, format CommitFormat) *BranchView
+	// BatchBranchStats resolves annotation stats (short SHA, commit count,
+	// additions/deletions) for every branch in batch, so annotation builders need
+	// no per-branch git and no PreloadBranchData/PreloadBranchStats.
+	BatchBranchStats(branches Branches) map[string]BranchStat
 }
 
 // GitDiffer handles diff and merge operations

--- a/internal/tui/log_ui.go
+++ b/internal/tui/log_ui.go
@@ -307,12 +307,11 @@ func (m *LogModel) enrichData() tea.Cmd {
 		// Detect worktrees (builds both empty and stack-root maps in one call)
 		wtData := GetWorktreeData(eng)
 
-		// Pre-load metadata and revisions for all branches to eliminate per-branch
-		// cache misses during parallel annotation building. PreloadBranchStats
-		// additionally warms the diff-stat and commit-count caches that
-		// BuildFullAnnotation reads, which PreloadBranchData does not cover.
-		eng.PreloadBranchData()
-		eng.PreloadBranchStats(allBranches)
+		// Resolve the git-computed annotation stats (short SHA, commit count, diff
+		// stats) for all branches as one batched value, instead of warming the
+		// engine-global caches. Forge status (CI) and worktree data above are
+		// separate concerns, joined into the annotation below.
+		stats := eng.BatchBranchStats(allBranches)
 
 		// Collect full annotations
 		start := time.Now()
@@ -325,7 +324,8 @@ func (m *LogModel) enrichData() tea.Cmd {
 		// shared map, then assemble the map serially.
 		built := make([]tree.BranchAnnotation, len(allBranches))
 		utils.Run(indexedBranches(allBranches), func(item indexedBranch) {
-			built[item.index] = BuildFullAnnotation(eng, item.branch, enrichment, AnnotationOptions{
+			stat := stats[item.branch.GetName()]
+			built[item.index] = BuildFullAnnotation(eng, item.branch, &stat, enrichment, AnnotationOptions{
 				SkipCommitMessages: true,
 			})
 		})

--- a/internal/tui/prompts.go
+++ b/internal/tui/prompts.go
@@ -748,7 +748,7 @@ func PromptBranchCheckout(branches []engine.Branch, eng engine.BranchReader) (st
 	// Add annotations for all branches
 	annotations := make(map[string]tree.BranchAnnotation)
 	for _, branch := range branches {
-		annotations[branch.GetName()] = GetBranchAnnotation(eng, branch, AnnotationOptions{})
+		annotations[branch.GetName()] = GetBranchAnnotation(eng, branch, nil, AnnotationOptions{})
 	}
 	renderer.SetAnnotations(annotations)
 

--- a/internal/tui/tree_renderer.go
+++ b/internal/tui/tree_renderer.go
@@ -294,8 +294,8 @@ type AnnotationOptions struct {
 // git operations (SHA, commits, diff stats), CI status, review status, and worktree info.
 // Pass nil for enrichment to get just the base annotation without CI/worktree enrichment.
 // Pass AnnotationOptions{} for the full annotation, or set Skip* flags to skip work.
-func BuildFullAnnotation(eng engine.Engine, branch engine.Branch, enrichment *AnnotationEnrichment, opts AnnotationOptions) tree.BranchAnnotation {
-	ann := GetBranchAnnotation(eng, branch, opts)
+func BuildFullAnnotation(eng engine.Engine, branch engine.Branch, stat *engine.BranchStat, enrichment *AnnotationEnrichment, opts AnnotationOptions) tree.BranchAnnotation {
+	ann := GetBranchAnnotation(eng, branch, stat, opts)
 
 	if enrichment == nil {
 		return ann
@@ -334,7 +334,11 @@ func BuildFullAnnotation(eng engine.Engine, branch engine.Branch, enrichment *An
 // GetBranchAnnotation returns a tree.BranchAnnotation populated with standard branch metadata.
 // This includes git operations (SHA, commit count, diff stats) which may be slow.
 // Pass AnnotationOptions{} for the full annotation, or set Skip* flags to skip work.
-func GetBranchAnnotation(eng engine.BranchReader, branch engine.Branch, opts AnnotationOptions) tree.BranchAnnotation {
+// GetBranchAnnotation populates a tree.BranchAnnotation. When stat is non-nil
+// the git-computed fields (short SHA, commit count, diff stats) are read from it
+// — a batched, passed-around value — instead of per-branch engine reads; when
+// nil it falls back to reading them from the engine.
+func GetBranchAnnotation(eng engine.BranchReader, branch engine.Branch, stat *engine.BranchStat, opts AnnotationOptions) tree.BranchAnnotation {
 	ann := tree.BranchAnnotation{
 		IsLocked:      branch.IsLocked(),
 		IsFrozen:      branch.IsFrozen(),
@@ -343,7 +347,9 @@ func GetBranchAnnotation(eng engine.BranchReader, branch engine.Branch, opts Ann
 	}
 
 	// Get short SHA for the branch
-	if sha, err := branch.GetRevision(); err == nil && len(sha) >= 7 {
+	if stat != nil {
+		ann.LocalSHA = stat.ShortSHA
+	} else if sha, err := branch.GetRevision(); err == nil && len(sha) >= 7 {
 		ann.LocalSHA = sha[:7]
 	}
 
@@ -356,14 +362,19 @@ func GetBranchAnnotation(eng engine.BranchReader, branch engine.Branch, opts Ann
 			ann.PRURL = prInfo.URL()
 		}
 
-		if !opts.SkipCommitMessages {
+		switch {
+		case !opts.SkipCommitMessages:
 			// Commit messages for detailed view
 			if commits, err := branch.GetAllCommits(engine.CommitFormatReadable); err == nil {
 				ann.CommitMessages = commits
 				ann.CommitCount = len(commits)
 			}
-		} else if count, err := eng.GetCommitCount(branch); err == nil {
-			ann.CommitCount = count
+		case stat != nil:
+			ann.CommitCount = stat.CommitCount
+		default:
+			if count, err := eng.GetCommitCount(branch); err == nil {
+				ann.CommitCount = count
+			}
 		}
 
 		// Merged downstack history
@@ -382,7 +393,10 @@ func GetBranchAnnotation(eng engine.BranchReader, branch engine.Branch, opts Ann
 
 		// Local stats
 		if !opts.SkipDiffStats {
-			if added, deleted, err := branch.GetDiffStats(); err == nil {
+			if stat != nil {
+				ann.LinesAdded = stat.LinesAdded
+				ann.LinesDeleted = stat.LinesDeleted
+			} else if added, deleted, err := branch.GetDiffStats(); err == nil {
 				ann.LinesAdded = added
 				ann.LinesDeleted = deleted
 			}


### PR DESCRIPTION

Third model slice, the richest consumer: the log annotation build. It
assembles a render row from three sources, and this makes that explicit.

- Branch state (short SHA, commit count, additions/deletions) now comes
  from engine.BatchBranchStats, one batched value passed into the
  annotation builder, instead of warming the global caches with
  PreloadBranchData/PreloadBranchStats. GetCommitCount gains a
  commitCountBetween helper (mirroring diffStatsBetween) so the batch
  resolves revisions once.
- Forge status (CI/review) stays a separate concern: log_ui still fetches
  it on its own channel and passes it as enrichment, joined into the
  annotation at render time rather than bundled into branch state.

GetBranchAnnotation/BuildFullAnnotation take an optional *BranchStat: the
log path passes the batch; the other callers (prompts, dashboard, CLI log)
pass nil and keep the per-branch engine fallback. The optional pointer is
the incremental-adoption seam for a shared helper.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1249**
  * **PR #1250**
    * **PR #1251** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->