### PR TITLE
feat: add mirror-fetch for server-managed checkouts

### DIFF
--- a/internal/api/provision/clone.go
+++ b/internal/api/provision/clone.go
@@ -38,18 +38,7 @@ func EnsureClone(ctx context.Context, p CloneParams) error {
 	}
 
 	cmd := exec.CommandContext(ctx, "git", "clone", "--", p.CloneURL, p.Dest)
-	// GIT_TERMINAL_PROMPT=0 makes a bad/empty token fail fast instead of
-	// blocking on an interactive credential prompt.
-	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
-	if p.Token != "" {
-		header := "Authorization: Basic " + basicAuthHeader("x-access-token", p.Token)
-		env = append(env,
-			"GIT_CONFIG_COUNT=1",
-			"GIT_CONFIG_KEY_0=http.extraHeader",
-			"GIT_CONFIG_VALUE_0="+header,
-		)
-	}
-	cmd.Env = env
+	cmd.Env = gitEnv(p.Token)
 
 	if out, err := cmd.CombinedOutput(); err != nil {
 		// Leave no half-written checkout behind so a retry starts clean.
@@ -70,4 +59,21 @@ func isGitRepo(dir string) bool {
 
 func basicAuthHeader(user, pass string) string {
 	return base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
+}
+
+// gitEnv returns the environment for a git subprocess: the process environment,
+// a disabled credential prompt (so a bad/empty token fails fast instead of
+// blocking on input), and — when token is non-empty — an Authorization header
+// supplied via GIT_CONFIG so the token never appears in argv or the repo config.
+func gitEnv(token string) []string {
+	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if token != "" {
+		header := "Authorization: Basic " + basicAuthHeader("x-access-token", token)
+		env = append(env,
+			"GIT_CONFIG_COUNT=1",
+			"GIT_CONFIG_KEY_0=http.extraHeader",
+			"GIT_CONFIG_VALUE_0="+header,
+		)
+	}
+	return env
 }

--- a/internal/api/provision/fetch.go
+++ b/internal/api/provision/fetch.go
@@ -1,0 +1,56 @@
+package provision
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// MirrorFetch updates a server-managed checkout to mirror its remote: it
+// force-updates local branch heads and stackit metadata refs from the remote
+// and prunes refs deleted upstream, so the served stack graph and stack
+// descriptions reflect GitHub.
+//
+// The checkout's HEAD is detached first because git refuses to fetch into the
+// currently checked-out branch; a managed mirror has no working branch, and the
+// server reads refs (not the working tree), so a frozen tree is harmless.
+//
+// token authenticates the fetch — a GitHub App installation token for private
+// repos; empty fetches without auth (public repos).
+func MirrorFetch(ctx context.Context, repoRoot, remote, token string) error {
+	if remote == "" {
+		remote = "origin"
+	}
+	if err := detachHead(ctx, repoRoot); err != nil {
+		return err
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "fetch", "--prune", remote,
+		"+refs/heads/*:refs/heads/*",
+		"+refs/stackit/metadata/*:refs/stackit/metadata/*",
+		"+refs/stackit/stacks/*:refs/stackit/stacks/*",
+	)
+	cmd.Env = gitEnv(token)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git mirror-fetch %s: %w: %s", remote, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// detachHead detaches the checkout's HEAD when it is on a branch, so a mirror
+// fetch can update every refs/heads/*. It is a no-op when HEAD is already
+// detached (the steady state after the first fetch).
+func detachHead(ctx context.Context, repoRoot string) error {
+	// symbolic-ref -q HEAD exits 0 (and prints the branch) when on a branch,
+	// non-zero when already detached — already detached means nothing to do.
+	onBranch := exec.CommandContext(ctx, "git", "-C", repoRoot, "symbolic-ref", "-q", "HEAD").Run() == nil
+	if !onBranch {
+		return nil
+	}
+	cmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "checkout", "--detach")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("detach HEAD: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/api/provision/fetch_test.go
+++ b/internal/api/provision/fetch_test.go
@@ -1,0 +1,85 @@
+package provision_test
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/getstackit/stackit/internal/api/provision"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/stretchr/testify/require"
+)
+
+func requireBranch(t *testing.T, repoRoot, branch string, present bool) {
+	t.Helper()
+	err := exec.Command("git", "-C", repoRoot, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch).Run()
+	if present {
+		require.NoError(t, err, "expected branch %q to exist", branch)
+	} else {
+		require.Error(t, err, "expected branch %q to be pruned", branch)
+	}
+}
+
+func requireRef(t *testing.T, repoRoot, ref string, present bool) {
+	t.Helper()
+	err := exec.Command("git", "-C", repoRoot, "rev-parse", "--verify", "--quiet", ref).Run()
+	if present {
+		require.NoError(t, err, "expected ref %q to exist", ref)
+	} else {
+		require.Error(t, err, "expected ref %q to be pruned", ref)
+	}
+}
+
+func TestMirrorFetchPullsNewBranchesAndDetachesHead(t *testing.T) {
+	t.Parallel()
+	src := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+	dest := filepath.Join(t.TempDir(), "mirror")
+	require.NoError(t, provision.EnsureClone(context.Background(), provision.CloneParams{CloneURL: src.Dir, Dest: dest}))
+
+	// A new branch appears upstream.
+	require.NoError(t, src.Repo.RunGitCommand("checkout", "-b", "feature"))
+	require.NoError(t, src.Repo.CreateChangeAndCommit("more", "more"))
+
+	require.NoError(t, provision.MirrorFetch(context.Background(), dest, "origin", ""))
+
+	requireBranch(t, dest, "feature", true)
+
+	// A mirror leaves HEAD detached so future fetches can update every head.
+	err := exec.Command("git", "-C", dest, "symbolic-ref", "-q", "HEAD").Run()
+	require.Error(t, err, "HEAD should be detached after a mirror fetch")
+}
+
+func TestMirrorFetchPrunesDeletedBranches(t *testing.T) {
+	t.Parallel()
+	src := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+	dest := filepath.Join(t.TempDir(), "mirror")
+	require.NoError(t, provision.EnsureClone(context.Background(), provision.CloneParams{CloneURL: src.Dir, Dest: dest}))
+
+	require.NoError(t, src.Repo.RunGitCommand("checkout", "-b", "feature"))
+	require.NoError(t, src.Repo.CreateChangeAndCommit("x", "x"))
+	require.NoError(t, provision.MirrorFetch(context.Background(), dest, "origin", ""))
+	requireBranch(t, dest, "feature", true)
+
+	// Delete it upstream (switch off it first), then re-mirror.
+	require.NoError(t, src.Repo.RunGitCommand("checkout", "-"))
+	require.NoError(t, src.Repo.RunGitCommand("branch", "-D", "feature"))
+	require.NoError(t, provision.MirrorFetch(context.Background(), dest, "origin", ""))
+
+	requireBranch(t, dest, "feature", false)
+}
+
+func TestMirrorFetchPullsStackMetadata(t *testing.T) {
+	t.Parallel()
+	src := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+	dest := filepath.Join(t.TempDir(), "mirror")
+	require.NoError(t, provision.EnsureClone(context.Background(), provision.CloneParams{CloneURL: src.Dir, Dest: dest}))
+
+	blob, err := src.Repo.RunGitCommandAndGetOutput("hash-object", "-w", "--stdin")
+	require.NoError(t, err)
+	require.NoError(t, src.Repo.RunGitCommand("update-ref", "refs/stackit/stacks/test-stack", blob))
+
+	require.NoError(t, provision.MirrorFetch(context.Background(), dest, "origin", ""))
+
+	requireRef(t, dest, "refs/stackit/stacks/test-stack", true)
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

provision.MirrorFetch force-updates a managed checkout's local branch heads and
stackit metadata refs from its remote and prunes refs deleted upstream, so the
served stack graph reflects GitHub. It detaches HEAD first (git refuses to
fetch into the checked-out branch); a managed mirror has no working branch and
the server reads refs, not the working tree, so a frozen tree is harmless.

The token (a GitHub App installation token, or empty for public repos) is
passed via the shared gitEnv helper extracted from the clone path, so it never
lands in argv or .git/config.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301** 👈
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*