### PR TITLE
refactor: tidy review nits in branch-state readers

### DIFF
--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -136,9 +136,11 @@ func (e *engineImpl) resolveBranchComparisonRevisions(branchName string) (base, 
 		parent = state.Parent
 	}
 
-	// Get base revision (stored parent revision)
+	// Get base revision (stored parent revision). An empty stored revision is
+	// treated as unset and falls back to the parent's current tip, matching
+	// statBase, which the batched diff-stat/commit-count readers use.
 	meta, err := e.readMetadata(branchName)
-	if rev := meta.GetParentBranchRevision(); err == nil && rev != nil {
+	if rev := meta.GetParentBranchRevision(); err == nil && rev != nil && *rev != "" {
 		base = *rev
 	} else {
 		baseRev, err := e.git.GetRevision(parent)

--- a/internal/git/pull_test.go
+++ b/internal/git/pull_test.go
@@ -188,7 +188,7 @@ func TestResolveExternallyCreatedCommits(t *testing.T) {
 	require.NoError(t, err)
 
 	// SHAs created outside the runner resolve by falling through to git. The
-	// full fetch flow is exercised in TestPullBranch_WithReload below.
+	// full fetch flow is exercised in TestPullBranch_FetchResolvesNewCommits below.
 
 	// Verify the new commit is resolvable
 	_, err = runner.GetCommitAuthor(newSha)
@@ -199,8 +199,9 @@ func TestResolveExternallyCreatedCommits(t *testing.T) {
 	require.NoError(t, err, "runner should still resolve old commits")
 }
 
-func TestPullBranch_WithReload(t *testing.T) {
-	// Test that PullBranch works correctly with the refspec fix and reload mechanism
+func TestPullBranch_FetchResolvesNewCommits(t *testing.T) {
+	// Test that PullBranch works correctly with the refspec fix: a commit fetched
+	// from the remote is resolvable through the long-lived runner afterward.
 
 	// 1. Setup a "remote" repository
 	remoteScene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
@@ -247,7 +248,7 @@ func TestPullBranch_WithReload(t *testing.T) {
 	require.Equal(t, remoteSha, localSha, "Local branch should match remote")
 
 	// 6. Verify the newly fetched commit is resolvable through the runner
-	// (this exercises the reload mechanism in PullBranch).
+	// (it falls through to git since the runner holds no per-process cache).
 	_, err = runner.GetCommitAuthor(remoteSha)
 	require.NoError(t, err, "runner should resolve the newly fetched commit")
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Two follow-ups from review of the batch-reader stack:

- resolveBranchComparisonRevisions now treats an empty stored parent
  revision as unset and falls back to the parent tip, matching statBase
  so the single-branch GetDiffStats/GetCommitCount agree with the batched
  readers in that edge case.
- Rename the stale TestPullBranch_WithReload (and drop lingering "reload"
  comments) now that the revision cache and ReloadRepository are gone.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781896357`.


* **PR #1252**
  * **PR #1253**
    * **PR #1254**
      * **PR #1256**
        * **PR #1257**
          * **PR #1258**
            * **PR #1259**
              * **PR #1260**
                * **PR #1261**
                  * **PR #1262**
                    * **PR #1263** 👈
                      * **PR #1264**
                        * **PR #1265**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1267 by jonnii*