### PR TITLE
perf: batch revision reads in validateBranchAncestry

### DIFF
--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -492,6 +492,24 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 // Returns an error if any branch has invalid parent relationships.
 // Note: Missing parents are tolerated as buildRebaseSpecs will handle auto-reparenting.
 func validateBranchAncestry(ctx *app.Context, branches engine.Branches) error {
+	// Resolve every branch and parent revision in one batched call instead of
+	// a git rev-parse per branch (and per parent).
+	names := make(map[string]struct{}, len(branches)*2)
+	for _, branch := range branches {
+		if branch.IsTrunk() {
+			continue
+		}
+		names[branch.GetName()] = struct{}{}
+		if parent := branch.GetParent(); parent != nil {
+			names[parent.GetName()] = struct{}{}
+		}
+	}
+	revNames := make([]string, 0, len(names))
+	for name := range names {
+		revNames = append(revNames, name)
+	}
+	revisions, _ := ctx.Engine.GetRevisions(revNames)
+
 	for _, branch := range branches {
 		branchName := branch.GetName()
 
@@ -501,9 +519,9 @@ func validateBranchAncestry(ctx *app.Context, branches engine.Branches) error {
 		}
 
 		// Verify branch itself exists
-		branchRev, err := branch.GetRevision()
-		if err != nil {
-			return fmt.Errorf("branch %s cannot be resolved: %w", branchName, err)
+		branchRev, ok := revisions.Rev(branchName)
+		if !ok {
+			return fmt.Errorf("branch %s cannot be resolved", branchName)
 		}
 
 		// If branch has a parent, validate it only if it exists
@@ -511,15 +529,15 @@ func validateBranchAncestry(ctx *app.Context, branches engine.Branches) error {
 		parent := branch.GetParent()
 		if parent != nil {
 			parentName := parent.GetName()
-			parentRev, err := parent.GetRevision()
-			if err != nil {
+			parentRev, ok := revisions.Rev(parentName)
+			if !ok {
 				// Parent doesn't exist - this is OK, auto-reparenting will handle it
 				ctx.Logger.Debug("parent branch missing, will auto-reparent branch=%v parent=%v", branchName, parentName)
 				continue
 			}
 
 			// Parent exists - verify they have a common ancestor
-			_, err = ctx.Engine.GetMergeBase(ctx.Context, parentRev, branchRev)
+			_, err := ctx.Engine.GetMergeBase(ctx.Context, parentRev, branchRev)
 			if err != nil {
 				return fmt.Errorf("branch %s and parent %s have no common ancestor: %w",
 					branchName, parentName, err)


### PR DESCRIPTION
## Summary

- `validateBranchAncestry` (run as a preflight check on every `restack`/`sync`/`modify`) resolved each branch's and its parent's revision with a separate `git rev-parse` subprocess per branch, doubling the git-process count before any actual restack work started.
- This is the exact N+1 anti-pattern documented in `.claude/rules/code-style.md` ("Batch Operations (N+1 Prevention)") — and it's already called out as unaddressed in `docs/plans/perf/restack.md` / `docs/plans/perf/modify.md` ("~3 git ops per branch... no revision cache").
- Replaced the per-branch `branch.GetRevision()` / `parent.GetRevision()` calls with a single upfront `ctx.Engine.GetRevisions(...)` batch call (the same batched API already used in `internal/actions/submit/planning.go`), so the whole preflight check now does one `git rev-parse` invocation regardless of stack size.
- Behavior is unchanged: a missing branch revision still errors, a missing parent still logs and falls through to auto-reparenting, and the merge-base check for existing parents is untouched.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/actions/...` (all packages pass)
- [x] `go vet ./internal/actions/...` / `gofmt -l` clean
- [x] `go test ./internal/integration/... -run 'Restack|Sync|Modify'` — covers all three GitHub merge methods (merge commit, squash, rebase) for restack/sync/modify flows


---
_Generated by [Claude Code](https://claude.ai/code/session_01JaPWhNu2Gu45M8pxoVyzK2)_