### PR TITLE
feat: add "Add repository" UI to the repo picker

### DIFF
--- a/apps/web/src/components/repo-picker/__tests__/add-repository.test.tsx
+++ b/apps/web/src/components/repo-picker/__tests__/add-repository.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { AddRepository } from "../add-repository";
+
+let mockReadOnly = false;
+vi.mock("@/components/providers/config-provider", () => ({
+  useConfig: () => ({ readOnly: mockReadOnly, authRequired: true }),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockReadOnly = false;
+});
+
+describe("AddRepository", () => {
+  it("posts owner/name and calls onAdded with the new repo", async () => {
+    const repo = { id: "octo-widget", displayName: "octo/widget", trunk: "main" };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: () => Promise.resolve(repo),
+    });
+    const onAdded = vi.fn();
+
+    render(<AddRepository onAdded={onAdded} />);
+    fireEvent.change(screen.getByLabelText("Repository owner"), {
+      target: { value: "octo" },
+    });
+    fireEvent.change(screen.getByLabelText("Repository name"), {
+      target: { value: "widget" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add/i }));
+
+    await waitFor(() => expect(onAdded).toHaveBeenCalledWith(repo));
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toContain("/api/v1/repos");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({ owner: "octo", name: "widget" });
+  });
+
+  it("surfaces the server error and does not call onAdded", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: () => Promise.resolve({ error: "repository not found or not accessible" }),
+    });
+    const onAdded = vi.fn();
+
+    render(<AddRepository onAdded={onAdded} />);
+    fireEvent.change(screen.getByLabelText("Repository owner"), {
+      target: { value: "octo" },
+    });
+    fireEvent.change(screen.getByLabelText("Repository name"), {
+      target: { value: "ghost" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "repository not found or not accessible"
+    );
+    expect(onAdded).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing on a read-only server", () => {
+    mockReadOnly = true;
+    const { container } = render(<AddRepository onAdded={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("disables Add until both fields are filled", () => {
+    render(<AddRepository onAdded={vi.fn()} />);
+    const button = screen.getByRole("button", { name: /add/i });
+    expect(button).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Repository owner"), {
+      target: { value: "octo" },
+    });
+    expect(button).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Repository name"), {
+      target: { value: "widget" },
+    });
+    expect(button).not.toBeDisabled();
+  });
+});

