### PR TITLE
fix: log GetPrInfo errors during consolidation instead of silently dropping them

### DIFF
--- a/internal/actions/merge/consolidate.go
+++ b/internal/actions/merge/consolidate.go
@@ -310,7 +310,11 @@ func (c *ConsolidateMergeExecutor) lockAndNotifyIndividualPRs(_ context.Context,
 
 	prUpdates := make(map[string]*engine.PrInfo, len(branchesToLock))
 	for _, b := range branchesToLock {
-		prInfo, _ := b.GetPrInfo()
+		prInfo, err := b.GetPrInfo()
+		if err != nil {
+			splog.Debug("Failed to read PR info for %s: %v", b.GetName(), err)
+			continue
+		}
 		if prInfo != nil {
 			prUpdates[b.GetName()] = prInfo.WithMergeBranch(consolidationBranch)
 		}

--- a/internal/actions/merge/multistack.go
+++ b/internal/actions/merge/multistack.go
@@ -288,7 +288,11 @@ func lockAndNotifyMultiStackPRs(ctx *app.Context, eng engine.Engine, includedSta
 	// Update PR info with consolidation branch
 	prUpdates := make(map[string]*engine.PrInfo, len(branchesToLock))
 	for _, b := range branchesToLock {
-		prInfo, _ := b.GetPrInfo()
+		prInfo, err := b.GetPrInfo()
+		if err != nil {
+			out.Debug("Failed to read PR info for %s: %v", b.GetName(), err)
+			continue
+		}
 		if prInfo != nil {
 			prUpdates[b.GetName()] = prInfo.WithMergeBranch(consolidationBranch)
 		}


### PR DESCRIPTION
## Summary

- `consolidate.go` and `multistack.go` both contained `prInfo, _ := b.GetPrInfo()` in the loop that builds PR updates before a consolidation merge
- A metadata read error would silently skip the branch's update, leaving its merge-branch pointer stale with no indication of what went wrong
- Changed to log at debug level (consistent with how the surrounding code handles other non-fatal errors in the same path) and `continue`

## Details

`GetPrInfo` calls `readMetadata` internally, which can fail on git/filesystem errors. The surrounding code already uses `splog.Debug`/`out.Debug` for non-fatal errors that shouldn't abort the operation — this fix matches that pattern rather than swallowing the error entirely.

The fix is identical in both files; the only difference is the logger (`splog` in `consolidate.go`, `out` in `multistack.go`).

## Test plan

- [ ] `go build ./internal/actions/merge/...` passes (verified)
- [ ] Consolidation merge still works when all PR info is readable (no behavior change on the happy path)
- [ ] On a metadata read failure, a debug log line now appears instead of silent skip

---
_Generated by [Claude Code](https://claude.ai/code/session_014rXSjUQzyiaXUcyyfLMAJH)_