### PR TITLE
refactor(engine): per-concern batch readers for branch state

### DIFF
--- a/internal/actions/stack_info.go
+++ b/internal/actions/stack_info.go
@@ -62,56 +62,40 @@ func StackInfoAction(ctx *app.Context, opts StackInfoOptions) error {
 	})
 	result := make([]StackBranchInfo, 0, len(stackBranches))
 
-	// Warm the revision/metadata and diff-stat caches once, and read PR
-	// submission status for the whole stack in a single batch, so the loop
-	// below does not spawn a git rev-parse, git diff, and (most costly) a
-	// git ls-remote per branch.
-	eng.PreloadBranchData()
-	eng.PreloadBranchStats(stackBranches)
+	// Read each per-branch concern the loop needs as its own batched value map —
+	// commits, diff stats, changed-file counts, and PR submission status — instead
+	// of warming an engine-global cache. The loop is a projection over these maps.
+	commits := eng.BatchCommits(stackBranches, engine.CommitFormatReadable)
+	diffs := eng.BatchDiffStats(stackBranches)
+	fileCounts := eng.BatchChangedFileCounts(ctx.Context, stackBranches)
 	prStatuses, _ := eng.BatchGetPRSubmissionStatus(stackBranches)
 
 	for _, branch := range stackBranches {
 		if branch.IsTrunk() {
 			continue
 		}
+		name := branch.GetName()
 
+		diff := diffs[name]
 		info := StackBranchInfo{
-			Name:           branch.GetName(),
+			Name:           name,
 			Parent:         branch.GetParentOrTrunk(),
 			IsLocked:       branch.IsLocked(),
 			IsFrozen:       branch.IsFrozen(),
 			Scope:          branch.GetScope().String(),
-			CommitMessages: []string{},
+			CommitMessages: commits[name],
+			DiffStats: DiffStats{
+				Additions:    diff.Added,
+				Deletions:    diff.Deleted,
+				FilesChanged: fileCounts[name],
+			},
 		}
-
-		// Commit messages
-		commits, err := branch.GetAllCommits(engine.CommitFormatReadable)
-		if err == nil {
-			info.CommitMessages = commits
-		}
-
-		// Diff stats
-		added, deleted, err := branch.GetDiffStats()
-		if err == nil {
-			info.DiffStats.Additions = added
-			info.DiffStats.Deletions = deleted
-		}
-
-		// Files changed
-		parentName := branch.GetParentOrTrunk()
-		parentRev, err := eng.GetRevision(eng.GetBranch(parentName))
-		if err == nil {
-			branchRev, err := branch.GetRevision()
-			if err == nil {
-				files, err := eng.GetChangedFiles(ctx.Context, parentRev, branchRev)
-				if err == nil {
-					info.DiffStats.FilesChanged = len(files)
-				}
-			}
+		if info.CommitMessages == nil {
+			info.CommitMessages = []string{}
 		}
 
 		// PR info
-		prStatus := prStatuses[branch.GetName()]
+		prStatus := prStatuses[name]
 		if prStatus.PRNumber != nil {
 			info.PRNumber = prStatus.PRNumber
 			if prStatus.PRInfo != nil {

--- a/internal/engine/branch_view.go
+++ b/internal/engine/branch_view.go
@@ -1,0 +1,147 @@
+package engine
+
+import (
+	"context"
+	"sync"
+)
+
+// DiffStat is a branch's additions/deletions relative to its divergence point.
+type DiffStat struct {
+	Added   int
+	Deleted int
+}
+
+// BranchStat holds the git-computed fields a branch annotation needs (short SHA,
+// commit count, additions/deletions), resolved in batch so annotation builders
+// do no per-branch git.
+type BranchStat struct {
+	ShortSHA     string
+	CommitCount  int
+	LinesAdded   int
+	LinesDeleted int
+}
+
+// batchByBranch is the shared scaffold behind the per-concern batch readers. It
+// resolves every branch's head revision, parent revision, and stored divergence
+// base in two batched, cache-backed reads, then runs fn for each branch in
+// parallel and collects the results by branch name. Callers supply only the
+// per-concern computation; the (otherwise duplicated) batched resolution lives
+// here once. storedBase is the metadata ParentBranchRevision ("" when unset);
+// each concern decides how to derive its base from storedBase/parentRev.
+func batchByBranch[T any](e *engineImpl, branches Branches, fn func(b Branch, head, parentRev, storedBase string) T) map[string]T {
+	result := make(map[string]T, len(branches))
+	if len(branches) == 0 {
+		return result
+	}
+
+	branchNames := make([]string, 0, len(branches))
+	revNames := make([]string, 0, len(branches)*2)
+	for _, b := range branches {
+		branchNames = append(branchNames, b.GetName())
+		revNames = append(revNames, b.GetName(), b.GetParentOrTrunk())
+	}
+	revs, _ := e.GetRevisions(revNames)
+	metas, _ := e.batchReadMetadata(branchNames)
+
+	type entry struct {
+		name string
+		val  T
+	}
+	entries := make([]entry, len(branches))
+	var wg sync.WaitGroup
+	for i, b := range branches {
+		wg.Add(1)
+		go func(i int, b Branch) {
+			defer wg.Done()
+			name := b.GetName()
+			storedBase := ""
+			if m := metas[name]; m != nil {
+				if rev := m.GetParentBranchRevision(); rev != nil && *rev != "" {
+					storedBase = *rev
+				}
+			}
+			entries[i] = entry{name: name, val: fn(b, revs[name], revs[b.GetParentOrTrunk()], storedBase)}
+		}(i, b)
+	}
+	wg.Wait()
+
+	for _, en := range entries {
+		result[en.name] = en.val
+	}
+	return result
+}
+
+// statBase returns the comparison base used by diff stats and commit counts:
+// the stored divergence point, or the parent's current tip when none is stored.
+func statBase(parentRev, storedBase string) string {
+	if storedBase != "" {
+		return storedBase
+	}
+	return parentRev
+}
+
+// BatchDiffStats returns each non-trunk branch's additions/deletions against its
+// divergence point, keyed by branch name, resolved in one batched pass.
+func (e *engineImpl) BatchDiffStats(branches Branches) map[string]DiffStat {
+	return batchByBranch(e, branches, func(b Branch, head, parentRev, storedBase string) DiffStat {
+		if e.IsTrunk(b) {
+			return DiffStat{}
+		}
+		added, deleted, _ := e.diffStatsBetween(statBase(parentRev, storedBase), head)
+		return DiffStat{Added: added, Deleted: deleted}
+	})
+}
+
+// BatchCommits returns each non-trunk branch's formatted commits, keyed by
+// branch name, resolved in one batched pass. It matches GetAllCommits, which
+// compares against the stored divergence base (empty when unset).
+func (e *engineImpl) BatchCommits(branches Branches, format CommitFormat) map[string][]string {
+	return batchByBranch(e, branches, func(b Branch, head, parentRev, storedBase string) []string {
+		if e.IsTrunk(b) {
+			return nil
+		}
+		commits, _ := e.commitsBetween(storedBase, head, format)
+		return commits
+	})
+}
+
+// BatchChangedFileCounts returns each non-trunk branch's number of changed files
+// against its parent's current tip (matching the existing stack-info behavior),
+// keyed by branch name, resolved in one batched pass.
+func (e *engineImpl) BatchChangedFileCounts(ctx context.Context, branches Branches) map[string]int {
+	return batchByBranch(e, branches, func(b Branch, head, parentRev, storedBase string) int {
+		if e.IsTrunk(b) || parentRev == "" || head == "" {
+			return 0
+		}
+		files, err := e.GetChangedFiles(ctx, parentRev, head)
+		if err != nil {
+			return 0
+		}
+		return len(files)
+	})
+}
+
+// BatchBranchStats resolves the annotation stats (short SHA, commit count,
+// additions/deletions) for every branch in one batched pass, keyed by branch
+// name. Forge status (CI, reviews) is a separate concern joined at render time,
+// not part of this.
+func (e *engineImpl) BatchBranchStats(branches Branches) map[string]BranchStat {
+	return batchByBranch(e, branches, func(b Branch, head, parentRev, storedBase string) BranchStat {
+		st := BranchStat{}
+		if len(head) >= 7 {
+			st.ShortSHA = head[:7]
+		}
+		if e.IsTrunk(b) {
+			return st
+		}
+		base := statBase(parentRev, storedBase)
+		if c, err := e.commitCountBetween(base, head); err == nil {
+			st.CommitCount = c
+		}
+		if a, d, err := e.diffStatsBetween(base, head); err == nil {
+			st.LinesAdded = a
+			st.LinesDeleted = d
+		}
+		return st
+	})
+}

--- a/internal/engine/branch_view_test.go
+++ b/internal/engine/branch_view_test.go
@@ -1,0 +1,80 @@
+package engine_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// TestBatchBranchStats asserts the batched stats match the per-branch accessors
+// they replace, so annotation builders can read from the batch instead of
+// warming the engine-global caches.
+func TestBatchBranchStats(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithLinearStack3()
+
+	branches := s.Engine.AllBranches()
+	stats := s.Engine.BatchBranchStats(branches)
+
+	for _, b := range branches {
+		name := b.GetName()
+		stat, ok := stats[name]
+		require.True(t, ok, "missing stat for %s", name)
+
+		// Short SHA matches GetRevision for every branch, including trunk.
+		if rev, err := s.Engine.GetRevision(b); err == nil && len(rev) >= 7 {
+			require.Equal(t, rev[:7], stat.ShortSHA, "ShortSHA for %s", name)
+		}
+
+		if b.IsTrunk() {
+			continue
+		}
+
+		wantCount, err := s.Engine.GetCommitCount(b)
+		require.NoError(t, err)
+		require.Equal(t, wantCount, stat.CommitCount, "CommitCount for %s", name)
+
+		wantAdded, wantDeleted, err := s.Engine.GetDiffStats(b)
+		require.NoError(t, err)
+		require.Equal(t, wantAdded, stat.LinesAdded, "LinesAdded for %s", name)
+		require.Equal(t, wantDeleted, stat.LinesDeleted, "LinesDeleted for %s", name)
+	}
+}
+
+// TestPerConcernBatchReaders asserts each per-concern batch reader matches the
+// single-branch accessor it batches, so consumers can compose the value maps.
+func TestPerConcernBatchReaders(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithLinearStack3()
+
+	branches := s.Engine.AllBranches()
+	diffs := s.Engine.BatchDiffStats(branches)
+	commits := s.Engine.BatchCommits(branches, engine.CommitFormatReadable)
+	divergence := s.Engine.BatchDivergencePoints(branches)
+
+	for _, b := range branches {
+		name := b.GetName()
+
+		if b.IsTrunk() {
+			continue
+		}
+
+		wantDiv, err := s.Engine.GetDivergencePoint(name)
+		require.NoError(t, err)
+		require.Equal(t, wantDiv, divergence[name], "divergence for %s", name)
+
+		wantAdded, wantDeleted, err := s.Engine.GetDiffStats(b)
+		require.NoError(t, err)
+		require.Equal(t, engine.DiffStat{Added: wantAdded, Deleted: wantDeleted}, diffs[name], "diff for %s", name)
+
+		wantCommits, err := s.Engine.GetAllCommits(b, engine.CommitFormatReadable)
+		require.NoError(t, err)
+		require.Equal(t, wantCommits, commits[name], "commits for %s", name)
+	}
+}

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -38,6 +38,15 @@ func (e *engineImpl) GetRevisions(branchNames []string) (map[string]string, []er
 	return e.git.BatchGetRevisions(branchNames)
 }
 
+// BatchDivergencePoints returns each branch's divergence point keyed by branch
+// name, matching GetDivergencePoint (the stored parent revision when present,
+// else the parent's current tip) but resolving the whole set in one batched pass.
+func (e *engineImpl) BatchDivergencePoints(branches Branches) map[string]string {
+	return batchByBranch(e, branches, func(b Branch, head, parentRev, storedBase string) string {
+		return statBase(parentRev, storedBase)
+	})
+}
+
 // GetCommitCount returns the number of commits for a branch.
 // Results are cached by (base, head) SHA pair and populated by PreloadBranchStats.
 func (e *engineImpl) GetCommitCount(branch Branch) (int, error) {
@@ -45,16 +54,23 @@ func (e *engineImpl) GetCommitCount(branch Branch) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	if branchRev == base {
+	return e.commitCountBetween(base, branchRev)
+}
+
+// commitCountBetween returns the commit count in (base, head], using the
+// (base, head)-keyed cache. It takes pre-resolved revisions so batched callers
+// need not re-resolve a branch's head.
+func (e *engineImpl) commitCountBetween(base, head string) (int, error) {
+	if head == base {
 		return 0, nil
 	}
 
-	cacheKey := base + ":" + branchRev
+	cacheKey := base + ":" + head
 	if v, ok := e.commitCountCache.Load(cacheKey); ok {
 		return v.(int), nil
 	}
 
-	out, err := e.git.RunGitCommandWithContext(context.Background(), "rev-list", "--count", base+".."+branchRev)
+	out, err := e.git.RunGitCommandWithContext(context.Background(), "rev-list", "--count", base+".."+head)
 	if err != nil {
 		return 0, err
 	}
@@ -70,17 +86,24 @@ func (e *engineImpl) GetDiffStats(branch Branch) (int, int, error) {
 	if err != nil {
 		return 0, 0, err
 	}
-	if branchRev == base {
+	return e.diffStatsBetween(base, branchRev)
+}
+
+// diffStatsBetween returns the additions/deletions between two revisions, using
+// the (base, head)-keyed cache. It takes pre-resolved revisions so batched
+// callers (the Batch* readers) need not re-resolve a branch's head.
+func (e *engineImpl) diffStatsBetween(base, head string) (int, int, error) {
+	if head == base {
 		return 0, 0, nil
 	}
 
-	cacheKey := base + ":" + branchRev
+	cacheKey := base + ":" + head
 	if v, ok := e.diffStatsCache.Load(cacheKey); ok {
 		stats := v.([2]int)
 		return stats[0], stats[1], nil
 	}
 
-	output, err := e.git.GetDiffNumstat(base, branchRev)
+	output, err := e.git.GetDiffNumstat(base, head)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -214,7 +237,12 @@ func (e *engineImpl) GetAllCommits(branch Branch, format CommitFormat) ([]string
 		baseRevision = *rev
 	}
 
-	// Use GetCommitRange directly to handle formatting in-process via go-git,
-	// avoiding per-commit git process spawns.
-	return e.git.GetCommitRange(context.Background(), baseRevision, branchRevision, string(format))
+	return e.commitsBetween(baseRevision, branchRevision, format)
+}
+
+// commitsBetween returns the formatted commits in (base, head]. It handles
+// formatting in-process via go-git, avoiding per-commit git process spawns, and
+// takes pre-resolved revisions so batched callers need not re-resolve the head.
+func (e *engineImpl) commitsBetween(base, head string, format CommitFormat) ([]string, error) {
+	return e.git.GetCommitRange(context.Background(), base, head, string(format))
 }

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -90,6 +90,9 @@ type BranchInfo interface {
 	// GetDivergencePoint returns the divergence point of a branch from its parent.
 	// Returns the ParentBranchRevision from metadata if valid, otherwise the parent's current revision.
 	GetDivergencePoint(branchName string) (string, error)
+	// BatchDivergencePoints returns the divergence point for every branch in one
+	// batched (git-free when metadata is cached) pass, keyed by branch name.
+	BatchDivergencePoints(branches Branches) map[string]string
 	// PreloadBranchData batch-loads metadata and revisions for all branches
 	// into their respective caches. Call before parallel annotation building
 	// to eliminate per-branch cache misses and mutex contention.
@@ -98,6 +101,17 @@ type BranchInfo interface {
 	// given branches in parallel. Call before utils.Run iteration so subsequent
 	// GetDiffStats / GetCommitCount calls are instant cache hits.
 	PreloadBranchStats(branches []Branch)
+	// BatchDiffStats, BatchCommits, and BatchChangedFileCounts each resolve one
+	// per-branch concern across the whole set in a single batched pass, returning
+	// a value map — the per-concern alternative to warming engine-global caches
+	// with PreloadBranchData/PreloadBranchStats.
+	BatchDiffStats(branches Branches) map[string]DiffStat
+	BatchCommits(branches Branches, format CommitFormat) map[string][]string
+	BatchChangedFileCounts(ctx context.Context, branches Branches) map[string]int
+	// BatchBranchStats resolves annotation stats (short SHA, commit count,
+	// additions/deletions) for every branch in one batched pass — a use-case
+	// bundle over the per-concern readers, for annotation builders.
+	BatchBranchStats(branches Branches) map[string]BranchStat
 }
 
 // GitDiffer handles diff and merge operations


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Introduce per-concern batch-value readers over a single shared scaffold,
and use them in stack-info. This is the foundation the flatten and log
slices build on.

batchByBranch resolves every branch head/parent revision and metadata in
two batched, cache-backed reads, then runs a per-concern closure in
parallel. BatchDiffStats, BatchCommits, BatchChangedFileCounts,
BatchDivergencePoints, and BatchBranchStats are each a thin closure over
it, returning a value map. The GetDiffStats/GetCommitCount/GetAllCommits
accessors gain (base, head) helpers so the batches resolve revisions once.

StackInfoAction composes the value maps it needs instead of warming the
engine-global revision/stat caches with PreloadBranchData/PreloadBranchStats.
No bundled view type: consumers read the maps they need.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781896357`.


* **PR #1252** 👈
  * **PR #1253**
    * **PR #1254**
      * **PR #1256**
        * **PR #1257**
          * **PR #1258**
            * **PR #1259**
              * **PR #1260**
                * **PR #1261**
                  * **PR #1262**
                    * **PR #1263**
                      * **PR #1264**
                        * **PR #1265**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1267 by jonnii*