### PR TITLE
Merging 5 PRs

### DIFF
--- a/internal/actions/stacklog/parse_commits_internal_test.go
+++ b/internal/actions/stacklog/parse_commits_internal_test.go
@@ -1,0 +1,27 @@
+package stacklog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseCommits proves the combined SHA+subject record is split correctly and
+// that a record with an empty subject still yields a Commit (it is not dropped) —
+// the failure mode of the previous index-paired two-list approach.
+func TestParseCommits(t *testing.T) {
+	t.Parallel()
+
+	records := []string{
+		"aaaa\x00feat: first",
+		"bbbb\x00", // empty subject: must still produce a Commit
+		"cccc\x00fix: third",
+	}
+
+	got := parseCommits(records)
+	require.Equal(t, []Commit{
+		{SHA: "aaaa", Subject: "feat: first"},
+		{SHA: "bbbb", Subject: ""},
+		{SHA: "cccc", Subject: "fix: third"},
+	}, got)
+}

--- a/internal/actions/stacklog/stacklog.go
+++ b/internal/actions/stacklog/stacklog.go
@@ -7,6 +7,8 @@
 package stacklog
 
 import (
+	"strings"
+
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
 )
@@ -20,12 +22,6 @@ type Source interface {
 	BatchCommits(branches engine.Branches, format engine.CommitFormat) map[string][]string
 	RefDecorations() (map[string][]git.RefDecoration, error)
 	GetRevisionForName(branchName string) (string, error)
-}
-
-// Decoration is a local branch or tag pointing at a commit.
-type Decoration struct {
-	Name  string
-	IsTag bool
 }
 
 // Commit is one commit on a stack branch, identified by its full SHA so the
