### PR TITLE
perf: batch metadata and revision reads in the restack plan loop

### DIFF
--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -40,25 +40,12 @@ func (e *engineImpl) RestackBranchesWithValidatedPlan(ctx context.Context, branc
 	return e.restackBranches(ctx, branches, validation, plan, progress)
 }
 
-func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, validation *RebaseValidation, plan *RestackPlan, progress RestackBranchProgressFunc) (RestackBatchResult, error) {
-	// Save current branch to restore after restacking
-	originalBranch := e.CurrentBranch()
-	var originalRev string
-	if originalBranch == nil {
-		originalRev, _ = e.git.GetCurrentRevision(ctx)
-	}
-
-	defer func() {
-		if originalBranch != nil {
-			_ = e.CheckoutBranch(ctx, *originalBranch)
-		} else if originalRev != "" {
-			_ = e.git.CheckoutDetached(ctx, originalRev)
-		}
-	}()
-
-	// 1. Collect all the data required for the restack (in bulk)
-	branchNames := branches.Names()
-
+// collectRestackData resolves the metadata and revisions restack planning and
+// application need — the given branches, every tracked ancestor up to trunk,
+// and trunk itself — in two batched reads instead of per-branch git calls.
+// Consumers treat the maps as a point-in-time snapshot and fall back to
+// individual reads on a miss.
+func (e *engineImpl) collectRestackData(branchNames []string) (map[string]*git.Meta, map[string]string) {
 	// Identify all potential parents and ancestors to fetch their metadata and revisions too
 	e.mu.RLock()
 	allInvolvedBranches := make(map[string]bool)
@@ -83,11 +70,29 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 	involvedBranchNames = append(involvedBranchNames, e.trunk)
 	e.mu.RUnlock()
 
-	// Fetch ALL metadata in parallel
-	allMeta, _ := e.batchReadMetadata(involvedBranchNames)
+	metaMap, _ := e.batchReadMetadata(involvedBranchNames)
+	revMap, _ := e.git.BatchGetRevisions(involvedBranchNames)
+	return metaMap, revMap
+}
 
-	// Fetch ALL revisions in parallel
-	allRevisions, _ := e.git.BatchGetRevisions(involvedBranchNames)
+func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, validation *RebaseValidation, plan *RestackPlan, progress RestackBranchProgressFunc) (RestackBatchResult, error) {
+	// Save current branch to restore after restacking
+	originalBranch := e.CurrentBranch()
+	var originalRev string
+	if originalBranch == nil {
+		originalRev, _ = e.git.GetCurrentRevision(ctx)
+	}
+
+	defer func() {
+		if originalBranch != nil {
+			_ = e.CheckoutBranch(ctx, *originalBranch)
+		} else if originalRev != "" {
+			_ = e.git.CheckoutDetached(ctx, originalRev)
+		}
+	}()
+
+	// 1. Collect all the data required for the restack (in bulk)
+	allMeta, allRevisions := e.collectRestackData(branches.Names())
 
 	// Snapshot the worktree list once. Restacking N branches used to call
 	// `git worktree list` N times for the "reset other worktree's working dir"

--- a/internal/engine/restack_plan.go
+++ b/internal/engine/restack_plan.go
@@ -19,8 +19,13 @@ func (e *engineImpl) PlanRestack(ctx context.Context, branches Branches) (*Resta
 	}
 	squashCache := git.NewSquashMergeCache()
 
+	// Resolve metadata and revisions for the branches, their tracked ancestors,
+	// and trunk in two batched reads instead of per-branch git calls. Planning
+	// is read-only, so the snapshot stays valid for the whole loop.
+	metaMap, revMap := e.collectRestackData(branches.Names())
+
 	for _, branch := range branches {
-		item, ok := e.planRestackBranch(ctx, branch, plan.BranchMap, squashCache)
+		item, ok := e.planRestackBranch(ctx, branch, plan.BranchMap, squashCache, metaMap, revMap)
 		if !ok {
 			continue
 		}
@@ -35,7 +40,7 @@ func (e *engineImpl) PlanRestack(ctx context.Context, branches Branches) (*Resta
 			if parentItem, ok := plan.Items[item.NewParent]; ok && parentItem.Action == RestackPlanApplyAnchor && parentItem.TargetRev != "" {
 				specNewParent = parentItem.TargetRev
 			} else if e.IsWorktreeAnchor(e.GetBranch(item.NewParent)) && item.ParentRev != "" {
-				if parentRev, err := e.GetBranch(item.NewParent).GetRevision(); err == nil && parentRev != item.ParentRev {
+				if parentRev, ok := e.planRev(revMap, item.NewParent); ok && parentRev != item.ParentRev {
 					specNewParent = item.ParentRev
 				}
 			}
@@ -51,7 +56,10 @@ func (e *engineImpl) PlanRestack(ctx context.Context, branches Branches) (*Resta
 	return plan, nil
 }
 
-func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plannedBranches map[string]bool, squashCache *git.SquashMergeCache) (RestackPlanItem, bool) {
+// planRestackBranch builds the plan item for one branch. metaMap and revMap
+// are batch-resolved snapshots from collectRestackData; lookups fall back to
+// individual reads on a miss so the maps are an optimization, not a contract.
+func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plannedBranches map[string]bool, squashCache *git.SquashMergeCache, metaMap map[string]*git.Meta, revMap map[string]string) (RestackPlanItem, bool) {
 	branchName := branch.GetName()
 	item := RestackPlanItem{Branch: branchName, Action: RestackPlanApplyValidated}
 
@@ -75,7 +83,7 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 	}
 	if parent != nil {
 		parentName = parent.GetName()
-		if _, err := e.GetBranch(parentName).GetRevision(); err != nil {
+		if _, ok := e.planRev(revMap, parentName); !ok {
 			if ancestors, ancestorErr := e.FindMostRecentTrackedAncestors(ctx, branchName); ancestorErr == nil && len(ancestors) > 0 {
 				parentName = ancestors[0]
 			} else {
@@ -95,8 +103,8 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 	}
 
 	if branch.IsFrozen() {
-		parentRev, err := e.GetBranch(parentName).GetRevision()
-		if err != nil {
+		parentRev, ok := e.planRev(revMap, parentName)
+		if !ok {
 			return item, false
 		}
 		remoteSha, err := e.git.GetRemoteRevision(branchName)
@@ -105,8 +113,8 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 			item.SkipResult = RestackBranchResult{Result: RestackUnneeded, Frozen: true}
 			return item, true
 		}
-		localSha, err := branch.GetRevision()
-		if err != nil {
+		localSha, ok := e.planRev(revMap, branchName)
+		if !ok {
 			return item, false
 		}
 		if localSha == remoteSha {
@@ -122,12 +130,12 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 	}
 
 	if branch.IsWorktreeAnchor() {
-		trunkRev, err := e.Trunk().GetRevision()
-		if err != nil {
+		trunkRev, ok := e.planRev(revMap, e.trunk)
+		if !ok {
 			return item, false
 		}
-		anchorRev, err := branch.GetRevision()
-		if err != nil {
+		anchorRev, ok := e.planRev(revMap, branchName)
+		if !ok {
 			return item, false
 		}
 		if anchorRev == trunkRev {
@@ -152,9 +160,13 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 	e.mu.RUnlock()
 	item.NewParent = parentName
 
-	meta, err := e.git.ReadMetadata(branchName)
-	if err != nil {
-		return item, false
+	meta := metaMap[branchName]
+	if meta == nil {
+		var err error
+		meta, err = e.git.ReadMetadata(branchName)
+		if err != nil {
+			return item, false
+		}
 	}
 
 	oldParentRev := ""
@@ -183,13 +195,13 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 	}
 	item.OldUpstream = oldParentRev
 
-	parentRev, err := e.GetBranch(parentName).GetRevision()
-	if err != nil {
+	parentRev, ok := e.planRev(revMap, parentName)
+	if !ok {
 		return item, false
 	}
 	if e.IsWorktreeAnchor(e.GetBranch(parentName)) {
-		trunkRev, err := e.Trunk().GetRevision()
-		if err != nil {
+		trunkRev, ok := e.planRev(revMap, e.trunk)
+		if !ok {
 			return item, false
 		}
 		if parentRev != trunkRev {
@@ -207,4 +219,18 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 	}
 
 	return item, true
+}
+
+// planRev returns a branch's revision from the batch-resolved snapshot,
+// falling back to an individual read on a miss. ok is false when the revision
+// cannot be resolved at all (e.g. the branch was deleted).
+func (e *engineImpl) planRev(revMap map[string]string, name string) (string, bool) {
+	if rev, ok := revMap[name]; ok {
+		return rev, true
+	}
+	rev, err := e.GetBranch(name).GetRevision()
+	if err != nil {
+		return "", false
+	}
+	return rev, true
 }


### PR DESCRIPTION

PlanRestack re-fetched metadata and several revisions individually for
every branch it planned, while the apply path already consumed prefetched
maps. The ancestor-crawl-plus-batch-read block is now extracted from
restackBranches into collectRestackData and shared by both paths, and
planRestackBranch reads from the snapshot maps with individual-read
fallbacks on a miss — planning is read-only, so the snapshot stays valid
for the whole loop. Decision logic (landed detection, frozen/anchor
handling, reparenting) is unchanged; only the read sources moved.