### PR TITLE
refactor: thread request context through analyzer and HTTP mappers

### DIFF
--- a/internal/api/handlers/branches.go
+++ b/internal/api/handlers/branches.go
@@ -73,7 +73,7 @@ func (h *BranchesHandler) listBranches(w http.ResponseWriter, r *http.Request, e
 		if checksMap != nil {
 			checks = checksMap[branch.GetName()]
 		}
-		responses = append(responses, httpcontract.MapBranch(entry.Engine, branch, node, checks))
+		responses = append(responses, httpcontract.MapBranch(r.Context(), entry.Engine, branch, node, checks))
 	}
 
 	writeJSON(w, responses)
@@ -101,6 +101,6 @@ func (h *BranchesHandler) getBranch(w http.ResponseWriter, r *http.Request, entr
 		}
 	}
 
-	resp := httpcontract.MapBranch(entry.Engine, branch, node, checks)
+	resp := httpcontract.MapBranch(r.Context(), entry.Engine, branch, node, checks)
 	writeJSON(w, resp)
 }

--- a/internal/api/handlers/stacks.go
+++ b/internal/api/handlers/stacks.go
@@ -85,6 +85,6 @@ func (h *StacksHandler) getStack(w http.ResponseWriter, r *http.Request, entry *
 		checksMap, _ = entry.GitHub.BatchGetPRChecksStatus(r.Context(), found.AllBranches)
 	}
 
-	detail := httpcontract.MapStackDetail(entry.Engine, graph, found.RootBranch, found.AllBranches, found.PRCount, found.Scope, checksMap)
+	detail := httpcontract.MapStackDetail(r.Context(), entry.Engine, graph, found.RootBranch, found.AllBranches, found.PRCount, found.Scope, checksMap)
 	writeJSON(w, detail)
 }

