### PR TITLE
feat: make submit output outcome-focused

### DIFF
--- a/apps/st-tui/main.go
+++ b/apps/st-tui/main.go
@@ -60,7 +60,7 @@ func runSubmitScenario(out output.Output, name string, delay time.Duration) {
 		printUsage(os.Stderr)
 		os.Exit(2)
 	}
-	runner, handler := stack.NewSubmitUI(out, output.NewNullLogger())
+	runner, handler := stack.NewSubmitUI(out, output.NewNullLogger(), false)
 	if runner != nil {
 		defer runner.Cleanup()
 	}

--- a/internal/cli/stack/submit.go
+++ b/internal/cli/stack/submit.go
@@ -45,6 +45,7 @@ type submitFlags struct {
 	noLabels             bool
 	noAssignees          bool
 	jsonOutput           bool
+	verbose              bool
 }
 
 func addSubmitFlags(cmd *cobra.Command, f *submitFlags) {
@@ -77,6 +78,7 @@ func addSubmitFlags(cmd *cobra.Command, f *submitFlags) {
 	cmd.Flags().BoolVar(&f.noLabels, "no-labels", false, "Don't apply default labels from config.")
 	cmd.Flags().BoolVar(&f.noAssignees, "no-assignees", false, "Don't apply default assignees from config.")
 	cmd.Flags().BoolVar(&f.jsonOutput, "json", false, "Output the plan and per-branch results as JSON.")
+	cmd.Flags().BoolVar(&f.verbose, "verbose", false, "Show the full branch-by-branch submission plan and results.")
 }
 
 func executeSubmit(cmd *cobra.Command, f *submitFlags) error {
@@ -155,7 +157,8 @@ func executeSubmit(cmd *cobra.Command, f *submitFlags) error {
 		// Action is the single source of truth for what to submit. The runner
 		// starts lazily (when the submission phase begins), so calling Action
 		// unconditionally no longer flashes the TUI when there's nothing to do.
-		runner, handler := NewSubmitUI(ctx.Output, ctx.Logger)
+		// A dry run's whole output IS the plan, so it always prints verbose.
+		runner, handler := NewSubmitUI(ctx.Output, ctx.Logger, f.verbose || f.dryRun)
 		defer runner.Cleanup()
 		return submit.Action(ctx, opts, handler)
 	})

--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -18,17 +18,18 @@ import (
 // NewSubmitUI creates a runner and handler pair for submit operations.
 // The runner manages terminal state; the handler processes events.
 // Caller must defer runner.Cleanup() to restore terminal on exit.
-func NewSubmitUI(out output.Output, logger output.Logger) (*tui.Runner, submit.Handler) {
+func NewSubmitUI(out output.Output, logger output.Logger, verbose bool) (*tui.Runner, submit.Handler) {
 	if tui.IsTTY() {
 		model := submitComponent.NewModel(nil)
+		model.Verbose = verbose
 		runner := tui.NewRunner(model, out, logger)
 		// Start lazily when the submission phase begins rather than here: the
 		// stack and plan print as plain lines, so a submit that turns out to
 		// have nothing to do never flashes the bubbletea startup/teardown
 		// sequence. See InteractiveSubmitHandler.OnEvent.
-		return runner, NewInteractiveSubmitHandler(runner, model, out)
+		return runner, NewInteractiveSubmitHandler(runner, model, out, verbose)
 	}
-	return nil, NewSimpleSubmitHandler(out)
+	return nil, NewSimpleSubmitHandler(out, verbose)
 }
 
 // maxNamedSkipGroup is the largest skipped-branch group that still lists its
@@ -41,6 +42,7 @@ const maxNamedSkipGroup = 3
 // the stack header and aligned columns.
 type planPrinter struct {
 	out       output.Output
+	verbose   bool
 	scopes    map[string]string
 	worktrees map[string]string
 	parents   map[string]string
@@ -96,6 +98,12 @@ func (p *planPrinter) Flush() {
 		return
 	}
 	p.printed = true
+	if !p.verbose {
+		if summary := p.compactSummary(); summary != "" {
+			p.out.Info("● %s", summary)
+		}
+		return
+	}
 
 	if p.solo {
 		p.printSoloLine(p.events[0])
@@ -126,6 +134,36 @@ func (p *planPrinter) Flush() {
 			p.printSkippedName(ev)
 		}
 	}
+}
+
+// compactSummary describes only the work that submit will perform. The
+// default submit output is an action summary, not a stack visualization; the
+// full branch-by-branch plan is available with --verbose.
+func (p *planPrinter) compactSummary() string {
+	var creates, updates int
+	for _, ev := range p.events {
+		if ev.Skipped {
+			continue
+		}
+		switch ev.Action {
+		case engine.SubmitActionCreate:
+			creates++
+		case engine.SubmitActionUpdate:
+			updates++
+		}
+	}
+
+	parts := make([]string, 0, 2)
+	if creates > 0 {
+		parts = append(parts, fmt.Sprintf("open %d %s", creates, pluralizePRs(creates)))
+	}
+	if updates > 0 {
+		parts = append(parts, fmt.Sprintf("update %d %s", updates, pluralizePRs(updates)))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "Will " + strings.Join(parts, " · ")
 }
 
 func (p *planPrinter) printActiveLine(ev submit.BranchPlanEvent) {
@@ -294,10 +332,16 @@ type branchItem struct {
 }
 
 // NewSimpleSubmitHandler creates a new simple submit handler
-func NewSimpleSubmitHandler(out output.Output) *SimpleSubmitHandler {
+func NewSimpleSubmitHandler(out output.Output, verbose ...bool) *SimpleSubmitHandler {
+	// Keep direct constructor callers (notably renderer tests and the TUI lab)
+	// detailed by default. The command always passes its explicit mode.
+	showVerbose := true
+	if len(verbose) > 0 {
+		showVerbose = verbose[0]
+	}
 	return &SimpleSubmitHandler{
 		BaseHandler: common.NewBaseHandler(out),
-		plan:        planPrinter{out: out},
+		plan:        planPrinter{out: out, verbose: showVerbose},
 		items:       make(map[string]*branchItem),
 	}
 }
@@ -339,11 +383,13 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 			}
 			h.order = append(h.order, branch.Name)
 		}
-		h.Output.Newline()
-		// A solo branch was already named in the plan line; the count header
-		// would just restate it.
-		if !h.plan.solo {
-			h.Output.Info("Submitting %d %s", len(ev.Branches), pluralizeBranches(len(ev.Branches)))
+		if h.plan.verbose {
+			h.Output.Newline()
+			if !h.plan.solo {
+				h.Output.Info("Submitting %d %s", len(ev.Branches), pluralizeBranches(len(ev.Branches)))
+			}
+		} else {
+			h.Output.Info("Submitting %d %s...", len(ev.Branches), pluralizePRs(len(ev.Branches)))
 		}
 
 	case submit.BranchProgressEvent:
@@ -374,8 +420,13 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 				return
 			}
 			item.reportedDone = true
-			// A solo branch reports its result in the completion summary
-			// (ref + URL together); a per-branch line here would duplicate it.
+			// Default output reports one final result rather than a noisy row per
+			// branch. Verbose mode retains the per-branch audit trail.
+			if !h.plan.verbose && !h.plan.solo {
+				return
+			}
+			// A solo branch reports its result in the completion summary (ref +
+			// URL together); a per-branch line here would duplicate it.
 			if h.plan.solo {
 				return
 			}
@@ -409,6 +460,12 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 		h.plan.Flush()
 		switch ev.Outcome {
 		case submit.OutcomeComplete:
+			if !h.plan.verbose {
+				if summary := submitComponent.FormatOutcomeSummary(h.submitItems(), ev.Duration); summary != "" {
+					h.Output.Info("%s", summary)
+				}
+				return
+			}
 			if summary := h.completionSummary(); summary != "" {
 				h.Output.Newline()
 				h.Output.Info("%s", summary)
@@ -429,7 +486,9 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 		default:
 			// Dry run, all up to date, canceled, nothing to submit: print the
 			// outcome so the run doesn't end silently.
-			if ev.Message != "" {
+			if ev.Outcome == submit.OutcomeUpToDate && !h.plan.verbose {
+				h.Output.Info("✓ Nothing to submit")
+			} else if ev.Message != "" {
 				h.Output.Info("%s", ev.Message)
 			}
 		}
@@ -484,6 +543,13 @@ func (i *branchItem) toSubmitItem() submitComponent.Item {
 	}
 }
 
+func pluralizePRs(count int) string {
+	if count == 1 {
+		return "PR"
+	}
+	return "PRs"
+}
+
 func pluralizeBranches(count int) string {
 	if count == 1 {
 		return "branch"
@@ -507,8 +573,12 @@ type InteractiveSubmitHandler struct {
 }
 
 // NewInteractiveSubmitHandler creates a new interactive submit handler
-func NewInteractiveSubmitHandler(runner *tui.Runner, model *submitComponent.Model, out output.Output) *InteractiveSubmitHandler {
-	return &InteractiveSubmitHandler{runner: runner, model: model, out: out, plan: planPrinter{out: out}}
+func NewInteractiveSubmitHandler(runner *tui.Runner, model *submitComponent.Model, out output.Output, verbose ...bool) *InteractiveSubmitHandler {
+	showVerbose := true
+	if len(verbose) > 0 {
+		showVerbose = verbose[0]
+	}
+	return &InteractiveSubmitHandler{runner: runner, model: model, out: out, plan: planPrinter{out: out, verbose: showVerbose}}
 }
 
 // OnEvent handles events from the submit action
@@ -549,9 +619,9 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 			}
 		}
 		h.model.Items = items
-		// The plan already named a solo branch and printed its base, so the TUI
-		// drops the count header and the per-row branch name.
-		h.model.Solo = h.plan.solo
+		// Verbose mode retains the traditional solo plan line; default mode is
+		// self-contained and keeps the branch name in its progress row.
+		h.model.Solo = h.plan.verbose && h.plan.solo
 
 		// Start the TUI now that there's real submission work to animate.
 		// Idempotent, so later events that arrive after this are safe.
@@ -590,7 +660,9 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 				printOnTrunkGuidance(h.out, ev.Message)
 				return
 			}
-			if ev.Outcome != submit.OutcomeFailed && ev.Message != "" {
+			if ev.Outcome == submit.OutcomeUpToDate && !h.plan.verbose {
+				h.out.Info("✓ Nothing to submit")
+			} else if ev.Outcome != submit.OutcomeFailed && ev.Message != "" {
 				h.out.Info("%s", ev.Message)
 			}
 			return

--- a/internal/cli/stack/submit_test.go
+++ b/internal/cli/stack/submit_test.go
@@ -33,8 +33,8 @@ func TestSubmitCommand(t *testing.T) {
 			return s.Repo.CheckoutBranch("branch-b")
 		})
 
-		// 1. Basic submit (downstack)
-		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--dry-run", "--no-edit", "--draft", "--no-interactive")
+		// 1. Basic submit (downstack). A dry run's whole output is the plan,
+		// so it always prints the detailed branch plan; --verbose is a no-op.
 		expected := testhelpers.NormalizeOutput(`
 Submit plan → main
 Will submit (2)
@@ -42,6 +42,10 @@ Will submit (2)
 ● branch-b → create (empty)
 Dry run complete
 `)
+		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--dry-run", "--no-edit", "--draft", "--no-interactive")
+		require.Equal(t, expected, testhelpers.NormalizeOutput(output))
+
+		output = runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--dry-run", "--no-edit", "--draft", "--no-interactive", "--verbose")
 		require.Equal(t, expected, testhelpers.NormalizeOutput(output))
 
 		// 2. Submit --stack (full stack)
@@ -99,12 +103,7 @@ Dry run complete
 
 		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "ss", "--no-edit", "--no-interactive")
 		expected := testhelpers.NormalizeOutput(`
-Submit plan → main
-No changes (3)
-  branch-a
-● branch-b
-  branch-c
-All PRs up to date
+✓ Nothing to submit
 `)
 		require.Equal(t, expected, testhelpers.NormalizeOutput(output))
 	})

--- a/internal/tui/components/submit/format.go
+++ b/internal/tui/components/submit/format.go
@@ -333,6 +333,57 @@ func FormatClosingSummary(items []Item, skipped int, elapsed time.Duration) stri
 	return line
 }
 
+// FormatOutcomeSummary renders the compact completion message used by the
+// normal submit experience. It deliberately omits unchanged branches and the
+// per-branch audit trail; --verbose retains those details.
+func FormatOutcomeSummary(items []Item, elapsed time.Duration) string {
+	var created, updated, failed int
+	for _, item := range items {
+		switch {
+		case item.Status == StatusError:
+			failed++
+		case item.Status == StatusDone && item.Action == ActionCreate:
+			created++
+		case item.Status == StatusDone && item.Action == ActionUpdate:
+			updated++
+		}
+	}
+
+	parts := make([]string, 0, 3)
+	if created > 0 {
+		parts = append(parts, fmt.Sprintf("opened %d %s", created, pluralPR(created)))
+	}
+	if updated > 0 {
+		parts = append(parts, fmt.Sprintf("updated %d %s", updated, pluralPR(updated)))
+	}
+	if failed > 0 {
+		parts = append(parts, fmt.Sprintf("%d %s failed", failed, pluralPR(failed)))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+
+	icon := "✓"
+	if failed > 0 {
+		icon = "✗"
+	}
+	line := icon + " " + strings.ToUpper(parts[0][:1]) + parts[0][1:]
+	if len(parts) > 1 {
+		line += " · " + strings.Join(parts[1:], " · ")
+	}
+	if elapsed > 0 {
+		line += " (" + formatElapsed(elapsed) + ")"
+	}
+	return line
+}
+
+func pluralPR(count int) string {
+	if count == 1 {
+		return "PR"
+	}
+	return "PRs"
+}
+
 // formatElapsed renders a duration compactly: "6.2s" under a minute, "1m23s" above.
 func formatElapsed(d time.Duration) string {
 	if d < time.Minute {

--- a/internal/tui/components/submit/format_test.go
+++ b/internal/tui/components/submit/format_test.go
@@ -194,6 +194,21 @@ func TestFormatClosingSummary(t *testing.T) {
 	require.Empty(t, FormatClosingSummary(nil, 0, time.Second))
 }
 
+func TestFormatOutcomeSummary(t *testing.T) {
+	t.Parallel()
+
+	items := []Item{
+		{BranchName: "a", Action: ActionCreate, Status: StatusDone},
+		{BranchName: "b", Action: ActionUpdate, Status: StatusDone},
+		{BranchName: "c", Action: ActionUpdate, Status: StatusError, Error: errors.New("boom")},
+	}
+
+	require.Equal(t,
+		"✗ Opened 1 PR · updated 1 PR · 1 PR failed (6.2s)",
+		FormatOutcomeSummary(items, 6200*time.Millisecond))
+	require.Empty(t, FormatOutcomeSummary(nil, time.Second))
+}
+
 func TestFormatFailureSummaryWithoutErrorDetail(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -19,6 +19,7 @@ type Model struct {
 	Items          []Item
 	Warnings       []string      // formatted warning lines, rendered after the rows and persisted on exit
 	Solo           bool          // single-branch submit — drop the count header and per-row name
+	Verbose        bool          // retain the detailed final per-branch result list
 	spinner        spinner.Model // lowercase for custom style
 	Styles         Styles
 }
@@ -52,6 +53,7 @@ func NewModel(items []Item) *Model {
 
 	return &Model{
 		Items:   items,
+		Verbose: true,
 		spinner: s,
 		Styles:  DefaultStyles(),
 	}
@@ -102,9 +104,18 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ProgressCompleteMsg:
 		m.Done = true
 		summary := m.completionSummary()
+		if !m.Verbose {
+			summary = FormatOutcomeSummary(m.Items, msg.Elapsed)
+			if failures := FormatFailureSummary(m.Items); failures != "" {
+				if summary != "" {
+					summary += "\n\n"
+				}
+				summary += failures
+			}
+		}
 		// The solo summary already names the single result; a count line would
 		// just restate it.
-		if !m.Solo && summary != "" {
+		if m.Verbose && !m.Solo && summary != "" {
 			if closing := FormatClosingSummary(m.Items, msg.Skipped, msg.Elapsed); closing != "" {
 				summary += "\n\n" + closing
 			}
@@ -170,7 +181,8 @@ func (m *Model) content() string {
 // screen clear.
 func (m *Model) completionSummary() string {
 	var summary string
-	if m.Solo {
+	switch {
+	case m.Verbose && m.Solo:
 		summary = FormatSoloSummary(m.Items)
 		if failures := FormatFailureSummary(m.Items); failures != "" {
 			if summary != "" {
@@ -178,8 +190,10 @@ func (m *Model) completionSummary() string {
 			}
 			summary += failures
 		}
-	} else {
+	case m.Verbose:
 		summary = FormatFinalList(m.Items)
+	default:
+		summary = FormatOutcomeSummary(m.Items, 0)
 	}
 	if summary == "" {
 		return m.content()
@@ -200,7 +214,10 @@ func (m *Model) header() string {
 	if count == 0 {
 		return ""
 	}
-	return fmt.Sprintf("Submitting %d %s", count, pluralBranch(count))
+	if m.Verbose {
+		return fmt.Sprintf("Submitting %d %s", count, pluralBranch(count))
+	}
+	return fmt.Sprintf("Submitting %d %s", count, pluralPR(count))
 }
 
 func pluralBranch(count int) string {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1784862381`.


* **PR #1416**
  * **PR #1417**
    * **PR #1418**
      * **PR #1419** 👈
        * **PR #1420**
          * **PR #1443**
            * **PR #1445**
              * **PR #1446**
                * **PR #1447**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1448 by jonnii*