### PR TITLE
feat(submit): print a closing summary with counts and elapsed time

### DIFF
--- a/internal/actions/submit/events.go
+++ b/internal/actions/submit/events.go
@@ -1,5 +1,7 @@
 package submit
 
+import "time"
+
 // Event represents a feedback event from the submit action.
 // Implementations should use type switches to handle specific event types.
 type Event interface {
@@ -106,8 +108,9 @@ const (
 
 // CompletionEvent indicates the action has finished.
 type CompletionEvent struct {
-	Outcome CompletionOutcome
-	Message string // human-readable detail, e.g. "All PRs up to date"
+	Outcome  CompletionOutcome
+	Message  string        // human-readable detail, e.g. "All PRs up to date"
+	Duration time.Duration // elapsed run time; set when branches were submitted
 }
 
 // Success reports whether the run ended without failure or cancellation.

--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/app"
@@ -74,6 +75,7 @@ type Info struct {
 
 // Action performs the submit operation with an event handler for progress feedback.
 func Action(ctx *app.Context, opts Options, handler Handler) error {
+	start := time.Now()
 	// Validate flags
 	if opts.Draft && opts.Publish {
 		return fmt.Errorf("can't use both --publish and --draft flags in one command")
@@ -379,7 +381,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	ctx.Logger.Info("submit completed branchCount=%v", len(branches))
 
-	handler.OnEvent(CompletionEvent{Outcome: OutcomeComplete, Message: "Submit complete"})
+	handler.OnEvent(CompletionEvent{Outcome: OutcomeComplete, Message: "Submit complete", Duration: time.Since(start)})
 	return nil
 }
 

--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -202,6 +202,17 @@ func (p *planPrinter) pad(name string, dim bool, current bool) string {
 	return style.ColorBranchNameBold(padded, current)
 }
 
+// skippedCount is the number of plan rows that were skipped.
+func (p *planPrinter) skippedCount() int {
+	n := 0
+	for _, ev := range p.events {
+		if ev.Skipped {
+			n++
+		}
+	}
+	return n
+}
+
 type skippedPlanGroup struct {
 	reason string
 	events []submit.BranchPlanEvent
@@ -396,6 +407,14 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 				h.Output.Newline()
 				h.Output.Info("%s", summary)
 			}
+			// The solo summary already names the single result; a count line
+			// would just restate it.
+			if !h.plan.solo {
+				if closing := submitComponent.FormatClosingSummary(h.submitItems(), h.plan.skippedCount(), ev.Duration); closing != "" {
+					h.Output.Newline()
+					h.Output.Info("%s", closing)
+				}
+			}
 		case submit.OutcomeOnTrunk:
 			printOnTrunkGuidance(h.Output, ev.Message)
 		case submit.OutcomeFailed:
@@ -569,7 +588,10 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 			}
 			return
 		}
-		h.runner.Send(submitComponent.ProgressCompleteMsg{})
+		h.runner.Send(submitComponent.ProgressCompleteMsg{
+			Skipped: h.plan.skippedCount(),
+			Elapsed: ev.Duration,
+		})
 		h.runner.Wait()
 	}
 }

