### PR TITLE
fix: polish sync output quality

### DIFF
--- a/internal/cli/stack/sync.go
+++ b/internal/cli/stack/sync.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/actions/sync"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/cli/common"
@@ -54,11 +56,11 @@ If trunk cannot be fast-forwarded to match remote, overwrites trunk with the rem
 				// sync.Action, so nothing is fast-forwarded, deleted, restacked,
 				// or pushed to GitHub. This is the whole contract of --dry-run.
 				if dryRun {
-					result := computeSyncDryRun(ctx, opts)
+					plan := computeSyncDryRun(ctx, opts)
 					if jsonOutput {
-						return renderSyncDryRunJSON(ctx.Output, result)
+						return renderSyncDryRunJSON(ctx.Output, plan.toResult())
 					}
-					renderSyncDryRunText(ctx.Output, result, restack)
+					renderSyncDryRunText(ctx.Output, plan)
 					return nil
 				}
 
@@ -82,10 +84,56 @@ If trunk cannot be fast-forwarded to match remote, overwrites trunk with the rem
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Don't prompt for confirmation before overwriting or deleting a branch")
 	cmd.Flags().BoolVar(&restack, "restack", false, "Restack all branches in the current stack")
 	cmd.Flags().BoolVar(&noRestack, "no-restack", false, "Skip restacking branches entirely")
-	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview metadata changes without applying them")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview what sync would do without making any changes")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format (requires --dry-run)")
 
 	return cmd
+}
+
+// dryRunPlan is the read-only snapshot of what a sync WOULD do, built from the
+// current (remote-aware) state. It carries enough detail to render a preview
+// that mirrors the live run — target revision, deletion reasons, restack
+// parents. The JSON contract is a stable, names-only projection (see toResult);
+// the richer fields here exist only to make the human-readable preview as
+// informative as the real sync.
+type dryRunPlan struct {
+	pullBranch    string              // trunk that would be pulled (empty if up to date)
+	pullRev       string              // short remote SHA the trunk would move to
+	clean         []dryRunCleanItem   // branches that would be deleted
+	restack       []dryRunRestackItem // branches that would be restacked
+	restackStacks []string            // deduped stack roots covering the restack set (JSON only)
+	skipped       []string            // dirty-worktree anchors whose stacks are skipped
+	restacked     bool                // whether --restack was requested
+}
+
+type dryRunCleanItem struct {
+	branch string
+	reason string // e.g. "merged into main", "closed on GitHub"
+}
+
+type dryRunRestackItem struct {
+	branch string
+	parent string
+}
+
+// toResult projects the plan onto the stable JSON contract (branch names only).
+// The shape is byte-compatible with what scripts already consume, so the richer
+// preview fields are deliberately dropped here.
+func (p dryRunPlan) toResult() sync.DryRunResult {
+	result := sync.DryRunResult{
+		WouldPull:          p.pullBranch,
+		WouldClean:         []string{},
+		WouldRestack:       []string{},
+		WouldRestackStacks: p.restackStacks,
+		SkippedStacks:      p.skipped,
+	}
+	for _, c := range p.clean {
+		result.WouldClean = append(result.WouldClean, c.branch)
+	}
+	for _, r := range p.restack {
+		result.WouldRestack = append(result.WouldRestack, r.branch)
+	}
+	return result
 }
 
 // computeSyncDryRun builds a read-only snapshot of what a sync WOULD do from the
@@ -94,19 +142,16 @@ If trunk cannot be fast-forwarded to match remote, overwrites trunk with the rem
 // or GitHub write. It intentionally reimplements a slice of sync.Action's
 // planning rather than running the action with a special handler, because a
 // dry-run is a query, not a simulation of the full interactive process.
