### PR TITLE
feat: omit operator identity from public read-only responses

### DIFF
--- a/internal/api/handlers/common.go
+++ b/internal/api/handlers/common.go
@@ -12,6 +12,23 @@ import (
 // substituted on the unscoped legacy routes that don't carry {repoID}.
 const defaultRepoID = "default"
 
+// Visibility controls whether a handler may expose operator- or
+// viewer-identifying fields in its response. A public (read-only) server
+// must not leak who is running it, so identity fields like currentUser are
+// omitted under VisibilityPublic.
+type Visibility int
+
+const (
+	// VisibilityPrivate is the authenticated/local posture: responses may
+	// include the operator/viewer identity.
+	VisibilityPrivate Visibility = iota
+	// VisibilityPublic is the anonymous read-only posture: identity fields
+	// are omitted so an unauthenticated caller can't learn who runs the
+	// server (and so reads don't trigger GitHub calls on the operator's
+	// token).
+	VisibilityPublic
+)
+
 // resolveRepo looks up the repo entry for the {repoID} path value on r.
 // If the path value is empty (legacy/unscoped route or direct test call)
 // it falls back to defaultRepoID. Returns false and writes a 404 when the

--- a/internal/api/handlers/view.go
+++ b/internal/api/handlers/view.go
@@ -8,14 +8,16 @@ import (
 
 // ViewHandler serves the combined view payload for the frontend.
 type ViewHandler struct {
-	reg *registry.Registry
+	reg        *registry.Registry
+	visibility Visibility
 }
 
 // NewViewHandler creates a handler that resolves the per-request repo from
 // the registry. Assembly logic lives in ViewAssembler so this handler stays
-// transport-focused.
-func NewViewHandler(reg *registry.Registry) *ViewHandler {
-	return &ViewHandler{reg: reg}
+// transport-focused. visibility controls whether the operator identity is
+// included in the payload (omitted for a public read-only server).
+func NewViewHandler(reg *registry.Registry, visibility Visibility) *ViewHandler {
+	return &ViewHandler{reg: reg, visibility: visibility}
 }
 
 // ServeHTTP handles GET view endpoints.
@@ -30,7 +32,7 @@ func (h *ViewHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	assembler := NewViewAssembler(entry.Engine, entry.GitHub, entry.Remote)
+	assembler := NewViewAssembler(entry.Engine, entry.GitHub, entry.Remote, h.visibility)
 	view, err := assembler.Build(r.Context())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/api/handlers/view_assembler.go
+++ b/internal/api/handlers/view_assembler.go
@@ -13,16 +13,18 @@ import (
 
 // ViewAssembler builds the combined /view payload.
 type ViewAssembler struct {
-	eng    engine.BranchReader
-	gh     github.Client
-	remote string
+	eng        engine.BranchReader
+	gh         github.Client
+	remote     string
+	visibility Visibility
 }
 
-func NewViewAssembler(eng engine.BranchReader, gh github.Client, remote string) *ViewAssembler {
+func NewViewAssembler(eng engine.BranchReader, gh github.Client, remote string, visibility Visibility) *ViewAssembler {
 	return &ViewAssembler{
-		eng:    eng,
-		gh:     gh,
-		remote: remote,
+		eng:        eng,
+		gh:         gh,
+		remote:     remote,
+		visibility: visibility,
 	}
 }
 
@@ -50,7 +52,13 @@ func (a *ViewAssembler) buildRepo(ctx context.Context) httpcontract.RepoResponse
 	var currentUser string
 	if a.gh != nil {
 		owner, repo = a.gh.GetOwnerRepo()
-		currentUser, _ = a.gh.GetCurrentUser(ctx)
+		// currentUser identifies the operator (it comes from the server's
+		// GitHub token). On a public read-only server we must not leak that,
+		// and we must not spend the operator's GitHub rate limit on
+		// anonymous reads — so the lookup is skipped entirely.
+		if a.visibility == VisibilityPrivate {
+			currentUser, _ = a.gh.GetCurrentUser(ctx)
+		}
 	}
 
 	return httpcontract.RepoResponse{

--- a/internal/api/handlers/view_assembler_test.go
+++ b/internal/api/handlers/view_assembler_test.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// fakeGitHub implements only the github.Client methods buildRepo touches.
+// The embedded interface is nil, so any other call panics — which keeps the
+// fake honest about what the code under test actually depends on.
+type fakeGitHub struct {
+	github.Client
+	owner       string
+	repo        string
+	currentUser string
+}
+
+func (f *fakeGitHub) GetOwnerRepo() (string, string) { return f.owner, f.repo }
+
+func (f *fakeGitHub) GetCurrentUser(context.Context) (string, error) {
+	return f.currentUser, nil
+}
+
+func TestBuildRepoOmitsCurrentUserWhenPublic(t *testing.T) {
+	t.Parallel()
+
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	gh := &fakeGitHub{owner: "acme", repo: "widgets", currentUser: "operator-login"}
+
+	t.Run("private includes the operator identity", func(t *testing.T) {
+		t.Parallel()
+		a := NewViewAssembler(s.Engine, gh, "origin", VisibilityPrivate)
+		repo := a.buildRepo(context.Background())
+		require.Equal(t, "operator-login", repo.CurrentUser)
+		require.Equal(t, "acme", repo.Owner)
+		require.Equal(t, "widgets", repo.Repo)
+	})
+
+	t.Run("public omits the operator identity", func(t *testing.T) {
+		t.Parallel()
+		a := NewViewAssembler(s.Engine, gh, "origin", VisibilityPublic)
+		repo := a.buildRepo(context.Background())
+		require.Empty(t, repo.CurrentUser, "a public read-only server must not leak who runs it")
+		// Repo coordinates are public information (they match the PRs on
+		// GitHub) and stay populated.
+		require.Equal(t, "acme", repo.Owner)
+		require.Equal(t, "widgets", repo.Repo)
+	})
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -101,7 +101,15 @@ func (s *Server) buildHandler() (http.Handler, error) {
 
 	reg := s.config.Registry
 
-	viewHandler := handlers.NewViewHandler(reg)
+	// A read-only server is meant to be public, so handlers must omit
+	// operator-identifying fields (and skip the GitHub calls that would
+	// fetch them on the operator's token).
+	visibility := handlers.VisibilityPrivate
+	if s.config.ReadOnly {
+		visibility = handlers.VisibilityPublic
+	}
+
+	viewHandler := handlers.NewViewHandler(reg, visibility)
 	repoHandler := handlers.NewRepoHandler(reg)
 	stacksHandler := handlers.NewStacksHandler(reg)
 	branchesHandler := handlers.NewBranchesHandler(reg)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The /view payload populated currentUser from the server's GitHub token,
i.e. the operator's identity — and did so with a live GitHub API call on
that token for every request. On a public read-only server that both
leaks who runs the server and spends the operator's rate limit on
anonymous traffic.

Introduce a Visibility (Private/Public) constant plumbed into the view
handler/assembler. Read-only mode resolves to VisibilityPublic, which
skips the GetCurrentUser lookup and leaves currentUser empty.

Audit of the rest of the read surface: commit authors use git %an (name
only, no email), and patches/PR/CI/commit fields are all public-by-design
for a public repo. No filesystem paths, tokens, or emails are serialized.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284** 👈
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*