### PR TITLE
docs: document runtime repo onboarding

### DIFF
--- a/api/openapi/stackit.yaml
+++ b/api/openapi/stackit.yaml
@@ -124,6 +124,50 @@ paths:
             text/event-stream:
               schema:
                 type: string
+  /api/v1/repos:
+    get:
+      summary: List repositories the server is serving (filtered to the caller).
+      operationId: listRepos
+      responses:
+        "200":
+          description: Repository index.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReposListResponse"
+    post:
+      summary: Onboard a GitHub repository (clone and start serving it).
+      description: >
+        Clones a GitHub repository the authenticated user can access and starts
+        serving it, recorded against that user so only they see it. Requires an
+        authenticated, writable, DB-backed server with a repos root configured;
+        read-only servers refuse with 405.
+      operationId: onboardRepo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OnboardRepoRequest"
+      responses:
+        "201":
+          description: The newly served repository.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RepoSummary"
+        "400":
+          description: Missing or invalid owner/name.
+        "401":
+          description: Authentication required.
+        "404":
+          description: Repository not found or not accessible to the caller.
+        "405":
+          description: Server is read-only.
+        "409":
+          description: Repository already onboarded.
+        "503":
+          description: Onboarding not available (no auth, database, or repos root).
 components:
   schemas:
     ViewResponse:
@@ -322,4 +366,34 @@ components:
           additionalProperties:
             type: string
         stackScope:
+          type: string
+    RepoSummary:
+      type: object
+      required: [id, displayName, trunk]
+      properties:
+        id:
+          type: string
+        displayName:
+          type: string
+        trunk:
+          type: string
+        currentBranch:
+          type: string
+    ReposListResponse:
+      type: object
+      required: [repos]
+      properties:
+        repos:
+          type: array
+          items:
+            $ref: "#/components/schemas/RepoSummary"
+    OnboardRepoRequest:
+      type: object
+      description: Provide either owner and name, or a github url.
+      properties:
+        owner:
+          type: string
+        name:
+          type: string
+        url:
           type: string

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -45,9 +45,11 @@ The container reads its repo list from a JSON file. Mount a volume at `/data`
 | `displayName` | no | Human label shown in the web UI; defaults to `id` |
 | `remote` | no | Git remote name; defaults to `origin` |
 
