### PR TITLE
fix: address review findings on stack-aware log

### DIFF
--- a/internal/actions/stacklog/parse_commits_internal_test.go
+++ b/internal/actions/stacklog/parse_commits_internal_test.go
@@ -1,0 +1,27 @@
+package stacklog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseCommits proves the combined SHA+subject record is split correctly and
+// that a record with an empty subject still yields a Commit (it is not dropped) —
+// the failure mode of the previous index-paired two-list approach.
+func TestParseCommits(t *testing.T) {
+	t.Parallel()
+
+	records := []string{
+		"aaaa\x00feat: first",
+		"bbbb\x00", // empty subject: must still produce a Commit
+		"cccc\x00fix: third",
+	}
+
+	got := parseCommits(records)
+	require.Equal(t, []Commit{
+		{SHA: "aaaa", Subject: "feat: first"},
+		{SHA: "bbbb", Subject: ""},
+		{SHA: "cccc", Subject: "fix: third"},
+	}, got)
+}

--- a/internal/actions/stacklog/stacklog.go
+++ b/internal/actions/stacklog/stacklog.go
@@ -7,6 +7,8 @@
 package stacklog
 
 import (
+	"strings"
+
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
 )
@@ -20,12 +22,6 @@ type Source interface {
 	BatchCommits(branches engine.Branches, format engine.CommitFormat) map[string][]string
 	RefDecorations() (map[string][]git.RefDecoration, error)
 	GetRevisionForName(branchName string) (string, error)
-}
-
-// Decoration is a local branch or tag pointing at a commit.
-type Decoration struct {
-	Name  string
-	IsTag bool
 }
 
 // Commit is one commit on a stack branch, identified by its full SHA so the
