### PR TITLE
refactor(log): annotate from batched stats, forge status separate

### DIFF
--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -264,7 +264,7 @@ func buildLogAnnotation(
 	enrichment *tui.AnnotationEnrichment,
 ) tree.BranchAnnotation {
 	if opts.Style != LogStyleShort {
-		return tui.BuildFullAnnotation(eng, branch, enrichment, tui.AnnotationOptions{
+		return tui.BuildFullAnnotation(eng, branch, nil, enrichment, tui.AnnotationOptions{
 			SkipCommitMessages: true,
 		})
 	}

--- a/internal/cli/dashboard/shippable_model.go
+++ b/internal/cli/dashboard/shippable_model.go
@@ -423,7 +423,7 @@ func (m *shippableModel) rebuildCache() {
 		for _, branchName := range stack.Stack.AllBranches {
 			branch := m.engine.GetBranch(branchName)
 			if branch.GetName() != "" {
-				ann := tui.GetBranchAnnotation(m.engine, branch, tui.AnnotationOptions{})
+				ann := tui.GetBranchAnnotation(m.engine, branch, nil, tui.AnnotationOptions{})
 				m.cache.branchAnnotations[branchName] = ann
 			}
 		}

--- a/internal/tui/log_ui.go
+++ b/internal/tui/log_ui.go
@@ -307,12 +307,11 @@ func (m *LogModel) enrichData() tea.Cmd {
 		// Detect worktrees (builds both empty and stack-root maps in one call)
 		wtData := GetWorktreeData(eng)
 
-		// Pre-load metadata and revisions for all branches to eliminate per-branch
-		// cache misses during parallel annotation building. PreloadBranchStats
-		// additionally warms the diff-stat and commit-count caches that
-		// BuildFullAnnotation reads, which PreloadBranchData does not cover.
-		eng.PreloadBranchData()
-		eng.PreloadBranchStats(allBranches)
+		// Resolve the git-computed annotation stats (short SHA, commit count, diff
+		// stats) for all branches as one batched value, instead of warming the
+		// engine-global caches. Forge status (CI) and worktree data above are
+		// separate concerns, joined into the annotation below.
+		stats := eng.BatchBranchStats(allBranches)
 
 		// Collect full annotations
 		start := time.Now()
@@ -325,7 +324,8 @@ func (m *LogModel) enrichData() tea.Cmd {
 		// shared map, then assemble the map serially.
 		built := make([]tree.BranchAnnotation, len(allBranches))
 		utils.Run(indexedBranches(allBranches), func(item indexedBranch) {
-			built[item.index] = BuildFullAnnotation(eng, item.branch, enrichment, AnnotationOptions{
+			stat := stats[item.branch.GetName()]
+			built[item.index] = BuildFullAnnotation(eng, item.branch, &stat, enrichment, AnnotationOptions{
 				SkipCommitMessages: true,
 			})
 		})

--- a/internal/tui/prompts.go
+++ b/internal/tui/prompts.go
@@ -748,7 +748,7 @@ func PromptBranchCheckout(branches []engine.Branch, eng engine.BranchReader) (st
 	// Add annotations for all branches
 	annotations := make(map[string]tree.BranchAnnotation)
 	for _, branch := range branches {
-		annotations[branch.GetName()] = GetBranchAnnotation(eng, branch, AnnotationOptions{})
+		annotations[branch.GetName()] = GetBranchAnnotation(eng, branch, nil, AnnotationOptions{})
 	}
 	renderer.SetAnnotations(annotations)
 

--- a/internal/tui/tree_renderer.go
+++ b/internal/tui/tree_renderer.go
@@ -294,8 +294,8 @@ type AnnotationOptions struct {
 // git operations (SHA, commits, diff stats), CI status, review status, and worktree info.
 // Pass nil for enrichment to get just the base annotation without CI/worktree enrichment.
 // Pass AnnotationOptions{} for the full annotation, or set Skip* flags to skip work.
-func BuildFullAnnotation(eng engine.Engine, branch engine.Branch, enrichment *AnnotationEnrichment, opts AnnotationOptions) tree.BranchAnnotation {
-	ann := GetBranchAnnotation(eng, branch, opts)
+func BuildFullAnnotation(eng engine.Engine, branch engine.Branch, stat *engine.BranchStat, enrichment *AnnotationEnrichment, opts AnnotationOptions) tree.BranchAnnotation {
+	ann := GetBranchAnnotation(eng, branch, stat, opts)
 
 	if enrichment == nil {
 		return ann
@@ -334,7 +334,11 @@ func BuildFullAnnotation(eng engine.Engine, branch engine.Branch, enrichment *An
 // GetBranchAnnotation returns a tree.BranchAnnotation populated with standard branch metadata.
 // This includes git operations (SHA, commit count, diff stats) which may be slow.
 // Pass AnnotationOptions{} for the full annotation, or set Skip* flags to skip work.
-func GetBranchAnnotation(eng engine.BranchReader, branch engine.Branch, opts AnnotationOptions) tree.BranchAnnotation {
+// GetBranchAnnotation populates a tree.BranchAnnotation. When stat is non-nil
+// the git-computed fields (short SHA, commit count, diff stats) are read from it
+// — a batched, passed-around value — instead of per-branch engine reads; when
+// nil it falls back to reading them from the engine.
+func GetBranchAnnotation(eng engine.BranchReader, branch engine.Branch, stat *engine.BranchStat, opts AnnotationOptions) tree.BranchAnnotation {
 	ann := tree.BranchAnnotation{
 		IsLocked:      branch.IsLocked(),
 		IsFrozen:      branch.IsFrozen(),
@@ -343,7 +347,9 @@ func GetBranchAnnotation(eng engine.BranchReader, branch engine.Branch, opts Ann
 	}
 
 	// Get short SHA for the branch
-	if sha, err := branch.GetRevision(); err == nil && len(sha) >= 7 {
+	if stat != nil {
+		ann.LocalSHA = stat.ShortSHA
+	} else if sha, err := branch.GetRevision(); err == nil && len(sha) >= 7 {
 		ann.LocalSHA = sha[:7]
 	}
 
@@ -356,14 +362,19 @@ func GetBranchAnnotation(eng engine.BranchReader, branch engine.Branch, opts Ann
 			ann.PRURL = prInfo.URL()
 		}
 
-		if !opts.SkipCommitMessages {
+		switch {
+		case !opts.SkipCommitMessages:
 			// Commit messages for detailed view
 			if commits, err := branch.GetAllCommits(engine.CommitFormatReadable); err == nil {
 				ann.CommitMessages = commits
 				ann.CommitCount = len(commits)
 			}
-		} else if count, err := eng.GetCommitCount(branch); err == nil {
-			ann.CommitCount = count
+		case stat != nil:
+			ann.CommitCount = stat.CommitCount
+		default:
+			if count, err := eng.GetCommitCount(branch); err == nil {
+				ann.CommitCount = count
+			}
 		}
 
 		// Merged downstack history
@@ -382,7 +393,10 @@ func GetBranchAnnotation(eng engine.BranchReader, branch engine.Branch, opts Ann
 
 		// Local stats
 		if !opts.SkipDiffStats {
-			if added, deleted, err := branch.GetDiffStats(); err == nil {
+			if stat != nil {
+				ann.LinesAdded = stat.LinesAdded
+				ann.LinesDeleted = stat.LinesDeleted
+			} else if added, deleted, err := branch.GetDiffStats(); err == nil {
 				ann.LinesAdded = added
 				ann.LinesDeleted = deleted
 			}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The log annotation build reads branch state (short SHA, commit count,
additions/deletions) from a single BatchBranchStats value instead of
warming the global caches. Forge status (CI/review) stays a separate
concern, fetched on its own channel and joined into the annotation at
render time. GetBranchAnnotation/BuildFullAnnotation take an optional
*BranchStat: log_ui passes the batch; the other callers pass nil and keep
the per-branch engine fallback.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781896357`.


* **PR #1252**
  * **PR #1253**
    * **PR #1254** 👈
      * **PR #1256**
        * **PR #1257**
          * **PR #1258**
            * **PR #1259**
              * **PR #1260**
                * **PR #1261**
                  * **PR #1262**
                    * **PR #1263**
                      * **PR #1264**
                        * **PR #1265**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1267 by jonnii*