### PR TITLE
perf(navigation): use branches-only load for quiet down and bottom

### DIFF
--- a/docs/plans/perf/cross-cutting.md
+++ b/docs/plans/perf/cross-cutting.md
@@ -16,11 +16,11 @@ This document collects the wins that remain open across multiple per-command ana
 
 **Files:** command wrappers in `internal/cli` (the engine side is done)
 
-Default context creation uses `LoadModeShared`. Commands already opted into the lighter `LoadModeBranchesOnly` path via `common.ApplyReadOnlyCurrentBranch`: exact quiet `co`, `parent`, default `trunk`.
+Default context creation uses `LoadModeShared`. Commands already opted into the lighter `LoadModeBranchesOnly` path: exact quiet `co`, `parent`, default `trunk`, and (quiet) `down` / `bottom`. `down`/`bottom` keep the managed-worktree check (checkout relies on it) and gate on `--quiet` because non-quiet checkout's `printBranchInfo` builds the full graph anyway; `bottom`'s `SwitchBranchAction` no longer builds the graph for the downward direction.
 
 Remaining adoption:
 
-- `children`, `up`, `top`, `bottom` still use the full `common.Run` bootstrap; `down` only walks the parent chain and is the best remaining candidate for the lighter mode.
+- `children`, `up`, `top` enumerate children, which forces a full `Graph()` build over `AllBranches()` — they cannot use `LoadModeBranchesOnly` (the per-branch lazy path is slower than one batch there), but they read no local metadata so they could drop from the default to `LoadModeShared`'s already-batched shared read and skip the local-metadata pass.
 - `info` and stack-graph views need more than branch-list mode but rely on the per-branch promotion path rather than a full load — confirm they don't force `LoadModeFull`.
 - Non-quiet/fuzzy `co` still pays broader bootstrap because it needs graph/worktree/checkout context.
 
@@ -165,7 +165,7 @@ These wins have fully landed. Numbering is preserved so per-command page referen
 
 For maximum impact per engineering hour:
 
-1. **#1 remaining load-mode adoption** — pure call-site changes (`down`, `bottom`) on top of finished engine infrastructure.
+1. **#1 remaining load-mode adoption** — `children`/`up`/`top` can drop from the default to `LoadModeShared` (skip the local-metadata batch); `down`/`bottom` already moved to `LoadModeBranchesOnly`.
 2. **#2 batch stack-wide status checks** — removes the per-parent `git rev-parse` walks in `submit` and `info`.
 3. **#8 `RebuildBranches`** — scopes the remaining full rebuilds in `absorb`/`untrack`.
 4. **#3 on-demand diff batching** — `info --diff`/`--patch` and `absorb`'s commit scan.

--- a/docs/plans/perf/navigation.md
+++ b/docs/plans/perf/navigation.md
@@ -36,12 +36,12 @@ These commands are bundled because they share one performance story: once the en
 > - Lazy `LoadMode`s with on-demand promotion: `LoadModeBranchesOnly`, `LoadModeShared`, `LoadModeFull` (`internal/engine/engine.go:167-184`), promoted via `ensureSharedLoaded`/`ensureLocalLoaded` (`engine_impl.go:249`, `:310`).
 > - **Per-branch** lazy shared-metadata load: `ensureBranchSharedLoaded` (`engine_impl.go:271`), wired into the branch-status accessors used by parent/down/trunk (`engine_branch_status.go`, `engine_reader.go:101`).
 > - `parent` uses `common.RunReadOnlyCurrentBranch` (`parent.go:24`); default `trunk` applies `common.ApplyReadOnlyCurrentBranch` (`trunk.go:34`). Both resolve to `LoadModeBranchesOnly` + skip the managed-worktree check (`internal/cli/common/common.go:72-82`).
+> - **`down` and `bottom`** opt into `LoadModeBranchesOnly` when `--quiet` (`down.go`, `bottom.go`), mirroring the quiet exact-checkout path in `co`. They keep the managed-worktree check (checkout relies on it for worktree switching), so they set only `EngineLoadMode` — not `RunReadOnlyCurrentBranch`. `bottom`'s path no longer builds the full graph: `SwitchBranchAction` builds `Graph()` only for `DirectionTop` (`internal/actions/navigation/action.go`), since `DirectionBottom`'s `traverseDownward` walks the parent chain only.
 
-Remaining work — the graph-based commands still use the full `common.Run` path (`LoadModeFull`):
-- `children` (`children.go:25`), `up` (`up.go:40`), `top` (`top.go:27`), `bottom` (`bottom.go:25`) build the whole `Graph()` over `AllBranches()`, so they need shared metadata for the stack — but none of them read frozen / NeedsPRBodyUpdate / PR state, so they could drop to `LoadModeShared` and skip the `BatchReadLocalMetadata` pass.
-- `down` (`down.go:30`) only walks the parent chain via `GetParent()`, which already triggers per-branch promotion — it is the strongest candidate for `LoadModeBranchesOnly`.
+Why quiet-gated: in non-quiet mode `printBranchInfo` builds the full `Graph()` (`internal/actions/checkout.go:161`), which under `LoadModeBranchesOnly` would do N per-branch lazy reads instead of one batched `BatchReadMetadata` — i.e. *worse*. Quiet checkout skips `printBranchInfo`, so the lazy parent-chain walk is a clean win.
 
-Measure first: for these commands the win is skipping the local-metadata batch (and, for `down`, deferring shared reads to the visited branches), not the per-branch reads the infrastructure already provides.
+Remaining work — the graph-based commands still use the full `common.Run` path:
+- `children` (`children.go:25`), `up` (`up.go:40`), `top` (`top.go:27`) build the whole `Graph()` over `AllBranches()`, so they genuinely need shared metadata for every branch — but none of them read frozen / NeedsPRBodyUpdate / PR state, so they could drop to `LoadModeShared` and skip the `BatchReadLocalMetadata` pass. (They cannot use `LoadModeBranchesOnly` — enumerating children forces a full graph build, where the per-branch lazy path is slower than one batch read.)
 
 ### 2. `up --to` should DFS once, not K x N *(small impact, low risk)*
 