@@ -47,8 +43,8 @@ type Branch struct {
 //
 // Branches are ordered top-down: the branch you're standing on first, its
 // trunk-most ancestor last; trunk itself is excluded (it's the boundary). When
-// HEAD is on trunk or detached, OnTrunk is true and Branches is empty, so
-// callers render trunk history alone.
+// HEAD is on trunk or detached, Branches is empty, so callers render trunk
+// history alone.
 //
 // Decorations is keyed by full commit SHA and covers every local branch head and
 // tag, so the renderer can annotate both the stack band and the trunk band from
@@ -57,15 +53,14 @@ type Result struct {
 	Branches    []Branch
 	TrunkName   string
 	TrunkTipSHA string // full SHA of the trunk tip, for the boundary marker
-	OnTrunk     bool
-	Decorations map[string][]Decoration
+	Decorations map[string][]git.RefDecoration
 }
 
 // Gather collects the current stack's ancestor-path commits plus the decoration
 // map and trunk-tip marker. It never walks above HEAD (children are out of
 // scope) and excludes trunk from the band.
 func Gather(src Source) (Result, error) {
-	decorations, err := decorationMap(src)
+	decorations, err := src.RefDecorations()
 	if err != nil {
 		return Result{}, err
 	}
@@ -84,21 +79,20 @@ func Gather(src Source) (Result, error) {
 
 	current := src.CurrentBranch()
 	if current == nil || current.IsTrunk() {
-		res.OnTrunk = true
 		return res, nil
 	}
 
 	// Downstack returns the ancestor path trunk-ward→current (trunk excluded).
 	// Reverse it so the branch we're standing on renders at the top.
-	chain := src.Graph(engine.SortStrategyAlphabetical).Downstack(*current, true)
-	branches := reversed(chain)
+	branches := src.Graph(engine.SortStrategyAlphabetical).Downstack(*current, true).Reverse()
 	if len(branches) == 0 {
 		// Current branch is untracked / not in the graph: no stack band to show.
 		return res, nil
 	}
 
-	shaByBranch := src.BatchCommits(branches, engine.CommitFormatSHA)
-	subjectByBranch := src.BatchCommits(branches, engine.CommitFormatSubject)
+	// One combined walk per branch yields both SHA and subject on each record,
+	// so the two never desync (an empty subject can't shift the pairing).
+	commitsByBranch := src.BatchCommits(branches, engine.CommitFormatSHASubject)
 
 	currentName := current.GetName()
 	for _, b := range branches {
@@ -106,47 +100,20 @@ func Gather(src Source) (Result, error) {
 		res.Branches = append(res.Branches, Branch{
 			Name:      name,
 			IsCurrent: name == currentName,
-			Commits:   zipCommits(shaByBranch[name], subjectByBranch[name]),
+			Commits:   parseCommits(commitsByBranch[name]),
 		})
 	}
 	return res, nil
 }
 
-// decorationMap reads ref decorations and converts them to the action type.
-func decorationMap(src Source) (map[string][]Decoration, error) {
-	raw, err := src.RefDecorations()
-	if err != nil {
-		return nil, err
-	}
-	out := make(map[string][]Decoration, len(raw))
-	for sha, refs := range raw {
-		converted := make([]Decoration, len(refs))
-		for i, r := range refs {
-			converted[i] = Decoration{Name: r.Name, IsTag: r.IsTag}
-		}
-		out[sha] = converted
-	}
-	return out, nil
-}
-
-// zipCommits pairs full SHAs with subjects. Both lists come from walking the
-// same branch range in the same (newest-first) order, so they align by index;
-// any length mismatch is defensive and simply truncates to the shorter list.
-func zipCommits(shas, subjects []string) []Commit {
-	n := min(len(shas), len(subjects))
-	commits := make([]Commit, n)
-	for i := range n {
-		commits[i] = Commit{SHA: shas[i], Subject: subjects[i]}
+// parseCommits splits each CommitFormatSHASubject record ("<full-sha>\x00<subject>")
+// into a Commit. A record with a trailing empty subject still yields a Commit with
+// an empty Subject (it is not dropped).
+func parseCommits(records []string) []Commit {
+	commits := make([]Commit, 0, len(records))
+	for _, rec := range records {
+		sha, subject, _ := strings.Cut(rec, "\x00")
+		commits = append(commits, Commit{SHA: sha, Subject: subject})
 	}
 	return commits
-}
-
-// reversed returns the branches in reverse order, so a trunk-ward→current chain
-// becomes current→trunk-ward (top-down for display).
-func reversed(branches engine.Branches) engine.Branches {
-	out := make([]engine.Branch, len(branches))
-	for i, b := range branches {
-		out[len(branches)-1-i] = b
-	}
-	return engine.NewBranches(out)
 }

--- a/internal/actions/stacklog/stacklog_test.go
+++ b/internal/actions/stacklog/stacklog_test.go
@@ -26,7 +26,7 @@ func TestGather_AncestorPathTopDown(t *testing.T) {
 	res, err := stacklog.Gather(s.Engine)
 	require.NoError(t, err)
 
-	require.False(t, res.OnTrunk)
+	require.NotEmpty(t, res.Branches)
 	require.Equal(t, "main", res.TrunkName)
 	require.NotEmpty(t, res.TrunkTipSHA)
 
@@ -65,7 +65,6 @@ func TestGather_OnTrunkHasNoStackBand(t *testing.T) {
 	res, err := stacklog.Gather(s.Engine)
 	require.NoError(t, err)
 
-	require.True(t, res.OnTrunk)
 	require.Empty(t, res.Branches)
 	require.Equal(t, "main", res.TrunkName)
 }

--- a/internal/cli/navigation/log.go
+++ b/internal/cli/navigation/log.go
@@ -14,6 +14,7 @@ import (
 	"github.com/getstackit/stackit/internal/actions/trunklog"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/output"
 )
 
@@ -70,18 +71,22 @@ field changes as breaking.`,
 				// current stack from HEAD down, a trunk boundary, then trunk
 				// history. A range/--since stays a plain changelog.
 				var content string
+				commitCount := len(res.Commits)
 				if req.From == "" {
 					stack, err := stacklog.Gather(ctx.Engine)
 					if err != nil {
 						return err
 					}
 					content = renderDefaultView(stack, res)
+					// The rendered default view includes the stack-band commits
+					// above the divider, so count them too — not just trunk.
+					commitCount += stackBandCommitCount(stack)
 				} else {
 					content = renderLog(res, nil, "", "")
 				}
 
 				if ctx.Interactive {
-					return displayLogPager(content, len(res.Commits))
+					return displayLogPager(content, commitCount)
 				}
 				displayLog(ctx.Output, content)
 				return nil
@@ -153,6 +158,16 @@ func renderDefaultView(stack stacklog.Result, trunk trunklog.Result) string {
 	return strings.Join(sections, "\n")
 }
 
+// stackBandCommitCount totals the commits across every branch in the stack band,
+// so the pager header reflects the stack commits rendered above the divider.
+func stackBandCommitCount(stack stacklog.Result) int {
+	total := 0
+	for _, br := range stack.Branches {
+		total += len(br.Commits)
+	}
+	return total
+}
+
 // renderStackBand renders the current stack's commits grouped by branch, newest
 // branch (HEAD) first. Each branch is a header followed by its commits; the HEAD
 // commit is marked distinctly. Returns "" when there is no stack band (on trunk).
@@ -207,7 +222,7 @@ func renderTrunkDivider(stack stacklog.Result) string {
 // When decos is non-nil each commit is annotated with the branches and tags
 // pointing at it (excluding excludeBranch and the divider's tip SHA, which are
 // already shown elsewhere).
-func renderLog(res trunklog.Result, decos map[string][]stacklog.Decoration, excludeBranch, skipSHA string) string {
+func renderLog(res trunklog.Result, decos map[string][]git.RefDecoration, excludeBranch, skipSHA string) string {
 	if len(res.Commits) == 0 {
 		return ""
 	}
@@ -260,7 +275,7 @@ func renderLog(res trunklog.Result, decos map[string][]stacklog.Decoration, excl
 // formatDecorations renders git-log-style "(tag: v1.0, feature)" annotations.
 // The branch named excludeBranch is omitted (it's already shown as a header or
 // divider label); tags are always shown. Returns "" when nothing remains.
-func formatDecorations(decos []stacklog.Decoration, excludeBranch string) string {
+func formatDecorations(decos []git.RefDecoration, excludeBranch string) string {
 	if len(decos) == 0 {
 		return ""
 	}

--- a/internal/cli/navigation/log_test.go
+++ b/internal/cli/navigation/log_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/actions/stacklog"
 	"github.com/getstackit/stackit/internal/actions/trunklog"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 func TestBuildLogRequest(t *testing.T) {
@@ -99,7 +100,7 @@ func TestRenderDefaultViewStackBandDividerAndDecorations(t *testing.T) {
 				Commits: []stacklog.Commit{{SHA: "e4f5a6b000000000", Subject: "feat: add base types"}},
 			},
 		},
-		Decorations: map[string][]stacklog.Decoration{
+		Decorations: map[string][]git.RefDecoration{
 			// Branch head on the current tip plus a tag — the head is suppressed
 			// (shown as the header), the tag is surfaced.
 			"a1b2c3d000000000": {{Name: "auth-api"}, {Name: "v2.0.0", IsTag: true}},
@@ -129,7 +130,6 @@ func TestRenderDefaultViewOnTrunkIsTrunkOnly(t *testing.T) {
 	stack := stacklog.Result{
 		TrunkName:   "main",
 		TrunkTipSHA: "9f81673000000000",
-		OnTrunk:     true,
 	}
 	trunk := trunklog.Result{Commits: []trunklog.Commit{
 		{SHA: "9f81673000000000", Message: "feat: latest"},
@@ -143,6 +143,19 @@ func TestRenderDefaultViewOnTrunkIsTrunkOnly(t *testing.T) {
 		"──────── main 9f81673 ────────",
 		"9f81673  feat: latest",
 	}, "\n"), plain)
+}
+
+func TestStackBandCommitCount(t *testing.T) {
+	t.Parallel()
+
+	stack := stacklog.Result{
+		Branches: []stacklog.Branch{
+			{Name: "a", Commits: []stacklog.Commit{{SHA: "1"}, {SHA: "2"}}},
+			{Name: "b", Commits: []stacklog.Commit{{SHA: "3"}}},
+		},
+	}
+	require.Equal(t, 3, stackBandCommitCount(stack))
+	require.Equal(t, 0, stackBandCommitCount(stacklog.Result{}))
 }
 
 func TestLogPagerViewUsesAltScreen(t *testing.T) {

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -54,6 +54,11 @@ const (
 	CommitFormatMessage CommitFormat = "MESSAGE" // Full commit message
 	// CommitFormatSubject is the first line of the commit message
 	CommitFormatSubject CommitFormat = "SUBJECT" // First line of commit message
+	// CommitFormatSHASubject pairs the full SHA and subject on one NUL-separated
+	// record per commit ("<full-sha>\x00<subject>"), so callers get both from a
+	// single walk without index-aligning two separate lists. The subject may be
+	// empty; the record is never blank because the SHA is always present.
+	CommitFormatSHASubject CommitFormat = "SHA_SUBJECT"
 )
 
 // Scope represents a branch scope that can be empty, a regular scope, or an inheritance breaker

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -699,6 +699,12 @@ func (r *runner) GetCommitRange(ctx context.Context, base, head, format string) 
 		return r.gitLogLines(ctx, rangeArg, "%h %s")
 	case "SUBJECT":
 		return r.gitLogLines(ctx, rangeArg, "%s")
+	case "SHA_SUBJECT":
+		// NUL-separated full SHA and subject on one record per commit. The line
+		// is never blank (%H is always present) so gitLogLines won't drop a
+		// commit with an empty subject, and the literal NUL survives the split
+		// on "\n". Callers split each entry on "\x00" to recover SHA + subject.
+		return r.gitLogLines(ctx, rangeArg, "%H%x00%s")
 	case "READABLE_WITH_DATE":
 		// Tab-separated: short SHA, RFC3339 UTC date, subject. Use Unix
 		// epoch from git and convert in Go to preserve the prior behavior of


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Single combined commit walk (CommitFormatSHASubject) so SHA and subject
never desync on empty subjects; drop the local reversed() helper for
Branches.Reverse(); remove the dead Result.OnTrunk field; and make the
log pager count include stack-band commits above the divider.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782702987`.


* **PR #1347**
  * **PR #1348**
    * **PR #1349**
      * **PR #1362** 👈
        * **PR #1363**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1364 by jonnii*