### PR TITLE
feat(web): GitHub-style path URLs for repos, branches, stacks, PRs

### DIFF
--- a/apps/web/src/app/[[...slug]]/page.tsx
+++ b/apps/web/src/app/[[...slug]]/page.tsx
@@ -1,0 +1,13 @@
+import { AppShell } from "@/components/app-shell";
+
+// `output: 'export'` emits a single index.html for the empty slug. Every deeper
+// path (/{owner}/{repo}/...) is matched by this optional catch-all and handled
+// client-side; the Go server serves the same index.html for those deep links on
+// hard refresh (SPA fallback in internal/api/static.go).
+export function generateStaticParams() {
+  return [{ slug: [] }];
+}
+
+export default function Page() {
+  return <AppShell />;
+}

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { Suspense } from "react";
-import { useSearchParams } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { AuthProvider } from "@/components/providers/auth-provider";
 import { ConfigProvider } from "@/components/providers/config-provider";
 import { RepoProvider } from "@/components/providers/repo-provider";
 import { RepoPicker } from "@/components/repo-picker/repo-picker";
 import { RepoView } from "@/components/repo-picker/repo-view";
 import { ReadOnlyBanner } from "@/components/read-only-banner";
+import { parseRepoPath } from "@/lib/repo-route";
 import type { ConfigResponse } from "@/lib/api";
 
 // The server's /api/v1/config endpoint is authoritative for read-only and
@@ -23,22 +23,21 @@ const CONFIG_FALLBACK: ConfigResponse = {
   authRequired: !AUTH_DISABLED,
 };
 
-// Single root page driving both the unscoped picker and the per-repo view.
+// Client shell driving both the unscoped picker and the per-repo view.
 //
