### PR TITLE
refactor: replace worktree detach bool with typed WorktreeDetachMode

### DIFF
--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -82,7 +82,7 @@ func restoreWorktreePath(ctx *app.Context, snapshot *worktreeSnapshot) error {
 	if snapshot.CheckoutBranch == "" {
 		return nil
 	}
-	return ctx.Engine.AddWorktree(ctx.Context, snapshot.Info.Path, snapshot.CheckoutBranch, false)
+	return ctx.Engine.AddWorktree(ctx.Context, snapshot.Info.Path, snapshot.CheckoutBranch, git.WorktreeAttached)
 }
 
 func restoreAnchorBranch(ctx *app.Context, snapshot *worktreeSnapshot) error {
@@ -457,7 +457,7 @@ func createAnchoredWorktree(ctx *app.Context, eng engine.Engine, repoRoot string
 		return nil, fmt.Errorf("worktree path %s already exists; remove it first or choose a different name", worktreePath)
 	}
 
-	if err := eng.AddWorktree(ctx.Context, worktreePath, checkoutBranch, false); err != nil {
+	if err := eng.AddWorktree(ctx.Context, worktreePath, checkoutBranch, git.WorktreeAttached); err != nil {
 		cleanup()
 		return nil, fmt.Errorf("failed to create worktree: %w", err)
 	}

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -469,11 +469,11 @@ func (d *demoGitRunner) GetCommitTemplate(_ context.Context) (string, error) {
 	return "", nil
 }
 
-func (d *demoGitRunner) AddWorktree(_ context.Context, _, _ string, _ bool) error {
+func (d *demoGitRunner) AddWorktree(_ context.Context, _, _ string, _ git.WorktreeDetachMode) error {
 	return nil
 }
 
-func (d *demoGitRunner) AddWorktreeWithOptions(_ context.Context, _, _ string, _, _ bool) error {
+func (d *demoGitRunner) AddWorktreeWithOptions(_ context.Context, _, _ string, _ git.WorktreeDetachMode, _ bool) error {
 	return nil
 }
 

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -33,7 +33,7 @@ const (
 )
 
 // AddWorktree adds a new worktree
-func (e *engineImpl) AddWorktree(ctx context.Context, path string, branch string, detach bool) error {
+func (e *engineImpl) AddWorktree(ctx context.Context, path string, branch string, detach git.WorktreeDetachMode) error {
 	return e.git.AddWorktree(ctx, path, branch, detach)
 }
 
@@ -122,7 +122,7 @@ func (e *engineImpl) CreateTemporaryWorktreeWithOptions(ctx context.Context, bra
 	// 3. Only the brief `git worktree` commands are serialized
 	e.worktreeMu.Lock()
 	e.maybePruneTempWorktreesLocked(ctx, prune)
-	err = e.addWorktreeWithRetryLocked(ctx, worktreePath, branch, true, checkout == WorktreeCheckoutShallow)
+	err = e.addWorktreeWithRetryLocked(ctx, worktreePath, branch, git.WorktreeDetached, checkout == WorktreeCheckoutShallow)
 	e.worktreeMu.Unlock()
 
 	if err != nil {
@@ -164,7 +164,7 @@ func (e *engineImpl) maybePruneTempWorktreesLocked(ctx context.Context, prune Wo
 
 // addWorktreeWithRetryLocked attempts to add a worktree, pruning and retrying once on failure.
 // Caller must hold worktreeMu.
-func (e *engineImpl) addWorktreeWithRetryLocked(ctx context.Context, path string, branch string, detach bool, noCheckout bool) error {
+func (e *engineImpl) addWorktreeWithRetryLocked(ctx context.Context, path string, branch string, detach git.WorktreeDetachMode, noCheckout bool) error {
 	if err := e.git.AddWorktreeWithOptions(ctx, path, branch, detach, noCheckout); err == nil {
 		return nil
 	}

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -276,7 +276,7 @@ type CommitOperations interface {
 
 // WorktreeOperations handles worktree management
 type WorktreeOperations interface {
-	AddWorktree(ctx context.Context, path string, branch string, detach bool) error
+	AddWorktree(ctx context.Context, path string, branch string, detach git.WorktreeDetachMode) error
 	RemoveWorktree(ctx context.Context, path string) error
 	ForceRemoveWorktree(ctx context.Context, path string) error
 	GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error)

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -201,8 +201,8 @@ type PatchOperations interface {
 
 // WorktreeOperations handles worktree management.
 type WorktreeOperations interface {
-	AddWorktree(ctx context.Context, path string, branch string, detach bool) error
-	AddWorktreeWithOptions(ctx context.Context, path string, branch string, detach bool, noCheckout bool) error
+	AddWorktree(ctx context.Context, path string, branch string, detach WorktreeDetachMode) error
+	AddWorktreeWithOptions(ctx context.Context, path string, branch string, detach WorktreeDetachMode, noCheckout bool) error
 	RemoveWorktree(ctx context.Context, path string) error
 	ForceRemoveWorktree(ctx context.Context, path string) error
 	ListWorktrees(ctx context.Context) (WorktreeList, error)

--- a/internal/git/tracing_runner.go
+++ b/internal/git/tracing_runner.go
@@ -909,12 +909,12 @@ func (t *tracingRunner) CheckCommutation(hunk Hunk, commitSHA, parentSHA string)
 
 // WorktreeOperations methods
 
-func (t *tracingRunner) AddWorktree(ctx context.Context, path string, branch string, detach bool) error {
+func (t *tracingRunner) AddWorktree(ctx context.Context, path string, branch string, detach WorktreeDetachMode) error {
 	// Don't trace - delegates to AddWorktreeWithOptions which is traced
 	return t.inner.AddWorktree(ctx, path, branch, detach)
 }
 
-func (t *tracingRunner) AddWorktreeWithOptions(ctx context.Context, path string, branch string, detach bool, noCheckout bool) error {
+func (t *tracingRunner) AddWorktreeWithOptions(ctx context.Context, path string, branch string, detach WorktreeDetachMode, noCheckout bool) error {
 	start := time.Now()
 	err := t.inner.AddWorktreeWithOptions(ctx, path, branch, detach, noCheckout)
 	t.trace("AddWorktreeWithOptions", time.Since(start), err == nil, err, slog.String("branch", branch))

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -81,14 +81,25 @@ type WorktreeMeta struct {
 	MainRepoDir  string    `json:"mainRepoDir"`    // Path to main repo (for detection)
 }
 
-func (r *runner) AddWorktree(ctx context.Context, path string, branch string, detach bool) error {
+// WorktreeDetachMode controls whether a new worktree checks out its branch
+// normally or at a detached HEAD (`git worktree add --detach`).
+type WorktreeDetachMode int
+
+const (
+	// WorktreeAttached checks out the branch normally (HEAD attached to it).
+	WorktreeAttached WorktreeDetachMode = iota
+	// WorktreeDetached adds the worktree at a detached HEAD.
+	WorktreeDetached
+)
+
+func (r *runner) AddWorktree(ctx context.Context, path string, branch string, detach WorktreeDetachMode) error {
 	return r.AddWorktreeWithOptions(ctx, path, branch, detach, false)
 }
 
 // AddWorktreeWithOptions adds a worktree with additional options
-func (r *runner) AddWorktreeWithOptions(ctx context.Context, path string, branch string, detach bool, noCheckout bool) error {
+func (r *runner) AddWorktreeWithOptions(ctx context.Context, path string, branch string, detach WorktreeDetachMode, noCheckout bool) error {
 	args := []string{"worktree", "add"}
-	if detach {
+	if detach == WorktreeDetached {
 		args = append(args, "--detach")
 	}
 	if noCheckout {

--- a/internal/git/worktree_ref_test.go
+++ b/internal/git/worktree_ref_test.go
@@ -35,7 +35,7 @@ func TestResolveRefInWorktree(t *testing.T) {
 
 	// Add worktree for feature branch using the main runner
 	mainRunner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
-	err = mainRunner.AddWorktree(context.Background(), worktreePath, "feature", false)
+	err = mainRunner.AddWorktree(context.Background(), worktreePath, "feature", git.WorktreeAttached)
 	require.NoError(t, err)
 
 	// Create a NEW runner pointing to the worktree

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -30,7 +30,7 @@ func TestWorktree(t *testing.T) {
 		worktreePath = filepath.Join(worktreePath, "worktree")
 
 		// Add worktree
-		err = runner.AddWorktree(context.Background(), worktreePath, "test-branch", false)
+		err = runner.AddWorktree(context.Background(), worktreePath, "test-branch", git.WorktreeAttached)
 		require.NoError(t, err)
 
 		// Verify worktree exists
@@ -62,7 +62,7 @@ func TestWorktree(t *testing.T) {
 		worktreePath := filepath.Join(tmpDir, "worktree-detached")
 
 		// Add detached worktree
-		err := runner.AddWorktree(context.Background(), worktreePath, "", true)
+		err := runner.AddWorktree(context.Background(), worktreePath, "", git.WorktreeDetached)
 		require.NoError(t, err)
 
 		// Verify worktree exists


### PR DESCRIPTION
## Summary

- `AddWorktree`/`AddWorktreeWithOptions` took a bare `detach bool`, producing unclear call sites like `AddWorktree(ctx, path, branch, false)` and `addWorktreeWithRetryLocked(ctx, worktreePath, branch, true, ...)` — exactly the anti-pattern called out in `.claude/rules/code-style.md`.
- The sibling `noCheckout` concept in the same function already gets this treatment one layer up (`WorktreeCheckoutMode` / `WorktreeCheckoutFull` / `WorktreeCheckoutShallow`), so `detach` was the odd one out.
- Introduces `git.WorktreeDetachMode` (`WorktreeAttached` / `WorktreeDetached`) and updates every implementation and call site — `internal/git` (runner, tracing wrapper, interface), `internal/engine` (interface, impl, retry helper), `internal/demo` (stub), `internal/actions/worktree`, and the git-layer tests — so no bare boolean literals remain at any `AddWorktree`/`AddWorktreeWithOptions` call site.
- Pure signature refactor: behavior is unchanged (the enum still lowers to the same `--detach` flag), so this is a mechanical, low-risk cleanup.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/git/... ./internal/engine/... ./internal/actions/worktree/...` (all worktree-related tests pass; one pre-existing, unrelated failure in `TestGetRepoInfo/parses_HTTPS_URL` reproduces identically on `main` before this change)
- [x] `gofmt -l` clean on all touched packages


---
_Generated by [Claude Code](https://claude.ai/code/session_013hEKKyMaDAEf1wTEURQTcg)_