### PR TITLE
feat: add stack-aware `st log` for trunk history

### DIFF
--- a/internal/actions/trunklog/trunklog.go
+++ b/internal/actions/trunklog/trunklog.go
@@ -1,0 +1,170 @@
+// Package trunklog gathers stack-aware trunk commit history for the `stackit log`
+// command. It reads trunk commits (a range or the most recent N), collapses
+// consolidated stacks into a single entry, and enriches PR titles from the forge
+// when available. The result is presentation-agnostic so CLI/JSON adapters can
+// render it however they need.
+package trunklog
+
+import (
+	"context"
+	"time"
+
+	"github.com/getstackit/stackit/internal/git"
+)
+
+// CommitSource is the narrow engine dependency this action needs.
+type CommitSource interface {
+	GetRecentTrunkCommits(count int) ([]git.RecentCommit, error)
+	GetTrunkCommitsInRange(from, to string) ([]git.RecentCommit, error)
+}
+
+// TitleResolver resolves PR titles from the forge. It is nil-safe: pass a nil
+// resolver when no GitHub client is available (offline) and PR titles are simply
+// omitted rather than treated as an error.
+type TitleResolver interface {
+	GetOwnerRepo() (owner, repo string)
+	BatchGetPRTitles(ctx context.Context, owner, repo string, prNumbers []int) (map[int]string, error)
+}
+
+// Request selects which trunk commits to gather.
+type Request struct {
+	From  string // lower-bound ref; empty selects the default recent-count view
+	To    string // upper-bound ref; empty defaults to the trunk tip (used with From)
+	Count int    // max commits for the default view; ignored when From is set
+}
+
+// Commit is one collapsed trunk entry, decoupled from the git and HTTP types.
+type Commit struct {
+	SHA           string
+	Message       string // PR title for enriched stack-merges, else the commit subject
+	Author        string
+	Date          time.Time
+	Kind          git.RecentCommitKind
+	PRNumber      int
+	StackSize     int
+	StackPRs      []int
+	StackPRTitles map[int]string
+	StackScope    string
+}
+
+// Result is the gathered, collapsed, enriched trunk history.
+type Result struct {
+	Commits []Commit
+	From    string
+	To      string
+}
+
+// Gather fetches trunk commits (a range when req.From is set, otherwise the most
+// recent req.Count), collapses consolidated stacks, and enriches PR titles when a
+// resolver is available. A nil resolver, missing owner/repo, or a forge error all
+// degrade gracefully to commits without PR titles rather than failing.
+func Gather(ctx context.Context, src CommitSource, titles TitleResolver, req Request) (Result, error) {
+	var (
+		raw []git.RecentCommit
+		err error
+	)
+	if req.From != "" {
+		raw, err = src.GetTrunkCommitsInRange(req.From, req.To)
+	} else {
+		raw, err = src.GetRecentTrunkCommits(req.Count)
+	}
+	if err != nil {
+		return Result{}, err
+	}
+
+	collapsed := git.CollapseStackMerges(raw)
+	prTitles := resolveTitles(ctx, titles, collapsed)
+
+	result := Result{
+		From:    req.From,
+		To:      req.To,
+		Commits: make([]Commit, 0, len(collapsed)),
+	}
+	for _, c := range collapsed {
+		result.Commits = append(result.Commits, toCommit(c, prTitles))
+	}
+	return result, nil
+}
+
+// resolveTitles returns PR-number → title for every PR referenced by the commits,
+// or nil when titles cannot be resolved (no resolver, no PRs, or a forge error).
+func resolveTitles(ctx context.Context, titles TitleResolver, commits []git.RecentCommit) map[int]string {
+	if titles == nil {
+		return nil
+	}
+	prNumbers := collectStackPRNumbers(commits)
+	if len(prNumbers) == 0 {
+		return nil
+	}
+	owner, repo := titles.GetOwnerRepo()
+	if owner == "" || repo == "" {
+		return nil
+	}
+	resolved, err := titles.BatchGetPRTitles(ctx, owner, repo, prNumbers)
+	if err != nil {
+		return nil
+	}
+	return resolved
+}
+
+// collectStackPRNumbers gathers the unique PR numbers referenced by the commits:
+// each commit's own PR plus the constituent PRs of stack-merges.
+func collectStackPRNumbers(commits []git.RecentCommit) []int {
+	seen := make(map[int]struct{})
+	var nums []int
+	add := func(n int) {
+		if n == 0 {
+			return
+		}
+		if _, ok := seen[n]; ok {
+			return
+		}
+		seen[n] = struct{}{}
+		nums = append(nums, n)
+	}
+	for _, c := range commits {
+		add(c.PRNumber)
+		for _, pr := range c.StackPRNumbers {
+			add(pr)
+		}
+	}
+	return nums
+}
+
+// toCommit maps a git.RecentCommit to the action Commit, substituting the
+// consolidation PR's title for the raw merge subject and attaching constituent
+// PR titles when available.
+func toCommit(c git.RecentCommit, prTitles map[int]string) Commit {
+	message := c.Subject
+	if c.StackSize > 0 && c.PRNumber != 0 && len(prTitles) > 0 {
+		if title, ok := prTitles[c.PRNumber]; ok {
+			message = title
+		}
+	}
+
+	out := Commit{
+		SHA:        c.SHA,
+		Message:    message,
+		Author:     c.Author,
+		Date:       c.Date,
+		Kind:       c.Kind,
+		PRNumber:   c.PRNumber,
+		StackSize:  c.StackSize,
+		StackPRs:   append([]int(nil), c.StackPRNumbers...),
+		StackScope: c.StackScope,
+	}
+
+	if c.StackSize > 0 && len(prTitles) > 0 {
+		stackTitles := make(map[int]string)
+		for _, pr := range c.StackPRNumbers {
+			if title, ok := prTitles[pr]; ok {
+				stackTitles[pr] = title
+			}
+		}
+		if len(stackTitles) > 0 {
+			out.StackPRTitles = stackTitles
+		}
+	}
+
+	return out
+}

