### PR TITLE
feat(submit): tailor submit output to stack shape

### DIFF
--- a/internal/actions/submit/events.go
+++ b/internal/actions/submit/events.go
@@ -93,6 +93,7 @@ const (
 	OutcomeDryRun          CompletionOutcome = "dry-run"           // plan reported, nothing submitted
 	OutcomeCanceled        CompletionOutcome = "canceled"          // user declined a confirmation
 	OutcomeNothingToSubmit CompletionOutcome = "nothing-to-submit" // no branches in scope / untracked
+	OutcomeOnTrunk         CompletionOutcome = "on-trunk"          // checked out on trunk; nothing to submit from here
 	OutcomeFailed          CompletionOutcome = "failed"            // at least one branch failed
 )
 

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -127,6 +127,20 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return err
 	}
 	if len(branches) == 0 {
+		// Standing on trunk is the most common reason there is nothing in scope:
+		// submit defaults to downstack, and downstack from trunk is just trunk
+		// (filtered out above). Surface a distinct outcome so the adapter can
+		// point the user at creating or checking out a branch rather than
+		// printing a bare "nothing to submit".
+		if opts.Branch == "" {
+			if cb := nav.CurrentBranch(); cb != nil && cb.IsTrunk() {
+				handler.OnEvent(CompletionEvent{
+					Outcome: OutcomeOnTrunk,
+					Message: fmt.Sprintf("You're on %s — nothing to submit from here.", cb.GetName()),
+				})
+				return nil
+			}
+		}
 		handler.OnEvent(CompletionEvent{Outcome: OutcomeNothingToSubmit, Message: "No branches to submit"})
 		return nil
 	}

