### PR TITLE
perf(test): parallelize merge action tests

### DIFF
--- a/internal/actions/merge/consolidate_test.go
+++ b/internal/actions/merge/consolidate_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestConsolidateMergeExecutor(t *testing.T) {
+	t.Parallel()
 	t.Run("pre-validation fails for out-of-sync branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -50,6 +52,7 @@ func TestConsolidateMergeExecutor(t *testing.T) {
 	})
 
 	t.Run("creates consolidation branch correctly", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -88,6 +91,7 @@ func TestConsolidateMergeExecutor(t *testing.T) {
 	})
 
 	t.Run("builds correct consolidation PR body", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -119,6 +123,7 @@ func TestConsolidateMergeExecutor(t *testing.T) {
 	})
 
 	t.Run("handles stack scope correctly", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"batch/feature-a": "main",
@@ -159,6 +164,7 @@ func TestConsolidateMergeExecutor(t *testing.T) {
 	})
 
 	t.Run("handles empty consolidation correctly", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Single branch on main
@@ -178,7 +184,9 @@ func TestConsolidateMergeExecutor(t *testing.T) {
 }
 
 func TestConsolidationStepExecution(t *testing.T) {
+	t.Parallel()
 	t.Run("executes consolidation step", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -212,7 +220,9 @@ func TestConsolidationStepExecution(t *testing.T) {
 }
 
 func TestConsolidationErrorHandling(t *testing.T) {
+	t.Parallel()
 	t.Run("handles closed PR gracefully", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -243,6 +253,7 @@ func TestConsolidationErrorHandling(t *testing.T) {
 	})
 
 	t.Run("handles draft PR with force flag", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -281,6 +292,7 @@ func TestConsolidationErrorHandling(t *testing.T) {
 	})
 
 	t.Run("execute with Wait: false skips waiting", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"branch1": "main",

--- a/internal/actions/merge/multistack_validation_test.go
+++ b/internal/actions/merge/multistack_validation_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func TestValidateBranchesMatchRemote(t *testing.T) {
+	t.Parallel()
 	t.Run("passes when all branches match remote", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t)
 
 		// Create a branch and push it
@@ -31,6 +33,7 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 	})
 
 	t.Run("fails when branch differs from remote", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t)
 
 		// Create a branch and push it
@@ -57,6 +60,7 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 	})
 
 	t.Run("fails with multiple mismatched branches", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t)
 
 		// Create first branch and push
@@ -92,6 +96,7 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 	})
 
 	t.Run("passes with multiple stacks all matching remote", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t)
 
 		// Create stack1
@@ -120,6 +125,7 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 	})
 
 	t.Run("fails when one stack has mismatched branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t)
 
 		// Create stack1 - will match remote
@@ -153,6 +159,7 @@ func TestValidateBranchesMatchRemote(t *testing.T) {
 	})
 
 	t.Run("handles branch not on remote gracefully", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t)
 
 		// Create a branch but don't push it

