### PR TITLE
fix(api): accept form-urlencoded webhook deliveries

### DIFF
--- a/internal/api/githubwebhook/githubwebhook.go
+++ b/internal/api/githubwebhook/githubwebhook.go
@@ -5,10 +5,12 @@
 package githubwebhook
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"net/url"
 	"strings"
 )
 
@@ -67,7 +69,7 @@ type pushPayload struct {
 // recognizable push payload, so the caller can ignore it without erroring.
 func ParsePush(body []byte) (owner, name string, ok bool) {
 	var p pushPayload
-	if err := json.Unmarshal(body, &p); err != nil {
+	if err := json.Unmarshal(normalizePushBody(body), &p); err != nil {
 		return "", "", false
 	}
 
@@ -92,4 +94,29 @@ func ParsePush(body []byte) (owner, name string, ok bool) {
 		return "", "", false
 	}
 	return owner, name, true
+}
+
+// normalizePushBody returns the JSON document from a webhook body, tolerating
+// both content types a GitHub webhook can be configured to send:
+//
+//   - application/json — the body already is the JSON document.
+//   - application/x-www-form-urlencoded — GitHub sends "payload=<url-encoded
+//     JSON>" instead, and a receiver that only json.Unmarshal's the raw body
+//     silently fails to find the repository (the cause of "push had no
+//     repository in payload").
+//
+// The HMAC signature is computed over the raw delivered bytes either way, so
+// Verify is unaffected; only the bytes we hand to the JSON parser need
+// unwrapping. Detection is by the "payload=" prefix — a JSON body always starts
+// with "{", so the two never collide.
+func normalizePushBody(body []byte) []byte {
+	const formPrefix = "payload="
+	if !bytes.HasPrefix(body, []byte(formPrefix)) {
+		return body
+	}
+	decoded, err := url.QueryUnescape(string(body[len(formPrefix):]))
+	if err != nil {
+		return body
+	}
+	return []byte(decoded)
 }

--- a/internal/api/githubwebhook/githubwebhook_test.go
+++ b/internal/api/githubwebhook/githubwebhook_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -87,6 +88,15 @@ func TestParsePush(t *testing.T) {
 			name:   "invalid json",
 			body:   `not json`,
 			wantOK: false,
+		},
+		{
+			// application/x-www-form-urlencoded delivery: GitHub wraps the JSON
+			// in a url-encoded "payload" field. Must parse the same as raw JSON.
+			name:      "form-urlencoded payload",
+			body:      "payload=" + url.QueryEscape(`{"repository":{"name":"widget","full_name":"octo/widget","owner":{"login":"octo"}}}`),
+			wantOwner: "octo",
+			wantName:  "widget",
+			wantOK:    true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION

A GitHub webhook configured with content type
application/x-www-form-urlencoded sends "payload=<url-encoded JSON>"
rather than a raw JSON body. The HMAC signature is over the raw bytes
either way, so the delivery verifies — but json.Unmarshal of the form
body fails, so ParsePush returned no repository and the push was
ignored ("webhook: push had no repository in payload"), silently
dropping the refresh.

Unwrap the payload field when the body is form-encoded (detected by the
"payload=" prefix, which raw JSON never has) so both content types
resolve the same coordinates.