### PR TITLE
feat: guard restack against un-pushed trunk and cover sync scenarios

### DIFF
--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -100,6 +100,9 @@ func PlanRestack(ctx *app.Context, opts RestackOptions) (*RestackPlan, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := guardUnpushedTrunk(ctx, eng, rawGroups); err != nil {
+		return nil, err
+	}
 	plan := &RestackPlan{opts: opts}
 	for _, g := range rawGroups {
 		sorted := eng.SortBranchesTopologically(g.branches)
@@ -380,6 +383,39 @@ func restackGroupsParallel(
 	}
 
 	return collector.restacked, collector.skipped, collector.conflicts, collector.joinedError()
+}
+
+// guardUnpushedTrunk refuses to restack when the local trunk has commits that
+// are not on its remote-tracking branch (origin/<trunk>). Restacking rebases
+// trunk-anchored branches onto the LOCAL trunk tip, so un-pushed/divergent
+// trunk commits would be baked into the stack — work that only exists locally
+// and may never land as-is. Reconciling trunk with the remote first (sync, or a
+// push) keeps restack building only on commits that exist on origin/<trunk>.
+//
+// It is a no-op when there is no work to do, and for repos with no
+// remote-tracking trunk ref (local-only, never fetched, fresh clone), which the
+// engine reports via HasRemoteRef=false.
+func guardUnpushedTrunk(ctx *app.Context, eng engine.BranchReader, groups []restackBranchGroup) error {
+	hasBranches := false
+	for _, g := range groups {
+		if len(g.branches) > 0 {
+			hasBranches = true
+			break
+		}
+	}
+	if !hasBranches {
+		return nil
+	}
+
+	state := eng.TrunkRemoteState(ctx.Context)
+	if !state.AheadOrDiverged {
+		return nil
+	}
+	return fmt.Errorf(
+		"local trunk %q has commits that are not on %q; restack would build the stack on those un-pushed commits.\n"+
+			"Reconcile trunk with the remote first (run `stackit sync`, or push trunk) so restack only builds on %s",
+		eng.Trunk().GetName(), state.RemoteRef, state.RemoteRef,
+	)
 }
 
 type restackBranchGroup struct {

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -293,6 +293,47 @@ func (e *engineImpl) ReadBranchRemoteStatuses(ctx context.Context, branches Bran
 	return results
 }
 
+// TrunkRemoteState reports how the local trunk relates to its remote-tracking
+// branch using only local refs (a rev-parse of refs/remotes/<remote>/<trunk>
+// plus an ancestry check). It never lists or fetches from the remote, so it is
+// cheap enough for the restack path and works offline.
+//
+// When no remote-tracking trunk ref exists locally (local-only repo, never
+// fetched, fresh clone) it returns HasRemoteRef=false and AheadOrDiverged=false
+// so callers leave such repos unguarded.
+func (e *engineImpl) TrunkRemoteState(ctx context.Context) TrunkRemoteState {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	e.mu.RLock()
+	trunk := e.trunk
+	e.mu.RUnlock()
+
+	remote := e.git.GetRemote()
+	state := TrunkRemoteState{RemoteRef: remote + "/" + trunk}
+
+	remoteSha, err := e.git.GetRemoteSha(remote, trunk)
+	if err != nil || remoteSha == "" {
+		return state
+	}
+	state.HasRemoteRef = true
+	state.RemoteSha = remoteSha
+
+	localSha, err := e.git.GetRevision(trunk)
+	if err != nil || localSha == "" {
+		return state
+	}
+	state.LocalSha = localSha
+
+	// Local trunk is "ahead or diverged" when it is NOT an ancestor of the
+	// remote-tracking trunk. Equal (a commit is its own ancestor) and behind
+	// both report ancestor=true, so neither trips the guard.
+	if isAncestor, err := e.git.IsAncestor(ctx, localSha, remoteSha); err == nil && !isAncestor {
+		state.AheadOrDiverged = true
+	}
+	return state
+}
+
 // GetMergedBranches returns a map of branches merged into the target branch
 func (e *engineImpl) GetMergedBranches(ctx context.Context, target string) (map[string]bool, error) {
 	return e.git.GetMergedBranches(ctx, target)

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -2,6 +2,7 @@ package engine_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -1153,6 +1154,95 @@ func TestReadBranchRemoteStatuses(t *testing.T) {
 		main := s.Engine.GetBranch("main")
 		status := s.Engine.ReadBranchRemoteStatuses(context.Background(), engine.BranchesOf(main)).ForBranch(main)
 		require.False(t, status.Matches(), "main should not match empty remote")
+	})
+}
+
+func TestTrunkRemoteState(t *testing.T) {
+	t.Parallel()
+
+	// setRemoteTrunk points refs/remotes/origin/main at the given ref (resolved to
+	// a SHA), simulating a fetched remote-tracking trunk without any network.
+	setRemoteTrunk := func(t *testing.T, s *scenario.Scenario, ref string) {
+		t.Helper()
+		sha, err := s.Scene.Repo.RunGitCommandAndGetOutput("rev-parse", "--verify", ref)
+		require.NoError(t, err)
+		require.NoError(t, s.Scene.Repo.RunGitCommand("update-ref", "refs/remotes/origin/main", strings.TrimSpace(sha)))
+	}
+
+	t.Run("no remote-tracking ref is not guarded", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		state := s.Engine.TrunkRemoteState(context.Background())
+		require.False(t, state.HasRemoteRef, "with no origin/main the guard must stay inert")
+		require.False(t, state.AheadOrDiverged)
+	})
+
+	t.Run("trunk equal to remote is not ahead", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		setRemoteTrunk(t, s, "main")
+
+		state := s.Engine.TrunkRemoteState(context.Background())
+		require.True(t, state.HasRemoteRef)
+		require.False(t, state.AheadOrDiverged, "synced trunk must not be flagged")
+		require.Equal(t, state.LocalSha, state.RemoteSha)
+		require.Equal(t, "origin/main", state.RemoteRef)
+	})
+
+	t.Run("trunk ahead of remote is flagged", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		setRemoteTrunk(t, s, "main")
+
+		// Local main advances past the recorded remote tip (un-pushed commit).
+		s.Commit("un-pushed trunk commit")
+
+		state := s.Engine.TrunkRemoteState(context.Background())
+		require.True(t, state.HasRemoteRef)
+		require.True(t, state.AheadOrDiverged, "local trunk ahead of origin/main must be flagged")
+		require.NotEqual(t, state.LocalSha, state.RemoteSha)
+	})
+
+	t.Run("trunk behind remote is not flagged", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		// Build a descendant commit and point origin/main at it, leaving local main
+		// strictly behind (still an ancestor of the remote).
+		require.NoError(t, s.Scene.Repo.RunGitCommand("branch", "remote-ahead", "main"))
+		require.NoError(t, s.Scene.Repo.CheckoutBranch("remote-ahead"))
+		s.Commit("landed on origin")
+		setRemoteTrunk(t, s, "remote-ahead")
+		require.NoError(t, s.Scene.Repo.CheckoutBranch("main"))
+
+		state := s.Engine.TrunkRemoteState(context.Background())
+		require.True(t, state.HasRemoteRef)
+		require.False(t, state.AheadOrDiverged, "trunk behind origin/main builds only on remote commits")
+	})
+
+	t.Run("trunk diverged from remote is flagged", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		// Common ancestor = current main tip.
+		base, err := s.Scene.Repo.RunGitCommandAndGetOutput("rev-parse", "--verify", "main")
+		require.NoError(t, err)
+		base = strings.TrimSpace(base)
+
+		// Remote-only commit on top of the common ancestor.
+		require.NoError(t, s.Scene.Repo.RunGitCommand("branch", "remote-work", base))
+		require.NoError(t, s.Scene.Repo.CheckoutBranch("remote-work"))
+		s.Commit("landed on origin only")
+		setRemoteTrunk(t, s, "remote-work")
+		require.NoError(t, s.Scene.Repo.CheckoutBranch("main"))
+
+		// Local main gets its own divergent commit on the same ancestor.
+		s.Commit("local divergent commit")
+
+		state := s.Engine.TrunkRemoteState(context.Background())
+		require.True(t, state.HasRemoteRef)
+		require.True(t, state.AheadOrDiverged, "diverged trunk must be flagged like the ahead case")
 	})
 }
 

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -74,6 +74,9 @@ type BranchStatus interface {
 	GetRemote() string
 	GetRemoteURL(ctx context.Context) (string, error)
 	ReadBranchRemoteStatuses(ctx context.Context, branches Branches) BranchRemoteStatuses
+	// TrunkRemoteState reports how the local trunk relates to its
+	// remote-tracking branch using only local refs (no network).
+	TrunkRemoteState(ctx context.Context) TrunkRemoteState
 	GetMergedBranches(ctx context.Context, target string) (map[string]bool, error)
 }
 

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -227,6 +227,26 @@ func (s BranchRemoteStatus) MissingRemote() bool {
 	return s.RemoteSha == ""
 }
 