--- a/internal/api/handlers/view_assembler.go
+++ b/internal/api/handlers/view_assembler.go
@@ -34,7 +34,7 @@ func (a *ViewAssembler) Build(ctx context.Context) (httpcontract.ViewResponse, e
 
 	graph := a.eng.Graph(engine.SortStrategySmart)
 	checksMap := a.fetchChecks(ctx, stacks)
-	details := a.mapStackDetails(graph, stacks, checksMap)
+	details := a.mapStackDetails(ctx, graph, stacks, checksMap)
 
 	recentlyMerged := a.fetchRecentlyMerged(ctx)
 
@@ -81,13 +81,14 @@ func (a *ViewAssembler) fetchChecks(ctx context.Context, stacks []merge.MultiSta
 }
 
 func (a *ViewAssembler) mapStackDetails(
+	ctx context.Context,
 	graph *engine.StackGraph,
 	stacks []merge.MultiStackInfo,
 	checksMap map[string]*github.CheckStatus,
 ) []httpcontract.StackDetail {
 	details := make([]httpcontract.StackDetail, 0, len(stacks))
 	for _, stack := range stacks {
-		detail := httpcontract.MapStackDetail(a.eng, graph, stack.RootBranch, stack.AllBranches, stack.PRCount, stack.Scope, checksMap)
+		detail := httpcontract.MapStackDetail(ctx, a.eng, graph, stack.RootBranch, stack.AllBranches, stack.PRCount, stack.Scope, checksMap)
 		details = append(details, detail)
 	}
 	return details

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -12,7 +12,7 @@ import (
 )
 
 // MapBranch converts an engine Branch and its StackNode into an API BranchResponse.
-func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.StackNode, checks *github.CheckStatus) BranchResponse {
+func MapBranch(ctx context.Context, eng engine.BranchReader, branch engine.Branch, node *engine.StackNode, checks *github.CheckStatus) BranchResponse {
 	resp := BranchResponse{
 		Name:         branch.GetName(),
 		Depth:        node.Depth,
@@ -72,7 +72,7 @@ func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.Stack
 	}
 
 	// Map remote status
-	remoteStatus := eng.ReadBranchRemoteStatuses(context.Background(), engine.BranchesOf(branch)).ForBranch(branch)
+	remoteStatus := eng.ReadBranchRemoteStatuses(ctx, engine.BranchesOf(branch)).ForBranch(branch)
 	resp.RemoteStatus = &RemoteStatus{
 		Ahead:         remoteStatus.Ahead(),
 		Behind:        remoteStatus.Behind(),
@@ -130,7 +130,7 @@ func MapStackSummary(eng engine.BranchReader, graph *engine.StackGraph, rootBran
 }
 
 // MapStackDetail creates a full StackDetail with all branch info.
-func MapStackDetail(eng engine.BranchReader, graph *engine.StackGraph, rootBranch string, allBranches []string, prCount int, scope string, checksMap map[string]*github.CheckStatus) StackDetail {
+func MapStackDetail(ctx context.Context, eng engine.BranchReader, graph *engine.StackGraph, rootBranch string, allBranches []string, prCount int, scope string, checksMap map[string]*github.CheckStatus) StackDetail {
 	// Derive owner from root branch's PR author
 	var owner string
 	if checksMap != nil {
@@ -158,7 +158,7 @@ func MapStackDetail(eng engine.BranchReader, graph *engine.StackGraph, rootBranc
 		if checksMap != nil {
 			checks = checksMap[name]
 		}
-		br := MapBranch(eng, node.Branch, node, checks)
+		br := MapBranch(ctx, eng, node.Branch, node, checks)
 		if isAnchor {
 			// Anchor's direct children become display roots
 			if br.Parent == anchorName {

--- a/internal/shippable/analyzer.go
+++ b/internal/shippable/analyzer.go
@@ -58,7 +58,7 @@ func (a *Analyzer) AnalyzeAll(ctx context.Context) (*AnalysisResult, error) {
 	}
 
 	for _, stack := range stacks {
-		analyzed := a.analyzeStack(stack, statusMap)
+		analyzed := a.analyzeStack(ctx, stack, statusMap)
 		result.Stacks = append(result.Stacks, analyzed)
 
 		// Update counts
@@ -93,12 +93,12 @@ func (a *Analyzer) AnalyzeStack(ctx context.Context, stack merge.MultiStackInfo)
 		statusMap = make(map[string]*github.CheckStatus)
 	}
 
-	analyzed := a.analyzeStack(stack, statusMap)
+	analyzed := a.analyzeStack(ctx, stack, statusMap)
 	return &analyzed, nil
 }
 
 // analyzeStack performs the actual analysis of a single stack.
-func (a *Analyzer) analyzeStack(stack merge.MultiStackInfo, statusMap map[string]*github.CheckStatus) Stack {
+func (a *Analyzer) analyzeStack(ctx context.Context, stack merge.MultiStackInfo, statusMap map[string]*github.CheckStatus) Stack {
 	result := Stack{
 		Stack:       stack,
 		ApprovalOK:  true,
@@ -126,7 +126,7 @@ func (a *Analyzer) analyzeStack(stack merge.MultiStackInfo, statusMap map[string
 			}
 		}
 
-		blocking := a.analyzeBranch(branchName, statusMap)
+		blocking := a.analyzeBranch(ctx, branchName, statusMap)
 		if blocking != nil {
 			result.BlockingPRs = append(result.BlockingPRs, *blocking)
 
@@ -153,7 +153,7 @@ func (a *Analyzer) analyzeStack(stack merge.MultiStackInfo, statusMap map[string
 }
 
 // analyzeBranch analyzes a single branch and returns blocking info if any.
-func (a *Analyzer) analyzeBranch(branchName string, statusMap map[string]*github.CheckStatus) *BlockingPR {
+func (a *Analyzer) analyzeBranch(ctx context.Context, branchName string, statusMap map[string]*github.CheckStatus) *BlockingPR {
 	// Get PR info from engine metadata
 	branch := a.eng.GetBranch(branchName)
 	prInfo, err := branch.GetPrInfo()
@@ -181,7 +181,7 @@ func (a *Analyzer) analyzeBranch(branchName string, statusMap map[string]*github
 	// Check if local branch matches remote
 	// This is critical for shipping: if local differs from remote, the octopus merge
 	// will use local SHAs but PRs track remote SHAs, so GitHub won't auto-close them
-	if !a.eng.ReadBranchRemoteStatuses(context.Background(), engine.BranchesOf(branch)).ForBranch(branch).Matches() {
+	if !a.eng.ReadBranchRemoteStatuses(ctx, engine.BranchesOf(branch)).ForBranch(branch).Matches() {
 		return &BlockingPR{
 			Branch:   branchName,
 			PRNumber: prNumber,


### PR DESCRIPTION
## Summary

- `ReadBranchRemoteStatuses` accepts a `context.Context` for cancellation, but two code paths were discarding the caller's context and substituting `context.Background()` instead
- In the shippability analyzer: `analyzeStack` → `analyzeBranch` didn't carry the context, so the `ReadBranchRemoteStatuses` call inside `analyzeBranch` couldn't be cancelled when the parent `AnalyzeAll`/`AnalyzeStack` request was cancelled
- In the HTTP mappers: `MapBranch` and `MapStackDetail` had the same issue — HTTP handlers pass `r.Context()` to GitHub calls but then dropped it when mapping branch responses

The fix threads `ctx` through the full call chain in both places: `AnalyzeAll(ctx)` → `analyzeStack(ctx, ...)` → `analyzeBranch(ctx, ...)` → `ReadBranchRemoteStatuses(ctx, ...)`, and similarly for the mapper functions through their HTTP handler callers.

## Test plan

- [ ] `go build ./...` passes (verified)
- [ ] `go vet ./internal/shippable/... ./internal/contracts/http/... ./internal/api/handlers/...` passes (verified)
- No behavioral change under normal operation; cancellation now propagates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFU4mGzaqwM2GVg1u4TryN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFU4mGzaqwM2GVg1u4TryN)_