### PR TITLE
feat(api): coalesce webhook-driven syncs per repo

### DIFF
--- a/internal/api/handlers/webhook.go
+++ b/internal/api/handlers/webhook.go
@@ -1,11 +1,8 @@
 package handlers
 
 import (
-	"context"
 	"io"
-	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/getstackit/stackit/internal/api/githubwebhook"
 )
@@ -15,15 +12,12 @@ import (
 // request from forcing an unbounded read before the signature is even checked.
 const maxWebhookBody = 1 << 20 // 1 MiB
 
-// webhookSyncTimeout bounds the background fetch+refresh kicked off by a
-// delivery, so a stuck remote can't leak goroutines.
-const webhookSyncTimeout = 2 * time.Minute
-
-// RepoSyncer mirror-fetches and refreshes a single managed repo by its GitHub
-// coordinates. The concrete implementation is *reposync.Syncer; the handler
-// takes the narrow interface so handlers stays decoupled from reposync.
-type RepoSyncer interface {
-	SyncRepo(ctx context.Context, owner, name string) error
+// RepoSyncTrigger requests an asynchronous, coalesced sync of a managed repo by
+// its GitHub coordinates. The concrete implementation is *reposync.Coalescer;
+// the handler takes the narrow interface so handlers stays decoupled from
+// reposync, and so the receiver never blocks on a fetch.
+type RepoSyncTrigger interface {
+	Trigger(owner, name string)
 }
 
 // WebhookHandler receives GitHub webhook deliveries at
@@ -36,21 +30,21 @@ type RepoSyncer interface {
 // authenticated solely by the HMAC signature, so it must fail closed when no
 // secret is configured — otherwise it would be an open refresh trigger.
 type WebhookHandler struct {
-	secret string
-	syncer RepoSyncer
+	secret  string
+	trigger RepoSyncTrigger
 }
 
-// NewWebhookHandler wires a webhook receiver. An empty secret or nil syncer
+// NewWebhookHandler wires a webhook receiver. An empty secret or nil trigger
 // leaves the endpoint disabled (it 404s), so it is safe to mount
 // unconditionally and gate purely on configuration.
-func NewWebhookHandler(secret string, syncer RepoSyncer) *WebhookHandler {
-	return &WebhookHandler{secret: secret, syncer: syncer}
+func NewWebhookHandler(secret string, trigger RepoSyncTrigger) *WebhookHandler {
+	return &WebhookHandler{secret: secret, trigger: trigger}
 }
 
 func (h *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Disabled when unconfigured: 404 so the endpoint is indistinguishable from
 	// a server that never had it, rather than advertising a misconfigured hook.
-	if h.secret == "" || h.syncer == nil {
+	if h.secret == "" || h.trigger == nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -88,16 +82,9 @@ func (h *WebhookHandler) handlePush(w http.ResponseWriter, body []byte) {
 		return
 	}
 
-	// A mirror-fetch is slow and GitHub expects a prompt response, so ack
-	// immediately and run the sync in the background, detached from the request.
-	// The inbound rate limiter bounds how often this fans out; a follow-up adds
-	// per-repo coalescing so a burst of pushes collapses to one fetch.
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), webhookSyncTimeout)
-		defer cancel()
-		if err := h.syncer.SyncRepo(ctx, owner, name); err != nil {
-			slog.Warn("webhook: sync failed", "owner", owner, "name", name, "error", err)
-		}
-	}()
+	// A mirror-fetch is slow and GitHub expects a prompt response, so hand off
+	// to the coalescer (which runs and de-dups the fetch off the request path)
+	// and ack immediately.
+	h.trigger.Trigger(owner, name)
 	w.WriteHeader(http.StatusAccepted)
 }

--- a/internal/api/handlers/webhook_test.go
+++ b/internal/api/handlers/webhook_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -17,6 +16,8 @@ import (
 	"github.com/getstackit/stackit/internal/api/githubwebhook"
 )
 
+// fakeSyncer records Trigger calls and signals each one on done, so a test can
+// wait for the (otherwise fire-and-forget) hand-off.
 type fakeSyncer struct {
 	mu    sync.Mutex
 	calls []string
@@ -27,7 +28,7 @@ func newFakeSyncer() *fakeSyncer {
 	return &fakeSyncer{done: make(chan struct{}, 1)}
 }
 
-func (f *fakeSyncer) SyncRepo(_ context.Context, owner, name string) error {
+func (f *fakeSyncer) Trigger(owner, name string) {
 	f.mu.Lock()
 	f.calls = append(f.calls, owner+"/"+name)
 	f.mu.Unlock()
@@ -35,7 +36,6 @@ func (f *fakeSyncer) SyncRepo(_ context.Context, owner, name string) error {
 	case f.done <- struct{}{}:
 	default:
 	}
-	return nil
 }
 
 func (f *fakeSyncer) called() []string {
@@ -98,11 +98,11 @@ func TestWebhookHandler_PushTriggersSync(t *testing.T) {
 	h.ServeHTTP(rr, webhookRequest("push", pushBody()))
 	require.Equal(t, http.StatusAccepted, rr.Code)
 
-	// The sync runs in a background goroutine; wait for it to land.
+	// Wait for the trigger hand-off (the real coalescer runs the fetch async).
 	select {
 	case <-sy.done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("SyncRepo was not called for a verified push")
+		t.Fatal("Trigger was not called for a verified push")
 	}
 	require.Equal(t, []string{"octo/widget"}, sy.called())
 }

--- a/internal/api/reposync/coalescer.go
+++ b/internal/api/reposync/coalescer.go
@@ -1,0 +1,95 @@
+package reposync
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// defaultSyncTimeout bounds a single coalesced sync so a stuck remote can't
+// pin a goroutine indefinitely.
+const defaultSyncTimeout = 2 * time.Minute
+
+// SyncFunc mirror-fetches and refreshes one repo by its GitHub coordinates.
+// (*Syncer).SyncRepo satisfies it.
+type SyncFunc func(ctx context.Context, owner, name string) error
+
+// Coalescer collapses repeated sync triggers for the same repo. At most one
+// sync runs per repo at a time; triggers that arrive while one is in flight set
+// a single pending flag, so a burst of pushes for a repo yields one extra sync
+// afterward rather than a fetch per delivery. This bounds live goroutines to the
+// number of distinct repos seeing traffic and keeps git subprocesses in check —
+// the webhook receiver can hand off every delivery without fanning out.
+type Coalescer struct {
+	sync    SyncFunc
+	timeout time.Duration
+
+	mu    sync.Mutex
+	state map[string]*repoSync
+}
+
+// repoSync tracks the in-flight/pending status for one repo key.
+type repoSync struct {
+	running bool
+	pending bool
+}
+
+// NewCoalescer wraps sync. A non-positive timeout uses defaultSyncTimeout.
+func NewCoalescer(sync SyncFunc, timeout time.Duration) *Coalescer {
+	if timeout <= 0 {
+		timeout = defaultSyncTimeout
+	}
+	return &Coalescer{sync: sync, timeout: timeout, state: make(map[string]*repoSync)}
+}
+
+// Trigger requests a sync for owner/name and returns immediately. It is safe for
+// concurrent use; repeated calls while a sync for the repo is in flight coalesce
+// into a single follow-up run.
+func (c *Coalescer) Trigger(owner, name string) {
+	key := owner + "/" + name
+
+	c.mu.Lock()
+	st := c.state[key]
+	if st == nil {
+		st = &repoSync{}
+		c.state[key] = st
+	}
+	if st.running {
+		// A sync is already running for this repo; mark that the latest state
+		// hasn't been synced yet. Any number of triggers in this window collapse
+		// to one follow-up.
+		st.pending = true
+		c.mu.Unlock()
+		return
+	}
+	st.running = true
+	c.mu.Unlock()
+
+	go c.drain(key, owner, name)
+}
+
+// drain runs syncs for key until no trigger arrived during the last run.
+func (c *Coalescer) drain(key, owner, name string) {
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+		err := c.sync(ctx, owner, name)
+		cancel()
+		if err != nil {
+			slog.Warn("sync: coalesced sync failed", "repo", key, "error", err)
+		}
+
+		c.mu.Lock()
+		st := c.state[key]
+		if st.pending {
+			// A trigger landed while we were syncing; run once more to pick it
+			// up, then re-check.
+			st.pending = false
+			c.mu.Unlock()
+			continue
+		}
+		delete(c.state, key)
+		c.mu.Unlock()
+		return
+	}
+}

--- a/internal/api/reposync/coalescer_test.go
+++ b/internal/api/reposync/coalescer_test.go
@@ -1,0 +1,104 @@
+package reposync
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoalescerSingleTriggerRunsOnce(t *testing.T) {
+	t.Parallel()
+	var mu sync.Mutex
+	calls := 0
+	c := NewCoalescer(func(context.Context, string, string) error {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		return nil
+	}, time.Minute)
+
+	c.Trigger("o", "r")
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return calls == 1
+	}, 2*time.Second, 5*time.Millisecond)
+}
+
+func TestCoalescerCollapsesBurstForSameRepo(t *testing.T) {
+	t.Parallel()
+	var mu sync.Mutex
+	calls := 0
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	c := NewCoalescer(func(context.Context, string, string) error {
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+		if n == 1 {
+			close(started)
+			<-release // hold the first sync so the burst lands while it runs
+		}
+		return nil
+	}, time.Minute)
+
+	c.Trigger("o", "r")
+	<-started // first sync is now in flight
+
+	// A burst of triggers while the first sync runs must collapse to exactly
+	// one follow-up, not one sync per trigger.
+	for range 5 {
+		c.Trigger("o", "r")
+	}
+	close(release)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return calls == 2
+	}, 2*time.Second, 5*time.Millisecond)
+
+	// Once drained, the state for the repo is cleared and the count is stable.
+	require.Eventually(t, func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return len(c.state) == 0
+	}, 2*time.Second, 5*time.Millisecond)
+
+	mu.Lock()
+	require.Equal(t, 2, calls, "burst must not produce more than one follow-up sync")
+	mu.Unlock()
+}
+
+func TestCoalescerRunsDistinctReposConcurrently(t *testing.T) {
+	t.Parallel()
+	started := make(chan string, 2)
+	release := make(chan struct{})
+
+	c := NewCoalescer(func(_ context.Context, owner, _ string) error {
+		started <- owner
+		<-release // block until both have started, proving they run in parallel
+		return nil
+	}, time.Minute)
+
+	c.Trigger("a", "r")
+	c.Trigger("b", "r")
+
+	got := map[string]bool{}
+	for range 2 {
+		select {
+		case owner := <-started:
+			got[owner] = true
+		case <-time.After(2 * time.Second):
+			t.Fatal("both repos did not start concurrently")
+		}
+	}
+	close(release)
+
+	require.Equal(t, map[string]bool{"a": true, "b": true}, got)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -118,6 +118,10 @@ type Server struct {
 	// interval loop (when enabled) and the webhook receiver drive it, so it is
 	// built once here regardless of whether the loop runs.
 	syncer *reposync.Syncer
+
+	// coalescer fronts the syncer for event-driven refreshes (the webhook
+	// receiver), collapsing a burst of pushes for one repo into a single fetch.
+	coalescer *reposync.Coalescer
 }
 
 // NewServer creates a new API server backed by the given registry.
@@ -133,6 +137,7 @@ func NewServer(cfg ServerConfig) *Server {
 		provider = cfg.RepoSyncTokens
 	}
 	s.syncer = reposync.New(cfg.Registry, provider, cfg.SyncInterval)
+	s.coalescer = reposync.NewCoalescer(s.syncer.SyncRepo, 0)
 
 	return s
 }
