### PR TITLE
refactor: share trunk PR-title enrichment between CLI and web

### DIFF
--- a/internal/actions/trunklog/trunklog.go
+++ b/internal/actions/trunklog/trunklog.go
@@ -92,7 +92,7 @@ func resolveTitles(ctx context.Context, titles TitleResolver, commits []git.Rece
 	if titles == nil {
 		return nil
 	}
-	prNumbers := collectStackPRNumbers(commits)
+	prNumbers := git.PRTitleNumbers(commits)
 	if len(prNumbers) == 0 {
 		return nil
 	}
@@ -107,64 +107,21 @@ func resolveTitles(ctx context.Context, titles TitleResolver, commits []git.Rece
 	return resolved
 }
 
-// collectStackPRNumbers gathers the unique PR numbers referenced by the commits:
-// each commit's own PR plus the constituent PRs of stack-merges.
-func collectStackPRNumbers(commits []git.RecentCommit) []int {
-	seen := make(map[int]struct{})
-	var nums []int
-	add := func(n int) {
-		if n == 0 {
-			return
-		}
-		if _, ok := seen[n]; ok {
-			return
-		}
-		seen[n] = struct{}{}
-		nums = append(nums, n)
-	}
-	for _, c := range commits {
-		add(c.PRNumber)
-		for _, pr := range c.StackPRNumbers {
-			add(pr)
-		}
-	}
-	return nums
-}
-
 // toCommit maps a git.RecentCommit to the action Commit, substituting the
 // consolidation PR's title for the raw merge subject and attaching constituent
-// PR titles when available.
+// PR titles when available. The message/title enrichment is shared with the HTTP
+// mapper via the git helpers.
 func toCommit(c git.RecentCommit, prTitles map[int]string) Commit {
-	message := c.Subject
-	if c.StackSize > 0 && c.PRNumber != 0 && len(prTitles) > 0 {
-		if title, ok := prTitles[c.PRNumber]; ok {
-			message = title
-		}
+	return Commit{
+		SHA:           c.SHA,
+		Message:       git.CollapsedMessage(c, prTitles),
+		Author:        c.Author,
+		Date:          c.Date,
+		Kind:          c.Kind,
+		PRNumber:      c.PRNumber,
+		StackSize:     c.StackSize,
+		StackPRs:      append([]int(nil), c.StackPRNumbers...),
+		StackScope:    c.StackScope,
+		StackPRTitles: git.ConstituentPRTitles(c, prTitles),
 	}
-
-	out := Commit{
-		SHA:        c.SHA,
-		Message:    message,
-		Author:     c.Author,
-		Date:       c.Date,
-		Kind:       c.Kind,
-		PRNumber:   c.PRNumber,
-		StackSize:  c.StackSize,
-		StackPRs:   append([]int(nil), c.StackPRNumbers...),
-		StackScope: c.StackScope,
-	}
-
-	if c.StackSize > 0 && len(prTitles) > 0 {
-		stackTitles := make(map[int]string)
-		for _, pr := range c.StackPRNumbers {
-			if title, ok := prTitles[pr]; ok {
-				stackTitles[pr] = title
-			}
-		}
-		if len(stackTitles) > 0 {
-			out.StackPRTitles = stackTitles
-		}
-	}
-
-	return out
 }

--- a/internal/api/handlers/view_assembler.go
+++ b/internal/api/handlers/view_assembler.go
@@ -119,26 +119,8 @@ func (a *ViewAssembler) fetchPRTitles(ctx context.Context, commits []git.RecentC
 		return nil
 	}
 
-	seen := make(map[int]struct{})
-	var prNumbers []int
-	for _, c := range commits {
-		if c.StackSize == 0 {
-			continue
-		}
-		// Include the consolidation PR itself so we can use its title as the display message
-		if c.PRNumber != 0 {
-			if _, ok := seen[c.PRNumber]; !ok {
-				seen[c.PRNumber] = struct{}{}
-				prNumbers = append(prNumbers, c.PRNumber)
-			}
-		}
-		for _, pr := range c.StackPRNumbers {
-			if _, ok := seen[pr]; !ok {
-				seen[pr] = struct{}{}
-				prNumbers = append(prNumbers, pr)
-			}
-		}
-	}
+	// PR-number collection is shared with the `stackit log` command via internal/git.
+	prNumbers := git.PRTitleNumbers(commits)
 	if len(prNumbers) == 0 {
 		return nil
 	}

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -291,38 +291,19 @@ func MapTrunkCommits(commits []git.RecentCommit, prTitles map[int]string) []Trun
 
 	result := make([]TrunkCommitResponse, 0, len(collapsed))
 	for _, c := range collapsed {
-		message := c.Subject
-		// For stack-merge commits, use the consolidation PR's title from GitHub
-		// instead of the raw "Merge pull request #N from ..." subject
-		if c.StackSize > 0 && c.PRNumber != 0 && len(prTitles) > 0 {
-			if title, ok := prTitles[c.PRNumber]; ok {
-				message = title
-			}
-		}
-
+		// Message substitution and constituent-title selection are shared with
+		// the `stackit log` command via internal/git.
 		resp := TrunkCommitResponse{
-			SHA:        shortSHA(c.SHA),
-			Message:    message,
-			Author:     c.Author,
-			Date:       c.Date.Format(time.RFC3339),
-			PRNumber:   c.PRNumber,
-			Kind:       string(c.Kind),
-			StackSize:  c.StackSize,
-			StackPRs:   append([]int(nil), c.StackPRNumbers...),
-			StackScope: c.StackScope,
-		}
-
-		// Populate PR titles for stack-merge commits when available
-		if c.StackSize > 0 && len(prTitles) > 0 {
-			titles := make(map[int]string)
-			for _, pr := range c.StackPRNumbers {
-				if title, ok := prTitles[pr]; ok {
-					titles[pr] = title
-				}
-			}
-			if len(titles) > 0 {
-				resp.StackPRTitles = titles
-			}
+			SHA:           shortSHA(c.SHA),
+			Message:       git.CollapsedMessage(c, prTitles),
+			Author:        c.Author,
+			Date:          c.Date.Format(time.RFC3339),
+			PRNumber:      c.PRNumber,
+			Kind:          string(c.Kind),
+			StackSize:     c.StackSize,
+			StackPRs:      append([]int(nil), c.StackPRNumbers...),
+			StackScope:    c.StackScope,
+			StackPRTitles: git.ConstituentPRTitles(c, prTitles),
 		}
 
 		if resp.Kind == "" {

--- a/internal/git/trunk_collapse.go
+++ b/internal/git/trunk_collapse.go
@@ -6,7 +6,9 @@ package git
 //
 // It is the dedup half shared by the HTTP "recently merged" mapper and the
 // `stackit log` command, so both collapse consolidated stacks identically.
-// PR-title enrichment and presentation shaping stay with each caller.
+// Presentation shaping (terminal vs JSX) stays with each caller; the PR-title
+// enrichment they both need lives in PRTitleNumbers / CollapsedMessage /
+// ConstituentPRTitles below.
 func CollapseStackMerges(commits []RecentCommit) []RecentCommit {
 	// Collect all PR numbers covered by stack-merge consolidation commits.
 	coveredPRs := make(map[int]struct{})
@@ -29,4 +31,67 @@ func CollapseStackMerges(commits []RecentCommit) []RecentCommit {
 		result = append(result, c)
 	}
 	return result
+}
+
+// PRTitleNumbers returns the unique PR numbers whose titles are needed to enrich
+// the given commits: for each stack-merge, its consolidation PR plus its
+// constituent PRs. Regular (non-stack) commits contribute nothing — their PR
+// title is never displayed — so callers don't over-fetch. Order is first-seen
+// stable. Safe to call on either the raw or the collapsed slice: collapse only
+// drops covered regular commits, never stack-merges, so both yield the same set.
+func PRTitleNumbers(commits []RecentCommit) []int {
+	seen := make(map[int]struct{})
+	var nums []int
+	add := func(n int) {
+		if n == 0 {
+			return
+		}
+		if _, ok := seen[n]; ok {
+			return
+		}
+		seen[n] = struct{}{}
+		nums = append(nums, n)
+	}
+	for _, c := range commits {
+		if c.StackSize == 0 {
+			continue
+		}
+		add(c.PRNumber)
+		for _, pr := range c.StackPRNumbers {
+			add(pr)
+		}
+	}
+	return nums
+}
+
+// CollapsedMessage returns the display message for a commit: a stack-merge uses
+// its consolidation PR's title when available, replacing the raw
+// "Merge pull request #N from ..." subject; everything else falls back to the
+// commit subject.
+func CollapsedMessage(c RecentCommit, prTitles map[int]string) string {
+	if c.StackSize > 0 && c.PRNumber != 0 && len(prTitles) > 0 {
+		if title, ok := prTitles[c.PRNumber]; ok {
+			return title
+		}
+	}
+	return c.Subject
+}
+
+// ConstituentPRTitles returns the subset of prTitles keyed by a stack-merge's
+// constituent PR numbers, or nil when the commit is not a stack-merge or no
+// titles apply.
+func ConstituentPRTitles(c RecentCommit, prTitles map[int]string) map[int]string {
+	if c.StackSize == 0 || len(prTitles) == 0 {
+		return nil
+	}
+	titles := make(map[int]string)
+	for _, pr := range c.StackPRNumbers {
+		if title, ok := prTitles[pr]; ok {
+			titles[pr] = title
+		}
+	}
+	if len(titles) == 0 {
+		return nil
+	}
+	return titles
 }

--- a/internal/git/trunk_collapse_test.go
+++ b/internal/git/trunk_collapse_test.go
@@ -70,3 +70,67 @@ func TestCollapseStackMerges(t *testing.T) {
 		})
 	}
 }
+
+func reg(pr int, subject string) git.RecentCommit {
+	return git.RecentCommit{PRNumber: pr, Subject: subject, Kind: git.RecentCommitKindRegular}
+}
+
+func merge(pr int, subject string, prs ...int) git.RecentCommit {
+	return git.RecentCommit{
+		PRNumber:       pr,
+		Subject:        subject,
+		Kind:           git.RecentCommitKindStackMerge,
+		StackSize:      len(prs),
+		StackPRNumbers: prs,
+	}
+}
+
+func TestPRTitleNumbers(t *testing.T) {
+	t.Parallel()
+
+	// Only stack-merges contribute (consolidation PR + constituents), deduped,
+	// first-seen order; regular commits' PRs are never displayed so are skipped.
+	commits := []git.RecentCommit{
+		merge(100, "consolidate", 1, 2),
+		reg(2, "feat: two (#2)"),  // covered constituent — and regular, so ignored
+		reg(9, "feat: nine (#9)"), // surviving regular — still ignored
+	}
+	require.Equal(t, []int{100, 1, 2}, git.PRTitleNumbers(commits))
+
+	require.Empty(t, git.PRTitleNumbers([]git.RecentCommit{reg(9, "feat (#9)")}))
+	require.Empty(t, git.PRTitleNumbers(nil))
+}
+
+func TestCollapsedMessage(t *testing.T) {
+	t.Parallel()
+
+	titles := map[int]string{100: "Consolidated title"}
+
+	// Stack-merge with a known title → title replaces the raw merge subject.
+	require.Equal(t, "Consolidated title",
+		git.CollapsedMessage(merge(100, "Merge pull request #100", 1, 2), titles))
+	// Stack-merge with no title for its PR → falls back to subject.
+	require.Equal(t, "Merge pull request #200",
+		git.CollapsedMessage(merge(200, "Merge pull request #200", 3), titles))
+	// Regular commit → always the subject, even if a title happens to exist.
+	require.Equal(t, "feat: hundred (#100)",
+		git.CollapsedMessage(reg(100, "feat: hundred (#100)"), titles))
+	// Empty subject stays empty.
+	require.Equal(t, "", git.CollapsedMessage(reg(0, ""), nil))
+}
+
+func TestConstituentPRTitles(t *testing.T) {
+	t.Parallel()
+
+	titles := map[int]string{1: "One", 2: "Two", 9: "Nine"}
+
+	// Only the commit's own constituents are selected, not unrelated titles.
+	require.Equal(t, map[int]string{1: "One", 2: "Two"},
+		git.ConstituentPRTitles(merge(100, "m", 1, 2), titles))
+	// Regular commit → nil regardless of titles.
+	require.Nil(t, git.ConstituentPRTitles(reg(1, "feat (#1)"), titles))
+	// Stack-merge whose constituents have no titles → nil, not empty map.
+	require.Nil(t, git.ConstituentPRTitles(merge(100, "m", 7, 8), titles))
+	// No titles available → nil.
+	require.Nil(t, git.ConstituentPRTitles(merge(100, "m", 1), nil))
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The collapse algorithm (git.CollapseStackMerges) was already shared between
the `stackit log` command and the web's Recently Merged view, but the
PR-title enrichment layered on top was duplicated three ways:

- PR-number collection (trunklog.collectStackPRNumbers vs the loop in the
  API view assembler's fetchPRTitles)
- consolidation-PR title substitution (trunklog.toCommit vs MapTrunkCommits)
- constituent-PR title-map building (same two)

Move all three into internal/git alongside CollapseStackMerges as
PRTitleNumbers, CollapsedMessage, and ConstituentPRTitles, which both the
action layer and the contract/handler layer already depend on. Rendering and
per-surface affordances stay separate.

The shared PRTitleNumbers gates on StackSize>0, matching the (tighter) web
behavior: trunklog previously also fetched surviving regular commits' titles,
which it never displayed, so this trims wasted GitHub fetches with no change
in output.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782702987`.


* **PR #1347**
  * **PR #1348**
    * **PR #1349**
      * **PR #1362**
        * **PR #1363** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1364 by jonnii*