### PR TITLE
perf(restack): fast-path empty parent file changes

### DIFF
--- a/internal/engine/rebase_validator.go
+++ b/internal/engine/rebase_validator.go
@@ -444,7 +444,7 @@ func (e *engineImpl) tryConflictFreeReplay(
 
 	// Get the files changed by the parent's new commits (what we're rebasing onto).
 	parentFiles, err := e.git.GetChangedFiles(ctx, spec.OldUpstream, resolvedParent)
-	if err != nil || len(parentFiles) == 0 {
+	if err != nil {
 		return "", false
 	}
 

--- a/internal/engine/rebase_validator_internal_test.go
+++ b/internal/engine/rebase_validator_internal_test.go
@@ -122,6 +122,34 @@ func TestTryConflictFreeReplaySingleCommitUsesMergeTreeWithExplicitMergeBase(t *
 	}, fakeGit.commitTreeCalls[1])
 }
 
+func TestTryConflictFreeReplayUsesFastPathWhenParentChangedNoFiles(t *testing.T) {
+	// Parent advanced without touching any files (same tree as old-base). An empty
+	// parent file set cannot overlap branch changes, so the fast path should still
+	// replay instead of falling back to a worktree dry-run.
+	fakeGit := &fastPathGit{
+		t:       t,
+		commits: []string{"feature-commit"},
+		parents: map[string]string{
+			"feature-commit": "old-base",
+		},
+		changedFiles: map[string][]string{
+			"new-parent": {},
+			"feature":    {"feature.txt"},
+		},
+	}
+	eng := &engineImpl{git: fakeGit}
+
+	newSHA, ok := eng.tryConflictFreeReplay(context.Background(), RebaseSpec{
+		Branch:      "feature",
+		NewParent:   "new-parent",
+		OldUpstream: "old-base",
+	}, "new-parent")
+
+	require.True(t, ok)
+	require.Equal(t, "new-sha-1", newSHA)
+	require.Len(t, fakeGit.mergeTreeCalls, 1)
+}
+
 func TestTryConflictFreeReplayMultiCommitChainsEachCommit(t *testing.T) {
 	// Branch has three commits (newest-first): c3 -> c2 -> c1 -> old-base.
 	fakeGit := &fastPathGit{


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782784721`.


* **PR #1365**
  * **PR #1366**
    * **PR #1367**
      * **PR #1368**
        * **PR #1371** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1372 by jonnii*