### PR TITLE
feat: adapt web UI to read-only servers

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -3,16 +3,25 @@
 import { Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import { AuthProvider } from "@/components/providers/auth-provider";
+import { ConfigProvider } from "@/components/providers/config-provider";
 import { RepoProvider } from "@/components/providers/repo-provider";
 import { RepoPicker } from "@/components/repo-picker/repo-picker";
 import { RepoView } from "@/components/repo-picker/repo-view";
+import { ReadOnlyBanner } from "@/components/read-only-banner";
+import type { ConfigResponse } from "@/lib/api";
 
-// NEXT_PUBLIC_STACKIT_AUTH_DISABLED=1 short-circuits the /auth/me check
-// at build time. Useful for `next dev` against a server started with
-// -auth-disabled, or for builds intended for deployments where the
-// operator has fronted the server with platform auth (Tailscale,
-// Cloudflare Access).
+// The server's /api/v1/config endpoint is authoritative for read-only and
+// auth-required at runtime. NEXT_PUBLIC_STACKIT_AUTH_DISABLED=1 only seeds
+// the fallback used when that endpoint can't be reached (e.g. an older
+// server), preserving the previous build-time behavior for `next dev`
+// against a server started with -auth-disabled, or platform-authed deploys.
 const AUTH_DISABLED = process.env.NEXT_PUBLIC_STACKIT_AUTH_DISABLED === "1";
+
+// Stable reference so ConfigProvider's effect doesn't re-run each render.
+const CONFIG_FALLBACK: ConfigResponse = {
+  readOnly: false,
+  authRequired: !AUTH_DISABLED,
+};
 
 // Single root page driving both the unscoped picker and the per-repo view.
 //
@@ -25,23 +34,28 @@ function Home() {
   const params = useSearchParams();
   const repoId = params.get("repo") ?? "";
 
-  if (!repoId) {
-    return <RepoPicker />;
-  }
-
   return (
-    <RepoProvider repoId={repoId}>
-      <RepoView />
-    </RepoProvider>
+    <>
+      <ReadOnlyBanner />
+      {repoId ? (
+        <RepoProvider repoId={repoId}>
+          <RepoView />
+        </RepoProvider>
+      ) : (
+        <RepoPicker />
+      )}
+    </>
   );
 }
 
 export default function Page() {
   return (
     <Suspense fallback={null}>
-      <AuthProvider disable={AUTH_DISABLED}>
-        <Home />
-      </AuthProvider>
+      <ConfigProvider fallback={CONFIG_FALLBACK}>
+        <AuthProvider>
+          <Home />
+        </AuthProvider>
+      </ConfigProvider>
     </Suspense>
   );
 }

--- a/apps/web/src/components/branch-detail/stack-detail.tsx
+++ b/apps/web/src/components/branch-detail/stack-detail.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/status/status-badge";
 import { StackDescription, StackColumn } from "@/components/swimlane/stack-column";
 import { useRepo } from "@/components/providers/repo-provider";
+import { useConfig } from "@/components/providers/config-provider";
 import { cn } from "@/lib/utils";
 import { stackStatusInfo } from "@/lib/status-config";
 import { computeStackStats } from "@/lib/stats";
@@ -30,6 +31,7 @@ export function StackDetailPanel({
   const issues = collectIssues(stack.branches);
   const stats = computeStackStats(stack.branches);
   const { refresh, repoId } = useRepo();
+  const { readOnly } = useConfig();
 
   const allHavePRs = stack.branches.every((b) => b.pr != null);
 
@@ -133,8 +135,9 @@ export function StackDetailPanel({
 
           <Separator />
 
-          {/* Submit button — hidden when all branches already have PRs */}
-          {!allHavePRs && (
+          {/* Submit button — hidden when all branches already have PRs, and
+              on a read-only server where writes are disabled. */}
+          {!readOnly && !allHavePRs && (
             <button
               onClick={handleSubmit}
               disabled={submitting || stack.status === "blocked"}

--- a/apps/web/src/components/providers/__tests__/config-provider.test.tsx
+++ b/apps/web/src/components/providers/__tests__/config-provider.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { ConfigProvider } from "../config-provider";
+import { ReadOnlyBanner } from "@/components/read-only-banner";
+import { fetchConfig, type ConfigResponse } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  fetchConfig: vi.fn(),
+}));
+
+const mockFetchConfig = fetchConfig as Mock;
+
+const WRITABLE_FALLBACK: ConfigResponse = { readOnly: false, authRequired: true };
+
+beforeEach(() => {
+  mockFetchConfig.mockReset();
+});
+
+describe("ConfigProvider + ReadOnlyBanner", () => {
+  it("shows the banner when the server reports read-only", async () => {
+    mockFetchConfig.mockResolvedValue({ readOnly: true, authRequired: false });
+
+    render(
+      <ConfigProvider fallback={WRITABLE_FALLBACK}>
+        <ReadOnlyBanner />
+      </ConfigProvider>
+    );
+
+    expect(await screen.findByRole("status")).toHaveTextContent(/read-only/i);
+  });
+
+  it("hides the banner on a writable server", async () => {
+    mockFetchConfig.mockResolvedValue({ readOnly: false, authRequired: true });
+
+    render(
+      <ConfigProvider fallback={WRITABLE_FALLBACK}>
+        <ReadOnlyBanner />
+      </ConfigProvider>
+    );
+
+    await waitFor(() => expect(screen.queryByText("Loading…")).not.toBeInTheDocument());
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the supplied defaults when /config is unreachable", async () => {
+    mockFetchConfig.mockRejectedValue(new Error("network"));
+
+    render(
+      <ConfigProvider fallback={{ readOnly: true, authRequired: false }}>
+        <ReadOnlyBanner />
+      </ConfigProvider>
+    );
+
+    // The fallback marks the server read-only, so the banner appears even
+    // though the fetch failed.
+    expect(await screen.findByRole("status")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/providers/auth-provider.tsx
+++ b/apps/web/src/components/providers/auth-provider.tsx
@@ -8,6 +8,7 @@ import {
   type MeResponse,
   UnauthorizedError,
 } from "@/lib/api";
+import { useConfig } from "@/components/providers/config-provider";
 
 interface AuthContextValue {
   // user is null while loading; remains null after a 401 (the provider will
@@ -31,10 +32,6 @@ export function useAuth() {
 
 interface AuthProviderProps {
   children: React.ReactNode;
-  // disable lets us short-circuit the auth check in dev / local-mode
-  // deployments where the server doesn't run /auth/*. The provider then
-  // pretends the user is signed in with a placeholder identity.
-  disable?: boolean;
 }
 
 const PLACEHOLDER_LOCAL_USER: MeResponse = { login: "local", id: 0 };
@@ -44,7 +41,16 @@ const PLACEHOLDER_LOCAL_USER: MeResponse = { login: "local", id: 0 };
 // on success it renders children with the user identity exposed via
 // context. Network failures other than 401 render a small error message
 // so the app doesn't silently hang on a broken backend.
-export function AuthProvider({ children, disable }: AuthProviderProps) {
+//
+// When the server reports that auth isn't required (a public read-only
+// server, or auth-disabled), the /auth/me check is skipped and a
+// placeholder identity is used — the same behavior the old build-time
+// NEXT_PUBLIC_STACKIT_AUTH_DISABLED flag produced, now driven by runtime
+// config so one build serves both private and public deployments.
+export function AuthProvider({ children }: AuthProviderProps) {
+  const { authRequired } = useConfig();
+  const disable = !authRequired;
+
   const [user, setUser] = useState<MeResponse | null>(() =>
     disable ? PLACEHOLDER_LOCAL_USER : null
   );

--- a/apps/web/src/components/providers/config-provider.tsx
+++ b/apps/web/src/components/providers/config-provider.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+import { fetchConfig, type ConfigResponse } from "@/lib/api";
+
+const ConfigContext = createContext<ConfigResponse>({
+  readOnly: false,
+  authRequired: true,
+});
+
+export function useConfig() {
+  return useContext(ConfigContext);
+}
+
+interface ConfigProviderProps {
+  // fallback is used when the server doesn't answer /config (e.g. an older
+  // build, or a network error). Pass a stable object so the effect doesn't
+  // re-run every render.
+  fallback: ConfigResponse;
+  children: React.ReactNode;
+}
+
+// ConfigProvider fetches server capabilities once and exposes them via
+// context. It blocks rendering until the value resolves (success or
+// fallback) so descendants — notably AuthProvider — can rely on it being
+// settled. The fetch is unauthenticated and cheap.
+export function ConfigProvider({ fallback, children }: ConfigProviderProps) {
+  const [config, setConfig] = useState<ConfigResponse | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchConfig()
+      .then((c) => {
+        if (!cancelled) setConfig(c);
+      })
+      .catch(() => {
+        // Degrade gracefully: a server without /config (or an unreachable
+        // one) falls back to the caller-supplied defaults rather than
+        // blocking the app.
+        if (!cancelled) setConfig(fallback);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [fallback]);
+
+  if (config === null) {
+    return (
+      <div className="flex min-h-screen items-center justify-center p-8">
+        <span className="text-sm text-muted-foreground">Loading…</span>
+      </div>
+    );
+  }
+
+  return <ConfigContext.Provider value={config}>{children}</ConfigContext.Provider>;
+}

--- a/apps/web/src/components/read-only-banner.tsx
+++ b/apps/web/src/components/read-only-banner.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useConfig } from "@/components/providers/config-provider";
+
+// ReadOnlyBanner shows a thin notice when the server is in read-only mode,
+// so viewers understand why write affordances (submit) are absent. It
+// renders nothing on a writable server.
+export function ReadOnlyBanner() {
+  const { readOnly } = useConfig();
+  if (!readOnly) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      className="w-full bg-amber-100 px-4 py-1.5 text-center text-xs font-medium text-amber-900 dark:bg-amber-950 dark:text-amber-200"
+    >
+      Read-only view — changes are disabled on this server.
+    </div>
+  );
+}

--- a/apps/web/src/lib/__tests__/api.test.ts
+++ b/apps/web/src/lib/__tests__/api.test.ts
@@ -7,6 +7,7 @@ import {
   fetchStack,
   fetchBranch,
   fetchBranchDiff,
+  fetchConfig,
 } from "../api";
 
 const mockFetch = vi.fn();
@@ -117,6 +118,19 @@ describe("fetchBranchDiff", () => {
       "/api/v1/repos/stackit/branch-diff?branch=feat%2Fbar",
       { credentials: "include" }
     );
+  });
+});
+
+describe("fetchConfig", () => {
+  it("reads the unauthenticated capabilities endpoint", async () => {
+    const data = { readOnly: true, authRequired: false };
+    mockOk(data);
+
+    const result = await fetchConfig();
+    expect(result).toEqual(data);
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/config", {
+      credentials: "include",
+    });
   });
 });
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -136,6 +136,16 @@ export interface ViewResponse {
   recentlyMerged?: TrunkCommitResponse[];
 }
 
+// --- Server Capabilities ---
+
+// ConfigResponse mirrors httpcontract.ConfigResponse. It advertises server
+// capabilities so the UI can adapt at runtime instead of relying on
+// build-time flags.
+export interface ConfigResponse {
+  readOnly: boolean;
+  authRequired: boolean;
+}
+
 // --- Auth Types ---
 
 export interface MeResponse {
@@ -171,6 +181,12 @@ async function fetchAPI<T>(path: string): Promise<T> {
 
 export function fetchMe(): Promise<MeResponse> {
   return fetchAPI<MeResponse>("/auth/me");
+}
+
+// fetchConfig reads server capabilities. It is served unauthenticated, so
+// the client can call it before deciding whether to attempt a login.
+export function fetchConfig(): Promise<ConfigResponse> {
+  return fetchAPI<ConfigResponse>("/api/v1/config");
 }
 
 export function authLoginURL(returnTo?: string): string {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The web app now discovers server capabilities at runtime via
/api/v1/config instead of build-time flags:

- ConfigProvider fetches {readOnly, authRequired} once and exposes it via
  useConfig(). It falls back to caller-supplied defaults (seeded from the
  old NEXT_PUBLIC_STACKIT_AUTH_DISABLED env) when the endpoint is
  unreachable, so a new build still works against an older server.
- AuthProvider skips the /auth/me gate when authRequired is false, so a
  public read-only server loads without a login prompt.
- The stack submit button (the only write affordance) is hidden when
  readOnly.
- A read-only banner explains why writes are absent.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288** 👈
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*