@@ -47,8 +43,8 @@ type Branch struct {
 //
 // Branches are ordered top-down: the branch you're standing on first, its
 // trunk-most ancestor last; trunk itself is excluded (it's the boundary). When
-// HEAD is on trunk or detached, OnTrunk is true and Branches is empty, so
-// callers render trunk history alone.
+// HEAD is on trunk or detached, Branches is empty, so callers render trunk
+// history alone.
 //
 // Decorations is keyed by full commit SHA and covers every local branch head and
 // tag, so the renderer can annotate both the stack band and the trunk band from
@@ -57,15 +53,14 @@ type Result struct {
 	Branches    []Branch
 	TrunkName   string
 	TrunkTipSHA string // full SHA of the trunk tip, for the boundary marker
-	OnTrunk     bool
-	Decorations map[string][]Decoration
+	Decorations map[string][]git.RefDecoration
 }
 
 // Gather collects the current stack's ancestor-path commits plus the decoration
 // map and trunk-tip marker. It never walks above HEAD (children are out of
 // scope) and excludes trunk from the band.
 func Gather(src Source) (Result, error) {
-	decorations, err := decorationMap(src)
+	decorations, err := src.RefDecorations()
 	if err != nil {
 		return Result{}, err
 	}
@@ -84,21 +79,20 @@ func Gather(src Source) (Result, error) {
 
 	current := src.CurrentBranch()
 	if current == nil || current.IsTrunk() {
-		res.OnTrunk = true
 		return res, nil
 	}
 
 	// Downstack returns the ancestor path trunk-ward→current (trunk excluded).
 	// Reverse it so the branch we're standing on renders at the top.
-	chain := src.Graph(engine.SortStrategyAlphabetical).Downstack(*current, true)
-	branches := reversed(chain)
+	branches := src.Graph(engine.SortStrategyAlphabetical).Downstack(*current, true).Reverse()
 	if len(branches) == 0 {
 		// Current branch is untracked / not in the graph: no stack band to show.
 		return res, nil
 	}
 
-	shaByBranch := src.BatchCommits(branches, engine.CommitFormatSHA)
-	subjectByBranch := src.BatchCommits(branches, engine.CommitFormatSubject)
+	// One combined walk per branch yields both SHA and subject on each record,
+	// so the two never desync (an empty subject can't shift the pairing).
+	commitsByBranch := src.BatchCommits(branches, engine.CommitFormatSHASubject)
 
 	currentName := current.GetName()
 	for _, b := range branches {
@@ -106,47 +100,20 @@ func Gather(src Source) (Result, error) {
 		res.Branches = append(res.Branches, Branch{
 			Name:      name,
 			IsCurrent: name == currentName,
-			Commits:   zipCommits(shaByBranch[name], subjectByBranch[name]),
+			Commits:   parseCommits(commitsByBranch[name]),
 		})
 	}
 	return res, nil
 }
 
-// decorationMap reads ref decorations and converts them to the action type.
-func decorationMap(src Source) (map[string][]Decoration, error) {
-	raw, err := src.RefDecorations()
-	if err != nil {
-		return nil, err
-	}
-	out := make(map[string][]Decoration, len(raw))
-	for sha, refs := range raw {
-		converted := make([]Decoration, len(refs))
-		for i, r := range refs {
-			converted[i] = Decoration{Name: r.Name, IsTag: r.IsTag}
-		}
-		out[sha] = converted
-	}
-	return out, nil
-}
-
-// zipCommits pairs full SHAs with subjects. Both lists come from walking the
-// same branch range in the same (newest-first) order, so they align by index;
-// any length mismatch is defensive and simply truncates to the shorter list.
-func zipCommits(shas, subjects []string) []Commit {
-	n := min(len(shas), len(subjects))
-	commits := make([]Commit, n)
-	for i := range n {
-		commits[i] = Commit{SHA: shas[i], Subject: subjects[i]}
+// parseCommits splits each CommitFormatSHASubject record ("<full-sha>\x00<subject>")
+// into a Commit. A record with a trailing empty subject still yields a Commit with
+// an empty Subject (it is not dropped).
+func parseCommits(records []string) []Commit {
+	commits := make([]Commit, 0, len(records))
+	for _, rec := range records {
+		sha, subject, _ := strings.Cut(rec, "\x00")
+		commits = append(commits, Commit{SHA: sha, Subject: subject})
 	}
 	return commits
-}
-
-// reversed returns the branches in reverse order, so a trunk-ward→current chain
-// becomes current→trunk-ward (top-down for display).
-func reversed(branches engine.Branches) engine.Branches {
-	out := make([]engine.Branch, len(branches))
-	for i, b := range branches {
-		out[len(branches)-1-i] = b
-	}
-	return engine.NewBranches(out)
 }

--- a/internal/actions/stacklog/stacklog.go
+++ b/internal/actions/stacklog/stacklog.go
@@ -1,0 +1,152 @@
+// Package stacklog gathers the current stack's commit band for the stack-aware
+// `stackit log` view: the commits on the branch you're standing on and its
+// ancestors down to (but not including) trunk, ordered top-down from HEAD. It
+// also surfaces the branch/tag decorations and trunk-tip marker the renderer
+// needs to draw a git-log-style view with a clear trunk boundary. The result is
+// presentation-agnostic so CLI/JSON adapters can render it however they need.
+package stacklog
+
+import (
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+)
+
+// Source is the narrow engine dependency this action needs. engine.Engine
+// satisfies it.
+type Source interface {
+	CurrentBranch() *engine.Branch
+	Trunk() engine.Branch
+	Graph(strategy engine.SortStrategy) *engine.StackGraph
+	BatchCommits(branches engine.Branches, format engine.CommitFormat) map[string][]string
+	RefDecorations() (map[string][]git.RefDecoration, error)
+	GetRevisionForName(branchName string) (string, error)
+}
+
+// Decoration is a local branch or tag pointing at a commit.
+type Decoration struct {
+	Name  string
+	IsTag bool
+}
+
+// Commit is one commit on a stack branch, identified by its full SHA so the
+// renderer can join it against the decoration map.
+type Commit struct {
+	SHA     string
+	Subject string
+}
+
+// Branch is one branch in the current stack's ancestor path, with its own
+// commits ordered newest-first (the branch tip first).
+type Branch struct {
+	Name      string
+	IsCurrent bool
+	Commits   []Commit
+}
+
+// Result is the gathered stack band.
+//
+// Branches are ordered top-down: the branch you're standing on first, its
+// trunk-most ancestor last; trunk itself is excluded (it's the boundary). When
+// HEAD is on trunk or detached, OnTrunk is true and Branches is empty, so
+// callers render trunk history alone.
+//
+// Decorations is keyed by full commit SHA and covers every local branch head and
+// tag, so the renderer can annotate both the stack band and the trunk band from
+// one map.
+type Result struct {
+	Branches    []Branch
+	TrunkName   string
+	TrunkTipSHA string // full SHA of the trunk tip, for the boundary marker
+	OnTrunk     bool
+	Decorations map[string][]Decoration
+}
+
+// Gather collects the current stack's ancestor-path commits plus the decoration
+// map and trunk-tip marker. It never walks above HEAD (children are out of
+// scope) and excludes trunk from the band.
+func Gather(src Source) (Result, error) {
+	decorations, err := decorationMap(src)
+	if err != nil {
+		return Result{}, err
+	}
+
+	trunk := src.Trunk()
+	trunkTip, err := src.GetRevisionForName(trunk.GetName())
+	if err != nil {
+		return Result{}, err
+	}
+
+	res := Result{
+		TrunkName:   trunk.GetName(),
+		TrunkTipSHA: trunkTip,
+		Decorations: decorations,
+	}
+
+	current := src.CurrentBranch()
+	if current == nil || current.IsTrunk() {
+		res.OnTrunk = true
+		return res, nil
+	}
+
+	// Downstack returns the ancestor path trunk-ward→current (trunk excluded).
+	// Reverse it so the branch we're standing on renders at the top.
+	chain := src.Graph(engine.SortStrategyAlphabetical).Downstack(*current, true)
+	branches := reversed(chain)
+	if len(branches) == 0 {
+		// Current branch is untracked / not in the graph: no stack band to show.
+		return res, nil
+	}
+
+	shaByBranch := src.BatchCommits(branches, engine.CommitFormatSHA)
+	subjectByBranch := src.BatchCommits(branches, engine.CommitFormatSubject)
+
+	currentName := current.GetName()
+	for _, b := range branches {
+		name := b.GetName()
+		res.Branches = append(res.Branches, Branch{
+			Name:      name,
+			IsCurrent: name == currentName,
+			Commits:   zipCommits(shaByBranch[name], subjectByBranch[name]),
+		})
+	}
+	return res, nil
+}
+
+// decorationMap reads ref decorations and converts them to the action type.
+func decorationMap(src Source) (map[string][]Decoration, error) {
+	raw, err := src.RefDecorations()
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string][]Decoration, len(raw))
+	for sha, refs := range raw {
+		converted := make([]Decoration, len(refs))
+		for i, r := range refs {
+			converted[i] = Decoration{Name: r.Name, IsTag: r.IsTag}
+		}
+		out[sha] = converted
+	}
+	return out, nil
+}
+
+// zipCommits pairs full SHAs with subjects. Both lists come from walking the
+// same branch range in the same (newest-first) order, so they align by index;
+// any length mismatch is defensive and simply truncates to the shorter list.
+func zipCommits(shas, subjects []string) []Commit {
+	n := min(len(shas), len(subjects))
+	commits := make([]Commit, n)
+	for i := range n {
+		commits[i] = Commit{SHA: shas[i], Subject: subjects[i]}
+	}
+	return commits
+}
+
+// reversed returns the branches in reverse order, so a trunk-ward→current chain
+// becomes current→trunk-ward (top-down for display).
+func reversed(branches engine.Branches) engine.Branches {
+	out := make([]engine.Branch, len(branches))
+	for i, b := range branches {
+		out[len(branches)-1-i] = b
+	}
+	return engine.NewBranches(out)
+}

--- a/internal/actions/stacklog/stacklog_test.go
+++ b/internal/actions/stacklog/stacklog_test.go
@@ -26,7 +26,7 @@ func TestGather_AncestorPathTopDown(t *testing.T) {
 	res, err := stacklog.Gather(s.Engine)
 	require.NoError(t, err)
 
-	require.False(t, res.OnTrunk)
+	require.NotEmpty(t, res.Branches)
 	require.Equal(t, "main", res.TrunkName)
 	require.NotEmpty(t, res.TrunkTipSHA)
 
@@ -65,7 +65,6 @@ func TestGather_OnTrunkHasNoStackBand(t *testing.T) {
 	res, err := stacklog.Gather(s.Engine)
 	require.NoError(t, err)
 
-	require.True(t, res.OnTrunk)
 	require.Empty(t, res.Branches)
 	require.Equal(t, "main", res.TrunkName)
 }

--- a/internal/actions/stacklog/stacklog_test.go
+++ b/internal/actions/stacklog/stacklog_test.go
@@ -1,0 +1,98 @@
+package stacklog_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions/stacklog"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+func branchNames(res stacklog.Result) []string {
+	names := make([]string, len(res.Branches))
+	for i, b := range res.Branches {
+		names[i] = b.Name
+	}
+	return names
+}
+
+func TestGather_AncestorPathTopDown(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).WithLinearStack3()
+	s.Checkout("c")
+
+	res, err := stacklog.Gather(s.Engine)
+	require.NoError(t, err)
+
+	require.False(t, res.OnTrunk)
+	require.Equal(t, "main", res.TrunkName)
+	require.NotEmpty(t, res.TrunkTipSHA)
+
+	// Current branch first, trunk-most ancestor last; trunk excluded.
+	require.Equal(t, []string{"c", "b", "a"}, branchNames(res))
+
+	require.True(t, res.Branches[0].IsCurrent, "c should be marked current")
+	require.False(t, res.Branches[1].IsCurrent)
+
+	// Each branch carries its own commit with a full SHA and readable subject.
+	for _, b := range res.Branches {
+		require.NotEmpty(t, b.Commits, "branch %s should have commits", b.Name)
+		require.Len(t, b.Commits[0].SHA, 40, "expected full SHA for %s", b.Name)
+		require.Contains(t, b.Commits[0].Subject, "change on "+b.Name)
+	}
+}
+
+func TestGather_FromMiddleOfStackExcludesChildren(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).WithLinearStack3()
+	s.Checkout("b")
+
+	res, err := stacklog.Gather(s.Engine)
+	require.NoError(t, err)
+
+	// Standing on b: only b and its ancestor a; child c is out of scope.
+	require.Equal(t, []string{"b", "a"}, branchNames(res))
+	require.True(t, res.Branches[0].IsCurrent)
+}
+
+func TestGather_OnTrunkHasNoStackBand(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).WithLinearStack3()
+	s.Checkout("main")
+
+	res, err := stacklog.Gather(s.Engine)
+	require.NoError(t, err)
+
+	require.True(t, res.OnTrunk)
+	require.Empty(t, res.Branches)
+	require.Equal(t, "main", res.TrunkName)
+}
+
+func TestGather_DecorationsIncludeBranchesAndTags(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).WithLinearStack3()
+	s.Checkout("c")
+	require.NoError(t, s.Scene.Repo.RunGitCommand("tag", "-a", "v1.0.0", "-m", "release"))
+
+	res, err := stacklog.Gather(s.Engine)
+	require.NoError(t, err)
+
+	// The tag on c's tip resolves to c's tip commit, alongside the branch head.
+	tipSHA := res.Branches[0].Commits[0].SHA
+	decos := res.Decorations[tipSHA]
+	require.NotEmpty(t, decos)
+
+	var sawBranch, sawTag bool
+	for _, d := range decos {
+		switch {
+		case d.IsTag && d.Name == "v1.0.0":
+			sawTag = true
+		case !d.IsTag && d.Name == "c":
+			sawBranch = true
+		}
+	}
+	require.True(t, sawBranch, "expected branch head 'c' decoration: %+v", decos)
+	require.True(t, sawTag, "expected annotated tag 'v1.0.0' decoration: %+v", decos)
+}

