### PR TITLE
fix(git): force-close subprocess pipes on timeout to prevent hangs

### DIFF
--- a/internal/git/command_waitdelay_test.go
+++ b/internal/git/command_waitdelay_test.go
@@ -1,0 +1,84 @@
+//go:build unix
+
+package git
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommandContextWaitDelayUnblocksPipeHoldingChild reproduces the deadlock
+// behind issue #1330 at the exec layer and proves that cmd.WaitDelay is what
+// breaks it.
+//
+// The runner captures a subprocess's stdout/stderr into buffers, so Go wires
+// them through os.Pipe and copies in a background goroutine. A `git fetch`
+// spawns an `ssh` grandchild that inherits the pipe's write end. When the
+// context deadline fires, exec kills the direct child (git/sh) — but the
+// grandchild survives and keeps the pipe open, so cmd.Run() blocks on the
+// copy goroutine forever even though the command "timed out". WaitDelay makes
+// Go force-close the pipe shortly after the kill, guaranteeing Run() returns.
+//
+// The shim `sleep <n> & sleep <n>` models this exactly: the backgrounded sleep
+// inherits stdout and outlives the foreground process that exec actually kills.
+func TestCommandContextWaitDelayUnblocksPipeHoldingChild(t *testing.T) {
+	t.Parallel()
+
+	// Short enough to keep the test fast; long enough to outlive the deadline
+	// and the assertion windows below, so the negative control is observably
+	// blocked before the orphaned child exits and cleans everything up.
+	const shim = "sleep 2 & sleep 2"
+
+	run := func(t *testing.T, waitDelay time.Duration) (chan error, time.Time) {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		t.Cleanup(cancel)
+
+		cmd := exec.CommandContext(ctx, "/bin/sh", "-c", shim)
+		cmd.WaitDelay = waitDelay
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+
+		done := make(chan error, 1)
+		start := time.Now()
+		go func() { done <- cmd.Run() }()
+		return done, start
+	}
+
+	t.Run("with WaitDelay Run returns shortly after the deadline", func(t *testing.T) {
+		t.Parallel()
+		done, start := run(t, 300*time.Millisecond)
+
+		select {
+		case <-done:
+			require.Less(t, time.Since(start), 1500*time.Millisecond,
+				"Run should return shortly after deadline+WaitDelay, not wait for the pipe-holding child")
+		case <-time.After(5 * time.Second):
+			t.Fatal("cmd.Run() hung despite WaitDelay — the issue #1330 deadlock is not fixed")
+		}
+	})
+
+	t.Run("without WaitDelay Run stays blocked on the pipe-holding child", func(t *testing.T) {
+		t.Parallel()
+		done, _ := run(t, 0)
+
+		select {
+		case <-done:
+			t.Fatal("expected Run() to stay blocked past the deadline (child holds the pipe) without WaitDelay")
+		case <-time.After(1 * time.Second):
+			// Expected: still blocked well past the 200ms deadline. Drain the
+			// channel once the orphaned child exits (~2s) so nothing leaks.
+		}
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("orphaned child never released the pipe")
+		}
+	})
+}

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -31,6 +31,15 @@ type DebugLogger interface {
 // DefaultCommandTimeout is the default timeout for git commands
 const DefaultCommandTimeout = 5 * time.Minute
 
+// CommandWaitDelay bounds how long we wait for a killed git/gh subprocess to
+// release its stdio pipes before force-closing them. Without it, a `git fetch`
+// can spawn an `ssh` grandchild that inherits the captured stdout/stderr pipe;
+// when the context deadline kills git, ssh keeps the pipe open and cmd.Run()
+// blocks indefinitely — the command times out but never returns, which is the
+// hang-until-reboot behind issue #1330. Setting WaitDelay makes Go force-close
+// the pipes shortly after the kill so Run() always returns.
+const CommandWaitDelay = 10 * time.Second
+
 // ErrStaleRemoteInfo indicates that a push failed because the remote has changed
 var ErrStaleRemoteInfo = errors.New("stale info")
 
@@ -159,6 +168,7 @@ func (r *runner) runGitInternal(ctx context.Context, input string, env []string,
 	r.debugLog("git %s", strings.Join(args, " "))
 
 	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.WaitDelay = CommandWaitDelay
 	if root := r.getRepoRoot(); root != "" {
 		cmd.Dir = root
 	}
@@ -207,6 +217,7 @@ func (r *runner) runGitStreaming(ctx context.Context, args ...string) (string, e
 	r.debugLog("git %s (streaming)", strings.Join(args, " "))
 
 	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.WaitDelay = CommandWaitDelay
 	if root := r.getRepoRoot(); root != "" {
 		cmd.Dir = root
 	}
@@ -245,6 +256,7 @@ func (r *runner) RunGHCommandWithContext(ctx context.Context, args ...string) (s
 	r.debugLog("gh %s", strings.Join(args, " "))
 
 	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd.WaitDelay = CommandWaitDelay
 	// Use repoRoot for gh commands to ensure they are scoped to the correct repo
 	if root := r.getRepoRoot(); root != "" {
 		cmd.Dir = root


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

A `git fetch` can spawn an `ssh` grandchild that inherits the captured
stdout/stderr pipe. When the context deadline killed git, ssh kept the
pipe open and cmd.Run() blocked forever — the command timed out but never
returned, hanging until the machine was rebooted (issue #1330).

Set cmd.WaitDelay on every exec.CommandContext so Go force-closes the
pipes shortly after the kill, guaranteeing Run() returns even when a
grandchild outlives the killed process.

<hr/>

<!-- STACKIT-SECTION-START -->
**Fix timeout hangs and make remote metadata bootstrap explicit**

Addresses a cluster of reliability issues around git subprocess timeouts, GitHub connectivity, and remote metadata fetching. Adds doctor diagnostics for stale lock files and ensures new branches are correctly configured to fetch remote metadata.

Key changes:
- **PR #1334 - make-remote-metadata-bootstrap-explicit**: Makes remote metadata fetching opt-in at engine startup rather than implicit; adds integration tests asserting commands do not fetch metadata at startup
- **PR #1335 - force-close-subprocess-pipes**: Force-closes subprocess pipes on timeout to prevent git processes from hanging indefinitely
- **PR #1336 - thread-context-into-BatchGetPRSubmissionStatus**: Threads context through `BatchGetPRSubmissionStatus` enabling proper cancellation and cleanup
- **PR #1337 - bound-GitHub-connectivity-checks**: Bounds doctor's GitHub connectivity checks with a short timeout; adds detection and diagnosis of stale git lock files
- **PR #1338 - add-client-level-timeout**: Adds a client-level timeout to the GitHub App transport to prevent indefinite waits on network operations
- **PR #1339 - configure-metadata-fetch-refspec**: Configures the metadata fetch refspec on `create` and `track` so new branches correctly pull remote metadata refs

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782435332`.


* **PR #1334**
  * **PR #1335** 👈
    * **PR #1336**
      * **PR #1337**
        * **PR #1338**
          * **PR #1339**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1341 by jonnii*