--- a/apps/web/src/components/repo-picker/add-repository.tsx
+++ b/apps/web/src/components/repo-picker/add-repository.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { useConfig } from "@/components/providers/config-provider";
+import { onboardRepo, type RepoSummary } from "@/lib/api";
+
+interface AddRepositoryProps {
+  /** Called with the newly served repo after a successful onboard. */
+  onAdded: (repo: RepoSummary) => void;
+}
+
+const inputClasses =
+  "flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50";
+
+export function AddRepository({ onAdded }: AddRepositoryProps) {
+  const { readOnly } = useConfig();
+  const [owner, setOwner] = useState("");
+  const [name, setName] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // A read-only server refuses writes; hide the affordance entirely.
+  if (readOnly) return null;
+
+  const canSubmit = owner.trim() !== "" && name.trim() !== "" && !submitting;
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const repo = await onboardRepo(owner.trim(), name.trim());
+      setOwner("");
+      setName("");
+      onAdded(repo);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add repository");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Add a repository</CardTitle>
+        <CardDescription>
+          Clone a GitHub repository you have access to and start managing its
+          stacks.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-col gap-3"
+          aria-label="Add repository"
+        >
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <input
+              type="text"
+              value={owner}
+              onChange={(e) => setOwner(e.target.value)}
+              placeholder="owner"
+              aria-label="Repository owner"
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
+              disabled={submitting}
+              className={inputClasses}
+            />
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="repository"
+              aria-label="Repository name"
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
+              disabled={submitting}
+              className={inputClasses}
+            />
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:opacity-50"
+            >
+              {submitting ? "Adding…" : "Add"}
+            </button>
+          </div>
+          {error && (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          )}
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/repo-picker/repo-picker.tsx
+++ b/apps/web/src/components/repo-picker/repo-picker.tsx
@@ -10,11 +10,15 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { fetchRepos, type RepoSummary } from "@/lib/api";
+import { AddRepository } from "./add-repository";
 
 export function RepoPicker() {
   const router = useRouter();
   const [repos, setRepos] = useState<RepoSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const openRepo = (id: string) =>
+    router.push(`/?repo=${encodeURIComponent(id)}`);
 
   useEffect(() => {
     let active = true;
@@ -54,12 +58,14 @@ export function RepoPicker() {
 
   if (repos.length === 0) {
     return (
-      <div className="flex h-screen flex-col items-center justify-center gap-2 text-sm">
-        <p className="font-medium">No repositories configured</p>
-        <p className="text-muted-foreground">
-          Pass <code className="rounded bg-muted px-1 py-0.5">-repos-config</code>{" "}
-          when starting the server, or use <code className="rounded bg-muted px-1 py-0.5">-cwd .</code> for single-repo mode.
-        </p>
+      <div className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 px-6 py-12">
+        <header className="flex flex-col gap-1">
+          <h1 className="text-2xl font-semibold">No repositories configured</h1>
+          <p className="text-sm text-muted-foreground">
+            Add a GitHub repository to get started.
+          </p>
+        </header>
+        <AddRepository onAdded={(repo) => openRepo(repo.id)} />
       </div>
     );
   }
@@ -80,7 +86,7 @@ export function RepoPicker() {
             <button
               type="button"
               data-testid={`repo-card-${repo.id}`}
-              onClick={() => router.push(`/?repo=${encodeURIComponent(repo.id)}`)}
+              onClick={() => openRepo(repo.id)}
               className="block w-full text-left transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
             >
               <Card>
@@ -105,6 +111,8 @@ export function RepoPicker() {
           </li>
         ))}
       </ul>
+
+      <AddRepository onAdded={(repo) => openRepo(repo.id)} />
     </div>
   );
 }

--- a/apps/web/src/lib/__tests__/api.test.ts
+++ b/apps/web/src/lib/__tests__/api.test.ts
@@ -8,6 +8,8 @@ import {
   fetchBranch,
   fetchBranchDiff,
   fetchConfig,
+  onboardRepo,
+  UnauthorizedError,
 } from "../api";
 
 const mockFetch = vi.fn();
@@ -42,6 +44,52 @@ describe("fetchRepos", () => {
     expect(mockFetch).toHaveBeenCalledWith("/api/v1/repos", {
       credentials: "include",
     });
+  });
+});
+
+describe("onboardRepo", () => {
+  it("POSTs owner/name with the CSRF header and returns the summary", async () => {
+    const repo = { id: "octo-widget", displayName: "octo/widget", trunk: "main" };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: () => Promise.resolve(repo),
+    });
+
+    const result = await onboardRepo("octo", "widget");
+    expect(result).toEqual(repo);
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("/api/v1/repos");
+    expect(init.method).toBe("POST");
+    expect(init.headers["X-Stackit-CSRF"]).toBe("1");
+    expect(JSON.parse(init.body)).toEqual({ owner: "octo", name: "widget" });
+  });
+
+  it("throws the server's error message on failure", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      json: () => Promise.resolve({ error: "repository not found or not accessible" }),
+    });
+
+    await expect(onboardRepo("octo", "ghost")).rejects.toThrow(
+      "repository not found or not accessible"
+    );
+  });
+
+  it("throws UnauthorizedError on 401", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      json: () => Promise.resolve({}),
+    });
+
+    await expect(onboardRepo("octo", "widget")).rejects.toBeInstanceOf(
+      UnauthorizedError
+    );
   });
 });
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -216,6 +216,34 @@ export function fetchRepos(): Promise<ReposListResponse> {
   return fetchAPI<ReposListResponse>("/api/v1/repos");
 }
 
+// onboardRepo asks the server to clone a GitHub repo and start serving it,
+// returning the newly served repo's summary. The caller's session must be able
+// to access owner/name; the server verifies that and 404s otherwise.
+export async function onboardRepo(owner: string, name: string): Promise<RepoSummary> {
+  const res = await fetch(`${API_BASE}/api/v1/repos`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      [CSRF_HEADER]: CSRF_HEADER_VALUE,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ owner, name }),
+  });
+  if (res.status === 401) {
+    throw new UnauthorizedError();
+  }
+  if (!res.ok) {
+    // The server returns {"error": "..."} for handled failures; surface it.
+    const detail = await res.json().catch(() => null);
+    const message =
+      detail && typeof detail.error === "string"
+        ? detail.error
+        : `API error: ${res.status} ${res.statusText}`;
+    throw new Error(message);
+  }
+  return res.json();
+}
+
 export function fetchView(repoId: string): Promise<ViewResponse> {
   return fetchAPI<ViewResponse>(repoPath(repoId, "view"));
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

A logged-in user can now onboard a repo from the web app. The repo picker
gains an owner/name form that POSTs to /api/v1/repos and, on success,
navigates to the newly served repo. The empty state leads with the form so a
fresh server is usable without operator config.

- api: onboardRepo(owner, name) posts with the CSRF header and surfaces the
  server's {"error"} message (and UnauthorizedError on 401).
- AddRepository self-hides on a read-only server (useConfig) since writes are
  refused there, and disables submit until both fields are filled.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297** 👈
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*