### PR TITLE
feat(submit): add --json output

### DIFF
--- a/internal/actions/submit/json_handler.go
+++ b/internal/actions/submit/json_handler.go
@@ -1,0 +1,131 @@
+package submit
+
+import (
+	"net/url"
+	"path"
+	"strconv"
+	"sync"
+)
+
+// JSONResult is the machine-readable summary of a submit run.
+type JSONResult struct {
+	Outcome  CompletionOutcome  `json:"outcome"`
+	Message  string             `json:"message,omitempty"`
+	Error    string             `json:"error,omitempty"`
+	Branches []JSONBranchResult `json:"branches"`
+}
+
+// JSONBranchResult is one branch's plan and result in submit JSON output.
+type JSONBranchResult struct {
+	Branch     string   `json:"branch"`
+	Action     string   `json:"action,omitempty"` // "create" or "update"
+	Status     string   `json:"status"`           // pending, done, error, skipped
+	PR         *int     `json:"pr,omitempty"`
+	URL        string   `json:"url,omitempty"`
+	SkipReason string   `json:"skip_reason,omitempty"`
+	Error      string   `json:"error,omitempty"`
+	Warnings   []string `json:"warnings,omitempty"`
+}
+
+// JSONHandler collects submit events into a JSONResult.
+type JSONHandler struct {
+	mu     sync.Mutex
+	Result *JSONResult
+	index  map[string]int // branch name -> position in Result.Branches
+}
+
+// NewJSONHandler creates a handler that collects submit results as JSON data.
+func NewJSONHandler() *JSONHandler {
+	return &JSONHandler{
+		Result: &JSONResult{Branches: []JSONBranchResult{}},
+		index:  map[string]int{},
+	}
+}
+
+// SetError records a run-level error on the result.
+func (h *JSONHandler) SetError(err error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.Result.Error = err.Error()
+	if h.Result.Outcome == "" {
+		h.Result.Outcome = OutcomeFailed
+	}
+}
+
+// OnEvent implements Handler.
+func (h *JSONHandler) OnEvent(e Event) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	switch ev := e.(type) {
+	case BranchPlanEvent:
+		b := h.branch(ev.BranchName)
+		b.Action = ev.Action
+		b.PR = ev.PRNumber
+		if ev.Skipped {
+			b.Status = string(StatusSkipped)
+			b.SkipReason = ev.SkipReason
+		} else {
+			b.Status = string(StatusPending)
+		}
+
+	case BranchProgressEvent:
+		b := h.branch(ev.BranchName)
+		// The footer sync re-emits done without a URL; never clobber fields
+		// already learned.
+		if ev.Status != "" {
+			b.Status = string(ev.Status)
+		}
+		if ev.URL != "" {
+			b.URL = ev.URL
+			if b.PR == nil {
+				b.PR = prNumberFromPullURL(ev.URL)
+			}
+		}
+		if ev.Error != nil {
+			b.Error = ev.Error.Error()
+		}
+
+	case BranchWarningEvent:
+		b := h.branch(ev.BranchName)
+		b.Warnings = append(b.Warnings, ev.Warning)
+
+	case CompletionEvent:
+		h.Result.Outcome = ev.Outcome
+		h.Result.Message = ev.Message
+	}
+}
+
+// branch returns the result entry for name, creating it on first sight so
+// event order never drops data.
+func (h *JSONHandler) branch(name string) *JSONBranchResult {
+	if i, ok := h.index[name]; ok {
+		return &h.Result.Branches[i]
+	}
+	h.index[name] = len(h.Result.Branches)
+	h.Result.Branches = append(h.Result.Branches, JSONBranchResult{Branch: name})
+	return &h.Result.Branches[len(h.Result.Branches)-1]
+}
+
+// prNumberFromPullURL extracts the PR number from a GitHub pull URL.
+func prNumberFromPullURL(raw string) *int {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil
+	}
+	n, err := strconv.Atoi(path.Base(u.Path))
+	if err != nil {
+		return nil
+	}
+	return &n
+}
+
+// Confirm auto-confirms with the default value — JSON output is non-interactive.
+func (h *JSONHandler) Confirm(_ string, defaultYes bool) (bool, error) {
+	return defaultYes, nil
+}
+
+// IsInteractive returns false — JSON handlers never prompt.
+func (h *JSONHandler) IsInteractive() bool {
+	return false
+}

