### PR TITLE
feat(submit): list skipped branch names in small plan groups

### DIFF
--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -30,6 +30,10 @@ func NewSubmitUI(out output.Output, logger output.Logger) (*tui.Runner, submit.H
 	return nil, NewSimpleSubmitHandler(out)
 }
 
+// maxNamedSkipGroup is the largest skipped-branch group that still lists its
+// branch names when there is active work; bigger groups show only the count.
+const maxNamedSkipGroup = 3
+
 // planPrinter prints the stack and per-branch plan as a single merged list,
 // shared by both submit handlers. It adapts its framing to the shape of the
 // work: a lone branch off trunk reads as a single PR, while a real stack keeps
@@ -112,7 +116,9 @@ func (p *planPrinter) Flush() {
 	}
 	for _, group := range skipped {
 		p.out.Info("%s", sectionHeader(skipGroupTitle(group.reason), len(group.events), true))
-		if len(active) > 0 {
+		// Small groups list their names so "why didn't my branch go out?" is
+		// answerable at a glance; only large groups collapse to a bare count.
+		if len(active) > 0 && len(group.events) > maxNamedSkipGroup {
 			continue
 		}
 		for _, ev := range group.events {

--- a/internal/cli/stack/submit_handlers_test.go
+++ b/internal/cli/stack/submit_handlers_test.go
@@ -106,9 +106,38 @@ func TestSimpleSubmitHandlerMergesPlanIntoStackList(t *testing.T) {
 	require.Contains(t, got, "Will submit (1)")
 	require.Contains(t, got, "● current-branch [CORE] → create")
 	require.Contains(t, got, "No changes (1)")
-	require.NotContains(t, got, "skipped-branch")
+	// Small skip groups list their names even when there is active work.
+	require.Contains(t, got, "skipped-branch")
 	require.NotContains(t, got, "skipped-branch — no changes")
 	require.Equal(t, 1, strings.Count(got, "current-branch"), "stack and plan must print as one merged list")
+}
+
+func TestPlanPrinterCollapsesLargeSkipGroups(t *testing.T) {
+	t.Parallel()
+
+	out := output.NewTestOutput()
+	handler := NewSimpleSubmitHandler(out)
+
+	branches := []string{"active-one", "skip-a", "skip-b", "skip-c", "skip-d"}
+	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+		Branches:    branches,
+		TrunkBranch: "main",
+	}})
+	handler.OnEvent(submitAction.BranchPlanEvent{BranchName: "active-one", Action: "create"})
+	for _, name := range branches[1:] {
+		handler.OnEvent(submitAction.BranchPlanEvent{
+			BranchName: name,
+			Skipped:    true,
+			SkipReason: "no changes",
+		})
+	}
+	handler.OnEvent(submitAction.PlanningCompleteEvent{})
+
+	got := ansi.Strip(out.String())
+	require.Contains(t, got, "No changes (4)")
+	// Groups above the naming threshold collapse to a bare count.
+	require.NotContains(t, got, "skip-a")
+	require.NotContains(t, got, "skip-d")
 }
 
 func TestInteractiveSubmitHandlerPrintsPlanWithoutStartingTUI(t *testing.T) {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Collapsed skip groups hid the branch names whenever anything was being
submitted, so a branch the user expected to go out was invisible behind a
bare count. Groups of three or fewer now list their names dimmed; larger
groups still collapse.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1783682845`.


* **PR #935**
  * **PR #1189**
    * **PR #1190**
      * **PR #1194**
        * **PR #1195**
          * **PR #1196**
            * **PR #1197**
              * **PR #1270**
                * **PR #1271**
                  * **PR #1399** 👈
                    * **PR #1400**
                      * **PR #1401**
                        * **PR #1402**
                          * **PR #1403**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1404 by jonnii*