### PR TITLE
feat: add server capabilities endpoint

### DIFF
--- a/internal/api/handlers/config.go
+++ b/internal/api/handlers/config.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"net/http"
+
+	httpcontract "github.com/getstackit/stackit/internal/contracts/http"
+)
+
+// ConfigHandler serves server capabilities at GET /api/v1/config. It carries
+// no repo state — the values are fixed at server startup — and is served
+// without a session so the web client can discover whether auth is required
+// before attempting a login.
+type ConfigHandler struct {
+	readOnly     bool
+	authRequired bool
+}
+
+// NewConfigHandler creates a handler that reports the given capabilities.
+func NewConfigHandler(readOnly, authRequired bool) *ConfigHandler {
+	return &ConfigHandler{readOnly: readOnly, authRequired: authRequired}
+}
+
+// ServeHTTP returns the capability payload.
+func (h *ConfigHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	writeJSON(w, httpcontract.ConfigResponse{
+		ReadOnly:     h.readOnly,
+		AuthRequired: h.authRequired,
+	})
+}

--- a/internal/api/readonly_test.go
+++ b/internal/api/readonly_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/api/auth"
 	"github.com/getstackit/stackit/internal/api/registry"
+	httpcontract "github.com/getstackit/stackit/internal/contracts/http"
 )
 
 // newTestHandler builds the full handler chain for a server with the given
@@ -127,4 +129,42 @@ func TestReadWriteModeRequiresSessionForReads(t *testing.T) {
 
 	// With auth configured and read-only off, anonymous reads are rejected.
 	require.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func fetchConfig(t *testing.T, handler http.Handler) httpcontract.ConfigResponse {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/config", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	var cfg httpcontract.ConfigResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &cfg))
+	return cfg
+}
+
+func TestConfigEndpointReadOnly(t *testing.T) {
+	t.Parallel()
+
+	cfg := fetchConfig(t, newTestHandler(t, true))
+	require.True(t, cfg.ReadOnly)
+	require.False(t, cfg.AuthRequired, "read-only servers serve reads anonymously")
+}
+
+func TestConfigEndpointReachableWithoutSession(t *testing.T) {
+	t.Parallel()
+
+	// Auth configured, read-only off: reads require a session, but /config
+	// must still be reachable anonymously so the client can discover that a
+	// login is required.
+	cfg := fetchConfig(t, newTestHandlerWithAuth(t, false, newTestAuthConfig(t)))
+	require.False(t, cfg.ReadOnly)
+	require.True(t, cfg.AuthRequired)
+}
+
+func TestConfigEndpointAuthDisabled(t *testing.T) {
+	t.Parallel()
+
+	// No auth configured: neither read-only nor auth-required.
+	cfg := fetchConfig(t, newTestHandler(t, false))
+	require.False(t, cfg.ReadOnly)
+	require.False(t, cfg.AuthRequired)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -131,6 +131,11 @@ func (s *Server) buildHandler() (http.Handler, error) {
 	eventsHandler := handlers.NewEventsHandler(reg, s.config.SSELimits)
 	reposListHandler := handlers.NewReposListHandler(reg)
 
+	// authRequired tells the client whether reads need a login. Read-only
+	// mode and auth-disabled both serve reads anonymously.
+	authRequired := s.config.Auth != nil && !s.config.ReadOnly
+	configHandler := handlers.NewConfigHandler(s.config.ReadOnly, authRequired)
+
 	// The submit route is the server's only mutating endpoint. In
 	// read-only mode it is replaced with a handler that refuses every
 	// request, so a public deployment cannot push branches or touch
@@ -181,14 +186,34 @@ func (s *Server) buildHandler() (http.Handler, error) {
 	// repo is meant to be publicly viewable without a login. Without this,
 	// a read-only server with Auth configured would still 401 anonymous
 	// readers and defeat the purpose of the mode.
-	var protectedAPI http.Handler = apiMux
+	var sessionGated http.Handler = apiMux
 	if s.config.Auth != nil && !s.config.ReadOnly {
-		protectedAPI = auth.RequireSession(s.config.Auth.SessionStore, apiMux)
+		sessionGated = auth.RequireSession(s.config.Auth.SessionStore, apiMux)
 	}
-	// CSRF header check wraps protectedAPI so it covers POST /submit. Safe
-	// methods (GET/HEAD/OPTIONS) pass through untouched, so the read API
-	// is unaffected.
-	protectedAPI = auth.RequireCSRFHeader(protectedAPI)
+	// CSRF header check wraps the session-gated API so it covers POST
+	// /submit. Safe methods (GET/HEAD/OPTIONS) pass through untouched, so the
+	// read API is unaffected.
+	sessionGated = auth.RequireCSRFHeader(sessionGated)
+
+	// /config advertises server capabilities and must be reachable without a
+	// session so the client can learn whether a login is required before
+	// attempting one. It bypasses the session gate but still gets the outer
+	// middleware (and rate limiting below).
+	publicAPIMux := http.NewServeMux()
+	for _, prefix := range prefixes {
+		publicAPIMux.Handle("GET "+prefix+"/config", configHandler)
+	}
+
+	// Combined API dispatch: public capability routes bypass the session
+	// gate; everything else is session-gated. Rate limiting wraps both so the
+	// public endpoint is protected from floods too.
+	var protectedAPI http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isConfigPath(r.URL.Path, prefixes) {
+			publicAPIMux.ServeHTTP(w, r)
+			return
+		}
+		sessionGated.ServeHTTP(w, r)
+	})
 
 	// Per-IP rate limiting guards the public API surface. A negative RPS
 	// disables it; otherwise it wraps the API so a single client can't flood
@@ -300,6 +325,17 @@ func displayHost(bind string) string {
 func isAPIPath(path string, prefixes []string) bool {
 	for _, prefix := range prefixes {
 		if path == prefix || strings.HasPrefix(path, prefix+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// isConfigPath reports whether path is the unauthenticated capabilities
+// endpoint for any configured prefix (e.g. /api/v1/config or /api/config).
+func isConfigPath(path string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if path == prefix+"/config" {
 			return true
 		}
 	}

--- a/internal/contracts/http/responses.go
+++ b/internal/contracts/http/responses.go
@@ -5,6 +5,20 @@
 // to evolve independently.
 package httpcontract
 
+// ConfigResponse advertises server capabilities so the web client can adapt
+// at runtime instead of relying on build-time flags. It is served
+// unauthenticated so the client can learn whether a login is required
+// before attempting one.
+type ConfigResponse struct {
+	// ReadOnly is true when the server refuses writes (the submit endpoint
+	// is disabled). The client hides write affordances.
+	ReadOnly bool `json:"readOnly"`
+	// AuthRequired is true when reads require a session. It is false on a
+	// public read-only server and when auth is disabled, so the client knows
+	// not to send the user through a login flow.
+	AuthRequired bool `json:"authRequired"`
+}
+
 // RepoSummary is one entry in ReposListResponse — the metadata clients
 // need to render a repo picker without hitting per-repo endpoints.
 type RepoSummary struct {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Add GET /api/v1/config returning {readOnly, authRequired} so the web
client can adapt at runtime — hide write affordances, and skip the login
flow on a public server — instead of relying on build-time env flags.

The endpoint is served without a session (it bypasses the session gate
but keeps the outer middleware and rate limiting), because the client
must be able to discover whether a login is required before it has one.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287** 👈
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*