### PR TITLE
fix: add reflog messages to restack ref moves

### DIFF
--- a/internal/actions/sync/sync_test.go
+++ b/internal/actions/sync/sync_test.go
@@ -243,12 +243,26 @@ func (r *runtimeConflictRunner) Rebase(ctx context.Context, branchName, upstream
 }
 
 func (r *runtimeConflictRunner) UpdateRefsBatch(ctx context.Context, updates []git.RefUpdate) error {
-	if !r.injected {
-		r.injected = true
-		r.rebaseInProgress = true
+	if r.injectRuntimeConflict() {
 		return nil
 	}
 	return r.Runner.UpdateRefsBatch(ctx, updates)
+}
+
+func (r *runtimeConflictRunner) UpdateRefsBatchWithLog(ctx context.Context, updates []git.RefUpdate, reflogMessage string) error {
+	if r.injectRuntimeConflict() {
+		return nil
+	}
+	return r.Runner.UpdateRefsBatchWithLog(ctx, updates, reflogMessage)
+}
+
+func (r *runtimeConflictRunner) injectRuntimeConflict() bool {
+	if !r.injected {
+		r.injected = true
+		r.rebaseInProgress = true
+		return true
+	}
+	return false
 }
 
 func (r *runtimeConflictRunner) CheckoutBranch(ctx context.Context, branchName string) error {

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -8,6 +8,12 @@ import (
 	"github.com/getstackit/stackit/internal/git"
 )
 
+const (
+	reflogRestack       = "stackit: restack"
+	reflogRestackFrozen = "stackit: restack (frozen)"
+	reflogRestackAnchor = "stackit: restack (anchor)"
+)
+
 // restackBranch rebases a branch onto its parent
 // If the parent has been merged/deleted, it will automatically reparent to the nearest valid ancestor.
 // worktrees and metaRefSHAs are snapshots taken by the caller — passing them
@@ -103,7 +109,7 @@ func (e *engineImpl) restackBranch(
 				{RefName: fmt.Sprintf("refs/heads/%s", branchName), NewSHA: remoteSha, OldSHA: localSha},
 				{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
 			}
-			if err := e.git.UpdateRefsBatch(ctx, updates); err != nil {
+			if err := e.git.UpdateRefsBatchWithLog(ctx, updates, reflogRestackFrozen); err != nil {
 				return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to update refs atomically for frozen branch %s: %w", branchName, err)
 			}
 
@@ -175,7 +181,7 @@ func (e *engineImpl) restackBranch(
 			{RefName: fmt.Sprintf("refs/heads/%s", branchName), NewSHA: trunkRev, OldSHA: anchorRev},
 			{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
 		}
-		if err := e.git.UpdateRefsBatch(ctx, updates); err != nil {
+		if err := e.git.UpdateRefsBatchWithLog(ctx, updates, reflogRestackAnchor); err != nil {
 			return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to update refs atomically for anchor %s: %w", branchName, err)
 		}
 
@@ -384,7 +390,7 @@ func (e *engineImpl) restackBranch(
 		{RefName: fmt.Sprintf("refs/heads/%s", branchName), NewSHA: newRev, OldSHA: oldBranchSHA},
 		{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
 	}
-	if err := e.git.UpdateRefsBatch(ctx, updates); err != nil {
+	if err := e.git.UpdateRefsBatchWithLog(ctx, updates, reflogRestack); err != nil {
 		return RestackBranchResult{
 			Result:            RestackConflict,
 			RebasedBranchBase: parentRev,
@@ -568,7 +574,7 @@ func (e *engineImpl) applyBranchAndMetadata(
 		{RefName: fmt.Sprintf("refs/heads/%s", branchName), NewSHA: newRev, OldSHA: oldBranchSHA},
 		{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
 	}
-	if err := e.git.UpdateRefsBatch(ctx, updates); err != nil {
+	if err := e.git.UpdateRefsBatchWithLog(ctx, updates, reflogRestack); err != nil {
 		return RestackBranchResult{Result: RestackConflict, RebasedBranchBase: parentRev}, fmt.Errorf("failed to update refs atomically: %w", err)
 	}
 

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -137,7 +137,7 @@ func (r *runner) UpdateBranchRef(ctx context.Context, branchName, revision strin
 		return fmt.Errorf("failed to resolve revision %s: %w", revision, err)
 	}
 	refName := fmt.Sprintf("refs/heads/%s", branchName)
-	if _, err := r.RunGitCommandWithContext(ctx, "update-ref", refName, sha); err != nil {
+	if _, err := r.RunGitCommandWithContext(ctx, "update-ref", "-m", "stackit: update branch ref", refName, sha); err != nil {
 		return fmt.Errorf("failed to update branch ref: %w", err)
 	}
 	return nil


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Branch ref updates during restack wrote blank "(no message)" reflog entries
because the validated, frozen-branch, and worktree-anchor paths all moved refs
with UpdateRefsBatch, which omits the -m flag. That made it impossible to tell
what moved a branch ref when debugging an incident.

Switch every restack ref move to UpdateRefsBatchWithLog with a descriptive
label ("stackit: restack", "stackit: restack (frozen)", "stackit: restack
(anchor)") and give UpdateBranchRef the same treatment, so every ref move a
restack performs is traceable in the reflog.

<hr/>

<!-- STACKIT-SECTION-START -->
**Harden restack/sync for multiplayer squash merges and landed branches**

Strengthens detection of work that landed via GitHub squash merges and tightens
restack safety so stacks built in shared repos do not replay already-merged
commits or build on un-pushed trunk.

Key changes:
- **detect squash merges via opt-in IsSquashMerged** (#1346): aggregate patch-id
  scan to recognize multi-commit squash merges that git cherry/ancestry miss.
- **add reflog messages to restack ref moves** (#1357): ref updates during
  restack now carry reflog context for easier recovery and debugging.
- **centralize landed-branch policy** (#1352): single source of truth for the
  landed/merged decision used by sync, restack, and cleanup.
- **squash-aware sync cleanup** (#1351): sync cleanup honors squash-merge
  detection when reparenting/removing landed branches.
- **route restack conflict aborts through standard abort** (#1350): conflict
  aborts use the standard abort path rather than absorb cleanup.
- **guard restack against un-pushed trunk** (#1355): refuse restack when local
  trunk is ahead of / diverged from origin/<trunk>, plus broad sync coverage.
- **document multiplayer collaboration findings** (#1356): docs for landed-work
  detection, the un-pushed trunk guard, and reparent invariants.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782655035`.


* **PR #1346**
  * **PR #1357** 👈
    * **PR #1352**
      * **PR #1351**
        * **PR #1350**
          * **PR #1355**
            * **PR #1356**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1361 by jonnii*