### PR TITLE
refactor(git): move hunk and trunk-history behavior onto types

### DIFF
--- a/internal/actions/absorb/restore.go
+++ b/internal/actions/absorb/restore.go
@@ -170,7 +170,7 @@ func applyModHunksToWorktree(ctx context.Context, eng engine.Engine, out output.
 
 	ok := true
 	for _, file := range order {
-		patch := git.BuildPatchFromHunks(byFile[file])
+		patch := git.Hunks(byFile[file]).Patch()
 		if patch == "" {
 			continue
 		}

--- a/internal/actions/trunklog/trunklog.go
+++ b/internal/actions/trunklog/trunklog.go
@@ -71,7 +71,7 @@ func Gather(ctx context.Context, src CommitSource, titles TitleResolver, req Req
 		return Result{}, err
 	}
 
-	collapsed := git.CollapseStackMerges(raw)
+	collapsed := git.RecentCommits(raw).Collapse()
 	prTitles := resolveTitles(ctx, titles, collapsed)
 
 	result := Result{
@@ -91,7 +91,7 @@ func resolveTitles(ctx context.Context, titles TitleResolver, commits []git.Rece
 	if titles == nil {
 		return nil
 	}
-	prNumbers := git.PRTitleNumbers(commits)
+	prNumbers := git.RecentCommits(commits).PRTitleNumbers()
 	if len(prNumbers) == 0 {
 		return nil
 	}
@@ -109,7 +109,7 @@ func resolveTitles(ctx context.Context, titles TitleResolver, commits []git.Rece
 func toCommit(c git.RecentCommit, prTitles map[int]string) Commit {
 	return Commit{
 		SHA:           c.SHA,
-		Message:       git.CollapsedMessage(c, prTitles),
+		Message:       c.DisplayMessage(prTitles),
 		Author:        c.Author,
 		Date:          c.Date,
 		Kind:          c.Kind,
@@ -117,6 +117,6 @@ func toCommit(c git.RecentCommit, prTitles map[int]string) Commit {
 		StackSize:     c.StackSize,
 		StackPRs:      append([]int(nil), c.StackPRNumbers...),
 		StackScope:    c.StackScope,
-		StackPRTitles: git.ConstituentPRTitles(c, prTitles),
+		StackPRTitles: c.ConstituentPRTitles(prTitles),
 	}
 }

--- a/internal/api/handlers/view_assembler.go
+++ b/internal/api/handlers/view_assembler.go
@@ -121,7 +121,7 @@ func (a *ViewAssembler) fetchPRTitles(ctx context.Context, commits []git.RecentC
 	}
 
 	// PR-number collection is shared with the `stackit log` command via internal/git.
-	prNumbers := git.PRTitleNumbers(commits)
+	prNumbers := git.RecentCommits(commits).PRTitleNumbers()
 	if len(prNumbers) == 0 {
 		return nil
 	}

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -293,7 +293,7 @@ func computeStackStatus(graph *engine.StackGraph, branchNames []string) string {
 func MapTrunkCommits(commits []git.RecentCommit, prTitles map[int]string) []TrunkCommitResponse {
 	// Drop constituent-PR commits already represented by a stack-merge. The
 	// collapse logic is shared with the `stackit log` command via internal/git.
-	collapsed := git.CollapseStackMerges(commits)
+	collapsed := git.RecentCommits(commits).Collapse()
 
 	result := make([]TrunkCommitResponse, 0, len(collapsed))
 	for _, c := range collapsed {
@@ -301,7 +301,7 @@ func MapTrunkCommits(commits []git.RecentCommit, prTitles map[int]string) []Trun
 		// the `stackit log` command via internal/git.
 		resp := TrunkCommitResponse{
 			SHA:           shortSHA(c.SHA),
-			Message:       git.CollapsedMessage(c, prTitles),
+			Message:       c.DisplayMessage(prTitles),
 			Author:        c.Author,
 			Date:          c.Date.Format(time.RFC3339),
 			PRNumber:      c.PRNumber,
@@ -309,7 +309,7 @@ func MapTrunkCommits(commits []git.RecentCommit, prTitles map[int]string) []Trun
 			StackSize:     c.StackSize,
 			StackPRs:      append([]int(nil), c.StackPRNumbers...),
 			StackScope:    c.StackScope,
-			StackPRTitles: git.ConstituentPRTitles(c, prTitles),
+			StackPRTitles: c.ConstituentPRTitles(prTitles),
 		}
 
 		if resp.Kind == "" {

--- a/internal/git/absorb.go
+++ b/internal/git/absorb.go
@@ -12,22 +12,22 @@ type HunkTarget struct {
 	CommitIndex int // Index in the commit list (0 = newest)
 }
 
-// hunkOverlaps checks if two hunks have overlapping line ranges.
+// Overlaps reports whether two hunks have overlapping line ranges.
 // It includes a safety margin to account for git context lines.
-func hunkOverlaps(h1, h2 Hunk) bool {
-	if h1.File != h2.File {
+func (h Hunk) Overlaps(other Hunk) bool {
+	if h.File != other.File {
 		return false
 	}
 
 	// Add safety margin of 3 lines (typical git context) to avoid conflicts
 	margin := 3
 
-	h1Start := h1.OldStart - margin
-	h1End := h1.OldStart + h1.OldCount + margin
-	h2Start := h2.NewStart
-	h2End := h2.NewStart + h2.NewCount
+	hStart := h.OldStart - margin
+	hEnd := h.OldStart + h.OldCount + margin
+	otherStart := other.NewStart
+	otherEnd := other.NewStart + other.NewCount
 
-	overlap := h1Start <= h2End && h2Start <= h1End
+	overlap := hStart <= otherEnd && otherStart <= hEnd
 	return overlap
 }
 

--- a/internal/git/hunk_split.go
+++ b/internal/git/hunk_split.go
@@ -6,12 +6,12 @@ import (
 	"strings"
 )
 
-// CanSplitHunk returns true if the hunk has context lines between changes,
+// CanSplit returns true if the hunk has context lines between changes,
 // meaning it can be split into multiple smaller hunks.
 // A hunk is splittable only when there's at least one context line that separates
 // two distinct groups of changes (additions/deletions).
-func CanSplitHunk(hunk Hunk) bool {
-	lines := strings.Split(hunk.Content, "\n")
+func (h Hunk) CanSplit() bool {
+	lines := strings.Split(h.Content, "\n")
 
 	// Track state: we need to find the pattern:
 	// change(s) -> context(s) -> change(s)
@@ -48,14 +48,14 @@ func CanSplitHunk(hunk Hunk) bool {
 	return false
 }
 
-// SplitHunk divides a hunk at the first context line after changes.
+// Split divides a hunk at the first context line after changes.
 // Returns the split hunks or an error if the hunk cannot be split.
-func SplitHunk(hunk Hunk) ([]Hunk, error) {
-	if !CanSplitHunk(hunk) {
-		return []Hunk{hunk}, nil
+func (h Hunk) Split() (Hunks, error) {
+	if !h.CanSplit() {
+		return Hunks{h}, nil
 	}
 
-	lines := strings.Split(hunk.Content, "\n")
+	lines := strings.Split(h.Content, "\n")
 
 	// Parse original hunk header
 	hunkHeaderRegex := regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$`)
@@ -63,7 +63,7 @@ func SplitHunk(hunk Hunk) ([]Hunk, error) {
 	var headerLine string
 	var headerSuffix string
 	var contentLines []string
-	origOldStart, origNewStart := hunk.OldStart, hunk.NewStart
+	origOldStart, origNewStart := h.OldStart, h.NewStart
 
 	for i, line := range lines {
 		if strings.HasPrefix(line, "@@") {
@@ -78,13 +78,13 @@ func SplitHunk(hunk Hunk) ([]Hunk, error) {
 	}
 
 	if headerLine == "" {
-		return []Hunk{hunk}, nil
+		return Hunks{h}, nil
 	}
 
 	// Find the split point - first context line after changes that has more changes after it
 	splitIndex := findSplitPoint(contentLines)
 	if splitIndex < 0 {
-		return []Hunk{hunk}, nil
+		return Hunks{h}, nil
 	}
 
 	// Split the content
@@ -104,30 +104,30 @@ func SplitHunk(hunk Hunk) ([]Hunk, error) {
 	// Build first hunk
 	firstHeader := fmt.Sprintf("@@ -%d,%d +%d,%d @@%s", firstOldStart, firstOldCount, firstNewStart, firstNewCount, headerSuffix)
 	firstHunk := Hunk{
-		File:      hunk.File,
+		File:      h.File,
 		OldStart:  firstOldStart,
 		OldCount:  firstOldCount,
 		NewStart:  firstNewStart,
 		NewCount:  firstNewCount,
 		Content:   firstHeader + "\n" + strings.Join(firstContent, "\n"),
-		IndexLine: hunk.IndexLine,
+		IndexLine: h.IndexLine,
 	}
 
 	// Build second hunk
 	secondHeader := fmt.Sprintf("@@ -%d,%d +%d,%d @@", secondOldStart, secondOldCount, secondNewStart, secondNewCount)
 	secondHunk := Hunk{
-		File:      hunk.File,
+		File:      h.File,
 		OldStart:  secondOldStart,
 		OldCount:  secondOldCount,
 		NewStart:  secondNewStart,
 		NewCount:  secondNewCount,
 		Content:   secondHeader + "\n" + strings.Join(secondContent, "\n"),
-		IndexLine: hunk.IndexLine,
+		IndexLine: h.IndexLine,
 	}
 
 	// Recursively split if possible
-	moreHunks, _ := SplitHunk(secondHunk)
-	result := make([]Hunk, 0, 1+len(moreHunks))
+	moreHunks, _ := secondHunk.Split()
+	result := make(Hunks, 0, 1+len(moreHunks))
 	result = append(result, firstHunk)
 	result = append(result, moreHunks...)
 
@@ -191,10 +191,10 @@ func countLines(lines []string) (oldCount, newCount int) {
 	return oldCount, newCount
 }
 
-// GetHunkPreview returns a short preview of the hunk content.
+// Preview returns a short preview of the hunk content.
 // maxLines specifies the maximum number of content lines to show.
-func GetHunkPreview(hunk Hunk, maxLines int) (preview string, totalLines int, hasMore bool) {
-	lines := strings.Split(hunk.Content, "\n")
+func (h Hunk) Preview(maxLines int) (preview string, totalLines int, hasMore bool) {
+	lines := strings.Split(h.Content, "\n")
 	contentLines := make([]string, 0, len(lines))
 
 	for _, line := range lines {
@@ -217,14 +217,26 @@ func GetHunkPreview(hunk Hunk, maxLines int) (preview string, totalLines int, ha
 	return strings.Join(contentLines[:maxLines], "\n"), totalLines, true
 }
 
-// GetHunkHeader extracts just the @@ header line from the hunk
-func GetHunkHeader(hunk Hunk) string {
-	lines := strings.SplitSeq(hunk.Content, "\n")
+// Header extracts just the @@ header line from the hunk.
+func (h Hunk) Header() string {
+	lines := strings.SplitSeq(h.Content, "\n")
 	for line := range lines {
 		if strings.HasPrefix(line, "@@") {
 			return line
 		}
 	}
 	// Fallback: generate header from hunk metadata
-	return fmt.Sprintf("@@ -%d,%d +%d,%d @@", hunk.OldStart, hunk.OldCount, hunk.NewStart, hunk.NewCount)
+	return fmt.Sprintf("@@ -%d,%d +%d,%d @@", h.OldStart, h.OldCount, h.NewStart, h.NewCount)
 }
+
+// CanSplitHunk is retained for callers that have not migrated to Hunk.CanSplit.
+func CanSplitHunk(h Hunk) bool { return h.CanSplit() }
+
+// SplitHunk is retained for callers that have not migrated to Hunk.Split.
+func SplitHunk(h Hunk) (Hunks, error) { return h.Split() }
+
+// GetHunkPreview is retained for callers that have not migrated to Hunk.Preview.
+func GetHunkPreview(h Hunk, maxLines int) (string, int, bool) { return h.Preview(maxLines) }
+
+// GetHunkHeader is retained for callers that have not migrated to Hunk.Header.
+func GetHunkHeader(h Hunk) string { return h.Header() }

--- a/internal/git/hunks.go
+++ b/internal/git/hunks.go
@@ -22,13 +22,16 @@ type Hunk struct {
 	FileMode      string // File mode (e.g., "100644", "100755") for new/deleted files
 }
 
+// Hunks is an ordered collection of diff hunks.
+type Hunks []Hunk
+
 // ParseDiffOutput parses a diff output into structured hunks
-func ParseDiffOutput(diffOutput string) ([]Hunk, error) {
+func ParseDiffOutput(diffOutput string) (Hunks, error) {
 	if diffOutput == "" {
-		return []Hunk{}, nil
+		return Hunks{}, nil
 	}
 
-	var hunks []Hunk
+	var hunks Hunks
 	lines := strings.Split(diffOutput, "\n")
 
 	// Regex to match hunk headers: @@ -old_start,old_count +new_start,new_count @@
@@ -184,10 +187,10 @@ func parseInt(s string) int {
 	return result
 }
 
-// BuildPatchFromHunks constructs a unified diff patch from selected hunks.
+// Patch constructs a unified diff patch from the selected hunks.
 // The patch can be applied using git apply --cached to stage specific hunks.
 // Binary files are handled separately as they have a different diff format.
-func BuildPatchFromHunks(hunks []Hunk) string {
+func (hunks Hunks) Patch() string {
 	if len(hunks) == 0 {
 		return ""
 	}
@@ -320,8 +323,8 @@ func GenerateNewFileHunk(filePath string, content []byte) Hunk {
 }
 
 // CountHunkLines returns the number of added and removed lines in a hunk
-func CountHunkLines(hunk Hunk) (added, removed int) {
-	lines := strings.SplitSeq(hunk.Content, "\n")
+func (h Hunk) LineCounts() (added, removed int) {
+	lines := strings.SplitSeq(h.Content, "\n")
 	for line := range lines {
 		if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++") {
 			added++
@@ -331,3 +334,9 @@ func CountHunkLines(hunk Hunk) (added, removed int) {
 	}
 	return added, removed
 }
+
+// BuildPatchFromHunks is retained for callers that have not migrated to Hunks.Patch.
+func BuildPatchFromHunks(hunks []Hunk) string { return Hunks(hunks).Patch() }
+
+// CountHunkLines is retained for callers that have not migrated to Hunk.LineCounts.
+func CountHunkLines(h Hunk) (added, removed int) { return h.LineCounts() }

--- a/internal/git/recent_commits.go
+++ b/internal/git/recent_commits.go
@@ -39,6 +39,9 @@ type RecentCommit struct {
 	StackScope     string           // from Stackit-Scope trailer (empty if absent)
 }
 
+// RecentCommits is an ordered collection of commits returned from git log.
+type RecentCommits []RecentCommit
+
 // commit log field separator used inside a record (never appears in commit
 // metadata when escaped through git's pretty format).
 const commitFieldSep = "\x1f"

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -1235,7 +1235,7 @@ func (r *runner) CheckCommutation(hunk Hunk, commitSHA, parentSHA string) (bool,
 			continue
 		}
 
-		if hunkOverlaps(hunk, commitHunk) {
+		if hunk.Overlaps(commitHunk) {
 			return false, nil
 		}
 	}

--- a/internal/git/staging.go
+++ b/internal/git/staging.go
@@ -144,7 +144,7 @@ func (r *runner) StageHunks(ctx context.Context, hunks []Hunk) error {
 
 	// Handle modifications with existing git apply --cached
 	if len(modHunks) > 0 {
-		patch := BuildPatchFromHunks(modHunks)
+		patch := Hunks(modHunks).Patch()
 		if patch != "" {
 			// Apply the patch to the index using git apply --cached
 			// We use --3way to handle conflicts better
@@ -164,7 +164,7 @@ func (r *runner) StageHunks(ctx context.Context, hunks []Hunk) error {
 						}
 						// Try to apply remaining modifications if any
 						if len(remainingHunks) > 0 {
-							remainingPatch := BuildPatchFromHunks(remainingHunks)
+							remainingPatch := Hunks(remainingHunks).Patch()
 							if remainingPatch != "" {
 								_, retryErr := r.runGitInternal(ctx, remainingPatch, nil, true, "apply", "--cached")
 								if retryErr != nil {
@@ -185,7 +185,7 @@ func (r *runner) StageHunks(ctx context.Context, hunks []Hunk) error {
 
 // stageNewFileHunk handles staging a single new file hunk by writing content to disk and staging it.
 func (r *runner) stageNewFileHunk(ctx context.Context, h Hunk) error {
-	content := extractContentFromHunk(h)
+	content := h.NewFileContent()
 	filePath := filepath.Join(r.getRepoRoot(), h.File)
 
 	// Create parent directories if they don't exist
@@ -270,10 +270,10 @@ func (r *runner) fileExistsInIndex(ctx context.Context, file string) (bool, erro
 	return false, fmt.Errorf("failed to read index for %s: %w", file, err)
 }
 
-// extractContentFromHunk extracts the file content from a new file hunk.
+// NewFileContent extracts the file content from a new file hunk.
 // It parses the unified diff format and returns only the added lines (without the + prefix).
 // Respects the "\ No newline at end of file" marker to preserve files without trailing newlines.
-func extractContentFromHunk(h Hunk) string {
+func (h Hunk) NewFileContent() string {
 	var lines []string
 	hasNoNewlineMarker := false
 	for line := range strings.SplitSeq(h.Content, "\n") {
@@ -298,6 +298,9 @@ func extractContentFromHunk(h Hunk) string {
 	}
 	return result
 }
+
+// extractContentFromHunk is retained for callers that have not migrated to Hunk.NewFileContent.
+func extractContentFromHunk(h Hunk) string { return h.NewFileContent() }
 
 // ApplyPatchToWorktree applies a patch to the working tree only (not the
 // index) by piping it to `git apply` via stdin. Unlike a stash pop, git apply

--- a/internal/git/trunk_collapse.go
+++ b/internal/git/trunk_collapse.go
@@ -1,6 +1,6 @@
 package git
 
-// CollapseStackMerges returns the input commits with constituent-PR commits
+// Collapse returns the commits with constituent-PR commits
 // dropped when their PR number is already represented by a stack-merge
 // consolidation commit in the same slice. Input order is preserved.
 //
@@ -9,7 +9,7 @@ package git
 // Presentation shaping (terminal vs JSX) stays with each caller; the PR-title
 // enrichment they both need lives in PRTitleNumbers / CollapsedMessage /
 // ConstituentPRTitles below.
-func CollapseStackMerges(commits []RecentCommit) []RecentCommit {
+func (commits RecentCommits) Collapse() RecentCommits {
 	// Collect all PR numbers covered by stack-merge consolidation commits.
 	coveredPRs := make(map[int]struct{})
 	for _, c := range commits {
@@ -20,7 +20,7 @@ func CollapseStackMerges(commits []RecentCommit) []RecentCommit {
 		}
 	}
 
-	result := make([]RecentCommit, 0, len(commits))
+	result := make(RecentCommits, 0, len(commits))
 	for _, c := range commits {
 		// Skip commits whose PR is already represented by a stack-merge.
 		if c.PRNumber != 0 && c.StackSize == 0 {
@@ -39,7 +39,7 @@ func CollapseStackMerges(commits []RecentCommit) []RecentCommit {
 // title is never displayed — so callers don't over-fetch. Order is first-seen
 // stable. Safe to call on either the raw or the collapsed slice: collapse only
 // drops covered regular commits, never stack-merges, so both yield the same set.
-func PRTitleNumbers(commits []RecentCommit) []int {
+func (commits RecentCommits) PRTitleNumbers() []int {
 	seen := make(map[int]struct{})
 	var nums []int
 	add := func(n int) {
@@ -64,11 +64,11 @@ func PRTitleNumbers(commits []RecentCommit) []int {
 	return nums
 }
 
-// CollapsedMessage returns the display message for a commit: a stack-merge uses
+// DisplayMessage returns the display message for a commit: a stack-merge uses
 // its consolidation PR's title when available, replacing the raw
 // "Merge pull request #N from ..." subject; everything else falls back to the
 // commit subject.
-func CollapsedMessage(c RecentCommit, prTitles map[int]string) string {
+func (c RecentCommit) DisplayMessage(prTitles map[int]string) string {
 	if c.StackSize > 0 && c.PRNumber != 0 && len(prTitles) > 0 {
 		if title, ok := prTitles[c.PRNumber]; ok {
 			return title
@@ -80,7 +80,7 @@ func CollapsedMessage(c RecentCommit, prTitles map[int]string) string {
 // ConstituentPRTitles returns the subset of prTitles keyed by a stack-merge's
 // constituent PR numbers, or nil when the commit is not a stack-merge or no
 // titles apply.
-func ConstituentPRTitles(c RecentCommit, prTitles map[int]string) map[int]string {
+func (c RecentCommit) ConstituentPRTitles(prTitles map[int]string) map[int]string {
 	if c.StackSize == 0 || len(prTitles) == 0 {
 		return nil
 	}
@@ -94,4 +94,22 @@ func ConstituentPRTitles(c RecentCommit, prTitles map[int]string) map[int]string
 		return nil
 	}
 	return titles
+}
+
+// CollapseStackMerges is retained for callers that have not migrated to RecentCommits.Collapse.
+func CollapseStackMerges(commits []RecentCommit) RecentCommits {
+	return RecentCommits(commits).Collapse()
+}
+
+// PRTitleNumbers is retained for callers that have not migrated to RecentCommits.PRTitleNumbers.
+func PRTitleNumbers(commits []RecentCommit) []int { return RecentCommits(commits).PRTitleNumbers() }
+
+// CollapsedMessage is retained for callers that have not migrated to RecentCommit.DisplayMessage.
+func CollapsedMessage(c RecentCommit, prTitles map[int]string) string {
+	return c.DisplayMessage(prTitles)
+}
+
+// ConstituentPRTitles is retained for callers that have not migrated to RecentCommit.ConstituentPRTitles.
+func ConstituentPRTitles(c RecentCommit, prTitles map[int]string) map[int]string {
+	return c.ConstituentPRTitles(prTitles)
 }

--- a/internal/tui/hunk_selector.go
+++ b/internal/tui/hunk_selector.go
@@ -145,7 +145,7 @@ func NewHunkSelectorModel(hunks []git.Hunk) *HunkSelectorModel {
 			Hunk:       h,
 			Selected:   false,
 			Expanded:   false,
-			Splittable: !h.Binary && git.CanSplitHunk(h),
+			Splittable: !h.Binary && h.CanSplit(),
 		}
 		if _, exists := fileMap[h.File]; !exists {
 			fileOrder = append(fileOrder, h.File)
@@ -319,7 +319,7 @@ func (m *HunkSelectorModel) renderHeader() string {
 	for _, item := range m.items {
 		if item.Selected {
 			selected++
-			added, removed := git.CountHunkLines(item.Hunk)
+			added, removed := item.Hunk.LineCounts()
 			totalAdded += added
 			totalRemoved += removed
 		}
@@ -393,8 +393,8 @@ func (m *HunkSelectorModel) updateViewportContent() {
 			}
 
 			// Hunk header line
-			header := git.GetHunkHeader(item.Hunk)
-			added, removed := git.CountHunkLines(item.Hunk)
+			header := item.Hunk.Header()
+			added, removed := item.Hunk.LineCounts()
 
 			headerText := fmt.Sprintf("%s +%d -%d", header, added, removed)
 			if item.Splittable {
@@ -409,10 +409,10 @@ func (m *HunkSelectorModel) updateViewportContent() {
 
 			// Show preview for current hunk or expanded hunks
 			if isCursor || item.Expanded {
-				preview, totalLines, hasMore := git.GetHunkPreview(item.Hunk, m.previewLines)
+				preview, totalLines, hasMore := item.Hunk.Preview(m.previewLines)
 				if item.Expanded {
 					// Show full content
-					preview, _, _ = git.GetHunkPreview(item.Hunk, totalLines)
+					preview, _, _ = item.Hunk.Preview(totalLines)
 				}
 
 				// Render diff lines with colors
@@ -476,7 +476,7 @@ func (m *HunkSelectorModel) ensureCursorVisible() {
 				if item.Hunk.Binary {
 					continue
 				}
-				_, totalLines, _ := git.GetHunkPreview(item.Hunk, m.previewLines)
+				_, totalLines, _ := item.Hunk.Preview(m.previewLines)
 				if item.Expanded {
 					linePos += totalLines
 				} else {
@@ -504,7 +504,7 @@ func (m *HunkSelectorModel) splitCurrentHunk() {
 		return
 	}
 
-	splitHunks, err := git.SplitHunk(item.Hunk)
+	splitHunks, err := item.Hunk.Split()
 	if err != nil || len(splitHunks) <= 1 {
 		return
 	}
@@ -518,7 +518,7 @@ func (m *HunkSelectorModel) splitCurrentHunk() {
 			Hunk:       h,
 			Selected:   item.Selected, // Preserve selection state
 			Expanded:   false,
-			Splittable: git.CanSplitHunk(h),
+			Splittable: h.CanSplit(),
 		})
 	}
 
@@ -604,7 +604,7 @@ func (m *HunkSelectorModel) SetHunks(hunks []git.Hunk) {
 			Hunk:       h,
 			Selected:   false,
 			Expanded:   false,
-			Splittable: !h.Binary && git.CanSplitHunk(h),
+			Splittable: !h.Binary && h.CanSplit(),
 		}
 		if _, exists := fileMap[h.File]; !exists {
 			fileOrder = append(fileOrder, h.File)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1783773622`.


* **PR #1410**
  * **PR #1411** 👈
    * **PR #1412**
      * **PR #1413**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1415 by jonnii*