### PR TITLE
perf: batch remote status lookups instead of one ls-remote per branch

### DIFF
--- a/internal/api/handlers/branches.go
+++ b/internal/api/handlers/branches.go
@@ -63,6 +63,9 @@ func (h *BranchesHandler) listBranches(w http.ResponseWriter, r *http.Request, e
 		checksMap, _ = entry.GitHub.BatchGetPRChecksStatus(r.Context(), names)
 	}
 
+	// One remote listing for all branches instead of one per branch.
+	remoteStatuses := entry.Engine.ReadBranchRemoteStatuses(r.Context(), engine.BranchesOf(branches...))
+
 	responses := make([]httpcontract.BranchResponse, 0, len(branches))
 	for _, branch := range branches {
 		node := graph.GetNode(branch.GetName())
@@ -73,7 +76,7 @@ func (h *BranchesHandler) listBranches(w http.ResponseWriter, r *http.Request, e
 		if checksMap != nil {
 			checks = checksMap[branch.GetName()]
 		}
-		responses = append(responses, httpcontract.MapBranch(r.Context(), entry.Engine, branch, node, checks))
+		responses = append(responses, httpcontract.MapBranch(entry.Engine, branch, node, checks, remoteStatuses.ForBranch(branch)))
 	}
 
 	writeJSON(w, responses)
@@ -101,6 +104,7 @@ func (h *BranchesHandler) getBranch(w http.ResponseWriter, r *http.Request, entr
 		}
 	}
 
-	resp := httpcontract.MapBranch(r.Context(), entry.Engine, branch, node, checks)
+	remoteStatus := entry.Engine.ReadBranchRemoteStatuses(r.Context(), engine.BranchesOf(branch)).ForBranch(branch)
+	resp := httpcontract.MapBranch(entry.Engine, branch, node, checks, remoteStatus)
 	writeJSON(w, resp)
 }

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -12,7 +12,10 @@ import (
 )
 
 // MapBranch converts an engine Branch and its StackNode into an API BranchResponse.
