### PR TITLE
fix(ci): stage server entrypoint in docker build context

### DIFF
--- a/.github/workflows/docker-main.yml
+++ b/.github/workflows/docker-main.yml
@@ -2,8 +2,9 @@ name: Docker (main)
 
 # Build and publish stackit-server container images on every push to main so
 # Railway (and any other ghcr.io consumer) can auto-deploy without cutting a
-# release tag. Goreleaser builds snapshot images locally with its snapshot
-# version, then we re-tag those as :main and :<short-sha> and push.
+# release tag. Uses the slim .goreleaser.docker.yml config (server image only;
+# no CLI build, UPX, or archives) to build snapshot images locally with the
+# snapshot version, then we re-tag those as :main and :<short-sha> and push.
 
 on:
   push:
@@ -55,7 +56,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --snapshot --clean --skip=archive,homebrew,scoop,nfpm,sbom,announce
+          args: release --snapshot --clean --config .goreleaser.docker.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser.docker.yml
+++ b/.goreleaser.docker.yml
@@ -1,0 +1,61 @@
+# Slim GoReleaser config used ONLY by the Docker (main) workflow to build and
+# push stackit-server snapshot images on pushes to main.
+#
+# The full release config (.goreleaser.yml) builds the CLI + server for every
+# OS/arch, UPX-compresses the CLI binaries (compress: best, ~5min on its own),
+# and produces archives/brews — none of which the container needs. The image
+# only consumes the linux/amd64 + linux/arm64 server binary, so this config
+# strips everything else: no CLI build, no UPX, no non-Linux targets, no
+# archives/brews. That removes the bulk of the workflow's runtime.
+#
+# Keep the `before` hooks, the server `build`, and the `dockers_v2` stanza in
+# sync with .goreleaser.yml.
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - pnpm install --frozen-lockfile
+    - pnpm --filter @stackit/web build
+    - ./scripts/sync-web-static.sh
+
+builds:
+  - id: server
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    main: ./apps/server
+    binary: stackit-server
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
+dockers_v2:
+  - id: server
+    ids: [server]
+    dockerfile: Dockerfile.server
+    images:
+      - ghcr.io/getstackit/stackit-server
+    tags:
+      - "{{ .Version }}"
+    # See .goreleaser.yml: stage the entrypoint script into the build context
+    # so the Dockerfile's `COPY docker/stackit-server-entrypoint.sh` resolves.
+    extra_files:
+      - docker/stackit-server-entrypoint.sh
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      "org.opencontainers.image.source": "https://github.com/getstackit/stackit"
+      "org.opencontainers.image.version": "{{.Version}}"
+      "org.opencontainers.image.revision": "{{.Commit}}"
+      "org.opencontainers.image.created": "{{.Date}}"
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -91,6 +91,12 @@ dockers_v2:
     tags:
       - "{{ .Version }}"
       - "{{ if not .IsSnapshot }}latest{{ end }}"
+    # Dockerfile.server COPYs the entrypoint script, which is not a build
+    # artifact. dockers_v2 only stages binaries + the Dockerfile in the build
+    # context, so list it here; goreleaser recreates the path so the
+    # `COPY docker/stackit-server-entrypoint.sh` in the Dockerfile resolves.
+    extra_files:
+      - docker/stackit-server-entrypoint.sh
     platforms:
       - linux/amd64
       - linux/arm64


### PR DESCRIPTION

Dockerfile.server gained a `COPY docker/stackit-server-entrypoint.sh`
in 9226bd48, but goreleaser dockers_v2 only stages built binaries and
the Dockerfile in the build context. The Docker (main) workflow failed
with "/docker/stackit-server-entrypoint.sh: not found", and the release
path would break the same way on the next tag.

Declare the script via dockers_v2 extra_files so goreleaser recreates
its path in the build context and the COPY resolves.