### PR TITLE
fix(stack-info): count changed files against the divergence point

### DIFF
--- a/internal/engine/branch_view.go
+++ b/internal/engine/branch_view.go
@@ -105,15 +105,21 @@ func (e *engineImpl) BatchCommits(branches Branches, format CommitFormat) map[st
 	})
 }
 
-// BatchChangedFileCounts returns each non-trunk branch's number of changed files
-// against its parent's current tip (matching the existing stack-info behavior),
-// keyed by branch name, resolved in one batched pass.
+// BatchChangedFileCounts returns each non-trunk branch's number of files changed
+// in its own range — measured against its divergence point, the same base
+// BatchDiffStats uses — keyed by branch name, resolved in one batched pass. This
+// keeps the file count consistent with the additions/deletions for a branch
+// whose parent has advanced since it diverged.
 func (e *engineImpl) BatchChangedFileCounts(ctx context.Context, branches Branches) map[string]int {
 	return batchByBranch(e, branches, func(b Branch, head, parentRev, storedBase string) int {
-		if e.IsTrunk(b) || parentRev == "" || head == "" {
+		if e.IsTrunk(b) {
 			return 0
 		}
-		files, err := e.GetChangedFiles(ctx, parentRev, head)
+		base := statBase(parentRev, storedBase)
+		if base == "" || head == "" {
+			return 0
+		}
+		files, err := e.GetChangedFiles(ctx, base, head)
 		if err != nil {
 			return 0
 		}

--- a/internal/engine/branch_view_test.go
+++ b/internal/engine/branch_view_test.go
@@ -1,6 +1,7 @@
 package engine_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -44,6 +45,29 @@ func TestBatchBranchStats(t *testing.T) {
 		require.Equal(t, wantAdded, stat.LinesAdded, "LinesAdded for %s", name)
 		require.Equal(t, wantDeleted, stat.LinesDeleted, "LinesDeleted for %s", name)
 	}
+}
+
+// TestBatchChangedFileCountsUsesDivergenceBase verifies the file count is
+// measured against the branch's divergence point (the same base as diff stats),
+// not its parent's current tip — so it stays consistent when the parent advances
+// past the branch without a restack.
+func TestBatchChangedFileCountsUsesDivergenceBase(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithLinearStack3() // main -> a -> b -> c
+
+	b := engine.BranchesOf(s.Engine.GetBranch("b"))
+
+	before := s.Engine.BatchChangedFileCounts(context.Background(), b)["b"]
+	require.GreaterOrEqual(t, before, 1)
+
+	// Advance b's parent (a) with a new commit touching a different file, without
+	// restacking b, so a's current tip moves past b's divergence point.
+	s.Checkout("a").CommitChange("a-advanced.txt", "advance a past b's divergence")
+
+	after := s.Engine.BatchChangedFileCounts(context.Background(), b)["b"]
+	require.Equal(t, before, after,
+		"files-changed must use the divergence base, not the parent's current tip")
 }
 
 // TestPerConcernBatchReaders asserts each per-concern batch reader matches the


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

stack-info measured a branch's changed-file count against its parent's
current tip, while additions/deletions and commit count use the branch's
divergence point. For a branch whose parent advanced since it diverged
(not yet restacked), the file count then described a different diff than
the line counts — it folded in the parent's newer commits.

Measure changed files against the divergence point too (the same base
BatchDiffStats uses), so all three metrics describe the branch's own
change set consistently. Behavior change, scoped to BatchChangedFileCounts
(only stack-info reads it). Added a test that advances a parent past a
child and asserts the count is unchanged.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781896357`.


* **PR #1252**
  * **PR #1253**
    * **PR #1254**
      * **PR #1256**
        * **PR #1257**
          * **PR #1258**
            * **PR #1259**
              * **PR #1260** 👈
                * **PR #1261**
                  * **PR #1262**
                    * **PR #1263**
                      * **PR #1264**
                        * **PR #1265**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1267 by jonnii*