### PR TITLE
feat: verify per-user GitHub repo access for onboarding

### DIFF
--- a/apps/server/auth.go
+++ b/apps/server/auth.go
@@ -84,7 +84,7 @@ func buildAuthConfig(authDisabled, publicMode bool) (*authBuildResult, error) {
 	}
 
 	return &authBuildResult{
-		cfg:   &api.AuthConfig{Handler: handler, SessionStore: store},
+		cfg:   &api.AuthConfig{Handler: handler, SessionStore: store, Cipher: cipher},
 		store: store,
 	}, nil
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -69,6 +69,12 @@ type ServerConfig struct {
 type AuthConfig struct {
 	Handler      *auth.Handler
 	SessionStore auth.Store
+
+	// Cipher decrypts the GitHub access token stored on a session. Handlers
+	// that act as the requesting user (e.g. runtime repo onboarding verifying
+	// the user's access to a repo) need it to recover the token from
+	// SessionFromContext. It is the same cipher the OAuth handler sealed with.
+	Cipher *auth.Cipher
 }
 
 // Server is the stackit-web HTTP server. Per-repo state (engine, watcher,

--- a/internal/github/repo_access.go
+++ b/internal/github/repo_access.go
@@ -1,0 +1,65 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-github/v67/github"
+)
+
+// ErrRepoAccessDenied is returned by CheckRepoAccess when the authenticated
+// user cannot see the repository. GitHub deliberately returns 404 (not 403)
+// for private repos a token can't read, so "not found" and "no access" are
+// indistinguishable and collapse into this one error.
+var ErrRepoAccessDenied = errors.New("github: repository not found or access denied")
+
+// RepoAccess describes a user's access to a GitHub repository — enough for the
+// onboarding flow to decide whether to proceed and how to clone it. Because the
+// lookup is authenticated with a specific user's token, CanPush reflects that
+// user's permission level, not the server's.
+type RepoAccess struct {
+	Owner         string
+	Name          string
+	DefaultBranch string
+	CloneURL      string
+	Private       bool
+	CanPush       bool
+}
+
+// CheckRepoAccess verifies that token grants access to owner/name on github.com
+// and returns the repository's canonical coordinates. A nil error means the
+// authenticated user can at least read the repo; ErrRepoAccessDenied means the
+// repo is missing or invisible to that token. Other errors are transport-level.
+func CheckRepoAccess(ctx context.Context, token, owner, name string) (*RepoAccess, error) {
+	client, err := createGitHubClient(ctx, "github.com", token)
+	if err != nil {
+		return nil, err
+	}
+	return repoAccessFromClient(ctx, client, owner, name)
+}
+
+// repoAccessFromClient performs the lookup against an already-built client so
+// tests can point client.BaseURL at a stub server.
+func repoAccessFromClient(ctx context.Context, client *github.Client, owner, name string) (*RepoAccess, error) {
+	repo, resp, err := client.Repositories.Get(ctx, owner, name)
+	if err != nil {
+		if resp != nil && (resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden) {
+			return nil, ErrRepoAccessDenied
+		}
+		return nil, fmt.Errorf("get repo %s/%s: %w", owner, name, err)
+	}
+
+	access := &RepoAccess{
+		Owner:         repo.GetOwner().GetLogin(),
+		Name:          repo.GetName(),
+		DefaultBranch: repo.GetDefaultBranch(),
+		CloneURL:      repo.GetCloneURL(),
+		Private:       repo.GetPrivate(),
+	}
+	if perms := repo.GetPermissions(); perms != nil {
+		access.CanPush = perms["push"]
+	}
+	return access, nil
+}

--- a/internal/github/repo_access_test.go
+++ b/internal/github/repo_access_test.go
@@ -1,0 +1,87 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-github/v67/github"
+	"github.com/stretchr/testify/require"
+)
+
+// clientForStub builds a go-github client pointed at srv so repoAccessFromClient
+// hits the stub instead of api.github.com.
+func clientForStub(t *testing.T, srv *httptest.Server) *github.Client {
+	t.Helper()
+	base, err := url.Parse(srv.URL + "/")
+	require.NoError(t, err)
+	c := github.NewClient(srv.Client())
+	c.BaseURL = base
+	return c
+}
+
+func TestRepoAccessFromClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("readable repo returns coordinates and push permission", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/repos/octo/widget", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"name": "widget",
+				"default_branch": "main",
+				"clone_url": "https://github.com/octo/widget.git",
+				"private": true,
+				"owner": {"login": "octo"},
+				"permissions": {"pull": true, "push": true, "admin": false}
+			}`))
+		}))
+		t.Cleanup(srv.Close)
+
+		access, err := repoAccessFromClient(context.Background(), clientForStub(t, srv), "octo", "widget")
+		require.NoError(t, err)
+		require.Equal(t, "octo", access.Owner)
+		require.Equal(t, "widget", access.Name)
+		require.Equal(t, "main", access.DefaultBranch)
+		require.Equal(t, "https://github.com/octo/widget.git", access.CloneURL)
+		require.True(t, access.Private)
+		require.True(t, access.CanPush)
+	})
+
+	t.Run("read-only repo reports no push", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"name":"widget","owner":{"login":"octo"},"permissions":{"pull":true,"push":false}}`))
+		}))
+		t.Cleanup(srv.Close)
+
+		access, err := repoAccessFromClient(context.Background(), clientForStub(t, srv), "octo", "widget")
+		require.NoError(t, err)
+		require.False(t, access.CanPush)
+	})
+
+	t.Run("404 collapses to access denied", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+		}))
+		t.Cleanup(srv.Close)
+
+		_, err := repoAccessFromClient(context.Background(), clientForStub(t, srv), "octo", "ghost")
+		require.ErrorIs(t, err, ErrRepoAccessDenied)
+	})
+
+	t.Run("403 collapses to access denied", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, `{"message":"Forbidden"}`, http.StatusForbidden)
+		}))
+		t.Cleanup(srv.Close)
+
+		_, err := repoAccessFromClient(context.Background(), clientForStub(t, srv), "octo", "secret")
+		require.ErrorIs(t, err, ErrRepoAccessDenied)
+	})
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Add the authorization gate that runtime onboarding needs to confirm the
requesting user — not the server — can actually reach a repo before it is
cloned and registered.

- internal/github: CheckRepoAccess looks up owner/name on github.com with a
  user's token and returns the repo's coordinates (default branch, clone URL,
  private flag, push permission). GitHub's 404-for-private behavior is
  collapsed into ErrRepoAccessDenied so "missing" and "no access" read the
  same, as they must.
- internal/api: expose the session Cipher on AuthConfig so handlers can
  recover a user's token from SessionFromContext, wired from apps/server.

No endpoint consumes these yet; that is the onboarding handler.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293** 👈
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*