### PR TITLE
feat: local single-repo web experience for mise dev

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -9,6 +9,11 @@
 # local development (`mise run dev`, the default STACKIT_ENV=local), every
 # STACKIT_GITHUB_* / STACKIT_SESSION_KEY / STACKIT_ALLOWED_GH_* variable can
 # stay blank and the server binds loopback with auth disabled.
+#
+# On a loopback bind auth is OFF even when these creds ARE set, so `mise run
+# dev` "just works" locally without an OAuth login. To exercise the login flow
+# locally, set STACKIT_AUTH=1 (or pass -auth) — it requires the STACKIT_GITHUB_*
+# values below.
 
 # --- GitHub OAuth app (https://github.com/settings/developers) ----------------
 # Create an OAuth App with:

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,9 @@
+# Shared dev Procfile for both `mise run dev` and `mise run dev:hosted`. The two
+# tasks differ only by STACKIT_DATABASE_URL, set at the task level in mise.toml:
+#   - `dev`        clears it → single-repo mode (discovers the cwd git repo, no
+#                  picker; the web UI opens that repo directly).
+#   - `dev:hosted` keeps the mise [env] value → DB-backed multi-tenant mode
+#                  (serves repos from the store, shows the picker; run
+#                  `mise run db:up` first).
 server: watchexec -r -e go -w apps/server -w internal -w api -- go run ./apps/server --port 8080
-web: pnpm --filter @stackit/web dev
+web: NEXT_PUBLIC_API_URL=http://localhost:8080 pnpm --filter @stackit/web dev

