### PR TITLE
refactor!: rename `st log` to `st tree`

### DIFF
--- a/.github/workflows/stackit.yml
+++ b/.github/workflows/stackit.yml
@@ -101,5 +101,5 @@ jobs:
             exit 0
           fi
 
-          echo "::error::This PR is not at the bottom of the stack. Please merge the parent PR first.%0AParent branch: $PARENT_BRANCH%0A%0AUse 'st log' to view the full stack."
+          echo "::error::This PR is not at the bottom of the stack. Please merge the parent PR first.%0AParent branch: $PARENT_BRANCH%0A%0AUse 'st tree' to view the full stack."
           exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ This installs Go, gotestsum, goimports, golangci-lint, and CLI utilities (ripgre
 
 4. View your stack:
    ```bash
-   stackit log
+   stackit tree
    ```
 
 5. Submit your changes:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Stacks naturally form a tree structure—a single branch can have multiple child
 
 ## Features
 
-- 🌳 **Visual branch tree** — See your entire stack at a glance with `stackit log`
+- 🌳 **Visual branch tree** — See your entire stack at a glance with `stackit tree`
 - 🔄 **Automatic restacking** — Keep all branches up to date when you rebase or modify a parent
 - 📤 **Submit entire stacks** — Push all branches and create/update PRs in one command with progress tracking
 - 🔀 **Smart merging** — Merge stacks bottom-up or squash top-down
@@ -139,7 +139,7 @@ stackit create add-logic -m "feat: implement logic"
 ### 4. Visualize the stack
 See your current position in the stack:
 ```bash
-stackit log
+stackit tree
 ```
 ```
 ● add-logic ← you are here
@@ -245,7 +245,7 @@ stack-submit --stack         # Creates/updates all PRs in the stack
 | Command | Description |
 |:---|:---|
 | `stackit state` | Snapshot of the stack, working tree, and any in-progress operation (`--json` for a complete machine-readable snapshot) |
-| `stackit log` | Display the branch tree |
+| `stackit tree` | Display the branch tree |
 | `stackit checkout` | Interactive branch switcher |
 | `stackit up` / `down` | Move to the child or parent branch |
 | `stackit top` / `bottom` | Move to the top or bottom of the stack |
@@ -446,11 +446,11 @@ For machine-readable status, **`stackit state --json`** is the single snapshot t
 read: the current branch and trunk, working-tree state (`staged`/`unstaged`/
 `untracked`), any in-progress `operation` (`rebase`/`merge`) with its
 `conflicted_files`, and the full `stack`. The embedded `stack` is the same shape as
-`stackit log --json` — each branch reports its structure (`parent`, `children`),
+`stackit tree --json` — each branch reports its structure (`parent`, `children`),
 PR/CI state (`pr.state`, `pr.ci_status`, `pr.review_status`), and stack health
 (`needs_restack`, `is_locked`, `is_frozen`, `scope`), with the status booleans
 always present (an explicit `false`, never omitted). One `stackit state --json`
-call replaces combining `git status`, `stackit log --json`, and `stackit info`
+call replaces combining `git status`, `stackit tree --json`, and `stackit info`
 (and `stackit status` still passes through to `git status`).
 
 ---

--- a/doc/src/cli/index.md
+++ b/doc/src/cli/index.md
@@ -36,7 +36,7 @@ Complete command-line reference for stackit.
 
 Move around your stack efficiently.
 
-- $$stackit log$$ - Display the branch tree
+- $$stackit tree$$ - Display the branch tree
 - $$stackit checkout$$ - Interactive branch switcher
 - $$stackit up$$ / $$stackit down$$ - Move between parent/child branches
 - $$stackit top$$ / $$stackit bottom$$ - Jump to extremes

--- a/doc/src/guide/index.md
+++ b/doc/src/guide/index.md
@@ -34,7 +34,7 @@ This guide covers core concepts and troubleshooting for stackit. For practical u
 
 ### Essential Commands
 
-- $$stackit log$$ - View your stack
+- $$stackit tree$$ - View your stack
 - $$stackit create$$ - Create a new branch
 - $$stackit submit$$ - Create/update PRs
 - $$stackit sync$$ - Update from trunk

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -13,7 +13,7 @@ description: Stackit is a CLI tool for managing stacked Git branches. Break larg
 
     ---
 
-    See your entire stack at a glance with $$stackit log$$
+    See your entire stack at a glance with $$stackit tree$$
 
 -   :material-refresh-auto:{ .lg .middle } **Automatic restacking**
 

--- a/doc/src/integrations/claude.md
+++ b/doc/src/integrations/claude.md
@@ -159,7 +159,7 @@ Agent skills complement regular stackit commands. You can mix and match:
 stack-create my-feature
 
 # Use regular commands for simple tasks
-stackit log
+stackit tree
 stackit checkout parent-branch
 
 # Back to an agent skill for multi-branch operations
@@ -169,7 +169,7 @@ stack-absorb
 ## Best practices
 
 1. **Let the agent handle complexity**: Use agent skills for operations involving multiple branches
-2. **Use regular commands for navigation**: Simple operations like $$stackit log$$ don't need AI assistance
+2. **Use regular commands for navigation**: Simple operations like $$stackit tree$$ don't need AI assistance
 3. **Review suggestions**: The agent will explain what it's doing—review before proceeding
 4. **Leverage context awareness**: The skills understand your stack structure and can make intelligent decisions
 

--- a/doc/src/start/index.md
+++ b/doc/src/start/index.md
@@ -58,7 +58,7 @@ stackit create add-logic -m "feat: implement logic"
 ### 5. Visualize the stack
 
 ```bash
-stackit log
+stackit tree
 ```
 
 ```

--- a/doc/src/start/stack.md
+++ b/doc/src/start/stack.md
@@ -44,7 +44,7 @@ stackit create add-logic -m "feat: implement logic"
 See your current position in the stack:
 
 ```bash
-stackit log
+stackit tree
 ```
 
 ```

--- a/doc/src/worktrees/getting-started.md
+++ b/doc/src/worktrees/getting-started.md
@@ -68,7 +68,7 @@ git add feature.go
 stackit create add-feature -m "feat: add new feature"
 
 # View the stack
-stackit log
+stackit tree
 
 # Submit PRs
 stackit submit

--- a/docs/plans/perf/log.md
+++ b/docs/plans/perf/log.md
@@ -6,7 +6,7 @@
 
 ```
 executeLog → common.Run                          (same bootstrap family as co)
-  └─ actions.LogAction
+  └─ actions.TreeAction
        ├─ if --json:        logActionJSON
        ├─ if interactive:   tui.NewLogModel + tea.Run      (separate TUI path)
        │
@@ -68,9 +68,9 @@ A TTL cache (say 30s) keyed on the sorted branch name list would make repeated `
 
 ```
 STACKIT_NO_LOGGING=1 hyperfine \
-  'stackit log' \
-  'stackit log short' \
-  'stackit log full'
+  'stackit tree' \
+  'stackit tree short' \
+  'stackit tree full'
 ```
 
-Instrument: `BatchGetPRChecksStatus`, the `utils.Run` block in `LogAction`, individual `GetDiffStats` calls, and commit count calls. The cross-section between FULL and short is the GitHub cost; the cross-section between log and log short is the per-branch annotation work.
+Instrument: `BatchGetPRChecksStatus`, the `utils.Run` block in `TreeAction`, individual `GetDiffStats` calls, and commit count calls. The cross-section between FULL and short is the GitHub cost; the cross-section between log and log short is the per-branch annotation work.

--- a/docs/worktree.md
+++ b/docs/worktree.md
@@ -214,7 +214,7 @@ When you create a worktree with `wt create`, Stackit creates an **anchor branch*
 
 Anchor branches are automatically hidden from most UI surfaces:
 
-- **`stackit log`** — Anchors are filtered out of the tree. A stack like `main → wt-anchor → feature` renders as `main → feature`.
+- **`stackit tree`** — Anchors are filtered out of the tree. A stack like `main → wt-anchor → feature` renders as `main → feature`.
 - **Navigation (`up`, `down`, `top`, `bottom`)** — Navigation commands skip over anchors. Moving "down" from a feature branch in a worktree goes straight to trunk, not to the anchor.
 - **`stackit submit`** — PR parent resolution skips anchors. A branch parented to an anchor will have its PR base set to trunk (or the nearest real ancestor), not the anchor branch.
 

--- a/internal/actions/merge/multistack_discover.go
+++ b/internal/actions/merge/multistack_discover.go
@@ -27,7 +27,7 @@ func DiscoverStacks(eng engine.BranchReader) ([]MultiStackInfo, error) {
 }
 
 // DiscoverStacksWithSort is like DiscoverStacks but allows specifying the sort strategy.
-// Use SortStrategySmart to match the ordering of `stackit log`.
+// Use SortStrategySmart to match the ordering of `stackit tree`.
 func DiscoverStacksWithSort(eng engine.BranchReader, strategy engine.SortStrategy) ([]MultiStackInfo, error) {
 	independentStacks := engine.DiscoverIndependentStacksWithSort(eng, strategy)
 

--- a/internal/actions/state.go
+++ b/internal/actions/state.go
@@ -24,7 +24,7 @@ type StateResult struct {
 	Trunk         string            `json:"trunk"`
 	WorkingTree   WorkingTreeStatus `json:"working_tree"`
 	Operation     OperationStatus   `json:"operation"`
-	Stack         LogJSONResult     `json:"stack"`
+	Stack         TreeJSONResult    `json:"stack"`
 }
 
 // WorkingTreeStatus reports the staged/unstaged/untracked state of the worktree.
@@ -71,7 +71,7 @@ func BuildState(ctx *app.Context, _ StateOptions) StateResult {
 
 	result := StateResult{
 		Trunk: eng.Trunk().GetName(),
-		Stack: BuildLogJSON(ctx, LogOptions{Style: LogStyleNormal, JSON: true}),
+		Stack: BuildTreeJSON(ctx, TreeOptions{Style: TreeStyleNormal, JSON: true}),
 	}
 
 	if cur := eng.CurrentBranch(); cur != nil {

--- a/internal/actions/tree.go
+++ b/internal/actions/tree.go
@@ -18,16 +18,16 @@ import (
 	"github.com/getstackit/stackit/internal/utils"
 )
 
-// LogStyle defines the output style for the log command
+// TreeStyle defines the output style for the tree command
 const (
-	LogStyleNormal = "NORMAL"
-	LogStyleFull   = "FULL"
-	LogStyleShort  = "SHORT"
+	TreeStyleNormal = "NORMAL"
+	TreeStyleFull   = "FULL"
+	TreeStyleShort  = "SHORT"
 )
 
-// LogOptions contains options for the log command
-type LogOptions struct {
-	Style         string // LogStyleNormal, LogStyleFull, or LogStyleShort
+// TreeOptions contains options for the tree command
+type TreeOptions struct {
+	Style         string // TreeStyleNormal, TreeStyleFull, or TreeStyleShort
 	Steps         *int
 	BranchName    string
 	ShowUntracked bool
@@ -36,15 +36,15 @@ type LogOptions struct {
 	JSON          bool // Output in JSON format
 }
 
-// LogJSONResult represents the JSON output for the log command
-type LogJSONResult struct {
-	Branches        []LogBranchInfo `json:"branches"`
-	Summary         LogSummary      `json:"summary"`
-	GitHubAvailable bool            `json:"github_available"`
+// TreeJSONResult represents the JSON output for the tree command
+type TreeJSONResult struct {
+	Branches        []TreeBranchInfo `json:"branches"`
+	Summary         TreeSummary      `json:"summary"`
+	GitHubAvailable bool             `json:"github_available"`
 }
 
-// LogBranchInfo represents a single branch in JSON output
-type LogBranchInfo struct {
+// TreeBranchInfo represents a single branch in JSON output
+type TreeBranchInfo struct {
 	Name      string `json:"name"`
 	Parent    string `json:"parent,omitempty"`
 	IsCurrent bool   `json:"is_current"`
@@ -55,19 +55,19 @@ type LogBranchInfo struct {
 	// "this field isn't reported". This is what lets agents read PR/CI status and
 	// needs_restack/locked/frozen from a single command instead of also querying
 	// `info --stack --json`.
-	IsLocked     bool       `json:"is_locked"`
-	IsFrozen     bool       `json:"is_frozen"`
-	NeedsRestack bool       `json:"needs_restack"`
-	Commits      int        `json:"commits"`
-	Additions    int        `json:"additions,omitempty"`
-	Deletions    int        `json:"deletions,omitempty"`
-	PR           *LogPRInfo `json:"pr,omitempty"`
-	Scope        string     `json:"scope,omitempty"`
-	Children     []string   `json:"children,omitempty"`
+	IsLocked     bool        `json:"is_locked"`
+	IsFrozen     bool        `json:"is_frozen"`
+	NeedsRestack bool        `json:"needs_restack"`
+	Commits      int         `json:"commits"`
+	Additions    int         `json:"additions,omitempty"`
+	Deletions    int         `json:"deletions,omitempty"`
+	PR           *TreePRInfo `json:"pr,omitempty"`
+	Scope        string      `json:"scope,omitempty"`
+	Children     []string    `json:"children,omitempty"`
 }
 
-// LogPRInfo represents PR information in JSON output
-type LogPRInfo struct {
+// TreePRInfo represents PR information in JSON output
+type TreePRInfo struct {
 	Number       int    `json:"number"`
 	URL          string `json:"url,omitempty"`
 	Title        string `json:"title,omitempty"`
@@ -77,24 +77,24 @@ type LogPRInfo struct {
 	CIStatus     string `json:"ci_status,omitempty"`
 }
 
-// LogSummary represents summary statistics in JSON output
-type LogSummary struct {
+// TreeSummary represents summary statistics in JSON output
+type TreeSummary struct {
 	TotalBranches int `json:"total_branches"`
 	ApprovedCount int `json:"approved_count"`
 	InReviewCount int `json:"in_review_count"`
 }
 
-// LogAction displays the branch tree
-func LogAction(ctx *app.Context, opts LogOptions) error {
+// TreeAction displays the branch tree
+func TreeAction(ctx *app.Context, opts TreeOptions) error {
 	// JSON output mode
 	if opts.JSON {
-		return logActionJSON(ctx, opts)
+		return treeActionJSON(ctx, opts)
 	}
 
 	// If interactive mode is requested or auto-detected
 	if opts.Interactive || (utils.IsInteractive() && opts.Steps == nil) {
 		// Run interactive TUI
-		m := tui.NewLogModel(ctx.Context, ctx.Engine, ctx.GitHub(), tui.LogOptions{
+		m := tui.NewTreeModel(ctx.Context, ctx.Engine, ctx.GitHub(), tui.TreeOptions{
 			Style:         opts.Style,
 			ShowUntracked: opts.ShowUntracked,
 			Logger:        ctx.Logger,
@@ -125,15 +125,15 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 		Mode:        tree.RenderModeFull, // We want the full tree characters with stats
 		Steps:       opts.Steps,
 		ShowSHAs:    opts.ShowSHAs,
-		HideSummary: opts.Style == LogStyleShort,
+		HideSummary: opts.Style == TreeStyleShort,
 	}
-	visibleBranches := visibleLogBranches(renderer, opts.BranchName, renderOpts, allBranches)
+	visibleBranches := visibleTreeBranches(renderer, opts.BranchName, renderOpts, allBranches)
 
 	// Resolve the git-computed annotation stats (short SHA, commit count, diff
 	// stats) for just the visible branches as one batched value. Scoped to the
 	// visible set, so bounded views stay cheap; the short style needs none.
 	var stats map[string]engine.BranchStat
-	if opts.Style != LogStyleShort {
+	if opts.Style != TreeStyleShort {
 		stats = ctx.Engine.BatchBranchStats(visibleBranches)
 	}
 
@@ -142,7 +142,7 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 
 	// Prefetch CI status in batch if in FULL style
 	var ciStatuses map[string]*github.CheckStatus
-	if opts.Style == LogStyleFull && ctx.GitHub() != nil {
+	if opts.Style == TreeStyleFull && ctx.GitHub() != nil {
 		branchNames := visibleBranches.Select(engine.BranchFilter{ExcludeTrunk: true, RequirePR: true}).Names()
 		if len(branchNames) > 0 {
 			ciStatuses, _ = ctx.GitHub().BatchGetPRChecksStatus(ctx.Context, branchNames)
@@ -163,7 +163,7 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 
 	if len(visibleBranches) > 0 {
 		utils.Run(visibleBranches.All(), func(branchObj engine.Branch) {
-			annotation := buildLogAnnotation(ctx.Engine, branchObj, stats[branchObj.GetName()], opts, wtData, enrichment)
+			annotation := buildTreeAnnotation(ctx.Engine, branchObj, stats[branchObj.GetName()], opts, wtData, enrichment)
 			results <- result{branchObj.GetName(), annotation}
 		})
 	}
@@ -224,7 +224,7 @@ func LogAction(ctx *app.Context, opts LogOptions) error {
 	return nil
 }
 
-func visibleLogBranches(renderer *tree.StackTreeRenderer, branchName string, opts tree.RenderOptions, branches engine.Branches) engine.Branches {
+func visibleTreeBranches(renderer *tree.StackTreeRenderer, branchName string, opts tree.RenderOptions, branches engine.Branches) engine.Branches {
 	branchByName := make(map[string]engine.Branch, len(branches))
 	for _, b := range branches {
 		branchByName[b.GetName()] = b
@@ -245,15 +245,15 @@ func visibleLogBranches(renderer *tree.StackTreeRenderer, branchName string, opt
 	return visible.Build()
 }
 
-func buildLogAnnotation(
+func buildTreeAnnotation(
 	eng engine.Engine,
 	branch engine.Branch,
 	stat engine.BranchStat,
-	opts LogOptions,
+	opts TreeOptions,
 	wtData *tui.WorktreeData,
 	enrichment *tui.AnnotationEnrichment,
 ) tree.BranchAnnotation {
-	if opts.Style != LogStyleShort {
+	if opts.Style != TreeStyleShort {
 		return tui.BuildFullAnnotation(eng, branch, stat, enrichment, tui.AnnotationOptions{
 			SkipCommitMessages: true,
 		})
@@ -278,9 +278,9 @@ func getUntrackedBranchNames(ctx *app.Context) []string {
 	return untracked.Names()
 }
 
-// logActionJSON generates JSON output for the log command.
-func logActionJSON(ctx *app.Context, opts LogOptions) error {
-	result := BuildLogJSON(ctx, opts)
+// treeActionJSON generates JSON output for the tree command.
+func treeActionJSON(ctx *app.Context, opts TreeOptions) error {
+	result := BuildTreeJSON(ctx, opts)
 
 	data, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {
@@ -290,11 +290,11 @@ func logActionJSON(ctx *app.Context, opts LogOptions) error {
 	return nil
 }
 
-// BuildLogJSON builds the structured log result (branch tree, PR/CI status, and
+// BuildTreeJSON builds the structured log result (branch tree, PR/CI status, and
 // per-branch health) without printing it, so other commands — e.g. `status` —
 // can embed the same stack snapshot. The CI status prefetch always runs to
 // provide complete data.
-func BuildLogJSON(ctx *app.Context, opts LogOptions) LogJSONResult {
+func BuildTreeJSON(ctx *app.Context, opts TreeOptions) TreeJSONResult {
 	eng := ctx.Engine
 	currentBranch := eng.CurrentBranch()
 	currentBranchName := ""
@@ -331,16 +331,16 @@ func BuildLogJSON(ctx *app.Context, opts LogOptions) LogJSONResult {
 	}
 
 	// Build result
-	result := LogJSONResult{
-		Branches:        []LogBranchInfo{},
-		Summary:         LogSummary{},
+	result := TreeJSONResult{
+		Branches:        []TreeBranchInfo{},
+		Summary:         TreeSummary{},
 		GitHubAvailable: ghClient != nil,
 	}
 
 	// Collect branch info in parallel using worker pool (each branch requires
 	// git subprocesses for commits and diff stats)
 	type branchResult struct {
-		info LogBranchInfo
+		info TreeBranchInfo
 	}
 	branchResults := make(chan branchResult, len(branchesToInclude))
 
@@ -361,7 +361,7 @@ func BuildLogJSON(ctx *app.Context, opts LogOptions) LogJSONResult {
 		utils.Run(processableBranches.All(), func(branch engine.Branch) {
 			branchName := branch.GetName()
 
-			info := LogBranchInfo{
+			info := TreeBranchInfo{
 				Name:         branchName,
 				IsCurrent:    branchName == currentBranchName,
 				IsTrunk:      branch.IsTrunk(),
@@ -400,7 +400,7 @@ func BuildLogJSON(ctx *app.Context, opts LogOptions) LogJSONResult {
 			if !branch.IsTrunk() {
 				prInfo, _ := branch.GetPrInfo()
 				if prInfo != nil && prInfo.Number() != nil {
-					info.PR = &LogPRInfo{
+					info.PR = &TreePRInfo{
 						Number:  *prInfo.Number(),
 						URL:     prInfo.URL(),
 						Title:   prInfo.Title(),
@@ -455,7 +455,7 @@ func BuildLogJSON(ctx *app.Context, opts LogOptions) LogJSONResult {
 	}
 
 	// Keep output stable across runs even when collection happens in parallel.
-	slices.SortFunc(result.Branches, func(a, b LogBranchInfo) int {
+	slices.SortFunc(result.Branches, func(a, b TreeBranchInfo) int {
 		return cmp.Compare(a.Name, b.Name)
 	})
 

--- a/internal/cli/branch/create_test.go
+++ b/internal/cli/branch/create_test.go
@@ -230,11 +230,11 @@ func TestCreateCommand(t *testing.T) {
 		require.Equal(t, "feature", currentBranch)
 
 		// Verify stackit is now initialized by running a command that requires init
-		// The log command would fail if not initialized, so success here proves auto-init worked
-		cmd = exec.Command(binaryPath, "log", "--stack")
+		// The tree command would fail if not initialized, so success here proves auto-init worked
+		cmd = exec.Command(binaryPath, "tree", "--stack")
 		cmd.Dir = scene.Dir
 		output, err = cmd.CombinedOutput()
-		require.NoError(t, err, "log command failed after auto-init: %s", string(output))
+		require.NoError(t, err, "tree command failed after auto-init: %s", string(output))
 		require.Contains(t, string(output), "feature")
 	})
 

--- a/internal/cli/dashboard/styles.go
+++ b/internal/cli/dashboard/styles.go
@@ -45,7 +45,7 @@ var (
 // lipgloss.HasDarkBackground (via DimStyle/SubtleStyle), which writes an
 // OSC 11 + DA1 query pair to stdout to ask the terminal for its background
 // color. Loading at package-init time means those queries leak as visible
-// escape codes on every CLI invocation — even ones like `stackit log` or
+// escape codes on every CLI invocation — even ones like `stackit tree` or
 // `stackit version` that don't render adaptive styles at all — because the
 // dashboard package is transitively imported by the root command.
 var (

--- a/internal/cli/integrations/agents/templates/agents-block.md
+++ b/internal/cli/integrations/agents/templates/agents-block.md
@@ -26,7 +26,7 @@ stackit submit                          # Submit all PRs
 | `stackit submit` | Push & create/update PRs |
 | `stackit restack --upstack` | Rebase children after editing a branch (never manual `git rebase`) |
 | `stackit sync` | Pull trunk, cleanup merged |
-| `stackit log` | Visualize branch tree |
+| `stackit tree` | Visualize branch tree |
 
 Run `/stackit` for the full skill, or `/stack-status` to check current state.
 <!-- stackit:end -->

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-absorb.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-absorb.md
@@ -51,7 +51,7 @@ Absorb staged fixes into the commits that last touched the changed lines.
 8. Finish with:
 
    ```bash
-   stackit log --no-interactive
+   stackit tree --no-interactive
    ```
 
 Do not continue past repeated verification failures; report the failing branch and recovery options.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-create.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-create.md
@@ -67,7 +67,7 @@ Use a staged preflight. Do not eagerly gather every git view up front.
 9. Verify after mutation, not before:
 
    ```bash
-   stackit log --no-interactive
+   stackit tree --no-interactive
    ```
 
 10. Report:
@@ -84,5 +84,5 @@ Use a staged preflight. Do not eagerly gather every git view up front.
 - Use `git commit` to create the branch.
 - Use `git checkout -b`.
 - Chain staging and creation in one shell command.
-- Run `git status`, multiple `git diff` variants, `git log`, and `stackit log` all up front when one or two targeted checks would do.
+- Run `git status`, multiple `git diff` variants, `git log`, and `stackit tree` all up front when one or two targeted checks would do.
 - Introduce a fallback branch name after a permission failure. Preserve the pattern-driven command and retry it with approval instead.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-describe.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-describe.md
@@ -11,7 +11,7 @@ Generate or refresh stack and PR descriptions from the current branch history.
 1. Inspect:
 
    ```bash
-   stackit log --no-interactive
+   stackit tree --no-interactive
    git log --oneline --decorate -20
    ```
 

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-extract.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-extract.md
@@ -31,7 +31,7 @@ Move files or commits off the current branch onto a new sibling, parent, or chil
 4. Verify:
 
    ```bash
-   stackit log --no-interactive
+   stackit tree --no-interactive
    git status --short
    ```
 

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-fix.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-fix.md
@@ -33,6 +33,6 @@ Diagnose stack problems and apply the smallest safe repair.
    stackit undo --no-interactive --yes
    ```
 
-5. Verify with `stackit log --no-interactive` and the lightest relevant build/test command.
+5. Verify with `stackit tree --no-interactive` and the lightest relevant build/test command.
 
 Do not delete branches or undo work without explicit user approval.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-fold.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-fold.md
@@ -42,4 +42,4 @@ Fold a branch into its parent when it is too small to review separately.
    stackit restack --branch <parent-branch> --upstack --no-interactive
    ```
 
-7. Verify with `stackit log --no-interactive`.
+7. Verify with `stackit tree --no-interactive`.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-modify.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-modify.md
@@ -42,10 +42,10 @@ Amend the current stacked branch or add a follow-up commit to it.
    printf '%s\n' "<message>" | stackit modify --no-interactive -c -F -
    ```
 
-4. Verify (run `stackit log` only after the mutation):
+4. Verify (run `stackit tree` only after the mutation):
 
    ```bash
-   stackit log --no-interactive
+   stackit tree --no-interactive
    ```
 
 `stackit modify` automatically restacks descendant branches — do not run a manual

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-plan.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-plan.md
@@ -77,7 +77,7 @@ Split uncommitted working-tree changes into multiple stacked branches. Primary o
 
      ```bash
      git branch -D "$BACKUP"
-     stackit log --no-interactive
+     stackit tree --no-interactive
      ```
 
    - **Failure:** any create produced an empty branch, any check failed, or any

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-resolve.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-resolve.md
@@ -33,6 +33,6 @@ Resolve an in-progress Stackit conflict and continue the operation.
 
 5. If another conflict appears, repeat.
 
-6. Verify with `stackit log --no-interactive` and the relevant check command.
+6. Verify with `stackit tree --no-interactive` and the relevant check command.
 
 Use `stackit abort --no-interactive` only if the user asks to abort.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-restack.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-restack.md
@@ -32,5 +32,5 @@ Rebase stack branches according to Stackit metadata.
    `stackit restack --branch <conflicted-branch> --upstack --no-interactive`, then
    resolve and `stackit continue`.
 
-5. Verify with `stackit log --no-interactive`. When done, report the result and
+5. Verify with `stackit tree --no-interactive`. When done, report the result and
    suggest `stackit submit` to update PRs, then stop.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-split.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-split.md
@@ -43,6 +43,6 @@ Split committed changes on the current branch into another stacked branch.
 
 7. Verify both resulting branches with the detected check command.
 
-8. Finish with `stackit log --no-interactive`.
+8. Finish with `stackit tree --no-interactive`.
 
 Use `stackit undo --no-interactive --yes` only after explicit rollback approval.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-status.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-status.md
@@ -1,5 +1,5 @@
 ---
-description: Use when the user wants to inspect stack health and state. Trigger phrases include "show the stack", "what's in my stack", "stack status", and "stack health". Reads `stackit log` and reports.
+description: Use when the user wants to inspect stack health and state. Trigger phrases include "show the stack", "what's in my stack", "stack status", and "stack health". Reads `stackit tree` and reports.
 ---
 
 # Stack Status
@@ -31,4 +31,4 @@ When you detect an issue, recommend the matching command (don't invent one):
 | PR approved / ready to merge | `stackit merge --yes --no-interactive` (merge the next ready PR) or `stackit merge ship --yes --no-interactive` (consolidate the whole stack) |
 | Trunk behind remote | `stackit sync --no-interactive` |
 
-Use plain `stackit log --no-interactive` when the user wants the visual stack.
+Use plain `stackit tree --no-interactive` when the user wants the visual stack.

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-sync.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-sync.md
@@ -48,5 +48,5 @@ Sync with trunk and clean up branches that have landed.
 7. Verify:
 
    ```bash
-   stackit log --no-interactive
+   stackit tree --no-interactive
    ```

--- a/internal/cli/integrations/agents/templates/codex/commands/stack-tidy.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-tidy.md
@@ -12,7 +12,7 @@ Squash branches whose history is dominated by fixup, WIP, or noise commits, leav
 
    ```bash
    git status --short
-   stackit log --no-interactive
+   stackit tree --no-interactive
    stackit info --stack --json --no-interactive
    ```
 
@@ -58,7 +58,7 @@ Squash branches whose history is dominated by fixup, WIP, or noise commits, leav
 9. Verify:
 
    ```bash
-   stackit log --no-interactive
+   stackit tree --no-interactive
    ```
 
 ## Do Not

--- a/internal/cli/integrations/agents/templates/codex/skill/SKILL.md
+++ b/internal/cli/integrations/agents/templates/codex/skill/SKILL.md
@@ -12,7 +12,7 @@ Stackit manages stacked Git branches: small dependent PRs instead of one large r
 - Pass `--no-interactive` on Stackit commands (or set `STACKIT_NO_INTERACTIVE=1` once in the environment instead of repeating the flag — interactive features also auto-disable when there's no TTY). Add `--force` for absorb and `--yes` for undo. Bare `stackit merge` (no flags) opens a TTY wizard; non-interactively, `stackit merge --yes` merges the next (bottom) ready PR, or `stackit merge ship --yes` consolidates the whole stack into one PR.
 - Stage changes before `stackit create`.
 - Pipe commit messages via `-F -`: `printf '%s\n' "feat: x" | stackit create -F - --no-interactive`.
-- After any mutation, run `stackit log --no-interactive` and report the resulting stack.
+- After any mutation, run `stackit tree --no-interactive` and report the resulting stack.
 
 ## Asking Policy
 

--- a/internal/cli/integrations/agents/templates/codex/skill/references/stack-plan-recovery.md
+++ b/internal/cli/integrations/agents/templates/codex/skill/references/stack-plan-recovery.md
@@ -25,13 +25,13 @@ branches are gone, checking after each:
 
 ```bash
 stackit undo --no-interactive --yes
-stackit log --no-interactive
+stackit tree --no-interactive
 ```
 
 ## Continue From The Last Successful Branch
 
 ```bash
-stackit log --no-interactive
+stackit tree --no-interactive
 git checkout stack-plan-backup-<timestamp>
 git diff <last-created-branch>..stack-plan-backup-<timestamp> --stat
 git checkout <last-created-branch>

--- a/internal/cli/integrations/agents/templates/codex/skill/references/workflows.md
+++ b/internal/cli/integrations/agents/templates/codex/skill/references/workflows.md
@@ -7,7 +7,7 @@ These notes support the narrow Codex skills. Prefer the narrow skill body when i
 ```bash
 git add -A
 printf '%s\n' "feat: add auth middleware" | stackit create -F - --no-interactive
-stackit log --no-interactive
+stackit tree --no-interactive
 ```
 
 With an explicit branch name:
@@ -29,7 +29,7 @@ Use another stacked branch when the work is a separate reviewable unit.
 ## Submit PRs
 
 ```bash
-stackit log --no-interactive
+stackit tree --no-interactive
 stackit submit --no-interactive
 stackit submit --stack --no-interactive
 stackit submit --draft --no-interactive

--- a/internal/cli/integrations/agents/templates/commands/stack-create.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-create.md
@@ -46,7 +46,7 @@ Create a new stacked branch with the current changes.
      - Options: Generate 2-3 sensible suggestions based on the codebase + user can type custom
    - Retry with `--scope <value>`
 10. If creation fails because Git cannot write under `.git/refs/heads` or create a `.lock` file, retry the exact same command with the required permission or approval. Do not change the branch name just to work around that failure.
-11. After success, run `stackit log --no-interactive` and report:
+11. After success, run `stackit tree --no-interactive` and report:
    - branch name
    - parent branch
    - commit subject

--- a/internal/cli/integrations/agents/templates/commands/stack-describe.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-describe.md
@@ -10,7 +10,7 @@ Generate a comprehensive description for the current stack based on all changes.
 
 ## Context
 - Current branch: !`git branch --show-current`
-- Stack state: !`stackit log --no-interactive`
+- Stack state: !`stackit tree --no-interactive`
 - Stack info: !`stackit info --stack --json --no-interactive`
 - Current description: !`stackit describe --show --no-interactive`
 

--- a/internal/cli/integrations/agents/templates/commands/stack-extract.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-extract.md
@@ -57,7 +57,7 @@ siblings on the same parent instead of a linear chain.
 
 After extraction, verify:
 ```bash
-stackit log  # Both branches should be siblings on the same parent
+stackit tree  # Both branches should be siblings on the same parent
 <build-command>      # All checks should pass (check README.md for project's build command)
 ```
 

--- a/internal/cli/integrations/agents/templates/commands/stack-fix.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-fix.md
@@ -24,14 +24,14 @@ Check the context and look for these indicators:
 **Build/lint/test failures** (user reports build errors, or you see compiler errors):
 - Follow the Build Failure Workflow below
 
-**Branches need restack** (stackit log shows "needs restack" or branches are out of sync):
+**Branches need restack** (stackit tree shows "needs restack" or branches are out of sync):
 - Restack only the affected independent stack:
   - If the affected branch is known, run `stackit restack --branch <affected-branch> --upstack --no-interactive`.
   - If only the stack root is known, run `stackit restack --branch <stack-root> --upstack --no-interactive`.
   - If several independent stack roots are known, run `stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
   - If every independent stack should be processed, run `stackit restack --all-stacks --continue-on-conflict --no-interactive`.
 
-**Orphaned branches** (stackit log shows branch with no parent, or parent was merged):
+**Orphaned branches** (stackit tree shows branch with no parent, or parent was merged):
 - Run `stackit sync --no-interactive`
 
 **Uncommitted changes** (git status shows modified/untracked files):
@@ -43,7 +43,7 @@ Check the context and look for these indicators:
     - "I'll commit them" - Wait for user to commit
     - "Discard them" - Reset working tree (destructive)
 
-**Not on tracked branch** (current branch not shown in stackit log with ◉):
+**Not on tracked branch** (current branch not shown in stackit tree with ◉):
 - Guide user to checkout a tracked branch first
 
 ### 2. Rebase Conflict Resolution Workflow
@@ -88,7 +88,7 @@ stackit modify --no-edit --no-interactive
 
 #### Step 6: Verify
 ```bash
-stackit log  # Should show clean tree, no "needs restack"
+stackit tree  # Should show clean tree, no "needs restack"
 <build-command>      # All checks should pass
 ```
 
@@ -182,7 +182,7 @@ If it stops at another failure, repeat from Step 2 (there may be multiple indepe
 ### 4. After Fixes
 
 Verify stack is healthy:
-- `stackit log` shows clean tree
+- `stackit tree` shows clean tree
 - All branches pass checks
 
 ## Key Insight

--- a/internal/cli/integrations/agents/templates/commands/stack-fold.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-fold.md
@@ -10,7 +10,7 @@ Fold (squash) granular branches into their parent branches.
 
 ## Context
 - Current branch: !`git branch --show-current`
-- Stack state: !`stackit log --no-interactive`
+- Stack state: !`stackit tree --no-interactive`
 - Stack info: !`stackit info --stack --json --no-interactive`
 
 ## Instructions

--- a/internal/cli/integrations/agents/templates/commands/stack-modify.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-modify.md
@@ -12,7 +12,7 @@ argument-hint: [-m "message"] [-a] [-c] [--no-edit]
 - Unstaged changes: !`git diff --stat | head -20`
 - Staged changes: !`git diff --cached --stat | head -20`
 - Recent commits on branch: !`git log --oneline -5`
-- Stack state: !`stackit log --no-interactive`
+- Stack state: !`stackit tree --no-interactive`
 
 ## Arguments
 $ARGUMENTS

--- a/internal/cli/integrations/agents/templates/commands/stack-plan.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-plan.md
@@ -441,7 +441,7 @@ After all branches are created successfully:
 git branch -D "$BACKUP_BRANCH"
 
 # Show the final stack
-stackit log --no-interactive
+stackit tree --no-interactive
 ```
 
 Present a summary:
@@ -458,7 +458,7 @@ Created N branches from Y files:
 Backup branch deleted (changes now live in stack).
 
 Stack structure:
-<stackit log output>
+<stackit tree output>
 
 Next steps:
 - Run /stack-submit to create PRs

--- a/internal/cli/integrations/agents/templates/commands/stack-resolve.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-resolve.md
@@ -126,7 +126,7 @@ After rebase continues successfully:
 
 2. **If clean:**
    ```bash
-   stackit log --no-interactive
+   stackit tree --no-interactive
    ```
    Show the updated stack state.
 

--- a/internal/cli/integrations/agents/templates/commands/stack-review.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-review.md
@@ -50,7 +50,7 @@ Perform code reviews on stack PRs in parallel, reporting high-confidence issues 
 Get all branches in the stack that have open PRs:
 
 ```bash
-stackit log --json --no-interactive
+stackit tree --json --no-interactive
 ```
 
 Parse the JSON to identify branches with PRs. For each branch, check if the PR is reviewable:

--- a/internal/cli/integrations/agents/templates/commands/stack-split.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-split.md
@@ -82,7 +82,7 @@ Get the commits on the current branch that will be analyzed for splitting:
 
 ```bash
 # Get parent branch from stackit metadata
-stackit log --no-interactive
+stackit tree --no-interactive
 
 # Get the diff between parent and current branch HEAD
 # This shows all changes that could be split
@@ -442,7 +442,7 @@ After both branches are verified successfully:
 
 ```bash
 # Show the final stack
-stackit log --no-interactive
+stackit tree --no-interactive
 ```
 
 Present a summary:
@@ -459,7 +459,7 @@ Child branch [<child-branch>]:
   - A hunks, B files
 
 Stack structure:
-<stackit log output>
+<stackit tree output>
 
 Recovery: If anything is wrong, run `stackit undo` to restore.
 

--- a/internal/cli/integrations/agents/templates/commands/stack-status.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-status.md
@@ -19,7 +19,7 @@ Summarize from the `stackit state --json` context:
 - Working tree (`working_tree`) and any in-progress `operation`
 - Parent/child relationships and any branches that need attention
 
-If the user wants the visual tree, run `stackit log --no-interactive` and show it.
+If the user wants the visual tree, run `stackit tree --no-interactive` and show it.
 
 ### Step 2: Health Analysis
 

--- a/internal/cli/integrations/agents/templates/commands/stack-submit.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-submit.md
@@ -78,5 +78,5 @@ After successful submit, use `AskUserQuestion`:
 
 Based on response:
 - **"Sync with trunk"**: Invoke `/stack-sync` skill using the `Skill` tool
-- **"Check PR status"**: Run `stackit log full --no-interactive`
+- **"Check PR status"**: Run `stackit tree full --no-interactive`
 - **"Done for now"**: End with summary including PR URLs from the submit output

--- a/internal/cli/integrations/agents/templates/commands/stack-sync.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-sync.md
@@ -23,7 +23,7 @@ Sync the stack with trunk: pull latest, cleanup merged branches, restack.
    - If refreshed `would_restack_stacks` has exactly one root, run `stackit restack --branch <that-root> --upstack --no-interactive`.
    - If refreshed `would_restack_stacks` lists several roots, run `stackit restack --stacks <root-a>,<root-b> --continue-on-conflict --no-interactive`.
    - If every remaining independent stack needs restack or the refreshed root list is unavailable, run `stackit restack --all-stacks --continue-on-conflict --no-interactive`.
-8. Show final state with `stackit log --json --no-interactive`.
+8. Show final state with `stackit tree --json --no-interactive`.
 
 If `--continue-on-conflict` reports skipped conflicts, no rebase is active for those skipped branches. To resolve one, run `stackit restack --branch <conflicted-branch> --upstack --no-interactive`, then resolve conflicts and run `stackit continue`.
 

--- a/internal/cli/integrations/agents/templates/commands/stack-tidy.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-tidy.md
@@ -11,7 +11,7 @@ Clean up commits across the stack by squashing fixup/WIP commits into meaningful
 ## Context
 - Current branch: !`git branch --show-current`
 - Uncommitted changes: !`git status --short`
-- Stack state: !`stackit log --no-interactive`
+- Stack state: !`stackit tree --no-interactive`
 - Stack info: !`stackit info --stack --json --no-interactive`
 
 ## Task
@@ -85,7 +85,7 @@ Skip REVIEW and SKIP branches.
 
 ### Step 7: Show Results
 
-Show final stack state with `stackit log --no-interactive`.
+Show final stack state with `stackit tree --no-interactive`.
 
 ## Tool Trust
 
@@ -113,5 +113,5 @@ After successful tidy, use `AskUserQuestion`:
 
 Based on response:
 - **"Submit changes"**: Invoke `/stack-submit` skill using the `Skill` tool
-- **"View final stack"**: Run `stackit log --no-interactive` and display
+- **"View final stack"**: Run `stackit tree --no-interactive` and display
 - **"Done for now"**: End with summary of what was tidied

--- a/internal/cli/integrations/agents/templates/commands/stack-verify.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-verify.md
@@ -153,5 +153,5 @@ After verification completes, use `AskUserQuestion` based on results:
 Based on response:
 - **"Submit PRs"**: Invoke `/stack-submit` skill using the `Skill` tool
 - **"Fix issues"**: Invoke `/stack-fix` skill using the `Skill` tool
-- **"View stack"** / **"View details"**: Run `stackit log --no-interactive`
+- **"View stack"** / **"View details"**: Run `stackit tree --no-interactive`
 - **"Done for now"**: End with summary of verification results

--- a/internal/cli/integrations/agents/templates/skill/SKILL.md
+++ b/internal/cli/integrations/agents/templates/skill/SKILL.md
@@ -37,7 +37,7 @@ You are an expert at using Stackit to manage stacked Git branches. Stackit helps
 
 ## Before Any Operation
 
-**Always run `stackit log --no-interactive` first** to understand:
+**Always run `stackit tree --no-interactive` first** to understand:
 - Current branch position in the stack
 - Parent/child relationships
 - Which branches need attention
@@ -100,7 +100,7 @@ bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
    echo "feat: add user authentication" | stackit create -F - --all --no-interactive
    ```
 4. If currently on trunk (e.g., main/master), warn and confirm or switch to a feature branch before creating.
-5. Show stack: `stackit log --no-interactive`
+5. Show stack: `stackit tree --no-interactive`
 
 ### Adding More Commits to a Branch
 
@@ -116,7 +116,7 @@ When to use multiple commits vs new branches:
 
 ### Submitting PRs
 
-1. Check stack state: `stackit log --no-interactive`
+1. Check stack state: `stackit tree --no-interactive`
 2. Submit options:
    - Current + ancestors: `stackit submit --no-interactive`
    - Entire stack: `stackit submit --stack --no-interactive`
@@ -246,7 +246,7 @@ When working with stacks, NEVER use these git commands:
 
 1. **NEVER use `git commit` to create new stacked branches** - always use `stackit create`
 2. **Stage changes BEFORE running `stackit create`** - it requires staged changes to work correctly
-3. **Check state before destructive operations** - run `stackit log` first
+3. **Check state before destructive operations** - run `stackit tree` first
 4. **Always validate after absorb** - absorb can cause compilation errors, see fix-absorb workflow
 5. **Handle conflicts gracefully** - guide user through resolution, see conflict-resolution workflow
 6. **Keep PRs small and focused** - suggest splitting if too large

--- a/internal/cli/integrations/agents/templates/skill/commands/navigation.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/navigation.md
@@ -8,8 +8,8 @@ Commands for moving through your stack and viewing stack state.
 
 | Command | Description |
 |---------|-------------|
-| `stackit log --no-interactive` | Display the branch tree visualization |
-| `stackit log full --no-interactive` | Show tree with GitHub PR status and CI checks |
+| `stackit tree --no-interactive` | Display the branch tree visualization |
+| `stackit tree full --no-interactive` | Show tree with GitHub PR status and CI checks |
 | `stackit checkout [branch] --no-interactive` | Switch to a specific branch |
 
 ## Movement Commands
@@ -32,6 +32,6 @@ Commands for moving through your stack and viewing stack state.
 
 ## Quick Tips
 
-- Always run `stackit log --no-interactive` first to understand your position
+- Always run `stackit tree --no-interactive` first to understand your position
 - Use `stackit checkout <branch> --no-interactive` to switch to a specific branch
-- `stackit log full --no-interactive` shows PR status - useful before submitting
+- `stackit tree full --no-interactive` shows PR status - useful before submitting

--- a/internal/cli/integrations/agents/templates/skill/commands/recovery.md
+++ b/internal/cli/integrations/agents/templates/skill/commands/recovery.md
@@ -48,7 +48,7 @@ stackit abort --no-interactive
 stackit undo --no-interactive --yes
 
 # Check if it worked
-stackit log --no-interactive
+stackit tree --no-interactive
 ```
 
 ### Branch Needs Restack
@@ -110,7 +110,7 @@ stackit modify --no-interactive
 
 ```bash
 # View structure
-stackit log --no-interactive
+stackit tree --no-interactive
 
 # Get detailed info
 stackit info --no-interactive
@@ -135,7 +135,7 @@ stackit debug --no-interactive
 ## Troubleshooting Checklist
 
 When things go wrong:
-1. Check status: `git status` and `stackit log --no-interactive`
+1. Check status: `git status` and `stackit tree --no-interactive`
 2. Look for interrupted operations (rebase, merge)
 3. Try `stackit doctor --no-interactive` for automatic fixes
 4. If stuck, `stackit abort --no-interactive` then `stackit undo --no-interactive --yes`

--- a/internal/cli/integrations/agents/templates/skill/reference.md
+++ b/internal/cli/integrations/agents/templates/skill/reference.md
@@ -37,8 +37,8 @@ bash ~/.claude/skills/stackit/scripts/analyze_stack.sh
 | Command | Description |
 |---------|-------------|
 | `stackit state --json` | Complete one-call snapshot (branch, working tree, in-progress operation, full stack) — preferred for programmatic reads |
-| `stackit log` | Display the branch tree visualization |
-| `stackit log full` | Show tree with GitHub PR status and CI checks |
+| `stackit tree` | Display the branch tree visualization |
+| `stackit tree full` | Show tree with GitHub PR status and CI checks |
 | `stackit checkout [branch]` | Switch to a specific branch |
 | `stackit up` | Move to the child branch |
 | `stackit down` | Move to the parent branch |

--- a/internal/cli/integrations/agents/templates/skill/scripts/analyze_stack.sh
+++ b/internal/cli/integrations/agents/templates/skill/scripts/analyze_stack.sh
@@ -28,14 +28,14 @@ if ! git rev-parse --git-dir > /dev/null 2>&1; then
 fi
 
 # Check if stackit is initialized
-if ! stackit log > /dev/null 2>&1; then
+if ! stackit tree > /dev/null 2>&1; then
     echo -e "${RED}❌ Stackit not initialized in this repository${NC}"
     echo "→ Run: stackit init"
     exit 1
 fi
 
 echo -e "${BLUE}Current Stack:${NC}"
-stackit log
+stackit tree
 echo
 
 # Fetch one authoritative snapshot as JSON: the working tree, any in-progress

--- a/internal/cli/integrations/agents/templates/skill/workflows/absorb-conflict.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/absorb-conflict.md
@@ -50,7 +50,7 @@ When absorb fails with a conflict, identify where the change should go:
 stackit absorb --dry-run --no-interactive
 
 # View commits in current branch's stack
-stackit log --no-interactive
+stackit tree --no-interactive
 
 # See what each commit changed
 git log --oneline --stat HEAD~5..HEAD
@@ -171,7 +171,7 @@ After resolution:
 
 ```bash
 # 1. Verify the stack structure
-stackit log --no-interactive
+stackit tree --no-interactive
 
 # 2. Build/test each affected branch (use project's commands from README.md)
 stackit foreach --no-interactive "<build-command>"
@@ -298,4 +298,4 @@ Check `git stash list` - absorb stashes changes before starting. Use `git stash 
 - All staged changes applied to appropriate commits
 - No conflict markers in any files
 - Stack builds and tests pass
-- `stackit log --no-interactive` shows clean structure
+- `stackit tree --no-interactive` shows clean structure

--- a/internal/cli/integrations/agents/templates/skill/workflows/conflict-resolution.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/conflict-resolution.md
@@ -366,7 +366,7 @@ When restacking affects multiple branches:
 
 ```bash
 # Example workflow
-stackit log --no-interactive  # Note branch order
+stackit tree --no-interactive  # Note branch order
 
 # Resolve first conflict
 git status  # See conflicted files
@@ -376,7 +376,7 @@ stackit continue --no-interactive
 
 # Before moving to next conflict, verify
 <build-command>
-stackit log --no-interactive  # Confirm structure still correct
+stackit tree --no-interactive  # Confirm structure still correct
 
 # Continue to next conflict
 # ... resolve conflicts ...
@@ -400,7 +400,7 @@ stackit continue --no-interactive
 
 ```bash
 # Operation already completed or aborted
-stackit log --no-interactive  # Check current state
+stackit tree --no-interactive  # Check current state
 ```
 
 ### "Conflict resolution broke the build"
@@ -452,7 +452,7 @@ stackit continue --no-interactive
 # → Restack completes
 
 # 8. Verify final state
-stackit log --no-interactive
+stackit tree --no-interactive
 # → Stack structure correct
 ```
 
@@ -462,4 +462,4 @@ stackit log --no-interactive
 - ✓ Project builds successfully
 - ✓ Tests pass
 - ✓ Operation completed (not still in progress)
-- ✓ Stack structure is correct (`stackit log --no-interactive`)
+- ✓ Stack structure is correct (`stackit tree --no-interactive`)

--- a/internal/cli/integrations/agents/templates/skill/workflows/fix-absorb.md
+++ b/internal/cli/integrations/agents/templates/skill/workflows/fix-absorb.md
@@ -243,5 +243,5 @@ stackit foreach --no-interactive "<build-command>"
 
 - ✓ All branches build without errors
 - ✓ All branches pass tests
-- ✓ Stack structure is clean (`stackit log --no-interactive` shows proper tree)
+- ✓ Stack structure is clean (`stackit tree --no-interactive` shows proper tree)
 - ✓ No git conflicts or issues

--- a/internal/cli/integrations/github/templates/stackit.yml
+++ b/internal/cli/integrations/github/templates/stackit.yml
@@ -101,5 +101,5 @@ jobs:
             exit 0
           fi
 
-          echo "::error::This PR is not at the bottom of the stack. Please merge the parent PR first.%0AParent branch: $PARENT_BRANCH%0A%0AUse 'st log' to view the full stack."
+          echo "::error::This PR is not at the bottom of the stack. Please merge the parent PR first.%0AParent branch: $PARENT_BRANCH%0A%0AUse 'st tree' to view the full stack."
           exit 1

--- a/internal/cli/navigation/checkout_handlers.go
+++ b/internal/cli/navigation/checkout_handlers.go
@@ -24,7 +24,7 @@ type InteractiveCheckoutHandler struct{}
 
 // SelectBranch prompts the user to select a branch using the interactive log selector
 func (h *InteractiveCheckoutHandler) SelectBranch(ctx *app.Context, opts actions.CheckoutOptions) (string, error) {
-	branchName, err := tui.PromptLogSelect(ctx.Context, ctx.Engine, ctx.GitHub(), tui.LogOptions{
+	branchName, err := tui.PromptTreeSelect(ctx.Context, ctx.Engine, ctx.GitHub(), tui.TreeOptions{
 		ShowUntracked:  opts.ShowUntracked,
 		SkipEnrichment: true, // Skip GitHub/git enrichment for faster startup
 		Inline:         true, // Run inline without taking over the terminal

--- a/internal/cli/navigation/tree.go
+++ b/internal/cli/navigation/tree.go
@@ -10,57 +10,57 @@ import (
 	"github.com/getstackit/stackit/internal/errors"
 )
 
-// NewLogCmd creates the log command
-func NewLogCmd() *cobra.Command {
-	f := &logFlags{}
+// NewTreeCmd creates the tree command
+func NewTreeCmd() *cobra.Command {
+	f := &treeFlags{}
 
 	cmd := &cobra.Command{
-		Use:          "log",
-		Short:        "Log all branches tracked by Stackit, showing dependencies and info for each",
+		Use:          "tree",
+		Short:        "Display the branch tree: all branches tracked by Stackit, with dependencies and info for each",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return executeLog(cmd, f, actions.LogStyleNormal)
+			return executeTree(cmd, f, actions.TreeStyleNormal)
 		},
 	}
 
-	addLogFlags(cmd, f)
+	addTreeFlags(cmd, f)
 
 	// Add subcommands
-	cmd.AddCommand(newLogFullCmd())
-	cmd.AddCommand(newLogShortCmd())
+	cmd.AddCommand(newTreeFullCmd())
+	cmd.AddCommand(newTreeShortCmd())
 
 	return cmd
 }
 
-func newLogFullCmd() *cobra.Command {
-	f := &logFlags{}
+func newTreeFullCmd() *cobra.Command {
+	f := &treeFlags{}
 	cmd := &cobra.Command{
 		Use:          "full",
-		Short:        "Log branches with GitHub state (PR status, CI checks)",
+		Short:        "Display the branch tree with GitHub state (PR status, CI checks)",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return executeLog(cmd, f, actions.LogStyleFull)
+			return executeTree(cmd, f, actions.TreeStyleFull)
 		},
 	}
-	addLogFlags(cmd, f)
+	addTreeFlags(cmd, f)
 	return cmd
 }
 
-func newLogShortCmd() *cobra.Command {
-	f := &logFlags{}
+func newTreeShortCmd() *cobra.Command {
+	f := &treeFlags{}
 	cmd := &cobra.Command{
 		Use:          "short",
-		Short:        "Log branches showing only the branch tree (no stats or PR info)",
+		Short:        "Display only the branch tree (no stats or PR info)",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return executeLog(cmd, f, actions.LogStyleShort)
+			return executeTree(cmd, f, actions.TreeStyleShort)
 		},
 	}
-	addLogFlags(cmd, f)
+	addTreeFlags(cmd, f)
 	return cmd
 }
 
-type logFlags struct {
+type treeFlags struct {
 	stack         bool
 	steps         int
 	showUntracked bool
@@ -69,7 +69,7 @@ type logFlags struct {
 	jsonOutput    bool
 }
 
-func addLogFlags(cmd *cobra.Command, f *logFlags) {
+func addTreeFlags(cmd *cobra.Command, f *treeFlags) {
 	cmd.Flags().BoolVarP(&f.stack, "stack", "s", false, "Only show ancestors and descendants of the current branch")
 	cmd.Flags().IntVarP(&f.steps, "steps", "n", 0, "Only show this many levels upstack and downstack. Implies --stack")
 	cmd.Flags().BoolVarP(&f.showUntracked, "show-untracked", "u", false, "Include untracked branches in interactive selection")
@@ -78,7 +78,7 @@ func addLogFlags(cmd *cobra.Command, f *logFlags) {
 	cmd.Flags().BoolVar(&f.jsonOutput, "json", false, "Output in JSON format")
 }
 
-func executeLog(cmd *cobra.Command, f *logFlags, style string) error {
+func executeTree(cmd *cobra.Command, f *treeFlags, style string) error {
 	return common.Run(cmd, func(ctx *app.Context) error {
 		eng := ctx.Engine
 
@@ -94,7 +94,7 @@ func executeLog(cmd *cobra.Command, f *logFlags, style string) error {
 		}
 
 		// Prepare options
-		opts := actions.LogOptions{
+		opts := actions.TreeOptions{
 			Style:         style,
 			BranchName:    branchName,
 			ShowUntracked: f.showUntracked,
@@ -107,7 +107,7 @@ func executeLog(cmd *cobra.Command, f *logFlags, style string) error {
 			opts.Steps = &f.steps
 		}
 
-		// Execute log action
-		return actions.LogAction(ctx, opts)
+		// Execute tree action
+		return actions.TreeAction(ctx, opts)
 	})
 }

--- a/internal/cli/navigation/tree_test.go
+++ b/internal/cli/navigation/tree_test.go
@@ -20,19 +20,19 @@ func TestLogCommand(t *testing.T) {
 		t.Fatal("stackit binary not built")
 	}
 
-	t.Run("log in empty repo", func(t *testing.T) {
+	t.Run("tree in empty repo", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
 
-		// Run log command
-		output, err := s.RunCliAndGetOutput("log")
+		// Run tree command
+		output, err := s.RunCliAndGetOutput("tree")
 
 		// Should succeed and show trunk branch
-		require.NoError(t, err, "log command failed: %s", output)
+		require.NoError(t, err, "tree command failed: %s", output)
 		require.Contains(t, output, "main")
 	})
 
-	t.Run("log with branches", func(t *testing.T) {
+	t.Run("tree with branches", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
 
@@ -43,29 +43,29 @@ func TestLogCommand(t *testing.T) {
 		// Checkout main
 		s.Checkout("main")
 
-		// Run log command with --show-untracked to see untracked branches
-		output, err := s.RunCliAndGetOutput("log", "--show-untracked")
+		// Run tree command with --show-untracked to see untracked branches
+		output, err := s.RunCliAndGetOutput("tree", "--show-untracked")
 
-		require.NoError(t, err, "log command failed: %s", output)
+		require.NoError(t, err, "tree command failed: %s", output)
 		require.Contains(t, output, "main")
 		require.Contains(t, output, "feature")
 	})
 
-	t.Run("log with --stack flag", func(t *testing.T) {
+	t.Run("tree with --stack flag", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
 
 		// Create and checkout a branch
 		s.CreateBranch("feature")
 
-		// Run log command with stack
-		output, err := s.RunCliAndGetOutput("log", "--stack")
+		// Run tree command with stack
+		output, err := s.RunCliAndGetOutput("tree", "--stack")
 
-		require.NoError(t, err, "log command failed: %s", output)
+		require.NoError(t, err, "tree command failed: %s", output)
 		require.Contains(t, output, "feature")
 	})
 
-	t.Run("log shows worktree indicator for stack with worktree", func(t *testing.T) {
+	t.Run("tree shows worktree indicator for stack with worktree", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
 		s.WithInitialCommit()
@@ -84,9 +84,9 @@ func TestLogCommand(t *testing.T) {
 		output, err := s.RunCliAndGetOutput("create", "-m", "worktree feature", "-w")
 		require.NoError(t, err, "create with worktree failed: %s", output)
 
-		// Run log command - should show worktree indicator
-		output, err = s.RunCliAndGetOutput("log")
-		require.NoError(t, err, "log command failed: %s", output)
-		require.Contains(t, output, "worktree", "log should show worktree indicator for branch with managed worktree")
+		// Run tree command - should show worktree indicator
+		output, err = s.RunCliAndGetOutput("tree")
+		require.NoError(t, err, "tree command failed: %s", output)
+		require.Contains(t, output, "worktree", "tree should show worktree indicator for branch with managed worktree")
 	})
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -105,7 +105,7 @@ Commit:  ` + commit + `
 	rootCmd.AddCommand(newInitCmd(version))
 	rootCmd.AddCommand(integrations.NewGithubCmd())
 	rootCmd.AddCommand(branch.NewLockCmd())
-	rootCmd.AddCommand(navigation.NewLogCmd())
+	rootCmd.AddCommand(navigation.NewTreeCmd())
 	rootCmd.AddCommand(navigation.NewMainCmd())
 	rootCmd.AddCommand(stack.NewMergeCmd())
 	rootCmd.AddCommand(branch.NewModifyCmd())

--- a/internal/cli/stack/move_test.go
+++ b/internal/cli/stack/move_test.go
@@ -103,9 +103,9 @@ Restacked branch3 on branch1.
 		require.Contains(t, output, "Run without --dry-run to execute")
 
 		// Verify branch was NOT actually moved (still has branch1 as parent)
-		logOutput := runCliCommandSuccess(t, binaryPath, scene.Dir, "log")
-		require.Contains(t, logOutput, "branch2")
-		require.Contains(t, logOutput, "branch1")
+		treeOutput := runCliCommandSuccess(t, binaryPath, scene.Dir, "tree")
+		require.Contains(t, treeOutput, "branch2")
+		require.Contains(t, treeOutput, "branch1")
 	})
 
 	t.Run("dry-run requires --onto flag", func(t *testing.T) {

--- a/internal/cli/stack/pluck.go
+++ b/internal/cli/stack/pluck.go
@@ -107,7 +107,7 @@ func interactivePluckOntoSelection(ctx *app.Context, sourceBranch string) (strin
 
 	// Show interactive selector
 	header := fmt.Sprintf("Select new parent for '%s' (children will be reparented to grandparent)", sourceBranch)
-	selected, err := tui.PromptLogSelect(ctx.Context, ctx.Engine, ctx.GitHub(), tui.LogOptions{
+	selected, err := tui.PromptTreeSelect(ctx.Context, ctx.Engine, ctx.GitHub(), tui.TreeOptions{
 		Style:   "FULL",
 		Exclude: excludedBranches,
 		Logger:  ctx.Logger,

--- a/internal/cli/stack/track_handlers.go
+++ b/internal/cli/stack/track_handlers.go
@@ -64,7 +64,7 @@ func (h *InteractiveTrackHandler) IsInteractive() bool {
 // PromptSelectParent prompts user to select a parent for the branch
 func (h *InteractiveTrackHandler) PromptSelectParent(ctx context.Context, eng engine.Engine, ghClient github.Client, logger output.Logger, branchName string) (string, error) {
 	// Show interactive selector
-	selected, err := tui.PromptLogSelect(ctx, eng, ghClient, tui.LogOptions{
+	selected, err := tui.PromptTreeSelect(ctx, eng, ghClient, tui.TreeOptions{
 		Style:  "FULL",
 		Logger: logger,
 		Exclude: map[string]bool{

--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -22,7 +22,7 @@ untracked), any in-progress rebase/merge with its conflicted files, and the full
 stack (structure, PR/CI status, and per-branch needs_restack/locked/frozen/scope).
 
 Use --json for one machine-readable snapshot — agents and scripts read everything
-from a single call instead of combining git status, stackit log, and stackit info.
+from a single call instead of combining git status, stackit tree, and stackit info.
 
 Examples:
   stackit state            # Human-readable summary

--- a/internal/integration/init_test.go
+++ b/internal/integration/init_test.go
@@ -38,8 +38,8 @@ func TestInitIntegration(t *testing.T) {
 
 		// Any stackit command should trigger migration.
 		cli := inprocess.NewInProcessCLI()
-		result := cli.Run(scene.Dir, "log")
-		require.NoError(t, result.Err, "log should succeed: %s", result.Output)
+		result := cli.Run(scene.Dir, "tree")
+		require.NoError(t, result.Err, "tree should succeed: %s", result.Output)
 
 		backupPath := filepath.Join(scene.Dir, ".git", ".stackit_config.migrated")
 		_, err = os.Stat(backupPath)

--- a/internal/integration/json_output_test.go
+++ b/internal/integration/json_output_test.go
@@ -20,7 +20,7 @@ import (
 func TestJSONOutput(t *testing.T) {
 	t.Parallel()
 
-	t.Run("log --json outputs valid JSON with branch info", func(t *testing.T) {
+	t.Run("tree --json outputs valid JSON with branch info", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)
 
@@ -34,13 +34,13 @@ func TestJSONOutput(t *testing.T) {
 			OnBranch("feature-b")
 
 		// Get JSON output
-		sh.Run("log --json")
+		sh.Run("tree --json")
 		output := sh.Output()
 
 		// Parse and verify JSON structure
-		var result actions.LogJSONResult
+		var result actions.TreeJSONResult
 		err := json.Unmarshal([]byte(output), &result)
-		require.NoError(t, err, "log --json should produce valid JSON")
+		require.NoError(t, err, "tree --json should produce valid JSON")
 
 		// Verify branches are present
 		require.GreaterOrEqual(t, len(result.Branches), 2, "should have at least 2 branches")
@@ -64,7 +64,7 @@ func TestJSONOutput(t *testing.T) {
 		require.False(t, result.GitHubAvailable)
 	})
 
-	t.Run("log --json outputs valid JSON with recommendations", func(t *testing.T) {
+	t.Run("tree --json outputs valid JSON with recommendations", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)
 
@@ -82,13 +82,13 @@ func TestJSONOutput(t *testing.T) {
 			Commit("extra", "extra content")
 
 		// Get JSON output
-		sh.Run("log --json")
+		sh.Run("tree --json")
 		output := sh.Output()
 
 		// Parse and verify JSON structure
-		var result actions.LogJSONResult
+		var result actions.TreeJSONResult
 		err := json.Unmarshal([]byte(output), &result)
-		require.NoError(t, err, "log --json should produce valid JSON")
+		require.NoError(t, err, "tree --json should produce valid JSON")
 
 		// Verify branches are present
 		require.GreaterOrEqual(t, len(result.Branches), 2, "should have at least 2 branches")
@@ -104,7 +104,7 @@ func TestJSONOutput(t *testing.T) {
 		require.True(t, foundRestackNeeded, "feature-b should show NeedsRestack=true")
 	})
 
-	t.Run("log --quiet outputs minimal when healthy", func(t *testing.T) {
+	t.Run("tree --quiet outputs minimal when healthy", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)
 
@@ -113,7 +113,7 @@ func TestJSONOutput(t *testing.T) {
 			Run("create feature-a -m 'Add feature A'")
 
 		// Get output with --quiet
-		sh.Run("log --quiet")
+		sh.Run("tree --quiet")
 		output := sh.Output()
 
 		// Should be empty or minimal when healthy
@@ -227,7 +227,7 @@ func TestJSONOutput(t *testing.T) {
 			"should deduplicate and sort restack roots; only alpha's stack has drift")
 	})
 
-	t.Run("log --json with mixed branch states", func(t *testing.T) {
+	t.Run("tree --json with mixed branch states", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)
 
@@ -254,10 +254,10 @@ func TestJSONOutput(t *testing.T) {
 			Commit("main-update", "updating main")
 
 		// Get JSON output
-		sh.Run("log --json")
+		sh.Run("tree --json")
 		output := sh.Output()
 
-		var result actions.LogJSONResult
+		var result actions.TreeJSONResult
 		err := json.Unmarshal([]byte(output), &result)
 		require.NoError(t, err)
 
@@ -275,7 +275,7 @@ func TestJSONOutput(t *testing.T) {
 		require.True(t, foundLocked, "should find locked branch")
 	})
 
-	t.Run("log --json includes children relationships", func(t *testing.T) {
+	t.Run("tree --json includes children relationships", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)
 
@@ -293,10 +293,10 @@ func TestJSONOutput(t *testing.T) {
 			Run("create feature-a-2 -m 'Add feature A2'")
 
 		// Get JSON output
-		sh.Run("log --json")
+		sh.Run("tree --json")
 		output := sh.Output()
 
-		var result actions.LogJSONResult
+		var result actions.TreeJSONResult
 		err := json.Unmarshal([]byte(output), &result)
 		require.NoError(t, err)
 

--- a/internal/integration/modify_test.go
+++ b/internal/integration/modify_test.go
@@ -23,7 +23,7 @@ func TestModifyWorkflow(t *testing.T) {
 			Run("create feature-c -m 'Add feature C'").
 			OnBranch("feature-c")
 
-		sh.Run("log --stack").
+		sh.Run("tree --stack").
 			OutputContains("feature-a").
 			OutputContains("feature-b").
 			OutputContains("feature-c")

--- a/internal/integration/move_pr_update_test.go
+++ b/internal/integration/move_pr_update_test.go
@@ -20,7 +20,7 @@ func TestMoveMarksPRBodyUpdateFlagPersists(t *testing.T) {
 		sh.ExpectNeedsPRBodyUpdate("feature-a", true)
 
 		// log and info must not clear the flag.
-		sh.Run("log")
+		sh.Run("tree")
 		sh.Run("info")
 
 		sh.ExpectNeedsPRBodyUpdate("feature-b", true)

--- a/internal/integration/stack_test.go
+++ b/internal/integration/stack_test.go
@@ -32,7 +32,7 @@ func TestStackWorkflow(t *testing.T) {
 			Run("create feature-c -m 'Add feature C'").
 			OnBranch("feature-c")
 
-		sh.Run("log --stack").
+		sh.Run("tree --stack").
 			OutputContains("feature-a").
 			OutputContains("feature-b").
 			OutputContains("feature-c")

--- a/internal/integration/track_test.go
+++ b/internal/integration/track_test.go
@@ -18,7 +18,7 @@ func TestTrackIntegration(t *testing.T) {
 			Run("create feature2 -m 'Add feature2'")
 
 		// Verify stack is working
-		shell.Run("log --stack").
+		shell.Run("tree --stack").
 			OutputContains("feature1").
 			OutputContains("feature2")
 
@@ -34,7 +34,7 @@ func TestTrackIntegration(t *testing.T) {
 		shell.Run("track feature2 --parent feature1")
 
 		// Verify stack is restored
-		shell.Run("log --stack").
+		shell.Run("tree --stack").
 			OutputContains("feature1").
 			OutputContains("feature2").
 			Checkout("feature2").
@@ -82,7 +82,7 @@ func TestTrackIntegration(t *testing.T) {
 			OutputContains("feature-a")
 
 		// Verify stack operations work
-		shell.Run("log").
+		shell.Run("tree").
 			OutputContains("feature-a").
 			OutputContains("feature-b").
 			OutputContains("feature-c")
@@ -109,7 +109,7 @@ func TestTrackIntegration(t *testing.T) {
 			Run("track layer3 --parent layer2")
 
 		// Verify the complete stack
-		shell.Run("log --stack").
+		shell.Run("tree --stack").
 			OutputContains("layer1").
 			OutputContains("layer2").
 			OutputContains("layer3").
@@ -215,7 +215,7 @@ func TestTrackIntegration(t *testing.T) {
 			Run("track --parent feature_split --force")
 
 		// Verify the stack
-		shell.Run("log").
+		shell.Run("tree").
 			OutputContains("feature").
 			OutputContains("feature_split")
 	})
@@ -333,7 +333,7 @@ func TestTrackIntegration(t *testing.T) {
 			Run("track feature-d --force")
 
 		// Verify the entire stack is restored (single log call checks all)
-		shell.Run("log --stack").
+		shell.Run("tree --stack").
 			OutputContains("feature-a").
 			OutputContains("feature-b").
 			OutputContains("feature-c").

--- a/internal/integration/worktree_comprehensive_test.go
+++ b/internal/integration/worktree_comprehensive_test.go
@@ -649,7 +649,7 @@ func TestWorktreeNavigation(t *testing.T) {
 		shW.Run("up").OnBranch("c")
 	})
 
-	run("log command works in worktree", func(_ *testing.T, sh *TestShell) {
+	run("tree command works in worktree", func(_ *testing.T, sh *TestShell) {
 		sh.WriteFile("feature.txt", "feature").
 			Run("create feature -w -m 'feature branch'")
 
@@ -660,7 +660,7 @@ func TestWorktreeNavigation(t *testing.T) {
 		shW.WriteFile("child.txt", "child").Run("create child -m 'child branch'")
 
 		// Log should show stack
-		shW.Run("log").
+		shW.Run("tree").
 			OutputContains("feature").
 			OutputContains("child")
 	})
@@ -894,7 +894,7 @@ func TestWorktreeUndoOperations(t *testing.T) {
 
 		// Verify stack log shows the branches from main repo
 		sh.Checkout("child")
-		sh.Run("log").
+		sh.Run("tree").
 			OutputContains("feature").
 			OutputContains("child")
 	})

--- a/internal/tui/keys/keys.go
+++ b/internal/tui/keys/keys.go
@@ -51,16 +51,16 @@ var DefaultReorder = ReorderKeyMap{
 	),
 }
 
-// LogKeyMap extends NavigationKeyMap with log-specific operations.
-type LogKeyMap struct {
+// TreeKeyMap extends NavigationKeyMap with tree-specific operations.
+type TreeKeyMap struct {
 	NavigationKeyMap
 	Search key.Binding
 	Expand key.Binding
 	Quit   key.Binding
 }
 
-// DefaultLog returns keybindings for log views.
-var DefaultLog = LogKeyMap{
+// DefaultTree returns keybindings for log views.
+var DefaultTree = TreeKeyMap{
 	NavigationKeyMap: DefaultNavigation,
 	Search: key.NewBinding(
 		key.WithKeys("/"),

--- a/internal/tui/move_model.go
+++ b/internal/tui/move_model.go
@@ -162,7 +162,7 @@ func NewMoveModel(eng engine.Engine, config MoveModelConfig) *MoveModel {
 	}
 	renderer.SetAnnotations(annotations)
 
-	// Render the tree (trunk at bottom to match st log)
+	// Render the tree (trunk at bottom to match st tree)
 	// Use SkipSelectionPrefix so we can add our own cursor indicators in viewSelecting
 	opts := tree.RenderOptions{
 		Mode:                tree.RenderModeSelect,

--- a/internal/tui/tree_ui.go
+++ b/internal/tui/tree_ui.go
@@ -28,18 +28,18 @@ const (
 	validationDebounceTime = 300 * time.Millisecond
 )
 
-// LogMode defines how the log is used
-type LogMode int
+// TreeMode defines how the log is used
+type TreeMode int
 
 const (
-	// LogModeView is the default view mode for browsing the log
-	LogModeView LogMode = iota
-	// LogModeSelect is the selection mode for choosing a branch
-	LogModeSelect
+	// TreeModeView is the default view mode for browsing the log
+	TreeModeView TreeMode = iota
+	// TreeModeSelect is the selection mode for choosing a branch
+	TreeModeSelect
 )
 
-// LogModel is the bubbletea model for the interactive log
-type LogModel struct {
+// TreeModel is the bubbletea model for the interactive log
+type TreeModel struct {
 	context      context.Context
 	engine       engine.Engine
 	githubClient github.Client
@@ -53,11 +53,11 @@ type LogModel struct {
 	logger       output.Logger
 
 	// Keys
-	logKeys    keys.LogKeyMap
+	treeKeys   keys.TreeKeyMap
 	selectKeys keys.SelectKeyMap
 
 	// State
-	mode           LogMode
+	mode           TreeMode
 	branches       []tree.RenderedBranch // Visible branches with their lines
 	selectedIndex  int
 	selectedBranch string
@@ -92,17 +92,17 @@ type LogModel struct {
 	lastValidatedBranch string               // Branch that was last validated
 }
 
-// NewLogModel creates a new LogModel
-func NewLogModel(ctx context.Context, eng engine.Engine, ghClient github.Client, opts LogOptions) *LogModel {
+// NewTreeModel creates a new TreeModel
+func NewTreeModel(ctx context.Context, eng engine.Engine, ghClient github.Client, opts TreeOptions) *TreeModel {
 	logger := opts.Logger
-	logDebug := func(msg string, args ...any) {
+	treeDebug := func(msg string, args ...any) {
 		if logger != nil {
 			logger.Debug(msg, args...)
 		}
 	}
 
 	initStart := time.Now()
-	logDebug("NewLogModel started")
+	treeDebug("NewTreeModel started")
 
 	// Build filter function
 	var filter func(string) bool
@@ -122,12 +122,12 @@ func NewLogModel(ctx context.Context, eng engine.Engine, ghClient github.Client,
 			emptyWorktreeNames[name] = true
 		}
 	}
-	logDebug("GetWorktreeData completed in %v, found %d empty worktrees", time.Since(start), len(wtData.EmptyWorktrees))
+	treeDebug("GetWorktreeData completed in %v, found %d empty worktrees", time.Since(start), len(wtData.EmptyWorktrees))
 
 	// Create renderer synchronously for instant display
 	start = time.Now()
 	renderer := NewStackTreeRendererWithOptions(eng, engine.SortStrategySmart, filter, emptyWorktreeNames)
-	logDebug("NewStackTreeRendererWithOptions completed in %v", time.Since(start))
+	treeDebug("NewStackTreeRendererWithOptions completed in %v", time.Since(start))
 
 	// Build minimal annotations synchronously (includes worktree info, no git/network calls)
 	start = time.Now()
@@ -147,7 +147,7 @@ func NewLogModel(ctx context.Context, eng engine.Engine, ghClient github.Client,
 		}
 	}
 	renderer.SetAnnotations(annotations)
-	logDebug("Minimal annotations with worktree completed in %v", time.Since(start))
+	treeDebug("Minimal annotations with worktree completed in %v", time.Since(start))
 
 	// Set initial selection
 	start = time.Now()
@@ -158,7 +158,7 @@ func NewLogModel(ctx context.Context, eng engine.Engine, ghClient github.Client,
 	} else {
 		selectedBranch = trunkName
 	}
-	logDebug("Initial selection completed in %v", time.Since(start))
+	treeDebug("Initial selection completed in %v", time.Since(start))
 
 	// Initialize search matches (all branches match when no search query)
 	searchMatches := make(map[string]bool)
@@ -166,9 +166,9 @@ func NewLogModel(ctx context.Context, eng engine.Engine, ghClient github.Client,
 		searchMatches[b.GetName()] = true
 	}
 
-	logDebug("NewLogModel completed in %v", time.Since(initStart))
+	treeDebug("NewTreeModel completed in %v", time.Since(initStart))
 
-	m := &LogModel{
+	m := &TreeModel{
 		context:           ctx,
 		engine:            eng,
 		githubClient:      ghClient,
@@ -177,7 +177,7 @@ func NewLogModel(ctx context.Context, eng engine.Engine, ghClient github.Client,
 		allBranches:       allBranches,
 		trunkName:         trunkName,
 		selectedBranch:    selectedBranch,
-		logKeys:           keys.DefaultLog,
+		treeKeys:          keys.DefaultTree,
 		selectKeys:        keys.DefaultSelect,
 		style:             opts.Style,
 		showUntracked:     opts.ShowUntracked,
@@ -189,26 +189,26 @@ func NewLogModel(ctx context.Context, eng engine.Engine, ghClient github.Client,
 		validateSelection: opts.ValidateSelection,
 		collapsed:         make(map[string]bool),
 		searchMatches:     searchMatches,
-		mode:              LogModeView,
+		mode:              TreeModeView,
 	}
 
 	return m
 }
 
-// newLogSelectModel creates a new LogModel in selection mode
-func newLogSelectModel(ctx context.Context, eng engine.Engine, ghClient github.Client, opts LogOptions) *LogModel {
-	m := NewLogModel(ctx, eng, ghClient, opts)
-	m.mode = LogModeSelect
+// newTreeSelectModel creates a new TreeModel in selection mode
+func newTreeSelectModel(ctx context.Context, eng engine.Engine, ghClient github.Client, opts TreeOptions) *TreeModel {
+	m := NewTreeModel(ctx, eng, ghClient, opts)
+	m.mode = TreeModeSelect
 	return m
 }
 
 // SetAltScreen sets whether the model should use alt screen mode
-func (m *LogModel) SetAltScreen(enabled bool) {
+func (m *TreeModel) SetAltScreen(enabled bool) {
 	m.altScreen = enabled
 }
 
 // Init initializes the bubbletea model
-func (m *LogModel) Init() tea.Cmd {
+func (m *TreeModel) Init() tea.Cmd {
 	// For inline mode, pre-render the tree immediately since we won't wait for WindowSizeMsg
 	if m.inline {
 		m.renderTree()
@@ -221,7 +221,7 @@ func (m *LogModel) Init() tea.Cmd {
 		}
 	}
 
-	// Renderer is already created with minimal data in NewLogModel.
+	// Renderer is already created with minimal data in NewTreeModel.
 	// Skip enrichment if requested (e.g., for checkout where GitHub data isn't needed).
 	if m.skipEnrichment {
 		return nil
@@ -231,7 +231,7 @@ func (m *LogModel) Init() tea.Cmd {
 }
 
 // log logs a message if logger is available
-func (m *LogModel) log(msg string, args ...any) {
+func (m *TreeModel) log(msg string, args ...any) {
 	if m.logger != nil {
 		m.logger.Debug(msg, args...)
 	}
@@ -239,7 +239,7 @@ func (m *LogModel) log(msg string, args ...any) {
 
 // enrichData returns a command that fetches full annotation data in the background.
 // This includes git operations and CI status network calls.
-func (m *LogModel) enrichData() tea.Cmd {
+func (m *TreeModel) enrichData() tea.Cmd {
 	// Capture values needed by the goroutine to avoid races on struct fields
 	ctx := m.context
 	eng := m.engine
@@ -248,7 +248,7 @@ func (m *LogModel) enrichData() tea.Cmd {
 	style := m.style
 	logger := m.logger
 
-	logDebug := func(msg string, args ...any) {
+	treeDebug := func(msg string, args ...any) {
 		if logger != nil {
 			logger.Debug(msg, args...)
 		}
@@ -263,7 +263,7 @@ func (m *LogModel) enrichData() tea.Cmd {
 	// Wrap with panic recovery
 	return SafeCmdFunc("TUI enrichment", logger, func() tea.Msg {
 		enrichStart := time.Now()
-		logDebug("TUI enrichment started")
+		treeDebug("TUI enrichment started")
 
 		// Channels for parallel results (buffered so goroutines don't block)
 		type ciResult struct {
@@ -287,7 +287,7 @@ func (m *LogModel) enrichData() tea.Cmd {
 					if err != nil {
 						logError("BatchGetPRChecksStatus failed: %v", err)
 					}
-					logDebug("BatchGetPRChecksStatus for %d branches completed in %v", len(branchNames), time.Since(start))
+					treeDebug("BatchGetPRChecksStatus for %d branches completed in %v", len(branchNames), time.Since(start))
 					ciChan <- ciResult{statuses: statuses, err: err}
 				}()
 			} else {
@@ -332,9 +332,9 @@ func (m *LogModel) enrichData() tea.Cmd {
 		for i, b := range allBranches {
 			annotations[b.GetName()] = built[i]
 		}
-		logDebug("Collected full annotations for %d branches in %v", len(allBranches), time.Since(start))
+		treeDebug("Collected full annotations for %d branches in %v", len(allBranches), time.Since(start))
 
-		logDebug("TUI enrichment completed in %v", time.Since(enrichStart))
+		treeDebug("TUI enrichment completed in %v", time.Since(enrichStart))
 
 		return enrichDataMsg{annotations: annotations}
 	})
@@ -348,7 +348,7 @@ type enrichDataMsg struct {
 // invalidateTreeCache marks the cached tree data as stale.
 // Call this when the tree structure or display changes (collapse, search, data enrichment).
 // Navigation (up/down) does NOT invalidate the cache - it uses the fast path.
-func (m *LogModel) invalidateTreeCache() {
+func (m *TreeModel) invalidateTreeCache() {
 	m.cachedTreeValid = false
 }
 
@@ -364,7 +364,7 @@ type validationResultMsg struct {
 }
 
 // Update handles message updates for the bubbletea model
-func (m *LogModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m *TreeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 
 	switch msg := msg.(type) {
@@ -406,20 +406,20 @@ func (m *LogModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Normal mode key handling - use shared keys with vim support
 		switch {
-		case m.mode == LogModeView && key.Matches(msg, m.logKeys.Quit):
+		case m.mode == TreeModeView && key.Matches(msg, m.treeKeys.Quit):
 			m.canceled = true
 			return m, tea.Quit
-		case m.mode == LogModeSelect && key.Matches(msg, m.selectKeys.Cancel):
+		case m.mode == TreeModeSelect && key.Matches(msg, m.selectKeys.Cancel):
 			m.canceled = true
 			return m, tea.Quit
-		case m.mode == LogModeSelect && key.Matches(msg, m.selectKeys.Search):
+		case m.mode == TreeModeSelect && key.Matches(msg, m.selectKeys.Search):
 			// Enter search mode (only in select mode)
 			m.inSearchMode = true
 			m.searchQuery = ""
 			m.updateSearchMatches()
 			m.invalidateTreeCache() // Search affects display
 			m.renderTree()
-		case key.Matches(msg, m.logKeys.Up):
+		case key.Matches(msg, m.treeKeys.Up):
 			if len(m.branches) > 0 {
 				newIndex := m.selectedIndex
 				// Try to find the next selectable branch going up
@@ -443,7 +443,7 @@ func (m *LogModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					cmds = append(cmds, cmd)
 				}
 			}
-		case key.Matches(msg, m.logKeys.Down):
+		case key.Matches(msg, m.treeKeys.Down):
 			if len(m.branches) > 0 {
 				newIndex := m.selectedIndex
 				// Try to find the next selectable branch going down
@@ -468,7 +468,7 @@ func (m *LogModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		case key.Matches(msg, m.selectKeys.Select):
-			if m.mode == LogModeSelect {
+			if m.mode == TreeModeSelect {
 				return m, tea.Quit
 			}
 			if m.selectedBranch != "" {
@@ -561,13 +561,13 @@ func (m *LogModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // renderTree updates the cached branches and viewport content with the current tree state.
 // In inline mode or before the viewport is ready, View() uses the cached branches directly.
 // Uses two-phase rendering for fast navigation: if only selection changed, reuses cached tree data.
-func (m *LogModel) renderTree() {
+func (m *TreeModel) renderTree() {
 	if m.renderer == nil {
 		return
 	}
 
 	mode := tree.RenderModeFull
-	if m.mode == LogModeSelect {
+	if m.mode == TreeModeSelect {
 		mode = tree.RenderModeSelect
 	}
 	opts := tree.RenderOptions{
@@ -610,7 +610,7 @@ func (m *LogModel) renderTree() {
 	}
 }
 
-func (m *LogModel) ensureVisible() {
+func (m *TreeModel) ensureVisible() {
 	if m.selectedIndex < 0 || m.selectedIndex >= len(m.branches) {
 		return
 	}
@@ -631,7 +631,7 @@ func (m *LogModel) ensureVisible() {
 }
 
 // updateSearchMatches updates the searchMatches map based on current searchQuery
-func (m *LogModel) updateSearchMatches() {
+func (m *TreeModel) updateSearchMatches() {
 	m.searchMatches = make(map[string]bool)
 
 	if m.searchQuery == "" {
@@ -650,7 +650,7 @@ func (m *LogModel) updateSearchMatches() {
 }
 
 // moveToFirstMatch moves selection to the first matching branch
-func (m *LogModel) moveToFirstMatch() {
+func (m *TreeModel) moveToFirstMatch() {
 	if m.searchQuery == "" {
 		return
 	}
@@ -666,7 +666,7 @@ func (m *LogModel) moveToFirstMatch() {
 }
 
 // scheduleValidation returns a command that triggers validation after debounce delay
-func (m *LogModel) scheduleValidation(branchName string) tea.Cmd {
+func (m *TreeModel) scheduleValidation(branchName string) tea.Cmd {
 	if m.validateSelection == nil {
 		return nil
 	}
@@ -681,7 +681,7 @@ func (m *LogModel) scheduleValidation(branchName string) tea.Cmd {
 }
 
 // runValidation runs the validation callback in a goroutine and returns a command
-func (m *LogModel) runValidation(branchName string) tea.Cmd {
+func (m *TreeModel) runValidation(branchName string) tea.Cmd {
 	if m.validateSelection == nil {
 		return nil
 	}
@@ -705,14 +705,14 @@ func (m *LogModel) runValidation(branchName string) tea.Cmd {
 }
 
 // View renders the bubbletea model
-func (m *LogModel) View() tea.View {
+func (m *TreeModel) View() tea.View {
 	if m.renderer == nil {
 		return tea.NewView("")
 	}
 
-	title := "Stackit Log"
+	title := "Stackit Tree"
 	help := "'q' quit, 'enter' expand/collapse, '↑/k' '↓/j' navigate"
-	if m.mode == LogModeSelect {
+	if m.mode == TreeModeSelect {
 		if m.header != "" {
 			title = m.header
 		} else {
@@ -738,7 +738,7 @@ func (m *LogModel) View() tea.View {
 	default:
 		// Fallback: render tree directly for immediate display before first renderTree call
 		mode := tree.RenderModeFull
-		if m.mode == LogModeSelect {
+		if m.mode == TreeModeSelect {
 			mode = tree.RenderModeSelect
 		}
 		opts := tree.RenderOptions{
@@ -761,7 +761,7 @@ func (m *LogModel) View() tea.View {
 	parts := []string{header, "", content}
 
 	// Add validation status footer if validation is enabled
-	if m.validateSelection != nil && m.mode == LogModeSelect {
+	if m.validateSelection != nil && m.mode == TreeModeSelect {
 		footer := m.renderValidationFooter()
 		if footer != "" {
 			parts = append(parts, "", footer)
@@ -776,7 +776,7 @@ func (m *LogModel) View() tea.View {
 }
 
 // renderValidationFooter renders the validation status footer
-func (m *LogModel) renderValidationFooter() string {
+func (m *TreeModel) renderValidationFooter() string {
 	if m.validationPending {
 		return style.ColorDim(" ⏳ Checking for conflicts...")
 	}
@@ -791,13 +791,13 @@ func (m *LogModel) renderValidationFooter() string {
 	return ""
 }
 
-// PromptLogSelect runs the interactive log in selection mode and returns the selected branch name
-func PromptLogSelect(ctx context.Context, eng engine.Engine, ghClient github.Client, opts LogOptions) (string, error) {
+// PromptTreeSelect runs the interactive log in selection mode and returns the selected branch name
+func PromptTreeSelect(ctx context.Context, eng engine.Engine, ghClient github.Client, opts TreeOptions) (string, error) {
 	if err := CheckInteractiveAllowed(); err != nil {
 		return "", err
 	}
 
-	m := newLogSelectModel(ctx, eng, ghClient, opts)
+	m := newTreeSelectModel(ctx, eng, ghClient, opts)
 
 	m.altScreen = !opts.Inline
 
@@ -807,7 +807,7 @@ func PromptLogSelect(ctx context.Context, eng engine.Engine, ghClient github.Cli
 		return "", err
 	}
 
-	res := finalModel.(*LogModel)
+	res := finalModel.(*TreeModel)
 	if res.canceled {
 		return "", errors.ErrCanceled
 	}
@@ -836,9 +836,9 @@ type SelectionValidation struct {
 	Message string // Status message to display (e.g., "Move will complete without conflicts")
 }
 
-// LogOptions repeated here to avoid circular dependency if needed,
-// but we'll probably use actions.LogOptions
-type LogOptions struct {
+// TreeOptions repeated here to avoid circular dependency if needed,
+// but we'll probably use actions.TreeOptions
+type TreeOptions struct {
 	Style               string
 	ShowUntracked       bool
 	Exclude             map[string]bool                  // Branches to exclude from selection


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

`stackit log` rendered the branch graph, which contradicts the universal
`git log` mental model where `log` means commit history. Rename it to
`stackit tree` and free the `log` verb for a forthcoming stack-aware
commit-history command.

Full rename: the CLI command, the internal Log* action/TUI symbols (which
actually describe the tree), file names, tests, and all docs and agent
templates. The `full` and `short` subcommands are preserved.

BREAKING CHANGE: `stackit log` no longer exists; use `stackit tree`
(with `tree full` / `tree short`).

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782099561`.


* **PR #1274** 👈
  * **PR #1275**
    * **PR #1276**
      * **PR #1277**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1278 by jonnii*