### PR TITLE
docs: document multiplayer collaboration findings

### DIFF
--- a/.claude/rules/multiplayer-safety.md
+++ b/.claude/rules/multiplayer-safety.md
@@ -1,0 +1,115 @@
+# Multiplayer Safety Invariants
+
+Guarantees that protect users who share a repository — especially when some
+collaborators do **not** use stackit. These are non-negotiable and extend
+[safety-invariants](safety-invariants.md) ("GitHub Merge Methods Are
+First-Class"). Full reference: [docs/multiplayer.md](../../docs/multiplayer.md).
+
+## Detection Must Work With Zero Stackit Metadata
+
+**A collaborator's merged branch can carry no stackit metadata at all. Landed-work
+detection must still succeed from Git history alone.**
+
+This applies to: restack, sync, branch cleanup, merged-branch detection, and any
+"did this branch's changes land on the target" decision.
+
+### Why This Matters
+
+A teammate who does not use stackit pushes a plain GitHub branch; you stack your
+work on top of it; they squash- or rebase-merge it through the GitHub UI. In your
+local view their branch has **no recorded PR number and no `MERGED` state** —
+only Git history reflects the merge. If detection requires PR metadata, it misses
+the merge and replays their pre-merge commits into your branch (issue #1345's
+data-loss shape).
+
+### Required Behavior
+
+- `branchLanded` must treat the Git fallback as valid **without** PR metadata
+  when the target is trunk. Do not re-gate the trunk Git fallback behind a
+  recorded PR number.
+- Cover every merge method for a non-stackit collaborator, not just the stackit
+  user. The detection signal differs by case:
+
+  | Merge method | Commits | Non-stackit detection signal |
+  |--------------|---------|------------------------------|
+  | Merge commit | any | ancestry (`IsMerged`) |
+  | Rebase | any | per-commit patch-id / `git cherry` (`IsMerged`) |
+  | Squash | single | `git cherry` matches the lone commit (`IsMerged`) |
+  | Squash | multi | **aggregate patch-id only (`IsSquashMerged`)** |
+
+- A single-commit squash test proves nothing about squash support — `git cherry`
+  already patch-matches it. **Multi-commit squash is the required coverage.**
+- The Git fallback stays limited to trunk. For a non-trunk (stacked) parent, rely
+  on `MERGED` PR metadata: patch-equivalence there can mean a local stack op made
+  a child empty, not that a PR landed.
+
+## Restack Only Builds On origin/<trunk>
+
+**`restack` must refuse when a remote exists and local trunk is ahead of /
+diverged from `origin/<trunk>`.**
+
+This applies to: the `restack` command path (`PlanRestack` / `guardUnpushedTrunk`).
+
+### Why This Matters
+
+Restack rebases trunk-anchored branches onto the **local** trunk tip. In a shared
+repo that is only safe when local trunk matches the remote — you must build your
+stack only on commits everyone else also has (`origin/<trunk>`). If local trunk
+has un-pushed or divergent commits, restack bakes machine-local work into the
+stack that may never land as-is.
+
+### Required Behavior
+
+- Resolve trunk-vs-remote state **locally, no network**: read
+  `refs/remotes/<remote>/<trunk>` and compare with
+  `IsAncestor(localTrunk, remoteTrunk)`.
+- **Ahead or diverged** (local trunk is NOT an ancestor of the remote trunk) →
+  reject with a message pointing at `stackit sync` / pushing trunk.
+- **Equal or behind** (ancestor is true) → allow. Behind is safe: the stack still
+  builds only on commits present on the remote.
+- **No remote-tracking ref** (local-only repo, fresh clone, never fetched) →
+  never guard. Solo users with no remote restack freely.
+- Only fire when the restack actually has branches to move; an empty restack is
+  never an error.
+- Do **not** extend this guard to `sync` / `modify` / `squash` / `reorder`
+  (they go through `RestackBranches`, not `PlanRestack`). `sync` is the
+  recommended way to reconcile trunk, so guarding it would deadlock the fix.
+
+## Reparent Past Landed Work, Never Replay It
+
+**After restack/sync past a merged parent, a branch must contain only its own
+commits — never the landed parent's pre-merge commits.**
+
+### Required Behavior
+
+- When a parent has landed, reparent its descendants onto the parent's base
+  without replaying the parent's commits. Invariant: `<base>..<branch>` equals
+  exactly the branch's own commits.
+- Never move an unrelated branch ref to a merged **sibling's** stale pre-merge
+  tip.
+- Never delete or reparent branch metadata based solely on SHA equality. Deletion
+  stays gated on submitted-PR metadata (`metaHasSubmittedPR`); reparenting is the
+  non-destructive path and does not require that gate.
+
+## Performance: Keep The Squash Scan Cold
+
+**`IsSquashMerged` (aggregate patch-id scan) must stay out of the hot
+`IsMerged` primitive and out of broad detection loops.**
+
+It runs a bounded log plus a patch-id per scanned commit. Call it only from
+explicit "did this branch land into trunk" decisions, after cheap `IsMerged` has
+already returned false. Folding it into `IsMerged` would put an expensive
+per-commit walk on every merge check.
+
+## Test Requirements
+
+Any change to detection, reparenting, or the guard must cover:
+
+- **All three GitHub merge methods** (merge commit, squash, rebase).
+- **Both user types** (stackit user with `MERGED` metadata; non-stackit
+  collaborator with zero metadata).
+- **A multi-commit squash** case specifically.
+- **Guard boundaries**: ahead/diverged rejected; equal/behind/no-remote/no-branches
+  allowed.
+
+See `docs/multiplayer.md` for the test-file map.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ api/openapi/       API contract source of truth
 
 - `docs/config.md` - Configuration system, keys, layered config
 - `docs/hooks.md` - Lifecycle hook configuration, env vars, approval flow, recipes
+- `docs/multiplayer.md` - Collaboration: detecting landed work from non-stackit teammates, the un-pushed trunk guard, reparent invariants
 - `docs/performance.md` - Remote-operation tuning (SSH reuse), diagnosing slow commands with the tracer
 - `docs/recipes.md` - Step-by-step file lists for cross-cutting changes
 - `docs/shipping.md` - Merge strategies, consolidation, multi-stack shipping

--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -1,0 +1,188 @@
+# Multiplayer (Collaboration)
+
+How stackit behaves when more than one person works on the same repository, and
+specifically when some collaborators **do not use stackit at all**. This is the
+"multiplayer" surface: detecting other people's landed work, reparenting your
+stack past it, and never building your stack on commits that only exist on your
+machine.
+
+For the lower-level merge-method guarantees this builds on, see
+[safety-invariants](../.claude/rules/safety-invariants.md) ("GitHub Merge
+Methods Are First-Class") and the companion rule
+[multiplayer-safety](../.claude/rules/multiplayer-safety.md).
+
+## The two kinds of collaborator
+
+Stackit has to be correct for both, and the difference is **how much metadata
+exists in your local view** of the other person's branch.
+
+| | Stackit user | Non-stackit collaborator |
+|---|---|---|
+| Branch metadata (`refs/stackit/metadata/*`) | Yes — recorded PR number, base, and state | None, or at most a local parent pointer you created |
+| When their PR merges | Their PR state becomes `MERGED` in metadata | Nothing changes in metadata; only Git history reflects it |
+| How you learn it landed | PR metadata (authoritative) **or** Git history | **Git history only** |
+
+The hard case is the non-stackit collaborator: a teammate pushes a plain GitHub
+branch, you stack your own work on top of it, and they squash- or rebase-merge
+it through the GitHub UI. Their merged work carries **zero stackit metadata**.
+Detection must fall back entirely to Git, with no PR number to lean on.
+
+This is the data-loss shape from issue #1345: if detection misses their merge,
+restack replays their pre-merge commits into *your* branch.
+
+## Landed-work detection
+
+"Did this branch's changes land on the target?" is answered by
+`engineImpl.branchLanded` (`internal/engine/engine_internal.go`), which combines
+metadata and Git signals. It deliberately does **not** require PR metadata for
+the trunk case, so the non-stackit collaborator works.
+
+Signals, in order:
+
+1. **Recorded PR state is `MERGED`** (`prStateIsMerged`) — authoritative across
+   all three GitHub merge methods. Only the stackit user has this.
+2. **Cheap Git merge check** (`git.IsMerged`) — merge-base equality, then
+   `git cherry` per-commit patch matching, then ancestry fallback. Covers merge
+   commits, rebase merges, and **single-commit** squash merges.
+3. **Aggregate patch-id scan** (`git.IsSquashMerged`) — the only signal that
+   catches a **multi-commit** squash with no PR metadata. Expensive, so it is
+   reached only as a fallback for explicit "did this land on trunk" decisions
+   (see Performance below).
+
+The Git fallback (steps 2–3) is **limited to trunk** as the target. For a
+non-trunk parent, patch-equivalence can also mean a local stack operation made a
+child empty, not that a GitHub PR landed — so for stacked parents stackit relies
+on `MERGED` PR metadata instead.
+
+### Why one Git predicate is never enough
+
+GitHub's three merge methods produce different histories for the same PR:
+
+| Method | Lands on base as | PR tip reachable from base? | Detected by |
+|--------|------------------|------------------------------|-------------|
+| Merge commit | A merge commit (parents include base + PR head) | Yes | ancestry / `IsMerged` |
+| Rebase merge | PR commits replayed with new SHAs, same patch-ids | No | `git cherry` / `IsMerged` |
+| Squash (single commit) | One combined commit | No | `git cherry` matches the lone commit / `IsMerged` |
+| Squash (multi commit) | One combined commit | No | aggregate patch-id only (`IsSquashMerged`) or `MERGED` metadata |
+
+`git cherry` can patch-match a *single*-commit squash, which is why
+single-commit squash tests prove nothing about multi-commit support. The
+multi-commit squash case is the real safety coverage.
+
+### Detection matrix (who detects what)
+
+For a parent whose changes landed on trunk, restacking the child past it:
+
+| Merge method | Commits | Stackit user (MERGED metadata) | Non-stackit (zero metadata) |
+|--------------|---------|--------------------------------|-----------------------------|
+| Merge commit | single | metadata or ancestry | ancestry (`IsMerged`) |
+| Merge commit | multi | metadata or ancestry | ancestry (`IsMerged`) |
+| Rebase | single | metadata or cherry | cherry (`IsMerged`) |
+| Rebase | multi | metadata or cherry | cherry (`IsMerged`) |
+| Squash | single | metadata or cherry | cherry (`IsMerged`) |
+| Squash | multi | metadata | **aggregate patch-id (`IsSquashMerged`)** |
+
+The bolded cell is the one that has no cheap signal and no metadata — it is why
+`IsSquashMerged` exists.
+
+## The reparent invariant
+
+When restack (or sync) sees a **merged parent**, it reparents descendants past
+the landed branch **without replaying that parent's commits**. The user-visible
+guarantee:
+
+> After restack, your branch contains **only your own commits** — never the
+> landed parent's pre-merge commits.
+
+Tested as `main..mine == 1` (your single commit) across the full detection
+matrix. If detection misses the merge, the count is higher because the parent's
+commits replayed into your branch.
+
+Stackit must also never move an unrelated branch ref to a merged **sibling's**
+stale pre-merge tip, and must never delete or reparent metadata based solely on
+SHA equality.
+
+## The un-pushed trunk guard
+
+Restack rebases trunk-anchored branches onto the **local trunk tip**. In a
+multiplayer repo that is only safe when local trunk matches the remote: you
+should only build your stack on commits that exist on `origin/<trunk>`, because
+those are the commits everyone else will also build on.
+
+If local trunk is **ahead of** or **diverged from** `origin/<trunk>` — e.g. you
+committed directly on `main` and never pushed — restacking would bake those
+un-pushed commits into your stack. That work exists only on your machine and may
+never land as-is. `stackit restack` refuses in that state:
+
+```
+local trunk "main" has commits that are not on "origin/main"; restack would
+build the stack on those un-pushed commits.
+Reconcile trunk with the remote first (run `stackit sync`, or push trunk) so
+restack only builds on origin/main
+```
+
+### How the guard decides
+
+`engine.TrunkRemoteState` (`internal/engine/engine_branch_status.go`) resolves
+the state **locally, with no network**:
+
+- Reads `refs/remotes/<remote>/<trunk>` via `GetRemoteSha` (a local `rev-parse`).
+- Compares local trunk to that ref with `IsAncestor(localSha, remoteSha)`.
+- Local trunk is **ahead or diverged** when it is **not** an ancestor of the
+  remote-tracking trunk. Equal and behind both report `ancestor=true` (a commit
+  is its own ancestor), so neither trips the guard.
+
+`guardUnpushedTrunk` (`internal/actions/restack.go`) consumes this inside
+`PlanRestack` and rejects before any rebase runs.
+
+| Local trunk vs `origin/<trunk>` | `AheadOrDiverged` | Restack |
+|---------------------------------|-------------------|---------|
+| Equal (synced) | false | allowed |
+| Behind (remote has more) | false | allowed — builds only on remote commits |
+| Ahead (un-pushed local commits) | true | **rejected** |
+| Diverged (each has unique commits) | true | **rejected** |
+| No remote-tracking ref (local-only/fresh clone) | false (`HasRemoteRef=false`) | allowed — nothing to guard against |
+
+Scope notes:
+
+- The guard only fires when the restack actually has branches to move (an empty
+  restack is never rejected).
+- It is wired into `PlanRestack` (the `restack` command path). Operations that
+  go through `RestackBranches` directly — `sync`, `modify`, `squash`, `reorder`
+  — are unaffected; `sync` is in fact the recommended way to reconcile trunk.
+- Local-only repos (no remote) are never guarded.
+
+## Performance: keep the squash scan cold
+
+`IsSquashMerged` runs a bounded log (`-200`) plus a patch-id per scanned target
+commit. It is intentionally **not** part of the hot `IsMerged` primitive and is
+not called in broad merge-detection loops — only from explicit "did this branch
+land into trunk" decisions, after the cheap `IsMerged` has already returned
+false. Keep it that way: folding the aggregate scan into `IsMerged` would put an
+expensive per-commit patch-id walk on every merge check.
+
+## Test coverage
+
+| Area | Test |
+|------|------|
+| Detection matrix (all methods × single/multi × stackit/non-stackit) | `internal/integration/restack_synced_trunk_matrix_test.go` |
+| Non-stackit collaborator squash/rebase, including fully untracked parent | `internal/integration/restack_untracked_collaborator_test.go` |
+| Multi-commit squash with stale/absent PR state, conflict-abort, reflog | `internal/integration/restack_squash_merge_test.go`, `internal/integration/restack_squash_conflict_abort_test.go` |
+| Un-pushed/diverged trunk guard (integration) | `internal/integration/restack_trunk_guard_test.go` |
+| `TrunkRemoteState` predicate (engine unit) | `internal/engine/engine_impl_test.go` (`TestTrunkRemoteState`) |
+
+When changing any of detection, reparenting, or the guard, cover **all three
+merge methods** and **both user types**, and include a **multi-commit** squash
+case — a single-commit squash proves nothing because `git cherry` already
+matches it.
+
+## Key code locations
+
+| Concern | Location |
+|---------|----------|
+| Landed-work detection | `internal/engine/engine_internal.go` (`branchLanded`, `prStateIsMerged`) |
+| Cheap merge check | `internal/git/merge_detection.go` (`IsMerged`) |
+| Aggregate squash scan | `internal/git/merge_detection.go` (`IsSquashMerged` / `isSquashMerged`) |
+| Reparent target selection | `internal/engine/engine_internal.go` (`shouldReparentBranch`, `findNearestValidAncestor`) |
+| Trunk-remote state | `internal/engine/engine_branch_status.go` (`TrunkRemoteState`) |
+| Restack guard | `internal/actions/restack.go` (`guardUnpushedTrunk`) |


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Add docs/multiplayer.md covering landed-work detection for non-stackit
collaborators (the zero-metadata case), the per-method detection matrix,
the un-pushed trunk guard, and the reparent invariant. Add a companion
.claude/rules/multiplayer-safety.md enforcing those guarantees alongside
safety-invariants.md, and index the new doc in AGENTS.md.

<hr/>

<!-- STACKIT-SECTION-START -->
**Harden restack/sync for multiplayer squash merges and landed branches**

Strengthens detection of work that landed via GitHub squash merges and tightens
restack safety so stacks built in shared repos do not replay already-merged
commits or build on un-pushed trunk.

Key changes:
- **detect squash merges via opt-in IsSquashMerged** (#1346): aggregate patch-id
  scan to recognize multi-commit squash merges that git cherry/ancestry miss.
- **add reflog messages to restack ref moves** (#1357): ref updates during
  restack now carry reflog context for easier recovery and debugging.
- **centralize landed-branch policy** (#1352): single source of truth for the
  landed/merged decision used by sync, restack, and cleanup.
- **squash-aware sync cleanup** (#1351): sync cleanup honors squash-merge
  detection when reparenting/removing landed branches.
- **route restack conflict aborts through standard abort** (#1350): conflict
  aborts use the standard abort path rather than absorb cleanup.
- **guard restack against un-pushed trunk** (#1355): refuse restack when local
  trunk is ahead of / diverged from origin/<trunk>, plus broad sync coverage.
- **document multiplayer collaboration findings** (#1356): docs for landed-work
  detection, the un-pushed trunk guard, and reparent invariants.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782655035`.


* **PR #1346**
  * **PR #1357**
    * **PR #1352**
      * **PR #1351**
        * **PR #1350**
          * **PR #1355**
            * **PR #1356** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1361 by jonnii*