### PR TITLE
feat: add the repo sync loop

### DIFF
--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -246,6 +246,8 @@ func addRegistryEntry(reg *registry.Registry, rc repoConfig) error {
 		Remote:      rc.Remote,
 		AddedBy:     rc.AddedBy,
 		Managed:     rc.Managed,
+		Owner:       rc.Owner,
+		Name:        rc.Name,
 	})
 	if err != nil {
 		return err

--- a/internal/api/handlers/onboard.go
+++ b/internal/api/handlers/onboard.go
@@ -185,6 +185,8 @@ func (h *OnboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Remote:      "origin",
 		AddedBy:     sess.GitHubLogin,
 		Managed:     true, // onboarded checkouts are server-owned mirrors.
+		Owner:       owner,
+		Name:        name,
 	})
 	if err != nil {
 		slog.Error("onboard: engine build failed (persisted; will load on restart)", "repo", id, "error", err)

--- a/internal/api/provision/provision.go
+++ b/internal/api/provision/provision.go
@@ -28,6 +28,10 @@ type EntryParams struct {
 	// Managed marks a server-owned mirror checkout the sync loop may
 	// mirror-fetch (see registry.EntryConfig.Managed).
 	Managed bool
+	// Owner and Name are the GitHub coordinates carried onto the entry so the
+	// sync loop can resolve an installation token.
+	Owner string
+	Name  string
 }
 
 // BuildEntry resolves p into a runtime context via app.GetContext and returns a
@@ -57,6 +61,8 @@ func BuildEntry(ctx context.Context, p EntryParams) (*registry.RepoEntry, error)
 		Remote:      p.Remote,
 		AddedBy:     p.AddedBy,
 		Managed:     p.Managed,
+		Owner:       p.Owner,
+		Name:        p.Name,
 		Engine:      runtimeCtx.Engine,
 		GitHub:      gh,
 	})

--- a/internal/api/registry/registry.go
+++ b/internal/api/registry/registry.go
@@ -44,8 +44,13 @@ type EntryConfig struct {
 	// the repos root) that the sync loop may mirror-fetch. The -cwd dev repo is
 	// the operator's own working tree and is left unmanaged.
 	Managed bool
-	Engine  engine.Engine
-	GitHub  github.Client
+	// Owner and Name are the GitHub coordinates, set for managed repos. The
+	// sync loop uses them to resolve a GitHub App installation token for the
+	// fetch.
+	Owner  string
+	Name   string
+	Engine engine.Engine
+	GitHub github.Client
 }
 
 // RepoEntry is the per-repository state required to serve API requests for
