### PR TITLE
feat(server): index repos by owner/repo for GitHub-style routes

### DIFF
--- a/internal/api/handlers/onboard.go
+++ b/internal/api/handlers/onboard.go
@@ -129,7 +129,17 @@ func (h *OnboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	id := repoID(owner, name)
+	// Guard both identities the registry indexes: the derived ID and the
+	// case-folded owner/repo key. repoID does not lowercase, so "Octo/Widget"
+	// and "octo/widget" yield distinct IDs but the same owner/repo key. Checking
+	// only the ID would let the second casing pass here, clone, persist a row,
+	// then fail at reg.Add with a 500 and an orphaned DB row. Catch the
+	// owner/repo collision up front so it's a clean 409 before any clone or write.
 	if _, exists := h.reg.Get(id); exists {
+		writeJSONError(w, http.StatusConflict, "repository already onboarded")
+		return
+	}
+	if _, exists := h.reg.GetByOwnerRepo(owner, name); exists {
 		writeJSONError(w, http.StatusConflict, "repository already onboarded")
 		return
 	}
@@ -229,7 +239,7 @@ func (h *OnboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	summary := httpcontract.RepoSummary{ID: entry.ID, DisplayName: entry.DisplayName}
+	summary := httpcontract.RepoSummary{ID: entry.ID, Owner: entry.Owner, Repo: entry.Name, DisplayName: entry.DisplayName}
 	if entry.Engine != nil {
 		summary.Trunk = entry.Engine.Trunk().GetName()
 		if cur := entry.Engine.CurrentBranch(); cur != nil {

--- a/internal/api/handlers/onboard_test.go
+++ b/internal/api/handlers/onboard_test.go
@@ -131,6 +131,27 @@ func TestOnboardHandlerDuplicate(t *testing.T) {
 	require.Equal(t, http.StatusConflict, rec.Code)
 }
 
+func TestOnboardHandlerDuplicateDifferentCasing(t *testing.T) {
+	t.Parallel()
+	reg := registry.New()
+	t.Cleanup(func() { _ = reg.Close() })
+	// An existing repo, indexed by its case-folded owner/repo key.
+	require.NoError(t, reg.Add(&registry.RepoEntry{ID: "octo-widget", Owner: "octo", Name: "widget", AddedBy: "alice"}))
+	cipher := onboardCipher(t)
+
+	h := NewOnboardHandler(reg, &fakeRepoStore{}, cipher, t.TempDir(), fakeTokenProvider{token: "inst-token"})
+	h.checkAccess = func(_ context.Context, _, _, _ string) (*github.RepoAccess, error) {
+		t.Fatal("onboard should 409 on the owner/repo collision before checking access or cloning")
+		return nil, nil
+	}
+
+	// Different casing derives a different repo ID, so the ID check passes and
+	// only the owner/repo index catches the collision. Without that guard this
+	// would clone and persist a row, then 500 at reg.Add with an orphaned row.
+	rec := doOnboard(t, h, cipher, `{"owner":"Octo","name":"Widget"}`)
+	require.Equal(t, http.StatusConflict, rec.Code)
+}
+
 func TestOnboardHandlerInvalidCoords(t *testing.T) {
 	t.Parallel()
 	reg := registry.New()

--- a/internal/api/handlers/repos.go
+++ b/internal/api/handlers/repos.go
@@ -35,6 +35,8 @@ func (h *ReposListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		summary := httpcontract.RepoSummary{
 			ID:          entry.ID,
+			Owner:       entry.Owner,
+			Repo:        entry.Name,
 			DisplayName: entry.DisplayName,
 		}
 		if entry.Engine != nil {

--- a/internal/api/handlers/repos_test.go
+++ b/internal/api/handlers/repos_test.go
@@ -21,11 +21,15 @@ func TestReposListHandler_ListsRegisteredRepos(t *testing.T) {
 	reg := registry.New()
 	require.NoError(t, reg.Add(&registry.RepoEntry{
 		ID:          "alpha",
+		Owner:       "acme",
+		Name:        "alpha",
 		DisplayName: "Alpha",
 		Engine:      s.Engine,
 	}))
 	require.NoError(t, reg.Add(&registry.RepoEntry{
 		ID:          "beta",
+		Owner:       "acme",
+		Name:        "beta",
 		DisplayName: "Beta",
 		Engine:      s.Engine,
 	}))
@@ -42,6 +46,8 @@ func TestReposListHandler_ListsRegisteredRepos(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
 	require.Len(t, resp.Repos, 2)
 	require.Equal(t, "alpha", resp.Repos[0].ID)
+	require.Equal(t, "acme", resp.Repos[0].Owner)
+	require.Equal(t, "alpha", resp.Repos[0].Repo)
 	require.Equal(t, "Alpha", resp.Repos[0].DisplayName)
 	require.Equal(t, "main", resp.Repos[0].Trunk)
 	require.Equal(t, "beta", resp.Repos[1].ID)

--- a/internal/api/provision/provision.go
+++ b/internal/api/provision/provision.go
@@ -54,6 +54,21 @@ func BuildEntry(ctx context.Context, p EntryParams) (*registry.RepoEntry, error)
 		slog.Warn("GitHub client unavailable", "repo", p.ID, "error", runtimeCtx.GitHubError())
 	}
 
+	// Onboarding passes explicit coordinates; the single-repo startup path does
+	// not. Derive owner/name from the GitHub remote so every repo with a remote
+	// is reachable by its GitHub-style /repos/{owner}/{repo} route, not just
+	// onboarded ones.
+	owner, name := p.Owner, p.Name
+	if (owner == "" || name == "") && gh != nil {
+		remoteOwner, remoteName := gh.GetOwnerRepo()
+		if owner == "" {
+			owner = remoteOwner
+		}
+		if name == "" {
+			name = remoteName
+		}
+	}
+
 	entry := registry.NewEntry(registry.EntryConfig{
 		ID:          p.ID,
 		DisplayName: p.DisplayName,
@@ -61,8 +76,8 @@ func BuildEntry(ctx context.Context, p EntryParams) (*registry.RepoEntry, error)
 		Remote:      p.Remote,
 		AddedBy:     p.AddedBy,
 		Managed:     p.Managed,
-		Owner:       p.Owner,
-		Name:        p.Name,
+		Owner:       owner,
+		Name:        name,
 		Engine:      runtimeCtx.Engine,
 		GitHub:      gh,
 	})

--- a/internal/api/registry/registry.go
+++ b/internal/api/registry/registry.go
@@ -30,6 +30,13 @@ const watcherDebounce = 200 * time.Millisecond
 // without escaping, keeping the routing surface simple.
 var idPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
+// ownerRepoKey is the lookup key for the owner/repo secondary index. GitHub
+// treats owner/repo case-insensitively, so we lowercase to match a request's
+// path segments regardless of how they were typed.
+func ownerRepoKey(owner, name string) string {
+	return strings.ToLower(owner + "/" + name)
+}
+
 // EntryConfig is the input to NewEntry. It captures the per-repo state the
 // constructor needs to wire up the broadcaster + watcher.
 type EntryConfig struct {
@@ -185,19 +192,30 @@ func (e *RepoEntry) Refresh() {
 	e.Broadcaster.Broadcast("refresh", "{}")
 }
 
-// Registry is a goroutine-safe collection of RepoEntries keyed by ID.
+// Registry is a goroutine-safe collection of RepoEntries keyed by ID, with a
+// secondary index keyed by owner/repo so handlers can resolve the GitHub-style
+// /repos/{owner}/{repo} routes.
 type Registry struct {
 	mu      sync.RWMutex
 	entries map[string]*RepoEntry
+	// byOwnerRepo maps a lowercased "owner/name" to the same entries. Only
+	// entries with both an owner and a name are indexed; a repo with no GitHub
+	// remote (empty coordinates) is reachable by ID but not by owner/repo.
+	byOwnerRepo map[string]*RepoEntry
 }
 
 // New returns an empty registry.
 func New() *Registry {
-	return &Registry{entries: make(map[string]*RepoEntry)}
+	return &Registry{
+		entries:     make(map[string]*RepoEntry),
+		byOwnerRepo: make(map[string]*RepoEntry),
+	}
 }
 
 // Add inserts an entry. The entry's ID must be non-empty, match the allowed
-// pattern, and be unique within the registry.
+// pattern, and be unique within the registry. When the entry carries GitHub
+// coordinates (Owner and Name), they must also be unique so the owner/repo
+// index stays unambiguous.
 func (r *Registry) Add(e *RepoEntry) error {
 	if e == nil {
 		return errors.New("registry: nil entry")
@@ -213,7 +231,17 @@ func (r *Registry) Add(e *RepoEntry) error {
 	if _, exists := r.entries[e.ID]; exists {
 		return fmt.Errorf("registry: duplicate repo ID %q", e.ID)
 	}
+	var key string
+	if e.Owner != "" && e.Name != "" {
+		key = ownerRepoKey(e.Owner, e.Name)
+		if _, exists := r.byOwnerRepo[key]; exists {
+			return fmt.Errorf("registry: duplicate repo %s/%s", e.Owner, e.Name)
+		}
+	}
 	r.entries[e.ID] = e
+	if key != "" {
+		r.byOwnerRepo[key] = e
+	}
 	return nil
 }
 
@@ -223,6 +251,18 @@ func (r *Registry) Get(id string) (*RepoEntry, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	e, ok := r.entries[id]
+	return e, ok
+}
+
+// GetByOwnerRepo returns the entry for owner/repo, matched case-insensitively.
+// The bool is false when no such entry exists or the coordinates are empty.
+func (r *Registry) GetByOwnerRepo(owner, repo string) (*RepoEntry, bool) {
+	if owner == "" || repo == "" {
+		return nil, false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	e, ok := r.byOwnerRepo[ownerRepoKey(owner, repo)]
 	return e, ok
 }
 
@@ -277,5 +317,6 @@ func (r *Registry) Close() error {
 		}
 	}
 	r.entries = nil
+	r.byOwnerRepo = nil
 	return errors.Join(errs...)
 }

--- a/internal/api/registry/registry_test.go
+++ b/internal/api/registry/registry_test.go
@@ -58,6 +58,50 @@ func TestRegistry_AddRejectsDuplicateID(t *testing.T) {
 	require.Contains(t, err.Error(), "duplicate repo ID")
 }
 
+func TestRegistry_AddRejectsDuplicateOwnerRepo(t *testing.T) {
+	t.Parallel()
+	r := New()
+	require.NoError(t, r.Add(&RepoEntry{ID: "a", Owner: "octo", Name: "widget"}))
+	// Same coordinates, different ID, different casing — still a collision.
+	err := r.Add(&RepoEntry{ID: "b", Owner: "Octo", Name: "Widget"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate repo")
+}
+
+func TestRegistry_GetByOwnerRepo(t *testing.T) {
+	t.Parallel()
+	r := New()
+	require.NoError(t, r.Add(&RepoEntry{ID: "managed", Owner: "Octo", Name: "Widget"}))
+	require.NoError(t, r.Add(&RepoEntry{ID: "no-remote"})) // empty coordinates: ID-only
+
+	t.Run("matches owner/repo case-insensitively", func(t *testing.T) {
+		t.Parallel()
+		e, ok := r.GetByOwnerRepo("octo", "widget")
+		require.True(t, ok)
+		require.Equal(t, "managed", e.ID)
+	})
+
+	t.Run("returns false when no repo matches", func(t *testing.T) {
+		t.Parallel()
+		_, ok := r.GetByOwnerRepo("octo", "missing")
+		require.False(t, ok)
+	})
+
+	t.Run("returns false for empty coordinates", func(t *testing.T) {
+		t.Parallel()
+		_, ok := r.GetByOwnerRepo("", "")
+		require.False(t, ok)
+	})
+
+	t.Run("entry without coordinates is not indexed by owner/repo", func(t *testing.T) {
+		t.Parallel()
+		_, byID := r.Get("no-remote")
+		require.True(t, byID, "should still be reachable by ID")
+		_, byOwnerRepo := r.GetByOwnerRepo("", "")
+		require.False(t, byOwnerRepo)
+	})
+}
+
 func TestRegistry_GetMissing(t *testing.T) {
 	t.Parallel()
 	r := New()

--- a/internal/contracts/http/responses.go
+++ b/internal/contracts/http/responses.go
@@ -20,9 +20,13 @@ type ConfigResponse struct {
 }
 
 // RepoSummary is one entry in ReposListResponse — the metadata clients
-// need to render a repo picker without hitting per-repo endpoints.
+// need to render a repo picker without hitting per-repo endpoints. Owner and
+// Repo are the GitHub coordinates the client uses to build /{owner}/{repo}
+// routes; they are omitted for a repo with no GitHub remote.
 type RepoSummary struct {
 	ID            string `json:"id"`
+	Owner         string `json:"owner,omitempty"`
+	Repo          string `json:"repo,omitempty"`
 	DisplayName   string `json:"displayName"`
 	Trunk         string `json:"trunk"`
 	CurrentBranch string `json:"currentBranch,omitempty"`


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Add an owner/repo secondary index to the registry (GetByOwnerRepo,
case-insensitive, with duplicate detection) and surface the GitHub
coordinates on RepoSummary so clients can build /{owner}/{repo} URLs.

provision.BuildEntry derives owner/name from the git remote when not
passed explicitly, so the local single-repo "default" checkout is
reachable by owner/repo like onboarded mirrors. Additive groundwork for
moving the API and web URLs from query params to path params.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782266218`.


* **PR #1313**
  * **PR #1314**
    * **PR #1315**
      * **PR #1316**
        * **PR #1317**
          * **PR #1318**
            * **PR #1319**
              * **PR #1320**
                * **PR #1322** 👈
                  * **PR #1323**
                    * **PR #1324**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1326 by jonnii*