### PR TITLE
Merging 3 PRs

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -37,7 +37,7 @@ const (
 
 | Instead of | Use |
 |------------|-----|
-| `MarkNeedsPRBodyUpdate` in a loop | `BatchMarkNeedsPRBodyUpdate(branchNames)` |
+| per-branch PR-body-update marking in a loop | `MarkBranchesForPRBodyUpdate(ctx, branchNames)` |
 | `ReadLocalMetadata` in a loop | `BatchReadLocalMetadata(branchNames)` |
 | `UpdateRef` in a loop | `UpdateRefsBatch(ctx, updates)` |
 | `DeleteRef` in a loop | `DeleteRefsBatch(ctx, refNames)` |
@@ -51,12 +51,13 @@ const (
 
 ```go
 // BAD - N git processes for N branches
-for _, name := range branchNames {
-    _ = eng.MarkNeedsPRBodyUpdate(name)
+for _, branch := range branches {
+    div, _ := eng.GetDivergencePoint(branch.GetName())
+    divPoints[branch.GetName()] = div
 }
 
-// GOOD - parallel reads + single atomic ref update
-_ = eng.BatchMarkNeedsPRBodyUpdate(branchNames)
+// GOOD - one batched, cache-backed pass
+divPoints := eng.BatchDivergencePoints(branches)
 ```
 
 When adding new operations that touch multiple branches or refs, prefer designing batch APIs from the start. Use `UpdateRefsBatch` for atomic multi-ref writes and `BatchReadLocalMetadata` / `BatchReadMetadata` for parallel reads.

--- a/.claude/rules/safety-invariants.md
+++ b/.claude/rules/safety-invariants.md
@@ -176,7 +176,7 @@ branchNames := make([]string, len(branches))
 for i, b := range branches {
     branchNames[i] = b.GetName()
 }
-_ = eng.BatchMarkNeedsPRBodyUpdate(branchNames)
+_ = eng.MarkBranchesForPRBodyUpdate(ctx, branchNames)
 if err := pushMetadataOnly(ctx, eng, branchName); err != nil {
     out.Debug("Failed: %v", err)
 }

--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -128,13 +128,21 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	// Get all commit SHAs from downstack branches (newest to oldest)
+	commitsByBranch := eng.BatchCommits(downstackBranches, engine.CommitFormatSHA)
 	commitSHAs := []string{}
 	for _, branch := range downstackBranches {
-		commits, err := branch.GetAllCommits(engine.CommitFormatSHA)
-		if err != nil {
-			return fmt.Errorf("failed to get commits for branch %s: %w", branch.GetName(), err)
+		// BatchCommits returns newest to oldest per branch, matching our search
+		// order. The batch reader swallows errors as nil; absorb must not route
+		// hunks against an incomplete commit list, so re-read any empty non-trunk
+		// branch individually to distinguish "legitimately empty" from "error".
+		commits := commitsByBranch[branch.GetName()]
+		if len(commits) == 0 && !branch.IsTrunk() {
+			var err error
+			commits, err = branch.GetAllCommits(engine.CommitFormatSHA)
+			if err != nil {
+				return fmt.Errorf("failed to get commits for branch %s: %w", branch.GetName(), err)
+			}
 		}
-		// GetAllCommits returns newest to oldest, which matches our search order.
 		commitSHAs = append(commitSHAs, commits...)
 	}
 

--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -133,10 +133,11 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	}
 
 	// Children: rebase onto grandparent (source's old parent)
+	childDivPoints := eng.BatchDivergencePoints(children)
 	for _, child := range children {
 		// Get the old upstream (divergence point)
-		childOldUpstream, divErr := eng.GetDivergencePoint(child.GetName())
-		if divErr != nil {
+		childOldUpstream := childDivPoints[child.GetName()]
+		if childOldUpstream == "" {
 			// Fallback to source revision if unavailable
 			childOldUpstream = sourceRev
 		}

--- a/internal/actions/split/wizard_test.go
+++ b/internal/actions/split/wizard_test.go
@@ -2,6 +2,8 @@ package split
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildTypeChoices(t *testing.T) {
@@ -53,13 +55,9 @@ func TestBuildTypeChoices(t *testing.T) {
 					availableCount, tt.wantAvailableCount)
 			}
 
-			if commitChoice == nil {
-				t.Fatal("buildTypeChoices() missing commit choice")
-			}
-			if commitChoice.Available != tt.wantCommitAvail {
-				t.Errorf("buildTypeChoices() commit.Available = %v, want %v",
-					commitChoice.Available, tt.wantCommitAvail)
-			}
+			require.NotNil(t, commitChoice, "buildTypeChoices() missing commit choice")
+			require.Equal(t, tt.wantCommitAvail, commitChoice.Available,
+				"buildTypeChoices() commit.Available")
 		})
 	}
 }

