### PR TITLE
feat(git): add RefDecorations for git-log-style ref annotations

### DIFF
--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -604,6 +604,10 @@ func (d *demoGitRunner) ListRefs(_ string) (map[string]string, error) {
 	return make(map[string]string), nil
 }
 
+func (d *demoGitRunner) RefDecorations() (map[string][]git.RefDecoration, error) {
+	return make(map[string][]git.RefDecoration), nil
+}
+
 func (d *demoGitRunner) ReadMetadata(_ string) (*git.Meta, error) {
 	return git.NewMeta(), nil
 }

--- a/internal/engine/engine_reader.go
+++ b/internal/engine/engine_reader.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 
 	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // AllBranches returns all branches.
@@ -232,6 +233,13 @@ func (e *engineImpl) FindBranchesForCommits(commitSHAs []string) map[string]stri
 	}
 
 	return result
+}
+
+// RefDecorations returns local branch and tag refs grouped by the commit SHA
+// they point at, for git-log-style annotations. Annotated tags are dereferenced
+// to the commit they wrap. Thin passthrough to the git layer.
+func (e *engineImpl) RefDecorations() (map[string][]git.RefDecoration, error) {
+	return e.git.RefDecorations()
 }
 
 // SortBranchesTopologically sorts branches so parents come before children.

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -23,6 +23,9 @@ type StackNavigator interface {
 	BranchesDepthFirst(startBranch Branch) iter.Seq2[Branch, int]
 	SortBranchesTopologically(branches Branches) Branches
 	FindBranchesForCommits(commitSHAs []string) map[string]string
+	// RefDecorations returns local branch and tag refs grouped by the commit SHA
+	// they point at (annotated tags dereferenced), for git-log-style annotations.
+	RefDecorations() (map[string][]git.RefDecoration, error)
 	// GetAllBranchNames returns the names of all local branches, including ones
 	// not tracked by stackit. Used by diagnostics that must see untracked or
 	// orphaned branches.

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -229,6 +229,9 @@ type RefOperations interface {
 	VerifyRef(ctx context.Context, refName string) error
 	DeleteRef(ctx context.Context, name string) error
 	ListRefs(prefix string) (map[string]string, error)
+	// RefDecorations returns local branch and tag refs grouped by the commit SHA
+	// they point at, dereferencing annotated tags to the wrapped commit.
+	RefDecorations() (map[string][]RefDecoration, error)
 }
 
 // ObjectOperations provides low-level Git object operations.

--- a/internal/git/ref_decorations.go
+++ b/internal/git/ref_decorations.go
@@ -1,0 +1,77 @@
+package git
+
+import (
+	"context"
+	"slices"
+	"strings"
+)
+
+// RefDecoration is a single local ref (branch head or tag) pointing at a commit.
+// It backs git-log-style "(main, tag: v1.4.0)" annotations.
+type RefDecoration struct {
+	Name  string // short ref name, e.g. "main" or "v1.4.0"
+	IsTag bool   // true for refs/tags/*, false for refs/heads/*
+}
+
+// RefDecorations returns local branch and tag refs grouped by the full commit
+// SHA they point at. Annotated tags are dereferenced to the commit they wrap
+// (via for-each-ref's `*objectname`) so a tag decoration lands on the commit, not
+// the intermediate tag object. Commits with no refs are simply absent from the map.
+//
+// Within each commit's slice the order is git-log-style and explicit: branch
+// heads first, then tags, alphabetical by name within each group. We sort rather
+// than lean on for-each-ref's refname order (which only happens to put "heads"
+// before "tags" lexically) so the grouping survives reordered ref args or a new
+// namespace like refs/remotes.
+func (r *runner) RefDecorations() (map[string][]RefDecoration, error) {
+	// %(*objectname) is empty for lightweight tags and branch heads, and the
+	// wrapped commit SHA for annotated tags. Prefer it when present.
+	out, err := r.RunGitCommandWithContext(context.Background(),
+		"for-each-ref",
+		"--format=%(refname)%00%(objectname)%00%(*objectname)",
+		"refs/heads", "refs/tags",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string][]RefDecoration)
+	for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.Split(line, "\x00")
+		if len(fields) < 2 {
+			continue
+		}
+		refname, objectname := fields[0], fields[1]
+		sha := objectname
+		if len(fields) >= 3 && fields[2] != "" {
+			sha = fields[2] // annotated tag: dereference to the wrapped commit
+		}
+		if sha == "" {
+			continue
+		}
+
+		switch {
+		case strings.HasPrefix(refname, "refs/tags/"):
+			result[sha] = append(result[sha], RefDecoration{Name: strings.TrimPrefix(refname, "refs/tags/"), IsTag: true})
+		case strings.HasPrefix(refname, "refs/heads/"):
+			result[sha] = append(result[sha], RefDecoration{Name: strings.TrimPrefix(refname, "refs/heads/")})
+		}
+	}
+
+	// Branch heads before tags, alphabetical within each group.
+	for _, decos := range result {
+		slices.SortFunc(decos, func(a, b RefDecoration) int {
+			if a.IsTag != b.IsTag {
+				if a.IsTag {
+					return 1
+				}
+				return -1
+			}
+			return strings.Compare(a.Name, b.Name)
+		})
+	}
+	return result, nil
+}