--- a/internal/actions/trunklog/trunklog.go
+++ b/internal/actions/trunklog/trunklog.go
@@ -92,7 +92,7 @@ func resolveTitles(ctx context.Context, titles TitleResolver, commits []git.Rece
 	if titles == nil {
 		return nil
 	}
-	prNumbers := collectStackPRNumbers(commits)
+	prNumbers := git.PRTitleNumbers(commits)
 	if len(prNumbers) == 0 {
 		return nil
 	}
@@ -107,64 +107,21 @@ func resolveTitles(ctx context.Context, titles TitleResolver, commits []git.Rece
 	return resolved
 }
 
-// collectStackPRNumbers gathers the unique PR numbers referenced by the commits:
-// each commit's own PR plus the constituent PRs of stack-merges.
-func collectStackPRNumbers(commits []git.RecentCommit) []int {
-	seen := make(map[int]struct{})
-	var nums []int
-	add := func(n int) {
-		if n == 0 {
-			return
-		}
-		if _, ok := seen[n]; ok {
-			return
-		}
-		seen[n] = struct{}{}
-		nums = append(nums, n)
-	}
-	for _, c := range commits {
-		add(c.PRNumber)
-		for _, pr := range c.StackPRNumbers {
-			add(pr)
-		}
-	}
-	return nums
-}
-
 // toCommit maps a git.RecentCommit to the action Commit, substituting the
 // consolidation PR's title for the raw merge subject and attaching constituent
-// PR titles when available.
+// PR titles when available. The message/title enrichment is shared with the HTTP
+// mapper via the git helpers.
 func toCommit(c git.RecentCommit, prTitles map[int]string) Commit {
-	message := c.Subject
-	if c.StackSize > 0 && c.PRNumber != 0 && len(prTitles) > 0 {
-		if title, ok := prTitles[c.PRNumber]; ok {
-			message = title
-		}
+	return Commit{
+		SHA:           c.SHA,
+		Message:       git.CollapsedMessage(c, prTitles),
+		Author:        c.Author,
+		Date:          c.Date,
+		Kind:          c.Kind,
+		PRNumber:      c.PRNumber,
+		StackSize:     c.StackSize,
+		StackPRs:      append([]int(nil), c.StackPRNumbers...),
+		StackScope:    c.StackScope,
+		StackPRTitles: git.ConstituentPRTitles(c, prTitles),
 	}
-
-	out := Commit{
-		SHA:        c.SHA,
-		Message:    message,
-		Author:     c.Author,
-		Date:       c.Date,
-		Kind:       c.Kind,
-		PRNumber:   c.PRNumber,
-		StackSize:  c.StackSize,
-		StackPRs:   append([]int(nil), c.StackPRNumbers...),
-		StackScope: c.StackScope,
-	}
-
-	if c.StackSize > 0 && len(prTitles) > 0 {
-		stackTitles := make(map[int]string)
-		for _, pr := range c.StackPRNumbers {
-			if title, ok := prTitles[pr]; ok {
-				stackTitles[pr] = title
-			}
-		}
-		if len(stackTitles) > 0 {
-			out.StackPRTitles = stackTitles
-		}
-	}
-
-	return out
 }

--- a/internal/api/handlers/view_assembler.go
+++ b/internal/api/handlers/view_assembler.go
@@ -119,26 +119,8 @@ func (a *ViewAssembler) fetchPRTitles(ctx context.Context, commits []git.RecentC
 		return nil
 	}
 
-	seen := make(map[int]struct{})
-	var prNumbers []int
-	for _, c := range commits {
-		if c.StackSize == 0 {
-			continue
-		}
-		// Include the consolidation PR itself so we can use its title as the display message
-		if c.PRNumber != 0 {
-			if _, ok := seen[c.PRNumber]; !ok {
-				seen[c.PRNumber] = struct{}{}
-				prNumbers = append(prNumbers, c.PRNumber)
-			}
-		}
-		for _, pr := range c.StackPRNumbers {
-			if _, ok := seen[pr]; !ok {
-				seen[pr] = struct{}{}
-				prNumbers = append(prNumbers, pr)
-			}
-		}
-	}
+	// PR-number collection is shared with the `stackit log` command via internal/git.
+	prNumbers := git.PRTitleNumbers(commits)
 	if len(prNumbers) == 0 {
 		return nil
 	}

--- a/internal/cli/navigation/log.go
+++ b/internal/cli/navigation/log.go
@@ -14,6 +14,7 @@ import (
 	"github.com/getstackit/stackit/internal/actions/trunklog"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/output"
 )
 
@@ -70,18 +71,22 @@ field changes as breaking.`,
 				// current stack from HEAD down, a trunk boundary, then trunk
 				// history. A range/--since stays a plain changelog.
 				var content string
+				commitCount := len(res.Commits)
 				if req.From == "" {
 					stack, err := stacklog.Gather(ctx.Engine)
 					if err != nil {
 						return err
 					}
 					content = renderDefaultView(stack, res)
+					// The rendered default view includes the stack-band commits
+					// above the divider, so count them too — not just trunk.
+					commitCount += stackBandCommitCount(stack)
 				} else {
 					content = renderLog(res, nil, "", "")
 				}
 
 				if ctx.Interactive {
-					return displayLogPager(content, len(res.Commits))
+					return displayLogPager(content, commitCount)
 				}
 				displayLog(ctx.Output, content)
 				return nil
@@ -153,6 +158,16 @@ func renderDefaultView(stack stacklog.Result, trunk trunklog.Result) string {
 	return strings.Join(sections, "\n")
 }
 
+// stackBandCommitCount totals the commits across every branch in the stack band,
+// so the pager header reflects the stack commits rendered above the divider.
+func stackBandCommitCount(stack stacklog.Result) int {
+	total := 0
+	for _, br := range stack.Branches {
+		total += len(br.Commits)
+	}
+	return total
+}
+
 // renderStackBand renders the current stack's commits grouped by branch, newest
 // branch (HEAD) first. Each branch is a header followed by its commits; the HEAD
 // commit is marked distinctly. Returns "" when there is no stack band (on trunk).
@@ -207,7 +222,7 @@ func renderTrunkDivider(stack stacklog.Result) string {
 // When decos is non-nil each commit is annotated with the branches and tags
 // pointing at it (excluding excludeBranch and the divider's tip SHA, which are
 // already shown elsewhere).
-func renderLog(res trunklog.Result, decos map[string][]stacklog.Decoration, excludeBranch, skipSHA string) string {
+func renderLog(res trunklog.Result, decos map[string][]git.RefDecoration, excludeBranch, skipSHA string) string {
 	if len(res.Commits) == 0 {
 		return ""
 	}
@@ -260,7 +275,7 @@ func renderLog(res trunklog.Result, decos map[string][]stacklog.Decoration, excl
 // formatDecorations renders git-log-style "(tag: v1.0, feature)" annotations.
 // The branch named excludeBranch is omitted (it's already shown as a header or
 // divider label); tags are always shown. Returns "" when nothing remains.
-func formatDecorations(decos []stacklog.Decoration, excludeBranch string) string {
+func formatDecorations(decos []git.RefDecoration, excludeBranch string) string {
 	if len(decos) == 0 {
 		return ""
 	}

--- a/internal/cli/navigation/log.go
+++ b/internal/cli/navigation/log.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/getstackit/stackit/internal/actions/stacklog"
 	"github.com/getstackit/stackit/internal/actions/trunklog"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/cli/common"
@@ -26,16 +27,19 @@ func NewLogCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "log [<from>..<to>]",
-		Short: "Show trunk commit history with stacks collapsed",
-		Long: `Show the trunk commit history, collapsing each consolidated stack-merge into a
-single entry that lists its constituent PRs (mirrors the web app's Recently
-Merged view).
+		Short: "Show your current stack and recent trunk history",
+		Long: `Show a stack-aware commit history.
 
-With no arguments it shows the most recent trunk commits. Pass a revision range
-to produce a changelog between two refs.
+With no arguments it shows the commits in your current stack from where you are
+(the branch you're on and its ancestors, grouped by branch with branch and tag
+decorations), a clear trunk boundary, then the recent trunk history below it with
+consolidated stack-merges collapsed into a single entry (mirrors the web app's
+Recently Merged view). On trunk it shows trunk history alone.
+
+Pass a revision range to produce a plain changelog between two refs instead.
 
 Examples:
-  stackit log                      # recent trunk history (stacks collapsed)
+  stackit log                      # current stack + recent trunk history
   stackit log v1.4.0..main         # changelog between two refs
   stackit log --since v1.4.0       # everything since v1.4.0 up to the trunk tip
   stackit log --json v1.4.0..main  # machine-readable (used by release tooling)
@@ -61,10 +65,25 @@ field changes as breaking.`,
 				if jsonOut {
 					return printLogJSON(ctx.Output, res)
 				}
-				if ctx.Interactive {
-					return displayLogPager(res)
+
+				// The default (no-range) view is stack-aware: it shows the
+				// current stack from HEAD down, a trunk boundary, then trunk
+				// history. A range/--since stays a plain changelog.
+				var content string
+				if req.From == "" {
+					stack, err := stacklog.Gather(ctx.Engine)
+					if err != nil {
+						return err
+					}
+					content = renderDefaultView(stack, res)
+				} else {
+					content = renderLog(res, nil, "", "")
 				}
-				displayLog(ctx.Output, res)
+
+				if ctx.Interactive {
+					return displayLogPager(content, len(res.Commits))
+				}
+				displayLog(ctx.Output, content)
 				return nil
 			})
 		},
