### PR TITLE
fix(submit): truncate long errors in progress rows

### DIFF
--- a/internal/tui/components/submit/format.go
+++ b/internal/tui/components/submit/format.go
@@ -137,11 +137,7 @@ func rowParts(item Item, spinnerView string, styles Styles) (string, string) {
 		}
 		return styles.DoneStyle.Render("✓"), styles.DoneStyle.Render(detail)
 	case StatusError:
-		detail := "failed"
-		if item.Error != nil {
-			detail = item.Error.Error()
-		}
-		return styles.ErrorStyle.Render("✗"), styles.ErrorStyle.Render(detail)
+		return styles.ErrorStyle.Render("✗"), styles.ErrorStyle.Render(compactErrorText(item.Error))
 	case StatusPending, "":
 		if item.IsSkipped {
 			reason := item.SkipReason
@@ -158,6 +154,28 @@ func rowParts(item Item, spinnerView string, styles Styles) (string, string) {
 	default:
 		return styles.DimStyle.Render("○"), styles.DimStyle.Render(item.Status)
 	}
+}
+
+// maxErrorDetailWidth caps the error text shown in a progress row so a long
+// git/gh message cannot shred the column layout mid-TUI.
+const maxErrorDetailWidth = 60
+
+// compactErrorText flattens an error to its trimmed first line, truncated to
+// fit a progress row. The full text still persists via FormatFailureSummary
+// when the TUI exits, so nothing is lost.
+func compactErrorText(err error) string {
+	if err == nil {
+		return "failed"
+	}
+	detail := err.Error()
+	if i := strings.IndexByte(detail, '\n'); i >= 0 {
+		detail = detail[:i]
+	}
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return "failed"
+	}
+	return TruncateMiddle(detail, maxErrorDetailWidth)
 }
 
 func actionLabel(action string) string {

--- a/internal/tui/components/submit/format_test.go
+++ b/internal/tui/components/submit/format_test.go
@@ -3,9 +3,11 @@ package submit
 import (
 	"errors"
 	"regexp"
+	"strings"
 	"testing"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 )
 
@@ -155,6 +157,23 @@ func TestModelCompletionSummaryIncludesFailuresAndWarnings(t *testing.T) {
 	require.Contains(t, summary, "#935 add-feature")
 	require.Contains(t, summary, "✗ fix-bug — failed to push branch: remote rejected")
 	require.Contains(t, summary, "⚠️  add-feature: failed to add labels")
+}
+
+func TestFormatCompactRowTruncatesLongErrors(t *testing.T) {
+	t.Parallel()
+
+	long := "failed to push branch: " + strings.Repeat("x", 100) + "\nhint: check your remote\nhint: and your credentials"
+	row := ansi.Strip(FormatCompactRow(Item{
+		BranchName: "jonnii/20260511011552/fix-bug",
+		Action:     ActionUpdate,
+		Status:     StatusError,
+		Error:      errors.New(long),
+	}, 80, "", DefaultStyles()))
+
+	require.NotContains(t, row, "\n", "row must stay on one line")
+	require.NotContains(t, row, "hint:")
+	require.Contains(t, row, "...")
+	require.LessOrEqual(t, lipgloss.Width(row), 80+maxErrorDetailWidth, "detail must be capped")
 }
 
 func TestFormatFailureSummaryWithoutErrorDetail(t *testing.T) {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

A multi-line or long git/gh error rendered verbatim into a progress row
wraps and shreds the column layout mid-TUI. Rows now show the trimmed
first line capped at 60 cells; the full error still persists through the
failure summary when the TUI exits.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1783682845`.


* **PR #935**
  * **PR #1189**
    * **PR #1190**
      * **PR #1194**
        * **PR #1195**
          * **PR #1196**
            * **PR #1197**
              * **PR #1270**
                * **PR #1271**
                  * **PR #1399**
                    * **PR #1400** 👈
                      * **PR #1401**
                        * **PR #1402**
                          * **PR #1403**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1404 by jonnii*