### PR TITLE
feat(create): configure metadata fetch refspec on create and track

### DIFF
--- a/internal/actions/create/create.go
+++ b/internal/actions/create/create.go
@@ -217,6 +217,14 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 		h.OnStep(StepTracking, handler.StatusCompleted, "Branch tracked")
 	}
 
+	// Opportunistically configure the metadata fetch refspec so a plain
+	// `git fetch` keeps pulling branch metadata. Local, idempotent, and a no-op
+	// when no remote is configured — closes the gap left by removing the implicit
+	// bootstrap from engine construction (issue #1330).
+	if err := eng.ConfigureRemoteMetadataSync(ctx.Context); err != nil {
+		out.Debug("Failed to configure metadata refspec: %v", err)
+	}
+
 	ctx.Logger.Info("branch created name=%v parent=%v hasCommit=%v", branchName, currentBranch, hasStaged)
 
 	// Create worktree if requested

--- a/internal/actions/track/action.go
+++ b/internal/actions/track/action.go
@@ -24,6 +24,14 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	eng := ctx.Engine
 	branchName := opts.BranchName
 
+	// Opportunistically configure the metadata fetch refspec so a plain
+	// `git fetch` keeps pulling branch metadata. Local, idempotent, and a no-op
+	// when no remote is configured — closes the gap left by removing the implicit
+	// bootstrap from engine construction (issue #1330).
+	if err := eng.ConfigureRemoteMetadataSync(ctx.Context); err != nil {
+		ctx.Output.Debug("Failed to configure metadata refspec: %v", err)
+	}
+
 	// Handle --parent flag (single branch tracking)
 	if opts.Parent != "" {
 		parent := opts.Parent

--- a/internal/engine/remote_sync.go
+++ b/internal/engine/remote_sync.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -518,8 +519,22 @@ func (e *engineImpl) FetchRemoteMetadata(ctx context.Context) error {
 	return e.FetchRemote(ctx, RemoteFetchRequest{IncludeMetadata: true})
 }
 
-// ConfigureRemoteMetadataSync adds the metadata refspec to the configured
-// remote so subsequent git fetches pick up metadata changes automatically.
+// ConfigureRemoteMetadataSync adds the metadata refspec to the resolved remote
+// so subsequent git fetches pick up metadata changes automatically. It is a
+// no-op when that remote has no URL (e.g. a remote-less repo), so such a repo is
+// never polluted with a dangling fetch refspec. The remote is resolved via
+// GetRemote (the current branch's tracking remote, falling back to origin), so
+// this works for non-origin remotes too.
 func (e *engineImpl) ConfigureRemoteMetadataSync(_ context.Context) error {
+	// `git config --get remote.<name>.url` exits non-zero when the remote does
+	// not exist; that absence is precisely the "no remote to configure" signal,
+	// so we treat the error as a no-op rather than a failure.
+	url, err := e.git.GetConfig(fmt.Sprintf("remote.%s.url", e.GetRemote()))
+	if err != nil {
+		return nil //nolint:nilerr // missing remote.<name>.url means there is no remote to sync
+	}
+	if strings.TrimSpace(url) == "" {
+		return nil
+	}
 	return e.git.EnsureMetadataRefspecConfigured()
 }

--- a/internal/engine/remote_sync_test.go
+++ b/internal/engine/remote_sync_test.go
@@ -1,0 +1,49 @@
+package engine_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+const metadataFetchRefspec = "+refs/stackit/metadata/*:refs/stackit/remote-metadata/*"
+
+// TestConfigureRemoteMetadataSyncResolvesNonOriginRemote pins the fix for the
+// origin-hardcoded guard: ConfigureRemoteMetadataSync must configure the metadata
+// refspec on the branch's actual tracking remote (here "upstream"), not skip it
+// just because there is no "origin" remote. Skipping it reintroduced the #1330
+// gap (a plain `git fetch` stops pulling branch metadata) for fork-style setups.
+func TestConfigureRemoteMetadataSyncResolvesNonOriginRemote(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+	// A repo whose only remote is "upstream" and whose current branch tracks it.
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("remote", "add", "upstream", "https://example.com/repo.git"))
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("config", "branch.main.remote", "upstream"))
+
+	require.NoError(t, sh.Engine.ConfigureRemoteMetadataSync(context.Background()))
+
+	upstreamRefspecs, _ := sh.Engine.Git().GetConfigAll("remote.upstream.fetch")
+	require.Contains(t, upstreamRefspecs, metadataFetchRefspec,
+		"metadata refspec must be configured on the resolved (non-origin) remote")
+
+	// origin never existed, so it must not have been polluted with a refspec.
+	originRefspecs, _ := sh.Engine.Git().GetConfigAll("remote.origin.fetch")
+	require.NotContains(t, originRefspecs, metadataFetchRefspec)
+}
+
+// TestConfigureRemoteMetadataSyncSkipsRemoteless asserts a remote-less repo is
+// never polluted with a dangling remote.origin.fetch entry.
+func TestConfigureRemoteMetadataSyncSkipsRemoteless(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+	require.NoError(t, sh.Engine.ConfigureRemoteMetadataSync(context.Background()))
+
+	refspecs, _ := sh.Engine.Git().GetConfigAll("remote.origin.fetch")
+	require.NotContains(t, refspecs, metadataFetchRefspec)
+}

