### PR TITLE
fix: squash-aware sync cleanup

### DIFF
--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -461,8 +461,30 @@ func (e *engineImpl) evaluateDeletionStatus(ctx context.Context, branchName stri
 		}
 	}
 
-	// 4. Check if merged into trunk
+	// 4. Check if merged into trunk (ancestry-based; covers merge commits)
 	if mergedBranches != nil && mergedBranches[branchName] {
+		return DeletionStatus{
+			SafeToDelete: true,
+			Reason:       fmt.Sprintf("merged into %s", trunkName),
+			Kind:         DeletionReasonMergedIntoTrunk,
+		}
+	}
+
+	// 4b. Squash and rebase merges don't appear in the ancestry-based
+	// mergedBranches set, and GitHub may have merged the PR before its local
+	// state synced to MERGED (so rule 3 didn't fire either). For branches that
+	// carry a recorded PR number, fall back to the same landed-branch detection
+	// restack uses (cheap cherry plus the gated squash patch-id scan), so cleanup
+	// keeps pace with squash-aware reparenting instead of leaving the merged
+	// branch behind.
+	//
+	// Gated on a recorded PR number for two reasons: it never auto-deletes an
+	// unsubmitted local branch whose diff happens to match trunk, and it keeps
+	// the expensive patch-id scan off the common no-PR path (consistent with how
+	// rule 5 gates its tree comparison behind PR metadata). branchLanded targets
+	// trunk specifically, so a branch squash-merged into a still-open parent is
+	// not treated as deletable.
+	if metaHasSubmittedPR(meta) && e.branchLanded(ctx, branchName, trunkName) {
 		return DeletionStatus{
 			SafeToDelete: true,
 			Reason:       fmt.Sprintf("merged into %s", trunkName),
@@ -479,8 +501,7 @@ func (e *engineImpl) evaluateDeletionStatus(ctx context.Context, branchName stri
 	if meta == nil {
 		return DeletionStatus{SafeToDelete: false, Reason: "", Kind: DeletionReasonNone}
 	}
-	prInfoMeta := meta.GetPrInfo()
-	if prInfoMeta == nil || prInfoMeta.Number == nil || *prInfoMeta.Number == 0 {
+	if !metaHasSubmittedPR(meta) {
 		return DeletionStatus{SafeToDelete: false, Reason: "", Kind: DeletionReasonNone}
 	}
 

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -87,6 +87,14 @@ func (e *engineImpl) prStateIsMerged(branchName string) bool {
 	return err == nil && prInfo != nil && prInfo.State() == prStateMerged
 }
 
+func metaHasSubmittedPR(meta *git.Meta) bool {
+	if meta == nil {
+		return false
+	}
+	prMeta := meta.GetPrInfo()
+	return prMeta != nil && prMeta.Number != nil && *prMeta.Number != 0
+}
+
 // branchLanded reports whether branchName's changes have landed into target.
 // PR metadata is authoritative across GitHub's merge, squash, and rebase merge
 // methods. Git fallback is intentionally limited to trunk: for non-trunk


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

`GetDeletionStatuses` only recognized a branch as merged via recorded PR state or ancestry (`git branch --merged`), both of which miss squash and rebase merges. A PR squash-merged on GitHub before its local state synced to `MERGED` would linger after `sync`, out of step with the squash-aware restack reparenting introduced earlier in this stack.

## Fix

Add a deletion rule that falls back to the same `branchLanded` check restack uses (cheap cherry plus the gated aggregate patch-id scan). It is:

- **gated on a recorded PR number** (`metaHasSubmittedPR`) so it never auto-deletes an unsubmitted local branch whose diff happens to match trunk, and keeps the expensive scan off the common no-PR path;
- **targeted at trunk specifically**, so a branch merged into a still-open parent is not deleted.

Introduces `metaHasSubmittedPR` and reuses it for the existing rule-5 PR gate.

## Test

Covered by the sync-cleanup scenarios in `internal/actions/sync` exercising squash-merged branches without synced `MERGED` state.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESxh6taTDwzMXcamMw9MEx)_

<hr/>

<!-- STACKIT-SECTION-START -->
**Harden restack/sync for multiplayer squash merges and landed branches**

Strengthens detection of work that landed via GitHub squash merges and tightens
restack safety so stacks built in shared repos do not replay already-merged
commits or build on un-pushed trunk.

Key changes:
- **detect squash merges via opt-in IsSquashMerged** (#1346): aggregate patch-id
  scan to recognize multi-commit squash merges that git cherry/ancestry miss.
- **add reflog messages to restack ref moves** (#1357): ref updates during
  restack now carry reflog context for easier recovery and debugging.
- **centralize landed-branch policy** (#1352): single source of truth for the
  landed/merged decision used by sync, restack, and cleanup.
- **squash-aware sync cleanup** (#1351): sync cleanup honors squash-merge
  detection when reparenting/removing landed branches.
- **route restack conflict aborts through standard abort** (#1350): conflict
  aborts use the standard abort path rather than absorb cleanup.
- **guard restack against un-pushed trunk** (#1355): refuse restack when local
  trunk is ahead of / diverged from origin/<trunk>, plus broad sync coverage.
- **document multiplayer collaboration findings** (#1356): docs for landed-work
  detection, the un-pushed trunk guard, and reparent invariants.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782655035`.


* **PR #1346**
  * **PR #1357**
    * **PR #1352**
      * **PR #1351** 👈
        * **PR #1350**
          * **PR #1355**
            * **PR #1356**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->


---
*Merged via consolidation into #1361 by jonnii*