--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -2,6 +2,9 @@ package stack
 
 import (
 	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
 
 	"github.com/getstackit/stackit/internal/actions/submit"
 	"github.com/getstackit/stackit/internal/cli/common"
@@ -28,39 +31,71 @@ func NewSubmitUI(out output.Output, logger output.Logger) (*tui.Runner, submit.H
 }
 
 // planPrinter prints the stack and per-branch plan as a single merged list,
-// shared by both submit handlers.
+// shared by both submit handlers. It adapts its framing to the shape of the
+// work: a lone branch off trunk reads as a single PR, while a real stack keeps
+// the stack header and aligned columns.
 type planPrinter struct {
 	out         output.Output
 	scopes      map[string]string
 	worktrees   map[string]string
+	parents     map[string]string
+	trunk       string
+	solo        bool // exactly one submittable branch — drop the stack framing
+	nameWidth   int  // widest decorated branch name, for column alignment
 	headerShown bool
 }
 
-// SetStack stashes the stack annotations so plan lines can include them.
+// SetStack stashes the stack annotations so plan lines can include them, and
+// derives the framing (solo vs stack) and column width from the full branch set
+// — both are known before the first plan line streams in.
 func (p *planPrinter) SetStack(stack submit.StackSnapshot) {
 	p.scopes = stack.ScopeMap
 	p.worktrees = stack.WorktreeMap
+	p.parents = stack.ParentMap
+	p.trunk = stack.TrunkBranch
+	p.solo = len(stack.Branches) == 1
+
+	for _, name := range stack.Branches {
+		if w := lipgloss.Width(p.decoratedName(name)); w > p.nameWidth {
+			p.nameWidth = w
+		}
+	}
+}
+
+// decoratedName is the display name plus scope and worktree annotations.
+func (p *planPrinter) decoratedName(branchName string) string {
+	name := submitComponent.DisplayBranchName(branchName)
+	if scope := p.scopes[branchName]; scope != "" {
+		name += " [" + scope + "]"
+	}
+	if p.worktrees[branchName] != "" {
+		name += " 📂 worktree"
+	}
+	return name
 }
 
 // PrintLine prints one branch of the plan, with the stack header before the
-// first line.
+// first line. A solo branch routes to the leaner single-PR rendering.
 func (p *planPrinter) PrintLine(ev submit.BranchPlanEvent) {
+	if p.solo {
+		p.printSoloLine(ev)
+		return
+	}
+
 	if !p.headerShown {
 		p.headerShown = true
-		p.out.Info("Stack to submit:")
+		header := "Stack to submit"
+		if p.trunk != "" {
+			header += " → " + p.trunk
+		}
+		p.out.Info("%s", header)
 	}
 
 	marker := "  "
 	if ev.IsCurrent {
 		marker = "● "
 	}
-	name := submitComponent.DisplayBranchName(ev.BranchName)
-	if scope := p.scopes[ev.BranchName]; scope != "" {
-		name += " [" + scope + "]"
-	}
-	if p.worktrees[ev.BranchName] != "" {
-		name += " 📂 worktree"
-	}
+	name := p.pad(p.decoratedName(ev.BranchName))
 
 	if ev.Skipped {
 		p.out.Info("%s%s %s", marker, style.ColorDim(name), style.ColorDim("— "+ev.SkipReason))
@@ -76,6 +111,48 @@ func (p *planPrinter) PrintLine(ev submit.BranchPlanEvent) {
 		line += " " + style.ColorDim("(empty)")
 	}
 	p.out.Info("%s", line)
+}
+
+// printSoloLine renders the plan for a single branch as "name → base action",
+// without the stack header — there is no stack to frame.
+func (p *planPrinter) printSoloLine(ev submit.BranchPlanEvent) {
+	name := p.decoratedName(ev.BranchName)
+	base := p.soloBase(ev.BranchName)
+
+	if ev.Skipped {
+		p.out.Info("%s → %s %s", name, base, style.ColorDim("— "+ev.SkipReason))
+		return
+	}
+
+	action := ev.Action
+	if ev.PRNumber != nil {
+		action = fmt.Sprintf("%s #%d", action, *ev.PRNumber)
+	}
+	line := fmt.Sprintf("%s → %s  %s", name, base, style.ColorDim(action))
+	if ev.Empty {
+		line += " " + style.ColorDim("(empty)")
+	}
+	p.out.Info("%s", line)
+}
+
+// soloBase is the display name of the branch's parent (its PR base), falling
+// back to the trunk name.
+func (p *planPrinter) soloBase(branchName string) string {
+	if parent := p.parents[branchName]; parent != "" {
+		return submitComponent.DisplayBranchName(parent)
+	}
+	if p.trunk != "" {
+		return p.trunk
+	}
+	return "trunk"
+}
+
+// pad right-pads name with spaces to nameWidth so the action column aligns.
+func (p *planPrinter) pad(name string) string {
+	if gap := p.nameWidth - lipgloss.Width(name); gap > 0 {
+		return name + strings.Repeat(" ", gap)
+	}
+	return name
 }
 
 // SimpleSubmitHandler implements submit.Handler with line-by-line output
@@ -139,7 +216,11 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 			h.order = append(h.order, branch.Name)
 		}
 		h.Output.Newline()
-		h.Output.Info("Submitting %d %s", len(ev.Branches), pluralizeBranches(len(ev.Branches)))
+		// A solo branch was already named in the plan line; the count header
+		// would just restate it.
+		if !h.plan.solo {
+			h.Output.Info("Submitting %d %s", len(ev.Branches), pluralizeBranches(len(ev.Branches)))
+		}
 
 	case submit.BranchProgressEvent:
 		item := h.items[ev.BranchName]
@@ -169,6 +250,11 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 				return
 			}
 			item.reportedDone = true
+			// A solo branch reports its result in the completion summary
+			// (ref + URL together); a per-branch line here would duplicate it.
+			if h.plan.solo {
+				return
+			}
 			actionDone := "created"
 			if item.action == "update" {
 				actionDone = "updated"
@@ -180,6 +266,10 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 			h.Output.Info("  ✓ %s %s", submitComponent.DisplayBranchName(ev.BranchName), detail)
 
 		case submit.StatusError:
+			if h.plan.solo {
+				h.Output.Info("  ✗ failed: %v", ev.Error)
+				return
+			}
 			h.Output.Info("  ✗ %s failed: %v", submitComponent.DisplayBranchName(ev.BranchName), ev.Error)
 		}
 