+// TrunkRemoteState describes how the local trunk relates to its remote-tracking
+// branch (e.g. origin/main) using only already-fetched local refs — never the
+// network. It is safe on the restack path and offline.
+type TrunkRemoteState struct {
+	// HasRemoteRef is false when no remote-tracking trunk ref exists locally: a
+	// local-only repo, a never-fetched remote, or a fresh clone without
+	// origin/<trunk>. Callers treat this as "unknown — do not guard".
+	HasRemoteRef bool
+	// AheadOrDiverged is true when the local trunk has commits that are not
+	// present on the remote-tracking trunk (local trunk is NOT an ancestor of
+	// origin/<trunk>). Equal or behind is false.
+	AheadOrDiverged bool
+	// LocalSha is the local trunk tip; RemoteSha is the remote-tracking tip.
+	LocalSha  string
+	RemoteSha string
+	// RemoteRef is the remote-tracking ref name, e.g. "origin/main", for
+	// user-facing messages.
+	RemoteRef string
+}
+
 // BranchRemoteStatuses maps branch names to their remote sync status.
 type BranchRemoteStatuses map[string]BranchRemoteStatus
 

--- a/internal/integration/restack_squash_merge_test.go
+++ b/internal/integration/restack_squash_merge_test.go
@@ -8,9 +8,28 @@ import (
 	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/actions/sync"
 	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/handlers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
+
+// markPrWithState records a PR number and an explicit (possibly stale) state on
+// a branch's metadata, without asserting the PR has merged. Used to simulate a
+// branch whose PR was merged on GitHub before its local state synced to MERGED.
+func markPrWithState(t *testing.T, sh *scenario.Scenario, branch string, prNumber int, state, base string) {
+	t.Helper()
+	meta, err := sh.Engine.Git().ReadMetadata(branch)
+	require.NoError(t, err)
+	num := prNumber
+	s := state
+	b := base
+	meta = meta.WithPrInfo(&git.PrInfoPersistence{
+		Number: &num,
+		State:  &s,
+		Base:   &b,
+	})
+	require.NoError(t, sh.Engine.Git().WriteMetadata(branch, meta))
+}
 
 // TestSquashMergeMultiCommitParent reproduces the case where a parent branch
 // with MULTIPLE commits is squash-merged on GitHub. The squash commit's
@@ -82,6 +101,9 @@ func TestRestackAfterMultiCommitSquashParentDeleted(t *testing.T) {
 	mainName := sh.Engine.Trunk().GetName()
 	sh.Checkout("main")
 	sh.CommitChange("file-p", "v1\nv2\nv3")
+	// The squash landed on the real trunk and was fetched, so origin/main carries
+	// it too; restack builds on synced trunk, not un-pushed local commits.
+	sh.SyncRemoteTrunkToLocal()
 
 	// Parent branch deleted locally (e.g. user cleanup after GitHub merge).
 	require.NoError(t, sh.Scene.Repo.RunGitCommand("branch", "-D", "parent"))
@@ -101,6 +123,195 @@ func TestRestackAfterMultiCommitSquashParentDeleted(t *testing.T) {
 	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("child"))
 	require.NoError(t, err)
 	require.Equal(t, 1, cCount, "child should not inherit parent's squashed commits")
+
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestRestackDetectsSquashMergeWithStalePRState covers running `stackit restack`
+// when the parent was squash-merged on GitHub but its local PR state has not yet
+// synced to MERGED (e.g. the merge happened out of band, or a prior sync ran
+// offline). The aggregate patch-id squash scan must detect the merge and cause
+// the child to reparent to trunk without replaying the parent's commits.
+func TestRestackDetectsSquashMergeWithStalePRState(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("parent").
+		CommitChange("file-p", "v1").
+		CommitChange("file-p", "v1\nv2").
+		TrackBranch("parent", "main")
+
+	sh.CreateBranch("child").
+		CommitChange("file-c", "c").
+		TrackBranch("child", "parent")
+
+	// Squash-merge parent onto main. The PR number is recorded but its state is
+	// stale (still OPEN) — simulating a GitHub UI squash-merge before st sync
+	// marked the PR MERGED.
+	mainName := sh.Engine.Trunk().GetName()
+	sh.Checkout("main")
+	sh.CommitChange("file-main", "unrelated")
+	sh.CommitChange("file-p", "v1\nv2")
+
+	// Stale PR state (OPEN, not MERGED) forces detection through the aggregate
+	// patch-id scan rather than PR metadata. The unrelated trunk commit means a
+	// whole-tree comparison would not match the parent tip.
+	markPrWithState(t, sh, "parent", 42, "OPEN", mainName)
+	// Trunk advanced from a real merge that was fetched, so origin/main matches.
+	sh.SyncRemoteTrunkToLocal()
+
+	sh.Checkout("child")
+	plan, err := actions.PlanRestack(sh.Context, actions.RestackOptions{
+		BranchName: "child",
+		Scope:      engine.StackRangeFull(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, actions.RestackAction(sh.Context, plan, &handlers.NullRestackHandler{}))
+
+	sh.Rebuild()
+	require.Equal(t, mainName, sh.Engine.GetBranch("child").GetParent().GetName(),
+		"child should reparent to main when the squash scan detects the parent merged")
+
+	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("child"))
+	require.NoError(t, err)
+	require.Equal(t, 1, cCount, "child should keep only its own commit")
+
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestSyncCleansUpSquashMergedBranchWithStalePRState covers sync's branch
+// cleanup when a PR was squash-merged on GitHub but its local state has not yet
+// synced to MERGED (e.g. the merge happened out of band, or a prior sync ran
+// offline). Ancestry-based merged detection misses squash merges, and the
+// MERGED-state rule never fires, so without aggregate patch-id detection the
+// merged branch would linger after sync. With a recorded PR number, cleanup must
+// detect the squash and delete it.
+func TestSyncCleansUpSquashMergedBranchWithStalePRState(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	// Multi-commit branch so the squash is genuinely combined (no single commit
+	// patch-matches the squashed result).
+	sh.CreateBranch("feature").
+		CommitChange("file-f", "v1").
+		CommitChange("file-f", "v1\nv2").
+		TrackBranch("feature", "main")
+
+	mainName := sh.Engine.Trunk().GetName()
+
+	// GitHub squash-merges feature: one combined commit lands on main. An
+	// unrelated trunk commit ensures a whole-tree comparison would not match.
+	sh.Checkout("main")
+	sh.CommitChange("file-unrelated", "x")
+	sh.CommitChange("file-f", "v1\nv2")
+
+	// PR number is recorded, but its state is stale (still OPEN) — not MERGED.
+	markPrWithState(t, sh, "feature", 7, "OPEN", mainName)
+
+	require.NoError(t, sync.Action(sh.Context, sync.Options{Restack: true}, nil))
+
+	branches, err := sh.Scene.Repo.GetLocalBranches()
+	require.NoError(t, err)
+	require.NotContains(t, branches, "feature",
+		"squash-merged branch with a stale PR state should be cleaned up by sync")
+
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestSyncKeepsUnmergedBranchWithPRNumber is the guard rail for the cleanup
+// above: a branch that carries a PR number but is genuinely NOT merged (it has
+// its own unlanded commit) must survive sync. This proves the squash-aware
+// deletion rule keys on actual patch equivalence, not merely on PR metadata
+// being present.
+func TestSyncKeepsUnmergedBranchWithPRNumber(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("feature").
+		CommitChange("file-f", "unique work").
+		TrackBranch("feature", "main")
+
+	mainName := sh.Engine.Trunk().GetName()
+
+	// Trunk moves forward with unrelated work; feature's own change never lands.
+	sh.Checkout("main")
+	sh.CommitChange("file-unrelated", "x")
+
+	markPrWithState(t, sh, "feature", 9, "OPEN", mainName)
+
+	require.NoError(t, sync.Action(sh.Context, sync.Options{Restack: true}, nil))
+
+	branches, err := sh.Scene.Repo.GetLocalBranches()
+	require.NoError(t, err)
+	require.Contains(t, branches, "feature",
+		"an unmerged branch must not be deleted just because it has a PR number")
+
+	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("feature"))
+	require.NoError(t, err)
+	require.Equal(t, 1, cCount, "feature must keep its own unlanded commit")
+
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestSquashMergedSiblingKeepsOwnCommit is the exact regression for issue #1345:
+// two branches A and B both forked directly off main (siblings, not a stack).
+// A is squash-merged on GitHub; after sync + restack, B must keep its own commit
+// and stay parented to main. The reported data loss was B's ref being moved onto
+// A's stale pre-merge tip, orphaning B's own work. This guards that B is never
+// reparented onto, nor reset to, the merged sibling.
+func TestSquashMergedSiblingKeepsOwnCommit(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	// A: two commits so the squash is genuinely multi-commit.
+	sh.CreateBranch("branch-a").
+		CommitChange("file-a", "a1").
+		CommitChange("file-a", "a1\na2").
+		TrackBranch("branch-a", "main")
+
+	// B: a sibling forked off main, with its own unique commit.
+	sh.Checkout("main")
+	sh.CreateBranch("branch-b").
+		CommitChange("file-b", "b").
+		TrackBranch("branch-b", "main")
+
+	mainName := sh.Engine.Trunk().GetName()
+
+	// Capture A's pre-merge tip — the exact SHA B must never be moved onto.
+	aStaleTip, err := sh.Engine.GetBranch("branch-a").GetRevision()
+	require.NoError(t, err)
+
+	// GitHub squash-merges A: one combined commit lands on main.
+	sh.Checkout("main")
+	sh.CommitChange("file-a", "a1\na2")
+	markPrMerged(t, sh, "branch-a", 1, mainName)
+
+	require.NoError(t, sync.Action(sh.Context, sync.Options{Restack: true}, nil))
+
+	// A is cleaned up; B survives.
+	branches, err := sh.Scene.Repo.GetLocalBranches()
+	require.NoError(t, err)
+	require.NotContains(t, branches, "branch-a", "squash-merged sibling should be deleted")
+	require.Contains(t, branches, "branch-b")
+
+	// B stays parented to main, never to the merged sibling.
+	require.Equal(t, mainName, sh.Engine.GetBranch("branch-b").GetParent().GetName(),
+		"sibling B must remain parented to main, not reparented onto merged A")
+
+	// B's ref must not have been moved onto A's stale tip.
+	bTip, err := sh.Engine.GetBranch("branch-b").GetRevision()
+	require.NoError(t, err)
+	require.NotEqual(t, aStaleTip, bTip,
+		"sibling B must never be reset to A's stale pre-merge tip (issue #1345 data loss)")
+
+	// B keeps exactly its own commit on top of main.
+	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("branch-b"))
+	require.NoError(t, err)
+	require.Equal(t, 1, cCount, "sibling B must keep only its own commit")
 
 	requireCleanWorkingTree(t, sh)
 }
@@ -129,6 +340,8 @@ func TestRestackAfterMultiCommitSquashWithoutSync(t *testing.T) {
 	sh.Checkout("main")
 	sh.CommitChange("file-p", "v1\nv2\nv3")
 	markPrMerged(t, sh, "parent", 1, mainName)
+	// The merge landed on the real trunk and was fetched, so origin/main matches.
+	sh.SyncRemoteTrunkToLocal()
 
 	// User runs `stackit restack` from the child without syncing first.
 	sh.Checkout("child")

--- a/internal/integration/restack_synced_trunk_matrix_test.go
+++ b/internal/integration/restack_synced_trunk_matrix_test.go
@@ -1,0 +1,138 @@
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/handlers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// This is the scenario 2 coverage matrix: restacking a child onto trunk after
+// its parent's changes LANDED on origin/main and were synced. It exercises every
+// GitHub merge method (merge commit, squash, rebase) for a parent with one and
+// with multiple commits, for both a stackit user (parent carries a MERGED PR)
+// and a non-stackit collaborator (parent carries zero stackit PR metadata).
+//
+// The invariant in all cases: the child reparents onto trunk and keeps ONLY its
+// own commit — the parent's landed commits must never replay into the child. The
+// trunk is modeled as synced (origin/main advanced via SyncRemoteTrunkToLocal),
+// which is what distinguishes this from scenario 1 (un-pushed trunk, rejected by
+// the guard).
+//
+// Detection coverage per strategy:
+//   - merge commit: parent tip is reachable from trunk → ancestry (IsMerged).
+//   - rebase merge: commits replayed with new SHAs but same patch-ids → cherry.
+//   - squash (single commit): the lone commit patch-matches the squash → cherry.
+//   - squash (multi commit): only the aggregate patch-id scan (no PR) or the
+//     MERGED PR metadata (stackit user) can prove it landed.
+
+type matrixMergeStrategy string
+
+const (
+	matrixMergeCommit matrixMergeStrategy = "merge-commit"
+	matrixSquash      matrixMergeStrategy = "squash"
+	matrixRebase      matrixMergeStrategy = "rebase"
+)
+
+func TestRestackOnSyncedTrunkMatrix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		commits     []string // successive contents of the parent's "shared" file
+		strategy    matrixMergeStrategy
+		stackitUser bool
+	}{
+		{"merge-commit/single/stackit", []string{"v1"}, matrixMergeCommit, true},
+		{"merge-commit/single/non-stackit", []string{"v1"}, matrixMergeCommit, false},
+		{"merge-commit/multi/stackit", []string{"v1", "v1\nv2"}, matrixMergeCommit, true},
+		{"merge-commit/multi/non-stackit", []string{"v1", "v1\nv2"}, matrixMergeCommit, false},
+		{"squash/single/stackit", []string{"v1"}, matrixSquash, true},
+		{"squash/single/non-stackit", []string{"v1"}, matrixSquash, false},
+		{"squash/multi/stackit", []string{"v1", "v1\nv2"}, matrixSquash, true},
+		{"squash/multi/non-stackit", []string{"v1", "v1\nv2"}, matrixSquash, false},
+		{"rebase/single/stackit", []string{"v1"}, matrixRebase, true},
+		{"rebase/single/non-stackit", []string{"v1"}, matrixRebase, false},
+		{"rebase/multi/stackit", []string{"v1", "v1\nv2"}, matrixRebase, true},
+		{"rebase/multi/non-stackit", []string{"v1", "v1\nv2"}, matrixRebase, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sh := scenario.NewRemoteScenario(t)
+			disableCommitSigning(t, sh)
+
+			// Parent branch with the requested commit history.
+			sh.CreateBranch("parent")
+			for _, content := range tc.commits {
+				sh.CommitChange("shared", content)
+			}
+			sh.TrackBranch("parent", "main")
+
+			// Child stacked on parent. It touches a unique file so its replay onto
+			// trunk never conflicts — isolating "did I inherit the parent's commits".
+			sh.CreateBranch("child").
+				CommitChange("child-only", "my work").
+				TrackBranch("child", "parent")
+
+			mainName := sh.Engine.Trunk().GetName()
+			parentSHAs := branchCommitSHAs(t, sh, "parent")
+
+			// Land the parent's changes on trunk via the chosen merge method.
+			sh.Checkout("main")
+			switch tc.strategy {
+			case matrixMergeCommit:
+				require.NoError(t, sh.Scene.Repo.RunGitCommand("merge", "--no-ff", "-m", "Merge parent (#1)", "parent"))
+			case matrixSquash:
+				sh.CommitChange("shared", tc.commits[len(tc.commits)-1])
+			case matrixRebase:
+				for _, c := range parentSHAs {
+					require.NoError(t, sh.Scene.Repo.RunGitCommand("cherry-pick", c))
+				}
+			}
+			sh.Rebuild()
+
+			// The merge landed on the real trunk and was fetched: origin/main now
+			// carries it, so the restack guard sees synced trunk (not un-pushed).
+			sh.SyncRemoteTrunkToLocal()
+
+			// A stackit user's parent carries a MERGED PR; a non-stackit
+			// collaborator's parent carries no stackit PR metadata at all.
+			if tc.stackitUser {
+				markPrMerged(t, sh, "parent", 1, mainName)
+			}
+
+			sh.Checkout("child")
+			plan, err := actions.PlanRestack(sh.Context, actions.RestackOptions{
+				BranchName: "child",
+				Scope:      engine.StackRangeFull(),
+			})
+			require.NoError(t, err)
+			require.NoError(t, actions.RestackAction(sh.Context, plan, &handlers.NullRestackHandler{}))
+			sh.Rebuild()
+
+			require.Equal(t, mainName, sh.Engine.GetBranch("child").GetParent().GetName(),
+				"child should reparent to trunk past the landed parent")
+			count, err := sh.Scene.Repo.GetCommitCount("main", "child")
+			require.NoError(t, err)
+			require.Equal(t, 1, count,
+				"child must contain only its own commit, never the parent's landed commits")
+			requireCleanWorkingTree(t, sh)
+		})
+	}
+}
+
+// branchCommitSHAs returns the SHAs of the commits on branch that are not on
+// main, oldest first.
+func branchCommitSHAs(t *testing.T, sh *scenario.Scenario, branch string) []string {
+	t.Helper()
+	out, err := sh.Scene.Repo.RunGitCommandAndGetOutput("rev-list", "--reverse", "main.."+branch)
+	require.NoError(t, err)
+	return strings.Fields(out)
+}

--- a/internal/integration/restack_trunk_guard_test.go
+++ b/internal/integration/restack_trunk_guard_test.go
@@ -1,0 +1,182 @@
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// These tests cover scenario 1: the local trunk has commits that are NOT on its
+// remote-tracking branch (origin/main). Restacking rebases trunk-anchored
+// branches onto the LOCAL trunk tip, so un-pushed or divergent trunk commits
+// would be baked into the stack — work that only exists locally and may never
+// land as-is. The restack trunk guard refuses in that state and tells the user
+// to reconcile trunk with the remote first.
+//
+// The distinction from scenario 2 (synced trunk, which must succeed) is purely
+// whether origin/<trunk> carries the trunk's new commits. The synced-trunk
+// tests advance origin/main via SyncRemoteTrunkToLocal; these deliberately do
+// not, so local trunk stays ahead of / diverged from the remote.
+
+// planRestackFeatureErr runs PlanRestack for the "feature" branch and returns
+// the error (if any) without asserting success — the guard rejects at plan time.
+func planRestackFeatureErr(t *testing.T, sh *scenario.Scenario) error {
+	t.Helper()
+	sh.Checkout("feature")
+	_, err := actions.PlanRestack(sh.Context, actions.RestackOptions{
+		BranchName: "feature",
+		Scope:      engine.StackRangeFull(),
+	})
+	return err
+}
+
+// TestRestackGuardRejectsTrunkAheadOfRemote is the headline scenario 1 case: we
+// committed directly on local main and never pushed, so local main is ahead of
+// origin/main. Restacking would build the stack on those un-pushed commits, so
+// the guard must reject before any rebase runs.
+func TestRestackGuardRejectsTrunkAheadOfRemote(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	// A normal stack on top of synced trunk.
+	sh.CreateBranch("feature").
+		CommitChange("feature", "my work").
+		TrackBranch("feature", "main")
+
+	// Commit directly on local main and DO NOT sync origin/main: local trunk is
+	// now ahead of its remote-tracking branch.
+	sh.Checkout("main")
+	sh.CommitChange("local-only", "un-pushed trunk commit")
+	sh.Rebuild()
+
+	err := planRestackFeatureErr(t, sh)
+	require.Error(t, err, "restack must refuse while local trunk is ahead of origin/main")
+	require.Contains(t, err.Error(), "origin/main",
+		"the error should name the remote-tracking trunk the user must reconcile with")
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestRestackGuardRejectsTrunkDivergedFromRemote covers the diverged shape:
+// local main and origin/main each have a unique commit on top of their common
+// ancestor. Restacking onto the local (divergent) trunk is just as unsafe as the
+// ahead case, so the guard must reject here too.
+func TestRestackGuardRejectsTrunkDivergedFromRemote(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("feature").
+		CommitChange("feature", "my work").
+		TrackBranch("feature", "main")
+
+	// Common ancestor = current main tip.
+	sh.Checkout("main")
+	base, err := sh.Scene.Repo.RunGitCommandAndGetOutput("rev-parse", "--verify", "main")
+	require.NoError(t, err)
+	base = trimSHA(base)
+
+	// Build a divergent remote commit from the common ancestor and point
+	// origin/main at it (a commit local main will never contain).
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("branch", "remote-work", base))
+	require.NoError(t, sh.Scene.Repo.CheckoutBranch("remote-work"))
+	sh.CommitChange("remote-file", "landed on origin only")
+	remoteSha, err := sh.Scene.Repo.RunGitCommandAndGetOutput("rev-parse", "--verify", "remote-work")
+	require.NoError(t, err)
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("update-ref", "refs/remotes/origin/main", trimSHA(remoteSha)))
+	require.NoError(t, sh.Scene.Repo.CheckoutBranch("main"))
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("branch", "-D", "remote-work"))
+
+	// Local main gets its own unique commit on top of the common ancestor.
+	sh.CommitChange("local-file", "local divergent commit")
+	sh.Rebuild()
+
+	guardErr := planRestackFeatureErr(t, sh)
+	require.Error(t, guardErr, "restack must refuse while local trunk has diverged from origin/main")
+	require.Contains(t, guardErr.Error(), "origin/main")
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestRestackAllowsTrunkBehindRemote is the boundary control: local trunk is
+// strictly behind origin/main (the remote has commits we haven't merged, but we
+// have no un-pushed trunk commits). Restacking builds only on commits that exist
+// on origin/main, so the guard must NOT fire.
+func TestRestackAllowsTrunkBehindRemote(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("feature").
+		CommitChange("feature", "my work").
+		TrackBranch("feature", "main")
+
+	// Advance origin/main ahead of local main (a descendant), leaving local main
+	// strictly behind. Local trunk stays an ancestor of origin/main.
+	sh.Checkout("main")
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("branch", "remote-ahead", "main"))
+	require.NoError(t, sh.Scene.Repo.CheckoutBranch("remote-ahead"))
+	sh.CommitChange("remote-file", "landed on origin")
+	remoteSha, err := sh.Scene.Repo.RunGitCommandAndGetOutput("rev-parse", "--verify", "remote-ahead")
+	require.NoError(t, err)
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("update-ref", "refs/remotes/origin/main", trimSHA(remoteSha)))
+	require.NoError(t, sh.Scene.Repo.CheckoutBranch("main"))
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("branch", "-D", "remote-ahead"))
+	sh.Rebuild()
+
+	err = planRestackFeatureErr(t, sh)
+	require.NoError(t, err, "restack must proceed when local trunk is merely behind origin/main")
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestRestackGuardNoOpWithoutRemote confirms local-only repos are unaffected:
+// with no remote-tracking trunk ref, the guard cannot (and must not) fire even
+// when local trunk has commits. A solo user with no remote restacks freely.
+func TestRestackGuardNoOpWithoutRemote(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewScenario(t, testhelpers.InitialCommitSceneSetup)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("feature").
+		CommitChange("feature", "my work").
+		TrackBranch("feature", "main")
+
+	// Commit on local main. There is no origin/main to compare against.
+	sh.Checkout("main")
+	sh.CommitChange("local-only", "trunk commit")
+	sh.Rebuild()
+
+	err := planRestackFeatureErr(t, sh)
+	require.NoError(t, err, "a repo with no remote-tracking trunk must not be guarded")
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestRestackGuardSkipsWhenNoBranches makes sure the guard does not turn an
+// empty restack (e.g. trunk with no children) into an error just because local
+// trunk happens to be ahead of the remote.
+func TestRestackGuardSkipsWhenNoBranches(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	// Trunk ahead of origin, but nothing is stacked on it.
+	sh.Checkout("main")
+	sh.CommitChange("local-only", "un-pushed trunk commit")
+	sh.Rebuild()
+
+	_, err := actions.PlanRestack(sh.Context, actions.RestackOptions{
+		BranchName: "main",
+		Scope:      engine.StackRangeFull(),
+	})
+	require.NoError(t, err, "an empty restack must not be rejected by the trunk guard")
+}
+
+// trimSHA strips trailing whitespace/newline from a rev-parse result.
+func trimSHA(s string) string {
+	return strings.TrimSpace(s)
+}

--- a/internal/integration/restack_untracked_collaborator_test.go
+++ b/internal/integration/restack_untracked_collaborator_test.go
@@ -1,0 +1,233 @@
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/handlers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// These tests model the real collaboration case: a teammate who does NOT use
+// stackit pushes a branch, I stack my own work on top of it, and the teammate
+// then squash- or rebase-merges their branch into main on GitHub. Their merged
+// work carries ZERO stackit metadata (no recorded PR number, no MERGED state) —
+// stackit only knows the branch as a local parent pointer, if that.
+//
+// The invariant under test: after I restack, my branch must contain ONLY my own
+// commit. If detection misses the teammate's merge, restack replays their
+// pre-merge commits into my branch (issue #1345's data-loss shape), and
+// `main..mine` carries their commits as well as mine.
+//
+// My commit touches a unique file so the replay never conflicts — that isolates
+// the "did I inherit foreign commits" question from any conflict noise.
+
+// reparentCountAfterRestack restacks `mine` and returns the number of commits
+// reachable from `mine` but not `main`. A correct restack onto main yields 1
+// (just my commit); inheriting the teammate's pre-merge commits yields more.
+func restackMineOntoTrunk(t *testing.T, sh *scenario.Scenario) {
+	t.Helper()
+	sh.Checkout("mine")
+	plan, err := actions.PlanRestack(sh.Context, actions.RestackOptions{
+		BranchName: "mine",
+		Scope:      engine.StackRangeFull(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, actions.RestackAction(sh.Context, plan, &handlers.NullRestackHandler{}))
+	sh.Rebuild()
+}
+
+func mineCommitsAboveTrunk(t *testing.T, sh *scenario.Scenario) int {
+	t.Helper()
+	count, err := sh.Scene.Repo.GetCommitCount("main", "mine")
+	require.NoError(t, err)
+	return count
+}
+
+// rebaseMergeOntoMain replays each of the listed commits onto main with new
+// SHAs, simulating GitHub's "Rebase and merge". Patch-ids are preserved. The
+// merge landed on the real trunk and was fetched, so origin/main is advanced to
+// match: restack builds on synced trunk, not un-pushed local commits.
+func rebaseMergeOntoMain(t *testing.T, sh *scenario.Scenario, commits []string) {
+	t.Helper()
+	sh.Checkout("main")
+	for _, c := range commits {
+		require.NoError(t, sh.Scene.Repo.RunGitCommand("cherry-pick", c))
+	}
+	sh.Rebuild()
+	sh.SyncRemoteTrunkToLocal()
+}
+
+func coworkerCommits(t *testing.T, sh *scenario.Scenario) []string {
+	t.Helper()
+	out, err := sh.Scene.Repo.RunGitCommandAndGetOutput("rev-list", "--reverse", "main..coworker")
+	require.NoError(t, err)
+	return strings.Fields(out)
+}
+
+// --- Squash merges ---------------------------------------------------------
+
+// TestUntrackedCoworkerMultiCommitSquash is the headline failing case: a
+// teammate's MULTI-commit branch is squash-merged into main with no stackit
+// metadata. `git cherry` cannot match the combined squash commit to any
+// individual commit; the aggregate-patch-id scan must detect it even without
+// a recorded PR number so my branch does not inherit the teammate's two
+// pre-squash commits.
+func TestUntrackedCoworkerMultiCommitSquash(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	// Teammate branch: two commits, tracked locally (so I can stack on it) but
+	// NO PR metadata — exactly what a non-stackit collaborator's branch looks
+	// like in my local view.
+	sh.CreateBranch("coworker").
+		CommitChange("shared", "v1").
+		CommitChange("shared", "v1\nv2").
+		TrackBranch("coworker", "main")
+
+	// My branch on top, touching a unique file so replay never conflicts.
+	sh.CreateBranch("mine").
+		CommitChange("mine", "my work").
+		TrackBranch("mine", "coworker")
+
+	// GitHub squash-merges the teammate's branch: one combined commit on main.
+	// The merge landed on the real trunk and was fetched, so origin/main matches.
+	sh.Checkout("main")
+	sh.CommitChange("shared", "v1\nv2")
+	sh.Rebuild()
+	sh.SyncRemoteTrunkToLocal()
+
+	restackMineOntoTrunk(t, sh)
+
+	require.Equal(t, "main", sh.Engine.GetBranch("mine").GetParent().GetName(),
+		"mine should reparent to main past the squash-merged teammate branch")
+	require.Equal(t, 1, mineCommitsAboveTrunk(t, sh),
+		"mine must contain only my own commit, not the teammate's pre-squash commits")
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestUntrackedCoworkerSingleCommitSquash is the control: a SINGLE-commit branch
+// squash-merged with no metadata. Here `git cherry` (cheap IsMerged) CAN match
+// the lone commit to the squash commit, so detection should succeed without any
+// PR number.
+func TestUntrackedCoworkerSingleCommitSquash(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("coworker").
+		CommitChange("shared", "only change").
+		TrackBranch("coworker", "main")
+
+	sh.CreateBranch("mine").
+		CommitChange("mine", "my work").
+		TrackBranch("mine", "coworker")
+
+	sh.Checkout("main")
+	sh.CommitChange("shared", "only change")
+	sh.Rebuild()
+	sh.SyncRemoteTrunkToLocal()
+
+	restackMineOntoTrunk(t, sh)
+
+	require.Equal(t, "main", sh.Engine.GetBranch("mine").GetParent().GetName(),
+		"mine should reparent to main past the single-commit squash")
+	require.Equal(t, 1, mineCommitsAboveTrunk(t, sh),
+		"mine must contain only my own commit")
+	requireCleanWorkingTree(t, sh)
+}
+
+// --- Rebase merges ---------------------------------------------------------
+
+// TestUntrackedCoworkerMultiCommitRebaseMerge covers GitHub "Rebase and merge"
+// of a MULTI-commit teammate branch with no metadata. Each commit is replayed
+// onto main with a new SHA but the same patch-id, so `git cherry` matches every
+// commit and cheap IsMerged detects the merge without a PR number.
+func TestUntrackedCoworkerMultiCommitRebaseMerge(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("coworker").
+		CommitChange("shared", "v1").
+		CommitChange("shared", "v1\nv2").
+		TrackBranch("coworker", "main")
+
+	sh.CreateBranch("mine").
+		CommitChange("mine", "my work").
+		TrackBranch("mine", "coworker")
+
+	rebaseMergeOntoMain(t, sh, coworkerCommits(t, sh))
+
+	restackMineOntoTrunk(t, sh)
+
+	require.Equal(t, "main", sh.Engine.GetBranch("mine").GetParent().GetName(),
+		"mine should reparent to main past the rebase-merged teammate branch")
+	require.Equal(t, 1, mineCommitsAboveTrunk(t, sh),
+		"mine must contain only my own commit after a rebase merge")
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestUntrackedCoworkerSingleCommitRebaseMerge is the single-commit rebase-merge
+// control.
+func TestUntrackedCoworkerSingleCommitRebaseMerge(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("coworker").
+		CommitChange("shared", "only change").
+		TrackBranch("coworker", "main")
+
+	sh.CreateBranch("mine").
+		CommitChange("mine", "my work").
+		TrackBranch("mine", "coworker")
+
+	rebaseMergeOntoMain(t, sh, coworkerCommits(t, sh))
+
+	restackMineOntoTrunk(t, sh)
+
+	require.Equal(t, "main", sh.Engine.GetBranch("mine").GetParent().GetName(),
+		"mine should reparent to main past the single-commit rebase merge")
+	require.Equal(t, 1, mineCommitsAboveTrunk(t, sh),
+		"mine must contain only my own commit")
+	requireCleanWorkingTree(t, sh)
+}
+
+// --- Fully untracked parent ------------------------------------------------
+
+// TestFullyUntrackedCoworkerMultiCommitSquash is the most literal "zero stackit
+// metadata" case: the teammate branch has NO metadata ref at all (never tracked
+// by stackit). My branch records it as a parent. After a multi-commit squash
+// merge, restack must still strip the teammate's commits.
+func TestFullyUntrackedCoworkerMultiCommitSquash(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	// coworker is a raw git branch with no stackit metadata of its own.
+	sh.CreateBranch("coworker").
+		CommitChange("shared", "v1").
+		CommitChange("shared", "v1\nv2")
+
+	// mine records coworker as parent (the only stackit metadata in play).
+	sh.CreateBranch("mine").
+		CommitChange("mine", "my work").
+		TrackBranch("mine", "coworker")
+
+	sh.Checkout("main")
+	sh.CommitChange("shared", "v1\nv2")
+	sh.Rebuild()
+	sh.SyncRemoteTrunkToLocal()
+
+	restackMineOntoTrunk(t, sh)
+
+	require.Equal(t, 1, mineCommitsAboveTrunk(t, sh),
+		"mine must contain only my own commit even when the merged parent was never tracked")
+	requireCleanWorkingTree(t, sh)
+}

--- a/testhelpers/scenario/scenario.go
+++ b/testhelpers/scenario/scenario.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"testing"
 
@@ -36,6 +37,9 @@ const flagNoInteractive = "--no-interactive"
 
 // branchParent is the default parent branch name used in diamond stack fixtures.
 const branchParent = "parent"
+
+// defaultTrunk is the trunk branch name used by the test scenarios.
+const defaultTrunk = "main"
 
 // SetGlobalInProcessRunner sets the global in-process runner in a thread-safe way.
 func SetGlobalInProcessRunner(runner InProcessRunner) {
@@ -97,7 +101,7 @@ func newScenarioWithScene(t *testing.T, scene *testhelpers.Scene) *Scenario {
 	cfg, _ := config.LoadConfig(scene.Dir)
 	trunk := cfg.Trunk()
 	if trunk == "" {
-		trunk = "main"
+		trunk = defaultTrunk
 	}
 	maxUndoDepth := cfg.UndoStackDepth()
 	if maxUndoDepth <= 0 {
@@ -221,6 +225,28 @@ func (s *Scenario) CommitChange(name, message string) *Scenario {
 	return s
 }
 
+// SyncRemoteTrunkToLocal advances the local remote-tracking ref
+// (refs/remotes/origin/<trunk>) to the current local trunk tip. It models a
+// `git fetch` after the trunk's new commits have already landed on the remote —
+// the "synced trunk" state — without running a full push/fetch round-trip.
+//
+// Use it after advancing local trunk (e.g. simulating a merge by committing on
+// main) so the restack trunk guard sees origin/<trunk> == local trunk. Without
+// it, local trunk looks ahead of the remote, which is the distinct "un-pushed
+// local commits" state the guard is meant to reject.
+func (s *Scenario) SyncRemoteTrunkToLocal() *Scenario {
+	s.T.Helper()
+	trunk := defaultTrunk
+	if s.Engine != nil {
+		trunk = s.Engine.Trunk().GetName()
+	}
+	sha, err := s.Scene.Repo.RunGitCommandAndGetOutput("rev-parse", "--verify", trunk)
+	require.NoError(s.T, err)
+	err = s.Scene.Repo.RunGitCommand("update-ref", "refs/remotes/origin/"+trunk, strings.TrimSpace(sha))
+	require.NoError(s.T, err)
+	return s
+}
+
 // TrackBranch tracks a branch with a parent in the engine.
 func (s *Scenario) TrackBranch(branch, parent string) *Scenario {
 	s.T.Helper()
@@ -236,7 +262,7 @@ func (s *Scenario) WithStack(structure map[string]string) *Scenario {
 	s.T.Helper()
 
 	// Ensure we have an initial commit on main if it's the root
-	if s.Engine.Trunk().GetName() == "main" {
+	if s.Engine.Trunk().GetName() == defaultTrunk {
 		messages, _ := s.Scene.Repo.ListCurrentBranchCommitMessages()
 		if len(messages) == 0 {
 			s.WithInitialCommit()


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Add a guard that refuses `restack` when a remote exists and local trunk
is ahead of / diverged from origin/<trunk>, so the stack is never rebuilt
on un-pushed trunk commits. Local-only repos (no remote-tracking trunk
ref) are unaffected. Backed by a new engine.TrunkRemoteState predicate.

Expand restack test coverage:
- scenario 1: trunk ahead/diverged is rejected; behind, no-remote, and
  no-branches restacks are allowed (integration + engine unit tests).
- scenario 2: a child reparents past a parent landed on synced trunk
  across {merge-commit, squash, rebase} x {single, multi} x
  {stackit PR metadata, non-stackit collaborator with zero metadata},
  always keeping only its own commit.

Also drop the now-dead landedCheckMode parameter from branchLanded; every
caller passed the same mode.

<hr/>

<!-- STACKIT-SECTION-START -->
**Harden restack/sync for multiplayer squash merges and landed branches**

Strengthens detection of work that landed via GitHub squash merges and tightens
restack safety so stacks built in shared repos do not replay already-merged
commits or build on un-pushed trunk.

Key changes:
- **detect squash merges via opt-in IsSquashMerged** (#1346): aggregate patch-id
  scan to recognize multi-commit squash merges that git cherry/ancestry miss.
- **add reflog messages to restack ref moves** (#1357): ref updates during
  restack now carry reflog context for easier recovery and debugging.
- **centralize landed-branch policy** (#1352): single source of truth for the
  landed/merged decision used by sync, restack, and cleanup.
- **squash-aware sync cleanup** (#1351): sync cleanup honors squash-merge
  detection when reparenting/removing landed branches.
- **route restack conflict aborts through standard abort** (#1350): conflict
  aborts use the standard abort path rather than absorb cleanup.
- **guard restack against un-pushed trunk** (#1355): refuse restack when local
  trunk is ahead of / diverged from origin/<trunk>, plus broad sync coverage.
- **document multiplayer collaboration findings** (#1356): docs for landed-work
  detection, the un-pushed trunk guard, and reparent invariants.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782655035`.


* **PR #1346**
  * **PR #1357**
    * **PR #1352**
      * **PR #1351**
        * **PR #1350**
          * **PR #1355** 👈
            * **PR #1356**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1361 by jonnii*