### PR TITLE
refactor: centralize landed branch policy

### DIFF
--- a/internal/engine/branch_tracking.go
+++ b/internal/engine/branch_tracking.go
@@ -173,12 +173,15 @@ func (e *engineImpl) setParentRecomputingDivergence(ctx context.Context, branch 
 			// Check if existing revision is still a valid ancestor of the branch
 			if isAncestor, _ := e.git.IsAncestor(ctx, *meta.GetParentBranchRevision(), branchName); isAncestor {
 				// Check if the old parent was merged into the new parent (the
-				// "merge" case). The PR state is checked first: patch-id
-				// detection (git cherry inside IsMerged) cannot recognize a
-				// multi-commit squash merge, and errors when the old parent
-				// ref is already deleted — clobbering the divergence point
-				// would make the next restack replay the merged commits.
-				if e.prStateIsMerged(oldParent) {
+				// "merge" case). For trunk targets, use the centralized landed
+				// policy so no-metadata collaborator squash merges preserve the
+				// child's old upstream instead of replaying the parent's commits.
+				// If the old parent ref is already gone, the stored divergence
+				// revision is still enough to compare its aggregate patch against
+				// trunk.
+				oldParentRev := *meta.GetParentBranchRevision()
+				if e.branchLanded(ctx, oldParent, parentBranchName) ||
+					e.branchLanded(ctx, oldParentRev, parentBranchName) {
 					shouldUpdateRevision = false
 				} else if merged, _ := e.git.IsMerged(ctx, oldParent, parentBranchName); merged {
 					shouldUpdateRevision = false

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -87,10 +87,42 @@ func (e *engineImpl) prStateIsMerged(branchName string) bool {
 	return err == nil && prInfo != nil && prInfo.State() == prStateMerged
 }
 
+// branchLanded reports whether branchName's changes have landed into target.
+// PR metadata is authoritative across GitHub's merge, squash, and rebase merge
+// methods. Git fallback is intentionally limited to trunk: for non-trunk
+// parents, patch-equivalence can also mean a local stack operation made a child
+// empty, not that a GitHub PR landed.
+//
+// The trunk Git fallback deliberately does not require stackit PR metadata.
+// Collaborators may squash- or rebase-merge a plain GitHub branch into main, and
+// a child stacked on that local branch still needs to reparent past it without
+// replaying the collaborator's commits. Callers that delete branches must add
+// their own metadata/confirmation gate before using this predicate.
+func (e *engineImpl) branchLanded(ctx context.Context, branchName, target string) bool {
+	if branchName == e.trunk {
+		return false
+	}
+	if e.prStateIsMerged(branchName) {
+		return true
+	}
+	if target == "" || target != e.trunk {
+		return false
+	}
+	// IsMerged covers ancestry and per-commit (rebase) merges cheaply.
+	if merged, err := e.git.IsMerged(ctx, branchName, target); err == nil && merged {
+		return true
+	}
+	// Squash merges need the aggregate patch-id scan, which is expensive and
+	// intentionally stays out of the hot IsMerged primitive. Only explicit
+	// "did this branch land into trunk" checks opt into it.
+	merged, err := e.git.IsSquashMerged(ctx, branchName, target)
+	return err == nil && merged
+}
+
 // shouldReparentBranch checks if a parent branch should be reparented
 // Returns true if the parent branch:
 // - No longer exists locally
-// - Has been merged into trunk
+// - Has been merged into its own parent
 // - Has a "MERGED" PR state in metadata
 func (e *engineImpl) shouldReparentBranch(ctx context.Context, parentBranchName string, metaMap map[string]*git.Meta) bool {
 	// Check if parent is trunk (no need to reparent)
@@ -110,9 +142,14 @@ func (e *engineImpl) shouldReparentBranch(ctx context.Context, parentBranchName 
 		return true
 	}
 
-	// Check if parent has been merged into trunk
-	merged, err := e.git.IsMerged(ctx, parentBranchName, e.trunk)
-	if err == nil && merged {
+	// Check if parent has landed. Git-only detection is safe for trunk; stacked
+	// PR bases rely on merged PR metadata so local fold/squash operations do
+	// not get mistaken for GitHub merges.
+	mergeTarget := e.trunk
+	if state := e.readState(parentBranchName); state != nil && state.Parent != "" {
+		mergeTarget = state.Parent
+	}
+	if e.branchLanded(ctx, parentBranchName, mergeTarget) {
 		return true
 	}
 

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -61,6 +61,10 @@ func (e *engineImpl) restackBranch(
 		return RestackBranchResult{Result: RestackUnneeded, LockReason: lockReason}, nil
 	}
 
+	if e.branchLanded(ctx, branchName, parent) {
+		return RestackBranchResult{Result: RestackUnneeded}, nil
+	}
+
 	if e.IsFrozen(branch) {
 		// For frozen branches, we update via hard reset to remote instead of rebase
 		remoteSha, err := e.git.GetRemoteRevision(branchName)

--- a/internal/engine/restack_plan.go
+++ b/internal/engine/restack_plan.go
@@ -62,17 +62,6 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 		return item, true
 	}
 
-	// A branch whose PR was already merged is awaiting sync cleanup. Rebasing
-	// it onto trunk would replay commits the merge already applied — for a
-	// multi-commit squash merge that conflicts on every commit, since no
-	// individual commit patch-matches the squashed result. Skip it;
-	// descendants still reparent past it via shouldReparentBranch.
-	if prInfo, err := e.GetPrInfo(branch); err == nil && prInfo != nil && prInfo.State() == prStateMerged {
-		item.Skip = true
-		item.SkipResult = RestackBranchResult{Result: RestackUnneeded}
-		return item, true
-	}
-
 	parent := branch.GetParent()
 	parentName := e.trunk
 	e.mu.RLock()
@@ -90,6 +79,16 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 				parentName = e.trunk
 			}
 		}
+	}
+
+	// If this branch has already landed, do not rebase it during restack. This
+	// covers merged PR metadata for all GitHub methods, plus Git-detected merge,
+	// rebase, and multi-commit squash histories on trunk even when the merged
+	// branch has no stackit PR metadata.
+	if e.branchLanded(ctx, branchName, parentName) {
+		item.Skip = true
+		item.SkipResult = RestackBranchResult{Result: RestackUnneeded}
+		return item, true
 	}
 
 	if branch.IsFrozen() {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Harden restack/sync for multiplayer squash merges and landed branches**

Strengthens detection of work that landed via GitHub squash merges and tightens
restack safety so stacks built in shared repos do not replay already-merged
commits or build on un-pushed trunk.

Key changes:
- **detect squash merges via opt-in IsSquashMerged** (#1346): aggregate patch-id
  scan to recognize multi-commit squash merges that git cherry/ancestry miss.
- **add reflog messages to restack ref moves** (#1357): ref updates during
  restack now carry reflog context for easier recovery and debugging.
- **centralize landed-branch policy** (#1352): single source of truth for the
  landed/merged decision used by sync, restack, and cleanup.
- **squash-aware sync cleanup** (#1351): sync cleanup honors squash-merge
  detection when reparenting/removing landed branches.
- **route restack conflict aborts through standard abort** (#1350): conflict
  aborts use the standard abort path rather than absorb cleanup.
- **guard restack against un-pushed trunk** (#1355): refuse restack when local
  trunk is ahead of / diverged from origin/<trunk>, plus broad sync coverage.
- **document multiplayer collaboration findings** (#1356): docs for landed-work
  detection, the un-pushed trunk guard, and reparent invariants.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782655035`.


* **PR #1346**
  * **PR #1357**
    * **PR #1352** 👈
      * **PR #1351**
        * **PR #1350**
          * **PR #1355**
            * **PR #1356**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1361 by jonnii*