### PR TITLE
perf: batch up-to-date checks instead of per-branch git calls

### DIFF
--- a/internal/actions/debug.go
+++ b/internal/actions/debug.go
@@ -136,6 +136,7 @@ func DebugAction(ctx *app.Context, opts DebugOptions) error {
 	branchNames := allBranches.Names()
 	allMeta, _ := eng.BatchReadMetadataRaw(branchNames)
 	revisions, _ := eng.GetRevisions(branchNames)
+	statuses := eng.ReadBranchStatuses(allBranches)
 
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
 	branchInfos := make([]BranchInfo, 0, len(allBranches))
@@ -181,11 +182,7 @@ func DebugAction(ctx *app.Context, opts DebugOptions) error {
 			branchInfo.MetadataRefSHA = metadataSHA
 		}
 
-		if !branchInfo.IsTrunk {
-			branchInfo.IsFixed = branchObj.IsBranchUpToDate()
-		} else {
-			branchInfo.IsFixed = true
-		}
+		branchInfo.IsFixed = statuses.IsUpToDate(branch)
 
 		branchInfos = append(branchInfos, branchInfo)
 	}

--- a/internal/actions/tree.go
+++ b/internal/actions/tree.go
@@ -366,9 +366,12 @@ func BuildTreeJSON(ctx *app.Context, opts TreeOptions) TreeJSONResult {
 	}
 	processableBranches := processable.Build()
 
-	// Resolve commit count and diff stats for all processable branches as one
-	// batched value, read in the loop below.
+	// Resolve commit count, diff stats, and up-to-date status for all
+	// processable branches as batched values, read in the loop below, instead
+	// of a per-branch IsBranchUpToDate() inside each worker (each of which
+	// would shell a separate `git rev-parse` for the parent).
 	stats := eng.BatchBranchStats(processableBranches)
+	statuses := eng.ReadBranchStatuses(processableBranches)
 
 	if len(processableBranches) > 0 {
 		utils.Run(processableBranches.All(), func(branch engine.Branch) {
@@ -380,7 +383,7 @@ func BuildTreeJSON(ctx *app.Context, opts TreeOptions) TreeJSONResult {
 				IsTrunk:      branch.IsTrunk(),
 				IsLocked:     branch.IsLocked(),
 				IsFrozen:     branch.IsFrozen(),
-				NeedsRestack: !branch.IsBranchUpToDate() && !branch.IsTrunk(),
+				NeedsRestack: !statuses.IsUpToDate(branch) && !branch.IsTrunk(),
 			}
 
 			// Parent

--- a/internal/cli/stack/sync.go
+++ b/internal/cli/stack/sync.go
@@ -163,6 +163,15 @@ func computeSyncDryRun(ctx context.Context, eng engine.Engine, opts sync.Options
 	allBranches := eng.AllBranches()
 	var candidateNames []string
 	restackRootSet := make(map[string]struct{})
+
+	// Resolve up-to-date status for every branch in one batched parent-revision
+	// read instead of a per-branch IsBranchUpToDate() inside the loop (each of
+	// which would shell a separate `git rev-parse` for the parent).
+	var statuses engine.BranchStatuses
+	if opts.Restack {
+		statuses = eng.ReadBranchStatuses(allBranches)
+	}
+
 	for _, branch := range allBranches {
 		if branch.IsTrunk() || !branch.IsTracked() {
 			continue
@@ -170,7 +179,7 @@ func computeSyncDryRun(ctx context.Context, eng engine.Engine, opts sync.Options
 		candidateNames = append(candidateNames, branch.GetName())
 
 		// Check restack status while iterating
-		if opts.Restack && !branch.IsBranchUpToDate() {
+		if opts.Restack && !statuses.IsUpToDate(branch) {
 			plan.restack = append(plan.restack, dryRunRestackItem{
 				branch: branch.GetName(),
 				parent: branch.GetParentOrTrunk(),


### PR DESCRIPTION
## Summary

- `sync --dry-run`, `debug`, and `tree --json` each looped over branches calling `Branch.IsBranchUpToDate()`, which shells a separate `git rev-parse` per branch to read its parent revision.
- `Engine.ReadBranchStatuses` already batches this into a single call — the same pattern already applied at `submit`/`submit_validation`/`info` call sites (see `docs/plans/perf/cross-cutting.md` item #2). This PR applies it to the three remaining stragglers.
- `sync.go`: only computes the batched statuses when `opts.Restack` is set, matching the existing guard so no extra work happens when restack status isn't needed.
- `debug.go`: also simplifies the `IsFixed` assignment, since `ReadBranchStatuses` already returns `true` for trunk.
- `tree.go`: batches alongside the existing `BatchBranchStats` call, ahead of the bounded `utils.Run` worker pool.

Purely a read-path change with identical semantics — verified with the existing test suite.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/cli/stack/... ./internal/actions/...` (all passing)
- [x] `gofmt -l` on changed files (clean)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PzyH9PVjvHb1yzk69yo14U)_