### PR TITLE
perf: batch divergence point lookups in move rebase spec building

### DIFF
--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -458,8 +458,8 @@ func BuildRebaseSpecs(eng engine.Engine, out output.Output, source, onto string,
 	// Since these are topologically ordered, each parent will be rebased before its children
 	sortedDescendants := eng.SortBranchesTopologically(descendants)
 
-	// Prefetch every descendant's parent revision in one batch instead of a
-	// git rev-parse per descendant.
+	// Prefetch every descendant's parent revision and divergence point in one
+	// batch instead of a git rev-parse and metadata read per descendant.
 	parentNames := make([]string, 0, len(sortedDescendants))
 	for _, d := range sortedDescendants {
 		if parent := d.GetParent(); parent != nil {
@@ -467,6 +467,7 @@ func BuildRebaseSpecs(eng engine.Engine, out output.Output, source, onto string,
 		}
 	}
 	parentRevs, _ := eng.GetRevisions(parentNames)
+	divergencePoints := eng.BatchDivergencePoints(sortedDescendants)
 
 	for _, d := range sortedDescendants {
 		if d.GetName() == source {
@@ -482,9 +483,8 @@ func BuildRebaseSpecs(eng engine.Engine, out output.Output, source, onto string,
 		}
 
 		// Get the old upstream (divergence point)
-		dOldUpstream, divErr := eng.GetDivergencePoint(d.GetName())
-		if divErr != nil {
-			out.Debug("Failed to get divergence point for %s: %v", d.GetName(), divErr)
+		dOldUpstream := divergencePoints[d.GetName()]
+		if dOldUpstream == "" {
 			dOldUpstream = parentRev // Fallback
 		}
 


### PR DESCRIPTION
## Summary

- `BuildRebaseSpecs` in `internal/actions/move/move.go` already batches parent-revision lookups for a moved branch's descendants ("Prefetch every descendant's parent revision in one batch instead of a git rev-parse per descendant"), but the very next block still called `eng.GetDivergencePoint(d.GetName())` once per descendant — each call does its own metadata read.
- Swap that per-descendant call for the existing `eng.BatchDivergencePoints(sortedDescendants)` reader, which resolves the divergence point for the whole set in one batched pass and has documented semantics identical to `GetDivergencePoint` (stored `ParentBranchRevision` if present, else the parent's current tip).
- For a `move` of a branch with N descendants, this removes N metadata reads, replacing them with one batched call — following the same pattern the function already uses for parent revisions, and the pattern used elsewhere in the engine (`BatchDiffStats`, `BatchBranchStats`).
- Fallback behavior is preserved: when no divergence point is available (empty string), the code still falls back to the descendant's parent revision.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/actions/move/...`
- [x] `go test ./internal/actions/move/...`
- [x] `go test ./internal/integration/... -run Move`


---
_Generated by [Claude Code](https://claude.ai/code/session_01SAR15xZ27ce6s45Xnigp6N)_