### PR TITLE
fix(doctor): bound GitHub connectivity checks with a short timeout

### DIFF
--- a/internal/actions/doctor/environment.go
+++ b/internal/actions/doctor/environment.go
@@ -38,8 +38,12 @@ func checkEnvironment(runner git.Runner, handler Handler, warnings int, errors i
 		}
 	}
 
-	// Check GitHub authentication
-	token, err := getGitHubToken(runner)
+	// Check GitHub authentication. Bound both the token probe and the
+	// connectivity check with one short deadline so an unreachable remote is
+	// reported quickly rather than hanging this diagnostic.
+	ghCtx, cancel := context.WithTimeout(context.Background(), remoteCheckTimeout)
+	defer cancel()
+	token, err := getGitHubToken(ghCtx, runner)
 	if err != nil {
 		warnings++
 		handler.OnCheck("github_auth", CheckWarning, "GitHub authentication not configured")
@@ -49,7 +53,6 @@ func checkEnvironment(runner git.Runner, handler Handler, warnings int, errors i
 			handler.OnCheck("github_auth", CheckWarning, "GitHub token is empty")
 		} else {
 			// Try to create a GitHub client to verify connectivity
-			ghCtx := context.Background()
 			client, err := github.NewGitHubClient(ghCtx, runner)
 			if err != nil {
 				warnings++

--- a/internal/actions/doctor/github.go
+++ b/internal/actions/doctor/github.go
@@ -5,12 +5,19 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/getstackit/stackit/internal/git"
 )
 
-// getGitHubToken gets the GitHub token (similar to internal/github/pr_info.go)
-func getGitHubToken(runner git.Runner) (string, error) {
+// remoteCheckTimeout bounds doctor's GitHub connectivity probes. Doctor is a
+// diagnostic, so a fast "unreachable" beats blocking for minutes on the git
+// runner's default timeout when the network or `gh` is wedged.
+const remoteCheckTimeout = 10 * time.Second
+
+// getGitHubToken gets the GitHub token (similar to internal/github/pr_info.go).
+// The context bounds the `gh auth token` probe.
+func getGitHubToken(ctx context.Context, runner git.Runner) (string, error) {
 	// Try environment variable first
 	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
 		// Trim whitespace to handle cases where secrets might have leading/trailing spaces
@@ -21,7 +28,7 @@ func getGitHubToken(runner git.Runner) (string, error) {
 	}
 
 	// Try gh CLI
-	output, err := runner.RunGHCommandWithContext(context.Background(), "auth", "token")
+	output, err := runner.RunGHCommandWithContext(ctx, "auth", "token")
 	if err != nil {
 		return "", fmt.Errorf("failed to get GitHub token: %w", err)
 	}

--- a/internal/actions/doctor/locks.go
+++ b/internal/actions/doctor/locks.go
@@ -1,0 +1,106 @@
+package doctor
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/getstackit/stackit/internal/git"
+)
+
+// staleLockThreshold is how old a git lock file must be before doctor treats it
+// as left over by a crashed or killed process rather than a live operation. A
+// hung `git fetch` (issue #1330) leaves exactly this kind of lock, which is why
+// "restarting the machine released the lock."
+const staleLockThreshold = 5 * time.Minute
+
+// lockFileNames are the well-known single-file locks git takes during ref,
+// index, config, and gc operations.
+var lockFileNames = []string{
+	"index.lock",
+	"HEAD.lock",
+	"ORIG_HEAD.lock",
+	"config.lock",
+	"packed-refs.lock",
+	"shallow.lock",
+	"gc.pid",
+}
+
+// checkGitLocks reports stale git lock files in the repository. It is a purely
+// local, read-only filesystem scan — no git process is spawned — so it stays in
+// the local-first part of the repository checks. A stale lock blocks every
+// subsequent git operation, so surfacing it lets a user recover without a
+// reboot.
+func checkGitLocks(repoRoot string, handler Handler, warnings int) int {
+	var stale, fresh []string
+	for _, p := range gitLockPaths(repoRoot) {
+		info, err := os.Stat(p)
+		if err != nil {
+			continue // not present (the common, healthy case)
+		}
+		name := lockDisplayName(repoRoot, p)
+		if age := time.Since(info.ModTime()); age >= staleLockThreshold {
+			stale = append(stale, fmt.Sprintf("%s (%s old)", name, age.Round(time.Second)))
+		} else {
+			fresh = append(fresh, name)
+		}
+	}
+
+	switch {
+	case len(stale) > 0:
+		warnings++
+		handler.OnCheck("git_locks", CheckWarning, fmt.Sprintf(
+			"stale git lock file(s) — remove them if no git process is running: %s",
+			strings.Join(stale, ", ")))
+	case len(fresh) > 0:
+		handler.OnCheck("git_locks", CheckPassed, fmt.Sprintf(
+			"git lock file(s) present but recent (an operation may be in progress): %s",
+			strings.Join(fresh, ", ")))
+	default:
+		handler.OnCheck("git_locks", CheckPassed, "No stale git lock files")
+	}
+	return warnings
+}
+
+// gitLockPaths returns every candidate lock path for the repository: the
+// well-known single-file locks in both the worktree and shared git dirs, plus
+// any per-ref *.lock files under refs/.
+func gitLockPaths(repoRoot string) []string {
+	gitDir := git.GetGitDir(repoRoot)
+	commonDir := git.GetGitCommonDir(repoRoot)
+
+	dirs := []string{gitDir}
+	if commonDir != gitDir {
+		dirs = append(dirs, commonDir)
+	}
+
+	paths := make([]string, 0, len(dirs)*len(lockFileNames))
+	for _, dir := range dirs {
+		for _, name := range lockFileNames {
+			paths = append(paths, filepath.Join(dir, name))
+		}
+	}
+
+	// Per-ref locks live next to the loose refs in the shared dir. Unreadable
+	// subtrees are skipped (err != nil) rather than failing the whole check.
+	refsDir := filepath.Join(commonDir, "refs")
+	_ = filepath.WalkDir(refsDir, func(p string, d fs.DirEntry, err error) error {
+		if err == nil && !d.IsDir() && strings.HasSuffix(p, ".lock") {
+			paths = append(paths, p)
+		}
+		return nil
+	})
+	return paths
+}
+
+// lockDisplayName renders a lock path relative to the repo root when possible,
+// so messages read as ".git/index.lock" rather than an absolute path.
+func lockDisplayName(repoRoot, p string) string {
+	if rel, err := filepath.Rel(repoRoot, p); err == nil && !strings.HasPrefix(rel, "..") {
+		return rel
+	}
+	return p
+}

--- a/internal/actions/doctor/locks_test.go
+++ b/internal/actions/doctor/locks_test.go
@@ -1,0 +1,99 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type recordedCheck struct {
+	name    string
+	status  CheckStatus
+	message string
+}
+
+type recordingHandler struct {
+	NullHandler
+	checks []recordedCheck
+}
+
+func (h *recordingHandler) OnCheck(name string, status CheckStatus, message string) {
+	h.checks = append(h.checks, recordedCheck{name, status, message})
+}
+
+func (h *recordingHandler) gitLocksCheck(t *testing.T) recordedCheck {
+	t.Helper()
+	for _, c := range h.checks {
+		if c.name == "git_locks" {
+			return c
+		}
+	}
+	require.Fail(t, "no git_locks check was recorded")
+	return recordedCheck{}
+}
+
+// newGitDir returns a repo root with an empty .git directory. checkGitLocks only
+// needs the directory structure, not a real repository.
+func newGitDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git", "refs", "heads"), 0o755))
+	return dir
+}
+
+func writeLock(t *testing.T, path string, age time.Duration) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, nil, 0o644))
+	when := time.Now().Add(-age)
+	require.NoError(t, os.Chtimes(path, when, when))
+}
+
+func TestCheckGitLocks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no locks passes", func(t *testing.T) {
+		t.Parallel()
+		dir := newGitDir(t)
+		rec := &recordingHandler{}
+
+		require.Equal(t, 0, checkGitLocks(dir, rec, 0))
+		require.Equal(t, CheckPassed, rec.gitLocksCheck(t).status)
+	})
+
+	t.Run("stale index.lock warns", func(t *testing.T) {
+		t.Parallel()
+		dir := newGitDir(t)
+		writeLock(t, filepath.Join(dir, ".git", "index.lock"), 10*time.Minute)
+		rec := &recordingHandler{}
+
+		require.Equal(t, 1, checkGitLocks(dir, rec, 0))
+		check := rec.gitLocksCheck(t)
+		require.Equal(t, CheckWarning, check.status)
+		require.Contains(t, check.message, "index.lock")
+	})
+
+	t.Run("stale per-ref lock warns", func(t *testing.T) {
+		t.Parallel()
+		dir := newGitDir(t)
+		writeLock(t, filepath.Join(dir, ".git", "refs", "heads", "main.lock"), 10*time.Minute)
+		rec := &recordingHandler{}
+
+		require.Equal(t, 1, checkGitLocks(dir, rec, 0))
+		check := rec.gitLocksCheck(t)
+		require.Equal(t, CheckWarning, check.status)
+		require.Contains(t, check.message, "main.lock")
+	})
+
+	t.Run("recent lock does not warn", func(t *testing.T) {
+		t.Parallel()
+		dir := newGitDir(t)
+		writeLock(t, filepath.Join(dir, ".git", "index.lock"), 2*time.Second)
+		rec := &recordingHandler{}
+
+		require.Equal(t, 0, checkGitLocks(dir, rec, 0))
+		require.Equal(t, CheckPassed, rec.gitLocksCheck(t).status)
+	})
+}