@@ -101,20 +120,94 @@ func buildLogRequest(args []string, since string, count int) (trunklog.Request, 
 	}
 }
 
-// displayLog renders the gathered trunk history as a terminal list, mirroring the
-// web "Recently Merged" panel: one line per collapsed commit, with stack-merges
-// expanding into their constituent PRs.
-func displayLog(out output.Output, res trunklog.Result) {
-	rendered := renderLog(res)
-	if rendered == "" {
+// displayLog prints already-rendered log content, falling back to a placeholder
+// when there is nothing to show.
+func displayLog(out output.Output, content string) {
+	if content == "" {
 		out.Println(output.Dim("No commits."))
 		return
 	}
-	out.Print(rendered)
+	out.Print(content)
 	out.Newline()
 }
 
-func renderLog(res trunklog.Result) string {
+// stackCommitSymbol marks the HEAD commit; otherSymbol marks every other commit
+// in the current stack band.
+const (
+	stackHeadSymbol  = "◉"
+	stackOtherSymbol = "◯"
+)
+
+// renderDefaultView composes the stack-aware default view: the current stack
+// from HEAD down (when not on trunk), a trunk boundary line, and the decorated
+// trunk history below it.
+func renderDefaultView(stack stacklog.Result, trunk trunklog.Result) string {
+	var sections []string
+	if band := renderStackBand(stack); band != "" {
+		sections = append(sections, band)
+	}
+	sections = append(sections, renderTrunkDivider(stack))
+	if body := renderLog(trunk, stack.Decorations, stack.TrunkName, stack.TrunkTipSHA); body != "" {
+		sections = append(sections, body)
+	}
+	return strings.Join(sections, "\n")
+}
+
+// renderStackBand renders the current stack's commits grouped by branch, newest
+// branch (HEAD) first. Each branch is a header followed by its commits; the HEAD
+// commit is marked distinctly. Returns "" when there is no stack band (on trunk).
+func renderStackBand(stack stacklog.Result) string {
+	if len(stack.Branches) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for bi, br := range stack.Branches {
+		if bi > 0 {
+			b.WriteString("\n")
+		}
+		if br.IsCurrent {
+			b.WriteString(output.Green(br.Name))
+		} else {
+			b.WriteString(output.Cyan(br.Name))
+		}
+		for ci, c := range br.Commits {
+			symbol := output.Dim(stackOtherSymbol)
+			if br.IsCurrent && ci == 0 {
+				symbol = output.Green(stackHeadSymbol)
+			}
+			b.WriteString("\n  ")
+			b.WriteString(symbol)
+			b.WriteString(" ")
+			b.WriteString(output.Yellow(shortSHA(c.SHA)))
+			b.WriteString("  ")
+			b.WriteString(c.Subject)
+			// The branch's own head ref is the header above; omit it here, but
+			// still surface tags and any other branch pointing at this commit.
+			if deco := formatDecorations(stack.Decorations[c.SHA], br.Name); deco != "" {
+				b.WriteString(" ")
+				b.WriteString(deco)
+			}
+		}
+	}
+	return b.String()
+}
+
+// renderTrunkDivider draws the boundary between the stack and trunk history,
+// labeled with the trunk name, its short tip SHA, and any tags on the tip.
+func renderTrunkDivider(stack stacklog.Result) string {
+	label := output.Cyan(stack.TrunkName) + " " + output.Yellow(shortSHA(stack.TrunkTipSHA))
+	if deco := formatDecorations(stack.Decorations[stack.TrunkTipSHA], stack.TrunkName); deco != "" {
+		label += " " + deco
+	}
+	return output.Dim("──────── ") + label + output.Dim(" ────────")
+}
+
+// renderLog renders trunk history, mirroring the web "Recently Merged" panel:
+// one line per collapsed commit, stack-merges expanding into constituent PRs.
+// When decos is non-nil each commit is annotated with the branches and tags
+// pointing at it (excluding excludeBranch and the divider's tip SHA, which are
+// already shown elsewhere).
+func renderLog(res trunklog.Result, decos map[string][]stacklog.Decoration, excludeBranch, skipSHA string) string {
 	if len(res.Commits) == 0 {
 		return ""
 	}
@@ -152,17 +245,47 @@ func renderLog(res trunklog.Result) string {
 			b.WriteString(" ")
 			b.WriteString(output.Cyan(fmt.Sprintf("(#%d)", c.PRNumber)))
 		}
+
+		if c.SHA != skipSHA {
+			if deco := formatDecorations(decos[c.SHA], excludeBranch); deco != "" {
+				b.WriteString(" ")
+				b.WriteString(deco)
+			}
+		}
 	}
 
 	return b.String()
 }
 
-func displayLogPager(res trunklog.Result) error {
-	content := renderLog(res)
+// formatDecorations renders git-log-style "(tag: v1.0, feature)" annotations.
+// The branch named excludeBranch is omitted (it's already shown as a header or
+// divider label); tags are always shown. Returns "" when nothing remains.
+func formatDecorations(decos []stacklog.Decoration, excludeBranch string) string {
+	if len(decos) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(decos))
+	for _, d := range decos {
+		switch {
+		case d.IsTag:
+			parts = append(parts, output.Yellow("tag: "+d.Name))
+		case d.Name == excludeBranch:
+			continue
+		default:
+			parts = append(parts, output.Cyan(d.Name))
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return output.Dim("(") + strings.Join(parts, output.Dim(", ")) + output.Dim(")")
+}
+
+func displayLogPager(content string, commitCount int) error {
 	if content == "" {
 		content = output.Dim("No commits.")
 	}
-	model := newLogPagerModel(content, len(res.Commits))
+	model := newLogPagerModel(content, commitCount)
 	_, err := tea.NewProgram(model, tea.WithInput(os.Stdin), tea.WithOutput(os.Stdout)).Run()
 	return err
 }

--- a/internal/cli/navigation/log_test.go
+++ b/internal/cli/navigation/log_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/actions/stacklog"
 	"github.com/getstackit/stackit/internal/actions/trunklog"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 func TestBuildLogRequest(t *testing.T) {
@@ -99,7 +100,7 @@ func TestRenderDefaultViewStackBandDividerAndDecorations(t *testing.T) {
 				Commits: []stacklog.Commit{{SHA: "e4f5a6b000000000", Subject: "feat: add base types"}},
 			},
 		},
-		Decorations: map[string][]stacklog.Decoration{
+		Decorations: map[string][]git.RefDecoration{
 			// Branch head on the current tip plus a tag — the head is suppressed
 			// (shown as the header), the tag is surfaced.
 			"a1b2c3d000000000": {{Name: "auth-api"}, {Name: "v2.0.0", IsTag: true}},
@@ -129,7 +130,6 @@ func TestRenderDefaultViewOnTrunkIsTrunkOnly(t *testing.T) {
 	stack := stacklog.Result{
 		TrunkName:   "main",
 		TrunkTipSHA: "9f81673000000000",
-		OnTrunk:     true,
 	}
 	trunk := trunklog.Result{Commits: []trunklog.Commit{
 		{SHA: "9f81673000000000", Message: "feat: latest"},
@@ -143,6 +143,19 @@ func TestRenderDefaultViewOnTrunkIsTrunkOnly(t *testing.T) {
 		"──────── main 9f81673 ────────",
 		"9f81673  feat: latest",
 	}, "\n"), plain)
+}
+
+func TestStackBandCommitCount(t *testing.T) {
+	t.Parallel()
+
+	stack := stacklog.Result{
+		Branches: []stacklog.Branch{
+			{Name: "a", Commits: []stacklog.Commit{{SHA: "1"}, {SHA: "2"}}},
+			{Name: "b", Commits: []stacklog.Commit{{SHA: "3"}}},
+		},
+	}
+	require.Equal(t, 3, stackBandCommitCount(stack))
+	require.Equal(t, 0, stackBandCommitCount(stacklog.Result{}))
 }
 
 func TestLogPagerViewUsesAltScreen(t *testing.T) {

--- a/internal/cli/navigation/log_test.go
+++ b/internal/cli/navigation/log_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 
+	"github.com/getstackit/stackit/internal/actions/stacklog"
 	"github.com/getstackit/stackit/internal/actions/trunklog"
 )
 
@@ -63,7 +64,7 @@ func TestRenderLogUsesColorAndPlainStructure(t *testing.T) {
 			StackPRs:      []int{10, 11},
 			StackPRTitles: map[int]string{10: "first", 11: "second"},
 		},
-	}})
+	}}, nil, "", "")
 
 	require.Contains(t, got, "\x1b[")
 	plain := ansi.Strip(got)
