### PR TITLE
perf: batch-read PR metadata in lock-and-notify operations

### DIFF
--- a/internal/actions/merge/consolidate.go
+++ b/internal/actions/merge/consolidate.go
@@ -308,15 +308,21 @@ func (c *ConsolidateMergeExecutor) lockAndNotifyIndividualPRs(_ context.Context,
 		}
 	}
 
+	lockNames := make([]string, len(branchesToLock))
+	for i, b := range branchesToLock {
+		lockNames[i] = b.GetName()
+	}
+	allMeta, metaErrs := c.engine.BatchReadMetadataRaw(lockNames)
+
 	prUpdates := make(map[string]*engine.PrInfo, len(branchesToLock))
 	for _, b := range branchesToLock {
-		prInfo, err := b.GetPrInfo()
-		if err != nil {
-			splog.Debug("Failed to read PR info for %s: %v", b.GetName(), err)
+		name := b.GetName()
+		if err, hasErr := metaErrs[name]; hasErr {
+			splog.Debug("Failed to read PR info for %s: %v", name, err)
 			continue
 		}
-		if prInfo != nil {
-			prUpdates[b.GetName()] = prInfo.WithMergeBranch(consolidationBranch)
+		if prInfo := engine.NewPrInfoFromMeta(allMeta[name]); prInfo != nil {
+			prUpdates[name] = prInfo.WithMergeBranch(consolidationBranch)
 		}
 	}
 	if len(prUpdates) > 0 {

--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -117,6 +117,7 @@ type mergeExecuteEngine interface {
 	engine.SyncManager
 	engine.StackRewriter
 	engine.RemoteMetadataManager
+	BatchReadMetadataRaw(branchNames []string) (map[string]*git.Meta, map[string]error)
 	Git() git.Runner
 }
 

--- a/internal/actions/merge/multistack.go
+++ b/internal/actions/merge/multistack.go
@@ -286,15 +286,21 @@ func lockAndNotifyMultiStackPRs(ctx *app.Context, eng engine.Engine, includedSta
 	}
 
 	// Update PR info with consolidation branch
+	lockNames := make([]string, len(branchesToLock))
+	for i, b := range branchesToLock {
+		lockNames[i] = b.GetName()
+	}
+	allMeta, metaErrs := eng.BatchReadMetadataRaw(lockNames)
+
 	prUpdates := make(map[string]*engine.PrInfo, len(branchesToLock))
 	for _, b := range branchesToLock {
-		prInfo, err := b.GetPrInfo()
-		if err != nil {
-			out.Debug("Failed to read PR info for %s: %v", b.GetName(), err)
+		name := b.GetName()
+		if err, hasErr := metaErrs[name]; hasErr {
+			out.Debug("Failed to read PR info for %s: %v", name, err)
 			continue
 		}
-		if prInfo != nil {
-			prUpdates[b.GetName()] = prInfo.WithMergeBranch(consolidationBranch)
+		if prInfo := engine.NewPrInfoFromMeta(allMeta[name]); prInfo != nil {
+			prUpdates[name] = prInfo.WithMergeBranch(consolidationBranch)
 		}
 	}
 	if len(prUpdates) > 0 {

--- a/internal/engine/engine_pr.go
+++ b/internal/engine/engine_pr.go
@@ -20,8 +20,11 @@ func (e *engineImpl) GetPrInfo(branch Branch) (*PrInfo, error) {
 
 // NewPrInfoFromMeta creates a PrInfo from git.Meta
 func NewPrInfoFromMeta(meta *git.Meta) *PrInfo {
+	if meta == nil {
+		return nil
+	}
 	prInfo := meta.GetPrInfo()
-	if meta == nil || prInfo == nil {
+	if prInfo == nil {
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

- Replace per-branch `GetPrInfo()` loops in `lockAndNotifyIndividualPRs` (consolidate) and `lockAndNotifyMultiStackPRs` (multistack) with a single `BatchReadMetadataRaw` call — all metadata now arrives in one git pipe transaction instead of N serial ref reads
- Fix a nil-dereference latent bug in `NewPrInfoFromMeta`: the `meta == nil` guard was placed after `meta.GetPrInfo()` was already called, which would panic if a nil `*git.Meta` was ever passed in; the guard now comes first
- Add `BatchReadMetadataRaw` to `mergeExecuteEngine` so the consolidate executor can use it through its interface

## Changes

**`internal/engine/engine_pr.go`** — bug fix: reorder nil guard in `NewPrInfoFromMeta` before the method call it's guarding against.

**`internal/actions/merge/execute.go`** — add `BatchReadMetadataRaw` to `mergeExecuteEngine` interface.

**`internal/actions/merge/multistack.go`** and **`internal/actions/merge/consolidate.go`** — replace the `for _, b := range branchesToLock { b.GetPrInfo() }` pattern with a single batch read followed by `NewPrInfoFromMeta` per result.

## Impact

For a stack with N branches being locked before consolidation, this reduces git ref reads from O(N) serial disk hits to O(1) batched pipe transaction. No behaviour change — the same PR info is read and the same updates are written.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzkpF9jdT8BLxv1bpNP52z)_