### PR TITLE
perf(submit,info): batch stack-wide up-to-date checks

### DIFF
--- a/docs/plans/perf/README.md
+++ b/docs/plans/perf/README.md
@@ -34,11 +34,10 @@ Per-command analysis of where `stackit` spends time, with proposed wins. All cla
 
 See [cross-cutting.md → Recommended attack order](cross-cutting.md#recommended-attack-order). TL;DR:
 
-1. Extend the conflict-free validation fast path to multi-commit branches (single-commit case already ships)
-2. Finish lightweight load-mode adoption on the remaining navigation commands
-3. Batch stack-wide status checks in `submit` + `info`
-4. `RebuildBranches([]string)` for `absorb` + `untrack` cleanup
-5. On-demand diff batching for `info --diff`/`--patch` and `absorb`
-6. Combine metadata transactions for `create` + `describe`; remaining hygiene
+1. `RebuildBranches([]string)` for `absorb` + `untrack` cleanup
+2. On-demand diff batching for `info --diff`/`--patch` and `absorb`
+3. Drop `children`/`up`/`top` from the default load to `LoadModeShared`
+4. Per-level worktree reuse for overlapping-file validation
+5. Combine metadata transactions for `create` + `describe`; remaining hygiene
 
-Several originally-planned wins have since landed — see [cross-cutting.md → Completed](cross-cutting.md#completed-since-last-revision) (go-git removal / `ReloadRepository`, snapshot batching + `undo.enabled` opt-out, `IsInManagedWorktree` gating, `scope`/`untrack` batching).
+Several originally-planned wins have since landed — see [cross-cutting.md → Completed](cross-cutting.md#completed-since-last-revision) (multi-commit conflict-free validation, batched stack-wide status checks in `submit`/`info`, quiet `down`/`bottom` branches-only load, go-git removal / `ReloadRepository`, snapshot batching + `undo.enabled` opt-out, `IsInManagedWorktree` gating, `scope`/`untrack` batching).

--- a/docs/plans/perf/cross-cutting.md
+++ b/docs/plans/perf/cross-cutting.md
@@ -28,23 +28,6 @@ Remaining adoption:
 
 ---
 
-### 2. Batch branch status reads at stack-iteration call sites
-
-> **Status:** Partially done. The batched reader `engine.ReadBranchStatuses` (`internal/engine/engine_branch_status.go:187`) exists and several actions use the `Batch*` readers. The remaining issue is specific call sites that still walk a stack calling per-branch up-to-date/restack checks.
-
-**Files:** call sites in `submit`, `info`
-
-Open call sites:
-
-- `submit` calls per-branch `branch.IsBranchUpToDate()` (`internal/cli/.../submit.go:153`, `submit_validation.go:121,127`), each hitting the uncached `IsUpToDate` with a fresh `git rev-parse` per parent.
-- `info`'s stack render loops `branch.NeedsRestack()` per branch (`internal/actions/stack_info.go:148-151`) → `IsUpToDate` → live parent SHA lookup, even though the heavy reads around it are already batched.
-
-**Proposal:** route these stack-wide status checks through `ReadBranchStatuses` (or a batched parent-revision helper) so the live per-parent SHA lookups happen once.
-
-**Affects:** info.md #1, submit.md #1.
-
----
-
 ### 3. Single batched git call for stats / diffs / revisions, never per branch
 
 > **Status:** Partially done. `tree` is fully on the batched path (`BatchDiffStats` / `BatchBranchStats` / `BatchCommits`, `internal/engine/branch_view.go`); `info` batches its stack stats too. Remaining N+1s are on the on-demand diff paths.
@@ -58,7 +41,7 @@ Remaining per-branch git invocations:
 
 **Proposal:** extend the batched stat/commit readers to these on-demand paths; the revision-keyed memoization already in `engine_branch_info.go` makes it safe.
 
-**Affects:** info.md #3, absorb.md #4.
+**Affects:** info.md #2, absorb.md #4.
 
 ---
 
@@ -157,6 +140,7 @@ These wins have fully landed. Numbering is preserved so per-command page referen
 
 - **#10 — Gate `IsInManagedWorktree` to commands that need it.** `SkipManagedWorktreeCheck` exists, is applied to read-only commands via `ApplyReadOnlyCurrentBranch`, and call sites are minimal (`common.go` + tests). Keep applying it to new read-only commands.
 - **#11 — Stop calling `ReloadRepository` after every commit.** go-git was removed entirely. There is no repo handle to close and no worktree re-scan; the expensive reopen this targeted no longer exists. The global revision cache it relied on is also gone (and a global revision cache is now an explicit anti-pattern — see `.claude/rules/code-style.md`).
+- **#2 — Batch branch status reads at stack-iteration call sites.** `submit` (`internal/actions/submit/submit.go`, `submit_validation.go`) and `info` (`internal/actions/stack_info.go`) now resolve up-to-date status for the whole branch set in one `eng.ReadBranchStatuses(...)` call (a single batched parent-revision read) instead of a per-branch `IsBranchUpToDate()` / `NeedsRestack()` that shelled a `git rev-parse` per parent.
 - **#6 — Conflict-impossible validation fast path.** `validateSingleSpec` calls `tryConflictFreeReplay` (`internal/engine/rebase_validator.go`): when the branch's changed files are disjoint from the parent's, it replays the branch onto the new base via `merge-tree --write-tree` + `commit-tree` with **no worktree**. Now covers **multi-commit branches** too — each commit is replayed oldest-first via `replayCommitConflictFree`, chained onto the previous result, preserving per-commit author identity and message. The remaining worktree-amortization idea lives on as #7.
 
 ---
@@ -165,12 +149,11 @@ These wins have fully landed. Numbering is preserved so per-command page referen
 
 For maximum impact per engineering hour:
 
-1. **#1 remaining load-mode adoption** — `children`/`up`/`top` can drop from the default to `LoadModeShared` (skip the local-metadata batch); `down`/`bottom` already moved to `LoadModeBranchesOnly`.
-2. **#2 batch stack-wide status checks** — removes the per-parent `git rev-parse` walks in `submit` and `info`.
-3. **#8 `RebuildBranches`** — scopes the remaining full rebuilds in `absorb`/`untrack`.
-4. **#3 on-demand diff batching** — `info --diff`/`--patch` and `absorb`'s commit scan.
-5. **#7 per-level worktree reuse** — amortizes the worktree cost that remains for genuinely overlapping multi-branch validation (the disjoint-file fast path #6 already eliminated the common case).
-6. **#9 combine txs** for `create` and `describe`; **#4 no-op snapshot skip**; **#5 / #12** hygiene.
+1. **#8 `RebuildBranches`** — scopes the remaining full rebuilds in `absorb`/`untrack`.
+2. **#3 on-demand diff batching** — `info --diff`/`--patch` and `absorb`'s commit scan.
+3. **#1 remaining load-mode adoption** — `children`/`up`/`top` can drop from the default to `LoadModeShared` (skip the local-metadata batch); `down`/`bottom` already moved to `LoadModeBranchesOnly`.
+4. **#7 per-level worktree reuse** — amortizes the worktree cost that remains for genuinely overlapping multi-branch validation (the disjoint-file fast path #6 already eliminated the common case).
+5. **#9 combine txs** for `create` and `describe`; **#4 no-op snapshot skip**; **#5 / #12** hygiene.
 
 ## Order-of-magnitude estimates
 
@@ -179,7 +162,6 @@ Back-of-envelope guesses to size effort vs reward, not measured. Completed items
 | Win | Affected commands | Typical saving per affected run |
 |---|---|---|
 | #1 remaining load-mode adoption | read-only/common commands | remaining bootstrap cost (50-500ms depending on branch count) |
-| #2 batch status checks | submit, info | N x `git rev-parse` per stack walk |
 | #3 on-demand diff batching | info, absorb | N x ~5ms `git` processes |
 | #8 RebuildBranches | absorb, untrack | full rebuild → scoped read |
 | #4 no-op snapshot skip | restack (no-work path) | 5-15ms |

--- a/docs/plans/perf/info.md
+++ b/docs/plans/perf/info.md
@@ -39,23 +39,17 @@ For **`info --diff` / `info --patch`**:
 For **`info <untracked-branch>`** (`internal/actions/info.go:78–92`):
 - Triggers a real **`git fetch refs/stackit/metadata`** network call via `eng.FetchRemoteMetadata`. Dominates everything — many seconds on slow networks. This is the only info path that does network I/O.
 
+## Already shipped (do not re-plan)
+
+- **Batched restack status in stack-wide info** — the `FixedMap` loop
+  (`internal/actions/stack_info.go`) now calls `eng.ReadBranchStatuses(stackBranches)`
+  once and reads `statuses.IsUpToDate(branch)`, instead of a per-branch
+  `NeedsRestack()` that shelled a `git rev-parse` for each parent. This was the
+  original win #1 (cross-cutting #2).
+
 ## Proposed wins (ranked)
 
-### 1. Batch the restack status in stack-wide info *(shared with cross-cutting.md #2)*
-
-> **Status:** Partially done. `StackInfoAction` (`internal/actions/stack_info.go:48`) already
-> batches the heavy per-branch reads: `BatchCommits`, `BatchDiffStats`,
-> `BatchChangedFileCounts`, and `BatchGetPRSubmissionStatus` (stack_info.go:68–74). The
-> default one-branch `info` path is small and needs nothing here.
-
-The remaining N+1 is the restack/`FixedMap` loop (`internal/actions/stack_info.go:148–151`),
-which calls `branch.NeedsRestack()` per branch. That resolves to `IsUpToDate` →
-`git.GetRevision(parent)` once per branch (no global revision cache by design), so a stack of
-N branches spawns N parent-revision lookups. Use the existing batched
-`ReadBranchStatuses` (`internal/engine/engine_branch_status.go:187`, which fans the parent
-revisions through `BatchGetRevisions`) to compute the `FixedMap` in one pass.
-
-### 2. Cache `FetchRemoteMetadata` per session *(small impact, low risk)*
+### 1. Cache `FetchRemoteMetadata` per session *(small impact, low risk)*
 
 `internal/actions/info.go:87` calls `eng.FetchRemoteMetadata` (→ `FetchRemote`,
 `internal/engine/branch_mutations.go:79`), which performs an unconditional network fetch
@@ -64,7 +58,7 @@ CLI this fires at most once per invocation, so the win only matters for a long-l
 (the API server / watcher), where calling info on the same untracked branch twice should not
 re-fetch. Add a process-lifetime guard around the metadata fetch if/when the engine is reused.
 
-### 3. Combine `GetAllCommits + GetParentCommitSHA` into one git call *(small impact, low risk)*
+### 2. Combine `GetAllCommits + GetParentCommitSHA` into one git call *(small impact, low risk)*
 
 For `--patch` mode, `internal/actions/info.go:190–193` does:
 - `GetAllCommits(SHA)` → walk commits
@@ -76,7 +70,7 @@ A single `git rev-list --parents` over the range produces both. Or read the stor
 revision directly — `meta.GetParentBranchRevision()` *is* the base revision and is already in
 cache after bootstrap (see `internal/engine/branch_tracking.go`).
 
-### 4. `GetCommitDate` could come from the engine state cache *(trivial)*
+### 3. `GetCommitDate` could come from the engine state cache *(trivial)*
 
 `GetCommitDate` (`internal/engine/engine_branch_info.go:13`) shells out to
 `git.GetCommitDate` per call. The branch SHA is cached after bootstrap, so a

--- a/docs/plans/perf/submit.md
+++ b/docs/plans/perf/submit.md
@@ -8,7 +8,7 @@
 NewSubmitCmd → executeSubmit → submit.Action         internal/actions/submit/submit.go:77
   ├─ if untracked target: prompt + eng.TrackBranch
   ├─ getBranchesToSubmit                              graph walk over the stack (planning.go:165)
-  ├─ for each branch: branch.IsBranchUpToDate         N × uncached parent rev-parse (submit.go:153)
+  ├─ eng.ReadBranchStatuses(branchObjs)               one batched parent rev-parse for all branches (submit.go)
   ├─ tree.NewStackTree + normalizeDisplayTreeParents  in-memory (builds its own parentMap, no eng.Graph)
   ├─ handler.OnEvent(StackDisplayEvent)               render
   │
@@ -31,8 +31,10 @@ NewSubmitCmd → executeSubmit → submit.Action         internal/actions/submit
 > Note: the branch push is already a single batched `git push` (`pushSubmittedBranches`,
 > submit.go:448), and remote SHAs come from `eng.ReadBranchRemoteStatuses` (the old
 > `PopulateRemoteShas` is gone). The footer pass already fetches all PR content in one
-> GraphQL query before fanning out. Several originally-planned wins have landed; the
-> remaining ones are below.
+> GraphQL query before fanning out. The per-branch up-to-date checks now go through one
+> batched `eng.ReadBranchStatuses` (both the display `fixedMap` and `validateBaseRevisions`),
+> replacing the old N × uncached `git rev-parse`. Several originally-planned wins have
+> landed; the remaining ones are below.
 
 ## Where time goes
 
@@ -50,22 +52,7 @@ For a **--restack submit**:
 
 ## Proposed wins (ranked)
 
-### 1. Batch per-branch `IsBranchUpToDate` checks *(shared with cross-cutting.md #2)*
-
-> **Status:** Not started. The batched engine reader `ReadBranchStatuses`
-> (`internal/engine/engine_branch_status.go:187`) already exists, but submit does
-> not route through it.
-
-`branch.IsBranchUpToDate()` → `engineImpl.IsUpToDate` (engine_branch_status.go:157) runs an
-**uncached** `git rev-parse` on the parent for every call. Submit calls it per branch in two
-places:
-- `submit.go:153` — building `fixedMap` for the display tree.
-- `submit_validation.go:121` and `:127` — inside `validateBaseRevisions`.
-
-Route both through `ReadBranchStatuses` (one `BatchGetRevisions` for all parents) so the
-planning path does one grouped read instead of N individual `rev-parse` invocations.
-
-### 2. Cache PR check/info reads across commands (shared with tree.md #4)
+### 1. Cache PR check/info reads across commands (shared with tree.md #4)
 
 > **Status:** Not started. The per-branch PR-info read this win originally
 > targeted is already batched: `ValidateBranchesToSubmit` syncs all PRs in one
@@ -78,15 +65,15 @@ recently, a short TTL cache (~30s) on `BatchGetPRChecksStatus` and the PR-info s
 a following `submit` skip the redundant GraphQL round trip. This is the cross-cutting cache
 shared with tree.md #4; submit is one consumer.
 
-### 3. Pre-build worktrees for parallel update path *(low impact today, useful for `--restack` path; shared with restack.md #4)*
+### 2. Pre-build worktrees for parallel update path *(low impact today, useful for `--restack` path; shared with restack.md #3)*
 
 > **Status:** Not started.
 
 When `--restack` is on, the inner `RestackBranches` builds worktrees per spec. If submit ran
 restack frequently (or for `--all-stacks`), a reusable worktree pool would help. Same shape as
-`restack.md` #4 — track the work there; submit benefits for free.
+`restack.md` #3 — track the work there; submit benefits for free.
 
-### 4. Combine the `SubmitFooter` update with the PR create/update call *(medium impact, low risk)*
+### 3. Combine the `SubmitFooter` update with the PR create/update call *(medium impact, low risk)*
 
 > **Status:** Partially done. The footer pass already fetches every PR's current
 > content in **one** GraphQL query up front (`actions.FetchPRContentForBranches`,
@@ -100,7 +87,7 @@ the body/title sent by `createPullRequestQuiet`/`updatePullRequestQuiet` so the 
 the same call. Saves the entire second-pass round trip when `--submit-footer` is on (the
 default for many users).
 
-### 5. Push metadata refs in the same `git push` as branch refs *(medium impact, medium risk)*
+### 4. Push metadata refs in the same `git push` as branch refs *(medium impact, medium risk)*
 
 > **Status:** Not started.
 
@@ -111,7 +98,7 @@ pushed all branch refs. The pattern is "1 batched branch push + 1 metadata push"
 fail-as-a-group; today's behavior tolerates a metadata-only push failure ("Run 'st sync' and
 try submitting again"). Keep the fallback.
 
-### 6. Sequential create path could parallelize after the first PR *(small impact, medium risk)*
+### 5. Sequential create path could parallelize after the first PR *(small impact, medium risk)*
 
 > **Status:** Not started.
 

--- a/internal/actions/stack_info.go
+++ b/internal/actions/stack_info.go
@@ -145,9 +145,13 @@ func StackInfoAction(ctx *app.Context, opts StackInfoOptions) error {
 		trunkName := eng.Trunk().GetName()
 		stackTree := tree.NewStackTree(stackBranches, currentBranch.GetName(), trunkName)
 		stackTree.FixedMap = make(map[string]bool)
+		// Resolve restack status for the whole stack in one batched parent-revision
+		// read instead of a per-branch NeedsRestack() (each of which would shell a
+		// separate `git rev-parse` for the parent).
+		statuses := eng.ReadBranchStatuses(stackBranches)
 		for _, branch := range stackBranches {
 			// IsFixed means it does NOT need restack
-			stackTree.FixedMap[branch.GetName()] = !branch.NeedsRestack()
+			stackTree.FixedMap[branch.GetName()] = statuses.IsUpToDate(branch)
 		}
 		stackTree.FixedMap[trunkName] = true
 

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -143,14 +143,22 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	// Build tree structure for display
 	branchObjs := make(engine.Branches, len(branches))
+	for i, branchName := range branches {
+		branchObjs[i] = nav.GetBranch(branchName)
+	}
+
+	// Resolve up-to-date status for every branch in one batched parent-revision
+	// read rather than a per-branch IsBranchUpToDate() (each of which shells a
+	// separate `git rev-parse` for the parent).
+	statuses := eng.ReadBranchStatuses(branchObjs)
+
 	fixedMap := make(map[string]bool)
 	scopeMap := make(map[string]string)
 	worktreeMap := make(map[string]string)
 
 	for i, branchName := range branches {
-		branch := nav.GetBranch(branchName)
-		branchObjs[i] = branch
-		fixedMap[branchName] = branch.IsBranchUpToDate()
+		branch := branchObjs[i]
+		fixedMap[branchName] = statuses.IsUpToDate(branch)
 		scopeMap[branchName] = branch.GetScope().String()
 
 		// Check if this branch belongs to a stack with a managed worktree.

--- a/internal/actions/submit/submit_validation.go
+++ b/internal/actions/submit/submit_validation.go
@@ -111,6 +111,15 @@ func validateBaseRevisions(branches []string, eng engine.BranchStatus, ctx *app.
 		return remoteStatuses
 	}
 
+	// Resolve up-to-date status for every branch in one batched parent-revision
+	// read instead of a per-branch IsBranchUpToDate() inside the loop (each of
+	// which would shell a separate `git rev-parse` for the parent).
+	branchObjs := make(engine.Branches, 0, len(branches))
+	for _, branchName := range branches {
+		branchObjs = append(branchObjs, eng.GetBranch(branchName))
+	}
+	statuses := eng.ReadBranchStatuses(branchObjs)
+
 	for _, branchName := range branches {
 		branch := eng.GetBranch(branchName)
 		parentBranchName := resolveSubmitParentName(nav, branch)
@@ -118,13 +127,13 @@ func validateBaseRevisions(branches []string, eng engine.BranchStatus, ctx *app.
 		parentBranch := eng.GetBranch(parentBranchName)
 		switch {
 		case parentBranch.IsTrunk():
-			if !branch.IsBranchUpToDate() {
+			if !statuses.IsUpToDate(branch) {
 				ctx.Output.Info("Note that %s has fallen behind trunk. You may encounter conflicts if you attempt to merge it.",
 					output.Branch(branchName, false))
 			}
 		case validatedBranches[parentBranchName]:
 			// Parent is in the submission list
-			if !branch.IsBranchUpToDate() {
+			if !statuses.IsUpToDate(branch) {
 				return fmt.Errorf("you are trying to submit at least one branch that has not been restacked on its parent. To resolve this, check out %s and run 'stackit restack'",
 					output.Branch(branchName, false))
 			}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Resolve restack/up-to-date status for a whole branch set in one batched
parent-revision read via eng.ReadBranchStatuses, instead of per-branch
IsBranchUpToDate()/NeedsRestack() calls that each shelled a git rev-parse
for the parent.

- submit: display fixedMap and validateBaseRevisions
- info: the stack-wide FixedMap loop in StackInfoAction

Semantics are identical (ReadBranchStatuses uses the same IsUpToDate rules,
including the not-tracked and empty-stored-revision edge cases); the parent
SHA lookups now happen once per command rather than N times.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782784721`.


* **PR #1365**
  * **PR #1366**
    * **PR #1367**
      * **PR #1368** 👈
        * **PR #1371**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1372 by jonnii*