### PR TITLE
fix: propagate fetch errors from PullBranch instead of swallowing them

### DIFF
--- a/internal/git/pull.go
+++ b/internal/git/pull.go
@@ -31,7 +31,12 @@ func (r *runner) PullBranch(ctx context.Context, remote, branchName string) (Pul
 	// Fetch with explicit refspec to update the remote-tracking branch.
 	// This ensures refs/remotes/<remote>/<branch> is actually updated.
 	refspec := BranchFetchRefspec(remote, branchName)
-	_ = r.fetchRemoteRefSpecs(ctx, remote, []string{refspec})
+	if err := r.fetchRemoteRefSpecs(ctx, remote, []string{refspec}); err != nil {
+		// A failed fetch leaves refs/remotes/<remote>/<branch> stale, so falling
+		// through to UpdateBranchFromRemote would compare local HEAD against an
+		// outdated cached SHA and could wrongly report PullUnneeded.
+		return PullConflict, fmt.Errorf("failed to fetch %s from %s: %w", branchName, remote, err)
+	}
 
 	return r.UpdateBranchFromRemote(ctx, remote, branchName)
 }

--- a/internal/git/pull_test.go
+++ b/internal/git/pull_test.go
@@ -257,6 +257,49 @@ func TestPullBranch_FetchResolvesNewCommits(t *testing.T) {
 	require.NoError(t, err, "runner should still resolve old commits")
 }
 
+func TestPullBranch_FetchFailurePropagatesError(t *testing.T) {
+	// Regression: if the fetch fails (e.g. remote unreachable), PullBranch must
+	// return the error instead of silently falling through to compare local HEAD
+	// against a stale remote-tracking ref, which could wrongly report
+	// PullUnneeded even though the remote was never actually checked.
+
+	// 1. Setup a "remote" repository and clone it locally.
+	remoteScene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+	remotePath, err := remoteScene.Repo.CreateBareRemote("upstream")
+	require.NoError(t, err)
+	err = remoteScene.Repo.PushBranch("upstream", "main")
+	require.NoError(t, err)
+
+	localDir, err := os.MkdirTemp("", "stackit-test-local-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(localDir) })
+
+	cmd := exec.Command("git", "clone", "--branch", "main", remotePath, localDir)
+	err = cmd.Run()
+	require.NoError(t, err)
+
+	runner := git.NewRunnerWithPath(localDir, nil)
+	err = runner.InitDefaultRepo()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	trackedBefore, err := runner.RunGitCommandWithContext(ctx, "rev-parse", "refs/remotes/origin/main")
+	require.NoError(t, err)
+
+	// 2. Break the remote so the fetch fails.
+	require.NoError(t, os.RemoveAll(remotePath))
+
+	// 3. PullBranch must surface the fetch error rather than reporting success.
+	result, err := runner.PullBranch(ctx, "origin", "main")
+	require.Error(t, err, "PullBranch should surface a fetch failure instead of swallowing it")
+	require.Equal(t, git.PullConflict, result)
+
+	// 4. The stale remote-tracking ref must be untouched by the failed fetch.
+	trackedAfter, err := runner.RunGitCommandWithContext(ctx, "rev-parse", "refs/remotes/origin/main")
+	require.NoError(t, err)
+	require.Equal(t, trackedBefore, trackedAfter)
+}
+
 func TestPullBranch_WorktreeCorruptsMainWorkspace(t *testing.T) {
 	// This test reproduces a critical bug where pulling trunk in a worktree
 	// corrupts the main workspace's index/working tree.


### PR DESCRIPTION
## Summary

`PullBranch` (`internal/git/pull.go`) discarded the error from fetching the remote-tracking ref (`_ = r.fetchRemoteRefSpecs(...)`) before falling through to `UpdateBranchFromRemote`, which compares local `HEAD` against whatever SHA happens to already be cached at `refs/remotes/<remote>/<branch>`.

If the fetch fails — no network, auth failure, deleted remote branch — that comparison runs against a stale cached SHA instead of a fresh one. If the stale SHA happens to match local `HEAD`, the function returns `PullUnneeded`, silently reporting "already synced" even though the remote was never actually checked. This path feeds `PullTrunk` and `sync`'s branch pull, i.e. the core trunk-sync flow (`internal/engine/pull.go`, `internal/actions/sync/branch_sync.go`).

This PR makes the fetch error propagate as `(PullConflict, err)` instead, matching how every other error path in the same function already behaves.

- Added `TestPullBranch_FetchFailurePropagatesError`, which breaks the remote after cloning, asserts `PullBranch` now returns an error, and asserts the remote-tracking ref is left untouched by the failed fetch.
- Verified no other call site of `fetchRemoteRefSpecs`, or any other fetch call in the codebase, swallows its error the same way — this was the only offender.

## Test plan

- [x] `go test ./internal/git/...` (all pass except a pre-existing, unrelated `TestGetRepoInfo` failure that reproduces identically on `main` — a local git-config parsing quirk in this environment)
- [x] `go test ./internal/engine/...`
- [x] `go test ./internal/actions/sync/...`
- [x] `gofmt -l` / `go vet` clean on changed files


---
_Generated by [Claude Code](https://claude.ai/code/session_01WDbpELYRuju9yw3hXzpQfG)_