### PR TITLE
perf(dashboard): batch commit messages in shippable rebuild

### DIFF
--- a/internal/cli/dashboard/shippable_model.go
+++ b/internal/cli/dashboard/shippable_model.go
@@ -420,8 +420,10 @@ func (m *shippableModel) rebuildCache() {
 		}
 
 		// Compute annotations for all branches in the stack, reading their
-		// git-computed stats from one batch rather than per branch (this runs on
-		// every refresh and on the auto-refresh timer).
+		// git-computed stats from batched value maps rather than per branch (this
+		// runs on every refresh and on the auto-refresh timer). The view renders
+		// with ShowCommitMessages, so resolve commit messages once via BatchCommits
+		// and skip the per-branch GetAllCommits inside GetBranchAnnotation.
 		stackBranches := engine.Branches{}
 		for _, branchName := range stack.Stack.AllBranches {
 			if branch := m.engine.GetBranch(branchName); branch.GetName() != "" {
@@ -429,8 +431,15 @@ func (m *shippableModel) rebuildCache() {
 			}
 		}
 		stats := m.engine.BatchBranchStats(stackBranches)
+		commits := m.engine.BatchCommits(stackBranches, engine.CommitFormatReadable)
 		for _, branch := range stackBranches {
-			m.cache.branchAnnotations[branch.GetName()] = tui.GetBranchAnnotation(m.engine, branch, stats[branch.GetName()], tui.AnnotationOptions{})
+			name := branch.GetName()
+			ann := tui.GetBranchAnnotation(m.engine, branch, stats[name], tui.AnnotationOptions{SkipCommitMessages: true})
+			if msgs := commits[name]; msgs != nil {
+				ann.CommitMessages = msgs
+				ann.CommitCount = len(msgs)
+			}
+			m.cache.branchAnnotations[name] = ann
 		}
 
 		// Cache blocking reasons per branch


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

rebuildCache annotated each branch with GetBranchAnnotation under
SkipCommitMessages=false, which spawned a per-branch GetAllCommits in the
serial render loop and then discarded the commit count BatchBranchStats
had already computed. The view renders with ShowCommitMessages, so resolve
the messages once via BatchCommits (parallel, in-process) and overlay them,
skipping the per-branch git. This path runs on every refresh and on the
auto-refresh timer.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781896357`.


* **PR #1252**
  * **PR #1253**
    * **PR #1254**
      * **PR #1256**
        * **PR #1257**
          * **PR #1258**
            * **PR #1259**
              * **PR #1260**
                * **PR #1261**
                  * **PR #1262** 👈
                    * **PR #1263**
                      * **PR #1264**
                        * **PR #1265**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1267 by jonnii*