### PR TITLE
fix(engine): base commit lists on the divergence point, not whole history

### DIFF
--- a/internal/engine/branch_view.go
+++ b/internal/engine/branch_view.go
@@ -100,14 +100,16 @@ func (e *engineImpl) BatchDiffStats(branches Branches) map[string]DiffStat {
 }
 
 // BatchCommits returns each non-trunk branch's formatted commits, keyed by
-// branch name, resolved in one batched pass. It matches GetAllCommits, which
-// compares against the stored divergence base (empty when unset).
+// branch name, resolved in one batched pass. It matches GetAllCommits: the base
+// is the stored divergence point, or the parent's current tip when none is
+// recorded — never an empty base, which would list a branch's entire history
+// back to the repo root.
 func (e *engineImpl) BatchCommits(branches Branches, format CommitFormat) map[string][]string {
 	return batchByBranch(e, branches, func(b Branch, head, parentRev, storedBase string) []string {
 		if e.IsTrunk(b) {
 			return nil
 		}
-		commits, _ := e.commitsBetween(storedBase, head, format)
+		commits, _ := e.commitsBetween(statBase(parentRev, storedBase), head, format)
 		return commits
 	})
 }

--- a/internal/engine/branch_view_test.go
+++ b/internal/engine/branch_view_test.go
@@ -102,3 +102,36 @@ func TestPerConcernBatchReaders(t *testing.T) {
 		require.Equal(t, wantCommits, commits[name], "commits for %s", name)
 	}
 }
+
+// TestCommitsFallBackToParentTipWithoutStoredDivergence verifies that a branch
+// with no recorded ParentBranchRevision lists only its own commits — measured
+// against the parent's current tip — rather than its entire history back to the
+// repo root (which an empty base would produce). Both GetAllCommits and the
+// batched BatchCommits must agree with the commit count on this fallback.
+func TestCommitsFallBackToParentTipWithoutStoredDivergence(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithLinearStack3() // main -> a -> b -> c
+
+	// Clear b's stored divergence point but keep its parent (a), so the commit
+	// base must fall back to the parent tip rather than an empty base.
+	meta, err := s.Engine.Git().ReadMetadata("b")
+	require.NoError(t, err)
+	require.NoError(t, s.Engine.Git().WriteMetadata("b", meta.WithParentBranchRevision(nil)))
+	require.NoError(t, s.Engine.Rebuild("main"))
+
+	b := s.Engine.GetBranch("b")
+
+	commits, err := s.Engine.GetAllCommits(b, engine.CommitFormatReadable)
+	require.NoError(t, err)
+
+	// Without the fallback, GetAllCommits walks b's whole history to the repo
+	// root while GetCommitCount walks only parent..b, so the two disagree.
+	count, err := s.Engine.GetCommitCount(b)
+	require.NoError(t, err)
+	require.Equal(t, count, len(commits),
+		"commit messages and count must use the same base when no divergence is stored")
+
+	batched := s.Engine.BatchCommits(engine.BranchesOf(b), engine.CommitFormatReadable)["b"]
+	require.Equal(t, commits, batched, "batched commits must match the single-branch accessor")
+}

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -188,10 +188,22 @@ func (e *engineImpl) GetAllCommits(branch Branch, format CommitFormat) ([]string
 		return nil, err
 	}
 
-	// Get parent revision (base)
+	// Base for the commit range: the stored divergence point, or the parent's
+	// current tip when none is recorded. Falling back to the parent tip — not an
+	// empty base, which lists the branch's entire history back to the repo root —
+	// keeps the result to the branch's own commits and consistent with the base
+	// GetDiffStats / GetCommitCount use.
 	var baseRevision string
-	if rev := meta.GetParentBranchRevision(); rev != nil {
+	if rev := meta.GetParentBranchRevision(); rev != nil && *rev != "" {
 		baseRevision = *rev
+	} else {
+		parent := e.trunk
+		if state := e.readState(branchName); state != nil {
+			parent = state.Parent
+		}
+		if parentRev, err := e.git.GetRevision(parent); err == nil {
+			baseRevision = parentRev
+		}
 	}
 
 	return e.commitsBetween(baseRevision, branchRevision, format)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

GetAllCommits (and so BatchCommits) fell back to an empty base when a
branch had no stored ParentBranchRevision, and GetCommitRange treats an
empty base as "git log <head>" — the branch's entire history back to the
repo root. The commit-count path already fell back to the parent tip, so
a metadata-less branch listed its whole history as "its commits" while
the count showed only the few since its parent.

Fall back to the parent's current tip (the divergence point) in both the
single-branch and batched paths, matching GetDiffStats/GetCommitCount.
This is a no-op for normally-tracked branches (stored revision present);
it only corrects the degraded/legacy-metadata case. A regression test
clears the stored divergence and asserts the message list and the count
agree (3 vs 1 before the fix).

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781896357`.


* **PR #1252**
  * **PR #1253**
    * **PR #1254**
      * **PR #1256**
        * **PR #1257**
          * **PR #1258**
            * **PR #1259**
              * **PR #1260**
                * **PR #1261**
                  * **PR #1262**
                    * **PR #1263**
                      * **PR #1264**
                        * **PR #1265** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1267 by jonnii*