### PR TITLE
perf: replace per-branch git reads with batch APIs in reparent, pluck, and absorb

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -37,7 +37,7 @@ const (
 
 | Instead of | Use |
 |------------|-----|
-| `MarkNeedsPRBodyUpdate` in a loop | `BatchMarkNeedsPRBodyUpdate(branchNames)` |
+| per-branch PR-body-update marking in a loop | `MarkBranchesForPRBodyUpdate(ctx, branchNames)` |
 | `ReadLocalMetadata` in a loop | `BatchReadLocalMetadata(branchNames)` |
 | `UpdateRef` in a loop | `UpdateRefsBatch(ctx, updates)` |
 | `DeleteRef` in a loop | `DeleteRefsBatch(ctx, refNames)` |
@@ -51,12 +51,13 @@ const (
 
 ```go
 // BAD - N git processes for N branches
-for _, name := range branchNames {
-    _ = eng.MarkNeedsPRBodyUpdate(name)
+for _, branch := range branches {
+    div, _ := eng.GetDivergencePoint(branch.GetName())
+    divPoints[branch.GetName()] = div
 }
 
-// GOOD - parallel reads + single atomic ref update
-_ = eng.BatchMarkNeedsPRBodyUpdate(branchNames)
+// GOOD - one batched, cache-backed pass
+divPoints := eng.BatchDivergencePoints(branches)
 ```
 
 When adding new operations that touch multiple branches or refs, prefer designing batch APIs from the start. Use `UpdateRefsBatch` for atomic multi-ref writes and `BatchReadLocalMetadata` / `BatchReadMetadata` for parallel reads.

--- a/.claude/rules/safety-invariants.md
+++ b/.claude/rules/safety-invariants.md
@@ -176,7 +176,7 @@ branchNames := make([]string, len(branches))
 for i, b := range branches {
     branchNames[i] = b.GetName()
 }
-_ = eng.BatchMarkNeedsPRBodyUpdate(branchNames)
+_ = eng.MarkBranchesForPRBodyUpdate(ctx, branchNames)
 if err := pushMetadataOnly(ctx, eng, branchName); err != nil {
     out.Debug("Failed: %v", err)
 }

--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -128,13 +128,21 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	// Get all commit SHAs from downstack branches (newest to oldest)
+	commitsByBranch := eng.BatchCommits(downstackBranches, engine.CommitFormatSHA)
 	commitSHAs := []string{}
 	for _, branch := range downstackBranches {
-		commits, err := branch.GetAllCommits(engine.CommitFormatSHA)
-		if err != nil {
-			return fmt.Errorf("failed to get commits for branch %s: %w", branch.GetName(), err)
+		// BatchCommits returns newest to oldest per branch, matching our search
+		// order. The batch reader swallows errors as nil; absorb must not route
+		// hunks against an incomplete commit list, so re-read any empty non-trunk
+		// branch individually to distinguish "legitimately empty" from "error".
+		commits := commitsByBranch[branch.GetName()]
+		if len(commits) == 0 && !branch.IsTrunk() {
+			var err error
+			commits, err = branch.GetAllCommits(engine.CommitFormatSHA)
+			if err != nil {
+				return fmt.Errorf("failed to get commits for branch %s: %w", branch.GetName(), err)
+			}
 		}
-		// GetAllCommits returns newest to oldest, which matches our search order.
 		commitSHAs = append(commitSHAs, commits...)
 	}
 

--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -133,10 +133,11 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	// Children: rebase onto grandparent (source's old parent)
+	childDivPoints := eng.BatchDivergencePoints(children)
 	for _, child := range children {
 		// Get the old upstream (divergence point)
-		childOldUpstream, divErr := eng.GetDivergencePoint(child.GetName())
-		if divErr != nil {
+		childOldUpstream := childDivPoints[child.GetName()]
+		if childOldUpstream == "" {
 			// Fallback to source revision if unavailable
 			childOldUpstream = sourceRev
 		}

--- a/internal/actions/track/action.go
+++ b/internal/actions/track/action.go
@@ -167,26 +167,25 @@ func trackBranchRecursively(ctx *app.Context, branchName string, handler Handler
 	allBranches := eng.AllBranches()
 	untrackedChildren := []string{}
 
-	for _, candidateBranch := range allBranches {
-		candidate := candidateBranch.GetName()
-		if candidate == branchName {
-			continue
-		}
+	// branchRev is loop-invariant; a failed lookup just disables child detection.
+	branchRev, revErr := eng.GetRevision(eng.GetBranch(branchName))
+	if revErr == nil {
+		for _, candidateBranch := range allBranches {
+			candidate := candidateBranch.GetName()
+			if candidate == branchName {
+				continue
+			}
 
-		// Check if candidate is a child (has this branch as merge base)
-		mergeBase, err := eng.GetMergeBase(ctx.Context, candidate, branchName)
-		if err != nil {
-			continue
-		}
+			// Check if candidate is a child (has this branch as merge base)
+			mergeBase, err := eng.GetMergeBase(ctx.Context, candidate, branchName)
+			if err != nil {
+				continue
+			}
 
-		branchRev, err := eng.GetRevision(eng.GetBranch(branchName))
-		if err != nil {
-			continue
-		}
-
-		// If merge base is the branch we just tracked, candidate is a child
-		if mergeBase == branchRev && !candidateBranch.IsTracked() {
-			untrackedChildren = append(untrackedChildren, candidate)
+			// If merge base is the branch we just tracked, candidate is a child
+			if mergeBase == branchRev && !candidateBranch.IsTracked() {
+				untrackedChildren = append(untrackedChildren, candidate)
+			}
 		}
 	}
 

--- a/internal/engine/branch_tracking.go
+++ b/internal/engine/branch_tracking.go
@@ -306,13 +306,17 @@ func (e *engineImpl) ReparentBranches(ctx context.Context, branchNames []string,
 // Automatically propagates each new parent's stack ID when a move crosses a
 // stack boundary.
 func (e *engineImpl) ReparentBranchesToParents(ctx context.Context, moves []BranchParentMove) error {
-	divPoints := make(map[string]string, len(moves))
+	branches := make(Branches, len(moves))
+	for i, m := range moves {
+		branches[i] = e.GetBranch(m.Branch)
+	}
+	divPoints := e.BatchDivergencePoints(branches)
 	for _, m := range moves {
-		div, err := e.GetDivergencePoint(m.Branch)
-		if err != nil {
-			return fmt.Errorf("failed to determine divergence point for %s: %w", m.Branch, err)
+		// The batch reader returns "" where the individual lookup would error;
+		// reparenting must not proceed with an unknown divergence point.
+		if divPoints[m.Branch] == "" {
+			return fmt.Errorf("failed to determine divergence point for %s", m.Branch)
 		}
-		divPoints[m.Branch] = div
 	}
 
 	for _, m := range moves {

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -383,7 +383,7 @@ func (r *runner) ListMetadata() (map[string]string, error) {
 // WriteMetadataBlobsBatch marshals each Meta to JSON and writes all the blobs
 // in one `git hash-object` invocation via CreateBlobsBatch. Returns SHAs in
 // input order. Does NOT update any refs — callers (transaction commit,
-// BatchMarkNeedsPRBodyUpdate) pair the SHAs with ref updates afterwards.
+// MarkBranchesForPRBodyUpdate) pair the SHAs with ref updates afterwards.
 func (r *runner) WriteMetadataBlobsBatch(ctx context.Context, metas []*Meta) ([]string, error) {
 	if len(metas) == 0 {
 		return nil, nil


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

ReparentBranchesToParents, pluck's child rebase specs, and absorb's
downstack commit collection each called an individual git-backed read in a
loop over branches. All three now resolve the whole set through the
existing batch readers (BatchDivergencePoints, BatchCommits), keeping the
fail-loud behavior where it matters: reparent still errors on an unknown
divergence point, and absorb re-reads any empty non-trunk branch
individually so a swallowed batch error can't shrink its commit list.

Also hoists a loop-invariant GetRevision out of track's child scan and
corrects the stale BatchMarkNeedsPRBodyUpdate name in the rules docs.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1783729756`.


* **PR #1405** 👈
  * **PR #1406**
    * **PR #1407**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1409 by jonnii*