### PR TITLE
feat(server): drive deploy posture from STACKIT_ENV, not $PORT

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,11 +4,11 @@
 # `mise run dev:server` load .env via the [env] block in mise.toml, so the
 # values flow into the server process automatically.
 #
-# Required only when running in "public mode" — i.e. when $PORT or
-# $STACKIT_PUBLIC is set (Railway, Fly, Heroku, etc). For purely local
-# development (`mise run dev`), every STACKIT_GITHUB_* / STACKIT_SESSION_KEY
-# / STACKIT_ALLOWED_GH_* variable can stay blank and the server will start
-# with auth disabled.
+# Required only in production (STACKIT_ENV=production, e.g. Railway, Fly,
+# Heroku), which binds 0.0.0.0 and requires auth (or -read-only). For purely
+# local development (`mise run dev`, the default STACKIT_ENV=local), every
+# STACKIT_GITHUB_* / STACKIT_SESSION_KEY / STACKIT_ALLOWED_GH_* variable can
+# stay blank and the server binds loopback with auth disabled.
 
 # --- GitHub OAuth app (https://github.com/settings/developers) ----------------
 # Create an OAuth App with:
@@ -37,12 +37,14 @@ STACKIT_ALLOWED_GH_ORG=
 # Required when -repos-config entries use owner+name instead of an absolute path.
 STACKIT_REPOS_ROOT=
 
-# --- Public mode override (rare) ----------------------------------------------
-# Set non-empty to force public-mode behavior (binds 0.0.0.0, requires auth)
-# even without $PORT. Leave blank for local dev.
-# STACKIT_PUBLIC=
+# --- Deployment posture -------------------------------------------------------
+# `local` (default) binds 127.0.0.1 with auth optional — leave it unset for dev.
+# `production` binds 0.0.0.0, emits JSON logs, forces Secure cookies, honors
+# $PORT, and requires auth (or -read-only). Set it on hosted deploys.
+# STACKIT_ENV=production
 
 # --- Port override ------------------------------------------------------------
-# PaaS hosts inject $PORT automatically; set it here only if running the
-# binary directly without `mise run dev`.
+# Only honored in production (PaaS hosts inject $PORT automatically). Ignored
+# in local, so a stray $PORT in your shell can't move the dev listener; pass
+# `-port` to the binary instead.
 # PORT=8080

--- a/apps/server/auth.go
+++ b/apps/server/auth.go
@@ -16,14 +16,29 @@ type authBuildResult struct {
 	store auth.Store // exposed separately so main can close it on shutdown
 }
 
+// authBuildParams describes the runtime posture buildAuthConfig needs. The
+// auth requirement keys off exposure (a non-loopback bind), not the env name:
+// a server reachable off-host must be authenticated or read-only, however it
+// got that way.
+type authBuildParams struct {
+	disabled bool // -auth-disabled was passed
+	exposed  bool // resolved bind is non-loopback (reachable off-host)
+	readOnly bool // read-only posture: writes impossible, reads anonymous
+	prod     bool // production env: force Secure cookies (behind TLS)
+}
+
 // buildAuthConfig wires up the OAuth handler, session store, and allowlist