@@ -189,10 +279,12 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 	case submit.CompletionEvent:
 		switch ev.Outcome {
 		case submit.OutcomeComplete:
-			if summary := submitComponent.FormatURLSummary(h.submitItems()); summary != "" {
+			if summary := h.completionSummary(); summary != "" {
 				h.Output.Newline()
 				h.Output.Info("%s", summary)
 			}
+		case submit.OutcomeOnTrunk:
+			printOnTrunkGuidance(h.Output, ev.Message)
 		case submit.OutcomeFailed:
 			// Quiet: the returned error is reported by the CLI; printing the
 			// generic message here would double-report the failure.
@@ -204,6 +296,27 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 			}
 		}
 	}
+}
+
+// completionSummary renders the post-submit PR list, leaning on the solo
+// formatting when only one branch was submitted.
+func (h *SimpleSubmitHandler) completionSummary() string {
+	if h.plan.solo {
+		return submitComponent.FormatSoloSummary(h.submitItems())
+	}
+	return submitComponent.FormatURLSummary(h.submitItems())
+}
+
+// printOnTrunkGuidance explains that submit does nothing from trunk and points
+// the user at the next step. headline carries the trunk-aware first line from
+// the action.
+func printOnTrunkGuidance(out output.Output, headline string) {
+	if headline != "" {
+		out.Info("%s", headline)
+	}
+	out.Tip("Check out a branch to submit its stack, or create one:")
+	out.Info("  stackit checkout <branch>")
+	out.Info("  stackit create -m \"feat: ...\"")
 }
 
 func (h *SimpleSubmitHandler) submitItems() []submitComponent.Item {
@@ -293,6 +406,9 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 			}
 		}
 		h.model.Items = items
+		// The plan already named a solo branch and printed its base, so the TUI
+		// drops the count header and the per-row branch name.
+		h.model.Solo = h.plan.solo
 
 		// Start the TUI now that there's real submission work to animate.
 		// Idempotent, so later events that arrive after this are safe.
@@ -326,6 +442,10 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 		// If the submission phase never started (nothing to submit, dry run,
 		// canceled), the TUI isn't running — print the outcome plainly.
 		if !h.runner.IsRunning() {
+			if ev.Outcome == submit.OutcomeOnTrunk {
+				printOnTrunkGuidance(h.out, ev.Message)
+				return
+			}
 			if ev.Outcome != submit.OutcomeFailed && ev.Message != "" {
 				h.out.Info("%s", ev.Message)
 			}

--- a/internal/cli/stack/submit_handlers_test.go
+++ b/internal/cli/stack/submit_handlers_test.go
@@ -100,7 +100,7 @@ func TestSimpleSubmitHandlerMergesPlanIntoStackList(t *testing.T) {
 	})
 
 	got := out.String()
-	require.Equal(t, 1, strings.Count(got, "Stack to submit:"))
+	require.Contains(t, got, "Stack to submit → main")
 	require.Contains(t, got, "● current-branch [CORE] → create")
 	require.Contains(t, got, "skipped-branch")
 	require.Contains(t, got, "— no changes")
@@ -130,8 +130,10 @@ func TestInteractiveSubmitHandlerPrintsPlanWithoutStartingTUI(t *testing.T) {
 	handler.OnEvent(submitAction.CompletionEvent{Outcome: submitAction.OutcomeUpToDate, Message: "All PRs up to date"})
 
 	got := out.String()
-	require.Contains(t, got, "Stack to submit:")
-	require.Contains(t, got, "up-to-date-branch")
+	// A lone branch drops the stack framing: no "Stack to submit" header, the
+	// branch reads as "name → base".
+	require.NotContains(t, got, "Stack to submit")
+	require.Contains(t, got, "up-to-date-branch → main")
 	require.Contains(t, got, "— no changes")
 	require.Contains(t, got, "All PRs up to date")
 }
