### PR TITLE
fix(engine): make remote metadata bootstrap explicit

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -216,7 +216,9 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[
 	deleteStatuses := make(map[string]engine.DeletionStatus) // name -> status
 	utilityBranches := make(map[string]bool)                 // branches that are utility type
 	var skippedInWorktree []string
-	remoteStatuses := eng.ReadBranchRemoteStatuses(c, allTrackedBranches.WithoutTrunk())
+	remoteCtx, cancelRemote := ctx.RemoteOperationContext()
+	remoteStatuses := eng.ReadBranchRemoteStatuses(remoteCtx, allTrackedBranches.WithoutTrunk())
+	cancelRemote()
 
 	for _, name := range candidateNames {
 		status := statuses[name]

--- a/internal/actions/debug.go
+++ b/internal/actions/debug.go
@@ -211,7 +211,12 @@ func DebugAction(ctx *app.Context, opts DebugOptions) error {
 
 	var remoteMetadataState *RemoteMetadataStateInfo
 	if opts.ShowRemote {
-		_ = eng.LoadRemoteMetadataCache()
+		remoteCtx, cancelRemote := ctx.RemoteOperationContext()
+		if err := eng.EnsureRemoteMetadata(remoteCtx); err != nil {
+			ctx.Output.Debug("Failed to fetch remote metadata: %v", err)
+			_ = eng.LoadRemoteMetadataCache()
+		}
+		cancelRemote()
 		remoteCache := eng.GetRemoteMetadataCache()
 
 		remoteRefs := make(map[string]RemoteRefInfo)

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -10,6 +10,7 @@ import (
 	"github.com/getstackit/stackit/internal/actions/validation"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/github"
 	"github.com/getstackit/stackit/internal/handlers"
 	"github.com/getstackit/stackit/internal/utils"
 )
@@ -183,7 +184,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		branchesToSync, usedMetadata = crawlAncestorsViaMetadata(eng, targetBranch, branchesToSync, parentMap, branchPRInfo)
 	}
 	if !usedMetadata {
-		branchesToSync = crawlAncestorsViaGitHub(ctx, remoteCtx, targetBranch, branchesToSync, parentMap, branchPRInfo)
+		branchesToSync = crawlAncestorsViaGitHub(remoteCtx, ctx.GitHub(), eng, targetBranch, branchesToSync, parentMap, branchPRInfo)
 	}
 
 	// If target branch exists locally, identify local descendants
@@ -480,16 +481,17 @@ func crawlAncestorsViaMetadata(eng engine.Engine, targetBranch string, branchesT
 // information. It prepends discovered ancestors to branchesToSync (trunk-first) and
 // records each branch's parent in parentMap and PR number in branchPRInfo. It is a
 // no-op when no GitHub client is configured. The (possibly grown) branchesToSync slice
-// is returned because ancestors are prepended.
-func crawlAncestorsViaGitHub(ctx *app.Context, gctx context.Context, targetBranch string, branchesToSync []string, parentMap map[string]string, branchPRInfo map[string]*int) []string {
-	if ctx.GitHub() == nil {
+// is returned because ancestors are prepended. The context bounds the GitHub reads; it
+// takes the narrow github.Client/engine.Engine it needs rather than the full app
+// context, so the unbounded command context is not reachable here by mistake.
+func crawlAncestorsViaGitHub(ctx context.Context, gh github.Client, eng engine.Engine, targetBranch string, branchesToSync []string, parentMap map[string]string, branchPRInfo map[string]*int) []string {
+	if gh == nil {
 		return branchesToSync
 	}
-	eng := ctx.Engine
-	owner, repo := ctx.GitHub().GetOwnerRepo()
+	owner, repo := gh.GetOwnerRepo()
 	current := targetBranch
 	for {
-		pr, err := ctx.GitHub().GetPullRequestByBranch(gctx, owner, repo, current)
+		pr, err := gh.GetPullRequestByBranch(ctx, owner, repo, current)
 		if err != nil || pr == nil {
 			break
 		}

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strconv"
@@ -114,6 +115,9 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		return err
 	}
 
+	remoteCtx, cancelRemote := ctx.RemoteOperationContext()
+	defer cancelRemote()
+
 	targetBranch := ""
 	var targetPRNumber *int
 	if branchOrPR == "" {
@@ -129,7 +133,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 				return fmt.Errorf("cannot resolve PR #%d: %w", prNum, err)
 			}
 			owner, repo := ctx.GitHub().GetOwnerRepo()
-			pr, err := ctx.GitHub().GetPullRequest(gctx, owner, repo, prNum)
+			pr, err := ctx.GitHub().GetPullRequest(remoteCtx, owner, repo, prNum)
 			if err != nil {
 				return fmt.Errorf("failed to get PR #%d: %w", prNum, err)
 			}
@@ -161,7 +165,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	// wildcard independent of which branch heads we request, so this single round trip
 	// brings down the entire stack's parent chain — letting us discover ancestors from
 	// local metadata instead of a serial, blocking GitHub crawl.
-	if err := eng.FetchRemote(gctx, engine.RemoteFetchRequest{
+	if err := eng.FetchRemote(remoteCtx, engine.RemoteFetchRequest{
 		Remote:          remote,
 		Branches:        []string{targetBranch},
 		IncludeMetadata: true,
@@ -179,7 +183,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 		branchesToSync, usedMetadata = crawlAncestorsViaMetadata(eng, targetBranch, branchesToSync, parentMap, branchPRInfo)
 	}
 	if !usedMetadata {
-		branchesToSync = crawlAncestorsViaGitHub(ctx, targetBranch, branchesToSync, parentMap, branchPRInfo)
+		branchesToSync = crawlAncestorsViaGitHub(ctx, remoteCtx, targetBranch, branchesToSync, parentMap, branchPRInfo)
 	}
 
 	// If target branch exists locally, identify local descendants
@@ -212,7 +216,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	}
 
 	if len(branchesToFetch) > 0 {
-		if err := eng.FetchRemote(gctx, engine.RemoteFetchRequest{
+		if err := eng.FetchRemote(remoteCtx, engine.RemoteFetchRequest{
 			Remote:   remote,
 			Branches: branchesToFetch,
 		}); err != nil {
@@ -255,7 +259,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 
 		var mu sync.Mutex
 		utils.Run(branchesToFetch, func(branchName string) {
-			if pr, err := ctx.GitHub().GetPullRequestByBranch(gctx, owner, repo, branchName); err == nil && pr != nil {
+			if pr, err := ctx.GitHub().GetPullRequestByBranch(remoteCtx, owner, repo, branchName); err == nil && pr != nil {
 				prNum := pr.Number
 				mu.Lock()
 				branchPRInfo[branchName] = &prNum
@@ -477,12 +481,11 @@ func crawlAncestorsViaMetadata(eng engine.Engine, targetBranch string, branchesT
 // records each branch's parent in parentMap and PR number in branchPRInfo. It is a
 // no-op when no GitHub client is configured. The (possibly grown) branchesToSync slice
 // is returned because ancestors are prepended.
-func crawlAncestorsViaGitHub(ctx *app.Context, targetBranch string, branchesToSync []string, parentMap map[string]string, branchPRInfo map[string]*int) []string {
+func crawlAncestorsViaGitHub(ctx *app.Context, gctx context.Context, targetBranch string, branchesToSync []string, parentMap map[string]string, branchPRInfo map[string]*int) []string {
 	if ctx.GitHub() == nil {
 		return branchesToSync
 	}
 	eng := ctx.Engine
-	gctx := ctx.Context
 	owner, repo := ctx.GitHub().GetOwnerRepo()
 	current := targetBranch
 	for {

--- a/internal/actions/info.go
+++ b/internal/actions/info.go
@@ -82,9 +82,11 @@ func InfoAction(ctx *app.Context, opts InfoOptions) error {
 		}
 
 		// For remote branches, fetch metadata to show the latest info
-		if err := eng.FetchRemoteMetadata(ctx.Context); err != nil {
+		remoteCtx, cancelRemote := ctx.RemoteOperationContext()
+		defer cancelRemote()
+		if err := eng.FetchRemoteMetadata(remoteCtx); err != nil {
 			out.Debug("Failed to fetch remote metadata: %v", err)
-		} else if err := eng.ApplyRemoteMetadataForBranches(ctx.Context, []string{branchName}); err != nil {
+		} else if err := eng.ApplyRemoteMetadataForBranches(remoteCtx, []string{branchName}); err != nil {
 			out.Debug("Failed to apply remote metadata for %s: %v", branchName, err)
 		}
 	}

--- a/internal/actions/lock/lock.go
+++ b/internal/actions/lock/lock.go
@@ -41,7 +41,9 @@ func Action(ctx *app.Context, branchName string, handler Handler) error {
 
 	// Check for unpushed commits
 	unpushedBranches := []string{}
-	remoteStatuses := eng.ReadBranchRemoteStatuses(ctx.Context, branches)
+	remoteCtx, cancelRemote := ctx.RemoteOperationContext()
+	remoteStatuses := eng.ReadBranchRemoteStatuses(remoteCtx, branches)
+	cancelRemote()
 	for _, b := range branches.WithoutTrunk() {
 		status := remoteStatuses[b.GetName()]
 		if !status.Matches() {

--- a/internal/actions/merge/helpers.go
+++ b/internal/actions/merge/helpers.go
@@ -27,7 +27,9 @@ func getMergeMethodWithPause(ctx *app.Context, githubClient github.Client, handl
 
 // calculateBaselineEstimate tries to find a branch with successful CI and use its timing as a baseline
 func calculateBaselineEstimate(ctx context.Context, plan *Plan, client github.Client, splog output.Output) time.Duration {
-	statuses, err := client.BatchGetPRChecksStatus(ctx, plan.BranchNames())
+	remoteCtx, cancelRemote := app.WithRemoteOperationTimeout(ctx)
+	defer cancelRemote()
+	statuses, err := client.BatchGetPRChecksStatus(remoteCtx, plan.BranchNames())
 	if err != nil {
 		return 0
 	}

--- a/internal/actions/merge/multistack.go
+++ b/internal/actions/merge/multistack.go
@@ -237,7 +237,9 @@ func validateBranchesMatchRemote(ctx context.Context, eng engine.Engine, stacks 
 			branchBuilder.Add(eng.GetBranch(branchName))
 		}
 	}
-	remoteStatuses := eng.ReadBranchRemoteStatuses(ctx, branchBuilder.Build())
+	remoteCtx, cancelRemote := app.WithRemoteOperationTimeout(ctx)
+	defer cancelRemote()
+	remoteStatuses := eng.ReadBranchRemoteStatuses(remoteCtx, branchBuilder.Build())
 
 	for _, stack := range stacks {
 		for _, branchName := range stack.AllBranches {

--- a/internal/actions/merge/plan.go
+++ b/internal/actions/merge/plan.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/errors"
 	"github.com/getstackit/stackit/internal/git"
@@ -275,10 +276,13 @@ func CollectMergeBranches(ctx context.Context, eng mergePlanEngine, splog output
 	// We don't strictly need allRevisions here yet, but it's good for cache
 	_, _ = eng.GetRevisions(involvedBranches)
 
+	remoteCtx, cancelRemote := app.WithRemoteOperationTimeout(ctx)
+	defer cancelRemote()
+
 	// Fetch CI statuses in batch if possible
 	var allCheckStatuses map[string]*github.CheckStatus
 	if githubClient != nil {
-		allCheckStatuses, _ = githubClient.BatchGetPRChecksStatus(ctx, allBranches)
+		allCheckStatuses, _ = githubClient.BatchGetPRChecksStatus(remoteCtx, allBranches)
 	}
 
 	statusBranchBuilder := engine.NewBranchesBuilder(len(allBranches) + 1)
@@ -287,7 +291,7 @@ func CollectMergeBranches(ctx context.Context, eng mergePlanEngine, splog output
 	}
 	statusBranchBuilder.Add(eng.Trunk())
 	statusBranches := statusBranchBuilder.Build()
-	remoteStatuses := eng.ReadBranchRemoteStatuses(ctx, statusBranches)
+	remoteStatuses := eng.ReadBranchRemoteStatuses(remoteCtx, statusBranches)
 
 	// 5. For each branch: fetch PR info, check status, CI checks in parallel
 	branchesToMerge := make([]BranchMergeInfo, len(allBranches))

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -195,8 +195,10 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	var remoteStatusCh chan engine.BranchRemoteStatuses
 	if !opts.DryRun {
 		remoteStatusCh = make(chan engine.BranchRemoteStatuses, 1)
+		remoteCtx, cancelRemote := ctx.RemoteOperationContext()
 		go func() {
-			remoteStatusCh <- eng.ReadBranchRemoteStatuses(ctx.Context, branchObjs)
+			defer cancelRemote()
+			remoteStatusCh <- eng.ReadBranchRemoteStatuses(remoteCtx, branchObjs)
 		}()
 	}
 

--- a/internal/actions/submit/submit_validation.go
+++ b/internal/actions/submit/submit_validation.go
@@ -25,9 +25,10 @@ func ValidateBranchesToSubmit(ctx *app.Context, branches []string) error {
 	if repoOwner != "" && repoName != "" {
 		// Collect updates from the callback (which may be called concurrently in the
 		// REST fallback) then write all PR info in one atomic batch.
+		remoteCtx, cancelRemote := ctx.RemoteOperationContext()
 		var mu sync.Mutex
 		updates := make(map[string]*engine.PrInfo)
-		if err := github.SyncPrInfo(ctx.Context, ctx.Git(), branches, repoOwner, repoName, func(name string, prInfo *github.PullRequestInfo) { //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
+		if err := github.SyncPrInfo(remoteCtx, ctx.Git(), branches, repoOwner, repoName, func(name string, prInfo *github.PullRequestInfo) { //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
 			branch := nav.GetBranch(name)
 
 			lockReason := engine.LockReasonNone
@@ -50,6 +51,7 @@ func ValidateBranchesToSubmit(ctx *app.Context, branches []string) error {
 			// Non-fatal, continue
 			ctx.Output.Debug("Failed to sync PR info: %v", err)
 		}
+		cancelRemote()
 		if err := pr.BatchUpsertPrInfo(ctx.Context, updates); err != nil {
 			ctx.Output.Debug("Failed to update PR info: %v", err)
 		}
@@ -101,7 +103,9 @@ func validateBaseRevisions(branches []string, eng engine.BranchStatus, ctx *app.
 				seen[parentName] = true
 				parentBranches = parentBranches.Append(eng.GetBranch(parentName))
 			}
-			remoteStatuses = eng.ReadBranchRemoteStatuses(ctx.Context, parentBranches)
+			remoteCtx, cancelRemote := ctx.RemoteOperationContext()
+			remoteStatuses = eng.ReadBranchRemoteStatuses(remoteCtx, parentBranches)
+			cancelRemote()
 			remoteRead = true
 		}
 		return remoteStatuses

--- a/internal/actions/sync/branch_sync.go
+++ b/internal/actions/sync/branch_sync.go
@@ -113,7 +113,8 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, remoteSta
 	// succeeded, UpdateBranchFromRemote does the local-only update (no network).
 	// If the batch fetch failed, fall back to the per-branch PullBranch, which
 	// re-fetches individually — preserving sync's warn-and-continue behavior
-	// rather than failing the whole sync.
+	// rather than failing the whole sync. Both paths run under the bounded
+	// remoteCtx so a single deadline governs the whole pass.
 	for _, branch := range behind {
 		// Check for context cancellation
 		if err := gctx.Err(); err != nil {
@@ -128,7 +129,7 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, remoteSta
 		if fetchErr != nil {
 			result, err = eng.PullBranch(remoteCtx, remote, branchName)
 		} else {
-			result, err = eng.UpdateBranchFromRemote(gctx, remote, branchName)
+			result, err = eng.UpdateBranchFromRemote(remoteCtx, remote, branchName)
 		}
 		ctx.Logger.Info("update branch from remote completed branch=%v durationMs=%v", branchName, time.Since(pullStart).Milliseconds())
 

--- a/internal/actions/sync/branch_sync.go
+++ b/internal/actions/sync/branch_sync.go
@@ -27,7 +27,9 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, remoteSta
 	// ls-remote overlaps the trunk fetch and GitHub call. Fall back to computing
 	// them here when the caller didn't supply them.
 	if remoteStatuses == nil {
-		remoteStatuses = eng.ReadBranchRemoteStatuses(gctx, allBranches)
+		remoteCtx, cancelRemote := ctx.RemoteOperationContext()
+		remoteStatuses = eng.ReadBranchRemoteStatuses(remoteCtx, allBranches)
+		cancelRemote()
 	}
 
 	syncStart := time.Now()
@@ -97,8 +99,10 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, remoteSta
 	// Fetch every behind branch in a single git fetch, replacing the previous
 	// N per-branch fetches (one network round trip instead of N).
 	behindNames := behind.Names()
+	remoteCtx, cancelRemote := ctx.RemoteOperationContext()
+	defer cancelRemote()
 	fetchStart := time.Now()
-	fetchErr := eng.FetchRemote(gctx, engine.RemoteFetchRequest{
+	fetchErr := eng.FetchRemote(remoteCtx, engine.RemoteFetchRequest{
 		Remote:   remote,
 		Branches: behindNames,
 	})
@@ -122,7 +126,7 @@ func syncStackBranches(ctx *app.Context, dirtyAnchors map[string]bool, remoteSta
 		var result engine.PullResult
 		var err error
 		if fetchErr != nil {
-			result, err = eng.PullBranch(gctx, remote, branchName)
+			result, err = eng.PullBranch(remoteCtx, remote, branchName)
 		} else {
 			result, err = eng.UpdateBranchFromRemote(gctx, remote, branchName)
 		}

--- a/internal/actions/sync/github_sync.go
+++ b/internal/actions/sync/github_sync.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -24,9 +25,8 @@ type GitHubSyncResult struct {
 
 // syncGitHubPRInfo fetches PR info from GitHub (network operation only)
 // This is designed to run in parallel with other network operations
-func syncGitHubPRInfo(ctx *app.Context) (*GitHubSyncResult, error) {
+func syncGitHubPRInfo(ctx *app.Context, gctx context.Context) (*GitHubSyncResult, error) {
 	nav := ctx.Navigator()
-	gctx := ctx.Context
 
 	setupStart := time.Now()
 	allBranches := nav.AllBranches()

--- a/internal/actions/sync/github_sync.go
+++ b/internal/actions/sync/github_sync.go
@@ -24,15 +24,17 @@ type GitHubSyncResult struct {
 }
 
 // syncGitHubPRInfo fetches PR info from GitHub (network operation only)
-// This is designed to run in parallel with other network operations
-func syncGitHubPRInfo(ctx *app.Context, gctx context.Context) (*GitHubSyncResult, error) {
+// This is designed to run in parallel with other network operations. The bounded
+// remoteCtx governs every network call; the app context only supplies the
+// navigator, logger, and git runner.
+func syncGitHubPRInfo(remoteCtx context.Context, ctx *app.Context) (*GitHubSyncResult, error) {
 	nav := ctx.Navigator()
 
 	setupStart := time.Now()
 	allBranches := nav.AllBranches()
 	branchNames := allBranches.Names()
 
-	repoOwner, repoName, err := nav.GetRepoInfo(gctx)
+	repoOwner, repoName, err := nav.GetRepoInfo(remoteCtx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get repository info: %w", err)
 	}
@@ -51,7 +53,7 @@ func syncGitHubPRInfo(ctx *app.Context, gctx context.Context) (*GitHubSyncResult
 
 	// Sync PR info from GitHub (this is already parallelized internally)
 	syncPrStart := time.Now()
-	if err := github.SyncPrInfo(gctx, ctx.Git(), branchNames, repoOwner, repoName, func(name string, prInfo *github.PullRequestInfo) { //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
+	if err := github.SyncPrInfo(remoteCtx, ctx.Git(), branchNames, repoOwner, repoName, func(name string, prInfo *github.PullRequestInfo) { //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
 		result.mu.Lock()
 		result.PRInfos[name] = prInfo
 		result.mu.Unlock()

--- a/internal/actions/sync/metadata_sync.go
+++ b/internal/actions/sync/metadata_sync.go
@@ -19,8 +19,10 @@ func syncRemoteMetadata(ctx *app.Context, opts *Options, handler Handler) error 
 	out := ctx.Output
 
 	// Fetch remote metadata refs
+	remoteCtx, cancelRemote := ctx.RemoteOperationContext()
+	defer cancelRemote()
 	fetchStart := time.Now()
-	if err := eng.FetchRemoteMetadata(ctx.Context); err != nil {
+	if err := eng.FetchRemoteMetadata(remoteCtx); err != nil {
 		// Non-fatal: remote may not have metadata yet
 		out.Debug("No remote metadata to fetch: %v", err)
 	}

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -105,17 +105,20 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// until later), so reading it once here is safe.
 	branchesForStatus := ctx.Navigator().AllBranches()
 
+	remoteCtx, cancelRemote := ctx.RemoteOperationContext()
+	defer cancelRemote()
+
 	parallelStart := time.Now()
 	ctx.Logger.Info("starting parallel phase")
 
-	g, _ := errgroup.WithContext(gctx)
+	g, _ := errgroup.WithContext(remoteCtx)
 
 	// Goroutine 1: Fetch trunk as a required operation, then refresh Stackit
 	// metadata refs on a best-effort basis.
 	g.Go(func() error {
 		ctx.Logger.Info("goroutine remote fetch started delayMs=%v", time.Since(parallelStart).Milliseconds())
 		fetchStart := time.Now()
-		trunkFetchErr = eng.FetchRemote(gctx, engine.RemoteFetchRequest{
+		trunkFetchErr = eng.FetchRemote(remoteCtx, engine.RemoteFetchRequest{
 			Remote:   eng.GetRemote(),
 			Branches: []string{eng.Trunk().GetName()},
 		})
@@ -126,7 +129,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		}
 
 		metadataFetchStart := time.Now()
-		metadataFetchErr = eng.FetchRemote(gctx, engine.RemoteFetchRequest{
+		metadataFetchErr = eng.FetchRemote(remoteCtx, engine.RemoteFetchRequest{
 			Remote:               eng.GetRemote(),
 			IncludeMetadata:      true,
 			IncludeStackMetadata: true,
@@ -142,7 +145,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	g.Go(func() error {
 		ctx.Logger.Info("goroutine github started delayMs=%v", time.Since(parallelStart).Milliseconds())
 		var err error
-		githubSyncResult, err = syncGitHubPRInfo(ctx)
+		githubSyncResult, err = syncGitHubPRInfo(ctx, remoteCtx)
 		githubErr = err
 		return nil
 	})
@@ -153,7 +156,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	g.Go(func() error {
 		ctx.Logger.Info("goroutine remote statuses started delayMs=%v", time.Since(parallelStart).Milliseconds())
 		statusStart := time.Now()
-		remoteStatuses = eng.ReadBranchRemoteStatuses(gctx, branchesForStatus)
+		remoteStatuses = eng.ReadBranchRemoteStatuses(remoteCtx, branchesForStatus)
 		ctx.Logger.Info("prefetch remote branch statuses completed durationMs=%v branchCount=%v", time.Since(statusStart).Milliseconds(), len(remoteStatuses))
 		return nil
 	})

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -145,7 +145,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	g.Go(func() error {
 		ctx.Logger.Info("goroutine github started delayMs=%v", time.Since(parallelStart).Milliseconds())
 		var err error
-		githubSyncResult, err = syncGitHubPRInfo(ctx, remoteCtx)
+		githubSyncResult, err = syncGitHubPRInfo(remoteCtx, ctx)
 		githubErr = err
 		return nil
 	})

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -262,7 +262,10 @@ func CreateAction(ctx *app.Context, opts CreateOptions) (*CreateResult, error) {
 	trunk := eng.Trunk()
 
 	// Check if trunk is behind remote and warn
-	if eng.ReadBranchRemoteStatuses(ctx.Context, engine.BranchesOf(trunk)).ForBranch(trunk).Behind() {
+	remoteCtx, cancelRemote := ctx.RemoteOperationContext()
+	trunkStatus := eng.ReadBranchRemoteStatuses(remoteCtx, engine.BranchesOf(trunk)).ForBranch(trunk)
+	cancelRemote()
+	if trunkStatus.Behind() {
 		out.Warn("Local %s is behind remote. Consider running 'st sync' first.", trunk.GetName())
 	}
 

--- a/internal/app/context.go
+++ b/internal/app/context.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/engine"
@@ -20,6 +21,10 @@ import (
 	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/utils"
 )
+
+// DefaultRemoteOperationTimeout bounds explicit remote operations launched by
+// commands when the parent command context does not already carry a deadline.
+const DefaultRemoteOperationTimeout = 5 * time.Minute
 
 // loggingDisabled reports whether STACKIT_NO_LOGGING is set to a truthy value.
 // Empty / unset / explicitly false-y values (0, false, ...) keep logging on,
@@ -59,6 +64,26 @@ type Context struct {
 	// Worktree context
 	InManagedWorktree bool                 // True if running from a stackit-managed worktree
 	WorktreeInfo      *engine.WorktreeInfo // Info about current worktree (nil if not in managed worktree)
+}
+
+// RemoteOperationContext returns a child context for explicit remote work. It
+// preserves an existing command deadline; otherwise it applies Stackit's
+// standard remote-operation timeout.
+func (c *Context) RemoteOperationContext() (context.Context, context.CancelFunc) {
+	return WithRemoteOperationTimeout(c.Context)
+}
+
+// WithRemoteOperationTimeout applies the default remote-operation timeout only
+// when the parent context has no deadline. The returned cancel function should
+// always be called by the caller.
+func WithRemoteOperationTimeout(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if _, ok := parent.Deadline(); ok {
+		return context.WithCancel(parent)
+	}
+	return context.WithTimeout(parent, DefaultRemoteOperationTimeout)
 }
 
 // githubLazy holds the lazy-initialization state for the GitHub client.

--- a/internal/app/context_test.go
+++ b/internal/app/context_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -55,6 +56,33 @@ func TestGitHubLazyErrorIsSharedAcrossContextCopies(t *testing.T) {
 	require.Nil(t, ctxCopy.GitHub())
 	require.ErrorIs(t, ctxCopy.GitHubError(), expectedErr)
 	require.Equal(t, 1, initCalls)
+}
+
+func TestRemoteOperationContextAddsDefaultDeadline(t *testing.T) {
+	t.Parallel()
+
+	ctx := &Context{Context: context.Background()}
+	remoteCtx, cancel := ctx.RemoteOperationContext()
+	defer cancel()
+
+	deadline, ok := remoteCtx.Deadline()
+	require.True(t, ok)
+	require.WithinDuration(t, time.Now().Add(DefaultRemoteOperationTimeout), deadline, time.Second)
+}
+
+func TestRemoteOperationContextPreservesExistingDeadline(t *testing.T) {
+	t.Parallel()
+
+	parentDeadline := time.Now().Add(30 * time.Second)
+	parent, parentCancel := context.WithDeadline(context.Background(), parentDeadline)
+	defer parentCancel()
+
+	remoteCtx, cancel := WithRemoteOperationTimeout(parent)
+	defer cancel()
+
+	deadline, ok := remoteCtx.Deadline()
+	require.True(t, ok)
+	require.Equal(t, parentDeadline, deadline)
 }
 
 type fakeGitHubClient struct{}

--- a/internal/cli/stack/merge/drain.go
+++ b/internal/cli/stack/merge/drain.go
@@ -218,7 +218,9 @@ func runMergeDrain(ctx *app.Context, opts mergeDrainOptions) error {
 
 		// Get the PR's NodeID for merge operations
 		owner, repo := ctx.GitHub().GetOwnerRepo()
-		prInfo, err := ctx.GitHub().GetPullRequest(ctx.Context, owner, repo, bottomPR.PRNumber)
+		remoteCtx, cancelRemote := ctx.RemoteOperationContext()
+		prInfo, err := ctx.GitHub().GetPullRequest(remoteCtx, owner, repo, bottomPR.PRNumber)
+		cancelRemote()
 		if err != nil {
 			return fmt.Errorf("failed to get PR #%d info: %w", bottomPR.PRNumber, err)
 		}

--- a/internal/cli/stack/merge/next.go
+++ b/internal/cli/stack/merge/next.go
@@ -145,7 +145,9 @@ func runMergeNext(ctx *app.Context, opts mergeNextOptions, postMergeHandler Post
 
 	// Get the PR's NodeID for merge operations
 	owner, repo := ctx.GitHub().GetOwnerRepo()
-	prInfo, err := ctx.GitHub().GetPullRequest(ctx.Context, owner, repo, bottomPR.PRNumber)
+	remoteCtx, cancelRemote := ctx.RemoteOperationContext()
+	prInfo, err := ctx.GitHub().GetPullRequest(remoteCtx, owner, repo, bottomPR.PRNumber)
+	cancelRemote()
 	if err != nil {
 		return fmt.Errorf("failed to get PR info: %w", err)
 	}

--- a/internal/cli/stack/merge/ship.go
+++ b/internal/cli/stack/merge/ship.go
@@ -390,7 +390,9 @@ func runMultiStackShip(ctx *app.Context, opts shipMultiStackOptions) error {
 // getPRNodeID fetches the NodeID for a PR by number
 func getPRNodeID(ctx *app.Context, prNumber int) (string, error) {
 	owner, repo := ctx.GitHub().GetOwnerRepo()
-	prInfo, err := ctx.GitHub().GetPullRequest(ctx.Context, owner, repo, prNumber)
+	remoteCtx, cancelRemote := ctx.RemoteOperationContext()
+	prInfo, err := ctx.GitHub().GetPullRequest(remoteCtx, owner, repo, prNumber)
+	cancelRemote()
 	if err != nil {
 		return "", err
 	}

--- a/internal/cli/stack/sync.go
+++ b/internal/cli/stack/sync.go
@@ -2,6 +2,7 @@
 package stack
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -56,7 +57,9 @@ If trunk cannot be fast-forwarded to match remote, overwrites trunk with the rem
 				// sync.Action, so nothing is fast-forwarded, deleted, restacked,
 				// or pushed to GitHub. This is the whole contract of --dry-run.
 				if dryRun {
-					plan := computeSyncDryRun(ctx, opts)
+					remoteCtx, cancelRemote := ctx.RemoteOperationContext()
+					plan := computeSyncDryRun(ctx, remoteCtx, opts)
+					cancelRemote()
 					if jsonOutput {
 						return renderSyncDryRunJSON(ctx.Output, plan.toResult())
 					}
@@ -142,13 +145,13 @@ func (p dryRunPlan) toResult() sync.DryRunResult {
 // or GitHub write. It intentionally reimplements a slice of sync.Action's
 // planning rather than running the action with a special handler, because a
 // dry-run is a query, not a simulation of the full interactive process.
-func computeSyncDryRun(ctx *app.Context, opts sync.Options) dryRunPlan {
+func computeSyncDryRun(ctx *app.Context, gctx context.Context, opts sync.Options) dryRunPlan {
 	eng := ctx.Engine
 	plan := dryRunPlan{restacked: opts.Restack}
 
 	// Check if trunk needs to be pulled from remote
 	trunk := eng.Trunk()
-	remoteStatus := eng.ReadBranchRemoteStatuses(ctx.Context, engine.BranchesOf(trunk)).ForBranch(trunk)
+	remoteStatus := eng.ReadBranchRemoteStatuses(gctx, engine.BranchesOf(trunk)).ForBranch(trunk)
 	if remoteStatus.Behind() {
 		plan.pullBranch = trunk.GetName()
 		plan.pullRev = shortSHA(remoteStatus.RemoteSha)

--- a/internal/cli/stack/sync.go
+++ b/internal/cli/stack/sync.go
@@ -58,7 +58,7 @@ If trunk cannot be fast-forwarded to match remote, overwrites trunk with the rem
 				// or pushed to GitHub. This is the whole contract of --dry-run.
 				if dryRun {
 					remoteCtx, cancelRemote := ctx.RemoteOperationContext()
-					plan := computeSyncDryRun(ctx, remoteCtx, opts)
+					plan := computeSyncDryRun(remoteCtx, ctx.Engine, opts)
 					cancelRemote()
 					if jsonOutput {
 						return renderSyncDryRunJSON(ctx.Output, plan.toResult())
@@ -144,14 +144,16 @@ func (p dryRunPlan) toResult() sync.DryRunResult {
 // reads PR/deletion state, but performs no fetch-and-merge, deletion, restack,
 // or GitHub write. It intentionally reimplements a slice of sync.Action's
 // planning rather than running the action with a special handler, because a
-// dry-run is a query, not a simulation of the full interactive process.
-func computeSyncDryRun(ctx *app.Context, gctx context.Context, opts sync.Options) dryRunPlan {
-	eng := ctx.Engine
+// dry-run is a query, not a simulation of the full interactive process. It takes
+// the bounded context and engine directly (not the full app context) so every
+// remote-status/deletion read shares one deadline and the unbounded command
+// context is not reachable here by mistake.
+func computeSyncDryRun(ctx context.Context, eng engine.Engine, opts sync.Options) dryRunPlan {
 	plan := dryRunPlan{restacked: opts.Restack}
 
 	// Check if trunk needs to be pulled from remote
 	trunk := eng.Trunk()
-	remoteStatus := eng.ReadBranchRemoteStatuses(gctx, engine.BranchesOf(trunk)).ForBranch(trunk)
+	remoteStatus := eng.ReadBranchRemoteStatuses(ctx, engine.BranchesOf(trunk)).ForBranch(trunk)
 	if remoteStatus.Behind() {
 		plan.pullBranch = trunk.GetName()
 		plan.pullRev = shortSHA(remoteStatus.RemoteSha)
@@ -193,7 +195,7 @@ func computeSyncDryRun(ctx *app.Context, gctx context.Context, opts sync.Options
 
 	// Batch-check deletion status for all candidates
 	if len(candidateNames) > 0 {
-		statuses, err := eng.GetDeletionStatuses(ctx.Context, candidateNames)
+		statuses, err := eng.GetDeletionStatuses(ctx, candidateNames)
 		if err == nil {
 			for _, name := range candidateNames {
 				if status, ok := statuses[name]; ok && status.SafeToDelete {
@@ -207,7 +209,7 @@ func computeSyncDryRun(ctx *app.Context, gctx context.Context, opts sync.Options
 	managedWorktrees, err := eng.ListManagedWorktrees()
 	if err == nil {
 		for _, wt := range managedWorktrees {
-			if hasChanges, _ := eng.WorktreeHasUncommittedChanges(ctx.Context, wt.Path); hasChanges {
+			if hasChanges, _ := eng.WorktreeHasUncommittedChanges(ctx, wt.Path); hasChanges {
 				plan.skipped = append(plan.skipped, wt.AnchorBranch)
 			}
 		}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -144,6 +144,7 @@ type RemoteFetchRequest struct {
 // RemoteFetcher provides batched remote fetch operations.
 type RemoteFetcher interface {
 	FetchRemote(ctx context.Context, req RemoteFetchRequest) error
+	EnsureRemoteMetadata(ctx context.Context) error
 }
 
 // ApplySplitOptions contains options for applying a split

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -119,8 +119,8 @@ type WorktreeEngineOptions struct {
 }
 
 // NewEngineForWorktree creates an engine for a worktree session using a snapshot
-// from the parent engine. This skips rebuildInternal and maybeAutoFetchRemoteMetadata
-// since worktrees share .git with the parent and the metadata is identical.
+// from the parent engine. This skips rebuildInternal since worktrees share .git
+// with the parent and the metadata is identical.
 func NewEngineForWorktree(opts WorktreeEngineOptions) (Engine, error) {
 	g := git.NewRunnerWithPath(opts.WorktreePath, nil)
 
@@ -221,10 +221,6 @@ func NewEngine(opts Options) (Engine, error) {
 			return nil, fmt.Errorf("failed to rebuild engine: %w", err)
 		}
 	}
-
-	// Auto-fetch remote metadata on first use (fresh clone scenario)
-	// Skip if refspec is already configured to avoid unnecessary work
-	e.maybeAutoFetchRemoteMetadata()
 
 	return e, nil
 }
@@ -328,40 +324,6 @@ func (e *engineImpl) ensureLocalLoaded() {
 
 		e.localLoaded.Store(true)
 	})
-}
-
-// maybeAutoFetchRemoteMetadata fetches remote metadata if this appears to be a fresh clone
-func (e *engineImpl) maybeAutoFetchRemoteMetadata() {
-	// Fast path: Check if refspec is already configured (most common case)
-	// This avoids expensive git config reads and network fetches for normal operations
-	remote := e.GetRemote()
-	refspecs, err := e.git.GetConfigAll(fmt.Sprintf("remote.%s.fetch", remote))
-	if err == nil {
-		metadataRefspec := "+refs/stackit/metadata/*:refs/stackit/remote-metadata/*"
-		if slices.Contains(refspecs, metadataRefspec) {
-			// Already configured, nothing to do - this is the fast path
-			// Skip loading remote metadata cache here - it's not needed for most commands
-			// and will be loaded lazily when actually needed (e.g., during sync operations)
-			return
-		}
-	}
-
-	// Not configured yet - this might be a fresh clone
-	// Try to fetch metadata refs (this is a network operation, so it's slow)
-	// Only do this if refspec isn't configured to avoid slowing down every command
-	if err := e.FetchRemote(context.Background(), RemoteFetchRequest{
-		Remote:          remote,
-		IncludeMetadata: true,
-	}); err != nil {
-		// No remote metadata available, or error fetching - that's okay
-		return
-	}
-
-	// Configure refspec for future fetches
-	_ = e.git.EnsureMetadataRefspecConfigured()
-
-	// Load remote metadata cache (only if we just fetched)
-	_ = e.LoadRemoteMetadataCache()
 }
 
 // Reset clears all branch metadata and rebuilds with new trunk

--- a/internal/engine/engine_loadmode_test.go
+++ b/internal/engine/engine_loadmode_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -43,6 +44,53 @@ func newEngineWithMode(t *testing.T, repoRoot string, mode engine.LoadMode) engi
 	})
 	require.NoError(t, err)
 	return eng
+}
+
+func TestNewEngineDoesNotFetchRemoteMetadata(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewRemoteScenario(t)
+
+	s.CreateBranch("feature").Commit("feature")
+	require.NoError(t, s.Engine.TrackBranch(context.Background(), "feature", "main"))
+	require.NoError(t, s.Scene.Repo.PushBranch("origin", "feature"))
+	require.NoError(t, s.Scene.Repo.RunGitCommand("push", "origin", "refs/stackit/metadata/feature"))
+	require.NoError(t, s.Scene.Repo.RunGitCommand("update-ref", "-d", "refs/stackit/remote-metadata/feature"))
+
+	eng, err := engine.NewEngine(engine.Options{
+		RepoRoot: s.Scene.Dir,
+		Trunk:    "main",
+		LoadMode: engine.LoadModeShared,
+	})
+	require.NoError(t, err)
+
+	const metadataRefspec = "+refs/stackit/metadata/*:refs/stackit/remote-metadata/*"
+	refspecs, err := eng.Git().GetConfigAll("remote.origin.fetch")
+	require.NoError(t, err)
+	require.NotContains(t, refspecs, metadataRefspec)
+
+	_, err = s.Scene.Repo.RunGitCommandAndGetOutput("rev-parse", "--verify", "refs/stackit/remote-metadata/feature")
+	require.Error(t, err, "engine construction must not fetch remote metadata")
+
+	deadlineCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, eng.EnsureRemoteMetadata(deadlineCtx))
+
+	refspecs, err = eng.Git().GetConfigAll("remote.origin.fetch")
+	require.NoError(t, err)
+	require.Contains(t, refspecs, metadataRefspec)
+
+	remoteMetadataSHA, err := s.Scene.Repo.RunGitCommandAndGetOutput("rev-parse", "--verify", "refs/stackit/remote-metadata/feature")
+	require.NoError(t, err)
+	require.NotEmpty(t, remoteMetadataSHA)
+	require.True(t, eng.GetRemoteMetadataCache().Has("feature"))
+}
+
+func TestEnsureRemoteMetadataRequiresDeadline(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewRemoteScenario(t)
+
+	eng := newEngineWithMode(t, s.Scene.Dir, engine.LoadModeShared)
+	require.ErrorContains(t, eng.EnsureRemoteMetadata(context.Background()), "requires a context with a deadline")
 }
 
 // TestLoadMode_FullParity asserts that under LoadModeFull every accessor

--- a/internal/engine/metadata_transport.go
+++ b/internal/engine/metadata_transport.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/getstackit/stackit/internal/git"
 )
@@ -10,6 +11,30 @@ import (
 // (refs/stackit/metadata/* and refs/stackit/stacks/*) and is the single point
 // where adapter code should reach to push, fetch, or test remote support — no
 // adapter should be calling git.Runner directly for these.
+
+// EnsureRemoteMetadata fetches the latest branch metadata refs, configures the
+// fetch refspec for future git fetches, and loads the fetched refs into the
+// engine cache. Callers must pass a context with a deadline because this may
+// perform network I/O.
+func (e *engineImpl) EnsureRemoteMetadata(ctx context.Context) error {
+	if ctx == nil {
+		return fmt.Errorf("ensure remote metadata requires a context with a deadline")
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		return fmt.Errorf("ensure remote metadata requires a context with a deadline")
+	}
+
+	if err := e.FetchRemote(ctx, RemoteFetchRequest{IncludeMetadata: true}); err != nil {
+		return err
+	}
+	if err := e.ConfigureRemoteMetadataSync(ctx); err != nil {
+		return err
+	}
+	if err := e.LoadRemoteMetadataCache(); err != nil {
+		return err
+	}
+	return nil
+}
 
 // TestRemoteMetadataCompatibility probes the configured remote to verify that
 // it accepts the metadata-ref namespace. Returns nil on success.

--- a/internal/integration/no_startup_fetch_test.go
+++ b/internal/integration/no_startup_fetch_test.go
@@ -1,0 +1,133 @@
+package integration
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/actions/create"
+	"github.com/getstackit/stackit/internal/actions/doctor"
+	syncaction "github.com/getstackit/stackit/internal/actions/sync"
+	"github.com/getstackit/stackit/internal/actions/track"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// countingFetchRunner counts the two network-bound git operations a startup
+// metadata bootstrap would use: `git fetch` (FetchRefSpecs) and `git ls-remote`
+// (FetchRemoteShas). Everything else delegates to a real runner unchanged.
+type countingFetchRunner struct {
+	git.Runner
+	fetchRefSpecs   atomic.Int64
+	fetchRemoteShas atomic.Int64
+}
+
+func (c *countingFetchRunner) FetchRefSpecs(ctx context.Context, remote string, refspecs []string) error {
+	c.fetchRefSpecs.Add(1)
+	return c.Runner.FetchRefSpecs(ctx, remote, refspecs)
+}
+
+func (c *countingFetchRunner) FetchRemoteShas(ctx context.Context, remote string) (map[string]string, error) {
+	c.fetchRemoteShas.Add(1)
+	return c.Runner.FetchRemoteShas(ctx, remote)
+}
+
+func (c *countingFetchRunner) totalFetches() int64 {
+	return c.fetchRefSpecs.Load() + c.fetchRemoteShas.Load()
+}
+
+// remoteMetadataScenario builds a repo whose remote carries stackit metadata
+// refs but whose local clone has NOT configured the metadata fetch refspec —
+// the exact trap that made pre-fix engine construction auto-fetch on every
+// command (#1330). Commands run against this state must stay offline at
+// startup; only sync should reach the remote, and only in its sync phase.
+func remoteMetadataScenario(t *testing.T) *scenario.Scenario {
+	t.Helper()
+	s := scenario.NewRemoteScenario(t)
+	s.CreateBranch("feature").CommitChange("f.txt", "f").TrackBranch("feature", "main")
+	require.NoError(t, s.Scene.Repo.RunGitCommand("push", "origin", "refs/stackit/metadata/feature"))
+	require.NoError(t, s.Scene.Repo.RunGitCommand("update-ref", "-d", "refs/stackit/remote-metadata/feature"))
+	// Ensure the metadata refspec is absent so a re-introduced auto-fetch would
+	// have a reason to fire (and be caught here). Ignore the error when it is
+	// already unset.
+	_ = s.Scene.Repo.RunGitCommand("config", "--unset-all", "remote.origin.fetch", "stackit/metadata")
+	s.Checkout("main")
+	return s
+}
+
+// countingContext builds a fresh engine over the scenario repo backed by a
+// fetch-counting runner, so a test can attribute every remote read to the
+// command under test.
+func countingContext(t *testing.T, s *scenario.Scenario) (*app.Context, *countingFetchRunner) {
+	t.Helper()
+	counting := &countingFetchRunner{Runner: git.NewRunnerWithPath(s.Scene.Dir, nil)}
+	eng, err := engine.NewEngine(engine.Options{RepoRoot: s.Scene.Dir, Trunk: "main", Git: counting})
+	require.NoError(t, err)
+	ctx := app.NewContext(eng, app.WithRepoRoot(s.Scene.Dir), app.WithWriter(&bytes.Buffer{}))
+	return ctx, counting
+}
+
+func TestCreateDoesNotFetchAtStartup(t *testing.T) {
+	t.Parallel()
+	s := remoteMetadataScenario(t)
+	require.NoError(t, os.WriteFile(filepath.Join(s.Scene.Dir, "new.txt"), []byte("x"), 0o644))
+	require.NoError(t, s.Scene.Repo.RunGitCommand("add", "-A"))
+
+	ctx, counting := countingContext(t, s)
+	_, err := create.Action(ctx, create.Options{Message: "feat: new"}, nil)
+	require.NoError(t, err)
+
+	require.Zero(t, counting.totalFetches(), "create must not fetch remote metadata at startup")
+}
+
+func TestTrackDoesNotFetchAtStartup(t *testing.T) {
+	t.Parallel()
+	s := remoteMetadataScenario(t)
+	require.NoError(t, s.Scene.Repo.RunGitCommand("branch", "extra", "main"))
+
+	ctx, counting := countingContext(t, s)
+	require.NoError(t, track.Action(ctx, track.Options{BranchName: "extra", Parent: "main"}, nil))
+
+	require.Zero(t, counting.totalFetches(), "track must not fetch remote metadata at startup")
+}
+
+func TestTreeDoesNotFetchAtStartup(t *testing.T) {
+	t.Parallel()
+	s := remoteMetadataScenario(t)
+
+	ctx, counting := countingContext(t, s)
+	require.NoError(t, actions.TreeAction(ctx, actions.TreeOptions{Style: actions.TreeStyleNormal}))
+
+	require.Zero(t, counting.totalFetches(), "tree (read-only nav) must not fetch remote metadata")
+}
+
+func TestDoctorDoesNotFetchAtStartup(t *testing.T) {
+	t.Parallel()
+	s := remoteMetadataScenario(t)
+
+	ctx, counting := countingContext(t, s)
+	// doctor's verdict (return value) is irrelevant here; we only assert it does
+	// no remote metadata fetch at startup.
+	_ = doctor.Action(ctx, doctor.Options{Trunk: "main"}, nil)
+
+	require.Zero(t, counting.totalFetches(), "doctor must not fetch remote metadata at startup")
+}
+
+func TestSyncFetchesDuringSyncPhase(t *testing.T) {
+	t.Parallel()
+	s := remoteMetadataScenario(t)
+
+	ctx, counting := countingContext(t, s)
+	require.NoError(t, syncaction.Action(ctx, syncaction.Options{}, nil))
+
+	require.GreaterOrEqual(t, counting.fetchRefSpecs.Load(), int64(1),
+		"sync must fetch from the remote during its sync phase")
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Fixes #1330

<hr/>

<!-- STACKIT-SECTION-START -->
**Fix timeout hangs and make remote metadata bootstrap explicit**

Addresses a cluster of reliability issues around git subprocess timeouts, GitHub connectivity, and remote metadata fetching. Adds doctor diagnostics for stale lock files and ensures new branches are correctly configured to fetch remote metadata.

Key changes:
- **PR #1334 - make-remote-metadata-bootstrap-explicit**: Makes remote metadata fetching opt-in at engine startup rather than implicit; adds integration tests asserting commands do not fetch metadata at startup
- **PR #1335 - force-close-subprocess-pipes**: Force-closes subprocess pipes on timeout to prevent git processes from hanging indefinitely
- **PR #1336 - thread-context-into-BatchGetPRSubmissionStatus**: Threads context through `BatchGetPRSubmissionStatus` enabling proper cancellation and cleanup
- **PR #1337 - bound-GitHub-connectivity-checks**: Bounds doctor's GitHub connectivity checks with a short timeout; adds detection and diagnosis of stale git lock files
- **PR #1338 - add-client-level-timeout**: Adds a client-level timeout to the GitHub App transport to prevent indefinite waits on network operations
- **PR #1339 - configure-metadata-fetch-refspec**: Configures the metadata fetch refspec on `create` and `track` so new branches correctly pull remote metadata refs

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782435332`.


* **PR #1334** 👈
  * **PR #1335**
    * **PR #1336**
      * **PR #1337**
        * **PR #1338**
          * **PR #1339**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1341 by jonnii*