### PR TITLE
test: add t.Parallel() to tests using parallel-safe scenarios

### DIFF
--- a/internal/actions/split/split_hunk_test.go
+++ b/internal/actions/split/split_hunk_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestGenerateDefaultBranchName(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name          string
 		originalName  string
@@ -55,6 +57,7 @@ func TestGenerateDefaultBranchName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := generateDefaultBranchName(tt.originalName, tt.existingNames)
 			if got != tt.want {
 				t.Errorf("generateDefaultBranchName(%q, %v) = %q, want %q",

--- a/internal/actions/submit/submit_metadata_test.go
+++ b/internal/actions/submit/submit_metadata_test.go
@@ -16,7 +16,9 @@ const (
 )
 
 func TestPreparePRMetadata_DraftStatus(t *testing.T) {
+	t.Parallel()
 	t.Run("new PR with --draft flag creates as draft", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		branchName := featureBranch
 
@@ -31,6 +33,7 @@ func TestPreparePRMetadata_DraftStatus(t *testing.T) {
 	})
 
 	t.Run("new PR with --publish flag creates as non-draft", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		branchName := featureBranch
 
@@ -45,6 +48,7 @@ func TestPreparePRMetadata_DraftStatus(t *testing.T) {
 	})
 
 	t.Run("new PR defaults to published (not draft)", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		branchName := featureBranch
 
@@ -59,6 +63,7 @@ func TestPreparePRMetadata_DraftStatus(t *testing.T) {
 	})
 
 	t.Run("existing PR preserves draft status", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		branchName := featureBranch
 
@@ -93,6 +98,7 @@ func TestPreparePRMetadata_DraftStatus(t *testing.T) {
 	})
 
 	t.Run("--draft flag overrides existing PR draft status", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		branchName := featureBranch
 
@@ -115,6 +121,7 @@ func TestPreparePRMetadata_DraftStatus(t *testing.T) {
 	})
 
 	t.Run("--publish flag overrides existing PR draft status", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		branchName := featureBranch
 
@@ -225,7 +232,9 @@ func TestPreparePRMetadata_InheritParentDraft(t *testing.T) {
 }
 
 func TestPreparePRMetadata_NoEdit(t *testing.T) {
+	t.Parallel()
 	t.Run("no-edit skips title and body editing", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		branchName := featureBranch
 
@@ -250,7 +259,9 @@ func TestPreparePRMetadata_NoEdit(t *testing.T) {
 }
 
 func TestGetPRBody_MultipleCommits(t *testing.T) {
+	t.Parallel()
 	t.Run("returns a bulleted list of subjects for multiple commits", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		branchName := "feature"
 

--- a/internal/actions/submit/submit_test.go
+++ b/internal/actions/submit/submit_test.go
@@ -536,6 +536,7 @@ func TestSubmitNoOpReadsRemoteOnceAndSkipsPush(t *testing.T) {
 }
 
 func TestSubmitPreservesLockStatus(t *testing.T) {
+	t.Parallel()
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 		WithStack(map[string]string{
 			"feature": "main",
@@ -577,6 +578,7 @@ func TestSubmitPreservesLockStatus(t *testing.T) {
 }
 
 func TestSubmitDryRunWithWorktreeAnchorParent(t *testing.T) {
+	t.Parallel()
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 		WithStack(map[string]string{
 			"wt-anchor": "main",
@@ -598,6 +600,7 @@ func TestSubmitDryRunWithWorktreeAnchorParent(t *testing.T) {
 }
 
 func TestSubmitDisplayTreeSkipsWorktreeAnchorParent(t *testing.T) {
+	t.Parallel()
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 		WithStack(map[string]string{
 			"wt-anchor": "main",

--- a/internal/engine/persistence_locked_test.go
+++ b/internal/engine/persistence_locked_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestPrInfoLockedPersistence(t *testing.T) {
+	t.Parallel()
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 	s.WithInitialCommit().
 		CreateBranch("feature").

--- a/internal/engine/undo_test.go
+++ b/internal/engine/undo_test.go
@@ -23,7 +23,9 @@ func snapshotOpts(command string, args ...string) engine.SnapshotOptions {
 }
 
 func TestTakeSnapshot(t *testing.T) {
+	t.Parallel()
 	t.Run("creates snapshot with branch and metadata SHAs", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 
 		// Create a stack: main -> feature
@@ -60,6 +62,7 @@ func TestTakeSnapshot(t *testing.T) {
 	})
 
 	t.Run("creates undo directory if it doesn't exist", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -73,6 +76,7 @@ func TestTakeSnapshot(t *testing.T) {
 	})
 
 	t.Run("captures current branch correctly", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -91,7 +95,9 @@ func TestTakeSnapshot(t *testing.T) {
 }
 
 func TestGetSnapshots(t *testing.T) {
+	t.Parallel()
 	t.Run("returns empty list when no snapshots exist", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -101,6 +107,7 @@ func TestGetSnapshots(t *testing.T) {
 	})
 
 	t.Run("returns snapshots sorted by time newest first", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -135,6 +142,7 @@ func TestGetSnapshots(t *testing.T) {
 	})
 
 	t.Run("includes display names with SHA and local timestamp", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -151,7 +159,9 @@ func TestGetSnapshots(t *testing.T) {
 }
 
 func TestLoadSnapshot(t *testing.T) {
+	t.Parallel()
 	t.Run("loads valid snapshot", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -174,6 +184,7 @@ func TestLoadSnapshot(t *testing.T) {
 	})
 
 	t.Run("returns error for non-existent snapshot", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -184,7 +195,9 @@ func TestLoadSnapshot(t *testing.T) {
 }
 
 func TestRestoreSnapshot(t *testing.T) {
+	t.Parallel()
 	t.Run("restores branch heads to snapshot state", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -233,6 +246,7 @@ func TestRestoreSnapshot(t *testing.T) {
 	})
 
 	t.Run("deletes branches created after snapshot", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -274,6 +288,7 @@ func TestRestoreSnapshot(t *testing.T) {
 	})
 
 	t.Run("restores metadata refs", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -308,6 +323,7 @@ func TestRestoreSnapshot(t *testing.T) {
 	})
 
 	t.Run("restores HEAD to original branch", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -338,6 +354,7 @@ func TestRestoreSnapshot(t *testing.T) {
 	})
 
 	t.Run("handles deleted branches gracefully", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -370,6 +387,7 @@ func TestRestoreSnapshot(t *testing.T) {
 	})
 
 	t.Run("switches to trunk if snapshot branch was deleted", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").
@@ -410,7 +428,9 @@ func TestRestoreSnapshot(t *testing.T) {
 }
 
 func TestEnforceMaxStackDepth(t *testing.T) {
+	t.Parallel()
 	t.Run("deletes oldest snapshots when exceeding max depth", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
@@ -432,7 +452,9 @@ func TestEnforceMaxStackDepth(t *testing.T) {
 }
 
 func TestSnapshotFileFormat(t *testing.T) {
+	t.Parallel()
 	t.Run("snapshot files are valid JSON", func(t *testing.T) {
+		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit().
 			CreateBranch("feature").


### PR DESCRIPTION
## Summary

Several test functions and their subtests were missing `t.Parallel()` despite using `scenario.NewScenario`, which calls `NewSceneParallel` underneath and gives each test its own isolated git repo. Without `t.Parallel()` these tests block a CPU core for their full duration and cannot overlap with other tests.

- `internal/engine/undo_test.go` — 6 test functions + 14 subtests (snapshot lifecycle tests)
- `internal/engine/persistence_locked_test.go` — 1 test function (PR info lock persistence)
- `internal/actions/submit/submit_metadata_test.go` — 3 test functions + 8 subtests (draft status, no-edit, PR body)
- `internal/actions/submit/submit_test.go` — 3 test functions (lock status, worktree anchor variants)
- `internal/actions/split/split_hunk_test.go` — 1 test function + 6 subtests (pure logic, no I/O)

All changed tests were verified to pass with parallelism enabled (PAUSE/CONT output confirms interleaved execution). The `TestGenerateDefaultBranchName` tests involve no git or file I/O and are especially cheap to parallelize.

## Test plan

- [x] `go test ./internal/actions/split/... -run TestGenerateDefaultBranchName -v` — PASS
- [x] `go test ./internal/engine/... -run "TestPrInfoLockedPersistence|TestTakeSnapshot|TestGetSnapshots|TestLoadSnapshot|TestRestoreSnapshot|TestEnforceMaxStackDepth|TestSnapshotFileFormat" -v` — PASS
- [x] `go test ./internal/actions/submit/... -run "TestPreparePRMetadata_DraftStatus|TestPreparePRMetadata_NoEdit|TestGetPRBody_MultipleCommits|TestSubmitPreservesLockStatus|TestSubmitDryRunWithWorktreeAnchorParent|TestSubmitDisplayTreeSkipsWorktreeAnchorParent" -v` — PASS
- [x] `go build ./...` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rx1oBgbvjX4AFRVgrufaFu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rx1oBgbvjX4AFRVgrufaFu)_