--- a/internal/actions/doctor/repository.go
+++ b/internal/actions/doctor/repository.go
@@ -58,5 +58,9 @@ func checkRepository(ctx *app.Context, handler Handler, warnings int, errors int
 		handler.OnCheck("initialized", CheckPassed, "stackit is initialized")
 	}
 
+	// Local, read-only scan for stale git lock files (a hung operation can leave
+	// one behind and block every later git command — see issue #1330).
+	warnings = checkGitLocks(ctx.RepoRoot, handler, warnings)
+
 	return warnings, errors
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

doctor's token probe (`gh auth token`) and client connectivity check ran
under context.Background(), so an unreachable remote left this diagnostic
blocking on the git runner's multi-minute default. Wrap both in a single
10s deadline so doctor reports "unreachable" quickly — which is the whole
point of a doctor command.

<hr/>

<!-- STACKIT-SECTION-START -->
**Fix timeout hangs and make remote metadata bootstrap explicit**

Addresses a cluster of reliability issues around git subprocess timeouts, GitHub connectivity, and remote metadata fetching. Adds doctor diagnostics for stale lock files and ensures new branches are correctly configured to fetch remote metadata.

Key changes:
- **PR #1334 - make-remote-metadata-bootstrap-explicit**: Makes remote metadata fetching opt-in at engine startup rather than implicit; adds integration tests asserting commands do not fetch metadata at startup
- **PR #1335 - force-close-subprocess-pipes**: Force-closes subprocess pipes on timeout to prevent git processes from hanging indefinitely
- **PR #1336 - thread-context-into-BatchGetPRSubmissionStatus**: Threads context through `BatchGetPRSubmissionStatus` enabling proper cancellation and cleanup
- **PR #1337 - bound-GitHub-connectivity-checks**: Bounds doctor's GitHub connectivity checks with a short timeout; adds detection and diagnosis of stale git lock files
- **PR #1338 - add-client-level-timeout**: Adds a client-level timeout to the GitHub App transport to prevent indefinite waits on network operations
- **PR #1339 - configure-metadata-fetch-refspec**: Configures the metadata fetch refspec on `create` and `track` so new branches correctly pull remote metadata refs

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782435332`.


* **PR #1334**
  * **PR #1335**
    * **PR #1336**
      * **PR #1337** 👈
        * **PR #1338**
          * **PR #1339**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1341 by jonnii*