### PR TITLE
perf(engine): batch revision lookups in FindMostRecentTrackedAncestors

### DIFF
--- a/internal/engine/engine_reader.go
+++ b/internal/engine/engine_reader.go
@@ -139,16 +139,10 @@ func (e *engineImpl) FindMostRecentTrackedAncestors(ctx context.Context, branchN
 
 	trunk := e.trunk
 
-	// Map of commit SHA to slice of tracked branch names
-	trackedBranchTips := make(map[string][]string)
-
-	// Add trunk tip
-	trunkRev, err := e.git.GetRevision(trunk)
-	if err == nil {
-		trackedBranchTips[trunkRev] = append(trackedBranchTips[trunkRev], trunk)
-	}
-
-	// Get all tracked branches and their tips
+	// Collect trunk plus every tracked candidate (skipping the branch itself
+	// and branches already merged into trunk) so their revisions can be
+	// resolved in a single batched git call instead of one per branch.
+	candidates := []string{trunk}
 	for _, candidate := range e.state.branches {
 		// Skip the branch itself and trunk (already handled)
 		if candidate == branchName || candidate == trunk {
@@ -165,13 +159,19 @@ func (e *engineImpl) FindMostRecentTrackedAncestors(ctx context.Context, branchN
 			continue
 		}
 
-		// Get candidate revision
-		candidateRev, err := e.git.GetRevision(candidate)
-		if err != nil {
+		candidates = append(candidates, candidate)
+	}
+
+	revisions, _ := e.git.BatchGetRevisions(candidates)
+
+	// Map of commit SHA to slice of tracked branch names
+	trackedBranchTips := make(map[string][]string)
+	for _, candidate := range candidates {
+		rev, ok := revisions[candidate]
+		if !ok {
 			continue
 		}
-
-		trackedBranchTips[candidateRev] = append(trackedBranchTips[candidateRev], candidate)
+		trackedBranchTips[rev] = append(trackedBranchTips[rev], candidate)
 	}
 
 	// Get history of the branch we're tracking


### PR DESCRIPTION
## Summary
- `FindMostRecentTrackedAncestors` (`internal/engine/engine_reader.go`) resolved trunk's revision and then, for every tracked candidate branch, called `e.git.GetRevision(candidate)` individually inside a loop — one `git rev-parse` subprocess per branch.
- The engine already exposes `BatchGetRevisions` for exactly this case (used elsewhere in the same package, e.g. `engine_sync.go`, `engine_branch_status.go`, `undo.go`), so this loop was an outlier.
- This change collects the eligible candidate names first (same filtering: skip self, skip trunk, tracked-only, skip merged-into-trunk), then resolves all of them plus trunk in a single `BatchGetRevisions` call, replacing N subprocess spawns with one.
- Behavior is unchanged: candidates whose revision fails to resolve are simply skipped, matching the previous per-branch `continue`-on-error semantics.

I checked for the same anti-pattern (a loop calling a single-item `GetRevision`/git operation per branch where a batch API already exists) elsewhere in `internal/engine` and didn't find another instance — the other `GetRevision` call sites are either single-branch lookups already fed from a batch-resolved map (with a per-miss fallback), or per-worker calls inside an already-bounded parallel pool (`rebase_validator.go`), so they don't need the same fix.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/engine/...` (all passing)
- [x] `go vet ./internal/engine/...`


---
_Generated by [Claude Code](https://claude.ai/code/session_01BrdxFkYdaC2QqmvDYDTGGB)_