### PR TITLE
fix(info): count changed files against the divergence point

### DIFF
--- a/internal/actions/info.go
+++ b/internal/actions/info.go
@@ -344,13 +344,15 @@ func outputBranchInfoJSON(ctx *app.Context, branch engine.Branch) error {
 		info.DiffStats.Deletions = deleted
 	}
 
-	// Files changed
-	if info.Parent != "" {
-		parentRev, err := eng.GetRevision(eng.GetBranch(info.Parent))
-		if err == nil {
+	// Files changed — measured against the branch's divergence point, the same
+	// base GetDiffStats uses above, so the file count stays consistent with the
+	// additions/deletions when the parent has advanced since the branch diverged.
+	if !isTrunk {
+		base, err := eng.GetDivergencePoint(branchName)
+		if err == nil && base != "" {
 			branchRev, err := branch.GetRevision()
 			if err == nil {
-				files, err := eng.GetChangedFiles(ctx.Context, parentRev, branchRev)
+				files, err := eng.GetChangedFiles(ctx.Context, base, branchRev)
 				if err == nil {
 					info.DiffStats.FilesChanged = len(files)
 				}

--- a/internal/actions/info_test.go
+++ b/internal/actions/info_test.go
@@ -1,0 +1,42 @@
+package actions
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// TestSingleBranchInfoFilesChangedUsesDivergenceBase verifies the single-branch
+// info path counts changed files against the branch's divergence point — the
+// same base as its additions/deletions — not the parent's current tip, so the
+// count stays stable when the parent advances without a restack.
+func TestSingleBranchInfoFilesChangedUsesDivergenceBase(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithLinearStack3() // main -> a -> b -> c
+
+	before := singleBranchFilesChanged(t, s, "b")
+	require.GreaterOrEqual(t, before, 1)
+
+	// Advance b's parent (a) with a commit touching a different file, without
+	// restacking b, so a's current tip moves past b's divergence point.
+	s.Checkout("a").CommitChange("a-advanced.txt", "advance a past b's divergence")
+
+	after := singleBranchFilesChanged(t, s, "b")
+	require.Equal(t, before, after,
+		"single-branch files-changed must use the divergence base, not the parent's current tip")
+}
+
+func singleBranchFilesChanged(t *testing.T, s *scenario.Scenario, name string) int {
+	t.Helper()
+	s.Output.Reset()
+	require.NoError(t, outputBranchInfoJSON(s.Context, s.Engine.GetBranch(name)))
+
+	var info SingleBranchInfo
+	require.NoError(t, json.Unmarshal(s.Output.Bytes(), &info))
+	return info.DiffStats.FilesChanged
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The single-branch info path measured FilesChanged against the parent's
current tip while its additions/deletions used the divergence point, so
the file count drifted out of sync once the parent advanced without a
restack. Use GetDivergencePoint as the base — the same fix already
applied to stack-info — so both stats agree.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781896357`.


* **PR #1252**
  * **PR #1253**
    * **PR #1254**
      * **PR #1256**
        * **PR #1257**
          * **PR #1258**
            * **PR #1259**
              * **PR #1260**
                * **PR #1261** 👈
                  * **PR #1262**
                    * **PR #1263**
                      * **PR #1264**
                        * **PR #1265**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1267 by jonnii*