### PR TITLE
perf(pluck): batch divergence-point lookups for source's children

### DIFF
--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -133,10 +133,11 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	// Children: rebase onto grandparent (source's old parent)
+	childDivergencePoints := eng.BatchDivergencePoints(children)
 	for _, child := range children {
 		// Get the old upstream (divergence point)
-		childOldUpstream, divErr := eng.GetDivergencePoint(child.GetName())
-		if divErr != nil {
+		childOldUpstream, ok := childDivergencePoints[child.GetName()]
+		if !ok || childOldUpstream == "" {
 			// Fallback to source revision if unavailable
 			childOldUpstream = sourceRev
 		}


### PR DESCRIPTION
## Summary
- `pluck` resolved each child branch's divergence point with a separate `GetDivergencePoint` call inside a `for` loop, spawning one metadata/git read per child (an N+1 pattern flagged by this repo's own [batch-operations rule](../.claude/rules/code-style.md)).
- Replace the loop with a single `eng.BatchDivergencePoints(children)` call, matching the pattern already used by `BatchDiffStats` / `BatchCommits` elsewhere in the engine.
- Behavior is unchanged: `BatchDivergencePoints` resolves the same value per branch (the stored parent revision, or the parent's current tip), and the existing fallback to `sourceRev` is preserved when no divergence point is found.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/actions/pluck/... ./internal/engine/...`
- [x] `gofmt -l internal/actions/pluck/pluck.go` (clean)


---
_Generated by [Claude Code](https://claude.ai/code/session_01E8mYtxdaGfLJVd5cQvoLzF)_