### PR TITLE
perf(tui): skip unused git-log spawn in branch checkout prompt

### DIFF
--- a/internal/tui/prompts.go
+++ b/internal/tui/prompts.go
@@ -750,7 +750,7 @@ func PromptBranchCheckout(branches []engine.Branch, eng engine.BranchReader) (st
 	stats := eng.BatchBranchStats(engine.Branches(branches))
 	annotations := make(map[string]tree.BranchAnnotation)
 	for _, branch := range branches {
-		annotations[branch.GetName()] = GetBranchAnnotation(eng, branch, stats[branch.GetName()], AnnotationOptions{})
+		annotations[branch.GetName()] = GetBranchAnnotation(eng, branch, stats[branch.GetName()], AnnotationOptions{SkipCommitMessages: true})
 	}
 	renderer.SetAnnotations(annotations)
 


### PR DESCRIPTION
## Summary
- `PromptBranchCheckout` built branch annotations with `AnnotationOptions{}`, which triggers a per-branch `git log` call (`GetAllCommits`) inside `GetBranchAnnotation` to populate `CommitMessages`/`CommitCount`.
- Neither field is read anywhere downstream: the checkout prompt only calls `renderer.FormatAnnotationColored`, which uses the batched `stat.CommitCount`/`ShortSHA`, never `CommitMessages`.
- Every other call site of `GetBranchAnnotation`/`BuildFullAnnotation` (`internal/cli/dashboard/shippable_model.go`, `internal/tui/tree_ui.go`, `internal/actions/tree.go`) already passes `SkipCommitMessages: true` for this reason — this was the one remaining outlier still spawning a `git log` subprocess per branch for output nobody consumes.
- Fix: pass `AnnotationOptions{SkipCommitMessages: true}` in `internal/tui/prompts.go`, matching the established pattern. One-line change, no behavior change (the discarded fields aren't rendered).

## Test plan
- [x] `go build ./internal/tui/...`
- [x] `go vet ./internal/tui/...`
- [x] `go test ./internal/tui/...` (all packages pass)

---
_Generated by [Claude Code](https://claude.ai/code/session_011bZcq1uJ25zY626oDM5yEf)_