### PR TITLE
fix: route restack conflict aborts through standard abort, not absorb cleanup

### DIFF
--- a/internal/actions/absorb/absorb_test.go
+++ b/internal/actions/absorb/absorb_test.go
@@ -750,6 +750,33 @@ func TestAbsorbConflictHandling(t *testing.T) {
 		require.True(t, IsAbsorbInProgress(s.Context))
 	})
 
+	t.Run("IsAbsorbInProgress returns false during a rebase even when detached", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		s.CreateBranch("test-branch")
+		s.TrackBranch("test-branch", "main")
+
+		testFile := filepath.Join(s.Scene.Dir, "test.go")
+		err := os.WriteFile(testFile, []byte("package main\n\nfunc test() {}\n"), 0600)
+		require.NoError(t, err)
+		s.RunGit("add", "test.go")
+		s.RunGit("commit", "-m", "add test.go")
+
+		// Reproduce the restack conflict workflow's state: HEAD detached AND a
+		// rebase in progress. EnterConflictWorkflow detaches on purpose, which
+		// leaves a "checkout: moving from" reflog entry. That alone used to make
+		// IsAbsorbInProgress report a phantom absorb, routing `stackit abort` to
+		// the absorb cleanup path instead of the standard rebase abort.
+		s.RunGit("checkout", "--detach", "HEAD")
+		rebaseMergeDir := filepath.Join(s.Scene.Dir, ".git", "rebase-merge")
+		require.NoError(t, os.MkdirAll(rebaseMergeDir, 0750))
+
+		// A rebase in progress means this is a restack/sync conflict, not an
+		// absorb — the standard abort owns it.
+		require.False(t, IsAbsorbInProgress(s.Context))
+	})
+
 	t.Run("ShowConflict displays staged changes info", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)

