### PR TITLE
refactor: embed NullRestackHandler instead of reimplementing no-op methods

### DIFF
--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -77,7 +77,9 @@ type GetHandler interface {
 }
 
 // GetNullHandler is a no-op handler for testing or when output is not needed
-type GetNullHandler struct{}
+type GetNullHandler struct {
+	handlers.NullRestackHandler
+}
 
 // Start implements GetHandler.
 func (h *GetNullHandler) Start(_ string, _ *int) {}
@@ -87,16 +89,6 @@ func (h *GetNullHandler) EmitEvent(_ GetEvent) {}
 
 // Complete implements GetHandler.
 func (h *GetNullHandler) Complete(_ GetSummary) {}
-
-// OnRestackStart implements RestackHandler.
-func (h *GetNullHandler) OnRestackStart(_ int) {}
-
-// OnRestackBranch implements RestackHandler.
-func (h *GetNullHandler) OnRestackBranch(_ string, _ handlers.RestackResult, _ string, _ *int, _ engine.LockReason, _ bool, _ bool, _ string, _ bool, _, _ string, _ int) {
-}
-
-// OnRestackComplete implements RestackHandler.
-func (h *GetNullHandler) OnRestackComplete(_, _ int, _ []string) {}
 
 // GetOptions contains options for the get command
 type GetOptions struct {

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -433,9 +433,11 @@ type Handler interface {
 
 // NullHandler is a no-op handler for testing or when output is not needed
 // NullHandler is a no-op handler for when nil is passed.
-// It embeds handler.NullBase for Cleanup() and IsInteractive().
+// It embeds handler.NullBase for Cleanup() and IsInteractive(), and
+// handlers.NullRestackHandler for the restack-specific no-op methods.
 type NullHandler struct {
 	handler.NullBase
+	handlers.NullRestackHandler
 }
 
 // Start implements Handler.
@@ -446,16 +448,6 @@ func (h *NullHandler) EmitEvent(Event) {}
 
 // Complete implements Handler.
 func (h *NullHandler) Complete(Summary) {}
-
-// OnRestackStart implements RestackHandler.
-func (h *NullHandler) OnRestackStart(int) {}
-
-// OnRestackBranch implements RestackHandler.
-func (h *NullHandler) OnRestackBranch(string, RestackResult, string, *int, engine.LockReason, bool, bool, string, bool, string, string, int) {
-}
-
-// OnRestackComplete implements RestackHandler.
-func (h *NullHandler) OnRestackComplete(int, int, []string) {}
 
 // PromptMetadataConflict implements Handler. Returns false (keep local) in non-interactive mode.
 func (h *NullHandler) PromptMetadataConflict(_ *engine.MetadataDiff) (bool, error) {


### PR DESCRIPTION
## Summary
- `GetNullHandler` (internal/actions/get.go) and `sync.NullHandler` (internal/actions/sync/sync.go) each hand-rolled the same three no-op `RestackHandler` methods (`OnRestackStart`, `OnRestackBranch`, `OnRestackComplete`) instead of embedding `handlers.NullRestackHandler`, which already provides them (and is already used this way elsewhere, e.g. `internal/actions/restack_test.go`).
- Embedding it removes the duplicated boilerplate and keeps both null handlers automatically in sync with the `RestackHandler` interface if it changes.
- No behavior change — both structs still satisfy their respective interfaces with identical no-op semantics.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/actions/... ./internal/handlers/...` (all pass)
- [x] `gofmt -l` on changed files (clean)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GuRFbZFo7nRhviwzRiPQpC)_