--- a/internal/actions/trunklog/trunklog_test.go
+++ b/internal/actions/trunklog/trunklog_test.go
@@ -1,0 +1,138 @@
+package trunklog_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions/trunklog"
+	"github.com/getstackit/stackit/internal/git"
+)
+
+type fakeSource struct {
+	recent      []git.RecentCommit
+	ranged      []git.RecentCommit
+	err         error
+	gotCount    int
+	gotFrom     string
+	gotTo       string
+	calledRange bool
+}
+
+func (f *fakeSource) GetRecentTrunkCommits(count int) ([]git.RecentCommit, error) {
+	f.gotCount = count
+	return f.recent, f.err
+}
+
+func (f *fakeSource) GetTrunkCommitsInRange(from, to string) ([]git.RecentCommit, error) {
+	f.calledRange = true
+	f.gotFrom, f.gotTo = from, to
+	return f.ranged, f.err
+}
+
+type fakeTitles struct {
+	titles map[int]string
+	gotPRs []int
+	err    error
+}
+
+func (f *fakeTitles) GetOwnerRepo() (string, string) { return "owner", "repo" }
+
+func (f *fakeTitles) BatchGetPRTitles(_ context.Context, _, _ string, prNumbers []int) (map[int]string, error) {
+	f.gotPRs = prNumbers
+	return f.titles, f.err
+}
+
+func reg(sha string, pr int, subject string) git.RecentCommit {
+	return git.RecentCommit{SHA: sha, Subject: subject, PRNumber: pr, Kind: git.RecentCommitKindRegular}
+}
+
+func merge(sha string, pr int, scope string, prs ...int) git.RecentCommit {
+	return git.RecentCommit{
+		SHA: sha, Subject: "Merge pull request #x", PRNumber: pr,
+		Kind: git.RecentCommitKindStackMerge, StackSize: len(prs),
+		StackPRNumbers: prs, StackScope: scope,
+	}
+}
+
+func TestGather_DefaultCountPath(t *testing.T) {
+	t.Parallel()
+	src := &fakeSource{recent: []git.RecentCommit{reg("a", 5, "feat: a (#5)")}}
+
+	res, err := trunklog.Gather(context.Background(), src, nil, trunklog.Request{Count: 10})
+	require.NoError(t, err)
+	require.False(t, src.calledRange)
+	require.Equal(t, 10, src.gotCount)
+	require.Len(t, res.Commits, 1)
+	require.Equal(t, "feat: a (#5)", res.Commits[0].Message)
+}
+
+func TestGather_RangePath(t *testing.T) {
+	t.Parallel()
+	src := &fakeSource{ranged: []git.RecentCommit{reg("a", 5, "feat: a")}}
+
+	res, err := trunklog.Gather(context.Background(), src, nil, trunklog.Request{From: "v1", To: "main"})
+	require.NoError(t, err)
+	require.True(t, src.calledRange)
+	require.Equal(t, "v1", src.gotFrom)
+	require.Equal(t, "main", src.gotTo)
+	require.Equal(t, "v1", res.From)
+	require.Equal(t, "main", res.To)
+	require.Len(t, res.Commits, 1)
+}
+
+func TestGather_CollapsesAndEnriches(t *testing.T) {
+	t.Parallel()
+	src := &fakeSource{recent: []git.RecentCommit{
+		merge("m", 100, "FEAT-1", 1, 2),
+		reg("c2", 2, "feat: two (#2)"),
+		reg("c1", 1, "feat: one (#1)"),
+	}}
+	titles := &fakeTitles{titles: map[int]string{100: "Consolidate", 1: "One", 2: "Two"}}
+
+	res, err := trunklog.Gather(context.Background(), src, titles, trunklog.Request{Count: 5})
+	require.NoError(t, err)
+
+	// Constituents collapse into the merge.
+	require.Len(t, res.Commits, 1)
+	got := res.Commits[0]
+	require.Equal(t, "Consolidate", got.Message) // merge subject replaced by PR title
+	require.Equal(t, "FEAT-1", got.StackScope)
+	require.Equal(t, []int{1, 2}, got.StackPRs)
+	require.Equal(t, map[int]string{1: "One", 2: "Two"}, got.StackPRTitles)
+
+	// PR numbers requested = consolidation PR + constituents, deduped.
+	require.ElementsMatch(t, []int{100, 1, 2}, titles.gotPRs)
+}
+
+func TestGather_OfflineNoTitles(t *testing.T) {
+	t.Parallel()
+	src := &fakeSource{recent: []git.RecentCommit{merge("m", 100, "FEAT-1", 1, 2)}}
+
+	res, err := trunklog.Gather(context.Background(), src, nil, trunklog.Request{Count: 5})
+	require.NoError(t, err)
+	require.Len(t, res.Commits, 1)
+	require.Equal(t, "Merge pull request #x", res.Commits[0].Message) // unchanged, no enrichment
+	require.Nil(t, res.Commits[0].StackPRTitles)
+}
+
+func TestGather_TitleErrorDegradesGracefully(t *testing.T) {
+	t.Parallel()
+	src := &fakeSource{recent: []git.RecentCommit{merge("m", 100, "", 1, 2)}}
+	titles := &fakeTitles{err: errors.New("rate limited")}
+
+	res, err := trunklog.Gather(context.Background(), src, titles, trunklog.Request{Count: 5})
+	require.NoError(t, err)
+	require.Len(t, res.Commits, 1)
+	require.Nil(t, res.Commits[0].StackPRTitles)
+}
+
+func TestGather_SourceErrorPropagates(t *testing.T) {
+	t.Parallel()
+	src := &fakeSource{err: errors.New("boom")}
+
+	_, err := trunklog.Gather(context.Background(), src, nil, trunklog.Request{Count: 5})
+	require.Error(t, err)
+}

