### PR TITLE
docs: document the sync loop and GitHub App

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -60,6 +60,9 @@ with every authenticated user.
 | `STACKIT_READ_ONLY` | Set to `1`/`true` to serve in read-only mode: the submit endpoint is disabled and reads are served anonymously, so a configured repo can be exposed to the public without write access. See [Read-only public mode](#read-only-public-mode). Equivalent to `-read-only`. |
 | `STACKIT_DATABASE_URL` | PostgreSQL connection string. When set, repos are served from the DB (and runtime [onboarding](#repository-onboarding) can persist new ones) instead of the `-cwd` single-repo shortcut. Equivalent to `-database-url`. |
 | `STACKIT_REPOS_ROOT` | Base directory under which per-repo checkouts live (`<root>/<owner>/<name>`). Required for DB-backed serving and onboarding. Equivalent to `-repos-root`. |
+| `STACKIT_GITHUB_APP_ID` | GitHub App ID; enables installation-token auth for onboarding clones and background syncs. See [GitHub App & background sync](#github-app--background-sync). |
+| `STACKIT_GITHUB_APP_PRIVATE_KEY` / `_FILE` | GitHub App private key (PEM contents, or a path in the `_FILE` variant). |
+| `STACKIT_SYNC_INTERVAL` | How often to mirror-fetch managed repos (e.g. `60s`); `0`/unset disables the sync loop. Equivalent to `-sync-interval`. |
 | `STACKIT_BASE_URL` | The canonical https:// URL the server is reachable at. Required when auth is enabled (used to build the OAuth callback URL). |
 | `STACKIT_GITHUB_CLIENT_ID` | GitHub OAuth App client ID. |
 | `STACKIT_GITHUB_CLIENT_SECRET` | GitHub OAuth App client secret. |
@@ -75,6 +78,7 @@ The most useful flags:
 |------|---------|---------|
 | `-database-url` | _(empty)_ | PostgreSQL connection string. Enables DB-backed multi-repo serving and runtime [onboarding](#repository-onboarding). Also settable via `STACKIT_DATABASE_URL`. |
 | `-repos-root` | _(empty)_ | Base directory for per-repo checkouts (`<root>/<owner>/<name>`). Required with `-database-url` and for onboarding. Also settable via `STACKIT_REPOS_ROOT`. |
+| `-sync-interval` | `0` | How often to mirror-fetch managed repos so served state stays current; `0` disables. Also settable via `STACKIT_SYNC_INTERVAL`. See [GitHub App & background sync](#github-app--background-sync). |
 | `-cwd` | _(empty)_ | Single-repo shortcut: serve the repo discovered from this path as `default`. Ignored when `-database-url` is set. |
 | `-port` | `8080` | Listen port; overrides `$PORT`. |
 | `-bind` | `127.0.0.1` (or `0.0.0.0` if `$PORT`/`$STACKIT_PUBLIC` are set) | Interface to bind on. Pass `-bind 0.0.0.0` explicitly to expose the server on a host where the heuristics don't fire. |
@@ -167,8 +171,10 @@ server:
    the server's token — so a user can only add repos they can already see. A
    repo they can't see returns `404` (indistinguishable from "not found", by
    design).
-2. Clones it to `<repos-root>/<owner>/<name>` using that user's token (passed
-   to git via env, never written to `.git/config`).
+2. Clones it to `<repos-root>/<owner>/<name>` using a **GitHub App installation
+   token** (not the user's session token), so the same durable credential
+   serves the background sync loop later. The App must be installed on the
+   owner; if it isn't, onboarding returns `400` asking the user to install it.
 3. Initializes stackit on the fresh checkout (trunk = the GitHub default
    branch) and starts serving it.
 4. Records the repo against the user's login, so **each user sees only the
@@ -181,19 +187,57 @@ Onboarding is refused (`503`) unless all of these hold; it is also disabled
 (`405`) in read-only mode, since it is a write:
 
 - **Auth is configured** (GitHub OAuth) — the flow acts as the requesting user.
+- **A GitHub App is configured** (see below) — clones and syncs use its
+  installation tokens.
 - **`-database-url`** is set — the new repo is persisted so it survives a
   restart.
 - **`-repos-root`** is set — somewhere to put the checkout.
 
-### Limitations (current)
+### Limitation: trusted users
 
-- **Trusted users.** The model assumes everyone who can sign in is trusted;
-  the repo ID is `<owner>-<name>` globally, so two users adding the same repo
-  collide (`409`).
-- **No automatic refresh yet.** The server reacts to local filesystem changes
-  but does not `git fetch` on its own, so an onboarded repo only updates when
-  something pulls it locally. A background fetch loop needs durable
-  credentials (a user's session token expires in 30 days), tracked separately.
+The model assumes everyone who can sign in is trusted; the repo ID is
+`<owner>-<name>` globally, so two users adding the same repo collide (`409`).
+
+## GitHub App & background sync
+
+Onboarding clones and the background sync loop authenticate with a **GitHub
+App**, whose installation access tokens are durable (minted and refreshed
+server-side), so the server can fetch with no user present.
+
+### Setting up the App
+
+1. Register a GitHub App (Settings → Developer settings → GitHub Apps).
+   Permissions: **Contents: Read-only** and **Metadata: Read-only**. Generate a
+   private key.
+2. Install the App on the orgs/accounts whose repos you'll serve. Users can
+   only onboard repos under an owner where the App is installed.
+3. Configure the server:
+
+| Var | Purpose |
+|-----|---------|
+| `STACKIT_GITHUB_APP_ID` | The numeric App ID. Setting it enables the provider. Equivalent to nothing on the CLI — App config is env-only. |
+| `STACKIT_GITHUB_APP_PRIVATE_KEY` | The App private key, PEM contents. |
+| `STACKIT_GITHUB_APP_PRIVATE_KEY_FILE` | Path to the PEM file, used when `_PRIVATE_KEY` is empty. |
+
+### The sync loop
+
+Set **`-sync-interval`** (or `STACKIT_SYNC_INTERVAL`, e.g. `60s`; `0` disables)
+to keep served repos current. On each tick the server mirror-fetches every
+managed checkout — force-updating local branch heads and stackit metadata from
+the remote and pruning deleted refs — then rebuilds and pushes a refresh to
+connected clients. Newly onboarded repos join the loop automatically.
+
+- Only **managed** checkouts (DB-backed / onboarded under the repos root) are
+  fetched. A `-cwd` dev repo is the operator's own working tree and is left
+  alone.
+- Private repos need the GitHub App (above) for the fetch. Without an App the
+  loop still runs but refreshes **public repos only**.
+- A recommended interval is `60s` or higher; very short intervals hammer the
+  remote and add little.
+
+> Note: GitHub App token minting is exercised by the `ghinstallation` library;
+> stackit's tests cover the surrounding logic with fakes. Verify end-to-end
+> against a real App before relying on it in production.
 
 ## Security posture
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

docs/deploy.md gains a "GitHub App & background sync" section (registering and
installing the App, the env config, and how the -sync-interval mirror-fetch
loop works, including public-only fallback and the managed-only scope), updates
the onboarding section to reflect installation-token clones requiring the App,
and adds the new env vars and -sync-interval flag to the config tables.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782174087`.


* **PR #1282**
  * **PR #1283**
    * **PR #1284**
      * **PR #1285**
        * **PR #1286**
          * **PR #1287**
            * **PR #1288**
              * **PR #1289**
                * **PR #1291**
                  * **PR #1292**
                    * **PR #1293**
                      * **PR #1294**
                        * **PR #1295**
                          * **PR #1296**
                            * **PR #1297**
                              * **PR #1298**
                                * **PR #1300**
                                  * **PR #1301**
                                    * **PR #1302**
                                      * **PR #1303**
                                        * **PR #1304**
                                          * **PR #1305**
                                            * **PR #1306**
                                              * **PR #1307** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1308 by jonnii*