### PR TITLE
fix(server): require https base URL for exposed auth servers

### DIFF
--- a/apps/server/auth.go
+++ b/apps/server/auth.go
@@ -71,6 +71,17 @@ func buildAuthConfig(p authBuildParams) (*authBuildResult, error) {
 		return nil, errors.New("STACKIT_SESSION_KEY is required when configuring auth (generate with: openssl rand -base64 32)")
 	}
 
+	// An exposed server issues the session cookie over the network. If its
+	// public base URL is plaintext http://, that bearer cookie travels in the
+	// clear: it can't be marked Secure (a Secure cookie is never sent back over
+	// http, which would silently break login), so it is capturable and
+	// replayable on the network path. Fail closed rather than ship that posture.
+	// Behind a TLS-terminating proxy the base URL is the public https:// URL, so
+	// this check passes and the internal http hop is fine.
+	if p.exposed && !strings.HasPrefix(baseURL, "https://") {
+		return nil, errors.New("the server is reachable off-host (non-loopback bind) but STACKIT_BASE_URL is not https://: the session cookie would be sent over plaintext and could be captured and replayed. Use an https:// base URL (terminate TLS at a proxy if needed), or bind loopback (STACKIT_ENV=local)")
+	}
+
 	cipher, err := auth.NewCipher(sessionKey)
 	if err != nil {
 		return nil, fmt.Errorf("STACKIT_SESSION_KEY: %w", err)
@@ -90,7 +101,10 @@ func buildAuthConfig(p authBuildParams) (*authBuildResult, error) {
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		BaseURL:      baseURL,
-		Cookies:      auth.CookieOptions{Secure: p.prod || strings.HasPrefix(baseURL, "https://")},
+		// Secure tracks actual exposure, not just the env name: any off-host
+		// (exposed) deployment serves the cookie over TLS — guaranteed by the
+		// https:// base-URL check above — so it must be marked Secure.
+		Cookies: auth.CookieOptions{Secure: p.prod || p.exposed || strings.HasPrefix(baseURL, "https://")},
 	}, store, allow, cipher)
 	if err != nil {
 		_ = store.Close()

--- a/apps/server/auth_test.go
+++ b/apps/server/auth_test.go
@@ -114,6 +114,59 @@ func TestBuildAuthConfig_HappyPath(t *testing.T) {
 	require.NoError(t, r.store.Close())
 }
 
+func TestBuildAuthConfig_ExposedHTTPBaseURLRefused(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel; these tests share process env.
+	withEnv(t, map[string]string{
+		"STACKIT_GITHUB_CLIENT_ID":     "id",
+		"STACKIT_GITHUB_CLIENT_SECRET": "secret",
+		"STACKIT_BASE_URL":             "http://10.0.0.5:8080",
+		"STACKIT_SESSION_KEY":          mustKey(t),
+		"STACKIT_ALLOWED_GH_USERS":     "jonnii",
+	})
+
+	// Exposed (off-host bind) + plaintext base URL would ship a non-Secure
+	// session cookie over the network. Fail closed.
+	_, err := buildAuthConfig(authBuildParams{exposed: true})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "https")
+}
+
+func TestBuildAuthConfig_ExposedHTTPSBaseURLOK(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel; these tests share process env.
+	withEnv(t, map[string]string{
+		"STACKIT_GITHUB_CLIENT_ID":     "id",
+		"STACKIT_GITHUB_CLIENT_SECRET": "secret",
+		"STACKIT_BASE_URL":             "https://example.com",
+		"STACKIT_SESSION_KEY":          mustKey(t),
+		"STACKIT_ALLOWED_GH_USERS":     "jonnii",
+	})
+
+	// Exposed over https:// (e.g. behind a TLS-terminating proxy) is the
+	// supported posture: boots with Secure cookies.
+	r, err := buildAuthConfig(authBuildParams{exposed: true})
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	require.NoError(t, r.store.Close())
+}
+
+func TestBuildAuthConfig_LocalHTTPBaseURLOK(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel; these tests share process env.
+	withEnv(t, map[string]string{
+		"STACKIT_GITHUB_CLIENT_ID":     "id",
+		"STACKIT_GITHUB_CLIENT_SECRET": "secret",
+		"STACKIT_BASE_URL":             "http://localhost:8080",
+		"STACKIT_SESSION_KEY":          mustKey(t),
+		"STACKIT_ALLOWED_GH_USERS":     "jonnii",
+	})
+
+	// Not exposed (loopback) + http:// is fine for local dev — the cookie never
+	// leaves the host.
+	r, err := buildAuthConfig(authBuildParams{})
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	require.NoError(t, r.store.Close())
+}
+
 func TestBuildAuthConfig_EmptyAllowlistErrors(t *testing.T) {
 	// t.Setenv is incompatible with t.Parallel; these tests share process env.
 	withEnv(t, map[string]string{


### PR DESCRIPTION

An exposed (non-loopback bind) server issues the session cookie over the
network, but the cookie's Secure attribute was derived from the env name
(p.prod) / base-URL string rather than actual exposure. A supported config
(STACKIT_ENV unset, -bind 0.0.0.0, STACKIT_BASE_URL=http://...) booted with
auth enforced yet shipped a non-Secure session bearer cookie in cleartext,
capturable and replayable on the network path.

Fail closed: refuse to boot an exposed, auth-enabled server whose base URL is
plaintext http:// (forcing Secure over http would silently break login, since
browsers drop Secure cookies on plaintext connections). Also tie the Secure
attribute to p.exposed as defense-in-depth. Behind a TLS-terminating proxy the
base URL is the public https:// URL, so production deployments are unaffected.