--- a/internal/git/ref_decorations_test.go
+++ b/internal/git/ref_decorations_test.go
@@ -1,0 +1,77 @@
+package git_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+)
+
+// findDecoration returns the decoration with the given name across all SHAs,
+// along with the SHA it points at.
+func findDecoration(decos map[string][]git.RefDecoration, name string) (string, git.RefDecoration, bool) {
+	for sha, list := range decos {
+		for _, d := range list {
+			if d.Name == name {
+				return sha, d, true
+			}
+		}
+	}
+	return "", git.RefDecoration{}, false
+}
+
+func TestRefDecorations(t *testing.T) {
+	t.Parallel()
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+
+	// A second commit so HEAD and the tag below can point at distinct commits.
+	require.NoError(t, scene.Repo.CreateChange("file1", "content1", false))
+	require.NoError(t, scene.Repo.RunGitCommand("add", "."))
+	require.NoError(t, scene.Repo.RunGitCommand("commit", "-m", "second"))
+
+	// Lightweight tag and annotated tag on the current commit.
+	require.NoError(t, scene.Repo.RunGitCommand("tag", "v1.0.0"))
+	require.NoError(t, scene.Repo.RunGitCommand("tag", "-a", "v2.0.0", "-m", "release 2"))
+	// A separate branch head.
+	require.NoError(t, scene.Repo.RunGitCommand("branch", "feature"))
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	decos, err := runner.RefDecorations()
+	require.NoError(t, err)
+
+	headSHA, err := runner.GetRef("refs/heads/main")
+	require.NoError(t, err)
+
+	// main and feature both point at the tip commit, as branch decorations.
+	mainSHA, mainDeco, ok := findDecoration(decos, "main")
+	require.True(t, ok, "expected main decoration")
+	require.False(t, mainDeco.IsTag)
+	require.Equal(t, headSHA, mainSHA)
+
+	_, featureDeco, ok := findDecoration(decos, "feature")
+	require.True(t, ok, "expected feature decoration")
+	require.False(t, featureDeco.IsTag)
+
+	// Lightweight tag points straight at the commit.
+	lwSHA, lwDeco, ok := findDecoration(decos, "v1.0.0")
+	require.True(t, ok, "expected lightweight tag decoration")
+	require.True(t, lwDeco.IsTag)
+	require.Equal(t, headSHA, lwSHA)
+
+	// Annotated tag is dereferenced to the wrapped commit, not the tag object.
+	annSHA, annDeco, ok := findDecoration(decos, "v2.0.0")
+	require.True(t, ok, "expected annotated tag decoration")
+	require.True(t, annDeco.IsTag)
+	require.Equal(t, headSHA, annSHA, "annotated tag should dereference to the commit SHA")
+
+	// All four refs point at HEAD: branch heads come first (alphabetical), then
+	// tags (alphabetical) — git-log-style, not for-each-ref's refname order.
+	require.Equal(t, []git.RefDecoration{
+		{Name: "feature"},
+		{Name: "main"},
+		{Name: "v1.0.0", IsTag: true},
+		{Name: "v2.0.0", IsTag: true},
+	}, decos[headSHA])
+}

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -1065,6 +1065,13 @@ func (t *tracingRunner) ListRefs(prefix string) (map[string]string, error) {
 	return result, err
 }
 
+func (t *tracingRunner) RefDecorations() (map[string][]RefDecoration, error) {
+	start := time.Now()
+	result, err := t.inner.RefDecorations()
+	t.trace("RefDecorations", time.Since(start), err == nil, err)
+	return result, err
+}
+
 // ObjectOperations methods
 
 func (t *tracingRunner) CreateBlob(content string) (string, error) {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Add a RefDecorations git primitive that groups local branch and tag refs
by the commit SHA they point at, dereferencing annotated tags to the
wrapped commit. Exposed through the engine as a thin passthrough.

Foundation for a stack-aware `log` view that decorates commits with the
branches and tags pointing at them.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782702987`.


* **PR #1347** 👈
  * **PR #1348**
    * **PR #1349**
      * **PR #1362**
        * **PR #1363**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1364 by jonnii*