### PR TITLE
perf(submit): batch revision resolution in planning

### DIFF
--- a/internal/actions/submit/planning.go
+++ b/internal/actions/submit/planning.go
@@ -16,9 +16,13 @@ func prepareBranchesForSubmit(ctx *app.Context, branches engine.Branches, opts O
 	submissionInfos := make([]Info, 0, len(branches))
 	nav := ctx.Navigator()
 
-	// Warm revision and metadata caches so the per-branch GetRevision calls in
-	// the loop are cache hits rather than a git rev-parse each.
-	ctx.Engine.PreloadBranchData()
+	// Resolve every branch and parent revision in one batched call so the head
+	// and base SHAs below are map lookups, not a git rev-parse per branch.
+	revNames := make([]string, 0, len(branches)*2)
+	for _, branch := range branches {
+		revNames = append(revNames, branch.GetName(), resolveSubmitParentName(nav, branch))
+	}
+	revisions, _ := ctx.Engine.GetRevisions(revNames)
 
 	// PR-info writes are collected here and persisted in one batched ref write
 	// after planning, instead of a git ref write per branch.
@@ -117,11 +121,10 @@ func prepareBranchesForSubmit(ctx *app.Context, branches engine.Branches, opts O
 		}
 		prUpdates[branchName] = pendingPrInfo(branch, metadata)
 
-		// Get SHAs
-		headSHA, _ := branch.GetRevision()
+		// Get SHAs from the batched revisions resolved above.
 		parentBranchName := resolveSubmitParentName(nav, branch)
-		parentBranch := nav.GetBranch(parentBranchName)
-		baseSHA, _ := parentBranch.GetRevision()
+		headSHA := revisions[branchName]
+		baseSHA := revisions[parentBranchName]
 
 		submissionInfo := Info{
 			BranchName: branchName,


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

prepareBranchesForSubmit warmed the global revision cache with
PreloadBranchData, then read each branch and parent revision through the
cache. Resolve them all in one batched GetRevisions up front and read the
head/base SHAs from the map, dropping the PreloadBranchData warm-up.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781896357`.


* **PR #1252**
  * **PR #1253**
    * **PR #1254**
      * **PR #1256** 👈
        * **PR #1257**
          * **PR #1258**
            * **PR #1259**
              * **PR #1260**
                * **PR #1261**
                  * **PR #1262**
                    * **PR #1263**
                      * **PR #1264**
                        * **PR #1265**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1267 by jonnii*