### PR TITLE
feat: add idempotent repo clone for onboarding

### DIFF
--- a/internal/api/provision/clone.go
+++ b/internal/api/provision/clone.go
@@ -1,0 +1,73 @@
+package provision
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// CloneParams describes a repository to clone for serving.
+type CloneParams struct {
+	// CloneURL is the source to clone from (e.g. https://github.com/owner/name.git).
+	CloneURL string
+	// Token authenticates the clone. It is passed to git via environment so it
+	// never appears in argv (visible to `ps`) and is never written to the
+	// cloned repo's config. Empty clones without authentication (public repos).
+	Token string
+	// Dest is the absolute checkout path, typically <reposRoot>/<owner>/<name>.
+	Dest string
+}
+
+// EnsureClone clones CloneURL into Dest unless Dest is already a git checkout.
+// It is idempotent: an existing checkout is treated as success and left
+// untouched, so re-onboarding a repo or restarting after a partial run is safe.
+//
+// The token is supplied through GIT_CONFIG_* env vars as an http.extraHeader,
+// not embedded in the remote URL — so a per-session user token is not persisted
+// to .git/config where it would outlive the session and leak to disk.
+func EnsureClone(ctx context.Context, p CloneParams) error {
+	if isGitRepo(p.Dest) {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(p.Dest), 0o750); err != nil {
+		return fmt.Errorf("create checkout parent: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "clone", "--", p.CloneURL, p.Dest)
+	// GIT_TERMINAL_PROMPT=0 makes a bad/empty token fail fast instead of
+	// blocking on an interactive credential prompt.
+	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if p.Token != "" {
+		header := "Authorization: Basic " + basicAuthHeader("x-access-token", p.Token)
+		env = append(env,
+			"GIT_CONFIG_COUNT=1",
+			"GIT_CONFIG_KEY_0=http.extraHeader",
+			"GIT_CONFIG_VALUE_0="+header,
+		)
+	}
+	cmd.Env = env
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		// Leave no half-written checkout behind so a retry starts clean.
+		_ = os.RemoveAll(p.Dest)
+		return fmt.Errorf("git clone %s: %w: %s", p.CloneURL, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// isGitRepo reports whether dir looks like a git checkout (has a .git entry).
+func isGitRepo(dir string) bool {
+	if dir == "" {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(dir, ".git"))
+	return err == nil
+}
+
+func basicAuthHeader(user, pass string) string {
+	return base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
+}

--- a/internal/api/provision/clone_test.go
+++ b/internal/api/provision/clone_test.go
@@ -1,0 +1,44 @@
+package provision_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/getstackit/stackit/internal/api/provision"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureClone(t *testing.T) {
+	t.Parallel()
+	// A local source repo stands in for the remote; cloning from a path
+	// exercises the same code path without a network or token.
+	src := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+	dest := filepath.Join(t.TempDir(), "octo", "widget")
+
+	err := provision.EnsureClone(context.Background(), provision.CloneParams{
+		CloneURL: src.Dir,
+		Dest:     dest,
+	})
+	require.NoError(t, err)
+	require.DirExists(t, filepath.Join(dest, ".git"))
+}
+
+func TestEnsureCloneIdempotent(t *testing.T) {
+	t.Parallel()
+	src := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+	dest := filepath.Join(t.TempDir(), "octo", "widget")
+
+	require.NoError(t, provision.EnsureClone(context.Background(), provision.CloneParams{
+		CloneURL: src.Dir,
+		Dest:     dest,
+	}))
+
+	// Second call with a bogus URL must be a no-op: an existing checkout is
+	// detected before any clone is attempted.
+	require.NoError(t, provision.EnsureClone(context.Background(), provision.CloneParams{
+		CloneURL: "https://github.com/should/not-be-touched.git",
+		Dest:     dest,
+	}))
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

provision.EnsureClone clones a repo into its checkout path unless one already
exists, so onboarding (and restarts after a partial run) can call it safely.

The user's token is passed to git via GIT_CONFIG_* env as an http.extraHeader
rather than embedded in the remote URL: a per-session token must not be
persisted to .git/config where it would outlive the session and sit on disk,
and the env form also keeps it out of argv. GIT_TERMINAL_PROMPT=0 makes a bad
token fail fast instead of blocking on a credential prompt, and a failed
clone removes its half-written checkout so a retry starts clean.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294** 👈
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*