### PR TITLE
perf(test): build stack fixtures with single checkout -b

### DIFF
--- a/testhelpers/git_repo.go
+++ b/testhelpers/git_repo.go
@@ -303,6 +303,13 @@ func (r *GitRepo) CreateAndCheckoutBranch(name string) error {
 	return r.runGitCommand("checkout", "-b", name)
 }
 
+// CreateAndCheckoutBranchFrom creates and checks out a new branch from an
+// explicit start point in a single git invocation, avoiding a separate
+// checkout of the start point first.
+func (r *GitRepo) CreateAndCheckoutBranchFrom(name, startPoint string) error {
+	return r.runGitCommand("checkout", "-b", name, startPoint)
+}
+
 // CheckoutBranch checks out a branch.
 func (r *GitRepo) CheckoutBranch(name string) error {
 	return r.runGitCommand("checkout", name)

--- a/testhelpers/scenario/scenario.go
+++ b/testhelpers/scenario/scenario.go
@@ -199,6 +199,15 @@ func (s *Scenario) CreateBranchQuiet(name string) *Scenario {
 	return s
 }
 
+// CreateBranchFromQuiet creates and checks out a new branch from an explicit
+// start point without rebuilding the engine, in a single git invocation.
+func (s *Scenario) CreateBranchFromQuiet(name, startPoint string) *Scenario {
+	s.T.Helper()
+	err := s.Scene.Repo.CreateAndCheckoutBranchFrom(name, startPoint)
+	require.NoError(s.T, err)
+	return s
+}
+
 // Rebuild refreshes the engine's internal state from the Git repository.
 func (s *Scenario) Rebuild() *Scenario {
 	s.T.Helper()
@@ -282,9 +291,9 @@ func (s *Scenario) WithStack(structure map[string]string) *Scenario {
 				continue
 			}
 			if created[parent] {
-				// Create branch without rebuilding engine
-				s.CheckoutQuiet(parent)
-				s.CreateBranchQuiet(branch)
+				// Create branch from its parent in a single git invocation
+				// (avoids a separate checkout of the parent first).
+				s.CreateBranchFromQuiet(branch, parent)
 
 				err := s.Scene.Repo.CreateChangeAndCommit("change on "+branch, branch)
 				require.NoError(s.T, err)


### PR DESCRIPTION

WithStack created each branch with a separate `checkout <parent>` followed
by `checkout -b <branch>`. Collapse these into one `git checkout -b <branch>
<parent>` via a new CreateAndCheckoutBranchFrom helper, removing one git
subprocess per branch. Cuts ~8% off scenario stack-build time (linear3
~440ms -> ~406ms), which compounds across the ~40 WithLinearStack/diamond
fixture call sites. Test-infra only; end state is identical.