@@ -78,7 +79,70 @@ func TestRenderLogUsesColorAndPlainStructure(t *testing.T) {
 func TestRenderLogEmpty(t *testing.T) {
 	t.Parallel()
 
-	require.Empty(t, renderLog(trunklog.Result{}))
+	require.Empty(t, renderLog(trunklog.Result{}, nil, "", ""))
+}
+
+func TestRenderDefaultViewStackBandDividerAndDecorations(t *testing.T) {
+	t.Parallel()
+
+	stack := stacklog.Result{
+		TrunkName:   "main",
+		TrunkTipSHA: "9f81673000000000",
+		Branches: []stacklog.Branch{
+			{
+				Name:      "auth-api",
+				IsCurrent: true,
+				Commits:   []stacklog.Commit{{SHA: "a1b2c3d000000000", Subject: "feat: wire auth API"}},
+			},
+			{
+				Name:    "auth-base",
+				Commits: []stacklog.Commit{{SHA: "e4f5a6b000000000", Subject: "feat: add base types"}},
+			},
+		},
+		Decorations: map[string][]stacklog.Decoration{
+			// Branch head on the current tip plus a tag — the head is suppressed
+			// (shown as the header), the tag is surfaced.
+			"a1b2c3d000000000": {{Name: "auth-api"}, {Name: "v2.0.0", IsTag: true}},
+			// A release tag down in trunk history.
+			"89e1be9000000000": {{Name: "v1.4.0", IsTag: true}},
+		},
+	}
+	trunk := trunklog.Result{Commits: []trunklog.Commit{
+		{SHA: "89e1be9000000000", Message: "feat: configure metadata", PRNumber: 1338},
+	}}
+
+	plain := ansi.Strip(renderDefaultView(stack, trunk))
+
+	require.Equal(t, strings.Join([]string{
+		"auth-api",
+		"  ◉ a1b2c3d  feat: wire auth API (tag: v2.0.0)",
+		"auth-base",
+		"  ◯ e4f5a6b  feat: add base types",
+		"──────── main 9f81673 ────────",
+		"89e1be9  feat: configure metadata (#1338) (tag: v1.4.0)",
+	}, "\n"), plain)
+}
+
+func TestRenderDefaultViewOnTrunkIsTrunkOnly(t *testing.T) {
+	t.Parallel()
+
+	stack := stacklog.Result{
+		TrunkName:   "main",
+		TrunkTipSHA: "9f81673000000000",
+		OnTrunk:     true,
+	}
+	trunk := trunklog.Result{Commits: []trunklog.Commit{
+		{SHA: "9f81673000000000", Message: "feat: latest"},
+	}}
+
+	plain := ansi.Strip(renderDefaultView(stack, trunk))
+
+	// No stack band; the divider (with the tip skipped from decoration) leads
+	// straight into trunk history.
+	require.Equal(t, strings.Join([]string{
+		"──────── main 9f81673 ────────",
+		"9f81673  feat: latest",
+	}, "\n"), plain)
 }
 
 func TestLogPagerViewUsesAltScreen(t *testing.T) {

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -291,38 +291,19 @@ func MapTrunkCommits(commits []git.RecentCommit, prTitles map[int]string) []Trun
 
 	result := make([]TrunkCommitResponse, 0, len(collapsed))
 	for _, c := range collapsed {
-		message := c.Subject
-		// For stack-merge commits, use the consolidation PR's title from GitHub
-		// instead of the raw "Merge pull request #N from ..." subject
-		if c.StackSize > 0 && c.PRNumber != 0 && len(prTitles) > 0 {
-			if title, ok := prTitles[c.PRNumber]; ok {
-				message = title
-			}
-		}
-
+		// Message substitution and constituent-title selection are shared with
+		// the `stackit log` command via internal/git.
 		resp := TrunkCommitResponse{
-			SHA:        shortSHA(c.SHA),
-			Message:    message,
-			Author:     c.Author,
-			Date:       c.Date.Format(time.RFC3339),
-			PRNumber:   c.PRNumber,
-			Kind:       string(c.Kind),
-			StackSize:  c.StackSize,
-			StackPRs:   append([]int(nil), c.StackPRNumbers...),
-			StackScope: c.StackScope,
-		}
-
-		// Populate PR titles for stack-merge commits when available
-		if c.StackSize > 0 && len(prTitles) > 0 {
-			titles := make(map[int]string)
-			for _, pr := range c.StackPRNumbers {
-				if title, ok := prTitles[pr]; ok {
-					titles[pr] = title
-				}
-			}
-			if len(titles) > 0 {
-				resp.StackPRTitles = titles
-			}
+			SHA:           shortSHA(c.SHA),
+			Message:       git.CollapsedMessage(c, prTitles),
+			Author:        c.Author,
+			Date:          c.Date.Format(time.RFC3339),
+			PRNumber:      c.PRNumber,
+			Kind:          string(c.Kind),
+			StackSize:     c.StackSize,
+			StackPRs:      append([]int(nil), c.StackPRNumbers...),
+			StackScope:    c.StackScope,
+			StackPRTitles: git.ConstituentPRTitles(c, prTitles),
 		}
 
 		if resp.Kind == "" {

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -604,6 +604,10 @@ func (d *demoGitRunner) ListRefs(_ string) (map[string]string, error) {
 	return make(map[string]string), nil
 }
 
+func (d *demoGitRunner) RefDecorations() (map[string][]git.RefDecoration, error) {
+	return make(map[string][]git.RefDecoration), nil
+}
+
 func (d *demoGitRunner) ReadMetadata(_ string) (*git.Meta, error) {
 	return git.NewMeta(), nil
 }

--- a/internal/engine/engine_reader.go
+++ b/internal/engine/engine_reader.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 
 	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // AllBranches returns all branches.
@@ -232,6 +233,13 @@ func (e *engineImpl) FindBranchesForCommits(commitSHAs []string) map[string]stri
 	}
 
 	return result
+}
+
+// RefDecorations returns local branch and tag refs grouped by the commit SHA
+// they point at, for git-log-style annotations. Annotated tags are dereferenced
+// to the commit they wrap. Thin passthrough to the git layer.
+func (e *engineImpl) RefDecorations() (map[string][]git.RefDecoration, error) {
+	return e.git.RefDecorations()
 }
 
 // SortBranchesTopologically sorts branches so parents come before children.

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -23,6 +23,9 @@ type StackNavigator interface {
 	BranchesDepthFirst(startBranch Branch) iter.Seq2[Branch, int]
 	SortBranchesTopologically(branches Branches) Branches
 	FindBranchesForCommits(commitSHAs []string) map[string]string
+	// RefDecorations returns local branch and tag refs grouped by the commit SHA
+	// they point at (annotated tags dereferenced), for git-log-style annotations.
+	RefDecorations() (map[string][]git.RefDecoration, error)
 	// GetAllBranchNames returns the names of all local branches, including ones
 	// not tracked by stackit. Used by diagnostics that must see untracked or
 	// orphaned branches.

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -54,6 +54,11 @@ const (
 	CommitFormatMessage CommitFormat = "MESSAGE" // Full commit message
 	// CommitFormatSubject is the first line of the commit message
 	CommitFormatSubject CommitFormat = "SUBJECT" // First line of commit message
+	// CommitFormatSHASubject pairs the full SHA and subject on one NUL-separated
+	// record per commit ("<full-sha>\x00<subject>"), so callers get both from a
+	// single walk without index-aligning two separate lists. The subject may be
+	// empty; the record is never blank because the SHA is always present.
+	CommitFormatSHASubject CommitFormat = "SHA_SUBJECT"
 )
 
 // Scope represents a branch scope that can be empty, a regular scope, or an inheritance breaker

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -229,6 +229,9 @@ type RefOperations interface {
 	VerifyRef(ctx context.Context, refName string) error
 	DeleteRef(ctx context.Context, name string) error
 	ListRefs(prefix string) (map[string]string, error)
+	// RefDecorations returns local branch and tag refs grouped by the commit SHA
+	// they point at, dereferencing annotated tags to the wrapped commit.
+	RefDecorations() (map[string][]RefDecoration, error)
 }
 
 // ObjectOperations provides low-level Git object operations.

--- a/internal/git/ref_decorations.go
+++ b/internal/git/ref_decorations.go
@@ -1,0 +1,77 @@
+package git
+
+import (
+	"context"
+	"slices"
+	"strings"
+)
+
+// RefDecoration is a single local ref (branch head or tag) pointing at a commit.
+// It backs git-log-style "(main, tag: v1.4.0)" annotations.
+type RefDecoration struct {
+	Name  string // short ref name, e.g. "main" or "v1.4.0"
+	IsTag bool   // true for refs/tags/*, false for refs/heads/*
+}
+
+// RefDecorations returns local branch and tag refs grouped by the full commit
+// SHA they point at. Annotated tags are dereferenced to the commit they wrap
+// (via for-each-ref's `*objectname`) so a tag decoration lands on the commit, not
+// the intermediate tag object. Commits with no refs are simply absent from the map.
+//
+// Within each commit's slice the order is git-log-style and explicit: branch
+// heads first, then tags, alphabetical by name within each group. We sort rather
+// than lean on for-each-ref's refname order (which only happens to put "heads"
+// before "tags" lexically) so the grouping survives reordered ref args or a new
+// namespace like refs/remotes.
+func (r *runner) RefDecorations() (map[string][]RefDecoration, error) {
+	// %(*objectname) is empty for lightweight tags and branch heads, and the
+	// wrapped commit SHA for annotated tags. Prefer it when present.
+	out, err := r.RunGitCommandWithContext(context.Background(),
+		"for-each-ref",
+		"--format=%(refname)%00%(objectname)%00%(*objectname)",
+		"refs/heads", "refs/tags",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string][]RefDecoration)
+	for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.Split(line, "\x00")
+		if len(fields) < 2 {
+			continue
+		}
+		refname, objectname := fields[0], fields[1]
+		sha := objectname
+		if len(fields) >= 3 && fields[2] != "" {
+			sha = fields[2] // annotated tag: dereference to the wrapped commit
+		}
+		if sha == "" {
+			continue
+		}
+
+		switch {
+		case strings.HasPrefix(refname, "refs/tags/"):
+			result[sha] = append(result[sha], RefDecoration{Name: strings.TrimPrefix(refname, "refs/tags/"), IsTag: true})
+		case strings.HasPrefix(refname, "refs/heads/"):
+			result[sha] = append(result[sha], RefDecoration{Name: strings.TrimPrefix(refname, "refs/heads/")})
+		}
+	}
+
+	// Branch heads before tags, alphabetical within each group.
+	for _, decos := range result {
+		slices.SortFunc(decos, func(a, b RefDecoration) int {
+			if a.IsTag != b.IsTag {
+				if a.IsTag {
+					return 1
+				}
+				return -1
+			}
+			return strings.Compare(a.Name, b.Name)
+		})
+	}
+	return result, nil
+}

--- a/internal/git/ref_decorations_test.go
+++ b/internal/git/ref_decorations_test.go
@@ -1,0 +1,77 @@
+package git_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+)
+
+// findDecoration returns the decoration with the given name across all SHAs,
+// along with the SHA it points at.
+func findDecoration(decos map[string][]git.RefDecoration, name string) (string, git.RefDecoration, bool) {
+	for sha, list := range decos {
+		for _, d := range list {
+			if d.Name == name {
+				return sha, d, true
+			}
+		}
+	}
+	return "", git.RefDecoration{}, false
+}
+
+func TestRefDecorations(t *testing.T) {
+	t.Parallel()
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+
+	// A second commit so HEAD and the tag below can point at distinct commits.
+	require.NoError(t, scene.Repo.CreateChange("file1", "content1", false))
+	require.NoError(t, scene.Repo.RunGitCommand("add", "."))
+	require.NoError(t, scene.Repo.RunGitCommand("commit", "-m", "second"))
+
+	// Lightweight tag and annotated tag on the current commit.
+	require.NoError(t, scene.Repo.RunGitCommand("tag", "v1.0.0"))
+	require.NoError(t, scene.Repo.RunGitCommand("tag", "-a", "v2.0.0", "-m", "release 2"))
+	// A separate branch head.
+	require.NoError(t, scene.Repo.RunGitCommand("branch", "feature"))
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	decos, err := runner.RefDecorations()
+	require.NoError(t, err)
+
+	headSHA, err := runner.GetRef("refs/heads/main")
+	require.NoError(t, err)
+
+	// main and feature both point at the tip commit, as branch decorations.
+	mainSHA, mainDeco, ok := findDecoration(decos, "main")
+	require.True(t, ok, "expected main decoration")
+	require.False(t, mainDeco.IsTag)
+	require.Equal(t, headSHA, mainSHA)
+
+	_, featureDeco, ok := findDecoration(decos, "feature")
+	require.True(t, ok, "expected feature decoration")
+	require.False(t, featureDeco.IsTag)
+
+	// Lightweight tag points straight at the commit.
+	lwSHA, lwDeco, ok := findDecoration(decos, "v1.0.0")
+	require.True(t, ok, "expected lightweight tag decoration")
+	require.True(t, lwDeco.IsTag)
+	require.Equal(t, headSHA, lwSHA)
+
+	// Annotated tag is dereferenced to the wrapped commit, not the tag object.
+	annSHA, annDeco, ok := findDecoration(decos, "v2.0.0")
+	require.True(t, ok, "expected annotated tag decoration")
+	require.True(t, annDeco.IsTag)
+	require.Equal(t, headSHA, annSHA, "annotated tag should dereference to the commit SHA")
+
+	// All four refs point at HEAD: branch heads come first (alphabetical), then
+	// tags (alphabetical) — git-log-style, not for-each-ref's refname order.
+	require.Equal(t, []git.RefDecoration{
+		{Name: "feature"},
+		{Name: "main"},
+		{Name: "v1.0.0", IsTag: true},
+		{Name: "v2.0.0", IsTag: true},
+	}, decos[headSHA])
+}

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -699,6 +699,12 @@ func (r *runner) GetCommitRange(ctx context.Context, base, head, format string) 
 		return r.gitLogLines(ctx, rangeArg, "%h %s")
 	case "SUBJECT":
 		return r.gitLogLines(ctx, rangeArg, "%s")