--- a/internal/cli/navigation/log.go
+++ b/internal/cli/navigation/log.go
@@ -1,0 +1,151 @@
+package navigation
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/getstackit/stackit/internal/actions/trunklog"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/output"
+)
+
+// NewLogCmd creates the log command: a stack-aware view of trunk commit history.
+func NewLogCmd() *cobra.Command {
+	var (
+		since   string
+		jsonOut bool
+		count   int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "log [<from>..<to>]",
+		Short: "Show trunk commit history with stacks collapsed",
+		Long: `Show the trunk commit history, collapsing each consolidated stack-merge into a
+single entry that lists its constituent PRs (mirrors the web app's Recently
+Merged view).
+
+With no arguments it shows the most recent trunk commits. Pass a revision range
+to produce a changelog between two refs.
+
+Examples:
+  stackit log                      # recent trunk history (stacks collapsed)
+  stackit log v1.4.0..main         # changelog between two refs
+  stackit log --since v1.4.0       # everything since v1.4.0 up to the trunk tip
+  stackit log --json v1.4.0..main  # machine-readable (used by release tooling)
+
+The --json output is a stability contract consumed by release tooling; treat
+field changes as breaking.`,
+		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			req, err := buildLogRequest(args, since, count)
+			if err != nil {
+				return err
+			}
+			return common.Run(cmd, func(ctx *app.Context) error {
+				var titles trunklog.TitleResolver
+				if gh := ctx.GitHub(); gh != nil {
+					titles = gh
+				}
+				res, err := trunklog.Gather(ctx.Context, ctx.Engine, titles, req)
+				if err != nil {
+					return err
+				}
+				if jsonOut {
+					return printLogJSON(ctx.Output, res)
+				}
+				displayLog(ctx.Output, res)
+				return nil
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&since, "since", "", "Show commits since <ref>, up to the trunk tip (shorthand for <ref>..)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON (stable contract for release tooling)")
+	cmd.Flags().IntVarP(&count, "count", "n", 25, "Max commits for the default view (ignored when a range is given)")
+
+	return cmd
+}
+
+// buildLogRequest resolves CLI args/flags into a trunklog.Request. A positional
+// argument is a "<from>..<to>" range; --since is shorthand for "<ref>..trunk".
+// The two are mutually exclusive.
+func buildLogRequest(args []string, since string, count int) (trunklog.Request, error) {
+	switch {
+	case len(args) == 1 && since != "":
+		return trunklog.Request{}, fmt.Errorf("cannot combine a range argument with --since")
+	case len(args) == 1:
+		from, to, ok := strings.Cut(args[0], "..")
+		if !ok {
+			return trunklog.Request{}, fmt.Errorf("expected a range like <from>..<to>, got %q", args[0])
+		}
+		if from == "" {
+			return trunklog.Request{}, fmt.Errorf("range %q is missing a lower bound", args[0])
+		}
+		return trunklog.Request{From: from, To: to}, nil
+	case since != "":
+		// To left empty so the engine anchors the upper bound at the trunk tip.
+		return trunklog.Request{From: since}, nil
+	default:
+		return trunklog.Request{Count: count}, nil
+	}
+}
+
+// displayLog renders the gathered trunk history as a terminal list, mirroring the
+// web "Recently Merged" panel: one line per collapsed commit, with stack-merges
+// expanding into their constituent PRs.
+func displayLog(out output.Output, res trunklog.Result) {
+	if len(res.Commits) == 0 {
+		out.Println(output.Dim("No commits."))
+		return
+	}
+
+	var b strings.Builder
+	for i, c := range res.Commits {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(output.Dim(shortSHA(c.SHA)))
+		b.WriteString("  ")
+		b.WriteString(c.Message)
+
+		switch {
+		case c.StackSize > 0:
+			meta := []string{}
+			if c.PRNumber != 0 {
+				meta = append(meta, fmt.Sprintf("#%d", c.PRNumber))
+			}
+			meta = append(meta, fmt.Sprintf("%d PRs", c.StackSize))
+			if c.StackScope != "" {
+				meta = append(meta, c.StackScope)
+			}
+			b.WriteString("  ")
+			b.WriteString(output.Dim("(" + strings.Join(meta, " · ") + ")"))
+			for _, pr := range c.StackPRs {
+				b.WriteString("\n    ")
+				line := fmt.Sprintf("#%d", pr)
+				if title, ok := c.StackPRTitles[pr]; ok && title != "" {
+					line += " " + title
+				}
+				b.WriteString(output.Dim(line))
+			}
+		case c.PRNumber != 0 && !strings.Contains(c.Message, fmt.Sprintf("(#%d)", c.PRNumber)):
+			b.WriteString(" ")
+			b.WriteString(output.Dim(fmt.Sprintf("(#%d)", c.PRNumber)))
+		}
+	}
+
+	out.Print(b.String())
+	out.Newline()
+}
+
+// shortSHA truncates a commit SHA to the conventional 7-character form.
+func shortSHA(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
+}

--- a/internal/cli/navigation/log_json.go
+++ b/internal/cli/navigation/log_json.go
@@ -1,0 +1,65 @@
+package navigation
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/getstackit/stackit/internal/actions/trunklog"
+	"github.com/getstackit/stackit/internal/output"
+)
+
+// logCommitJSON is the per-commit shape emitted by `stackit log --json`. It is a
+// CLI-owned contract (deliberately not the HTTP DTO) consumed by release tooling;
+// field renames/removals are breaking. Field names mirror the web DTO for
+// recognizability.
+type logCommitJSON struct {
+	SHA           string         `json:"sha"`
+	Message       string         `json:"message"`
+	Author        string         `json:"author"`
+	Date          string         `json:"date"` // RFC3339
+	Kind          string         `json:"kind"` // "regular" | "stack-merge"
+	PRNumber      int            `json:"prNumber,omitempty"`
+	StackSize     int            `json:"stackSize,omitempty"`
+	StackPRs      []int          `json:"stackPRs,omitempty"`
+	StackPRTitles map[int]string `json:"stackPRTitles,omitempty"`
+	StackScope    string         `json:"stackScope,omitempty"`
+}
+
+// logJSON is the top-level `stackit log --json` payload.
+type logJSON struct {
+	From    string          `json:"from,omitempty"`
+	To      string          `json:"to,omitempty"`
+	Commits []logCommitJSON `json:"commits"`
+}
+
+// printLogJSON marshals the gathered trunk history to indented JSON.
+func printLogJSON(out output.Output, res trunklog.Result) error {
+	payload := logJSON{
+		From:    res.From,
+		To:      res.To,
+		Commits: make([]logCommitJSON, 0, len(res.Commits)),
+	}
+	for _, c := range res.Commits {
+		payload.Commits = append(payload.Commits, logCommitJSON{
+			SHA:           shortSHA(c.SHA),
+			Message:       c.Message,
+			Author:        c.Author,
+			Date:          c.Date.Format(time.RFC3339),
+			Kind:          string(c.Kind),
+			PRNumber:      c.PRNumber,
+			StackSize:     c.StackSize,
+			StackPRs:      c.StackPRs,
+			StackPRTitles: c.StackPRTitles,
+			StackScope:    c.StackScope,
+		})
+	}
+
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+	out.Print(string(data))
+	out.Newline()
+	return nil
+}

--- a/internal/cli/navigation/log_test.go
+++ b/internal/cli/navigation/log_test.go
@@ -1,0 +1,43 @@
+package navigation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions/trunklog"
+)
+
+func TestBuildLogRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    []string
+		since   string
+		count   int
+		want    trunklog.Request
+		wantErr string
+	}{
+		{name: "default count view", count: 25, want: trunklog.Request{Count: 25}},
+		{name: "explicit range", args: []string{"v1..main"}, want: trunklog.Request{From: "v1", To: "main"}},
+		{name: "open-ended range to trunk", args: []string{"v1.."}, want: trunklog.Request{From: "v1"}},
+		{name: "since shorthand", since: "v1", want: trunklog.Request{From: "v1"}},
+		{name: "range and since conflict", args: []string{"v1..main"}, since: "v1", wantErr: "cannot combine"},
+		{name: "missing range separator", args: []string{"foo"}, wantErr: "expected a range"},
+		{name: "missing lower bound", args: []string{"..main"}, wantErr: "missing a lower bound"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := buildLogRequest(tt.args, tt.since, tt.count)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -105,6 +105,7 @@ Commit:  ` + commit + `
 	rootCmd.AddCommand(newInitCmd(version))
 	rootCmd.AddCommand(integrations.NewGithubCmd())
 	rootCmd.AddCommand(branch.NewLockCmd())
+	rootCmd.AddCommand(navigation.NewLogCmd())
 	rootCmd.AddCommand(navigation.NewTreeCmd())
 	rootCmd.AddCommand(navigation.NewMainCmd())
 	rootCmd.AddCommand(stack.NewMergeCmd())

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -285,25 +285,12 @@ func computeStackStatus(graph *engine.StackGraph, branchNames []string) string {
 // filtered out so that consolidated stacks don't show duplicate entries.
 // prTitles is an optional map of PR number to title; pass nil if unavailable.
 func MapTrunkCommits(commits []git.RecentCommit, prTitles map[int]string) []TrunkCommitResponse {
-	// Collect all PR numbers that are covered by stack-merge consolidation commits.
-	coveredPRs := make(map[int]struct{})
-	for _, c := range commits {
-		if c.StackSize > 0 {
-			for _, pr := range c.StackPRNumbers {
-				coveredPRs[pr] = struct{}{}
-			}
-		}
-	}
+	// Drop constituent-PR commits already represented by a stack-merge. The
+	// collapse logic is shared with the `stackit log` command via internal/git.
+	collapsed := git.CollapseStackMerges(commits)
 
-	result := make([]TrunkCommitResponse, 0, len(commits))
-	for _, c := range commits {
-		// Skip commits whose PR is already represented by a stack-merge.
-		if c.PRNumber != 0 && c.StackSize == 0 {
-			if _, covered := coveredPRs[c.PRNumber]; covered {
-				continue
-			}
-		}
-
+	result := make([]TrunkCommitResponse, 0, len(collapsed))
+	for _, c := range collapsed {
 		message := c.Subject
 		// For stack-merge commits, use the consolidation PR's title from GitHub
 		// instead of the raw "Merge pull request #N from ..." subject

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -441,6 +441,10 @@ func (d *demoGitRunner) GetRecentCommits(_ context.Context, _ string, _ int) ([]
 	return nil, nil
 }
 
+func (d *demoGitRunner) GetRecentCommitsInRange(_ context.Context, _ string) ([]git.RecentCommit, error) {
+	return nil, nil
+}
+
 func (d *demoGitRunner) GetStatusPorcelain(_ context.Context) (string, error) {
 	return "M  test.txt", nil
 }

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -164,6 +164,16 @@ func (e *engineImpl) GetRecentTrunkCommits(count int) ([]git.RecentCommit, error
 	return e.git.GetRecentCommits(context.Background(), e.trunk, count)
 }
 
+// GetTrunkCommitsInRange returns the commits in the revision range from..to with
+// stack trailer metadata. An empty `to` defaults to the trunk branch tip. Use it
+// to build a changelog over a tag range (e.g. from "v1.4.0" to trunk).
+func (e *engineImpl) GetTrunkCommitsInRange(from, to string) ([]git.RecentCommit, error) {
+	if to == "" {
+		to = e.trunk
+	}
+	return e.git.GetRecentCommitsInRange(context.Background(), from+".."+to)
+}
+
 // GetAllCommits returns commits for a branch in various formats
 func (e *engineImpl) GetAllCommits(branch Branch, format CommitFormat) ([]string, error) {
 	branchName := branch.GetName()

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -86,6 +86,7 @@ type BranchInfo interface {
 	GetRevisions(branchNames []string) (map[string]string, []error)
 	GetCurrentRevision(ctx context.Context) (string, error)
 	GetRecentTrunkCommits(count int) ([]git.RecentCommit, error)
+	GetTrunkCommitsInRange(from, to string) ([]git.RecentCommit, error)
 	GetReflog(ctx context.Context, count int, format string) (string, error)
 	// GetDivergencePoint returns the divergence point of a branch from its parent.
 	// Returns the ParentBranchRevision from metadata if valid, otherwise the parent's current revision.

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -85,6 +85,7 @@ type CommitReader interface {
 	GetCommitSHA(branchName string, offset int) (string, error)
 	GetCommitLog(sha, format string) (string, error)
 	GetRecentCommits(ctx context.Context, branchName string, count int) ([]RecentCommit, error)
+	GetRecentCommitsInRange(ctx context.Context, revRange string) ([]RecentCommit, error)
 	GetCommitTemplate(ctx context.Context) (string, error)
 	GetParentCommitSHA(commitSHA string) (string, error)
 }

--- a/internal/git/recent_commits.go
+++ b/internal/git/recent_commits.go
@@ -55,20 +55,34 @@ func (r *runner) GetRecentCommits(ctx context.Context, branchName string, count 
 	if count <= 0 {
 		return nil, nil
 	}
+	return r.recentCommits(ctx, fmt.Sprintf("-n%d", count), branchName)
+}
 
+// GetRecentCommitsInRange returns the commits in a revision range (e.g.
+// "v1.4.0..main"), newest first, with the same stack trailer parsing as
+// GetRecentCommits. An empty range returns no commits.
+func (r *runner) GetRecentCommitsInRange(ctx context.Context, revRange string) ([]RecentCommit, error) {
+	if strings.TrimSpace(revRange) == "" {
+		return nil, nil
+	}
+	return r.recentCommits(ctx, revRange)
+}
+
+// recentCommits runs `git log -z` with the trailer-aware format over the given
+// log selector args (e.g. "-n10","main" or "v1.4.0..main") and parses the
+// records into RecentCommit values. It is the shared core of GetRecentCommits
+// and GetRecentCommitsInRange.
+func (r *runner) recentCommits(ctx context.Context, revArgs ...string) ([]RecentCommit, error) {
 	format := strings.Join([]string{
 		"%H", "%an", "%aI", "%B",
 	}, commitFieldSep)
 
-	out, err := r.RunGitCommandRawWithContext(ctx,
-		"log",
-		fmt.Sprintf("-n%d", count),
-		"-z",
-		"--format="+format,
-		branchName,
-	)
+	args := append([]string{"log"}, revArgs...)
+	args = append(args, "-z", "--format="+format)
+
+	out, err := r.RunGitCommandRawWithContext(ctx, args...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to walk recent commits on %s: %w", branchName, err)
+		return nil, fmt.Errorf("failed to walk recent commits (%v): %w", revArgs, err)
 	}
 
 	records := splitNulTerminated(out)

--- a/internal/git/recent_commits_test.go
+++ b/internal/git/recent_commits_test.go
@@ -178,3 +178,45 @@ func TestGetRecentCommits_MergeCommitWithTitleBeforeTrailers(t *testing.T) {
 	require.Equal(t, "Consolidate auth stack", commits[0].Subject)
 	require.Equal(t, 786, commits[0].PRNumber)
 }
+
+func TestGetRecentCommitsInRange(t *testing.T) {
+	t.Parallel()
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+
+	// Tag the baseline, then add two commits past it.
+	require.NoError(t, scene.Repo.RunGitCommand("tag", "v0"))
+
+	require.NoError(t, scene.Repo.CreateChange("file1", "content1", false))
+	require.NoError(t, scene.Repo.RunGitCommand("add", "."))
+	require.NoError(t, scene.Repo.RunGitCommand("commit", "-m", "First past baseline"))
+
+	require.NoError(t, scene.Repo.CreateChange("file2", "content2", false))
+	require.NoError(t, scene.Repo.RunGitCommand("add", "."))
+	require.NoError(t, scene.Repo.RunGitCommand(
+		"commit",
+		"-m", "Consolidate stack",
+		"-m", "Stackit-Stack-Size: 2\nStackit-PRs: 7,8\nStackit-Scope: FEAT-9",
+	))
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+
+	// Range excludes the tagged baseline; newest first, parses trailers.
+	commits, err := runner.GetRecentCommitsInRange(context.Background(), "v0..main")
+	require.NoError(t, err)
+	require.Len(t, commits, 2)
+	require.Equal(t, "Consolidate stack", commits[0].Subject)
+	require.Equal(t, 2, commits[0].StackSize)
+	require.Equal(t, []int{7, 8}, commits[0].StackPRNumbers)
+	require.Equal(t, git.RecentCommitKindStackMerge, commits[0].Kind)
+	require.Equal(t, "First past baseline", commits[1].Subject)
+}
+
+func TestGetRecentCommitsInRange_Empty(t *testing.T) {
+	t.Parallel()
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	commits, err := runner.GetRecentCommitsInRange(context.Background(), "")
+	require.NoError(t, err)
+	require.Empty(t, commits)
+}

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -443,6 +443,13 @@ func (t *tracingRunner) GetRecentCommits(ctx context.Context, branchName string,
 	return result, err
 }
 
+func (t *tracingRunner) GetRecentCommitsInRange(ctx context.Context, revRange string) ([]RecentCommit, error) {
+	start := time.Now()
+	result, err := t.inner.GetRecentCommitsInRange(ctx, revRange)
+	t.trace("GetRecentCommitsInRange", time.Since(start), err == nil, err, slog.String("range", revRange))
+	return result, err
+}
+
 func (t *tracingRunner) GetCommitTemplate(ctx context.Context) (string, error) {
 	start := time.Now()
 	result, err := t.inner.GetCommitTemplate(ctx)

--- a/internal/git/trunk_collapse.go
+++ b/internal/git/trunk_collapse.go
@@ -1,0 +1,32 @@
+package git
+
+// CollapseStackMerges returns the input commits with constituent-PR commits
+// dropped when their PR number is already represented by a stack-merge
+// consolidation commit in the same slice. Input order is preserved.
+//
+// It is the dedup half shared by the HTTP "recently merged" mapper and the
+// `stackit log` command, so both collapse consolidated stacks identically.
+// PR-title enrichment and presentation shaping stay with each caller.
+func CollapseStackMerges(commits []RecentCommit) []RecentCommit {
+	// Collect all PR numbers covered by stack-merge consolidation commits.
+	coveredPRs := make(map[int]struct{})
+	for _, c := range commits {
+		if c.StackSize > 0 {
+			for _, pr := range c.StackPRNumbers {
+				coveredPRs[pr] = struct{}{}
+			}
+		}
+	}
+
+	result := make([]RecentCommit, 0, len(commits))
+	for _, c := range commits {
+		// Skip commits whose PR is already represented by a stack-merge.
+		if c.PRNumber != 0 && c.StackSize == 0 {
+			if _, covered := coveredPRs[c.PRNumber]; covered {
+				continue
+			}
+		}
+		result = append(result, c)
+	}
+	return result
+}

--- a/internal/git/trunk_collapse_test.go
+++ b/internal/git/trunk_collapse_test.go
@@ -1,0 +1,72 @@
+package git_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/git"
+)
+
+func TestCollapseStackMerges(t *testing.T) {
+	t.Parallel()
+
+	reg := func(pr int) git.RecentCommit {
+		return git.RecentCommit{PRNumber: pr, Kind: git.RecentCommitKindRegular}
+	}
+	merge := func(pr int, prs ...int) git.RecentCommit {
+		return git.RecentCommit{
+			PRNumber:       pr,
+			Kind:           git.RecentCommitKindStackMerge,
+			StackSize:      len(prs),
+			StackPRNumbers: prs,
+		}
+	}
+	prNumbers := func(commits []git.RecentCommit) []int {
+		out := make([]int, len(commits))
+		for i, c := range commits {
+			out[i] = c.PRNumber
+		}
+		return out
+	}
+
+	tests := []struct {
+		name string
+		in   []git.RecentCommit
+		want []int // expected PRNumbers, in order
+	}{
+		{
+			name: "no stack merges passes through",
+			in:   []git.RecentCommit{reg(3), reg(2), reg(1)},
+			want: []int{3, 2, 1},
+		},
+		{
+			name: "stack merge drops all its constituents",
+			in:   []git.RecentCommit{merge(100, 1, 2, 3), reg(3), reg(2), reg(1)},
+			want: []int{100},
+		},
+		{
+			name: "partial coverage keeps uncovered commits",
+			in:   []git.RecentCommit{merge(100, 1, 2), reg(3), reg(2), reg(1)},
+			want: []int{100, 3},
+		},
+		{
+			name: "order preserved among survivors",
+			in:   []git.RecentCommit{reg(9), merge(100, 1), reg(8), reg(1)},
+			want: []int{9, 100, 8},
+		},
+		{
+			name: "empty input",
+			in:   nil,
+			want: []int{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := git.CollapseStackMerges(tt.in)
+			require.Equal(t, tt.want, prNumbers(got))
+		})
+	}
+}

--- a/internal/integration/log_test.go
+++ b/internal/integration/log_test.go
@@ -1,0 +1,46 @@
+package integration
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLogTrunkHistory covers the stack-aware `stackit log` command end-to-end.
+// Collapse/enrichment behavior is unit-tested in internal/git and
+// internal/actions/trunklog; this verifies CLI wiring, JSON shape, and arg
+// parsing in-process (offline, no GitHub).
+func TestLogTrunkHistory(t *testing.T) {
+	t.Parallel()
+
+	t.Run("log renders trunk history without error", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Run("log")
+	})
+
+	t.Run("log --json emits parseable commits", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Run("log --json")
+
+		var result struct {
+			Commits []struct {
+				SHA     string `json:"sha"`
+				Message string `json:"message"`
+				Kind    string `json:"kind"`
+			} `json:"commits"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(sh.Output()), &result), "log --json should produce valid JSON")
+		require.GreaterOrEqual(t, len(result.Commits), 1, "trunk should have at least one commit")
+		require.NotEmpty(t, result.Commits[0].SHA)
+		require.Equal(t, "regular", result.Commits[0].Kind)
+	})
+
+	t.Run("log rejects a non-range argument", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.RunExpectError("log foo").OutputContains("expected a range")
+	})
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

`stackit log` now shows trunk commit history with consolidated stacks
collapsed into a single entry that lists their constituent PRs — the same
view the web app's Recently Merged panel renders. It supports a revision
range (`st log v1.4.0..main`) and `--since` for changelogs, plus `--json`
for machine consumers such as release tooling.

- git: GetRecentCommitsInRange (shares a core with GetRecentCommits) and
  CollapseStackMerges, now reused by the HTTP recently-merged mapper.
- engine: GetTrunkCommitsInRange.
- actions/trunklog: gathers, collapses, and enriches PR titles via an
  injected, nil-safe GitHub resolver (degrades to no titles offline).
- cli: `log` command with range/--since/--json/-n, registered on root.

The --json output is a CLI-owned stability contract for release tooling.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782099561`.


* **PR #1274**
  * **PR #1275** 👈
    * **PR #1276**
      * **PR #1277**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1278 by jonnii*