### PR TITLE
refactor: finish annotation batching, drop dead reload hook, add guardrail

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -42,6 +42,10 @@ const (
 | `UpdateRef` in a loop | `UpdateRefsBatch(ctx, updates)` |
 | `DeleteRef` in a loop | `DeleteRefsBatch(ctx, refNames)` |
 | `PushBranch` in a loop | `PushMetadataRefs(ctx, branches)` |
+| `GetRevision` in a loop | `GetRevisions(branchNames)` |
+| `GetDiffStats` / `GetCommitCount` in a loop | `BatchDiffStats(branches)` / `BatchBranchStats(branches)` |
+| `GetAllCommits` in a loop | `BatchCommits(branches, format)` |
+| `GetDivergencePoint` in a loop | `BatchDivergencePoints(branches)` |
 
 **Why:** Each git command spawns a process (~2-5ms overhead). Each GitHub API call takes ~200-500ms. For N branches, a loop costs O(N × overhead) while a batch costs O(1) or O(N) with parallelism.
 
@@ -56,6 +60,12 @@ _ = eng.BatchMarkNeedsPRBodyUpdate(branchNames)
 ```
 
 When adding new operations that touch multiple branches or refs, prefer designing batch APIs from the start. Use `UpdateRefsBatch` for atomic multi-ref writes and `BatchReadLocalMetadata` / `BatchReadMetadata` for parallel reads.
+
+### Branch-state reads return values, not a global cache
+
+Multi-branch reads of revisions, commits, diff stats, and divergence points go through the `Batch*` readers above, which return value maps you resolve once and pass around (often composed at the call site, e.g. `commits := eng.BatchCommits(...)`). Do **not** reintroduce an ambient/global revision cache or a `PreloadBranchData`-style warm-up. That pattern was removed deliberately: a globally cached revision could go stale between a read and a later read within the same operation (a correctness hazard, not just a perf concern), and explicit passed-around values are far easier to reason about. The revision-keyed diff-stat/commit-count memoization that remains is safe precisely because it is keyed by content, not warmed globally.
+
+Forge status (CI, checks, review state) is a **separate concern** from branch state. Fetch it once via the GitHub batchers and join it to branch data at the consumer/render layer; never fold live forge status into the branch-state readers.
 
 ## Error Handling
 

--- a/internal/actions/log.go
+++ b/internal/actions/log.go
@@ -163,11 +163,7 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 
 	if len(visibleBranches) > 0 {
 		utils.Run(visibleBranches.All(), func(branchObj engine.Branch) {
-			var stat *engine.BranchStat
-			if s, ok := stats[branchObj.GetName()]; ok {
-				stat = &s
-			}
-			annotation := buildLogAnnotation(ctx.Engine, branchObj, stat, opts, wtData, enrichment)
+			annotation := buildLogAnnotation(ctx.Engine, branchObj, stats[branchObj.GetName()], opts, wtData, enrichment)
 			results <- result{branchObj.GetName(), annotation}
 		})
 	}
@@ -252,7 +248,7 @@ func visibleLogBranches(renderer *tree.StackTreeRenderer, branchName string, opt
 func buildLogAnnotation(
 	eng engine.Engine,
 	branch engine.Branch,
-	stat *engine.BranchStat,
+	stat engine.BranchStat,
 	opts LogOptions,
 	wtData *tui.WorktreeData,
 	enrichment *tui.AnnotationEnrichment,
@@ -265,7 +261,8 @@ func buildLogAnnotation(
 
 	annotation := tui.GetMinimalAnnotationWithWorktreeAndEmpty(eng, branch, wtData)
 	if opts.ShowSHAs {
-		if stat != nil {
+		// The short style does not batch stats, so resolve the SHA directly.
+		if stat.ShortSHA != "" {
 			annotation.LocalSHA = stat.ShortSHA
 		} else if sha, err := branch.GetRevision(); err == nil && len(sha) >= 7 {
 			annotation.LocalSHA = sha[:7]

--- a/internal/cli/dashboard/shippable_model.go
+++ b/internal/cli/dashboard/shippable_model.go
@@ -419,13 +419,18 @@ func (m *shippableModel) rebuildCache() {
 			}
 		}
 
-		// Compute annotations for all branches in the stack
+		// Compute annotations for all branches in the stack, reading their
+		// git-computed stats from one batch rather than per branch (this runs on
+		// every refresh and on the auto-refresh timer).
+		stackBranches := engine.Branches{}
 		for _, branchName := range stack.Stack.AllBranches {
-			branch := m.engine.GetBranch(branchName)
-			if branch.GetName() != "" {
-				ann := tui.GetBranchAnnotation(m.engine, branch, nil, tui.AnnotationOptions{})
-				m.cache.branchAnnotations[branchName] = ann
+			if branch := m.engine.GetBranch(branchName); branch.GetName() != "" {
+				stackBranches = stackBranches.Append(branch)
 			}
+		}
+		stats := m.engine.BatchBranchStats(stackBranches)
+		for _, branch := range stackBranches {
+			m.cache.branchAnnotations[branch.GetName()] = tui.GetBranchAnnotation(m.engine, branch, stats[branch.GetName()], tui.AnnotationOptions{})
 		}
 
 		// Cache blocking reasons per branch

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -53,14 +53,14 @@ func (r *runner) CommitWithOptions(opts CommitOptions) error {
 		if err != nil {
 			return err
 		}
-		return r.ReloadRepository()
+		return nil
 	}
 
 	err := r.RunGitCommandInteractive(args...)
 	if err != nil {
 		return err
 	}
-	return r.ReloadRepository()
+	return nil
 }
 
 func (r *runner) Commit(message string, verbose int, noVerify bool) error {
@@ -76,5 +76,5 @@ func (r *runner) CommitAmendNoEdit(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return r.ReloadRepository()
+	return nil
 }

--- a/internal/git/pull_test.go
+++ b/internal/git/pull_test.go
@@ -161,9 +161,9 @@ func TestFetch_ForceUpdatedRemoteBranch(t *testing.T) {
 	require.Equal(t, shaB, trackedB, "remote-tracking ref should update to force-pushed commit B")
 }
 
-func TestReloadRepository(t *testing.T) {
-	// Test that the runner can resolve commits created externally — the
-	// revision cache must invalidate / pass through to git for unknown SHAs.
+func TestResolveExternallyCreatedCommits(t *testing.T) {
+	// The runner resolves commits created outside it (e.g. by a fetch) by
+	// passing through to git; there is no per-process cache to invalidate.
 
 	// 1. Setup a repository
 	scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
@@ -187,9 +187,8 @@ func TestReloadRepository(t *testing.T) {
 	newSha, err := scene.Repo.GetCurrentSHA()
 	require.NoError(t, err)
 
-	// PullBranch normally triggers the reload after fetch; this test verifies
-	// the runner falls through to git for SHAs that aren't in its cache. The
-	// full fetch+reload flow is exercised in TestPullBranch_WithReload below.
+	// SHAs created outside the runner resolve by falling through to git. The
+	// full fetch flow is exercised in TestPullBranch_WithReload below.
 
 	// Verify the new commit is resolvable
 	_, err = runner.GetCommitAuthor(newSha)

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -487,14 +487,6 @@ func (r *runner) ensureRepo() error {
 	return nil
 }
 
-// ReloadRepository is a no-op retained for callers that expect a post-fetch
-// reload hook. The cached repo root is stable for the life of the process
-// (stackit doesn't change the working directory), so there is nothing to
-// invalidate.
-func (r *runner) ReloadRepository() error {
-	return nil
-}
-
 func (r *runner) InitDefaultRepo() error {
 	return r.ensureRepo()
 }
@@ -1097,7 +1089,7 @@ func (r *runner) fetchRemoteRefSpecs(ctx context.Context, remote string, refspec
 	if _, err := r.RunGitCommandWithContext(ctx, args...); err != nil {
 		return fmt.Errorf("git fetch failed: %w", err)
 	}
-	return r.ReloadRepository()
+	return nil
 }
 
 func (r *runner) pushOriginRefSpecs(ctx context.Context, refspecs []string) error {

--- a/internal/tui/log_ui.go
+++ b/internal/tui/log_ui.go
@@ -324,8 +324,7 @@ func (m *LogModel) enrichData() tea.Cmd {
 		// shared map, then assemble the map serially.
 		built := make([]tree.BranchAnnotation, len(allBranches))
 		utils.Run(indexedBranches(allBranches), func(item indexedBranch) {
-			stat := stats[item.branch.GetName()]
-			built[item.index] = BuildFullAnnotation(eng, item.branch, &stat, enrichment, AnnotationOptions{
+			built[item.index] = BuildFullAnnotation(eng, item.branch, stats[item.branch.GetName()], enrichment, AnnotationOptions{
 				SkipCommitMessages: true,
 			})
 		})

--- a/internal/tui/prompts.go
+++ b/internal/tui/prompts.go
@@ -745,10 +745,12 @@ func PromptBranchCheckout(branches []engine.Branch, eng engine.BranchReader) (st
 	trunk := eng.Trunk()
 	renderer := NewStackTreeRenderer(eng)
 
-	// Add annotations for all branches
+	// Add annotations for all branches, reading their git-computed stats from a
+	// single batch rather than per branch.
+	stats := eng.BatchBranchStats(engine.Branches(branches))
 	annotations := make(map[string]tree.BranchAnnotation)
 	for _, branch := range branches {
-		annotations[branch.GetName()] = GetBranchAnnotation(eng, branch, nil, AnnotationOptions{})
+		annotations[branch.GetName()] = GetBranchAnnotation(eng, branch, stats[branch.GetName()], AnnotationOptions{})
 	}
 	renderer.SetAnnotations(annotations)
 

--- a/internal/tui/tree_renderer.go
+++ b/internal/tui/tree_renderer.go
@@ -294,7 +294,7 @@ type AnnotationOptions struct {
 // git operations (SHA, commits, diff stats), CI status, review status, and worktree info.
 // Pass nil for enrichment to get just the base annotation without CI/worktree enrichment.
 // Pass AnnotationOptions{} for the full annotation, or set Skip* flags to skip work.
-func BuildFullAnnotation(eng engine.Engine, branch engine.Branch, stat *engine.BranchStat, enrichment *AnnotationEnrichment, opts AnnotationOptions) tree.BranchAnnotation {
+func BuildFullAnnotation(eng engine.Engine, branch engine.Branch, stat engine.BranchStat, enrichment *AnnotationEnrichment, opts AnnotationOptions) tree.BranchAnnotation {
 	ann := GetBranchAnnotation(eng, branch, stat, opts)
 
 	if enrichment == nil {
@@ -331,26 +331,18 @@ func BuildFullAnnotation(eng engine.Engine, branch engine.Branch, stat *engine.B
 	return ann
 }
 
-// GetBranchAnnotation returns a tree.BranchAnnotation populated with standard branch metadata.
-// This includes git operations (SHA, commit count, diff stats) which may be slow.
-// Pass AnnotationOptions{} for the full annotation, or set Skip* flags to skip work.
-// GetBranchAnnotation populates a tree.BranchAnnotation. When stat is non-nil
-// the git-computed fields (short SHA, commit count, diff stats) are read from it
-// — a batched, passed-around value — instead of per-branch engine reads; when
-// nil it falls back to reading them from the engine.
-func GetBranchAnnotation(eng engine.BranchReader, branch engine.Branch, stat *engine.BranchStat, opts AnnotationOptions) tree.BranchAnnotation {
+// GetBranchAnnotation returns a tree.BranchAnnotation for a branch. The
+// git-computed fields (short SHA, commit count, diff stats) come from stat, a
+// batched value the caller resolves with BatchBranchStats — code annotating a
+// set of branches must build that batch rather than reading per branch. Pass
+// AnnotationOptions{} for the full annotation, or set Skip* flags to skip work.
+func GetBranchAnnotation(eng engine.BranchReader, branch engine.Branch, stat engine.BranchStat, opts AnnotationOptions) tree.BranchAnnotation {
 	ann := tree.BranchAnnotation{
 		IsLocked:      branch.IsLocked(),
 		IsFrozen:      branch.IsFrozen(),
 		Scope:         eng.GetScope(branch).String(),
 		ExplicitScope: branch.GetExplicitScope().String(),
-	}
-
-	// Get short SHA for the branch
-	if stat != nil {
-		ann.LocalSHA = stat.ShortSHA
-	} else if sha, err := branch.GetRevision(); err == nil && len(sha) >= 7 {
-		ann.LocalSHA = sha[:7]
+		LocalSHA:      stat.ShortSHA,
 	}
 
 	if !branch.IsTrunk() {
@@ -362,19 +354,14 @@ func GetBranchAnnotation(eng engine.BranchReader, branch engine.Branch, stat *en
 			ann.PRURL = prInfo.URL()
 		}
 
-		switch {
-		case !opts.SkipCommitMessages:
-			// Commit messages for detailed view
+		// Commit messages for the detailed view; otherwise the batched count.
+		if !opts.SkipCommitMessages {
 			if commits, err := branch.GetAllCommits(engine.CommitFormatReadable); err == nil {
 				ann.CommitMessages = commits
 				ann.CommitCount = len(commits)
 			}
-		case stat != nil:
+		} else {
 			ann.CommitCount = stat.CommitCount
-		default:
-			if count, err := eng.GetCommitCount(branch); err == nil {
-				ann.CommitCount = count
-			}
 		}
 
 		// Merged downstack history
@@ -393,13 +380,8 @@ func GetBranchAnnotation(eng engine.BranchReader, branch engine.Branch, stat *en
 
 		// Local stats
 		if !opts.SkipDiffStats {
-			if stat != nil {
-				ann.LinesAdded = stat.LinesAdded
-				ann.LinesDeleted = stat.LinesDeleted
-			} else if added, deleted, err := branch.GetDiffStats(); err == nil {
-				ann.LinesAdded = added
-				ann.LinesDeleted = deleted
-			}
+			ann.LinesAdded = stat.LinesAdded
+			ann.LinesDeleted = stat.LinesDeleted
 		}
 	}
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Three related follow-ups now that the global revision cache is gone:

1. Make GetBranchAnnotation/BuildFullAnnotation take a non-optional
   BranchStat value and migrate the last two nil callers (prompts and the
   shippable dashboard) to resolve stats with BatchBranchStats. This drops
   the optional-pointer dual path from the shared helper and removes a
   per-branch revision/diff N+1 — notably in the dashboard, which rebuilds
   annotations on every refresh and on the auto-refresh timer.

2. Add a guardrail to .claude/rules/code-style.md: list the per-concern
   branch-state batch readers, and document that multi-branch reads use
   them rather than an ambient global revision cache (removed on purpose),
   and that forge status is a separate concern joined at render.

3. Remove ReloadRepository, which became a no-op when the revision cache
   was deleted. Its four call sites now return nil directly; the test that
   covered it is renamed to what it actually checks (resolving externally
   created commits by passing through to git).

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781896357`.


* **PR #1252**
  * **PR #1253**
    * **PR #1254**
      * **PR #1256**
        * **PR #1257**
          * **PR #1258**
            * **PR #1259** 👈
              * **PR #1260**
                * **PR #1261**
                  * **PR #1262**
                    * **PR #1263**
                      * **PR #1264**
                        * **PR #1265**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1267 by jonnii*