--- a/internal/actions/navigation/action.go
+++ b/internal/actions/navigation/action.go
@@ -35,12 +35,15 @@ func SwitchBranchAction(direction Direction, ctx *app.Context, handler Handler) 
 	var targetBranch string
 	var err error
 
-	graph := ctx.Engine.Graph(engine.SortStrategyAlphabetical)
-
 	switch direction {
 	case DirectionBottom:
+		// Walks the parent chain only — no full graph needed, so the command can
+		// run under LoadModeBranchesOnly and lazily promote just the chain.
 		targetBranch = traverseDownward(currentBranch.GetName(), ctx)
 	case DirectionTop:
+		// Walking toward the tips needs child relationships, which requires the
+		// full stack graph.
+		graph := ctx.Engine.Graph(engine.SortStrategyAlphabetical)
 		targetBranch, err = traverseUpward(currentBranch.GetName(), ctx, graph, handler)
 		if err != nil {
 			return actions.CheckoutResult{}, err

--- a/internal/cli/navigation/bottom.go
+++ b/internal/cli/navigation/bottom.go
@@ -8,6 +8,7 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/cli/common"
 	"github.com/getstackit/stackit/internal/cli/stack"
+	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/utils"
 )
 
@@ -22,7 +23,17 @@ This command navigates down the parent chain from the current branch until
 it reaches the first branch that has trunk as its parent (or trunk itself).`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return common.Run(cmd, func(ctx *app.Context) error {
+			// bottom walks the parent chain only (DirectionBottom no longer builds
+			// the full stack graph). In quiet mode no branch info is printed, so the
+			// lighter branches-only load with lazy per-branch promotion suffices —
+			// mirroring the quiet exact-checkout path in `co`. The managed-worktree
+			// check is intentionally preserved (checkout relies on it).
+			opts := common.GetGlobalOptions(cmd)
+			if opts.Quiet {
+				loadMode := engine.LoadModeBranchesOnly
+				opts.EngineLoadMode = &loadMode
+			}
+			return common.RunWithOptions(cmd, opts, func(ctx *app.Context) error {
 				handler := stack.NewNavigationUI(ctx.Output, utils.IsInteractive())
 				result, err := navigation.SwitchBranchAction(navigation.DirectionBottom, ctx, handler)
 				if err != nil {

--- a/internal/cli/navigation/down.go
+++ b/internal/cli/navigation/down.go
@@ -6,6 +6,7 @@ import (
 	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/errors"
 	"github.com/getstackit/stackit/internal/tui/style"
 )
@@ -27,7 +28,18 @@ as an argument to move multiple levels at once.`,
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return common.Run(cmd, func(ctx *app.Context) error {
+			// down only walks the parent chain and checks out an exact branch. In
+			// quiet mode no branch info is printed (which would build the full stack
+			// graph), so the lighter branches-only load with lazy per-branch promotion
+			// is sufficient — mirroring the quiet exact-checkout path in `co`. The
+			// managed-worktree check is intentionally preserved (checkout relies on it
+			// for worktree switching).
+			opts := common.GetGlobalOptions(cmd)
+			if opts.Quiet {
+				loadMode := engine.LoadModeBranchesOnly
+				opts.EngineLoadMode = &loadMode
+			}
+			return common.RunWithOptions(cmd, opts, func(ctx *app.Context) error {
 				parsedSteps, err := parsePositiveSteps(args, steps)
 				if err != nil {
 					return err

--- a/internal/cli/navigation/navigation_test.go
+++ b/internal/cli/navigation/navigation_test.go
@@ -86,6 +86,29 @@ func TestNavigationCommands(t *testing.T) {
 		require.Equal(t, "main", strings.TrimSpace(output))
 	})
 
+	t.Run("quiet down and bottom navigate correctly under light load path", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+
+		// Create stack: main -> a -> b -> c
+		s.RunCli("create", "a", "-m", "a").
+			RunCli("create", "b", "-m", "b").
+			RunCli("create", "c", "-m", "c")
+
+		// Quiet down/bottom opt into LoadModeBranchesOnly; verify they still land
+		// on the correct branch (parent-chain traversal + checkout) end-to-end.
+		s.RunCli("down", "--quiet")
+		s.ExpectBranch("b")
+
+		s.RunCli("bottom", "--quiet")
+		s.ExpectBranch("a")
+
+		// Multi-step quiet down from the tip walks several parents at once.
+		s.Checkout("c").
+			RunCli("down", "2", "--quiet")
+		s.ExpectBranch("a")
+	})
+
 	t.Run("trunk and first branch navigation", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Quiet `down` and `bottom` walk only the parent chain and check out an
exact branch, so they can run under LoadModeBranchesOnly with lazy
per-branch metadata promotion instead of the full shared load — mirroring
the quiet exact-checkout path in `co`.

Gated on --quiet because non-quiet checkout prints branch info, which
builds the full stack graph (one batched metadata read beats N lazy
per-branch reads). The managed-worktree check is preserved since checkout
relies on it for worktree switching, so only EngineLoadMode is set.

SwitchBranchAction now builds the graph only for the upward (top)
direction; the downward (bottom) traversal walks parents and never needed
it, so bottom no longer forces a full graph build.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782784721`.


* **PR #1365**
  * **PR #1366**
    * **PR #1367** 👈
      * **PR #1368**
        * **PR #1371**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1372 by jonnii*