### PR TITLE
refactor: eliminate duplicated filter loops in AnalysisResult

### DIFF
--- a/internal/shippable/types.go
+++ b/internal/shippable/types.go
@@ -117,49 +117,27 @@ type AnalysisResult struct {
 	IncompleteCount int     // Number of incomplete stacks
 }
 
-// GetShippable returns only the stacks that are ready to ship.
-func (r *AnalysisResult) GetShippable() []Stack {
+func (r *AnalysisResult) filterByStatus(status Status) []Stack {
 	var result []Stack
 	for _, s := range r.Stacks {
-		if s.IsShippable() {
+		if s.Status == status {
 			result = append(result, s)
 		}
 	}
 	return result
 }
+
+// GetShippable returns only the stacks that are ready to ship.
+func (r *AnalysisResult) GetShippable() []Stack { return r.filterByStatus(StatusShippable) }
 
 // GetPending returns only the stacks that are pending.
-func (r *AnalysisResult) GetPending() []Stack {
-	var result []Stack
-	for _, s := range r.Stacks {
-		if s.IsPending() {
-			result = append(result, s)
-		}
-	}
-	return result
-}
+func (r *AnalysisResult) GetPending() []Stack { return r.filterByStatus(StatusPending) }
 
 // GetBlocked returns only the stacks that are blocked.
-func (r *AnalysisResult) GetBlocked() []Stack {
-	var result []Stack
-	for _, s := range r.Stacks {
-		if s.IsBlocked() {
-			result = append(result, s)
-		}
-	}
-	return result
-}
+func (r *AnalysisResult) GetBlocked() []Stack { return r.filterByStatus(StatusBlocked) }
 
 // GetIncomplete returns only the stacks that are incomplete.
-func (r *AnalysisResult) GetIncomplete() []Stack {
-	var result []Stack
-	for _, s := range r.Stacks {
-		if s.IsIncomplete() {
-			result = append(result, s)
-		}
-	}
-	return result
-}
+func (r *AnalysisResult) GetIncomplete() []Stack { return r.filterByStatus(StatusIncomplete) }
 
 // HasShippable returns true if there are any shippable stacks.
 func (r *AnalysisResult) HasShippable() bool {


### PR DESCRIPTION
## Summary

- Extract a private `filterByStatus(status Status) []Stack` helper on `AnalysisResult`
- Replace four identical filter loops in `GetShippable`, `GetPending`, `GetBlocked`, and `GetIncomplete` with single-line delegations to the helper

The four public methods had structurally identical loop bodies — only the status value differed. The loop now lives in one place; adding a new status filter in the future is a one-liner.

## Test plan

- [ ] Existing tests in `internal/shippable/types_test.go` cover all four filter methods — no behavior change, all pass unchanged
- [ ] `go test ./internal/shippable/...` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkwUL2iiWRFdBa4DeqsMVc)_