### PR TITLE
feat: detect squash merges via opt-in IsSquashMerged

### DIFF
--- a/.claude/rules/safety-invariants.md
+++ b/.claude/rules/safety-invariants.md
@@ -2,6 +2,64 @@
 
 Critical guarantees that all operations must maintain. These are non-negotiable.
 
+## GitHub Merge Methods Are First-Class
+
+**Stackit must correctly handle PRs merged through all GitHub UI merge methods:
+merge commit, squash merge, and rebase merge.**
+
+This applies to: sync, restack, branch cleanup, merged-branch detection, stack
+navigation, merge orchestration, and any operation that decides whether branch
+changes have landed on trunk or another parent branch.
+
+### Why This Matters
+
+GitHub's three merge methods produce different Git histories for the same PR:
+
+| Method | What lands on the base branch | Is the PR branch tip reachable from base? | Can ancestry prove it merged? |
+|--------|-------------------------------|-------------------------------------------|-------------------------------|
+| Merge commit | A merge commit whose parents include the base and PR head | Yes | Yes |
+| Squash merge | One new commit containing the combined PR diff | No | No |
+| Rebase merge | New commits replaying the PR commits onto base | No | No |
+
+For merge commits, `git merge-base --is-ancestor <branch> <base>` and
+`git branch --merged <base>` are meaningful. For squash and rebase merges they
+are not: the PR's original commits are not ancestors of the base branch even
+though the PR landed.
+
+Squash merges are especially risky for stacked changes because a multi-commit
+PR lands as one combined commit. Per-commit patch matching (`git cherry`) can
+fail even when the branch's final diff is present on trunk. Rebase merges keep
+one commit per PR commit but rewrite SHAs, so ancestry still fails.
+
+### Required Behavior
+
+Code must not define "merged" using a single Git predicate. A merged PR can be
+proven by a combination of signals, including:
+
+- PR metadata that records the PR state as merged
+- The GitHub-reported landed commit being reachable from the target branch
+- Ancestry when the PR used a merge commit
+- Patch/range equivalence when the PR used rebase merge
+- Aggregate diff equivalence or recorded landed metadata when the PR used
+  squash merge
+
+When sync or restack sees a merged parent, it must reparent descendants past the
+landed branch without replaying that parent's commits. When it sees a merged
+sibling, it must never move an unrelated branch ref to the sibling's stale
+pre-merge tip.
+
+### Implementation Rules
+
+- Do not assume `IsAncestor(branch, trunk)` means "not merged" when it returns
+  false.
+- Do not assume `git branch --merged` covers squash or rebase merges.
+- Do not assume `git cherry` covers multi-commit squash merges.
+- Do not delete or reparent branch metadata based solely on SHA equality.
+- Preserve or fetch enough PR information to distinguish "closed unmerged" from
+  "merged by any GitHub method".
+- Any change to sync, restack, cleanup, or merge detection must consider all
+  three GitHub merge methods explicitly.
+
 ## No Detached HEAD State
 
 **Operations must NEVER leave the user in a detached HEAD state when cancelled or on failure.**

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -313,6 +313,21 @@ t.Run("test1", func(t *testing.T) { ... })
 t.Run("squash", func(t *testing.T) { ... })
 ```
 
+## GitHub Merge Method Coverage
+
+When testing sync, restack, branch cleanup, merged-branch detection, or merge
+orchestration, cover the GitHub merge method that matters for the behavior:
+
+| Method | Test shape |
+|--------|------------|
+| Merge commit | PR branch tip is reachable from trunk; ancestry-based detection should work. |
+| Squash merge | PR changes land as one combined commit; original PR commits are not ancestors of trunk. Include a multi-commit PR when testing patch/diff equivalence. |
+| Rebase merge | PR commits are replayed onto trunk with new SHAs; original PR commits are not ancestors of trunk. |
+
+Do not rely on a single-commit squash test to prove squash support: `git cherry`
+can already patch-match that case. Multi-commit squash tests are the important
+safety coverage for replay/reparenting bugs.
+
 ## Debugging Failing Tests
 
 Set `DEBUG=1` to preserve test directories:

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -217,6 +217,24 @@ PR information persisted in branch metadata.
 | `lockReason` | `*LockReason` | Lock status parsed from PR footer |
 | `mergeBranch` | `*string` | Merge branch name for consolidated PRs |
 
+### Merge Method Compatibility
+
+PR metadata is part of Stackit's safety model. A PR state of `"MERGED"` means
+the branch's changes landed, but it does not imply the branch tip is reachable
+from trunk:
+
+- GitHub merge commits preserve ancestry, so the PR branch tip is reachable from
+  the base branch.
+- GitHub squash merges create one new commit for the combined PR diff; the
+  original PR commits are not reachable from the base branch.
+- GitHub rebase merges replay commits with new SHAs; the original PR commits are
+  not reachable from the base branch.
+
+Code that consumes `prInfo.state`, updates merged metadata, cleans branches, or
+restacks descendants must treat all three GitHub merge methods as valid. Do not
+use ancestry alone to decide whether a PR's changes landed, and do not treat a
+non-ancestor branch tip as proof that a merged PR still needs to be replayed.
+
 ### MergedParent
 
 **Source**: `internal/git/metadata.go:76-80`

--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -31,6 +31,33 @@ stackit merge ship         # Consolidate stack into single atomic PR (waits by d
 
 Shipping stacked changes is fundamentally different from shipping linear PRs. Stackit provides multiple merge strategies optimized for different scenarios, plus advanced multi-stack consolidation for high-velocity teams.
 
+## GitHub Merge Methods
+
+GitHub supports three PR merge methods through the merge button. Stackit must
+support all three because repositories can choose any combination of them, and a
+stack may be merged by a teammate or automation outside of Stackit.
+
+| Method | What GitHub writes to the base branch | Original PR commits reachable from base? | Detection implications |
+|--------|----------------------------------------|------------------------------------------|------------------------|
+| Merge commit | A merge commit whose parents include the old base and the PR head | Yes | Ancestry checks work: the PR branch tip is reachable from base. |
+| Squash merge | One new commit containing the PR's combined final diff | No | Ancestry fails. Multi-commit PRs may also fail per-commit patch matching because one combined commit replaced many commits. |
+| Rebase merge | New commits replaying the PR commits onto the current base | No | Ancestry fails because SHAs are rewritten. Per-commit patch matching usually works, but conflict resolution or rewritten patches can change the result. |
+
+For stacked changes, these differences affect sync, restack, cleanup, and stack
+navigation:
+
+- A branch can be merged even when its tip is not an ancestor of trunk.
+- A merged parent must be skipped when restacking descendants, or the parent's
+  already-landed commits can be replayed into children.
+- A merged sibling must never be treated as a new base for an unrelated branch.
+- PR state and landed-commit metadata are safety signals, not just display
+  fields.
+
+The configured merge method (`stackit.merge.method`, or `--method` on merge
+commands) controls how Stackit asks GitHub to merge PRs. It does not limit what
+sync/restack must understand: those commands must recognize all three methods
+when reading repository history and PR state.
+
 ## Merge Status View
 
 Use `stackit merge status` to see an overview of your mergeable work:

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -393,6 +393,10 @@ func (d *demoGitRunner) IsMerged(_ context.Context, _, _ string) (bool, error) {
 	return false, nil
 }
 
+func (d *demoGitRunner) IsSquashMerged(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
+
 func (d *demoGitRunner) GetMergedBranches(_ context.Context, _ string) (map[string]bool, error) {
 	return make(map[string]bool), nil
 }

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -96,6 +96,7 @@ type DiffOperations interface {
 	GetMergeBaseByRef(ctx context.Context, ref1, ref2 string) (string, error)
 	IsAncestor(ctx context.Context, ancestor, descendant string) (bool, error)
 	IsMerged(ctx context.Context, branchName, target string) (bool, error)
+	IsSquashMerged(ctx context.Context, branchName, target string) (bool, error)
 	GetMergedBranches(ctx context.Context, target string) (map[string]bool, error)
 	IsDiffEmpty(ctx context.Context, branchName, base string) (bool, error)
 	GetChangedFiles(ctx context.Context, base, head string) ([]string, error)

--- a/internal/git/merge_detection.go
+++ b/internal/git/merge_detection.go
@@ -85,6 +85,15 @@ func (r *runner) GetUnmergedFiles(ctx context.Context) ([]string, error) {
 	return strings.Split(strings.TrimSpace(output), "\n"), nil
 }
 
+// IsMerged reports whether branchName's commits have landed in target using
+// cheap Git history checks only: ancestry, and per-commit patch matching via
+// `git cherry` (which covers plain merge commits and rebase merges, since both
+// preserve each commit's patch-id). It deliberately does NOT detect squash
+// merges — those collapse N commits into one new commit that matches no
+// individual branch commit, and proving equivalence needs an aggregate patch-id
+// scan over the target's recent history. That scan is too expensive to run on
+// every IsMerged call (this is invoked in loops over every tracked branch), so
+// callers that have a reason to suspect a squash merge opt into IsSquashMerged.
 func (r *runner) IsMerged(ctx context.Context, branchName, target string) (bool, error) {
 	// Get merge base
 	mergeBase, err := r.GetMergeBase(ctx, branchName, target)
@@ -127,4 +136,102 @@ func (r *runner) IsMerged(ctx context.Context, branchName, target string) (bool,
 	}
 
 	return true, nil
+}
+
+// IsSquashMerged reports whether branchName was squash-merged into target by
+// comparing the branch's aggregate diff patch-id against commits added to
+// target since the branch diverged. Unlike IsMerged it does not short-circuit
+// on ancestry or per-commit matches, so callers use it as a fallback once
+// IsMerged returns false. It is comparatively expensive (a bounded log plus a
+// patch-id per scanned target commit), so keep it out of broad IsMerged loops
+// and call it only from explicit landing decisions.
+func (r *runner) IsSquashMerged(ctx context.Context, branchName, target string) (bool, error) {
+	mergeBase, err := r.GetMergeBase(ctx, branchName, target)
+	if err != nil {
+		return false, fmt.Errorf("failed to get merge base: %w", err)
+	}
+	branchRev, err := r.GetRevision(branchName)
+	if err != nil {
+		return false, fmt.Errorf("failed to get branch revision: %w", err)
+	}
+	return r.isSquashMerged(ctx, branchRev, mergeBase, target)
+}
+
+// isSquashMerged detects whether branchName was squash-merged into target by
+// comparing the aggregate branch diff's patch-id against commits reachable from
+// target but not from mergeBase (i.e. commits added since the branch diverged).
+// A squash merge creates a single commit whose diff matches the branch's
+// combined diff even when unrelated target commits mean the full tree differs.
+//
+// Failure modes are biased toward the safe direction:
+//
+//   - False negative: if the target rewrote the same files between mergeBase and
+//     the squash, or the squash landed further back than the scanned window, the
+//     patch-ids differ and this returns false. Callers then rebase the branch and
+//     surface any conflict in a throwaway validation worktree — no data loss.
+//   - False positive: a match means some target commit has a byte-identical
+//     combined diff (after --stable normalization), which means the branch's
+//     changes already landed. Treating it as merged is correct in that case; an
+//     accidental collision of unrelated changes is not realistic for patch-ids.
+//
+// The scan is bounded to keep long-lived trunks cheap; exceeding it only costs a
+// false negative, never a wrong "merged".
+func (r *runner) isSquashMerged(ctx context.Context, branchRev, mergeBase, target string) (bool, error) {
+	branchPatchID, err := r.diffPatchID(ctx, mergeBase, branchRev)
+	if err != nil {
+		return false, nil //nolint:nilerr
+	}
+	if branchPatchID == "" {
+		return false, nil
+	}
+
+	// Enumerate commits on target since the merge-base (up to 200
+	// commits to bound the scan on long-lived trunks).
+	logOutput, err := r.RunGitCommandWithContext(ctx, "log", "--format=%H", "-200", mergeBase+".."+target)
+	if err != nil {
+		return false, nil //nolint:nilerr
+	}
+
+	for commitSHA := range strings.SplitSeq(strings.TrimSpace(logOutput), "\n") {
+		commitSHA = strings.TrimSpace(commitSHA)
+		if commitSHA == "" {
+			continue
+		}
+		commitPatchID, patchErr := r.commitPatchID(ctx, commitSHA)
+		if patchErr != nil {
+			continue
+		}
+		if commitPatchID == branchPatchID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (r *runner) diffPatchID(ctx context.Context, base, head string) (string, error) {
+	diffOutput, err := r.RunGitCommandRawWithContext(ctx, "diff", "--no-ext-diff", "--full-index", base, head)
+	if err != nil {
+		return "", err
+	}
+	return r.patchID(ctx, diffOutput)
+}
+
+func (r *runner) commitPatchID(ctx context.Context, commitSHA string) (string, error) {
+	diffOutput, err := r.RunGitCommandRawWithContext(ctx, "show", "--format=", "--no-ext-diff", "--full-index", commitSHA)
+	if err != nil {
+		return "", err
+	}
+	return r.patchID(ctx, diffOutput)
+}
+
+func (r *runner) patchID(ctx context.Context, diffOutput string) (string, error) {
+	if strings.TrimSpace(diffOutput) == "" {
+		return "", nil
+	}
+	output, err := r.runGitInternal(ctx, diffOutput, nil, true, "patch-id", "--stable")
+	if err != nil {
+		return "", err
+	}
+	patchID, _, _ := strings.Cut(strings.TrimSpace(output), " ")
+	return patchID, nil
 }

--- a/internal/git/merge_detection_test.go
+++ b/internal/git/merge_detection_test.go
@@ -2,6 +2,7 @@ package git_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,7 +24,7 @@ func TestIsMerged(t *testing.T) {
 		require.NoError(t, err)
 
 		// Initialize git repo
-		runner := git.NewRunner(nil)
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
 
 		// Branch is not merged
 		merged, err := runner.IsMerged(context.Background(), "branch1", "main")
@@ -47,11 +48,75 @@ func TestIsMerged(t *testing.T) {
 		require.NoError(t, err)
 
 		// Initialize git repo
-		runner := git.NewRunner(nil)
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
 
 		// Branch should be merged
 		merged, err := runner.IsMerged(context.Background(), "branch1", "main")
 		require.NoError(t, err)
 		require.True(t, merged)
+	})
+
+	t.Run("returns true for rebase-merged branch", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+
+		err := scene.Repo.CreateAndCheckoutBranch("branch1")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("branch1 change 1", "b1")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("branch1 change 2", "b2")
+		require.NoError(t, err)
+
+		commitsOutput, err := scene.Repo.RunGitCommandAndGetOutput("rev-list", "--reverse", "main..branch1")
+		require.NoError(t, err)
+		commits := strings.Fields(commitsOutput)
+		require.Len(t, commits, 2)
+
+		err = scene.Repo.CheckoutBranch("main")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("unrelated trunk change", "trunk")
+		require.NoError(t, err)
+		for _, commit := range commits {
+			err = scene.Repo.RunGitCommand("cherry-pick", commit)
+			require.NoError(t, err)
+		}
+
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+		merged, err := runner.IsMerged(context.Background(), "branch1", "main")
+		require.NoError(t, err)
+		require.True(t, merged)
+	})
+
+	// A multi-commit squash matches no individual branch commit, so the cheap
+	// per-commit IsMerged cannot see it — only the aggregate-patch-id
+	// IsSquashMerged can. This split keeps the expensive scan off the hot
+	// IsMerged path.
+	t.Run("multi-commit squash: IsMerged false, IsSquashMerged true", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+
+		err := scene.Repo.CreateAndCheckoutBranch("branch1")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("v1", "feature")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("v1\nv2", "feature")
+		require.NoError(t, err)
+
+		err = scene.Repo.CheckoutBranch("main")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("unrelated trunk change", "trunk")
+		require.NoError(t, err)
+		err = scene.Repo.RunGitCommand("merge", "--squash", "branch1")
+		require.NoError(t, err)
+		err = scene.Repo.RunGitCommand("commit", "-m", "squash branch1")
+		require.NoError(t, err)
+
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+
+		merged, err := runner.IsMerged(context.Background(), "branch1", "main")
+		require.NoError(t, err)
+		require.False(t, merged, "cheap IsMerged must not detect a multi-commit squash")
+
+		squashMerged, err := runner.IsSquashMerged(context.Background(), "branch1", "main")
+		require.NoError(t, err)
+		require.True(t, squashMerged, "IsSquashMerged must detect the aggregate squash")
 	})
 }

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -494,6 +494,13 @@ func (t *tracingRunner) IsMerged(ctx context.Context, branchName, target string)
 	return result, err
 }
 
+func (t *tracingRunner) IsSquashMerged(ctx context.Context, branchName, target string) (bool, error) {
+	start := time.Now()
+	result, err := t.inner.IsSquashMerged(ctx, branchName, target)
+	t.trace("IsSquashMerged", time.Since(start), err == nil, err, slog.String("branch", branchName), slog.String("target", target))
+	return result, err
+}
+
 func (t *tracingRunner) GetMergedBranches(ctx context.Context, target string) (map[string]bool, error) {
 	start := time.Now()
 	result, err := t.inner.GetMergedBranches(ctx, target)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Fixes #1345

A multi-commit PR squash-merged on GitHub lands as a single combined commit whose patch-id matches none of the branch's individual commits, so the cheap per-commit `git cherry` check in `IsMerged` misses it. When a child is stacked on such a parent, restack/sync would replay the landed parent's pre-merge commits instead of reparenting past it (issue #1345's data-loss shape) — and this can happen with **zero stackit metadata** when a non-stackit collaborator merges a plain GitHub branch.

## Fix

Add a dedicated `IsSquashMerged` (`internal/git/merge_detection.go`) that compares the branch's *aggregate* diff patch-id against the patch-ids of commits added to the target since the branch diverged. A squash produces one commit whose combined diff matches the branch's combined diff even when unrelated target commits mean the full trees differ.

Keep it as a **separate opt-in method** rather than folding it into `IsMerged`: the aggregate scan is a bounded log plus a patch-id per scanned commit — far too expensive for the `O(branches)` loops that call `IsMerged`. `IsMerged` stays cheap (ancestry + per-commit cherry, which already cover merge and rebase merges); only explicit "did this branch land" decisions opt into the squash scan. This is why there is no separate "keep the scan off the hot path" follow-up — the cost boundary is built into the design here.

Failure is biased safe: a miss rebases the branch and surfaces any conflict in the validation worktree (no data loss); a match means the same combined change already landed.

## Test

`internal/git/merge_detection_test.go` covers a multi-commit squash merged into the target without recorded PR state, asserting `IsSquashMerged` detects it where the per-commit `IsMerged` check does not.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESxh6taTDwzMXcamMw9MEx)_

<hr/>

<!-- STACKIT-SECTION-START -->
**Harden restack/sync for multiplayer squash merges and landed branches**

Strengthens detection of work that landed via GitHub squash merges and tightens
restack safety so stacks built in shared repos do not replay already-merged
commits or build on un-pushed trunk.

Key changes:
- **detect squash merges via opt-in IsSquashMerged** (#1346): aggregate patch-id
  scan to recognize multi-commit squash merges that git cherry/ancestry miss.
- **add reflog messages to restack ref moves** (#1357): ref updates during
  restack now carry reflog context for easier recovery and debugging.
- **centralize landed-branch policy** (#1352): single source of truth for the
  landed/merged decision used by sync, restack, and cleanup.
- **squash-aware sync cleanup** (#1351): sync cleanup honors squash-merge
  detection when reparenting/removing landed branches.
- **route restack conflict aborts through standard abort** (#1350): conflict
  aborts use the standard abort path rather than absorb cleanup.
- **guard restack against un-pushed trunk** (#1355): refuse restack when local
  trunk is ahead of / diverged from origin/<trunk>, plus broad sync coverage.
- **document multiplayer collaboration findings** (#1356): docs for landed-work
  detection, the un-pushed trunk guard, and reparent invariants.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782655035`.


* **PR #1346** 👈
  * **PR #1357**
    * **PR #1352**
      * **PR #1351**
        * **PR #1350**
          * **PR #1355**
            * **PR #1356**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->


---
*Merged via consolidation into #1361 by jonnii*