### PR TITLE
feat: add POST /api/v1/repos onboarding endpoint

### DIFF
--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -189,6 +190,16 @@ func run() error {
 		slog.Warn("auth: DISABLED (no STACKIT_GITHUB_* env or -auth-disabled set). Do not expose this port publicly.")
 	}
 
+	// Resolve the repos root to an absolute path so onboarded checkouts land
+	// in the same place boot-loaded repos resolve to (loadReposFromDB also
+	// makes it absolute), keeping persisted repos host-portable.
+	absReposRoot := *reposRoot
+	if absReposRoot != "" {
+		if abs, absErr := filepath.Abs(absReposRoot); absErr == nil {
+			absReposRoot = abs
+		}
+	}
+
 	server := api.NewServer(api.ServerConfig{
 		BindAddr:    *bind,
 		Port:        *port,
@@ -199,6 +210,7 @@ func run() error {
 		Auth:        authCfg,
 		ReadOnly:    *readOnly,
 		RepoStore:   repoStore,
+		ReposRoot:   absReposRoot,
 	})
 
 	errCh := make(chan error, 1)

--- a/internal/api/handlers/onboard.go
+++ b/internal/api/handlers/onboard.go
@@ -1,0 +1,264 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/getstackit/stackit/internal/api/auth"
+	"github.com/getstackit/stackit/internal/api/provision"
+	"github.com/getstackit/stackit/internal/api/registry"
+	"github.com/getstackit/stackit/internal/api/reqid"
+	"github.com/getstackit/stackit/internal/api/store"
+	httpcontract "github.com/getstackit/stackit/internal/contracts/http"
+	"github.com/getstackit/stackit/internal/github"
+)
+
+// RepoPersister is the slice of the repo store the onboarding handler needs.
+// A nil RepoPersister means persistence is unavailable (no -database-url) and
+// onboarding is refused.
+type RepoPersister interface {
+	AddRepo(ctx context.Context, r store.Repo) (store.Repo, error)
+}
+
+// OnboardHandler serves POST /api/v1/repos: a logged-in user asks the server to
+// clone a GitHub repo and start serving it. The user's own token both
+// authorizes the request (they must be able to see the repo) and clones it, and
+// the repo is recorded against their login so only they see it (see visibleTo).
+type OnboardHandler struct {
+	reg       *registry.Registry
+	store     RepoPersister
+	cipher    *auth.Cipher
+	reposRoot string
+
+	// checkAccess is the one network dependency; it is an injectable seam so
+	// tests can authorize without reaching GitHub. Clone/init/build are local
+	// git operations and run for real.
+	checkAccess func(ctx context.Context, token, owner, name string) (*github.RepoAccess, error)
+}
+
+// NewOnboardHandler wires an onboarding handler. store and cipher may be nil
+// (persistence/auth not configured), in which case requests are refused with a
+// clear 503; the handler guards at request time so it is safe to mount
+// unconditionally.
+func NewOnboardHandler(reg *registry.Registry, st RepoPersister, cipher *auth.Cipher, reposRoot string) *OnboardHandler {
+	return &OnboardHandler{
+		reg:         reg,
+		store:       st,
+		cipher:      cipher,
+		reposRoot:   reposRoot,
+		checkAccess: github.CheckRepoAccess,
+	}
+}
+
+var (
+	// ownerPattern mirrors GitHub login rules: alphanumerics and single
+	// hyphens, no leading/trailing hyphen. No dots — that also blocks path
+	// traversal through the owner segment.
+	ownerPattern = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$`)
+	// namePattern allows dots (repo names like "repo.js") but ".." is rejected
+	// separately so it can't escape the repos root.
+	namePattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+	// idUnsafe collapses anything outside the registry's ID alphabet (which
+	// excludes dots) so a dotted repo name still yields a valid repo ID.
+	idUnsafe = regexp.MustCompile(`[^A-Za-z0-9_-]+`)
+)
+
+func (h *OnboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Onboarding acts as the requesting user and persists the result, so it
+	// needs auth (a cipher to recover the token), a store, and a place to put
+	// checkouts. Each missing prerequisite is a clear, actionable 503.
+	switch {
+	case h.cipher == nil:
+		writeJSONError(w, http.StatusServiceUnavailable, "onboarding requires authentication to be configured")
+		return
+	case h.store == nil:
+		writeJSONError(w, http.StatusServiceUnavailable, "onboarding requires a database (-database-url)")
+		return
+	case h.reposRoot == "":
+		writeJSONError(w, http.StatusServiceUnavailable, "onboarding requires a repos root (-repos-root)")
+		return
+	}
+
+	sess := auth.SessionFromContext(r.Context())
+	if sess == nil {
+		writeJSONError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	var req httpcontract.OnboardRepoRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 4<<10)).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	owner, name, ok := resolveCoords(req)
+	if !ok {
+		writeJSONError(w, http.StatusBadRequest, "owner and name are required (or a github url)")
+		return
+	}
+	if !validRepoCoords(owner, name) {
+		writeJSONError(w, http.StatusBadRequest, "invalid owner or repository name")
+		return
+	}
+
+	id := repoID(owner, name)
+	if _, exists := h.reg.Get(id); exists {
+		writeJSONError(w, http.StatusConflict, "repository already onboarded")
+		return
+	}
+
+	token, err := sess.AccessToken(h.cipher)
+	if err != nil {
+		writeJSONError(w, http.StatusForbidden, "session has no github token")
+		return
+	}
+
+	access, err := h.checkAccess(r.Context(), token, owner, name)
+	if err != nil {
+		if errors.Is(err, github.ErrRepoAccessDenied) {
+			// Mirror "not found" so a caller can't probe for the existence of
+			// repos they can't access.
+			writeJSONError(w, http.StatusNotFound, "repository not found or not accessible")
+			return
+		}
+		slog.Error("onboard: access check failed", "owner", owner, "name", name, "error", err)
+		writeJSONError(w, http.StatusBadGateway, "could not verify repository access")
+		return
+	}
+
+	dest := filepath.Join(h.reposRoot, owner, name)
+	displayName := owner + "/" + name
+	cloneURL := access.CloneURL
+	if cloneURL == "" {
+		cloneURL = "https://github.com/" + owner + "/" + name + ".git"
+	}
+
+	slog.Info("audit", "action", "onboard", "actor", sess.GitHubLogin, "repo", id, "request_id", reqid.FromContext(r.Context())) //nolint:gosec // structured slog fields
+
+	if err := provision.EnsureClone(r.Context(), provision.CloneParams{CloneURL: cloneURL, Token: token, Dest: dest}); err != nil {
+		slog.Error("onboard: clone failed", "repo", id, "error", err)
+		writeJSONError(w, http.StatusBadGateway, "failed to clone repository")
+		return
+	}
+
+	// A freshly cloned repo isn't a stackit repo yet; initialize it (set the
+	// trunk to the GitHub default branch) so the engine can serve it.
+	if err := provision.EnsureInitialized(r.Context(), dest, access.DefaultBranch); err != nil {
+		slog.Error("onboard: init failed", "repo", id, "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "failed to initialize repository")
+		return
+	}
+
+	// Persist before registering so the durable record exists first; a crash
+	// between the two recovers on the next restart (the row reloads). Path is
+	// stored empty so it re-derives from owner/name under whatever repos root
+	// the host uses, matching the store's host-portable design.
+	if _, err := h.store.AddRepo(r.Context(), store.Repo{
+		ID:          id,
+		DisplayName: displayName,
+		Owner:       owner,
+		Name:        name,
+		Remote:      "origin",
+		AddedBy:     sess.GitHubLogin,
+	}); err != nil {
+		slog.Error("onboard: persist failed", "repo", id, "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "failed to record repository")
+		return
+	}
+
+	entry, err := provision.BuildEntry(r.Context(), provision.EntryParams{
+		ID:          id,
+		DisplayName: displayName,
+		Path:        dest,
+		Remote:      "origin",
+		AddedBy:     sess.GitHubLogin,
+	})
+	if err != nil {
+		slog.Error("onboard: engine build failed (persisted; will load on restart)", "repo", id, "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "repository recorded but failed to start serving")
+		return
+	}
+	if err := h.reg.Add(entry); err != nil {
+		slog.Error("onboard: registry add failed (persisted; will load on restart)", "repo", id, "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "repository recorded but failed to start serving")
+		return
+	}
+
+	summary := httpcontract.RepoSummary{ID: entry.ID, DisplayName: entry.DisplayName}
+	if entry.Engine != nil {
+		summary.Trunk = entry.Engine.Trunk().GetName()
+		if cur := entry.Engine.CurrentBranch(); cur != nil {
+			summary.CurrentBranch = cur.GetName()
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(summary)
+}
+
+// resolveCoords extracts owner/name from the request, accepting either explicit
+// fields or a github URL / "owner/name" shorthand in the URL field.
+func resolveCoords(req httpcontract.OnboardRepoRequest) (owner, name string, ok bool) {
+	owner = strings.TrimSpace(req.Owner)
+	name = strings.TrimSpace(req.Name)
+	if owner != "" && name != "" {
+		return owner, name, true
+	}
+	if u := strings.TrimSpace(req.URL); u != "" {
+		return parseRepoURL(u)
+	}
+	return "", "", false
+}
+
+// parseRepoURL accepts "https://github.com/owner/name(.git)", "github.com/owner/name",
+// or "owner/name" and returns the two segments.
+func parseRepoURL(raw string) (owner, name string, ok bool) {
+	s := strings.TrimSuffix(strings.TrimSpace(raw), ".git")
+	if i := strings.Index(s, "github.com/"); i >= 0 {
+		s = s[i+len("github.com/"):]
+	}
+	parts := strings.Split(strings.Trim(s, "/"), "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+// validRepoCoords rejects coordinates that are malformed or could escape the
+// repos root via path traversal.
+func validRepoCoords(owner, name string) bool {
+	switch {
+	case !ownerPattern.MatchString(owner):
+		return false
+	case !namePattern.MatchString(name):
+		return false
+	case name == "." || name == ".." || strings.Contains(name, ".."):
+		return false
+	default:
+		return true
+	}
+}
+
+// repoID derives the registry/store ID from owner/name, collapsing characters
+// outside the ID alphabet (e.g. dots) so the result is always a valid ID.
+func repoID(owner, name string) string {
+	return strings.Trim(idUnsafe.ReplaceAllString(owner+"-"+name, "-"), "-")
+}
+
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/internal/api/handlers/onboard_test.go
+++ b/internal/api/handlers/onboard_test.go
@@ -1,0 +1,149 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/getstackit/stackit/internal/api/auth"
+	"github.com/getstackit/stackit/internal/api/registry"
+	"github.com/getstackit/stackit/internal/api/store"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRepoStore struct {
+	added []store.Repo
+	err   error
+}
+
+func (f *fakeRepoStore) AddRepo(_ context.Context, r store.Repo) (store.Repo, error) {
+	if f.err != nil {
+		return store.Repo{}, f.err
+	}
+	f.added = append(f.added, r)
+	return r, nil
+}
+
+func onboardCipher(t *testing.T) *auth.Cipher {
+	t.Helper()
+	c, err := auth.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
+	require.NoError(t, err)
+	return c
+}
+
+// doOnboard sends body as user "alice" through RequireSession into h, using a
+// session store keyed by the same cipher h holds so the token round-trips.
+func doOnboard(t *testing.T, h *OnboardHandler, cipher *auth.Cipher, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	sessions := auth.NewMemoryStore(cipher)
+	t.Cleanup(func() { _ = sessions.Close() })
+	sess, err := sessions.Create("alice", 1, "user-token")
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repos", strings.NewReader(body))
+	req.AddCookie(&http.Cookie{Name: "stackit_session", Value: sess.ID})
+	rec := httptest.NewRecorder()
+	auth.RequireSession(sessions, h).ServeHTTP(rec, req)
+	return rec
+}
+
+func TestOnboardHandlerSuccess(t *testing.T) {
+	t.Parallel()
+	src := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+	reg := registry.New()
+	t.Cleanup(func() { _ = reg.Close() })
+	repoStore := &fakeRepoStore{}
+	cipher := onboardCipher(t)
+	reposRoot := t.TempDir()
+
+	h := NewOnboardHandler(reg, repoStore, cipher, reposRoot)
+	h.checkAccess = func(_ context.Context, token, owner, name string) (*github.RepoAccess, error) {
+		require.Equal(t, "user-token", token)
+		return &github.RepoAccess{Owner: owner, Name: name, CloneURL: src.Dir, DefaultBranch: "main"}, nil
+	}
+
+	rec := doOnboard(t, h, cipher, `{"owner":"octo","name":"widget"}`)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	entry, ok := reg.Get("octo-widget")
+	require.True(t, ok)
+	require.Equal(t, "alice", entry.AddedBy)
+	require.Equal(t, "octo/widget", entry.DisplayName)
+
+	require.Len(t, repoStore.added, 1)
+	require.Equal(t, "octo-widget", repoStore.added[0].ID)
+	require.Equal(t, "alice", repoStore.added[0].AddedBy)
+	require.Equal(t, "octo", repoStore.added[0].Owner)
+	require.Equal(t, "widget", repoStore.added[0].Name)
+	require.Empty(t, repoStore.added[0].Path, "path is stored empty so it re-derives under the host's repos root")
+
+	require.DirExists(t, filepath.Join(reposRoot, "octo", "widget", ".git"))
+}
+
+func TestOnboardHandlerAccessDenied(t *testing.T) {
+	t.Parallel()
+	reg := registry.New()
+	t.Cleanup(func() { _ = reg.Close() })
+	cipher := onboardCipher(t)
+
+	h := NewOnboardHandler(reg, &fakeRepoStore{}, cipher, t.TempDir())
+	h.checkAccess = func(_ context.Context, _, _, _ string) (*github.RepoAccess, error) {
+		return nil, github.ErrRepoAccessDenied
+	}
+
+	rec := doOnboard(t, h, cipher, `{"owner":"octo","name":"secret"}`)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Empty(t, reg.List())
+}
+
+func TestOnboardHandlerDuplicate(t *testing.T) {
+	t.Parallel()
+	reg := registry.New()
+	t.Cleanup(func() { _ = reg.Close() })
+	require.NoError(t, reg.Add(&registry.RepoEntry{ID: "octo-widget", AddedBy: "alice"}))
+	cipher := onboardCipher(t)
+
+	h := NewOnboardHandler(reg, &fakeRepoStore{}, cipher, t.TempDir())
+	rec := doOnboard(t, h, cipher, `{"owner":"octo","name":"widget"}`)
+	require.Equal(t, http.StatusConflict, rec.Code)
+}
+
+func TestOnboardHandlerInvalidCoords(t *testing.T) {
+	t.Parallel()
+	reg := registry.New()
+	t.Cleanup(func() { _ = reg.Close() })
+	cipher := onboardCipher(t)
+
+	h := NewOnboardHandler(reg, &fakeRepoStore{}, cipher, t.TempDir())
+	rec := doOnboard(t, h, cipher, `{"owner":"../etc","name":"passwd"}`)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestOnboardHandlerRequiresSession(t *testing.T) {
+	t.Parallel()
+	reg := registry.New()
+	t.Cleanup(func() { _ = reg.Close() })
+	h := NewOnboardHandler(reg, &fakeRepoStore{}, onboardCipher(t), t.TempDir())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repos", strings.NewReader(`{"owner":"octo","name":"widget"}`))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestOnboardHandlerRequiresStore(t *testing.T) {
+	t.Parallel()
+	reg := registry.New()
+	t.Cleanup(func() { _ = reg.Close() })
+	h := NewOnboardHandler(reg, nil, onboardCipher(t), t.TempDir())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repos", strings.NewReader(`{"owner":"octo","name":"widget"}`))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}

--- a/internal/api/provision/init.go
+++ b/internal/api/provision/init.go
@@ -1,0 +1,47 @@
+package provision
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	initaction "github.com/getstackit/stackit/internal/actions/init"
+	"github.com/getstackit/stackit/internal/config"
+	"github.com/getstackit/stackit/internal/git"
+)
+
+// EnsureInitialized makes repoRoot a stackit repo if it is not one already, so a
+// freshly cloned checkout can be served (app.GetContext refuses uninitialized
+// repos). trunk is the preferred trunk branch — typically the GitHub default
+// branch — and is inferred when empty or absent locally. Initializing an
+// already-initialized repo is a no-op, so this is safe on the boot path too.
+func EnsureInitialized(ctx context.Context, repoRoot, trunk string) error {
+	cfg, err := config.LoadConfig(repoRoot)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	if cfg.IsInitialized() {
+		return nil
+	}
+
+	runner := git.NewRunnerWithPath(repoRoot, nil)
+	branchNames, err := runner.GetAllBranchNames(ctx)
+	if err != nil {
+		return fmt.Errorf("list branches: %w", err)
+	}
+	if len(branchNames) == 0 {
+		return fmt.Errorf("repository has no branches")
+	}
+
+	if trunk == "" || !slices.Contains(branchNames, trunk) {
+		trunk = initaction.InferTrunk(ctx, runner, branchNames)
+	}
+	if trunk == "" {
+		return fmt.Errorf("could not determine trunk branch")
+	}
+
+	if err := cfg.SetTrunk(trunk); err != nil {
+		return fmt.Errorf("set trunk: %w", err)
+	}
+	return nil
+}

--- a/internal/api/readonly_test.go
+++ b/internal/api/readonly_test.go
@@ -82,6 +82,25 @@ func TestReadOnlyModeRefusesSubmit(t *testing.T) {
 	require.JSONEq(t, `{"error":"server is read-only"}`, rr.Body.String())
 }
 
+// onboardRequest builds a POST to the onboarding route with the CSRF header
+// set so it clears RequireCSRFHeader and reaches the routed handler.
+func onboardRequest() *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repos", nil)
+	req.Header.Set(auth.CSRFHeader, "1")
+	return req
+}
+
+func TestReadOnlyModeRefusesOnboard(t *testing.T) {
+	t.Parallel()
+
+	handler := newTestHandler(t, true)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, onboardRequest())
+
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+	require.JSONEq(t, `{"error":"server is read-only"}`, rr.Body.String())
+}
+
 func TestReadOnlyModeAllowsReads(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -62,6 +62,11 @@ type ServerConfig struct {
 	// repo onboarding persists new repos here so they survive a restart; when
 	// nil, onboarding is unavailable and the registry is fixed at boot.
 	RepoStore *store.Store
+
+	// ReposRoot is the absolute base directory under which onboarded repos are
+	// checked out (<ReposRoot>/<owner>/<name>). Required for runtime
+	// onboarding; when empty, onboarding is refused.
+	ReposRoot string
 }
 
 // AuthConfig is the runtime auth setup. SessionStore must outlive the
@@ -158,9 +163,28 @@ func (s *Server) buildHandler() (http.Handler, error) {
 		submitHandler = readOnlyWriteHandler()
 	}
 
+	// Runtime onboarding (POST /repos) acts as the requesting user, so it needs
+	// the session cipher and the persistence store. Both may be absent
+	// (auth-disabled / no DB); the handler refuses with a clear 503 in that
+	// case. Read-only mode replaces it with the write-refusal handler, exactly
+	// like submit.
+	var cipher *auth.Cipher
+	if s.config.Auth != nil {
+		cipher = s.config.Auth.Cipher
+	}
+	var persister handlers.RepoPersister
+	if s.config.RepoStore != nil {
+		persister = s.config.RepoStore
+	}
+	var onboardHandler http.Handler = handlers.NewOnboardHandler(reg, persister, cipher, s.config.ReposRoot)
+	if s.config.ReadOnly {
+		onboardHandler = readOnlyWriteHandler()
+	}
+
 	for _, prefix := range prefixes {
 		// Unscoped index of available repos.
 		apiMux.Handle("GET "+prefix+"/repos", reposListHandler)
+		apiMux.Handle("POST "+prefix+"/repos", onboardHandler)
 
 		// New multi-repo routes. {repoID} resolves through the registry;
 		// unknown IDs return 404 from inside the handler.

--- a/internal/contracts/http/responses.go
+++ b/internal/contracts/http/responses.go
@@ -33,6 +33,16 @@ type ReposListResponse struct {
 	Repos []RepoSummary `json:"repos"`
 }
 
+// OnboardRepoRequest is the body for POST /api/v1/repos — a request to clone a
+// GitHub repository and start serving it. Provide either Owner+Name or URL;
+// URL is a convenience that is parsed into owner/name. On success the server
+// responds 201 with a RepoSummary for the newly served repo.
+type OnboardRepoRequest struct {
+	Owner string `json:"owner,omitempty"`
+	Name  string `json:"name,omitempty"`
+	URL   string `json:"url,omitempty"`
+}
+
 // ViewResponse is the combined response for the frontend view.
 // It bundles repo metadata and all stack details into a single payload
 // to avoid N+1 API calls.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

A logged-in user can now add a GitHub repo through the API. The flow ties
together the prior pieces: verify the user's own token can see the repo
(404 on denial, so existence isn't disclosed), clone it with that token,
initialize stackit on the fresh checkout (set trunk to the GitHub default
branch via the new provision.EnsureInitialized), then persist and register
it against the user's login for per-user visibility.

The handler self-guards: it returns a clear 503 when auth, a database, or a
repos root is not configured, 401 without a session, 409 on a repo already
onboarded, and 400 on coordinates that are malformed or could traverse out
of the repos root. Persisting before registering means a crash mid-onboard
recovers on the next restart. Read-only mode replaces the route with the
write-refusal handler, exactly like submit.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296** 👈
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*