### PR TITLE
feat: scope repo visibility to the user who added it

### DIFF
--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -232,6 +232,7 @@ func addRegistryEntry(reg *registry.Registry, rc repoConfig) error {
 		DisplayName: rc.DisplayName,
 		Path:        rc.Path,
 		Remote:      rc.Remote,
+		AddedBy:     rc.AddedBy,
 	})
 	if err != nil {
 		return err

--- a/apps/server/repos_config.go
+++ b/apps/server/repos_config.go
@@ -32,6 +32,11 @@ type repoConfig struct {
 	Path string
 
 	Remote string
+
+	// AddedBy is the GitHub login of the user who onboarded this repo, or
+	// empty for operator-seeded rows. Carried through to the registry entry so
+	// the server can scope per-user visibility.
+	AddedBy string
 }
 
 // repoIDPattern restricts repo IDs to characters that survive in URL paths

--- a/apps/server/repos_db.go
+++ b/apps/server/repos_db.go
@@ -41,6 +41,7 @@ func loadReposFromDB(ctx context.Context, st *store.Store, reposRoot string) ([]
 			Name:        r.Name,
 			Path:        r.Path,
 			Remote:      r.Remote,
+			AddedBy:     r.AddedBy,
 		}
 		if err := normalizeRepoEntry(&rc, reposRoot); err != nil {
 			slog.Warn("repo skipped (invalid config)", "repo", r.ID, "error", err)

--- a/internal/api/handlers/common.go
+++ b/internal/api/handlers/common.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 
+	"github.com/getstackit/stackit/internal/api/auth"
 	"github.com/getstackit/stackit/internal/api/registry"
 	"github.com/getstackit/stackit/internal/utils"
 )
@@ -32,18 +33,41 @@ const (
 // resolveRepo looks up the repo entry for the {repoID} path value on r.
 // If the path value is empty (legacy/unscoped route or direct test call)
 // it falls back to defaultRepoID. Returns false and writes a 404 when the
-// repoID does not exist in the registry.
+// repoID does not exist in the registry or is not visible to the requesting
+// user. A repo invisible to the caller 404s (not 403) so its existence is not
+// disclosed.
 func resolveRepo(reg *registry.Registry, w http.ResponseWriter, r *http.Request) (*registry.RepoEntry, bool) {
 	id := r.PathValue("repoID")
 	if id == "" {
 		id = defaultRepoID
 	}
 	entry, ok := reg.Get(id)
-	if !ok {
+	if !ok || !visibleTo(entry, requestUser(r)) {
 		http.NotFound(w, r)
 		return nil, false
 	}
 	return entry, true
+}
+
+// requestUser returns the authenticated GitHub login for r, or "" when the
+// request is anonymous — read-only or auth-disabled servers, which carry no
+// session and are deliberately open.
+func requestUser(r *http.Request) string {
+	if sess := auth.SessionFromContext(r.Context()); sess != nil {
+		return sess.GitHubLogin
+	}
+	return ""
+}
+
+// visibleTo reports whether entry should be visible to user. A repo with no
+// recorded adder (operator-seeded) is shared with everyone; a repo onboarded by
+// a user is visible only to that user. Anonymous readers have no identity to
+// match, so they see only shared repos.
+func visibleTo(entry *registry.RepoEntry, user string) bool {
+	if entry.AddedBy == "" {
+		return true
+	}
+	return user != "" && entry.AddedBy == user
 }
 
 // validateBranchName runs branch name through the same validator the CLI

--- a/internal/api/handlers/repos.go
+++ b/internal/api/handlers/repos.go
@@ -26,9 +26,13 @@ func (h *ReposListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	user := requestUser(r)
 	entries := h.reg.List()
 	summaries := make([]httpcontract.RepoSummary, 0, len(entries))
 	for _, entry := range entries {
+		if !visibleTo(entry, user) {
+			continue
+		}
 		summary := httpcontract.RepoSummary{
 			ID:          entry.ID,
 			DisplayName: entry.DisplayName,

--- a/internal/api/handlers/visibility_test.go
+++ b/internal/api/handlers/visibility_test.go
@@ -1,0 +1,135 @@
+package handlers
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/getstackit/stackit/internal/api/auth"
+	"github.com/getstackit/stackit/internal/api/registry"
+	httpcontract "github.com/getstackit/stackit/internal/contracts/http"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVisibleTo(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		addedBy string
+		user    string
+		want    bool
+	}{
+		{"anonymous sees shared repo", "", "", true},
+		{"anonymous cannot see user repo", "alice", "", false},
+		{"shared repo visible to all", "", "bob", true},
+		{"owner sees own repo", "alice", "alice", true},
+		{"other user cannot see", "alice", "bob", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, visibleTo(&registry.RepoEntry{AddedBy: tt.addedBy}, tt.user))
+		})
+	}
+}
+
+// sessionFor wraps next in RequireSession and returns the wrapped handler plus
+// a request already bearing a valid session cookie for login.
+func sessionFor(t *testing.T, login string, next http.Handler) (http.Handler, *http.Request) {
+	t.Helper()
+	cipher, err := auth.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
+	require.NoError(t, err)
+	store := auth.NewMemoryStore(cipher)
+	t.Cleanup(func() { _ = store.Close() })
+	sess, err := store.Create(login, 1, "tok")
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repos", nil)
+	req.AddCookie(&http.Cookie{Name: "stackit_session", Value: sess.ID})
+	return auth.RequireSession(store, next), req
+}
+
+func listIDs(t *testing.T, h http.Handler, req *http.Request) []string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp httpcontract.ReposListResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	ids := make([]string, 0, len(resp.Repos))
+	for _, r := range resp.Repos {
+		ids = append(ids, r.ID)
+	}
+	return ids
+}
+
+func TestReposListFiltersByUser(t *testing.T) {
+	t.Parallel()
+	reg := registry.New()
+	require.NoError(t, reg.Add(&registry.RepoEntry{ID: "shared"}))
+	require.NoError(t, reg.Add(&registry.RepoEntry{ID: "alice-repo", AddedBy: "alice"}))
+	require.NoError(t, reg.Add(&registry.RepoEntry{ID: "bob-repo", AddedBy: "bob"}))
+	handler := NewReposListHandler(reg)
+
+	t.Run("anonymous sees shared only", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/repos", nil)
+		require.ElementsMatch(t, []string{"shared"}, listIDs(t, handler, req))
+	})
+
+	t.Run("alice sees shared and her own", func(t *testing.T) {
+		t.Parallel()
+		gated, req := sessionFor(t, "alice", handler)
+		require.ElementsMatch(t, []string{"shared", "alice-repo"}, listIDs(t, gated, req))
+	})
+
+	t.Run("bob sees shared and his own", func(t *testing.T) {
+		t.Parallel()
+		gated, req := sessionFor(t, "bob", handler)
+		require.ElementsMatch(t, []string{"shared", "bob-repo"}, listIDs(t, gated, req))
+	})
+}
+
+// TestResolveRepoVisibility checks the scoped-route gate: a repo a user did not
+// add is invisible (404), while shared and own repos resolve.
+func TestResolveRepoVisibility(t *testing.T) {
+	t.Parallel()
+	reg := registry.New()
+	require.NoError(t, reg.Add(&registry.RepoEntry{ID: "alice-repo", AddedBy: "alice"}))
+
+	// A tiny handler that 200s when resolveRepo succeeds.
+	probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := resolveRepo(reg, w, r); !ok {
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	withRepoID := func(req *http.Request, id string) *http.Request {
+		req.SetPathValue("repoID", id)
+		return req
+	}
+
+	t.Run("owner resolves", func(t *testing.T) {
+		t.Parallel()
+		gated, base := sessionFor(t, "alice", probe)
+		rec := httptest.NewRecorder()
+		gated.ServeHTTP(rec, withRepoID(base, "alice-repo"))
+		require.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("other user gets 404", func(t *testing.T) {
+		t.Parallel()
+		gated, base := sessionFor(t, "bob", probe)
+		rec := httptest.NewRecorder()
+		gated.ServeHTTP(rec, withRepoID(base, "alice-repo"))
+		require.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("anonymous gets 404", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		probe.ServeHTTP(rec, withRepoID(httptest.NewRequest(http.MethodGet, "/api/v1/repos/alice-repo/view", nil), "alice-repo"))
+		require.Equal(t, http.StatusNotFound, rec.Code)
+	})
+}

--- a/internal/api/provision/provision.go
+++ b/internal/api/provision/provision.go
@@ -21,6 +21,10 @@ type EntryParams struct {
 	DisplayName string
 	Path        string
 	Remote      string
+	// AddedBy is the GitHub login of the user who onboarded this repo, or
+	// empty for operator-seeded repos. Carried onto the registry entry for
+	// per-user visibility scoping.
+	AddedBy string
 }
 
 // BuildEntry resolves p into a runtime context via app.GetContext and returns a
@@ -48,6 +52,7 @@ func BuildEntry(ctx context.Context, p EntryParams) (*registry.RepoEntry, error)
 		DisplayName: p.DisplayName,
 		RepoRoot:    runtimeCtx.RepoRoot,
 		Remote:      p.Remote,
+		AddedBy:     p.AddedBy,
 		Engine:      runtimeCtx.Engine,
 		GitHub:      gh,
 	})

--- a/internal/api/registry/registry.go
+++ b/internal/api/registry/registry.go
@@ -36,8 +36,12 @@ type EntryConfig struct {
 	DisplayName string
 	RepoRoot    string
 	Remote      string
-	Engine      engine.Engine
-	GitHub      github.Client
+	// AddedBy is the GitHub login of the user who onboarded this repo, or
+	// empty for operator-seeded repos. Handlers use it to scope per-user
+	// visibility so a user only sees repos they added.
+	AddedBy string
+	Engine  engine.Engine
+	GitHub  github.Client
 }
 
 // RepoEntry is the per-repository state required to serve API requests for
@@ -49,8 +53,11 @@ type RepoEntry struct {
 	DisplayName string
 	RepoRoot    string
 	Remote      string
-	Engine      engine.Engine
-	GitHub      github.Client
+	// AddedBy is the GitHub login of the user who onboarded this repo, or
+	// empty for operator-seeded repos visible to everyone.
+	AddedBy string
+	Engine  engine.Engine
+	GitHub  github.Client
 
 	Broadcaster *Broadcaster
 	Watcher     *watcher.RefWatcher
@@ -67,6 +74,7 @@ func NewEntry(cfg EntryConfig) *RepoEntry {
 		DisplayName: cfg.DisplayName,
 		RepoRoot:    cfg.RepoRoot,
 		Remote:      cfg.Remote,
+		AddedBy:     cfg.AddedBy,
 		Engine:      cfg.Engine,
 		GitHub:      cfg.GitHub,
 		Broadcaster: NewBroadcaster(),

--- a/internal/api/store/migrations/000002_repos_added_by.down.sql
+++ b/internal/api/store/migrations/000002_repos_added_by.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS repos_added_by_idx;
+ALTER TABLE repos DROP COLUMN IF EXISTS added_by;

--- a/internal/api/store/migrations/000002_repos_added_by.up.sql
+++ b/internal/api/store/migrations/000002_repos_added_by.up.sql
@@ -1,0 +1,6 @@
+-- added_by records the GitHub login of the user who onboarded the repo at
+-- runtime. Repos seeded directly (operator-managed) leave it empty, which the
+-- server treats as "shared with all authenticated users".
+ALTER TABLE repos ADD COLUMN added_by TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX repos_added_by_idx ON repos (added_by);

--- a/internal/api/store/queries/get_repo.sql
+++ b/internal/api/store/queries/get_repo.sql
@@ -1,4 +1,4 @@
 -- name: GetRepo :one
-SELECT id, display_name, owner, name, path, remote, created_at, updated_at
+SELECT id, display_name, owner, name, path, remote, created_at, updated_at, added_by
 FROM repos
 WHERE id = $1;

--- a/internal/api/store/queries/insert_repo.sql
+++ b/internal/api/store/queries/insert_repo.sql
@@ -1,4 +1,4 @@
 -- name: InsertRepo :one
-INSERT INTO repos (id, display_name, owner, name, path, remote)
-VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, display_name, owner, name, path, remote, created_at, updated_at;
+INSERT INTO repos (id, display_name, owner, name, path, remote, added_by)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+RETURNING id, display_name, owner, name, path, remote, created_at, updated_at, added_by;

--- a/internal/api/store/queries/list_repos.sql
+++ b/internal/api/store/queries/list_repos.sql
@@ -1,4 +1,4 @@
 -- name: ListRepos :many
-SELECT id, display_name, owner, name, path, remote, created_at, updated_at
+SELECT id, display_name, owner, name, path, remote, created_at, updated_at, added_by
 FROM repos
 ORDER BY id;

--- a/internal/api/store/repos.go
+++ b/internal/api/store/repos.go
@@ -26,8 +26,11 @@ type Repo struct {
 	Name        string
 	Path        string
 	Remote      string
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	// AddedBy is the GitHub login of the user who onboarded the repo at
+	// runtime, or empty for operator-seeded repos (shared with everyone).
+	AddedBy   string
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 func repoFromRow(r reposdb.Repo) Repo {
@@ -38,6 +41,7 @@ func repoFromRow(r reposdb.Repo) Repo {
 		Name:        r.Name,
 		Path:        r.Path,
 		Remote:      r.Remote,
+		AddedBy:     r.AddedBy,
 		CreatedAt:   r.CreatedAt,
 		UpdatedAt:   r.UpdatedAt,
 	}
@@ -79,6 +83,7 @@ func (s *Store) AddRepo(ctx context.Context, r Repo) (Repo, error) {
 		Name:        r.Name,
 		Path:        r.Path,
 		Remote:      r.Remote,
+		AddedBy:     r.AddedBy,
 	})
 	if err != nil {
 		return Repo{}, fmt.Errorf("add repo %q: %w", r.ID, err)

--- a/internal/api/store/reposdb/get_repo.sql.go
+++ b/internal/api/store/reposdb/get_repo.sql.go
@@ -10,7 +10,7 @@ import (
 )
 
 const getRepo = `-- name: GetRepo :one
-SELECT id, display_name, owner, name, path, remote, created_at, updated_at
+SELECT id, display_name, owner, name, path, remote, created_at, updated_at, added_by
 FROM repos
 WHERE id = $1
 `
@@ -27,6 +27,7 @@ func (q *Queries) GetRepo(ctx context.Context, id string) (Repo, error) {
 		&i.Remote,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.AddedBy,
 	)
 	return i, err
 }

--- a/internal/api/store/reposdb/insert_repo.sql.go
+++ b/internal/api/store/reposdb/insert_repo.sql.go
@@ -10,9 +10,9 @@ import (
 )
 
 const insertRepo = `-- name: InsertRepo :one
-INSERT INTO repos (id, display_name, owner, name, path, remote)
-VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, display_name, owner, name, path, remote, created_at, updated_at
+INSERT INTO repos (id, display_name, owner, name, path, remote, added_by)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+RETURNING id, display_name, owner, name, path, remote, created_at, updated_at, added_by
 `
 
 type InsertRepoParams struct {
@@ -22,6 +22,7 @@ type InsertRepoParams struct {
 	Name        string
 	Path        string
 	Remote      string
+	AddedBy     string
 }
 
 func (q *Queries) InsertRepo(ctx context.Context, arg InsertRepoParams) (Repo, error) {
@@ -32,6 +33,7 @@ func (q *Queries) InsertRepo(ctx context.Context, arg InsertRepoParams) (Repo, e
 		arg.Name,
 		arg.Path,
 		arg.Remote,
+		arg.AddedBy,
 	)
 	var i Repo
 	err := row.Scan(
@@ -43,6 +45,7 @@ func (q *Queries) InsertRepo(ctx context.Context, arg InsertRepoParams) (Repo, e
 		&i.Remote,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.AddedBy,
 	)
 	return i, err
 }

--- a/internal/api/store/reposdb/list_repos.sql.go
+++ b/internal/api/store/reposdb/list_repos.sql.go
@@ -10,7 +10,7 @@ import (
 )
 
 const listRepos = `-- name: ListRepos :many
-SELECT id, display_name, owner, name, path, remote, created_at, updated_at
+SELECT id, display_name, owner, name, path, remote, created_at, updated_at, added_by
 FROM repos
 ORDER BY id
 `
@@ -33,6 +33,7 @@ func (q *Queries) ListRepos(ctx context.Context) ([]Repo, error) {
 			&i.Remote,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.AddedBy,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/api/store/reposdb/models.go
+++ b/internal/api/store/reposdb/models.go
@@ -17,4 +17,5 @@ type Repo struct {
 	Remote      string
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
+	AddedBy     string
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Record who onboarded a repo and show each user only their own repos, so the
multi-tenant onboarding flow can't leak one user's private repo to another.

- store: add an added_by column (migration 000002) carried on store.Repo and
  set by AddRepo; regenerate sqlc.
- registry/provision/apps-server: plumb AddedBy from the DB row onto each
  registry entry so handlers can filter without a per-request DB hit.
- handlers: GET /repos lists only repos visible to the caller, and resolveRepo
  404s a repo the caller can't see (404, not 403, so existence isn't
  disclosed). A repo with no recorded adder is operator-seeded and shared with
  everyone; anonymous requests (read-only / auth-disabled servers, which have
  no per-user identity and disable onboarding) see everything.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295** 👈
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*