--- a/internal/actions/absorb/conflict.go
+++ b/internal/actions/absorb/conflict.go
@@ -11,9 +11,23 @@ import (
 
 // IsAbsorbInProgress checks if there's a failed absorb operation that needs cleanup.
 // This is detected by checking for:
-// 1. Detached HEAD state, OR
-// 2. Presence of absorb stash marker
+// 1. Presence of absorb stash marker, OR
+// 2. Detached HEAD state with no rebase/merge in progress
 func IsAbsorbInProgress(ctx *app.Context) bool {
+	// A rebase or merge in progress is owned by the standard conflict-workflow
+	// abort (restack/sync/merge). EnterConflictWorkflow deliberately detaches
+	// HEAD before the conflict rebase — which writes a "checkout: moving from"
+	// reflog entry — and persists continuation + snapshot state for the standard
+	// abort to roll back. Absorb's own failure mode is a cherry-pick conflict,
+	// which never leaves a rebase-merge/rebase-apply directory. So an in-progress
+	// rebase/merge means this is NOT an absorb to clean up. Without this guard the
+	// conflict workflow's detach is misread as a mid-absorb failure, routing
+	// `stackit abort` to absorb cleanup — which never runs `git rebase --abort`
+	// and leaves the repo stuck mid-rebase with stale continuation state.
+	if ctx.Engine.IsRebaseInProgress(ctx.Context) || ctx.Engine.IsMergeInProgress(ctx.Context) {
+		return false
+	}
+
 	// Check for absorb stash marker
 	stashList, _ := ctx.Engine.StashList(ctx.Context)
 	if strings.Contains(stashList, absorbStashMarker) {

--- a/internal/integration/restack_squash_conflict_abort_test.go
+++ b/internal/integration/restack_squash_conflict_abort_test.go
@@ -1,0 +1,145 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// revParse returns the resolved SHA of a ref in the test repo.
+func (s *TestShell) revParse(ref string) string {
+	s.t.Helper()
+	s.Git("rev-parse " + ref)
+	return strings.TrimSpace(s.Output())
+}
+
+// fileContent reads a working-tree file from the test repo.
+func (s *TestShell) fileContent(name string) string {
+	s.t.Helper()
+	data, err := os.ReadFile(filepath.Join(s.scene.Dir, name))
+	require.NoError(s.t, err, "failed to read %s", name)
+	return string(data)
+}
+
+// TestSquashMergedParentConflictAbortPreservesChild locks in the escalation path
+// from issue #1345.
+//
+// Setup: main -> parent (multi-commit) -> child. The parent is squash-merged
+// onto main with no PR metadata, so detection must come from aggregate patch-id,
+// not recorded MERGED metadata. A later trunk edit touches the same line the
+// child touches, so when the child reparents onto trunk its own commit CONFLICTS.
+//
+// The invariant: after the conflict is aborted, the child must be restored to its
+// original commit — its work intact, never reset to the squash-merged parent's
+// stale tip, never left mid-rebase or detached. This is exactly the data loss the
+// issue reported (a branch reset to a sibling's tip with its own commit orphaned).
+func TestSquashMergedParentConflictAbortPreservesChild(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t)
+
+	// main -> parent: two commits so the squash is genuinely multi-commit
+	// (per-commit patch matching via git cherry cannot detect it).
+	sh.WriteFile("shared.txt", "base\np2\n").
+		Run("create parent -m 'parent c1'").
+		OnBranch("parent")
+	sh.WriteFile("notes.txt", "parent note\n").
+		Git("commit -m 'parent c2'")
+
+	// parent -> child: the child rewrites the shared line and adds a unique file.
+	sh.WriteFile("shared.txt", "base\nCHILD\n").
+		WriteFile("child-only.txt", "child work\n").
+		Run("create child -m 'child commit'").
+		OnBranch("child")
+
+	childOrig := sh.revParse("child")
+
+	// GitHub squash-merges parent: one combined commit lands on main carrying the
+	// parent's aggregate diff. No PR metadata is recorded, so detection must fall
+	// through to the patch-id scan.
+	sh.Checkout("main")
+	parentStaleTip := sh.revParse("parent")
+	sh.WriteFile("shared.txt", "base\np2\n").
+		WriteFile("notes.txt", "parent note\n").
+		Git("commit -m 'squash-merge parent (#1)'")
+
+	// A later trunk commit edits the same shared line the child rewrote, so the
+	// child's replay onto trunk is guaranteed to conflict.
+	sh.WriteFile("shared.txt", "base\nMAINEDIT\n").
+		Git("commit -m 'trunk edit on shared line'")
+
+	// Restack the child. Detection reparents it past the squash-merged parent onto
+	// main, and replaying its commit conflicts on shared.txt.
+	sh.Checkout("child").
+		RunExpectError("restack --upstack").
+		OutputContains("conflict")
+
+	// Abort: must roll the child fully back to where it started. The conflict
+	// workflow detaches HEAD (writing a "checkout: moving from" reflog entry),
+	// which previously fooled the abort router into treating this restack conflict
+	// as a failed absorb — that path never ran `git rebase --abort`, leaving the
+	// repo stuck mid-rebase. Assert we took the standard rebase-abort path.
+	sh.Run("abort --force").
+		OutputContains("Aborting rebase").
+		OutputNotContains("absorb")
+
+	require.Equal(t, childOrig, sh.revParse("child"),
+		"child must be restored to its original commit after aborting the conflicted restack")
+	require.NotEqual(t, parentStaleTip, sh.revParse("child"),
+		"child must never point at the squash-merged parent's stale tip")
+	require.Equal(t, "base\nCHILD\n", sh.fileContent("shared.txt"),
+		"child's own change must survive the aborted restack")
+	require.Equal(t, "child work\n", sh.fileContent("child-only.txt"),
+		"child's unique file must survive the aborted restack")
+
+	// No rebase left in progress, and we are back on a real branch (not detached).
+	sh.Git("status")
+	require.NotContains(t, sh.Output(), "rebas", "no rebase should be in progress after abort")
+	sh.OnBranch("child")
+
+	sh.Git("status --porcelain")
+	require.Empty(t, strings.TrimSpace(sh.Output()), "working tree should be clean after abort")
+}
+
+// TestRestackWritesReflogMessageOnReparent locks in the second half of the fix:
+// branch ref moves during restack must be annotated in the reflog. Issue #1345
+// noted that blank "(no message)" reflog entries made the incident impossible to
+// trace. Here a squash-merged parent with no PR metadata causes the child to
+// reparent cleanly onto trunk; the resulting ref move must carry a "stackit:
+// restack" message instead of an empty one.
+func TestRestackWritesReflogMessageOnReparent(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t)
+
+	sh.WriteFile("shared.txt", "base\np2\n").
+		Run("create parent -m 'parent c1'").
+		OnBranch("parent")
+	sh.WriteFile("notes.txt", "parent note\n").
+		Git("commit -m 'parent c2'")
+
+	// Child adds only a unique file so its replay onto trunk applies cleanly.
+	sh.WriteFile("child-only.txt", "child work\n").
+		Run("create child -m 'child commit'").
+		OnBranch("child")
+
+	// Squash-merge parent onto main without PR metadata. Detection falls through
+	// to the aggregate patch-id scan.
+	sh.Checkout("main")
+	sh.WriteFile("shared.txt", "base\np2\n").
+		WriteFile("notes.txt", "parent note\n").
+		Git("commit -m 'squash-merge parent (#1)'")
+
+	sh.Checkout("child").
+		Run("restack --upstack")
+
+	// The child reparented onto main; its ref move must be annotated.
+	sh.Git("reflog show child")
+	require.Contains(t, sh.Output(), "stackit: restack",
+		"restack must annotate branch ref moves in the reflog, not leave blank entries")
+	sh.ExpectBranchParent("child", "main")
+
+	sh.Git("status --porcelain")
+	require.Empty(t, strings.TrimSpace(sh.Output()), "working tree should be clean after restack")
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

EnterConflictWorkflow deliberately detaches HEAD before the conflict rebase so a
later `git rebase --abort` can never move a branch ref to the failed rebase's
target. That detach writes a "checkout: moving from" reflog entry, which
IsAbsorbInProgress treated as a sign of a mid-absorb failure. As a result
`stackit abort` after a restack/sync conflict was routed to the absorb cleanup
path, which re-checks-out the branch but never runs `git rebase --abort` and
never clears continuation/snapshot state — leaving the repo stuck mid-rebase.

Absorb's own failure mode is a cherry-pick conflict, which never leaves a
rebase-merge/rebase-apply directory. So an in-progress rebase or merge means the
conflict is owned by the standard conflict-workflow abort, not absorb. Guard
IsAbsorbInProgress accordingly.

Covered by an integration test that drives a squash-merged-parent restack to a
real conflict, aborts, and asserts the child is restored to its original commit
with no rebase left in progress, plus a unit test for the detection guard.

<hr/>

<!-- STACKIT-SECTION-START -->
**Harden restack/sync for multiplayer squash merges and landed branches**

Strengthens detection of work that landed via GitHub squash merges and tightens
restack safety so stacks built in shared repos do not replay already-merged
commits or build on un-pushed trunk.

Key changes:
- **detect squash merges via opt-in IsSquashMerged** (#1346): aggregate patch-id
  scan to recognize multi-commit squash merges that git cherry/ancestry miss.
- **add reflog messages to restack ref moves** (#1357): ref updates during
  restack now carry reflog context for easier recovery and debugging.
- **centralize landed-branch policy** (#1352): single source of truth for the
  landed/merged decision used by sync, restack, and cleanup.
- **squash-aware sync cleanup** (#1351): sync cleanup honors squash-merge
  detection when reparenting/removing landed branches.
- **route restack conflict aborts through standard abort** (#1350): conflict
  aborts use the standard abort path rather than absorb cleanup.
- **guard restack against un-pushed trunk** (#1355): refuse restack when local
  trunk is ahead of / diverged from origin/<trunk>, plus broad sync coverage.
- **document multiplayer collaboration findings** (#1356): docs for landed-work
  detection, the un-pushed trunk guard, and reparent invariants.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782655035`.


* **PR #1346**
  * **PR #1357**
    * **PR #1352**
      * **PR #1351**
        * **PR #1350** 👈
          * **PR #1355**
            * **PR #1356**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1361 by jonnii*