### PR TITLE
perf(tui): batch restack-status checks in tree renderer and checkout prompt

### DIFF
--- a/internal/tui/prompts.go
+++ b/internal/tui/prompts.go
@@ -754,6 +754,10 @@ func PromptBranchCheckout(branches []engine.Branch, eng engine.BranchReader) (st
 	}
 	renderer.SetAnnotations(annotations)
 
+	// Resolve restack status for all branches in one batched parent-revision
+	// read instead of a per-branch IsUpToDate() call in the loop below.
+	statuses := eng.ReadBranchStatuses(engine.Branches(branches))
+
 	// Build StackGraph for efficient traversals
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
 
@@ -801,7 +805,7 @@ func PromptBranchCheckout(branches []engine.Branch, eng engine.BranchReader) (st
 		coloredBranchName += renderer.FormatAnnotationColored(annotation)
 
 		// Add restack indicator if needed
-		if !eng.IsUpToDate(branch) {
+		if !statuses.IsUpToDate(branch) {
 			coloredBranchName += " " + style.ColorNeedsRestack(tree.RestackSuggestedLabel)
 		}
 

--- a/internal/tui/tree_renderer.go
+++ b/internal/tui/tree_renderer.go
@@ -36,7 +36,7 @@ func NewStackTreeRendererWithOptions(eng engine.BranchReader, strategy engine.So
 // This decouples the tree renderer from the engine package.
 type graphData struct {
 	graph            *engine.StackGraph
-	eng              engine.BranchReader
+	statuses         engine.BranchStatuses
 	visibleAnchors   map[string]bool
 	flattenedChildOf map[string][]string
 }
@@ -114,11 +114,10 @@ func (d *graphData) IsTrunk(branchName string) bool {
 
 // IsFixed returns whether the branch is up-to-date with its parent.
 func (d *graphData) IsFixed(branchName string) bool {
-	node := d.graph.GetNode(branchName)
-	if node == nil {
+	if d.graph.GetNode(branchName) == nil {
 		return false
 	}
-	return d.eng.IsUpToDate(node.Branch)
+	return d.statuses.IsUpToDateByName(branchName)
 }
 
 func (d *graphData) isHiddenAnchor(branchName string) bool {
@@ -167,10 +166,15 @@ func newStackTreeRendererInternal(eng engine.BranchReader, strategy engine.SortS
 
 	graph := engine.BuildStackGraph(eng, strategy, branchFilter)
 
+	// Resolve restack status for every branch in one batched parent-revision
+	// read instead of a per-branch IsUpToDate() call during tree traversal
+	// (each of which would shell a separate `git rev-parse` for the parent).
+	statuses := eng.ReadBranchStatuses(eng.AllBranches())
+
 	// Use the Data interface instead of callback functions
 	data := &graphData{
 		graph:            graph,
-		eng:              eng,
+		statuses:         statuses,
 		visibleAnchors:   emptyWorktrees,
 		flattenedChildOf: make(map[string][]string),
 	}


### PR DESCRIPTION
## Summary

- `newStackTreeRendererInternal` (`internal/tui/tree_renderer.go`) called `eng.IsUpToDate(branch)` once per visible branch during every tree render, each call shelling a separate `git rev-parse` to resolve the parent revision.
- `PromptBranchCheckout` (`internal/tui/prompts.go`) had the identical pattern in its branch-choice loop, right next to a `BatchBranchStats` call that already batches correctly.
- Both are fixed by resolving restack status for the whole branch set up front via the existing `engine.ReadBranchStatuses` batch API (already used by `stack_info`, `checkout`, and `submit`) and looking up results by name/branch during the loop instead of hitting the engine per branch.

This matches the "Batch Operations (N+1 Prevention)" rule in `.claude/rules/code-style.md` — `GetRevision` in a loop should use `GetRevisions`/`ReadBranchStatuses` instead. `StackGraph`'s own doc comment also states it's meant to be used "for traversals/rendering without further engine calls," which the per-branch `IsUpToDate` call was violating.

No behavior change: `ReadBranchStatuses` computes the same up-to-date semantics per branch, just resolved together in one batched parent-revision read.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/tui/...`
- [x] `gofmt -l` on changed files (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HGGsVr1e2fx15VSkQp9W66)_