--- a/internal/actions/submit/json_handler_test.go
+++ b/internal/actions/submit/json_handler_test.go
@@ -1,0 +1,60 @@
+package submit
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONHandlerCollectsPlanAndResults(t *testing.T) {
+	t.Parallel()
+
+	pr := 934
+	h := NewJSONHandler()
+
+	h.OnEvent(BranchPlanEvent{BranchName: "update-me", Action: "update", PRNumber: &pr})
+	h.OnEvent(BranchPlanEvent{BranchName: "create-me", Action: "create"})
+	h.OnEvent(BranchPlanEvent{BranchName: "skip-me", Skipped: true, SkipReason: "no changes"})
+	h.OnEvent(BranchProgressEvent{
+		BranchName: "create-me",
+		Status:     StatusDone,
+		URL:        "https://github.com/getstackit/stackit/pull/935",
+	})
+	h.OnEvent(BranchProgressEvent{BranchName: "update-me", Status: StatusError, Error: errors.New("remote rejected")})
+	h.OnEvent(BranchWarningEvent{BranchName: "create-me", Warning: "failed to add labels"})
+	// Footer sync re-emits done without a URL; learned fields must survive.
+	h.OnEvent(BranchProgressEvent{BranchName: "create-me", Status: StatusDone})
+	h.OnEvent(CompletionEvent{Outcome: OutcomeComplete, Message: "Submit complete"})
+
+	require.Equal(t, OutcomeComplete, h.Result.Outcome)
+	require.Equal(t, "Submit complete", h.Result.Message)
+	require.Len(t, h.Result.Branches, 3)
+
+	updated := h.Result.Branches[0]
+	require.Equal(t, "update-me", updated.Branch)
+	require.Equal(t, "update", updated.Action)
+	require.Equal(t, string(StatusError), updated.Status)
+	require.Equal(t, 934, *updated.PR)
+	require.Equal(t, "remote rejected", updated.Error)
+
+	created := h.Result.Branches[1]
+	require.Equal(t, string(StatusDone), created.Status)
+	require.Equal(t, "https://github.com/getstackit/stackit/pull/935", created.URL)
+	require.Equal(t, 935, *created.PR, "PR number derives from the URL when the plan had none")
+	require.Equal(t, []string{"failed to add labels"}, created.Warnings)
+
+	skipped := h.Result.Branches[2]
+	require.Equal(t, string(StatusSkipped), skipped.Status)
+	require.Equal(t, "no changes", skipped.SkipReason)
+}
+
+func TestJSONHandlerSetErrorDefaultsOutcome(t *testing.T) {
+	t.Parallel()
+
+	h := NewJSONHandler()
+	h.SetError(errors.New("boom"))
+
+	require.Equal(t, "boom", h.Result.Error)
+	require.Equal(t, OutcomeFailed, h.Result.Outcome)
+}

