### PR TITLE
feat: add read-only server mode that disables writes

### DIFF
--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -74,6 +75,7 @@ func run() error {
 		enableLegacy  = flag.Bool("legacy-api-prefix", true, "Also expose legacy /api endpoints")
 		shutdownGrace = flag.Duration("shutdown-timeout", 10*time.Second, "Graceful shutdown timeout")
 		authDisabled  = flag.Bool("auth-disabled", false, "Disable GitHub OAuth gate. Refused in public mode ($PORT or $STACKIT_PUBLIC).")
+		readOnly      = flag.Bool("read-only", envBool("STACKIT_READ_ONLY"), "Serve in read-only mode: the submit endpoint is disabled so the repo can be exposed publicly without write access. Also set via STACKIT_READ_ONLY.")
 	)
 	flag.Parse()
 
@@ -191,6 +193,7 @@ func run() error {
 		StaticFS:    staticFS,
 		Registry:    reg,
 		Auth:        authCfg,
+		ReadOnly:    *readOnly,
 	})
 
 	errCh := make(chan error, 1)
@@ -246,6 +249,15 @@ func addRegistryEntry(reg *registry.Registry, rc repoConfig) error {
 	}
 
 	return reg.Add(entry)
+}
+
+// envBool reports whether the named environment variable is set to a truthy
+// value (1, t, true, etc. per strconv.ParseBool). Unset or unparseable
+// values are false, so STACKIT_READ_ONLY=0 disables the mode rather than
+// tripping it the way a bare presence check would.
+func envBool(name string) bool {
+	v, err := strconv.ParseBool(os.Getenv(name))
+	return err == nil && v
 }
 
 func parseCSV(raw string) []string {

--- a/internal/api/readonly.go
+++ b/internal/api/readonly.go
@@ -1,0 +1,19 @@
+package api
+
+import "net/http"
+
+// readOnlyWriteHandler refuses mutating requests on a read-only server. It
+// replaces the submit handler when ServerConfig.ReadOnly is set, so the
+// write path is gone by construction — there is no code path that can push
+// branches or update GitHub, regardless of auth or who is calling.
+//
+// It returns 405 (the method is disabled on this server) with a JSON body
+// so clients can distinguish a read-only refusal from a missing route (404)
+// or a failed auth/CSRF check (401/403).
+func readOnlyWriteHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		_, _ = w.Write([]byte(`{"error":"server is read-only"}`))
+	})
+}

