### PR TITLE
test: use require in split wizard test to fix staticcheck SA5011

### DIFF
--- a/internal/actions/split/wizard_test.go
+++ b/internal/actions/split/wizard_test.go
@@ -2,6 +2,8 @@ package split
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildTypeChoices(t *testing.T) {
@@ -53,13 +55,9 @@ func TestBuildTypeChoices(t *testing.T) {
 					availableCount, tt.wantAvailableCount)
 			}
 
-			if commitChoice == nil {
-				t.Fatal("buildTypeChoices() missing commit choice")
-			}
-			if commitChoice.Available != tt.wantCommitAvail {
-				t.Errorf("buildTypeChoices() commit.Available = %v, want %v",
-					commitChoice.Available, tt.wantCommitAvail)
-			}
+			require.NotNil(t, commitChoice, "buildTypeChoices() missing commit choice")
+			require.Equal(t, tt.wantCommitAvail, commitChoice.Available,
+				"buildTypeChoices() commit.Available")
 		})
 	}
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

staticcheck flagged a possible nil dereference after the t.Fatal nil
guard; require.NotNil is recognized as terminating and matches the
repo's require-over-assert convention.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1783729756`.


* **PR #1405**
  * **PR #1406**
    * **PR #1407** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1409 by jonnii*