--- a/apps/server/auth.go
+++ b/apps/server/auth.go
@@ -19,17 +19,19 @@ type authBuildResult struct {
 // authBuildParams describes the runtime posture buildAuthConfig needs. The
 // auth requirement keys off exposure (a non-loopback bind), not the env name:
 // a server reachable off-host must be authenticated or read-only, however it
-// got that way.
+// got that way. On a loopback bind auth is off by default — a local run should
+// "just work" without a login — so forceAuth opts back in for testing OAuth.
 type authBuildParams struct {
-	disabled bool // -auth-disabled was passed
-	exposed  bool // resolved bind is non-loopback (reachable off-host)
-	readOnly bool // read-only posture: writes impossible, reads anonymous
-	prod     bool // production env: force Secure cookies (behind TLS)
+	disabled  bool // -auth-disabled was passed
+	forceAuth bool // -auth was passed: opt into the OAuth gate on a loopback bind
+	exposed   bool // resolved bind is non-loopback (reachable off-host)
+	readOnly  bool // read-only posture: writes impossible, reads anonymous
+	prod      bool // production env: force Secure cookies (behind TLS)
 }
 
 // buildAuthConfig wires up the OAuth handler, session store, and allowlist
 // from environment variables. Returns (nil, nil) when auth is off (explicitly
-// disabled, or unconfigured on a non-exposed/read-only server); an error when
+// disabled, or on a loopback bind that didn't opt in via -auth); an error when
 // an exposed, writable server would be left unauthenticated.
 func buildAuthConfig(p authBuildParams) (*authBuildResult, error) {
 	// An exposed, writable server must be authenticated. Read-only removes the
@@ -37,9 +39,21 @@ func buildAuthConfig(p authBuildParams) (*authBuildResult, error) {
 	mustAuth := p.exposed && !p.readOnly
 
 	if p.disabled {
+		if p.forceAuth {
+			return nil, errors.New("-auth and -auth-disabled are mutually exclusive")
+		}
 		if mustAuth {
 			return nil, errors.New("-auth-disabled is not allowed when the server is reachable off-host (non-loopback bind): it would expose an unauthenticated, writable server. Pass -read-only, bind loopback (STACKIT_ENV=local), or configure GitHub OAuth")
 		}
+		return nil, nil
+	}
+
+	// On a loopback bind (not exposed, not read-only-mandated) auth is off by
+	// default even when GitHub creds are present in the environment: a local
+	// run should "just work" without sending the operator through an OAuth
+	// login. Opt in with -auth (STACKIT_AUTH) to exercise the login flow
+	// locally. An exposed server still falls through to the required-auth path.
+	if !mustAuth && !p.forceAuth {
 		return nil, nil
 	}
 
@@ -48,14 +62,14 @@ func buildAuthConfig(p authBuildParams) (*authBuildResult, error) {
 	baseURL := strings.TrimSpace(os.Getenv("STACKIT_BASE_URL"))
 	sessionKey := strings.TrimSpace(os.Getenv("STACKIT_SESSION_KEY"))
 
-	// When the server isn't exposed (local loopback) or is read-only, missing
-	// OAuth config is "off by default" — a local dev binary shouldn't need env
-	// vars to boot, and a read-only server serves reads anonymously anyway.
+	// Auth is now required (exposed+writable) or explicitly requested (-auth).
+	// Wholly unconfigured OAuth is an error in both cases — the message differs
+	// so the operator knows which lever they tripped.
 	if clientID == "" && clientSecret == "" && baseURL == "" && sessionKey == "" {
-		if mustAuth {
-			return nil, errors.New("the server is reachable off-host (non-loopback bind) but auth is not configured: set STACKIT_GITHUB_CLIENT_ID, STACKIT_GITHUB_CLIENT_SECRET, STACKIT_BASE_URL, STACKIT_SESSION_KEY (and STACKIT_ALLOWED_GH_USERS or STACKIT_ALLOWED_GH_ORG), or pass -read-only to serve anonymously")
+		if p.forceAuth {
+			return nil, errors.New("-auth was set but GitHub OAuth is not configured: set STACKIT_GITHUB_CLIENT_ID, STACKIT_GITHUB_CLIENT_SECRET, STACKIT_BASE_URL, STACKIT_SESSION_KEY (and STACKIT_ALLOWED_GH_USERS or STACKIT_ALLOWED_GH_ORG)")
 		}
-		return nil, nil
+		return nil, errors.New("the server is reachable off-host (non-loopback bind) but auth is not configured: set STACKIT_GITHUB_CLIENT_ID, STACKIT_GITHUB_CLIENT_SECRET, STACKIT_BASE_URL, STACKIT_SESSION_KEY (and STACKIT_ALLOWED_GH_USERS or STACKIT_ALLOWED_GH_ORG), or pass -read-only to serve anonymously")
 	}
 
 	if clientID == "" {

--- a/apps/server/auth_test.go
+++ b/apps/server/auth_test.go
@@ -91,7 +91,9 @@ func TestBuildAuthConfig_PartialEnvErrors(t *testing.T) {
 		"STACKIT_ALLOWED_GH_USERS":     "jonnii",
 	})
 
-	_, err := buildAuthConfig(authBuildParams{})
+	// forceAuth so the loopback default-off path doesn't short-circuit before
+	// the per-field validation we want to exercise.
+	_, err := buildAuthConfig(authBuildParams{forceAuth: true})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "STACKIT_GITHUB_CLIENT_SECRET")
 }
@@ -106,12 +108,57 @@ func TestBuildAuthConfig_HappyPath(t *testing.T) {
 		"STACKIT_ALLOWED_GH_USERS":     "jonnii",
 	})
 
-	r, err := buildAuthConfig(authBuildParams{})
+	// forceAuth: a loopback bind is anonymous by default even with full creds.
+	r, err := buildAuthConfig(authBuildParams{forceAuth: true})
 	require.NoError(t, err)
 	require.NotNil(t, r)
 	require.NotNil(t, r.cfg.Handler)
 	require.NotNil(t, r.cfg.SessionStore)
 	require.NoError(t, r.store.Close())
+}
+
+func TestBuildAuthConfig_LocalCredsPresentDefaultsOff(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel; these tests share process env.
+	withEnv(t, map[string]string{
+		"STACKIT_GITHUB_CLIENT_ID":     "id",
+		"STACKIT_GITHUB_CLIENT_SECRET": "secret",
+		"STACKIT_BASE_URL":             "http://localhost:8080",
+		"STACKIT_SESSION_KEY":          mustKey(t),
+		"STACKIT_ALLOWED_GH_USERS":     "jonnii",
+	})
+
+	// The local-experience guarantee: a loopback bind with full GitHub creds in
+	// the environment still boots anonymously, so `stackit-server` in a repo
+	// "just works" without an OAuth login.
+	r, err := buildAuthConfig(authBuildParams{})
+	require.NoError(t, err)
+	require.Nil(t, r, "loopback bind defaults to anonymous even with creds present")
+}
+
+func TestBuildAuthConfig_ForceAuthNoCredsErrors(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel; these tests share process env.
+	withEnv(t, map[string]string{
+		"STACKIT_GITHUB_CLIENT_ID":     "",
+		"STACKIT_GITHUB_CLIENT_SECRET": "",
+		"STACKIT_BASE_URL":             "",
+		"STACKIT_SESSION_KEY":          "",
+		"STACKIT_ALLOWED_GH_USERS":     "",
+		"STACKIT_ALLOWED_GH_ORG":       "",
+	})
+
+	// -auth on a loopback bind with no OAuth config is a usage error: the
+	// operator asked for the login flow but gave nothing to authenticate with.
+	_, err := buildAuthConfig(authBuildParams{forceAuth: true})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "-auth")
+}
+
+func TestBuildAuthConfig_DisabledAndForceConflict(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildAuthConfig(authBuildParams{disabled: true, forceAuth: true})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
 }
 
 func TestBuildAuthConfig_ExposedHTTPBaseURLRefused(t *testing.T) {
@@ -160,8 +207,8 @@ func TestBuildAuthConfig_LocalHTTPBaseURLOK(t *testing.T) {
 	})
 
 	// Not exposed (loopback) + http:// is fine for local dev — the cookie never
-	// leaves the host.
-	r, err := buildAuthConfig(authBuildParams{})
+	// leaves the host. forceAuth because a loopback bind is otherwise anonymous.
+	r, err := buildAuthConfig(authBuildParams{forceAuth: true})
 	require.NoError(t, err)
 	require.NotNil(t, r)
 	require.NoError(t, r.store.Close())
@@ -178,7 +225,9 @@ func TestBuildAuthConfig_EmptyAllowlistErrors(t *testing.T) {
 		"STACKIT_ALLOWED_GH_ORG":       "",
 	})
 
-	_, err := buildAuthConfig(authBuildParams{})
+	// forceAuth so the empty-allowlist validation runs (loopback is otherwise
+	// anonymous and would short-circuit before the allowlist is built).
+	_, err := buildAuthConfig(authBuildParams{forceAuth: true})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "allowlist")
 }

