### PR TITLE
perf: keep squash-merge scan off the hot IsMerged path

### DIFF
--- a/.claude/rules/safety-invariants.md
+++ b/.claude/rules/safety-invariants.md
@@ -2,6 +2,64 @@
 
 Critical guarantees that all operations must maintain. These are non-negotiable.
 
+## GitHub Merge Methods Are First-Class
+
+**Stackit must correctly handle PRs merged through all GitHub UI merge methods:
+merge commit, squash merge, and rebase merge.**
+
+This applies to: sync, restack, branch cleanup, merged-branch detection, stack
+navigation, merge orchestration, and any operation that decides whether branch
+changes have landed on trunk or another parent branch.
+
+### Why This Matters
+
+GitHub's three merge methods produce different Git histories for the same PR:
+
+| Method | What lands on the base branch | Is the PR branch tip reachable from base? | Can ancestry prove it merged? |
+|--------|-------------------------------|-------------------------------------------|-------------------------------|
+| Merge commit | A merge commit whose parents include the base and PR head | Yes | Yes |
+| Squash merge | One new commit containing the combined PR diff | No | No |
+| Rebase merge | New commits replaying the PR commits onto base | No | No |
+
+For merge commits, `git merge-base --is-ancestor <branch> <base>` and
+`git branch --merged <base>` are meaningful. For squash and rebase merges they
+are not: the PR's original commits are not ancestors of the base branch even
+though the PR landed.
+
+Squash merges are especially risky for stacked changes because a multi-commit
+PR lands as one combined commit. Per-commit patch matching (`git cherry`) can
+fail even when the branch's final diff is present on trunk. Rebase merges keep
+one commit per PR commit but rewrite SHAs, so ancestry still fails.
+
+### Required Behavior
+
+Code must not define "merged" using a single Git predicate. A merged PR can be
+proven by a combination of signals, including:
+
+- PR metadata that records the PR state as merged
+- The GitHub-reported landed commit being reachable from the target branch
+- Ancestry when the PR used a merge commit
+- Patch/range equivalence when the PR used rebase merge
+- Aggregate diff equivalence or recorded landed metadata when the PR used
+  squash merge
+
+When sync or restack sees a merged parent, it must reparent descendants past the
+landed branch without replaying that parent's commits. When it sees a merged
+sibling, it must never move an unrelated branch ref to the sibling's stale
+pre-merge tip.
+
+### Implementation Rules
+
+- Do not assume `IsAncestor(branch, trunk)` means "not merged" when it returns
+  false.
+- Do not assume `git branch --merged` covers squash or rebase merges.
+- Do not assume `git cherry` covers multi-commit squash merges.
+- Do not delete or reparent branch metadata based solely on SHA equality.
+- Preserve or fetch enough PR information to distinguish "closed unmerged" from
+  "merged by any GitHub method".
+- Any change to sync, restack, cleanup, or merge detection must consider all
+  three GitHub merge methods explicitly.
+
 ## No Detached HEAD State
 
 **Operations must NEVER leave the user in a detached HEAD state when cancelled or on failure.**

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -313,6 +313,21 @@ t.Run("test1", func(t *testing.T) { ... })
 t.Run("squash", func(t *testing.T) { ... })
 ```
 
+## GitHub Merge Method Coverage
+
+When testing sync, restack, branch cleanup, merged-branch detection, or merge
+orchestration, cover the GitHub merge method that matters for the behavior:
+
+| Method | Test shape |
+|--------|------------|
+| Merge commit | PR branch tip is reachable from trunk; ancestry-based detection should work. |
+| Squash merge | PR changes land as one combined commit; original PR commits are not ancestors of trunk. Include a multi-commit PR when testing patch/diff equivalence. |
+| Rebase merge | PR commits are replayed onto trunk with new SHAs; original PR commits are not ancestors of trunk. |
+
+Do not rely on a single-commit squash test to prove squash support: `git cherry`
+can already patch-match that case. Multi-commit squash tests are the important
+safety coverage for replay/reparenting bugs.
+
 ## Debugging Failing Tests
 
 Set `DEBUG=1` to preserve test directories:

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -217,6 +217,24 @@ PR information persisted in branch metadata.
 | `lockReason` | `*LockReason` | Lock status parsed from PR footer |
 | `mergeBranch` | `*string` | Merge branch name for consolidated PRs |
 
+### Merge Method Compatibility
+
+PR metadata is part of Stackit's safety model. A PR state of `"MERGED"` means
+the branch's changes landed, but it does not imply the branch tip is reachable
+from trunk:
+
+- GitHub merge commits preserve ancestry, so the PR branch tip is reachable from
+  the base branch.
+- GitHub squash merges create one new commit for the combined PR diff; the
+  original PR commits are not reachable from the base branch.
+- GitHub rebase merges replay commits with new SHAs; the original PR commits are
+  not reachable from the base branch.
+
+Code that consumes `prInfo.state`, updates merged metadata, cleans branches, or
+restacks descendants must treat all three GitHub merge methods as valid. Do not
+use ancestry alone to decide whether a PR's changes landed, and do not treat a
+non-ancestor branch tip as proof that a merged PR still needs to be replayed.
+
 ### MergedParent
 
 **Source**: `internal/git/metadata.go:76-80`

--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -31,6 +31,33 @@ stackit merge ship         # Consolidate stack into single atomic PR (waits by d
 
 Shipping stacked changes is fundamentally different from shipping linear PRs. Stackit provides multiple merge strategies optimized for different scenarios, plus advanced multi-stack consolidation for high-velocity teams.
 
+## GitHub Merge Methods
+
+GitHub supports three PR merge methods through the merge button. Stackit must
+support all three because repositories can choose any combination of them, and a
+stack may be merged by a teammate or automation outside of Stackit.
+
+| Method | What GitHub writes to the base branch | Original PR commits reachable from base? | Detection implications |
+|--------|----------------------------------------|------------------------------------------|------------------------|
+| Merge commit | A merge commit whose parents include the old base and the PR head | Yes | Ancestry checks work: the PR branch tip is reachable from base. |
+| Squash merge | One new commit containing the PR's combined final diff | No | Ancestry fails. Multi-commit PRs may also fail per-commit patch matching because one combined commit replaced many commits. |
+| Rebase merge | New commits replaying the PR commits onto the current base | No | Ancestry fails because SHAs are rewritten. Per-commit patch matching usually works, but conflict resolution or rewritten patches can change the result. |
+
+For stacked changes, these differences affect sync, restack, cleanup, and stack
+navigation:
+
+- A branch can be merged even when its tip is not an ancestor of trunk.
+- A merged parent must be skipped when restacking descendants, or the parent's
+  already-landed commits can be replayed into children.
+- A merged sibling must never be treated as a new base for an unrelated branch.
+- PR state and landed-commit metadata are safety signals, not just display
+  fields.
+
+The configured merge method (`stackit.merge.method`, or `--method` on merge
+commands) controls how Stackit asks GitHub to merge PRs. It does not limit what
+sync/restack must understand: those commands must recognize all three methods
+when reading repository history and PR state.
+
 ## Merge Status View
 
 Use `stackit merge status` to see an overview of your mergeable work:

--- a/internal/actions/absorb/absorb_test.go
+++ b/internal/actions/absorb/absorb_test.go
@@ -750,6 +750,33 @@ func TestAbsorbConflictHandling(t *testing.T) {
 		require.True(t, IsAbsorbInProgress(s.Context))
 	})
 
+	t.Run("IsAbsorbInProgress returns false during a rebase even when detached", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		s.CreateBranch("test-branch")
+		s.TrackBranch("test-branch", "main")
+
+		testFile := filepath.Join(s.Scene.Dir, "test.go")
+		err := os.WriteFile(testFile, []byte("package main\n\nfunc test() {}\n"), 0600)
+		require.NoError(t, err)
+		s.RunGit("add", "test.go")
+		s.RunGit("commit", "-m", "add test.go")
+
+		// Reproduce the restack conflict workflow's state: HEAD detached AND a
+		// rebase in progress. EnterConflictWorkflow detaches on purpose, which
+		// leaves a "checkout: moving from" reflog entry. That alone used to make
+		// IsAbsorbInProgress report a phantom absorb, routing `stackit abort` to
+		// the absorb cleanup path instead of the standard rebase abort.
+		s.RunGit("checkout", "--detach", "HEAD")
+		rebaseMergeDir := filepath.Join(s.Scene.Dir, ".git", "rebase-merge")
+		require.NoError(t, os.MkdirAll(rebaseMergeDir, 0750))
+
+		// A rebase in progress means this is a restack/sync conflict, not an
+		// absorb — the standard abort owns it.
+		require.False(t, IsAbsorbInProgress(s.Context))
+	})
+
 	t.Run("ShowConflict displays staged changes info", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)

--- a/internal/actions/absorb/conflict.go
+++ b/internal/actions/absorb/conflict.go
@@ -11,9 +11,23 @@ import (
 
 // IsAbsorbInProgress checks if there's a failed absorb operation that needs cleanup.
 // This is detected by checking for:
-// 1. Detached HEAD state, OR
-// 2. Presence of absorb stash marker
+// 1. Presence of absorb stash marker, OR
+// 2. Detached HEAD state with no rebase/merge in progress
 func IsAbsorbInProgress(ctx *app.Context) bool {
+	// A rebase or merge in progress is owned by the standard conflict-workflow
+	// abort (restack/sync/merge). EnterConflictWorkflow deliberately detaches
+	// HEAD before the conflict rebase — which writes a "checkout: moving from"
+	// reflog entry — and persists continuation + snapshot state for the standard
+	// abort to roll back. Absorb's own failure mode is a cherry-pick conflict,
+	// which never leaves a rebase-merge/rebase-apply directory. So an in-progress
+	// rebase/merge means this is NOT an absorb to clean up. Without this guard the
+	// conflict workflow's detach is misread as a mid-absorb failure, routing
+	// `stackit abort` to absorb cleanup — which never runs `git rebase --abort`
+	// and leaves the repo stuck mid-rebase with stale continuation state.
+	if ctx.Engine.IsRebaseInProgress(ctx.Context) || ctx.Engine.IsMergeInProgress(ctx.Context) {
+		return false
+	}
+
 	// Check for absorb stash marker
 	stashList, _ := ctx.Engine.StashList(ctx.Context)
 	if strings.Contains(stashList, absorbStashMarker) {

--- a/internal/actions/sync/sync_test.go
+++ b/internal/actions/sync/sync_test.go
@@ -243,12 +243,26 @@ func (r *runtimeConflictRunner) Rebase(ctx context.Context, branchName, upstream
 }
 
 func (r *runtimeConflictRunner) UpdateRefsBatch(ctx context.Context, updates []git.RefUpdate) error {
-	if !r.injected {
-		r.injected = true
-		r.rebaseInProgress = true
+	if r.injectRuntimeConflict() {
 		return nil
 	}
 	return r.Runner.UpdateRefsBatch(ctx, updates)
+}
+
+func (r *runtimeConflictRunner) UpdateRefsBatchWithLog(ctx context.Context, updates []git.RefUpdate, reflogMessage string) error {
+	if r.injectRuntimeConflict() {
+		return nil
+	}
+	return r.Runner.UpdateRefsBatchWithLog(ctx, updates, reflogMessage)
+}
+
+func (r *runtimeConflictRunner) injectRuntimeConflict() bool {
+	if !r.injected {
+		r.injected = true
+		r.rebaseInProgress = true
+		return true
+	}
+	return false
 }
 
 func (r *runtimeConflictRunner) CheckoutBranch(ctx context.Context, branchName string) error {

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -393,6 +393,10 @@ func (d *demoGitRunner) IsMerged(_ context.Context, _, _ string) (bool, error) {
 	return false, nil
 }
 
+func (d *demoGitRunner) IsSquashMerged(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
+
 func (d *demoGitRunner) GetMergedBranches(_ context.Context, _ string) (map[string]bool, error) {
 	return make(map[string]bool), nil
 }

--- a/internal/engine/branch_tracking.go
+++ b/internal/engine/branch_tracking.go
@@ -178,7 +178,7 @@ func (e *engineImpl) setParentRecomputingDivergence(ctx context.Context, branch 
 				// multi-commit squash merge, and errors when the old parent
 				// ref is already deleted — clobbering the divergence point
 				// would make the next restack replay the merged commits.
-				if e.prStateIsMerged(oldParent) {
+				if e.branchLanded(ctx, oldParent, parentBranchName, landedMetadataOnly) {
 					shouldUpdateRevision = false
 				} else if merged, _ := e.git.IsMerged(ctx, oldParent, parentBranchName); merged {
 					shouldUpdateRevision = false

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -483,14 +483,12 @@ func (e *engineImpl) evaluateDeletionStatus(ctx context.Context, branchName stri
 	// with how rule 5 gates its tree comparison behind PR metadata). IsMerged
 	// targets trunk specifically, so a branch squash-merged into a still-open
 	// parent is not treated as deletable.
-	if meta != nil {
-		if prMeta := meta.GetPrInfo(); prMeta != nil && prMeta.Number != nil && *prMeta.Number != 0 {
-			if merged, err := e.git.IsMerged(ctx, branchName, trunkName); err == nil && merged {
-				return DeletionStatus{
-					SafeToDelete: true,
-					Reason:       fmt.Sprintf("merged into %s", trunkName),
-					Kind:         DeletionReasonMergedIntoTrunk,
-				}
+	if metaHasSubmittedPR(meta) {
+		if merged, err := e.git.IsMerged(ctx, branchName, trunkName); err == nil && merged {
+			return DeletionStatus{
+				SafeToDelete: true,
+				Reason:       fmt.Sprintf("merged into %s", trunkName),
+				Kind:         DeletionReasonMergedIntoTrunk,
 			}
 		}
 	}
@@ -504,8 +502,7 @@ func (e *engineImpl) evaluateDeletionStatus(ctx context.Context, branchName stri
 	if meta == nil {
 		return DeletionStatus{SafeToDelete: false, Reason: "", Kind: DeletionReasonNone}
 	}
-	prInfoMeta := meta.GetPrInfo()
-	if prInfoMeta == nil || prInfoMeta.Number == nil || *prInfoMeta.Number == 0 {
+	if !metaHasSubmittedPR(meta) {
 		return DeletionStatus{SafeToDelete: false, Reason: "", Kind: DeletionReasonNone}
 	}
 

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -461,12 +461,37 @@ func (e *engineImpl) evaluateDeletionStatus(ctx context.Context, branchName stri
 		}
 	}
 
-	// 4. Check if merged into trunk
+	// 4. Check if merged into trunk (ancestry-based; covers merge commits)
 	if mergedBranches != nil && mergedBranches[branchName] {
 		return DeletionStatus{
 			SafeToDelete: true,
 			Reason:       fmt.Sprintf("merged into %s", trunkName),
 			Kind:         DeletionReasonMergedIntoTrunk,
+		}
+	}
+
+	// 4b. Squash and rebase merges don't appear in the ancestry-based
+	// mergedBranches set, and GitHub may have merged the PR before its local
+	// state synced to MERGED (so rule 3 didn't fire either). For branches that
+	// carry a recorded PR number, fall back to the same aggregate patch-id
+	// detection restack uses, so cleanup keeps pace with squash-aware
+	// reparenting instead of leaving the merged branch behind.
+	//
+	// Gated on a recorded PR number for two reasons: it never auto-deletes an
+	// unsubmitted local branch whose diff happens to match trunk, and it keeps
+	// the expensive cherry/patch-id scan off the common no-PR path (consistent
+	// with how rule 5 gates its tree comparison behind PR metadata). IsMerged
+	// targets trunk specifically, so a branch squash-merged into a still-open
+	// parent is not treated as deletable.
+	if meta != nil {
+		if prMeta := meta.GetPrInfo(); prMeta != nil && prMeta.Number != nil && *prMeta.Number != 0 {
+			if merged, err := e.git.IsMerged(ctx, branchName, trunkName); err == nil && merged {
+				return DeletionStatus{
+					SafeToDelete: true,
+					Reason:       fmt.Sprintf("merged into %s", trunkName),
+					Kind:         DeletionReasonMergedIntoTrunk,
+				}
+			}
 		}
 	}
 

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -473,23 +473,22 @@ func (e *engineImpl) evaluateDeletionStatus(ctx context.Context, branchName stri
 	// 4b. Squash and rebase merges don't appear in the ancestry-based
 	// mergedBranches set, and GitHub may have merged the PR before its local
 	// state synced to MERGED (so rule 3 didn't fire either). For branches that
-	// carry a recorded PR number, fall back to the same aggregate patch-id
-	// detection restack uses, so cleanup keeps pace with squash-aware
-	// reparenting instead of leaving the merged branch behind.
+	// carry a recorded PR number, fall back to the same landed-branch detection
+	// restack uses (cheap cherry plus the gated squash patch-id scan), so cleanup
+	// keeps pace with squash-aware reparenting instead of leaving the merged
+	// branch behind.
 	//
 	// Gated on a recorded PR number for two reasons: it never auto-deletes an
 	// unsubmitted local branch whose diff happens to match trunk, and it keeps
-	// the expensive cherry/patch-id scan off the common no-PR path (consistent
-	// with how rule 5 gates its tree comparison behind PR metadata). IsMerged
-	// targets trunk specifically, so a branch squash-merged into a still-open
-	// parent is not treated as deletable.
-	if metaHasSubmittedPR(meta) {
-		if merged, err := e.git.IsMerged(ctx, branchName, trunkName); err == nil && merged {
-			return DeletionStatus{
-				SafeToDelete: true,
-				Reason:       fmt.Sprintf("merged into %s", trunkName),
-				Kind:         DeletionReasonMergedIntoTrunk,
-			}
+	// the expensive patch-id scan off the common no-PR path (consistent with how
+	// rule 5 gates its tree comparison behind PR metadata). branchLanded targets
+	// trunk specifically, so a branch squash-merged into a still-open parent is
+	// not treated as deletable.
+	if metaHasSubmittedPR(meta) && e.branchLanded(ctx, branchName, trunkName, landedMetadataOrTrunkGit) {
+		return DeletionStatus{
+			SafeToDelete: true,
+			Reason:       fmt.Sprintf("merged into %s", trunkName),
+			Kind:         DeletionReasonMergedIntoTrunk,
 		}
 	}
 

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -87,17 +87,39 @@ func (e *engineImpl) prStateIsMerged(branchName string) bool {
 	return err == nil && prInfo != nil && prInfo.State() == prStateMerged
 }
 
-// branchChangesLanded reports whether branchName's changes have landed into
-// target. PR metadata is authoritative across GitHub's merge, squash, and
-// rebase merge methods. The Git fallback is limited to trunk: for non-trunk
+func metaHasSubmittedPR(meta *git.Meta) bool {
+	if meta == nil {
+		return false
+	}
+	prMeta := meta.GetPrInfo()
+	return prMeta != nil && prMeta.Number != nil && *prMeta.Number != 0
+}
+
+type landedCheckMode int
+
+const (
+	// landedMetadataOnly trusts recorded PR state but does not infer anything
+	// from Git history.
+	landedMetadataOnly landedCheckMode = iota
+	// landedMetadataOrTrunkGit trusts recorded PR state, and also allows Git
+	// merge detection when the target is trunk.
+	landedMetadataOrTrunkGit
+)
+
+// branchLanded reports whether branchName's changes have landed into target.
+// PR metadata is authoritative across GitHub's merge, squash, and rebase merge
+// methods. Git fallback is intentionally limited to trunk: for non-trunk
 // parents, patch-equivalence can also mean a local stack operation made a child
 // empty, not that a GitHub PR landed.
-func (e *engineImpl) branchChangesLanded(ctx context.Context, branchName, target string) bool {
+func (e *engineImpl) branchLanded(ctx context.Context, branchName, target string, mode landedCheckMode) bool {
 	if branchName == e.trunk {
 		return false
 	}
 	if e.prStateIsMerged(branchName) {
 		return true
+	}
+	if mode != landedMetadataOrTrunkGit {
+		return false
 	}
 	if target == "" || target != e.trunk {
 		return false
@@ -136,7 +158,7 @@ func (e *engineImpl) shouldReparentBranch(ctx context.Context, parentBranchName 
 	if state := e.readState(parentBranchName); state != nil && state.Parent != "" {
 		mergeTarget = state.Parent
 	}
-	if e.branchChangesLanded(ctx, parentBranchName, mergeTarget) {
+	if e.branchLanded(ctx, parentBranchName, mergeTarget, landedMetadataOrTrunkGit) {
 		return true
 	}
 

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -95,6 +95,19 @@ func metaHasSubmittedPR(meta *git.Meta) bool {
 	return prMeta != nil && prMeta.Number != nil && *prMeta.Number != 0
 }
 
+// branchHasSubmittedPR reports whether a branch has a recorded PR number,
+// resolving metadata from the engine cache/disk. Used to gate the expensive
+// squash-merge scan: a branch that was never submitted cannot have been merged
+// on GitHub.
+func (e *engineImpl) branchHasSubmittedPR(branchName string) bool {
+	prInfo, err := e.GetPrInfo(e.GetBranch(branchName))
+	if err != nil || prInfo == nil {
+		return false
+	}
+	num := prInfo.Number()
+	return num != nil && *num != 0
+}
+
 type landedCheckMode int
 
 const (
@@ -124,7 +137,20 @@ func (e *engineImpl) branchLanded(ctx context.Context, branchName, target string
 	if target == "" || target != e.trunk {
 		return false
 	}
-	merged, err := e.git.IsMerged(ctx, branchName, target)
+	// IsMerged covers ancestry and per-commit (rebase) merges cheaply.
+	if merged, err := e.git.IsMerged(ctx, branchName, target); err == nil && merged {
+		return true
+	}
+	// Squash merges that haven't been reflected in PR state yet need the
+	// aggregate patch-id scan, which is expensive — gate it behind a recorded PR
+	// number so it stays off the hot path for actively-developed branches that
+	// have no PR. IsMerged is called in loops over every tracked branch, so the
+	// scan must not run there; only the explicit "did this branch land" checks
+	// (restack/reparent) opt into it.
+	if !e.branchHasSubmittedPR(branchName) {
+		return false
+	}
+	merged, err := e.git.IsSquashMerged(ctx, branchName, target)
 	return err == nil && merged
 }
 

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -87,10 +87,29 @@ func (e *engineImpl) prStateIsMerged(branchName string) bool {
 	return err == nil && prInfo != nil && prInfo.State() == prStateMerged
 }
 
+// branchChangesLanded reports whether branchName's changes have landed into
+// target. PR metadata is authoritative across GitHub's merge, squash, and
+// rebase merge methods. The Git fallback is limited to trunk: for non-trunk
+// parents, patch-equivalence can also mean a local stack operation made a child
+// empty, not that a GitHub PR landed.
+func (e *engineImpl) branchChangesLanded(ctx context.Context, branchName, target string) bool {
+	if branchName == e.trunk {
+		return false
+	}
+	if e.prStateIsMerged(branchName) {
+		return true
+	}
+	if target == "" || target != e.trunk {
+		return false
+	}
+	merged, err := e.git.IsMerged(ctx, branchName, target)
+	return err == nil && merged
+}
+
 // shouldReparentBranch checks if a parent branch should be reparented
 // Returns true if the parent branch:
 // - No longer exists locally
-// - Has been merged into trunk
+// - Has been merged into its own parent
 // - Has a "MERGED" PR state in metadata
 func (e *engineImpl) shouldReparentBranch(ctx context.Context, parentBranchName string, metaMap map[string]*git.Meta) bool {
 	// Check if parent is trunk (no need to reparent)
@@ -110,9 +129,14 @@ func (e *engineImpl) shouldReparentBranch(ctx context.Context, parentBranchName 
 		return true
 	}
 
-	// Check if parent has been merged into trunk
-	merged, err := e.git.IsMerged(ctx, parentBranchName, e.trunk)
-	if err == nil && merged {
+	// Check if parent has landed. Git-only detection is safe for trunk; stacked
+	// PR bases rely on merged PR metadata so local fold/squash operations do
+	// not get mistaken for GitHub merges.
+	mergeTarget := e.trunk
+	if state := e.readState(parentBranchName); state != nil && state.Parent != "" {
+		mergeTarget = state.Parent
+	}
+	if e.branchChangesLanded(ctx, parentBranchName, mergeTarget) {
 		return true
 	}
 

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -55,6 +55,10 @@ func (e *engineImpl) restackBranch(
 		return RestackBranchResult{Result: RestackUnneeded, LockReason: lockReason}, nil
 	}
 
+	if e.branchChangesLanded(ctx, branchName, parent) {
+		return RestackBranchResult{Result: RestackUnneeded}, nil
+	}
+
 	if e.IsFrozen(branch) {
 		// For frozen branches, we update via hard reset to remote instead of rebase
 		remoteSha, err := e.git.GetRemoteRevision(branchName)
@@ -384,7 +388,7 @@ func (e *engineImpl) restackBranch(
 		{RefName: fmt.Sprintf("refs/heads/%s", branchName), NewSHA: newRev, OldSHA: oldBranchSHA},
 		{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
 	}
-	if err := e.git.UpdateRefsBatch(ctx, updates); err != nil {
+	if err := e.git.UpdateRefsBatchWithLog(ctx, updates, "stackit: restack"); err != nil {
 		return RestackBranchResult{
 			Result:            RestackConflict,
 			RebasedBranchBase: parentRev,
@@ -568,7 +572,7 @@ func (e *engineImpl) applyBranchAndMetadata(
 		{RefName: fmt.Sprintf("refs/heads/%s", branchName), NewSHA: newRev, OldSHA: oldBranchSHA},
 		{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
 	}
-	if err := e.git.UpdateRefsBatch(ctx, updates); err != nil {
+	if err := e.git.UpdateRefsBatchWithLog(ctx, updates, "stackit: restack"); err != nil {
 		return RestackBranchResult{Result: RestackConflict, RebasedBranchBase: parentRev}, fmt.Errorf("failed to update refs atomically: %w", err)
 	}
 

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -107,7 +107,7 @@ func (e *engineImpl) restackBranch(
 				{RefName: fmt.Sprintf("refs/heads/%s", branchName), NewSHA: remoteSha, OldSHA: localSha},
 				{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
 			}
-			if err := e.git.UpdateRefsBatch(ctx, updates); err != nil {
+			if err := e.git.UpdateRefsBatchWithLog(ctx, updates, "stackit: restack (frozen)"); err != nil {
 				return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to update refs atomically for frozen branch %s: %w", branchName, err)
 			}
 
@@ -179,7 +179,7 @@ func (e *engineImpl) restackBranch(
 			{RefName: fmt.Sprintf("refs/heads/%s", branchName), NewSHA: trunkRev, OldSHA: anchorRev},
 			{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
 		}
-		if err := e.git.UpdateRefsBatch(ctx, updates); err != nil {
+		if err := e.git.UpdateRefsBatchWithLog(ctx, updates, "stackit: restack (anchor)"); err != nil {
 			return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to update refs atomically for anchor %s: %w", branchName, err)
 		}
 

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -8,6 +8,12 @@ import (
 	"github.com/getstackit/stackit/internal/git"
 )
 
+const (
+	reflogRestack       = "stackit: restack"
+	reflogRestackFrozen = "stackit: restack (frozen)"
+	reflogRestackAnchor = "stackit: restack (anchor)"
+)
+
 // restackBranch rebases a branch onto its parent
 // If the parent has been merged/deleted, it will automatically reparent to the nearest valid ancestor.
 // worktrees and metaRefSHAs are snapshots taken by the caller — passing them
@@ -55,7 +61,7 @@ func (e *engineImpl) restackBranch(
 		return RestackBranchResult{Result: RestackUnneeded, LockReason: lockReason}, nil
 	}
 
-	if e.branchChangesLanded(ctx, branchName, parent) {
+	if e.branchLanded(ctx, branchName, parent, landedMetadataOrTrunkGit) {
 		return RestackBranchResult{Result: RestackUnneeded}, nil
 	}
 
@@ -107,7 +113,7 @@ func (e *engineImpl) restackBranch(
 				{RefName: fmt.Sprintf("refs/heads/%s", branchName), NewSHA: remoteSha, OldSHA: localSha},
 				{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
 			}
-			if err := e.git.UpdateRefsBatchWithLog(ctx, updates, "stackit: restack (frozen)"); err != nil {
+			if err := e.git.UpdateRefsBatchWithLog(ctx, updates, reflogRestackFrozen); err != nil {
 				return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to update refs atomically for frozen branch %s: %w", branchName, err)
 			}
 
@@ -179,7 +185,7 @@ func (e *engineImpl) restackBranch(
 			{RefName: fmt.Sprintf("refs/heads/%s", branchName), NewSHA: trunkRev, OldSHA: anchorRev},
 			{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
 		}
-		if err := e.git.UpdateRefsBatchWithLog(ctx, updates, "stackit: restack (anchor)"); err != nil {
+		if err := e.git.UpdateRefsBatchWithLog(ctx, updates, reflogRestackAnchor); err != nil {
 			return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to update refs atomically for anchor %s: %w", branchName, err)
 		}
 
@@ -388,7 +394,7 @@ func (e *engineImpl) restackBranch(
 		{RefName: fmt.Sprintf("refs/heads/%s", branchName), NewSHA: newRev, OldSHA: oldBranchSHA},
 		{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
 	}
-	if err := e.git.UpdateRefsBatchWithLog(ctx, updates, "stackit: restack"); err != nil {
+	if err := e.git.UpdateRefsBatchWithLog(ctx, updates, reflogRestack); err != nil {
 		return RestackBranchResult{
 			Result:            RestackConflict,
 			RebasedBranchBase: parentRev,
@@ -572,7 +578,7 @@ func (e *engineImpl) applyBranchAndMetadata(
 		{RefName: fmt.Sprintf("refs/heads/%s", branchName), NewSHA: newRev, OldSHA: oldBranchSHA},
 		{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
 	}
-	if err := e.git.UpdateRefsBatchWithLog(ctx, updates, "stackit: restack"); err != nil {
+	if err := e.git.UpdateRefsBatchWithLog(ctx, updates, reflogRestack); err != nil {
 		return RestackBranchResult{Result: RestackConflict, RebasedBranchBase: parentRev}, fmt.Errorf("failed to update refs atomically: %w", err)
 	}
 

--- a/internal/engine/restack_plan.go
+++ b/internal/engine/restack_plan.go
@@ -62,17 +62,6 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 		return item, true
 	}
 
-	// A branch whose PR was already merged is awaiting sync cleanup. Rebasing
-	// it onto trunk would replay commits the merge already applied — for a
-	// multi-commit squash merge that conflicts on every commit, since no
-	// individual commit patch-matches the squashed result. Skip it;
-	// descendants still reparent past it via shouldReparentBranch.
-	if prInfo, err := e.GetPrInfo(branch); err == nil && prInfo != nil && prInfo.State() == prStateMerged {
-		item.Skip = true
-		item.SkipResult = RestackBranchResult{Result: RestackUnneeded}
-		return item, true
-	}
-
 	parent := branch.GetParent()
 	parentName := e.trunk
 	e.mu.RLock()
@@ -96,7 +85,7 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 	// covers merged PR metadata for all GitHub methods, plus Git-detected merge,
 	// rebase, and multi-commit squash histories on trunk before sync refreshes
 	// PR metadata.
-	if e.branchChangesLanded(ctx, branchName, parentName) {
+	if e.branchLanded(ctx, branchName, parentName, landedMetadataOrTrunkGit) {
 		item.Skip = true
 		item.SkipResult = RestackBranchResult{Result: RestackUnneeded}
 		return item, true

--- a/internal/engine/restack_plan.go
+++ b/internal/engine/restack_plan.go
@@ -92,6 +92,16 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 		}
 	}
 
+	// If this branch has already landed, do not rebase it during restack. This
+	// covers merged PR metadata for all GitHub methods, plus Git-detected merge,
+	// rebase, and multi-commit squash histories on trunk before sync refreshes
+	// PR metadata.
+	if e.branchChangesLanded(ctx, branchName, parentName) {
+		item.Skip = true
+		item.SkipResult = RestackBranchResult{Result: RestackUnneeded}
+		return item, true
+	}
+
 	if branch.IsFrozen() {
 		parentRev, err := e.GetBranch(parentName).GetRevision()
 		if err != nil {

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -137,7 +137,7 @@ func (r *runner) UpdateBranchRef(ctx context.Context, branchName, revision strin
 		return fmt.Errorf("failed to resolve revision %s: %w", revision, err)
 	}
 	refName := fmt.Sprintf("refs/heads/%s", branchName)
-	if _, err := r.RunGitCommandWithContext(ctx, "update-ref", refName, sha); err != nil {
+	if _, err := r.RunGitCommandWithContext(ctx, "update-ref", "-m", "stackit: update branch ref", refName, sha); err != nil {
 		return fmt.Errorf("failed to update branch ref: %w", err)
 	}
 	return nil

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -96,6 +96,7 @@ type DiffOperations interface {
 	GetMergeBaseByRef(ctx context.Context, ref1, ref2 string) (string, error)
 	IsAncestor(ctx context.Context, ancestor, descendant string) (bool, error)
 	IsMerged(ctx context.Context, branchName, target string) (bool, error)
+	IsSquashMerged(ctx context.Context, branchName, target string) (bool, error)
 	GetMergedBranches(ctx context.Context, target string) (map[string]bool, error)
 	IsDiffEmpty(ctx context.Context, branchName, base string) (bool, error)
 	GetChangedFiles(ctx context.Context, base, head string) ([]string, error)

--- a/internal/git/merge_detection.go
+++ b/internal/git/merge_detection.go
@@ -85,40 +85,31 @@ func (r *runner) GetUnmergedFiles(ctx context.Context) ([]string, error) {
 	return strings.Split(strings.TrimSpace(output), "\n"), nil
 }
 
-type mergeEvidence string
-
-const (
-	mergeEvidenceNone        mergeEvidence = "none"
-	mergeEvidenceAncestor    mergeEvidence = "ancestor"
-	mergeEvidenceCherry      mergeEvidence = "cherry"
-	mergeEvidencePatchID     mergeEvidence = "patch_id"
-	mergeEvidenceAggregateID mergeEvidence = "aggregate_patch_id"
-)
-
+// IsMerged reports whether branchName's commits have landed in target using
+// cheap Git history checks only: ancestry, and per-commit patch matching via
+// `git cherry` (which covers plain merge commits and rebase merges, since both
+// preserve each commit's patch-id). It deliberately does NOT detect squash
+// merges — those collapse N commits into one new commit that matches no
+// individual branch commit, and proving equivalence needs an aggregate patch-id
+// scan over the target's recent history. That scan is too expensive to run on
+// every IsMerged call (this is invoked in loops over every tracked branch), so
+// callers that have a reason to suspect a squash merge opt into IsSquashMerged.
 func (r *runner) IsMerged(ctx context.Context, branchName, target string) (bool, error) {
-	merged, _, err := r.detectMerge(ctx, branchName, target)
-	if err != nil {
-		return false, err
-	}
-	return merged, nil
-}
-
-func (r *runner) detectMerge(ctx context.Context, branchName, target string) (bool, mergeEvidence, error) {
 	// Get merge base
 	mergeBase, err := r.GetMergeBase(ctx, branchName, target)
 	if err != nil {
-		return false, mergeEvidenceNone, fmt.Errorf("failed to get merge base: %w", err)
+		return false, fmt.Errorf("failed to get merge base: %w", err)
 	}
 
 	// Get branch revision
 	branchRev, err := r.GetRevision(branchName)
 	if err != nil {
-		return false, mergeEvidenceNone, fmt.Errorf("failed to get branch revision: %w", err)
+		return false, fmt.Errorf("failed to get branch revision: %w", err)
 	}
 
 	// If merge base equals branch revision, branch is already merged
 	if mergeBase == branchRev {
-		return true, mergeEvidenceAncestor, nil
+		return true, nil
 	}
 
 	// Use git cherry to check if all commits are in trunk
@@ -128,43 +119,42 @@ func (r *runner) detectMerge(ctx context.Context, branchName, target string) (bo
 	if err != nil {
 		// If cherry fails, fall back to simpler check
 		// Check if branch tip is reachable from trunk
-		merged, ancestorErr := r.IsAncestor(ctx, branchRev, target)
-		if ancestorErr != nil {
-			return false, mergeEvidenceNone, ancestorErr
-		}
-		evidence := mergeEvidenceNone
-		if merged {
-			evidence = mergeEvidenceAncestor
-		}
-		return merged, evidence, nil
+		return r.IsAncestor(ctx, branchRev, target)
 	}
 
 	// If cherry output is empty or all lines start with '-', branch is merged
 	if cherryOutput == "" {
-		return true, mergeEvidenceCherry, nil
+		return true, nil
 	}
 
 	// Check if all commits are marked as merged (lines starting with '-')
 	lines := strings.SplitSeq(strings.TrimSpace(cherryOutput), "\n")
 	for line := range lines {
 		if line != "" && line[0] != '-' {
-			// cherry reports unmerged commits; but squash merges combine all branch
-			// commits into one new commit, so no individual branch commit has to
-			// match. Fall back to aggregate patch-id comparison for the whole branch
-			// diff against commits added to the target since the branch diverged.
-			merged, err := r.isSquashMerged(ctx, branchRev, mergeBase, target)
-			if err != nil {
-				return false, mergeEvidenceNone, err
-			}
-			evidence := mergeEvidenceNone
-			if merged {
-				evidence = mergeEvidenceAggregateID
-			}
-			return merged, evidence, nil
+			return false, nil
 		}
 	}
 
-	return true, mergeEvidencePatchID, nil
+	return true, nil
+}
+
+// IsSquashMerged reports whether branchName was squash-merged into target by
+// comparing the branch's aggregate diff patch-id against commits added to
+// target since the branch diverged. Unlike IsMerged it does not short-circuit
+// on ancestry or per-commit matches, so callers use it as a fallback once
+// IsMerged returns false. It is comparatively expensive (a bounded log plus a
+// patch-id per scanned target commit), so gate it behind a signal that the
+// branch may genuinely have merged — e.g. a recorded PR number.
+func (r *runner) IsSquashMerged(ctx context.Context, branchName, target string) (bool, error) {
+	mergeBase, err := r.GetMergeBase(ctx, branchName, target)
+	if err != nil {
+		return false, fmt.Errorf("failed to get merge base: %w", err)
+	}
+	branchRev, err := r.GetRevision(branchName)
+	if err != nil {
+		return false, fmt.Errorf("failed to get branch revision: %w", err)
+	}
+	return r.isSquashMerged(ctx, branchRev, mergeBase, target)
 }
 
 // isSquashMerged detects whether branchName was squash-merged into target by

--- a/internal/git/merge_detection.go
+++ b/internal/git/merge_detection.go
@@ -122,9 +122,92 @@ func (r *runner) IsMerged(ctx context.Context, branchName, target string) (bool,
 	lines := strings.SplitSeq(strings.TrimSpace(cherryOutput), "\n")
 	for line := range lines {
 		if line != "" && line[0] != '-' {
-			return false, nil
+			// cherry reports unmerged commits; but squash merges combine all branch
+			// commits into one new commit, so no individual branch commit has to
+			// match. Fall back to aggregate patch-id comparison for the whole branch
+			// diff against commits added to the target since the branch diverged.
+			return r.isSquashMerged(ctx, branchRev, mergeBase, target)
 		}
 	}
 
 	return true, nil
+}
+
+// isSquashMerged detects whether branchName was squash-merged into target by
+// comparing the aggregate branch diff's patch-id against commits reachable from
+// target but not from mergeBase (i.e. commits added since the branch diverged).
+// A squash merge creates a single commit whose diff matches the branch's
+// combined diff even when unrelated target commits mean the full tree differs.
+//
+// Failure modes are biased toward the safe direction:
+//
+//   - False negative: if the target rewrote the same files between mergeBase and
+//     the squash, or the squash landed further back than the scanned window, the
+//     patch-ids differ and this returns false. Callers then rebase the branch and
+//     surface any conflict in a throwaway validation worktree — no data loss.
+//   - False positive: a match means some target commit has a byte-identical
+//     combined diff (after --stable normalization), which means the branch's
+//     changes already landed. Treating it as merged is correct in that case; an
+//     accidental collision of unrelated changes is not realistic for patch-ids.
+//
+// The scan is bounded to keep long-lived trunks cheap; exceeding it only costs a
+// false negative, never a wrong "merged".
+func (r *runner) isSquashMerged(ctx context.Context, branchRev, mergeBase, target string) (bool, error) {
+	branchPatchID, err := r.diffPatchID(ctx, mergeBase, branchRev)
+	if err != nil {
+		return false, nil //nolint:nilerr
+	}
+	if branchPatchID == "" {
+		return false, nil
+	}
+
+	// Enumerate commits on target since the merge-base (up to 200
+	// commits to bound the scan on long-lived trunks).
+	logOutput, err := r.RunGitCommandWithContext(ctx, "log", "--format=%H", "-200", mergeBase+".."+target)
+	if err != nil {
+		return false, nil //nolint:nilerr
+	}
+
+	for commitSHA := range strings.SplitSeq(strings.TrimSpace(logOutput), "\n") {
+		commitSHA = strings.TrimSpace(commitSHA)
+		if commitSHA == "" {
+			continue
+		}
+		commitPatchID, patchErr := r.commitPatchID(ctx, commitSHA)
+		if patchErr != nil {
+			continue
+		}
+		if commitPatchID == branchPatchID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (r *runner) diffPatchID(ctx context.Context, base, head string) (string, error) {
+	diffOutput, err := r.RunGitCommandRawWithContext(ctx, "diff", "--no-ext-diff", "--full-index", base, head)
+	if err != nil {
+		return "", err
+	}
+	return r.patchID(ctx, diffOutput)
+}
+
+func (r *runner) commitPatchID(ctx context.Context, commitSHA string) (string, error) {
+	diffOutput, err := r.RunGitCommandRawWithContext(ctx, "show", "--format=", "--no-ext-diff", "--full-index", commitSHA)
+	if err != nil {
+		return "", err
+	}
+	return r.patchID(ctx, diffOutput)
+}
+
+func (r *runner) patchID(ctx context.Context, diffOutput string) (string, error) {
+	if strings.TrimSpace(diffOutput) == "" {
+		return "", nil
+	}
+	output, err := r.runGitInternal(ctx, diffOutput, nil, true, "patch-id", "--stable")
+	if err != nil {
+		return "", err
+	}
+	patchID, _, _ := strings.Cut(strings.TrimSpace(output), " ")
+	return patchID, nil
 }

--- a/internal/git/merge_detection.go
+++ b/internal/git/merge_detection.go
@@ -85,22 +85,40 @@ func (r *runner) GetUnmergedFiles(ctx context.Context) ([]string, error) {
 	return strings.Split(strings.TrimSpace(output), "\n"), nil
 }
 
+type mergeEvidence string
+
+const (
+	mergeEvidenceNone        mergeEvidence = "none"
+	mergeEvidenceAncestor    mergeEvidence = "ancestor"
+	mergeEvidenceCherry      mergeEvidence = "cherry"
+	mergeEvidencePatchID     mergeEvidence = "patch_id"
+	mergeEvidenceAggregateID mergeEvidence = "aggregate_patch_id"
+)
+
 func (r *runner) IsMerged(ctx context.Context, branchName, target string) (bool, error) {
+	merged, _, err := r.detectMerge(ctx, branchName, target)
+	if err != nil {
+		return false, err
+	}
+	return merged, nil
+}
+
+func (r *runner) detectMerge(ctx context.Context, branchName, target string) (bool, mergeEvidence, error) {
 	// Get merge base
 	mergeBase, err := r.GetMergeBase(ctx, branchName, target)
 	if err != nil {
-		return false, fmt.Errorf("failed to get merge base: %w", err)
+		return false, mergeEvidenceNone, fmt.Errorf("failed to get merge base: %w", err)
 	}
 
 	// Get branch revision
 	branchRev, err := r.GetRevision(branchName)
 	if err != nil {
-		return false, fmt.Errorf("failed to get branch revision: %w", err)
+		return false, mergeEvidenceNone, fmt.Errorf("failed to get branch revision: %w", err)
 	}
 
 	// If merge base equals branch revision, branch is already merged
 	if mergeBase == branchRev {
-		return true, nil
+		return true, mergeEvidenceAncestor, nil
 	}
 
 	// Use git cherry to check if all commits are in trunk
@@ -110,12 +128,20 @@ func (r *runner) IsMerged(ctx context.Context, branchName, target string) (bool,
 	if err != nil {
 		// If cherry fails, fall back to simpler check
 		// Check if branch tip is reachable from trunk
-		return r.IsAncestor(ctx, branchRev, target)
+		merged, ancestorErr := r.IsAncestor(ctx, branchRev, target)
+		if ancestorErr != nil {
+			return false, mergeEvidenceNone, ancestorErr
+		}
+		evidence := mergeEvidenceNone
+		if merged {
+			evidence = mergeEvidenceAncestor
+		}
+		return merged, evidence, nil
 	}
 
 	// If cherry output is empty or all lines start with '-', branch is merged
 	if cherryOutput == "" {
-		return true, nil
+		return true, mergeEvidenceCherry, nil
 	}
 
 	// Check if all commits are marked as merged (lines starting with '-')
@@ -126,11 +152,19 @@ func (r *runner) IsMerged(ctx context.Context, branchName, target string) (bool,
 			// commits into one new commit, so no individual branch commit has to
 			// match. Fall back to aggregate patch-id comparison for the whole branch
 			// diff against commits added to the target since the branch diverged.
-			return r.isSquashMerged(ctx, branchRev, mergeBase, target)
+			merged, err := r.isSquashMerged(ctx, branchRev, mergeBase, target)
+			if err != nil {
+				return false, mergeEvidenceNone, err
+			}
+			evidence := mergeEvidenceNone
+			if merged {
+				evidence = mergeEvidenceAggregateID
+			}
+			return merged, evidence, nil
 		}
 	}
 
-	return true, nil
+	return true, mergeEvidencePatchID, nil
 }
 
 // isSquashMerged detects whether branchName was squash-merged into target by

--- a/internal/git/merge_detection_test.go
+++ b/internal/git/merge_detection_test.go
@@ -86,7 +86,11 @@ func TestIsMerged(t *testing.T) {
 		require.True(t, merged)
 	})
 
-	t.Run("returns true for multi-commit squash after unrelated trunk change", func(t *testing.T) {
+	// A multi-commit squash matches no individual branch commit, so the cheap
+	// per-commit IsMerged cannot see it — only the aggregate-patch-id
+	// IsSquashMerged can. This split keeps the expensive scan off the hot
+	// IsMerged path.
+	t.Run("multi-commit squash: IsMerged false, IsSquashMerged true", func(t *testing.T) {
 		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
 
 		err := scene.Repo.CreateAndCheckoutBranch("branch1")
@@ -106,8 +110,13 @@ func TestIsMerged(t *testing.T) {
 		require.NoError(t, err)
 
 		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+
 		merged, err := runner.IsMerged(context.Background(), "branch1", "main")
 		require.NoError(t, err)
-		require.True(t, merged)
+		require.False(t, merged, "cheap IsMerged must not detect a multi-commit squash")
+
+		squashMerged, err := runner.IsSquashMerged(context.Background(), "branch1", "main")
+		require.NoError(t, err)
+		require.True(t, squashMerged, "IsSquashMerged must detect the aggregate squash")
 	})
 }

--- a/internal/git/merge_detection_test.go
+++ b/internal/git/merge_detection_test.go
@@ -2,6 +2,7 @@ package git_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,7 +24,7 @@ func TestIsMerged(t *testing.T) {
 		require.NoError(t, err)
 
 		// Initialize git repo
-		runner := git.NewRunner(nil)
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
 
 		// Branch is not merged
 		merged, err := runner.IsMerged(context.Background(), "branch1", "main")
@@ -47,9 +48,64 @@ func TestIsMerged(t *testing.T) {
 		require.NoError(t, err)
 
 		// Initialize git repo
-		runner := git.NewRunner(nil)
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
 
 		// Branch should be merged
+		merged, err := runner.IsMerged(context.Background(), "branch1", "main")
+		require.NoError(t, err)
+		require.True(t, merged)
+	})
+
+	t.Run("returns true for rebase-merged branch", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+
+		err := scene.Repo.CreateAndCheckoutBranch("branch1")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("branch1 change 1", "b1")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("branch1 change 2", "b2")
+		require.NoError(t, err)
+
+		commitsOutput, err := scene.Repo.RunGitCommandAndGetOutput("rev-list", "--reverse", "main..branch1")
+		require.NoError(t, err)
+		commits := strings.Fields(commitsOutput)
+		require.Len(t, commits, 2)
+
+		err = scene.Repo.CheckoutBranch("main")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("unrelated trunk change", "trunk")
+		require.NoError(t, err)
+		for _, commit := range commits {
+			err = scene.Repo.RunGitCommand("cherry-pick", commit)
+			require.NoError(t, err)
+		}
+
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+		merged, err := runner.IsMerged(context.Background(), "branch1", "main")
+		require.NoError(t, err)
+		require.True(t, merged)
+	})
+
+	t.Run("returns true for multi-commit squash after unrelated trunk change", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+
+		err := scene.Repo.CreateAndCheckoutBranch("branch1")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("v1", "feature")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("v1\nv2", "feature")
+		require.NoError(t, err)
+
+		err = scene.Repo.CheckoutBranch("main")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("unrelated trunk change", "trunk")
+		require.NoError(t, err)
+		err = scene.Repo.RunGitCommand("merge", "--squash", "branch1")
+		require.NoError(t, err)
+		err = scene.Repo.RunGitCommand("commit", "-m", "squash branch1")
+		require.NoError(t, err)
+
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
 		merged, err := runner.IsMerged(context.Background(), "branch1", "main")
 		require.NoError(t, err)
 		require.True(t, merged)

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -494,6 +494,13 @@ func (t *tracingRunner) IsMerged(ctx context.Context, branchName, target string)
 	return result, err
 }
 
+func (t *tracingRunner) IsSquashMerged(ctx context.Context, branchName, target string) (bool, error) {
+	start := time.Now()
+	result, err := t.inner.IsSquashMerged(ctx, branchName, target)
+	t.trace("IsSquashMerged", time.Since(start), err == nil, err, slog.String("branch", branchName), slog.String("target", target))
+	return result, err
+}
+
 func (t *tracingRunner) GetMergedBranches(ctx context.Context, target string) (map[string]bool, error) {
 	start := time.Now()
 	result, err := t.inner.GetMergedBranches(ctx, target)

--- a/internal/integration/restack_squash_conflict_abort_test.go
+++ b/internal/integration/restack_squash_conflict_abort_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // revParse returns the resolved SHA of a ref in the test repo.
@@ -14,6 +16,22 @@ func (s *TestShell) revParse(ref string) string {
 	s.t.Helper()
 	s.Git("rev-parse " + ref)
 	return strings.TrimSpace(s.Output())
+}
+
+// recordPR stamps a PR number and state onto a branch's metadata. The squash
+// scan is gated behind a recorded PR number, so detection tests must give the
+// merged branch a PR to mirror real GitHub usage (a squash-merged branch always
+// had a PR).
+func (s *TestShell) recordPR(branch string, prNumber int, state, base string) {
+	s.t.Helper()
+	runner := git.NewRunnerWithPath(s.Dir(), nil)
+	meta, err := runner.ReadMetadata(branch)
+	require.NoError(s.t, err)
+	num := prNumber
+	st := state
+	b := base
+	meta = meta.WithPrInfo(&git.PrInfoPersistence{Number: &num, State: &st, Base: &b})
+	require.NoError(s.t, runner.WriteMetadata(branch, meta))
 }
 
 // fileContent reads a working-tree file from the test repo.
@@ -28,9 +46,10 @@ func (s *TestShell) fileContent(name string) string {
 // from issue #1345.
 //
 // Setup: main -> parent (multi-commit) -> child. The parent is squash-merged onto
-// main WITHOUT any recorded PR state, so detection must come from aggregate
-// patch-id, not metadata. A later trunk edit touches the same line the child
-// touches, so when the child reparents onto trunk its own commit CONFLICTS.
+// main with a stale (OPEN) PR state, so detection must come from aggregate
+// patch-id, not recorded MERGED metadata. A later trunk edit touches the same
+// line the child touches, so when the child reparents onto trunk its own commit
+// CONFLICTS.
 //
 // The invariant: after the conflict is aborted, the child must be restored to its
 // original commit — its work intact, never reset to the squash-merged parent's
@@ -57,12 +76,14 @@ func TestSquashMergedParentConflictAbortPreservesChild(t *testing.T) {
 	childOrig := sh.revParse("child")
 
 	// GitHub squash-merges parent: one combined commit lands on main carrying the
-	// parent's aggregate diff. No PR state is recorded (no SimulateBranchMerged).
+	// parent's aggregate diff. The PR state stays stale (OPEN), so detection must
+	// fall through to the patch-id scan, which is gated behind a recorded PR number.
 	sh.Checkout("main")
 	parentStaleTip := sh.revParse("parent")
 	sh.WriteFile("shared.txt", "base\np2\n").
 		WriteFile("notes.txt", "parent note\n").
 		Git("commit -m 'squash-merge parent (#1)'")
+	sh.recordPR("parent", 1, "OPEN", "main")
 
 	// A later trunk commit edits the same shared line the child rewrote, so the
 	// child's replay onto trunk is guaranteed to conflict.
@@ -105,9 +126,9 @@ func TestSquashMergedParentConflictAbortPreservesChild(t *testing.T) {
 // TestRestackWritesReflogMessageOnReparent locks in the second half of the fix:
 // branch ref moves during restack must be annotated in the reflog. Issue #1345
 // noted that blank "(no message)" reflog entries made the incident impossible to
-// trace. Here a squash-merged parent (no PR state) causes the child to reparent
-// cleanly onto trunk; the resulting ref move must carry a "stackit: restack"
-// message instead of an empty one.
+// trace. Here a squash-merged parent (stale PR state) causes the child to
+// reparent cleanly onto trunk; the resulting ref move must carry a
+// "stackit: restack" message instead of an empty one.
 func TestRestackWritesReflogMessageOnReparent(t *testing.T) {
 	t.Parallel()
 	sh := NewTestShellInProcess(t)
@@ -123,11 +144,14 @@ func TestRestackWritesReflogMessageOnReparent(t *testing.T) {
 		Run("create child -m 'child commit'").
 		OnBranch("child")
 
-	// Squash-merge parent onto main with no recorded PR state.
+	// Squash-merge parent onto main. The PR state is still stale (OPEN), so
+	// detection falls through to the aggregate patch-id scan, which is gated
+	// behind a recorded PR number.
 	sh.Checkout("main")
 	sh.WriteFile("shared.txt", "base\np2\n").
 		WriteFile("notes.txt", "parent note\n").
 		Git("commit -m 'squash-merge parent (#1)'")
+	sh.recordPR("parent", 1, "OPEN", "main")
 
 	sh.Checkout("child").
 		Run("restack --upstack")

--- a/internal/integration/restack_squash_conflict_abort_test.go
+++ b/internal/integration/restack_squash_conflict_abort_test.go
@@ -1,0 +1,143 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// revParse returns the resolved SHA of a ref in the test repo.
+func (s *TestShell) revParse(ref string) string {
+	s.t.Helper()
+	s.Git("rev-parse " + ref)
+	return strings.TrimSpace(s.Output())
+}
+
+// fileContent reads a working-tree file from the test repo.
+func (s *TestShell) fileContent(name string) string {
+	s.t.Helper()
+	data, err := os.ReadFile(filepath.Join(s.scene.Dir, name))
+	require.NoError(s.t, err, "failed to read %s", name)
+	return string(data)
+}
+
+// TestSquashMergedParentConflictAbortPreservesChild locks in the escalation path
+// from issue #1345.
+//
+// Setup: main -> parent (multi-commit) -> child. The parent is squash-merged onto
+// main WITHOUT any recorded PR state, so detection must come from aggregate
+// patch-id, not metadata. A later trunk edit touches the same line the child
+// touches, so when the child reparents onto trunk its own commit CONFLICTS.
+//
+// The invariant: after the conflict is aborted, the child must be restored to its
+// original commit — its work intact, never reset to the squash-merged parent's
+// stale tip, never left mid-rebase or detached. This is exactly the data loss the
+// issue reported (a branch reset to a sibling's tip with its own commit orphaned).
+func TestSquashMergedParentConflictAbortPreservesChild(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t)
+
+	// main -> parent: two commits so the squash is genuinely multi-commit
+	// (per-commit patch matching via git cherry cannot detect it).
+	sh.WriteFile("shared.txt", "base\np2\n").
+		Run("create parent -m 'parent c1'").
+		OnBranch("parent")
+	sh.WriteFile("notes.txt", "parent note\n").
+		Git("commit -m 'parent c2'")
+
+	// parent -> child: the child rewrites the shared line and adds a unique file.
+	sh.WriteFile("shared.txt", "base\nCHILD\n").
+		WriteFile("child-only.txt", "child work\n").
+		Run("create child -m 'child commit'").
+		OnBranch("child")
+
+	childOrig := sh.revParse("child")
+
+	// GitHub squash-merges parent: one combined commit lands on main carrying the
+	// parent's aggregate diff. No PR state is recorded (no SimulateBranchMerged).
+	sh.Checkout("main")
+	parentStaleTip := sh.revParse("parent")
+	sh.WriteFile("shared.txt", "base\np2\n").
+		WriteFile("notes.txt", "parent note\n").
+		Git("commit -m 'squash-merge parent (#1)'")
+
+	// A later trunk commit edits the same shared line the child rewrote, so the
+	// child's replay onto trunk is guaranteed to conflict.
+	sh.WriteFile("shared.txt", "base\nMAINEDIT\n").
+		Git("commit -m 'trunk edit on shared line'")
+
+	// Restack the child. Detection reparents it past the squash-merged parent onto
+	// main, and replaying its commit conflicts on shared.txt.
+	sh.Checkout("child").
+		RunExpectError("restack --upstack").
+		OutputContains("conflict")
+
+	// Abort: must roll the child fully back to where it started. The conflict
+	// workflow detaches HEAD (writing a "checkout: moving from" reflog entry),
+	// which previously fooled the abort router into treating this restack conflict
+	// as a failed absorb — that path never ran `git rebase --abort`, leaving the
+	// repo stuck mid-rebase. Assert we took the standard rebase-abort path.
+	sh.Run("abort --force").
+		OutputContains("Aborting rebase").
+		OutputNotContains("absorb")
+
+	require.Equal(t, childOrig, sh.revParse("child"),
+		"child must be restored to its original commit after aborting the conflicted restack")
+	require.NotEqual(t, parentStaleTip, sh.revParse("child"),
+		"child must never point at the squash-merged parent's stale tip")
+	require.Equal(t, "base\nCHILD\n", sh.fileContent("shared.txt"),
+		"child's own change must survive the aborted restack")
+	require.Equal(t, "child work\n", sh.fileContent("child-only.txt"),
+		"child's unique file must survive the aborted restack")
+
+	// No rebase left in progress, and we are back on a real branch (not detached).
+	sh.Git("status")
+	require.NotContains(t, sh.Output(), "rebas", "no rebase should be in progress after abort")
+	sh.OnBranch("child")
+
+	sh.Git("status --porcelain")
+	require.Empty(t, strings.TrimSpace(sh.Output()), "working tree should be clean after abort")
+}
+
+// TestRestackWritesReflogMessageOnReparent locks in the second half of the fix:
+// branch ref moves during restack must be annotated in the reflog. Issue #1345
+// noted that blank "(no message)" reflog entries made the incident impossible to
+// trace. Here a squash-merged parent (no PR state) causes the child to reparent
+// cleanly onto trunk; the resulting ref move must carry a "stackit: restack"
+// message instead of an empty one.
+func TestRestackWritesReflogMessageOnReparent(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t)
+
+	sh.WriteFile("shared.txt", "base\np2\n").
+		Run("create parent -m 'parent c1'").
+		OnBranch("parent")
+	sh.WriteFile("notes.txt", "parent note\n").
+		Git("commit -m 'parent c2'")
+
+	// Child adds only a unique file so its replay onto trunk applies cleanly.
+	sh.WriteFile("child-only.txt", "child work\n").
+		Run("create child -m 'child commit'").
+		OnBranch("child")
+
+	// Squash-merge parent onto main with no recorded PR state.
+	sh.Checkout("main")
+	sh.WriteFile("shared.txt", "base\np2\n").
+		WriteFile("notes.txt", "parent note\n").
+		Git("commit -m 'squash-merge parent (#1)'")
+
+	sh.Checkout("child").
+		Run("restack --upstack")
+
+	// The child reparented onto main; its ref move must be annotated.
+	sh.Git("reflog show child")
+	require.Contains(t, sh.Output(), "stackit: restack",
+		"restack must annotate branch ref moves in the reflog, not leave blank entries")
+	sh.ExpectBranchParent("child", "main")
+
+	sh.Git("status --porcelain")
+	require.Empty(t, strings.TrimSpace(sh.Output()), "working tree should be clean after restack")
+}

--- a/internal/integration/restack_squash_merge_test.go
+++ b/internal/integration/restack_squash_merge_test.go
@@ -124,12 +124,13 @@ func TestRestackAfterMultiCommitSquashParentDeleted(t *testing.T) {
 	requireCleanWorkingTree(t, sh)
 }
 
-// TestRestackDetectsSquashMergeWithoutPRState covers running `stackit restack`
-// when the parent was squash-merged but no PR state has been recorded (e.g.
-// the branch was merged directly without a PR, or st sync has not run yet).
-// Aggregate patch-id comparison in IsMerged must detect the squash and cause
-// the child to reparent to trunk without replaying the parent's commits.
-func TestRestackDetectsSquashMergeWithoutPRState(t *testing.T) {
+// TestRestackDetectsSquashMergeWithStalePRState covers running `stackit restack`
+// when the parent was squash-merged on GitHub but its local PR state has not yet
+// synced to MERGED (e.g. the merge happened out of band, or a prior sync ran
+// offline). The aggregate patch-id squash scan must detect the merge — gated on
+// the parent's recorded PR number — and cause the child to reparent to trunk
+// without replaying the parent's commits.
+func TestRestackDetectsSquashMergeWithStalePRState(t *testing.T) {
 	t.Parallel()
 	sh := scenario.NewRemoteScenario(t)
 	disableCommitSigning(t, sh)
@@ -143,17 +144,20 @@ func TestRestackDetectsSquashMergeWithoutPRState(t *testing.T) {
 		CommitChange("file-c", "c").
 		TrackBranch("child", "parent")
 
-	// Squash-merge parent onto main WITHOUT recording PR state.
-	// This simulates a branch merged via the GitHub UI before st sync has
-	// had a chance to mark the PR as MERGED in local metadata.
+	// Squash-merge parent onto main. The PR number is recorded but its state is
+	// stale (still OPEN) — simulating a GitHub UI squash-merge before st sync
+	// marked the PR MERGED. The recorded PR number is what gates the otherwise
+	// expensive squash patch-id scan.
 	mainName := sh.Engine.Trunk().GetName()
 	sh.Checkout("main")
 	sh.CommitChange("file-main", "unrelated")
 	sh.CommitChange("file-p", "v1\nv2")
 
-	// Intentionally skip markPrMerged — IsMerged must detect the squash from
-	// Git history. The unrelated trunk commit means a whole-tree comparison
-	// would not match the parent tip.
+	// Stale PR state (OPEN, not MERGED) forces detection through the aggregate
+	// patch-id scan rather than PR metadata. The unrelated trunk commit means a
+	// whole-tree comparison would not match the parent tip.
+	markPrWithState(t, sh, "parent", 42, "OPEN", mainName)
+
 	sh.Checkout("child")
 	plan, err := actions.PlanRestack(sh.Context, actions.RestackOptions{
 		BranchName: "child",
@@ -164,7 +168,7 @@ func TestRestackDetectsSquashMergeWithoutPRState(t *testing.T) {
 
 	sh.Rebuild()
 	require.Equal(t, mainName, sh.Engine.GetBranch("child").GetParent().GetName(),
-		"child should reparent to main when IsMerged detects squash via aggregate patch-id")
+		"child should reparent to main when the squash scan detects the parent merged")
 
 	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("child"))
 	require.NoError(t, err)

--- a/internal/integration/restack_squash_merge_test.go
+++ b/internal/integration/restack_squash_merge_test.go
@@ -105,6 +105,55 @@ func TestRestackAfterMultiCommitSquashParentDeleted(t *testing.T) {
 	requireCleanWorkingTree(t, sh)
 }
 
+// TestRestackDetectsSquashMergeWithoutPRState covers running `stackit restack`
+// when the parent was squash-merged but no PR state has been recorded (e.g.
+// the branch was merged directly without a PR, or st sync has not run yet).
+// Aggregate patch-id comparison in IsMerged must detect the squash and cause
+// the child to reparent to trunk without replaying the parent's commits.
+func TestRestackDetectsSquashMergeWithoutPRState(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("parent").
+		CommitChange("file-p", "v1").
+		CommitChange("file-p", "v1\nv2").
+		TrackBranch("parent", "main")
+
+	sh.CreateBranch("child").
+		CommitChange("file-c", "c").
+		TrackBranch("child", "parent")
+
+	// Squash-merge parent onto main WITHOUT recording PR state.
+	// This simulates a branch merged via the GitHub UI before st sync has
+	// had a chance to mark the PR as MERGED in local metadata.
+	mainName := sh.Engine.Trunk().GetName()
+	sh.Checkout("main")
+	sh.CommitChange("file-main", "unrelated")
+	sh.CommitChange("file-p", "v1\nv2")
+
+	// Intentionally skip markPrMerged — IsMerged must detect the squash from
+	// Git history. The unrelated trunk commit means a whole-tree comparison
+	// would not match the parent tip.
+	sh.Checkout("child")
+	plan, err := actions.PlanRestack(sh.Context, actions.RestackOptions{
+		BranchName: "child",
+		Scope:      engine.StackRangeFull(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, actions.RestackAction(sh.Context, plan, &handlers.NullRestackHandler{}))
+
+	sh.Rebuild()
+	require.Equal(t, mainName, sh.Engine.GetBranch("child").GetParent().GetName(),
+		"child should reparent to main when IsMerged detects squash via aggregate patch-id")
+
+	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("child"))
+	require.NoError(t, err)
+	require.Equal(t, 1, cCount, "child should keep only its own commit")
+
+	requireCleanWorkingTree(t, sh)
+}
+
 // TestRestackAfterMultiCommitSquashWithoutSync covers running `stackit restack`
 // BEFORE sync has cleaned up the squash-merged parent. The parent branch still
 // exists locally with a MERGED PR state; restack itself does the reparenting

--- a/internal/integration/restack_squash_merge_test.go
+++ b/internal/integration/restack_squash_merge_test.go
@@ -8,9 +8,28 @@ import (
 	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/actions/sync"
 	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/handlers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
+
+// markPrWithState records a PR number and an explicit (possibly stale) state on
+// a branch's metadata, without asserting the PR has merged. Used to simulate a
+// branch whose PR was merged on GitHub before its local state synced to MERGED.
+func markPrWithState(t *testing.T, sh *scenario.Scenario, branch string, prNumber int, state, base string) {
+	t.Helper()
+	meta, err := sh.Engine.Git().ReadMetadata(branch)
+	require.NoError(t, err)
+	num := prNumber
+	s := state
+	b := base
+	meta = meta.WithPrInfo(&git.PrInfoPersistence{
+		Number: &num,
+		State:  &s,
+		Base:   &b,
+	})
+	require.NoError(t, sh.Engine.Git().WriteMetadata(branch, meta))
+}
 
 // TestSquashMergeMultiCommitParent reproduces the case where a parent branch
 // with MULTIPLE commits is squash-merged on GitHub. The squash commit's
@@ -150,6 +169,142 @@ func TestRestackDetectsSquashMergeWithoutPRState(t *testing.T) {
 	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("child"))
 	require.NoError(t, err)
 	require.Equal(t, 1, cCount, "child should keep only its own commit")
+
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestSyncCleansUpSquashMergedBranchWithStalePRState covers sync's branch
+// cleanup when a PR was squash-merged on GitHub but its local state has not yet
+// synced to MERGED (e.g. the merge happened out of band, or a prior sync ran
+// offline). Ancestry-based merged detection misses squash merges, and the
+// MERGED-state rule never fires, so without aggregate patch-id detection the
+// merged branch would linger after sync. With a recorded PR number, cleanup must
+// detect the squash and delete it.
+func TestSyncCleansUpSquashMergedBranchWithStalePRState(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	// Multi-commit branch so the squash is genuinely combined (no single commit
+	// patch-matches the squashed result).
+	sh.CreateBranch("feature").
+		CommitChange("file-f", "v1").
+		CommitChange("file-f", "v1\nv2").
+		TrackBranch("feature", "main")
+
+	mainName := sh.Engine.Trunk().GetName()
+
+	// GitHub squash-merges feature: one combined commit lands on main. An
+	// unrelated trunk commit ensures a whole-tree comparison would not match.
+	sh.Checkout("main")
+	sh.CommitChange("file-unrelated", "x")
+	sh.CommitChange("file-f", "v1\nv2")
+
+	// PR number is recorded, but its state is stale (still OPEN) — not MERGED.
+	markPrWithState(t, sh, "feature", 7, "OPEN", mainName)
+
+	require.NoError(t, sync.Action(sh.Context, sync.Options{Restack: true}, nil))
+
+	branches, err := sh.Scene.Repo.GetLocalBranches()
+	require.NoError(t, err)
+	require.NotContains(t, branches, "feature",
+		"squash-merged branch with a stale PR state should be cleaned up by sync")
+
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestSyncKeepsUnmergedBranchWithPRNumber is the guard rail for the cleanup
+// above: a branch that carries a PR number but is genuinely NOT merged (it has
+// its own unlanded commit) must survive sync. This proves the squash-aware
+// deletion rule keys on actual patch equivalence, not merely on PR metadata
+// being present.
+func TestSyncKeepsUnmergedBranchWithPRNumber(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("feature").
+		CommitChange("file-f", "unique work").
+		TrackBranch("feature", "main")
+
+	mainName := sh.Engine.Trunk().GetName()
+
+	// Trunk moves forward with unrelated work; feature's own change never lands.
+	sh.Checkout("main")
+	sh.CommitChange("file-unrelated", "x")
+
+	markPrWithState(t, sh, "feature", 9, "OPEN", mainName)
+
+	require.NoError(t, sync.Action(sh.Context, sync.Options{Restack: true}, nil))
+
+	branches, err := sh.Scene.Repo.GetLocalBranches()
+	require.NoError(t, err)
+	require.Contains(t, branches, "feature",
+		"an unmerged branch must not be deleted just because it has a PR number")
+
+	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("feature"))
+	require.NoError(t, err)
+	require.Equal(t, 1, cCount, "feature must keep its own unlanded commit")
+
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestSquashMergedSiblingKeepsOwnCommit is the exact regression for issue #1345:
+// two branches A and B both forked directly off main (siblings, not a stack).
+// A is squash-merged on GitHub; after sync + restack, B must keep its own commit
+// and stay parented to main. The reported data loss was B's ref being moved onto
+// A's stale pre-merge tip, orphaning B's own work. This guards that B is never
+// reparented onto, nor reset to, the merged sibling.
+func TestSquashMergedSiblingKeepsOwnCommit(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	// A: two commits so the squash is genuinely multi-commit.
+	sh.CreateBranch("branch-a").
+		CommitChange("file-a", "a1").
+		CommitChange("file-a", "a1\na2").
+		TrackBranch("branch-a", "main")
+
+	// B: a sibling forked off main, with its own unique commit.
+	sh.Checkout("main")
+	sh.CreateBranch("branch-b").
+		CommitChange("file-b", "b").
+		TrackBranch("branch-b", "main")
+
+	mainName := sh.Engine.Trunk().GetName()
+
+	// Capture A's pre-merge tip — the exact SHA B must never be moved onto.
+	aStaleTip, err := sh.Engine.GetBranch("branch-a").GetRevision()
+	require.NoError(t, err)
+
+	// GitHub squash-merges A: one combined commit lands on main.
+	sh.Checkout("main")
+	sh.CommitChange("file-a", "a1\na2")
+	markPrMerged(t, sh, "branch-a", 1, mainName)
+
+	require.NoError(t, sync.Action(sh.Context, sync.Options{Restack: true}, nil))
+
+	// A is cleaned up; B survives.
+	branches, err := sh.Scene.Repo.GetLocalBranches()
+	require.NoError(t, err)
+	require.NotContains(t, branches, "branch-a", "squash-merged sibling should be deleted")
+	require.Contains(t, branches, "branch-b")
+
+	// B stays parented to main, never to the merged sibling.
+	require.Equal(t, mainName, sh.Engine.GetBranch("branch-b").GetParent().GetName(),
+		"sibling B must remain parented to main, not reparented onto merged A")
+
+	// B's ref must not have been moved onto A's stale tip.
+	bTip, err := sh.Engine.GetBranch("branch-b").GetRevision()
+	require.NoError(t, err)
+	require.NotEqual(t, aStaleTip, bTip,
+		"sibling B must never be reset to A's stale pre-merge tip (issue #1345 data loss)")
+
+	// B keeps exactly its own commit on top of main.
+	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("branch-b"))
+	require.NoError(t, err)
+	require.Equal(t, 1, cCount, "sibling B must keep only its own commit")
 
 	requireCleanWorkingTree(t, sh)
 }


### PR DESCRIPTION

The squash-detection fix baked the aggregate patch-id scan into the
IsMerged primitive, which is called in O(branches) loops (ancestor
resolution, branch tracking, IsMergedIntoTrunk). That regressed every
stack-wide operation by spawning up to ~400 git subprocesses per branch
on a cold cache.

Split the expensive scan into a separate opt-in IsSquashMerged method.
IsMerged stays cheap (ancestry + per-commit cherry, which already covers
merge and rebase merges); only the explicit "did this branch land"
checks (restack reparenting, sync cleanup) opt into the squash scan via
branchLanded.

Gate the squash scan behind a recorded PR number: a branch that was
never submitted cannot have been squash-merged on GitHub, so a
patch-equivalent-to-trunk branch with no PR is no longer a false
positive. Routing both restack and sync detection through branchLanded
gives them consistent gating.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1346**
  * **PR #1350**
    * **PR #1351**
      * **PR #1352**
        * **PR #1354** 👈
          * **PR #1355**
            * **PR #1356**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->