### PR TITLE
feat(api): debounce webhook-triggered syncs

### DIFF
--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -65,19 +65,20 @@ func setupLogging(jsonOutput bool) {
 
 func run() error {
 	var (
-		port          = flag.Int("port", 8080, "Port to listen on")
-		bind          = flag.String("bind", "", "Interface to bind on. Defaults to 127.0.0.1 (loopback); STACKIT_ENV=production binds 0.0.0.0.")
-		cwd           = flag.String("cwd", "", "Working directory for repository detection (single-repo shortcut; ignored when -database-url is set)")
-		databaseURL   = flag.String("database-url", os.Getenv("STACKIT_DATABASE_URL"), "PostgreSQL connection string. When set, repos are served from the DB instead of the -cwd single-repo shortcut.")
-		reposRoot     = flag.String("repos-root", os.Getenv("STACKIT_REPOS_ROOT"), "Base directory under which per-repo checkouts live (<reposRoot>/<owner>/<name>) for DB-sourced repos.")
-		remote        = flag.String("remote", "origin", "Default git remote name for the single-repo -cwd shortcut")
-		corsOrigins   = flag.String("cors", "http://localhost:3000,http://localhost:5173", "Comma-separated allowed CORS origins")
-		apiPrefix     = flag.String("api-prefix", "/api/v1", "Canonical API prefix")
-		enableLegacy  = flag.Bool("legacy-api-prefix", true, "Also expose legacy /api endpoints")
-		shutdownGrace = flag.Duration("shutdown-timeout", 10*time.Second, "Graceful shutdown timeout")
-		authDisabled  = flag.Bool("auth-disabled", false, "Disable GitHub OAuth gate. Refused when the server binds a non-loopback interface (e.g. STACKIT_ENV=production) unless -read-only is set.")
-		readOnly      = flag.Bool("read-only", envBool("STACKIT_READ_ONLY"), "Serve in read-only mode: the submit endpoint is disabled so the repo can be exposed publicly without write access. Also set via STACKIT_READ_ONLY.")
-		syncInterval  = flag.Duration("sync-interval", envSyncInterval(), "How often to mirror-fetch managed repos from their remotes so served state stays current. Defaults to 5m (the webhook backstop); 0 disables the loop. Also set via STACKIT_SYNC_INTERVAL (e.g. 60s).")
+		port            = flag.Int("port", 8080, "Port to listen on")
+		bind            = flag.String("bind", "", "Interface to bind on. Defaults to 127.0.0.1 (loopback); STACKIT_ENV=production binds 0.0.0.0.")
+		cwd             = flag.String("cwd", "", "Working directory for repository detection (single-repo shortcut; ignored when -database-url is set)")
+		databaseURL     = flag.String("database-url", os.Getenv("STACKIT_DATABASE_URL"), "PostgreSQL connection string. When set, repos are served from the DB instead of the -cwd single-repo shortcut.")
+		reposRoot       = flag.String("repos-root", os.Getenv("STACKIT_REPOS_ROOT"), "Base directory under which per-repo checkouts live (<reposRoot>/<owner>/<name>) for DB-sourced repos.")
+		remote          = flag.String("remote", "origin", "Default git remote name for the single-repo -cwd shortcut")
+		corsOrigins     = flag.String("cors", "http://localhost:3000,http://localhost:5173", "Comma-separated allowed CORS origins")
+		apiPrefix       = flag.String("api-prefix", "/api/v1", "Canonical API prefix")
+		enableLegacy    = flag.Bool("legacy-api-prefix", true, "Also expose legacy /api endpoints")
+		shutdownGrace   = flag.Duration("shutdown-timeout", 10*time.Second, "Graceful shutdown timeout")
+		authDisabled    = flag.Bool("auth-disabled", false, "Disable GitHub OAuth gate. Refused when the server binds a non-loopback interface (e.g. STACKIT_ENV=production) unless -read-only is set.")
+		readOnly        = flag.Bool("read-only", envBool("STACKIT_READ_ONLY"), "Serve in read-only mode: the submit endpoint is disabled so the repo can be exposed publicly without write access. Also set via STACKIT_READ_ONLY.")
+		syncInterval    = flag.Duration("sync-interval", envSyncInterval(), "How often to mirror-fetch managed repos from their remotes so served state stays current. Defaults to 5m (the webhook backstop); 0 disables the loop. Also set via STACKIT_SYNC_INTERVAL (e.g. 60s).")
+		webhookDebounce = flag.Duration("webhook-debounce", envWebhookDebounce(), "Quiet window a repo's webhook pushes wait out before a fetch, so a stack submit's burst of pushes collapses into one refresh. Defaults to 2s; 0 dispatches immediately. Also set via STACKIT_WEBHOOK_DEBOUNCE (e.g. 5s).")
 	)
 	flag.Parse()
 
@@ -239,6 +240,7 @@ func run() error {
 		ReposRoot:           absReposRoot,
 		RepoSyncTokens:      appProvider,
 		SyncInterval:        *syncInterval,
+		WebhookDebounce:     *webhookDebounce,
 		GitHubWebhookSecret: strings.TrimSpace(os.Getenv("STACKIT_GITHUB_WEBHOOK_SECRET")),
 	})
 
@@ -313,6 +315,26 @@ func envSyncInterval() time.Duration {
 	d, err := time.ParseDuration(raw)
 	if err != nil {
 		return defaultSyncInterval
+	}
+	return d
+}
+
+// defaultWebhookDebounce is the quiet window webhook-triggered fetches wait out
+// when STACKIT_WEBHOOK_DEBOUNCE is unset, collapsing a stack submit's burst of
+// pushes into a single refresh.
+const defaultWebhookDebounce = 2 * time.Second
+
+// envWebhookDebounce resolves the webhook-debounce default: STACKIT_WEBHOOK_DEBOUNCE
+// when set ("0" dispatches immediately), otherwise defaultWebhookDebounce. An
+// unparseable value falls back to the default.
+func envWebhookDebounce() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("STACKIT_WEBHOOK_DEBOUNCE"))
+	if raw == "" {
+		return defaultWebhookDebounce
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return defaultWebhookDebounce
 	}
 	return d
 }

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -64,6 +64,7 @@ with every authenticated user.
 | `STACKIT_GITHUB_APP_PRIVATE_KEY` / `_FILE` | GitHub App private key (PEM contents, or a path in the `_FILE` variant). |
 | `STACKIT_GITHUB_WEBHOOK_SECRET` | Shared secret GitHub signs webhook deliveries with. Set it to enable the [webhook receiver](#evented-refresh-webhooks) for immediate, push-driven refreshes; unset leaves the endpoint disabled (404). |
 | `STACKIT_SYNC_INTERVAL` | How often to mirror-fetch managed repos (e.g. `60s`); defaults to `5m`, `0` disables the sync loop. Equivalent to `-sync-interval`. See [GitHub App & background sync](#github-app--background-sync). |
+| `STACKIT_WEBHOOK_DEBOUNCE` | Quiet window a repo's webhook pushes wait out before a fetch, so a stack submit's burst of branch pushes collapses into one refresh (e.g. `5s`); defaults to `2s`, `0` dispatches immediately. Equivalent to `-webhook-debounce`. |
 | `STACKIT_BASE_URL` | The canonical https:// URL the server is reachable at. Required when auth is enabled (used to build the OAuth callback URL). |
 | `STACKIT_GITHUB_CLIENT_ID` | GitHub OAuth App client ID. |
 | `STACKIT_GITHUB_CLIENT_SECRET` | GitHub OAuth App client secret. |
@@ -80,6 +81,7 @@ The most useful flags:
 | `-database-url` | _(empty)_ | PostgreSQL connection string. Enables DB-backed multi-repo serving and runtime [onboarding](#repository-onboarding). Also settable via `STACKIT_DATABASE_URL`. |
 | `-repos-root` | _(empty)_ | Base directory for per-repo checkouts (`<root>/<owner>/<name>`). Required with `-database-url` and for onboarding. Also settable via `STACKIT_REPOS_ROOT`. |
 | `-sync-interval` | `5m` | How often to mirror-fetch managed repos so served state stays current; `0` disables. Also settable via `STACKIT_SYNC_INTERVAL`. See [GitHub App & background sync](#github-app--background-sync). |
+| `-webhook-debounce` | `2s` | Quiet window a repo's webhook pushes wait out before a fetch, collapsing a stack submit's burst into one refresh; `0` dispatches immediately. Also settable via `STACKIT_WEBHOOK_DEBOUNCE`. |
 | `-cwd` | _(empty)_ | Single-repo shortcut: serve the repo discovered from this path as `default`. Ignored when `-database-url` is set. |
 | `-port` | `8080` | Listen port; overrides `$PORT`. |
 | `-bind` | `127.0.0.1` (or `0.0.0.0` when `STACKIT_ENV=production`) | Interface to bind on. Pass `-bind 0.0.0.0` explicitly to expose the server without setting `STACKIT_ENV=production`. Binding a non-loopback interface requires auth or `-read-only`. |
@@ -271,7 +273,10 @@ point a GitHub webhook at the server:
    read-side operation).
 3. On a verified push the server resolves the repo, mirror-fetches it, and
    refreshes — acking GitHub immediately and doing the fetch in the background.
-   A burst of pushes for one repo coalesces into a single fetch.
+   Pushes for one repo are **debounced** (`-webhook-debounce`, default `2s`) and
+   coalesced, so a stack submit's burst of branch pushes settles into a single
+   fetch rather than one per branch. The receiver accepts both webhook content
+   types (`application/json` and `application/x-www-form-urlencoded`).
 
 **Verifying a delivery in the logs.** A push you can trace end to end produces:
 

--- a/internal/api/reposync/coalescer.go
+++ b/internal/api/reposync/coalescer.go
@@ -12,45 +12,66 @@ import (
 // pin a goroutine indefinitely.
 const defaultSyncTimeout = 2 * time.Minute
 
+// defaultDebounce is the quiet window a repo's triggers wait out before syncing.
+// Submitting a stack pushes its branches in quick succession, each firing a
+// webhook; debouncing collapses that sequence into a single fetch once the
+// pushes settle, instead of one fetch per branch.
+const defaultDebounce = 2 * time.Second
+
 // SyncFunc mirror-fetches and refreshes one repo by its GitHub coordinates.
 // (*Syncer).SyncRepo satisfies it.
 type SyncFunc func(ctx context.Context, owner, name string) error
 
-// Coalescer collapses repeated sync triggers for the same repo. At most one
-// sync runs per repo at a time; triggers that arrive while one is in flight set
-// a single pending flag, so a burst of pushes for a repo yields one extra sync
-// afterward rather than a fetch per delivery. This bounds live goroutines to the
+// Coalescer debounces and collapses repeated sync triggers for the same repo.
+// A trigger (re)arms a per-repo timer; the sync runs only after the timer's
+// quiet window elapses with no newer trigger, so a burst of pushes — e.g. a
+// whole stack submit — yields a single fetch once they settle. At most one sync
+// runs per repo at a time; a trigger that lands while one is in flight sets a
+// pending flag for exactly one follow-up. This bounds live goroutines to the
 // number of distinct repos seeing traffic and keeps git subprocesses in check —
 // the webhook receiver can hand off every delivery without fanning out.
 type Coalescer struct {
-	sync    SyncFunc
-	timeout time.Duration
+	sync     SyncFunc
+	timeout  time.Duration
+	debounce time.Duration
 
 	mu    sync.Mutex
 	state map[string]*repoSync
 }
 
-// repoSync tracks the in-flight/pending status for one repo key.
+// repoSync tracks the debounce timer and in-flight/pending status for one repo
+// key. gen disambiguates a just-fired timer from a fresher one re-armed by a
+// trigger that raced it, so at most one run() proceeds per key.
 type repoSync struct {
 	running bool
 	pending bool
+	gen     uint64
+	timer   *time.Timer
 }
 
-// NewCoalescer wraps sync. A non-positive timeout uses defaultSyncTimeout.
-func NewCoalescer(sync SyncFunc, timeout time.Duration) *Coalescer {
+// NewCoalescer wraps sync. A non-positive timeout uses defaultSyncTimeout; a
+// negative debounce uses defaultDebounce, while a zero debounce dispatches
+// immediately (no quiet window).
+func NewCoalescer(sync SyncFunc, timeout, debounce time.Duration) *Coalescer {
 	if timeout <= 0 {
 		timeout = defaultSyncTimeout
 	}
-	return &Coalescer{sync: sync, timeout: timeout, state: make(map[string]*repoSync)}
+	if debounce < 0 {
+		debounce = defaultDebounce
+	}
+	return &Coalescer{sync: sync, timeout: timeout, debounce: debounce, state: make(map[string]*repoSync)}
 }
 
 // Trigger requests a sync for owner/name and returns immediately. It is safe for
-// concurrent use; repeated calls while a sync for the repo is in flight coalesce
-// into a single follow-up run.
+// concurrent use. The sync is debounced: a burst of triggers keeps bumping the
+// timer out and collapses into one run once the quiet window elapses; triggers
+// that land while a sync is already running coalesce into a single follow-up.
 func (c *Coalescer) Trigger(owner, name string) {
 	key := owner + "/" + name
 
 	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	st := c.state[key]
 	if st == nil {
 		st = &repoSync{}
@@ -61,17 +82,35 @@ func (c *Coalescer) Trigger(owner, name string) {
 		// hasn't been synced yet. Any number of triggers in this window collapse
 		// to one follow-up.
 		st.pending = true
+		return
+	}
+
+	// (Re)arm the debounce timer. Bumping gen and stopping any prior timer means
+	// a timer that already fired (its run() not yet past the lock) sees a stale
+	// gen and bows out, so only the latest timer's run() proceeds.
+	st.gen++
+	gen := st.gen
+	if st.timer != nil {
+		st.timer.Stop()
+	}
+	st.timer = time.AfterFunc(c.debounce, func() { c.run(key, owner, name, gen) })
+}
+
+// run executes syncs for key until no trigger arrived during the last run. It
+// is the debounce timer's callback; gen guards against a superseded timer.
+func (c *Coalescer) run(key, owner, name string, gen uint64) {
+	c.mu.Lock()
+	st := c.state[key]
+	if st == nil || st.gen != gen || st.running {
+		// A newer trigger re-armed the timer (and will fire its own run), or a
+		// run is already active for this key. This fire is stale; drop it.
 		c.mu.Unlock()
 		return
 	}
 	st.running = true
+	st.timer = nil
 	c.mu.Unlock()
 
-	go c.drain(key, owner, name)
-}
-
-// drain runs syncs for key until no trigger arrived during the last run.
-func (c *Coalescer) drain(key, owner, name string) {
 	for {
 		ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 		err := c.sync(ctx, owner, name)

--- a/internal/api/reposync/coalescer_test.go
+++ b/internal/api/reposync/coalescer_test.go
@@ -18,7 +18,7 @@ func TestCoalescerSingleTriggerRunsOnce(t *testing.T) {
 		calls++
 		mu.Unlock()
 		return nil
-	}, time.Minute)
+	}, time.Minute, 0)
 
 	c.Trigger("o", "r")
 	require.Eventually(t, func() bool {
@@ -45,7 +45,7 @@ func TestCoalescerCollapsesBurstForSameRepo(t *testing.T) {
 			<-release // hold the first sync so the burst lands while it runs
 		}
 		return nil
-	}, time.Minute)
+	}, time.Minute, 0)
 
 	c.Trigger("o", "r")
 	<-started // first sync is now in flight
@@ -75,6 +75,38 @@ func TestCoalescerCollapsesBurstForSameRepo(t *testing.T) {
 	mu.Unlock()
 }
 
+func TestCoalescerDebouncesBurstIntoOneSync(t *testing.T) {
+	t.Parallel()
+	var mu sync.Mutex
+	calls := 0
+	c := NewCoalescer(func(context.Context, string, string) error {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		return nil
+	}, time.Minute, 60*time.Millisecond)
+
+	// A stack submit's pushes arrive in quick succession. Each trigger lands
+	// inside the debounce window and re-arms the timer, so the whole burst
+	// collapses into a single sync once the pushes settle.
+	for range 5 {
+		c.Trigger("o", "r")
+		time.Sleep(10 * time.Millisecond) // 10ms < 60ms debounce
+	}
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return calls == 1
+	}, 2*time.Second, 5*time.Millisecond)
+
+	// Give any stray timer ample time to fire; the count must stay at one.
+	time.Sleep(150 * time.Millisecond)
+	mu.Lock()
+	require.Equal(t, 1, calls, "debounced burst must collapse to a single sync")
+	mu.Unlock()
+}
+
 func TestCoalescerRunsDistinctReposConcurrently(t *testing.T) {
 	t.Parallel()
 	started := make(chan string, 2)
@@ -84,7 +116,7 @@ func TestCoalescerRunsDistinctReposConcurrently(t *testing.T) {
 		started <- owner
 		<-release // block until both have started, proving they run in parallel
 		return nil
-	}, time.Minute)
+	}, time.Minute, 0)
 
 	c.Trigger("a", "r")
 	c.Trigger("b", "r")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -91,6 +91,12 @@ type ServerConfig struct {
 	// stays as a backstop). Empty disables the endpoint (it 404s), which is the
 	// correct posture for local/dev servers GitHub can't reach.
 	GitHubWebhookSecret string
+
+	// WebhookDebounce is the quiet window a repo's webhook triggers wait out
+	// before a fetch runs, so a stack submit's burst of pushes collapses into a
+	// single refresh. Negative uses the package default; zero dispatches
+	// immediately.
+	WebhookDebounce time.Duration
 }
 
 // AuthConfig is the runtime auth setup. SessionStore must outlive the
@@ -137,7 +143,7 @@ func NewServer(cfg ServerConfig) *Server {
 		provider = cfg.RepoSyncTokens
 	}
 	s.syncer = reposync.New(cfg.Registry, provider, cfg.SyncInterval)
-	s.coalescer = reposync.NewCoalescer(s.syncer.SyncRepo, 0)
+	s.coalescer = reposync.NewCoalescer(s.syncer.SyncRepo, 0, cfg.WebhookDebounce)
 
 	return s
 }


### PR DESCRIPTION

Submitting a stack pushes its branches in quick succession, each firing
a webhook. The coalescer collapsed pushes that overlapped an in-flight
fetch, but a sequence spaced just beyond a fetch still produced one
fetch (and SSE refresh) per branch.

Debounce each repo, key off a per-repo timer that a trigger re-arms: the
sync runs only after a quiet window elapses with no newer push, so a
whole stack submit settles into a single fetch. A generation counter
makes a just-fired timer racing a fresh trigger a no-op, preserving the
single-flight-per-repo guarantee. Tunable via -webhook-debounce /
STACKIT_WEBHOOK_DEBOUNCE (default 2s; 0 dispatches immediately).