--- a/apps/server/main.go
+++ b/apps/server/main.go
@@ -65,17 +65,21 @@ func setupLogging(jsonOutput bool) {
 
 func run() error {
 	var (
-		port            = flag.Int("port", 8080, "Port to listen on")
-		bind            = flag.String("bind", "", "Interface to bind on. Defaults to 127.0.0.1 (loopback); STACKIT_ENV=production binds 0.0.0.0.")
-		cwd             = flag.String("cwd", "", "Working directory for repository detection (single-repo shortcut; ignored when -database-url is set)")
-		databaseURL     = flag.String("database-url", os.Getenv("STACKIT_DATABASE_URL"), "PostgreSQL connection string. When set, repos are served from the DB instead of the -cwd single-repo shortcut.")
-		reposRoot       = flag.String("repos-root", os.Getenv("STACKIT_REPOS_ROOT"), "Base directory under which per-repo checkouts live (<reposRoot>/<owner>/<name>) for DB-sourced repos.")
-		remote          = flag.String("remote", "origin", "Default git remote name for the single-repo -cwd shortcut")
-		corsOrigins     = flag.String("cors", "http://localhost:3000,http://localhost:5173", "Comma-separated allowed CORS origins")
-		apiPrefix       = flag.String("api-prefix", "/api/v1", "Canonical API prefix")
-		enableLegacy    = flag.Bool("legacy-api-prefix", true, "Also expose legacy /api endpoints")
-		shutdownGrace   = flag.Duration("shutdown-timeout", 10*time.Second, "Graceful shutdown timeout")
+		port          = flag.Int("port", 8080, "Port to listen on")
+		bind          = flag.String("bind", "", "Interface to bind on. Defaults to 127.0.0.1 (loopback); STACKIT_ENV=production binds 0.0.0.0.")
+		cwd           = flag.String("cwd", "", "Working directory for repository detection (single-repo shortcut; ignored when -database-url is set)")
+		databaseURL   = flag.String("database-url", os.Getenv("STACKIT_DATABASE_URL"), "PostgreSQL connection string. When set, repos are served from the DB instead of the -cwd single-repo shortcut.")
+		reposRoot     = flag.String("repos-root", os.Getenv("STACKIT_REPOS_ROOT"), "Base directory under which per-repo checkouts live (<reposRoot>/<owner>/<name>) for DB-sourced repos.")
+		remote        = flag.String("remote", "origin", "Default git remote name for the single-repo -cwd shortcut")
+		corsOrigins   = flag.String("cors", "http://localhost:3000,http://localhost:5173", "Comma-separated allowed CORS origins")
+		apiPrefix     = flag.String("api-prefix", "/api/v1", "Canonical API prefix")
+		enableLegacy  = flag.Bool("legacy-api-prefix", true, "Also expose legacy /api endpoints")
+		shutdownGrace = flag.Duration("shutdown-timeout", 10*time.Second, "Graceful shutdown timeout")
+		// Intentionally flag-only (no STACKIT_* env binding): disabling the auth
+		// gate must be a deliberate, visible act on the command line, not
+		// something a stray env var in a shell or deploy config can switch on.
 		authDisabled    = flag.Bool("auth-disabled", false, "Disable GitHub OAuth gate. Refused when the server binds a non-loopback interface (e.g. STACKIT_ENV=production) unless -read-only is set.")
+		authForce       = flag.Bool("auth", envBool("STACKIT_AUTH"), "Force-enable the GitHub OAuth gate on a loopback bind to test the login flow locally (loopback binds are anonymous by default even when STACKIT_GITHUB_* is set). Ignored when the bind is exposed (auth is already required there). Also set via STACKIT_AUTH.")
 		readOnly        = flag.Bool("read-only", envBool("STACKIT_READ_ONLY"), "Serve in read-only mode: the submit endpoint is disabled so the repo can be exposed publicly without write access. Also set via STACKIT_READ_ONLY.")
 		syncInterval    = flag.Duration("sync-interval", envSyncInterval(), "How often to mirror-fetch managed repos from their remotes so served state stays current. Defaults to 5m (the webhook backstop); 0 disables the loop. Also set via STACKIT_SYNC_INTERVAL (e.g. 60s).")
 		webhookDebounce = flag.Duration("webhook-debounce", envWebhookDebounce(), "Quiet window a repo's webhook pushes wait out before a fetch, so a stack submit's burst of pushes collapses into one refresh. Defaults to 2s; 0 dispatches immediately. Also set via STACKIT_WEBHOOK_DEBOUNCE (e.g. 5s).")
@@ -186,10 +190,11 @@ func run() error {
 	}
 
 	authBuild, err := buildAuthConfig(authBuildParams{
-		disabled: *authDisabled,
-		exposed:  exposed,
-		readOnly: *readOnly,
-		prod:     prod,
+		disabled:  *authDisabled,
+		forceAuth: *authForce,
+		exposed:   exposed,
+		readOnly:  *readOnly,
+		prod:      prod,
 	})
 	if err != nil {
 		return err
@@ -204,7 +209,7 @@ func run() error {
 		}()
 		slog.Info("auth: GitHub OAuth gate enabled")
 	} else {
-		slog.Warn("auth: DISABLED (no STACKIT_GITHUB_* env or -auth-disabled set). Do not expose this port publicly.")
+		slog.Warn("auth: DISABLED — anonymous access. Expected on a loopback bind; pass -auth (STACKIT_AUTH) to test the OAuth login flow locally. Never expose this port publicly.")
 	}
 
 	// GitHub App provider authenticates onboarding clones and background syncs.
@@ -228,9 +233,17 @@ func run() error {
 	}
 
 	server := api.NewServer(api.ServerConfig{
-		BindAddr:            *bind,
-		Port:                *port,
-		CORSOrigins:         parseCSV(*corsOrigins),
+		BindAddr:    *bind,
+		Port:        *port,
+		CORSOrigins: parseCSV(*corsOrigins),
+		// On a loopback bind, accept any loopback browser origin so a local dev
+		// web server on an environment-assigned port (e.g. cmux-set $PORT) isn't
+		// blocked by CORS. Never enabled when exposed.
+		AllowLoopbackOrigins: !exposed,
+		// Single-repo mode: anything but DB-backed multi-tenant serves one repo
+		// discovered from -cwd, so the web client opens it directly instead of
+		// showing the (hosted-only) repo picker.
+		SingleRepo:          *databaseURL == "",
 		APIPrefixes:         prefixes,
 		StaticFS:            staticFS,
 		Registry:            reg,

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,13 @@
 import type { NextConfig } from "next";
+import { PHASE_PRODUCTION_BUILD } from "next/constants";
 
-const nextConfig: NextConfig = {
-  output: "export",
-};
-
-export default nextConfig;
+// `output: "export"` emits a static SPA that the Go server embeds and serves
+// (with an index.html fallback for deep links). It is only correct for the
+// production build: under `next dev` it forces every navigable path to be
+// enumerated in generateStaticParams, which breaks client-side navigation to
+// dynamic /{owner}/{repo}/... routes (the app routes entirely client-side via
+// usePathname). So enable it only for `next build`; `next dev` runs as a normal
+// dev server where the optional catch-all handles every path.
+export default (phase: string): NextConfig => ({
+  output: phase === PHASE_PRODUCTION_BUILD ? "export" : undefined,
+});

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -2,7 +2,7 @@
 
 import { usePathname } from "next/navigation";
 import { AuthProvider } from "@/components/providers/auth-provider";
-import { ConfigProvider } from "@/components/providers/config-provider";
+import { ConfigProvider, useConfig } from "@/components/providers/config-provider";
 import { RepoProvider } from "@/components/providers/repo-provider";
 import { RepoPicker } from "@/components/repo-picker/repo-picker";
 import { RepoView } from "@/components/repo-picker/repo-view";
@@ -21,6 +21,7 @@ const AUTH_DISABLED = process.env.NEXT_PUBLIC_STACKIT_AUTH_DISABLED === "1";
 const CONFIG_FALLBACK: ConfigResponse = {
   readOnly: false,
   authRequired: !AUTH_DISABLED,
+  singleRepo: false,
 };
 
 // Client shell driving both the unscoped picker and the per-repo view.
@@ -32,6 +33,7 @@ const CONFIG_FALLBACK: ConfigResponse = {
 // shell for deep links on refresh (see internal/api/static.go).
 function Home() {
   const { owner, repo } = parseRepoPath(usePathname());
+  const { singleRepo } = useConfig();
 
   return (
     <>
@@ -41,7 +43,7 @@ function Home() {
           <RepoView />
         </RepoProvider>
       ) : (
-        <RepoPicker />
+        <RepoPicker autoOpenSingle={singleRepo} />
       )}
     </>
   );

--- a/apps/web/src/components/providers/config-provider.tsx
+++ b/apps/web/src/components/providers/config-provider.tsx
@@ -6,6 +6,7 @@ import { fetchConfig, type ConfigResponse } from "@/lib/api";
 const ConfigContext = createContext<ConfigResponse>({
   readOnly: false,
   authRequired: true,
+  singleRepo: false,
 });
 
 export function useConfig() {

--- a/apps/web/src/components/repo-picker/__tests__/repo-picker.test.tsx
+++ b/apps/web/src/components/repo-picker/__tests__/repo-picker.test.tsx
@@ -3,9 +3,10 @@ import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { RepoPicker } from "../repo-picker";
 
 const mockPush = vi.fn();
+const mockReplace = vi.fn();
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: mockPush }),
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
 }));
 
 const mockFetch = vi.fn();
@@ -14,6 +15,7 @@ global.fetch = mockFetch;
 beforeEach(() => {
   mockFetch.mockReset();
   mockPush.mockReset();
+  mockReplace.mockReset();
 });
 
 function mockRepos(data: unknown) {
@@ -60,6 +62,34 @@ describe("RepoPicker", () => {
     await waitFor(() => {
       expect(screen.getByText(/No repositories configured/i)).toBeDefined();
     });
+  });
+
+  it("auto-opens the sole repo in single-repo mode", async () => {
+    mockRepos({
+      repos: [{ id: "stackit", owner: "acme", repo: "web", displayName: "Stackit", trunk: "main" }],
+    });
+
+    render(<RepoPicker autoOpenSingle />);
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/acme/web");
+    });
+    // It redirects rather than rendering the picker UI.
+    expect(screen.queryByText(/Choose a repository/i)).toBeNull();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the picker in single-repo mode when the sole repo has no remote", async () => {
+    mockRepos({
+      repos: [{ id: "local", displayName: "Local", trunk: "main" }],
+    });
+
+    render(<RepoPicker autoOpenSingle />);
+
+    // No GitHub coordinates → can't build a path → show the list instead of
+    // silently redirecting nowhere.
+    expect(await screen.findByTestId("repo-card-local")).toBeDefined();
+    expect(mockReplace).not.toHaveBeenCalled();
   });
 
   it("renders an error message when the fetch fails", async () => {

--- a/apps/web/src/components/repo-picker/repo-picker.tsx
+++ b/apps/web/src/components/repo-picker/repo-picker.tsx
@@ -13,7 +13,19 @@ import { fetchRepos, type RepoSummary } from "@/lib/api";
 import { buildRepoPath } from "@/lib/repo-route";
 import { AddRepository } from "./add-repository";
 
-export function RepoPicker() {
+interface RepoPickerProps {
+  // autoOpenSingle navigates straight to the sole repo (single-repo / local
+  // mode) instead of rendering the picker — choosing a repo is only meaningful
+  // in the hosted, multi-repo model.
+  autoOpenSingle?: boolean;
+}
+
+// openableRepo reports whether a repo can be addressed in the path-based UI —
+// it needs GitHub coordinates, which a repo with no remote lacks.
+const openableRepo = (repo: RepoSummary): repo is RepoSummary & { owner: string; repo: string } =>
+  Boolean(repo.owner && repo.repo);
+
+export function RepoPicker({ autoOpenSingle = false }: RepoPickerProps) {
   const router = useRouter();
   const [repos, setRepos] = useState<RepoSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -21,7 +33,7 @@ export function RepoPicker() {
   // Repos are addressed by their GitHub coordinates. A repo with no remote has
   // none and can't be opened in the path-based UI.
   const openRepo = (repo: RepoSummary) => {
-    if (!repo.owner || !repo.repo) return;
+    if (!openableRepo(repo)) return;
     router.push(buildRepoPath(repo.owner, repo.repo, null));
   };
 
@@ -40,6 +52,25 @@ export function RepoPicker() {
       active = false;
     };
   }, []);
+
+  // In single-repo mode, redirect straight to the one repo once it loads.
+  // router.replace (not push) keeps the picker out of history so Back doesn't
+  // bounce here. Falls through to the normal render when the repo can't be
+  // addressed (no remote) so the user still sees a useful state.
+  const soleRepo = autoOpenSingle && repos?.length === 1 ? repos[0] : null;
+  useEffect(() => {
+    if (soleRepo && openableRepo(soleRepo)) {
+      router.replace(buildRepoPath(soleRepo.owner, soleRepo.repo, null));
+    }
+  }, [soleRepo, router]);
+
+  if (soleRepo && openableRepo(soleRepo)) {
+    return (
+      <div className="flex h-screen items-center justify-center text-sm text-muted-foreground">
+        Opening {soleRepo.displayName || soleRepo.id}…
+      </div>
+    );
+  }
 
   if (error) {
     return (

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -153,6 +153,10 @@ export interface ViewResponse {
 export interface ConfigResponse {
   readOnly: boolean;
   authRequired: boolean;
+  // singleRepo is true in local single-repo mode: the client opens the sole
+  // repo directly instead of showing the (hosted-only) repo picker. Optional
+  // so an older server that omits it is treated as multi-tenant.
+  singleRepo?: boolean;
 }
 
 // --- Auth Types ---

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -55,8 +55,9 @@ with every authenticated user.
 
 | Var | Purpose |
 |-----|---------|
-| `STACKIT_ENV` | Deployment posture: `local` (default) or `production`. `production` binds `0.0.0.0`, emits JSON logs, forces `Secure` cookies, honors `$PORT`, and requires auth (or `-read-only`). `local` binds loopback (`127.0.0.1`) with auth optional. Set it to `production` on every hosted deploy. |
+| `STACKIT_ENV` | Deployment posture: `local` (default) or `production`. `production` binds `0.0.0.0`, emits JSON logs, forces `Secure` cookies, honors `$PORT`, and requires auth (or `-read-only`). `local` binds loopback (`127.0.0.1`) and serves anonymously — auth is off **even when the `STACKIT_GITHUB_*` creds are set**, so `mise run dev` "just works" without an OAuth login. Set `STACKIT_AUTH=1` to exercise the login flow locally. Set `STACKIT_ENV=production` on every hosted deploy. |
 | `PORT` | Listen port for **production** deploys. Honored when `-port` isn't passed and `STACKIT_ENV=production` — PaaS hosts (Railway, Fly, Heroku) inject it. Ignored in `local` so a stray `$PORT` from a dev shell can't move the listener. Defaults to `8080`. |
+| `STACKIT_AUTH` | Set to `1`/`true` to force-enable the GitHub OAuth gate on a loopback bind, so you can test the login flow locally (loopback binds are anonymous by default even when `STACKIT_GITHUB_*` is set). Ignored when the bind is exposed — auth is already required there. Requires the `STACKIT_GITHUB_*` values to be configured. Equivalent to `-auth`. |
 | `STACKIT_READ_ONLY` | Set to `1`/`true` to serve in read-only mode: the submit endpoint is disabled and reads are served anonymously, so a configured repo can be exposed to the public without write access. See [Read-only public mode](#read-only-public-mode). Equivalent to `-read-only`. |
 | `STACKIT_DATABASE_URL` | PostgreSQL connection string. When set, repos are served from the DB (and runtime [onboarding](#repository-onboarding) can persist new ones) instead of the `-cwd` single-repo shortcut. Equivalent to `-database-url`. |
 | `STACKIT_REPOS_ROOT` | Base directory under which per-repo checkouts live (`<root>/<owner>/<name>`). Required for DB-backed serving and onboarding. Equivalent to `-repos-root`. |
@@ -85,8 +86,9 @@ The most useful flags:
 | `-cwd` | _(empty)_ | Single-repo shortcut: serve the repo discovered from this path as `default`. Ignored when `-database-url` is set. |
 | `-port` | `8080` | Listen port; overrides `$PORT`. |
 | `-bind` | `127.0.0.1` (or `0.0.0.0` when `STACKIT_ENV=production`) | Interface to bind on. Pass `-bind 0.0.0.0` explicitly to expose the server without setting `STACKIT_ENV=production`. Binding a non-loopback interface requires auth or `-read-only`. |
-| `-cors` | `http://localhost:3000,http://localhost:5173` | Comma-separated allowed CORS origins. Loopback origins are **not** allowed implicitly — list each origin you want to accept. |
-| `-auth-disabled` | `false` | Skip the GitHub OAuth gate. **Refused** when the server binds a non-loopback interface (e.g. `STACKIT_ENV=production`) unless `-read-only` is set. Use only for local dev or when fronted by platform auth (Tailscale, Cloudflare Access). |
+| `-cors` | `http://localhost:3000,http://localhost:5173` | Comma-separated allowed CORS origins. On an **exposed** bind, loopback origins are **not** allowed implicitly — list each origin you want to accept. On a **loopback** bind, any loopback origin (`localhost`/`127.0.0.1`/`[::1]` on any port) is accepted automatically, since a local dev web server's port is environment-assigned. |
+| `-auth` | `false` | Force-enable the GitHub OAuth gate on a loopback bind to test the login flow locally. Ignored when the bind is exposed (auth is already required there). Mutually exclusive with `-auth-disabled`. Also settable via `STACKIT_AUTH`. |
+| `-auth-disabled` | `false` | Skip the GitHub OAuth gate. **Refused** when the server binds a non-loopback interface (e.g. `STACKIT_ENV=production`) unless `-read-only` is set. Flag-only by design (no env binding), so a stray env var can't disable auth. Use only for local dev or when fronted by platform auth (Tailscale, Cloudflare Access). |
 | `-read-only` | `false` | Serve in read-only mode: disable the submit endpoint and serve reads anonymously. Safe to expose publicly. See [Read-only public mode](#read-only-public-mode). Also settable via `STACKIT_READ_ONLY`. |
 
 Run `stackit-server -h` inside the container for the full list.
@@ -359,7 +361,9 @@ this doc revision and follow-on PRs):
 - Security headers on every response: `X-Content-Type-Options: nosniff`,
   `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, `HSTS` with a
   two-year max-age, and a CSP locked to `'self'` for scripts/connects.
-- CORS allowlist is exact-match; no implicit loopback bypass.
+- CORS allowlist is exact-match on an exposed bind; no implicit loopback
+  bypass there. The automatic loopback-origin allowance is gated to loopback
+  binds only (local dev), so an exposed deploy is unaffected.
 - Per-IP request rate limiting (token bucket), concurrent-SSE caps
   (global + per-IP) with bounded lifetime, and a branch-diff concurrency
   throttle — abuse bounds for a public deployment, on by default.

--- a/docs/web.md
+++ b/docs/web.md
@@ -123,6 +123,12 @@ form that calls `onboardRepo`; on success it navigates to the new repo's
 (`useConfig().readOnly`) since writes are refused there. See
 [Repository onboarding](./deploy.md#repository-onboarding).
 
+In single-repo mode (`useConfig().singleRepo`, set by a server with no
+`STACKIT_DATABASE_URL`), the picker is skipped entirely: `RepoPicker`
+`router.replace`s straight to the sole repo once it loads, so Back doesn't
+bounce through it. It falls back to the normal render if that repo has no
+GitHub coordinates (no remote) and so can't be addressed in the path UI.
+
 The API base URL is configured via `NEXT_PUBLIC_API_URL`. Default is empty
 (same-origin) so the embedded production build, served by the Go binary,
 hits whatever host the page came from. Set it explicitly when running
@@ -179,8 +185,13 @@ Components generated with `shadcn` CLI using New York style. Config in `componen
 ### Running Locally
 
 ```bash
-# Both server + web (recommended)
+# Both server + web (recommended) — local single-repo mode: serves the
+# current git repo and the UI opens it directly (no picker).
 mise run dev
+
+# Both server + web in DB-backed multi-tenant mode (the hosted model;
+# shows the repo picker). Run `mise run db:up` first.
+mise run dev:hosted
 
 # Web only (needs API running separately)
 mise run web:dev
@@ -188,6 +199,11 @@ mise run web:dev
 # Server only
 go run ./apps/server --port 8080
 ```
+
+`dev` and `dev:hosted` share `Procfile.dev`; they differ only in whether
+`STACKIT_DATABASE_URL` is set (the `dev` task clears it). When the server
+reports `singleRepo` via `/api/v1/config`, the web client skips the picker
+and navigates straight to the sole repo.
 
 The web dev server runs at `http://localhost:3000` and proxies API requests to `http://localhost:8080`.
 

--- a/internal/api/handlers/config.go
+++ b/internal/api/handlers/config.go
@@ -13,11 +13,12 @@ import (
 type ConfigHandler struct {
 	readOnly     bool
 	authRequired bool
+	singleRepo   bool
 }
 
 // NewConfigHandler creates a handler that reports the given capabilities.
-func NewConfigHandler(readOnly, authRequired bool) *ConfigHandler {
-	return &ConfigHandler{readOnly: readOnly, authRequired: authRequired}
+func NewConfigHandler(readOnly, authRequired, singleRepo bool) *ConfigHandler {
+	return &ConfigHandler{readOnly: readOnly, authRequired: authRequired, singleRepo: singleRepo}
 }
 
 // ServeHTTP returns the capability payload.
@@ -29,5 +30,6 @@ func (h *ConfigHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, httpcontract.ConfigResponse{
 		ReadOnly:     h.readOnly,
 		AuthRequired: h.authRequired,
+		SingleRepo:   h.singleRepo,
 	})
 }

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -5,7 +5,9 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"log/slog"
+	"net"
 	"net/http"
+	"net/url"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -117,11 +119,14 @@ func maxBodyMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// corsMiddleware adds CORS headers for the given allowed origins. Origins
-// must be configured explicitly via -cors; there is no implicit loopback
-// allowance, so the server is safe to run on a host shared with untrusted
-// processes.
-func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
+// corsMiddleware adds CORS headers for the given allowed origins. Origins are
+// configured explicitly via -cors. When allowLoopback is set (only on a
+// loopback bind, never when the server is exposed), any loopback origin
+// (localhost / 127.0.0.1 / [::1] on any port, http or https) is also accepted —
+// local dev web servers get an environment-assigned port, so a fixed allowlist
+// can't keep up. An exposed server keeps the strict explicit allowlist, so it
+// stays safe on a host shared with untrusted processes.
+func corsMiddleware(allowedOrigins []string, allowLoopback bool, next http.Handler) http.Handler {
 	originSet := make(map[string]struct{}, len(allowedOrigins))
 	for _, o := range allowedOrigins {
 		originSet[strings.TrimRight(o, "/")] = struct{}{}
@@ -129,7 +134,11 @@ func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		origin := strings.TrimRight(r.Header.Get("Origin"), "/")
-		if _, ok := originSet[origin]; ok {
+		_, allowed := originSet[origin]
+		if !allowed && allowLoopback && isLoopbackOrigin(origin) {
+			allowed = true
+		}
+		if allowed {
 			h := w.Header()
 			h.Set("Access-Control-Allow-Origin", origin)
 			h.Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
@@ -146,6 +155,29 @@ func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+// isLoopbackOrigin reports whether origin is an http(s) URL whose host is a
+// loopback address (localhost, 127.0.0.0/8, or ::1), on any port. Used to
+// accept the environment-assigned port of a local dev web server without an
+// explicit allowlist entry. Only consulted on a loopback bind.
+func isLoopbackOrigin(origin string) bool {
+	if origin == "" {
+		return false
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
+	host := u.Hostname()
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // loggingMiddleware logs each request with method, path, status, duration,

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -27,7 +27,7 @@ func TestStatusWriterImplementsFlusherWhenWrappedWriterDoes(t *testing.T) {
 func TestCORSMiddlewareAllowsConfiguredOrigin(t *testing.T) {
 	t.Parallel()
 
-	handler := corsMiddleware([]string{"http://example.com"}, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := corsMiddleware([]string{"http://example.com"}, false, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -47,12 +47,11 @@ func TestCORSMiddlewareAllowsConfiguredOrigin(t *testing.T) {
 func TestCORSMiddlewareRejectsLoopbackOriginByDefault(t *testing.T) {
 	t.Parallel()
 
-	// Previously the middleware allowed any loopback origin automatically.
-	// On a public deploy that opens an attack surface for anything else
-	// running on the host, so the rule was removed; localhost must be in
-	// -cors to be accepted.
+	// With allowLoopback off (the exposed-server posture), loopback origins are
+	// not auto-allowed: localhost must be in -cors to be accepted, so the server
+	// is safe on a host shared with untrusted processes.
 	for _, origin := range []string{"http://localhost:5100", "http://127.0.0.1:3000", "http://[::1]:5173"} {
-		handler := corsMiddleware(nil, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handler := corsMiddleware(nil, false, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
 
@@ -66,10 +65,49 @@ func TestCORSMiddlewareRejectsLoopbackOriginByDefault(t *testing.T) {
 	}
 }
 
+func TestCORSMiddlewareAllowsLoopbackOriginWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	// On a loopback bind (local dev), any loopback origin is accepted on its
+	// environment-assigned port without an explicit allowlist entry.
+	for _, origin := range []string{"http://localhost:5100", "http://127.0.0.1:3000", "http://[::1]:5173"} {
+		handler := corsMiddleware(nil, true, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/view", nil)
+		req.Header.Set("Origin", origin)
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		require.Equalf(t, origin, rr.Header().Get("Access-Control-Allow-Origin"), "loopback origin %q should be allowed", origin)
+		require.Equal(t, "true", rr.Header().Get("Access-Control-Allow-Credentials"))
+	}
+}
+
+func TestCORSMiddlewareRejectsNonLoopbackOriginEvenWhenLoopbackEnabled(t *testing.T) {
+	t.Parallel()
+
+	// allowLoopback widens only to loopback hosts; a non-local origin is still
+	// rejected unless explicitly in -cors.
+	handler := corsMiddleware(nil, true, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/view", nil)
+	req.Header.Set("Origin", "http://evil.example.com")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
 func TestCORSMiddlewareRejectsUnconfiguredNonLocalOrigin(t *testing.T) {
 	t.Parallel()
 
-	handler := corsMiddleware(nil, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := corsMiddleware(nil, false, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 

--- a/internal/api/readonly_test.go
+++ b/internal/api/readonly_test.go
@@ -186,4 +186,22 @@ func TestConfigEndpointAuthDisabled(t *testing.T) {
 	cfg := fetchConfig(t, newTestHandler(t, false))
 	require.False(t, cfg.ReadOnly)
 	require.False(t, cfg.AuthRequired)
+	require.False(t, cfg.SingleRepo, "multi-tenant by default")
+}
+
+func TestConfigEndpointSingleRepo(t *testing.T) {
+	t.Parallel()
+
+	// Single-repo (local) mode is advertised so the web client opens the sole
+	// repo directly instead of showing the hosted-only picker.
+	srv := NewServer(ServerConfig{
+		APIPrefixes: []string{"/api/v1"},
+		Registry:    registry.New(),
+		SingleRepo:  true,
+	})
+	handler, err := srv.buildHandler()
+	require.NoError(t, err)
+
+	cfg := fetchConfig(t, handler)
+	require.True(t, cfg.SingleRepo)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -29,6 +29,14 @@ type ServerConfig struct {
 	BindAddr    string
 	Port        int
 	CORSOrigins []string
+
+	// AllowLoopbackOrigins accepts any loopback browser origin (localhost /
+	// 127.0.0.1 / [::1] on any port) in addition to CORSOrigins. apps/server
+	// sets it only on a loopback bind so local dev web servers — whose port is
+	// environment-assigned — work without a fixed allowlist entry. An exposed
+	// server leaves it false and keeps the strict explicit allowlist.
+	AllowLoopbackOrigins bool
+
 	APIPrefixes []string
 	StaticFS    fs.FS
 	Registry    *registry.Registry
@@ -46,6 +54,11 @@ type ServerConfig struct {
 	// BranchDiffConcurrency caps how many branch-diff requests run their git
 	// subprocesses at once. Zero takes the handler default.
 	BranchDiffConcurrency int
+
+	// SingleRepo marks single-repo mode (the local -cwd/discovery shortcut, not
+	// the DB-backed multi-tenant model). It is surfaced via /api/v1/config so
+	// the web client skips the repo picker and opens the sole repo directly.
+	SingleRepo bool
 
 	// ReadOnly puts the server into a public read-only posture: the
 	// mutating submit route is replaced with a handler that refuses with
@@ -224,7 +237,7 @@ func (s *Server) buildHandler() (http.Handler, error) {
 	// authRequired tells the client whether reads need a login. Read-only
 	// mode and auth-disabled both serve reads anonymously.
 	authRequired := s.config.Auth != nil && !s.config.ReadOnly
-	configHandler := handlers.NewConfigHandler(s.config.ReadOnly, authRequired)
+	configHandler := handlers.NewConfigHandler(s.config.ReadOnly, authRequired, s.config.SingleRepo)
 
 	// The submit route is the server's only mutating endpoint. In
 	// read-only mode it is replaced with a handler that refuses every
@@ -379,7 +392,7 @@ func (s *Server) buildHandler() (http.Handler, error) {
 	// middleware that short-circuits).
 	handler := loggingMiddleware(root)
 	handler = maxBodyMiddleware(handler)
-	handler = corsMiddleware(s.config.CORSOrigins, handler)
+	handler = corsMiddleware(s.config.CORSOrigins, s.config.AllowLoopbackOrigins, handler)
 	handler = securityHeadersMiddleware(csp, handler)
 	handler = requestIDMiddleware(handler)
 	handler = recoverMiddleware(handler)

--- a/internal/contracts/http/responses.go
+++ b/internal/contracts/http/responses.go
@@ -17,6 +17,11 @@ type ConfigResponse struct {
 	// public read-only server and when auth is disabled, so the client knows
 	// not to send the user through a login flow.
 	AuthRequired bool `json:"authRequired"`
+	// SingleRepo is true when the server runs in single-repo mode (the local
+	// `-cwd`/discovery shortcut, not the DB-backed multi-tenant model). The
+	// client skips the repo picker and opens the sole repo directly — picking
+	// a repo is only meaningful in the hosted, multi-repo model.
+	SingleRepo bool `json:"singleRepo"`
 }
 
 // RepoSummary is one entry in ReposListResponse — the metadata clients

--- a/mise.toml
+++ b/mise.toml
@@ -288,7 +288,14 @@ run = """
 """
 
 [tasks.dev]
-description = "Run server + web dev servers using overmind and Procfile.dev"
+description = "Run server + web dev servers (local single-repo mode: serves the current git repo, no picker)"
+# Clear STACKIT_DATABASE_URL (set in [env]) so the server takes the single-repo
+# cwd shortcut instead of the DB-backed multi-tenant path. Both dev tasks share
+# Procfile.dev; this inline clear is the only difference from dev:hosted.
+run = "STACKIT_DATABASE_URL= overmind start -f Procfile.dev"
+
+[tasks."dev:hosted"]
+description = "Run server + web dev servers in DB-backed multi-tenant mode (the hosted model; run db:up first)"
 run = "overmind start -f Procfile.dev"
 
 [tasks."dev:stop"]


### PR DESCRIPTION

Make `mise dev` (and stackit-server on a loopback bind) serve the current
git repo as a frictionless local experience, instead of the DB-backed
hosted model with a repo picker and an OAuth gate.

- auth: on a loopback bind, default to anonymous even when STACKIT_GITHUB_*
  creds are present; opt into the OAuth login flow with -auth / STACKIT_AUTH.
- CORS: accept any loopback origin (localhost/127.0.0.1/[::1], any port) on a
  loopback bind, so a dev web server on an environment-assigned port isn't
  blocked. Exposed servers keep the strict explicit allowlist.
- single-repo mode: advertise SingleRepo via /api/v1/config; the web shell
  auto-opens the sole repo (router.replace) instead of the hosted-only picker.
- dev tooling: mise dev now runs single-repo (clears STACKIT_DATABASE_URL so
  the server discovers the cwd repo); add mise dev:hosted + Procfile.dev.hosted
  for the DB-backed model. Procfile.dev points the web dev server at the API
  (NEXT_PUBLIC_API_URL); next.config only applies output:export at build time
  so next dev can client-route to dynamic /{owner}/{repo} paths.