### PR TITLE
fix(github): add client-level timeout to GitHub App transport

### DIFF
--- a/internal/github/app.go
+++ b/internal/github/app.go
@@ -5,10 +5,28 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/v73/github"
 )
+
+// appHTTPTimeout is the client-level ceiling for GitHub App HTTP calls
+// (installation discovery and JWT token minting). Callers pass a context
+// deadline, but http.DefaultTransport sets no timeout of its own, so a stalled
+// socket reached with a context.Background() that slips through could hang
+// indefinitely. This is the belt-and-suspenders bound.
+const appHTTPTimeout = 30 * time.Second
+
+// appHTTPTransport clones http.DefaultTransport and adds a response-header
+// timeout so a remote that accepts the connection but never replies cannot
+// wedge a request. DefaultTransport is shared process-wide and must not be
+// mutated in place, hence the clone.
+func appHTTPTransport() *http.Transport {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.ResponseHeaderTimeout = appHTTPTimeout
+	return tr
+}
 
 // AppTokenProvider mints GitHub App installation access tokens for repositories.
 // Installation tokens are durable — the underlying transport refreshes them
@@ -29,13 +47,13 @@ type AppTokenProvider struct {
 // NewAppTokenProvider builds a provider from a GitHub App ID and its
 // PEM-encoded private key (PKCS#1 or PKCS#8).
 func NewAppTokenProvider(appID int64, privateKeyPEM []byte) (*AppTokenProvider, error) {
-	apps, err := ghinstallation.NewAppsTransport(http.DefaultTransport, appID, privateKeyPEM)
+	apps, err := ghinstallation.NewAppsTransport(appHTTPTransport(), appID, privateKeyPEM)
 	if err != nil {
 		return nil, fmt.Errorf("github app transport: %w", err)
 	}
 	return &AppTokenProvider{
 		apps:           apps,
-		resolveClient:  github.NewClient(&http.Client{Transport: apps}),
+		resolveClient:  github.NewClient(&http.Client{Transport: apps, Timeout: appHTTPTimeout}),
 		installByOwner: make(map[string]int64),
 		transports:     make(map[int64]*ghinstallation.Transport),
 	}, nil


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The App provider built its transport on http.DefaultTransport, which sets no
timeout, and the resolve client had no Timeout either — so a stalled socket
reached via a context.Background() that slips through could hang indefinitely.
Clone the transport with a ResponseHeaderTimeout (covers JWT/token minting)
and give the resolve client a full Timeout, as a defense-in-depth ceiling
beneath the per-call context deadlines.

<hr/>

<!-- STACKIT-SECTION-START -->
**Fix timeout hangs and make remote metadata bootstrap explicit**

Addresses a cluster of reliability issues around git subprocess timeouts, GitHub connectivity, and remote metadata fetching. Adds doctor diagnostics for stale lock files and ensures new branches are correctly configured to fetch remote metadata.

Key changes:
- **PR #1334 - make-remote-metadata-bootstrap-explicit**: Makes remote metadata fetching opt-in at engine startup rather than implicit; adds integration tests asserting commands do not fetch metadata at startup
- **PR #1335 - force-close-subprocess-pipes**: Force-closes subprocess pipes on timeout to prevent git processes from hanging indefinitely
- **PR #1336 - thread-context-into-BatchGetPRSubmissionStatus**: Threads context through `BatchGetPRSubmissionStatus` enabling proper cancellation and cleanup
- **PR #1337 - bound-GitHub-connectivity-checks**: Bounds doctor's GitHub connectivity checks with a short timeout; adds detection and diagnosis of stale git lock files
- **PR #1338 - add-client-level-timeout**: Adds a client-level timeout to the GitHub App transport to prevent indefinite waits on network operations
- **PR #1339 - configure-metadata-fetch-refspec**: Configures the metadata fetch refspec on `create` and `track` so new branches correctly pull remote metadata refs

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782435332`.


* **PR #1334**
  * **PR #1335**
    * **PR #1336**
      * **PR #1337**
        * **PR #1338** 👈
          * **PR #1339**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1341 by jonnii*