### PR TITLE
refactor: make the entry refresh path reusable

### DIFF
--- a/internal/api/registry/registry.go
+++ b/internal/api/registry/registry.go
@@ -62,6 +62,14 @@ type RepoEntry struct {
 	Broadcaster *Broadcaster
 	Watcher     *watcher.RefWatcher
 
+	// refresh state: trunkName is captured at construction; lastCurrentBranch
+	// tracks the served HEAD across refreshes to detect branch switches.
+	// refreshMu serializes refresh() so the ref watcher and the sync loop
+	// can't rebuild the engine concurrently.
+	refreshMu         sync.Mutex
+	trunkName         string
+	lastCurrentBranch string
+
 	closers []func() error
 }
 
@@ -82,7 +90,11 @@ func NewEntry(cfg EntryConfig) *RepoEntry {
 	entry.AddCloser(func() error { entry.Broadcaster.Close(); return nil })
 
 	if cfg.RepoRoot != "" && cfg.Engine != nil {
-		entry.Watcher = watcher.NewRefWatcher(cfg.RepoRoot, watcherDebounce, makeWatcherCallback(entry))
+		entry.trunkName = cfg.Engine.Trunk().GetName()
+		if cb := cfg.Engine.CurrentBranch(); cb != nil {
+			entry.lastCurrentBranch = cb.GetName()
+		}
+		entry.Watcher = watcher.NewRefWatcher(cfg.RepoRoot, watcherDebounce, entry.refresh)
 		watcherDone := make(chan error, 1)
 		go func() {
 			watcherDone <- entry.Watcher.Start()
@@ -120,38 +132,37 @@ func (e *RepoEntry) close() error {
 	return errors.Join(errs...)
 }
 
-// makeWatcherCallback returns the function the ref watcher invokes when
-// the repo's refs change. It rebuilds the engine, detects branch switches,
-// and re-broadcasts both "branch_switched" and "refresh" so connected SSE
-// clients refetch.
-func makeWatcherCallback(entry *RepoEntry) func() {
-	trunkName := entry.Engine.Trunk().GetName()
-	var lastCurrentBranch string
-	if cb := entry.Engine.CurrentBranch(); cb != nil {
-		lastCurrentBranch = cb.GetName()
+// refresh rebuilds the engine from current refs and broadcasts a "refresh"
+// event (plus "branch_switched" when the served HEAD changed) so connected SSE
+// clients refetch. It is the shared post-change path invoked by both the ref
+// watcher (local changes) and the sync loop (remote changes); refreshMu
+// serializes the two so the engine isn't rebuilt concurrently.
+func (e *RepoEntry) refresh() {
+	if e.Engine == nil {
+		return
+	}
+	e.refreshMu.Lock()
+	defer e.refreshMu.Unlock()
+
+	if err := e.Engine.Rebuild(e.trunkName); err != nil {
+		slog.Error("engine rebuild failed", "repo", e.ID, "error", err)
+		return
 	}
 
-	return func() {
-		if err := entry.Engine.Rebuild(trunkName); err != nil {
-			slog.Error("engine rebuild failed", "repo", entry.ID, "error", err)
-			return
+	if cb := e.Engine.CurrentBranch(); cb != nil {
+		newBranch := cb.GetName()
+		if e.lastCurrentBranch != "" && newBranch != e.lastCurrentBranch {
+			data, _ := json.Marshal(map[string]string{
+				"from":      e.lastCurrentBranch,
+				"to":        newBranch,
+				"timestamp": time.Now().Format(time.RFC3339),
+			})
+			e.Broadcaster.Broadcast("branch_switched", string(data))
 		}
-
-		if cb := entry.Engine.CurrentBranch(); cb != nil {
-			newBranch := cb.GetName()
-			if lastCurrentBranch != "" && newBranch != lastCurrentBranch {
-				data, _ := json.Marshal(map[string]string{
-					"from":      lastCurrentBranch,
-					"to":        newBranch,
-					"timestamp": time.Now().Format(time.RFC3339),
-				})
-				entry.Broadcaster.Broadcast("branch_switched", string(data))
-			}
-			lastCurrentBranch = newBranch
-		}
-
-		entry.Broadcaster.Broadcast("refresh", "{}")
+		e.lastCurrentBranch = newBranch
 	}
+
+	e.Broadcaster.Broadcast("refresh", "{}")
 }
 
 // Registry is a goroutine-safe collection of RepoEntries keyed by ID.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Extract the watcher callback's rebuild + branch-switch-detect + broadcast logic
into a RepoEntry.refresh() method, with the trunk name and last-served branch
held on the entry behind a mutex. The ref watcher now calls entry.refresh
directly, and the upcoming sync loop will call the same method after a remote
fetch — so local and remote changes go through one serialized path that can't
rebuild the engine concurrently.

Pure refactor: watcher behavior is unchanged.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302** 👈
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*