### PR TITLE
Harden restack/sync for multiplayer squash merges and landed branches

### DIFF
--- a/.claude/rules/multiplayer-safety.md
+++ b/.claude/rules/multiplayer-safety.md
@@ -1,0 +1,115 @@
+# Multiplayer Safety Invariants
+
+Guarantees that protect users who share a repository — especially when some
+collaborators do **not** use stackit. These are non-negotiable and extend
+[safety-invariants](safety-invariants.md) ("GitHub Merge Methods Are
+First-Class"). Full reference: [docs/multiplayer.md](../../docs/multiplayer.md).
+
+## Detection Must Work With Zero Stackit Metadata
+
+**A collaborator's merged branch can carry no stackit metadata at all. Landed-work
+detection must still succeed from Git history alone.**
+
+This applies to: restack, sync, branch cleanup, merged-branch detection, and any
+"did this branch's changes land on the target" decision.
+
+### Why This Matters
+
+A teammate who does not use stackit pushes a plain GitHub branch; you stack your
+work on top of it; they squash- or rebase-merge it through the GitHub UI. In your
+local view their branch has **no recorded PR number and no `MERGED` state** —
+only Git history reflects the merge. If detection requires PR metadata, it misses
+the merge and replays their pre-merge commits into your branch (issue #1345's
+data-loss shape).
+
+### Required Behavior
+
+- `branchLanded` must treat the Git fallback as valid **without** PR metadata
+  when the target is trunk. Do not re-gate the trunk Git fallback behind a
+  recorded PR number.
+- Cover every merge method for a non-stackit collaborator, not just the stackit
+  user. The detection signal differs by case:
+
+  | Merge method | Commits | Non-stackit detection signal |
+  |--------------|---------|------------------------------|
+  | Merge commit | any | ancestry (`IsMerged`) |
+  | Rebase | any | per-commit patch-id / `git cherry` (`IsMerged`) |
+  | Squash | single | `git cherry` matches the lone commit (`IsMerged`) |
+  | Squash | multi | **aggregate patch-id only (`IsSquashMerged`)** |
+
+- A single-commit squash test proves nothing about squash support — `git cherry`
+  already patch-matches it. **Multi-commit squash is the required coverage.**
+- The Git fallback stays limited to trunk. For a non-trunk (stacked) parent, rely
+  on `MERGED` PR metadata: patch-equivalence there can mean a local stack op made
+  a child empty, not that a PR landed.
+
+## Restack Only Builds On origin/<trunk>
+
+**`restack` must refuse when a remote exists and local trunk is ahead of /
+diverged from `origin/<trunk>`.**
+
+This applies to: the `restack` command path (`PlanRestack` / `guardUnpushedTrunk`).
+
+### Why This Matters
+
+Restack rebases trunk-anchored branches onto the **local** trunk tip. In a shared
+repo that is only safe when local trunk matches the remote — you must build your
+stack only on commits everyone else also has (`origin/<trunk>`). If local trunk
+has un-pushed or divergent commits, restack bakes machine-local work into the
+stack that may never land as-is.
+
+### Required Behavior
+
+- Resolve trunk-vs-remote state **locally, no network**: read
+  `refs/remotes/<remote>/<trunk>` and compare with
+  `IsAncestor(localTrunk, remoteTrunk)`.
+- **Ahead or diverged** (local trunk is NOT an ancestor of the remote trunk) →
+  reject with a message pointing at `stackit sync` / pushing trunk.
+- **Equal or behind** (ancestor is true) → allow. Behind is safe: the stack still
+  builds only on commits present on the remote.
+- **No remote-tracking ref** (local-only repo, fresh clone, never fetched) →
+  never guard. Solo users with no remote restack freely.
+- Only fire when the restack actually has branches to move; an empty restack is
+  never an error.
+- Do **not** extend this guard to `sync` / `modify` / `squash` / `reorder`
+  (they go through `RestackBranches`, not `PlanRestack`). `sync` is the
+  recommended way to reconcile trunk, so guarding it would deadlock the fix.
+
+## Reparent Past Landed Work, Never Replay It
+
+**After restack/sync past a merged parent, a branch must contain only its own
+commits — never the landed parent's pre-merge commits.**
+
+### Required Behavior
+
+- When a parent has landed, reparent its descendants onto the parent's base
+  without replaying the parent's commits. Invariant: `<base>..<branch>` equals
+  exactly the branch's own commits.
+- Never move an unrelated branch ref to a merged **sibling's** stale pre-merge
+  tip.
+- Never delete or reparent branch metadata based solely on SHA equality. Deletion
+  stays gated on submitted-PR metadata (`metaHasSubmittedPR`); reparenting is the
+  non-destructive path and does not require that gate.
+
+## Performance: Keep The Squash Scan Cold
+
+**`IsSquashMerged` (aggregate patch-id scan) must stay out of the hot
+`IsMerged` primitive and out of broad detection loops.**
+
+It runs a bounded log plus a patch-id per scanned commit. Call it only from
+explicit "did this branch land into trunk" decisions, after cheap `IsMerged` has
+already returned false. Folding it into `IsMerged` would put an expensive
+per-commit walk on every merge check.
+
+## Test Requirements
+
+Any change to detection, reparenting, or the guard must cover:
+
+- **All three GitHub merge methods** (merge commit, squash, rebase).
+- **Both user types** (stackit user with `MERGED` metadata; non-stackit
+  collaborator with zero metadata).
+- **A multi-commit squash** case specifically.
+- **Guard boundaries**: ahead/diverged rejected; equal/behind/no-remote/no-branches
+  allowed.
+
+See `docs/multiplayer.md` for the test-file map.

--- a/.claude/rules/safety-invariants.md
+++ b/.claude/rules/safety-invariants.md
@@ -2,6 +2,64 @@
 
 Critical guarantees that all operations must maintain. These are non-negotiable.
 
+## GitHub Merge Methods Are First-Class
+
+**Stackit must correctly handle PRs merged through all GitHub UI merge methods:
+merge commit, squash merge, and rebase merge.**
+
+This applies to: sync, restack, branch cleanup, merged-branch detection, stack
+navigation, merge orchestration, and any operation that decides whether branch
+changes have landed on trunk or another parent branch.
+
+### Why This Matters
+
+GitHub's three merge methods produce different Git histories for the same PR:
+
+| Method | What lands on the base branch | Is the PR branch tip reachable from base? | Can ancestry prove it merged? |
+|--------|-------------------------------|-------------------------------------------|-------------------------------|
+| Merge commit | A merge commit whose parents include the base and PR head | Yes | Yes |
+| Squash merge | One new commit containing the combined PR diff | No | No |
+| Rebase merge | New commits replaying the PR commits onto base | No | No |
+
+For merge commits, `git merge-base --is-ancestor <branch> <base>` and
+`git branch --merged <base>` are meaningful. For squash and rebase merges they
+are not: the PR's original commits are not ancestors of the base branch even
+though the PR landed.
+
+Squash merges are especially risky for stacked changes because a multi-commit
+PR lands as one combined commit. Per-commit patch matching (`git cherry`) can
+fail even when the branch's final diff is present on trunk. Rebase merges keep
+one commit per PR commit but rewrite SHAs, so ancestry still fails.
+
+### Required Behavior
+
+Code must not define "merged" using a single Git predicate. A merged PR can be
+proven by a combination of signals, including:
+
+- PR metadata that records the PR state as merged
+- The GitHub-reported landed commit being reachable from the target branch
+- Ancestry when the PR used a merge commit
+- Patch/range equivalence when the PR used rebase merge
+- Aggregate diff equivalence or recorded landed metadata when the PR used
+  squash merge
+
+When sync or restack sees a merged parent, it must reparent descendants past the
+landed branch without replaying that parent's commits. When it sees a merged
+sibling, it must never move an unrelated branch ref to the sibling's stale
+pre-merge tip.
+
+### Implementation Rules
+
+- Do not assume `IsAncestor(branch, trunk)` means "not merged" when it returns
+  false.
+- Do not assume `git branch --merged` covers squash or rebase merges.
+- Do not assume `git cherry` covers multi-commit squash merges.
+- Do not delete or reparent branch metadata based solely on SHA equality.
+- Preserve or fetch enough PR information to distinguish "closed unmerged" from
+  "merged by any GitHub method".
+- Any change to sync, restack, cleanup, or merge detection must consider all
+  three GitHub merge methods explicitly.
+
 ## No Detached HEAD State
 
 **Operations must NEVER leave the user in a detached HEAD state when cancelled or on failure.**

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -313,6 +313,21 @@ t.Run("test1", func(t *testing.T) { ... })
 t.Run("squash", func(t *testing.T) { ... })
 ```
 
+## GitHub Merge Method Coverage
+
+When testing sync, restack, branch cleanup, merged-branch detection, or merge
+orchestration, cover the GitHub merge method that matters for the behavior:
+
+| Method | Test shape |
+|--------|------------|
+| Merge commit | PR branch tip is reachable from trunk; ancestry-based detection should work. |
+| Squash merge | PR changes land as one combined commit; original PR commits are not ancestors of trunk. Include a multi-commit PR when testing patch/diff equivalence. |
+| Rebase merge | PR commits are replayed onto trunk with new SHAs; original PR commits are not ancestors of trunk. |
+
+Do not rely on a single-commit squash test to prove squash support: `git cherry`
+can already patch-match that case. Multi-commit squash tests are the important
+safety coverage for replay/reparenting bugs.
+
 ## Debugging Failing Tests
 
 Set `DEBUG=1` to preserve test directories:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ api/openapi/       API contract source of truth
 
 - `docs/config.md` - Configuration system, keys, layered config
 - `docs/hooks.md` - Lifecycle hook configuration, env vars, approval flow, recipes
+- `docs/multiplayer.md` - Collaboration: detecting landed work from non-stackit teammates, the un-pushed trunk guard, reparent invariants
 - `docs/performance.md` - Remote-operation tuning (SSH reuse), diagnosing slow commands with the tracer
 - `docs/recipes.md` - Step-by-step file lists for cross-cutting changes
 - `docs/shipping.md` - Merge strategies, consolidation, multi-stack shipping

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -217,6 +217,24 @@ PR information persisted in branch metadata.
 | `lockReason` | `*LockReason` | Lock status parsed from PR footer |
 | `mergeBranch` | `*string` | Merge branch name for consolidated PRs |
 
+### Merge Method Compatibility
+
+PR metadata is part of Stackit's safety model. A PR state of `"MERGED"` means
+the branch's changes landed, but it does not imply the branch tip is reachable
+from trunk:
+
+- GitHub merge commits preserve ancestry, so the PR branch tip is reachable from
+  the base branch.
+- GitHub squash merges create one new commit for the combined PR diff; the
+  original PR commits are not reachable from the base branch.
+- GitHub rebase merges replay commits with new SHAs; the original PR commits are
+  not reachable from the base branch.
+
+Code that consumes `prInfo.state`, updates merged metadata, cleans branches, or
+restacks descendants must treat all three GitHub merge methods as valid. Do not
+use ancestry alone to decide whether a PR's changes landed, and do not treat a
+non-ancestor branch tip as proof that a merged PR still needs to be replayed.
+
 ### MergedParent
 
 **Source**: `internal/git/metadata.go:76-80`

--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -1,0 +1,188 @@
+# Multiplayer (Collaboration)
+
+How stackit behaves when more than one person works on the same repository, and
+specifically when some collaborators **do not use stackit at all**. This is the
+"multiplayer" surface: detecting other people's landed work, reparenting your
+stack past it, and never building your stack on commits that only exist on your
+machine.
+
+For the lower-level merge-method guarantees this builds on, see
+[safety-invariants](../.claude/rules/safety-invariants.md) ("GitHub Merge
+Methods Are First-Class") and the companion rule
+[multiplayer-safety](../.claude/rules/multiplayer-safety.md).
+
+## The two kinds of collaborator
+
+Stackit has to be correct for both, and the difference is **how much metadata
+exists in your local view** of the other person's branch.
+
+| | Stackit user | Non-stackit collaborator |
+|---|---|---|
+| Branch metadata (`refs/stackit/metadata/*`) | Yes — recorded PR number, base, and state | None, or at most a local parent pointer you created |
+| When their PR merges | Their PR state becomes `MERGED` in metadata | Nothing changes in metadata; only Git history reflects it |
+| How you learn it landed | PR metadata (authoritative) **or** Git history | **Git history only** |
+
+The hard case is the non-stackit collaborator: a teammate pushes a plain GitHub
+branch, you stack your own work on top of it, and they squash- or rebase-merge
+it through the GitHub UI. Their merged work carries **zero stackit metadata**.
+Detection must fall back entirely to Git, with no PR number to lean on.
+
+This is the data-loss shape from issue #1345: if detection misses their merge,
+restack replays their pre-merge commits into *your* branch.
+
+## Landed-work detection
+
+"Did this branch's changes land on the target?" is answered by
+`engineImpl.branchLanded` (`internal/engine/engine_internal.go`), which combines
+metadata and Git signals. It deliberately does **not** require PR metadata for
+the trunk case, so the non-stackit collaborator works.
+
+Signals, in order:
+
+1. **Recorded PR state is `MERGED`** (`prStateIsMerged`) — authoritative across
+   all three GitHub merge methods. Only the stackit user has this.
+2. **Cheap Git merge check** (`git.IsMerged`) — merge-base equality, then
+   `git cherry` per-commit patch matching, then ancestry fallback. Covers merge
+   commits, rebase merges, and **single-commit** squash merges.
+3. **Aggregate patch-id scan** (`git.IsSquashMerged`) — the only signal that
+   catches a **multi-commit** squash with no PR metadata. Expensive, so it is
+   reached only as a fallback for explicit "did this land on trunk" decisions
+   (see Performance below).
+
+The Git fallback (steps 2–3) is **limited to trunk** as the target. For a
+non-trunk parent, patch-equivalence can also mean a local stack operation made a
+child empty, not that a GitHub PR landed — so for stacked parents stackit relies
+on `MERGED` PR metadata instead.
+
+### Why one Git predicate is never enough
+
+GitHub's three merge methods produce different histories for the same PR:
+
+| Method | Lands on base as | PR tip reachable from base? | Detected by |
+|--------|------------------|------------------------------|-------------|
+| Merge commit | A merge commit (parents include base + PR head) | Yes | ancestry / `IsMerged` |
+| Rebase merge | PR commits replayed with new SHAs, same patch-ids | No | `git cherry` / `IsMerged` |
+| Squash (single commit) | One combined commit | No | `git cherry` matches the lone commit / `IsMerged` |
+| Squash (multi commit) | One combined commit | No | aggregate patch-id only (`IsSquashMerged`) or `MERGED` metadata |
+
+`git cherry` can patch-match a *single*-commit squash, which is why
+single-commit squash tests prove nothing about multi-commit support. The
+multi-commit squash case is the real safety coverage.
+
+### Detection matrix (who detects what)
+
+For a parent whose changes landed on trunk, restacking the child past it:
+
+| Merge method | Commits | Stackit user (MERGED metadata) | Non-stackit (zero metadata) |
+|--------------|---------|--------------------------------|-----------------------------|
+| Merge commit | single | metadata or ancestry | ancestry (`IsMerged`) |
+| Merge commit | multi | metadata or ancestry | ancestry (`IsMerged`) |
+| Rebase | single | metadata or cherry | cherry (`IsMerged`) |
+| Rebase | multi | metadata or cherry | cherry (`IsMerged`) |
+| Squash | single | metadata or cherry | cherry (`IsMerged`) |
+| Squash | multi | metadata | **aggregate patch-id (`IsSquashMerged`)** |
+
+The bolded cell is the one that has no cheap signal and no metadata — it is why
+`IsSquashMerged` exists.
+
+## The reparent invariant
+
+When restack (or sync) sees a **merged parent**, it reparents descendants past
+the landed branch **without replaying that parent's commits**. The user-visible
+guarantee:
+
+> After restack, your branch contains **only your own commits** — never the
+> landed parent's pre-merge commits.
+
+Tested as `main..mine == 1` (your single commit) across the full detection
+matrix. If detection misses the merge, the count is higher because the parent's
+commits replayed into your branch.
+
+Stackit must also never move an unrelated branch ref to a merged **sibling's**
+stale pre-merge tip, and must never delete or reparent metadata based solely on
+SHA equality.
+
+## The un-pushed trunk guard
+
+Restack rebases trunk-anchored branches onto the **local trunk tip**. In a
+multiplayer repo that is only safe when local trunk matches the remote: you
+should only build your stack on commits that exist on `origin/<trunk>`, because
+those are the commits everyone else will also build on.
+
+If local trunk is **ahead of** or **diverged from** `origin/<trunk>` — e.g. you
+committed directly on `main` and never pushed — restacking would bake those
+un-pushed commits into your stack. That work exists only on your machine and may
+never land as-is. `stackit restack` refuses in that state:
+
+```
+local trunk "main" has commits that are not on "origin/main"; restack would
+build the stack on those un-pushed commits.
+Reconcile trunk with the remote first (run `stackit sync`, or push trunk) so
+restack only builds on origin/main
+```
+
+### How the guard decides
+
+`engine.TrunkRemoteState` (`internal/engine/engine_branch_status.go`) resolves
+the state **locally, with no network**:
+
+- Reads `refs/remotes/<remote>/<trunk>` via `GetRemoteSha` (a local `rev-parse`).
+- Compares local trunk to that ref with `IsAncestor(localSha, remoteSha)`.
+- Local trunk is **ahead or diverged** when it is **not** an ancestor of the
+  remote-tracking trunk. Equal and behind both report `ancestor=true` (a commit
+  is its own ancestor), so neither trips the guard.
+
+`guardUnpushedTrunk` (`internal/actions/restack.go`) consumes this inside
+`PlanRestack` and rejects before any rebase runs.
+
+| Local trunk vs `origin/<trunk>` | `AheadOrDiverged` | Restack |
+|---------------------------------|-------------------|---------|
+| Equal (synced) | false | allowed |
+| Behind (remote has more) | false | allowed — builds only on remote commits |
+| Ahead (un-pushed local commits) | true | **rejected** |
+| Diverged (each has unique commits) | true | **rejected** |
+| No remote-tracking ref (local-only/fresh clone) | false (`HasRemoteRef=false`) | allowed — nothing to guard against |
+
+Scope notes:
+
+- The guard only fires when the restack actually has branches to move (an empty
+  restack is never rejected).
+- It is wired into `PlanRestack` (the `restack` command path). Operations that
+  go through `RestackBranches` directly — `sync`, `modify`, `squash`, `reorder`
+  — are unaffected; `sync` is in fact the recommended way to reconcile trunk.
+- Local-only repos (no remote) are never guarded.
+
+## Performance: keep the squash scan cold
+
+`IsSquashMerged` runs a bounded log (`-200`) plus a patch-id per scanned target
+commit. It is intentionally **not** part of the hot `IsMerged` primitive and is
+not called in broad merge-detection loops — only from explicit "did this branch
+land into trunk" decisions, after the cheap `IsMerged` has already returned
+false. Keep it that way: folding the aggregate scan into `IsMerged` would put an
+expensive per-commit patch-id walk on every merge check.
+
+## Test coverage
+
+| Area | Test |
+|------|------|
+| Detection matrix (all methods × single/multi × stackit/non-stackit) | `internal/integration/restack_synced_trunk_matrix_test.go` |
+| Non-stackit collaborator squash/rebase, including fully untracked parent | `internal/integration/restack_untracked_collaborator_test.go` |
+| Multi-commit squash with stale/absent PR state, conflict-abort, reflog | `internal/integration/restack_squash_merge_test.go`, `internal/integration/restack_squash_conflict_abort_test.go` |
+| Un-pushed/diverged trunk guard (integration) | `internal/integration/restack_trunk_guard_test.go` |
+| `TrunkRemoteState` predicate (engine unit) | `internal/engine/engine_impl_test.go` (`TestTrunkRemoteState`) |
+
+When changing any of detection, reparenting, or the guard, cover **all three
+merge methods** and **both user types**, and include a **multi-commit** squash
+case — a single-commit squash proves nothing because `git cherry` already
+matches it.
+
+## Key code locations
+
+| Concern | Location |
+|---------|----------|
+| Landed-work detection | `internal/engine/engine_internal.go` (`branchLanded`, `prStateIsMerged`) |
+| Cheap merge check | `internal/git/merge_detection.go` (`IsMerged`) |
+| Aggregate squash scan | `internal/git/merge_detection.go` (`IsSquashMerged` / `isSquashMerged`) |
+| Reparent target selection | `internal/engine/engine_internal.go` (`shouldReparentBranch`, `findNearestValidAncestor`) |
+| Trunk-remote state | `internal/engine/engine_branch_status.go` (`TrunkRemoteState`) |
+| Restack guard | `internal/actions/restack.go` (`guardUnpushedTrunk`) |

--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -31,6 +31,33 @@ stackit merge ship         # Consolidate stack into single atomic PR (waits by d
 
 Shipping stacked changes is fundamentally different from shipping linear PRs. Stackit provides multiple merge strategies optimized for different scenarios, plus advanced multi-stack consolidation for high-velocity teams.
 
+## GitHub Merge Methods
+
+GitHub supports three PR merge methods through the merge button. Stackit must
+support all three because repositories can choose any combination of them, and a
+stack may be merged by a teammate or automation outside of Stackit.
+
+| Method | What GitHub writes to the base branch | Original PR commits reachable from base? | Detection implications |
+|--------|----------------------------------------|------------------------------------------|------------------------|
+| Merge commit | A merge commit whose parents include the old base and the PR head | Yes | Ancestry checks work: the PR branch tip is reachable from base. |
+| Squash merge | One new commit containing the PR's combined final diff | No | Ancestry fails. Multi-commit PRs may also fail per-commit patch matching because one combined commit replaced many commits. |
+| Rebase merge | New commits replaying the PR commits onto the current base | No | Ancestry fails because SHAs are rewritten. Per-commit patch matching usually works, but conflict resolution or rewritten patches can change the result. |
+
+For stacked changes, these differences affect sync, restack, cleanup, and stack
+navigation:
+
+- A branch can be merged even when its tip is not an ancestor of trunk.
+- A merged parent must be skipped when restacking descendants, or the parent's
+  already-landed commits can be replayed into children.
+- A merged sibling must never be treated as a new base for an unrelated branch.
+- PR state and landed-commit metadata are safety signals, not just display
+  fields.
+
+The configured merge method (`stackit.merge.method`, or `--method` on merge
+commands) controls how Stackit asks GitHub to merge PRs. It does not limit what
+sync/restack must understand: those commands must recognize all three methods
+when reading repository history and PR state.
+
 ## Merge Status View
 
 Use `stackit merge status` to see an overview of your mergeable work:

--- a/internal/actions/absorb/absorb_test.go
+++ b/internal/actions/absorb/absorb_test.go
@@ -750,6 +750,33 @@ func TestAbsorbConflictHandling(t *testing.T) {
 		require.True(t, IsAbsorbInProgress(s.Context))
 	})
 
+	t.Run("IsAbsorbInProgress returns false during a rebase even when detached", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		s.CreateBranch("test-branch")
+		s.TrackBranch("test-branch", "main")
+
+		testFile := filepath.Join(s.Scene.Dir, "test.go")
+		err := os.WriteFile(testFile, []byte("package main\n\nfunc test() {}\n"), 0600)
+		require.NoError(t, err)
+		s.RunGit("add", "test.go")
+		s.RunGit("commit", "-m", "add test.go")
+
+		// Reproduce the restack conflict workflow's state: HEAD detached AND a
+		// rebase in progress. EnterConflictWorkflow detaches on purpose, which
+		// leaves a "checkout: moving from" reflog entry. That alone used to make
+		// IsAbsorbInProgress report a phantom absorb, routing `stackit abort` to
+		// the absorb cleanup path instead of the standard rebase abort.
+		s.RunGit("checkout", "--detach", "HEAD")
+		rebaseMergeDir := filepath.Join(s.Scene.Dir, ".git", "rebase-merge")
+		require.NoError(t, os.MkdirAll(rebaseMergeDir, 0750))
+
+		// A rebase in progress means this is a restack/sync conflict, not an
+		// absorb — the standard abort owns it.
+		require.False(t, IsAbsorbInProgress(s.Context))
+	})
+
 	t.Run("ShowConflict displays staged changes info", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)

--- a/internal/actions/absorb/conflict.go
+++ b/internal/actions/absorb/conflict.go
@@ -11,9 +11,23 @@ import (
 
 // IsAbsorbInProgress checks if there's a failed absorb operation that needs cleanup.
 // This is detected by checking for:
-// 1. Detached HEAD state, OR
-// 2. Presence of absorb stash marker
+// 1. Presence of absorb stash marker, OR
+// 2. Detached HEAD state with no rebase/merge in progress
 func IsAbsorbInProgress(ctx *app.Context) bool {
+	// A rebase or merge in progress is owned by the standard conflict-workflow
+	// abort (restack/sync/merge). EnterConflictWorkflow deliberately detaches
+	// HEAD before the conflict rebase — which writes a "checkout: moving from"
+	// reflog entry — and persists continuation + snapshot state for the standard
+	// abort to roll back. Absorb's own failure mode is a cherry-pick conflict,
+	// which never leaves a rebase-merge/rebase-apply directory. So an in-progress
+	// rebase/merge means this is NOT an absorb to clean up. Without this guard the
+	// conflict workflow's detach is misread as a mid-absorb failure, routing
+	// `stackit abort` to absorb cleanup — which never runs `git rebase --abort`
+	// and leaves the repo stuck mid-rebase with stale continuation state.
+	if ctx.Engine.IsRebaseInProgress(ctx.Context) || ctx.Engine.IsMergeInProgress(ctx.Context) {
+		return false
+	}
+
 	// Check for absorb stash marker
 	stashList, _ := ctx.Engine.StashList(ctx.Context)
 	if strings.Contains(stashList, absorbStashMarker) {

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -100,6 +100,9 @@ func PlanRestack(ctx *app.Context, opts RestackOptions) (*RestackPlan, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := guardUnpushedTrunk(ctx, eng, rawGroups); err != nil {
+		return nil, err
+	}
 	plan := &RestackPlan{opts: opts}
 	for _, g := range rawGroups {
 		sorted := eng.SortBranchesTopologically(g.branches)
@@ -380,6 +383,39 @@ func restackGroupsParallel(
 	}
 
 	return collector.restacked, collector.skipped, collector.conflicts, collector.joinedError()
+}
+
+// guardUnpushedTrunk refuses to restack when the local trunk has commits that
+// are not on its remote-tracking branch (origin/<trunk>). Restacking rebases
+// trunk-anchored branches onto the LOCAL trunk tip, so un-pushed/divergent
+// trunk commits would be baked into the stack — work that only exists locally
+// and may never land as-is. Reconciling trunk with the remote first (sync, or a
+// push) keeps restack building only on commits that exist on origin/<trunk>.
+//
+// It is a no-op when there is no work to do, and for repos with no
+// remote-tracking trunk ref (local-only, never fetched, fresh clone), which the
+// engine reports via HasRemoteRef=false.
+func guardUnpushedTrunk(ctx *app.Context, eng engine.BranchReader, groups []restackBranchGroup) error {
+	hasBranches := false
+	for _, g := range groups {
+		if len(g.branches) > 0 {
+			hasBranches = true
+			break
+		}
+	}
+	if !hasBranches {
+		return nil
+	}
+
+	state := eng.TrunkRemoteState(ctx.Context)
+	if !state.AheadOrDiverged {
+		return nil
+	}
+	return fmt.Errorf(
+		"local trunk %q has commits that are not on %q; restack would build the stack on those un-pushed commits.\n"+
+			"Reconcile trunk with the remote first (run `stackit sync`, or push trunk) so restack only builds on %s",
+		eng.Trunk().GetName(), state.RemoteRef, state.RemoteRef,
+	)
 }
 
 type restackBranchGroup struct {

--- a/internal/actions/sync/sync_test.go
+++ b/internal/actions/sync/sync_test.go
@@ -243,12 +243,26 @@ func (r *runtimeConflictRunner) Rebase(ctx context.Context, branchName, upstream
 }
 
 func (r *runtimeConflictRunner) UpdateRefsBatch(ctx context.Context, updates []git.RefUpdate) error {
-	if !r.injected {
-		r.injected = true
-		r.rebaseInProgress = true
+	if r.injectRuntimeConflict() {
 		return nil
 	}
 	return r.Runner.UpdateRefsBatch(ctx, updates)
+}
+
+func (r *runtimeConflictRunner) UpdateRefsBatchWithLog(ctx context.Context, updates []git.RefUpdate, reflogMessage string) error {
+	if r.injectRuntimeConflict() {
+		return nil
+	}
+	return r.Runner.UpdateRefsBatchWithLog(ctx, updates, reflogMessage)
+}
+
+func (r *runtimeConflictRunner) injectRuntimeConflict() bool {
+	if !r.injected {
+		r.injected = true
+		r.rebaseInProgress = true
+		return true
+	}
+	return false
 }
 
 func (r *runtimeConflictRunner) CheckoutBranch(ctx context.Context, branchName string) error {

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -393,6 +393,10 @@ func (d *demoGitRunner) IsMerged(_ context.Context, _, _ string) (bool, error) {
 	return false, nil
 }
 
+func (d *demoGitRunner) IsSquashMerged(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
+
 func (d *demoGitRunner) GetMergedBranches(_ context.Context, _ string) (map[string]bool, error) {
 	return make(map[string]bool), nil
 }

--- a/internal/engine/branch_tracking.go
+++ b/internal/engine/branch_tracking.go
@@ -173,12 +173,15 @@ func (e *engineImpl) setParentRecomputingDivergence(ctx context.Context, branch 
 			// Check if existing revision is still a valid ancestor of the branch
 			if isAncestor, _ := e.git.IsAncestor(ctx, *meta.GetParentBranchRevision(), branchName); isAncestor {
 				// Check if the old parent was merged into the new parent (the
-				// "merge" case). The PR state is checked first: patch-id
-				// detection (git cherry inside IsMerged) cannot recognize a
-				// multi-commit squash merge, and errors when the old parent
-				// ref is already deleted — clobbering the divergence point
-				// would make the next restack replay the merged commits.
-				if e.prStateIsMerged(oldParent) {
+				// "merge" case). For trunk targets, use the centralized landed
+				// policy so no-metadata collaborator squash merges preserve the
+				// child's old upstream instead of replaying the parent's commits.
+				// If the old parent ref is already gone, the stored divergence
+				// revision is still enough to compare its aggregate patch against
+				// trunk.
+				oldParentRev := *meta.GetParentBranchRevision()
+				if e.branchLanded(ctx, oldParent, parentBranchName) ||
+					e.branchLanded(ctx, oldParentRev, parentBranchName) {
 					shouldUpdateRevision = false
 				} else if merged, _ := e.git.IsMerged(ctx, oldParent, parentBranchName); merged {
 					shouldUpdateRevision = false

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -461,8 +461,30 @@ func (e *engineImpl) evaluateDeletionStatus(ctx context.Context, branchName stri
 		}
 	}
 
-	// 4. Check if merged into trunk
+	// 4. Check if merged into trunk (ancestry-based; covers merge commits)
 	if mergedBranches != nil && mergedBranches[branchName] {
+		return DeletionStatus{
+			SafeToDelete: true,
+			Reason:       fmt.Sprintf("merged into %s", trunkName),
+			Kind:         DeletionReasonMergedIntoTrunk,
+		}
+	}
+
+	// 4b. Squash and rebase merges don't appear in the ancestry-based
+	// mergedBranches set, and GitHub may have merged the PR before its local
+	// state synced to MERGED (so rule 3 didn't fire either). For branches that
+	// carry a recorded PR number, fall back to the same landed-branch detection
+	// restack uses (cheap cherry plus the gated squash patch-id scan), so cleanup
+	// keeps pace with squash-aware reparenting instead of leaving the merged
+	// branch behind.
+	//
+	// Gated on a recorded PR number for two reasons: it never auto-deletes an
+	// unsubmitted local branch whose diff happens to match trunk, and it keeps
+	// the expensive patch-id scan off the common no-PR path (consistent with how
+	// rule 5 gates its tree comparison behind PR metadata). branchLanded targets
+	// trunk specifically, so a branch squash-merged into a still-open parent is
+	// not treated as deletable.
+	if metaHasSubmittedPR(meta) && e.branchLanded(ctx, branchName, trunkName) {
 		return DeletionStatus{
 			SafeToDelete: true,
 			Reason:       fmt.Sprintf("merged into %s", trunkName),
@@ -479,8 +501,7 @@ func (e *engineImpl) evaluateDeletionStatus(ctx context.Context, branchName stri
 	if meta == nil {
 		return DeletionStatus{SafeToDelete: false, Reason: "", Kind: DeletionReasonNone}
 	}
-	prInfoMeta := meta.GetPrInfo()
-	if prInfoMeta == nil || prInfoMeta.Number == nil || *prInfoMeta.Number == 0 {
+	if !metaHasSubmittedPR(meta) {
 		return DeletionStatus{SafeToDelete: false, Reason: "", Kind: DeletionReasonNone}
 	}
 

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -293,6 +293,47 @@ func (e *engineImpl) ReadBranchRemoteStatuses(ctx context.Context, branches Bran
 	return results
 }
 
+// TrunkRemoteState reports how the local trunk relates to its remote-tracking
+// branch using only local refs (a rev-parse of refs/remotes/<remote>/<trunk>
+// plus an ancestry check). It never lists or fetches from the remote, so it is
+// cheap enough for the restack path and works offline.
+//
+// When no remote-tracking trunk ref exists locally (local-only repo, never
+// fetched, fresh clone) it returns HasRemoteRef=false and AheadOrDiverged=false
+// so callers leave such repos unguarded.
+func (e *engineImpl) TrunkRemoteState(ctx context.Context) TrunkRemoteState {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	e.mu.RLock()
+	trunk := e.trunk
+	e.mu.RUnlock()
+
+	remote := e.git.GetRemote()
+	state := TrunkRemoteState{RemoteRef: remote + "/" + trunk}
+
+	remoteSha, err := e.git.GetRemoteSha(remote, trunk)
+	if err != nil || remoteSha == "" {
+		return state
+	}
+	state.HasRemoteRef = true
+	state.RemoteSha = remoteSha
+
+	localSha, err := e.git.GetRevision(trunk)
+	if err != nil || localSha == "" {
+		return state
+	}
+	state.LocalSha = localSha
+
+	// Local trunk is "ahead or diverged" when it is NOT an ancestor of the
+	// remote-tracking trunk. Equal (a commit is its own ancestor) and behind
+	// both report ancestor=true, so neither trips the guard.
+	if isAncestor, err := e.git.IsAncestor(ctx, localSha, remoteSha); err == nil && !isAncestor {
+		state.AheadOrDiverged = true
+	}
+	return state
+}
+
 // GetMergedBranches returns a map of branches merged into the target branch
 func (e *engineImpl) GetMergedBranches(ctx context.Context, target string) (map[string]bool, error) {
 	return e.git.GetMergedBranches(ctx, target)

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -2,6 +2,7 @@ package engine_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -1153,6 +1154,95 @@ func TestReadBranchRemoteStatuses(t *testing.T) {
 		main := s.Engine.GetBranch("main")
 		status := s.Engine.ReadBranchRemoteStatuses(context.Background(), engine.BranchesOf(main)).ForBranch(main)
 		require.False(t, status.Matches(), "main should not match empty remote")
+	})
+}
+
+func TestTrunkRemoteState(t *testing.T) {
+	t.Parallel()
+
+	// setRemoteTrunk points refs/remotes/origin/main at the given ref (resolved to
+	// a SHA), simulating a fetched remote-tracking trunk without any network.
+	setRemoteTrunk := func(t *testing.T, s *scenario.Scenario, ref string) {
+		t.Helper()
+		sha, err := s.Scene.Repo.RunGitCommandAndGetOutput("rev-parse", "--verify", ref)
+		require.NoError(t, err)
+		require.NoError(t, s.Scene.Repo.RunGitCommand("update-ref", "refs/remotes/origin/main", strings.TrimSpace(sha)))
+	}
+
+	t.Run("no remote-tracking ref is not guarded", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		state := s.Engine.TrunkRemoteState(context.Background())
+		require.False(t, state.HasRemoteRef, "with no origin/main the guard must stay inert")
+		require.False(t, state.AheadOrDiverged)
+	})
+
+	t.Run("trunk equal to remote is not ahead", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		setRemoteTrunk(t, s, "main")
+
+		state := s.Engine.TrunkRemoteState(context.Background())
+		require.True(t, state.HasRemoteRef)
+		require.False(t, state.AheadOrDiverged, "synced trunk must not be flagged")
+		require.Equal(t, state.LocalSha, state.RemoteSha)
+		require.Equal(t, "origin/main", state.RemoteRef)
+	})
+
+	t.Run("trunk ahead of remote is flagged", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		setRemoteTrunk(t, s, "main")
+
+		// Local main advances past the recorded remote tip (un-pushed commit).
+		s.Commit("un-pushed trunk commit")
+
+		state := s.Engine.TrunkRemoteState(context.Background())
+		require.True(t, state.HasRemoteRef)
+		require.True(t, state.AheadOrDiverged, "local trunk ahead of origin/main must be flagged")
+		require.NotEqual(t, state.LocalSha, state.RemoteSha)
+	})
+
+	t.Run("trunk behind remote is not flagged", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		// Build a descendant commit and point origin/main at it, leaving local main
+		// strictly behind (still an ancestor of the remote).
+		require.NoError(t, s.Scene.Repo.RunGitCommand("branch", "remote-ahead", "main"))
+		require.NoError(t, s.Scene.Repo.CheckoutBranch("remote-ahead"))
+		s.Commit("landed on origin")
+		setRemoteTrunk(t, s, "remote-ahead")
+		require.NoError(t, s.Scene.Repo.CheckoutBranch("main"))
+
+		state := s.Engine.TrunkRemoteState(context.Background())
+		require.True(t, state.HasRemoteRef)
+		require.False(t, state.AheadOrDiverged, "trunk behind origin/main builds only on remote commits")
+	})
+
+	t.Run("trunk diverged from remote is flagged", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		// Common ancestor = current main tip.
+		base, err := s.Scene.Repo.RunGitCommandAndGetOutput("rev-parse", "--verify", "main")
+		require.NoError(t, err)
+		base = strings.TrimSpace(base)
+
+		// Remote-only commit on top of the common ancestor.
+		require.NoError(t, s.Scene.Repo.RunGitCommand("branch", "remote-work", base))
+		require.NoError(t, s.Scene.Repo.CheckoutBranch("remote-work"))
+		s.Commit("landed on origin only")
+		setRemoteTrunk(t, s, "remote-work")
+		require.NoError(t, s.Scene.Repo.CheckoutBranch("main"))
+
+		// Local main gets its own divergent commit on the same ancestor.
+		s.Commit("local divergent commit")
+
+		state := s.Engine.TrunkRemoteState(context.Background())
+		require.True(t, state.HasRemoteRef)
+		require.True(t, state.AheadOrDiverged, "diverged trunk must be flagged like the ahead case")
 	})
 }
 

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -87,6 +87,14 @@ func (e *engineImpl) prStateIsMerged(branchName string) bool {
 	return err == nil && prInfo != nil && prInfo.State() == prStateMerged
 }
 
+func metaHasSubmittedPR(meta *git.Meta) bool {
+	if meta == nil {
+		return false
+	}
+	prMeta := meta.GetPrInfo()
+	return prMeta != nil && prMeta.Number != nil && *prMeta.Number != 0
+}
+
 // branchLanded reports whether branchName's changes have landed into target.
 // PR metadata is authoritative across GitHub's merge, squash, and rebase merge
 // methods. Git fallback is intentionally limited to trunk: for non-trunk

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -87,10 +87,42 @@ func (e *engineImpl) prStateIsMerged(branchName string) bool {
 	return err == nil && prInfo != nil && prInfo.State() == prStateMerged
 }
 
+// branchLanded reports whether branchName's changes have landed into target.
+// PR metadata is authoritative across GitHub's merge, squash, and rebase merge
+// methods. Git fallback is intentionally limited to trunk: for non-trunk
+// parents, patch-equivalence can also mean a local stack operation made a child
+// empty, not that a GitHub PR landed.
+//
+// The trunk Git fallback deliberately does not require stackit PR metadata.
+// Collaborators may squash- or rebase-merge a plain GitHub branch into main, and
+// a child stacked on that local branch still needs to reparent past it without
+// replaying the collaborator's commits. Callers that delete branches must add
+// their own metadata/confirmation gate before using this predicate.
+func (e *engineImpl) branchLanded(ctx context.Context, branchName, target string) bool {
+	if branchName == e.trunk {
+		return false
+	}
+	if e.prStateIsMerged(branchName) {
+		return true
+	}
+	if target == "" || target != e.trunk {
+		return false
+	}
+	// IsMerged covers ancestry and per-commit (rebase) merges cheaply.
+	if merged, err := e.git.IsMerged(ctx, branchName, target); err == nil && merged {
+		return true
+	}
+	// Squash merges need the aggregate patch-id scan, which is expensive and
+	// intentionally stays out of the hot IsMerged primitive. Only explicit
+	// "did this branch land into trunk" checks opt into it.
+	merged, err := e.git.IsSquashMerged(ctx, branchName, target)
+	return err == nil && merged
+}
+
 // shouldReparentBranch checks if a parent branch should be reparented
 // Returns true if the parent branch:
 // - No longer exists locally
-// - Has been merged into trunk
+// - Has been merged into its own parent
 // - Has a "MERGED" PR state in metadata
 func (e *engineImpl) shouldReparentBranch(ctx context.Context, parentBranchName string, metaMap map[string]*git.Meta) bool {
 	// Check if parent is trunk (no need to reparent)
@@ -110,9 +142,14 @@ func (e *engineImpl) shouldReparentBranch(ctx context.Context, parentBranchName 
 		return true
 	}
 
-	// Check if parent has been merged into trunk
-	merged, err := e.git.IsMerged(ctx, parentBranchName, e.trunk)
-	if err == nil && merged {
+	// Check if parent has landed. Git-only detection is safe for trunk; stacked
+	// PR bases rely on merged PR metadata so local fold/squash operations do
+	// not get mistaken for GitHub merges.
+	mergeTarget := e.trunk
+	if state := e.readState(parentBranchName); state != nil && state.Parent != "" {
+		mergeTarget = state.Parent
+	}
+	if e.branchLanded(ctx, parentBranchName, mergeTarget) {
 		return true
 	}
 

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -74,6 +74,9 @@ type BranchStatus interface {
 	GetRemote() string
 	GetRemoteURL(ctx context.Context) (string, error)
 	ReadBranchRemoteStatuses(ctx context.Context, branches Branches) BranchRemoteStatuses
+	// TrunkRemoteState reports how the local trunk relates to its
+	// remote-tracking branch using only local refs (no network).
+	TrunkRemoteState(ctx context.Context) TrunkRemoteState
 	GetMergedBranches(ctx context.Context, target string) (map[string]bool, error)
 }
 

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -8,6 +8,12 @@ import (
 	"github.com/getstackit/stackit/internal/git"
 )
 
+const (
+	reflogRestack       = "stackit: restack"
+	reflogRestackFrozen = "stackit: restack (frozen)"
+	reflogRestackAnchor = "stackit: restack (anchor)"
+)
+
 // restackBranch rebases a branch onto its parent
 // If the parent has been merged/deleted, it will automatically reparent to the nearest valid ancestor.
 // worktrees and metaRefSHAs are snapshots taken by the caller — passing them
@@ -103,7 +109,7 @@ func (e *engineImpl) restackBranch(
 				{RefName: fmt.Sprintf("refs/heads/%s", branchName), NewSHA: remoteSha, OldSHA: localSha},
 				{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
 			}
-			if err := e.git.UpdateRefsBatch(ctx, updates); err != nil {
+			if err := e.git.UpdateRefsBatchWithLog(ctx, updates, reflogRestackFrozen); err != nil {
 				return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to update refs atomically for frozen branch %s: %w", branchName, err)
 			}
 
@@ -175,7 +181,7 @@ func (e *engineImpl) restackBranch(
 			{RefName: fmt.Sprintf("refs/heads/%s", branchName), NewSHA: trunkRev, OldSHA: anchorRev},
 			{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
 		}
-		if err := e.git.UpdateRefsBatch(ctx, updates); err != nil {
+		if err := e.git.UpdateRefsBatchWithLog(ctx, updates, reflogRestackAnchor); err != nil {
 			return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to update refs atomically for anchor %s: %w", branchName, err)
 		}
 
@@ -384,7 +390,7 @@ func (e *engineImpl) restackBranch(
 		{RefName: fmt.Sprintf("refs/heads/%s", branchName), NewSHA: newRev, OldSHA: oldBranchSHA},
 		{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
 	}
-	if err := e.git.UpdateRefsBatch(ctx, updates); err != nil {
+	if err := e.git.UpdateRefsBatchWithLog(ctx, updates, reflogRestack); err != nil {
 		return RestackBranchResult{
 			Result:            RestackConflict,
 			RebasedBranchBase: parentRev,
@@ -568,7 +574,7 @@ func (e *engineImpl) applyBranchAndMetadata(
 		{RefName: fmt.Sprintf("refs/heads/%s", branchName), NewSHA: newRev, OldSHA: oldBranchSHA},
 		{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
 	}
-	if err := e.git.UpdateRefsBatch(ctx, updates); err != nil {
+	if err := e.git.UpdateRefsBatchWithLog(ctx, updates, reflogRestack); err != nil {
 		return RestackBranchResult{Result: RestackConflict, RebasedBranchBase: parentRev}, fmt.Errorf("failed to update refs atomically: %w", err)
 	}
 

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -61,6 +61,10 @@ func (e *engineImpl) restackBranch(
 		return RestackBranchResult{Result: RestackUnneeded, LockReason: lockReason}, nil
 	}
 
+	if e.branchLanded(ctx, branchName, parent) {
+		return RestackBranchResult{Result: RestackUnneeded}, nil
+	}
+
 	if e.IsFrozen(branch) {
 		// For frozen branches, we update via hard reset to remote instead of rebase
 		remoteSha, err := e.git.GetRemoteRevision(branchName)

--- a/internal/engine/restack_plan.go
+++ b/internal/engine/restack_plan.go
@@ -62,17 +62,6 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 		return item, true
 	}
 
-	// A branch whose PR was already merged is awaiting sync cleanup. Rebasing
-	// it onto trunk would replay commits the merge already applied — for a
-	// multi-commit squash merge that conflicts on every commit, since no
-	// individual commit patch-matches the squashed result. Skip it;
-	// descendants still reparent past it via shouldReparentBranch.
-	if prInfo, err := e.GetPrInfo(branch); err == nil && prInfo != nil && prInfo.State() == prStateMerged {
-		item.Skip = true
-		item.SkipResult = RestackBranchResult{Result: RestackUnneeded}
-		return item, true
-	}
-
 	parent := branch.GetParent()
 	parentName := e.trunk
 	e.mu.RLock()
@@ -90,6 +79,16 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 				parentName = e.trunk
 			}
 		}
+	}
+
+	// If this branch has already landed, do not rebase it during restack. This
+	// covers merged PR metadata for all GitHub methods, plus Git-detected merge,
+	// rebase, and multi-commit squash histories on trunk even when the merged
+	// branch has no stackit PR metadata.
+	if e.branchLanded(ctx, branchName, parentName) {
+		item.Skip = true
+		item.SkipResult = RestackBranchResult{Result: RestackUnneeded}
+		return item, true
 	}
 
 	if branch.IsFrozen() {

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -227,6 +227,26 @@ func (s BranchRemoteStatus) MissingRemote() bool {
 	return s.RemoteSha == ""
 }
 
+// TrunkRemoteState describes how the local trunk relates to its remote-tracking
+// branch (e.g. origin/main) using only already-fetched local refs — never the
+// network. It is safe on the restack path and offline.
+type TrunkRemoteState struct {
+	// HasRemoteRef is false when no remote-tracking trunk ref exists locally: a
+	// local-only repo, a never-fetched remote, or a fresh clone without
+	// origin/<trunk>. Callers treat this as "unknown — do not guard".
+	HasRemoteRef bool
+	// AheadOrDiverged is true when the local trunk has commits that are not
+	// present on the remote-tracking trunk (local trunk is NOT an ancestor of
+	// origin/<trunk>). Equal or behind is false.
+	AheadOrDiverged bool
+	// LocalSha is the local trunk tip; RemoteSha is the remote-tracking tip.
+	LocalSha  string
+	RemoteSha string
+	// RemoteRef is the remote-tracking ref name, e.g. "origin/main", for
+	// user-facing messages.
+	RemoteRef string
+}
+
 // BranchRemoteStatuses maps branch names to their remote sync status.
 type BranchRemoteStatuses map[string]BranchRemoteStatus
 

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -137,7 +137,7 @@ func (r *runner) UpdateBranchRef(ctx context.Context, branchName, revision strin
 		return fmt.Errorf("failed to resolve revision %s: %w", revision, err)
 	}
 	refName := fmt.Sprintf("refs/heads/%s", branchName)
-	if _, err := r.RunGitCommandWithContext(ctx, "update-ref", refName, sha); err != nil {
+	if _, err := r.RunGitCommandWithContext(ctx, "update-ref", "-m", "stackit: update branch ref", refName, sha); err != nil {
 		return fmt.Errorf("failed to update branch ref: %w", err)
 	}
 	return nil

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -96,6 +96,7 @@ type DiffOperations interface {
 	GetMergeBaseByRef(ctx context.Context, ref1, ref2 string) (string, error)
 	IsAncestor(ctx context.Context, ancestor, descendant string) (bool, error)
 	IsMerged(ctx context.Context, branchName, target string) (bool, error)
+	IsSquashMerged(ctx context.Context, branchName, target string) (bool, error)
 	GetMergedBranches(ctx context.Context, target string) (map[string]bool, error)
 	IsDiffEmpty(ctx context.Context, branchName, base string) (bool, error)
 	GetChangedFiles(ctx context.Context, base, head string) ([]string, error)

--- a/internal/git/merge_detection.go
+++ b/internal/git/merge_detection.go
@@ -85,6 +85,15 @@ func (r *runner) GetUnmergedFiles(ctx context.Context) ([]string, error) {
 	return strings.Split(strings.TrimSpace(output), "\n"), nil
 }
 
+// IsMerged reports whether branchName's commits have landed in target using
+// cheap Git history checks only: ancestry, and per-commit patch matching via
+// `git cherry` (which covers plain merge commits and rebase merges, since both
+// preserve each commit's patch-id). It deliberately does NOT detect squash
+// merges — those collapse N commits into one new commit that matches no
+// individual branch commit, and proving equivalence needs an aggregate patch-id
+// scan over the target's recent history. That scan is too expensive to run on
+// every IsMerged call (this is invoked in loops over every tracked branch), so
+// callers that have a reason to suspect a squash merge opt into IsSquashMerged.
 func (r *runner) IsMerged(ctx context.Context, branchName, target string) (bool, error) {
 	// Get merge base
 	mergeBase, err := r.GetMergeBase(ctx, branchName, target)
@@ -127,4 +136,102 @@ func (r *runner) IsMerged(ctx context.Context, branchName, target string) (bool,
 	}
 
 	return true, nil
+}
+
+// IsSquashMerged reports whether branchName was squash-merged into target by
+// comparing the branch's aggregate diff patch-id against commits added to
+// target since the branch diverged. Unlike IsMerged it does not short-circuit
+// on ancestry or per-commit matches, so callers use it as a fallback once
+// IsMerged returns false. It is comparatively expensive (a bounded log plus a
+// patch-id per scanned target commit), so keep it out of broad IsMerged loops
+// and call it only from explicit landing decisions.
+func (r *runner) IsSquashMerged(ctx context.Context, branchName, target string) (bool, error) {
+	mergeBase, err := r.GetMergeBase(ctx, branchName, target)
+	if err != nil {
+		return false, fmt.Errorf("failed to get merge base: %w", err)
+	}
+	branchRev, err := r.GetRevision(branchName)
+	if err != nil {
+		return false, fmt.Errorf("failed to get branch revision: %w", err)
+	}
+	return r.isSquashMerged(ctx, branchRev, mergeBase, target)
+}
+
+// isSquashMerged detects whether branchName was squash-merged into target by
+// comparing the aggregate branch diff's patch-id against commits reachable from
+// target but not from mergeBase (i.e. commits added since the branch diverged).
+// A squash merge creates a single commit whose diff matches the branch's
+// combined diff even when unrelated target commits mean the full tree differs.
+//
+// Failure modes are biased toward the safe direction:
+//
+//   - False negative: if the target rewrote the same files between mergeBase and
+//     the squash, or the squash landed further back than the scanned window, the
+//     patch-ids differ and this returns false. Callers then rebase the branch and
+//     surface any conflict in a throwaway validation worktree — no data loss.
+//   - False positive: a match means some target commit has a byte-identical
+//     combined diff (after --stable normalization), which means the branch's
+//     changes already landed. Treating it as merged is correct in that case; an
+//     accidental collision of unrelated changes is not realistic for patch-ids.
+//
+// The scan is bounded to keep long-lived trunks cheap; exceeding it only costs a
+// false negative, never a wrong "merged".
+func (r *runner) isSquashMerged(ctx context.Context, branchRev, mergeBase, target string) (bool, error) {
+	branchPatchID, err := r.diffPatchID(ctx, mergeBase, branchRev)
+	if err != nil {
+		return false, nil //nolint:nilerr
+	}
+	if branchPatchID == "" {
+		return false, nil
+	}
+
+	// Enumerate commits on target since the merge-base (up to 200
+	// commits to bound the scan on long-lived trunks).
+	logOutput, err := r.RunGitCommandWithContext(ctx, "log", "--format=%H", "-200", mergeBase+".."+target)
+	if err != nil {
+		return false, nil //nolint:nilerr
+	}
+
+	for commitSHA := range strings.SplitSeq(strings.TrimSpace(logOutput), "\n") {
+		commitSHA = strings.TrimSpace(commitSHA)
+		if commitSHA == "" {
+			continue
+		}
+		commitPatchID, patchErr := r.commitPatchID(ctx, commitSHA)
+		if patchErr != nil {
+			continue
+		}
+		if commitPatchID == branchPatchID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (r *runner) diffPatchID(ctx context.Context, base, head string) (string, error) {
+	diffOutput, err := r.RunGitCommandRawWithContext(ctx, "diff", "--no-ext-diff", "--full-index", base, head)
+	if err != nil {
+		return "", err
+	}
+	return r.patchID(ctx, diffOutput)
+}
+
+func (r *runner) commitPatchID(ctx context.Context, commitSHA string) (string, error) {
+	diffOutput, err := r.RunGitCommandRawWithContext(ctx, "show", "--format=", "--no-ext-diff", "--full-index", commitSHA)
+	if err != nil {
+		return "", err
+	}
+	return r.patchID(ctx, diffOutput)
+}
+
+func (r *runner) patchID(ctx context.Context, diffOutput string) (string, error) {
+	if strings.TrimSpace(diffOutput) == "" {
+		return "", nil
+	}
+	output, err := r.runGitInternal(ctx, diffOutput, nil, true, "patch-id", "--stable")
+	if err != nil {
+		return "", err
+	}
+	patchID, _, _ := strings.Cut(strings.TrimSpace(output), " ")
+	return patchID, nil
 }

--- a/internal/git/merge_detection_test.go
+++ b/internal/git/merge_detection_test.go
@@ -2,6 +2,7 @@ package git_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,7 +24,7 @@ func TestIsMerged(t *testing.T) {
 		require.NoError(t, err)
 
 		// Initialize git repo
-		runner := git.NewRunner(nil)
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
 
 		// Branch is not merged
 		merged, err := runner.IsMerged(context.Background(), "branch1", "main")
@@ -47,11 +48,75 @@ func TestIsMerged(t *testing.T) {
 		require.NoError(t, err)
 
 		// Initialize git repo
-		runner := git.NewRunner(nil)
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
 
 		// Branch should be merged
 		merged, err := runner.IsMerged(context.Background(), "branch1", "main")
 		require.NoError(t, err)
 		require.True(t, merged)
+	})
+
+	t.Run("returns true for rebase-merged branch", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+
+		err := scene.Repo.CreateAndCheckoutBranch("branch1")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("branch1 change 1", "b1")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("branch1 change 2", "b2")
+		require.NoError(t, err)
+
+		commitsOutput, err := scene.Repo.RunGitCommandAndGetOutput("rev-list", "--reverse", "main..branch1")
+		require.NoError(t, err)
+		commits := strings.Fields(commitsOutput)
+		require.Len(t, commits, 2)
+
+		err = scene.Repo.CheckoutBranch("main")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("unrelated trunk change", "trunk")
+		require.NoError(t, err)
+		for _, commit := range commits {
+			err = scene.Repo.RunGitCommand("cherry-pick", commit)
+			require.NoError(t, err)
+		}
+
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+		merged, err := runner.IsMerged(context.Background(), "branch1", "main")
+		require.NoError(t, err)
+		require.True(t, merged)
+	})
+
+	// A multi-commit squash matches no individual branch commit, so the cheap
+	// per-commit IsMerged cannot see it — only the aggregate-patch-id
+	// IsSquashMerged can. This split keeps the expensive scan off the hot
+	// IsMerged path.
+	t.Run("multi-commit squash: IsMerged false, IsSquashMerged true", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+
+		err := scene.Repo.CreateAndCheckoutBranch("branch1")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("v1", "feature")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("v1\nv2", "feature")
+		require.NoError(t, err)
+
+		err = scene.Repo.CheckoutBranch("main")
+		require.NoError(t, err)
+		err = scene.Repo.CreateChangeAndCommit("unrelated trunk change", "trunk")
+		require.NoError(t, err)
+		err = scene.Repo.RunGitCommand("merge", "--squash", "branch1")
+		require.NoError(t, err)
+		err = scene.Repo.RunGitCommand("commit", "-m", "squash branch1")
+		require.NoError(t, err)
+
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+
+		merged, err := runner.IsMerged(context.Background(), "branch1", "main")
+		require.NoError(t, err)
+		require.False(t, merged, "cheap IsMerged must not detect a multi-commit squash")
+
+		squashMerged, err := runner.IsSquashMerged(context.Background(), "branch1", "main")
+		require.NoError(t, err)
+		require.True(t, squashMerged, "IsSquashMerged must detect the aggregate squash")
 	})
 }

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -494,6 +494,13 @@ func (t *tracingRunner) IsMerged(ctx context.Context, branchName, target string)
 	return result, err
 }
 
+func (t *tracingRunner) IsSquashMerged(ctx context.Context, branchName, target string) (bool, error) {
+	start := time.Now()
+	result, err := t.inner.IsSquashMerged(ctx, branchName, target)
+	t.trace("IsSquashMerged", time.Since(start), err == nil, err, slog.String("branch", branchName), slog.String("target", target))
+	return result, err
+}
+
 func (t *tracingRunner) GetMergedBranches(ctx context.Context, target string) (map[string]bool, error) {
 	start := time.Now()
 	result, err := t.inner.GetMergedBranches(ctx, target)

--- a/internal/integration/restack_squash_conflict_abort_test.go
+++ b/internal/integration/restack_squash_conflict_abort_test.go
@@ -1,0 +1,145 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// revParse returns the resolved SHA of a ref in the test repo.
+func (s *TestShell) revParse(ref string) string {
+	s.t.Helper()
+	s.Git("rev-parse " + ref)
+	return strings.TrimSpace(s.Output())
+}
+
+// fileContent reads a working-tree file from the test repo.
+func (s *TestShell) fileContent(name string) string {
+	s.t.Helper()
+	data, err := os.ReadFile(filepath.Join(s.scene.Dir, name))
+	require.NoError(s.t, err, "failed to read %s", name)
+	return string(data)
+}
+
+// TestSquashMergedParentConflictAbortPreservesChild locks in the escalation path
+// from issue #1345.
+//
+// Setup: main -> parent (multi-commit) -> child. The parent is squash-merged
+// onto main with no PR metadata, so detection must come from aggregate patch-id,
+// not recorded MERGED metadata. A later trunk edit touches the same line the
+// child touches, so when the child reparents onto trunk its own commit CONFLICTS.
+//
+// The invariant: after the conflict is aborted, the child must be restored to its
+// original commit — its work intact, never reset to the squash-merged parent's
+// stale tip, never left mid-rebase or detached. This is exactly the data loss the
+// issue reported (a branch reset to a sibling's tip with its own commit orphaned).
+func TestSquashMergedParentConflictAbortPreservesChild(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t)
+
+	// main -> parent: two commits so the squash is genuinely multi-commit
+	// (per-commit patch matching via git cherry cannot detect it).
+	sh.WriteFile("shared.txt", "base\np2\n").
+		Run("create parent -m 'parent c1'").
+		OnBranch("parent")
+	sh.WriteFile("notes.txt", "parent note\n").
+		Git("commit -m 'parent c2'")
+
+	// parent -> child: the child rewrites the shared line and adds a unique file.
+	sh.WriteFile("shared.txt", "base\nCHILD\n").
+		WriteFile("child-only.txt", "child work\n").
+		Run("create child -m 'child commit'").
+		OnBranch("child")
+
+	childOrig := sh.revParse("child")
+
+	// GitHub squash-merges parent: one combined commit lands on main carrying the
+	// parent's aggregate diff. No PR metadata is recorded, so detection must fall
+	// through to the patch-id scan.
+	sh.Checkout("main")
+	parentStaleTip := sh.revParse("parent")
+	sh.WriteFile("shared.txt", "base\np2\n").
+		WriteFile("notes.txt", "parent note\n").
+		Git("commit -m 'squash-merge parent (#1)'")
+
+	// A later trunk commit edits the same shared line the child rewrote, so the
+	// child's replay onto trunk is guaranteed to conflict.
+	sh.WriteFile("shared.txt", "base\nMAINEDIT\n").
+		Git("commit -m 'trunk edit on shared line'")
+
+	// Restack the child. Detection reparents it past the squash-merged parent onto
+	// main, and replaying its commit conflicts on shared.txt.
+	sh.Checkout("child").
+		RunExpectError("restack --upstack").
+		OutputContains("conflict")
+
+	// Abort: must roll the child fully back to where it started. The conflict
+	// workflow detaches HEAD (writing a "checkout: moving from" reflog entry),
+	// which previously fooled the abort router into treating this restack conflict
+	// as a failed absorb — that path never ran `git rebase --abort`, leaving the
+	// repo stuck mid-rebase. Assert we took the standard rebase-abort path.
+	sh.Run("abort --force").
+		OutputContains("Aborting rebase").
+		OutputNotContains("absorb")
+
+	require.Equal(t, childOrig, sh.revParse("child"),
+		"child must be restored to its original commit after aborting the conflicted restack")
+	require.NotEqual(t, parentStaleTip, sh.revParse("child"),
+		"child must never point at the squash-merged parent's stale tip")
+	require.Equal(t, "base\nCHILD\n", sh.fileContent("shared.txt"),
+		"child's own change must survive the aborted restack")
+	require.Equal(t, "child work\n", sh.fileContent("child-only.txt"),
+		"child's unique file must survive the aborted restack")
+
+	// No rebase left in progress, and we are back on a real branch (not detached).
+	sh.Git("status")
+	require.NotContains(t, sh.Output(), "rebas", "no rebase should be in progress after abort")
+	sh.OnBranch("child")
+
+	sh.Git("status --porcelain")
+	require.Empty(t, strings.TrimSpace(sh.Output()), "working tree should be clean after abort")
+}
+
+// TestRestackWritesReflogMessageOnReparent locks in the second half of the fix:
+// branch ref moves during restack must be annotated in the reflog. Issue #1345
+// noted that blank "(no message)" reflog entries made the incident impossible to
+// trace. Here a squash-merged parent with no PR metadata causes the child to
+// reparent cleanly onto trunk; the resulting ref move must carry a "stackit:
+// restack" message instead of an empty one.
+func TestRestackWritesReflogMessageOnReparent(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t)
+
+	sh.WriteFile("shared.txt", "base\np2\n").
+		Run("create parent -m 'parent c1'").
+		OnBranch("parent")
+	sh.WriteFile("notes.txt", "parent note\n").
+		Git("commit -m 'parent c2'")
+
+	// Child adds only a unique file so its replay onto trunk applies cleanly.
+	sh.WriteFile("child-only.txt", "child work\n").
+		Run("create child -m 'child commit'").
+		OnBranch("child")
+
+	// Squash-merge parent onto main without PR metadata. Detection falls through
+	// to the aggregate patch-id scan.
+	sh.Checkout("main")
+	sh.WriteFile("shared.txt", "base\np2\n").
+		WriteFile("notes.txt", "parent note\n").
+		Git("commit -m 'squash-merge parent (#1)'")
+
+	sh.Checkout("child").
+		Run("restack --upstack")
+
+	// The child reparented onto main; its ref move must be annotated.
+	sh.Git("reflog show child")
+	require.Contains(t, sh.Output(), "stackit: restack",
+		"restack must annotate branch ref moves in the reflog, not leave blank entries")
+	sh.ExpectBranchParent("child", "main")
+
+	sh.Git("status --porcelain")
+	require.Empty(t, strings.TrimSpace(sh.Output()), "working tree should be clean after restack")
+}

--- a/internal/integration/restack_squash_merge_test.go
+++ b/internal/integration/restack_squash_merge_test.go
@@ -8,9 +8,28 @@ import (
 	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/actions/sync"
 	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/handlers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
+
+// markPrWithState records a PR number and an explicit (possibly stale) state on
+// a branch's metadata, without asserting the PR has merged. Used to simulate a
+// branch whose PR was merged on GitHub before its local state synced to MERGED.
+func markPrWithState(t *testing.T, sh *scenario.Scenario, branch string, prNumber int, state, base string) {
+	t.Helper()
+	meta, err := sh.Engine.Git().ReadMetadata(branch)
+	require.NoError(t, err)
+	num := prNumber
+	s := state
+	b := base
+	meta = meta.WithPrInfo(&git.PrInfoPersistence{
+		Number: &num,
+		State:  &s,
+		Base:   &b,
+	})
+	require.NoError(t, sh.Engine.Git().WriteMetadata(branch, meta))
+}
 
 // TestSquashMergeMultiCommitParent reproduces the case where a parent branch
 // with MULTIPLE commits is squash-merged on GitHub. The squash commit's
@@ -82,6 +101,9 @@ func TestRestackAfterMultiCommitSquashParentDeleted(t *testing.T) {
 	mainName := sh.Engine.Trunk().GetName()
 	sh.Checkout("main")
 	sh.CommitChange("file-p", "v1\nv2\nv3")
+	// The squash landed on the real trunk and was fetched, so origin/main carries
+	// it too; restack builds on synced trunk, not un-pushed local commits.
+	sh.SyncRemoteTrunkToLocal()
 
 	// Parent branch deleted locally (e.g. user cleanup after GitHub merge).
 	require.NoError(t, sh.Scene.Repo.RunGitCommand("branch", "-D", "parent"))
@@ -101,6 +123,195 @@ func TestRestackAfterMultiCommitSquashParentDeleted(t *testing.T) {
 	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("child"))
 	require.NoError(t, err)
 	require.Equal(t, 1, cCount, "child should not inherit parent's squashed commits")
+
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestRestackDetectsSquashMergeWithStalePRState covers running `stackit restack`
+// when the parent was squash-merged on GitHub but its local PR state has not yet
+// synced to MERGED (e.g. the merge happened out of band, or a prior sync ran
+// offline). The aggregate patch-id squash scan must detect the merge and cause
+// the child to reparent to trunk without replaying the parent's commits.
+func TestRestackDetectsSquashMergeWithStalePRState(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("parent").
+		CommitChange("file-p", "v1").
+		CommitChange("file-p", "v1\nv2").
+		TrackBranch("parent", "main")
+
+	sh.CreateBranch("child").
+		CommitChange("file-c", "c").
+		TrackBranch("child", "parent")
+
+	// Squash-merge parent onto main. The PR number is recorded but its state is
+	// stale (still OPEN) — simulating a GitHub UI squash-merge before st sync
+	// marked the PR MERGED.
+	mainName := sh.Engine.Trunk().GetName()
+	sh.Checkout("main")
+	sh.CommitChange("file-main", "unrelated")
+	sh.CommitChange("file-p", "v1\nv2")
+
+	// Stale PR state (OPEN, not MERGED) forces detection through the aggregate
+	// patch-id scan rather than PR metadata. The unrelated trunk commit means a
+	// whole-tree comparison would not match the parent tip.
+	markPrWithState(t, sh, "parent", 42, "OPEN", mainName)
+	// Trunk advanced from a real merge that was fetched, so origin/main matches.
+	sh.SyncRemoteTrunkToLocal()
+
+	sh.Checkout("child")
+	plan, err := actions.PlanRestack(sh.Context, actions.RestackOptions{
+		BranchName: "child",
+		Scope:      engine.StackRangeFull(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, actions.RestackAction(sh.Context, plan, &handlers.NullRestackHandler{}))
+
+	sh.Rebuild()
+	require.Equal(t, mainName, sh.Engine.GetBranch("child").GetParent().GetName(),
+		"child should reparent to main when the squash scan detects the parent merged")
+
+	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("child"))
+	require.NoError(t, err)
+	require.Equal(t, 1, cCount, "child should keep only its own commit")
+
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestSyncCleansUpSquashMergedBranchWithStalePRState covers sync's branch
+// cleanup when a PR was squash-merged on GitHub but its local state has not yet
+// synced to MERGED (e.g. the merge happened out of band, or a prior sync ran
+// offline). Ancestry-based merged detection misses squash merges, and the
+// MERGED-state rule never fires, so without aggregate patch-id detection the
+// merged branch would linger after sync. With a recorded PR number, cleanup must
+// detect the squash and delete it.
+func TestSyncCleansUpSquashMergedBranchWithStalePRState(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	// Multi-commit branch so the squash is genuinely combined (no single commit
+	// patch-matches the squashed result).
+	sh.CreateBranch("feature").
+		CommitChange("file-f", "v1").
+		CommitChange("file-f", "v1\nv2").
+		TrackBranch("feature", "main")
+
+	mainName := sh.Engine.Trunk().GetName()
+
+	// GitHub squash-merges feature: one combined commit lands on main. An
+	// unrelated trunk commit ensures a whole-tree comparison would not match.
+	sh.Checkout("main")
+	sh.CommitChange("file-unrelated", "x")
+	sh.CommitChange("file-f", "v1\nv2")
+
+	// PR number is recorded, but its state is stale (still OPEN) — not MERGED.
+	markPrWithState(t, sh, "feature", 7, "OPEN", mainName)
+
+	require.NoError(t, sync.Action(sh.Context, sync.Options{Restack: true}, nil))
+
+	branches, err := sh.Scene.Repo.GetLocalBranches()
+	require.NoError(t, err)
+	require.NotContains(t, branches, "feature",
+		"squash-merged branch with a stale PR state should be cleaned up by sync")
+
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestSyncKeepsUnmergedBranchWithPRNumber is the guard rail for the cleanup
+// above: a branch that carries a PR number but is genuinely NOT merged (it has
+// its own unlanded commit) must survive sync. This proves the squash-aware
+// deletion rule keys on actual patch equivalence, not merely on PR metadata
+// being present.
+func TestSyncKeepsUnmergedBranchWithPRNumber(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("feature").
+		CommitChange("file-f", "unique work").
+		TrackBranch("feature", "main")
+
+	mainName := sh.Engine.Trunk().GetName()
+
+	// Trunk moves forward with unrelated work; feature's own change never lands.
+	sh.Checkout("main")
+	sh.CommitChange("file-unrelated", "x")
+
+	markPrWithState(t, sh, "feature", 9, "OPEN", mainName)
+
+	require.NoError(t, sync.Action(sh.Context, sync.Options{Restack: true}, nil))
+
+	branches, err := sh.Scene.Repo.GetLocalBranches()
+	require.NoError(t, err)
+	require.Contains(t, branches, "feature",
+		"an unmerged branch must not be deleted just because it has a PR number")
+
+	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("feature"))
+	require.NoError(t, err)
+	require.Equal(t, 1, cCount, "feature must keep its own unlanded commit")
+
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestSquashMergedSiblingKeepsOwnCommit is the exact regression for issue #1345:
+// two branches A and B both forked directly off main (siblings, not a stack).
+// A is squash-merged on GitHub; after sync + restack, B must keep its own commit
+// and stay parented to main. The reported data loss was B's ref being moved onto
+// A's stale pre-merge tip, orphaning B's own work. This guards that B is never
+// reparented onto, nor reset to, the merged sibling.
+func TestSquashMergedSiblingKeepsOwnCommit(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	// A: two commits so the squash is genuinely multi-commit.
+	sh.CreateBranch("branch-a").
+		CommitChange("file-a", "a1").
+		CommitChange("file-a", "a1\na2").
+		TrackBranch("branch-a", "main")
+
+	// B: a sibling forked off main, with its own unique commit.
+	sh.Checkout("main")
+	sh.CreateBranch("branch-b").
+		CommitChange("file-b", "b").
+		TrackBranch("branch-b", "main")
+
+	mainName := sh.Engine.Trunk().GetName()
+
+	// Capture A's pre-merge tip — the exact SHA B must never be moved onto.
+	aStaleTip, err := sh.Engine.GetBranch("branch-a").GetRevision()
+	require.NoError(t, err)
+
+	// GitHub squash-merges A: one combined commit lands on main.
+	sh.Checkout("main")
+	sh.CommitChange("file-a", "a1\na2")
+	markPrMerged(t, sh, "branch-a", 1, mainName)
+
+	require.NoError(t, sync.Action(sh.Context, sync.Options{Restack: true}, nil))
+
+	// A is cleaned up; B survives.
+	branches, err := sh.Scene.Repo.GetLocalBranches()
+	require.NoError(t, err)
+	require.NotContains(t, branches, "branch-a", "squash-merged sibling should be deleted")
+	require.Contains(t, branches, "branch-b")
+
+	// B stays parented to main, never to the merged sibling.
+	require.Equal(t, mainName, sh.Engine.GetBranch("branch-b").GetParent().GetName(),
+		"sibling B must remain parented to main, not reparented onto merged A")
+
+	// B's ref must not have been moved onto A's stale tip.
+	bTip, err := sh.Engine.GetBranch("branch-b").GetRevision()
+	require.NoError(t, err)
+	require.NotEqual(t, aStaleTip, bTip,
+		"sibling B must never be reset to A's stale pre-merge tip (issue #1345 data loss)")
+
+	// B keeps exactly its own commit on top of main.
+	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("branch-b"))
+	require.NoError(t, err)
+	require.Equal(t, 1, cCount, "sibling B must keep only its own commit")
 
 	requireCleanWorkingTree(t, sh)
 }
@@ -129,6 +340,8 @@ func TestRestackAfterMultiCommitSquashWithoutSync(t *testing.T) {
 	sh.Checkout("main")
 	sh.CommitChange("file-p", "v1\nv2\nv3")
 	markPrMerged(t, sh, "parent", 1, mainName)
+	// The merge landed on the real trunk and was fetched, so origin/main matches.
+	sh.SyncRemoteTrunkToLocal()
 
 	// User runs `stackit restack` from the child without syncing first.
 	sh.Checkout("child")

--- a/internal/integration/restack_synced_trunk_matrix_test.go
+++ b/internal/integration/restack_synced_trunk_matrix_test.go
@@ -1,0 +1,138 @@
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/handlers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// This is the scenario 2 coverage matrix: restacking a child onto trunk after
+// its parent's changes LANDED on origin/main and were synced. It exercises every
+// GitHub merge method (merge commit, squash, rebase) for a parent with one and
+// with multiple commits, for both a stackit user (parent carries a MERGED PR)
+// and a non-stackit collaborator (parent carries zero stackit PR metadata).
+//
+// The invariant in all cases: the child reparents onto trunk and keeps ONLY its
+// own commit — the parent's landed commits must never replay into the child. The
+// trunk is modeled as synced (origin/main advanced via SyncRemoteTrunkToLocal),
+// which is what distinguishes this from scenario 1 (un-pushed trunk, rejected by
+// the guard).
+//
+// Detection coverage per strategy:
+//   - merge commit: parent tip is reachable from trunk → ancestry (IsMerged).
+//   - rebase merge: commits replayed with new SHAs but same patch-ids → cherry.
+//   - squash (single commit): the lone commit patch-matches the squash → cherry.
+//   - squash (multi commit): only the aggregate patch-id scan (no PR) or the
+//     MERGED PR metadata (stackit user) can prove it landed.
+
+type matrixMergeStrategy string
+
+const (
+	matrixMergeCommit matrixMergeStrategy = "merge-commit"
+	matrixSquash      matrixMergeStrategy = "squash"
+	matrixRebase      matrixMergeStrategy = "rebase"
+)
+
+func TestRestackOnSyncedTrunkMatrix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		commits     []string // successive contents of the parent's "shared" file
+		strategy    matrixMergeStrategy
+		stackitUser bool
+	}{
+		{"merge-commit/single/stackit", []string{"v1"}, matrixMergeCommit, true},
+		{"merge-commit/single/non-stackit", []string{"v1"}, matrixMergeCommit, false},
+		{"merge-commit/multi/stackit", []string{"v1", "v1\nv2"}, matrixMergeCommit, true},
+		{"merge-commit/multi/non-stackit", []string{"v1", "v1\nv2"}, matrixMergeCommit, false},
+		{"squash/single/stackit", []string{"v1"}, matrixSquash, true},
+		{"squash/single/non-stackit", []string{"v1"}, matrixSquash, false},
+		{"squash/multi/stackit", []string{"v1", "v1\nv2"}, matrixSquash, true},
+		{"squash/multi/non-stackit", []string{"v1", "v1\nv2"}, matrixSquash, false},
+		{"rebase/single/stackit", []string{"v1"}, matrixRebase, true},
+		{"rebase/single/non-stackit", []string{"v1"}, matrixRebase, false},
+		{"rebase/multi/stackit", []string{"v1", "v1\nv2"}, matrixRebase, true},
+		{"rebase/multi/non-stackit", []string{"v1", "v1\nv2"}, matrixRebase, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sh := scenario.NewRemoteScenario(t)
+			disableCommitSigning(t, sh)
+
+			// Parent branch with the requested commit history.
+			sh.CreateBranch("parent")
+			for _, content := range tc.commits {
+				sh.CommitChange("shared", content)
+			}
+			sh.TrackBranch("parent", "main")
+
+			// Child stacked on parent. It touches a unique file so its replay onto
+			// trunk never conflicts — isolating "did I inherit the parent's commits".
+			sh.CreateBranch("child").
+				CommitChange("child-only", "my work").
+				TrackBranch("child", "parent")
+
+			mainName := sh.Engine.Trunk().GetName()
+			parentSHAs := branchCommitSHAs(t, sh, "parent")
+
+			// Land the parent's changes on trunk via the chosen merge method.
+			sh.Checkout("main")
+			switch tc.strategy {
+			case matrixMergeCommit:
+				require.NoError(t, sh.Scene.Repo.RunGitCommand("merge", "--no-ff", "-m", "Merge parent (#1)", "parent"))
+			case matrixSquash:
+				sh.CommitChange("shared", tc.commits[len(tc.commits)-1])
+			case matrixRebase:
+				for _, c := range parentSHAs {
+					require.NoError(t, sh.Scene.Repo.RunGitCommand("cherry-pick", c))
+				}
+			}
+			sh.Rebuild()
+
+			// The merge landed on the real trunk and was fetched: origin/main now
+			// carries it, so the restack guard sees synced trunk (not un-pushed).
+			sh.SyncRemoteTrunkToLocal()
+
+			// A stackit user's parent carries a MERGED PR; a non-stackit
+			// collaborator's parent carries no stackit PR metadata at all.
+			if tc.stackitUser {
+				markPrMerged(t, sh, "parent", 1, mainName)
+			}
+
+			sh.Checkout("child")
+			plan, err := actions.PlanRestack(sh.Context, actions.RestackOptions{
+				BranchName: "child",
+				Scope:      engine.StackRangeFull(),
+			})
+			require.NoError(t, err)
+			require.NoError(t, actions.RestackAction(sh.Context, plan, &handlers.NullRestackHandler{}))
+			sh.Rebuild()
+
+			require.Equal(t, mainName, sh.Engine.GetBranch("child").GetParent().GetName(),
+				"child should reparent to trunk past the landed parent")
+			count, err := sh.Scene.Repo.GetCommitCount("main", "child")
+			require.NoError(t, err)
+			require.Equal(t, 1, count,
+				"child must contain only its own commit, never the parent's landed commits")
+			requireCleanWorkingTree(t, sh)
+		})
+	}
+}
+
+// branchCommitSHAs returns the SHAs of the commits on branch that are not on
+// main, oldest first.
+func branchCommitSHAs(t *testing.T, sh *scenario.Scenario, branch string) []string {
+	t.Helper()
+	out, err := sh.Scene.Repo.RunGitCommandAndGetOutput("rev-list", "--reverse", "main.."+branch)
+	require.NoError(t, err)
+	return strings.Fields(out)
+}

--- a/internal/integration/restack_trunk_guard_test.go
+++ b/internal/integration/restack_trunk_guard_test.go
@@ -1,0 +1,182 @@
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// These tests cover scenario 1: the local trunk has commits that are NOT on its
+// remote-tracking branch (origin/main). Restacking rebases trunk-anchored
+// branches onto the LOCAL trunk tip, so un-pushed or divergent trunk commits
+// would be baked into the stack — work that only exists locally and may never
+// land as-is. The restack trunk guard refuses in that state and tells the user
+// to reconcile trunk with the remote first.
+//
+// The distinction from scenario 2 (synced trunk, which must succeed) is purely
+// whether origin/<trunk> carries the trunk's new commits. The synced-trunk
+// tests advance origin/main via SyncRemoteTrunkToLocal; these deliberately do
+// not, so local trunk stays ahead of / diverged from the remote.
+
+// planRestackFeatureErr runs PlanRestack for the "feature" branch and returns
+// the error (if any) without asserting success — the guard rejects at plan time.
+func planRestackFeatureErr(t *testing.T, sh *scenario.Scenario) error {
+	t.Helper()
+	sh.Checkout("feature")
+	_, err := actions.PlanRestack(sh.Context, actions.RestackOptions{
+		BranchName: "feature",
+		Scope:      engine.StackRangeFull(),
+	})
+	return err
+}
+
+// TestRestackGuardRejectsTrunkAheadOfRemote is the headline scenario 1 case: we
+// committed directly on local main and never pushed, so local main is ahead of
+// origin/main. Restacking would build the stack on those un-pushed commits, so
+// the guard must reject before any rebase runs.
+func TestRestackGuardRejectsTrunkAheadOfRemote(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	// A normal stack on top of synced trunk.
+	sh.CreateBranch("feature").
+		CommitChange("feature", "my work").
+		TrackBranch("feature", "main")
+
+	// Commit directly on local main and DO NOT sync origin/main: local trunk is
+	// now ahead of its remote-tracking branch.
+	sh.Checkout("main")
+	sh.CommitChange("local-only", "un-pushed trunk commit")
+	sh.Rebuild()
+
+	err := planRestackFeatureErr(t, sh)
+	require.Error(t, err, "restack must refuse while local trunk is ahead of origin/main")
+	require.Contains(t, err.Error(), "origin/main",
+		"the error should name the remote-tracking trunk the user must reconcile with")
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestRestackGuardRejectsTrunkDivergedFromRemote covers the diverged shape:
+// local main and origin/main each have a unique commit on top of their common
+// ancestor. Restacking onto the local (divergent) trunk is just as unsafe as the
+// ahead case, so the guard must reject here too.
+func TestRestackGuardRejectsTrunkDivergedFromRemote(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("feature").
+		CommitChange("feature", "my work").
+		TrackBranch("feature", "main")
+
+	// Common ancestor = current main tip.
+	sh.Checkout("main")
+	base, err := sh.Scene.Repo.RunGitCommandAndGetOutput("rev-parse", "--verify", "main")
+	require.NoError(t, err)
+	base = trimSHA(base)
+
+	// Build a divergent remote commit from the common ancestor and point
+	// origin/main at it (a commit local main will never contain).
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("branch", "remote-work", base))
+	require.NoError(t, sh.Scene.Repo.CheckoutBranch("remote-work"))
+	sh.CommitChange("remote-file", "landed on origin only")
+	remoteSha, err := sh.Scene.Repo.RunGitCommandAndGetOutput("rev-parse", "--verify", "remote-work")
+	require.NoError(t, err)
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("update-ref", "refs/remotes/origin/main", trimSHA(remoteSha)))
+	require.NoError(t, sh.Scene.Repo.CheckoutBranch("main"))
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("branch", "-D", "remote-work"))
+
+	// Local main gets its own unique commit on top of the common ancestor.
+	sh.CommitChange("local-file", "local divergent commit")
+	sh.Rebuild()
+
+	guardErr := planRestackFeatureErr(t, sh)
+	require.Error(t, guardErr, "restack must refuse while local trunk has diverged from origin/main")
+	require.Contains(t, guardErr.Error(), "origin/main")
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestRestackAllowsTrunkBehindRemote is the boundary control: local trunk is
+// strictly behind origin/main (the remote has commits we haven't merged, but we
+// have no un-pushed trunk commits). Restacking builds only on commits that exist
+// on origin/main, so the guard must NOT fire.
+func TestRestackAllowsTrunkBehindRemote(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("feature").
+		CommitChange("feature", "my work").
+		TrackBranch("feature", "main")
+
+	// Advance origin/main ahead of local main (a descendant), leaving local main
+	// strictly behind. Local trunk stays an ancestor of origin/main.
+	sh.Checkout("main")
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("branch", "remote-ahead", "main"))
+	require.NoError(t, sh.Scene.Repo.CheckoutBranch("remote-ahead"))
+	sh.CommitChange("remote-file", "landed on origin")
+	remoteSha, err := sh.Scene.Repo.RunGitCommandAndGetOutput("rev-parse", "--verify", "remote-ahead")
+	require.NoError(t, err)
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("update-ref", "refs/remotes/origin/main", trimSHA(remoteSha)))
+	require.NoError(t, sh.Scene.Repo.CheckoutBranch("main"))
+	require.NoError(t, sh.Scene.Repo.RunGitCommand("branch", "-D", "remote-ahead"))
+	sh.Rebuild()
+
+	err = planRestackFeatureErr(t, sh)
+	require.NoError(t, err, "restack must proceed when local trunk is merely behind origin/main")
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestRestackGuardNoOpWithoutRemote confirms local-only repos are unaffected:
+// with no remote-tracking trunk ref, the guard cannot (and must not) fire even
+// when local trunk has commits. A solo user with no remote restacks freely.
+func TestRestackGuardNoOpWithoutRemote(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewScenario(t, testhelpers.InitialCommitSceneSetup)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("feature").
+		CommitChange("feature", "my work").
+		TrackBranch("feature", "main")
+
+	// Commit on local main. There is no origin/main to compare against.
+	sh.Checkout("main")
+	sh.CommitChange("local-only", "trunk commit")
+	sh.Rebuild()
+
+	err := planRestackFeatureErr(t, sh)
+	require.NoError(t, err, "a repo with no remote-tracking trunk must not be guarded")
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestRestackGuardSkipsWhenNoBranches makes sure the guard does not turn an
+// empty restack (e.g. trunk with no children) into an error just because local
+// trunk happens to be ahead of the remote.
+func TestRestackGuardSkipsWhenNoBranches(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	// Trunk ahead of origin, but nothing is stacked on it.
+	sh.Checkout("main")
+	sh.CommitChange("local-only", "un-pushed trunk commit")
+	sh.Rebuild()
+
+	_, err := actions.PlanRestack(sh.Context, actions.RestackOptions{
+		BranchName: "main",
+		Scope:      engine.StackRangeFull(),
+	})
+	require.NoError(t, err, "an empty restack must not be rejected by the trunk guard")
+}
+
+// trimSHA strips trailing whitespace/newline from a rev-parse result.
+func trimSHA(s string) string {
+	return strings.TrimSpace(s)
+}

--- a/internal/integration/restack_untracked_collaborator_test.go
+++ b/internal/integration/restack_untracked_collaborator_test.go
@@ -1,0 +1,233 @@
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/handlers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// These tests model the real collaboration case: a teammate who does NOT use
+// stackit pushes a branch, I stack my own work on top of it, and the teammate
+// then squash- or rebase-merges their branch into main on GitHub. Their merged
+// work carries ZERO stackit metadata (no recorded PR number, no MERGED state) —
+// stackit only knows the branch as a local parent pointer, if that.
+//
+// The invariant under test: after I restack, my branch must contain ONLY my own
+// commit. If detection misses the teammate's merge, restack replays their
+// pre-merge commits into my branch (issue #1345's data-loss shape), and
+// `main..mine` carries their commits as well as mine.
+//
+// My commit touches a unique file so the replay never conflicts — that isolates
+// the "did I inherit foreign commits" question from any conflict noise.
+
+// reparentCountAfterRestack restacks `mine` and returns the number of commits
+// reachable from `mine` but not `main`. A correct restack onto main yields 1
+// (just my commit); inheriting the teammate's pre-merge commits yields more.
+func restackMineOntoTrunk(t *testing.T, sh *scenario.Scenario) {
+	t.Helper()
+	sh.Checkout("mine")
+	plan, err := actions.PlanRestack(sh.Context, actions.RestackOptions{
+		BranchName: "mine",
+		Scope:      engine.StackRangeFull(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, actions.RestackAction(sh.Context, plan, &handlers.NullRestackHandler{}))
+	sh.Rebuild()
+}
+
+func mineCommitsAboveTrunk(t *testing.T, sh *scenario.Scenario) int {
+	t.Helper()
+	count, err := sh.Scene.Repo.GetCommitCount("main", "mine")
+	require.NoError(t, err)
+	return count
+}
+
+// rebaseMergeOntoMain replays each of the listed commits onto main with new
+// SHAs, simulating GitHub's "Rebase and merge". Patch-ids are preserved. The
+// merge landed on the real trunk and was fetched, so origin/main is advanced to
+// match: restack builds on synced trunk, not un-pushed local commits.
+func rebaseMergeOntoMain(t *testing.T, sh *scenario.Scenario, commits []string) {
+	t.Helper()
+	sh.Checkout("main")
+	for _, c := range commits {
+		require.NoError(t, sh.Scene.Repo.RunGitCommand("cherry-pick", c))
+	}
+	sh.Rebuild()
+	sh.SyncRemoteTrunkToLocal()
+}
+
+func coworkerCommits(t *testing.T, sh *scenario.Scenario) []string {
+	t.Helper()
+	out, err := sh.Scene.Repo.RunGitCommandAndGetOutput("rev-list", "--reverse", "main..coworker")
+	require.NoError(t, err)
+	return strings.Fields(out)
+}
+
+// --- Squash merges ---------------------------------------------------------
+
+// TestUntrackedCoworkerMultiCommitSquash is the headline failing case: a
+// teammate's MULTI-commit branch is squash-merged into main with no stackit
+// metadata. `git cherry` cannot match the combined squash commit to any
+// individual commit; the aggregate-patch-id scan must detect it even without
+// a recorded PR number so my branch does not inherit the teammate's two
+// pre-squash commits.
+func TestUntrackedCoworkerMultiCommitSquash(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	// Teammate branch: two commits, tracked locally (so I can stack on it) but
+	// NO PR metadata — exactly what a non-stackit collaborator's branch looks
+	// like in my local view.
+	sh.CreateBranch("coworker").
+		CommitChange("shared", "v1").
+		CommitChange("shared", "v1\nv2").
+		TrackBranch("coworker", "main")
+
+	// My branch on top, touching a unique file so replay never conflicts.
+	sh.CreateBranch("mine").
+		CommitChange("mine", "my work").
+		TrackBranch("mine", "coworker")
+
+	// GitHub squash-merges the teammate's branch: one combined commit on main.
+	// The merge landed on the real trunk and was fetched, so origin/main matches.
+	sh.Checkout("main")
+	sh.CommitChange("shared", "v1\nv2")
+	sh.Rebuild()
+	sh.SyncRemoteTrunkToLocal()
+
+	restackMineOntoTrunk(t, sh)
+
+	require.Equal(t, "main", sh.Engine.GetBranch("mine").GetParent().GetName(),
+		"mine should reparent to main past the squash-merged teammate branch")
+	require.Equal(t, 1, mineCommitsAboveTrunk(t, sh),
+		"mine must contain only my own commit, not the teammate's pre-squash commits")
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestUntrackedCoworkerSingleCommitSquash is the control: a SINGLE-commit branch
+// squash-merged with no metadata. Here `git cherry` (cheap IsMerged) CAN match
+// the lone commit to the squash commit, so detection should succeed without any
+// PR number.
+func TestUntrackedCoworkerSingleCommitSquash(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("coworker").
+		CommitChange("shared", "only change").
+		TrackBranch("coworker", "main")
+
+	sh.CreateBranch("mine").
+		CommitChange("mine", "my work").
+		TrackBranch("mine", "coworker")
+
+	sh.Checkout("main")
+	sh.CommitChange("shared", "only change")
+	sh.Rebuild()
+	sh.SyncRemoteTrunkToLocal()
+
+	restackMineOntoTrunk(t, sh)
+
+	require.Equal(t, "main", sh.Engine.GetBranch("mine").GetParent().GetName(),
+		"mine should reparent to main past the single-commit squash")
+	require.Equal(t, 1, mineCommitsAboveTrunk(t, sh),
+		"mine must contain only my own commit")
+	requireCleanWorkingTree(t, sh)
+}
+
+// --- Rebase merges ---------------------------------------------------------
+
+// TestUntrackedCoworkerMultiCommitRebaseMerge covers GitHub "Rebase and merge"
+// of a MULTI-commit teammate branch with no metadata. Each commit is replayed
+// onto main with a new SHA but the same patch-id, so `git cherry` matches every
+// commit and cheap IsMerged detects the merge without a PR number.
+func TestUntrackedCoworkerMultiCommitRebaseMerge(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("coworker").
+		CommitChange("shared", "v1").
+		CommitChange("shared", "v1\nv2").
+		TrackBranch("coworker", "main")
+
+	sh.CreateBranch("mine").
+		CommitChange("mine", "my work").
+		TrackBranch("mine", "coworker")
+
+	rebaseMergeOntoMain(t, sh, coworkerCommits(t, sh))
+
+	restackMineOntoTrunk(t, sh)
+
+	require.Equal(t, "main", sh.Engine.GetBranch("mine").GetParent().GetName(),
+		"mine should reparent to main past the rebase-merged teammate branch")
+	require.Equal(t, 1, mineCommitsAboveTrunk(t, sh),
+		"mine must contain only my own commit after a rebase merge")
+	requireCleanWorkingTree(t, sh)
+}
+
+// TestUntrackedCoworkerSingleCommitRebaseMerge is the single-commit rebase-merge
+// control.
+func TestUntrackedCoworkerSingleCommitRebaseMerge(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	sh.CreateBranch("coworker").
+		CommitChange("shared", "only change").
+		TrackBranch("coworker", "main")
+
+	sh.CreateBranch("mine").
+		CommitChange("mine", "my work").
+		TrackBranch("mine", "coworker")
+
+	rebaseMergeOntoMain(t, sh, coworkerCommits(t, sh))
+
+	restackMineOntoTrunk(t, sh)
+
+	require.Equal(t, "main", sh.Engine.GetBranch("mine").GetParent().GetName(),
+		"mine should reparent to main past the single-commit rebase merge")
+	require.Equal(t, 1, mineCommitsAboveTrunk(t, sh),
+		"mine must contain only my own commit")
+	requireCleanWorkingTree(t, sh)
+}
+
+// --- Fully untracked parent ------------------------------------------------
+
+// TestFullyUntrackedCoworkerMultiCommitSquash is the most literal "zero stackit
+// metadata" case: the teammate branch has NO metadata ref at all (never tracked
+// by stackit). My branch records it as a parent. After a multi-commit squash
+// merge, restack must still strip the teammate's commits.
+func TestFullyUntrackedCoworkerMultiCommitSquash(t *testing.T) {
+	t.Parallel()
+	sh := scenario.NewRemoteScenario(t)
+	disableCommitSigning(t, sh)
+
+	// coworker is a raw git branch with no stackit metadata of its own.
+	sh.CreateBranch("coworker").
+		CommitChange("shared", "v1").
+		CommitChange("shared", "v1\nv2")
+
+	// mine records coworker as parent (the only stackit metadata in play).
+	sh.CreateBranch("mine").
+		CommitChange("mine", "my work").
+		TrackBranch("mine", "coworker")
+
+	sh.Checkout("main")
+	sh.CommitChange("shared", "v1\nv2")
+	sh.Rebuild()
+	sh.SyncRemoteTrunkToLocal()
+
+	restackMineOntoTrunk(t, sh)
+
+	require.Equal(t, 1, mineCommitsAboveTrunk(t, sh),
+		"mine must contain only my own commit even when the merged parent was never tracked")
+	requireCleanWorkingTree(t, sh)
+}

--- a/testhelpers/scenario/scenario.go
+++ b/testhelpers/scenario/scenario.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"testing"
 
@@ -36,6 +37,9 @@ const flagNoInteractive = "--no-interactive"
 
 // branchParent is the default parent branch name used in diamond stack fixtures.
 const branchParent = "parent"
+
+// defaultTrunk is the trunk branch name used by the test scenarios.
+const defaultTrunk = "main"
 
 // SetGlobalInProcessRunner sets the global in-process runner in a thread-safe way.
 func SetGlobalInProcessRunner(runner InProcessRunner) {
@@ -97,7 +101,7 @@ func newScenarioWithScene(t *testing.T, scene *testhelpers.Scene) *Scenario {
 	cfg, _ := config.LoadConfig(scene.Dir)
 	trunk := cfg.Trunk()
 	if trunk == "" {
-		trunk = "main"
+		trunk = defaultTrunk
 	}
 	maxUndoDepth := cfg.UndoStackDepth()
 	if maxUndoDepth <= 0 {
@@ -221,6 +225,28 @@ func (s *Scenario) CommitChange(name, message string) *Scenario {
 	return s
 }
 
+// SyncRemoteTrunkToLocal advances the local remote-tracking ref
+// (refs/remotes/origin/<trunk>) to the current local trunk tip. It models a
+// `git fetch` after the trunk's new commits have already landed on the remote —
+// the "synced trunk" state — without running a full push/fetch round-trip.
+//
+// Use it after advancing local trunk (e.g. simulating a merge by committing on
+// main) so the restack trunk guard sees origin/<trunk> == local trunk. Without
+// it, local trunk looks ahead of the remote, which is the distinct "un-pushed
+// local commits" state the guard is meant to reject.
+func (s *Scenario) SyncRemoteTrunkToLocal() *Scenario {
+	s.T.Helper()
+	trunk := defaultTrunk
+	if s.Engine != nil {
+		trunk = s.Engine.Trunk().GetName()
+	}
+	sha, err := s.Scene.Repo.RunGitCommandAndGetOutput("rev-parse", "--verify", trunk)
+	require.NoError(s.T, err)
+	err = s.Scene.Repo.RunGitCommand("update-ref", "refs/remotes/origin/"+trunk, strings.TrimSpace(sha))
+	require.NoError(s.T, err)
+	return s
+}
+
 // TrackBranch tracks a branch with a parent in the engine.
 func (s *Scenario) TrackBranch(branch, parent string) *Scenario {
 	s.T.Helper()
@@ -236,7 +262,7 @@ func (s *Scenario) WithStack(structure map[string]string) *Scenario {
 	s.T.Helper()
 
 	// Ensure we have an initial commit on main if it's the root
-	if s.Engine.Trunk().GetName() == "main" {
+	if s.Engine.Trunk().GetName() == defaultTrunk {
 		messages, _ := s.Scene.Repo.ListCurrentBranchCommitMessages()
 		if len(messages) == 0 {
 			s.WithInitialCommit()


### PR DESCRIPTION
**Harden restack/sync for multiplayer squash merges and landed branches**

Strengthens detection of work that landed via GitHub squash merges and tightens
restack safety so stacks built in shared repos do not replay already-merged
commits or build on un-pushed trunk.

Key changes:
- **detect squash merges via opt-in IsSquashMerged** (#1346): aggregate patch-id
  scan to recognize multi-commit squash merges that git cherry/ancestry miss.
- **add reflog messages to restack ref moves** (#1357): ref updates during
  restack now carry reflog context for easier recovery and debugging.
- **centralize landed-branch policy** (#1352): single source of truth for the
  landed/merged decision used by sync, restack, and cleanup.
- **squash-aware sync cleanup** (#1351): sync cleanup honors squash-merge
  detection when reparenting/removing landed branches.
- **route restack conflict aborts through standard abort** (#1350): conflict
  aborts use the standard abort path rather than absorb cleanup.
- **guard restack against un-pushed trunk** (#1355): refuse restack when local
  trunk is ahead of / diverged from origin/<trunk>, plus broad sync coverage.
- **document multiplayer collaboration findings** (#1356): docs for landed-work
  detection, the un-pushed trunk guard, and reparent invariants.

This PR merges the following changes:

1. **#1346** feat: detect squash merges via opt-in IsSquashMerged
2. **#1357** fix: add reflog messages to restack ref moves
3. **#1352** refactor: centralize landed branch policy
4. **#1351** fix: squash-aware sync cleanup
5. **#1350** fix: route restack conflict aborts through standard abort, not absorb cleanup
6. **#1355** feat: guard restack against un-pushed trunk and cover sync scenarios
7. **#1356** docs: document multiplayer collaboration findings

### Stack

```
main
  └─ claude/ecstatic-goldberg-xwxg4z (#1346)
    └─ jonnii/20260627025000/add-reflog-messages-to-restack-ref-moves (#1357)
      └─ jonnii/20260627031544/centralize-landed-branch-policy (#1352)
        └─ jonnii/20260627024601/squash-aware-sync-cleanup-and-reflog-messages-on (#1351)
          └─ jonnii/20260627024546/route-restack-conflict-aborts-through-standard (#1350)
            └─ jonnii/20260627151314/guard-restack-against-un-pushed-trunk-and-cover (#1355)
              └─ jonnii/20260627151716/document-multiplayer-collaboration-findings (#1356)
```

Stackit-Stack-Size: 7
Stackit-PRs: 1346,1357,1352,1351,1350,1355,1356
