### PR TITLE
feat: mark server-managed mirror checkouts

### DIFF
--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -245,6 +245,7 @@ func addRegistryEntry(reg *registry.Registry, rc repoConfig) error {
 		Path:        rc.Path,
 		Remote:      rc.Remote,
 		AddedBy:     rc.AddedBy,
+		Managed:     rc.Managed,
 	})
 	if err != nil {
 		return err

--- a/apps/server/repos_config.go
+++ b/apps/server/repos_config.go
@@ -37,6 +37,10 @@ type repoConfig struct {
 	// empty for operator-seeded rows. Carried through to the registry entry so
 	// the server can scope per-user visibility.
 	AddedBy string
+
+	// Managed marks a server-owned mirror checkout the sync loop may
+	// mirror-fetch. True for DB-backed repos; false for the -cwd dev repo.
+	Managed bool
 }
 
 // repoIDPattern restricts repo IDs to characters that survive in URL paths

--- a/apps/server/repos_db.go
+++ b/apps/server/repos_db.go
@@ -42,6 +42,7 @@ func loadReposFromDB(ctx context.Context, st *store.Store, reposRoot string) ([]
 			Path:        r.Path,
 			Remote:      r.Remote,
 			AddedBy:     r.AddedBy,
+			Managed:     true, // DB-backed checkouts are server-owned mirrors.
 		}
 		if err := normalizeRepoEntry(&rc, reposRoot); err != nil {
 			slog.Warn("repo skipped (invalid config)", "repo", r.ID, "error", err)

--- a/internal/api/handlers/onboard.go
+++ b/internal/api/handlers/onboard.go
@@ -184,6 +184,7 @@ func (h *OnboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Path:        dest,
 		Remote:      "origin",
 		AddedBy:     sess.GitHubLogin,
+		Managed:     true, // onboarded checkouts are server-owned mirrors.
 	})
 	if err != nil {
 		slog.Error("onboard: engine build failed (persisted; will load on restart)", "repo", id, "error", err)

--- a/internal/api/handlers/onboard_test.go
+++ b/internal/api/handlers/onboard_test.go
@@ -74,6 +74,7 @@ func TestOnboardHandlerSuccess(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "alice", entry.AddedBy)
 	require.Equal(t, "octo/widget", entry.DisplayName)
+	require.True(t, entry.Managed, "onboarded repos are server-managed mirrors")
 
 	require.Len(t, repoStore.added, 1)
 	require.Equal(t, "octo-widget", repoStore.added[0].ID)

--- a/internal/api/provision/provision.go
+++ b/internal/api/provision/provision.go
@@ -25,6 +25,9 @@ type EntryParams struct {
 	// empty for operator-seeded repos. Carried onto the registry entry for
 	// per-user visibility scoping.
 	AddedBy string
+	// Managed marks a server-owned mirror checkout the sync loop may
+	// mirror-fetch (see registry.EntryConfig.Managed).
+	Managed bool
 }
 
 // BuildEntry resolves p into a runtime context via app.GetContext and returns a
@@ -53,6 +56,7 @@ func BuildEntry(ctx context.Context, p EntryParams) (*registry.RepoEntry, error)
 		RepoRoot:    runtimeCtx.RepoRoot,
 		Remote:      p.Remote,
 		AddedBy:     p.AddedBy,
+		Managed:     p.Managed,
 		Engine:      runtimeCtx.Engine,
 		GitHub:      gh,
 	})

--- a/internal/api/registry/registry.go
+++ b/internal/api/registry/registry.go
@@ -40,6 +40,10 @@ type EntryConfig struct {
 	// empty for operator-seeded repos. Handlers use it to scope per-user
 	// visibility so a user only sees repos they added.
 	AddedBy string
+	// Managed marks a server-owned mirror checkout (DB-backed / onboarded under
+	// the repos root) that the sync loop may mirror-fetch. The -cwd dev repo is
+	// the operator's own working tree and is left unmanaged.
+	Managed bool
 	Engine  engine.Engine
 	GitHub  github.Client
 }
@@ -56,6 +60,9 @@ type RepoEntry struct {
 	// AddedBy is the GitHub login of the user who onboarded this repo, or
 	// empty for operator-seeded repos visible to everyone.
 	AddedBy string
+	// Managed marks a server-owned mirror checkout the sync loop may
+	// mirror-fetch (see EntryConfig.Managed).
+	Managed bool
 	Engine  engine.Engine
 	GitHub  github.Client
 
@@ -83,6 +90,7 @@ func NewEntry(cfg EntryConfig) *RepoEntry {
 		RepoRoot:    cfg.RepoRoot,
 		Remote:      cfg.Remote,
 		AddedBy:     cfg.AddedBy,
+		Managed:     cfg.Managed,
 		Engine:      cfg.Engine,
 		GitHub:      cfg.GitHub,
 		Broadcaster: NewBroadcaster(),


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Add a Managed flag to registry entries, plumbed through provision.EntryParams
and apps/server. DB-backed and onboarded checkouts are set Managed (they are
server-owned mirrors of GitHub); the -cwd dev repo stays unmanaged because it
is the operator's own working tree.

The sync loop will mirror-fetch only Managed entries, so it can't clobber
unpushed local work in a dev checkout.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303** 👈
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*