-func MapBranch(ctx context.Context, eng engine.BranchReader, branch engine.Branch, node *engine.StackNode, checks *github.CheckStatus) BranchResponse {
+// remoteStatus should come from a single ReadBranchRemoteStatuses call covering
+// all branches being mapped in the current request, not a per-branch call, since
+// each ReadBranchRemoteStatuses call lists the remote's refs.
+func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.StackNode, checks *github.CheckStatus, remoteStatus engine.BranchRemoteStatus) BranchResponse {
 	resp := BranchResponse{
 		Name:         branch.GetName(),
 		Depth:        node.Depth,
@@ -72,7 +75,6 @@ func MapBranch(ctx context.Context, eng engine.BranchReader, branch engine.Branc
 	}
 
 	// Map remote status
-	remoteStatus := eng.ReadBranchRemoteStatuses(ctx, engine.BranchesOf(branch)).ForBranch(branch)
 	resp.RemoteStatus = &RemoteStatus{
 		Ahead:         remoteStatus.Ahead(),
 		Behind:        remoteStatus.Behind(),
@@ -145,7 +147,8 @@ func MapStackDetail(ctx context.Context, eng engine.BranchReader, graph *engine.
 	isAnchor := summary.HasWorktree
 	anchorName := rootBranch
 
-	branches := make([]BranchResponse, 0, len(allBranches))
+	nodes := make([]*engine.StackNode, 0, len(allBranches))
+	stackBranches := make(engine.Branches, 0, len(allBranches))
 	for _, name := range allBranches {
 		if isAnchor && name == anchorName {
 			continue
@@ -154,11 +157,21 @@ func MapStackDetail(ctx context.Context, eng engine.BranchReader, graph *engine.
 		if node == nil {
 			continue
 		}
+		nodes = append(nodes, node)
+		stackBranches = append(stackBranches, node.Branch)
+	}
+
+	// One remote listing for the whole stack instead of one per branch.
+	remoteStatuses := eng.ReadBranchRemoteStatuses(ctx, stackBranches)
+
+	branches := make([]BranchResponse, 0, len(nodes))
+	for _, node := range nodes {
+		name := node.Branch.GetName()
 		var checks *github.CheckStatus
 		if checksMap != nil {
 			checks = checksMap[name]
 		}
-		br := MapBranch(ctx, eng, node.Branch, node, checks)
+		br := MapBranch(eng, node.Branch, node, checks, remoteStatuses.ForBranch(node.Branch))
 		if isAnchor {
 			// Anchor's direct children become display roots
 			if br.Parent == anchorName {

--- a/internal/shippable/analyzer.go
+++ b/internal/shippable/analyzer.go
@@ -117,6 +117,22 @@ func (a *Analyzer) analyzeStack(ctx context.Context, stack merge.MultiStackInfo,
 		}
 	}
 
+	// Only branches with updateable PRs need remote status. Missing and draft
+	// PRs return before the not-pushed check, so keep incomplete stacks offline.
+	remoteStatusBranches := make(engine.Branches, 0, len(stack.AllBranches))
+	for _, branchName := range stack.AllBranches {
+		branch := a.eng.GetBranch(branchName)
+		prInfo, err := branch.GetPrInfo()
+		if err == nil && prInfo != nil && prInfo.Number() != nil && !prInfo.IsDraft() {
+			remoteStatusBranches = append(remoteStatusBranches, branch)
+		}
+	}
+	remoteStatuses := &branchRemoteStatusProvider{
+		ctx:      ctx,
+		eng:      a.eng,
+		branches: remoteStatusBranches,
+	}
+
 	// Check each branch in the stack
 	for _, branchName := range stack.AllBranches {
 		// Extract author from first branch with PR status
@@ -126,7 +142,7 @@ func (a *Analyzer) analyzeStack(ctx context.Context, stack merge.MultiStackInfo,
 			}
 		}
 
-		blocking := a.analyzeBranch(ctx, branchName, statusMap)
+		blocking := a.analyzeBranch(branchName, statusMap, remoteStatuses)
 		if blocking != nil {
 			result.BlockingPRs = append(result.BlockingPRs, *blocking)
 
@@ -153,7 +169,9 @@ func (a *Analyzer) analyzeStack(ctx context.Context, stack merge.MultiStackInfo,
 }
 
 // analyzeBranch analyzes a single branch and returns blocking info if any.
-func (a *Analyzer) analyzeBranch(ctx context.Context, branchName string, statusMap map[string]*github.CheckStatus) *BlockingPR {
+// remoteStatuses lazily reads remote status once for branches that can reach
+// the not-pushed check.
+func (a *Analyzer) analyzeBranch(branchName string, statusMap map[string]*github.CheckStatus, remoteStatuses *branchRemoteStatusProvider) *BlockingPR {
 	// Get PR info from engine metadata
 	branch := a.eng.GetBranch(branchName)
 	prInfo, err := branch.GetPrInfo()
@@ -181,7 +199,7 @@ func (a *Analyzer) analyzeBranch(ctx context.Context, branchName string, statusM
 	// Check if local branch matches remote
 	// This is critical for shipping: if local differs from remote, the octopus merge
 	// will use local SHAs but PRs track remote SHAs, so GitHub won't auto-close them
-	if !a.eng.ReadBranchRemoteStatuses(ctx, engine.BranchesOf(branch)).ForBranch(branch).Matches() {
+	if !remoteStatuses.ForBranch(branch).Matches() {
 		return &BlockingPR{
 			Branch:   branchName,
 			PRNumber: prNumber,
@@ -237,6 +255,29 @@ func (a *Analyzer) analyzeBranch(ctx context.Context, branchName string, statusM
 
 	// No blocking issues found
 	return nil
+}
+
+type branchRemoteStatusProvider struct {
+	ctx      context.Context
+	eng      engine.BranchReader
+	branches engine.Branches
+
+	loaded   bool
+	statuses engine.BranchRemoteStatuses
+}
+
+func (p *branchRemoteStatusProvider) ForBranch(branch engine.Branch) engine.BranchRemoteStatus {
+	if p == nil {
+		return engine.BranchRemoteStatus{}
+	}
+	if !p.loaded {
+		p.statuses = engine.BranchRemoteStatuses{}
+		if len(p.branches) > 0 {
+			p.statuses = p.eng.ReadBranchRemoteStatuses(p.ctx, p.branches)
+		}
+		p.loaded = true
+	}
+	return p.statuses.ForBranch(branch)
 }
 
 // determineStatus determines the overall Status based on analysis results.

--- a/internal/shippable/analyzer_test.go
+++ b/internal/shippable/analyzer_test.go
@@ -1,0 +1,101 @@
+package shippable
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+type countingRemoteRunner struct {
+	git.Runner
+	fetchRemoteShas atomic.Int64
+}
+
+func (c *countingRemoteRunner) FetchRemoteShas(ctx context.Context, remote string) (map[string]string, error) {
+	c.fetchRemoteShas.Add(1)
+	return c.Runner.FetchRemoteShas(ctx, remote)
+}
+
+func newCountingAnalyzer(t *testing.T, dir string) (*Analyzer, engine.Engine, *countingRemoteRunner) {
+	t.Helper()
+
+	counting := &countingRemoteRunner{Runner: git.NewRunnerWithPath(dir, nil)}
+	eng, err := engine.NewEngine(engine.Options{
+		RepoRoot: dir,
+		Trunk:    "main",
+		Git:      counting,
+	})
+	require.NoError(t, err)
+
+	return NewAnalyzer(eng, nil), eng, counting
+}
+
+func TestAnalyzerSkipsRemoteStatusForIncompleteStacks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing PRs", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{"P": "main", "C": "P"})
+		analyzer, _, counting := newCountingAnalyzer(t, s.Scene.Dir)
+
+		stack, err := analyzer.AnalyzeStack(context.Background(), merge.MultiStackInfo{
+			RootBranch:  "P",
+			AllBranches: []string{"P", "C"},
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, StatusIncomplete, stack.Status)
+		require.Equal(t, int64(0), counting.fetchRemoteShas.Load(),
+			"stacks with no PRs should not read remote branch status")
+	})
+
+	t.Run("draft PRs", func(t *testing.T) {
+		t.Parallel()
+
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{"P": "main", "C": "P"})
+		analyzer, eng, counting := newCountingAnalyzer(t, s.Scene.Dir)
+		require.NoError(t, eng.UpsertPrInfo(context.Background(), eng.GetBranch("P"), testhelpers.NewTestPrInfoDraft(101)))
+		require.NoError(t, eng.UpsertPrInfo(context.Background(), eng.GetBranch("C"), testhelpers.NewTestPrInfoDraft(102)))
+
+		stack, err := analyzer.AnalyzeStack(context.Background(), merge.MultiStackInfo{
+			RootBranch:  "P",
+			AllBranches: []string{"P", "C"},
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, StatusIncomplete, stack.Status)
+		require.Equal(t, int64(0), counting.fetchRemoteShas.Load(),
+			"draft-only stacks should not read remote branch status")
+	})
+}
+
+func TestAnalyzerReadsRemoteStatusOnceForUpdateStack(t *testing.T) {
+	t.Parallel()
+
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"P": "main", "C": "P"})
+	analyzer, eng, counting := newCountingAnalyzer(t, s.Scene.Dir)
+	require.NoError(t, eng.UpsertPrInfo(context.Background(), eng.GetBranch("P"), testhelpers.NewTestPrInfo(101)))
+	require.NoError(t, eng.UpsertPrInfo(context.Background(), eng.GetBranch("C"), testhelpers.NewTestPrInfo(102)))
+
+	stack, err := analyzer.AnalyzeStack(context.Background(), merge.MultiStackInfo{
+		RootBranch:  "P",
+		AllBranches: []string{"P", "C"},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, StatusBlocked, stack.Status)
+	require.Equal(t, int64(1), counting.fetchRemoteShas.Load(),
+		"update stacks should read remote branch status once for the whole stack")
+}


### PR DESCRIPTION
## Summary
- `MapBranch`/`MapStackDetail` (the branch/stack HTTP API handlers) and the shippability `Analyzer` each called `eng.ReadBranchRemoteStatuses` once per branch, and every call runs a full `git ls-remote --heads --refs <remote>` against the whole remote.
- For a stack of N branches this turned a single branch-listing request or shippability scan into N remote round-trips fetching the same data over and over.
- The engine already exposes `ReadBranchRemoteStatuses` as a batch API (and the pattern of computing it once and indexing with `.ForBranch()` is already used correctly in `internal/actions/lock`, `internal/actions/clean_branches.go`, `internal/actions/sync`, and `internal/actions/submit`) — this PR applies that same pattern to the two remaining call sites that were still doing it per-branch.
- `MapBranch` and `analyzeBranch` now take a precomputed remote-status value/map instead of resolving it themselves, and the two callers (`MapStackDetail`/`branches.go` handlers, and `analyzeStack`) batch the lookup once before their loops.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/contracts/http/... ./internal/api/... ./internal/shippable/...`
- [x] `go test ./internal/...` (full suite passes except a pre-existing, unrelated `internal/git` failure reproduced identically on `main`)
- [x] `gofmt -l` on changed files (clean)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WqUoDsqWkp43v3Di6uUhsC)_