### PR TITLE
Merging 5 PRs

### DIFF
--- a/docs/plans/perf/README.md
+++ b/docs/plans/perf/README.md
@@ -34,9 +34,11 @@ Per-command analysis of where `stackit` spends time, with proposed wins. All cla
 
 See [cross-cutting.md → Recommended attack order](cross-cutting.md#recommended-attack-order). TL;DR:
 
-1. Expand lightweight load modes
-2. Conflict-impossible validation for restack
-3. Preload stack stats for `tree`
-4. `RebuildBranches([]string)` for `untrack` + `absorb` cleanup
-5. Snapshot batching / undo opt-out
-6. Coalesce remaining staging `worktree.Status()` calls
+1. Extend the conflict-free validation fast path to multi-commit branches (single-commit case already ships)
+2. Finish lightweight load-mode adoption on the remaining navigation commands
+3. Batch stack-wide status checks in `submit` + `info`
+4. `RebuildBranches([]string)` for `absorb` + `untrack` cleanup
+5. On-demand diff batching for `info --diff`/`--patch` and `absorb`
+6. Combine metadata transactions for `create` + `describe`; remaining hygiene
+
+Several originally-planned wins have since landed — see [cross-cutting.md → Completed](cross-cutting.md#completed-since-last-revision) (go-git removal / `ReloadRepository`, snapshot batching + `undo.enabled` opt-out, `IsInManagedWorktree` gating, `scope`/`untrack` batching).

--- a/docs/plans/perf/README.md
+++ b/docs/plans/perf/README.md
@@ -34,11 +34,10 @@ Per-command analysis of where `stackit` spends time, with proposed wins. All cla
 
 See [cross-cutting.md → Recommended attack order](cross-cutting.md#recommended-attack-order). TL;DR:
 
-1. Extend the conflict-free validation fast path to multi-commit branches (single-commit case already ships)
-2. Finish lightweight load-mode adoption on the remaining navigation commands
-3. Batch stack-wide status checks in `submit` + `info`
-4. `RebuildBranches([]string)` for `absorb` + `untrack` cleanup
-5. On-demand diff batching for `info --diff`/`--patch` and `absorb`
-6. Combine metadata transactions for `create` + `describe`; remaining hygiene
+1. `RebuildBranches([]string)` for `absorb` + `untrack` cleanup
+2. On-demand diff batching for `info --diff`/`--patch` and `absorb`
+3. Drop `children`/`up`/`top` from the default load to `LoadModeShared`
+4. Per-level worktree reuse for overlapping-file validation
+5. Combine metadata transactions for `create` + `describe`; remaining hygiene
 
-Several originally-planned wins have since landed — see [cross-cutting.md → Completed](cross-cutting.md#completed-since-last-revision) (go-git removal / `ReloadRepository`, snapshot batching + `undo.enabled` opt-out, `IsInManagedWorktree` gating, `scope`/`untrack` batching).
+Several originally-planned wins have since landed — see [cross-cutting.md → Completed](cross-cutting.md#completed-since-last-revision) (multi-commit conflict-free validation, batched stack-wide status checks in `submit`/`info`, quiet `down`/`bottom` branches-only load, go-git removal / `ReloadRepository`, snapshot batching + `undo.enabled` opt-out, `IsInManagedWorktree` gating, `scope`/`untrack` batching).

--- a/docs/plans/perf/absorb.md
+++ b/docs/plans/perf/absorb.md
@@ -48,9 +48,18 @@ NewAbsorbCmd → common.Run                            (same bootstrap as co)
 
 ## Proposed wins (ranked)
 
-### 1. Same worktree-validation fix benefits the post-absorb restack *(shared with modify.md #1)*
+### 1. Worktree reuse for the overlapping-file post-absorb restack *(shared with modify.md #1)*
 
-`RestackBranches` here goes through the same `ValidateRebases` worktree-per-spec path. Trivially-safe rebases (very common after absorb — most hunks land in a single ancestor and don't change descendant-touched files) could skip validation entirely.
+> **Status:** Partly addressed for free. `RestackBranches` here goes through the
+> same `ValidateRebases` path, which now has a shipped conflict-free fast path:
+> rebases whose files are disjoint from the parent's changes skip the worktree
+> entirely (single- *and* multi-commit). After absorb most hunks land in a single
+> ancestor and don't touch descendant files, so this common case already takes the
+> no-worktree path automatically.
+
+Remaining: branches whose files **overlap** the absorbed change still create a
+validation worktree each. The shared worktree-reuse-per-depth-level idea
+(`modify.md` #1) is what's left to amortize those.
 
 ### 2. Drop the redundant pre-staging `HasStagedChanges` call *(small, low risk)*
 

--- a/docs/plans/perf/absorb.md
+++ b/docs/plans/perf/absorb.md
@@ -23,8 +23,7 @@ NewAbsorbCmd → common.Run                            (same bootstrap as co)
        ├─ for each hunk:
        │     eng.FindTargetCommitForHunk             tries applying hunk to successive commits — most expensive part per-hunk
        │
-       ├─ for each target:
-       │     eng.FindBranchForCommit                 lookup
+       ├─ eng.FindBranchesForCommits(targets)        single batched scan (was per-hunk lookup)
        │
        ├─ if --dry-run: print + maybe JSON; return
        │
@@ -53,9 +52,14 @@ NewAbsorbCmd → common.Run                            (same bootstrap as co)
 
 `RestackBranches` here goes through the same `ValidateRebases` worktree-per-spec path. Trivially-safe rebases (very common after absorb — most hunks land in a single ancestor and don't change descendant-touched files) could skip validation entirely.
 
-### 2. Combine the two `HasStagedChanges` calls *(small, low risk)*
+### 2. Drop the redundant pre-staging `HasStagedChanges` call *(small, low risk)*
 
-`absorb.go:63` checks before staging, `:78` checks after. The first call is *only* used to decide whether to print "Nothing to absorb" — which the second call also catches. Drop the first one; the user-facing message arrives one staging op later but the behavior is the same.
+`absorb.go:63` checks before staging, `:78` checks after. The first call's
+*result is already discarded* (`_, err := eng.HasStagedChanges(...)`) — only its
+error is propagated; the "Nothing to absorb" decision is made entirely off the
+second call at `:78`. So the first `HasStagedChanges` is a pure `worktree.Status()`
+full-tree walk with no behavioral effect. Delete it outright. (Same underlying
+`worktree.Status()` cost as `create.md` #1.)
 
 ### 3. Scope `eng.Rebuild("")` to touched branches *(medium, medium risk)*
 
@@ -65,9 +69,10 @@ After absorb, only the modified branches and their descendants have changed. A `
 
 `absorb.go:121–130` calls `GetAllCommits(SHA)` per branch and then walks. One `git rev-list --boundary <trunk>..<current>` returns all SHAs in one process. The per-branch attribution can be done from the parent-revision metadata already in the cache.
 
-### 5. `FindBranchForCommit` could come from a commit→branch map built during the SHA walk *(trivial)*
-
-While iterating `downstackBranches` to collect SHAs, also populate `commitSHA → branchName`. Then `FindBranchForCommit` becomes a map lookup. Today it's a separate function call per target hunk.
+> Note: the separate target→branch attribution step (`FindBranchesForCommits`,
+> `engine_reader.go:201`) *also* calls `GetAllCommits` per branch. If win #4
+> builds a `commitSHA → branchName` map during the single rev-list walk, that
+> batched scan can be dropped too — folding former win #5 into this one.
 
 ## Validation
 

--- a/docs/plans/perf/co.md
+++ b/docs/plans/perf/co.md
@@ -7,9 +7,9 @@
 ```
 NewCheckoutCmd.RunE
   ├─ if --quiet and exact branch/trunk:
-  │    opts.EngineLoadMode = LoadModeBranchesOnly
+  │    globalOpts.EngineLoadMode = &LoadModeBranchesOnly
   │
-  └─ common.Run                              internal/cli/common/common.go
+  └─ common.RunWithOptions                   internal/cli/common/common.go
        ├─ app.GetContextWithWriter
        │    ├─ git.NewRunner / DiscoverRepoRoot
        │    ├─ config.LoadConfig
@@ -17,10 +17,11 @@ NewCheckoutCmd.RunE
        │    └─ engine.NewEngine
        │         ├─ LoadModeBranchesOnly: GetAllBranchNames only
        │         └─ default LoadModeShared: shared metadata, local metadata lazy
-       └─ Engine.IsInManagedWorktree() unless skipped by command options
+       └─ Engine.IsInManagedWorktree() unless SkipManagedWorktreeCheck
   └─ common.Checkout → actions.CheckoutAction
        ├─ resolveBranchName
-       │    └─ eng.AllBranches() (already cached, cheap)
+       │    ├─ eng.BranchNames().Contains(input)  (O(1) exact match, returns early)
+       │    └─ eng.AllBranches() only for scope/fuzzy fallback
        ├─ getWorktreeSwitchInfo
        │    ├─ Engine.GetStackRootForBranch
        │    └─ Engine.GetWorktreeForStack
@@ -42,6 +43,16 @@ NewCheckoutCmd.RunE
 
 ### 1. Expand lightweight bootstrap beyond exact quiet checkout *(high impact, medium risk)*
 
+> **Status:** Partially done. The opt-in and the per-branch promotion mechanism
+> both exist. `NewCheckoutCmd.RunE` opts exact quiet `co <branch>` and
+> `co --trunk --quiet` into `LoadModeBranchesOnly`
+> (`internal/cli/navigation/checkout.go:37`). Lazy single-branch promotion is
+> already implemented via `ensureBranchSharedLoaded`
+> (`internal/engine/engine_impl.go:271`), which loads one branch's shared
+> metadata without triggering the full `ensureSharedLoaded` batch — accessors
+> like `GetParent` and `ReadBranchStatuses` already call it. The remaining work
+> is to extend the CLI opt-in beyond the quiet path.
+
 Exact quiet `co <branch>` and `co --trunk --quiet` already opt into `LoadModeBranchesOnly`. The remaining common cases are:
 
 - exact non-quiet checkout, where branch info needs a small ancestor slice rather than full repo metadata;
@@ -54,13 +65,18 @@ Use branch-list mode first, then promote only the chosen branch's stack/worktree
 
 `printBranchInfo` is informational. It is already behind `--quiet` and uses batched status reads; add a config option to disable it by default for users who prioritize checkout latency over guidance.
 
-### 3. Skip double `AllBranches` traversal *(trivial)*
+### 3. Keep auditing managed-worktree checks *(small impact, command-specific)*
 
-`resolveBranchName` builds a name slice and scans it linearly. With an exact name in hand, do one map lookup via `Engine.GetBranch` first and return immediately. Only fall back to the slice scan for fuzzy/scope matching.
+> **Status:** Partially done. The `SkipManagedWorktreeCheck` opt-out already exists
+> (`app.GlobalOptions.SkipManagedWorktreeCheck`, honored in
+> `RunWithOptions` at `internal/cli/common/common.go:47`, and set by
+> `ApplyReadOnlyCurrentBranch` / `RunReadOnlyCurrentBranch`). Checkout itself
+> still needs `IsInManagedWorktree` (`internal/engine/engine_worktree.go:315`).
 
-### 4. Keep auditing managed-worktree checks *(small impact, command-specific)*
-
-Checkout itself needs `IsInManagedWorktree`. The remaining win is not in `co`, but in commands that reuse checkout helpers or command wrappers without needing worktree switching.
+Remaining work is an audit, not a change in `co`: find commands that reuse
+checkout helpers or command wrappers but never switch worktrees, and route them
+through `RunReadOnlyCurrentBranch` (or set `SkipManagedWorktreeCheck`) so they
+skip the managed-worktree probe.
 
 ## How to validate
 

--- a/docs/plans/perf/create.md
+++ b/docs/plans/perf/create.md
@@ -6,19 +6,23 @@
 
 ```
 NewCreateCmd.RunE → common.Run                       (same bootstrap as co)
-  └─ create.Action                                   internal/actions/create/create.go:38
+  └─ create.Action                                   internal/actions/create/create.go:42
        ├─ validation.MustBeOnBranch
-       ├─ actions.TakeBestEffortSnapshot
+       │     └─ eng.ValidateOnBranch → eng.CurrentBranch()  ← shells `git symbolic-ref` (NOT cached)
+       ├─ eng.CurrentBranch().GetName()              ← shells GetCurrentBranch again (create.go:56)
+       ├─ actions.TakeBestEffortSnapshot             internal/actions/common.go:45
+       │     │   (no-op when config undo.enabled=false)
        │     └─ engine.TakeSnapshot                  internal/engine/undo.go:108
-       │           ├─ for each branch: branch.GetRevision()        N revision lookups (not preloaded)
-       │           ├─ git.ListMetadata                              one go-git ref iter
-       │           ├─ json.MarshalIndent + os.WriteFile             snapshot file
-       │           └─ enforceMaxStackDepth                          os.ReadDir + sort + maybe os.Remove
+       │           ├─ git.BatchGetRevisions(branches)        one rev-parse for all branches
+       │           ├─ git.ListMetadata                       one go-git ref iter
+       │           ├─ json.MarshalIndent + os.WriteFile      snapshot file
+       │           └─ enforceMaxStackDepth                   os.ReadDir + sort + maybe os.Remove
        │
-       ├─ eng.HasStagedChanges                       internal/git/staging.go:102
-       │     └─ worktree.Status()                    ← O(working tree)
+       ├─ eng.HasStagedChanges                       internal/git/staging.go:55 (`git diff --cached --quiet`)
        ├─ if interactive + no staged:
-       │     eng.HasUnstagedChanges                  → another worktree.Status()
+       │     eng.HasUnstagedChanges                  internal/git/staging.go:62 (`git diff --quiet`)
+       ├─ if non-interactive + no staged guard:
+       │     eng.HasUnstagedChanges + eng.HasUntrackedFiles  two more git subprocesses
        │
        ├─ stage (optional, only if --all/--update/--patch):
        │     git.StageChanges                        forks `git add ...`
@@ -30,19 +34,17 @@ NewCreateCmd.RunE → common.Run                       (same bootstrap as co)
        │
        ├─ eng.AllBranches() + slices.ContainsFunc    O(N) duplicate check, cached
        │
-       ├─ eng.CreateAndCheckoutBranch                internal/engine/engine_writer.go:296
-       │     └─ git.runner.CreateAndCheckoutBranch   internal/git/branches.go:91
-       │           └─ native `git checkout -b <branch>`
+       ├─ eng.CreateAndCheckoutBranch                internal/engine/branch_mutations.go:365
+       │     ├─ git.runner.CreateAndCheckoutBranch   internal/git/branches.go:45 (native `git checkout -b`)
+       │     └─ addKnownBranchLocked                 pushes new branch into e.state.branches
        │
-       ├─ if staged: eng.Commit                      internal/engine/engine_writer.go:709
-       │     └─ git.runner.Commit                    internal/git/commit.go:68
-       │           ├─ shells `git commit -m ...`     ← user hooks dominate
-       │           ├─ revisionCache.InvalidateAll
-       │           └─ ReloadRepository               ← closes + reopens go-git repo
+       ├─ if staged: eng.Commit                      internal/engine/commit_ops.go:10
+       │     └─ git.runner.CommitWithOptions         internal/git/commit.go:20
+       │           └─ shells `git commit ...`        ← user hooks dominate (no go-git reload anymore)
        │
-       ├─ eng.TrackBranch                            internal/engine/engine_writer.go:91
-       │     ├─ git.GetCurrentBranch                 cheap (HEAD)
-       │     ├─ optional GetAllBranchNames           usually a no-op (already cached)
+       ├─ eng.TrackBranch                            internal/engine/branch_tracking.go:12
+       │     ├─ git.GetCurrentBranch                 cheap (HEAD), but redundant re-shell
+       │     ├─ GetAllBranchNames re-fetch           gated; no longer fires (branch already cached)
        │     └─ SetParent → metadata transaction     1 ref write
        │
        ├─ if --scope: eng.SetScope                   another metadata transaction
@@ -51,46 +53,41 @@ NewCreateCmd.RunE → common.Run                       (same bootstrap as co)
 
 ## Where time goes (largest → smallest, typical interactive create)
 
-1. **`git commit` subprocess + user hooks** — the user's pre-commit hook usually dominates wall time when present. Stackit can't change that, but it can avoid duplicate work around it (see #4).
-2. **`ReloadRepository`** (`internal/git/runner.go:480`) after every commit. Closes the go-git `*Repository`, invalidates the entire revision cache, and re-opens. Re-opens of large repos cost real I/O; throwing away `revisionCache.AllBranchRevisions` is wasteful since only the freshly committed branch's SHA changed.
-3. **`worktree.Status()` × 1–2** — `HasStagedChanges` calls it once, and `HasUnstagedChanges` calls it again in the interactive prompt path. Checkout no longer adds an extra go-git status walk. Each remaining status check is a full working-tree walk; on a big repo this is the dominant non-hook cost.
-4. **`TakeSnapshot`** (`internal/engine/undo.go:108`). Iterates `e.state.branches` and calls `branch.GetRevision()` per branch, hitting `r.revisionCache` one entry at a time. Also calls `git.ListMetadata` (separate ref iter) and an `os.ReadDir` for stack-depth enforcement. On a 50-branch repo this is ~50 cached lookups + 1 metadata scan + snapshot write — usually 5–15ms but it runs on every mutation.
+1. **`git commit` subprocess + user hooks** — the user's pre-commit hook usually dominates wall time when present. Stackit can't change that. (`ReloadRepository` after commit is gone — `Commit` now just shells `git commit` with no go-git reload or cache invalidation, see `internal/git/commit.go`.)
+2. **`git diff` staging probes × 1–3** — `HasStagedChanges` runs `git diff --cached --quiet`; the interactive prompt adds `HasUnstagedChanges`; the non-interactive empty-tree guard adds `HasUnstagedChanges` + `HasUntrackedFiles`. These are cheap native git subprocesses (not full go-git working-tree walks), but they are separate processes that could be collapsed into one `git status --porcelain`.
+3. **`GetCurrentBranch` shelled 2–3×** — `validation.MustBeOnBranch` → `CurrentBranch()` re-shells, `create.go:56` re-shells, and `TrackBranch` re-shells again. `CurrentBranch()` does not consult any cache; it always shells `git symbolic-ref`.
+4. **`TakeSnapshot`** (`internal/engine/undo.go:108`). Now batches revisions in one `BatchGetRevisions` call and is skipped entirely when `undo.enabled=false`. Remaining per-call cost: `git.ListMetadata` (ref iter), the JSON write, and `enforceMaxStackDepth`'s `os.ReadDir + sort` on every mutation.
 5. **Bootstrap (`rebuildInternal`)** — same fixed cost as `co.md` describes.
-6. **`TrackBranch` re-fetches `GetCurrentBranch`** inside its critical section (`internal/engine/engine_writer.go:102`) even though we just created the branch. Small but pointless.
+6. **`SetScope` does its own metadata transaction** instead of bundling with the parent-set in `TrackBranch`. Two ref writes where one would do.
 7. **`getCommitMessageForBranch`** when no `-m` is provided opens an editor or reads from stdin — user-blocking, not stackit's fault.
-8. **`SetScope` does its own metadata transaction** instead of bundling with the parent-set in `TrackBranch`. Two ref writes where one would do.
 
 ## Proposed wins (ranked)
 
-### 1. Coalesce staging `worktree.Status()` calls *(medium impact, low risk)*
+### 1. Coalesce staging probes into one `git status` *(low impact, low risk)*
 
-`HasStagedChanges` and `HasUnstagedChanges` both walk the working tree. Add a single `RepoStatus` (`{HasStaged, HasUnstaged, HasUntracked}`) call early in `create.Action`, cache it on the engine for the duration of the request, and reuse it for prompts/validation. Same fix benefits `modify`, `absorb`, and `submit`.
+> **Status:** Premise corrected. The probes are **not** go-git `worktree.Status()` walks — `HasStagedChanges` / `HasUnstagedChanges` run `git diff --cached --quiet` / `git diff --quiet` (`internal/git/staging.go:55,62`) and `HasUntrackedFiles` runs `git ls-files`. So the original "full working-tree walk" cost is overstated; this is now a smaller, optional win.
 
-### 2. Snapshot should use batched revisions and skip on opt-out *(medium impact, low risk)*
+The non-interactive guard (`internal/actions/create/create.go:125–137`) can fire three separate git subprocesses (`HasStagedChanges`, then `HasUnstagedChanges` + `HasUntrackedFiles`). Add a single `RepoStatus` (`{HasStaged, HasUnstaged, HasUntracked}`) call backed by one `git status --porcelain`, cache it on the engine for the request, and reuse it for staging decisions and the guard. Same fix benefits `modify`, `absorb`, and `submit`.
 
-`TakeSnapshot` should call `BatchGetRevisions` (or use the revision cache after `LoadAllBranchRevisions`) instead of iterating per-branch. Also: snapshots are only consumed by `undo`. For users that never undo, the work and disk write are pure overhead. Add a config flag (`undo.enabled=false`) and short-circuit `TakeBestEffortSnapshot` when it's off.
+### 2. Lazy `enforceMaxStackDepth` *(small, low risk)*
 
-Also: `enforceMaxStackDepth` does `os.ReadDir + sort + os.Remove`. Cheap individually, but on every mutating command it adds up. Lazy enforcement (only when the directory size exceeds N × max-depth) is fine.
+> **Status:** Partially done. Batched revisions are implemented — `TakeSnapshot` already calls `e.git.BatchGetRevisions(e.state.branches)` (`internal/engine/undo.go:121`). The opt-out is implemented — `TakeBestEffortSnapshot` short-circuits when `undo.enabled=false` (`internal/actions/common.go:45–48`, config key `stackit.undo.enabled` in `internal/config/keys.go:18`). Only the lazy-enforcement item below remains.
 
-### 3. Drop or scope `ReloadRepository` after commit *(medium impact, medium risk)*
+`enforceMaxStackDepth` (`internal/engine/undo.go:172`) does `os.ReadDir + sort + os.Remove` on every snapshot. Cheap individually but it runs on every mutating command. Enforce lazily (only when the directory entry count exceeds N × max-depth) so the common case skips the directory scan and sort.
 
-`ReloadRepository` throws away the entire go-git in-memory state to pick up a single new commit. Two cheaper options:
-- Just invalidate the affected branch in `revisionCache` (`revisionCache.Invalidate(branchName)`) and let go-git re-read its packed refs lazily.
-- Re-open only the refs subsystem, not the whole repo.
+### 3. Bundle parent-set + scope into one metadata transaction *(small, low risk)*
 
-Risk: go-git caches loose-object packs; if we don't reload we may miss the new commit object on subsequent lookups. Easiest first step is `revisionCache.Invalidate(branchName)` plus a targeted ref refresh.
+`TrackBranch` opens a transaction to write the parent ref (`SetParent`, `internal/engine/branch_tracking.go:66`). `create.Action` then calls `SetScope` (`internal/actions/create/create.go:264`), which opens another (`internal/engine/branch_tracking.go:371`). They could be one: add a `TrackWithScope` / `SetParentAndScope` helper that writes both in a single transaction. (Note: `SetScopeAndMarkForUpdate` at `branch_tracking.go:401` already shows the pattern for bundling two writes, but it does not cover the parent-set.) Saves one ref write + one git ref update on every `create --scope`.
 
-### 4. Bundle parent-set + scope into one metadata transaction *(small, low risk)*
+### 4. Use a cached current branch instead of re-shelling *(trivial)*
 
-`TrackBranch` opens a transaction to write the parent ref. `SetScope` opens another. They could be one: extend `SetParent` to accept an optional scope, or expose a `TrackWithScope` helper that does both atomically. Saves one ref write + one git ref update.
+`CurrentBranch()` (`internal/engine/engine_reader.go:48`) always shells `git symbolic-ref` and ignores `e.currentBranch` except to overwrite it. In a single `create` it is invoked at least three times: `validation.MustBeOnBranch` → `ValidateOnBranch`, then `create.go:56`, then again inside `TrackBranch` (`branch_tracking.go:23`). Bootstrap already knows the current branch; provide a cached read (e.g. `CurrentBranchName()` backed by `e.currentBranch`, refreshed only on mutation) and have the validator and `create.Action` consult it. The fix is more involved than "call `CurrentBranch()`" because that method itself re-shells.
 
-### 5. Skip `TrackBranch`'s "validate branches exist" re-fetch *(trivial)*
+## Already implemented (removed from the plan)
 
-`internal/engine/engine_writer.go:107–139` re-runs `GetAllBranchNames` if the just-created branch isn't in the cached list. After `CreateAndCheckoutBranch`, that cache is stale — but we know the answer (we just created it). Have `CreateAndCheckoutBranch` push the branch into `e.state.branches` (it already does, `engine_writer.go:307`), and have `TrackBranch` trust the cache.
-
-### 6. Defer `validation.MustBeOnBranch` `GetCurrentBranch` to use cached value *(trivial)*
-
-Bootstrap already populated `e.currentBranch`. The validator should consult `eng.CurrentBranch()` (cached) rather than re-shelling.
+- **`ReloadRepository` after commit** — removed. `Commit` (`internal/engine/commit_ops.go:10` → `internal/git/commit.go:20`) shells `git commit` with no go-git repo reload or revision-cache invalidation. The go-git `*Repository` / `revisionCache` machinery this win targeted no longer exists.
+- **Snapshot batched revisions + opt-out** — see win #2 status note.
+- **Skip `TrackBranch`'s "validate branches exist" re-fetch** — done. `CreateAndCheckoutBranch` pushes the new branch into `e.state.branches` via `addKnownBranchLocked` (`internal/engine/branch_mutations.go:375`), so the `GetAllBranchNames` re-fetch in `TrackBranch` (`branch_tracking.go:28–42`) no longer fires for the create path.
 
 ## Validation
 
@@ -99,4 +96,4 @@ STACKIT_NO_LOGGING=1 hyperfine --warmup 1 \
   'cd /tmp/scratch && git add . && stackit create -m "perf: noop"'
 ```
 
-Run with a no-op pre-commit hook (or `--no-verify` if that flag is available) to isolate the stackit overhead from user hook cost. Instrument: each remaining `worktree.Status()` call, `TakeSnapshot`, `ReloadRepository`, and `git commit`.
+Run with a no-op pre-commit hook (or `--no-verify` if that flag is available) to isolate the stackit overhead from user hook cost. Instrument: the `git diff`/`git status` staging probes, `GetCurrentBranch` shells, `TakeSnapshot`, and `git commit`.

--- a/docs/plans/perf/cross-cutting.md
+++ b/docs/plans/perf/cross-cutting.md
@@ -97,18 +97,6 @@ Remaining redundant probes:
 
 ---
 
-### 6. Conflict-impossible validation: avoid per-spec worktrees when safe
-
-> **Status:** Partially done — the core mechanism shipped. `validateSingleSpec` calls `tryConflictFreeReplay` (`internal/engine/rebase_validator.go:355`, def `:419`): it compares the changed-file sets (`rebaseFileOverlap`) and, when disjoint, builds the rebased SHA via `merge-tree --write-tree` + `commit-tree` with **no worktree**.
-
-**Files:** `internal/engine/rebase_validator.go`
-
-**Remaining:** the fast path bails when `len(commits) != 1`, so multi-commit branches still fall back to the worktree-per-spec path. Extend `tryConflictFreeReplay` to replay multiple commits (sequential `merge-tree`/`commit-tree`, or a single range replay) while keeping the disjoint-file-set guard.
-
-**Affects:** modify.md #1, restack.md #1, absorb.md #1.
-
----
-
 ### 7. Reuse a single worktree per depth level for validation
 
 When #6's fast path can't apply (genuinely overlapping changes, multi-commit), validation still creates one worktree per spec (`rebase_validator.go:367`). It could amortize worktree creation across siblings at the same depth: one worktree per concurrency lane, reset between specs via `git rebase --abort` + `git reset --hard`. Note the tradeoff with the existing per-spec parallelism.
@@ -169,6 +157,7 @@ These wins have fully landed. Numbering is preserved so per-command page referen
 
 - **#10 — Gate `IsInManagedWorktree` to commands that need it.** `SkipManagedWorktreeCheck` exists, is applied to read-only commands via `ApplyReadOnlyCurrentBranch`, and call sites are minimal (`common.go` + tests). Keep applying it to new read-only commands.
 - **#11 — Stop calling `ReloadRepository` after every commit.** go-git was removed entirely. There is no repo handle to close and no worktree re-scan; the expensive reopen this targeted no longer exists. The global revision cache it relied on is also gone (and a global revision cache is now an explicit anti-pattern — see `.claude/rules/code-style.md`).
+- **#6 — Conflict-impossible validation fast path.** `validateSingleSpec` calls `tryConflictFreeReplay` (`internal/engine/rebase_validator.go`): when the branch's changed files are disjoint from the parent's, it replays the branch onto the new base via `merge-tree --write-tree` + `commit-tree` with **no worktree**. Now covers **multi-commit branches** too — each commit is replayed oldest-first via `replayCommitConflictFree`, chained onto the previous result, preserving per-commit author identity and message. The remaining worktree-amortization idea lives on as #7.
 
 ---
 
@@ -176,11 +165,11 @@ These wins have fully landed. Numbering is preserved so per-command page referen
 
 For maximum impact per engineering hour:
 
-1. **#6 multi-commit fast path** — the single-commit conflict-free replay already ships; extending it to multi-commit branches is the biggest remaining win for `modify`/`restack`/`absorb`.
-2. **#1 remaining load-mode adoption** — pure call-site changes (`children`, `down`, `up`, `top`, `bottom`) on top of finished engine infrastructure.
-3. **#2 batch stack-wide status checks** — removes the per-parent `git rev-parse` walks in `submit` and `info`.
-4. **#8 `RebuildBranches`** — scopes the remaining full rebuilds in `absorb`/`untrack`.
-5. **#3 on-demand diff batching** — `info --diff`/`--patch` and `absorb`'s commit scan.
+1. **#1 remaining load-mode adoption** — pure call-site changes (`down`, `bottom`) on top of finished engine infrastructure.
+2. **#2 batch stack-wide status checks** — removes the per-parent `git rev-parse` walks in `submit` and `info`.
+3. **#8 `RebuildBranches`** — scopes the remaining full rebuilds in `absorb`/`untrack`.
+4. **#3 on-demand diff batching** — `info --diff`/`--patch` and `absorb`'s commit scan.
+5. **#7 per-level worktree reuse** — amortizes the worktree cost that remains for genuinely overlapping multi-branch validation (the disjoint-file fast path #6 already eliminated the common case).
 6. **#9 combine txs** for `create` and `describe`; **#4 no-op snapshot skip**; **#5 / #12** hygiene.
 
 ## Order-of-magnitude estimates
@@ -189,7 +178,6 @@ Back-of-envelope guesses to size effort vs reward, not measured. Completed items
 
 | Win | Affected commands | Typical saving per affected run |
 |---|---|---|
-| #6 multi-commit fast path | modify, restack, absorb | N x ~300ms worktree creation (multi-commit branches) |
 | #1 remaining load-mode adoption | read-only/common commands | remaining bootstrap cost (50-500ms depending on branch count) |
 | #2 batch status checks | submit, info | N x `git rev-parse` per stack walk |
 | #3 on-demand diff batching | info, absorb | N x ~5ms `git` processes |

--- a/docs/plans/perf/cross-cutting.md
+++ b/docs/plans/perf/cross-cutting.md
@@ -4,117 +4,114 @@ This document collects the wins that remain open across multiple per-command ana
 
 **How to read this:** the items are ordered by **how many of the analyzed commands benefit**, not by per-command magnitude. The "Affects" column lists which command pages discuss the same fix.
 
+**Status legend:** items that have fully landed since this plan was written are listed under [Completed](#completed-since-last-revision) at the bottom rather than deleted outright, so their numbering doesn't shift the references in the per-command pages.
+
 ---
 
 ## Tier 1: Touch one place, many commands get faster
 
-### 1. Expand lightweight engine load modes to the remaining safe commands
+### 1. Expand lightweight engine load modes to the remaining read-only commands
 
-> **Status:** Partially done. Three load modes exist (`LoadModeFull`, `LoadModeShared`, `LoadModeBranchesOnly`). Quiet/exact checkout and several read-only views already opt into `LoadModeBranchesOnly`. Remaining open: `children`, `info`, fuzzy `co`, `up`/`down`/`top`/`bottom`/`main` still use broader bootstrap.
+> **Status:** Partially done. The infrastructure is complete — three load modes (`LoadModeFull`, `LoadModeShared`, `LoadModeBranchesOnly`) plus **per-branch lazy promotion** (`ensureBranchSharedLoaded`, `internal/engine/engine_impl.go:271`, wired into `GetParent` and the branch-status readers). What remains is purely per-command *adoption*, not new plumbing.
 
-**Files:** `internal/app/context.go`, `internal/engine/engine_impl.go`, command wrappers in `internal/cli`
+**Files:** command wrappers in `internal/cli` (the engine side is done)
 
-`engine.LoadModeShared` and `engine.LoadModeBranchesOnly` already exist. Default context creation uses `LoadModeShared`, and exact quiet checkout plus several read-only views now opt into `LoadModeBranchesOnly`.
+Default context creation uses `LoadModeShared`. Commands already opted into the lighter `LoadModeBranchesOnly` path via `common.ApplyReadOnlyCurrentBranch`: exact quiet `co`, `parent`, default `trunk`.
 
-The remaining win is broader adoption and a true lazy-by-branch path:
+Remaining adoption:
 
-- `children`, `info`, and stack graph views still need more metadata than branch-list mode but often not the full repo.
-- Non-quiet/fuzzy `co`, `up`, `down`, `top`, `bottom`, and `main` still pay broader bootstrap because they need graph/worktree/checkout context.
-- `track --parent` only needs the parent + child branch.
+- `children`, `up`, `top`, `bottom` still use the full `common.Run` bootstrap; `down` only walks the parent chain and is the best remaining candidate for the lighter mode.
+- `info` and stack-graph views need more than branch-list mode but rely on the per-branch promotion path rather than a full load — confirm they don't force `LoadModeFull`.
+- Non-quiet/fuzzy `co` still pays broader bootstrap because it needs graph/worktree/checkout context.
 
-**Proposal:** keep `LoadModeBranchesOnly` for exact branch-list cases, and add/expand lazy metadata loading for graph commands that only need the current stack. Metadata should be promoted per branch or per stack root on first access instead of forcing every repo branch into memory at startup.
-
-**Affects:** co.md, navigation.md, info.md, scope.md, describe.md.
+**Affects:** co.md, navigation.md, info.md.
 
 ---
 
 ### 2. Batch branch status reads at stack-iteration call sites
 
-**Files:** `internal/engine/engine_branch_status.go`, call sites in `submit`, `info`, and stack renderers
+> **Status:** Partially done. The batched reader `engine.ReadBranchStatuses` (`internal/engine/engine_branch_status.go:187`) exists and several actions use the `Batch*` readers. The remaining issue is specific call sites that still walk a stack calling per-branch up-to-date/restack checks.
 
-`ReadBranchStatuses` exists and `checkout` branch info uses it. The remaining issue is call sites that iterate a stack and call `IsBranchUpToDate`/revision lookups branch-by-branch.
+**Files:** call sites in `submit`, `info`
 
-**Proposal:** route stack-wide status checks through `ReadBranchStatuses` or a similar batched parent-revision helper. The engine already keeps metadata in memory after bootstrap; the expensive part to avoid is repeated live parent SHA lookups while walking a stack.
+Open call sites:
 
-**Affects:** info.md #1, submit.md #1, any stack-wide status renderer.
+- `submit` calls per-branch `branch.IsBranchUpToDate()` (`internal/cli/.../submit.go:153`, `submit_validation.go:121,127`), each hitting the uncached `IsUpToDate` with a fresh `git rev-parse` per parent.
+- `info`'s stack render loops `branch.NeedsRestack()` per branch (`internal/actions/stack_info.go:148-151`) → `IsUpToDate` → live parent SHA lookup, even though the heavy reads around it are already batched.
+
+**Proposal:** route these stack-wide status checks through `ReadBranchStatuses` (or a batched parent-revision helper) so the live per-parent SHA lookups happen once.
+
+**Affects:** info.md #1, submit.md #1.
 
 ---
 
 ### 3. Single batched git call for stats / diffs / revisions, never per branch
 
-**Files:** `internal/engine/engine_branch_info.go`, `internal/git/commit_info.go`
+> **Status:** Partially done. `tree` is fully on the batched path (`BatchDiffStats` / `BatchBranchStats` / `BatchCommits`, `internal/engine/branch_view.go`); `info` batches its stack stats too. Remaining N+1s are on the on-demand diff paths.
 
-Per-branch git invocations are the most pervasive N+1 pattern in the codebase. `tree` and `submit` already batch several revision/stat reads. The same pattern needs to extend to:
+**Files:** `internal/engine/engine_branch_info.go`, `internal/actions/absorb.go`, `internal/actions/info.go`
 
-- **diff stats**: keep branch-tree views on one batched stat path.
-- **commit counts/ranges**: normal/full `tree` no longer loads commit messages, but still needs counts per branch.
-- **diff content** for `info --diff` / `info --patch`: only on demand, but should be cached once computed.
+Remaining per-branch git invocations:
 
-**Proposal:** keep expanding `eng.BatchBranchStats(branches)`/future preload helpers so tree calls it once and `info`, `submit`, etc., consult the same cache when set.
+- **`info --diff` / `info --patch`**: `GetAllCommits` + `GetParentCommitSHA` per render (`info.go:190-193`, `:226-229`); compute once and reuse.
+- **`absorb`**: per-branch `GetAllCommits` loop (`absorb.go:121-130`), plus the batched-scan path also calls `GetAllCommits` per branch — fold both into a single `git rev-list`.
 
-**Affects:** tree.md #1, info.md #3, absorb.md #4, modify.md #6.
+**Proposal:** extend the batched stat/commit readers to these on-demand paths; the revision-keyed memoization already in `engine_branch_info.go` makes it safe.
+
+**Affects:** info.md #3, absorb.md #4.
 
 ---
 
-### 4. Snapshot taking should batch revisions and be opt-out
+### 4. Snapshot taking: skip when there's no work
 
-> **Status:** Partially done. `BatchGetRevisions` is now used in `TakeSnapshot` (`undo.go`), eliminating the per-branch revision loop. The `undo.enabled` opt-out config flag is not yet implemented.
+> **Status:** Mostly done. `TakeSnapshot` uses `BatchGetRevisions` (`internal/engine/undo.go:121`) — no per-branch revision loop. The `undo.enabled` opt-out is implemented: config key `stackit.undo.enabled` (`internal/config/keys.go:18`), honored by `TakeBestEffortSnapshot` (`internal/actions/common.go`), which no-ops when disabled.
 
-**Files:** `internal/engine/undo.go`
+**Files:** `internal/actions/common.go`, `internal/actions/restack.go`, `internal/engine/undo.go`
 
-Every mutating command (`create`, `modify`, `absorb`, `restack`) calls `TakeBestEffortSnapshot`, which iterates `state.branches` and calls `branch.GetRevision()` per branch. Two issues:
+Remaining:
 
-- Per-branch loop instead of `BatchGetRevisions` (already exists).
-- The snapshot is only ever read by `stackit undo`; for users who never undo, it is pure overhead.
+- **Skip the snapshot on no-op operations.** `RestackAction` (`internal/actions/restack.go:153`) takes a snapshot before discovering there's no work to do; gate it on `plan.HasWork()`. The same "snapshot only just before a real mutation" principle applies to other actions that frequently short-circuit.
+- **Lazy `enforceMaxStackDepth`** (`undo.go:172`) still does an `os.ReadDir` + sort on every snapshot.
 
-**Proposal:**
-
-- Use `BatchGetRevisions` or read from `revisionCache` after `LoadAllBranchRevisions`.
-- Add `undo.enabled` config flag (default `true`); when `false`, `TakeBestEffortSnapshot` is a no-op.
-- Move snapshot capture to just before mutation, not at the start of an action. Many actions short-circuit without ever needing a snapshot.
-
-**Affects:** create.md #2, restack.md #5 + #6, absorb.md.
+**Affects:** restack.md, create.md.
 
 ---
 
 ## Tier 2: Reusable plumbing for expensive operations
 
-### 5. Coalesce `worktree.Status()` across the action's request
+### 5. Coalesce staging status probes within an action
 
-**Files:** `internal/git/staging.go`, all reused by multiple actions
+> **Status:** Premise obsolete. go-git has been removed; the staging helpers no longer do a full working-tree walk. `HasStagedChanges` / `HasUnstagedChanges` now shell `git diff --cached --quiet` / `git diff --quiet` (`internal/git/staging.go:55,62`). This is a much smaller win than originally described — coalescing redundant subprocesses, not eliminating tree walks.
 
-Checkout no longer calls go-git's `worktree.Status()`, but staging helpers still can run the same full working-tree walk multiple times in one action. `create` can call `HasStagedChanges` and then `HasUnstagedChanges`; `absorb` calls `HasStagedChanges` before and after staging; `modify` checks staged changes after optional staging.
+**Files:** `internal/git/staging.go` and callers
 
-**Proposal:** an action-scoped `RepoStatus` value (`{HasStaged, HasUnstaged, HasUntracked, modified files}`) computed once per request and cached on `app.Context`. Pass it through to staging/validation helpers where needed.
+Remaining redundant probes:
 
-**Affects:** create.md #1, modify.md #3, absorb.md #2.
+- `create`'s non-interactive guard can fire up to three separate status subprocesses (`create.go:125-137`).
+- `absorb` calls `HasStagedChanges` twice and now *discards* the first result entirely (`absorb.go:63`, `:78`) — that first call can simply be deleted.
+- `modify`'s angle is **closed** — its `HasStagedChanges` is just a `git diff --cached --quiet`, no tree walk.
+
+**Proposal:** an action-scoped `RepoStatus` value (one `git status --porcelain`) computed once per request where multiple probes remain.
+
+**Affects:** create.md #1, absorb.md #2.
 
 ---
 
 ### 6. Conflict-impossible validation: avoid per-spec worktrees when safe
 
+> **Status:** Partially done — the core mechanism shipped. `validateSingleSpec` calls `tryConflictFreeReplay` (`internal/engine/rebase_validator.go:355`, def `:419`): it compares the changed-file sets (`rebaseFileOverlap`) and, when disjoint, builds the rebased SHA via `merge-tree --write-tree` + `commit-tree` with **no worktree**.
+
 **Files:** `internal/engine/rebase_validator.go`
 
-The single biggest cost on `modify` (mid-stack), `restack`, and `--restack`-mode `submit` is creating a worktree per descendant spec to dry-run the rebase.
+**Remaining:** the fast path bails when `len(commits) != 1`, so multi-commit branches still fall back to the worktree-per-spec path. Extend `tryConflictFreeReplay` to replay multiple commits (sequential `merge-tree`/`commit-tree`, or a single range replay) while keeping the disjoint-file-set guard.
 
-**Proposal:** add a safe fast path before scheduling worktree validation. The validator currently produces the rewritten SHAs that later apply steps consume, so this is not just "skip validation"; the fast path must either directly compute/apply the safe replay result or share a cheap replay path that produces equivalent output.
-
-A first classifier can compare:
-
-- `git diff --name-only <old-parent>..<new-parent>` (the change being rebased onto)
-- `git diff --name-only <old-parent>..<branch>` (the change being rebased)
-
-If the file sets are disjoint, no content conflict is possible and the direct replay path can avoid the temporary worktree.
-
-**Affects:** modify.md #1, restack.md #1, absorb.md #1, submit.md #3 indirectly.
+**Affects:** modify.md #1, restack.md #1, absorb.md #1.
 
 ---
 
 ### 7. Reuse a single worktree per depth level for validation
 
-**Files:** `internal/engine/rebase_validator.go`
-
-If #6 is not enough because the stack genuinely has overlapping changes, validation could still amortize worktree creation across siblings at the same depth: one worktree per concurrency lane, reset between specs via `git rebase --abort` + `git reset --hard`.
+When #6's fast path can't apply (genuinely overlapping changes, multi-commit), validation still creates one worktree per spec (`rebase_validator.go:367`). It could amortize worktree creation across siblings at the same depth: one worktree per concurrency lane, reset between specs via `git rebase --abort` + `git reset --hard`. Note the tradeoff with the existing per-spec parallelism.
 
 **Affects:** modify.md #2, restack.md #3, absorb.md #1.
 
@@ -122,61 +119,56 @@ If #6 is not enough because the stack genuinely has overlapping changes, validat
 
 ### 8. Scoped engine rebuild: `RebuildBranches([]string)`
 
-**Files:** `internal/engine/engine_internal.go`, `internal/engine/engine_writer.go`
+> **Status:** Open (method does not exist), but the motivating N+1 is already fixed. `untrack` no longer rebuilds per branch — `UntrackBranches` (`internal/engine/branch_tracking.go:82-98`) does a single `DeleteRefsBatch` + one `rebuild()`.
 
-`engine.rebuild()` re-reads metadata for every branch in the repo even when only a handful changed. The worst offender is `UntrackBranch`, which calls `rebuild()` per branch in the loop.
+**Files:** `internal/engine/engine_internal.go`
 
-**Proposal:** a `RebuildBranches([]string)` engine method that re-reads only the listed branches' metadata + revisions, then merges into `state.branchState`. Use from `untrack` (batched), `absorb` post-apply, `modify` post-commit, etc.
+`engine.rebuild()` still re-reads metadata for every branch in the repo even when only a handful changed. A `RebuildBranches([]string)` method would re-read only the listed branches' metadata + revisions and merge into `state.branchState`.
 
-**Affects:** absorb.md #3, track-untrack.md #1 + #2.
+Remaining beneficiaries (each still does a full rebuild):
+
+- `untrack`'s single post-batch rebuild (`internal/actions/untrack/action.go`).
+- `absorb` post-apply (`absorb.go:297` calls `Rebuild("")`).
+
+**Affects:** absorb.md #3, track-untrack.md #2.
 
 ---
 
 ### 9. Combine commit + metadata writes into single transactions
 
-**Files:** `internal/engine/transaction.go`, callers in `engine_writer.go`
+> **Status:** Partially done. `scope` is complete — `SetScopeAndMarkForUpdate` (`internal/engine/branch_tracking.go:401`) writes the scope ref and the PR-update flag in one transaction.
 
-Commands that mutate both the parent ref and an adjacent metadata field (scope, lock, PR-update flag, description) issue two separate transactions today. Each transaction is a ref-update round trip. Combining them is straightforward via `withMetadataTx` once the engine exposes the right helpers.
+**Files:** `internal/engine/transaction.go`, `internal/engine/branch_tracking.go`, `internal/git/stack_metadata.go`
 
-**Affects:** create.md #4, scope.md #1, describe.md #2.
+Remaining commands that issue two separate ref-update round trips:
+
+- **`create`**: `TrackBranch`→`SetParent` and `SetScope` are separate transactions; no `SetParentAndScope` helper exists.
+- **`describe`**: `SetStackDescription` (stack-meta ref) and `MarkBranchesForPRBodyUpdate` (per-branch local-meta refs) are separate write phases. `WriteStackMetaBlob` (`internal/git/stack_metadata.go:122`) already returns a blob SHA without a ref write, so both can fold into one `UpdateRefsBatch`.
+
+**Affects:** create.md #4, describe.md #1.
 
 ---
 
 ## Tier 3: Smaller universal hygiene
 
-### 10. Continue gating `IsInManagedWorktree` to commands that need it
-
-> **Status:** Done. Call sites are minimal — only `common.go` + tests. `SkipManagedWorktreeCheck` is applied to read-only commands. Continue applying to any new commands added.
-
-**File:** `internal/cli/common/common.go`
-
-`SkipManagedWorktreeCheck` exists and several read-only commands use it. Continue moving commands that do not branch on managed-worktree state onto this option.
-
-**Affects:** co.md and navigation.md indirectly.
-
----
-
-### 11. Stop calling `ReloadRepository` after every commit
-
-> **Status:** Done. go-git has been completely removed from the codebase. `ReloadRepository()` is now a two-line function that calls `revisionCache.InvalidateAll()` — no repo handle close, no worktree re-scan. The expensive go-git worktree reopen described below no longer exists. The remaining micro-optimisation (invalidating only the affected branch's cache entry rather than all entries) is low priority.
-
-**File:** `internal/git/commit.go`
-
-~~Closes the entire go-git repo handle to pick up one new commit. Cheaper: invalidate just the affected branch in `revisionCache` and let go-git re-read the new packed ref lazily.~~
-
-**Affects:** create.md #3, modify.md #4, absorb.md post-apply, anywhere a commit is created.
-
----
-
 ### 12. Replace per-call `config.LoadConfig` with `ctx.Config`
 
-> **Status:** Partially done. `trunk.go` and `hookmiddleware.go` have been updated. Other callers in `internal/cli/` remain.
+> **Status:** Partially done. `trunk.go`'s `findTrunkForBranch` now reads `ctx.Config.AllTrunks()`; `hookmiddleware.go` updated.
 
 **Files:** `internal/cli/navigation/trunk.go`, others
 
-Bootstrap already loads config into `ctx.Config`. Several commands re-load it. Trivial to fix; affects perf only marginally but is a clean-up alongside the bigger items.
+Remaining: `handleAddTrunk` (`trunk.go:75`) still calls `config.LoadConfig` because it needs a writable `*GitConfig` (`ctx.Config` is the read-only `Configurer` interface, which lacks `AddTrunk`/`Save`). This is not a trivial swap and may not be worth it. Audit `internal/cli` for any remaining read-only `config.LoadConfig` callers that can use `ctx.Config` directly.
 
-**Affects:** navigation.md #4.
+**Affects:** navigation.md.
+
+---
+
+## Completed since last revision
+
+These wins have fully landed. Numbering is preserved so per-command page references stay valid.
+
+- **#10 — Gate `IsInManagedWorktree` to commands that need it.** `SkipManagedWorktreeCheck` exists, is applied to read-only commands via `ApplyReadOnlyCurrentBranch`, and call sites are minimal (`common.go` + tests). Keep applying it to new read-only commands.
+- **#11 — Stop calling `ReloadRepository` after every commit.** go-git was removed entirely. There is no repo handle to close and no worktree re-scan; the expensive reopen this targeted no longer exists. The global revision cache it relied on is also gone (and a global revision cache is now an explicit anti-pattern — see `.claude/rules/code-style.md`).
 
 ---
 
@@ -184,31 +176,29 @@ Bootstrap already loads config into `ctx.Config`. Several commands re-load it. T
 
 For maximum impact per engineering hour:
 
-1. **#1 (expand lightweight load modes)** — biggest perceived speedup on read-only/common commands.
-2. **#6 (safe validation fast path)** — biggest single win for `modify`, the second most-run hot-path mutating command.
-3. **#3 (preload stack stats)** — keeps `tree` on an O(1) batched stats path instead of per-branch git processes.
-4. **#8 (`RebuildBranches`)** — fixes the `untrack` N+1 and improves `absorb` / `modify` cleanup.
-5. **#4 (snapshot batching / opt-out)** — small but hits every mutating command.
-6. **#5 (coalesce status checks)** — removes duplicate working-tree scans that still remain outside checkout.
-7. The remaining items are mostly hygiene that compound once the above are in.
+1. **#6 multi-commit fast path** — the single-commit conflict-free replay already ships; extending it to multi-commit branches is the biggest remaining win for `modify`/`restack`/`absorb`.
+2. **#1 remaining load-mode adoption** — pure call-site changes (`children`, `down`, `up`, `top`, `bottom`) on top of finished engine infrastructure.
+3. **#2 batch stack-wide status checks** — removes the per-parent `git rev-parse` walks in `submit` and `info`.
+4. **#8 `RebuildBranches`** — scopes the remaining full rebuilds in `absorb`/`untrack`.
+5. **#3 on-demand diff batching** — `info --diff`/`--patch` and `absorb`'s commit scan.
+6. **#9 combine txs** for `create` and `describe`; **#4 no-op snapshot skip**; **#5 / #12** hygiene.
 
 ## Order-of-magnitude estimates
 
-These are back-of-envelope guesses to size effort vs reward, not measured:
+Back-of-envelope guesses to size effort vs reward, not measured. Completed items omitted.
 
 | Win | Affected commands | Typical saving per affected run |
 |---|---|---|
-| #1 expand load modes | read-only/common commands | remaining bootstrap cost (50-500ms depending on branch count) |
-| #6 safe validation fast path | modify, restack, absorb | N x ~300ms worktree creation |
-| #3 preload stack stats | tree, info | N x ~5ms `git diff --numstat` processes |
-| #8 RebuildBranches | untrack, absorb, modify, sync | K x full rebuild on multi-branch operations |
-| #4 snapshot batching | every mutating command | 5-15ms |
-| #5 coalesce Status | create, modify, absorb | duplicate Status walks |
-| #9 combine txs | create, scope, describe | 1 ref write per command |
-| #11 scoped reload | create, modify, absorb | 1 go-git reopen |
+| #6 multi-commit fast path | modify, restack, absorb | N x ~300ms worktree creation (multi-commit branches) |
+| #1 remaining load-mode adoption | read-only/common commands | remaining bootstrap cost (50-500ms depending on branch count) |
+| #2 batch status checks | submit, info | N x `git rev-parse` per stack walk |
+| #3 on-demand diff batching | info, absorb | N x ~5ms `git` processes |
+| #8 RebuildBranches | absorb, untrack | full rebuild → scoped read |
+| #4 no-op snapshot skip | restack (no-work path) | 5-15ms |
+| #9 combine txs | create, describe | 1 ref write per command |
 
 ## What not to touch
 
 - **`git commit` itself and pre-commit hooks.** The user owns hook cost.
-- **GitHub API latency.** Batching is already in place; further wins are caching with TTL (`tree.md`, `submit.md`) which is bounded by correctness.
-- **go-git's internals.** Checkout is already a native-Git exception because the go-git checkout/status path was materially slower on large working trees. Keep the broader default as go-git where it is correct and fast enough; do not rewrite go-git internals.
+- **GitHub API latency.** Batching is already in place; further wins are caching with TTL (`tree.md`, `submit.md`) which is bounded by correctness — and, for the CLI's per-process model, would have to be on-disk to persist across invocations.
+- **A global/ambient revision cache or `PreloadBranchData`-style warm-up.** Deliberately removed; reintroducing it is an anti-pattern (`.claude/rules/code-style.md`). Batch readers return values you pass around instead.

--- a/docs/plans/perf/cross-cutting.md
+++ b/docs/plans/perf/cross-cutting.md
@@ -28,23 +28,6 @@ Remaining adoption:
 
 ---
 
-### 2. Batch branch status reads at stack-iteration call sites
-
-> **Status:** Partially done. The batched reader `engine.ReadBranchStatuses` (`internal/engine/engine_branch_status.go:187`) exists and several actions use the `Batch*` readers. The remaining issue is specific call sites that still walk a stack calling per-branch up-to-date/restack checks.
-
-**Files:** call sites in `submit`, `info`
-
-Open call sites:
-
-- `submit` calls per-branch `branch.IsBranchUpToDate()` (`internal/cli/.../submit.go:153`, `submit_validation.go:121,127`), each hitting the uncached `IsUpToDate` with a fresh `git rev-parse` per parent.
-- `info`'s stack render loops `branch.NeedsRestack()` per branch (`internal/actions/stack_info.go:148-151`) → `IsUpToDate` → live parent SHA lookup, even though the heavy reads around it are already batched.
-
-**Proposal:** route these stack-wide status checks through `ReadBranchStatuses` (or a batched parent-revision helper) so the live per-parent SHA lookups happen once.
-
-**Affects:** info.md #1, submit.md #1.
-
----
-
 ### 3. Single batched git call for stats / diffs / revisions, never per branch
 
 > **Status:** Partially done. `tree` is fully on the batched path (`BatchDiffStats` / `BatchBranchStats` / `BatchCommits`, `internal/engine/branch_view.go`); `info` batches its stack stats too. Remaining N+1s are on the on-demand diff paths.
@@ -58,7 +41,7 @@ Remaining per-branch git invocations:
 
 **Proposal:** extend the batched stat/commit readers to these on-demand paths; the revision-keyed memoization already in `engine_branch_info.go` makes it safe.
 
-**Affects:** info.md #3, absorb.md #4.
+**Affects:** info.md #2, absorb.md #4.
 
 ---
 
@@ -157,6 +140,7 @@ These wins have fully landed. Numbering is preserved so per-command page referen
 
 - **#10 — Gate `IsInManagedWorktree` to commands that need it.** `SkipManagedWorktreeCheck` exists, is applied to read-only commands via `ApplyReadOnlyCurrentBranch`, and call sites are minimal (`common.go` + tests). Keep applying it to new read-only commands.
 - **#11 — Stop calling `ReloadRepository` after every commit.** go-git was removed entirely. There is no repo handle to close and no worktree re-scan; the expensive reopen this targeted no longer exists. The global revision cache it relied on is also gone (and a global revision cache is now an explicit anti-pattern — see `.claude/rules/code-style.md`).
+- **#2 — Batch branch status reads at stack-iteration call sites.** `submit` (`internal/actions/submit/submit.go`, `submit_validation.go`) and `info` (`internal/actions/stack_info.go`) now resolve up-to-date status for the whole branch set in one `eng.ReadBranchStatuses(...)` call (a single batched parent-revision read) instead of a per-branch `IsBranchUpToDate()` / `NeedsRestack()` that shelled a `git rev-parse` per parent.
 - **#6 — Conflict-impossible validation fast path.** `validateSingleSpec` calls `tryConflictFreeReplay` (`internal/engine/rebase_validator.go`): when the branch's changed files are disjoint from the parent's, it replays the branch onto the new base via `merge-tree --write-tree` + `commit-tree` with **no worktree**. Now covers **multi-commit branches** too — each commit is replayed oldest-first via `replayCommitConflictFree`, chained onto the previous result, preserving per-commit author identity and message. The remaining worktree-amortization idea lives on as #7.
 
 ---
@@ -165,12 +149,11 @@ These wins have fully landed. Numbering is preserved so per-command page referen
 
 For maximum impact per engineering hour:
 
-1. **#1 remaining load-mode adoption** — `children`/`up`/`top` can drop from the default to `LoadModeShared` (skip the local-metadata batch); `down`/`bottom` already moved to `LoadModeBranchesOnly`.
-2. **#2 batch stack-wide status checks** — removes the per-parent `git rev-parse` walks in `submit` and `info`.
-3. **#8 `RebuildBranches`** — scopes the remaining full rebuilds in `absorb`/`untrack`.
-4. **#3 on-demand diff batching** — `info --diff`/`--patch` and `absorb`'s commit scan.
-5. **#7 per-level worktree reuse** — amortizes the worktree cost that remains for genuinely overlapping multi-branch validation (the disjoint-file fast path #6 already eliminated the common case).
-6. **#9 combine txs** for `create` and `describe`; **#4 no-op snapshot skip**; **#5 / #12** hygiene.
+1. **#8 `RebuildBranches`** — scopes the remaining full rebuilds in `absorb`/`untrack`.
+2. **#3 on-demand diff batching** — `info --diff`/`--patch` and `absorb`'s commit scan.
+3. **#1 remaining load-mode adoption** — `children`/`up`/`top` can drop from the default to `LoadModeShared` (skip the local-metadata batch); `down`/`bottom` already moved to `LoadModeBranchesOnly`.
+4. **#7 per-level worktree reuse** — amortizes the worktree cost that remains for genuinely overlapping multi-branch validation (the disjoint-file fast path #6 already eliminated the common case).
+5. **#9 combine txs** for `create` and `describe`; **#4 no-op snapshot skip**; **#5 / #12** hygiene.
 
 ## Order-of-magnitude estimates
 
@@ -179,7 +162,6 @@ Back-of-envelope guesses to size effort vs reward, not measured. Completed items
 | Win | Affected commands | Typical saving per affected run |
 |---|---|---|
 | #1 remaining load-mode adoption | read-only/common commands | remaining bootstrap cost (50-500ms depending on branch count) |
-| #2 batch status checks | submit, info | N x `git rev-parse` per stack walk |
 | #3 on-demand diff batching | info, absorb | N x ~5ms `git` processes |
 | #8 RebuildBranches | absorb, untrack | full rebuild → scoped read |
 | #4 no-op snapshot skip | restack (no-work path) | 5-15ms |

--- a/docs/plans/perf/cross-cutting.md
+++ b/docs/plans/perf/cross-cutting.md
@@ -16,11 +16,11 @@ This document collects the wins that remain open across multiple per-command ana
 
 **Files:** command wrappers in `internal/cli` (the engine side is done)
 
-Default context creation uses `LoadModeShared`. Commands already opted into the lighter `LoadModeBranchesOnly` path via `common.ApplyReadOnlyCurrentBranch`: exact quiet `co`, `parent`, default `trunk`.
+Default context creation uses `LoadModeShared`. Commands already opted into the lighter `LoadModeBranchesOnly` path: exact quiet `co`, `parent`, default `trunk`, and (quiet) `down` / `bottom`. `down`/`bottom` keep the managed-worktree check (checkout relies on it) and gate on `--quiet` because non-quiet checkout's `printBranchInfo` builds the full graph anyway; `bottom`'s `SwitchBranchAction` no longer builds the graph for the downward direction.
 
 Remaining adoption:
 
-- `children`, `up`, `top`, `bottom` still use the full `common.Run` bootstrap; `down` only walks the parent chain and is the best remaining candidate for the lighter mode.
+- `children`, `up`, `top` enumerate children, which forces a full `Graph()` build over `AllBranches()` — they cannot use `LoadModeBranchesOnly` (the per-branch lazy path is slower than one batch there), but they read no local metadata so they could drop from the default to `LoadModeShared`'s already-batched shared read and skip the local-metadata pass.
 - `info` and stack-graph views need more than branch-list mode but rely on the per-branch promotion path rather than a full load — confirm they don't force `LoadModeFull`.
 - Non-quiet/fuzzy `co` still pays broader bootstrap because it needs graph/worktree/checkout context.
 
@@ -165,7 +165,7 @@ These wins have fully landed. Numbering is preserved so per-command page referen
 
 For maximum impact per engineering hour:
 
-1. **#1 remaining load-mode adoption** — pure call-site changes (`down`, `bottom`) on top of finished engine infrastructure.
+1. **#1 remaining load-mode adoption** — `children`/`up`/`top` can drop from the default to `LoadModeShared` (skip the local-metadata batch); `down`/`bottom` already moved to `LoadModeBranchesOnly`.
 2. **#2 batch stack-wide status checks** — removes the per-parent `git rev-parse` walks in `submit` and `info`.
 3. **#8 `RebuildBranches`** — scopes the remaining full rebuilds in `absorb`/`untrack`.
 4. **#3 on-demand diff batching** — `info --diff`/`--patch` and `absorb`'s commit scan.

--- a/docs/plans/perf/describe.md
+++ b/docs/plans/perf/describe.md
@@ -11,52 +11,60 @@ newDescribeCmd → common.Run → describe.Action          internal/actions/desc
   │
   ├─ --show: branches-only bootstrap, print + return  (no network)
   ├─ --clear:
-  │    ├─ eng.ClearStackDescription                   metadata transaction
+  │    ├─ eng.ClearStackDescription                   metadata write (stack-meta ref)
   │    └─ markStackAndPushMetadata                    see below
-  ├─ -m / -d:
+  ├─ -m / -d / stdin:
   │    └─ applyStackDescription
-  │         ├─ eng.SetStackDescription                metadata transaction
+  │         ├─ eng.SetStackDescription                metadata write (stack-meta ref)
   │         └─ markStackAndPushMetadata
   └─ interactive:
-       ├─ eng.GetStackDescription                     cache read
+       ├─ eng.GetStackDescription                     cache read       describe.go:96
        ├─ tui.OpenEditor                              user-blocking
        └─ applyStackDescription
 
-markStackAndPushMetadata:
-  ├─ graph.CollectBranches(root)                      in-memory walk over stack
-  ├─ eng.BatchMarkNeedsPRBodyUpdate(branchNames)      ← writes ONE meta ref PER branch
-  └─ actions.PushMetadataOnly                         `git push refs/stackit/metadata/<root>`
+markStackAndPushMetadata:                             describe.go:135
+  ├─ eng.Graph + graph.CollectBranches(root).Names()  in-memory walk over stack
+  ├─ eng.MarkBranchesForPRBodyUpdate(branchNames)     batched: one blob-batch + one UpdateRefsBatch
+  └─ actions.PushMetadataOnly                          one `git push` of metadata refs
 ```
 
 ## Where time goes
 
 1. **`actions.PushMetadataOnly`** — one network round trip. Same cost story as `scope.md` #1.
-2. **`BatchMarkNeedsPRBodyUpdate(branchNames)`** — currently writes one ref per branch. Let me verify what "Batch" means here in practice.
+2. **`SetStackDescription` / `ClearStackDescription`** — one stack-meta ref write
+   (`WriteStackMeta` → `CreateBlob` + `UpdateRef`).
+3. **`MarkBranchesForPRBodyUpdate`** — already a single batched write across all
+   stack branches (blob-batch + atomic `UpdateRefsBatch`).
 
-Looking at `engine_writer.go:1062` (not pasted here), `BatchMarkNeedsPRBodyUpdate` should ideally write all the flags in a single `UpdateRefsBatch` call. The CLAUDE.md "Batch Operations" rule explicitly calls this out. If it does — good. If it just loops `MarkNeedsPRBodyUpdate` internally, that's an N+1.
-
-3. **`SetStackDescription` (or `ClearStackDescription`)** — one metadata transaction.
-4. **Bootstrap + open editor** — `--show` already uses branches-only mode and skips the managed-worktree check; mutating/editor paths still use the normal context.
-
-For a stack with 10 branches, the metadata phase writes 1 description + 10 mark-flags + 1 push. The push dominates by an order of magnitude.
+For a stack with 10 branches the metadata phase does: 1 stack-meta ref write +
+1 batched local-metadata write (covering all 10 branches) + 1 push. The push
+dominates by an order of magnitude.
 
 ## Wins (ranked)
 
-### 1. Ensure `BatchMarkNeedsPRBodyUpdate` is genuinely batched *(check first; high impact if it isn't)*
+### 1. Fold the stack-description write and the PR-update flag write into one ref batch *(shared with scope.md #1)*
 
-This is one of the "use batch APIs" examples from `.claude/rules/code-style.md`. Confirm via `internal/engine/engine_writer.go:1062` that the implementation uses `UpdateRefsBatch` or `withMetadataTx` over the whole branch set. If it's a loop, the cost on a 20-branch stack is 20 × ref writes + 20 × tx overhead = ~50–200ms wasted. (The fact that it's called `Batch...` suggests it is — verify before optimizing.)
+> **Status:** Not started. The premise in the original plan ("they touch
+> overlapping metadata, one tx over `{stackRoot, ...branches}`") was wrong and has
+> been corrected here.
 
-### 2. Combine `SetStackDescription` + `BatchMarkNeedsPRBodyUpdate` in one tx *(shared with scope.md #1)*
+The two writes target **different** refs and run as two separate, non-atomic
+phases today:
 
-The description write and the mark-for-PR-update write touch overlapping metadata. One transaction over `{stackRoot, ...branches}` is enough.
+- `SetStackDescription` writes the **stack-meta ref** keyed by stack ID
+  (`StackMetaRefName(stackID)`) via `WriteStackMeta` (`internal/engine/stack_id.go:39`,
+  `internal/git/stack_metadata.go:81`).
+- `MarkBranchesForPRBodyUpdate` writes the **per-branch local-metadata refs**
+  via `WriteLocalMetadataBlobsBatch` + `UpdateRefsBatch`
+  (`internal/engine/pr_flags.go:14`).
 
-### 3. Defer the metadata push for `--show` — already done *(trivial confirmation)*
-
-`--show` short-circuits before any writes/pushes. Good.
-
-### 4. Editor mode: don't re-fetch description after editor closes *(trivial)*
-
-`describe.go:96` reads `existingDesc` before opening the editor; `applyStackDescription` writes the new one. No redundant read on this path. Good.
+They can still be collapsed into a single atomic `UpdateRefsBatch`:
+`WriteStackMetaBlob` (`internal/git/stack_metadata.go:122`) already returns a blob
+SHA without touching a ref — exactly for transactional writes. Build one
+`[]git.RefUpdate` containing the stack-meta ref update plus every local-metadata
+ref update and commit them in one `UpdateRefsBatch` call. This removes one git
+process (the standalone `WriteStackMeta` `UpdateRef`) and makes the
+description-set + mark-for-update atomic. The push afterward is unchanged.
 
 ## Validation
 
@@ -66,4 +74,7 @@ STACKIT_NO_LOGGING=1 hyperfine \
   'stackit describe -m "Test"'
 ```
 
-The delta isolates the metadata write + push from the bootstrap baseline. Instrument: each metadata transaction, `PushMetadataRefs`, and confirm `BatchMarkNeedsPRBodyUpdate` is a single ref-write batch (it should be — confirm via `git update-ref --stdin` or equivalent).
+The delta isolates the metadata write + push from the bootstrap baseline.
+Instrument each ref write and `PushMetadataForBranches`; after win #1 the
+description-set path should show a single combined `UpdateRefsBatch` rather than a
+`WriteStackMeta` `UpdateRef` followed by a separate batch.

--- a/docs/plans/perf/info.md
+++ b/docs/plans/perf/info.md
@@ -9,8 +9,8 @@ newInfoCmd → common.Run                              (same bootstrap as co)
   └─ actions.InfoAction                              internal/actions/info.go:61
        ├─ if --stack: StackInfoAction                (separate stack-wide path)
        ├─ ResolveBranchName                          cheap (cache lookup)
-       ├─ if untracked: FetchMetadataRefs + LoadRemoteMetadataCache + ApplyRemoteMetadataIfExists
-       │     ← network fetch — only on untracked-branch path
+       ├─ if untracked: FetchRemoteMetadata + ApplyRemoteMetadataForBranches
+       │     ← network fetch — only on untracked-branch path (info.go:85–91)
        ├─ if --json: outputBranchInfoJSON            JSON path
        │
        ├─ branch.IsBranchUpToDate                    parent revision lookup + cached metadata
@@ -19,7 +19,7 @@ newInfoCmd → common.Run                              (same bootstrap as co)
        ├─ branch.GetPrInfo                           cache hit
        ├─ graph.ChildBranches                        in-memory
        │
-       └─ if --patch: branch.GetAllCommits + eng.ShowCommits(stat?)
+       └─ if --patch: branch.GetAllCommits + eng.GetParentCommitSHA + eng.ShowCommits(stat?)
           if --diff:  branch.GetAllCommits + eng.GetParentCommitSHA + eng.ShowDiff(stat?)
           else:        branch.GetAllCommits(Readable)
 ```
@@ -28,7 +28,7 @@ newInfoCmd → common.Run                              (same bootstrap as co)
 
 For the **default `stackit info` on the current branch** (no flags):
 1. **Bootstrap** dominates — info does ~5 git ops after bootstrap.
-2. `branch.IsBranchUpToDate` still does a live parent revision lookup. For one branch this is small, but stack-wide variants should use batched status reads.
+2. `branch.IsBranchUpToDate` still does a live parent revision lookup. For one branch this is small.
 3. `branch.GetCommitDate` shells out per call.
 4. `branch.GetAllCommits(Readable)` walks the commit range via go-git.
 
@@ -36,38 +36,52 @@ For **`info --diff` / `info --patch`**:
 1. **`eng.ShowDiff` / `eng.ShowCommits`** dominates. These shell to `git show` / `git diff`. Cost scales with the diff size, not stackit overhead.
 2. `branch.GetAllCommits(SHA)` then `GetParentCommitSHA` adds an extra git op pair to find the base. For `--patch`, the base lookup uses the *oldest* commit's parent SHA — a separate `git rev-parse` is needed because `GetAllCommits` returns SHAs but not their parents.
 
-For **`info <untracked-branch>`** (`internal/actions/info.go:78–97`):
-- Triggers a real **`git fetch refs/stackit/metadata`** network call. Dominates everything — many seconds on slow networks. This is the only info path that does network I/O.
+For **`info <untracked-branch>`** (`internal/actions/info.go:78–92`):
+- Triggers a real **`git fetch refs/stackit/metadata`** network call via `eng.FetchRemoteMetadata`. Dominates everything — many seconds on slow networks. This is the only info path that does network I/O.
 
 ## Proposed wins (ranked)
 
-### 1. Reuse batched status reads for stack-wide info *(shared with cross-cutting.md #2)*
+### 1. Batch the restack status in stack-wide info *(shared with cross-cutting.md #2)*
 
-For the default one-branch `info` path this is small. For JSON/stack-wide info, avoid looping through branches with individual `IsBranchUpToDate` calls; use `ReadBranchStatuses` or a batched parent-revision helper.
+> **Status:** Partially done. `StackInfoAction` (`internal/actions/stack_info.go:48`) already
+> batches the heavy per-branch reads: `BatchCommits`, `BatchDiffStats`,
+> `BatchChangedFileCounts`, and `BatchGetPRSubmissionStatus` (stack_info.go:68–74). The
+> default one-branch `info` path is small and needs nothing here.
 
-### 2. Cache `FetchMetadataRefs` per session *(small impact, low risk)*
+The remaining N+1 is the restack/`FixedMap` loop (`internal/actions/stack_info.go:148–151`),
+which calls `branch.NeedsRestack()` per branch. That resolves to `IsUpToDate` →
+`git.GetRevision(parent)` once per branch (no global revision cache by design), so a stack of
+N branches spawns N parent-revision lookups. Use the existing batched
+`ReadBranchStatuses` (`internal/engine/engine_branch_status.go:187`, which fans the parent
+revisions through `BatchGetRevisions`) to compute the `FixedMap` in one pass.
 
-`internal/actions/info.go:85` fetches every time an untracked branch is queried. Cache the result for the process lifetime — calling info on the same untracked branch twice should not re-fetch.
+### 2. Cache `FetchRemoteMetadata` per session *(small impact, low risk)*
+
+`internal/actions/info.go:87` calls `eng.FetchRemoteMetadata` (→ `FetchRemote`,
+`internal/engine/branch_mutations.go:79`), which performs an unconditional network fetch
+every time an untracked branch is queried. There is no session memoization. For the one-shot
+CLI this fires at most once per invocation, so the win only matters for a long-lived engine
+(the API server / watcher), where calling info on the same untracked branch twice should not
+re-fetch. Add a process-lifetime guard around the metadata fetch if/when the engine is reused.
 
 ### 3. Combine `GetAllCommits + GetParentCommitSHA` into one git call *(small impact, low risk)*
 
-For `--patch` mode, `internal/actions/info.go:197–201` does:
+For `--patch` mode, `internal/actions/info.go:190–193` does:
 - `GetAllCommits(SHA)` → walk commits
 - `GetParentCommitSHA(oldestSHA)` → another rev-parse
 
-A single `git rev-list --parents` over the range produces both. Or read `meta.GetParentBranchRevision()` directly — that *is* the base revision and is already in cache after bootstrap.
+The `--diff` non-trunk branch repeats the same pair at `internal/actions/info.go:226–229`.
+
+A single `git rev-list --parents` over the range produces both. Or read the stored parent
+revision directly — `meta.GetParentBranchRevision()` *is* the base revision and is already in
+cache after bootstrap (see `internal/engine/branch_tracking.go`).
 
 ### 4. `GetCommitDate` could come from the engine state cache *(trivial)*
 
-The branch SHA is cached after bootstrap. A `git log -1 --format=%ct <sha>` is needed once per HEAD — could be batched into a `branchState` field at rebuild time if `info`/`tree` become hot enough to care.
-
-### 5. Skip the second `eng.GetBranch(branchName)` calls *(trivial)*
-
-`internal/actions/info.go:156` and `:170` re-resolve `branchObj` twice when the earlier `branch` is already correct. Map lookups are cheap but pointless.
-
-### 6. JSON mode does its own work (`outputBranchInfoJSON`)
-
-Not read here — likely shares the same per-branch cost. Should reuse the same cached state as the text path.
+`GetCommitDate` (`internal/engine/engine_branch_info.go:13`) shells out to
+`git.GetCommitDate` per call. The branch SHA is cached after bootstrap, so a
+`git log -1 --format=%ct <sha>` is needed once per HEAD — could be batched into a
+`branchState` field at rebuild time if `info`/`tree` become hot enough to care.
 
 ## Validation
 

--- a/docs/plans/perf/info.md
+++ b/docs/plans/perf/info.md
@@ -39,23 +39,17 @@ For **`info --diff` / `info --patch`**:
 For **`info <untracked-branch>`** (`internal/actions/info.go:78–92`):
 - Triggers a real **`git fetch refs/stackit/metadata`** network call via `eng.FetchRemoteMetadata`. Dominates everything — many seconds on slow networks. This is the only info path that does network I/O.
 
+## Already shipped (do not re-plan)
+
+- **Batched restack status in stack-wide info** — the `FixedMap` loop
+  (`internal/actions/stack_info.go`) now calls `eng.ReadBranchStatuses(stackBranches)`
+  once and reads `statuses.IsUpToDate(branch)`, instead of a per-branch
+  `NeedsRestack()` that shelled a `git rev-parse` for each parent. This was the
+  original win #1 (cross-cutting #2).
+
 ## Proposed wins (ranked)
 
-### 1. Batch the restack status in stack-wide info *(shared with cross-cutting.md #2)*
-
-> **Status:** Partially done. `StackInfoAction` (`internal/actions/stack_info.go:48`) already
-> batches the heavy per-branch reads: `BatchCommits`, `BatchDiffStats`,
-> `BatchChangedFileCounts`, and `BatchGetPRSubmissionStatus` (stack_info.go:68–74). The
-> default one-branch `info` path is small and needs nothing here.
-
-The remaining N+1 is the restack/`FixedMap` loop (`internal/actions/stack_info.go:148–151`),
-which calls `branch.NeedsRestack()` per branch. That resolves to `IsUpToDate` →
-`git.GetRevision(parent)` once per branch (no global revision cache by design), so a stack of
-N branches spawns N parent-revision lookups. Use the existing batched
-`ReadBranchStatuses` (`internal/engine/engine_branch_status.go:187`, which fans the parent
-revisions through `BatchGetRevisions`) to compute the `FixedMap` in one pass.
-
-### 2. Cache `FetchRemoteMetadata` per session *(small impact, low risk)*
+### 1. Cache `FetchRemoteMetadata` per session *(small impact, low risk)*
 
 `internal/actions/info.go:87` calls `eng.FetchRemoteMetadata` (→ `FetchRemote`,
 `internal/engine/branch_mutations.go:79`), which performs an unconditional network fetch
@@ -64,7 +58,7 @@ CLI this fires at most once per invocation, so the win only matters for a long-l
 (the API server / watcher), where calling info on the same untracked branch twice should not
 re-fetch. Add a process-lifetime guard around the metadata fetch if/when the engine is reused.
 
-### 3. Combine `GetAllCommits + GetParentCommitSHA` into one git call *(small impact, low risk)*
+### 2. Combine `GetAllCommits + GetParentCommitSHA` into one git call *(small impact, low risk)*
 
 For `--patch` mode, `internal/actions/info.go:190–193` does:
 - `GetAllCommits(SHA)` → walk commits
@@ -76,7 +70,7 @@ A single `git rev-list --parents` over the range produces both. Or read the stor
 revision directly — `meta.GetParentBranchRevision()` *is* the base revision and is already in
 cache after bootstrap (see `internal/engine/branch_tracking.go`).
 
-### 4. `GetCommitDate` could come from the engine state cache *(trivial)*
+### 3. `GetCommitDate` could come from the engine state cache *(trivial)*
 
 `GetCommitDate` (`internal/engine/engine_branch_info.go:13`) shells out to
 `git.GetCommitDate` per call. The branch SHA is cached after bootstrap, so a

--- a/docs/plans/perf/modify.md
+++ b/docs/plans/perf/modify.md
@@ -2,6 +2,10 @@
 
 **Tier:** deep (the second hot-path mutating command after `create`; runs on every iteration).
 
+> **Audit note (2026-06):** This plan was re-checked against the code. Several
+> wins already shipped or were made obsolete by the removal of the global
+> revision cache / go-git reload machinery. Remaining work is wins #2 and #5.
+
 ## Call graph
 
 ```
@@ -9,78 +13,128 @@ NewModifyCmd.RunE → common.Run                       (same bootstrap as co)
   └─ actions.ModifyAction                            internal/actions/modify.go:34
        ├─ validation.ModifyBranchChain               cheap ancestry checks
        ├─ validation.MustNotHaveRebaseInProgress     fs check on .git/rebase-merge etc.
-       ├─ if amending: eng.IsBranchEmpty(currentBranch)   git rev-list / metadata compare
-       ├─ git.StageChanges(opts)                     shells `git add ...` (only if --all/--update/--patch)
-       ├─ eng.HasStagedChanges                       worktree.Status() — full tree walk
+       ├─ if amending: eng.IsBranchEmpty(currentBranch)   engine_branch_status.go:351
+       ├─ eng.StageChanges(opts)                     git add ... (only if --all/--update/--patch)
+       ├─ eng.HasStagedChanges                       git diff --cached --quiet (staging.go:55)
        │
-       ├─ eng.CommitWithOptions                      internal/engine/engine_writer.go:718
+       ├─ eng.CommitWithOptions                      internal/engine/commit_ops.go:19
        │     └─ git.runner.CommitWithOptions         internal/git/commit.go:20
-       │           ├─ shells `git commit --amend …`  user hooks dominate when present
-       │           ├─ revisionCache.InvalidateAll
-       │           └─ ReloadRepository               closes + reopens go-git repo
+       │           └─ shells `git commit --amend …`  user hooks dominate when present
        │
        └─ if children exist:
-            RestackBranches                          internal/actions/common.go:96
-              └─ restackBranchesWithPlan             internal/actions/common.go:111
+            RestackBranches                          internal/actions/common.go:99
+              └─ restackBranchesWithPlan             internal/actions/common.go:114
                    ├─ validateBranchAncestry         per-branch ancestry probe
-                   ├─ Engine.PlanRestack             ~3 git ops per branch (sha + parent sha + check)
-                   └─ Engine.ValidateRebases         internal/engine/rebase_validator.go:72
+                   ├─ Engine.PlanRestack             internal/engine/restack_plan.go:10 (~several git ops per branch)
+                   └─ Engine.ValidateRebases         internal/engine/rebase_validator.go:73
                         ├─ git.PruneWorktrees(ctx)   one-shot per call
                         ├─ groupSpecsByDepth         in-memory
                         └─ for each level, in parallel (up to MaxConcurrency):
-                             validateSingleSpec
-                               ├─ wt.CreateSession   ← `git worktree add` (slow, fs-bound)
+                             validateSingleSpec       rebase_validator.go:335
+                               ├─ tryConflictFreeReplay  ← fast path, no worktree (rebase_validator.go:425)
+                               ├─ wt.CreateSession   ← `git worktree add` (slow path only)
                                ├─ dryRunRebase       shells `git rebase --onto …`
                                └─ wt.Cleanup        ← `git worktree remove`
 ```
 
 ## Where time goes (typical leaf-branch amend with N descendants)
 
-1. **`git worktree add` × N specs** inside `ValidateRebases`. Each worktree creation is hundreds of ms on large repos (file copy of the working tree contents). Branches at the same depth are parallelized — but every spec still gets its own worktree. For an amend with one descendant: one worktree. For five: five worktrees in parallel, capped at `MaxConcurrency`. This is the single biggest cost on a non-leaf modify.
+1. **`git worktree add` per spec** inside `ValidateRebases`, **only when the fast
+   path misses**. `validateSingleSpec` now tries `tryConflictFreeReplay` first
+   (see "Already shipped" below): for a single-commit descendant whose files are
+   disjoint from the parent's new changes, no worktree is created at all. The
+   worktree cost only applies to multi-commit descendants or overlapping file
+   sets. When it does apply, branches at the same depth are parallelized but each
+   still gets its own worktree.
 2. **User pre-commit hook** during the `git commit --amend`. Outside stackit's control but it runs every modify.
-3. **`ReloadRepository`** after the amend (`internal/git/commit.go:57`). Closes and re-opens the go-git repo, wiping the revision cache. Same cost as in `create.md` #3.
-4. **`PlanRestack`** — ~3 git ops per descendant. Currently bounded by descendant count, not particularly parallel. For a deep stack, this is meaningful.
-5. **`worktree.Status()`** in `HasStagedChanges` (`internal/git/staging.go:103`). Same full-tree walk pattern as in `create.md` #1.
-6. **Bootstrap (`rebuildInternal`)** — fixed cost; see `co.md`.
+3. **`PlanRestack`** — several git ops per descendant, run sequentially. For a
+   deep stack, this is meaningful. See win #5.
+4. **Bootstrap (`rebuildInternal`)** — fixed cost; see `co.md`.
 
-For a **leaf branch amend** (no children): the restack block is skipped entirely. The dominant non-hook cost is `worktree.Status()` (#5) + `ReloadRepository` (#3) + bootstrap. Big win there is shared with `create`.
+`HasStagedChanges` is now a cheap `git diff --cached --quiet` index probe, no
+longer a full working-tree walk, so it is no longer a notable cost.
 
-For a **mid-stack amend**: the worktree-validate dance dominates everything else.
+For a **leaf branch amend** (no children): the restack block is skipped entirely.
+For a **mid-stack amend** with multi-commit or overlapping descendants: the
+worktree-validate dance still dominates.
+
+## Already shipped (do not re-plan)
+
+- **Conflict-free fast path** — `validateSingleSpec` calls `tryConflictFreeReplay`
+  (`internal/engine/rebase_validator.go:355,425`), which compares
+  `GetChangedFiles(old-parent..new-parent)` against
+  `GetChangedFiles(old-parent..branch)` and, when the file sets are disjoint for a
+  single-commit branch, computes the rebased tree via `merge-tree --write-tree` +
+  `commit-tree` with no worktree. This is the original win #1.
+- **`HasStagedChanges` coalescing** — moot: `HasStagedChanges` is now
+  `git diff --cached --quiet` (`internal/git/staging.go:55`), not a `Status()`
+  tree walk. The expensive walk the old win targeted no longer exists.
+- **`ReloadRepository` scoping** — moot: `ReloadRepository`, the go-git reopen,
+  and the global `revisionCache` were removed entirely. `git.CommitWithOptions`
+  (`internal/git/commit.go:20`) no longer reloads anything. Revisions are read
+  per-call via `git rev-parse` with batch readers (`BatchGetRevisions`) where
+  multiple branches are needed.
+- **Revision-cache pre-warming** — obsolete: there is no longer a global revision
+  cache to pre-warm (`LoadAllBranchRevisions` / `PreloadBranchData` were removed
+  and must not be reintroduced — see `.claude/rules/code-style.md`,
+  "Branch-state reads return values, not a global cache").
 
 ## Proposed wins (ranked)
 
-### 1. Skip `ValidateRebases` when the amend is conflict-free *(high impact, medium risk)*
+### 1. Extend conflict-free replay to multi-commit branches *(medium impact, high risk)*
 
-After an amend, every descendant's rebase is `rebase --onto <new-parent-sha> <old-parent-sha> <branch>`. If git can compute that as a fast-forward (the old parent is an ancestor of the new parent and no descendant commits touch the same files), there is no possibility of conflict. The validator could classify specs into:
+> **Status:** Partially done. The single-commit conflict-free fast path is
+> shipped (`tryConflictFreeReplay`, `internal/engine/rebase_validator.go:425`).
+> It bails out for multi-commit branches (`len(commits) != 1` → falls back to the
+> worktree path).
 
-- **Trivially safe**: parent moved but descendant commits don't overlap with the diff between old/new parent — apply directly, no worktree.
-- **Needs validation**: otherwise.
-
-Cheap heuristic: compare `git diff --name-only old-parent..new-parent` with `git diff --name-only old-parent..branch` per spec. If the file sets are disjoint, no conflict is possible. The check is one `diff --name-only` per spec instead of one full worktree+rebase.
-
-For a typical amend that only touches one file in a leaf branch, this collapses N worktrees into N file-set comparisons (each ~1ms).
+Remaining work: handle multi-commit descendants without a worktree. This requires
+iterating each commit's diff and confirming the *aggregate* branch file set is
+disjoint from the parent's new changes, then replaying commits onto the new
+parent via repeated `commit-tree` (or a single squashed `merge-tree` when commit
+identity can be preserved). Higher risk than the single-commit case because each
+intermediate commit's tree must be reconstructed in order; keep it strictly
+opt-in to the proven-disjoint case and fall back to the worktree path on any
+uncertainty.
 
 ### 2. Reuse a single validation worktree per depth level *(medium impact, medium risk)*
 
-`ValidateRebasesParallel` creates one worktree per spec. Within a depth level, branches are siblings — they all share the same upstream. A single reusable worktree per level (or per goroutine in a worker pool) could `git rebase --onto … && git rebase --abort` (or reset to a known state) between specs, paying worktree creation O(levels × concurrency) instead of O(specs).
+> **Status:** Not started. `validateSingleSpec`
+> (`internal/engine/rebase_validator.go:367`) still calls
+> `CreateTemporaryWorktreeWithOptions` once per spec that reaches the slow path.
 
-Risk: rerere state and partial-rebase state need careful reset between specs. The current per-spec isolation is the safe design — opt-in path for the validated-good case is safer.
+For specs that miss the fast path, `ValidateRebasesParallel` creates one worktree
+per spec. Within a depth level, branches are siblings sharing the same upstream. A
+reusable worktree per worker (worker pool) could `git rebase --onto … && git
+rebase --abort`/reset between specs, paying worktree creation O(levels ×
+concurrency) instead of O(slow-path specs).
 
-### 3. Same `worktree.Status()` coalescing as `create` *(low impact for modify, shared fix)*
+Risk: rerere state and partial-rebase state need careful reset between specs. The
+current per-spec isolation is the safe design — make this an opt-in path for the
+validated-good case. Note the impact is now smaller than originally estimated,
+since the fast path already eliminates worktrees for the common single-commit
+disjoint case.
 
-`HasStagedChanges` here calls `worktree.Status()`. `StageChanges` may have just finished a `git add` and knows what was staged. Returning a "staged any files?" flag from `StageChanges` would let us skip the second status walk. Same fix benefits `create`, `absorb`, `submit`.
+### 3. Reduce `PlanRestack`'s per-branch git ops *(small impact)*
 
-### 4. Same `ReloadRepository` scoping as `create` *(see create.md #3)*
+> **Status:** Not started. `PlanRestack` (`internal/engine/restack_plan.go:10`)
+> loops over branches sequentially; `planRestackBranch` does several git ops per
+> branch (`GetRevision`, `ReadMetadata`, `IsAncestor`, `GetMergeBase`).
 
-Invalidate just the affected branch's revision rather than dropping the whole go-git handle.
+The original plan suggested pre-warming via `PreloadBranchData` — **that approach
+is no longer available and is explicitly forbidden** (no ambient revision cache).
+Instead:
 
-### 5. Parallelize `PlanRestack`'s per-branch git ops *(small impact)*
+- Batch the revision lookups up front with `Engine.GetRevisions` /
+  `git.BatchGetRevisions` (one `rev-parse` for all branches) and the metadata
+  reads with `BatchReadMetadata`, then pass the resolved value maps into
+  `planRestackBranch`.
+- If further parallelism is wanted, use a **bounded** fan-out (`utils.Run`), not
+  one goroutine per branch — see `.claude/rules/code-style.md` "Bound parallel
+  fan-out".
 
-`PlanRestack` runs ~3 git ops per branch sequentially. Most are revision lookups that go through `revisionCache`. After `PreloadBranchData` (which modify doesn't currently call but easily could) most of these would be cache hits and the issue vanishes. Cheaper than building a fan-out.
-
-### 6. Pre-warm the revision cache before restack *(trivial)*
-
-Call `LoadAllBranchRevisions` (the same revision-batching pattern used by tree stats) before `PlanRestack` so its per-branch SHA lookups are all cache hits. One go-git ref iter vs. N individual lookups.
+Cheapest first step is the batch reads; only add fan-out if profiling still shows
+`PlanRestack` as hot.
 
 ## Validation
 
@@ -89,9 +143,13 @@ Call `LoadAllBranchRevisions` (the same revision-batching pattern used by tree s
 STACKIT_NO_LOGGING=1 hyperfine \
   'echo // noop >> file.go; stackit modify -a --no-edit'
 
-# Mid-stack (5 descendants) — measures worktree validation cost
+# Mid-stack (5 multi-commit descendants) — measures worktree validation cost
 STACKIT_NO_LOGGING=1 hyperfine \
   'echo // noop >> file.go; stackit modify -a --no-edit'
 ```
 
-Instrument: each `validateSingleSpec`, the worktree creation specifically, `ValidateRebases` total, `git commit`, `ReloadRepository`. The delta between leaf and mid-stack is essentially the worktree validation cost.
+Use multi-commit descendants for the mid-stack case so the conflict-free fast
+path does not absorb the cost being measured. Instrument: each
+`validateSingleSpec`, the worktree creation specifically, `ValidateRebases` total,
+`PlanRestack`, and `git commit`. The delta between leaf and mid-stack is
+essentially the worktree validation cost that survives the fast path.

--- a/docs/plans/perf/modify.md
+++ b/docs/plans/perf/modify.md
@@ -41,31 +41,33 @@ NewModifyCmd.RunE → common.Run                       (same bootstrap as co)
 
 1. **`git worktree add` per spec** inside `ValidateRebases`, **only when the fast
    path misses**. `validateSingleSpec` now tries `tryConflictFreeReplay` first
-   (see "Already shipped" below): for a single-commit descendant whose files are
-   disjoint from the parent's new changes, no worktree is created at all. The
-   worktree cost only applies to multi-commit descendants or overlapping file
-   sets. When it does apply, branches at the same depth are parallelized but each
+   (see "Already shipped" below): for any descendant (single- or multi-commit)
+   whose files are disjoint from the parent's new changes, no worktree is created
+   at all. The worktree cost only applies to descendants with **overlapping file
+   sets**. When it does apply, branches at the same depth are parallelized but each
    still gets its own worktree.
 2. **User pre-commit hook** during the `git commit --amend`. Outside stackit's control but it runs every modify.
 3. **`PlanRestack`** — several git ops per descendant, run sequentially. For a
-   deep stack, this is meaningful. See win #5.
+   deep stack, this is meaningful. See win #2.
 4. **Bootstrap (`rebuildInternal`)** — fixed cost; see `co.md`.
 
 `HasStagedChanges` is now a cheap `git diff --cached --quiet` index probe, no
 longer a full working-tree walk, so it is no longer a notable cost.
 
 For a **leaf branch amend** (no children): the restack block is skipped entirely.
-For a **mid-stack amend** with multi-commit or overlapping descendants: the
-worktree-validate dance still dominates.
+For a **mid-stack amend** with overlapping descendants: the worktree-validate
+dance still dominates.
 
 ## Already shipped (do not re-plan)
 
-- **Conflict-free fast path** — `validateSingleSpec` calls `tryConflictFreeReplay`
-  (`internal/engine/rebase_validator.go:355,425`), which compares
-  `GetChangedFiles(old-parent..new-parent)` against
-  `GetChangedFiles(old-parent..branch)` and, when the file sets are disjoint for a
-  single-commit branch, computes the rebased tree via `merge-tree --write-tree` +
-  `commit-tree` with no worktree. This is the original win #1.
+- **Conflict-free fast path (single- and multi-commit)** — `validateSingleSpec`
+  calls `tryConflictFreeReplay` (`internal/engine/rebase_validator.go:355`), which
+  compares `GetChangedFiles(old-parent..new-parent)` against
+  `GetChangedFiles(old-parent..branch)` and, when the file sets are disjoint,
+  replays the branch onto the new base with no worktree. Multi-commit branches are
+  replayed commit-by-commit via `replayCommitConflictFree` (oldest first, chained
+  onto the previous rebased result), preserving each commit's author identity and
+  message. This was the original win #1.
 - **`HasStagedChanges` coalescing** — moot: `HasStagedChanges` is now
   `git diff --cached --quiet` (`internal/git/staging.go:55`), not a `Status()`
   tree walk. The expensive walk the old win targeted no longer exists.
@@ -81,23 +83,7 @@ worktree-validate dance still dominates.
 
 ## Proposed wins (ranked)
 
-### 1. Extend conflict-free replay to multi-commit branches *(medium impact, high risk)*
-
-> **Status:** Partially done. The single-commit conflict-free fast path is
-> shipped (`tryConflictFreeReplay`, `internal/engine/rebase_validator.go:425`).
-> It bails out for multi-commit branches (`len(commits) != 1` → falls back to the
-> worktree path).
-
-Remaining work: handle multi-commit descendants without a worktree. This requires
-iterating each commit's diff and confirming the *aggregate* branch file set is
-disjoint from the parent's new changes, then replaying commits onto the new
-parent via repeated `commit-tree` (or a single squashed `merge-tree` when commit
-identity can be preserved). Higher risk than the single-commit case because each
-intermediate commit's tree must be reconstructed in order; keep it strictly
-opt-in to the proven-disjoint case and fall back to the worktree path on any
-uncertainty.
-
-### 2. Reuse a single validation worktree per depth level *(medium impact, medium risk)*
+### 1. Reuse a single validation worktree per depth level *(medium impact, medium risk)*
 
 > **Status:** Not started. `validateSingleSpec`
 > (`internal/engine/rebase_validator.go:367`) still calls
@@ -112,10 +98,11 @@ concurrency) instead of O(slow-path specs).
 Risk: rerere state and partial-rebase state need careful reset between specs. The
 current per-spec isolation is the safe design — make this an opt-in path for the
 validated-good case. Note the impact is now smaller than originally estimated,
-since the fast path already eliminates worktrees for the common single-commit
-disjoint case.
+since the fast path already eliminates worktrees for any disjoint-file case
+(single- or multi-commit); only branches with files overlapping the parent's
+changes still reach this slow path.
 
-### 3. Reduce `PlanRestack`'s per-branch git ops *(small impact)*
+### 2. Reduce `PlanRestack`'s per-branch git ops *(small impact)*
 
 > **Status:** Not started. `PlanRestack` (`internal/engine/restack_plan.go:10`)
 > loops over branches sequentially; `planRestackBranch` does several git ops per
@@ -143,13 +130,15 @@ Cheapest first step is the batch reads; only add fan-out if profiling still show
 STACKIT_NO_LOGGING=1 hyperfine \
   'echo // noop >> file.go; stackit modify -a --no-edit'
 
-# Mid-stack (5 multi-commit descendants) — measures worktree validation cost
+# Mid-stack (5 descendants with OVERLAPPING files) — measures worktree validation cost
 STACKIT_NO_LOGGING=1 hyperfine \
   'echo // noop >> file.go; stackit modify -a --no-edit'
 ```
 
-Use multi-commit descendants for the mid-stack case so the conflict-free fast
-path does not absorb the cost being measured. Instrument: each
+Use descendants whose files **overlap** the parent's changes for the mid-stack
+case so the conflict-free fast path does not absorb the cost being measured
+(disjoint single- and multi-commit branches now both take the no-worktree path).
+Instrument: each
 `validateSingleSpec`, the worktree creation specifically, `ValidateRebases` total,
 `PlanRestack`, and `git commit`. The delta between leaf and mid-stack is
 essentially the worktree validation cost that survives the fast path.

--- a/docs/plans/perf/navigation.md
+++ b/docs/plans/perf/navigation.md
@@ -36,12 +36,12 @@ These commands are bundled because they share one performance story: once the en
 > - Lazy `LoadMode`s with on-demand promotion: `LoadModeBranchesOnly`, `LoadModeShared`, `LoadModeFull` (`internal/engine/engine.go:167-184`), promoted via `ensureSharedLoaded`/`ensureLocalLoaded` (`engine_impl.go:249`, `:310`).
 > - **Per-branch** lazy shared-metadata load: `ensureBranchSharedLoaded` (`engine_impl.go:271`), wired into the branch-status accessors used by parent/down/trunk (`engine_branch_status.go`, `engine_reader.go:101`).
 > - `parent` uses `common.RunReadOnlyCurrentBranch` (`parent.go:24`); default `trunk` applies `common.ApplyReadOnlyCurrentBranch` (`trunk.go:34`). Both resolve to `LoadModeBranchesOnly` + skip the managed-worktree check (`internal/cli/common/common.go:72-82`).
+> - **`down` and `bottom`** opt into `LoadModeBranchesOnly` when `--quiet` (`down.go`, `bottom.go`), mirroring the quiet exact-checkout path in `co`. They keep the managed-worktree check (checkout relies on it for worktree switching), so they set only `EngineLoadMode` — not `RunReadOnlyCurrentBranch`. `bottom`'s path no longer builds the full graph: `SwitchBranchAction` builds `Graph()` only for `DirectionTop` (`internal/actions/navigation/action.go`), since `DirectionBottom`'s `traverseDownward` walks the parent chain only.
 
-Remaining work — the graph-based commands still use the full `common.Run` path (`LoadModeFull`):
-- `children` (`children.go:25`), `up` (`up.go:40`), `top` (`top.go:27`), `bottom` (`bottom.go:25`) build the whole `Graph()` over `AllBranches()`, so they need shared metadata for the stack — but none of them read frozen / NeedsPRBodyUpdate / PR state, so they could drop to `LoadModeShared` and skip the `BatchReadLocalMetadata` pass.
-- `down` (`down.go:30`) only walks the parent chain via `GetParent()`, which already triggers per-branch promotion — it is the strongest candidate for `LoadModeBranchesOnly`.
+Why quiet-gated: in non-quiet mode `printBranchInfo` builds the full `Graph()` (`internal/actions/checkout.go:161`), which under `LoadModeBranchesOnly` would do N per-branch lazy reads instead of one batched `BatchReadMetadata` — i.e. *worse*. Quiet checkout skips `printBranchInfo`, so the lazy parent-chain walk is a clean win.
 
-Measure first: for these commands the win is skipping the local-metadata batch (and, for `down`, deferring shared reads to the visited branches), not the per-branch reads the infrastructure already provides.
+Remaining work — the graph-based commands still use the full `common.Run` path:
+- `children` (`children.go:25`), `up` (`up.go:40`), `top` (`top.go:27`) build the whole `Graph()` over `AllBranches()`, so they genuinely need shared metadata for every branch — but none of them read frozen / NeedsPRBodyUpdate / PR state, so they could drop to `LoadModeShared` and skip the `BatchReadLocalMetadata` pass. (They cannot use `LoadModeBranchesOnly` — enumerating children forces a full graph build, where the per-branch lazy path is slower than one batch read.)
 
 ### 2. `up --to` should DFS once, not K x N *(small impact, low risk)*
 

--- a/docs/plans/perf/navigation.md
+++ b/docs/plans/perf/navigation.md
@@ -14,7 +14,7 @@ These commands are bundled because they share one performance story: once the en
 | `up` (`up.go`) | builds `graph`, walks children; with `--to` builds `Range(RecursiveChildren)` per child | yes |
 | `top` (`top.go`) → `actions/navigation.SwitchBranchAction` | walks children to leaf, may prompt | yes |
 | `bottom` (`bottom.go`) → same | walks parent chain to trunk-adjacent | yes |
-| `trunk` (default) (`trunk.go`) | branches-only bootstrap + walks parent chain + `config.LoadConfig` | no |
+| `trunk` (default) (`trunk.go`) | branches-only bootstrap + walks parent chain (trunks list from `ctx.Config`) | no |
 | `trunk --add` | `GetAllBranchNames` + `LoadConfig` + `Save` | no |
 | `main` / `m` (`main.go`) | nothing | yes (`actions.CheckoutOptions{CheckoutTrunk: true}`) |
 
@@ -23,31 +23,39 @@ These commands are bundled because they share one performance story: once the en
 1. **Bootstrap / metadata promotion** — see `co.md`. `parent` and default `trunk` already use `LoadModeBranchesOnly` and skip the managed-worktree check. `children` and graph-heavy commands still need broader metadata.
 2. **Native `git checkout`** for commands that end with a branch switch. The previous go-git status/checkout tax is gone; remaining cost is Git's checkout work plus Stackit command overhead.
 3. **`up --to <branch>`** specifically: for each child of the current branch, calls `graph.Range(child, {RecursiveChildren: true})` (`internal/cli/navigation/up.go:79`), then `slices.Contains` over the result. If the current branch has K children and a total of N descendants, this is O(K x N). On a deep tree with many siblings, this is the only non-bootstrap cost worth noting. Cheap fix: do one downstack DFS rooted at the current branch, build a child-to-leaves map, and look up `toBranch` in O(1).
-4. **`trunk --add`** does a redundant `GetAllBranchNames` to verify the branch exists. Engine state already has this list. Substitute `eng.GetBranch(trunkName).Exists()` or check membership in `e.state.branches`.
-5. **`findTrunkForBranch`** (`trunk.go:138`) calls `config.LoadConfig` from scratch even though `app.Context.Config` is already populated. Use `ctx.Config`.
+4. **`trunk --add`** does a redundant `GetAllBranchNames` (a git subprocess) to verify the branch exists, even though the engine already loaded the full local branch list into `state.branches` at construction (`loadBranchList` / `GetAllBranchNames`). Substitute `ctx.Engine.BranchNames().Contains(trunkName)` (the `*BranchSet` from `engine.BranchNames()`).
+5. **`findTrunkForBranch`** already reuses `ctx.Config` — it takes a `trunks []string` parameter sourced from `ctx.Config.AllTrunks()` (`trunk.go:131`) and no longer calls `config.LoadConfig`. The only remaining `config.LoadConfig` call is in `handleAddTrunk` (`trunk.go:75`), where it loads a *writable* `*GitConfig` for `AddTrunk`/`Save`; `ctx.Config` is the read-only `Configurer` interface and lacks those methods, so it is not a drop-in substitute.
 
 ## Proposed wins (ranked)
 
-### 1. Expand lightweight bootstrap for graph-based navigation *(high impact, medium risk)*
+### 1. Expand lightweight bootstrap for graph-based navigation *(medium impact, medium risk)*
 
-`parent` and default `trunk` already use branches-only mode. The remaining read-only and graph-adjacent commands need:
-- current branch (one HEAD read)
-- the metadata ref for the current branch (to find its parent)
-- optionally the metadata refs for its direct children
+> **Status:** Partially done. The lazy engine infrastructure exists and is applied to the single-branch commands; the graph-based commands still bootstrap full.
+>
+> Already in place:
+> - Lazy `LoadMode`s with on-demand promotion: `LoadModeBranchesOnly`, `LoadModeShared`, `LoadModeFull` (`internal/engine/engine.go:167-184`), promoted via `ensureSharedLoaded`/`ensureLocalLoaded` (`engine_impl.go:249`, `:310`).
+> - **Per-branch** lazy shared-metadata load: `ensureBranchSharedLoaded` (`engine_impl.go:271`), wired into the branch-status accessors used by parent/down/trunk (`engine_branch_status.go`, `engine_reader.go:101`).
+> - `parent` uses `common.RunReadOnlyCurrentBranch` (`parent.go:24`); default `trunk` applies `common.ApplyReadOnlyCurrentBranch` (`trunk.go:34`). Both resolve to `LoadModeBranchesOnly` + skip the managed-worktree check (`internal/cli/common/common.go:72-82`).
 
-This is at most 3-10 metadata reads versus the N branch reads that a full shared-metadata bootstrap performs. A lazy engine mode where metadata is fetched per branch/stack on first access would make `children` and the early validate steps for `up`/`down`/`top`/`bottom` cheaper.
+Remaining work — the graph-based commands still use the full `common.Run` path (`LoadModeFull`):
+- `children` (`children.go:25`), `up` (`up.go:40`), `top` (`top.go:27`), `bottom` (`bottom.go:25`) build the whole `Graph()` over `AllBranches()`, so they need shared metadata for the stack — but none of them read frozen / NeedsPRBodyUpdate / PR state, so they could drop to `LoadModeShared` and skip the `BatchReadLocalMetadata` pass.
+- `down` (`down.go:30`) only walks the parent chain via `GetParent()`, which already triggers per-branch promotion — it is the strongest candidate for `LoadModeBranchesOnly`.
+
+Measure first: for these commands the win is skipping the local-metadata batch (and, for `down`, deferring shared reads to the visited branches), not the per-branch reads the infrastructure already provides.
 
 ### 2. `up --to` should DFS once, not K x N *(small impact, low risk)*
 
-`internal/cli/navigation/up.go:75–88`: build `descendantsOf := map[branchName]bool` by walking from each child once. Then `descendantsOf[toBranch]` is O(1). Saves real work only on wide stacks with `--to`, but the current code is unnecessarily quadratic.
+`internal/cli/navigation/up.go:75–99` (the `graph.Range` call is at `up.go:79`): build `descendantsOf := map[branchName]bool` by walking from each child once. Then `descendantsOf[toBranch]` is O(1). Saves real work only on wide stacks with `--to`, but the current code is unnecessarily quadratic.
 
 ### 3. `trunk` should reuse `ctx.Config` *(trivial)*
 
-`handleAddTrunk` (`trunk.go:71`) and `findTrunkForBranch` (`trunk.go:140`) both call `config.LoadConfig` again. Bootstrap already loaded it into `ctx.Config`. Substitute.
+> **Status:** Mostly done. `findTrunkForBranch` no longer loads config — it takes a `trunks []string` parameter from `ctx.Config.AllTrunks()` (`trunk.go:131`, `:137`), and `handleShowTrunk` reads `ctx.Config` directly.
+
+The only remaining `config.LoadConfig` call is in `handleAddTrunk` (`trunk.go:75`). It is **not** a trivial substitution: it needs a writable `*GitConfig` to call `AddTrunk` + `Save`, but `ctx.Config` is the read-only `Configurer` interface (`internal/config/interface.go`), which exposes neither method. Closing this would require either type-asserting `ctx.Config.(*config.GitConfig)` or widening the interface — weigh that against the fact that `--add` is a rare, write-path command where the extra read is negligible. Likely not worth doing.
 
 ### 4. `trunk --add` should skip `GetAllBranchNames` *(trivial)*
 
-`trunk.go:60`. The engine already has the branch list. `slices.Contains(eng.AllBranchNames(), name)` (or a `Engine.HasBranch` helper) avoids spawning a git command.
+`trunk.go:64` calls `ctx.Engine.GetAllBranchNames(ctx)`, which spawns a git subprocess. The engine already loaded the full local branch list into `state.branches` at construction (every `LoadMode` runs `loadBranchList` / `rebuildInternal`, both backed by `GetAllBranchNames`). Substitute `ctx.Engine.BranchNames().Contains(trunkName)` — `BranchNames()` returns the cached `*BranchSet` (`internal/engine/branch_set.go:23`) for an O(1) in-memory check, no subprocess. (Note: there is no `AllBranchNames()` or `HasBranch` helper; `BranchNames()` is the right entry point.)
 
 ## Validation
 

--- a/docs/plans/perf/restack.md
+++ b/docs/plans/perf/restack.md
@@ -6,57 +6,98 @@
 
 ```
 NewRestackCmd → common.Run                           (same bootstrap as co)
-  └─ actions.PlanRestack                             internal/actions/restack.go:92
+  └─ actions.PlanRestack                             internal/actions/restack.go:97
        ├─ planRestackBranchGroups                    O(branches) graph walk
        └─ for each group:
             ├─ eng.SortBranchesTopologically
             └─ eng.PlanRestack                       ~3 git ops per branch (sha + parent sha + check)
   └─ if plan.HasBranches:
-       actions.RestackAction                         internal/actions/restack.go:121
-         ├─ TakeBestEffortSnapshot                   see create.md #2
+       actions.RestackAction                         internal/actions/restack.go:129
+         ├─ TakeBestEffortSnapshot                   see create.md #2 (skipped when undo disabled)
          ├─ rerere.EnsureEnabled                     one config read/write
          │
          └─ for each group (parallel if --parallel):
-              restackBranchesWithPlan                internal/actions/common.go:111
+              restackBranchesWithPlan                internal/actions/common.go:114
                 ├─ validateBranchAncestry            cheap
-                ├─ Engine.ValidateRebases            ← per-spec worktrees (see modify.md #1)
+                ├─ Engine.ValidateRebases            ← per-spec worktrees, with a conflict-free
+                │                                       fast path (see win #1)
                 ├─ (apply or conflict workflow)
                 └─ engine state writes
 ```
 
 ## Where time goes
 
-1. **`Engine.ValidateRebases`** dominates — same per-spec worktree creation that hurts `modify` and `absorb`. Restack's worst case is "stack of 8 branches all touch the same file" → 8 worktrees, validated in dependency order with width-level parallelism.
-2. **`Engine.PlanRestack`** — ~3 git ops per branch, run twice if the CLI builds the plan AND the action rebuilds it (which today's code explicitly avoids by passing `enginePlan` through). Still O(branches) git ops once.
-3. **`TakeBestEffortSnapshot`** — same per-branch revision iteration as `create.md` #2.
-4. **`--parallel` with worktrees** — `restackGroupsParallel` (not read here) dispatches independent stack groups to separate worktrees. Each worktree creation is hundreds of ms; for the multi-stack case this is a feature (parallelism beats serial worktree-creates), but each group still individually pays per-spec validation.
+1. **`Engine.ValidateRebases`** dominates — same per-spec worktree creation that hurts `modify` and `absorb`. A conflict-free fast path now skips the worktree for **single-commit** branches whose diff is disjoint from the parent's (`tryConflictFreeReplay`, `internal/engine/rebase_validator.go:355,419`). Multi-commit branches still pay a worktree each, so a "stack of 8 branches all touch the same file" still validates in dependency order with width-level parallelism.
+2. **`Engine.PlanRestack`** — ~3 git ops per branch, built once in the CLI and threaded through to the action via `enginePlan` (it is not rebuilt). Still O(branches) git ops once. Each lookup hits git directly (no revision cache — see the note under removed wins).
+3. **`TakeBestEffortSnapshot`** — already batches its revision reads via `BatchGetRevisions` (`internal/engine/undo.go:121`), so the cost is one `git rev-parse` plus metadata listing, not per-branch iteration. It is skipped entirely when `undo.enabled=false`. Remaining overhead: it still runs for a no-op restack (see win #2).
+4. **`--parallel` with worktrees** — `restackGroupsParallel` (`internal/actions/restack.go:310`) dispatches independent stack groups to separate worktrees, created on demand via a bounded `utils.RunWithWorkers` pool. Each worktree creation is hundreds of ms; for the multi-stack case this is a feature (parallelism beats serial worktree-creates), but each group still individually pays per-spec validation.
 5. **Bootstrap** — same fixed cost as `co.md`.
 
 ## Proposed wins (ranked)
 
-### 1. The big shared win: avoid validation worktrees when conflict-impossible *(shared with modify.md #1)*
+### 1. Extend the conflict-free fast path to multi-commit branches *(shared with modify.md #1)*
 
-Per-spec diff-file overlap check turns most stack restacks into "0 validation worktrees needed". For typical post-amend restacks, the descendant commits don't touch the same files as the parent's amend diff. This needs a direct safe-replay path that still produces the rewritten SHAs consumed by the apply phase; once that exists, the classifier collapses many cases to a few `git diff --name-only` invocations.
+> **Status:** Partially done. The single-commit case is implemented:
+> `validateSingleSpec` calls `tryConflictFreeReplay`
+> (`internal/engine/rebase_validator.go:355`), which compares the parent's and
+> branch's changed-file sets (`rebaseFileOverlap`) and, when disjoint, produces
+> the rebased SHA with `git merge-tree --write-tree` + `commit-tree` — no
+> worktree. This already collapses typical post-amend restacks (one commit per
+> branch, disjoint files) to a few `git diff --name-only` invocations.
 
-### 2. Pre-warm revision cache before `PlanRestack` *(small, free)*
+Remaining work: `tryConflictFreeReplay` bails out for any branch with more than
+one commit (`len(commits) != 1` → fall back to the worktree path). Multi-commit
+branches still create a validation worktree even when every commit's diff is
+disjoint from the parent's amend diff. Extend the safe-replay path to iterate
+each commit (cherry-pick-equivalent via repeated `merge-tree`/`commit-tree`)
+when the aggregate file sets are disjoint, so deep stacks of small multi-commit
+branches also skip worktrees.
 
-`engine.PlanRestack` does ~3 SHA lookups per branch. After a batched revision preload (the same pattern used by tree stats), all lookups hit cache. Add the call before `PlanRestack` in `actions.PlanRestack` (`internal/actions/restack.go:92`). Same fix benefits `modify` indirectly through `RestackBranches`.
+### 2. Skip the snapshot when `!plan.HasWork()` *(trivial)*
 
-### 3. Reuse validation worktree per depth level *(shared with modify.md #2)*
+`TakeBestEffortSnapshot` runs unconditionally in `RestackAction`
+(`internal/actions/restack.go:153`), before the work is dispatched. The CLI
+already short-circuits a no-op restack to the simple sync handler
+(`internal/cli/stack/restack.go:142-144`), but it still calls `RestackAction`,
+which takes the snapshot first. For an up-to-date stack the snapshot is pure
+overhead.
 
-Within a level (sibling branches), one worktree could validate all sibling specs back-to-back via `git rebase --onto … && git rebase --abort` between specs. Caps worktree creation at `levels × concurrency` instead of N.
+Move `TakeBestEffortSnapshot` after a `plan.HasWork()` gate (or only take it
+when about to mutate refs). The `undo.enabled=false` skip is already handled
+inside `TakeBestEffortSnapshot` (`internal/actions/common.go`), so this is the
+only remaining snapshot win.
 
-### 4. `--all-stacks` parallel mode should pre-build a worktree pool *(small impact, low risk)*
+### 3. Reuse a validation worktree per depth level *(shared with modify.md #2)*
 
-`restackGroupsParallel` creates worktrees on demand. For large `--all-stacks` runs, a pre-allocated pool of `jobs` worktrees that gets reused across groups avoids redundant `git worktree add`/`git worktree remove` cycles. Particularly noticeable when many groups have few branches each.
+Within a level (sibling branches that fall through the fast path),
+`validateSingleSpec` creates a fresh worktree per spec
+(`internal/engine/rebase_validator.go:367`). One worktree could validate all
+sibling specs back-to-back via `git rebase --onto … && git rebase --abort`
+between specs, capping worktree creation at roughly `levels × concurrency`
+instead of one per fall-through spec. Note this trades some intra-level
+parallelism (siblings currently validate concurrently across worktrees) for
+fewer `git worktree add`/`remove` cycles, so measure before committing.
 
-### 5. Snapshot scoping (shared with create.md #2)
+### 4. `--all-stacks` parallel mode should reuse a worktree pool *(small impact, low risk)*
 
-If `undo.enabled=false`, skip `TakeBestEffortSnapshot` entirely. For a no-op restack on an up-to-date stack (`!plan.HasWork()`), snapshot is pure overhead.
+`restackGroupsParallel` (`internal/actions/restack.go:310`) creates a worktree
+per group on demand inside `utils.RunWithWorkers` and tears it down with
+`defer cleanup()`. For large `--all-stacks` runs, a pre-allocated pool of
+`jobs` worktrees reused across groups would avoid redundant
+`git worktree add`/`git worktree remove` cycles. Particularly noticeable when
+many groups have few branches each.
 
-### 6. Skip snapshot when `!plan.HasWork()` *(trivial)*
+## Removed / no-longer-applicable wins
 
-Already short-circuits to the simple sync handler when nothing changes. The snapshot in `RestackAction` runs before that branch is taken. Move `TakeBestEffortSnapshot` after the no-work check, or only take a snapshot when we're about to mutate refs.
+- **Pre-warm a revision cache before `PlanRestack`** — removed. There is no
+  ambient/global revision cache to warm: `GetRevision` resolves through git
+  each call, and `.claude/rules/code-style.md` explicitly forbids reintroducing
+  an ambient revision cache or a `PreloadBranchData`-style warm-up (it was
+  removed deliberately as a staleness hazard). The only safe batching here is
+  `BatchGetRevisions`, which the snapshot path already uses.
+- **Snapshot scoping when `undo.enabled=false`** — done.
+  `TakeBestEffortSnapshot` early-returns when `ctx.Config.UndoEnabled()` is
+  false (`internal/actions/common.go`).
 
 ## Validation
 
@@ -71,4 +112,6 @@ STACKIT_NO_LOGGING=1 hyperfine 'stackit restack --upstack'
 STACKIT_NO_LOGGING=1 hyperfine 'stackit restack --all-stacks --parallel'
 ```
 
-Instrument: `ValidateRebases` total + per-spec, `PlanRestack`, `TakeBestEffortSnapshot`. The delta between up-to-date and needs-work is the validation cost.
+Instrument: `ValidateRebases` total + per-spec (fast-path vs worktree path),
+`PlanRestack`, `TakeBestEffortSnapshot`. The delta between up-to-date and
+needs-work is the validation cost.

--- a/docs/plans/perf/restack.md
+++ b/docs/plans/perf/restack.md
@@ -20,40 +20,22 @@ NewRestackCmd → common.Run                           (same bootstrap as co)
               restackBranchesWithPlan                internal/actions/common.go:114
                 ├─ validateBranchAncestry            cheap
                 ├─ Engine.ValidateRebases            ← per-spec worktrees, with a conflict-free
-                │                                       fast path (see win #1)
+                │                                       fast path for disjoint-file branches (shipped)
                 ├─ (apply or conflict workflow)
                 └─ engine state writes
 ```
 
 ## Where time goes
 
-1. **`Engine.ValidateRebases`** dominates — same per-spec worktree creation that hurts `modify` and `absorb`. A conflict-free fast path now skips the worktree for **single-commit** branches whose diff is disjoint from the parent's (`tryConflictFreeReplay`, `internal/engine/rebase_validator.go:355,419`). Multi-commit branches still pay a worktree each, so a "stack of 8 branches all touch the same file" still validates in dependency order with width-level parallelism.
+1. **`Engine.ValidateRebases`** dominates — same per-spec worktree creation that hurts `modify` and `absorb`. A conflict-free fast path now skips the worktree for **any** branch (single- or multi-commit) whose diff is disjoint from the parent's (`tryConflictFreeReplay`, `internal/engine/rebase_validator.go:355`). Only branches whose files overlap the parent's changes still pay a worktree each, so a "stack of 8 branches all touch the same file" still validates in dependency order with width-level parallelism.
 2. **`Engine.PlanRestack`** — ~3 git ops per branch, built once in the CLI and threaded through to the action via `enginePlan` (it is not rebuilt). Still O(branches) git ops once. Each lookup hits git directly (no revision cache — see the note under removed wins).
-3. **`TakeBestEffortSnapshot`** — already batches its revision reads via `BatchGetRevisions` (`internal/engine/undo.go:121`), so the cost is one `git rev-parse` plus metadata listing, not per-branch iteration. It is skipped entirely when `undo.enabled=false`. Remaining overhead: it still runs for a no-op restack (see win #2).
+3. **`TakeBestEffortSnapshot`** — already batches its revision reads via `BatchGetRevisions` (`internal/engine/undo.go:121`), so the cost is one `git rev-parse` plus metadata listing, not per-branch iteration. It is skipped entirely when `undo.enabled=false`. Remaining overhead: it still runs for a no-op restack (see win #1).
 4. **`--parallel` with worktrees** — `restackGroupsParallel` (`internal/actions/restack.go:310`) dispatches independent stack groups to separate worktrees, created on demand via a bounded `utils.RunWithWorkers` pool. Each worktree creation is hundreds of ms; for the multi-stack case this is a feature (parallelism beats serial worktree-creates), but each group still individually pays per-spec validation.
 5. **Bootstrap** — same fixed cost as `co.md`.
 
 ## Proposed wins (ranked)
 
-### 1. Extend the conflict-free fast path to multi-commit branches *(shared with modify.md #1)*
-
-> **Status:** Partially done. The single-commit case is implemented:
-> `validateSingleSpec` calls `tryConflictFreeReplay`
-> (`internal/engine/rebase_validator.go:355`), which compares the parent's and
-> branch's changed-file sets (`rebaseFileOverlap`) and, when disjoint, produces
-> the rebased SHA with `git merge-tree --write-tree` + `commit-tree` — no
-> worktree. This already collapses typical post-amend restacks (one commit per
-> branch, disjoint files) to a few `git diff --name-only` invocations.
-
-Remaining work: `tryConflictFreeReplay` bails out for any branch with more than
-one commit (`len(commits) != 1` → fall back to the worktree path). Multi-commit
-branches still create a validation worktree even when every commit's diff is
-disjoint from the parent's amend diff. Extend the safe-replay path to iterate
-each commit (cherry-pick-equivalent via repeated `merge-tree`/`commit-tree`)
-when the aggregate file sets are disjoint, so deep stacks of small multi-commit
-branches also skip worktrees.
-
-### 2. Skip the snapshot when `!plan.HasWork()` *(trivial)*
+### 1. Skip the snapshot when `!plan.HasWork()` *(trivial)*
 
 `TakeBestEffortSnapshot` runs unconditionally in `RestackAction`
 (`internal/actions/restack.go:153`), before the work is dispatched. The CLI
@@ -67,7 +49,7 @@ when about to mutate refs). The `undo.enabled=false` skip is already handled
 inside `TakeBestEffortSnapshot` (`internal/actions/common.go`), so this is the
 only remaining snapshot win.
 
-### 3. Reuse a validation worktree per depth level *(shared with modify.md #2)*
+### 2. Reuse a validation worktree per depth level *(shared with modify.md #1)*
 
 Within a level (sibling branches that fall through the fast path),
 `validateSingleSpec` creates a fresh worktree per spec
@@ -78,7 +60,7 @@ instead of one per fall-through spec. Note this trades some intra-level
 parallelism (siblings currently validate concurrently across worktrees) for
 fewer `git worktree add`/`remove` cycles, so measure before committing.
 
-### 4. `--all-stacks` parallel mode should reuse a worktree pool *(small impact, low risk)*
+### 3. `--all-stacks` parallel mode should reuse a worktree pool *(small impact, low risk)*
 
 `restackGroupsParallel` (`internal/actions/restack.go:310`) creates a worktree
 per group on demand inside `utils.RunWithWorkers` and tears it down with

--- a/docs/plans/perf/scope.md
+++ b/docs/plans/perf/scope.md
@@ -6,40 +6,34 @@
 
 ```
 newScopeCmd → common.Run → scope.Action               internal/actions/scope/action.go:22
-  ├─ --show: branches-only bootstrap, read explicit + resolved scope; print (no network)
+  ├─ --show: read explicit + resolved scope; print (no network)
   ├─ --unset:
-  │    ├─ eng.SetScope(Empty)                        metadata transaction (1 ref)
-  │    ├─ eng.BatchMarkNeedsPRBodyUpdate              metadata transaction (1 ref)
+  │    ├─ eng.SetScopeAndMarkForUpdate(Empty)         single metadata transaction (scope + PR-update flag)
   │    └─ actions.PushMetadataOnly                    `git push refs/stackit/metadata/<branch>`
   │
   └─ set scope:
-       ├─ eng.SetScope(newScope)                     metadata transaction
+       ├─ eng.SetScopeAndMarkForUpdate(newScope)      single metadata transaction (scope + PR-update flag)
        ├─ if scope-in-branch-name and renamed:
        │    handler.PromptConfirmRename
        │    eng.RenameBranch                          ref rename + checkout
-       ├─ eng.BatchMarkNeedsPRBodyUpdate              another metadata transaction
        └─ actions.PushMetadataOnly                    `git push`
 ```
 
 ## Where time goes
 
-1. **`actions.PushMetadataOnly`** — one `git push` (network round trip, 200–500ms typical). Dominates everything else when remote-sync is on.
-2. **`TestRemoteRefCompatibility`** on first run — another network round trip. Only runs once per repo (caches in `IsRemoteSyncEnabled`).
-3. **Two metadata transactions** per call: `SetScope` writes one ref, `BatchMarkNeedsPRBodyUpdate` writes another. Both go through the metadata tx machinery; each is ~2–5ms.
-4. **Bootstrap** — `--show` already uses branches-only mode and skips the managed-worktree check. Mutating scope paths still use the normal engine context.
-5. **`--show`** is the fast path and should mostly be current-branch metadata promotion after bootstrap.
+1. **`actions.PushMetadataOnly`** — one `git push` (network round trip, 200–500ms typical). Dominates everything else when remote-sync is on. (`internal/actions/metadata.go:18`)
+2. **`PrepareRemoteMetadataPush`** on first run — another network round trip. Only runs once per repo (caches in the remote-sync gate).
+3. **One metadata transaction** per mutating call: `SetScopeAndMarkForUpdate` writes the scope and the `NeedsPRBodyUpdate` flag in a single ref update (`internal/engine/branch_tracking.go:401`).
+4. **Bootstrap** — the mutating scope paths use the normal engine context.
+5. **`--show`** is the fast path: current-branch metadata read after bootstrap, no network.
 
 `RenameBranch` is rare — only triggered when the user explicitly confirms — but it does a real branch checkout + ref rename and is more expensive than the rest combined when it runs.
 
 ## Wins (ranked)
 
-### 1. Combine the two metadata writes into one transaction *(small impact, low risk)*
+### 1. Make the metadata push async-friendly *(medium impact, medium risk)*
 
-`SetScope` then `BatchMarkNeedsPRBodyUpdate` are two separate transactions touching the same branch's metadata. The engine's `withMetadataTx` could absorb both writes into one ref update — saves one git ref write. Fix touches `scope/action.go:73` and `:118`. Same pattern affects `describe`, `lock`, anywhere a command both mutates metadata and marks the branch for PR sync.
-
-### 2. Make the metadata push async-friendly *(medium impact, medium risk)*
-
-For non-interactive `--unset` and `--set`, the user is blocked on `git push` of metadata before the command returns. Stackit's [`safety-invariants.md`](../../.claude/rules/safety-invariants.md) explicitly notes that GitHub writes should defer to `sync`, but the *metadata ref push* itself is the heavy bit here. Options:
+For non-interactive `--unset` and `--set`, the user is blocked on `git push` of metadata before the command returns (`scope/action.go:72` and `:117` → `actions.PushMetadataOnly`). Stackit's [`safety-invariants.md`](../../.claude/rules/safety-invariants.md) explicitly notes that GitHub writes should defer to `sync`, but the *metadata ref push* itself is the heavy bit here. Options:
 
 - Background the push (fork a `git push` in the background, return immediately, log failures). Risk: user runs `submit` before metadata sync — but `submit` would re-push anyway, so the failure mode is benign.
 - Batch metadata pushes across consecutive `scope`/`describe`/`lock` commands during a single shell session via a debounce. Complex; only worth it if these commands run in bursts.

--- a/docs/plans/perf/submit.md
+++ b/docs/plans/perf/submit.md
@@ -8,7 +8,7 @@
 NewSubmitCmd → executeSubmit → submit.Action         internal/actions/submit/submit.go:77
   ├─ if untracked target: prompt + eng.TrackBranch
   ├─ getBranchesToSubmit                              graph walk over the stack (planning.go:165)
-  ├─ for each branch: branch.IsBranchUpToDate         N × uncached parent rev-parse (submit.go:153)
+  ├─ eng.ReadBranchStatuses(branchObjs)               one batched parent rev-parse for all branches (submit.go)
   ├─ tree.NewStackTree + normalizeDisplayTreeParents  in-memory (builds its own parentMap, no eng.Graph)
   ├─ handler.OnEvent(StackDisplayEvent)               render
   │
@@ -31,8 +31,10 @@ NewSubmitCmd → executeSubmit → submit.Action         internal/actions/submit
 > Note: the branch push is already a single batched `git push` (`pushSubmittedBranches`,
 > submit.go:448), and remote SHAs come from `eng.ReadBranchRemoteStatuses` (the old
 > `PopulateRemoteShas` is gone). The footer pass already fetches all PR content in one
-> GraphQL query before fanning out. Several originally-planned wins have landed; the
-> remaining ones are below.
+> GraphQL query before fanning out. The per-branch up-to-date checks now go through one
+> batched `eng.ReadBranchStatuses` (both the display `fixedMap` and `validateBaseRevisions`),
+> replacing the old N × uncached `git rev-parse`. Several originally-planned wins have
+> landed; the remaining ones are below.
 
 ## Where time goes
 
@@ -50,22 +52,7 @@ For a **--restack submit**:
 
 ## Proposed wins (ranked)
 
-### 1. Batch per-branch `IsBranchUpToDate` checks *(shared with cross-cutting.md #2)*
-
-> **Status:** Not started. The batched engine reader `ReadBranchStatuses`
-> (`internal/engine/engine_branch_status.go:187`) already exists, but submit does
-> not route through it.
-
-`branch.IsBranchUpToDate()` → `engineImpl.IsUpToDate` (engine_branch_status.go:157) runs an
-**uncached** `git rev-parse` on the parent for every call. Submit calls it per branch in two
-places:
-- `submit.go:153` — building `fixedMap` for the display tree.
-- `submit_validation.go:121` and `:127` — inside `validateBaseRevisions`.
-
-Route both through `ReadBranchStatuses` (one `BatchGetRevisions` for all parents) so the
-planning path does one grouped read instead of N individual `rev-parse` invocations.
-
-### 2. Cache PR check/info reads across commands (shared with tree.md #4)
+### 1. Cache PR check/info reads across commands (shared with tree.md #4)
 
 > **Status:** Not started. The per-branch PR-info read this win originally
 > targeted is already batched: `ValidateBranchesToSubmit` syncs all PRs in one
@@ -78,15 +65,15 @@ recently, a short TTL cache (~30s) on `BatchGetPRChecksStatus` and the PR-info s
 a following `submit` skip the redundant GraphQL round trip. This is the cross-cutting cache
 shared with tree.md #4; submit is one consumer.
 
-### 3. Pre-build worktrees for parallel update path *(low impact today, useful for `--restack` path; shared with restack.md #4)*
+### 2. Pre-build worktrees for parallel update path *(low impact today, useful for `--restack` path; shared with restack.md #3)*
 
 > **Status:** Not started.
 
 When `--restack` is on, the inner `RestackBranches` builds worktrees per spec. If submit ran
 restack frequently (or for `--all-stacks`), a reusable worktree pool would help. Same shape as
-`restack.md` #4 — track the work there; submit benefits for free.
+`restack.md` #3 — track the work there; submit benefits for free.
 
-### 4. Combine the `SubmitFooter` update with the PR create/update call *(medium impact, low risk)*
+### 3. Combine the `SubmitFooter` update with the PR create/update call *(medium impact, low risk)*
 
 > **Status:** Partially done. The footer pass already fetches every PR's current
 > content in **one** GraphQL query up front (`actions.FetchPRContentForBranches`,
@@ -100,7 +87,7 @@ the body/title sent by `createPullRequestQuiet`/`updatePullRequestQuiet` so the 
 the same call. Saves the entire second-pass round trip when `--submit-footer` is on (the
 default for many users).
 
-### 5. Push metadata refs in the same `git push` as branch refs *(medium impact, medium risk)*
+### 4. Push metadata refs in the same `git push` as branch refs *(medium impact, medium risk)*
 
 > **Status:** Not started.
 
@@ -111,7 +98,7 @@ pushed all branch refs. The pattern is "1 batched branch push + 1 metadata push"
 fail-as-a-group; today's behavior tolerates a metadata-only push failure ("Run 'st sync' and
 try submitting again"). Keep the fallback.
 
-### 6. Sequential create path could parallelize after the first PR *(small impact, medium risk)*
+### 5. Sequential create path could parallelize after the first PR *(small impact, medium risk)*
 
 > **Status:** Not started.
 

--- a/docs/plans/perf/submit.md
+++ b/docs/plans/perf/submit.md
@@ -5,75 +5,121 @@
 ## Call graph
 
 ```
-NewSubmitCmd → executeSubmit → submit.Action         internal/actions/submit/submit.go:110
+NewSubmitCmd → executeSubmit → submit.Action         internal/actions/submit/submit.go:77
   ├─ if untracked target: prompt + eng.TrackBranch
-  ├─ getBranchesToSubmit                              graph walk over the stack
-  ├─ pr.PopulateRemoteShas                            one `for-each-ref refs/remotes/...`
-  ├─ for each branch: branch.IsBranchUpToDate         N × parent revision lookup/status check
-  ├─ tree.NewStackTree + normalizeDisplayTreeParents  in-memory
+  ├─ getBranchesToSubmit                              graph walk over the stack (planning.go:165)
+  ├─ for each branch: branch.IsBranchUpToDate         N × uncached parent rev-parse (submit.go:153)
+  ├─ tree.NewStackTree + normalizeDisplayTreeParents  in-memory (builds its own parentMap, no eng.Graph)
   ├─ handler.OnEvent(StackDisplayEvent)               render
   │
   ├─ if --restack: actions.RestackBranches            ← per-spec worktree validation (see modify.md #1)
-  ├─ ValidateBranchesToSubmit                         per-branch checks
-  ├─ prepareBranchesForSubmit                         per-branch metadata + PR planning
-  │     ↳ may call GitHub for existing PR info
+  ├─ (real submit) go eng.ReadBranchRemoteStatuses    one `ls-remote`, concurrent with validation (submit.go:195)
+  ├─ ValidateBranchesToSubmit                         per-branch checks (submit_validation.go)
+  ├─ prepareBranchesForSubmit                         batched PR-submission-status + revisions (planning.go:15)
   │
   ├─ getGitHubClient                                  lazy init (one-time)
+  ├─ pushSubmittedBranches                            ← single batched `git push` of all branch refs (submit.go:275)
   ├─ for each branch:
-  │     submitBranch                                  ← `git push` + GraphQL PR create/update
+  │     submitBranch                                  ← GraphQL PR create/update (push already done)
   │       sequential for creates (PR number ordering)
   │       parallel for updates (utils.Run)
   │
-  ├─ if SubmitFooter: utils.Run(branches, UpdateBranchPRMetadata)   ← N × GraphQL update
-  └─ pushMetadataRefs(branches)                       one `git push refs/stackit/metadata/...`
+  ├─ if SubmitFooter: FetchPRContentForBranches (1 query) + utils.Run(UpdateBranchPRMetadataWithContent)  (submit.go:314)
+  └─ pushMetadataRefs(branches)                       one `git push refs/stackit/metadata/...` (submit.go:330)
 ```
+
+> Note: the branch push is already a single batched `git push` (`pushSubmittedBranches`,
+> submit.go:448), and remote SHAs come from `eng.ReadBranchRemoteStatuses` (the old
+> `PopulateRemoteShas` is gone). The footer pass already fetches all PR content in one
+> GraphQL query before fanning out. Several originally-planned wins have landed; the
+> remaining ones are below.
 
 ## Where time goes
 
 For an **update-style submit** (PRs already exist, no restack needed):
-1. **`git push` per branch** — each is a network round trip. Parallelized. Dominates everything else; typical 200–500ms per push, bounded by `MaxConcurrency` and remote rate limits.
-2. **GitHub GraphQL "update PR" calls** — also network-bound, also parallelized.
-3. **`SubmitFooter` updates** — another N GraphQL round-trips after the pushes. Already parallel. Often the slowest single phase because it sets per-branch PR body footers that include the stack listing.
-4. **`pushMetadataRefs`** — one combined push for `refs/stackit/metadata/*`. Single round trip.
-5. **`PopulateRemoteShas`** — one shell git command.
+1. **Branch `git push`** — now a single batched push of all branch refs (`pushSubmittedBranches`), not one push per branch. Still the dominant network cost.
+2. **GitHub GraphQL "update PR" calls** — network-bound, parallelized via `utils.Run`.
+3. **`SubmitFooter` updates** — a second parallel pass of N GraphQL updates after the create/update loop. Content is now pre-fetched in one query, but each branch's footer/title write is still its own round trip.
+4. **`pushMetadataRefs`** — one combined push for `refs/stackit/metadata/*`. Separate round trip from the branch push.
 
 For a **new-stack submit** (creates):
-- Submission is **sequential** (`internal/actions/submit/submit.go:296`) to guarantee sequential PR numbers. This is by design but pays N × push-latency serially.
+- Submission is **sequential** (`internal/actions/submit/submit.go:281–291`) to guarantee sequential PR numbers. By design, but pays N × create-latency serially.
 
 For a **--restack submit**:
 - `RestackBranches` pays the per-spec worktree validation tax (`modify.md` #1).
-
-Local (non-network) overhead is small compared to remote calls. The dominant local cost is bootstrap plus per-branch up-to-date checks while walking the stack.
 
 ## Proposed wins (ranked)
 
 ### 1. Batch per-branch `IsBranchUpToDate` checks *(shared with cross-cutting.md #2)*
 
-`internal/actions/submit/submit.go` calls `branch.IsBranchUpToDate()` for every branch in the stack. Route this through `ReadBranchStatuses` or an equivalent batched parent-revision lookup so the submit planning path does one grouped read instead of N individual checks.
+> **Status:** Not started. The batched engine reader `ReadBranchStatuses`
+> (`internal/engine/engine_branch_status.go:187`) already exists, but submit does
+> not route through it.
 
-### 2. Cache PR check status reads (shared with tree.md #4)
+`branch.IsBranchUpToDate()` → `engineImpl.IsUpToDate` (engine_branch_status.go:157) runs an
+**uncached** `git rev-parse` on the parent for every call. Submit calls it per branch in two
+places:
+- `submit.go:153` — building `fixedMap` for the display tree.
+- `submit_validation.go:121` and `:127` — inside `validateBaseRevisions`.
 
-`prepareBranchesForSubmit` reads existing PR info per branch. If `tree full` ran recently or if the user invoked `submit` after a `state`/`tree` view, a process-level TTL cache (~30s) on `BatchGetPRChecksStatus` and per-PR info reads would skip redundant GraphQL calls.
+Route both through `ReadBranchStatuses` (one `BatchGetRevisions` for all parents) so the
+planning path does one grouped read instead of N individual `rev-parse` invocations.
 
-### 3. Pre-build worktrees for parallel update path *(low impact today, useful for `--restack` path)*
+### 2. Cache PR check/info reads across commands (shared with tree.md #4)
 
-When `--restack` is on, the inner `RestackBranches` builds worktrees per spec. If submit ran restack frequently (or for `--all-stacks`), a reusable worktree pool would help. Same shape as `restack.md` #4.
+> **Status:** Not started. The per-branch PR-info read this win originally
+> targeted is already batched: `ValidateBranchesToSubmit` syncs all PRs in one
+> `github.SyncPrInfo` query (submit_validation.go:31), and planning resolves
+> submission status via `BatchGetPRSubmissionStatusWithRemote`
+> (engine/engine_pr.go:179). What remains is the cross-command cache.
+
+There is no process-/disk-level TTL cache today. If `tree full` or a `state`/`tree` view ran
+recently, a short TTL cache (~30s) on `BatchGetPRChecksStatus` and the PR-info sync would let
+a following `submit` skip the redundant GraphQL round trip. This is the cross-cutting cache
+shared with tree.md #4; submit is one consumer.
+
+### 3. Pre-build worktrees for parallel update path *(low impact today, useful for `--restack` path; shared with restack.md #4)*
+
+> **Status:** Not started.
+
+When `--restack` is on, the inner `RestackBranches` builds worktrees per spec. If submit ran
+restack frequently (or for `--all-stacks`), a reusable worktree pool would help. Same shape as
+`restack.md` #4 — track the work there; submit benefits for free.
 
 ### 4. Combine the `SubmitFooter` update with the PR create/update call *(medium impact, low risk)*
 
-`internal/actions/submit/submit.go:325–337` runs a second pass of N GraphQL calls solely to write the footer. Each existing `submitBranch` call already issues a GraphQL update — extend it to include the rendered footer in the same call. Saves the entire second-pass round trip when `--submit-footer` is on (which is the default for many users).
+> **Status:** Partially done. The footer pass already fetches every PR's current
+> content in **one** GraphQL query up front (`actions.FetchPRContentForBranches`,
+> submit.go:315) instead of a GET per branch. The remaining cost is the second
+> write pass.
+
+`internal/actions/submit/submit.go:314–327` still runs a separate pass of N GraphQL
+*update* calls (`UpdateBranchPRMetadataWithContent`) solely to write the footer, after
+`submitBranch` already issued a create/update for each branch. Fold the rendered footer into
+the body/title sent by `createPullRequestQuiet`/`updatePullRequestQuiet` so the footer ships in
+the same call. Saves the entire second-pass round trip when `--submit-footer` is on (the
+default for many users).
 
 ### 5. Push metadata refs in the same `git push` as branch refs *(medium impact, medium risk)*
 
-`pushMetadataRefs` is a separate `git push refs/stackit/metadata/*` at the end. For a stack of N branches the push pattern is "N branch pushes + 1 metadata push". A single `git push --atomic` listing both groups would save one round trip. Risk: atomic pushes fail-as-a-group; today's behavior tolerates a metadata-only push failure ("Run 'st sync' and try submitting again"). Keep the fallback.
+> **Status:** Not started.
+
+`pushMetadataRefs` (called at submit.go:330, defined at submit.go:696) is a separate
+`git push refs/stackit/metadata/*` after `pushSubmittedBranches` (submit.go:275) has already
+pushed all branch refs. The pattern is "1 batched branch push + 1 metadata push". A single
+`git push --atomic` listing both ref groups would save one round trip. Risk: atomic pushes
+fail-as-a-group; today's behavior tolerates a metadata-only push failure ("Run 'st sync' and
+try submitting again"). Keep the fallback.
 
 ### 6. Sequential create path could parallelize after the first PR *(small impact, medium risk)*
 
-The reason creates are sequential is to get sequential PR numbers. After the first branch's PR is created (and its number known), subsequent creates only need *its number* — not the sequence. Could submit branches in batches: first one alone, then the rest in parallel referencing each other by number. Tricky because stacked PR descriptions reference each other; needs careful ordering.
+> **Status:** Not started.
 
-### 7. `getBranchesToSubmit` could skip the redundant `Graph` walk *(trivial)*
-
-If the action wants the stack containing the current branch, `eng.Graph` is built lazily; submit already builds one for `tree.NewStackTree`. Reuse the same graph rather than rebuilding inside `getBranchesToSubmit`.
+Creates are sequential (`submit.go:281–291`) to get sequential PR numbers. After the first
+branch's PR is created (number known), subsequent creates only need *its number* — not the
+sequence. Could submit in batches: first one alone, then the rest in parallel referencing each
+other by number. Tricky because stacked PR descriptions reference each other; needs careful
+ordering.
 
 ## Validation
 
@@ -83,4 +129,7 @@ STACKIT_NO_LOGGING=1 hyperfine \
   'stackit submit'
 ```
 
-The delta is the push + GraphQL cost — almost entirely network. Instrument: each `submitBranch`, `pushMetadataRefs`, the per-branch `IsBranchUpToDate` loop, and the `SubmitFooter` update phase. The `--dry-run` baseline isolates planning from network.
+The delta is the push + GraphQL cost — almost entirely network. Instrument: the batched
+`pushSubmittedBranches`, `pushMetadataRefs`, the per-branch `IsBranchUpToDate` loop (win #1),
+and the `SubmitFooter` update phase (win #4). The `--dry-run` baseline isolates planning from
+network.

--- a/docs/plans/perf/track-untrack.md
+++ b/docs/plans/perf/track-untrack.md
@@ -1,6 +1,8 @@
 # `track` and `untrack` — Performance Analysis
 
-**Tier:** medium (less frequent than navigation/modify, but `untrack` has a real N+1 today).
+**Tier:** medium (less frequent than navigation/modify). `untrack`'s K+1-rebuild
+N+1 has since been fixed; the remaining work is in interactive `track` plus a
+shared scoped-rebuild item.
 
 ## `track`
 
@@ -14,25 +16,31 @@ newTrackCmd → common.Run → track.Action               internal/actions/track
   │    └─ eng.TrackBranch                              metadata write (1 ref)
   │
   ├─ if --force:
-  │    ├─ eng.FindMostRecentTrackedAncestors          walks ref ancestry
+  │    ├─ eng.FindMostRecentTrackedAncestors          action.go:84, walks ref ancestry
   │    └─ eng.TrackBranch
   │
   └─ interactive (no --parent):
-       trackBranchRecursively                          internal/actions/track/action.go:103
-         ├─ eng.FindMostRecentTrackedAncestors
+       trackBranchRecursively                          internal/actions/track/action.go:111
+         ├─ eng.FindMostRecentTrackedAncestors         action.go:122
          ├─ handler.PromptSelectParent                 user-blocking
          ├─ eng.TrackBranch
-         ├─ for each branch in AllBranches:           ← N branches
-         │     eng.GetMergeBase(candidate, branchName) ← `git merge-base` per branch (N calls)
-         │     eng.GetRevision(branchName)             cached on second iter
+         ├─ for each branch in AllBranches:           ← N branches (action.go:170)
+         │     eng.GetMergeBase(candidate, branchName) ← `git merge-base` per branch (N calls, action.go:177)
+         │     eng.GetRevision(branchName)             recomputed per iter (action.go:182)
          │     comparison
          └─ recurse into untracked children
 ```
 
 ### Where time goes
 
-1. **Per-candidate `eng.GetMergeBase`** in the child-detection loop (`action.go:169`). For each branch in the repo, a separate `git merge-base <candidate> <branchName>` is called. On a 50-branch repo, that's 50 git merge-base processes. This is the dominant cost in interactive track.
-2. **`FindMostRecentTrackedAncestors`** — runs once (or twice — `:76` and `:114` in the same flow). Walks ancestry — bounded by parent-chain depth, not by N.
+1. **Per-candidate `eng.GetMergeBase`** in the child-detection loop
+   (`action.go:177`). For each branch in the repo a separate
+   `git merge-base <candidate> <branchName>` is shelled (`GetMergeBase` calls
+   straight through to git with no memoization — `internal/engine/engine_git_ops.go:128`).
+   On a 50-branch repo that's 50 git processes. Dominant cost in interactive track.
+2. **`FindMostRecentTrackedAncestors`** — runs once (or twice — `:84` and `:122`
+   across the force/interactive flows). Walks ancestry — bounded by parent-chain
+   depth, not by N.
 3. **`eng.TrackBranch`** is cheap (one metadata ref write).
 4. **Bootstrap** — fixed cost; small relative to the merge-base loop above.
 
@@ -40,15 +48,23 @@ newTrackCmd → common.Run → track.Action               internal/actions/track
 
 #### 1. Replace per-candidate `GetMergeBase` with a single `rev-list` *(high impact, low risk)*
 
-`internal/actions/track/action.go:159–183` is the classic "find all descendants of a commit" question. One `git rev-list --children <branchName>..HEAD` (or `git for-each-ref --contains <branchName-sha>`) gives all branches that contain the branch's tip in one process. N+1 → 1.
+`internal/actions/track/action.go:170–191` is the classic "find all descendants
+of a commit" question. One `git rev-list --children <branchName>..HEAD` (or
+`git for-each-ref --contains <branchName-sha>`) gives all branches that contain
+the branch's tip in one process. N+1 → 1.
 
-#### 2. Cache `GetRevision` in the candidate loop *(trivial)*
+#### 2. Hoist `GetRevision(branchName)` out of the candidate loop *(trivial)*
 
-`eng.GetRevision(eng.GetBranch(branchName))` is called inside the loop (`:174`) per candidate. Move it outside; it doesn't change.
+`eng.GetRevision(eng.GetBranch(branchName))` is recomputed inside the loop
+(`action.go:182`) on every candidate even though `branchName` is invariant for
+the whole loop. `GetRevision` is **not** cached (it shells
+`git rev-parse` via `runner.getRevision` → `resolveRefSHA` each call —
+`internal/git/commit_info.go:56`), so this is N redundant rev-parse calls. Resolve
+it once before the loop.
 
-#### 3. Pre-warm with `LoadAllBranchRevisions` *(small impact, free)*
-
-Track does several `GetRevision` calls; if `LoadAllBranchRevisions` is called once at the start of `Action`, every subsequent revision lookup is a cache hit (one go-git ref iter vs many separate ones).
+> Note: win #1 subsumes this if implemented — the rev-list rewrite removes the
+> per-candidate merge-base/revision comparison entirely. Keep #2 only as the
+> minimal standalone fix if #1 is deferred.
 
 ## `untrack`
 
@@ -57,31 +73,37 @@ Track does several `GetRevision` calls; if `LoadAllBranchRevisions` is called on
 ```
 newUntrackCmd → common.Run → untrack.Action            internal/actions/untrack/action.go:18
   ├─ eng.Graph + graph.Range(RecursiveChildren)        in-memory
-  ├─ for each descendant:
-  │     eng.UntrackBranch(name)                        engine_writer.go:148
-  │       ├─ git.DeleteMetadata                        1 ref delete
-  │       └─ eng.rebuild()                             ← FULL REBUILD per descendant
-  └─ eng.UntrackBranch(branchName)                     another rebuild
+  ├─ collect descendant names + branch name
+  └─ eng.UntrackBranches(allNames)                      engine/branch_tracking.go:82
+       ├─ git.DeleteRefsBatch(metadataRefNames)         1 batched ref delete
+       └─ eng.rebuild()                                 1 rebuild for the whole set
 ```
 
 ### Where time goes
 
-1. **`eng.rebuild()` inside `UntrackBranch`** — see `internal/engine/engine_writer.go:155`. Each call does the full `GetAllBranchNames + batchReadMetadata + batchReadLocalMetadata` pass. Untracking a stack of K descendants triggers `K+1` full rebuilds. On a 30-branch repo untracking a 10-branch substack, that's 11 × (full branch enumeration + metadata read for every branch). The biggest performance bug in either command.
+1. **`eng.rebuild()` inside `UntrackBranches`** — `internal/engine/branch_tracking.go:97`.
+   Now runs **once** for the whole untrack (batched), not K+1 times. The remaining
+   cost is that the single rebuild is still a *full* repo pass
+   (`GetAllBranchNames + batchReadMetadata + batchReadLocalMetadata`) rather than
+   scoped to the touched branches — see win #1.
 2. Bootstrap — fixed cost.
 
 ### Wins
 
-#### 1. Batch the metadata deletes and rebuild once *(high impact, low risk)*
+#### 1. Scope the rebuild to touched branches *(shared with cross-cutting #8 / absorb)*
 
-Replace the per-branch `eng.UntrackBranch(name)` loop with:
-- a single `git.DeleteRefsBatch(metadataRefNames)` (the engine already exposes `DeleteRefsBatch`),
-- one `eng.rebuild()` afterwards.
+> **Status:** The N+1 (one full rebuild per descendant) is already fixed.
+> `untrack.Action` collects all names and calls the batched
+> `eng.UntrackBranches` (`internal/actions/untrack/action.go:58`), which does a
+> single `git.DeleteRefsBatch` plus a single `eng.rebuild()`
+> (`internal/engine/branch_tracking.go:82–98`). Remaining work below is only the
+> scoped-rebuild improvement.
 
-For untracking 10 branches: 10 rebuilds → 1 rebuild, plus 10 → 1 ref deletes. The fix is one helper method on the engine: `BatchUntrackBranches([]string) error`.
-
-#### 2. Scope the rebuild to touched branches *(shared with absorb.md #4)*
-
-If the engine grew a `RebuildBranches([]string)`, even the single-branch untrack path would only re-read the affected metadata rather than the whole repo's worth.
+The engine still does a full `rebuild()` after the batch delete. If the engine
+grew a `RebuildBranches([]string)` (cross-cutting item #8, also wanted by
+`absorb` / `modify` / `sync`), the untrack path would re-read only the affected
+metadata rather than the whole repo's worth. This method does **not** exist yet
+(only `rebuild()` / `rebuildInternal()` in `internal/engine/engine_internal.go`).
 
 ## Validation
 
@@ -95,4 +117,7 @@ STACKIT_NO_LOGGING=1 hyperfine 'stackit track <branch>'                       # 
 STACKIT_NO_LOGGING=1 hyperfine 'stackit untrack <root> -f'
 ```
 
-Instrument: the merge-base loop in `trackBranchRecursively`, every `eng.rebuild()` invocation, every `eng.UntrackBranch` call. The untrack rebuild count should be 1, not K+1, after the fix.
+Instrument: the merge-base loop in `trackBranchRecursively` (still N×merge-base),
+and every `eng.rebuild()` invocation. The untrack rebuild count is already 1
+(not K+1); a `RebuildBranches` would make that single rebuild scoped rather than
+full-repo.

--- a/docs/plans/perf/tree.md
+++ b/docs/plans/perf/tree.md
@@ -2,62 +2,59 @@
 
 **Tier:** deep (the dashboard view — run constantly, FULL hits GitHub).
 
+> **Status:** Most planned wins are already implemented. Diff stats, commit
+> counts, and SHAs are resolved in a single batched, `(base, head)`-cached pass
+> (`Engine.BatchBranchStats`); annotation metadata reads go through the shared
+> metadata cache; and the annotation worker pool is already bounded by
+> `GOMAXPROCS`. The only remaining proposed win is cross-invocation caching of
+> GitHub PR-check status (see Proposed wins below).
+
 ## Call graph (non-interactive, the common shell case)
 
 ```
 executeTree → common.Run                         (same bootstrap family as co)
-  └─ actions.TreeAction
-       ├─ if --json:        treeActionJSON
+  └─ actions.TreeAction                           (internal/actions/tree.go:88)
+       ├─ if --json:        treeActionJSON → BuildTreeJSON
        ├─ if interactive:   tui.NewTreeModel + tea.Run     (separate TUI path)
        │
        ├─ tui.GetWorktreeData(eng)                         one parse over engine state
-       ├─ Engine.BatchBranchStats                          one batched stats pass
+       ├─ Engine.BatchBranchStats(visibleBranches)         one batched stats pass
        │
        ├─ if FULL: github.BatchGetPRChecksStatus(branchesWithPRs)
        │
-       └─ utils.Run(visible branches, ...)
-              └─ tui.BuildFullAnnotationWithOptions
-                    └─ GetBranchAnnotationWithOptions
-                          ├─ branch.GetRevision()          from batched stats
-                          ├─ branch.GetPrInfo()            cache hit (preloaded)
-                          ├─ commit count                  from batched stats
-                          └─ diff stats                    from batched stats
+       └─ utils.Run(visible branches, ...)                 GOMAXPROCS-bounded pool
+              └─ buildTreeAnnotation
+                    └─ tui.BuildFullAnnotation / GetBranchAnnotation
+                          ├─ stat.ShortSHA                 from batched stats
+                          ├─ branch.GetPrInfo()            shared metadata cache
+                          ├─ stat.CommitCount              from batched stats
+                          └─ stat.LinesAdded/Deleted       from batched stats
 ```
 
 ## Where time goes (largest -> smallest, typical FULL run)
 
-1. **`BatchGetPRChecksStatus`**. Single network round trip but it is GitHub GraphQL — typically 300-800ms. The call is already filtered to branches with PRs and skipped when none are eligible, so the remaining win is caching across runs.
-2. **Branch stats batching**. `BatchBranchStats` resolves short SHAs, commit counts, and diff stats for the visible branches. It avoids the old per-branch `GetDiffStats` and `GetCommitCount` loops, but remains proportional to the number of rendered branches.
-3. **Annotation rendering**. Normal/full renders no longer load commit messages, but each visible branch still runs through annotation construction and PR metadata reads.
+1. **`BatchGetPRChecksStatus`**. Single network round trip but it is GitHub GraphQL — typically 300-800ms. The call is already filtered to branches with PRs (`BranchFilter{ExcludeTrunk: true, RequirePR: true}`) and skipped when none are eligible, so the remaining win is caching across runs.
+2. **Branch stats batching**. `BatchBranchStats` resolves short SHAs, commit counts, and diff stats for the visible branches in one batched, `(base, head)`-cached pass. It remains proportional to the number of rendered branches but does no per-branch N+1 git.
+3. **Annotation rendering**. Normal/full renders skip commit messages (`AnnotationOptions{SkipCommitMessages: true}`), so each visible branch only does cache-backed PR-metadata reads plus assembly from the batched stats.
 4. **Bootstrap**. `LoadModeShared` avoids local metadata at startup, but tree still needs repo-wide shared metadata to render the graph.
 
-For `tree short` and `tree` (NORMAL): no GitHub round trip, so branch stats and annotation construction dominate.
+For `tree short` and `tree` (NORMAL): no GitHub round trip. `tree short` skips `BatchBranchStats` entirely (`opts.Style != TreeStyleShort` gate), so annotation construction dominates.
 
-For `tree --json`: same shape as the embedded `state --json` stack snapshot, including PR check status only for branches that have PR metadata.
+For `tree --json`: same shape as the embedded `state --json` stack snapshot (`BuildTreeJSON`), including PR check status only for branches that have PR metadata.
 
 ## Proposed wins (ranked)
 
-### 1. Batch diff stats across all branches *(high impact, medium effort)*
+### 1. Cache `BatchGetPRChecksStatus` between consecutive tree invocations *(medium impact, low risk)*
 
-`GetDiffStats` is the worst N+1 in this command. Replace per-branch `git diff --numstat <base> <head>` with a single stack-level pass, or at least cache by `(base, head)` and cap subprocess fanout.
+A TTL cache (say 30s) keyed on the sorted branch name list would make repeated `tree full` invocations during a typing/review burst near-instant. Invalidate on `submit`.
 
-Estimated saving on a 20-branch stack: 60-160ms -> ~10-20ms.
-
-### 2. Batch commit counts/ranges *(medium impact, medium effort)*
-
-Commit messages are no longer populated for normal/full tree, and `tree short` skips this work. The remaining cost is branch range counting. A stack-level `git rev-list --boundary` pass could produce counts for every branch and also feed `info` / `absorb` range needs.
-
-### 3. Keep metadata reads on the bootstrap/shared-cache path *(small but free)*
-
-By the time tree renders, bootstrap should already have populated shared metadata and the cache layer should be hot. Keep future tree changes from reintroducing per-branch metadata reads in the annotation path.
-
-### 4. Cache `BatchGetPRChecksStatus` between consecutive tree invocations *(medium impact, low risk)*
-
-A TTL cache (say 30s) keyed on the sorted branch name list would make repeated `tree full` invocations during a typing/review burst instant. Invalidate on `submit`.
-
-### 5. Worker pool bounded by repository fanout, not branch count *(small, future)*
-
-`utils.Run(allBranches, ...)` can fan out heavily. For very large repos, bound work by `Engine.MaxConcurrency`, especially while each goroutine can fork git for diff stats.
+> **Note on feasibility:** the CLI runs each `tree` as a fresh process, so an
+> in-memory cache on `StackitGitHubClient` would not survive between
+> invocations — the cache must be **on-disk** (or served by the long-lived API
+> server, where an in-memory TTL cache does help). Today
+> `BatchGetPRChecksStatus` (internal/github/client_real.go:125) calls
+> `BatchGetPRChecksStatusGraphQL` directly with no caching layer, so this is
+> not started.
 
 ## Validation
 
@@ -68,4 +65,4 @@ STACKIT_NO_LOGGING=1 hyperfine \
   'stackit tree full'
 ```
 
-Instrument: `BatchGetPRChecksStatus`, the `utils.Run` block in `TreeAction`, batched branch stats, and annotation construction. The cross-section between FULL and short is the GitHub cost; the cross-section between tree and tree short is the per-branch annotation work.
+Instrument: `BatchGetPRChecksStatus`, the `utils.Run` block in `TreeAction`, batched branch stats (`BatchBranchStats`), and annotation construction. The cross-section between FULL and short is the GitHub cost; the cross-section between tree and tree short is the per-branch annotation work.

--- a/internal/actions/navigation/action.go
+++ b/internal/actions/navigation/action.go
@@ -35,12 +35,15 @@ func SwitchBranchAction(direction Direction, ctx *app.Context, handler Handler) 
 	var targetBranch string
 	var err error
 
-	graph := ctx.Engine.Graph(engine.SortStrategyAlphabetical)
-
 	switch direction {
 	case DirectionBottom:
+		// Walks the parent chain only — no full graph needed, so the command can
+		// run under LoadModeBranchesOnly and lazily promote just the chain.
 		targetBranch = traverseDownward(currentBranch.GetName(), ctx)
 	case DirectionTop:
+		// Walking toward the tips needs child relationships, which requires the
+		// full stack graph.
+		graph := ctx.Engine.Graph(engine.SortStrategyAlphabetical)
 		targetBranch, err = traverseUpward(currentBranch.GetName(), ctx, graph, handler)
 		if err != nil {
 			return actions.CheckoutResult{}, err

--- a/internal/actions/stack_info.go
+++ b/internal/actions/stack_info.go
@@ -145,9 +145,13 @@ func StackInfoAction(ctx *app.Context, opts StackInfoOptions) error {
 		trunkName := eng.Trunk().GetName()
 		stackTree := tree.NewStackTree(stackBranches, currentBranch.GetName(), trunkName)
 		stackTree.FixedMap = make(map[string]bool)
+		// Resolve restack status for the whole stack in one batched parent-revision
+		// read instead of a per-branch NeedsRestack() (each of which would shell a
+		// separate `git rev-parse` for the parent).
+		statuses := eng.ReadBranchStatuses(stackBranches)
 		for _, branch := range stackBranches {
 			// IsFixed means it does NOT need restack
-			stackTree.FixedMap[branch.GetName()] = !branch.NeedsRestack()
+			stackTree.FixedMap[branch.GetName()] = statuses.IsUpToDate(branch)
 		}
 		stackTree.FixedMap[trunkName] = true
 

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -143,14 +143,22 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	// Build tree structure for display
 	branchObjs := make(engine.Branches, len(branches))
+	for i, branchName := range branches {
+		branchObjs[i] = nav.GetBranch(branchName)
+	}
+
+	// Resolve up-to-date status for every branch in one batched parent-revision
+	// read rather than a per-branch IsBranchUpToDate() (each of which shells a
+	// separate `git rev-parse` for the parent).
+	statuses := eng.ReadBranchStatuses(branchObjs)
+
 	fixedMap := make(map[string]bool)
 	scopeMap := make(map[string]string)
 	worktreeMap := make(map[string]string)
 
 	for i, branchName := range branches {
-		branch := nav.GetBranch(branchName)
-		branchObjs[i] = branch
-		fixedMap[branchName] = branch.IsBranchUpToDate()
+		branch := branchObjs[i]
+		fixedMap[branchName] = statuses.IsUpToDate(branch)
 		scopeMap[branchName] = branch.GetScope().String()
 
 		// Check if this branch belongs to a stack with a managed worktree.

--- a/internal/actions/submit/submit_validation.go
+++ b/internal/actions/submit/submit_validation.go
@@ -111,6 +111,15 @@ func validateBaseRevisions(branches []string, eng engine.BranchStatus, ctx *app.
 		return remoteStatuses
 	}
 
+	// Resolve up-to-date status for every branch in one batched parent-revision
+	// read instead of a per-branch IsBranchUpToDate() inside the loop (each of
+	// which would shell a separate `git rev-parse` for the parent).
+	branchObjs := make(engine.Branches, 0, len(branches))
+	for _, branchName := range branches {
+		branchObjs = append(branchObjs, eng.GetBranch(branchName))
+	}
+	statuses := eng.ReadBranchStatuses(branchObjs)
+
 	for _, branchName := range branches {
 		branch := eng.GetBranch(branchName)
 		parentBranchName := resolveSubmitParentName(nav, branch)
@@ -118,13 +127,13 @@ func validateBaseRevisions(branches []string, eng engine.BranchStatus, ctx *app.
 		parentBranch := eng.GetBranch(parentBranchName)
 		switch {
 		case parentBranch.IsTrunk():
-			if !branch.IsBranchUpToDate() {
+			if !statuses.IsUpToDate(branch) {
 				ctx.Output.Info("Note that %s has fallen behind trunk. You may encounter conflicts if you attempt to merge it.",
 					output.Branch(branchName, false))
 			}
 		case validatedBranches[parentBranchName]:
 			// Parent is in the submission list
-			if !branch.IsBranchUpToDate() {
+			if !statuses.IsUpToDate(branch) {
 				return fmt.Errorf("you are trying to submit at least one branch that has not been restacked on its parent. To resolve this, check out %s and run 'stackit restack'",
 					output.Branch(branchName, false))
 			}

--- a/internal/cli/navigation/bottom.go
+++ b/internal/cli/navigation/bottom.go
@@ -8,6 +8,7 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/cli/common"
 	"github.com/getstackit/stackit/internal/cli/stack"
+	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/utils"
 )
 
@@ -22,7 +23,17 @@ This command navigates down the parent chain from the current branch until
 it reaches the first branch that has trunk as its parent (or trunk itself).`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return common.Run(cmd, func(ctx *app.Context) error {
+			// bottom walks the parent chain only (DirectionBottom no longer builds
+			// the full stack graph). In quiet mode no branch info is printed, so the
+			// lighter branches-only load with lazy per-branch promotion suffices —
+			// mirroring the quiet exact-checkout path in `co`. The managed-worktree
+			// check is intentionally preserved (checkout relies on it).
+			opts := common.GetGlobalOptions(cmd)
+			if opts.Quiet {
+				loadMode := engine.LoadModeBranchesOnly
+				opts.EngineLoadMode = &loadMode
+			}
+			return common.RunWithOptions(cmd, opts, func(ctx *app.Context) error {
 				handler := stack.NewNavigationUI(ctx.Output, utils.IsInteractive())
 				result, err := navigation.SwitchBranchAction(navigation.DirectionBottom, ctx, handler)
 				if err != nil {

--- a/internal/cli/navigation/down.go
+++ b/internal/cli/navigation/down.go
@@ -6,6 +6,7 @@ import (
 	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/errors"
 	"github.com/getstackit/stackit/internal/tui/style"
 )
@@ -27,7 +28,18 @@ as an argument to move multiple levels at once.`,
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return common.Run(cmd, func(ctx *app.Context) error {
+			// down only walks the parent chain and checks out an exact branch. In
+			// quiet mode no branch info is printed (which would build the full stack
+			// graph), so the lighter branches-only load with lazy per-branch promotion
+			// is sufficient — mirroring the quiet exact-checkout path in `co`. The
+			// managed-worktree check is intentionally preserved (checkout relies on it
+			// for worktree switching).
+			opts := common.GetGlobalOptions(cmd)
+			if opts.Quiet {
+				loadMode := engine.LoadModeBranchesOnly
+				opts.EngineLoadMode = &loadMode
+			}
+			return common.RunWithOptions(cmd, opts, func(ctx *app.Context) error {
 				parsedSteps, err := parsePositiveSteps(args, steps)
 				if err != nil {
 					return err

--- a/internal/cli/navigation/navigation_test.go
+++ b/internal/cli/navigation/navigation_test.go
@@ -86,6 +86,29 @@ func TestNavigationCommands(t *testing.T) {
 		require.Equal(t, "main", strings.TrimSpace(output))
 	})
 
+	t.Run("quiet down and bottom navigate correctly under light load path", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)
+
+		// Create stack: main -> a -> b -> c
+		s.RunCli("create", "a", "-m", "a").
+			RunCli("create", "b", "-m", "b").
+			RunCli("create", "c", "-m", "c")
+
+		// Quiet down/bottom opt into LoadModeBranchesOnly; verify they still land
+		// on the correct branch (parent-chain traversal + checkout) end-to-end.
+		s.RunCli("down", "--quiet")
+		s.ExpectBranch("b")
+
+		s.RunCli("bottom", "--quiet")
+		s.ExpectBranch("a")
+
+		// Multi-step quiet down from the tip walks several parents at once.
+		s.Checkout("c").
+			RunCli("down", "2", "--quiet")
+		s.ExpectBranch("a")
+	})
+
 	t.Run("trunk and first branch navigation", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenarioParallel(t, testhelpers.BasicSceneSetup).WithBinaryPath(binaryPath)

--- a/internal/engine/rebase_validator.go
+++ b/internal/engine/rebase_validator.go
@@ -444,7 +444,7 @@ func (e *engineImpl) tryConflictFreeReplay(
 
 	// Get the files changed by the parent's new commits (what we're rebasing onto).
 	parentFiles, err := e.git.GetChangedFiles(ctx, spec.OldUpstream, resolvedParent)
-	if err != nil || len(parentFiles) == 0 {
+	if err != nil {
 		return "", false
 	}
 

--- a/internal/engine/rebase_validator.go
+++ b/internal/engine/rebase_validator.go
@@ -417,20 +417,28 @@ func (e *engineImpl) validateSingleSpec(
 }
 
 // tryConflictFreeReplay tries to produce the rebased SHA without a worktree for
-// single-commit branches where the parent's new changes and the branch's changes
-// touch completely disjoint file sets (a content conflict is therefore impossible).
+// branches where the parent's new changes and the branch's changes touch
+// completely disjoint file sets (a content conflict is therefore impossible).
 //
-// Returns (newSHA, true) on success; returns ("", false) to signal the caller to
-// fall back to the full worktree path.
+// Multi-commit branches are supported only when the commit range is linear: each
+// commit is replayed individually, oldest first, chained onto the previous
+// rebased result so per-commit author identity and messages are preserved. The
+// branch-level disjoint-file check is a sufficient conflict guarantee for every
+// commit, because each commit's changes are a subset of the branch's overall
+// changes — none of which touch a file the parent changed.
+//
+// Returns (newSHA, true) on success, where newSHA is the rebased branch tip;
+// returns ("", false) to signal the caller to fall back to the full worktree path.
 func (e *engineImpl) tryConflictFreeReplay(
 	ctx context.Context,
 	spec RebaseSpec,
 	resolvedParent string,
 ) (string, bool) {
-	// Only handle single-commit branches — multi-commit replay requires iterating
-	// each commit individually and is deferred to the worktree path.
 	commits, err := e.git.GetCommitRangeSHAs(ctx, spec.OldUpstream, spec.Branch)
-	if err != nil || len(commits) != 1 {
+	if err != nil || len(commits) == 0 {
+		return "", false
+	}
+	if !e.commitRangeIsLinear(commits, spec.OldUpstream) {
 		return "", false
 	}
 
@@ -451,12 +459,68 @@ func (e *engineImpl) tryConflictFreeReplay(
 		return "", false
 	}
 
-	// File sets are disjoint — compute the rebased tree via merge-tree.
+	// File sets are disjoint — replay each commit onto the new base. commits is
+	// newest-first, so iterate in reverse (oldest first). The oldest commit's
+	// original parent is OldUpstream; every later commit's original parent is the
+	// commit immediately before it. Each replayed commit becomes the new base for
+	// the next, so author identity and message are preserved per commit.
+	newBase := resolvedParent
+	for i := len(commits) - 1; i >= 0; i-- {
+		mergeBase := spec.OldUpstream
+		if i+1 < len(commits) {
+			mergeBase = commits[i+1]
+		}
+		newSHA, ok := e.replayCommitConflictFree(ctx, commits[i], mergeBase, newBase)
+		if !ok {
+			return "", false
+		}
+		newBase = newSHA
+	}
+	return newBase, true
+}
+
+// commitRangeIsLinear reports whether commits (newest-first) form a simple
+// single-parent chain rooted at oldUpstream. The replay fast path relies on that
+// shape to preserve git rebase semantics; merge commits and side-branch commits
+// must fall back to the real worktree rebase.
+func (e *engineImpl) commitRangeIsLinear(commits []string, oldUpstream string) bool {
+	for i := len(commits) - 1; i >= 0; i-- {
+		parentRaw, err := e.git.GetCommitLog(commits[i], "%P")
+		if err != nil {
+			return false
+		}
+		parents := strings.Fields(parentRaw)
+		if len(parents) != 1 {
+			return false
+		}
+
+		expectedParent := oldUpstream
+		if i+1 < len(commits) {
+			expectedParent = commits[i+1]
+		}
+		if parents[0] != expectedParent {
+			return false
+		}
+	}
+	return true
+}
+
+// replayCommitConflictFree replays a single commit onto newBase without a
+// worktree, given the commit's original parent (the 3-way merge base). The caller
+// must have established that the branch's changes are disjoint from the new base's
+// changes, so the merge is guaranteed conflict-free.
+//
+// Returns (newSHA, true) on success; returns ("", false) to signal fallback.
+func (e *engineImpl) replayCommitConflictFree(
+	ctx context.Context,
+	commitSHA, mergeBase, newBase string,
+) (string, bool) {
+	// Compute the rebased tree via merge-tree.
 	// git merge-tree --write-tree --merge-base <base> <ours> <theirs>
-	// OURS  = resolvedParent (the new base we're rebasing onto)
-	// THEIRS = spec.Branch  (carries our changes on top of OldUpstream)
+	// OURS  = newBase  (the rebased parent so far)
+	// THEIRS = commitSHA (this commit's snapshot on top of its original parent)
 	treeSHARaw, err := e.git.RunGitCommandWithContext(ctx,
-		"merge-tree", "--write-tree", "--merge-base", spec.OldUpstream, resolvedParent, spec.Branch)
+		"merge-tree", "--write-tree", "--merge-base", mergeBase, newBase, commitSHA)
 	if err != nil {
 		return "", false
 	}
@@ -468,7 +532,6 @@ func (e *engineImpl) tryConflictFreeReplay(
 	}
 
 	// Preserve the original commit's author identity and message.
-	commitSHA := commits[0] // single commit, newest-first list
 	authorName, err := e.git.GetCommitLog(commitSHA, "%an")
 	if err != nil {
 		return "", false
@@ -493,7 +556,7 @@ func (e *engineImpl) tryConflictFreeReplay(
 	}
 
 	newSHARaw, err := e.git.RunGitCommandWithEnv(ctx, env,
-		"commit-tree", treeSHA, "-p", resolvedParent, "-m", strings.TrimSpace(msg))
+		"commit-tree", treeSHA, "-p", newBase, "-m", strings.TrimSpace(msg))
 	if err != nil {
 		return "", false
 	}

--- a/internal/engine/rebase_validator_internal_test.go
+++ b/internal/engine/rebase_validator_internal_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,50 +10,67 @@ import (
 	"github.com/getstackit/stackit/internal/git"
 )
 
+// fastPathGit is a fake git.Runner that records the merge-tree / commit-tree
+// calls tryConflictFreeReplay makes, so we can assert the exact replay sequence
+// without a real repository.
 type fastPathGit struct {
 	git.Runner
 
-	t              *testing.T
-	mergeTreeArgs  []string
-	commitTreeEnv  []string
-	commitTreeArgs []string
+	t *testing.T
+
+	// commits returned by GetCommitRangeSHAs (newest-first).
+	commits []string
+	// parent lists keyed by commit SHA, as returned by git log --format=%P.
+	parents map[string]string
+	// changed files keyed by the diff head ("new-parent" / branch name).
+	changedFiles map[string][]string
+
+	// recorded calls, in order.
+	mergeTreeCalls  [][]string
+	commitTreeCalls [][]string
+
+	// monotonic counter so each synthesized commit SHA is unique.
+	commitTreeN int
 }
 
 func (g *fastPathGit) GetCommitRangeSHAs(_ context.Context, base, head string) ([]string, error) {
 	require.Equal(g.t, "old-base", base)
 	require.Equal(g.t, "feature", head)
-	return []string{"feature-commit"}, nil
+	return g.commits, nil
 }
 
 func (g *fastPathGit) GetChangedFiles(_ context.Context, base, head string) ([]string, error) {
 	require.Equal(g.t, "old-base", base)
-	switch head {
-	case "new-parent":
-		return []string{"parent.txt"}, nil
-	case "feature":
-		return []string{"feature.txt"}, nil
-	default:
+	files, ok := g.changedFiles[head]
+	if !ok {
 		g.t.Fatalf("unexpected changed-files head: %s", head)
-		return nil, nil
 	}
+	return files, nil
 }
 
 func (g *fastPathGit) RunGitCommandWithContext(_ context.Context, args ...string) (string, error) {
-	g.mergeTreeArgs = append([]string(nil), args...)
-	return "tree-sha\n", nil
+	g.mergeTreeCalls = append(g.mergeTreeCalls, append([]string(nil), args...))
+	// The tree SHA is derived from the commit being replayed (the last arg) so
+	// assertions can tie a tree back to its source commit.
+	return "tree-of-" + args[len(args)-1] + "\n", nil
 }
 
 func (g *fastPathGit) GetCommitLog(sha, format string) (string, error) {
-	require.Equal(g.t, "feature-commit", sha)
 	switch format {
+	case "%P":
+		parent, ok := g.parents[sha]
+		if !ok {
+			g.t.Fatalf("unexpected parent lookup for commit: %s", sha)
+		}
+		return parent + "\n", nil
 	case "%an":
-		return "Author Name\n", nil
+		return "Author " + sha + "\n", nil
 	case "%ae":
-		return "author@example.com\n", nil
+		return sha + "@example.com\n", nil
 	case "%aI":
 		return "2026-06-01T12:00:00-04:00\n", nil
 	case "%B":
-		return "subject\n\nbody\n", nil
+		return "subject " + sha + "\n", nil
 	default:
 		g.t.Fatalf("unexpected commit log format: %s", format)
 		return "", nil
@@ -60,13 +78,24 @@ func (g *fastPathGit) GetCommitLog(sha, format string) (string, error) {
 }
 
 func (g *fastPathGit) RunGitCommandWithEnv(_ context.Context, env []string, args ...string) (string, error) {
-	g.commitTreeEnv = append([]string(nil), env...)
-	g.commitTreeArgs = append([]string(nil), args...)
-	return "new-sha\n", nil
+	g.commitTreeCalls = append(g.commitTreeCalls, append([]string(nil), env...))
+	g.commitTreeCalls = append(g.commitTreeCalls, append([]string(nil), args...))
+	g.commitTreeN++
+	return fmt.Sprintf("new-sha-%d\n", g.commitTreeN), nil
 }
 
-func TestTryConflictFreeReplayUsesMergeTreeWithExplicitMergeBase(t *testing.T) {
-	fakeGit := &fastPathGit{t: t}
+func TestTryConflictFreeReplaySingleCommitUsesMergeTreeWithExplicitMergeBase(t *testing.T) {
+	fakeGit := &fastPathGit{
+		t:       t,
+		commits: []string{"feature-commit"},
+		parents: map[string]string{
+			"feature-commit": "old-base",
+		},
+		changedFiles: map[string][]string{
+			"new-parent": {"parent.txt"},
+			"feature":    {"feature.txt"},
+		},
+	}
 	eng := &engineImpl{git: fakeGit}
 
 	newSHA, ok := eng.tryConflictFreeReplay(context.Background(), RebaseSpec{
@@ -76,26 +105,66 @@ func TestTryConflictFreeReplayUsesMergeTreeWithExplicitMergeBase(t *testing.T) {
 	}, "new-parent")
 
 	require.True(t, ok)
-	require.Equal(t, "new-sha", newSHA)
+	require.Equal(t, "new-sha-1", newSHA)
+	// Single commit: merge base is OldUpstream, ours is the new parent, theirs is
+	// the commit SHA itself (not the branch name).
+	require.Equal(t, [][]string{{
+		"merge-tree", "--write-tree", "--merge-base",
+		"old-base", "new-parent", "feature-commit",
+	}}, fakeGit.mergeTreeCalls)
 	require.Equal(t, []string{
-		"merge-tree",
-		"--write-tree",
-		"--merge-base",
-		"old-base",
-		"new-parent",
-		"feature",
-	}, fakeGit.mergeTreeArgs)
-	require.Equal(t, []string{
-		"GIT_AUTHOR_NAME=Author Name",
-		"GIT_AUTHOR_EMAIL=author@example.com",
+		"GIT_AUTHOR_NAME=Author feature-commit",
+		"GIT_AUTHOR_EMAIL=feature-commit@example.com",
 		"GIT_AUTHOR_DATE=2026-06-01T12:00:00-04:00",
-	}, fakeGit.commitTreeEnv)
+	}, fakeGit.commitTreeCalls[0])
 	require.Equal(t, []string{
-		"commit-tree",
-		"tree-sha",
-		"-p",
-		"new-parent",
-		"-m",
-		"subject\n\nbody",
-	}, fakeGit.commitTreeArgs)
+		"commit-tree", "tree-of-feature-commit", "-p", "new-parent", "-m", "subject feature-commit",
+	}, fakeGit.commitTreeCalls[1])
+}
+
+func TestTryConflictFreeReplayMultiCommitChainsEachCommit(t *testing.T) {
+	// Branch has three commits (newest-first): c3 -> c2 -> c1 -> old-base.
+	fakeGit := &fastPathGit{
+		t:       t,
+		commits: []string{"c3", "c2", "c1"},
+		parents: map[string]string{
+			"c1": "old-base",
+			"c2": "c1",
+			"c3": "c2",
+		},
+		changedFiles: map[string][]string{
+			"new-parent": {"parent.txt"},
+			"feature":    {"a.txt", "b.txt", "c.txt"},
+		},
+	}
+	eng := &engineImpl{git: fakeGit}
+
+	newSHA, ok := eng.tryConflictFreeReplay(context.Background(), RebaseSpec{
+		Branch:      "feature",
+		NewParent:   "new-parent",
+		OldUpstream: "old-base",
+	}, "new-parent")
+
+	require.True(t, ok)
+	// The returned SHA is the rebased tip (third commit-tree result).
+	require.Equal(t, "new-sha-3", newSHA)
+
+	// Each commit is replayed oldest-first, with its original parent as the merge
+	// base and the previous rebased result as the new base.
+	require.Equal(t, [][]string{
+		{"merge-tree", "--write-tree", "--merge-base", "old-base", "new-parent", "c1"},
+		{"merge-tree", "--write-tree", "--merge-base", "c1", "new-sha-1", "c2"},
+		{"merge-tree", "--write-tree", "--merge-base", "c2", "new-sha-2", "c3"},
+	}, fakeGit.mergeTreeCalls)
+
+	// commit-tree parents chain: c1 onto new-parent, c2 onto new-sha-1, c3 onto new-sha-2.
+	require.Equal(t, []string{
+		"commit-tree", "tree-of-c1", "-p", "new-parent", "-m", "subject c1",
+	}, fakeGit.commitTreeCalls[1])
+	require.Equal(t, []string{
+		"commit-tree", "tree-of-c2", "-p", "new-sha-1", "-m", "subject c2",
+	}, fakeGit.commitTreeCalls[3])
+	require.Equal(t, []string{
+		"commit-tree", "tree-of-c3", "-p", "new-sha-2", "-m", "subject c3",
+	}, fakeGit.commitTreeCalls[5])
 }

--- a/internal/engine/rebase_validator_internal_test.go
+++ b/internal/engine/rebase_validator_internal_test.go
@@ -122,6 +122,34 @@ func TestTryConflictFreeReplaySingleCommitUsesMergeTreeWithExplicitMergeBase(t *
 	}, fakeGit.commitTreeCalls[1])
 }
 
+func TestTryConflictFreeReplayUsesFastPathWhenParentChangedNoFiles(t *testing.T) {
+	// Parent advanced without touching any files (same tree as old-base). An empty
+	// parent file set cannot overlap branch changes, so the fast path should still
+	// replay instead of falling back to a worktree dry-run.
+	fakeGit := &fastPathGit{
+		t:       t,
+		commits: []string{"feature-commit"},
+		parents: map[string]string{
+			"feature-commit": "old-base",
+		},
+		changedFiles: map[string][]string{
+			"new-parent": {},
+			"feature":    {"feature.txt"},
+		},
+	}
+	eng := &engineImpl{git: fakeGit}
+
+	newSHA, ok := eng.tryConflictFreeReplay(context.Background(), RebaseSpec{
+		Branch:      "feature",
+		NewParent:   "new-parent",
+		OldUpstream: "old-base",
+	}, "new-parent")
+
+	require.True(t, ok)
+	require.Equal(t, "new-sha-1", newSHA)
+	require.Len(t, fakeGit.mergeTreeCalls, 1)
+}
+
 func TestTryConflictFreeReplayMultiCommitChainsEachCommit(t *testing.T) {
 	// Branch has three commits (newest-first): c3 -> c2 -> c1 -> old-base.
 	fakeGit := &fastPathGit{

--- a/internal/engine/rebase_validator_test.go
+++ b/internal/engine/rebase_validator_test.go
@@ -144,6 +144,107 @@ func TestValidateRebases(t *testing.T) {
 		require.NotEmpty(t, result.NewSHAs["branch3"])
 	})
 
+	t.Run("validates multi-commit branch with disjoint files via fast path", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		// branch1 forks from main's current tip and gets THREE commits, each
+		// touching a distinct file. Capture the fork point as the old upstream.
+		branch1OldBase, err := s.Engine.GetRevision(s.Engine.Trunk())
+		require.NoError(t, err)
+
+		s.CreateBranch("branch1").
+			CommitChange("a", "commit a").
+			CommitChange("b", "commit b").
+			CommitChange("c", "commit c").
+			TrackBranch("branch1", "main")
+
+		// main advances by touching a file disjoint from everything branch1 touches,
+		// so the conflict-free fast path replays each branch commit without a worktree.
+		s.Checkout("main").
+			CommitChange("parent", "parent change").
+			Checkout("branch1")
+
+		mainRev, err := s.Engine.GetRevision(s.Engine.Trunk())
+		require.NoError(t, err)
+
+		specs := []engine.RebaseSpec{
+			{
+				Branch:      "branch1",
+				NewParent:   mainRev,
+				OldUpstream: branch1OldBase,
+			},
+		}
+
+		result, err := s.Engine.ValidateRebases(context.Background(), specs)
+		require.NoError(t, err)
+		require.True(t, result.Success)
+		newTip := result.NewSHAs["branch1"]
+		require.NotEmpty(t, newTip)
+
+		// The rebased tip must sit directly on the advanced main and carry exactly
+		// the branch's three original commits.
+		replayed, err := s.Engine.Git().GetCommitRangeSHAs(context.Background(), mainRev, newTip)
+		require.NoError(t, err)
+		require.Len(t, replayed, 3, "all three branch commits should be replayed onto new main")
+
+		// Per-commit messages are preserved in order. replayed is newest-first, so
+		// replayed[0] is "commit c" and replayed[2] is "commit a".
+		msgC, err := s.Engine.Git().GetCommitLog(replayed[0], "%s")
+		require.NoError(t, err)
+		require.Equal(t, "commit c", msgC)
+		msgA, err := s.Engine.Git().GetCommitLog(replayed[2], "%s")
+		require.NoError(t, err)
+		require.Equal(t, "commit a", msgA)
+
+		// The rebased tip's tree contains both the parent's change and all three
+		// branch changes (4 distinct files relative to the fork point).
+		filesFromBase, err := s.Engine.Git().GetChangedFiles(context.Background(), branch1OldBase, newTip)
+		require.NoError(t, err)
+		require.Len(t, filesFromBase, 4)
+	})
+
+	t.Run("matches git rebase semantics for branch range containing merge commit", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		oldBase, err := s.Engine.GetRevision(s.Engine.Trunk())
+		require.NoError(t, err)
+
+		s.CreateBranch("feature").
+			CommitChange("feature.txt", "feature change").
+			TrackBranch("feature", "main")
+
+		s.Checkout("main").
+			CreateBranch("side").
+			CommitChange("side.txt", "side change")
+
+		s.Checkout("feature").
+			RunGit("merge", "--no-ff", "side", "-m", "merge side")
+
+		s.Checkout("main").
+			CommitChange("parent.txt", "parent change").
+			Checkout("feature")
+
+		mainRev, err := s.Engine.GetRevision(s.Engine.Trunk())
+		require.NoError(t, err)
+
+		result, err := s.Engine.ValidateRebases(context.Background(), []engine.RebaseSpec{{
+			Branch:      "feature",
+			NewParent:   mainRev,
+			OldUpstream: oldBase,
+		}})
+		require.NoError(t, err)
+		require.True(t, result.Success)
+		newTip := result.NewSHAs["feature"]
+		require.NotEmpty(t, newTip)
+
+		replayedSubjects, err := s.Engine.Git().GetCommitRange(context.Background(), mainRev, newTip, "SUBJECT")
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"feature change", "side change"}, replayedSubjects)
+		require.NotContains(t, replayedSubjects, "merge side")
+	})
+
 	t.Run("stops at first conflict in chain", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)


### PR DESCRIPTION
This PR merges the following changes:

1. **#1365** docs: reconcile perf plans with current code
2. **#1366** perf(restack): replay multi-commit branches conflict-free without a worktree
3. **#1367** perf(navigation): use branches-only load for quiet down and bottom
4. **#1368** perf(submit,info): batch stack-wide up-to-date checks
5. **#1371** perf(restack): fast-path empty parent file changes

### Stack

```
main
  └─ jonnii/20260629050656/reconcile-perf-plans-with-current-code (#1365)
    └─ jonnii/20260629103236/replay-multi-commit-branches-conflict-free (#1366)
      └─ jonnii/20260629103816/use-branches-only-load-for-quiet-down-and-bottom (#1367)
        └─ jonnii/20260629110824/batch-stack-wide-up-to-date-checks (#1368)
          └─ jonnii/20260630015717/fast-path-empty-parent-file-changes (#1371)
```

Stackit-Stack-Size: 5
Stackit-PRs: 1365,1366,1367,1368,1371