-You are responsible for cloning the repos into the mounted volume and
-running `stackit init` inside each one before starting the container.
-(Clone-from-URL + auto-init are Phase 4.)
+For DB-backed deployments (`-database-url`), repos can instead be added at
+runtime by logged-in users — the server clones and initializes them for you.
+See [Repository onboarding](#repository-onboarding). You can still pre-seed
+repos by inserting rows directly; a row with an empty `added_by` is shared
+with every authenticated user.
 
 ### Environment
 
@@ -56,6 +58,8 @@ running `stackit init` inside each one before starting the container.
 | `PORT` | Listen port. Honored when `-port` isn't passed explicitly — needed for Railway, Fly, Heroku. Defaults to `8080`. Setting this also implicitly switches the server into "public mode" (binds `0.0.0.0`, requires auth env). |
 | `STACKIT_PUBLIC` | Explicit version of the same signal. Set when you mean to expose the server publicly without `$PORT` (e.g. behind a tunnel). |
 | `STACKIT_READ_ONLY` | Set to `1`/`true` to serve in read-only mode: the submit endpoint is disabled and reads are served anonymously, so a configured repo can be exposed to the public without write access. See [Read-only public mode](#read-only-public-mode). Equivalent to `-read-only`. |
+| `STACKIT_DATABASE_URL` | PostgreSQL connection string. When set, repos are served from the DB (and runtime [onboarding](#repository-onboarding) can persist new ones) instead of the `-cwd` single-repo shortcut. Equivalent to `-database-url`. |
+| `STACKIT_REPOS_ROOT` | Base directory under which per-repo checkouts live (`<root>/<owner>/<name>`). Required for DB-backed serving and onboarding. Equivalent to `-repos-root`. |
 | `STACKIT_BASE_URL` | The canonical https:// URL the server is reachable at. Required when auth is enabled (used to build the OAuth callback URL). |
 | `STACKIT_GITHUB_CLIENT_ID` | GitHub OAuth App client ID. |
 | `STACKIT_GITHUB_CLIENT_SECRET` | GitHub OAuth App client secret. |
@@ -69,7 +73,9 @@ The most useful flags:
 
 | Flag | Default | Purpose |
 |------|---------|---------|
-| `-repos-config` | _(empty)_ | Path to the JSON repos file. Required for multi-repo mode. |
+| `-database-url` | _(empty)_ | PostgreSQL connection string. Enables DB-backed multi-repo serving and runtime [onboarding](#repository-onboarding). Also settable via `STACKIT_DATABASE_URL`. |
+| `-repos-root` | _(empty)_ | Base directory for per-repo checkouts (`<root>/<owner>/<name>`). Required with `-database-url` and for onboarding. Also settable via `STACKIT_REPOS_ROOT`. |
+| `-cwd` | _(empty)_ | Single-repo shortcut: serve the repo discovered from this path as `default`. Ignored when `-database-url` is set. |
 | `-port` | `8080` | Listen port; overrides `$PORT`. |
 | `-bind` | `127.0.0.1` (or `0.0.0.0` if `$PORT`/`$STACKIT_PUBLIC` are set) | Interface to bind on. Pass `-bind 0.0.0.0` explicitly to expose the server on a host where the heuristics don't fire. |
 | `-cors` | `http://localhost:3000,http://localhost:5173` | Comma-separated allowed CORS origins. Loopback origins are **not** allowed implicitly — list each origin you want to accept. |
@@ -150,6 +156,44 @@ A public endpoint needs limits even when it only serves reads:
 The defaults are generous enough for normal use. A deployment fronted by a
 CDN/proxy should ensure `X-Forwarded-For` is set so the per-IP limits key on
 the real client rather than collapsing every visitor onto the proxy IP.
+
+## Repository onboarding
+
+On a DB-backed server, logged-in users can add their own repos through the web
+app (the "Add a repository" form on the picker) or `POST /api/v1/repos`. The
+server:
+
+1. Verifies the **requesting user's** GitHub token can access the repo — not
+   the server's token — so a user can only add repos they can already see. A
+   repo they can't see returns `404` (indistinguishable from "not found", by
+   design).
+2. Clones it to `<repos-root>/<owner>/<name>` using that user's token (passed
+   to git via env, never written to `.git/config`).
+3. Initializes stackit on the fresh checkout (trunk = the GitHub default
+   branch) and starts serving it.
+4. Records the repo against the user's login, so **each user sees only the
+   repos they added**. A repo with an empty `added_by` (operator-seeded) is
+   shared with everyone.
+
+### Requirements
+
+Onboarding is refused (`503`) unless all of these hold; it is also disabled
+(`405`) in read-only mode, since it is a write:
+
+- **Auth is configured** (GitHub OAuth) — the flow acts as the requesting user.
+- **`-database-url`** is set — the new repo is persisted so it survives a
+  restart.
+- **`-repos-root`** is set — somewhere to put the checkout.
+
+### Limitations (current)
+
+- **Trusted users.** The model assumes everyone who can sign in is trusted;
+  the repo ID is `<owner>-<name>` globally, so two users adding the same repo
+  collide (`409`).
+- **No automatic refresh yet.** The server reacts to local filesystem changes
+  but does not `git fetch` on its own, so an onboarded repo only updates when
+  something pulls it locally. A background fetch loop needs durable
+  credentials (a user's session token expires in 30 days), tracked separately.
 
 ## Security posture
 

--- a/docs/web.md
+++ b/docs/web.md
@@ -107,7 +107,14 @@ All fetch functions live in `src/lib/api.ts`:
 | `fetchStacks()` | GET | `/api/stacks` | All stack summaries |
 | `fetchStack(root)` | GET | `/api/stacks/{root}` | Single stack detail |
 | `fetchBranch(name)` | GET | `/api/branches/{name}` | Single branch detail |
+| `fetchRepos()` | GET | `/api/v1/repos` | Repos the caller may see (picker) |
+| `onboardRepo(owner, name)` | POST | `/api/v1/repos` | Clone & serve a GitHub repo |
 | `submitStack(root)` | POST | `/api/submit/{root}` | Trigger stack submission |
+
+The repo picker (`src/components/repo-picker/`) renders an `AddRepository`
+form that calls `onboardRepo`; on success it navigates to the new repo. The
+form self-hides on a read-only server (`useConfig().readOnly`) since writes are
+refused there. See [Repository onboarding](./deploy.md#repository-onboarding).
 
 The API base URL is configured via `NEXT_PUBLIC_API_URL`. Default is empty
 (same-origin) so the embedded production build, served by the Go binary,


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

- api/openapi: add the /api/v1/repos path (GET index + POST onboard) and the
  RepoSummary / ReposListResponse / OnboardRepoRequest schemas.
- docs/deploy.md: add a "Repository onboarding" section (flow, requirements,
  multi-tenant visibility, and the trusted-users / no-auto-fetch limitations),
  document the -database-url / -repos-root flags and env vars that were
  missing, and replace the "Phase 4" placeholder now that clone-from-URL +
  auto-init ship.
- docs/web.md: list fetchRepos / onboardRepo and describe the AddRepository
  form and its read-only gating.

Note: deploy.md still describes a `-repos-config` JSON file that the server no
longer accepts (it reads repos from -database-url now); fully reconciling that
stale section is left as separate doc-debt.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298** 👈
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*