### PR TITLE
refactor: trim redundant preloads from agent skill templates

### DIFF
--- a/internal/cli/integrations/agents/templates/commands/stack-describe.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-describe.md
@@ -10,8 +10,7 @@ Generate a comprehensive description for the current stack based on all changes.
 
 ## Context
 - Current branch: !`git branch --show-current`
-- Stack state: !`stackit tree --no-interactive`
-- Stack info: !`stackit info --stack --json --no-interactive`
+- Stack info (branches, parents, commit messages, diff stats): !`stackit info --stack --json --no-interactive`
 - Current description: !`stackit describe --show --no-interactive`
 
 ## Instructions

--- a/internal/cli/integrations/agents/templates/commands/stack-fold.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-fold.md
@@ -10,8 +10,7 @@ Fold (squash) granular branches into their parent branches.
 
 ## Context
 - Current branch: !`git branch --show-current`
-- Stack state: !`stackit tree --no-interactive`
-- Stack info: !`stackit info --stack --json --no-interactive`
+- Stack info (branches, parents, commit messages, diff stats): !`stackit info --stack --json --no-interactive`
 
 ## Instructions
 

--- a/internal/cli/integrations/agents/templates/commands/stack-split.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-split.md
@@ -84,8 +84,11 @@ Get the commits on the current branch that will be analyzed for splitting:
 # Get parent branch from stackit metadata
 stackit tree --no-interactive
 
-# Get the diff between parent and current branch HEAD
-# This shows all changes that could be split
+# Survey size first (bounded), then read what you need
+git diff --stat <parent-branch>..HEAD
+# Full diff of all changes that could be split. For a large diff, avoid dumping
+# everything into context — read per-file instead:
+#   git diff <parent-branch>..HEAD -- <path>
 git diff <parent-branch>..HEAD
 
 # Also get commit history for context

--- a/internal/cli/integrations/agents/templates/commands/stack-tidy.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-tidy.md
@@ -11,8 +11,7 @@ Clean up commits across the stack by squashing fixup/WIP commits into meaningful
 ## Context
 - Current branch: !`git branch --show-current`
 - Uncommitted changes: !`git status --short`
-- Stack state: !`stackit tree --no-interactive`
-- Stack info: !`stackit info --stack --json --no-interactive`
+- Stack info (branches, parents, commit messages, diff stats): !`stackit info --stack --json --no-interactive`
 
 ## Task
 


### PR DESCRIPTION

The `st log` -> `st tree` rename turned the stale `stackit log` preload in
installed skills into an unbounded trunk-history dump, bloating agent context.
The repo templates were already migrated to `stackit tree`, but several still
preload BOTH `stackit tree` and `stackit info --stack --json` even though the
instructions only consume the JSON (which already carries branch structure,
commit messages, and diff stats).

- describe/fold/tidy: drop the redundant `stackit tree` preload; keep the JSON
- split: survey `git diff --stat` before the full cross-branch diff and steer
  toward per-file reads for large changes

No remaining preload runs an unbounded command: all are bounded by current
stack size or head-capped.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1279** 👈
  * **PR #1280**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->