### PR TITLE
feat: allow anonymous reads in read-only mode

### DIFF
--- a/internal/api/readonly_test.go
+++ b/internal/api/readonly_test.go
@@ -26,6 +26,41 @@ func newTestHandler(t *testing.T, readOnly bool) http.Handler {
 	return handler
 }
 
+// newTestHandlerWithAuth is newTestHandler with an AuthConfig attached so
+// session enforcement is in play.
+func newTestHandlerWithAuth(t *testing.T, readOnly bool, authCfg *AuthConfig) http.Handler {
+	t.Helper()
+	srv := NewServer(ServerConfig{
+		APIPrefixes: []string{"/api/v1"},
+		Registry:    registry.New(),
+		ReadOnly:    readOnly,
+		Auth:        authCfg,
+	})
+	handler, err := srv.buildHandler()
+	require.NoError(t, err)
+	return handler
+}
+
+// newTestAuthConfig builds an AuthConfig backed by an in-memory session
+// store. No session is ever created, so requests are effectively anonymous —
+// which is exactly what we want to assert read-only mode lets through.
+func newTestAuthConfig(t *testing.T) *AuthConfig {
+	t.Helper()
+	key, err := auth.GenerateSessionKey()
+	require.NoError(t, err)
+	cipher, err := auth.NewCipher(key)
+	require.NoError(t, err)
+	store := auth.NewMemoryStore(cipher)
+	t.Cleanup(func() { _ = store.Close() })
+	handler, err := auth.NewHandler(auth.Config{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		BaseURL:      "http://localhost",
+	}, store, nil, cipher)
+	require.NoError(t, err)
+	return &AuthConfig{Handler: handler, SessionStore: store}
+}
+
 // submitRequest builds a POST to the submit route with the CSRF header set,
 // so it clears RequireCSRFHeader and reaches the routed handler.
 func submitRequest() *http.Request {
@@ -69,4 +104,27 @@ func TestReadWriteModeKeepsSubmitRoute(t *testing.T) {
 	// resolves to an unknown repo instead.
 	require.NotEqual(t, http.StatusMethodNotAllowed, rr.Code)
 	require.NotContains(t, rr.Body.String(), "server is read-only")
+}
+
+func TestReadOnlyModeAllowsAnonymousReadsWithAuthConfigured(t *testing.T) {
+	t.Parallel()
+
+	handler := newTestHandlerWithAuth(t, true, newTestAuthConfig(t))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/repos", nil))
+
+	// Read-only mode skips session enforcement, so an anonymous reader
+	// gets the repos index even though auth is configured.
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestReadWriteModeRequiresSessionForReads(t *testing.T) {
+	t.Parallel()
+
+	handler := newTestHandlerWithAuth(t, false, newTestAuthConfig(t))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/repos", nil))
+
+	// With auth configured and read-only off, anonymous reads are rejected.
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -153,8 +153,14 @@ func (s *Server) buildHandler() (http.Handler, error) {
 	// Apply session enforcement to /api/* only. /auth/* and static assets
 	// stay unauthenticated so the user can complete the login flow and
 	// land on the SPA shell.
+	//
+	// Read-only mode skips session enforcement entirely: the API is all
+	// reads (the lone write route is the read-only refusal handler), so the
+	// repo is meant to be publicly viewable without a login. Without this,
+	// a read-only server with Auth configured would still 401 anonymous
+	// readers and defeat the purpose of the mode.
 	var protectedAPI http.Handler = apiMux
-	if s.config.Auth != nil {
+	if s.config.Auth != nil && !s.config.ReadOnly {
 		protectedAPI = auth.RequireSession(s.config.Auth.SessionStore, apiMux)
 	}
 	// CSRF header check wraps protectedAPI so it covers POST /submit. Safe


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Read-only mode now skips session enforcement so a configured repo is
publicly viewable without a login. The read API is all GETs and the lone
write route is already the read-only refusal handler, so dropping the
session gate exposes nothing mutating.

Without this, a read-only server with GitHub OAuth configured would still
401 anonymous readers, defeating the point of the mode. Normal (non
read-only) servers are unchanged: reads still require a session when auth
is configured.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283** 👈
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*