### PR TITLE
refactor: extract buildBatchPRNodeQuery to eliminate duplicated GraphQL boilerplate

### DIFF
--- a/internal/github/pr_operations.go
+++ b/internal/github/pr_operations.go
@@ -667,6 +667,29 @@ func getPRMergeableStateBasic(ctx context.Context, runner GitCommandRunner, prNo
 	}, nil
 }
 
+// buildBatchPRNodeQuery builds a batch GraphQL query for fetching multiple PR nodes by ID.
+// fields is the space-separated list of GraphQL field names to select within the PullRequest fragment.
+func buildBatchPRNodeQuery(queryName string, prNodeIDs []string, fields string) (string, map[string]any) {
+	queryParts := make([]string, 0, len(prNodeIDs))
+	variables := make(map[string]any, len(prNodeIDs))
+	for i, nodeID := range prNodeIDs {
+		alias := fmt.Sprintf("pr%d", i)
+		varName := fmt.Sprintf("nodeId%d", i)
+		queryParts = append(queryParts, fmt.Sprintf(`%s: node(id: $%s) { ... on PullRequest { %s } }`, alias, varName, fields))
+		variables[varName] = nodeID
+	}
+
+	varDecls := make([]string, 0, len(prNodeIDs))
+	for i := range prNodeIDs {
+		varDecls = append(varDecls, fmt.Sprintf("$nodeId%d: ID!", i))
+	}
+
+	return fmt.Sprintf("query %s(%s) { %s }",
+		queryName,
+		strings.Join(varDecls, ", "),
+		strings.Join(queryParts, " ")), variables
+}
+
 // BatchGetPRMergeableStates checks mergeable state for multiple PRs in a single GraphQL query.
 // Returns a map from node ID to PRMergeableState. If a PR fails to fetch, it won't be in the map.
 func BatchGetPRMergeableStates(ctx context.Context, runner GitCommandRunner, prNodeIDs []string) (map[string]*PRMergeableState, error) {
@@ -674,32 +697,7 @@ func BatchGetPRMergeableStates(ctx context.Context, runner GitCommandRunner, prN
 		return make(map[string]*PRMergeableState), nil
 	}
 
-	// Build query with aliases for each PR
-	queryParts := make([]string, 0, len(prNodeIDs))
-	variables := make(map[string]any, len(prNodeIDs))
-	for i, nodeID := range prNodeIDs {
-		alias := fmt.Sprintf("pr%d", i)
-		varName := fmt.Sprintf("nodeId%d", i)
-		queryParts = append(queryParts, fmt.Sprintf(`%s: node(id: $%s) {
-			... on PullRequest {
-				id
-				mergeable
-				mergeStateStatus
-				state
-			}
-		}`, alias, varName))
-		variables[varName] = nodeID
-	}
-
-	// Build variable declarations
-	varDecls := make([]string, 0, len(prNodeIDs))
-	for i := range prNodeIDs {
-		varDecls = append(varDecls, fmt.Sprintf("$nodeId%d: ID!", i))
-	}
-
-	query := fmt.Sprintf("query BatchGetPRMergeableStates(%s) { %s }",
-		strings.Join(varDecls, ", "),
-		strings.Join(queryParts, " "))
+	query, variables := buildBatchPRNodeQuery("BatchGetPRMergeableStates", prNodeIDs, "id mergeable mergeStateStatus state")
 
 	body, err := executeGraphQLQuery(ctx, runner, query, variables)
 	if err != nil {
@@ -742,29 +740,7 @@ func BatchGetPRMergeableStates(ctx context.Context, runner GitCommandRunner, prN
 // batchGetPRMergeableStatesBasic fetches PR mergeable states without the mergeStateStatus field,
 // used as a fallback for GitHub Enterprise instances that don't support that field.
 func batchGetPRMergeableStatesBasic(ctx context.Context, runner GitCommandRunner, prNodeIDs []string) (map[string]*PRMergeableState, error) {
-	queryParts := make([]string, 0, len(prNodeIDs))
-	variables := make(map[string]any, len(prNodeIDs))
-	for i, nodeID := range prNodeIDs {
-		alias := fmt.Sprintf("pr%d", i)
-		varName := fmt.Sprintf("nodeId%d", i)
-		queryParts = append(queryParts, fmt.Sprintf(`%s: node(id: $%s) {
-			... on PullRequest {
-				id
-				mergeable
-				state
-			}
-		}`, alias, varName))
-		variables[varName] = nodeID
-	}
-
-	varDecls := make([]string, 0, len(prNodeIDs))
-	for i := range prNodeIDs {
-		varDecls = append(varDecls, fmt.Sprintf("$nodeId%d: ID!", i))
-	}
-
-	query := fmt.Sprintf("query BatchGetPRMergeableStates(%s) { %s }",
-		strings.Join(varDecls, ", "),
-		strings.Join(queryParts, " "))
+	query, variables := buildBatchPRNodeQuery("BatchGetPRMergeableStates", prNodeIDs, "id mergeable state")
 
 	body, err := executeGraphQLQuery(ctx, runner, query, variables)
 	if err != nil {


### PR DESCRIPTION
## Summary

- `BatchGetPRMergeableStates` and `batchGetPRMergeableStatesBasic` each contained ~20 lines of identical GraphQL query-building boilerplate: a `queryParts` loop, a separate `varDecls` loop, and a `Sprintf` to assemble the final query string.
- Extracted a `buildBatchPRNodeQuery(queryName, prNodeIDs, fields)` helper that consolidates all of this into one place, reducing each callsite to a single line.
- The only difference between the two functions — whether `mergeStateStatus` is included — is now visible immediately as the `fields` argument.

## Before / After

**Before** — 20 lines of boilerplate repeated twice:
```go
queryParts := make([]string, 0, len(prNodeIDs))
variables := make(map[string]any, len(prNodeIDs))
for i, nodeID := range prNodeIDs {
    alias := fmt.Sprintf("pr%d", i)
    varName := fmt.Sprintf("nodeId%d", i)
    queryParts = append(queryParts, fmt.Sprintf(`%s: node(id: $%s) { ... }`, alias, varName))
    variables[varName] = nodeID
}
varDecls := make([]string, 0, len(prNodeIDs))
for i := range prNodeIDs {
    varDecls = append(varDecls, fmt.Sprintf("$nodeId%d: ID!", i))
}
query := fmt.Sprintf("query BatchGetPRMergeableStates(%s) { %s }", ...)
```

**After** — one line per callsite:
```go
query, variables := buildBatchPRNodeQuery("BatchGetPRMergeableStates", prNodeIDs, "id mergeable mergeStateStatus state")
```

## Test plan

- [x] `go test ./internal/github/...` passes
- No behavior change — query structure and response parsing are identical

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpUtP3x2KYU9a6zi3xJ7ZP)_