--- a/internal/actions/merge/multistack_worktree_test.go
+++ b/internal/actions/merge/multistack_worktree_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestMultiStackWorktreeExecutor_ConflictingStackResetsState(t *testing.T) {
+	t.Parallel()
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 	// stack1 modifies test.txt to "stack1"
@@ -51,6 +52,7 @@ func TestMultiStackWorktreeExecutor_ConflictingStackResetsState(t *testing.T) {
 }
 
 func TestMultiStackWorktreeExecutor_PullsTrunkBeforeMerge(t *testing.T) {
+	t.Parallel()
 	s := scenario.NewRemoteScenario(t)
 
 	remotePath, err := s.Scene.Repo.RunGitCommandAndGetOutput("remote", "get-url", "origin")
@@ -83,6 +85,7 @@ func TestMultiStackWorktreeExecutor_PullsTrunkBeforeMerge(t *testing.T) {
 }
 
 func TestMultiStackWorktreeExecutor_OctopusMergeCreatesSingleCommit(t *testing.T) {
+	t.Parallel()
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 	// Create a stack with 3 branches: branch1 -> branch2 -> branch3
@@ -161,6 +164,7 @@ func TestMultiStackWorktreeExecutor_OctopusMergeCreatesSingleCommit(t *testing.T
 }
 
 func TestMultiStackWorktreeExecutor_GlobalOctopusMergeAcrossStacks(t *testing.T) {
+	t.Parallel()
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 	// Create stack1 with 2 branches modifying different files

--- a/internal/actions/merge/plan_test.go
+++ b/internal/actions/merge/plan_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestCreateMergePlan(t *testing.T) {
+	t.Parallel()
 	t.Run("creates plan for bottom-up strategy", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -49,6 +51,7 @@ func TestCreateMergePlan(t *testing.T) {
 	})
 
 	t.Run("validates draft PRs", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -75,6 +78,7 @@ func TestCreateMergePlan(t *testing.T) {
 	})
 
 	t.Run("allows draft PRs with force", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",
@@ -101,6 +105,7 @@ func TestCreateMergePlan(t *testing.T) {
 	})
 
 	t.Run("identifies upstack branches for restacking in branching stack", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"P":   "main",
@@ -150,6 +155,7 @@ func TestCreateMergePlan(t *testing.T) {
 	})
 
 	t.Run("creates plan for scope-based merge", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"feature-a": "main",
@@ -205,6 +211,7 @@ func TestCreateMergePlan(t *testing.T) {
 	})
 
 	t.Run("scope-based merge excludes branches without matching scope", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"scoped-a":   "main",
@@ -251,6 +258,7 @@ func TestCreateMergePlan(t *testing.T) {
 	})
 
 	t.Run("scope-based merge fails when no branches found with scope", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch-a": "main",
@@ -273,6 +281,7 @@ func TestCreateMergePlan(t *testing.T) {
 	})
 
 	t.Run("scope-based merge handles scope inheritance", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"parent":     "main",
@@ -318,6 +327,7 @@ func TestCreateMergePlan(t *testing.T) {
 	})
 
 	t.Run("creates plan for consolidate strategy", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 			WithStack(map[string]string{
 				"branch1": "main",

--- a/internal/actions/merge/pr_generator_test.go
+++ b/internal/actions/merge/pr_generator_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestPRContentGenerator_GenerateConsolidationPR(t *testing.T) {
+	t.Parallel()
 	t.Run("single_branch_no_pr", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithStack(map[string]string{
 			"feature-a": "main",
@@ -30,6 +32,7 @@ func TestPRContentGenerator_GenerateConsolidationPR(t *testing.T) {
 	})
 
 	t.Run("multiple_branches_with_prs", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithStack(map[string]string{
 			"feature-a":   "main",
@@ -48,6 +51,7 @@ func TestPRContentGenerator_GenerateConsolidationPR(t *testing.T) {
 	})
 
 	t.Run("branches_with_scope", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithStack(map[string]string{
 			"feature-a": "main",
@@ -65,7 +69,9 @@ func TestPRContentGenerator_GenerateConsolidationPR(t *testing.T) {
 }
 
 func TestPRContentGenerator_GenerateConsolidationPR_WithStackDescription(t *testing.T) {
+	t.Parallel()
 	t.Run("with_stack_description_uses_title", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithStack(map[string]string{
 			"feature-a": "main",
@@ -88,6 +94,7 @@ func TestPRContentGenerator_GenerateConsolidationPR_WithStackDescription(t *test
 	})
 
 	t.Run("with_stack_description_title_only", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithStack(map[string]string{
 			"feature-a":   "main",
@@ -110,6 +117,7 @@ func TestPRContentGenerator_GenerateConsolidationPR_WithStackDescription(t *test
 	})
 
 	t.Run("no_description_fallback", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithStack(map[string]string{
 			"feature-a": "main",
@@ -130,7 +138,9 @@ func TestPRContentGenerator_GenerateConsolidationPR_WithStackDescription(t *test
 }
 
 func TestPRContentGenerator_GenerateMultiStackPR(t *testing.T) {
+	t.Parallel()
 	t.Run("single_stack", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithStack(map[string]string{
 			"feature-a": "main",
@@ -147,6 +157,7 @@ func TestPRContentGenerator_GenerateMultiStackPR(t *testing.T) {
 	})
 
 	t.Run("with_excluded_stacks", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithStack(map[string]string{
 			"feature-a": "main",
@@ -164,6 +175,7 @@ func TestPRContentGenerator_GenerateMultiStackPR(t *testing.T) {
 	})
 
 	t.Run("mixed_scopes_omits_scope_trailer", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithStack(map[string]string{
 			"feature-a": "main",

--- a/internal/actions/merge/worktree_merge_test.go
+++ b/internal/actions/merge/worktree_merge_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestExecuteInWorktree(t *testing.T) {
+	t.Parallel()
 	t.Run("successfully merges in worktree", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewRemoteScenario(t).
 			WithStack(map[string]string{
 				"branch-a": "main",
@@ -83,6 +85,7 @@ func TestExecuteInWorktree(t *testing.T) {
 	})
 
 	t.Run("deletes branch that is checked out in a separate worktree", func(t *testing.T) {
+		t.Parallel()
 		// This test verifies that when a branch is checked out in a worktree,
 		// the merge execution properly removes the worktree before deleting the branch.
 		// Previously, the deletion would fail silently because git refuses to delete


### PR DESCRIPTION

Add t.Parallel() to 13 serial top-level funcs (and their isolated
per-subtest scenarios) in internal/actions/merge. These funcs ran in
the sequential phase, with TestExecuteInWorktree (11.6s),
TestCreateMergePlan, TestValidateBranchesMatchRemote and the
consolidate tests serializing behind each other.

Wall time 38s to 12s (minus 68 percent). Coverage-block guard: 2080
blocks preserved, no regression. Verified with
go test -race -p=1 -parallel=2 (CI flags) three times.