-func computeSyncDryRun(ctx *app.Context, opts sync.Options) sync.DryRunResult {
+func computeSyncDryRun(ctx *app.Context, opts sync.Options) dryRunPlan {
 	eng := ctx.Engine
-
-	result := sync.DryRunResult{
-		WouldClean:   []string{},
-		WouldRestack: []string{},
-	}
+	plan := dryRunPlan{restacked: opts.Restack}
 
 	// Check if trunk needs to be pulled from remote
 	trunk := eng.Trunk()
 	remoteStatus := eng.ReadBranchRemoteStatuses(ctx.Context, engine.BranchesOf(trunk)).ForBranch(trunk)
 	if remoteStatus.Behind() {
-		result.WouldPull = trunk.GetName()
+		plan.pullBranch = trunk.GetName()
+		plan.pullRev = shortSHA(remoteStatus.RemoteSha)
 	}
 
 	// Collect candidate branches for deletion and restack checks
@@ -121,7 +166,10 @@ func computeSyncDryRun(ctx *app.Context, opts sync.Options) sync.DryRunResult {
 
 		// Check restack status while iterating
 		if opts.Restack && !branch.IsBranchUpToDate() {
-			result.WouldRestack = append(result.WouldRestack, branch.GetName())
+			plan.restack = append(plan.restack, dryRunRestackItem{
+				branch: branch.GetName(),
+				parent: branch.GetParentOrTrunk(),
+			})
 			if root := eng.GetStackRootForBranch(branch); root != "" {
 				restackRootSet[root] = struct{}{}
 			}
@@ -137,7 +185,7 @@ func computeSyncDryRun(ctx *app.Context, opts sync.Options) sync.DryRunResult {
 			roots = append(roots, root)
 		}
 		sort.Strings(roots)
-		result.WouldRestackStacks = roots
+		plan.restackStacks = roots
 	}
 
 	// Batch-check deletion status for all candidates
@@ -146,7 +194,7 @@ func computeSyncDryRun(ctx *app.Context, opts sync.Options) sync.DryRunResult {
 		if err == nil {
 			for _, name := range candidateNames {
 				if status, ok := statuses[name]; ok && status.SafeToDelete {
-					result.WouldClean = append(result.WouldClean, name)
+					plan.clean = append(plan.clean, dryRunCleanItem{branch: name, reason: status.Reason})
 				}
 			}
 		}
@@ -157,12 +205,12 @@ func computeSyncDryRun(ctx *app.Context, opts sync.Options) sync.DryRunResult {
 	if err == nil {
 		for _, wt := range managedWorktrees {
 			if hasChanges, _ := eng.WorktreeHasUncommittedChanges(ctx.Context, wt.Path); hasChanges {
-				result.SkippedStacks = append(result.SkippedStacks, wt.AnchorBranch)
+				plan.skipped = append(plan.skipped, wt.AnchorBranch)
 			}
 		}
 	}
 
-	return result
+	return plan
 }
 
 // renderSyncDryRunJSON prints the dry-run snapshot as indented JSON. The shape
@@ -176,34 +224,60 @@ func renderSyncDryRunJSON(out output.Output, result sync.DryRunResult) error {
 	return nil
 }
 
-// renderSyncDryRunText prints a human-readable preview of what a sync would do.
-// restackRequested mirrors the --restack flag so we can hint that restacking is
-// only previewed when explicitly requested (WouldRestack is empty otherwise).
-func renderSyncDryRunText(out output.Output, result sync.DryRunResult, restackRequested bool) {
+// renderSyncDryRunText prints a human-readable preview of what a sync would do,
+// mirroring the live run's shape: grouped sections, then a one-line summary, then
+// the command to apply it. Secondary detail (target revision, deletion reason,
+// restack parent) is dimmed so branch names stay scannable.
+func renderSyncDryRunText(out output.Output, plan dryRunPlan) {
 	out.Info("🔍 Dry run — no changes will be made.")
 
 	printed := false
-	section := func(title string, items []string) {
-		if len(items) == 0 {
-			return
-		}
+
+	if plan.pullBranch != "" {
 		out.Newline()
-		out.Info("%s", title)
-		for _, name := range items {
+		out.Info("Would pull from remote:")
+		line := "  " + style.ColorBranchName(plan.pullBranch, false)
+		if plan.pullRev != "" {
+			line += " → " + style.ColorDim(plan.pullRev)
+		}
+		out.Info("%s", line)
+		printed = true
+	}
+
+	if len(plan.clean) > 0 {
+		out.Newline()
+		out.Info("Would delete (merged or closed PRs):")
+		for _, c := range plan.clean {
+			line := "  " + style.ColorBranchName(c.branch, false)
+			if c.reason != "" {
+				line += " " + style.ColorDim("("+c.reason+")")
+			}
+			out.Info("%s", line)
+		}
+		printed = true
+	}
+
+	if len(plan.restack) > 0 {
+		out.Newline()
+		out.Info("Would restack:")
+		for _, r := range plan.restack {
+			line := "  " + style.ColorBranchName(r.branch, false)
+			if r.parent != "" {
+				line += " " + style.ColorDim("on "+r.parent)
+			}
+			out.Info("%s", line)
+		}
+		printed = true
+	}
+
+	if len(plan.skipped) > 0 {
+		out.Newline()
+		out.Info("Skipped (worktree has uncommitted changes):")
+		for _, name := range plan.skipped {
 			out.Info("  %s", style.ColorBranchName(name, false))
 		}
 		printed = true
 	}
-
-	if result.WouldPull != "" {
-		out.Newline()
-		out.Info("Would pull from remote:")
-		out.Info("  %s", style.ColorBranchName(result.WouldPull, false))
-		printed = true
-	}
-	section("Would delete (merged or closed PRs):", result.WouldClean)
-	section("Would restack:", result.WouldRestack)
-	section("Skipped (worktree has uncommitted changes):", result.SkippedStacks)
 
 	if !printed {
 		out.Newline()
@@ -212,8 +286,41 @@ func renderSyncDryRunText(out output.Output, result sync.DryRunResult, restackRe
 	}
 
 	out.Newline()
-	if !restackRequested {
+	if summary := dryRunSummaryLine(plan); summary != "" {
+		out.Info("Summary: %s", summary)
+	}
+	if !plan.restacked {
 		out.Info("%s", style.ColorDim("Restacking is previewed only with --restack."))
 	}
 	out.Info("Run %s to apply.", style.ColorCyan("stackit sync"))
+}
+
+// dryRunSummaryLine renders the one-line "would …" tally that mirrors the live
+// sync's "✅ Summary:" line, so a preview and a real run read the same shape.
+func dryRunSummaryLine(plan dryRunPlan) string {
+	var parts []string
+	if plan.pullBranch != "" {
+		parts = append(parts, "pull trunk")
+	}
+	if n := len(plan.clean); n > 0 {
+		parts = append(parts, fmt.Sprintf("delete %d", n))
+	}
+	if n := len(plan.restack); n > 0 {
+		parts = append(parts, fmt.Sprintf("restack %d", n))
+	}
+	if n := len(plan.skipped); n > 0 {
+		parts = append(parts, fmt.Sprintf("skip %d %s", n, actions.Pluralize("stack", n)))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "would " + strings.Join(parts, ", ")
+}
+
+// shortSHA truncates a full git SHA to its 7-character short form for display.
+func shortSHA(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
 }

--- a/internal/cli/stack/sync_dryrun_golden_test.go
+++ b/internal/cli/stack/sync_dryrun_golden_test.go
@@ -5,49 +5,81 @@ import (
 	"path/filepath"
 	"testing"
 
-	syncAction "github.com/getstackit/stackit/internal/actions/sync"
+	"github.com/stretchr/testify/require"
+
 	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/testhelpers/golden"
 )
 
+// TestDryRunPlanToResult locks the JSON contract: the rich preview plan must
+// project to a names-only DryRunResult, dropping the display detail (target
+// revision, deletion reason, restack parent) that only the text preview uses.
+func TestDryRunPlanToResult(t *testing.T) {
+	t.Parallel()
+	plan := dryRunPlan{
+		pullBranch:    "main",
+		pullRev:       "abc1234",
+		clean:         []dryRunCleanItem{{branch: "feat-old", reason: "merged into main"}},
+		restack:       []dryRunRestackItem{{branch: "feat-api", parent: "main"}},
+		restackStacks: []string{"feat-api"},
+		skipped:       []string{"feat-wip"},
+	}
+	result := plan.toResult()
+	require.Equal(t, "main", result.WouldPull)
+	require.Equal(t, []string{"feat-old"}, result.WouldClean)
+	require.Equal(t, []string{"feat-api"}, result.WouldRestack)
+	require.Equal(t, []string{"feat-api"}, result.WouldRestackStacks)
+	require.Equal(t, []string{"feat-wip"}, result.SkippedStacks)
+}
+
 // Golden coverage for the human-readable `sync --dry-run` preview. The dry-run
-// is a read-only query, so its renderer takes a plain DryRunResult — no engine,
-// no repository. See sync.go:computeSyncDryRun for where the result is built.
+// is a read-only query, so its renderer takes a plain dryRunPlan — no engine, no
+// repository. See sync.go:computeSyncDryRun for where the plan is built.
 
 type syncDryRunGoldenCase struct {
-	name             string
-	result           syncAction.DryRunResult
-	restackRequested bool
+	name string
+	plan dryRunPlan
 }
 
 func syncDryRunGoldenCases() []syncDryRunGoldenCase {
 	return []syncDryRunGoldenCase{
 		{
-			name:   "nothing_to_do",
-			result: syncAction.DryRunResult{},
+			name: "nothing_to_do",
+			plan: dryRunPlan{},
 		},
 		{
 			name: "pull_and_clean",
-			result: syncAction.DryRunResult{
-				WouldPull:  "main",
-				WouldClean: []string{"feat-login", "feat-old"},
+			plan: dryRunPlan{
+				pullBranch: "main",
+				pullRev:    "abc1234",
+				clean: []dryRunCleanItem{
+					{branch: "feat-login", reason: "merged into main"},
+					{branch: "feat-old", reason: "closed on GitHub"},
+				},
 			},
 		},
 		{
-			name:             "restack_requested",
-			restackRequested: true,
-			result: syncAction.DryRunResult{
-				WouldRestack: []string{"feat-api", "feat-ui"},
+			name: "restack_requested",
+			plan: dryRunPlan{
+				restacked: true,
+				restack: []dryRunRestackItem{
+					{branch: "feat-api", parent: "main"},
+					{branch: "feat-ui", parent: "feat-api"},
+				},
 			},
 		},
 		{
-			name:             "full",
-			restackRequested: true,
-			result: syncAction.DryRunResult{
-				WouldPull:     "main",
-				WouldClean:    []string{"feat-old"},
-				WouldRestack:  []string{"feat-api", "feat-ui"},
-				SkippedStacks: []string{"feat-wip"},
+			name: "full",
+			plan: dryRunPlan{
+				restacked:  true,
+				pullBranch: "main",
+				pullRev:    "abc1234",
+				clean:      []dryRunCleanItem{{branch: "feat-old", reason: "merged into main"}},
+				restack: []dryRunRestackItem{
+					{branch: "feat-api", parent: "main"},
+					{branch: "feat-ui", parent: "feat-api"},
+				},
+				skipped: []string{"feat-wip"},
 			},
 		},
 	}
@@ -59,7 +91,7 @@ func TestSyncDryRunGolden(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			buf := &bytes.Buffer{}
-			renderSyncDryRunText(output.NewConsoleOutput(buf, false), c.result, c.restackRequested)
+			renderSyncDryRunText(output.NewConsoleOutput(buf, false), c.plan)
 			golden.Assert(t, filepath.Join("testdata", "sync", "dryrun", c.name+".golden"), golden.StripANSI(buf.String()))
 		})
 	}

--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/getstackit/stackit/internal/tui"
 	syncComponent "github.com/getstackit/stackit/internal/tui/components/sync"
 	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // NewSyncUI creates a runner and handler pair for sync operations.
@@ -33,25 +34,21 @@ func NewSyncUI(out output.Output, logger output.Logger) (*tui.Runner, syncAction
 //
 // Phase headers are printed lazily: a header is emitted the first time its phase
 // produces an actual line, so phases that do nothing (e.g. nothing to clean or
-// restack) stay silent instead of printing an empty header. Completed items are
-// prefixed with a green ✓ and warnings with ⚠️, matching the interactive TUI.
+// restack) stay silent instead of printing an empty header. Item rows are led by
+// a single-width status marker (✓ done, ⚠ skipped, → in progress) from
+// internal/tui/style, so they align in one column and match the interactive TUI.
 type SimpleSyncHandler struct {
 	common.BaseHandler
-	totalOps      int
-	currentOp     int
-	startedPhases map[syncAction.Phase]bool
-	headerPrinted map[syncAction.Phase]bool
-	anyHeader     bool
+	totalOps  int
+	currentOp int
+	headers   *utils.LazyHeaders[syncAction.Phase]
 }
-
-// successTick is the green ✓ used to prefix completed sync items, matching the
-// interactive TUI's check mark.
-func successTick() string { return style.ColorGreen("✓") }
 
 // NewSimpleSyncHandler creates a new SimpleSyncHandler
 func NewSimpleSyncHandler(out output.Output) *SimpleSyncHandler {
 	return &SimpleSyncHandler{
 		BaseHandler: common.NewBaseHandler(out),
+		headers:     utils.NewLazyHeaders[syncAction.Phase](),
 	}
 }
 
@@ -72,10 +69,7 @@ func (h *SimpleSyncHandler) EmitEvent(event syncAction.Event) {
 	// the header is emitted lazily by item() the first time the phase produces a
 	// real line, so phases that do nothing stay silent.
 	if event.Type == syncAction.EventStarted {
-		if h.startedPhases == nil {
-			h.startedPhases = make(map[syncAction.Phase]bool)
-		}
-		h.startedPhases[event.Phase] = true
+		h.headers.Start(event.Phase)
 		return
 	}
 
@@ -89,7 +83,7 @@ func (h *SimpleSyncHandler) Complete(summary syncAction.Summary) {
 	defer h.Unlock()
 
 	// Separate phase activity from the final line (only if anything printed).
-	if h.anyHeader {
+	if h.headers.Any() {
 		h.Output.Newline()
 	}
 
@@ -107,21 +101,14 @@ func (h *SimpleSyncHandler) Complete(summary syncAction.Summary) {
 // restack drives items via OnRestackBranch without starting a phase, so it keeps
 // its headerless output while still gaining the ✓/→ item polish.
 func (h *SimpleSyncHandler) ensurePhaseHeader(phase syncAction.Phase) {
-	if !h.startedPhases[phase] {
+	emit, separate := h.headers.CommitOnItem(phase)
+	if !emit {
 		return
 	}
-	if h.headerPrinted == nil {
-		h.headerPrinted = make(map[syncAction.Phase]bool)
-	}
-	if h.headerPrinted[phase] {
-		return
-	}
-	if h.anyHeader {
+	if separate {
 		h.Output.Newline()
 	}
 	h.printPhaseHeader(phase)
-	h.headerPrinted[phase] = true
-	h.anyHeader = true
 }
 
 // item prints one phase line, emitting the phase header first if needed.
@@ -211,11 +198,11 @@ func (h *SimpleSyncHandler) printTrunkEvent(event syncAction.Event) {
 	if event.Type == syncAction.EventCompleted {
 		if event.NewRevision != "" {
 			h.item(event.Phase, "  %s %s fast-forwarded to %s",
-				successTick(),
+				style.MarkSuccess(),
 				style.ColorBranchName(event.Branch, false),
 				style.ColorDim(event.NewRevision))
 		} else {
-			h.item(event.Phase, "  %s %s is up to date", successTick(), style.ColorBranchName(event.Branch, false))
+			h.item(event.Phase, "  %s %s is up to date", style.MarkSuccess(), style.ColorBranchName(event.Branch, false))
 		}
 	}
 }
@@ -225,15 +212,16 @@ func (h *SimpleSyncHandler) printBranchSyncEvent(event syncAction.Event) {
 	case syncAction.EventCompleted:
 		if event.NewRevision != "" {
 			h.item(event.Phase, "  %s %s fast-forwarded to %s",
-				successTick(),
+				style.MarkSuccess(),
 				style.ColorBranchName(event.Branch, false),
 				style.ColorDim(event.NewRevision))
 		} else {
-			h.item(event.Phase, "  %s %s is up to date", successTick(), style.ColorBranchName(event.Branch, false))
+			h.item(event.Phase, "  %s %s is up to date", style.MarkSuccess(), style.ColorBranchName(event.Branch, false))
 		}
 	case syncAction.EventSkipped:
 		if event.Conflict {
-			h.item(event.Phase, "  ⚠️ %s diverged from remote (skipping)",
+			h.item(event.Phase, "  %s %s diverged from remote (skipping)",
+				style.MarkWarning(),
 				style.ColorBranchName(event.Branch, false))
 		}
 	}
@@ -243,11 +231,11 @@ func (h *SimpleSyncHandler) printGitHubEvent(event syncAction.Event) {
 	switch event.Type {
 	case syncAction.EventProgress:
 		if event.Branch != "" {
-			h.item(event.Phase, "  Updating PR for %s", style.ColorBranchName(event.Branch, false))
+			h.item(event.Phase, "  %s Updating PR for %s", style.MarkProgress(), style.ColorBranchName(event.Branch, false))
 		}
 	case syncAction.EventCompleted:
 		if event.Message != "" {
-			h.item(event.Phase, "  %s %s", successTick(), event.Message)
+			h.item(event.Phase, "  %s %s", style.MarkSuccess(), event.Message)
 		}
 	}
 }
@@ -259,7 +247,7 @@ func (h *SimpleSyncHandler) printCleanEvent(event syncAction.Event) {
 			prInfo = fmt.Sprintf(" (PR #%d)", *event.PRNumber)
 		}
 		h.item(event.Phase, "  %s Deleted %s%s %s",
-			successTick(),
+			style.MarkSuccess(),
 			style.ColorBranchName(event.Branch, false),
 			prInfo,
 			style.ColorDim(event.Message))
@@ -282,7 +270,7 @@ func (h *SimpleSyncHandler) printRestackEvent(event syncAction.Event) {
 	case syncAction.EventCompleted:
 		switch {
 		case event.NewRevision != "":
-			msg := fmt.Sprintf("  %s Restacked %s%s", successTick(), branchStr, prInfo)
+			msg := fmt.Sprintf("  %s Restacked %s%s", style.MarkSuccess(), branchStr, prInfo)
 			if event.Parent != "" {
 				msg += fmt.Sprintf(" on %s", style.ColorBranchName(event.Parent, false))
 			}
@@ -296,11 +284,11 @@ func (h *SimpleSyncHandler) printRestackEvent(event syncAction.Event) {
 		case event.Frozen:
 			h.item(event.Phase, "  %s%s %s", branchStr, prInfo, common.ReasonFrozen)
 		default:
-			h.item(event.Phase, "  %s %s%s up to date", successTick(), branchStr, prInfo)
+			h.item(event.Phase, "  %s %s%s up to date", style.MarkSuccess(), branchStr, prInfo)
 		}
 	case syncAction.EventSkipped:
 		if event.Conflict {
-			h.item(event.Phase, "  ⚠️ Skipped %s%s (conflict)", branchStr, prInfo)
+			h.item(event.Phase, "  %s Skipped %s%s (conflict)", style.MarkWarning(), branchStr, prInfo)
 		} else {
 			h.item(event.Phase, "  Skipped %s%s %s", branchStr, prInfo, style.ColorDim(event.Message))
 		}
@@ -454,12 +442,12 @@ func (h *InteractiveSyncHandler) EmitEvent(event syncAction.Event) {
 	}
 
 	// Build detail message and determine status
-	detail, isWarn := h.formatEventDetail(event)
+	detail, mark := h.formatEventDetail(event)
 	if detail != "" {
 		h.runner.Send(syncComponent.PhaseDetailMsg{
 			Phase:   syncComponent.Phase(event.Phase),
 			Message: detail,
-			IsWarn:  isWarn,
+			Mark:    mark,
 		})
 	}
 
@@ -471,37 +459,38 @@ func (h *InteractiveSyncHandler) EmitEvent(event syncAction.Event) {
 	})
 }
 
-// formatEventDetail formats an event into a detail string with warning status
-func (h *InteractiveSyncHandler) formatEventDetail(event syncAction.Event) (detail string, isWarn bool) {
+// formatEventDetail formats an event into a detail string and the status mark
+// that should lead its row in the TUI.
+func (h *InteractiveSyncHandler) formatEventDetail(event syncAction.Event) (detail string, mark syncComponent.DetailMark) {
 	switch event.Phase {
 	case syncAction.PhaseTrunk:
 		if event.Type == syncAction.EventCompleted {
 			if event.NewRevision != "" {
-				return fmt.Sprintf("%s fast-forwarded to %s", event.Branch, event.NewRevision), false
+				return fmt.Sprintf("%s fast-forwarded to %s", event.Branch, event.NewRevision), syncComponent.MarkDone
 			}
-			return fmt.Sprintf("%s is up to date", event.Branch), false
+			return fmt.Sprintf("%s is up to date", event.Branch), syncComponent.MarkDone
 		}
 	case syncAction.PhaseBranches:
 		switch event.Type {
 		case syncAction.EventCompleted:
 			if event.NewRevision != "" {
-				return fmt.Sprintf("%s fast-forwarded to %s", event.Branch, event.NewRevision), false
+				return fmt.Sprintf("%s fast-forwarded to %s", event.Branch, event.NewRevision), syncComponent.MarkDone
 			}
-			return fmt.Sprintf("%s is up to date", event.Branch), false
+			return fmt.Sprintf("%s is up to date", event.Branch), syncComponent.MarkDone
 		case syncAction.EventSkipped:
 			if event.Conflict {
-				return fmt.Sprintf("%s diverged from remote (skipping)", event.Branch), true
+				return fmt.Sprintf("%s diverged from remote (skipping)", event.Branch), syncComponent.MarkWarn
 			}
 		}
 	case syncAction.PhaseGitHub:
 		switch event.Type {
 		case syncAction.EventProgress:
 			if event.Branch != "" {
-				return fmt.Sprintf("Updating PR for %s", event.Branch), false
+				return fmt.Sprintf("Updating PR for %s", event.Branch), syncComponent.MarkInProgress
 			}
 		case syncAction.EventCompleted:
 			if event.Message != "" {
-				return event.Message, false
+				return event.Message, syncComponent.MarkDone
 			}
 		}
 	case syncAction.PhaseClean:
@@ -510,11 +499,11 @@ func (h *InteractiveSyncHandler) formatEventDetail(event syncAction.Event) (deta
 			if event.PRNumber != nil {
 				prInfo = fmt.Sprintf(" (PR #%d)", *event.PRNumber)
 			}
-			return fmt.Sprintf("Deleted %s%s %s", event.Branch, prInfo, event.Message), false
+			return fmt.Sprintf("Deleted %s%s %s", event.Branch, prInfo, event.Message), syncComponent.MarkDone
 		}
 	case syncAction.PhaseRestack:
 		if event.Branch == "" {
-			return "", false
+			return "", syncComponent.MarkDone
 		}
 		prInfo := ""
 		if event.PRNumber != nil {
@@ -530,8 +519,8 @@ func (h *InteractiveSyncHandler) formatEventDetail(event syncAction.Event) (deta
 				if event.Parent != "" {
 					msg += fmt.Sprintf(" on %s", event.Parent)
 				}
-				msg += fmt.Sprintf(" -> %s", event.NewRevision)
-				return msg, false
+				msg += fmt.Sprintf(" → %s", event.NewRevision)
+				return msg, syncComponent.MarkDone
 			}
 			reason := common.ReasonNoRestackNeeded
 			if event.IsLocked() {
@@ -541,17 +530,17 @@ func (h *InteractiveSyncHandler) formatEventDetail(event syncAction.Event) (deta
 			}
 
 			if reason == common.ReasonNoRestackNeeded {
-				return fmt.Sprintf("%s%s up to date", displayName, prInfo), false
+				return fmt.Sprintf("%s%s up to date", displayName, prInfo), syncComponent.MarkDone
 			}
-			return fmt.Sprintf("%s%s %s", displayName, prInfo, reason), false
+			return fmt.Sprintf("%s%s %s", displayName, prInfo, reason), syncComponent.MarkDone
 		case syncAction.EventSkipped:
 			if event.Conflict {
-				return fmt.Sprintf("Skipped %s%s (conflict)", displayName, prInfo), true
+				return fmt.Sprintf("Skipped %s%s (conflict)", displayName, prInfo), syncComponent.MarkWarn
 			}
-			return fmt.Sprintf("Skipped %s%s %s", displayName, prInfo, event.Message), false
+			return fmt.Sprintf("Skipped %s%s %s", displayName, prInfo, event.Message), syncComponent.MarkDone
 		}
 	}
-	return "", false
+	return "", syncComponent.MarkDone
 }
 
 // Complete is called when sync finishes
@@ -610,14 +599,15 @@ func (h *InteractiveSyncHandler) OnRestackBranch(branch string, result syncActio
 	defer h.mu.Unlock()
 
 	// Build detail message
-	detail := h.formatRestackDetail(branch, result, newRev, prNumber, lockReason, frozen, isCurrent, parent, rerereResolvedCount)
+	detail, mark := h.formatRestackDetail(branch, result, newRev, prNumber, lockReason, frozen, isCurrent, parent, rerereResolvedCount)
 	if detail != "" {
 		if reparented {
-			detail = fmt.Sprintf("Reparented %s -> %s. %s", oldParent, newParent, detail)
+			detail = fmt.Sprintf("Reparented %s → %s. %s", oldParent, newParent, detail)
 		}
 		h.runner.Send(syncComponent.PhaseDetailMsg{
 			Phase:   syncComponent.Phase(syncAction.PhaseRestack),
 			Message: detail,
+			Mark:    mark,
 		})
 	}
 
@@ -629,8 +619,11 @@ func (h *InteractiveSyncHandler) OnRestackBranch(branch string, result syncActio
 	})
 }
 
-// formatRestackDetail formats a restack event into a detail string
-func (h *InteractiveSyncHandler) formatRestackDetail(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, rerereResolvedCount int) string {
+// formatRestackDetail formats a restack event into a detail string and the
+// status mark that should lead its row. The conflict case returns MarkWarn
+// rather than baking a glyph into the string, so the model owns the marker (the
+// streaming handler does the same).
+func (h *InteractiveSyncHandler) formatRestackDetail(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, rerereResolvedCount int) (string, syncComponent.DetailMark) {
 	prInfo := ""
 	if prNumber != nil {
 		prInfo = fmt.Sprintf(" (PR #%d)", *prNumber)
@@ -648,7 +641,7 @@ func (h *InteractiveSyncHandler) formatRestackDetail(branch string, result syncA
 		if rerereResolvedCount > 0 {
 			msg += " " + actions.FormatRerereResolved(rerereResolvedCount)
 		}
-		return msg
+		return msg, syncComponent.MarkDone
 	case syncAction.RestackUnneeded:
 		reason := common.ReasonNoRestackNeeded
 		if lockReason.IsLocked() {
@@ -658,13 +651,13 @@ func (h *InteractiveSyncHandler) formatRestackDetail(branch string, result syncA
 		}
 
 		if reason == common.ReasonNoRestackNeeded {
-			return fmt.Sprintf("%s%s up to date", displayName, prInfo)
+			return fmt.Sprintf("%s%s up to date", displayName, prInfo), syncComponent.MarkDone
 		}
-		return fmt.Sprintf("%s%s %s", displayName, prInfo, reason)
+		return fmt.Sprintf("%s%s %s", displayName, prInfo, reason), syncComponent.MarkDone
 	case syncAction.RestackConflict:
-		return fmt.Sprintf("⚠️ Skipped %s%s (conflict)", displayName, prInfo)
+		return fmt.Sprintf("Skipped %s%s (conflict)", displayName, prInfo), syncComponent.MarkWarn
 	}
-	return ""
+	return "", syncComponent.MarkDone
 }
 
 // OnRestackComplete implements RestackHandler for standalone restack operations

--- a/internal/cli/stack/testdata/sync/branch_diverged_skipped.golden
+++ b/internal/cli/stack/testdata/sync/branch_diverged_skipped.golden
@@ -2,6 +2,6 @@
   ✓ main fast-forwarded to a1b2c3d
 
 📥 Syncing stack branches...
-  ⚠️ feat-api diverged from remote (skipping)
+  ⚠ feat-api diverged from remote (skipping)
 
 ✅ Summary: pulled trunk

--- a/internal/cli/stack/testdata/sync/dryrun/full.golden
+++ b/internal/cli/stack/testdata/sync/dryrun/full.golden
@@ -1,16 +1,17 @@
 🔍 Dry run — no changes will be made.
 
 Would pull from remote:
-  main
+  main → abc1234
 
 Would delete (merged or closed PRs):
-  feat-old
+  feat-old (merged into main)
 
 Would restack:
-  feat-api
-  feat-ui
+  feat-api on main
+  feat-ui on feat-api
 
 Skipped (worktree has uncommitted changes):
   feat-wip
 
+Summary: would pull trunk, delete 1, restack 2, skip 1 stack
 Run stackit sync to apply.

--- a/internal/cli/stack/testdata/sync/dryrun/pull_and_clean.golden
+++ b/internal/cli/stack/testdata/sync/dryrun/pull_and_clean.golden
@@ -1,11 +1,12 @@
 🔍 Dry run — no changes will be made.
 
 Would pull from remote:
-  main
+  main → abc1234
 
 Would delete (merged or closed PRs):
-  feat-login
-  feat-old
+  feat-login (merged into main)
+  feat-old (closed on GitHub)
 
+Summary: would pull trunk, delete 2
 Restacking is previewed only with --restack.
 Run stackit sync to apply.

--- a/internal/cli/stack/testdata/sync/dryrun/restack_requested.golden
+++ b/internal/cli/stack/testdata/sync/dryrun/restack_requested.golden
@@ -1,7 +1,8 @@
 🔍 Dry run — no changes will be made.
 
 Would restack:
-  feat-api
-  feat-ui
+  feat-api on main
+  feat-ui on feat-api
 
+Summary: would restack 2
 Run stackit sync to apply.

--- a/internal/cli/stack/testdata/sync/full_sync.golden
+++ b/internal/cli/stack/testdata/sync/full_sync.golden
@@ -16,7 +16,7 @@
 
 📚 Restacking branches...
   ✓ Restacked feat-ui (PR #202) on feat-api → c3d4e5f
-  ⚠️ Skipped feat-report (PR #203) (conflict)
+  ⚠ Skipped feat-report (PR #203) (conflict)
 
 ⚠️  Found conflicts in 1 branch during restack:
   • feat-report

--- a/internal/cli/stack/testdata/sync/github_pr_updated.golden
+++ b/internal/cli/stack/testdata/sync/github_pr_updated.golden
@@ -2,7 +2,7 @@
   ✓ main fast-forwarded to a1b2c3d
 
 🔄 Fetching PR info from GitHub...
-  Updating PR for feat-api
+  → Updating PR for feat-api
   ✓ Updated 1 PR description
 
 ✅ Summary: pulled trunk

--- a/internal/cli/stack/testdata/sync/restack_conflict_declined.golden
+++ b/internal/cli/stack/testdata/sync/restack_conflict_declined.golden
@@ -1,6 +1,6 @@
 📚 Restacking branches...
   ✓ Restacked feat-api (PR #201) on main → b2c3d4e
-  ⚠️ Skipped feat-ui (PR #202) (conflict)
+  ⚠ Skipped feat-ui (PR #202) (conflict)
 
 ⚠️  Found conflicts in 1 branch during restack:
   • feat-ui

--- a/internal/tui/components/sync/model.go
+++ b/internal/tui/components/sync/model.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/tui/core"
 	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // Phase represents a sync phase
@@ -26,10 +27,31 @@ const (
 	PhaseRestack  Phase = "restack"
 )
 
-var (
-	checkMark = lipgloss.NewStyle().Foreground(lipgloss.Color(style.ColorSuccess)).SetString("✓")
-	warnMark  = lipgloss.NewStyle().Foreground(lipgloss.Color(style.ColorWarning)).SetString("⚠")
+// DetailMark selects the status glyph shown on a detail row. Using a typed
+// constant (rather than a bare bool) keeps the three states distinct at the call
+// site and matches the streaming handler's markers.
+type DetailMark int
+
+const (
+	// MarkDone shows a green ✓ for a completed item.
+	MarkDone DetailMark = iota
+	// MarkWarn shows an orange ⚠ for a skipped/attention item.
+	MarkWarn
+	// MarkInProgress shows a dim → for an item still in flight.
+	MarkInProgress
 )
+
+// glyph returns the colored marker string for this status.
+func (d DetailMark) glyph() string {
+	switch d {
+	case MarkWarn:
+		return style.MarkWarning()
+	case MarkInProgress:
+		return style.MarkProgress()
+	default:
+		return style.MarkSuccess()
+	}
+}
 
 // Model is the bubbletea model for sync progress.
 // It embeds core.BaseModel for standard lifecycle handling.
@@ -48,9 +70,11 @@ type Model struct {
 	// first detail. Phases that do nothing (nothing to sync/clean/restack) never
 	// print an empty header. CurrentPhase still updates eagerly so the live
 	// spinner reflects what's happening during slow phases.
-	phaseHeaders       map[Phase]string
-	committedPhases    map[Phase]bool
-	anyHeaderCommitted bool
+	//
+	// phaseHeaders holds each phase's pending header text; headers tracks the
+	// commit decision (the same utils.LazyHeaders rule the streaming handler uses).
+	phaseHeaders map[Phase]string
+	headers      *utils.LazyHeaders[Phase]
 }
 
 // PhaseStartMsg indicates a phase has started
@@ -68,7 +92,7 @@ type PhaseCompleteMsg struct {
 type PhaseDetailMsg struct {
 	Phase   Phase
 	Message string
-	IsWarn  bool // If true, shows ⚠ instead of ✓
+	Mark    DetailMark // Status glyph for the row (defaults to MarkDone)
 }
 
 // ProgressTickMsg updates the progress bar
@@ -96,11 +120,11 @@ func NewModel(totalOps int) *Model {
 	s.Style = commonStyles.Spinner
 
 	m := &Model{
-		TotalOps:        totalOps,
-		Progress:        p,
-		spinner:         s,
-		phaseHeaders:    make(map[Phase]string),
-		committedPhases: make(map[Phase]bool),
+		TotalOps:     totalOps,
+		Progress:     p,
+		spinner:      s,
+		phaseHeaders: make(map[Phase]string),
+		headers:      utils.NewLazyHeaders[Phase](),
 	}
 	m.Width = 80 // Set BaseModel's Width
 	return m
@@ -147,6 +171,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.CurrentPhase = msg.Phase
 		m.CurrentDetail = ""
 		m.phaseHeaders[msg.Phase] = msg.Message
+		m.headers.Start(msg.Phase)
 		return m, nil
 
 	case PhaseCompleteMsg:
@@ -156,24 +181,18 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case PhaseDetailMsg:
 		// Print completed item above the TUI (package-manager pattern)
 		m.CurrentDetail = msg.Message
-		mark := checkMark.String()
-		if msg.IsWarn {
-			mark = warnMark.String()
-		}
-		detail := tea.Printf("  %s %s", mark, msg.Message)
+		detail := tea.Printf("  %s %s", msg.Mark.glyph(), msg.Message)
 
 		// Commit the phase header the first time the phase produces a detail,
 		// separated from the previous phase group by a blank line. A detail for
 		// a phase that was never started (e.g. standalone restack) just prints
 		// without a header.
-		if header, started := m.phaseHeaders[msg.Phase]; started && !m.committedPhases[msg.Phase] {
-			m.committedPhases[msg.Phase] = true
+		if emit, separate := m.headers.CommitOnItem(msg.Phase); emit {
 			var cmds []tea.Cmd
-			if m.anyHeaderCommitted {
+			if separate {
 				cmds = append(cmds, tea.Printf(""))
 			}
-			m.anyHeaderCommitted = true
-			cmds = append(cmds, tea.Printf("%s", header), detail)
+			cmds = append(cmds, tea.Printf("%s", m.phaseHeaders[msg.Phase]), detail)
 			return m, tea.Sequence(cmds...)
 		}
 		return m, detail

--- a/internal/tui/components/sync/model_test.go
+++ b/internal/tui/components/sync/model_test.go
@@ -9,7 +9,28 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/getstackit/stackit/internal/tui"
+	"github.com/getstackit/stackit/internal/tui/style"
 )
+
+func TestDetailMark_Glyph(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		mark DetailMark
+		want string
+	}{
+		{"done shows ✓", MarkDone, style.GlyphSuccess},
+		{"warn shows ⚠", MarkWarn, style.GlyphWarning},
+		{"in progress shows →", MarkInProgress, style.GlyphProgress},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// glyph() wraps the rune in color codes; assert the rune is present.
+			assert.Contains(t, tt.mark.glyph(), tt.want)
+		})
+	}
+}
 
 // viewString extracts the string content from a tea.View for test assertions.
 func viewString(v tea.View) string {
@@ -61,7 +82,7 @@ func TestModel_Update_PhaseStartMsg(t *testing.T) {
 	assert.Equal(t, PhaseTrunk, m.CurrentPhase)
 	assert.Equal(t, "", m.CurrentDetail) // Detail cleared on phase start
 	assert.Nil(t, cmd, "phase start should defer its header until the first detail")
-	assert.False(t, m.committedPhases[PhaseTrunk], "header should not be committed before any detail")
+	assert.False(t, m.headers.Committed(PhaseTrunk), "header should not be committed before any detail")
 }
 
 func TestModel_Update_EmptyPhaseSuppressed(t *testing.T) {
@@ -75,9 +96,9 @@ func TestModel_Update_EmptyPhaseSuppressed(t *testing.T) {
 	newModel, _ = m.Update(PhaseStartMsg{Phase: PhaseClean, Message: "🧹 Cleaning branches..."})
 	m = newModel.(*Model)
 
-	assert.False(t, m.committedPhases[PhaseBranches], "empty branches phase should not commit a header")
-	assert.False(t, m.committedPhases[PhaseClean], "empty clean phase should not commit a header")
-	assert.False(t, m.anyHeaderCommitted, "no headers should have been committed")
+	assert.False(t, m.headers.Committed(PhaseBranches), "empty branches phase should not commit a header")
+	assert.False(t, m.headers.Committed(PhaseClean), "empty clean phase should not commit a header")
+	assert.False(t, m.headers.Any(), "no headers should have been committed")
 }
 
 func TestModel_Update_PhaseTransition(t *testing.T) {
@@ -114,7 +135,7 @@ func TestModel_Update_PhaseDetailMsg(t *testing.T) {
 
 	assert.Equal(t, "main fast-forwarded to abc1234", m.CurrentDetail)
 	assert.NotNil(t, cmd, "should return print command")
-	assert.True(t, m.committedPhases[PhaseTrunk], "first detail should commit the phase header")
+	assert.True(t, m.headers.Committed(PhaseTrunk), "first detail should commit the phase header")
 }
 
 func TestModel_Update_PhaseDetailMsg_WithWarn(t *testing.T) {
@@ -122,11 +143,11 @@ func TestModel_Update_PhaseDetailMsg_WithWarn(t *testing.T) {
 	model := NewModel(10)
 	model.Init()
 
-	// Add a detail with warning flag
+	// Add a detail with warning mark
 	newModel, cmd := model.Update(PhaseDetailMsg{
 		Phase:   PhaseTrunk,
 		Message: "branch diverged",
-		IsWarn:  true,
+		Mark:    MarkWarn,
 	})
 	m := newModel.(*Model)
 

--- a/internal/tui/style/markers.go
+++ b/internal/tui/style/markers.go
@@ -1,0 +1,35 @@
+package style
+
+import "charm.land/lipgloss/v2"
+
+// Status markers lead individual item rows in streaming and TUI output (the
+// lines printed beneath a phase header). Each glyph is a single display cell, so
+// successive rows align in one column regardless of which status leads them.
+//
+// This is a deliberate two-tier visual language: emoji (📥 🧹 📚 ✅ ✨) are
+// reserved for section headers and summaries, while these thin, colored glyphs
+// mark the items underneath. Keeping the item markers single-width is what makes
+// the text after them line up.
+const (
+	// GlyphSuccess marks a completed item.
+	GlyphSuccess = "✓"
+	// GlyphWarning marks a skipped item or an item that needs attention.
+	GlyphWarning = "⚠"
+	// GlyphProgress marks an item whose work has started but not yet finished.
+	GlyphProgress = "→"
+)
+
+// MarkSuccess returns the green ✓ shown on completed item rows.
+func MarkSuccess() string {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSuccess)).Render(GlyphSuccess)
+}
+
+// MarkWarning returns the orange ⚠ shown on skipped/attention item rows.
+func MarkWarning() string {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(ColorWarning)).Render(GlyphWarning)
+}
+
+// MarkProgress returns the dimmed → shown on in-progress item rows.
+func MarkProgress() string {
+	return DimStyle().Render(GlyphProgress)
+}

--- a/internal/utils/lazy_headers.go
+++ b/internal/utils/lazy_headers.go
@@ -1,0 +1,54 @@
+package utils
+
+// LazyHeaders decides when a keyed section's header should be emitted to a
+// streaming display: at most once, on the section's first item, and only for
+// sections that were explicitly started. Successive emitted headers are
+// separated from the previous one by a blank line.
+//
+// It holds no output of its own — callers emit based on its decisions — so the
+// same logic drives both the non-TTY sync handler (which writes lines straight
+// to output) and the bubbletea sync model (which accumulates tea.Cmds). Keeping
+// the rule in one place stops the two from drifting apart.
+//
+// The zero value is not ready for use; construct with NewLazyHeaders.
+type LazyHeaders[K comparable] struct {
+	started   map[K]bool
+	committed map[K]bool
+	any       bool
+}
+
+// NewLazyHeaders returns a ready-to-use tracker keyed by K.
+func NewLazyHeaders[K comparable]() *LazyHeaders[K] {
+	return &LazyHeaders[K]{
+		started:   make(map[K]bool),
+		committed: make(map[K]bool),
+	}
+}
+
+// Start records that a section has begun. Its header is not emitted yet — that
+// happens lazily on the first item via CommitOnItem — so a section that starts
+// but never produces an item stays silent.
+func (l *LazyHeaders[K]) Start(key K) { l.started[key] = true }
+
+// CommitOnItem is called as a section produces an item. It reports whether the
+// section's header should be emitted now (emit) — true exactly once, for the
+// first item of a started, not-yet-committed section — and whether that header
+// needs a blank-line separator from the previous section (separate). Items for
+// a section that was never started return (false, false), so callers that drive
+// items without starting a phase stay headerless.
+func (l *LazyHeaders[K]) CommitOnItem(key K) (emit, separate bool) {
+	if !l.started[key] || l.committed[key] {
+		return false, false
+	}
+	l.committed[key] = true
+	separate = l.any
+	l.any = true
+	return true, separate
+}
+
+// Committed reports whether the given section's header has been emitted.
+func (l *LazyHeaders[K]) Committed(key K) bool { return l.committed[key] }
+
+// Any reports whether any header has been emitted, e.g. to decide whether a
+// trailing separator is needed before a summary line.
+func (l *LazyHeaders[K]) Any() bool { return l.any }

--- a/internal/utils/lazy_headers_test.go
+++ b/internal/utils/lazy_headers_test.go
@@ -1,0 +1,69 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLazyHeaders_CommitsOnceOnFirstItem(t *testing.T) {
+	t.Parallel()
+	h := NewLazyHeaders[string]()
+	h.Start("trunk")
+
+	assert.False(t, h.Committed("trunk"))
+	assert.False(t, h.Any())
+
+	// First item commits the header, with no separator (nothing before it).
+	emit, separate := h.CommitOnItem("trunk")
+	assert.True(t, emit, "first item should commit the header")
+	assert.False(t, separate, "first header needs no separator")
+	assert.True(t, h.Committed("trunk"))
+	assert.True(t, h.Any())
+
+	// Subsequent items for the same section never re-emit the header.
+	emit, separate = h.CommitOnItem("trunk")
+	assert.False(t, emit)
+	assert.False(t, separate)
+}
+
+func TestLazyHeaders_SeparatesSuccessiveSections(t *testing.T) {
+	t.Parallel()
+	h := NewLazyHeaders[string]()
+	h.Start("trunk")
+	h.Start("github")
+
+	emit, separate := h.CommitOnItem("trunk")
+	assert.True(t, emit)
+	assert.False(t, separate, "first committed header has no separator")
+
+	// The second section's header is separated from the first by a blank line.
+	emit, separate = h.CommitOnItem("github")
+	assert.True(t, emit)
+	assert.True(t, separate, "later headers are separated from the previous group")
+}
+
+func TestLazyHeaders_UnstartedSectionStaysSilent(t *testing.T) {
+	t.Parallel()
+	h := NewLazyHeaders[string]()
+
+	// An item for a section that never started (e.g. standalone restack drives
+	// items without starting a phase) must not emit a header.
+	emit, separate := h.CommitOnItem("restack")
+	assert.False(t, emit)
+	assert.False(t, separate)
+	assert.False(t, h.Committed("restack"))
+	assert.False(t, h.Any())
+}
+
+func TestLazyHeaders_StartedButNoItemStaysSilent(t *testing.T) {
+	t.Parallel()
+	h := NewLazyHeaders[string]()
+	h.Start("branches")
+	h.Start("clean")
+
+	// Phases that start but never produce an item commit nothing.
+	assert.False(t, h.Committed("branches"))
+	assert.False(t, h.Committed("clean"))
+	assert.False(t, h.Any())
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Three related refinements to sync's streaming, interactive, and dry-run
output, building on the empty-phase-header work:

- Aligned status markers. Item rows under a phase header were led by an
  inconsistent mix (green ✓ color "2", a double-width ⚠️ emoji, and an
  unmarked progress line) that didn't line up and disagreed between the
  streaming handler and the TUI. One source of truth in internal/tui/style
  now provides single-width ✓ / ⚠ / → markers; emoji stay reserved for
  section headers and summaries. PhaseDetailMsg trades its IsWarn bool for a
  typed DetailMark, which also lets the GitHub progress line carry a →.
  Fixes two latent glitches: the interactive sync restack printed "-> rev"
  instead of "→", and the standalone restack conflict rendered "✓ ⚠️ Skipped".

- Enriched dry-run preview. The --dry-run preview listed bare branch names,
  strictly less informative than the sync it previews. It now mirrors the
  live run: trunk pull target ("main → abc1234"), deletion reason
  ("feat-old (merged into main)"), restack parent ("feat-api on main"), and a
  one-line "Summary: would pull trunk, delete 1, restack 2" tally. The JSON
  contract is unchanged — dryRunPlan.toResult() projects back to the same
  names-only DryRunResult, locked by a test.

- Shared lazy-header rule. The "commit a phase header once, on its first
  item, with a separator between groups" logic existed twice and had already
  drifted; extracted into a tiny generic, output-free utils.LazyHeaders[K]
  used by both handlers.

<hr/>

<!-- STACKIT-SECTION-START -->
**Sync output quality**

Makes `stackit sync` output trustworthy and clean across all three surfaces
(JSON, non-TTY streaming, and the interactive TUI).

- Make `--dry-run` a true read-only preview instead of silently applying
  fast-forwards, deletions, restacks, and GitHub writes.
- Declutter the streaming output: lazy phase headers, fix doubled ⚠️, add
  ✓/→ item markers.
- Suppress empty phase headers in the interactive TUI to match.
- Polish: one shared single-width status-marker vocabulary, an enriched
  dry-run preview that mirrors the live run, and a deduped lazy-header rule.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1781901935`.


* **PR #1236**
  * **PR #1237**
    * **PR #1238**
      * **PR #1268** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1269 by jonnii*