@@ -162,6 +164,60 @@ func TestPlanPrinterShowsPRNumbersAndEmptyAnnotation(t *testing.T) {
 	require.Contains(t, got, "update-me → update #1189")
 	require.Contains(t, got, "empty-one → create")
 	require.Contains(t, got, "(empty)")
+}
+
+func TestSimpleSubmitHandlerSoloSubmitDropsStackFraming(t *testing.T) {
+	t.Parallel()
+
+	out := output.NewTestOutput()
+	handler := NewSimpleSubmitHandler(out)
+	branch := "jonnii/20260511011552/tighten-submit-output"
+
+	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+		Branches:      []string{branch},
+		CurrentBranch: branch,
+		TrunkBranch:   "main",
+		ParentMap:     map[string]string{branch: "main"},
+	}})
+	handler.OnEvent(submitAction.BranchPlanEvent{
+		BranchName: branch,
+		Action:     "create",
+		IsCurrent:  true,
+	})
+	handler.OnEvent(submitAction.SubmissionStartEvent{
+		Branches: []submitAction.BranchInfo{{Name: branch, Action: "create"}},
+	})
+	handler.OnEvent(submitAction.BranchProgressEvent{
+		BranchName: branch,
+		Status:     submitAction.StatusDone,
+		URL:        "https://github.com/getstackit/stackit/pull/1270",
+	})
+	handler.OnEvent(submitAction.CompletionEvent{Outcome: submitAction.OutcomeComplete, Message: "Submit complete"})
+
+	got := out.String()
+	require.Contains(t, got, "tighten-submit-output → main")
+	require.NotContains(t, got, "Stack to submit")
+	require.NotContains(t, got, "Submitting 1 branch")
+	require.NotContains(t, got, "Pull requests")
+	require.Contains(t, got, "#1270 created")
+	require.Contains(t, got, "https://github.com/getstackit/stackit/pull/1270")
+}
+
+func TestSimpleSubmitHandlerOnTrunkGuidance(t *testing.T) {
+	t.Parallel()
+
+	out := output.NewTestOutput()
+	handler := NewSimpleSubmitHandler(out)
+
+	handler.OnEvent(submitAction.CompletionEvent{
+		Outcome: submitAction.OutcomeOnTrunk,
+		Message: "You're on main — nothing to submit from here.",
+	})
+
+	got := out.String()
+	require.Contains(t, got, "You're on main — nothing to submit from here.")
+	require.Contains(t, got, "stackit checkout <branch>")
+	require.Contains(t, got, "stackit create")
 }
 
 func TestSimpleSubmitHandlerPrintsBranchWarnings(t *testing.T) {

--- a/internal/cli/stack/submit_test.go
+++ b/internal/cli/stack/submit_test.go
@@ -34,7 +34,7 @@ func TestSubmitCommand(t *testing.T) {
 		// 1. Basic submit (downstack)
 		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--dry-run", "--no-edit", "--draft", "--no-interactive")
 		expected := testhelpers.NormalizeOutput(`
-Stack to submit:
+Stack to submit → main
   branch-a → create (empty)
 ● branch-b → create (empty)
 Dry run complete
@@ -44,7 +44,7 @@ Dry run complete
 		// 2. Submit --stack (full stack)
 		output = runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--stack", "--dry-run", "--no-edit", "--draft", "--no-interactive")
 		expectedStack := testhelpers.NormalizeOutput(`
-Stack to submit:
+Stack to submit → main
   branch-a → create (empty)
 ● branch-b → create (empty)
   branch-c → create (empty)
@@ -57,6 +57,26 @@ Dry run complete
 		require.Equal(t, expectedStack, testhelpers.NormalizeOutput(output), "ss alias should behave like submit --stack")
 	})
 
+	t.Run("solo branch drops stack framing", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+			if err := testhelpers.InitialCommitSceneSetup(s); err != nil {
+				return err
+			}
+			runCliCommand(binaryPath, s.Dir, "init")
+			runCliCommand(binaryPath, s.Dir, "create", "solo-branch")
+			return nil
+		})
+
+		// A lone branch off trunk reads as "name → base", with no "Stack to
+		// submit" header.
+		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--dry-run", "--no-edit", "--draft", "--no-interactive")
+		normalized := testhelpers.NormalizeOutput(output)
+		require.NotContains(t, normalized, "Stack to submit")
+		require.Contains(t, normalized, "solo-branch → main")
+		require.Contains(t, normalized, "Dry run complete")
+	})
+
 	t.Run("no branches to submit reports cleanly", func(t *testing.T) {
 		t.Parallel()
 		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
@@ -67,10 +87,12 @@ Dry run complete
 			return nil
 		})
 