+	case "SHA_SUBJECT":
+		// NUL-separated full SHA and subject on one record per commit. The line
+		// is never blank (%H is always present) so gitLogLines won't drop a
+		// commit with an empty subject, and the literal NUL survives the split
+		// on "\n". Callers split each entry on "\x00" to recover SHA + subject.
+		return r.gitLogLines(ctx, rangeArg, "%H%x00%s")
 	case "READABLE_WITH_DATE":
 		// Tab-separated: short SHA, RFC3339 UTC date, subject. Use Unix
 		// epoch from git and convert in Go to preserve the prior behavior of

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -1065,6 +1065,13 @@ func (t *tracingRunner) ListRefs(prefix string) (map[string]string, error) {
 	return result, err
 }
 
+func (t *tracingRunner) RefDecorations() (map[string][]RefDecoration, error) {
+	start := time.Now()
+	result, err := t.inner.RefDecorations()
+	t.trace("RefDecorations", time.Since(start), err == nil, err)
+	return result, err
+}
+
 // ObjectOperations methods
 
 func (t *tracingRunner) CreateBlob(content string) (string, error) {

--- a/internal/git/trunk_collapse.go
+++ b/internal/git/trunk_collapse.go
@@ -6,7 +6,9 @@ package git
 //
 // It is the dedup half shared by the HTTP "recently merged" mapper and the
 // `stackit log` command, so both collapse consolidated stacks identically.
-// PR-title enrichment and presentation shaping stay with each caller.
+// Presentation shaping (terminal vs JSX) stays with each caller; the PR-title
+// enrichment they both need lives in PRTitleNumbers / CollapsedMessage /
+// ConstituentPRTitles below.
 func CollapseStackMerges(commits []RecentCommit) []RecentCommit {
 	// Collect all PR numbers covered by stack-merge consolidation commits.
 	coveredPRs := make(map[int]struct{})
@@ -29,4 +31,67 @@ func CollapseStackMerges(commits []RecentCommit) []RecentCommit {
 		result = append(result, c)
 	}
 	return result
+}
+
+// PRTitleNumbers returns the unique PR numbers whose titles are needed to enrich
+// the given commits: for each stack-merge, its consolidation PR plus its
+// constituent PRs. Regular (non-stack) commits contribute nothing — their PR
+// title is never displayed — so callers don't over-fetch. Order is first-seen
+// stable. Safe to call on either the raw or the collapsed slice: collapse only
+// drops covered regular commits, never stack-merges, so both yield the same set.
+func PRTitleNumbers(commits []RecentCommit) []int {
+	seen := make(map[int]struct{})
+	var nums []int
+	add := func(n int) {
+		if n == 0 {
+			return
+		}
+		if _, ok := seen[n]; ok {
+			return
+		}
+		seen[n] = struct{}{}
+		nums = append(nums, n)
+	}
+	for _, c := range commits {
+		if c.StackSize == 0 {
+			continue
+		}
+		add(c.PRNumber)
+		for _, pr := range c.StackPRNumbers {
+			add(pr)
+		}
+	}
+	return nums
+}
+
+// CollapsedMessage returns the display message for a commit: a stack-merge uses
+// its consolidation PR's title when available, replacing the raw
+// "Merge pull request #N from ..." subject; everything else falls back to the
+// commit subject.
+func CollapsedMessage(c RecentCommit, prTitles map[int]string) string {
+	if c.StackSize > 0 && c.PRNumber != 0 && len(prTitles) > 0 {
+		if title, ok := prTitles[c.PRNumber]; ok {
+			return title
+		}
+	}
+	return c.Subject
+}
+
+// ConstituentPRTitles returns the subset of prTitles keyed by a stack-merge's
+// constituent PR numbers, or nil when the commit is not a stack-merge or no
+// titles apply.
+func ConstituentPRTitles(c RecentCommit, prTitles map[int]string) map[int]string {
+	if c.StackSize == 0 || len(prTitles) == 0 {
+		return nil
+	}
+	titles := make(map[int]string)
+	for _, pr := range c.StackPRNumbers {
+		if title, ok := prTitles[pr]; ok {
+			titles[pr] = title
+		}
+	}
+	if len(titles) == 0 {
+		return nil
+	}
+	return titles
 }

--- a/internal/git/trunk_collapse_test.go
+++ b/internal/git/trunk_collapse_test.go
@@ -70,3 +70,67 @@ func TestCollapseStackMerges(t *testing.T) {
 		})
 	}
 }
