### PR TITLE
feat(submit): unify the post-submit output into one final list

### DIFF
--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -387,6 +387,11 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 				detail = ref + " " + actionDone
 			}
 			h.Output.Info("  ✓ %s %s", submitComponent.DisplayBranchName(ev.BranchName), detail)
+			// A newly created PR is the one the user needs to open; updated
+			// PRs rarely need their URL re-pasted.
+			if item.action == "create" && item.url != "" {
+				h.Output.Info("     %s", item.url)
+			}
 
 		case submit.StatusError:
 			if h.plan.solo {
@@ -430,13 +435,14 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 	}
 }
 
-// completionSummary renders the post-submit PR list, leaning on the solo
-// formatting when only one branch was submitted.
+// completionSummary renders the post-submit result for a solo submit (ref +
+// URL together). A stack submit already streamed one line per branch — with
+// URLs on creates — so repeating them as a block would double the list.
 func (h *SimpleSubmitHandler) completionSummary() string {
 	if h.plan.solo {
 		return submitComponent.FormatSoloSummary(h.submitItems())
 	}
-	return submitComponent.FormatURLSummary(h.submitItems())
+	return ""
 }
 
 // printOnTrunkGuidance explains that submit does nothing from trunk and points

--- a/internal/cli/stack/submit_handlers_test.go
+++ b/internal/cli/stack/submit_handlers_test.go
@@ -13,33 +13,41 @@ import (
 	submitComponent "github.com/getstackit/stackit/internal/tui/components/submit"
 )
 