--- a/internal/api/readonly_test.go
+++ b/internal/api/readonly_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/api/auth"
+	"github.com/getstackit/stackit/internal/api/registry"
+)
+
+// newTestHandler builds the full handler chain for a server with the given
+// read-only setting and an empty registry. Auth is left nil so the tests
+// exercise routing without a session store.
+func newTestHandler(t *testing.T, readOnly bool) http.Handler {
+	t.Helper()
+	srv := NewServer(ServerConfig{
+		APIPrefixes: []string{"/api/v1"},
+		Registry:    registry.New(),
+		ReadOnly:    readOnly,
+	})
+	handler, err := srv.buildHandler()
+	require.NoError(t, err)
+	return handler
+}
+
+// submitRequest builds a POST to the submit route with the CSRF header set,
+// so it clears RequireCSRFHeader and reaches the routed handler.
+func submitRequest() *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repos/default/stacks/main/submit", nil)
+	req.Header.Set(auth.CSRFHeader, "1")
+	return req
+}
+
+func TestReadOnlyModeRefusesSubmit(t *testing.T) {
+	t.Parallel()
+
+	handler := newTestHandler(t, true)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, submitRequest())
+
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+	require.JSONEq(t, `{"error":"server is read-only"}`, rr.Body.String())
+}
+
+func TestReadOnlyModeAllowsReads(t *testing.T) {
+	t.Parallel()
+
+	handler := newTestHandler(t, true)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/repos", nil))
+
+	// The read API is untouched by read-only mode: the repos index still
+	// answers 200 (with an empty list for an empty registry).
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestReadWriteModeKeepsSubmitRoute(t *testing.T) {
+	t.Parallel()
+
+	handler := newTestHandler(t, false)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, submitRequest())
+
+	// In normal mode the submit route is live and reaches the real handler.
+	// It won't 405 with the read-only body; against an empty registry it
+	// resolves to an unknown repo instead.
+	require.NotEqual(t, http.StatusMethodNotAllowed, rr.Code)
+	require.NotContains(t, rr.Body.String(), "server is read-only")
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -27,6 +27,13 @@ type ServerConfig struct {
 	StaticFS    fs.FS
 	Registry    *registry.Registry
 
+	// ReadOnly puts the server into a public read-only posture: the
+	// mutating submit route is replaced with a handler that refuses with
+	// 405 so writes are impossible by construction, not just by policy.
+	// This is the safety floor for exposing a repo publicly — a read-only
+	// server cannot push branches or touch GitHub no matter who calls it.
+	ReadOnly bool
+
 	// Auth bundles the OAuth handler, session store, and surrounding state
 	// needed to gate /api/* routes behind GitHub login. When nil the server
 	// runs without authentication; that mode is only safe on a private
@@ -58,9 +65,35 @@ func NewServer(cfg ServerConfig) *Server {
 
 // Start begins serving HTTP requests. It blocks until the server is stopped.
 func (s *Server) Start() error {
+	handler, err := s.buildHandler()
+	if err != nil {
+		return err
+	}
+
+	s.httpServer = &http.Server{
+		Addr:              fmt.Sprintf("%s:%d", s.config.BindAddr, s.config.Port),
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		MaxHeaderBytes:    1 << 20, // 1 MiB
+	}
+
+	mode := "read-write"
+	if s.config.ReadOnly {
+		mode = "read-only"
+	}
+	slog.Info("stackit-web server listening", "url", fmt.Sprintf("http://%s:%d", displayHost(s.config.BindAddr), s.config.Port), "mode", mode)
+	return s.httpServer.ListenAndServe()
+}
+
+// buildHandler assembles the full HTTP handler chain (routes + middleware)
+// without binding a listener, so tests can exercise routing and read-only
+// behavior via httptest. Start wraps the result in an *http.Server.
+func (s *Server) buildHandler() (http.Handler, error) {
 	csp, err := buildCSP(s.config.StaticFS)
 	if err != nil {
-		return fmt.Errorf("build CSP from static FS: %w", err)
+		return nil, fmt.Errorf("build CSP from static FS: %w", err)
 	}
 
 	apiMux := http.NewServeMux()
@@ -73,9 +106,17 @@ func (s *Server) Start() error {
 	stacksHandler := handlers.NewStacksHandler(reg)
 	branchesHandler := handlers.NewBranchesHandler(reg)
 	branchDiffHandler := handlers.NewBranchDiffHandler(reg)
-	submitHandler := handlers.NewSubmitHandler(reg)
 	eventsHandler := handlers.NewEventsHandler(reg)
 	reposListHandler := handlers.NewReposListHandler(reg)
+
+	// The submit route is the server's only mutating endpoint. In
+	// read-only mode it is replaced with a handler that refuses every
+	// request, so a public deployment cannot push branches or touch
+	// GitHub regardless of who calls it.
+	var submitHandler http.Handler = handlers.NewSubmitHandler(reg)
+	if s.config.ReadOnly {
+		submitHandler = readOnlyWriteHandler()
+	}
 
 	for _, prefix := range prefixes {
 		// Unscoped index of available repos.
@@ -165,17 +206,7 @@ func (s *Server) Start() error {
 	handler = requestIDMiddleware(handler)
 	handler = recoverMiddleware(handler)
 
-	s.httpServer = &http.Server{
-		Addr:              fmt.Sprintf("%s:%d", s.config.BindAddr, s.config.Port),
-		Handler:           handler,
-		ReadHeaderTimeout: 10 * time.Second,
-		WriteTimeout:      30 * time.Second,
-		IdleTimeout:       120 * time.Second,
-		MaxHeaderBytes:    1 << 20, // 1 MiB
-	}
-
-	slog.Info("stackit-web server listening", "url", fmt.Sprintf("http://%s:%d", displayHost(s.config.BindAddr), s.config.Port))
-	return s.httpServer.ListenAndServe()
+	return handler, nil
 }
 
 // Shutdown gracefully stops the server. The registry's watchers and


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Introduce a -read-only flag (and STACKIT_READ_ONLY env) that puts the
server into a public read-only posture. The submit route — the server's
only mutating endpoint — is replaced with a handler that refuses every
request with 405, so a read-only deployment cannot push branches or
touch GitHub regardless of who calls it. This is the safety floor for
exposing a repo publicly.

Extracts the handler-building logic out of Start into a testable
buildHandler() seam so routing and read-only behavior can be exercised
via httptest without binding a listener.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282** 👈
  * **PR #1283**
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*