-		// On trunk with no stacked branches there is nothing to submit. Action
-		// is the single source of truth now (HasSubmitWork was folded in), so it
-		// must still surface the outcome.
+		// On trunk with no stacked branches there is nothing to submit. Standing
+		// on trunk is surfaced distinctly: the action points the user at creating
+		// or checking out a branch rather than printing a bare "nothing to submit".
 		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--no-edit", "--no-interactive")
-		require.Contains(t, testhelpers.NormalizeOutput(output), "No branches to submit")
+		normalized := testhelpers.NormalizeOutput(output)
+		require.Contains(t, normalized, "You're on main — nothing to submit from here.")
+		require.Contains(t, normalized, "stackit create")
 	})
 }

--- a/internal/tui/components/submit/format.go
+++ b/internal/tui/components/submit/format.go
@@ -109,6 +109,17 @@ func FormatCompactRow(item Item, width int, spinnerView string, styles Styles) s
 	return fmt.Sprintf("  %s %s%s%s", icon, name, strings.Repeat(" ", gapWidth), detail)
 }
 
+// FormatSoloRow renders the progress row for a single-branch submit. The branch
+// name is omitted — the plan line already named it — so the row is just the
+// status icon and detail (e.g. "  ✓ #1270 created").
+func FormatSoloRow(item Item, spinnerView string, styles Styles) string {
+	icon, detail := rowParts(item, spinnerView, styles)
+	if detail == "" {
+		return "  " + icon
+	}
+	return "  " + icon + " " + detail
+}
+
 func rowParts(item Item, spinnerView string, styles Styles) (string, string) {
 	switch item.Status {
 	case StatusSubmitting:
@@ -244,6 +255,20 @@ func FormatLinkedURLSummary(items []Item) string {
 		return ""
 	}
 	return "Pull requests\n\n" + strings.Join(rows, "\n")
+}
+
+// FormatSoloSummary renders the post-submit result for a single-branch submit:
+// the PR ref and action on one line, the URL on the next, both indented. Unlike
+// the stack summary there is no "Pull requests" header — one PR needs no list.
+func FormatSoloSummary(items []Item) string {
+	for _, item := range items {
+		if item.URL == "" {
+			continue
+		}
+		label := strings.TrimSpace(PRRef(item) + " " + pastTense(item.Action))
+		return "  " + label + "\n  " + item.URL
+	}
+	return ""
 }
 
 // FormatFailureSummary renders failed branches with their errors. The progress

--- a/internal/tui/components/submit/format_test.go
+++ b/internal/tui/components/submit/format_test.go
@@ -36,6 +36,61 @@ func TestFormatCompactRowOmitsInlineURL(t *testing.T) {
 	require.LessOrEqual(t, lipgloss.Width(stripANSIEscape(row)), 60)
 }
 
+func TestFormatSoloRowOmitsBranchName(t *testing.T) {
+	t.Parallel()
+
+	pr := 1270
+	row := stripANSIEscape(FormatSoloRow(Item{
+		BranchName: "jonnii/20260511011552/tighten-submit-output",
+		Action:     ActionCreate,
+		Status:     StatusDone,
+		PRNumber:   &pr,
+		URL:        "https://github.com/getstackit/stackit/pull/1270",
+	}, "", DefaultStyles()))
+
+	require.Equal(t, "  ✓ #1270 created", row)
+	require.NotContains(t, row, "tighten-submit-output")
+}
+
+func TestFormatSoloSummaryShowsRefAndURL(t *testing.T) {
+	t.Parallel()
+
+	pr := 1270
+	summary := FormatSoloSummary([]Item{{
+		BranchName: "jonnii/20260511011552/tighten-submit-output",
+		Action:     ActionCreate,
+		Status:     StatusDone,
+		PRNumber:   &pr,
+		URL:        "https://github.com/getstackit/stackit/pull/1270",
+	}})
+
+	require.Equal(t, "  #1270 created\n  https://github.com/getstackit/stackit/pull/1270", summary)
+	require.NotContains(t, summary, "Pull requests")
+}
+
+func TestModelSoloDropsHeaderAndName(t *testing.T) {
+	t.Parallel()
+
+	pr := 1270
+	m := NewModel([]Item{{
+		BranchName: "jonnii/20260511011552/tighten-submit-output",
+		Action:     ActionCreate,
+		Status:     StatusDone,
+		PRNumber:   &pr,
+		URL:        "https://github.com/getstackit/stackit/pull/1270",
+	}})
+	m.Solo = true
+
+	content := stripANSIEscape(m.content())
+	require.NotContains(t, content, "Submitting")
+	require.NotContains(t, content, "tighten-submit-output")
+	require.Contains(t, content, "#1270 created")
+
+	summary := stripANSIEscape(m.completionSummary())
+	require.NotContains(t, summary, "Pull requests")
+	require.Contains(t, summary, "https://github.com/getstackit/stackit/pull/1270")
+}
+
 func TestFormatURLSummaryRendersClickableRows(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -17,6 +17,7 @@ type Model struct {
 	core.BaseModel // Embedded for ReadySignaler interface
 	Items          []Item
 	Warnings       []string      // formatted warning lines, rendered after the rows and persisted on exit
+	Solo           bool          // single-branch submit — drop the count header and per-row name
 	spinner        spinner.Model // lowercase for custom style
 	Styles         Styles
 }
@@ -132,7 +133,11 @@ func (m *Model) content() string {
 		width = defaultSubmitWidth
 	}
 	for i, item := range m.Items {
-		b.WriteString(FormatCompactRow(item, width, m.spinner.View(), m.Styles))
+		if m.Solo {
+			b.WriteString(FormatSoloRow(item, m.spinner.View(), m.Styles))
+		} else {
+			b.WriteString(FormatCompactRow(item, width, m.spinner.View(), m.Styles))
+		}
 		if i < len(m.Items)-1 {
 			b.WriteString("\n")
 		}
@@ -152,7 +157,12 @@ func (m *Model) content() string {
 // which would otherwise be erased with the progress display. Warnings are
 // appended in either case so they survive the screen clear.
 func (m *Model) completionSummary() string {
-	summary := FormatLinkedURLSummary(m.Items)
+	var summary string
+	if m.Solo {
+		summary = FormatSoloSummary(m.Items)
+	} else {
+		summary = FormatLinkedURLSummary(m.Items)
+	}
 	if failures := FormatFailureSummary(m.Items); failures != "" {
 		if summary != "" {
 			summary += "\n\n"
@@ -169,6 +179,11 @@ func (m *Model) completionSummary() string {
 }
 
 func (m *Model) header() string {
+	// A solo submit is framed by the plan line printed above the TUI; a count
+	// header would just restate it.
+	if m.Solo {
+		return ""
+	}
 	count := len(m.Items)
 	if count == 0 {
 		return ""


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Submit framed every run the same way — a "Stack to submit:" header and a
per-branch tree — regardless of whether there was a real stack to show.
The output now adapts to where submit is run from:

- A lone branch off trunk reads as a single PR ("name → base"), dropping
  the stack header, the "Submitting 1 branch" count, the per-row branch
  name, and the "Pull requests" list in favor of a bare ref + URL.
- A real stack keeps the stack framing, now annotated with its base
  ("Stack to submit → main") and aligned action columns.
- Running submit while checked out on trunk surfaces a distinct outcome
  (OutcomeOnTrunk) that points at creating or checking out a branch,
  rather than a bare "No branches to submit".

The plan snapshot already carries the branch set, current branch, and
trunk, so the shape is known before the first plan line streams in.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1783682845`.


* **PR #935**
  * **PR #1189**
    * **PR #1190**
      * **PR #1194**
        * **PR #1195**
          * **PR #1196**
            * **PR #1197**
              * **PR #1270** 👈
                * **PR #1271**
                  * **PR #1399**
                    * **PR #1400**
                      * **PR #1401**
                        * **PR #1402**
                          * **PR #1403**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1404 by jonnii*