### PR TITLE
feat: cap concurrent SSE connections

### DIFF
--- a/internal/api/handlers/events.go
+++ b/internal/api/handlers/events.go
@@ -12,13 +12,23 @@ import (
 // Each connection is scoped to one repo: subscribers to /repos/A/events
 // only see events broadcast on repo A.
 type EventsHandler struct {
-	reg *registry.Registry
+	reg         *registry.Registry
+	limiter     *sseLimiter
+	maxLifetime time.Duration
 }
 
 // NewEventsHandler creates a handler that resolves the per-request repo
-// from the registry and streams from that repo's broadcaster.
-func NewEventsHandler(reg *registry.Registry) *EventsHandler {
-	return &EventsHandler{reg: reg}
+// from the registry and streams from that repo's broadcaster. limits bound
+// concurrent connections so an unauthenticated public deployment can't be
+// exhausted by clients opening unbounded streams; zero fields take the
+// package defaults.
+func NewEventsHandler(reg *registry.Registry, limits SSELimits) *EventsHandler {
+	limits = limits.withDefaults()
+	return &EventsHandler{
+		reg:         reg,
+		limiter:     newSSELimiter(limits.MaxGlobal, limits.MaxPerIP),
+		maxLifetime: limits.MaxLifetime,
+	}
 }
 
 // ServeHTTP handles the SSE connection for one repo.
@@ -50,6 +60,15 @@ func (h *EventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Reserve a connection slot before streaming. A public server must cap
+	// concurrent streams or anyone can exhaust it by opening connections.
+	ip := ClientIP(r)
+	if !h.limiter.acquire(ip) {
+		http.Error(w, "too many connections", http.StatusTooManyRequests)
+		return
+	}
+	defer h.limiter.release(ip)
+
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
@@ -67,12 +86,29 @@ func (h *EventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	flusher.Flush()
 
+	// Bound how long a single connection can hold its slot. EventSource
+	// reconnects on its own, so this is transparent to clients.
+	lifetime := time.NewTimer(h.maxLifetime)
+	defer lifetime.Stop()
+
+	// Periodic keepalive: keeps proxies from idling the stream out and makes
+	// a dead client fail the write below, releasing its slot promptly.
+	heartbeat := time.NewTicker(sseHeartbeatInterval)
+	defer heartbeat.Stop()
+
 	for {
 		select {
 		case <-r.Context().Done():
 			return
 		case <-entry.Broadcaster.Done():
 			return
+		case <-lifetime.C:
+			return
+		case <-heartbeat.C:
+			if _, err := fmt.Fprint(w, ": keepalive\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
 		case msg, ok := <-ch:
 			if !ok {
 				return

--- a/internal/api/handlers/events_test.go
+++ b/internal/api/handlers/events_test.go
@@ -41,7 +41,7 @@ func TestEventsHandlerReturnsWhenBroadcasterCloses(t *testing.T) {
 		ID:          "default",
 		Broadcaster: broadcaster,
 	}))
-	handler := NewEventsHandler(reg)
+	handler := NewEventsHandler(reg, SSELimits{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/repos/default/events", nil)
 	req.SetPathValue("repoID", "default")
@@ -68,6 +68,51 @@ func TestEventsHandlerReturnsWhenBroadcasterCloses(t *testing.T) {
 	}
 }
 
+func TestEventsHandlerRejectsBeyondPerIPCap(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.New()
+	broadcaster := registry.NewBroadcaster()
+	require.NoError(t, reg.Add(&registry.RepoEntry{
+		ID:          "default",
+		Broadcaster: broadcaster,
+	}))
+	handler := NewEventsHandler(reg, SSELimits{MaxPerIP: 1})
+
+	// First connection holds the only per-IP slot. Run it in the background;
+	// it blocks streaming until the broadcaster closes.
+	firstReq := httptest.NewRequest(http.MethodGet, "/api/v1/repos/default/events", nil)
+	firstReq.SetPathValue("repoID", "default")
+	first := newSignalingResponseWriter()
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(first, firstReq)
+		close(done)
+	}()
+
+	select {
+	case <-first.wrote:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first SSE connection to establish")
+	}
+
+	// Second connection from the same IP exceeds the cap and is rejected
+	// without blocking.
+	secondReq := httptest.NewRequest(http.MethodGet, "/api/v1/repos/default/events", nil)
+	secondReq.SetPathValue("repoID", "default")
+	second := httptest.NewRecorder()
+	handler.ServeHTTP(second, secondReq)
+	require.Equal(t, http.StatusTooManyRequests, second.Code)
+
+	// Releasing the first slot (broadcaster shutdown) lets the goroutine exit.
+	broadcaster.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first connection did not exit after broadcaster shutdown")
+	}
+}
+
 func TestEventsHandlerReturns404ForUnknownRepo(t *testing.T) {
 	t.Parallel()
 
@@ -76,7 +121,7 @@ func TestEventsHandlerReturns404ForUnknownRepo(t *testing.T) {
 		ID:          "default",
 		Broadcaster: registry.NewBroadcaster(),
 	}))
-	handler := NewEventsHandler(reg)
+	handler := NewEventsHandler(reg, SSELimits{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/repos/missing/events", nil)
 	req.SetPathValue("repoID", "missing")

--- a/internal/api/handlers/sse_limit.go
+++ b/internal/api/handlers/sse_limit.go
@@ -1,0 +1,123 @@
+package handlers
+
+import (
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Default SSE resource bounds. They are generous enough that normal use
+// (a handful of browser tabs) never trips them, but they cap the blast
+// radius of an unauthenticated public deployment where anyone can open
+// long-lived streams.
+const (
+	defaultSSEMaxGlobal   = 512
+	defaultSSEMaxPerIP    = 32
+	defaultSSEMaxLifetime = 30 * time.Minute
+	// sseHeartbeatInterval is how often a keepalive comment is written. It
+	// keeps proxies from idling the connection out and — more importantly —
+	// surfaces dead clients via a failed write, so their slots are released
+	// back to the limiter instead of leaking until max lifetime.
+	sseHeartbeatInterval = 25 * time.Second
+)
+
+// SSELimits bounds concurrent Server-Sent Events connections. Zero fields
+// fall back to the package defaults, so callers can set only what they want
+// to override.
+type SSELimits struct {
+	// MaxGlobal caps concurrent SSE connections across all repos. 0 -> default.
+	MaxGlobal int
+	// MaxPerIP caps concurrent SSE connections from a single client IP.
+	// 0 -> default.
+	MaxPerIP int
+	// MaxLifetime force-closes a connection after this duration. EventSource
+	// clients reconnect transparently, so a bounded lifetime caps how long
+	// any single connection can hold resources. 0 -> default.
+	MaxLifetime time.Duration
+}
+
+func (l SSELimits) withDefaults() SSELimits {
+	if l.MaxGlobal == 0 {
+		l.MaxGlobal = defaultSSEMaxGlobal
+	}
+	if l.MaxPerIP == 0 {
+		l.MaxPerIP = defaultSSEMaxPerIP
+	}
+	if l.MaxLifetime == 0 {
+		l.MaxLifetime = defaultSSEMaxLifetime
+	}
+	return l
+}
+
+// sseLimiter tracks active SSE connection counts globally and per client IP.
+// A negative or zero cap disables that dimension.
+type sseLimiter struct {
+	maxGlobal int
+	maxPerIP  int
+
+	mu     sync.Mutex
+	global int
+	perIP  map[string]int
+}
+
+func newSSELimiter(maxGlobal, maxPerIP int) *sseLimiter {
+	return &sseLimiter{
+		maxGlobal: maxGlobal,
+		maxPerIP:  maxPerIP,
+		perIP:     make(map[string]int),
+	}
+}
+
+// acquire reserves a connection slot for ip. It returns false (reserving
+// nothing) when the global or per-IP cap is already reached, so the caller
+// must not release on a false result.
+func (l *sseLimiter) acquire(ip string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.maxGlobal > 0 && l.global >= l.maxGlobal {
+		return false
+	}
+	if l.maxPerIP > 0 && l.perIP[ip] >= l.maxPerIP {
+		return false
+	}
+	l.global++
+	l.perIP[ip]++
+	return true
+}
+
+// release returns a slot previously taken by acquire.
+func (l *sseLimiter) release(ip string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.global > 0 {
+		l.global--
+	}
+	switch n := l.perIP[ip]; {
+	case n <= 1:
+		delete(l.perIP, ip)
+	default:
+		l.perIP[ip] = n - 1
+	}
+}
+
+// ClientIP extracts the caller's IP for per-IP limiting. It honors the
+// left-most X-Forwarded-For entry (set by a trusted proxy/CDN in front of a
+// public deployment) and falls back to the connection's RemoteAddr. Behind a
+// proxy that doesn't set the header, all callers collapse to the proxy IP —
+// a deployment concern, not a code one.
+func ClientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if first, _, found := strings.Cut(xff, ","); found {
+			xff = first
+		}
+		if ip := strings.TrimSpace(xff); ip != "" {
+			return ip
+		}
+	}
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
+}

--- a/internal/api/handlers/sse_limit_test.go
+++ b/internal/api/handlers/sse_limit_test.go
@@ -1,0 +1,71 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSSELimiterGlobalCap(t *testing.T) {
+	t.Parallel()
+
+	l := newSSELimiter(2, 0) // global 2, per-IP unlimited
+	require.True(t, l.acquire("a"))
+	require.True(t, l.acquire("b"))
+	require.False(t, l.acquire("c"), "third connection exceeds the global cap")
+
+	l.release("a")
+	require.True(t, l.acquire("c"), "releasing a slot lets a new connection in")
+}
+
+func TestSSELimiterPerIPCap(t *testing.T) {
+	t.Parallel()
+
+	l := newSSELimiter(0, 1) // global unlimited, per-IP 1
+	require.True(t, l.acquire("1.1.1.1"))
+	require.False(t, l.acquire("1.1.1.1"), "second connection from the same IP is capped")
+	require.True(t, l.acquire("2.2.2.2"), "a different IP has its own budget")
+
+	l.release("1.1.1.1")
+	require.True(t, l.acquire("1.1.1.1"), "releasing frees the per-IP slot")
+}
+
+func TestSSELimiterReleaseIsBounded(t *testing.T) {
+	t.Parallel()
+
+	l := newSSELimiter(1, 1)
+	// Over-releasing must not drive counters negative and grant phantom slots.
+	l.release("x")
+	require.True(t, l.acquire("x"))
+	require.False(t, l.acquire("x"))
+}
+
+func TestClientIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		xff        string
+		want       string
+	}{
+		{name: "remote addr host", remoteAddr: "203.0.113.5:54321", want: "203.0.113.5"},
+		{name: "xff takes precedence", remoteAddr: "10.0.0.1:80", xff: "198.51.100.7", want: "198.51.100.7"},
+		{name: "xff leftmost of chain", remoteAddr: "10.0.0.1:80", xff: "198.51.100.7, 10.0.0.1", want: "198.51.100.7"},
+		{name: "xff trimmed", remoteAddr: "10.0.0.1:80", xff: "  198.51.100.7  ", want: "198.51.100.7"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = tc.remoteAddr
+			if tc.xff != "" {
+				req.Header.Set("X-Forwarded-For", tc.xff)
+			}
+			require.Equal(t, tc.want, ClientIP(req))
+		})
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -27,6 +27,11 @@ type ServerConfig struct {
 	StaticFS    fs.FS
 	Registry    *registry.Registry
 
+	// SSELimits bounds concurrent Server-Sent Events connections. Zero
+	// fields take the package defaults, which are generous enough for normal
+	// use but cap the blast radius of a public deployment.
+	SSELimits handlers.SSELimits
+
 	// ReadOnly puts the server into a public read-only posture: the
 	// mutating submit route is replaced with a handler that refuses with
 	// 405 so writes are impossible by construction, not just by policy.
@@ -114,7 +119,7 @@ func (s *Server) buildHandler() (http.Handler, error) {
 	stacksHandler := handlers.NewStacksHandler(reg)
 	branchesHandler := handlers.NewBranchesHandler(reg)
 	branchDiffHandler := handlers.NewBranchDiffHandler(reg)
-	eventsHandler := handlers.NewEventsHandler(reg)
+	eventsHandler := handlers.NewEventsHandler(reg, s.config.SSELimits)
 	reposListHandler := handlers.NewReposListHandler(reg)
 
 	// The submit route is the server's only mutating endpoint. In


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The events stream had no bound on subscribers, so a public deployment
could be exhausted by anyone opening unbounded long-lived connections.

Add an SSE limiter with a global and per-IP concurrent-connection cap
(generous defaults, overridable via ServerConfig.SSELimits); over-cap
requests get 429. Each stream also gets a bounded max lifetime and a
periodic keepalive — the keepalive both stops proxies from idling the
connection out and surfaces dead clients via a failed write so their
slots are reclaimed promptly instead of leaking until max lifetime.

Adds ClientIP (honors X-Forwarded-For from a trusted proxy, falls back to
RemoteAddr), shared with the rate limiter in the next change.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284**
      * **PR #1285** 👈
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*