--- a/internal/cli/stack/submit_handlers_test.go
+++ b/internal/cli/stack/submit_handlers_test.go
@@ -3,6 +3,7 @@ package stack
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
@@ -72,7 +73,7 @@ func TestSimpleSubmitHandlerPreservesURLAcrossFooterSync(t *testing.T) {
 	got := out.String()
 	require.Contains(t, got, "https://github.com/getstackit/stackit/pull/934")
 	require.NotContains(t, got, "syncing")
-	require.Equal(t, 1, strings.Count(got, "✓"), "footer sync must not re-report a finished branch")
+	require.Equal(t, 1, strings.Count(got, "✓ guard-runner"), "footer sync must not re-report a finished branch")
 }
 
 func TestSimpleSubmitHandlerMergesPlanIntoStackList(t *testing.T) {
@@ -110,6 +111,31 @@ func TestSimpleSubmitHandlerMergesPlanIntoStackList(t *testing.T) {
 	require.Contains(t, got, "skipped-branch")
 	require.NotContains(t, got, "skipped-branch — no changes")
 	require.Equal(t, 1, strings.Count(got, "current-branch"), "stack and plan must print as one merged list")
+}
+
+func TestSimpleSubmitHandlerPrintsClosingSummary(t *testing.T) {
+	t.Parallel()
+
+	out := output.NewTestOutput()
+	handler := NewSimpleSubmitHandler(out)
+
+	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+		Branches:    []string{"create-me", "update-me", "skip-me"},
+		TrunkBranch: "main",
+	}})
+	handler.OnEvent(submitAction.BranchPlanEvent{BranchName: "create-me", Action: "create"})
+	handler.OnEvent(submitAction.BranchPlanEvent{BranchName: "update-me", Action: "update"})
+	handler.OnEvent(submitAction.BranchPlanEvent{BranchName: "skip-me", Skipped: true, SkipReason: "no changes"})
+	handler.OnEvent(submitAction.SubmissionStartEvent{Branches: []submitAction.BranchInfo{
+		{Name: "create-me", Action: "create"},
+		{Name: "update-me", Action: "update"},
+	}})
+	handler.OnEvent(submitAction.BranchProgressEvent{BranchName: "create-me", Status: submitAction.StatusDone, URL: "https://github.com/x/y/pull/1"})
+	handler.OnEvent(submitAction.BranchProgressEvent{BranchName: "update-me", Status: submitAction.StatusDone, URL: "https://github.com/x/y/pull/2"})
+	handler.OnEvent(submitAction.CompletionEvent{Outcome: submitAction.OutcomeComplete, Duration: 6200 * time.Millisecond})
+
+	got := ansi.Strip(out.String())
+	require.Contains(t, got, "✓ 1 created, 1 updated, 1 unchanged (6.2s)")
 }
 
 func TestPlanPrinterCollapsesLargeSkipGroups(t *testing.T) {

--- a/internal/tui/components/submit/format.go
+++ b/internal/tui/components/submit/format.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 
 	"charm.land/lipgloss/v2"
@@ -287,6 +288,57 @@ func FormatSoloSummary(items []Item) string {
 		return "  " + label + "\n  " + item.URL
 	}
 	return ""
+}
+
+// FormatClosingSummary renders the one-line run summary: counts by outcome
+// plus elapsed time, e.g. "✓ 1 created, 2 updated, 4 unchanged (6.2s)".
+func FormatClosingSummary(items []Item, skipped int, elapsed time.Duration) string {
+	var created, updated, failed int
+	for _, item := range items {
+		switch {
+		case item.Status == StatusError:
+			failed++
+		case item.Status == StatusDone && item.Action == ActionCreate:
+			created++
+		case item.Status == StatusDone && item.Action == ActionUpdate:
+			updated++
+		}
+	}
+
+	parts := make([]string, 0, 4)
+	if created > 0 {
+		parts = append(parts, fmt.Sprintf("%d created", created))
+	}
+	if updated > 0 {
+		parts = append(parts, fmt.Sprintf("%d updated", updated))
+	}
+	if failed > 0 {
+		parts = append(parts, fmt.Sprintf("%d failed", failed))
+	}
+	if skipped > 0 {
+		parts = append(parts, fmt.Sprintf("%d unchanged", skipped))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+
+	icon := "✓"
+	if failed > 0 {
+		icon = "✗"
+	}
+	line := icon + " " + strings.Join(parts, ", ")
+	if elapsed > 0 {
+		line += " (" + formatElapsed(elapsed) + ")"
+	}
+	return line
+}
+
+// formatElapsed renders a duration compactly: "6.2s" under a minute, "1m23s" above.
+func formatElapsed(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	return d.Round(time.Second).String()
 }
 
 // FormatFailureSummary renders failed branches with their errors. The progress

--- a/internal/tui/components/submit/format_test.go
+++ b/internal/tui/components/submit/format_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
@@ -174,6 +175,26 @@ func TestFormatCompactRowTruncatesLongErrors(t *testing.T) {
 	require.NotContains(t, row, "hint:")
 	require.Contains(t, row, "...")
 	require.LessOrEqual(t, lipgloss.Width(row), 80+maxErrorDetailWidth, "detail must be capped")
+}
+
+func TestFormatClosingSummary(t *testing.T) {
+	t.Parallel()
+
+	items := []Item{
+		{BranchName: "a", Action: ActionCreate, Status: StatusDone},
+		{BranchName: "b", Action: ActionUpdate, Status: StatusDone},
+		{BranchName: "c", Action: ActionUpdate, Status: StatusDone},
+		{BranchName: "d", Action: ActionUpdate, Status: StatusError, Error: errors.New("boom")},
+	}
+
+	require.Equal(t,
+		"✗ 1 created, 2 updated, 1 failed, 4 unchanged (6.2s)",
+		FormatClosingSummary(items, 4, 6200*time.Millisecond))
+	require.Equal(t,
+		"✓ 1 created (1m23s)",
+		FormatClosingSummary(items[:1], 0, 83*time.Second))
+	require.Equal(t, "✓ 1 created", FormatClosingSummary(items[:1], 0, 0))
+	require.Empty(t, FormatClosingSummary(nil, 0, time.Second))
 }
 
 func TestFormatFailureSummaryWithoutErrorDetail(t *testing.T) {

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -4,6 +4,7 @@ package submit
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
@@ -37,8 +38,11 @@ type WarningMsg struct {
 	Warning    string
 }
 
-// ProgressCompleteMsg is sent when all submissions are finished
-type ProgressCompleteMsg struct{}
+// ProgressCompleteMsg is sent when all submissions are finished.
+type ProgressCompleteMsg struct {
+	Skipped int           // branches skipped in the plan, shown as "unchanged"
+	Elapsed time.Duration // total run time; zero when unknown
+}
 
 // NewModel creates a new submit model
 func NewModel(items []Item) *Model {
@@ -98,6 +102,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ProgressCompleteMsg:
 		m.Done = true
 		summary := m.completionSummary()
+		// The solo summary already names the single result; a count line would
+		// just restate it.
+		if !m.Solo && summary != "" {
+			if closing := FormatClosingSummary(m.Items, msg.Skipped, msg.Elapsed); closing != "" {
+				summary += "\n\n" + closing
+			}
+		}
 		if summary != "" {
 			return m, tea.Sequence(
 				tea.Printf("\n%s", summary),


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

After a stack submit completes, a single line like
"2 updated, 1 created, 4 unchanged (6.2s)" summarizes the run — the
line people actually read in CI logs. The action now stamps the run
duration on the completion event; both handlers render the same
formatter. Solo submits skip it, their one-line summary already says
everything.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1783682845`.


* **PR #935**
  * **PR #1189**
    * **PR #1190**
      * **PR #1194**
        * **PR #1195**
          * **PR #1196**
            * **PR #1197**
              * **PR #1270**
                * **PR #1271**
                  * **PR #1399**
                    * **PR #1400**
                      * **PR #1401** 👈
                        * **PR #1402**
                          * **PR #1403**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1404 by jonnii*