--- a/internal/actions/track/action.go
+++ b/internal/actions/track/action.go
@@ -167,26 +167,25 @@ func trackBranchRecursively(ctx *app.Context, branchName string, handler Handler
 	allBranches := eng.AllBranches()
 	untrackedChildren := []string{}
 
-	for _, candidateBranch := range allBranches {
-		candidate := candidateBranch.GetName()
-		if candidate == branchName {
-			continue
-		}
+	// branchRev is loop-invariant; a failed lookup just disables child detection.
+	branchRev, revErr := eng.GetRevision(eng.GetBranch(branchName))
+	if revErr == nil {
+		for _, candidateBranch := range allBranches {
+			candidate := candidateBranch.GetName()
+			if candidate == branchName {
+				continue
+			}
 
-		// Check if candidate is a child (has this branch as merge base)
-		mergeBase, err := eng.GetMergeBase(ctx.Context, candidate, branchName)
-		if err != nil {
-			continue
-		}
+			// Check if candidate is a child (has this branch as merge base)
+			mergeBase, err := eng.GetMergeBase(ctx.Context, candidate, branchName)
+			if err != nil {
+				continue
+			}
 
-		branchRev, err := eng.GetRevision(eng.GetBranch(branchName))
-		if err != nil {
-			continue
-		}
-
-		// If merge base is the branch we just tracked, candidate is a child
-		if mergeBase == branchRev && !candidateBranch.IsTracked() {
-			untrackedChildren = append(untrackedChildren, candidate)
+			// If merge base is the branch we just tracked, candidate is a child
+			if mergeBase == branchRev && !candidateBranch.IsTracked() {
+				untrackedChildren = append(untrackedChildren, candidate)
+			}
 		}
 	}
 

--- a/internal/api/handlers/branches.go
+++ b/internal/api/handlers/branches.go
@@ -63,8 +63,12 @@ func (h *BranchesHandler) listBranches(w http.ResponseWriter, r *http.Request, e
 		checksMap, _ = entry.GitHub.BatchGetPRChecksStatus(r.Context(), names)
 	}
 
-	// One remote listing for all branches instead of one per branch.
-	remoteStatuses := entry.Engine.ReadBranchRemoteStatuses(r.Context(), engine.BranchesOf(branches...))
+	// One remote listing, one stats pass, and one commits pass for all
+	// branches instead of one of each per branch.
+	branchSet := engine.BranchesOf(branches...)
+	remoteStatuses := entry.Engine.ReadBranchRemoteStatuses(r.Context(), branchSet)
+	stats := entry.Engine.BatchBranchStats(branchSet)
+	commitsByBranch := entry.Engine.BatchCommits(branchSet, engine.CommitFormatReadableWithDate)
 
 	responses := make([]httpcontract.BranchResponse, 0, len(branches))
 	for _, branch := range branches {
@@ -76,7 +80,7 @@ func (h *BranchesHandler) listBranches(w http.ResponseWriter, r *http.Request, e
 		if checksMap != nil {
 			checks = checksMap[branch.GetName()]
 		}
-		responses = append(responses, httpcontract.MapBranch(entry.Engine, branch, node, checks, remoteStatuses.ForBranch(branch)))
+		responses = append(responses, httpcontract.MapBranch(entry.Engine, branch, node, checks, remoteStatuses.ForBranch(branch), stats[branch.GetName()], commitsByBranch[branch.GetName()]))
 	}
 
 	writeJSON(w, responses)
@@ -104,7 +108,10 @@ func (h *BranchesHandler) getBranch(w http.ResponseWriter, r *http.Request, entr
 		}
 	}
 
-	remoteStatus := entry.Engine.ReadBranchRemoteStatuses(r.Context(), engine.BranchesOf(branch)).ForBranch(branch)
-	resp := httpcontract.MapBranch(entry.Engine, branch, node, checks, remoteStatus)
+	branchSet := engine.BranchesOf(branch)
+	remoteStatus := entry.Engine.ReadBranchRemoteStatuses(r.Context(), branchSet).ForBranch(branch)
+	stat := entry.Engine.BatchBranchStats(branchSet)[branchName]
+	commits := entry.Engine.BatchCommits(branchSet, engine.CommitFormatReadableWithDate)[branchName]
+	resp := httpcontract.MapBranch(entry.Engine, branch, node, checks, remoteStatus, stat, commits)
 	writeJSON(w, resp)
 }

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -12,10 +12,11 @@ import (
 )
 
 // MapBranch converts an engine Branch and its StackNode into an API BranchResponse.
-// remoteStatus should come from a single ReadBranchRemoteStatuses call covering
-// all branches being mapped in the current request, not a per-branch call, since
-// each ReadBranchRemoteStatuses call lists the remote's refs.
-func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.StackNode, checks *github.CheckStatus, remoteStatus engine.BranchRemoteStatus) BranchResponse {
+// remoteStatus, stat, and commits should each come from a single batch call
+// covering all branches being mapped in the current request
+// (ReadBranchRemoteStatuses, BatchBranchStats, BatchCommits), not per-branch
+// calls — per-branch reads spawn a git process per field per branch.
+func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.StackNode, checks *github.CheckStatus, remoteStatus engine.BranchRemoteStatus, stat engine.BranchStat, commits []string) BranchResponse {
 	resp := BranchResponse{
 		Name:         branch.GetName(),
 		Depth:        node.Depth,
@@ -38,9 +39,10 @@ func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.Stack
 		resp.Scope = scope.String()
 	}
 
-	if rev, err := branch.GetRevision(); err == nil {
-		resp.Revision = shortSHA(rev)
-	}
+	resp.Revision = stat.ShortSHA
+	resp.CommitCount = stat.CommitCount
+	resp.LinesAdded = stat.LinesAdded
+	resp.LinesDeleted = stat.LinesDeleted
 
 	if date, err := branch.GetCommitDate(); err == nil {
 		resp.CommitDate = date.Format(time.RFC3339)
@@ -50,17 +52,8 @@ func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.Stack
 		resp.CommitAuthor = author
 	}
 
-	if count, err := branch.GetCommitCount(); err == nil {
-		resp.CommitCount = count
-	}
-
-	if added, deleted, err := branch.GetDiffStats(); err == nil {
-		resp.LinesAdded = added
-		resp.LinesDeleted = deleted
-	}
-
 	// Map commits
-	if commits, err := eng.GetAllCommits(branch, engine.CommitFormatReadableWithDate); err == nil {
+	if len(commits) > 0 {
 		resp.Commits = mapCommitsWithDate(commits)
 	}
 
@@ -161,8 +154,11 @@ func MapStackDetail(ctx context.Context, eng engine.BranchReader, graph *engine.
 		stackBranches = append(stackBranches, node.Branch)
 	}
 
-	// One remote listing for the whole stack instead of one per branch.
+	// One remote listing, one stats pass, and one commits pass for the whole
+	// stack instead of one of each per branch.
 	remoteStatuses := eng.ReadBranchRemoteStatuses(ctx, stackBranches)
+	stats := eng.BatchBranchStats(stackBranches)
+	commitsByBranch := eng.BatchCommits(stackBranches, engine.CommitFormatReadableWithDate)
 
 	branches := make([]BranchResponse, 0, len(nodes))
 	for _, node := range nodes {
@@ -171,7 +167,7 @@ func MapStackDetail(ctx context.Context, eng engine.BranchReader, graph *engine.
 		if checksMap != nil {
 			checks = checksMap[name]
 		}
-		br := MapBranch(eng, node.Branch, node, checks, remoteStatuses.ForBranch(node.Branch))
+		br := MapBranch(eng, node.Branch, node, checks, remoteStatuses.ForBranch(node.Branch), stats[name], commitsByBranch[name])
 		if isAnchor {
 			// Anchor's direct children become display roots
 			if br.Parent == anchorName {

--- a/internal/engine/branch_tracking.go
+++ b/internal/engine/branch_tracking.go
@@ -306,13 +306,17 @@ func (e *engineImpl) ReparentBranches(ctx context.Context, branchNames []string,
 // Automatically propagates each new parent's stack ID when a move crosses a
 // stack boundary.
 func (e *engineImpl) ReparentBranchesToParents(ctx context.Context, moves []BranchParentMove) error {
-	divPoints := make(map[string]string, len(moves))
+	branches := make(Branches, len(moves))
+	for i, m := range moves {
+		branches[i] = e.GetBranch(m.Branch)
+	}
+	divPoints := e.BatchDivergencePoints(branches)
 	for _, m := range moves {
-		div, err := e.GetDivergencePoint(m.Branch)
-		if err != nil {
-			return fmt.Errorf("failed to determine divergence point for %s: %w", m.Branch, err)
+		// The batch reader returns "" where the individual lookup would error;
+		// reparenting must not proceed with an unknown divergence point.
+		if divPoints[m.Branch] == "" {
+			return fmt.Errorf("failed to determine divergence point for %s", m.Branch)
 		}
-		divPoints[m.Branch] = div
 	}
 
 	for _, m := range moves {

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -383,7 +383,7 @@ func (r *runner) ListMetadata() (map[string]string, error) {
 // WriteMetadataBlobsBatch marshals each Meta to JSON and writes all the blobs
 // in one `git hash-object` invocation via CreateBlobsBatch. Returns SHAs in
 // input order. Does NOT update any refs — callers (transaction commit,
-// BatchMarkNeedsPRBodyUpdate) pair the SHAs with ref updates afterwards.
+// MarkBranchesForPRBodyUpdate) pair the SHAs with ref updates afterwards.
 func (r *runner) WriteMetadataBlobsBatch(ctx context.Context, metas []*Meta) ([]string, error) {
 	if len(metas) == 0 {
 		return nil, nil


### PR DESCRIPTION
This PR merges the following changes:

1. **#1405** perf: replace per-branch git reads with batch APIs in reparent, pluck, and absorb
2. **#1406** perf(api): batch per-branch git reads in the branch/stack mappers
3. **#1407** test: use require in split wizard test to fix staticcheck SA5011

### Stack

```
main
  └─ jonnii/20260710115443/replace-per-branch-git-reads-with-batch-APIs-in (#1405)
    └─ jonnii/20260710115736/batch-per-branch-git-reads-in-the-branch/stack (#1406)
      └─ jonnii/20260710115826/use-require-in-split-wizard-test-to-fix (#1407)
```

Stackit-Stack-Size: 3
Stackit-PRs: 1405,1406,1407
