### PR TITLE
fix(server): nil-safe current branch on detached-HEAD mirrors

### DIFF
--- a/internal/api/handlers/repo.go
+++ b/internal/api/handlers/repo.go
@@ -40,7 +40,7 @@ func (h *RepoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Owner:         owner,
 		Repo:          repo,
 		Trunk:         entry.Engine.Trunk().GetName(),
-		CurrentBranch: entry.Engine.CurrentBranch().GetName(),
+		CurrentBranch: entry.Engine.CurrentBranchName(),
 		Remote:        entry.Remote,
 	}
 

--- a/internal/api/handlers/view_assembler.go
+++ b/internal/api/handlers/view_assembler.go
@@ -65,7 +65,7 @@ func (a *ViewAssembler) buildRepo(ctx context.Context) httpcontract.RepoResponse
 		Owner:         owner,
 		Repo:          repo,
 		Trunk:         a.eng.Trunk().GetName(),
-		CurrentBranch: a.eng.CurrentBranch().GetName(),
+		CurrentBranch: a.eng.CurrentBranchName(),
 		Remote:        a.remote,
 		CurrentUser:   currentUser,
 	}

--- a/internal/api/handlers/view_assembler_test.go
+++ b/internal/api/handlers/view_assembler_test.go
@@ -53,3 +53,29 @@ func TestBuildRepoOmitsCurrentUserWhenPublic(t *testing.T) {
 		require.Equal(t, "widgets", repo.Repo)
 	})
 }
+
+// TestBuildSurvivesDetachedHEAD reproduces the server-mirror crash: managed
+// repo checkouts run with a detached HEAD, so engine.CurrentBranch() is nil.
+// The whole /view assembly path (Build -> MapStackDetail -> MapStackSummary)
+// must read the current branch nil-safely rather than dereference it.
+func TestBuildSurvivesDetachedHEAD(t *testing.T) {
+	t.Parallel()
+
+	// A linear stack so the mapper actually runs MapStackSummary per stack —
+	// without one, the loop is empty and the panic site is never reached.
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithLinearStack3()
+
+	head, err := s.Scene.Repo.GetRevision("HEAD")
+	require.NoError(t, err)
+	require.NoError(t, s.Scene.Repo.CheckoutDetached(head))
+	require.Nil(t, s.Engine.CurrentBranch(), "scenario must be in detached HEAD")
+
+	// gh is nil: the anonymous public read path with no GitHub calls, mirroring
+	// the request that panicked.
+	a := NewViewAssembler(s.Engine, nil, "origin", VisibilityPublic)
+	view, err := a.Build(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, view.Repo.CurrentBranch, "detached HEAD has no current branch")
+	require.NotEmpty(t, view.Stacks, "the stack should still be mapped while detached")
+}

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -16,7 +16,7 @@ func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.Stack
 	resp := BranchResponse{
 		Name:         branch.GetName(),
 		Depth:        node.Depth,
-		IsCurrent:    branch.GetName() == eng.CurrentBranch().GetName(),
+		IsCurrent:    branch.GetName() == eng.CurrentBranchName(),
 		NeedsRestack: branch.NeedsRestack(),
 		IsLocked:     branch.IsLocked(),
 		IsFrozen:     branch.IsFrozen(),
@@ -85,7 +85,7 @@ func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.Stack
 
 // MapStackSummary creates a StackSummary from stack discovery info.
 func MapStackSummary(eng engine.BranchReader, graph *engine.StackGraph, rootBranch string, allBranches []string, prCount int, scope string, owner string) StackSummary {
-	currentBranch := eng.CurrentBranch().GetName()
+	currentBranch := eng.CurrentBranchName()
 	isCurrent := slices.Contains(allBranches, currentBranch)
 
 	// Detect worktree anchor and filter it from display branches

--- a/internal/engine/engine_reader.go
+++ b/internal/engine/engine_reader.go
@@ -64,6 +64,16 @@ func (e *engineImpl) CurrentBranch() *Branch {
 	return &branch
 }
 
+// CurrentBranchName returns the current branch name, or "" when HEAD is not on
+// a branch (e.g. a detached-HEAD server mirror). Use this for nil-safe reads
+// where a missing current branch should be absent rather than an error.
+func (e *engineImpl) CurrentBranchName() string {
+	if cb := e.CurrentBranch(); cb != nil {
+		return cb.GetName()
+	}
+	return ""
+}
+
 // ValidateOnBranch ensures the user is on a branch
 func (e *engineImpl) ValidateOnBranch() (string, error) {
 	currentBranch := e.CurrentBranch()

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -13,6 +13,10 @@ type StackNavigator interface {
 	AllBranches() Branches
 	BranchNames() *BranchSet
 	CurrentBranch() *Branch
+	// CurrentBranchName returns the current branch name, or "" when HEAD is not
+	// on a branch (e.g. a detached-HEAD server mirror). Nil-safe alternative to
+	// CurrentBranch().GetName().
+	CurrentBranchName() string
 	Trunk() Branch
 	GetBranch(branchName string) Branch
 	Graph(strategy SortStrategy) *StackGraph


### PR DESCRIPTION

Server-managed repo mirrors run with a detached HEAD, so engine
CurrentBranch() returns nil there. The /view assembly path dereferenced
it directly (CurrentBranch().GetName()) in MapStackSummary, MapBranch,
the view assembler, and the repo handler, panicking the request.

Add a nil-safe Engine.CurrentBranchName() that returns "" when HEAD is
not on a branch, and route all four contract/handler sites through it.
An empty current branch is the correct answer for a detached mirror:
nothing is highlighted as current.