### PR TITLE
fix: make stack-describe build context cheapest-first

### DIFF
--- a/internal/cli/integrations/agents/templates/codex/commands/stack-describe.md
+++ b/internal/cli/integrations/agents/templates/codex/commands/stack-describe.md
@@ -8,12 +8,37 @@ Generate or refresh stack and PR descriptions from the current branch history.
 
 ## Workflow
 
-1. Inspect:
+1. Build context cheapest-first. Work down this ladder and **stop as soon as you
+   can write an accurate description** — most stacks never need past the first rung.
+   **Never run a full `git diff` of the stack;** it burns enormous context for
+   little signal over the cheaper sources below.
 
-   ```bash
-   stackit tree --no-interactive
-   git log --oneline --decorate -20
-   ```
+   1. **Commit subjects — cheapest.** Usually all you need:
+
+      ```bash
+      stackit tree --no-interactive
+      git log --oneline --decorate -20
+      ```
+
+   2. **PR descriptions — cheap, high-signal.** When subjects are thin and a
+      branch has a PR, read the existing PR body (a human/agent already
+      summarized intent) and synthesize from it rather than from code:
+
+      ```bash
+      gh pr view <pr_number> --json title,body -q '.title, .body'
+      ```
+
+   3. **Changed file names — cheap, names only.** To see which subsystems a
+      branch touches without reading contents:
+
+      ```bash
+      git diff --name-only <parent>..<branch>
+      ```
+
+   If after all of this the intent is still unclear on a large stack and your
+   harness supports delegating to a sub-agent, have the sub-agent read the diff
+   and return a 2–3 sentence summary so the diff stays out of your main context.
+   Otherwise describe from the signals above — do not read the full diff yourself.
 
 2. Generate a title and description from the history:
    - **Title** — max 72 chars, imperative mood, summarizes the whole stack.

--- a/internal/cli/integrations/agents/templates/commands/stack-describe.md
+++ b/internal/cli/integrations/agents/templates/commands/stack-describe.md
@@ -1,7 +1,7 @@
 ---
 description: Generate or update stack description from changes
 model: sonnet
-allowed-tools: Bash(stackit:*), Bash(git:*), Read, Glob, Grep
+allowed-tools: Bash(stackit:*), Bash(git:*), Bash(gh:*), Read, Glob, Grep, Task
 ---
 
 # Stack Describe
@@ -15,18 +15,48 @@ Generate a comprehensive description for the current stack based on all changes.
 
 ## Instructions
 
-### Step 1: Analyze Stack Changes
+### Step 1: Build Context (cheapest sources first)
 
-For each branch in the stack (from the stack info JSON), gather:
+Build just enough understanding to describe the stack accurately. Work **down**
+this ladder and **stop as soon as you can write an accurate description** — each
+rung costs more context than the last, and most stacks never need past rung 1.
 
-1. **Commit messages** - Already available in `commit_messages` field
-2. **Diff statistics** - Already available in `diff_stats` field
-3. **File changes** - Prefer the loaded `diff_stats`; only run `git diff <parent>..<branch> --stat` if you need per-file detail it doesn't cover
+**Never run a full `git diff` of the stack into this context.** It burns enormous
+context for little marginal signal over the cheaper sources below. If you truly
+need to read code, do it via a sub-agent (rung 4) so the cost stays out of this
+conversation.
 
-If the stack has complex changes, optionally read key files to understand:
-- What features are being added
-- What bugs are being fixed
-- What refactoring is happening
+1. **Commit messages + diff stats — already in context, free.** The injected JSON
+   has `commit_messages` and `diff_stats` per branch. For most stacks — especially
+   ones with clear conventional-commit subjects — this is enough. Write the
+   description and skip the rest.
+
+2. **PR descriptions — cheap, high-signal.** When commit subjects are thin but
+   branches have a `pr_number`, fetch the existing PR bodies; a human or agent
+   already summarized intent there. Synthesize from these rather than from code:
+
+   ```bash
+   gh pr view <pr_number> --json title,body -q '.title, .body'
+   ```
+
+3. **Changed file list — cheap, names only.** To see which subsystems a branch
+   touches without reading contents (`diff_stats` already gives the counts):
+
+   ```bash
+   git diff --name-only <parent>..<branch>
+   ```
+
+4. **Sub-agent deep dive — for large/complex stacks only.** If the stack is large
+   (many branches, or large `diff_stats`) and rungs 1–3 still leave intent
+   unclear, **do not pull diffs into this context.** Dispatch sub-agents instead:
+   each reads in its **own** context window and returns only a short summary, so
+   this conversation stays lean. Spawn one `Explore` agent per branch (or per
+   logical group), running independent agents in parallel:
+
+   > Read `git diff <parent>..<branch>` and return 2–3 sentences: what changed and
+   > why. Return only the summary, never the diff itself.
+
+   Then synthesize the returned summaries into the description.
 
 ### Step 2: Generate Description
 


### PR DESCRIPTION

The stack-describe command templates invited the agent to read files and run
`git diff` per branch even though commit messages and diff stats are already
injected. On large stacks that pulled full diffs into context and blew the
context window.

Replace that with a cheapest-first escalation ladder shared by the Claude and
Codex templates: commit messages + diff stats (free) -> PR descriptions via
`gh pr view` -> changed file names via `git diff --name-only` -> sub-agent deep
dive that reads diffs in its own context and returns a short summary. A full
stack `git diff` is forbidden. Widen the Claude command allowed-tools to add
`Bash(gh:*)` and `Task` so the new rungs are usable.

<hr/>

<!-- STACKIT-SECTION-START -->
**fix: make stack-describe build context cheapest-first**

Rework the `/stack-describe` skill so it builds just enough understanding to
describe a stack accurately, spending the least context possible.

Key changes:
- Replace the old context-gathering guidance with an explicit "cheapest sources
  first" ladder: commit messages + diff stats (free, already in context) → PR
  descriptions → changed file list → sub-agent deep dive.
- Stop as soon as the description can be written accurately; most stacks never
  go past rung 1.
- Forbid running a full `git diff` of the stack into the skill context; when
  code must be read, dispatch parallel `Explore` sub-agents that read in their
  own context windows and return only short summaries.

This keeps the describe flow lean on large stacks and avoids burning context on
low-signal full diffs.

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->