-// from environment variables. Returns (nil, nil, nil) when auth is
-// explicitly disabled; an error when required env is missing in public
-// mode.
-func buildAuthConfig(authDisabled, publicMode bool) (*authBuildResult, error) {
-	if authDisabled {
-		if publicMode {
-			return nil, errors.New("-auth-disabled is not allowed when $PORT or $STACKIT_PUBLIC are set; remove the flag or unset the env vars")
+// from environment variables. Returns (nil, nil) when auth is off (explicitly
+// disabled, or unconfigured on a non-exposed/read-only server); an error when
+// an exposed, writable server would be left unauthenticated.
+func buildAuthConfig(p authBuildParams) (*authBuildResult, error) {
+	// An exposed, writable server must be authenticated. Read-only removes the
+	// write route by construction, so anonymous reads are safe there.
+	mustAuth := p.exposed && !p.readOnly
+
+	if p.disabled {
+		if mustAuth {
+			return nil, errors.New("-auth-disabled is not allowed when the server is reachable off-host (non-loopback bind): it would expose an unauthenticated, writable server. Pass -read-only, bind loopback (STACKIT_ENV=local), or configure GitHub OAuth")
 		}
 		return nil, nil
 	}
@@ -33,13 +48,12 @@ func buildAuthConfig(authDisabled, publicMode bool) (*authBuildResult, error) {
 	baseURL := strings.TrimSpace(os.Getenv("STACKIT_BASE_URL"))
 	sessionKey := strings.TrimSpace(os.Getenv("STACKIT_SESSION_KEY"))
 
-	// Outside public mode, missing OAuth config is "off by default" —
-	// users running a local dev binary shouldn't have to set env vars to
-	// boot. They can pass -auth-disabled explicitly to make the intent
-	// clear, or just leave the OAuth env unset.
+	// When the server isn't exposed (local loopback) or is read-only, missing
+	// OAuth config is "off by default" — a local dev binary shouldn't need env
+	// vars to boot, and a read-only server serves reads anonymously anyway.
 	if clientID == "" && clientSecret == "" && baseURL == "" && sessionKey == "" {
-		if publicMode {
-			return nil, errors.New("public mode requires STACKIT_GITHUB_CLIENT_ID, STACKIT_GITHUB_CLIENT_SECRET, STACKIT_BASE_URL, STACKIT_SESSION_KEY (and STACKIT_ALLOWED_GH_USERS or STACKIT_ALLOWED_GH_ORG); pass -auth-disabled if you really mean to run open")
+		if mustAuth {
+			return nil, errors.New("the server is reachable off-host (non-loopback bind) but auth is not configured: set STACKIT_GITHUB_CLIENT_ID, STACKIT_GITHUB_CLIENT_SECRET, STACKIT_BASE_URL, STACKIT_SESSION_KEY (and STACKIT_ALLOWED_GH_USERS or STACKIT_ALLOWED_GH_ORG), or pass -read-only to serve anonymously")
 		}
 		return nil, nil
 	}
@@ -76,7 +90,7 @@ func buildAuthConfig(authDisabled, publicMode bool) (*authBuildResult, error) {
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		BaseURL:      baseURL,
-		Cookies:      auth.CookieOptions{Secure: publicMode || strings.HasPrefix(baseURL, "https://")},
+		Cookies:      auth.CookieOptions{Secure: p.prod || strings.HasPrefix(baseURL, "https://")},
 	}, store, allow, cipher)
 	if err != nil {
 		_ = store.Close()

--- a/apps/server/auth_test.go
+++ b/apps/server/auth_test.go
@@ -11,16 +11,26 @@ import (
 func TestBuildAuthConfig_DisabledLocalOK(t *testing.T) {
 	t.Parallel()
 
-	r, err := buildAuthConfig(true, false)
+	r, err := buildAuthConfig(authBuildParams{disabled: true})
 	require.NoError(t, err)
 	require.Nil(t, r)
 }
 
-func TestBuildAuthConfig_DisabledInPublicModeRefused(t *testing.T) {
+func TestBuildAuthConfig_DisabledExposedRefused(t *testing.T) {
 	t.Parallel()
 
-	_, err := buildAuthConfig(true, true)
+	_, err := buildAuthConfig(authBuildParams{disabled: true, exposed: true})
 	require.Error(t, err)
+}
+
+func TestBuildAuthConfig_DisabledExposedReadOnlyOK(t *testing.T) {
+	t.Parallel()
+
+	// Read-only removes the write route, so disabling auth on an exposed
+	// read-only server is safe — reads are anonymous by design.
+	r, err := buildAuthConfig(authBuildParams{disabled: true, exposed: true, readOnly: true})
+	require.NoError(t, err)
+	require.Nil(t, r)
 }
 
 func TestBuildAuthConfig_NoEnvLocalFallsThroughToUnauthed(t *testing.T) {
@@ -34,12 +44,12 @@ func TestBuildAuthConfig_NoEnvLocalFallsThroughToUnauthed(t *testing.T) {
 		"STACKIT_ALLOWED_GH_ORG":       "",
 	})
 
-	r, err := buildAuthConfig(false, false)
+	r, err := buildAuthConfig(authBuildParams{})
 	require.NoError(t, err)
-	require.Nil(t, r, "no env + local mode = no auth, no error")
+	require.Nil(t, r, "no env + not exposed = no auth, no error")
 }
 
-func TestBuildAuthConfig_NoEnvInPublicModeRefused(t *testing.T) {
+func TestBuildAuthConfig_NoEnvExposedRefused(t *testing.T) {
 	// t.Setenv is incompatible with t.Parallel; these tests share process env.
 	withEnv(t, map[string]string{
 		"STACKIT_GITHUB_CLIENT_ID":     "",
@@ -50,8 +60,25 @@ func TestBuildAuthConfig_NoEnvInPublicModeRefused(t *testing.T) {
 		"STACKIT_ALLOWED_GH_ORG":       "",
 	})
 
-	_, err := buildAuthConfig(false, true)
+	_, err := buildAuthConfig(authBuildParams{exposed: true})
 	require.Error(t, err)
+}
+
+func TestBuildAuthConfig_NoEnvExposedReadOnlyOK(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel; these tests share process env.
+	withEnv(t, map[string]string{
+		"STACKIT_GITHUB_CLIENT_ID":     "",
+		"STACKIT_GITHUB_CLIENT_SECRET": "",
+		"STACKIT_BASE_URL":             "",
+		"STACKIT_SESSION_KEY":          "",
+		"STACKIT_ALLOWED_GH_USERS":     "",
+		"STACKIT_ALLOWED_GH_ORG":       "",
+	})
+
+	// An exposed read-only server boots anonymously with no OAuth env.
+	r, err := buildAuthConfig(authBuildParams{exposed: true, readOnly: true})
+	require.NoError(t, err)
+	require.Nil(t, r)
 }
 
 func TestBuildAuthConfig_PartialEnvErrors(t *testing.T) {
@@ -64,7 +91,7 @@ func TestBuildAuthConfig_PartialEnvErrors(t *testing.T) {
 		"STACKIT_ALLOWED_GH_USERS":     "jonnii",
 	})
 
-	_, err := buildAuthConfig(false, false)
+	_, err := buildAuthConfig(authBuildParams{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "STACKIT_GITHUB_CLIENT_SECRET")
 }
@@ -79,7 +106,7 @@ func TestBuildAuthConfig_HappyPath(t *testing.T) {
 		"STACKIT_ALLOWED_GH_USERS":     "jonnii",
 	})
 
-	r, err := buildAuthConfig(false, false)
+	r, err := buildAuthConfig(authBuildParams{})
 	require.NoError(t, err)
 	require.NotNil(t, r)
 	require.NotNil(t, r.cfg.Handler)
@@ -98,7 +125,7 @@ func TestBuildAuthConfig_EmptyAllowlistErrors(t *testing.T) {
 		"STACKIT_ALLOWED_GH_ORG":       "",
 	})
 
-	_, err := buildAuthConfig(false, false)
+	_, err := buildAuthConfig(authBuildParams{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "allowlist")
 }

--- a/apps/server/bind.go
+++ b/apps/server/bind.go
@@ -1,17 +1,22 @@
 package main
 
+const (
+	bindLoopback      = "127.0.0.1"
+	bindAllInterfaces = "0.0.0.0"
+)
+
 // resolveBind picks the default bind address when the operator did not pass
 // -bind explicitly. Locally we want 127.0.0.1 so the API isn't reachable to
 // other users on the host; PaaS / container deploys flip to 0.0.0.0 because
-// the platform's router is on a different interface. publicHint is true when
-// $PORT or $STACKIT_PUBLIC are set, both of which signal a hosted runtime.
-func resolveBind(flagBind *string, bindExplicit, publicHint bool) {
+// the platform's router is on a different interface. prod is true when
+// STACKIT_ENV=production, which signals a hosted runtime.
+func resolveBind(flagBind *string, bindExplicit, prod bool) {
 	if bindExplicit {
 		return
 	}
-	if publicHint {
-		*flagBind = "0.0.0.0"
+	if prod {
+		*flagBind = bindAllInterfaces
 		return
 	}
-	*flagBind = "127.0.0.1"
+	*flagBind = bindLoopback
 }

--- a/apps/server/bind_test.go
+++ b/apps/server/bind_test.go
@@ -6,25 +6,25 @@ func TestResolveBind(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name       string
-		bind       string
-		explicit   bool
-		publicHint bool
-		want       string
+		name     string
+		bind     string
+		explicit bool
+		prod     bool
+		want     string
 	}{
 		{name: "explicit operator value wins", bind: "10.0.0.5", explicit: true, want: "10.0.0.5"},
 		{name: "explicit empty value wins too", bind: "", explicit: true, want: ""},
-		{name: "PaaS hint flips to all interfaces", publicHint: true, want: "0.0.0.0"},
+		{name: "production flips to all interfaces", prod: true, want: "0.0.0.0"},
 		{name: "local default is loopback", want: "127.0.0.1"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			b := tc.bind
-			resolveBind(&b, tc.explicit, tc.publicHint)
+			resolveBind(&b, tc.explicit, tc.prod)
 			if b != tc.want {
-				t.Fatalf("resolveBind(%q, explicit=%v, publicHint=%v) = %q, want %q",
-					tc.bind, tc.explicit, tc.publicHint, b, tc.want)
+				t.Fatalf("resolveBind(%q, explicit=%v, prod=%v) = %q, want %q",
+					tc.bind, tc.explicit, tc.prod, b, tc.want)
 			}
 		})
 	}

--- a/apps/server/env.go
+++ b/apps/server/env.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// serverEnv selects the deployment posture: a coherent bundle of defaults for
+// the bind interface, log format, cookie security, and whether $PORT is
+// honored. It is the single source of truth for "am I running locally or
+// hosted", replacing the old heuristic that inferred this from $PORT — which
+// collided with dev shells (cmux, Heroku-style toolchains) that export $PORT
+// generically and silently flipped a local server into a public, auth-gated one.
+type serverEnv int
+
+const (
+	envLocal serverEnv = iota
+	envProduction
+)
+
+const (
+	envNameLocal      = "local"
+	envNameProduction = "production"
+)
+
+func (e serverEnv) isProduction() bool { return e == envProduction }
+
+func (e serverEnv) String() string {
+	if e == envProduction {
+		return envNameProduction
+	}
+	return envNameLocal
+}
+
+// resolveEnv parses STACKIT_ENV. Unset (or "local"/"development") means local;
+// "production" means hosted. Unrecognized values are a hard error so a typo on
+// a deploy fails loudly rather than silently picking the wrong posture. The
+// default is local — the fail-safe direction, since local binds loopback: a
+// hosted deploy that forgets the var becomes unreachable, never exposed.
+func resolveEnv(raw string) (serverEnv, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", envNameLocal, "development", "dev":
+		return envLocal, nil
+	case envNameProduction, "prod":
+		return envProduction, nil
+	default:
+		return envLocal, fmt.Errorf("invalid STACKIT_ENV %q: want \"local\" or \"production\"", raw)
+	}
+}
+
+// isLoopbackBind reports whether addr binds only the loopback interface, so an
+// unauthenticated server on it is not reachable off-host. Empty ("all
+// interfaces"), 0.0.0.0, and :: are treated as exposed, not loopback.
+func isLoopbackBind(addr string) bool {
+	addr = strings.TrimSpace(addr)
+	if addr == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(addr)
+	return ip != nil && ip.IsLoopback()
+}

--- a/apps/server/env_test.go
+++ b/apps/server/env_test.go
@@ -1,0 +1,75 @@
+package main
+
+import "testing"
+
+func TestResolveEnv(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		raw     string
+		want    serverEnv
+		wantErr bool
+	}{
+		{name: "unset defaults to local", raw: "", want: envLocal},
+		{name: "local", raw: "local", want: envLocal},
+		{name: "local uppercase", raw: "LOCAL", want: envLocal},
+		{name: "development alias", raw: "development", want: envLocal},
+		{name: "dev alias", raw: "dev", want: envLocal},
+		{name: "production", raw: "production", want: envProduction},
+		{name: "production trimmed and cased", raw: "  Production  ", want: envProduction},
+		{name: "prod alias", raw: "prod", want: envProduction},
+		{name: "unknown is an error", raw: "staging", wantErr: true},
+		{name: "typo is an error", raw: "prdouction", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveEnv(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("resolveEnv(%q) = %v, want error", tc.raw, got)
+				}
+				// Even on error, the fail-safe fallback is local.
+				if got != envLocal {
+					t.Fatalf("resolveEnv(%q) error fallback = %v, want envLocal", tc.raw, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveEnv(%q) unexpected error: %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Fatalf("resolveEnv(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsLoopbackBind(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{addr: "127.0.0.1", want: true},
+		{addr: "127.0.0.2", want: true}, // 127.0.0.0/8 is all loopback
+		{addr: "::1", want: true},
+		{addr: "localhost", want: true},
+		{addr: " 127.0.0.1 ", want: true}, // trimmed
+		{addr: "", want: false},           // empty = all interfaces = exposed
+		{addr: "0.0.0.0", want: false},
+		{addr: "::", want: false},
+		{addr: "192.168.1.5", want: false},
+		{addr: "10.0.0.5", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.addr, func(t *testing.T) {
+			t.Parallel()
+			if got := isLoopbackBind(tc.addr); got != tc.want {
+				t.Fatalf("isLoopbackBind(%q) = %v, want %v", tc.addr, got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -45,7 +45,7 @@ func main() {
 }
 
 // setupLogging configures the default slog logger. Production deploys
-// (PORT or STACKIT_PUBLIC set) emit JSON with a level field so log
+// (STACKIT_ENV=production) emit JSON with a level field so log
 // aggregators tag entries correctly; local runs use the text handler
 // for readability. Output goes to stdout so platforms like Railway
 // don't classify everything as error (which is what happens when the
@@ -66,7 +66,7 @@ func setupLogging(jsonOutput bool) {
 func run() error {
 	var (
 		port          = flag.Int("port", 8080, "Port to listen on")
-		bind          = flag.String("bind", "", "Interface to bind on. Defaults to 127.0.0.1; switches to 0.0.0.0 when $PORT or $STACKIT_PUBLIC is set.")
+		bind          = flag.String("bind", "", "Interface to bind on. Defaults to 127.0.0.1 (loopback); STACKIT_ENV=production binds 0.0.0.0.")
 		cwd           = flag.String("cwd", "", "Working directory for repository detection (single-repo shortcut; ignored when -database-url is set)")
 		databaseURL   = flag.String("database-url", os.Getenv("STACKIT_DATABASE_URL"), "PostgreSQL connection string. When set, repos are served from the DB instead of the -cwd single-repo shortcut.")
 		reposRoot     = flag.String("repos-root", os.Getenv("STACKIT_REPOS_ROOT"), "Base directory under which per-repo checkouts live (<reposRoot>/<owner>/<name>) for DB-sourced repos.")
@@ -75,19 +75,21 @@ func run() error {
 		apiPrefix     = flag.String("api-prefix", "/api/v1", "Canonical API prefix")
 		enableLegacy  = flag.Bool("legacy-api-prefix", true, "Also expose legacy /api endpoints")
 		shutdownGrace = flag.Duration("shutdown-timeout", 10*time.Second, "Graceful shutdown timeout")
-		authDisabled  = flag.Bool("auth-disabled", false, "Disable GitHub OAuth gate. Refused in public mode ($PORT or $STACKIT_PUBLIC).")
+		authDisabled  = flag.Bool("auth-disabled", false, "Disable GitHub OAuth gate. Refused when the server binds a non-loopback interface (e.g. STACKIT_ENV=production) unless -read-only is set.")
 		readOnly      = flag.Bool("read-only", envBool("STACKIT_READ_ONLY"), "Serve in read-only mode: the submit endpoint is disabled so the repo can be exposed publicly without write access. Also set via STACKIT_READ_ONLY.")
 		syncInterval  = flag.Duration("sync-interval", envDuration("STACKIT_SYNC_INTERVAL"), "How often to mirror-fetch managed repos from their remotes so served state stays current. 0 disables the loop. Also set via STACKIT_SYNC_INTERVAL (e.g. 60s).")
 	)
 	flag.Parse()
 
-	publicMode := os.Getenv("PORT") != "" || os.Getenv("STACKIT_PUBLIC") != ""
-	setupLogging(publicMode)
+	env, err := resolveEnv(os.Getenv("STACKIT_ENV"))
+	if err != nil {
+		return err
+	}
+	prod := env.isProduction()
+	setupLogging(prod)
 
-	slog.Info("stackit-server starting", "version", version, "commit", commit, "built", date)
+	slog.Info("stackit-server starting", "version", version, "commit", commit, "built", date, "env", env.String())
 
-	// Honor $PORT when -port wasn't passed explicitly. PaaS hosts (Railway,
-	// Fly, Heroku) inject the port this way.
 	portExplicit := false
 	bindExplicit := false
 	cwdExplicit := false
@@ -101,10 +103,18 @@ func run() error {
 			cwdExplicit = true
 		}
 	})
-	if err := resolvePort(port, portExplicit, os.Getenv("PORT")); err != nil {
+	// $PORT is the PaaS convention (Railway, Fly, Heroku inject it); honored
+	// only in production so a stray $PORT from a dev shell can't move the local
+	// listener. resolveBind likewise binds loopback locally, 0.0.0.0 in prod.
+	if err := resolvePort(port, portExplicit, prod, os.Getenv("PORT")); err != nil {
 		return err
 	}
-	resolveBind(bind, bindExplicit, publicMode)
+	resolveBind(bind, bindExplicit, prod)
+
+	// The auth requirement keys off actual exposure (a non-loopback bind),
+	// not the env name: binding off-host without auth or read-only is refused
+	// no matter how we got there (prod default, explicit -bind, etc.).
+	exposed := !isLoopbackBind(*bind)
 
 	staticFS, err := fs.Sub(staticFiles, "static")
 	if err != nil {
@@ -174,7 +184,12 @@ func run() error {
 		}
 	}
 
-	authBuild, err := buildAuthConfig(*authDisabled, publicMode)
+	authBuild, err := buildAuthConfig(authBuildParams{
+		disabled: *authDisabled,
+		exposed:  exposed,
+		readOnly: *readOnly,
+		prod:     prod,
+	})
 	if err != nil {
 		return err
 	}

--- a/apps/server/port.go
+++ b/apps/server/port.go
@@ -7,10 +7,16 @@ import (
 )
 
 // resolvePort applies a $PORT fallback when -port wasn't passed explicitly.
-// flagPort is the destination flag pointer. When portExplicit is true the
-// env value is ignored (the operator wins). An empty env is a no-op.
-func resolvePort(flagPort *int, portExplicit bool, env string) error {
+// flagPort is the destination flag pointer. When portExplicit is true the env
+// value is ignored (the operator wins). $PORT is the PaaS convention, so it is
+// honored only in production (prod); locally it is ignored, so a stray $PORT
+// exported by a dev shell (cmux, Heroku toolbelt, ...) can't move the listener.
+// An empty env is a no-op.
+func resolvePort(flagPort *int, portExplicit, prod bool, env string) error {
 	if portExplicit {
+		return nil
+	}
+	if !prod {
 		return nil
 	}
 	env = strings.TrimSpace(env)

--- a/apps/server/port_test.go
+++ b/apps/server/port_test.go
@@ -13,39 +13,59 @@ func TestResolvePort(t *testing.T) {
 		name           string
 		start          int
 		portExplicit   bool
+		prod           bool
 		env            string
 		wantPort       int
 		wantErrContain string
 	}{
 		{
-			name:     "no env keeps default",
+			name:     "prod no env keeps default",
 			start:    8080,
+			prod:     true,
 			env:      "",
 			wantPort: 8080,
 		},
 		{
-			name:     "env populates default",
+			name:     "prod env populates default",
 			start:    8080,
+			prod:     true,
 			env:      "3000",
 			wantPort: 3000,
 		},
 		{
 			name:     "explicit flag wins over env",
 			start:    9999,
+			prod:     true,
 			env:      "3000",
 			wantPort: 9999, portExplicit: true,
 		},
 		{
-			name:     "whitespace env is treated as unset",
+			name:     "prod whitespace env is treated as unset",
 			start:    8080,
+			prod:     true,
 			env:      "   ",
 			wantPort: 8080,
 		},
 		{
-			name:           "invalid env returns error",
+			name:           "prod invalid env returns error",
 			start:          8080,
+			prod:           true,
 			env:            "not-a-number",
 			wantErrContain: "invalid PORT env",
+		},
+		{
+			name:     "local ignores env",
+			start:    8080,
+			prod:     false,
+			env:      "3000",
+			wantPort: 8080,
+		},
+		{
+			name:     "local ignores invalid env without error",
+			start:    8080,
+			prod:     false,
+			env:      "not-a-number",
+			wantPort: 8080,
 		},
 	}
 
@@ -53,7 +73,7 @@ func TestResolvePort(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			port := tt.start
-			err := resolvePort(&port, tt.portExplicit, tt.env)
+			err := resolvePort(&port, tt.portExplicit, tt.prod, tt.env)
 			if tt.wantErrContain != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.wantErrContain)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -55,8 +55,8 @@ with every authenticated user.
 
 | Var | Purpose |
 |-----|---------|
-| `PORT` | Listen port. Honored when `-port` isn't passed explicitly — needed for Railway, Fly, Heroku. Defaults to `8080`. Setting this also implicitly switches the server into "public mode" (binds `0.0.0.0`, requires auth env). |
-| `STACKIT_PUBLIC` | Explicit version of the same signal. Set when you mean to expose the server publicly without `$PORT` (e.g. behind a tunnel). |
+| `STACKIT_ENV` | Deployment posture: `local` (default) or `production`. `production` binds `0.0.0.0`, emits JSON logs, forces `Secure` cookies, honors `$PORT`, and requires auth (or `-read-only`). `local` binds loopback (`127.0.0.1`) with auth optional. Set it to `production` on every hosted deploy. |
+| `PORT` | Listen port for **production** deploys. Honored when `-port` isn't passed and `STACKIT_ENV=production` — PaaS hosts (Railway, Fly, Heroku) inject it. Ignored in `local` so a stray `$PORT` from a dev shell can't move the listener. Defaults to `8080`. |
 | `STACKIT_READ_ONLY` | Set to `1`/`true` to serve in read-only mode: the submit endpoint is disabled and reads are served anonymously, so a configured repo can be exposed to the public without write access. See [Read-only public mode](#read-only-public-mode). Equivalent to `-read-only`. |
 | `STACKIT_DATABASE_URL` | PostgreSQL connection string. When set, repos are served from the DB (and runtime [onboarding](#repository-onboarding) can persist new ones) instead of the `-cwd` single-repo shortcut. Equivalent to `-database-url`. |
 | `STACKIT_REPOS_ROOT` | Base directory under which per-repo checkouts live (`<root>/<owner>/<name>`). Required for DB-backed serving and onboarding. Equivalent to `-repos-root`. |
@@ -81,9 +81,9 @@ The most useful flags:
 | `-sync-interval` | `0` | How often to mirror-fetch managed repos so served state stays current; `0` disables. Also settable via `STACKIT_SYNC_INTERVAL`. See [GitHub App & background sync](#github-app--background-sync). |
 | `-cwd` | _(empty)_ | Single-repo shortcut: serve the repo discovered from this path as `default`. Ignored when `-database-url` is set. |
 | `-port` | `8080` | Listen port; overrides `$PORT`. |
-| `-bind` | `127.0.0.1` (or `0.0.0.0` if `$PORT`/`$STACKIT_PUBLIC` are set) | Interface to bind on. Pass `-bind 0.0.0.0` explicitly to expose the server on a host where the heuristics don't fire. |
+| `-bind` | `127.0.0.1` (or `0.0.0.0` when `STACKIT_ENV=production`) | Interface to bind on. Pass `-bind 0.0.0.0` explicitly to expose the server without setting `STACKIT_ENV=production`. Binding a non-loopback interface requires auth or `-read-only`. |
 | `-cors` | `http://localhost:3000,http://localhost:5173` | Comma-separated allowed CORS origins. Loopback origins are **not** allowed implicitly — list each origin you want to accept. |
-| `-auth-disabled` | `false` | Skip the GitHub OAuth gate. **Refused** when `$PORT` or `$STACKIT_PUBLIC` is set. Use only for local dev or when fronted by platform auth (Tailscale, Cloudflare Access). |
+| `-auth-disabled` | `false` | Skip the GitHub OAuth gate. **Refused** when the server binds a non-loopback interface (e.g. `STACKIT_ENV=production`) unless `-read-only` is set. Use only for local dev or when fronted by platform auth (Tailscale, Cloudflare Access). |
 | `-read-only` | `false` | Serve in read-only mode: disable the submit endpoint and serve reads anonymously. Safe to expose publicly. See [Read-only public mode](#read-only-public-mode). Also settable via `STACKIT_READ_ONLY`. |
 
 Run `stackit-server -h` inside the container for the full list.
@@ -262,8 +262,10 @@ this doc revision and follow-on PRs):
 
 - Process runs as the unprivileged `stackit` user (uid 10001) inside the
   container — neither user nor group is `root`.
-- Default bind is `127.0.0.1`; the `$PORT`/`$STACKIT_PUBLIC` heuristic
-  flips to `0.0.0.0` so PaaS routers can reach the port.
+- Default bind is `127.0.0.1`; `STACKIT_ENV=production` flips to
+  `0.0.0.0` so PaaS routers can reach the port. Binding any non-loopback
+  interface requires auth or `-read-only` — the server refuses to start
+  otherwise.
 - Request body capped at 1 MiB; `MaxHeaderBytes` at 1 MiB; `WriteTimeout`
   30 s, `IdleTimeout` 120 s, `ReadHeaderTimeout` 10 s.
 - Panic recovery middleware: a panicking handler returns 500 but cannot
@@ -343,7 +345,12 @@ cat > data/repos.json <<'EOF'
 { "repos": [ { "id": "stackit", "path": "/data/repos/stackit" } ] }
 EOF
 
+# STACKIT_ENV=production binds 0.0.0.0 so the -p mapping can reach the
+# server inside the container; STACKIT_READ_ONLY=1 exposes it without
+# needing OAuth set up (a non-loopback bind requires auth or read-only).
 docker run --rm -p 8080:8080 \
+  -e STACKIT_ENV=production \
+  -e STACKIT_READ_ONLY=1 \
   -v "$(pwd)/data:/data" \
   ghcr.io/getstackit/stackit-server:latest \
   -repos-config /data/repos.json
@@ -358,8 +365,11 @@ open http://localhost:8080
 1. **Service** — deploy from image `ghcr.io/getstackit/stackit-server:main`
    (or pin to `:latest` / `:vX.Y.Z`).
 2. **Volume** — mount at `/data`. Use at least a few GB; clones land here.
-3. **Variables** — Railway injects `PORT` automatically; no other vars are
-   required for the Phase 1 container.
+3. **Variables** — set `STACKIT_ENV=production` (binds `0.0.0.0` so Railway's
+   router can reach the port, and enforces auth). Railway injects `PORT`
+   automatically. Add the auth vars (`STACKIT_GITHUB_*`, `STACKIT_SESSION_KEY`,
+   an allowlist) for a write-capable deploy, or set `STACKIT_READ_ONLY=1` to
+   expose it read-only without auth.
 4. **Start command** — leave blank to use the image's `ENTRYPOINT`, then set
    the **Command** (Railway's arg override) to:
    ```

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -24,8 +24,8 @@ const apiPathPrefix = "/api"
 // ServerConfig holds configuration for the API server.
 type ServerConfig struct {
 	// BindAddr is the host/IP to listen on. Empty means "all interfaces".
-	// apps/server picks a safe default (127.0.0.1) and switches to the
-	// public-facing form when PORT or STACKIT_PUBLIC is set.
+	// apps/server picks a safe default (127.0.0.1) and binds 0.0.0.0 when
+	// STACKIT_ENV=production.
 	BindAddr    string
 	Port        int
 	CORSOrigins []string
@@ -58,8 +58,8 @@ type ServerConfig struct {
 	// needed to gate /api/* routes behind GitHub login. When nil the server
 	// runs without authentication; that mode is only safe on a private
 	// network (localhost dev, tunneled access). apps/server refuses to
-	// start unauthenticated when STACKIT_PUBLIC or $PORT are set unless
-	// -auth-disabled is passed explicitly.
+	// start unauthenticated when it binds a non-loopback interface unless
+	// -read-only is set.
 	Auth *AuthConfig
 
 	// RepoStore is the persistence backend for repo configuration. It is set


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The server inferred "public mode" (bind 0.0.0.0, JSON logs, Secure
cookies, required auth) from $PORT or STACKIT_PUBLIC being set. That
overloaded $PORT and collided with dev shells (cmux, Heroku toolbelt)
that export $PORT generically, silently flipping a local server into a
public, auth-gated one — the "Couldn't reach the API" failure locally.

Introduce STACKIT_ENV (local default | production) as the single source
of truth for posture. $PORT is demoted to a listen-port hint honored
only in production, so a stray $PORT can't move the local listener.

The auth requirement now keys off actual exposure — a non-loopback bind
must have auth configured or -read-only, and -auth-disabled is refused
there — rather than the env name. This makes the safety guarantee
independent of how the server got exposed and fixes a latent gap where a
read-only public server with no OAuth env couldn't boot.

BREAKING: hosted deploys must set STACKIT_ENV=production (Railway/Fly/
etc.); STACKIT_PUBLIC is removed. Docs and .env.template updated.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782266218`.


* **PR #1313**
  * **PR #1314** 👈
    * **PR #1315**
      * **PR #1316**
        * **PR #1317**
          * **PR #1318**
            * **PR #1319**
              * **PR #1320**
                * **PR #1322**
                  * **PR #1323**
                    * **PR #1324**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1326 by jonnii*