### PR TITLE
refactor: extract reusable repo-entry builder

### DIFF
--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -17,9 +17,9 @@ import (
 	"time"
 
 	"github.com/getstackit/stackit/internal/api"
+	"github.com/getstackit/stackit/internal/api/provision"
 	"github.com/getstackit/stackit/internal/api/registry"
 	"github.com/getstackit/stackit/internal/api/store"
-	"github.com/getstackit/stackit/internal/app"
 )
 
 // all: is required because Next static exports use underscore-prefixed paths like _next/.
@@ -218,36 +218,19 @@ func run() error {
 	}
 }
 
-// addRegistryEntry resolves rc into an engine via app.GetContext and adds
-// the resulting RepoEntry to reg, registering a logger-close callback so
-// reg.Close releases the file handle on shutdown.
+// addRegistryEntry resolves rc into a RepoEntry via provision.BuildEntry and
+// adds it to reg. The build path is shared with runtime onboarding so startup
+// and "add a repo" can't drift.
 func addRegistryEntry(reg *registry.Registry, rc repoConfig) error {
-	opts := app.GetDefaultGlobalOptions()
-	opts.Cwd = rc.Path
-	opts.Interactive = false
-
-	runtimeCtx, err := app.GetContext(context.Background(), opts)
+	entry, err := provision.BuildEntry(context.Background(), provision.EntryParams{
+		ID:          rc.ID,
+		DisplayName: rc.DisplayName,
+		Path:        rc.Path,
+		Remote:      rc.Remote,
+	})
 	if err != nil {
 		return err
 	}
-
-	gh := runtimeCtx.GitHub()
-	if gh == nil && runtimeCtx.GitHubError() != nil {
-		slog.Warn("GitHub client unavailable", "repo", rc.ID, "error", runtimeCtx.GitHubError())
-	}
-
-	entry := registry.NewEntry(registry.EntryConfig{
-		ID:          rc.ID,
-		DisplayName: rc.DisplayName,
-		RepoRoot:    runtimeCtx.RepoRoot,
-		Remote:      rc.Remote,
-		Engine:      runtimeCtx.Engine,
-		GitHub:      gh,
-	})
-	if runtimeCtx.Logger != nil {
-		entry.AddCloser(runtimeCtx.Logger.Close)
-	}
-
 	return reg.Add(entry)
 }
 

--- a/internal/api/provision/provision.go
+++ b/internal/api/provision/provision.go
@@ -1,0 +1,59 @@
+// Package provision builds registry entries from repo coordinates, resolving
+// the per-repo engine and GitHub client through the app bootstrap layer. It is
+// the shared path used by both server startup and runtime repo onboarding, so
+// the two can't drift in how they wire an engine, broadcaster, and ref watcher.
+package provision
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/getstackit/stackit/internal/api/registry"
+	"github.com/getstackit/stackit/internal/app"
+)
+
+// EntryParams is the resolved input needed to build a registry entry: a
+// URL-safe ID, a display label, the on-disk checkout Path, and the git Remote
+// name. Coordinate resolution (owner/name → <reposRoot>/<owner>/<name>) happens
+// in the caller, before BuildEntry.
+type EntryParams struct {
+	ID          string
+	DisplayName string
+	Path        string
+	Remote      string
+}
+
+// BuildEntry resolves p into a runtime context via app.GetContext and returns a
+// ready registry.RepoEntry — broadcaster and ref watcher started, logger close
+// hook attached. The caller adds it to the registry. An empty Path falls back
+// to git discovery from the process working directory, matching the single-repo
+// startup shortcut.
+func BuildEntry(ctx context.Context, p EntryParams) (*registry.RepoEntry, error) {
+	opts := app.GetDefaultGlobalOptions()
+	opts.Cwd = p.Path
+	opts.Interactive = false
+
+	runtimeCtx, err := app.GetContext(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	gh := runtimeCtx.GitHub()
+	if gh == nil && runtimeCtx.GitHubError() != nil {
+		slog.Warn("GitHub client unavailable", "repo", p.ID, "error", runtimeCtx.GitHubError())
+	}
+
+	entry := registry.NewEntry(registry.EntryConfig{
+		ID:          p.ID,
+		DisplayName: p.DisplayName,
+		RepoRoot:    runtimeCtx.RepoRoot,
+		Remote:      p.Remote,
+		Engine:      runtimeCtx.Engine,
+		GitHub:      gh,
+	})
+	if runtimeCtx.Logger != nil {
+		entry.AddCloser(runtimeCtx.Logger.Close)
+	}
+
+	return entry, nil
+}

--- a/internal/api/provision/provision_test.go
+++ b/internal/api/provision/provision_test.go
@@ -1,0 +1,39 @@
+package provision_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/getstackit/stackit/internal/api/provision"
+	"github.com/getstackit/stackit/internal/api/registry"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildEntry verifies the shared build path produces a fully wired entry
+// (engine + broadcaster + watcher) that the registry can adopt and close.
+func TestBuildEntry(t *testing.T) {
+	t.Parallel()
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+
+	entry, err := provision.BuildEntry(context.Background(), provision.EntryParams{
+		ID:          "owner-repo",
+		DisplayName: "owner/repo",
+		Path:        scene.Dir,
+		Remote:      "origin",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+
+	// Adopt into a registry so its closers (watcher goroutine) tear down.
+	reg := registry.New()
+	require.NoError(t, reg.Add(entry))
+	t.Cleanup(func() { _ = reg.Close() })
+
+	require.Equal(t, "owner-repo", entry.ID)
+	require.Equal(t, "owner/repo", entry.DisplayName)
+	require.Equal(t, "origin", entry.Remote)
+	require.NotNil(t, entry.Engine)
+	require.NotNil(t, entry.Broadcaster)
+	require.NotEmpty(t, entry.RepoRoot)
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Pull the entry-construction logic (app.GetContext -> registry.NewEntry plus
the logger-close hook) out of apps/server/main.go's addRegistryEntry into a
new leaf package, internal/api/provision. Both server startup and the
upcoming runtime "add a repo" handler build entries through this one path, so
they can't drift in how they wire an engine, broadcaster, and ref watcher.

Pure refactor: addRegistryEntry now delegates to provision.BuildEntry and
behavior is unchanged.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291** 👈
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*