### PR TITLE
feat: thread repo store into the API server

### DIFF
--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -121,12 +121,16 @@ func run() error {
 		}
 	}()
 
+	// repoStore is non-nil only in DB-backed mode; it is handed to the server
+	// so runtime onboarding can persist newly added repos.
+	var repoStore *store.Store
 	switch {
 	case *databaseURL != "":
 		st, err := store.Open(context.Background(), *databaseURL)
 		if err != nil {
 			return err
 		}
+		repoStore = st
 		defer func() {
 			if closeErr := st.Close(); closeErr != nil {
 				slog.Error("repo store close failed", "error", closeErr)
@@ -194,6 +198,7 @@ func run() error {
 		Registry:    reg,
 		Auth:        authCfg,
 		ReadOnly:    *readOnly,
+		RepoStore:   repoStore,
 	})
 
 	errCh := make(chan error, 1)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getstackit/stackit/internal/api/auth"
 	"github.com/getstackit/stackit/internal/api/handlers"
 	"github.com/getstackit/stackit/internal/api/registry"
+	"github.com/getstackit/stackit/internal/api/store"
 )
 
 // ServerConfig holds configuration for the API server.
@@ -55,6 +56,12 @@ type ServerConfig struct {
 	// start unauthenticated when STACKIT_PUBLIC or $PORT are set unless
 	// -auth-disabled is passed explicitly.
 	Auth *AuthConfig
+
+	// RepoStore is the persistence backend for repo configuration. It is set
+	// only when the server runs in DB-backed mode (-database-url). Runtime
+	// repo onboarding persists new repos here so they survive a restart; when
+	// nil, onboarding is unavailable and the registry is fixed at boot.
+	RepoStore *store.Store
 }
 
 // AuthConfig is the runtime auth setup. SessionStore must outlive the


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Add a RepoStore field to api.ServerConfig and wire the DB-backed store
through from apps/server. The store was previously created at boot solely to
load repos into the registry, then dropped; hoisting it to function scope and
handing it to the server lets the upcoming runtime onboarding handler persist
newly added repos so they survive a restart.

Wiring only: RepoStore is nil outside DB-backed mode, and no handler consumes
it yet.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292** 👈
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*