### PR TITLE
test(store): use testcontainers locally instead of a fixed local Postgres

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,11 +3,15 @@ experimental = true
 
 [env]
 STACKIT_NO_LOGGING = "1"                                    # Used for tests
-# Postgres connection strings for the API server's repo store (apps/server).
-# `db:up` starts a matching local Postgres via docker-compose. Tests target the
-# _test database; see internal/api/store/testpostgres.
+# Postgres connection string for the API server's repo store (apps/server).
+# `db:up` starts a matching local Postgres via docker-compose for `mise run dev`.
+#
+# Store tests do NOT use this DB. They provision a throwaway Postgres via
+# testcontainers (internal/api/store/testpostgres) and skip when Docker is
+# unavailable, so no manual `db:up` is needed to run the suite. Export
+# STACKIT_TEST_DATABASE_URL yourself to point them at an external DB instead
+# (CI does this with a service container in .github/workflows/test.yml).
 STACKIT_DATABASE_URL = "postgres://stackit:stackit@localhost:5432/stackit?sslmode=disable"
-STACKIT_TEST_DATABASE_URL = "postgres://stackit:stackit@localhost:5432/stackit_test?sslmode=disable"
 GOBIN = "{{ config_root }}/bin"
 PROJECT_ROOT = "{{ config_root }}"
 _.path = ["{{ config_root }}/bin", "{{ env.HOME }}/go/bin"]


### PR DESCRIPTION

Store tests already provision a throwaway Postgres via testcontainers, but
mise.toml exported STACKIT_TEST_DATABASE_URL for every command. The harness
prefers that env var over starting a container, so local runs always targeted
the docker-compose Postgres on localhost:5432 and hard-failed on SASL auth
(and could never have worked anyway, since db:up creates the stackit database,
not stackit_test).

Drop STACKIT_TEST_DATABASE_URL from mise.toml [env] so local test runs fall
through to a throwaway testcontainer (and t.Skip gracefully when Docker is
unavailable). CI is unaffected: it sets the var itself in the test step,
pointing at its service container.