### PR TITLE
refactor: replace manual trunk-filter loops with WithoutTrunk()

### DIFF
--- a/internal/actions/freeze.go
+++ b/internal/actions/freeze.go
@@ -31,13 +31,7 @@ func FreezeAction(ctx *app.Context, branchName string) error {
 		IncludeCurrent:   true,
 	})
 
-	branchesToFreeze := engine.Branches{}
-	for _, b := range branches {
-		if b.IsTrunk() {
-			continue
-		}
-		branchesToFreeze = branchesToFreeze.Append(b)
-	}
+	branchesToFreeze := branches.WithoutTrunk()
 
 	if len(branchesToFreeze) > 0 {
 		res, err := eng.SetFrozen(ctx, branchesToFreeze, true)

--- a/internal/actions/lock/lock.go
+++ b/internal/actions/lock/lock.go
@@ -42,10 +42,7 @@ func Action(ctx *app.Context, branchName string, handler Handler) error {
 	// Check for unpushed commits
 	unpushedBranches := []string{}
 	remoteStatuses := eng.ReadBranchRemoteStatuses(ctx.Context, branches)
-	for _, b := range branches {
-		if b.IsTrunk() {
-			continue
-		}
+	for _, b := range branches.WithoutTrunk() {
 		status := remoteStatuses[b.GetName()]
 		if !status.Matches() {
 			if status.Ahead() || status.MissingRemote() || status.Diverged() {
@@ -75,10 +72,7 @@ func Action(ctx *app.Context, branchName string, handler Handler) error {
 
 	affectedBranches := []string{}
 	branchesToLock := engine.Branches{}
-	for _, b := range branches {
-		if b.IsTrunk() {
-			continue
-		}
+	for _, b := range branches.WithoutTrunk() {
 		if b.IsLocked() {
 			out.Info("Branch %s is already locked.", output.Branch(b.GetName(), b.GetName() == branchName))
 			continue
@@ -143,12 +137,9 @@ func Unlock(ctx *app.Context, branchName string, handler Handler) error {
 		RecursiveParents: true,
 	})
 
-	lockedDownstack := engine.Branches{}
-	for _, b := range downstack {
-		if !b.IsTrunk() && b.IsLocked() {
-			lockedDownstack = lockedDownstack.Append(b)
-		}
-	}
+	lockedDownstack := downstack.WithoutTrunk().Filter(func(b engine.Branch) bool {
+		return b.IsLocked()
+	})
 
 	if len(lockedDownstack) > 0 && handler.IsInteractive() {
 		// Collect branch names for the prompt
@@ -162,10 +153,7 @@ func Unlock(ctx *app.Context, branchName string, handler Handler) error {
 
 	affectedBranches := []string{}
 	branchesToUnlock := engine.Branches{}
-	for _, b := range branches {
-		if b.IsTrunk() {
-			continue
-		}
+	for _, b := range branches.WithoutTrunk() {
 		if !b.IsLocked() {
 			out.Info("Branch %s is already unlocked.", output.Branch(b.GetName(), b.GetName() == branchName))
 			continue

--- a/internal/actions/unfreeze.go
+++ b/internal/actions/unfreeze.go
@@ -27,13 +27,7 @@ func UnfreezeAction(ctx *app.Context, branchName string) error {
 		RecursiveChildren: true,
 	})
 
-	branchesToUnfreeze := engine.Branches{}
-	for _, b := range branches {
-		if b.IsTrunk() {
-			continue
-		}
-		branchesToUnfreeze = branchesToUnfreeze.Append(b)
-	}
+	branchesToUnfreeze := branches.WithoutTrunk()
 
 	if len(branchesToUnfreeze) > 0 {
 		res, err := eng.SetFrozen(ctx, branchesToUnfreeze, false)


### PR DESCRIPTION
## Summary

- `freeze.go` and `unfreeze.go` each had a 6-line loop that collected non-trunk branches into a new `Branches` value — collapsed to a single `branches.WithoutTrunk()` call
- `lock.go` had three similar loops and one `!IsTrunk() && IsLocked()` combined filter — all replaced with `WithoutTrunk()` iteration or a `Filter` predicate
- `Branches.WithoutTrunk()` already existed for exactly this purpose; this change makes all callers consistent with the existing API

No behaviour change — the removed loops were functionally identical to `WithoutTrunk()`.

## Test plan

- [x] `go test ./internal/actions/...` — all packages pass including `lock` and `freeze`/`unfreeze` (covered via the action-level integration tests)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU4vGptp45VFoiQKnPDRWv)_