### PR TITLE
feat: run the repo sync loop on an interval

### DIFF
--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -77,6 +77,7 @@ func run() error {
 		shutdownGrace = flag.Duration("shutdown-timeout", 10*time.Second, "Graceful shutdown timeout")
 		authDisabled  = flag.Bool("auth-disabled", false, "Disable GitHub OAuth gate. Refused in public mode ($PORT or $STACKIT_PUBLIC).")
 		readOnly      = flag.Bool("read-only", envBool("STACKIT_READ_ONLY"), "Serve in read-only mode: the submit endpoint is disabled so the repo can be exposed publicly without write access. Also set via STACKIT_READ_ONLY.")
+		syncInterval  = flag.Duration("sync-interval", envDuration("STACKIT_SYNC_INTERVAL"), "How often to mirror-fetch managed repos from their remotes so served state stays current. 0 disables the loop. Also set via STACKIT_SYNC_INTERVAL (e.g. 60s).")
 	)
 	flag.Parse()
 
@@ -222,6 +223,7 @@ func run() error {
 		RepoStore:      repoStore,
 		ReposRoot:      absReposRoot,
 		RepoSyncTokens: appProvider,
+		SyncInterval:   *syncInterval,
 	})
 
 	errCh := make(chan error, 1)
@@ -273,6 +275,16 @@ func addRegistryEntry(reg *registry.Registry, rc repoConfig) error {
 func envBool(name string) bool {
 	v, err := strconv.ParseBool(os.Getenv(name))
 	return err == nil && v
+}
+
+// envDuration parses the named environment variable as a Go duration (e.g.
+// "60s"). Unset or unparseable values yield 0, which disables the sync loop.
+func envDuration(name string) time.Duration {
+	d, err := time.ParseDuration(strings.TrimSpace(os.Getenv(name)))
+	if err != nil {
+		return 0
+	}
+	return d
 }
 
 func parseCSV(raw string) []string {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getstackit/stackit/internal/api/auth"
 	"github.com/getstackit/stackit/internal/api/handlers"
 	"github.com/getstackit/stackit/internal/api/registry"
+	"github.com/getstackit/stackit/internal/api/reposync"
 	"github.com/getstackit/stackit/internal/api/store"
 	githubpkg "github.com/getstackit/stackit/internal/github"
 )
@@ -74,6 +75,11 @@ type ServerConfig struct {
 	// Nil when no GitHub App is configured, in which case onboarding is refused
 	// and the sync loop can only fetch public repos.
 	RepoSyncTokens *githubpkg.AppTokenProvider
+
+	// SyncInterval, when > 0, enables the background sync loop: every interval
+	// each managed repo is mirror-fetched from its remote so the served state
+	// stays current without a local actor. Zero disables it.
+	SyncInterval time.Duration
 }
 
 // AuthConfig is the runtime auth setup. SessionStore must outlive the
@@ -95,6 +101,7 @@ type AuthConfig struct {
 type Server struct {
 	config     ServerConfig
 	httpServer *http.Server
+	syncCancel context.CancelFunc
 }
 
 // NewServer creates a new API server backed by the given registry.
@@ -118,12 +125,35 @@ func (s *Server) Start() error {
 		MaxHeaderBytes:    1 << 20, // 1 MiB
 	}
 
+	s.startSyncLoop()
+
 	mode := "read-write"
 	if s.config.ReadOnly {
 		mode = "read-only"
 	}
 	slog.Info("stackit-web server listening", "url", fmt.Sprintf("http://%s:%d", displayHost(s.config.BindAddr), s.config.Port), "mode", mode)
 	return s.httpServer.ListenAndServe()
+}
+
+// startSyncLoop launches the background repo sync loop when SyncInterval > 0.
+// It runs until Shutdown cancels its context. With no GitHub App configured the
+// loop still runs but can only refresh public repos.
+func (s *Server) startSyncLoop() {
+	if s.config.SyncInterval <= 0 {
+		return
+	}
+	var provider reposync.TokenProvider
+	if s.config.RepoSyncTokens != nil {
+		provider = s.config.RepoSyncTokens
+	} else {
+		slog.Warn("repo sync: no GitHub App configured; only public repos will refresh")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.syncCancel = cancel
+	syncer := reposync.New(s.config.Registry, provider, s.config.SyncInterval)
+	go syncer.Run(ctx)
+	slog.Info("repo sync loop enabled", "interval", s.config.SyncInterval.String())
 }
 
 // buildHandler assembles the full HTTP handler chain (routes + middleware)
@@ -320,6 +350,9 @@ func (s *Server) buildHandler() (http.Handler, error) {
 // Shutdown gracefully stops the server. The registry's watchers and
 // broadcasters are torn down separately by main.go's defer reg.Close().
 func (s *Server) Shutdown(ctx context.Context) error {
+	if s.syncCancel != nil {
+		s.syncCancel()
+	}
 	if s.httpServer != nil {
 		return s.httpServer.Shutdown(ctx)
 	}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Wire the sync loop into the server lifecycle. A new -sync-interval flag
(STACKIT_SYNC_INTERVAL, e.g. 60s; 0 disables) sets ServerConfig.SyncInterval;
when positive, Start launches the reposync loop in a background goroutine and
Shutdown cancels it. The loop uses the GitHub App provider wired in the
previous change for authenticated fetches, falling back to public-only with a
warning when no App is configured.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306** 👈
                                              * **PR #1307**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*