### PR TITLE
feat: clone onboarded repos with a GitHub App token

### DIFF
--- a/apps/server/app.go
+++ b/apps/server/app.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/getstackit/stackit/internal/github"
+)
+
+// buildAppProvider constructs a GitHub App installation-token provider from the
+// environment, or returns (nil, nil) when no App is configured. The App
+// authenticates onboarding clones and background repo syncs.
+//
+// STACKIT_GITHUB_APP_ID is the numeric App ID. The private key comes from
+// STACKIT_GITHUB_APP_PRIVATE_KEY (PEM contents) or, when that is empty,
+// STACKIT_GITHUB_APP_PRIVATE_KEY_FILE (a path to the PEM file).
+func buildAppProvider() (*github.AppTokenProvider, error) {
+	idStr := strings.TrimSpace(os.Getenv("STACKIT_GITHUB_APP_ID"))
+	if idStr == "" {
+		return nil, nil
+	}
+	appID, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("STACKIT_GITHUB_APP_ID: %w", err)
+	}
+
+	keyPEM := []byte(os.Getenv("STACKIT_GITHUB_APP_PRIVATE_KEY"))
+	if len(keyPEM) == 0 {
+		path := strings.TrimSpace(os.Getenv("STACKIT_GITHUB_APP_PRIVATE_KEY_FILE"))
+		if path == "" {
+			return nil, fmt.Errorf("STACKIT_GITHUB_APP_ID is set but no private key (set STACKIT_GITHUB_APP_PRIVATE_KEY or STACKIT_GITHUB_APP_PRIVATE_KEY_FILE)")
+		}
+		keyPEM, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read STACKIT_GITHUB_APP_PRIVATE_KEY_FILE: %w", err)
+		}
+	}
+
+	return github.NewAppTokenProvider(appID, keyPEM)
+}

--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -190,6 +190,16 @@ func run() error {
 		slog.Warn("auth: DISABLED (no STACKIT_GITHUB_* env or -auth-disabled set). Do not expose this port publicly.")
 	}
 
+	// GitHub App provider authenticates onboarding clones and background syncs.
+	// Nil when no App is configured.
+	appProvider, err := buildAppProvider()
+	if err != nil {
+		return err
+	}
+	if appProvider != nil {
+		slog.Info("github app: installation-token provider enabled")
+	}
+
 	// Resolve the repos root to an absolute path so onboarded checkouts land
 	// in the same place boot-loaded repos resolve to (loadReposFromDB also
 	// makes it absolute), keeping persisted repos host-portable.
@@ -201,16 +211,17 @@ func run() error {
 	}
 
 	server := api.NewServer(api.ServerConfig{
-		BindAddr:    *bind,
-		Port:        *port,
-		CORSOrigins: parseCSV(*corsOrigins),
-		APIPrefixes: prefixes,
-		StaticFS:    staticFS,
-		Registry:    reg,
-		Auth:        authCfg,
-		ReadOnly:    *readOnly,
-		RepoStore:   repoStore,
-		ReposRoot:   absReposRoot,
+		BindAddr:       *bind,
+		Port:           *port,
+		CORSOrigins:    parseCSV(*corsOrigins),
+		APIPrefixes:    prefixes,
+		StaticFS:       staticFS,
+		Registry:       reg,
+		Auth:           authCfg,
+		ReadOnly:       *readOnly,
+		RepoStore:      repoStore,
+		ReposRoot:      absReposRoot,
+		RepoSyncTokens: appProvider,
 	})
 
 	errCh := make(chan error, 1)

--- a/internal/api/handlers/onboard.go
+++ b/internal/api/handlers/onboard.go
@@ -27,15 +27,26 @@ type RepoPersister interface {
 	AddRepo(ctx context.Context, r store.Repo) (store.Repo, error)
 }
 
+// InstallationTokenProvider mints a durable GitHub App installation token for a
+// repo. Onboarding clones with it (not the user's token) so the same credential
+// works for the background sync loop later. The concrete implementation is
+// *github.AppTokenProvider.
+type InstallationTokenProvider interface {
+	InstallationToken(ctx context.Context, owner, name string) (string, error)
+}
+
 // OnboardHandler serves POST /api/v1/repos: a logged-in user asks the server to
