### PR TITLE
perf(restack): replay multi-commit branches conflict-free without a worktree

### DIFF
--- a/docs/plans/perf/absorb.md
+++ b/docs/plans/perf/absorb.md
@@ -48,9 +48,18 @@ NewAbsorbCmd → common.Run                            (same bootstrap as co)
 
 ## Proposed wins (ranked)
 
-### 1. Same worktree-validation fix benefits the post-absorb restack *(shared with modify.md #1)*
+### 1. Worktree reuse for the overlapping-file post-absorb restack *(shared with modify.md #1)*
 
-`RestackBranches` here goes through the same `ValidateRebases` worktree-per-spec path. Trivially-safe rebases (very common after absorb — most hunks land in a single ancestor and don't change descendant-touched files) could skip validation entirely.
+> **Status:** Partly addressed for free. `RestackBranches` here goes through the
+> same `ValidateRebases` path, which now has a shipped conflict-free fast path:
+> rebases whose files are disjoint from the parent's changes skip the worktree
+> entirely (single- *and* multi-commit). After absorb most hunks land in a single
+> ancestor and don't touch descendant files, so this common case already takes the
+> no-worktree path automatically.
+
+Remaining: branches whose files **overlap** the absorbed change still create a
+validation worktree each. The shared worktree-reuse-per-depth-level idea
+(`modify.md` #1) is what's left to amortize those.
 
 ### 2. Drop the redundant pre-staging `HasStagedChanges` call *(small, low risk)*
 

--- a/docs/plans/perf/cross-cutting.md
+++ b/docs/plans/perf/cross-cutting.md
@@ -97,18 +97,6 @@ Remaining redundant probes:
 
 ---
 
-### 6. Conflict-impossible validation: avoid per-spec worktrees when safe
-
-> **Status:** Partially done — the core mechanism shipped. `validateSingleSpec` calls `tryConflictFreeReplay` (`internal/engine/rebase_validator.go:355`, def `:419`): it compares the changed-file sets (`rebaseFileOverlap`) and, when disjoint, builds the rebased SHA via `merge-tree --write-tree` + `commit-tree` with **no worktree**.
-
-**Files:** `internal/engine/rebase_validator.go`
-
-**Remaining:** the fast path bails when `len(commits) != 1`, so multi-commit branches still fall back to the worktree-per-spec path. Extend `tryConflictFreeReplay` to replay multiple commits (sequential `merge-tree`/`commit-tree`, or a single range replay) while keeping the disjoint-file-set guard.
-
-**Affects:** modify.md #1, restack.md #1, absorb.md #1.
-
----
-
 ### 7. Reuse a single worktree per depth level for validation
 
 When #6's fast path can't apply (genuinely overlapping changes, multi-commit), validation still creates one worktree per spec (`rebase_validator.go:367`). It could amortize worktree creation across siblings at the same depth: one worktree per concurrency lane, reset between specs via `git rebase --abort` + `git reset --hard`. Note the tradeoff with the existing per-spec parallelism.
@@ -169,6 +157,7 @@ These wins have fully landed. Numbering is preserved so per-command page referen
 
 - **#10 — Gate `IsInManagedWorktree` to commands that need it.** `SkipManagedWorktreeCheck` exists, is applied to read-only commands via `ApplyReadOnlyCurrentBranch`, and call sites are minimal (`common.go` + tests). Keep applying it to new read-only commands.
 - **#11 — Stop calling `ReloadRepository` after every commit.** go-git was removed entirely. There is no repo handle to close and no worktree re-scan; the expensive reopen this targeted no longer exists. The global revision cache it relied on is also gone (and a global revision cache is now an explicit anti-pattern — see `.claude/rules/code-style.md`).
+- **#6 — Conflict-impossible validation fast path.** `validateSingleSpec` calls `tryConflictFreeReplay` (`internal/engine/rebase_validator.go`): when the branch's changed files are disjoint from the parent's, it replays the branch onto the new base via `merge-tree --write-tree` + `commit-tree` with **no worktree**. Now covers **multi-commit branches** too — each commit is replayed oldest-first via `replayCommitConflictFree`, chained onto the previous result, preserving per-commit author identity and message. The remaining worktree-amortization idea lives on as #7.
 
 ---
 
@@ -176,11 +165,11 @@ These wins have fully landed. Numbering is preserved so per-command page referen
 
 For maximum impact per engineering hour:
 
-1. **#6 multi-commit fast path** — the single-commit conflict-free replay already ships; extending it to multi-commit branches is the biggest remaining win for `modify`/`restack`/`absorb`.
-2. **#1 remaining load-mode adoption** — pure call-site changes (`children`, `down`, `up`, `top`, `bottom`) on top of finished engine infrastructure.
-3. **#2 batch stack-wide status checks** — removes the per-parent `git rev-parse` walks in `submit` and `info`.
-4. **#8 `RebuildBranches`** — scopes the remaining full rebuilds in `absorb`/`untrack`.
-5. **#3 on-demand diff batching** — `info --diff`/`--patch` and `absorb`'s commit scan.
+1. **#1 remaining load-mode adoption** — pure call-site changes (`down`, `bottom`) on top of finished engine infrastructure.
+2. **#2 batch stack-wide status checks** — removes the per-parent `git rev-parse` walks in `submit` and `info`.
+3. **#8 `RebuildBranches`** — scopes the remaining full rebuilds in `absorb`/`untrack`.
+4. **#3 on-demand diff batching** — `info --diff`/`--patch` and `absorb`'s commit scan.
+5. **#7 per-level worktree reuse** — amortizes the worktree cost that remains for genuinely overlapping multi-branch validation (the disjoint-file fast path #6 already eliminated the common case).
 6. **#9 combine txs** for `create` and `describe`; **#4 no-op snapshot skip**; **#5 / #12** hygiene.
 
 ## Order-of-magnitude estimates
@@ -189,7 +178,6 @@ Back-of-envelope guesses to size effort vs reward, not measured. Completed items
 
 | Win | Affected commands | Typical saving per affected run |
 |---|---|---|
-| #6 multi-commit fast path | modify, restack, absorb | N x ~300ms worktree creation (multi-commit branches) |
 | #1 remaining load-mode adoption | read-only/common commands | remaining bootstrap cost (50-500ms depending on branch count) |
 | #2 batch status checks | submit, info | N x `git rev-parse` per stack walk |
 | #3 on-demand diff batching | info, absorb | N x ~5ms `git` processes |

--- a/docs/plans/perf/modify.md
+++ b/docs/plans/perf/modify.md
@@ -41,31 +41,33 @@ NewModifyCmd.RunE → common.Run                       (same bootstrap as co)
 
 1. **`git worktree add` per spec** inside `ValidateRebases`, **only when the fast
    path misses**. `validateSingleSpec` now tries `tryConflictFreeReplay` first
-   (see "Already shipped" below): for a single-commit descendant whose files are
-   disjoint from the parent's new changes, no worktree is created at all. The
-   worktree cost only applies to multi-commit descendants or overlapping file
-   sets. When it does apply, branches at the same depth are parallelized but each
+   (see "Already shipped" below): for any descendant (single- or multi-commit)
+   whose files are disjoint from the parent's new changes, no worktree is created
+   at all. The worktree cost only applies to descendants with **overlapping file
+   sets**. When it does apply, branches at the same depth are parallelized but each
    still gets its own worktree.
 2. **User pre-commit hook** during the `git commit --amend`. Outside stackit's control but it runs every modify.
 3. **`PlanRestack`** — several git ops per descendant, run sequentially. For a
-   deep stack, this is meaningful. See win #5.
+   deep stack, this is meaningful. See win #2.
 4. **Bootstrap (`rebuildInternal`)** — fixed cost; see `co.md`.
 
 `HasStagedChanges` is now a cheap `git diff --cached --quiet` index probe, no
 longer a full working-tree walk, so it is no longer a notable cost.
 
 For a **leaf branch amend** (no children): the restack block is skipped entirely.
-For a **mid-stack amend** with multi-commit or overlapping descendants: the
-worktree-validate dance still dominates.
+For a **mid-stack amend** with overlapping descendants: the worktree-validate
+dance still dominates.
 
 ## Already shipped (do not re-plan)
 
-- **Conflict-free fast path** — `validateSingleSpec` calls `tryConflictFreeReplay`
-  (`internal/engine/rebase_validator.go:355,425`), which compares
-  `GetChangedFiles(old-parent..new-parent)` against
-  `GetChangedFiles(old-parent..branch)` and, when the file sets are disjoint for a
-  single-commit branch, computes the rebased tree via `merge-tree --write-tree` +
-  `commit-tree` with no worktree. This is the original win #1.
+- **Conflict-free fast path (single- and multi-commit)** — `validateSingleSpec`
+  calls `tryConflictFreeReplay` (`internal/engine/rebase_validator.go:355`), which
+  compares `GetChangedFiles(old-parent..new-parent)` against
+  `GetChangedFiles(old-parent..branch)` and, when the file sets are disjoint,
+  replays the branch onto the new base with no worktree. Multi-commit branches are
+  replayed commit-by-commit via `replayCommitConflictFree` (oldest first, chained
+  onto the previous rebased result), preserving each commit's author identity and
+  message. This was the original win #1.
 - **`HasStagedChanges` coalescing** — moot: `HasStagedChanges` is now
   `git diff --cached --quiet` (`internal/git/staging.go:55`), not a `Status()`
   tree walk. The expensive walk the old win targeted no longer exists.
@@ -81,23 +83,7 @@ worktree-validate dance still dominates.
 
 ## Proposed wins (ranked)
 
-### 1. Extend conflict-free replay to multi-commit branches *(medium impact, high risk)*
-
-> **Status:** Partially done. The single-commit conflict-free fast path is
-> shipped (`tryConflictFreeReplay`, `internal/engine/rebase_validator.go:425`).
-> It bails out for multi-commit branches (`len(commits) != 1` → falls back to the
-> worktree path).
-
-Remaining work: handle multi-commit descendants without a worktree. This requires
-iterating each commit's diff and confirming the *aggregate* branch file set is
-disjoint from the parent's new changes, then replaying commits onto the new
-parent via repeated `commit-tree` (or a single squashed `merge-tree` when commit
-identity can be preserved). Higher risk than the single-commit case because each
-intermediate commit's tree must be reconstructed in order; keep it strictly
-opt-in to the proven-disjoint case and fall back to the worktree path on any
-uncertainty.
-
-### 2. Reuse a single validation worktree per depth level *(medium impact, medium risk)*
+### 1. Reuse a single validation worktree per depth level *(medium impact, medium risk)*
 
 > **Status:** Not started. `validateSingleSpec`
 > (`internal/engine/rebase_validator.go:367`) still calls
@@ -112,10 +98,11 @@ concurrency) instead of O(slow-path specs).
 Risk: rerere state and partial-rebase state need careful reset between specs. The
 current per-spec isolation is the safe design — make this an opt-in path for the
 validated-good case. Note the impact is now smaller than originally estimated,
-since the fast path already eliminates worktrees for the common single-commit
-disjoint case.
+since the fast path already eliminates worktrees for any disjoint-file case
+(single- or multi-commit); only branches with files overlapping the parent's
+changes still reach this slow path.
 
-### 3. Reduce `PlanRestack`'s per-branch git ops *(small impact)*
+### 2. Reduce `PlanRestack`'s per-branch git ops *(small impact)*
 
 > **Status:** Not started. `PlanRestack` (`internal/engine/restack_plan.go:10`)
 > loops over branches sequentially; `planRestackBranch` does several git ops per
@@ -143,13 +130,15 @@ Cheapest first step is the batch reads; only add fan-out if profiling still show
 STACKIT_NO_LOGGING=1 hyperfine \
   'echo // noop >> file.go; stackit modify -a --no-edit'
 
-# Mid-stack (5 multi-commit descendants) — measures worktree validation cost
+# Mid-stack (5 descendants with OVERLAPPING files) — measures worktree validation cost
 STACKIT_NO_LOGGING=1 hyperfine \
   'echo // noop >> file.go; stackit modify -a --no-edit'
 ```
 
-Use multi-commit descendants for the mid-stack case so the conflict-free fast
-path does not absorb the cost being measured. Instrument: each
+Use descendants whose files **overlap** the parent's changes for the mid-stack
+case so the conflict-free fast path does not absorb the cost being measured
+(disjoint single- and multi-commit branches now both take the no-worktree path).
+Instrument: each
 `validateSingleSpec`, the worktree creation specifically, `ValidateRebases` total,
 `PlanRestack`, and `git commit`. The delta between leaf and mid-stack is
 essentially the worktree validation cost that survives the fast path.

--- a/docs/plans/perf/restack.md
+++ b/docs/plans/perf/restack.md
@@ -20,40 +20,22 @@ NewRestackCmd → common.Run                           (same bootstrap as co)
               restackBranchesWithPlan                internal/actions/common.go:114
                 ├─ validateBranchAncestry            cheap
                 ├─ Engine.ValidateRebases            ← per-spec worktrees, with a conflict-free
-                │                                       fast path (see win #1)
+                │                                       fast path for disjoint-file branches (shipped)
                 ├─ (apply or conflict workflow)
                 └─ engine state writes
 ```
 
 ## Where time goes
 
-1. **`Engine.ValidateRebases`** dominates — same per-spec worktree creation that hurts `modify` and `absorb`. A conflict-free fast path now skips the worktree for **single-commit** branches whose diff is disjoint from the parent's (`tryConflictFreeReplay`, `internal/engine/rebase_validator.go:355,419`). Multi-commit branches still pay a worktree each, so a "stack of 8 branches all touch the same file" still validates in dependency order with width-level parallelism.
+1. **`Engine.ValidateRebases`** dominates — same per-spec worktree creation that hurts `modify` and `absorb`. A conflict-free fast path now skips the worktree for **any** branch (single- or multi-commit) whose diff is disjoint from the parent's (`tryConflictFreeReplay`, `internal/engine/rebase_validator.go:355`). Only branches whose files overlap the parent's changes still pay a worktree each, so a "stack of 8 branches all touch the same file" still validates in dependency order with width-level parallelism.
 2. **`Engine.PlanRestack`** — ~3 git ops per branch, built once in the CLI and threaded through to the action via `enginePlan` (it is not rebuilt). Still O(branches) git ops once. Each lookup hits git directly (no revision cache — see the note under removed wins).
-3. **`TakeBestEffortSnapshot`** — already batches its revision reads via `BatchGetRevisions` (`internal/engine/undo.go:121`), so the cost is one `git rev-parse` plus metadata listing, not per-branch iteration. It is skipped entirely when `undo.enabled=false`. Remaining overhead: it still runs for a no-op restack (see win #2).
+3. **`TakeBestEffortSnapshot`** — already batches its revision reads via `BatchGetRevisions` (`internal/engine/undo.go:121`), so the cost is one `git rev-parse` plus metadata listing, not per-branch iteration. It is skipped entirely when `undo.enabled=false`. Remaining overhead: it still runs for a no-op restack (see win #1).
 4. **`--parallel` with worktrees** — `restackGroupsParallel` (`internal/actions/restack.go:310`) dispatches independent stack groups to separate worktrees, created on demand via a bounded `utils.RunWithWorkers` pool. Each worktree creation is hundreds of ms; for the multi-stack case this is a feature (parallelism beats serial worktree-creates), but each group still individually pays per-spec validation.
 5. **Bootstrap** — same fixed cost as `co.md`.
 
 ## Proposed wins (ranked)
 
-### 1. Extend the conflict-free fast path to multi-commit branches *(shared with modify.md #1)*
-
-> **Status:** Partially done. The single-commit case is implemented:
-> `validateSingleSpec` calls `tryConflictFreeReplay`
-> (`internal/engine/rebase_validator.go:355`), which compares the parent's and
-> branch's changed-file sets (`rebaseFileOverlap`) and, when disjoint, produces
-> the rebased SHA with `git merge-tree --write-tree` + `commit-tree` — no
-> worktree. This already collapses typical post-amend restacks (one commit per
-> branch, disjoint files) to a few `git diff --name-only` invocations.
-
-Remaining work: `tryConflictFreeReplay` bails out for any branch with more than
-one commit (`len(commits) != 1` → fall back to the worktree path). Multi-commit
-branches still create a validation worktree even when every commit's diff is
-disjoint from the parent's amend diff. Extend the safe-replay path to iterate
-each commit (cherry-pick-equivalent via repeated `merge-tree`/`commit-tree`)
-when the aggregate file sets are disjoint, so deep stacks of small multi-commit
-branches also skip worktrees.
-
-### 2. Skip the snapshot when `!plan.HasWork()` *(trivial)*
+### 1. Skip the snapshot when `!plan.HasWork()` *(trivial)*
 
 `TakeBestEffortSnapshot` runs unconditionally in `RestackAction`
 (`internal/actions/restack.go:153`), before the work is dispatched. The CLI
@@ -67,7 +49,7 @@ when about to mutate refs). The `undo.enabled=false` skip is already handled
 inside `TakeBestEffortSnapshot` (`internal/actions/common.go`), so this is the
 only remaining snapshot win.
 
-### 3. Reuse a validation worktree per depth level *(shared with modify.md #2)*
+### 2. Reuse a validation worktree per depth level *(shared with modify.md #1)*
 
 Within a level (sibling branches that fall through the fast path),
 `validateSingleSpec` creates a fresh worktree per spec
@@ -78,7 +60,7 @@ instead of one per fall-through spec. Note this trades some intra-level
 parallelism (siblings currently validate concurrently across worktrees) for
 fewer `git worktree add`/`remove` cycles, so measure before committing.
 
-### 4. `--all-stacks` parallel mode should reuse a worktree pool *(small impact, low risk)*
+### 3. `--all-stacks` parallel mode should reuse a worktree pool *(small impact, low risk)*
 
 `restackGroupsParallel` (`internal/actions/restack.go:310`) creates a worktree
 per group on demand inside `utils.RunWithWorkers` and tears it down with

--- a/internal/engine/rebase_validator.go
+++ b/internal/engine/rebase_validator.go
@@ -417,20 +417,28 @@ func (e *engineImpl) validateSingleSpec(
 }
 
 // tryConflictFreeReplay tries to produce the rebased SHA without a worktree for
-// single-commit branches where the parent's new changes and the branch's changes
-// touch completely disjoint file sets (a content conflict is therefore impossible).
+// branches where the parent's new changes and the branch's changes touch
+// completely disjoint file sets (a content conflict is therefore impossible).
 //
-// Returns (newSHA, true) on success; returns ("", false) to signal the caller to
-// fall back to the full worktree path.
+// Multi-commit branches are supported only when the commit range is linear: each
+// commit is replayed individually, oldest first, chained onto the previous
+// rebased result so per-commit author identity and messages are preserved. The
+// branch-level disjoint-file check is a sufficient conflict guarantee for every
+// commit, because each commit's changes are a subset of the branch's overall
+// changes — none of which touch a file the parent changed.
+//
+// Returns (newSHA, true) on success, where newSHA is the rebased branch tip;
+// returns ("", false) to signal the caller to fall back to the full worktree path.
 func (e *engineImpl) tryConflictFreeReplay(
 	ctx context.Context,
 	spec RebaseSpec,
 	resolvedParent string,
 ) (string, bool) {
-	// Only handle single-commit branches — multi-commit replay requires iterating
-	// each commit individually and is deferred to the worktree path.
 	commits, err := e.git.GetCommitRangeSHAs(ctx, spec.OldUpstream, spec.Branch)
-	if err != nil || len(commits) != 1 {
+	if err != nil || len(commits) == 0 {
+		return "", false
+	}
+	if !e.commitRangeIsLinear(commits, spec.OldUpstream) {
 		return "", false
 	}
 
@@ -451,12 +459,68 @@ func (e *engineImpl) tryConflictFreeReplay(
 		return "", false
 	}
 
-	// File sets are disjoint — compute the rebased tree via merge-tree.
+	// File sets are disjoint — replay each commit onto the new base. commits is
+	// newest-first, so iterate in reverse (oldest first). The oldest commit's
+	// original parent is OldUpstream; every later commit's original parent is the
+	// commit immediately before it. Each replayed commit becomes the new base for
+	// the next, so author identity and message are preserved per commit.
+	newBase := resolvedParent
+	for i := len(commits) - 1; i >= 0; i-- {
+		mergeBase := spec.OldUpstream
+		if i+1 < len(commits) {
+			mergeBase = commits[i+1]
+		}
+		newSHA, ok := e.replayCommitConflictFree(ctx, commits[i], mergeBase, newBase)
+		if !ok {
+			return "", false
+		}
+		newBase = newSHA
+	}
+	return newBase, true
+}
+
+// commitRangeIsLinear reports whether commits (newest-first) form a simple
+// single-parent chain rooted at oldUpstream. The replay fast path relies on that
+// shape to preserve git rebase semantics; merge commits and side-branch commits
+// must fall back to the real worktree rebase.
+func (e *engineImpl) commitRangeIsLinear(commits []string, oldUpstream string) bool {
+	for i := len(commits) - 1; i >= 0; i-- {
+		parentRaw, err := e.git.GetCommitLog(commits[i], "%P")
+		if err != nil {
+			return false
+		}
+		parents := strings.Fields(parentRaw)
+		if len(parents) != 1 {
+			return false
+		}
+
+		expectedParent := oldUpstream
+		if i+1 < len(commits) {
+			expectedParent = commits[i+1]
+		}
+		if parents[0] != expectedParent {
+			return false
+		}
+	}
+	return true
+}
+
+// replayCommitConflictFree replays a single commit onto newBase without a
+// worktree, given the commit's original parent (the 3-way merge base). The caller
+// must have established that the branch's changes are disjoint from the new base's
+// changes, so the merge is guaranteed conflict-free.
+//
+// Returns (newSHA, true) on success; returns ("", false) to signal fallback.
+func (e *engineImpl) replayCommitConflictFree(
+	ctx context.Context,
+	commitSHA, mergeBase, newBase string,
+) (string, bool) {
+	// Compute the rebased tree via merge-tree.
 	// git merge-tree --write-tree --merge-base <base> <ours> <theirs>
-	// OURS  = resolvedParent (the new base we're rebasing onto)
-	// THEIRS = spec.Branch  (carries our changes on top of OldUpstream)
+	// OURS  = newBase  (the rebased parent so far)
+	// THEIRS = commitSHA (this commit's snapshot on top of its original parent)
 	treeSHARaw, err := e.git.RunGitCommandWithContext(ctx,
-		"merge-tree", "--write-tree", "--merge-base", spec.OldUpstream, resolvedParent, spec.Branch)
+		"merge-tree", "--write-tree", "--merge-base", mergeBase, newBase, commitSHA)
 	if err != nil {
 		return "", false
 	}
@@ -468,7 +532,6 @@ func (e *engineImpl) tryConflictFreeReplay(
 	}
 
 	// Preserve the original commit's author identity and message.
-	commitSHA := commits[0] // single commit, newest-first list
 	authorName, err := e.git.GetCommitLog(commitSHA, "%an")
 	if err != nil {
 		return "", false
@@ -493,7 +556,7 @@ func (e *engineImpl) tryConflictFreeReplay(
 	}
 
 	newSHARaw, err := e.git.RunGitCommandWithEnv(ctx, env,
-		"commit-tree", treeSHA, "-p", resolvedParent, "-m", strings.TrimSpace(msg))
+		"commit-tree", treeSHA, "-p", newBase, "-m", strings.TrimSpace(msg))
 	if err != nil {
 		return "", false
 	}

--- a/internal/engine/rebase_validator_internal_test.go
+++ b/internal/engine/rebase_validator_internal_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,50 +10,67 @@ import (
 	"github.com/getstackit/stackit/internal/git"
 )
 
+// fastPathGit is a fake git.Runner that records the merge-tree / commit-tree
+// calls tryConflictFreeReplay makes, so we can assert the exact replay sequence
+// without a real repository.
 type fastPathGit struct {
 	git.Runner
 
-	t              *testing.T
-	mergeTreeArgs  []string
-	commitTreeEnv  []string
-	commitTreeArgs []string
+	t *testing.T
+
+	// commits returned by GetCommitRangeSHAs (newest-first).
+	commits []string
+	// parent lists keyed by commit SHA, as returned by git log --format=%P.
+	parents map[string]string
+	// changed files keyed by the diff head ("new-parent" / branch name).
+	changedFiles map[string][]string
+
+	// recorded calls, in order.
+	mergeTreeCalls  [][]string
+	commitTreeCalls [][]string
+
+	// monotonic counter so each synthesized commit SHA is unique.
+	commitTreeN int
 }
 
 func (g *fastPathGit) GetCommitRangeSHAs(_ context.Context, base, head string) ([]string, error) {
 	require.Equal(g.t, "old-base", base)
 	require.Equal(g.t, "feature", head)
-	return []string{"feature-commit"}, nil
+	return g.commits, nil
 }
 
 func (g *fastPathGit) GetChangedFiles(_ context.Context, base, head string) ([]string, error) {
 	require.Equal(g.t, "old-base", base)
-	switch head {
-	case "new-parent":
-		return []string{"parent.txt"}, nil
-	case "feature":
-		return []string{"feature.txt"}, nil
-	default:
+	files, ok := g.changedFiles[head]
+	if !ok {
 		g.t.Fatalf("unexpected changed-files head: %s", head)
-		return nil, nil
 	}
+	return files, nil
 }
 
 func (g *fastPathGit) RunGitCommandWithContext(_ context.Context, args ...string) (string, error) {
-	g.mergeTreeArgs = append([]string(nil), args...)
-	return "tree-sha\n", nil
+	g.mergeTreeCalls = append(g.mergeTreeCalls, append([]string(nil), args...))
+	// The tree SHA is derived from the commit being replayed (the last arg) so
+	// assertions can tie a tree back to its source commit.
+	return "tree-of-" + args[len(args)-1] + "\n", nil
 }
 
 func (g *fastPathGit) GetCommitLog(sha, format string) (string, error) {
-	require.Equal(g.t, "feature-commit", sha)
 	switch format {
+	case "%P":
+		parent, ok := g.parents[sha]
+		if !ok {
+			g.t.Fatalf("unexpected parent lookup for commit: %s", sha)
+		}
+		return parent + "\n", nil
 	case "%an":
-		return "Author Name\n", nil
+		return "Author " + sha + "\n", nil
 	case "%ae":
-		return "author@example.com\n", nil
+		return sha + "@example.com\n", nil
 	case "%aI":
 		return "2026-06-01T12:00:00-04:00\n", nil
 	case "%B":
-		return "subject\n\nbody\n", nil
+		return "subject " + sha + "\n", nil
 	default:
 		g.t.Fatalf("unexpected commit log format: %s", format)
 		return "", nil
@@ -60,13 +78,24 @@ func (g *fastPathGit) GetCommitLog(sha, format string) (string, error) {
 }
 
 func (g *fastPathGit) RunGitCommandWithEnv(_ context.Context, env []string, args ...string) (string, error) {
-	g.commitTreeEnv = append([]string(nil), env...)
-	g.commitTreeArgs = append([]string(nil), args...)
-	return "new-sha\n", nil
+	g.commitTreeCalls = append(g.commitTreeCalls, append([]string(nil), env...))
+	g.commitTreeCalls = append(g.commitTreeCalls, append([]string(nil), args...))
+	g.commitTreeN++
+	return fmt.Sprintf("new-sha-%d\n", g.commitTreeN), nil
 }
 
-func TestTryConflictFreeReplayUsesMergeTreeWithExplicitMergeBase(t *testing.T) {
-	fakeGit := &fastPathGit{t: t}
+func TestTryConflictFreeReplaySingleCommitUsesMergeTreeWithExplicitMergeBase(t *testing.T) {
+	fakeGit := &fastPathGit{
+		t:       t,
+		commits: []string{"feature-commit"},
+		parents: map[string]string{
+			"feature-commit": "old-base",
+		},
+		changedFiles: map[string][]string{
+			"new-parent": {"parent.txt"},
+			"feature":    {"feature.txt"},
+		},
+	}
 	eng := &engineImpl{git: fakeGit}
 
 	newSHA, ok := eng.tryConflictFreeReplay(context.Background(), RebaseSpec{
@@ -76,26 +105,66 @@ func TestTryConflictFreeReplayUsesMergeTreeWithExplicitMergeBase(t *testing.T) {
 	}, "new-parent")
 
 	require.True(t, ok)
-	require.Equal(t, "new-sha", newSHA)
+	require.Equal(t, "new-sha-1", newSHA)
+	// Single commit: merge base is OldUpstream, ours is the new parent, theirs is
+	// the commit SHA itself (not the branch name).
+	require.Equal(t, [][]string{{
+		"merge-tree", "--write-tree", "--merge-base",
+		"old-base", "new-parent", "feature-commit",
+	}}, fakeGit.mergeTreeCalls)
 	require.Equal(t, []string{
-		"merge-tree",
-		"--write-tree",
-		"--merge-base",
-		"old-base",
-		"new-parent",
-		"feature",
-	}, fakeGit.mergeTreeArgs)
-	require.Equal(t, []string{
-		"GIT_AUTHOR_NAME=Author Name",
-		"GIT_AUTHOR_EMAIL=author@example.com",
+		"GIT_AUTHOR_NAME=Author feature-commit",
+		"GIT_AUTHOR_EMAIL=feature-commit@example.com",
 		"GIT_AUTHOR_DATE=2026-06-01T12:00:00-04:00",
-	}, fakeGit.commitTreeEnv)
+	}, fakeGit.commitTreeCalls[0])
 	require.Equal(t, []string{
-		"commit-tree",
-		"tree-sha",
-		"-p",
-		"new-parent",
-		"-m",
-		"subject\n\nbody",
-	}, fakeGit.commitTreeArgs)
+		"commit-tree", "tree-of-feature-commit", "-p", "new-parent", "-m", "subject feature-commit",
+	}, fakeGit.commitTreeCalls[1])
+}
+
+func TestTryConflictFreeReplayMultiCommitChainsEachCommit(t *testing.T) {
+	// Branch has three commits (newest-first): c3 -> c2 -> c1 -> old-base.
+	fakeGit := &fastPathGit{
+		t:       t,
+		commits: []string{"c3", "c2", "c1"},
+		parents: map[string]string{
+			"c1": "old-base",
+			"c2": "c1",
+			"c3": "c2",
+		},
+		changedFiles: map[string][]string{
+			"new-parent": {"parent.txt"},
+			"feature":    {"a.txt", "b.txt", "c.txt"},
+		},
+	}
+	eng := &engineImpl{git: fakeGit}
+
+	newSHA, ok := eng.tryConflictFreeReplay(context.Background(), RebaseSpec{
+		Branch:      "feature",
+		NewParent:   "new-parent",
+		OldUpstream: "old-base",
+	}, "new-parent")
+
+	require.True(t, ok)
+	// The returned SHA is the rebased tip (third commit-tree result).
+	require.Equal(t, "new-sha-3", newSHA)
+
+	// Each commit is replayed oldest-first, with its original parent as the merge
+	// base and the previous rebased result as the new base.
+	require.Equal(t, [][]string{
+		{"merge-tree", "--write-tree", "--merge-base", "old-base", "new-parent", "c1"},
+		{"merge-tree", "--write-tree", "--merge-base", "c1", "new-sha-1", "c2"},
+		{"merge-tree", "--write-tree", "--merge-base", "c2", "new-sha-2", "c3"},
+	}, fakeGit.mergeTreeCalls)
+
+	// commit-tree parents chain: c1 onto new-parent, c2 onto new-sha-1, c3 onto new-sha-2.
+	require.Equal(t, []string{
+		"commit-tree", "tree-of-c1", "-p", "new-parent", "-m", "subject c1",
+	}, fakeGit.commitTreeCalls[1])
+	require.Equal(t, []string{
+		"commit-tree", "tree-of-c2", "-p", "new-sha-1", "-m", "subject c2",
+	}, fakeGit.commitTreeCalls[3])
+	require.Equal(t, []string{
+		"commit-tree", "tree-of-c3", "-p", "new-sha-2", "-m", "subject c3",
+	}, fakeGit.commitTreeCalls[5])
 }

--- a/internal/engine/rebase_validator_test.go
+++ b/internal/engine/rebase_validator_test.go
@@ -144,6 +144,107 @@ func TestValidateRebases(t *testing.T) {
 		require.NotEmpty(t, result.NewSHAs["branch3"])
 	})
 
+	t.Run("validates multi-commit branch with disjoint files via fast path", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		// branch1 forks from main's current tip and gets THREE commits, each
+		// touching a distinct file. Capture the fork point as the old upstream.
+		branch1OldBase, err := s.Engine.GetRevision(s.Engine.Trunk())
+		require.NoError(t, err)
+
+		s.CreateBranch("branch1").
+			CommitChange("a", "commit a").
+			CommitChange("b", "commit b").
+			CommitChange("c", "commit c").
+			TrackBranch("branch1", "main")
+
+		// main advances by touching a file disjoint from everything branch1 touches,
+		// so the conflict-free fast path replays each branch commit without a worktree.
+		s.Checkout("main").
+			CommitChange("parent", "parent change").
+			Checkout("branch1")
+
+		mainRev, err := s.Engine.GetRevision(s.Engine.Trunk())
+		require.NoError(t, err)
+
+		specs := []engine.RebaseSpec{
+			{
+				Branch:      "branch1",
+				NewParent:   mainRev,
+				OldUpstream: branch1OldBase,
+			},
+		}
+
+		result, err := s.Engine.ValidateRebases(context.Background(), specs)
+		require.NoError(t, err)
+		require.True(t, result.Success)
+		newTip := result.NewSHAs["branch1"]
+		require.NotEmpty(t, newTip)
+
+		// The rebased tip must sit directly on the advanced main and carry exactly
+		// the branch's three original commits.
+		replayed, err := s.Engine.Git().GetCommitRangeSHAs(context.Background(), mainRev, newTip)
+		require.NoError(t, err)
+		require.Len(t, replayed, 3, "all three branch commits should be replayed onto new main")
+
+		// Per-commit messages are preserved in order. replayed is newest-first, so
+		// replayed[0] is "commit c" and replayed[2] is "commit a".
+		msgC, err := s.Engine.Git().GetCommitLog(replayed[0], "%s")
+		require.NoError(t, err)
+		require.Equal(t, "commit c", msgC)
+		msgA, err := s.Engine.Git().GetCommitLog(replayed[2], "%s")
+		require.NoError(t, err)
+		require.Equal(t, "commit a", msgA)
+
+		// The rebased tip's tree contains both the parent's change and all three
+		// branch changes (4 distinct files relative to the fork point).
+		filesFromBase, err := s.Engine.Git().GetChangedFiles(context.Background(), branch1OldBase, newTip)
+		require.NoError(t, err)
+		require.Len(t, filesFromBase, 4)
+	})
+
+	t.Run("matches git rebase semantics for branch range containing merge commit", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		oldBase, err := s.Engine.GetRevision(s.Engine.Trunk())
+		require.NoError(t, err)
+
+		s.CreateBranch("feature").
+			CommitChange("feature.txt", "feature change").
+			TrackBranch("feature", "main")
+
+		s.Checkout("main").
+			CreateBranch("side").
+			CommitChange("side.txt", "side change")
+
+		s.Checkout("feature").
+			RunGit("merge", "--no-ff", "side", "-m", "merge side")
+
+		s.Checkout("main").
+			CommitChange("parent.txt", "parent change").
+			Checkout("feature")
+
+		mainRev, err := s.Engine.GetRevision(s.Engine.Trunk())
+		require.NoError(t, err)
+
+		result, err := s.Engine.ValidateRebases(context.Background(), []engine.RebaseSpec{{
+			Branch:      "feature",
+			NewParent:   mainRev,
+			OldUpstream: oldBase,
+		}})
+		require.NoError(t, err)
+		require.True(t, result.Success)
+		newTip := result.NewSHAs["feature"]
+		require.NotEmpty(t, newTip)
+
+		replayedSubjects, err := s.Engine.Git().GetCommitRange(context.Background(), mainRev, newTip, "SUBJECT")
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"feature change", "side change"}, replayedSubjects)
+		require.NotContains(t, replayedSubjects, "merge side")
+	})
+
 	t.Run("stops at first conflict in chain", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Extend tryConflictFreeReplay beyond single-commit branches. When the
branch's changed files are disjoint from the new parent's changes (a
condition that holds for every commit, since each commit's changes are a
subset of the branch's), replay each commit oldest-first via merge-tree +
commit-tree, chaining onto the previous rebased result and preserving each
commit's author identity and message.

This eliminates the per-spec validation worktree (~300ms each) for the
common disjoint-file case on multi-commit descendants during modify,
restack, and absorb. Only branches whose files overlap the parent's
changes still fall back to the worktree path.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782784721`.


* **PR #1365**
  * **PR #1366** 👈
    * **PR #1367**
      * **PR #1368**
        * **PR #1371**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1372 by jonnii*