+
+func reg(pr int, subject string) git.RecentCommit {
+	return git.RecentCommit{PRNumber: pr, Subject: subject, Kind: git.RecentCommitKindRegular}
+}
+
+func merge(pr int, subject string, prs ...int) git.RecentCommit {
+	return git.RecentCommit{
+		PRNumber:       pr,
+		Subject:        subject,
+		Kind:           git.RecentCommitKindStackMerge,
+		StackSize:      len(prs),
+		StackPRNumbers: prs,
+	}
+}
+
+func TestPRTitleNumbers(t *testing.T) {
+	t.Parallel()
+
+	// Only stack-merges contribute (consolidation PR + constituents), deduped,
+	// first-seen order; regular commits' PRs are never displayed so are skipped.
+	commits := []git.RecentCommit{
+		merge(100, "consolidate", 1, 2),
+		reg(2, "feat: two (#2)"),  // covered constituent — and regular, so ignored
+		reg(9, "feat: nine (#9)"), // surviving regular — still ignored
+	}
+	require.Equal(t, []int{100, 1, 2}, git.PRTitleNumbers(commits))
+
+	require.Empty(t, git.PRTitleNumbers([]git.RecentCommit{reg(9, "feat (#9)")}))
+	require.Empty(t, git.PRTitleNumbers(nil))
+}
+
+func TestCollapsedMessage(t *testing.T) {
+	t.Parallel()
+
+	titles := map[int]string{100: "Consolidated title"}
+
+	// Stack-merge with a known title → title replaces the raw merge subject.
+	require.Equal(t, "Consolidated title",
+		git.CollapsedMessage(merge(100, "Merge pull request #100", 1, 2), titles))
+	// Stack-merge with no title for its PR → falls back to subject.
+	require.Equal(t, "Merge pull request #200",
+		git.CollapsedMessage(merge(200, "Merge pull request #200", 3), titles))
+	// Regular commit → always the subject, even if a title happens to exist.
+	require.Equal(t, "feat: hundred (#100)",
+		git.CollapsedMessage(reg(100, "feat: hundred (#100)"), titles))
+	// Empty subject stays empty.
+	require.Equal(t, "", git.CollapsedMessage(reg(0, ""), nil))
+}
+
+func TestConstituentPRTitles(t *testing.T) {
+	t.Parallel()
+
+	titles := map[int]string{1: "One", 2: "Two", 9: "Nine"}
+
+	// Only the commit's own constituents are selected, not unrelated titles.
+	require.Equal(t, map[int]string{1: "One", 2: "Two"},
+		git.ConstituentPRTitles(merge(100, "m", 1, 2), titles))
+	// Regular commit → nil regardless of titles.
+	require.Nil(t, git.ConstituentPRTitles(reg(1, "feat (#1)"), titles))
+	// Stack-merge whose constituents have no titles → nil, not empty map.
+	require.Nil(t, git.ConstituentPRTitles(merge(100, "m", 7, 8), titles))
+	// No titles available → nil.
+	require.Nil(t, git.ConstituentPRTitles(merge(100, "m", 1), nil))
+}


### PR DESCRIPTION
This PR merges the following changes:

1. **#1347** feat(git): add RefDecorations for git-log-style ref annotations
2. **#1348** feat(stacklog): gather current stack commit band for log
3. **#1349** feat(log): make default log view stack-aware with decorations
4. **#1362** fix: address review findings on stack-aware log
5. **#1363** refactor: share trunk PR-title enrichment between CLI and web

### Stack

```
main
  └─ jonnii/20260627010049/add-RefDecorations-for-git-log-style-ref (#1347)
    └─ jonnii/20260627010546/gather-current-stack-commit-band-for-log (#1348)
      └─ jonnii/20260627011104/make-default-log-view-stack-aware-with-decorations (#1349)
        └─ jonnii/20260629021522/address-review-findings-on-stack-aware-log (#1362)
          └─ jonnii/20260629022913/share-trunk-PR-title-enrichment-between-CLI-and (#1363)
```

Stackit-Stack-Size: 5
Stackit-PRs: 1347,1348,1349,1362,1363