@@ -304,7 +309,7 @@ func (s *Server) buildHandler() (http.Handler, error) {
 	//   - /webhooks/github receives GitHub push deliveries (authenticated by
 	//     HMAC signature, not a session) and refreshes the matching managed
 	//     repo. It self-disables (404) when no webhook secret is configured.
-	webhookHandler := handlers.NewWebhookHandler(s.config.GitHubWebhookSecret, s.syncer)
+	webhookHandler := handlers.NewWebhookHandler(s.config.GitHubWebhookSecret, s.coalescer)
 	publicAPIMux := http.NewServeMux()
 	for _, prefix := range prefixes {
 		publicAPIMux.Handle("GET "+prefix+"/config", configHandler)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The webhook receiver previously spawned a goroutine and a git fetch per
delivery. A burst of pushes for one repo (or a rapid-fire series) would fan out
into concurrent fetches of the same checkout.

reposync.Coalescer fronts the syncer: at most one sync runs per repo at a time,
and any triggers that arrive while one is in flight collapse into a single
follow-up run. This bounds live goroutines to the number of distinct repos
seeing traffic and keeps git subprocesses in check.

The receiver now hands off through a narrow RepoSyncTrigger interface
(Trigger(owner, name)) and acks immediately, so it never blocks on a fetch and
owns no concurrency itself. The shared coalescer is built once in NewServer.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782266218`.


* **PR #1313**
  * **PR #1314**
    * **PR #1315**
      * **PR #1316**
        * **PR #1317**
          * **PR #1318** 👈
            * **PR #1319**
              * **PR #1320**
                * **PR #1322**
                  * **PR #1323**
                    * **PR #1324**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1326 by jonnii*