### PR TITLE
perf(api): batch per-branch git reads in the branch/stack mappers

### DIFF
--- a/internal/api/handlers/branches.go
+++ b/internal/api/handlers/branches.go
@@ -63,8 +63,12 @@ func (h *BranchesHandler) listBranches(w http.ResponseWriter, r *http.Request, e
 		checksMap, _ = entry.GitHub.BatchGetPRChecksStatus(r.Context(), names)
 	}
 
-	// One remote listing for all branches instead of one per branch.
-	remoteStatuses := entry.Engine.ReadBranchRemoteStatuses(r.Context(), engine.BranchesOf(branches...))
+	// One remote listing, one stats pass, and one commits pass for all
+	// branches instead of one of each per branch.
+	branchSet := engine.BranchesOf(branches...)
+	remoteStatuses := entry.Engine.ReadBranchRemoteStatuses(r.Context(), branchSet)
+	stats := entry.Engine.BatchBranchStats(branchSet)
+	commitsByBranch := entry.Engine.BatchCommits(branchSet, engine.CommitFormatReadableWithDate)
 
 	responses := make([]httpcontract.BranchResponse, 0, len(branches))
 	for _, branch := range branches {
@@ -76,7 +80,7 @@ func (h *BranchesHandler) listBranches(w http.ResponseWriter, r *http.Request, e
 		if checksMap != nil {
 			checks = checksMap[branch.GetName()]
 		}
-		responses = append(responses, httpcontract.MapBranch(entry.Engine, branch, node, checks, remoteStatuses.ForBranch(branch)))
+		responses = append(responses, httpcontract.MapBranch(entry.Engine, branch, node, checks, remoteStatuses.ForBranch(branch), stats[branch.GetName()], commitsByBranch[branch.GetName()]))
 	}
 
 	writeJSON(w, responses)
@@ -104,7 +108,10 @@ func (h *BranchesHandler) getBranch(w http.ResponseWriter, r *http.Request, entr
 		}
 	}
 
-	remoteStatus := entry.Engine.ReadBranchRemoteStatuses(r.Context(), engine.BranchesOf(branch)).ForBranch(branch)
-	resp := httpcontract.MapBranch(entry.Engine, branch, node, checks, remoteStatus)
+	branchSet := engine.BranchesOf(branch)
+	remoteStatus := entry.Engine.ReadBranchRemoteStatuses(r.Context(), branchSet).ForBranch(branch)
+	stat := entry.Engine.BatchBranchStats(branchSet)[branchName]
+	commits := entry.Engine.BatchCommits(branchSet, engine.CommitFormatReadableWithDate)[branchName]
+	resp := httpcontract.MapBranch(entry.Engine, branch, node, checks, remoteStatus, stat, commits)
 	writeJSON(w, resp)
 }

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -12,10 +12,11 @@ import (
 )
 
 // MapBranch converts an engine Branch and its StackNode into an API BranchResponse.
-// remoteStatus should come from a single ReadBranchRemoteStatuses call covering
-// all branches being mapped in the current request, not a per-branch call, since
-// each ReadBranchRemoteStatuses call lists the remote's refs.
-func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.StackNode, checks *github.CheckStatus, remoteStatus engine.BranchRemoteStatus) BranchResponse {
+// remoteStatus, stat, and commits should each come from a single batch call
+// covering all branches being mapped in the current request
+// (ReadBranchRemoteStatuses, BatchBranchStats, BatchCommits), not per-branch
+// calls — per-branch reads spawn a git process per field per branch.
+func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.StackNode, checks *github.CheckStatus, remoteStatus engine.BranchRemoteStatus, stat engine.BranchStat, commits []string) BranchResponse {
 	resp := BranchResponse{
 		Name:         branch.GetName(),
 		Depth:        node.Depth,
@@ -38,9 +39,10 @@ func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.Stack
 		resp.Scope = scope.String()
 	}
 
-	if rev, err := branch.GetRevision(); err == nil {
-		resp.Revision = shortSHA(rev)
-	}
+	resp.Revision = stat.ShortSHA
+	resp.CommitCount = stat.CommitCount
+	resp.LinesAdded = stat.LinesAdded
+	resp.LinesDeleted = stat.LinesDeleted
 
 	if date, err := branch.GetCommitDate(); err == nil {
 		resp.CommitDate = date.Format(time.RFC3339)
@@ -50,17 +52,8 @@ func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.Stack
 		resp.CommitAuthor = author
 	}
 
-	if count, err := branch.GetCommitCount(); err == nil {
-		resp.CommitCount = count
-	}
-
-	if added, deleted, err := branch.GetDiffStats(); err == nil {
-		resp.LinesAdded = added
-		resp.LinesDeleted = deleted
-	}
-
 	// Map commits
-	if commits, err := eng.GetAllCommits(branch, engine.CommitFormatReadableWithDate); err == nil {
+	if len(commits) > 0 {
 		resp.Commits = mapCommitsWithDate(commits)
 	}
 
@@ -161,8 +154,11 @@ func MapStackDetail(ctx context.Context, eng engine.BranchReader, graph *engine.
 		stackBranches = append(stackBranches, node.Branch)
 	}
 
-	// One remote listing for the whole stack instead of one per branch.
+	// One remote listing, one stats pass, and one commits pass for the whole
+	// stack instead of one of each per branch.
 	remoteStatuses := eng.ReadBranchRemoteStatuses(ctx, stackBranches)
+	stats := eng.BatchBranchStats(stackBranches)
+	commitsByBranch := eng.BatchCommits(stackBranches, engine.CommitFormatReadableWithDate)
 
 	branches := make([]BranchResponse, 0, len(nodes))
 	for _, node := range nodes {
@@ -171,7 +167,7 @@ func MapStackDetail(ctx context.Context, eng engine.BranchReader, graph *engine.
 		if checksMap != nil {
 			checks = checksMap[name]
 		}
-		br := MapBranch(eng, node.Branch, node, checks, remoteStatuses.ForBranch(node.Branch))
+		br := MapBranch(eng, node.Branch, node, checks, remoteStatuses.ForBranch(node.Branch), stats[name], commitsByBranch[name])
 		if isAnchor {
 			// Anchor's direct children become display roots
 			if br.Parent == anchorName {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

MapBranch made six individual git-backed calls per branch (revision,
commit count, diff stats, commits, date, author), and both MapStackDetail
and the branches handlers invoked it in a loop — ~6 git processes per
branch per request. Callers now resolve stats and commits once for the
whole set via BatchBranchStats and BatchCommits and pass them in,
mirroring how remote statuses were already batched.

Commit date and author remain per-branch calls; they have no batch
reader yet.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1783729756`.


* **PR #1405**
  * **PR #1406** 👈
    * **PR #1407**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1409 by jonnii*