-func TestSimpleSubmitHandlerPrintsFinalURLSummary(t *testing.T) {
+func TestSimpleSubmitHandlerStreamsOneListWithURLsOnCreates(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
 	handler := NewSimpleSubmitHandler(out)
-	branch := "jonnii/20260511011552/guard-runner.repoRoot-reads-with-repoMu-to-fix"
+	updated := "jonnii/20260511011552/guard-runner.repoRoot-reads-with-repoMu-to-fix"
+	created := "jonnii/20260511011552/add-feature"
 
 	handler.OnEvent(submitAction.SubmissionStartEvent{
-		Branches: []submitAction.BranchInfo{{
-			Name:   branch,
-			Action: "update",
-		}},
+		Branches: []submitAction.BranchInfo{
+			{Name: updated, Action: "update"},
+			{Name: created, Action: "create"},
+		},
 	})
 	handler.OnEvent(submitAction.BranchProgressEvent{
-		BranchName: branch,
+		BranchName: updated,
 		Status:     submitAction.StatusDone,
 		URL:        "https://github.com/getstackit/stackit/pull/934",
+	})
+	handler.OnEvent(submitAction.BranchProgressEvent{
+		BranchName: created,
+		Status:     submitAction.StatusDone,
+		URL:        "https://github.com/getstackit/stackit/pull/935",
 	})
 	handler.OnEvent(submitAction.CompletionEvent{Outcome: submitAction.OutcomeComplete, Message: "Submit complete"})
 
 	got := out.String()
-	require.Contains(t, got, "Submitting 1 branch")
+	require.Contains(t, got, "Submitting 2 branches")
 	require.Contains(t, got, "✓ guard-runner.repoRoot-reads-with-repoMu-to-fix #934 updated")
-	require.Contains(t, got, "Pull requests")
-	require.Contains(t, got, "#934 guard-runner.repoRoot-reads-with-repoMu-to-fix")
-	require.Contains(t, got, "     https://github.com/getstackit/stackit/pull/934")
-	require.NotContains(t, got, "updated → https://github.com/getstackit/stackit/pull/934")
+	require.Contains(t, got, "✓ add-feature #935 created")
+	// Only the newly created PR prints its raw URL; no trailing summary block
+	// repeats the list.
+	require.Contains(t, got, "     https://github.com/getstackit/stackit/pull/935")
+	require.NotContains(t, got, "https://github.com/getstackit/stackit/pull/934")
+	require.NotContains(t, got, "Pull requests")
 }
 
 func TestSimpleSubmitHandlerPreservesURLAcrossFooterSync(t *testing.T) {
@@ -52,7 +60,7 @@ func TestSimpleSubmitHandlerPreservesURLAcrossFooterSync(t *testing.T) {
 	handler.OnEvent(submitAction.SubmissionStartEvent{
 		Branches: []submitAction.BranchInfo{{
 			Name:   branch,
-			Action: "update",
+			Action: "create",
 		}},
 	})
 	handler.OnEvent(submitAction.BranchProgressEvent{
@@ -71,7 +79,7 @@ func TestSimpleSubmitHandlerPreservesURLAcrossFooterSync(t *testing.T) {
 	handler.OnEvent(submitAction.CompletionEvent{Outcome: submitAction.OutcomeComplete, Message: "Submit complete"})
 
 	got := out.String()
-	require.Contains(t, got, "https://github.com/getstackit/stackit/pull/934")
+	require.Equal(t, 1, strings.Count(got, "https://github.com/getstackit/stackit/pull/934"))
 	require.NotContains(t, got, "syncing")
 	require.Equal(t, 1, strings.Count(got, "✓ guard-runner"), "footer sync must not re-report a finished branch")
 }

--- a/internal/tui/components/submit/format.go
+++ b/internal/tui/components/submit/format.go
@@ -228,52 +228,49 @@ func prNumberFromURL(raw string) (int, bool) {
 	return n, err == nil
 }
 
-// FormatURLSummary renders clickable PR URLs after submit completes.
-func FormatURLSummary(items []Item) string {
-	rows := make([]string, 0, len(items))
-	for _, item := range items {
-		if item.URL == "" {
-			continue
-		}
-		ref := PRRef(item)
-		if ref == "" {
-			ref = "-"
-		}
-		name := DisplayBranchName(item.BranchName)
-		rows = append(rows, fmt.Sprintf("%s %s\n     %s", ref, name, item.URL))
-	}
-	if len(rows) == 0 {
-		return ""
-	}
-	return "Pull requests\n\n" + strings.Join(rows, "\n")
-}
-
 // hyperlink wraps text in an OSC 8 terminal hyperlink escape sequence.
 // Terminals without OSC 8 support ignore the sequence and show the plain text.
 func hyperlink(url, text string) string {
 	return "\x1b]8;;" + url + "\x1b\\" + text + "\x1b]8;;\x1b\\"
 }
 
-// FormatLinkedURLSummary renders the post-submit PR list with clickable labels
-// and visible URLs. Keeping the URL visible matters for copy/paste, logs, and
-// terminals that do not expose OSC 8 links clearly.
-func FormatLinkedURLSummary(items []Item) string {
+// FormatFinalList renders the persisted post-submit result: one row per
+// branch with its final status, the row hyperlinked to its PR. Raw URL lines
+// print only for newly created PRs — those are the ones the user needs to
+// open; updated PRs rarely need their URL re-pasted.
+func FormatFinalList(items []Item) string {
 	rows := make([]string, 0, len(items))
 	for _, item := range items {
-		if item.URL == "" {
-			continue
-		}
-		ref := PRRef(item)
-		if ref == "" {
-			ref = "-"
-		}
 		name := DisplayBranchName(item.BranchName)
-		rows = append(rows, fmt.Sprintf("%s\n     %s", hyperlink(item.URL, fmt.Sprintf("%s %s", ref, name)), item.URL))
+		switch item.Status {
+		case StatusError:
+			detail := "failed"
+			if item.Error != nil {
+				detail = item.Error.Error()
+			}
+			rows = append(rows, fmt.Sprintf("✗ %s — %s", name, detail))
+
+		case StatusDone:
+			detail := pastTense(item.Action)
+			if ref := PRRef(item); ref != "" {
+				detail = ref + " " + detail
+			}
+			row := fmt.Sprintf("✓ %s %s", name, detail)
+			if item.URL != "" {
+				row = hyperlink(item.URL, row)
+			}
+			if item.Action == ActionCreate && item.URL != "" {
+				row += "\n     " + item.URL
+			}
+			rows = append(rows, row)
+
+		default:
+			// Not a terminal state: nothing was submitted for this branch, so
+			// there is no result to persist. An all-pending list stays empty,
+			// which lets completionSummary fall back to the plan view.
+		}
 	}
-	if len(rows) == 0 {
-		return ""
-	}
-	return "Pull requests\n\n" + strings.Join(rows, "\n")
+	return strings.Join(rows, "\n")
 }
 
 // FormatSoloSummary renders the post-submit result for a single-branch submit:

--- a/internal/tui/components/submit/format_test.go
+++ b/internal/tui/components/submit/format_test.go
@@ -94,40 +94,38 @@ func TestModelSoloDropsHeaderAndName(t *testing.T) {
 	require.Contains(t, summary, "https://github.com/getstackit/stackit/pull/1270")
 }
 
-func TestFormatURLSummaryRendersClickableRows(t *testing.T) {
+func TestFormatFinalList(t *testing.T) {
 	t.Parallel()
 
-	summary := FormatURLSummary([]Item{
+	summary := FormatFinalList([]Item{
 		{
 			BranchName: "jonnii/20260511011552/guard-runner.repoRoot-reads-with-repoMu-to-fix",
 			Action:     ActionUpdate,
 			Status:     StatusDone,
 			URL:        "https://github.com/getstackit/stackit/pull/934",
 		},
-	})
-
-	require.Equal(t, `Pull requests
-
-#934 guard-runner.repoRoot-reads-with-repoMu-to-fix
-     https://github.com/getstackit/stackit/pull/934`, summary)
-}
-
-func TestFormatLinkedURLSummaryEmitsHyperlinks(t *testing.T) {
-	t.Parallel()
-
-	summary := FormatLinkedURLSummary([]Item{
 		{
 			BranchName: "jonnii/20260511011552/add-feature",
 			Action:     ActionCreate,
 			Status:     StatusDone,
 			URL:        "https://github.com/getstackit/stackit/pull/935",
 		},
+		{
+			BranchName: "jonnii/20260511011552/fix-bug",
+			Action:     ActionUpdate,
+			Status:     StatusError,
+			Error:      errors.New("remote rejected"),
+		},
 	})
 
-	require.Equal(t, "Pull requests\n\n"+
-		"\x1b]8;;https://github.com/getstackit/stackit/pull/935\x1b\\#935 add-feature\x1b]8;;\x1b\\\n"+
-		"     https://github.com/getstackit/stackit/pull/935",
+	require.Equal(t,
+		"\x1b]8;;https://github.com/getstackit/stackit/pull/934\x1b\\✓ guard-runner.repoRoot-reads-with-repoMu-to-fix #934 updated\x1b]8;;\x1b\\\n"+
+			// Only the newly created PR prints its raw URL.
+			"\x1b]8;;https://github.com/getstackit/stackit/pull/935\x1b\\✓ add-feature #935 created\x1b]8;;\x1b\\\n"+
+			"     https://github.com/getstackit/stackit/pull/935\n"+
+			"✗ fix-bug — remote rejected",
 		summary)
+	require.NotContains(t, summary, "Pull requests")
 }
 
 func TestModelCompletionSummaryIncludesFailuresAndWarnings(t *testing.T) {
@@ -154,8 +152,7 @@ func TestModelCompletionSummaryIncludesFailuresAndWarnings(t *testing.T) {
 	m = updated.(*Model)
 
 	summary := m.completionSummary()
-	require.Contains(t, summary, "Pull requests")
-	require.Contains(t, summary, "#935 add-feature")
+	require.Contains(t, summary, "✓ add-feature #935 created")
 	require.Contains(t, summary, "✗ fix-bug — failed to push branch: remote rejected")
 	require.Contains(t, summary, "⚠️  add-feature: failed to add labels")
 }
@@ -262,8 +259,8 @@ func TestModelCompletionSummaryPrefersSubmissionResults(t *testing.T) {
 	}})
 
 	summary := m.completionSummary()
-	require.Contains(t, summary, "Pull requests")
-	require.Contains(t, summary, "https://github.com/getstackit/stackit/pull/934")
+	require.Contains(t, summary, "✓ feature-1 #934 updated")
+	require.NotContains(t, summary, "Submitting")
 }
 
 func stripANSIEscape(s string) string {

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -163,22 +163,23 @@ func (m *Model) content() string {
 }
 
 // completionSummary is the output persisted to the terminal when the TUI
-// exits. After a submission it lists PR URLs and failures; when nothing was
-// submitted (dry run, all up to date) it falls back to the final plan view,
-// which would otherwise be erased with the progress display. Warnings are
-// appended in either case so they survive the screen clear.
+// exits. After a submission it lists every branch's final result (including
+// failures); when nothing was submitted (dry run, all up to date) it falls
+// back to the final plan view, which would otherwise be erased with the
+// progress display. Warnings are appended in either case so they survive the
+// screen clear.
 func (m *Model) completionSummary() string {
 	var summary string
 	if m.Solo {
 		summary = FormatSoloSummary(m.Items)
-	} else {
-		summary = FormatLinkedURLSummary(m.Items)
-	}
-	if failures := FormatFailureSummary(m.Items); failures != "" {
-		if summary != "" {
-			summary += "\n\n"
+		if failures := FormatFailureSummary(m.Items); failures != "" {
+			if summary != "" {
+				summary += "\n\n"
+			}
+			summary += failures
 		}
-		summary += failures
+	} else {
+		summary = FormatFinalList(m.Items)
 	}
 	if summary == "" {
 		return m.content()


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The run used to end with a "Pull requests" block repeating refs and
URLs the progress rows had already shown. The TUI now persists a single
final list — one hyperlinked row per branch with its result, failures
inline, and a raw URL only for newly created PRs (the ones the user
needs to open). The non-TTY handler streams the same shape live and
drops its trailing summary block. Branches that never reached a
terminal state render nothing, preserving the fall-back to the plan
view when nothing was submitted.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1783682845`.


* **PR #935**
  * **PR #1189**
    * **PR #1190**
      * **PR #1194**
        * **PR #1195**
          * **PR #1196**
            * **PR #1197**
              * **PR #1270**
                * **PR #1271**
                  * **PR #1399**
                    * **PR #1400**
                      * **PR #1401**
                        * **PR #1402** 👈
                          * **PR #1403**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1404 by jonnii*