--- a/internal/cli/stack/submit.go
+++ b/internal/cli/stack/submit.go
@@ -2,6 +2,9 @@
 package stack
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/getstackit/stackit/internal/actions/submit"
@@ -41,6 +44,7 @@ type submitFlags struct {
 	cli                  bool
 	noLabels             bool
 	noAssignees          bool
+	jsonOutput           bool
 }
 
 func addSubmitFlags(cmd *cobra.Command, f *submitFlags) {
@@ -72,6 +76,7 @@ func addSubmitFlags(cmd *cobra.Command, f *submitFlags) {
 	cmd.Flags().BoolVar(&f.cli, "cli", false, "Edit PR metadata via the CLI instead of on web.")
 	cmd.Flags().BoolVar(&f.noLabels, "no-labels", false, "Don't apply default labels from config.")
 	cmd.Flags().BoolVar(&f.noAssignees, "no-assignees", false, "Don't apply default assignees from config.")
+	cmd.Flags().BoolVar(&f.jsonOutput, "json", false, "Output the plan and per-branch results as JSON.")
 }
 
 func executeSubmit(cmd *cobra.Command, f *submitFlags) error {
@@ -130,6 +135,21 @@ func executeSubmit(cmd *cobra.Command, f *submitFlags) error {
 			ConfigLabels:    configLabels,
 			ConfigReviewers: cfg.SubmitReviewers(),
 			ConfigAssignees: configAssignees,
+		}
+
+		if f.jsonOutput {
+			cmd.SilenceErrors = true
+			jsonHandler := submit.NewJSONHandler()
+			err := submit.Action(ctx, opts, jsonHandler)
+			if err != nil {
+				jsonHandler.SetError(err)
+			}
+			data, marshalErr := json.MarshalIndent(jsonHandler.Result, "", "  ")
+			if marshalErr != nil {
+				return fmt.Errorf("failed to marshal JSON: %w", marshalErr)
+			}
+			ctx.Output.Info("%s", string(data))
+			return err
 		}
 
 		// Action is the single source of truth for what to submit. The runner

--- a/internal/tui/components/submit/format.go
+++ b/internal/tui/components/submit/format.go
@@ -161,20 +161,25 @@ func rowParts(item Item, spinnerView string, styles Styles) (string, string) {
 // git/gh message cannot shred the column layout mid-TUI.
 const maxErrorDetailWidth = 60
 
+// errorText is err's message, or a generic label when there is none.
+func errorText(err error) string {
+	if err == nil {
+		return "failed"
+	}
+	return err.Error()
+}
+
 // compactErrorText flattens an error to its trimmed first line, truncated to
 // fit a progress row. The full text still persists via FormatFailureSummary
 // when the TUI exits, so nothing is lost.
 func compactErrorText(err error) string {
-	if err == nil {
-		return "failed"
-	}
-	detail := err.Error()
+	detail := errorText(err)
 	if i := strings.IndexByte(detail, '\n'); i >= 0 {
 		detail = detail[:i]
 	}
 	detail = strings.TrimSpace(detail)
 	if detail == "" {
-		return "failed"
+		detail = errorText(nil)
 	}
 	return TruncateMiddle(detail, maxErrorDetailWidth)
 }
@@ -244,11 +249,7 @@ func FormatFinalList(items []Item) string {
 		name := DisplayBranchName(item.BranchName)
 		switch item.Status {
 		case StatusError:
-			detail := "failed"
-			if item.Error != nil {
-				detail = item.Error.Error()
-			}
-			rows = append(rows, fmt.Sprintf("✗ %s — %s", name, detail))
+			rows = append(rows, fmt.Sprintf("✗ %s — %s", name, errorText(item.Error)))
 
 		case StatusDone:
 			detail := pastTense(item.Action)
@@ -347,11 +348,7 @@ func FormatFailureSummary(items []Item) string {
 		if item.Status != StatusError {
 			continue
 		}
-		detail := "failed"
-		if item.Error != nil {
-			detail = item.Error.Error()
-		}
-		rows = append(rows, fmt.Sprintf("✗ %s — %s", DisplayBranchName(item.BranchName), detail))
+		rows = append(rows, fmt.Sprintf("✗ %s — %s", DisplayBranchName(item.BranchName), errorText(item.Error)))
 	}
 	if len(rows) == 0 {
 		return ""


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Agents and CI had to scrape the human submit output with regexes to
recover PR numbers and URLs. --json routes the run through a collecting
handler (same pattern as foreach --json) and prints one document with
the outcome plus per-branch action, status, PR number, URL, skip
reason, error, and warnings. PR numbers derive from the created PR's
URL when the plan had none.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1783682845`.


* **PR #935**
  * **PR #1189**
    * **PR #1190**
      * **PR #1194**
        * **PR #1195**
          * **PR #1196**
            * **PR #1197**
              * **PR #1270**
                * **PR #1271**
                  * **PR #1399**
                    * **PR #1400**
                      * **PR #1401**
                        * **PR #1402**
                          * **PR #1403** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1404 by jonnii*