### PR TITLE
refactor(engine): bound batchByBranch fan-out, add concurrency rule

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -67,6 +67,37 @@ Multi-branch reads of revisions, commits, diff stats, and divergence points go t
 
 Forge status (CI, checks, review state) is a **separate concern** from branch state. Fetch it once via the GitHub batchers and join it to branch data at the consumer/render layer; never fold live forge status into the branch-state readers.
 
+### Bound parallel fan-out
+
+**Never spawn one goroutine per item over a caller-controlled slice.** Branch sets, ref lists, and spec lists are unbounded in size — a stack can have dozens of branches, and each parallel task on a cold cache may spawn a git subprocess. `wg.Add(1); go func(){…}()` inside a `for range items` loop fans out to as many concurrent goroutines (and subprocesses) as there are items, which exhausts file descriptors and thrashes the scheduler on large inputs.
+
+Use a **bounded worker pool** instead. The work still runs in parallel, but at most `GOMAXPROCS` tasks at once:
+
+```go
+// BAD - one goroutine (and possibly one git process) per branch, unbounded
+var wg sync.WaitGroup
+for i, b := range branches {
+    wg.Add(1)
+    go func(i int, b Branch) {
+        defer wg.Done()
+        results[i] = expensive(b) // may spawn git on a cold cache
+    }(i, b)
+}
+wg.Wait()
+
+// GOOD - bounded pool; each worker writes only its own index, so no locking
+type indexed struct{ i int; b Branch }
+items := make([]indexed, len(branches))
+for i, b := range branches { items[i] = indexed{i, b} }
+utils.Run(items, func(it indexed) { results[it.i] = expensive(it.b) })
+```
+
+- **`utils.Run`** — default `GOMAXPROCS` workers. Reach for this first; it's what `batchByBranch` and the log/annotation builders use.
+- **`utils.RunWithWorkers(items, n, fn)`** — when you need a specific cap (e.g. to throttle network calls below the CPU count).
+- **Semaphore** (`make(chan struct{}, maxConcurrency)`) — when goroutines must coordinate cancellation or collect results through a channel rather than write indexed slots. See `internal/engine/rebase_validator.go` for the canonical pattern (parent-context check before acquiring the semaphore so an outer cancel short-circuits queued siblings).
+
+A single long-lived background goroutine running *alongside* the main work (one `go func` total, not one per item) is fine and does not need a pool.
+
 ## Error Handling
 
 - Always handle errors explicitly (never `_`)

--- a/internal/engine/branch_view.go
+++ b/internal/engine/branch_view.go
@@ -2,7 +2,8 @@ package engine
 
 import (
 	"context"
-	"sync"
+
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // DiffStat is a branch's additions/deletions relative to its divergence point.
@@ -23,11 +24,16 @@ type BranchStat struct {
 
 // batchByBranch is the shared scaffold behind the per-concern batch readers. It
 // resolves every branch's head revision, parent revision, and stored divergence
-// base in two batched, cache-backed reads, then runs fn for each branch in
-// parallel and collects the results by branch name. Callers supply only the
-// per-concern computation; the (otherwise duplicated) batched resolution lives
-// here once. storedBase is the metadata ParentBranchRevision ("" when unset);
-// each concern decides how to derive its base from storedBase/parentRev.
+// base in two batched, cache-backed reads, then runs fn for each branch on a
+// bounded worker pool and collects the results by branch name. Callers supply
+// only the per-concern computation; the (otherwise duplicated) batched
+// resolution lives here once. storedBase is the metadata ParentBranchRevision
+// ("" when unset); each concern decides how to derive its base from
+// storedBase/parentRev.
+//
+// Concurrency is bounded by utils.Run (GOMAXPROCS workers) rather than spawning
+// one goroutine per branch, so a large stack does not fan out to hundreds of
+// concurrent git subprocesses on a cold cache.
 func batchByBranch[T any](e *engineImpl, branches Branches, fn func(b Branch, head, parentRev, storedBase string) T) map[string]T {
 	result := make(map[string]T, len(branches))
 	if len(branches) == 0 {
@@ -43,30 +49,31 @@ func batchByBranch[T any](e *engineImpl, branches Branches, fn func(b Branch, he
 	revs, _ := e.GetRevisions(revNames)
 	metas, _ := e.batchReadMetadata(branchNames)
 
-	type entry struct {
-		name string
-		val  T
+	// Each worker writes only its own index, so the slice is filled without
+	// synchronization and assembled into the result map serially afterward.
+	type indexedBranch struct {
+		index  int
+		branch Branch
 	}
-	entries := make([]entry, len(branches))
-	var wg sync.WaitGroup
+	indexed := make([]indexedBranch, len(branches))
+	values := make([]T, len(branches))
 	for i, b := range branches {
-		wg.Add(1)
-		go func(i int, b Branch) {
-			defer wg.Done()
-			name := b.GetName()
-			storedBase := ""
-			if m := metas[name]; m != nil {
-				if rev := m.GetParentBranchRevision(); rev != nil && *rev != "" {
-					storedBase = *rev
-				}
-			}
-			entries[i] = entry{name: name, val: fn(b, revs[name], revs[b.GetParentOrTrunk()], storedBase)}
-		}(i, b)
+		indexed[i] = indexedBranch{index: i, branch: b}
 	}
-	wg.Wait()
 
-	for _, en := range entries {
-		result[en.name] = en.val
+	utils.Run(indexed, func(item indexedBranch) {
+		name := item.branch.GetName()
+		storedBase := ""
+		if m := metas[name]; m != nil {
+			if rev := m.GetParentBranchRevision(); rev != nil && *rev != "" {
+				storedBase = *rev
+			}
+		}
+		values[item.index] = fn(item.branch, revs[name], revs[item.branch.GetParentOrTrunk()], storedBase)
+	})
+
+	for i, b := range branches {
+		result[b.GetName()] = values[i]
 	}
 	return result
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

batchByBranch spawned one goroutine per branch, so a large stack on a
cold cache could fan out to dozens of concurrent git subprocesses. Run
the per-branch work on the existing utils.Run pool (GOMAXPROCS workers)
instead; each worker writes only its own slice index so no locking is
needed and the result map is assembled serially afterward.

Sweep confirms this was the only unbounded per-item fan-out in
production: rebase_validator already bounds with a semaphore, and the
other go-func sites are single background goroutines. Add a "Bound
parallel fan-out" rule to code-style.md so the pattern stays fixed.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781896357`.


* **PR #1252**
  * **PR #1253**
    * **PR #1254**
      * **PR #1256**
        * **PR #1257**
          * **PR #1258**
            * **PR #1259**
              * **PR #1260**
                * **PR #1261**
                  * **PR #1262**
                    * **PR #1263**
                      * **PR #1264** 👈
                        * **PR #1265**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1267 by jonnii*