### PR TITLE
perf(sync): reuse branch remote statuses during cleanup

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -19,6 +19,7 @@ type CleanBranchesOptions struct {
 	Force             bool
 	InManagedWorktree bool   // True if running from a stackit-managed worktree
 	CurrentBranch     string // Name of the current branch (used to skip deletion in worktree)
+	RemoteStatuses    engine.BranchRemoteStatuses
 }
 
 // CleanBranchesResult contains the result of cleaning branches
@@ -222,9 +223,18 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[
 	deleteStatuses := make(map[string]engine.DeletionStatus) // name -> status
 	utilityBranches := make(map[string]bool)                 // branches that are utility type
 	var skippedInWorktree []string
-	remoteCtx, cancelRemote := ctx.RemoteOperationContext()
-	remoteStatuses := eng.ReadBranchRemoteStatuses(remoteCtx, allTrackedBranches.WithoutTrunk())
-	cancelRemote()
+	remoteStatuses := opts.RemoteStatuses
+	if remoteStatuses == nil {
+		branchesNeedingRemoteStatus := engine.NewBranchesBuilder(len(candidateNames))
+		for _, name := range candidateNames {
+			if statuses[name].SafeToDelete {
+				branchesNeedingRemoteStatus.Add(eng.GetBranch(name))
+			}
+		}
+		remoteCtx, cancelRemote := ctx.RemoteOperationContext()
+		remoteStatuses = eng.ReadBranchRemoteStatuses(remoteCtx, branchesNeedingRemoteStatus.Build())
+		cancelRemote()
+	}
 
 	for _, name := range candidateNames {
 		status := statuses[name]

--- a/internal/actions/clean_branches_test.go
+++ b/internal/actions/clean_branches_test.go
@@ -265,6 +265,32 @@ func TestCleanBranches(t *testing.T) {
 		require.Equal(t, "branch1", parent.GetName(), "planning should not mutate branch metadata")
 	})
 
+	t.Run("uses supplied remote statuses for unpushed detection", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"branch1": "main",
+			})
+
+		prInfo := testhelpers.NewTestPrInfoMerged(1, "main")
+		err := s.Engine.UpsertPrInfo(context.Background(), s.Engine.GetBranch("branch1"), prInfo)
+		require.NoError(t, err)
+
+		plan, err := actions.PlanBranchDeletions(s.Context, actions.CleanBranchesOptions{
+			Force: true,
+			RemoteStatuses: engine.BranchRemoteStatuses{
+				"branch1": {
+					LocalSha:       "local",
+					RemoteSha:      "remote",
+					CommonAncestor: "remote",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Contains(t, plan.BranchesToDelete, "branch1")
+		require.True(t, plan.UnpushedBranches["branch1"], "branch1 should use the supplied ahead status")
+	})
+
 	t.Run("does not mark branch without unpushed changes as unpushed", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).

--- a/internal/actions/sync/branch_cleaning.go
+++ b/internal/actions/sync/branch_cleaning.go
@@ -9,11 +9,12 @@ import (
 
 	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/output"
 )
 
 // cleanBranches handles cleaning merged/closed branches
-func cleanBranches(ctx *app.Context, opts *Options, dirtyAnchors map[string]bool, handler Handler, summary *Summary) (*actions.CleanBranchesResult, error) {
+func cleanBranches(ctx *app.Context, opts *Options, dirtyAnchors map[string]bool, remoteStatuses engine.BranchRemoteStatuses, handler Handler, summary *Summary) (*actions.CleanBranchesResult, error) {
 	// Only emit phase start if we have branches that might need cleaning
 	allBranches := ctx.Engine.AllBranches()
 	hasBranchesToCheck := false
@@ -41,6 +42,7 @@ func cleanBranches(ctx *app.Context, opts *Options, dirtyAnchors map[string]bool
 		Force:             opts.Force,
 		InManagedWorktree: ctx.InManagedWorktree,
 		CurrentBranch:     currentBranchName,
+		RemoteStatuses:    remoteStatuses,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/actions/sync/branch_cleaning_test.go
+++ b/internal/actions/sync/branch_cleaning_test.go
@@ -32,6 +32,7 @@ func TestCleanBranchesNonInteractiveRespectsDirtyStackFilter(t *testing.T) {
 		s.Context,
 		&Options{Force: true},
 		map[string]bool{"branch1": true},
+		nil,
 		&NullHandler{},
 		&Summary{},
 	)
@@ -89,6 +90,7 @@ func TestCleanBranchesInteractiveDoesNotAutoDeleteUnpushedUtilityBranch(t *testi
 	result, err := cleanBranches(
 		s.Context,
 		&Options{Force: true},
+		nil,
 		nil,
 		handler,
 		&Summary{},

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -199,7 +199,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	// Phase 3: Clean branches (delete merged/closed)
-	cleanResult, err := cleanBranches(ctx, &opts, dirtyAnchors, handler, summary)
+	cleanResult, err := cleanBranches(ctx, &opts, dirtyAnchors, remoteStatuses, handler, summary)
 	if err != nil {
 		return fmt.Errorf("failed to clean branches: %w", err)
 	}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1782787315`.


* **PR #1374**
  * **PR #1375** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1376 by jonnii*