-// clone a GitHub repo and start serving it. The user's own token both
-// authorizes the request (they must be able to see the repo) and clones it, and
-// the repo is recorded against their login so only they see it (see visibleTo).
+// clone a GitHub repo and start serving it. The user's token authorizes the
+// request (they must be able to see the repo); the clone itself uses a durable
+// GitHub App installation token so the same credential serves later background
+// syncs. The repo is recorded against the user's login so only they see it
+// (see visibleTo).
 type OnboardHandler struct {
 	reg       *registry.Registry
 	store     RepoPersister
 	cipher    *auth.Cipher
 	reposRoot string
+	tokens    InstallationTokenProvider
 
 	// checkAccess is the one network dependency; it is an injectable seam so
 	// tests can authorize without reaching GitHub. Clone/init/build are local
@@ -43,16 +54,17 @@ type OnboardHandler struct {
 	checkAccess func(ctx context.Context, token, owner, name string) (*github.RepoAccess, error)
 }
 
-// NewOnboardHandler wires an onboarding handler. store and cipher may be nil
-// (persistence/auth not configured), in which case requests are refused with a
-// clear 503; the handler guards at request time so it is safe to mount
-// unconditionally.
-func NewOnboardHandler(reg *registry.Registry, st RepoPersister, cipher *auth.Cipher, reposRoot string) *OnboardHandler {
+// NewOnboardHandler wires an onboarding handler. store, cipher, and tokens may
+// be nil (persistence / auth / GitHub App not configured), in which case
+// requests are refused with a clear 503; the handler guards at request time so
+// it is safe to mount unconditionally.
+func NewOnboardHandler(reg *registry.Registry, st RepoPersister, cipher *auth.Cipher, reposRoot string, tokens InstallationTokenProvider) *OnboardHandler {
 	return &OnboardHandler{
 		reg:         reg,
 		store:       st,
 		cipher:      cipher,
 		reposRoot:   reposRoot,
+		tokens:      tokens,
 		checkAccess: github.CheckRepoAccess,
 	}
 }
@@ -85,6 +97,9 @@ func (h *OnboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	case h.store == nil:
 		writeJSONError(w, http.StatusServiceUnavailable, "onboarding requires a database (-database-url)")
+		return
+	case h.tokens == nil:
+		writeJSONError(w, http.StatusServiceUnavailable, "onboarding requires a configured GitHub App")
 		return
 	case h.reposRoot == "":
 		writeJSONError(w, http.StatusServiceUnavailable, "onboarding requires a repos root (-repos-root)")
@@ -145,11 +160,26 @@ func (h *OnboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		cloneURL = "https://github.com/" + owner + "/" + name + ".git"
 	}
 
+	// Clone with a durable GitHub App installation token (not the user's
+	// session token), so the same credential serves later background syncs. This
+	// requires the App to be installed on the owner.
+	instToken, err := h.tokens.InstallationToken(r.Context(), owner, name)
+	if err != nil {
+		slog.Warn("onboard: installation token unavailable", "owner", owner, "name", name, "error", err)
+		writeJSONError(w, http.StatusBadRequest, "the Stackit GitHub App is not installed on "+owner+"; install it and try again")
+		return
+	}
+
 	slog.Info("audit", "action", "onboard", "actor", sess.GitHubLogin, "repo", id, "request_id", reqid.FromContext(r.Context())) //nolint:gosec // structured slog fields
 
-	if err := provision.EnsureClone(r.Context(), provision.CloneParams{CloneURL: cloneURL, Token: token, Dest: dest}); err != nil {
+	if err := provision.EnsureClone(r.Context(), provision.CloneParams{CloneURL: cloneURL, Token: instToken, Dest: dest}); err != nil {
 		slog.Error("onboard: clone failed", "repo", id, "error", err)
 		writeJSONError(w, http.StatusBadGateway, "failed to clone repository")
+		return
+	}
+	if err := provision.MirrorFetch(r.Context(), dest, "origin", instToken); err != nil {
+		slog.Error("onboard: mirror fetch failed", "repo", id, "error", err)
+		writeJSONError(w, http.StatusBadGateway, "failed to fetch repository metadata")
 		return
 	}
 

--- a/internal/api/handlers/onboard_test.go
+++ b/internal/api/handlers/onboard_test.go
@@ -3,8 +3,10 @@ package handlers
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -28,6 +30,15 @@ func (f *fakeRepoStore) AddRepo(_ context.Context, r store.Repo) (store.Repo, er
 	}
 	f.added = append(f.added, r)
 	return r, nil
+}
+
+type fakeTokenProvider struct {
+	token string
+	err   error
+}
+
+func (f fakeTokenProvider) InstallationToken(_ context.Context, _, _ string) (string, error) {
+	return f.token, f.err
 }
 
 func onboardCipher(t *testing.T) *auth.Cipher {
@@ -55,13 +66,17 @@ func doOnboard(t *testing.T, h *OnboardHandler, cipher *auth.Cipher, body string
 func TestOnboardHandlerSuccess(t *testing.T) {
 	t.Parallel()
 	src := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+	blob, err := src.Repo.RunGitCommandAndGetOutput("hash-object", "-w", "--stdin")
+	require.NoError(t, err)
+	require.NoError(t, src.Repo.RunGitCommand("update-ref", "refs/stackit/stacks/test-stack", blob))
+
 	reg := registry.New()
 	t.Cleanup(func() { _ = reg.Close() })
 	repoStore := &fakeRepoStore{}
 	cipher := onboardCipher(t)
 	reposRoot := t.TempDir()
 
-	h := NewOnboardHandler(reg, repoStore, cipher, reposRoot)
+	h := NewOnboardHandler(reg, repoStore, cipher, reposRoot, fakeTokenProvider{token: "inst-token"})
 	h.checkAccess = func(_ context.Context, token, owner, name string) (*github.RepoAccess, error) {
 		require.Equal(t, "user-token", token)
 		return &github.RepoAccess{Owner: owner, Name: name, CloneURL: src.Dir, DefaultBranch: "main"}, nil
@@ -84,6 +99,8 @@ func TestOnboardHandlerSuccess(t *testing.T) {
 	require.Empty(t, repoStore.added[0].Path, "path is stored empty so it re-derives under the host's repos root")
 
 	require.DirExists(t, filepath.Join(reposRoot, "octo", "widget", ".git"))
+	err = exec.Command("git", "-C", filepath.Join(reposRoot, "octo", "widget"), "rev-parse", "--verify", "--quiet", "refs/stackit/stacks/test-stack").Run()
+	require.NoError(t, err, "onboarding should mirror stack metadata before serving the repo")
 }
 
 func TestOnboardHandlerAccessDenied(t *testing.T) {
@@ -92,7 +109,7 @@ func TestOnboardHandlerAccessDenied(t *testing.T) {
 	t.Cleanup(func() { _ = reg.Close() })
 	cipher := onboardCipher(t)
 
-	h := NewOnboardHandler(reg, &fakeRepoStore{}, cipher, t.TempDir())
+	h := NewOnboardHandler(reg, &fakeRepoStore{}, cipher, t.TempDir(), fakeTokenProvider{token: "inst-token"})
 	h.checkAccess = func(_ context.Context, _, _, _ string) (*github.RepoAccess, error) {
 		return nil, github.ErrRepoAccessDenied
 	}
@@ -109,7 +126,7 @@ func TestOnboardHandlerDuplicate(t *testing.T) {
 	require.NoError(t, reg.Add(&registry.RepoEntry{ID: "octo-widget", AddedBy: "alice"}))
 	cipher := onboardCipher(t)
 
-	h := NewOnboardHandler(reg, &fakeRepoStore{}, cipher, t.TempDir())
+	h := NewOnboardHandler(reg, &fakeRepoStore{}, cipher, t.TempDir(), fakeTokenProvider{token: "inst-token"})
 	rec := doOnboard(t, h, cipher, `{"owner":"octo","name":"widget"}`)
 	require.Equal(t, http.StatusConflict, rec.Code)
 }
@@ -120,7 +137,7 @@ func TestOnboardHandlerInvalidCoords(t *testing.T) {
 	t.Cleanup(func() { _ = reg.Close() })
 	cipher := onboardCipher(t)
 
-	h := NewOnboardHandler(reg, &fakeRepoStore{}, cipher, t.TempDir())
+	h := NewOnboardHandler(reg, &fakeRepoStore{}, cipher, t.TempDir(), fakeTokenProvider{token: "inst-token"})
 	rec := doOnboard(t, h, cipher, `{"owner":"../etc","name":"passwd"}`)
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
@@ -129,7 +146,7 @@ func TestOnboardHandlerRequiresSession(t *testing.T) {
 	t.Parallel()
 	reg := registry.New()
 	t.Cleanup(func() { _ = reg.Close() })
-	h := NewOnboardHandler(reg, &fakeRepoStore{}, onboardCipher(t), t.TempDir())
+	h := NewOnboardHandler(reg, &fakeRepoStore{}, onboardCipher(t), t.TempDir(), fakeTokenProvider{token: "inst-token"})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/repos", strings.NewReader(`{"owner":"octo","name":"widget"}`))
 	rec := httptest.NewRecorder()
@@ -141,10 +158,41 @@ func TestOnboardHandlerRequiresStore(t *testing.T) {
 	t.Parallel()
 	reg := registry.New()
 	t.Cleanup(func() { _ = reg.Close() })
-	h := NewOnboardHandler(reg, nil, onboardCipher(t), t.TempDir())
+	h := NewOnboardHandler(reg, nil, onboardCipher(t), t.TempDir(), fakeTokenProvider{token: "inst-token"})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/repos", strings.NewReader(`{"owner":"octo","name":"widget"}`))
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestOnboardHandlerRequiresGitHubApp(t *testing.T) {
+	t.Parallel()
+	reg := registry.New()
+	t.Cleanup(func() { _ = reg.Close() })
+	// nil token provider => no GitHub App configured.
+	h := NewOnboardHandler(reg, &fakeRepoStore{}, onboardCipher(t), t.TempDir(), nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repos", strings.NewReader(`{"owner":"octo","name":"widget"}`))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestOnboardHandlerAppNotInstalled(t *testing.T) {
+	t.Parallel()
+	reg := registry.New()
+	t.Cleanup(func() { _ = reg.Close() })
+	cipher := onboardCipher(t)
+
+	// User can see the repo, but the App isn't installed on the owner.
+	h := NewOnboardHandler(reg, &fakeRepoStore{}, cipher, t.TempDir(), fakeTokenProvider{err: errors.New("installation not found")})
+	h.checkAccess = func(_ context.Context, _, owner, name string) (*github.RepoAccess, error) {
+		return &github.RepoAccess{Owner: owner, Name: name}, nil
+	}
+
+	rec := doOnboard(t, h, cipher, `{"owner":"octo","name":"widget"}`)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "GitHub App")
+	require.Empty(t, reg.List())
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/getstackit/stackit/internal/api/handlers"
 	"github.com/getstackit/stackit/internal/api/registry"
 	"github.com/getstackit/stackit/internal/api/store"
+	githubpkg "github.com/getstackit/stackit/internal/github"
 )
 
 // ServerConfig holds configuration for the API server.
@@ -67,6 +68,12 @@ type ServerConfig struct {
 	// checked out (<ReposRoot>/<owner>/<name>). Required for runtime
 	// onboarding; when empty, onboarding is refused.
 	ReposRoot string
+
+	// RepoSyncTokens mints GitHub App installation tokens for git operations on
+	// managed repos. It authenticates onboarding clones and background syncs.
+	// Nil when no GitHub App is configured, in which case onboarding is refused
+	// and the sync loop can only fetch public repos.
+	RepoSyncTokens *githubpkg.AppTokenProvider
 }
 
 // AuthConfig is the runtime auth setup. SessionStore must outlive the
@@ -176,7 +183,11 @@ func (s *Server) buildHandler() (http.Handler, error) {
 	if s.config.RepoStore != nil {
 		persister = s.config.RepoStore
 	}
-	var onboardHandler http.Handler = handlers.NewOnboardHandler(reg, persister, cipher, s.config.ReposRoot)
+	var tokens handlers.InstallationTokenProvider
+	if s.config.RepoSyncTokens != nil {
+		tokens = s.config.RepoSyncTokens
+	}
+	var onboardHandler http.Handler = handlers.NewOnboardHandler(reg, persister, cipher, s.config.ReposRoot, tokens)
 	if s.config.ReadOnly {
 		onboardHandler = readOnlyWriteHandler()
 	}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Unify onboarding on GitHub App installation tokens: the user's session token
still authorizes the request (they must be able to see the repo), but the
clone now uses a durable App installation token so the same credential serves
the background sync loop later. The App must be installed on the repo's owner;
if it isn't, onboarding returns a clear 400 telling the user to install it.

Onboarding now also requires a configured GitHub App (503 otherwise),
alongside the existing auth/database/repos-root prerequisites. apps/server
builds the provider from STACKIT_GITHUB_APP_ID + STACKIT_GITHUB_APP_PRIVATE_KEY
(or _FILE) and hands it to the server via ServerConfig.RepoSyncTokens, which
the sync loop will also use.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305** 👈
                                            * **PR #1306**
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*