@@ -63,8 +68,12 @@ type RepoEntry struct {
 	// Managed marks a server-owned mirror checkout the sync loop may
 	// mirror-fetch (see EntryConfig.Managed).
 	Managed bool
-	Engine  engine.Engine
-	GitHub  github.Client
+	// Owner and Name are the GitHub coordinates, set for managed repos; the
+	// sync loop resolves an installation token from them.
+	Owner  string
+	Name   string
+	Engine engine.Engine
+	GitHub github.Client
 
 	Broadcaster *Broadcaster
 	Watcher     *watcher.RefWatcher
@@ -91,6 +100,8 @@ func NewEntry(cfg EntryConfig) *RepoEntry {
 		Remote:      cfg.Remote,
 		AddedBy:     cfg.AddedBy,
 		Managed:     cfg.Managed,
+		Owner:       cfg.Owner,
+		Name:        cfg.Name,
 		Engine:      cfg.Engine,
 		GitHub:      cfg.GitHub,
 		Broadcaster: NewBroadcaster(),
@@ -102,7 +113,7 @@ func NewEntry(cfg EntryConfig) *RepoEntry {
 		if cb := cfg.Engine.CurrentBranch(); cb != nil {
 			entry.lastCurrentBranch = cb.GetName()
 		}
-		entry.Watcher = watcher.NewRefWatcher(cfg.RepoRoot, watcherDebounce, entry.refresh)
+		entry.Watcher = watcher.NewRefWatcher(cfg.RepoRoot, watcherDebounce, entry.Refresh)
 		watcherDone := make(chan error, 1)
 		go func() {
 			watcherDone <- entry.Watcher.Start()
@@ -140,12 +151,12 @@ func (e *RepoEntry) close() error {
 	return errors.Join(errs...)
 }
 
-// refresh rebuilds the engine from current refs and broadcasts a "refresh"
+// Refresh rebuilds the engine from current refs and broadcasts a "refresh"
 // event (plus "branch_switched" when the served HEAD changed) so connected SSE
 // clients refetch. It is the shared post-change path invoked by both the ref
 // watcher (local changes) and the sync loop (remote changes); refreshMu
 // serializes the two so the engine isn't rebuilt concurrently.
-func (e *RepoEntry) refresh() {
+func (e *RepoEntry) Refresh() {
 	if e.Engine == nil {
 		return
 	}

--- a/internal/api/reposync/syncer.go
+++ b/internal/api/reposync/syncer.go
@@ -1,0 +1,104 @@
+// Package reposync keeps server-managed repo checkouts in step with their
+// remotes. On an interval it mirror-fetches each managed registry entry — using
+// a GitHub App installation token for auth — and triggers the entry's refresh
+// so connected clients see the update, with no local actor required.
+package reposync
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/getstackit/stackit/internal/api/provision"
+	"github.com/getstackit/stackit/internal/api/registry"
+	"github.com/getstackit/stackit/internal/utils"
+)
+
+// defaultWorkers bounds concurrent fetches per pass. Fetches are network-bound,
+// so a small pool is gentle on the remote and the file-descriptor table.
+const defaultWorkers = 4
+
+// TokenProvider mints a credential for fetching owner/name. The concrete
+// implementation is *github.AppTokenProvider; a nil provider fetches without
+// auth (public repos only).
+type TokenProvider interface {
+	InstallationToken(ctx context.Context, owner, name string) (string, error)
+}
+
+// Syncer mirror-fetches managed registry entries on an interval.
+type Syncer struct {
+	reg      *registry.Registry
+	provider TokenProvider
+	interval time.Duration
+	workers  int
+
+	// Seams, defaulting to the real implementations, so tests can drive the
+	// loop without git or a network.
+	fetch   func(ctx context.Context, repoRoot, remote, token string) error
+	refresh func(e *registry.RepoEntry)
+}
+
+// New builds a Syncer. provider may be nil (no GitHub App configured), in which
+// case fetches carry no auth and only public repos refresh.
+func New(reg *registry.Registry, provider TokenProvider, interval time.Duration) *Syncer {
+	return &Syncer{
+		reg:      reg,
+		provider: provider,
+		interval: interval,
+		workers:  defaultWorkers,
+		fetch:    provision.MirrorFetch,
+		refresh:  (*registry.RepoEntry).Refresh,
+	}
+}
+
+// Run mirror-fetches all managed entries every interval until ctx is canceled.
+// It blocks; start it in a goroutine.
+func (s *Syncer) Run(ctx context.Context) {
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.syncOnce(ctx)
+		}
+	}
+}
+
+// syncOnce fetches every managed entry once, with bounded concurrency. The
+// registry is re-read each pass, so repos onboarded after start join the loop.
+func (s *Syncer) syncOnce(ctx context.Context) {
+	var managed []*registry.RepoEntry
+	for _, e := range s.reg.List() {
+		if e.Managed {
+			managed = append(managed, e)
+		}
+	}
+	if len(managed) == 0 {
+		return
+	}
+	utils.RunWithWorkers(managed, s.workers, func(e *registry.RepoEntry) {
+		if ctx.Err() != nil {
+			return
+		}
+		s.syncEntry(ctx, e)
+	})
+}
+
+func (s *Syncer) syncEntry(ctx context.Context, e *registry.RepoEntry) {
+	token := ""
+	if s.provider != nil {
+		t, err := s.provider.InstallationToken(ctx, e.Owner, e.Name)
+		if err != nil {
+			slog.Warn("sync: installation token unavailable; skipping", "repo", e.ID, "error", err)
+			return
+		}
+		token = t
+	}
+	if err := s.fetch(ctx, e.RepoRoot, e.Remote, token); err != nil {
+		slog.Warn("sync: fetch failed", "repo", e.ID, "error", err)
+		return
+	}
+	s.refresh(e)
+}

--- a/internal/api/reposync/syncer_test.go
+++ b/internal/api/reposync/syncer_test.go
@@ -1,0 +1,114 @@
+package reposync
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/getstackit/stackit/internal/api/registry"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeProvider struct {
+	token string
+	err   error
+}
+
+func (f fakeProvider) InstallationToken(_ context.Context, _, _ string) (string, error) {
+	return f.token, f.err
+}
+
+func managedEntry(id, owner, name, root string) *registry.RepoEntry {
+	return &registry.RepoEntry{ID: id, Managed: true, Owner: owner, Name: name, RepoRoot: root, Remote: "origin"}
+}
+
+func TestSyncOnceFetchesManagedOnly(t *testing.T) {
+	t.Parallel()
+	reg := registry.New()
+	require.NoError(t, reg.Add(managedEntry("managed", "octo", "widget", "/r/m")))
+	require.NoError(t, reg.Add(&registry.RepoEntry{ID: "unmanaged", Owner: "octo", Name: "dev"}))
+
+	var mu sync.Mutex
+	fetched := map[string]string{}
+	refreshed := map[string]bool{}
+
+	s := New(reg, fakeProvider{token: "inst-token"}, time.Minute)
+	s.fetch = func(_ context.Context, repoRoot, _, token string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		fetched[repoRoot] = token
+		return nil
+	}
+	s.refresh = func(e *registry.RepoEntry) {
+		mu.Lock()
+		defer mu.Unlock()
+		refreshed[e.ID] = true
+	}
+
+	s.syncOnce(context.Background())
+
+	require.Equal(t, map[string]string{"/r/m": "inst-token"}, fetched, "only the managed repo is fetched, with its installation token")
+	require.Equal(t, map[string]bool{"managed": true}, refreshed)
+}
+
+func TestSyncEntrySkipsRefreshOnFetchError(t *testing.T) {
+	t.Parallel()
+	reg := registry.New()
+	require.NoError(t, reg.Add(managedEntry("m", "o", "n", "/r")))
+
+	refreshed := false
+	s := New(reg, fakeProvider{token: "t"}, time.Minute)
+	s.fetch = func(context.Context, string, string, string) error { return errors.New("boom") }
+	s.refresh = func(*registry.RepoEntry) { refreshed = true }
+
+	s.syncOnce(context.Background())
+	require.False(t, refreshed, "a failed fetch must not refresh stale state")
+}
+
+func TestSyncEntrySkipsOnTokenError(t *testing.T) {
+	t.Parallel()
+	reg := registry.New()
+	require.NoError(t, reg.Add(managedEntry("m", "o", "n", "/r")))
+
+	fetchCalled := false
+	s := New(reg, fakeProvider{err: errors.New("not installed")}, time.Minute)
+	s.fetch = func(context.Context, string, string, string) error { fetchCalled = true; return nil }
+	s.refresh = func(*registry.RepoEntry) {}
+
+	s.syncOnce(context.Background())
+	require.False(t, fetchCalled, "no token means no fetch")
+}
+
+func TestSyncEntryNilProviderUsesEmptyToken(t *testing.T) {
+	t.Parallel()
+	reg := registry.New()
+	require.NoError(t, reg.Add(managedEntry("m", "o", "n", "/r")))
+
+	var gotToken string
+	s := New(reg, nil, time.Minute)
+	s.fetch = func(_ context.Context, _, _, token string) error { gotToken = token; return nil }
+	s.refresh = func(*registry.RepoEntry) {}
+
+	s.syncOnce(context.Background())
+	require.Equal(t, "", gotToken, "no provider means an unauthenticated (public) fetch")
+}
+
+func TestRunStopsOnContextCancel(t *testing.T) {
+	t.Parallel()
+	s := New(registry.New(), nil, time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.Run(ctx)
+		close(done)
+	}()
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

internal/api/reposync.Syncer mirror-fetches every managed registry entry on an
interval and triggers the entry's refresh, so a hosted server keeps onboarded
repos current with no local actor. It re-reads the registry each pass (so
newly onboarded repos join automatically), bounds concurrent fetches, and skips
a repo whose installation token can't be resolved or whose fetch fails rather
than failing the whole pass.

Supporting changes: carry the GitHub owner/name onto registry entries (the sync
loop resolves an installation token from them) and export RepoEntry.Refresh so
the syncer can reuse the watcher's rebuild+broadcast path.

Auth comes from an injected TokenProvider (the GitHub App provider); a nil
provider fetches unauthenticated, refreshing public repos only. The fetch and
refresh steps are seams so the loop is tested without git or a network.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304** 👈
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*