-// The Next.js build is `output: 'export'`, so only the root URL is emitted.
-// We scope to a repo via the `?repo=<id>` query string rather than a path
-// segment — that way the same static index.html handles every repo in both
-// `next dev` and the embedded production server, with no per-repo route to
-// pre-generate.
+// The Next.js build is `output: 'export'`, so only index.html is emitted; the
+// optional catch-all route ([[...slug]]) lets that one shell handle every path.
+// We scope to a repo via the path — GitHub-style `/{owner}/{repo}/...` — parsed
+// here from usePathname, with the Go server's SPA fallback serving the same
+// shell for deep links on refresh (see internal/api/static.go).
 function Home() {
-  const params = useSearchParams();
-  const repoId = params.get("repo") ?? "";
+  const { owner, repo } = parseRepoPath(usePathname());
 
   return (
     <>
       <ReadOnlyBanner />
-      {repoId ? (
-        <RepoProvider repoId={repoId}>
+      {owner && repo ? (
+        <RepoProvider owner={owner} repo={repo}>
           <RepoView />
         </RepoProvider>
       ) : (
@@ -48,14 +47,12 @@ function Home() {
   );
 }
 
-export default function Page() {
+export function AppShell() {
   return (
-    <Suspense fallback={null}>
-      <ConfigProvider fallback={CONFIG_FALLBACK}>
-        <AuthProvider>
-          <Home />
-        </AuthProvider>
-      </ConfigProvider>
-    </Suspense>
+    <ConfigProvider fallback={CONFIG_FALLBACK}>
+      <AuthProvider>
+        <Home />
+      </AuthProvider>
+    </ConfigProvider>
   );
 }

--- a/apps/web/src/components/branch-detail/branch-diff.tsx
+++ b/apps/web/src/components/branch-detail/branch-diff.tsx
@@ -226,7 +226,7 @@ function parseConventionalCommit(message: string): ConventionalCommit | null {
 }
 
 export function BranchDiff({ branchName, revision, commits, onExit }: BranchDiffProps) {
-  const { repoId } = useRepo();
+  const { repoRef } = useRepo();
   const [diff, setDiff] = useState<BranchDiffResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -246,7 +246,7 @@ export function BranchDiff({ branchName, revision, commits, onExit }: BranchDiff
       setDiff(null);
     });
 
-    fetchBranchDiff(repoId, branchName)
+    fetchBranchDiff(repoRef, branchName)
       .then((result) => {
         if (!active) return;
         setDiff(result);
@@ -263,7 +263,7 @@ export function BranchDiff({ branchName, revision, commits, onExit }: BranchDiff
     return () => {
       active = false;
     };
-  }, [branchName, revision, repoId]);
+  }, [branchName, revision, repoRef]);
 
   const parsed = useMemo(() => {
     if (!diff?.patch.trim()) {

--- a/apps/web/src/components/branch-detail/stack-detail.tsx
+++ b/apps/web/src/components/branch-detail/stack-detail.tsx
@@ -30,7 +30,7 @@ export function StackDetailPanel({
   const status = stackStatusInfo[stack.status] || stackStatusInfo.incomplete;
   const issues = collectIssues(stack.branches);
   const stats = computeStackStats(stack.branches);
-  const { refresh, repoId } = useRepo();
+  const { refresh, repoRef } = useRepo();
   const { readOnly } = useConfig();
 
   const allHavePRs = stack.branches.every((b) => b.pr != null);
@@ -42,7 +42,7 @@ export function StackDetailPanel({
     setSubmitting(true);
     setSubmitResult(null);
     try {
-      const result = await submitStack(repoId, stack.rootBranch);
+      const result = await submitStack(repoRef, stack.rootBranch);
       setSubmitResult(result);
       refresh();
     } catch (err) {

--- a/apps/web/src/components/providers/repo-provider.tsx
+++ b/apps/web/src/components/providers/repo-provider.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useContext,
   useEffect,
+  useMemo,
   useState,
   useCallback,
   useRef,
@@ -11,6 +12,7 @@ import {
 } from "react";
 import {
   fetchView,
+  type RepoRef,
   type RepoResponse,
   type StackDetail,
   type TrunkCommitResponse,
@@ -23,7 +25,7 @@ import { diffViews } from "@/lib/diff-views";
 const MAX_EVENTS = 100;
 
 interface RepoState {
-  repoId: string;
+  repoRef: RepoRef;
   repo: RepoResponse | null;
   stackDetails: StackDetail[];
   recentlyMerged: TrunkCommitResponse[];
@@ -43,7 +45,17 @@ export function useRepo() {
   return ctx;
 }
 
-export function RepoProvider({ repoId, children }: { repoId: string; children: ReactNode }) {
+export function RepoProvider({
+  owner,
+  repo: repoName,
+  children,
+}: {
+  owner: string;
+  repo: string;
+  children: ReactNode;
+}) {
+  // Stable ref so the load/SSE effects don't re-run on every render.
+  const repoRef = useMemo<RepoRef>(() => ({ owner, repo: repoName }), [owner, repoName]);
   const [repo, setRepo] = useState<RepoResponse | null>(null);
   const [stackDetails, setStackDetails] = useState<StackDetail[]>([]);
   const [recentlyMerged, setRecentlyMerged] = useState<TrunkCommitResponse[]>([]);
@@ -69,7 +81,7 @@ export function RepoProvider({ repoId, children }: { repoId: string; children: R
 
   const loadData = useCallback(async () => {
     try {
-      const view = await fetchView(repoId);
+      const view = await fetchView(repoRef);
       setRepo(view.repo);
 
       // Diff against previous view to detect changes
@@ -88,7 +100,7 @@ export function RepoProvider({ repoId, children }: { repoId: string; children: R
     } finally {
       setLoading(false);
     }
-  }, [addEvents, repoId]);
+  }, [addEvents, repoRef]);
 
   // Initial load
   useEffect(() => {
@@ -100,12 +112,12 @@ export function RepoProvider({ repoId, children }: { repoId: string; children: R
   }, [loadData]);
 
   // SSE updates trigger refresh; server events get added directly
-  useSSE(repoId, loadData, addEvent);
+  useSSE(repoRef, loadData, addEvent);
 
   return (
     <RepoContext.Provider
       value={{
-        repoId,
+        repoRef,
         repo,
         stackDetails,
         recentlyMerged,

--- a/apps/web/src/components/repo-picker/__tests__/repo-picker.test.tsx
+++ b/apps/web/src/components/repo-picker/__tests__/repo-picker.test.tsx
@@ -40,16 +40,16 @@ describe("RepoPicker", () => {
     expect(screen.getByText("Other Project")).toBeDefined();
   });
 
-  it("navigates to /?repo={repoId} on click", async () => {
+  it("navigates to /{owner}/{repo} on click", async () => {
     mockRepos({
-      repos: [{ id: "stackit", displayName: "Stackit", trunk: "main" }],
+      repos: [{ id: "stackit", owner: "acme", repo: "web", displayName: "Stackit", trunk: "main" }],
     });
 
     render(<RepoPicker />);
 
     const card = await screen.findByTestId("repo-card-stackit");
     fireEvent.click(card);
-    expect(mockPush).toHaveBeenCalledWith("/?repo=stackit");
+    expect(mockPush).toHaveBeenCalledWith("/acme/web");
   });
 
   it("shows the empty-state message when no repos are configured", async () => {

--- a/apps/web/src/components/repo-picker/repo-picker.tsx
+++ b/apps/web/src/components/repo-picker/repo-picker.tsx
@@ -10,6 +10,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { fetchRepos, type RepoSummary } from "@/lib/api";
+import { buildRepoPath } from "@/lib/repo-route";
 import { AddRepository } from "./add-repository";
 
 export function RepoPicker() {
@@ -17,8 +18,12 @@ export function RepoPicker() {
   const [repos, setRepos] = useState<RepoSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const openRepo = (id: string) =>
-    router.push(`/?repo=${encodeURIComponent(id)}`);
+  // Repos are addressed by their GitHub coordinates. A repo with no remote has
+  // none and can't be opened in the path-based UI.
+  const openRepo = (repo: RepoSummary) => {
+    if (!repo.owner || !repo.repo) return;
+    router.push(buildRepoPath(repo.owner, repo.repo, null));
+  };
 
   useEffect(() => {
     let active = true;
@@ -65,7 +70,7 @@ export function RepoPicker() {
             Add a GitHub repository to get started.
           </p>
         </header>
-        <AddRepository onAdded={(repo) => openRepo(repo.id)} />
+        <AddRepository onAdded={(repo) => openRepo(repo)} />
       </div>
     );
   }
@@ -86,7 +91,7 @@ export function RepoPicker() {
             <button
               type="button"
               data-testid={`repo-card-${repo.id}`}
-              onClick={() => openRepo(repo.id)}
+              onClick={() => openRepo(repo)}
               className="block w-full text-left transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-xl"
             >
               <Card>
@@ -112,7 +117,7 @@ export function RepoPicker() {
         ))}
       </ul>
 
-      <AddRepository onAdded={(repo) => openRepo(repo.id)} />
+      <AddRepository onAdded={(repo) => openRepo(repo)} />
     </div>
   );
 }

--- a/apps/web/src/components/repo-picker/repo-view.tsx
+++ b/apps/web/src/components/repo-picker/repo-view.tsx
@@ -74,7 +74,7 @@ export function RepoView() {
               <OwnerSwimlane
                 label="You"
                 stacks={yourStacks}
-                selectedBranch={selection?.type === "branch" ? selection.name : null}
+                selectedBranch={selectedBranch?.name ?? null}
                 selectedStack={selection?.type === "stack" ? selection.rootBranch : null}
                 onSelectBranch={handleSelectBranch}
                 onSelectStack={handleSelectStack}
@@ -89,7 +89,7 @@ export function RepoView() {
                 label={`@${owner}`}
                 lastActive={getLastActiveDate(stacks)}
                 stacks={stacks}
-                selectedBranch={selection?.type === "branch" ? selection.name : null}
+                selectedBranch={selectedBranch?.name ?? null}
                 selectedStack={selection?.type === "stack" ? selection.rootBranch : null}
                 onSelectBranch={handleSelectBranch}
                 onSelectStack={handleSelectStack}

--- a/apps/web/src/hooks/use-url-selection.ts
+++ b/apps/web/src/hooks/use-url-selection.ts
@@ -2,40 +2,45 @@
 
 import { useCallback, useMemo, useState } from "react";
 import type { BranchResponse, StackDetail } from "@/lib/api";
+import {
+  buildRepoPath,
+  parseRepoPath,
+  type Selection,
+} from "@/lib/repo-route";
 
-export type Selection =
-  | { type: "branch"; name: string }
-  | { type: "stack"; rootBranch: string };
+export type { Selection };
 
 function readInitialSelection(): Selection | null {
   if (typeof window === "undefined") return null;
-  const params = new URLSearchParams(window.location.search);
-  const branch = params.get("branch");
-  if (branch) return { type: "branch", name: branch };
-  const stack = params.get("stack");
-  if (stack) return { type: "stack", rootBranch: stack };
-  return null;
+  return parseRepoPath(window.location.pathname).selection;
 }
 
-function updateUrl(params: Record<string, string | null>) {
-  const url = new URL(window.location.href);
-  for (const [key, value] of Object.entries(params)) {
-    if (value === null) {
-      url.searchParams.delete(key);
-    } else {
-      url.searchParams.set(key, value);
-    }
-  }
-  window.history.replaceState({}, "", url.toString());
+// navigate rewrites the path for the current repo to reflect selection,
+// without adding a history entry (matching the previous query-param behavior).
+// The owner/repo are read back from the current path so the hook needs no repo
+// props.
+function navigate(selection: Selection | null) {
+  const { owner, repo } = parseRepoPath(window.location.pathname);
+  if (!owner || !repo) return;
+  window.history.replaceState({}, "", buildRepoPath(owner, repo, selection));
 }
 
 export function useUrlSelection(stackDetails: StackDetail[]) {
   const [selection, setSelection] = useState<Selection | null>(readInitialSelection);
 
   const selectedBranch = useMemo(() => {
-    if (!selection || selection.type !== "branch") return null;
+    if (!selection) return null;
+    // A "pull" selection is a deep link by PR number; resolve it to the branch
+    // carrying that PR once the data has loaded.
+    const match =
+      selection.type === "branch"
+        ? (b: BranchResponse) => b.name === selection.name
+        : selection.type === "pull"
+          ? (b: BranchResponse) => b.pr?.number === selection.number
+          : null;
+    if (!match) return null;
     for (const stack of stackDetails) {
-      const found = stack.branches.find((b) => b.name === selection.name);
+      const found = stack.branches.find(match);
       if (found) return found;
     }
     return null;
@@ -56,18 +61,14 @@ export function useUrlSelection(stackDetails: StackDetail[]) {
   }, [selectedBranch, stackDetails]);
 
   const handleSelectBranch = useCallback((branch: BranchResponse | null) => {
-    if (branch) {
-      setSelection({ type: "branch", name: branch.name });
-      updateUrl({ branch: branch.name, stack: null });
-    } else {
-      setSelection(null);
-      updateUrl({ branch: null, stack: null });
-    }
+    const next: Selection | null = branch ? { type: "branch", name: branch.name } : null;
+    setSelection(next);
+    navigate(next);
   }, []);
 
   const handleClearSelection = useCallback(() => {
     setSelection(null);
-    updateUrl({ branch: null, stack: null });
+    navigate(null);
   }, []);
 
   const handleSelectStack = useCallback((stack: StackDetail) => {
@@ -75,13 +76,7 @@ export function useUrlSelection(stackDetails: StackDetail[]) {
       const deselecting = prev?.type === "stack" && prev.rootBranch === stack.rootBranch;
       const next = deselecting ? null : { type: "stack" as const, rootBranch: stack.rootBranch };
 
-      queueMicrotask(() => {
-        if (next) {
-          updateUrl({ branch: null, stack: stack.rootBranch });
-        } else {
-          updateUrl({ branch: null, stack: null });
-        }
-      });
+      queueMicrotask(() => navigate(next));
 
       return next;
     });

--- a/apps/web/src/lib/__tests__/api.test.ts
+++ b/apps/web/src/lib/__tests__/api.test.ts
@@ -15,6 +15,9 @@ import {
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
+// Repos are addressed by GitHub coordinates; one ref reused across cases.
+const REF = { owner: "acme", repo: "web" } as const;
+
 beforeEach(() => {
   mockFetch.mockReset();
 });
@@ -94,52 +97,52 @@ describe("onboardRepo", () => {
 });
 
 describe("fetchView", () => {
-  it("scopes to repoId", async () => {
+  it("scopes to owner/repo", async () => {
     const data = { repo: {}, stacks: [] };
     mockOk(data);
 
-    const result = await fetchView("stackit");
+    const result = await fetchView(REF);
     expect(result).toEqual(data);
     expect(mockFetch).toHaveBeenCalledWith(
-      "/api/v1/repos/stackit/view",
+      "/api/v1/repos/acme/web/view",
       { credentials: "include" }
     );
   });
 });
 
 describe("fetchRepo", () => {
-  it("scopes to repoId", async () => {
+  it("scopes to owner/repo", async () => {
     const data = { owner: "test", repo: "repo", trunk: "main", currentBranch: "main", remote: "origin" };
     mockOk(data);
 
-    const result = await fetchRepo("stackit");
+    const result = await fetchRepo(REF);
     expect(result).toEqual(data);
     expect(mockFetch).toHaveBeenCalledWith(
-      "/api/v1/repos/stackit/repo",
+      "/api/v1/repos/acme/web/repo",
       { credentials: "include" }
     );
   });
 });
 
 describe("fetchStacks", () => {
-  it("scopes to repoId", async () => {
+  it("scopes to owner/repo", async () => {
     mockOk([]);
-    const result = await fetchStacks("stackit");
+    const result = await fetchStacks(REF);
     expect(result).toEqual([]);
     expect(mockFetch).toHaveBeenCalledWith(
-      "/api/v1/repos/stackit/stacks",
+      "/api/v1/repos/acme/web/stacks",
       { credentials: "include" }
     );
   });
 });
 
 describe("fetchStack", () => {
-  it("encodes both repoId and branch name in URL", async () => {
+  it("encodes the branch name in URL", async () => {
     mockOk({ rootBranch: "feat/foo", branches: [] });
 
-    await fetchStack("stackit", "feat/foo");
+    await fetchStack(REF, "feat/foo");
     expect(mockFetch).toHaveBeenCalledWith(
-      "/api/v1/repos/stackit/stacks/feat%2Ffoo",
+      "/api/v1/repos/acme/web/stacks/feat%2Ffoo",
       { credentials: "include" }
     );
   });
@@ -149,21 +152,21 @@ describe("fetchBranch", () => {
   it("encodes branch name in URL", async () => {
     mockOk({ name: "feat/bar" });
 
-    await fetchBranch("stackit", "feat/bar");
+    await fetchBranch(REF, "feat/bar");
     expect(mockFetch).toHaveBeenCalledWith(
-      "/api/v1/repos/stackit/branches/feat%2Fbar",
+      "/api/v1/repos/acme/web/branches/feat%2Fbar",
       { credentials: "include" }
     );
   });
 });
 
 describe("fetchBranchDiff", () => {
-  it("sends encoded branch name in query string", async () => {
+  it("sends the encoded branch name as a path segment", async () => {
     mockOk({ branch: "feat/bar", baseRevision: "abc", headRevision: "def", patch: "" });
 
-    await fetchBranchDiff("stackit", "feat/bar");
+    await fetchBranchDiff(REF, "feat/bar");
     expect(mockFetch).toHaveBeenCalledWith(
-      "/api/v1/repos/stackit/branch-diff?branch=feat%2Fbar",
+      "/api/v1/repos/acme/web/branch-diff/feat%2Fbar",
       { credentials: "include" }
     );
   });
@@ -186,12 +189,12 @@ describe("error handling", () => {
   it("throws on non-ok response", async () => {
     mockError(404, "Not Found");
 
-    await expect(fetchRepo("stackit")).rejects.toThrow("API error: 404 Not Found");
+    await expect(fetchRepo(REF)).rejects.toThrow("API error: 404 Not Found");
   });
 
   it("throws on 500 response", async () => {
     mockError(500, "Internal Server Error");
 
-    await expect(fetchView("stackit")).rejects.toThrow("API error: 500 Internal Server Error");
+    await expect(fetchView(REF)).rejects.toThrow("API error: 500 Internal Server Error");
   });
 });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -25,9 +25,18 @@ export interface RepoResponse {
 
 export interface RepoSummary {
   id: string;
+  owner?: string;
+  repo?: string;
   displayName: string;
   trunk: string;
   currentBranch?: string;
+}
+
+// RepoRef identifies a repo by its GitHub coordinates — the shape every
+// per-repo endpoint is keyed by (/api/v1/repos/{owner}/{repo}/...).
+export interface RepoRef {
+  owner: string;
+  repo: string;
 }
 
 export interface ReposListResponse {
@@ -208,8 +217,8 @@ export async function logout(): Promise<void> {
   }
 }
 
-function repoPath(repoId: string, suffix: string): string {
-  return `/api/v1/repos/${encodeURIComponent(repoId)}/${suffix}`;
+function repoPath(ref: RepoRef, suffix: string): string {
+  return `/api/v1/repos/${encodeURIComponent(ref.owner)}/${encodeURIComponent(ref.repo)}/${suffix}`;
 }
 
 export function fetchRepos(): Promise<ReposListResponse> {
@@ -244,34 +253,32 @@ export async function onboardRepo(owner: string, name: string): Promise<RepoSumm
   return res.json();
 }
 
-export function fetchView(repoId: string): Promise<ViewResponse> {
-  return fetchAPI<ViewResponse>(repoPath(repoId, "view"));
+export function fetchView(ref: RepoRef): Promise<ViewResponse> {
+  return fetchAPI<ViewResponse>(repoPath(ref, "view"));
 }
 
-export function fetchRepo(repoId: string): Promise<RepoResponse> {
-  return fetchAPI<RepoResponse>(repoPath(repoId, "repo"));
+export function fetchRepo(ref: RepoRef): Promise<RepoResponse> {
+  return fetchAPI<RepoResponse>(repoPath(ref, "repo"));
 }
 
-export function fetchStacks(repoId: string): Promise<StackSummary[]> {
-  return fetchAPI<StackSummary[]>(repoPath(repoId, "stacks"));
+export function fetchStacks(ref: RepoRef): Promise<StackSummary[]> {
+  return fetchAPI<StackSummary[]>(repoPath(ref, "stacks"));
 }
 
-export function fetchStack(repoId: string, rootBranch: string): Promise<StackDetail> {
-  return fetchAPI<StackDetail>(repoPath(repoId, `stacks/${encodeURIComponent(rootBranch)}`));
+export function fetchStack(ref: RepoRef, rootBranch: string): Promise<StackDetail> {
+  return fetchAPI<StackDetail>(repoPath(ref, `stacks/${encodeURIComponent(rootBranch)}`));
 }
 
-export function fetchBranches(repoId: string): Promise<BranchResponse[]> {
-  return fetchAPI<BranchResponse[]>(repoPath(repoId, "branches"));
+export function fetchBranches(ref: RepoRef): Promise<BranchResponse[]> {
+  return fetchAPI<BranchResponse[]>(repoPath(ref, "branches"));
 }
 
-export function fetchBranch(repoId: string, name: string): Promise<BranchResponse> {
-  return fetchAPI<BranchResponse>(repoPath(repoId, `branches/${encodeURIComponent(name)}`));
+export function fetchBranch(ref: RepoRef, name: string): Promise<BranchResponse> {
+  return fetchAPI<BranchResponse>(repoPath(ref, `branches/${encodeURIComponent(name)}`));
 }
 
-export function fetchBranchDiff(repoId: string, name: string): Promise<BranchDiffResponse> {
-  return fetchAPI<BranchDiffResponse>(
-    repoPath(repoId, `branch-diff?branch=${encodeURIComponent(name)}`)
-  );
+export function fetchBranchDiff(ref: RepoRef, name: string): Promise<BranchDiffResponse> {
+  return fetchAPI<BranchDiffResponse>(repoPath(ref, `branch-diff/${encodeURIComponent(name)}`));
 }
 
 // --- Event Feed Types ---
@@ -312,9 +319,9 @@ export interface SubmitResponse {
 
 // --- Mutation Functions ---
 
-export async function submitStack(repoId: string, rootBranch: string): Promise<SubmitResponse> {
+export async function submitStack(ref: RepoRef, rootBranch: string): Promise<SubmitResponse> {
   const res = await fetch(
-    `${API_BASE}${repoPath(repoId, `stacks/${encodeURIComponent(rootBranch)}/submit`)}`,
+    `${API_BASE}${repoPath(ref, `stacks/${encodeURIComponent(rootBranch)}/submit`)}`,
     {
       method: "POST",
       credentials: "include",

--- a/apps/web/src/lib/repo-route.ts
+++ b/apps/web/src/lib/repo-route.ts
@@ -1,0 +1,82 @@
+// Parsing and building for the GitHub-style browser URLs:
+//
+//   /{owner}/{repo}                     repo home (no selection)
+//   /{owner}/{repo}/tree/{branch}       a branch (branch may contain slashes)
+//   /{owner}/{repo}/stack/{rootBranch}  a whole stack
+//   /{owner}/{repo}/pull/{number}       a PR, resolved client-side to its branch
+//
+// Branch and stack names can contain slashes, so they occupy every segment
+// after the section keyword and are encoded per-segment (slashes stay as path
+// separators; other special characters are percent-encoded).
+
+export type Selection =
+  | { type: "branch"; name: string }
+  | { type: "stack"; rootBranch: string }
+  | { type: "pull"; number: number };
+
+export interface ParsedRoute {
+  owner: string | null;
+  repo: string | null;
+  selection: Selection | null;
+}
+
+// encodeName encodes a branch/stack name for a URL path, preserving its
+// slashes as separators so `feat/login` becomes `feat/login`, not `feat%2Flogin`.
+function encodeName(name: string): string {
+  return name.split("/").map(encodeURIComponent).join("/");
+}
+
+// decodeName reverses encodeName for a list of path segments.
+function decodeName(segments: string[]): string {
+  return segments.map(decodeURIComponent).join("/");
+}
+
+export function parseRepoPath(pathname: string): ParsedRoute {
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length < 2) {
+    return { owner: null, repo: null, selection: null };
+  }
+
+  const owner = decodeURIComponent(segments[0]);
+  const repo = decodeURIComponent(segments[1]);
+  const rest = segments.slice(2);
+
+  let selection: Selection | null = null;
+  if (rest.length >= 2) {
+    const [section, ...tail] = rest;
+    switch (section) {
+      case "tree":
+        selection = { type: "branch", name: decodeName(tail) };
+        break;
+      case "stack":
+        selection = { type: "stack", rootBranch: decodeName(tail) };
+        break;
+      case "pull": {
+        const number = Number(tail[0]);
+        if (Number.isInteger(number)) {
+          selection = { type: "pull", number };
+        }
+        break;
+      }
+    }
+  }
+
+  return { owner, repo, selection };
+}
+
+export function buildRepoPath(
+  owner: string,
+  repo: string,
+  selection: Selection | null
+): string {
+  const base = `/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+  if (!selection) return base;
+  switch (selection.type) {
+    case "branch":
+      return `${base}/tree/${encodeName(selection.name)}`;
+    case "stack":
+      return `${base}/stack/${encodeName(selection.rootBranch)}`;
+    case "pull":
+      return `${base}/pull/${selection.number}`;
+  }
+}

--- a/apps/web/src/lib/use-sse.ts
+++ b/apps/web/src/lib/use-sse.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useEffectEvent } from "react";
-import type { FeedEvent } from "@/lib/api";
+import type { FeedEvent, RepoRef } from "@/lib/api";
 
 // Empty default = same-origin requests. See api.ts for rationale.
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
@@ -14,7 +14,7 @@ type SSECallback = () => void;
  * Optionally calls onEvent for server-sourced feed events.
  */
 export function useSSE(
-  repoId: string,
+  ref: RepoRef,
   onUpdate: SSECallback,
   onEvent?: (event: FeedEvent) => void
 ) {
@@ -23,8 +23,9 @@ export function useSSE(
     onEvent?.(event);
   });
 
+  const { owner, repo } = ref;
   useEffect(() => {
-    const url = `${API_BASE}/api/v1/repos/${encodeURIComponent(repoId)}/events`;
+    const url = `${API_BASE}/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/events`;
     const eventSource = new EventSource(url);
 
     eventSource.addEventListener("stacks_updated", () => {
@@ -61,5 +62,5 @@ export function useSSE(
     return () => {
       eventSource.close();
     };
-  }, [repoId]);
+  }, [owner, repo]);
 }

--- a/docs/web.md
+++ b/docs/web.md
@@ -30,9 +30,10 @@ apps/web/
 ├── src/
 │   ├── app/                    Pages and layouts
 │   │   ├── layout.tsx          Root layout (providers, fonts, metadata)
-│   │   ├── page.tsx            Main dashboard page
+│   │   ├── [[...slug]]/page.tsx Optional catch-all → renders AppShell (SPA)
 │   │   └── globals.css         Global styles, CSS variables, animations
 │   ├── components/
+│   │   ├── app-shell.tsx       Path → picker vs per-repo view dispatcher
 │   │   ├── providers/
 │   │   │   ├── repo-provider.tsx   Main data context (repo, stacks, events)
 │   │   │   └── theme-provider.tsx  Light/dark/system theme context
@@ -51,6 +52,7 @@ apps/web/
 │   │   └── use-previous.ts     Track previous state value
 │   ├── lib/
 │   │   ├── api.ts              API client, fetch functions, type definitions
+│   │   ├── repo-route.ts       Parse/build GitHub-style /{owner}/{repo}/... URLs
 │   │   ├── use-sse.ts          SSE hook for real-time updates
 │   │   ├── diff-views.ts       View snapshot diffing for event detection
 │   │   ├── utils.ts            cn() helper for class merging
@@ -69,7 +71,7 @@ apps/web/
 ```
 layout.tsx
 └── ThemeProvider → RepoProvider → TooltipProvider
-    └── page.tsx
+    └── [[...slug]]/page.tsx → AppShell
         ├── Header (repo info, refresh, theme toggle)
         ├── LeftPanel (scrollable)
         │   ├── OwnerSwimlane ("You")
@@ -87,9 +89,9 @@ layout.tsx
 
 ## Data Flow
 
-1. **RepoProvider** calls `fetchView()` on mount → GET `/api/view`
+1. **RepoProvider** calls `fetchView(repoRef)` on mount → GET `/api/v1/repos/{owner}/{repo}/view`
 2. Response contains: repo metadata, all stack details, recently merged commits
-3. **SSE hook** (`useSSE`) connects to `/api/events` for real-time updates
+3. **SSE hook** (`useSSE`) connects to `/api/v1/repos/{owner}/{repo}/events` for real-time updates
 4. On SSE event (`stacks_updated`, `branch_changed`, `refresh`, `branch_switched`), RepoProvider refetches
 5. **View diffing** (`diff-views.ts`) compares old and new snapshots to generate `FeedEvent` objects
 6. Events are displayed in the **EventFeed** component (capped at 100 events)
@@ -98,23 +100,28 @@ layout.tsx
 
 ### Client
 
-All fetch functions live in `src/lib/api.ts`:
+All fetch functions live in `src/lib/api.ts`. Per-repo endpoints are keyed by
+GitHub coordinates: the functions take a `RepoRef` (`{ owner, repo }`) and build
+`/api/v1/repos/{owner}/{repo}/...` URLs via the `repoPath` helper. `RepoProvider`
+holds a memoized `repoRef` and exposes it through `useRepo()`.
 
 | Function | Method | Endpoint | Purpose |
 |----------|--------|----------|---------|
-| `fetchView()` | GET | `/api/view` | Combined dashboard payload |
-| `fetchRepo()` | GET | `/api/repo` | Repository metadata |
-| `fetchStacks()` | GET | `/api/stacks` | All stack summaries |
-| `fetchStack(root)` | GET | `/api/stacks/{root}` | Single stack detail |
-| `fetchBranch(name)` | GET | `/api/branches/{name}` | Single branch detail |
 | `fetchRepos()` | GET | `/api/v1/repos` | Repos the caller may see (picker) |
 | `onboardRepo(owner, name)` | POST | `/api/v1/repos` | Clone & serve a GitHub repo |
-| `submitStack(root)` | POST | `/api/submit/{root}` | Trigger stack submission |
+| `fetchView(ref)` | GET | `/api/v1/repos/{owner}/{repo}/view` | Combined dashboard payload |
+| `fetchRepo(ref)` | GET | `/api/v1/repos/{owner}/{repo}/repo` | Repository metadata |
+| `fetchStacks(ref)` | GET | `/api/v1/repos/{owner}/{repo}/stacks` | All stack summaries |
+| `fetchStack(ref, root)` | GET | `/api/v1/repos/{owner}/{repo}/stacks/{root}` | Single stack detail |
+| `fetchBranch(ref, name)` | GET | `/api/v1/repos/{owner}/{repo}/branches/{name}` | Single branch detail |
+| `fetchBranchDiff(ref, name)` | GET | `/api/v1/repos/{owner}/{repo}/branch-diff/{name}` | Raw branch patch |
+| `submitStack(ref, root)` | POST | `/api/v1/repos/{owner}/{repo}/stacks/{root}/submit` | Trigger stack submission |
 
 The repo picker (`src/components/repo-picker/`) renders an `AddRepository`
-form that calls `onboardRepo`; on success it navigates to the new repo. The
-form self-hides on a read-only server (`useConfig().readOnly`) since writes are
-refused there. See [Repository onboarding](./deploy.md#repository-onboarding).
+form that calls `onboardRepo`; on success it navigates to the new repo's
+`/{owner}/{repo}` path. The form self-hides on a read-only server
+(`useConfig().readOnly`) since writes are refused there. See
+[Repository onboarding](./deploy.md#repository-onboarding).
 
 The API base URL is configured via `NEXT_PUBLIC_API_URL`. Default is empty
 (same-origin) so the embedded production build, served by the Go binary,
@@ -128,7 +135,8 @@ API response types in the frontend (`src/lib/api.ts`) mirror Go structs in `inte
 
 ### SSE Events
 
-The SSE hook in `src/lib/use-sse.ts` subscribes to `/api/events`:
+The SSE hook in `src/lib/use-sse.ts` takes a `RepoRef` and subscribes to
+`/api/v1/repos/{owner}/{repo}/events`:
 
 | Event Type | Trigger |
 |------------|---------|
@@ -243,10 +251,35 @@ src/components/status/__tests__/status-badge.test.tsx
 2. For component styles: use Tailwind utility classes
 3. For new animations: add `@keyframes` in `globals.css`, use via Tailwind `animate-*` class
 
-### Add a New Page
+### Routing (single SPA shell)
 
-Next.js App Router: create `src/app/<route>/page.tsx`. The static export will generate `<route>/index.html`.
+The app is a single client-rendered shell, not per-route pages. `output: "export"`
+emits one `index.html` from an optional catch-all route, `src/app/[[...slug]]/page.tsx`
+(a server component that exports `generateStaticParams` returning `[{ slug: [] }]`
+and renders `<AppShell>`). `AppShell` (`src/components/app-shell.tsx`) reads
+`usePathname()` and dispatches: an empty path shows the repo picker; `/{owner}/{repo}`
+mounts `RepoProvider` + `RepoView`. Deep links work on hard refresh because the Go
+server serves the same `index.html` for extension-less paths (SPA fallback in
+`internal/api/static.go`).
+
+To add a genuinely separate page you would add another route folder, but prefer
+extending the path scheme parsed in `src/lib/repo-route.ts`.
 
 ### Branch Selection & URL State
 
-Selection state is tracked via URL params (`?branch=name` or `?stack=rootBranch`). Update selection by changing URL params (client-side).
+URLs mirror GitHub and are the source of selection state:
+
+| Path | View |
+|------|------|
+| `/{owner}/{repo}` | Repo home, no selection |
+| `/{owner}/{repo}/tree/{branch}` | A branch (branch may contain slashes) |
+| `/{owner}/{repo}/stack/{rootBranch}` | A whole stack |
+| `/{owner}/{repo}/pull/{number}` | A PR, resolved client-side to its branch |
+
+`src/lib/repo-route.ts` is the single place that parses and builds these paths
+(`parseRepoPath` / `buildRepoPath`), encoding branch/stack names per-segment so
+slashes stay as separators. `useUrlSelection` (`src/hooks/use-url-selection.ts`)
+reads the initial selection from the path and updates it with
+`history.replaceState` (no history entry per in-repo selection, matching the
+prior behavior). A `pull` selection has no branch until the view loads; the hook
+resolves it to the branch carrying that PR number.

--- a/internal/api/static.go
+++ b/internal/api/static.go
@@ -23,6 +23,21 @@ var fallbackIndexHTML = []byte(`<!doctype html>
 </html>
 `)
 
+// assetExts are the file extensions of real static build output (Next's hashed
+// JS/CSS/media under _next/, plus root icons and manifests). A request whose
+// path ends in one of these but isn't on disk is a stale or missing asset and
+// must 404 — serving index.html for a <script>/<link>/<img> surfaces as a
+// confusing "unexpected token '<'" (or a silently broken asset) in the browser.
+// Any other dotted path is a client route (e.g. a branch named "v1.2.0") and
+// falls through to the SPA shell.
+var assetExts = map[string]bool{
+	".js": true, ".mjs": true, ".css": true, ".map": true, ".json": true,
+	".ico": true, ".png": true, ".jpg": true, ".jpeg": true, ".gif": true,
+	".svg": true, ".webp": true, ".avif": true, ".woff": true, ".woff2": true,
+	".ttf": true, ".otf": true, ".eot": true, ".txt": true, ".xml": true,
+	".wasm": true, ".webmanifest": true,
+}
+
 func newStaticHandler(staticFS fs.FS) http.Handler {
 	indexHTML := fallbackIndexHTML
 	var fileServer http.Handler
@@ -55,9 +70,12 @@ func newStaticHandler(staticFS fs.FS) http.Handler {
 			}
 		}
 
-		// Return 404 for unknown files with extensions, but fallback to SPA index
-		// for extension-less client routes (e.g. /stacks/main).
-		if path.Ext(cleanPath) != "" {
+		// Not on disk: a missing static asset 404s, but every other unknown path
+		// is a client-side route and gets the SPA shell. We key this on a known
+		// set of asset extensions rather than "has any extension", because branch
+		// routes carry dots too — /{owner}/{repo}/tree/release/v1.2.0 ends in
+		// ".0", which must not be mistaken for a file and 404'd (see assetExts).
+		if assetExts[strings.ToLower(path.Ext(cleanPath))] {
 			http.NotFound(w, r)
 			return
 		}

--- a/internal/api/static_test.go
+++ b/internal/api/static_test.go
@@ -85,6 +85,29 @@ func TestStaticHandler(t *testing.T) {
 		}
 	})
 
+	// Branch names routinely contain dots (v1.2.0, 2026.01, fix.bug). Their URLs
+	// must serve the SPA shell on a cold load, not 404 as if the trailing ".0"
+	// were a missing asset — that would break deep links to dotted branches,
+	// which is the whole point of the path-URL scheme.
+	t.Run("falls back to index for dotted branch routes", func(t *testing.T) {
+		for _, p := range []string{
+			"/octo/widget/tree/release/v1.2.0",
+			"/octo/widget/tree/2026.01",
+			"/octo/widget/stack/fix.bug",
+		} {
+			req := httptest.NewRequest(http.MethodGet, p, nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("%s: want 200, got %d", p, rr.Code)
+			}
+			if !strings.Contains(rr.Body.String(), "index") {
+				t.Fatalf("%s: unexpected body: %q", p, rr.Body.String())
+			}
+		}
+	})
+
 	t.Run("nil fs serves fallback placeholder", func(t *testing.T) {
 		var nilFS fs.FS
 		handler := newStaticHandler(nilFS)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Move the web app off ?repo=/?branch= query params to path-based URLs that
mirror GitHub:

  /{owner}/{repo}                     repo home
  /{owner}/{repo}/tree/{branch}       a branch
  /{owner}/{repo}/stack/{rootBranch}  a whole stack
  /{owner}/{repo}/pull/{number}       a PR (resolved client-side to its branch)

The single static page becomes an optional catch-all ([[...slug]]) that
renders one SPA shell; the Go server already serves index.html for deep
links on refresh. New lib/repo-route.ts is the single parser/builder for
these paths, encoding branch/stack names per-segment so slashes stay
separators. The API client and SSE hook now take a RepoRef ({owner,
repo}) and call the /repos/{owner}/{repo}/... routes; RepoProvider takes
owner/repo props and exposes repoRef via useRepo().

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782266218`.


* **PR #1313**
  * **PR #1314**
    * **PR #1315**
      * **PR #1316**
        * **PR #1317**
          * **PR #1318**
            * **PR #1319**
              * **PR #1320**
                * **PR #1322**
                  * **PR #1323**
                    * **PR #1324** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1326 by jonnii*