--- a/internal/integration/create_metadata_refspec_test.go
+++ b/internal/integration/create_metadata_refspec_test.go
@@ -1,0 +1,60 @@
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const wantMetadataFetchRefspec = "+refs/stackit/metadata/*:refs/stackit/remote-metadata/*"
+
+// TestCreateConfiguresMetadataRefspec asserts that creating a branch with a
+// remote opportunistically configures the metadata fetch refspec, so a plain
+// `git fetch` keeps pulling branch metadata. This closes the gap left by
+// removing the implicit metadata bootstrap from engine construction (#1330).
+func TestCreateConfiguresMetadataRefspec(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t, WithRemote())
+
+	// Fresh state: the metadata refspec is not configured yet.
+	require.NotContains(t, fetchRefspecs(t, sh), wantMetadataFetchRefspec)
+
+	sh.Write("a.txt", "a").Run("create feat -m 'feat: a'")
+
+	require.Contains(t, fetchRefspecs(t, sh), wantMetadataFetchRefspec)
+}
+
+// TestTrackConfiguresMetadataRefspec asserts the same opportunistic
+// configuration happens on track.
+func TestTrackConfiguresMetadataRefspec(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t, WithRemote())
+
+	// A plain git branch that stackit does not yet track.
+	sh.Git("checkout -b feat").Write("a.txt", "a").Git("commit -m wip").Checkout("main")
+	require.NotContains(t, fetchRefspecs(t, sh), wantMetadataFetchRefspec)
+
+	sh.Run("track feat --parent main")
+
+	require.Contains(t, fetchRefspecs(t, sh), wantMetadataFetchRefspec)
+}
+
+// TestCreateWithoutRemoteSkipsMetadataRefspec asserts a remote-less repo is not
+// polluted with a dangling remote.origin.fetch entry.
+func TestCreateWithoutRemoteSkipsMetadataRefspec(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t)
+
+	sh.Write("a.txt", "a").Run("create feat -m 'feat: a'")
+
+	require.NotContains(t, fetchRefspecs(t, sh), wantMetadataFetchRefspec)
+}
+
+// fetchRefspecs returns the configured remote.origin.fetch refspecs, or "" when
+// no remote is configured (git config exits non-zero, which is expected then).
+func fetchRefspecs(t *testing.T, sh *TestShell) string {
+	t.Helper()
+	out, _ := sh.Scene().Repo.RunGitCommandAndGetOutput("config", "--get-all", "remote.origin.fetch")
+	return strings.TrimSpace(out)
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Removing the implicit metadata bootstrap from engine construction (#1330)
means the refspec is now only configured by sync/debug. Configure it
opportunistically on create and track too — a local, idempotent, best-effort
write gated on a remote existing — so a plain `git fetch` keeps pulling
branch metadata without waiting for the first sync.

<hr/>

<!-- STACKIT-SECTION-START -->
**Fix timeout hangs and make remote metadata bootstrap explicit**

Addresses a cluster of reliability issues around git subprocess timeouts, GitHub connectivity, and remote metadata fetching. Adds doctor diagnostics for stale lock files and ensures new branches are correctly configured to fetch remote metadata.

Key changes:
- **PR #1334 - make-remote-metadata-bootstrap-explicit**: Makes remote metadata fetching opt-in at engine startup rather than implicit; adds integration tests asserting commands do not fetch metadata at startup
- **PR #1335 - force-close-subprocess-pipes**: Force-closes subprocess pipes on timeout to prevent git processes from hanging indefinitely
- **PR #1336 - thread-context-into-BatchGetPRSubmissionStatus**: Threads context through `BatchGetPRSubmissionStatus` enabling proper cancellation and cleanup
- **PR #1337 - bound-GitHub-connectivity-checks**: Bounds doctor's GitHub connectivity checks with a short timeout; adds detection and diagnosis of stale git lock files
- **PR #1338 - add-client-level-timeout**: Adds a client-level timeout to the GitHub App transport to prevent indefinite waits on network operations
- **PR #1339 - configure-metadata-fetch-refspec**: Configures the metadata fetch refspec on `create` and `track` so new branches correctly pull remote metadata refs

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782435332`.


* **PR #1334**
  * **PR #1335**
    * **PR #1336**
      * **PR #1337**
        * **PR #1338**
          * **PR #1339** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1341 by jonnii*