### PR TITLE
fix: close stdin and reap process when restarting git cat-file --batch

### DIFF
--- a/internal/git/object_reader.go
+++ b/internal/git/object_reader.go
@@ -57,6 +57,16 @@ func (r *objectReader) start() error {
 	return nil
 }
 
+// killLocked terminates the current process and releases its stdin pipe and
+// process resources so a restart doesn't leak the pipe's file descriptor or
+// leave a zombie process behind. Caller must hold r.mu.
+func (r *objectReader) killLocked() {
+	_ = r.stdin.Close()
+	_ = r.cmd.Process.Kill()
+	_ = r.cmd.Wait()
+	r.cmd = nil
+}
+
 // readResponse reads one response from stdout. Caller must hold r.mu.
 func (r *objectReader) readResponse(ref string) (string, bool, error) {
 	header, err := r.stdout.ReadString('\n')
@@ -99,8 +109,7 @@ func (r *objectReader) ReadObject(ref string) (string, bool, error) {
 	}
 	if _, err := fmt.Fprintf(r.stdin, "%s\n", ref); err != nil {
 		// Process died; restart and retry once
-		_ = r.cmd.Process.Kill()
-		r.cmd = nil
+		r.killLocked()
 		if startErr := r.start(); startErr != nil {
 			return "", false, startErr
 		}
@@ -128,8 +137,7 @@ func (r *objectReader) ReadObjectsBatch(refs []string) (map[string]string, error
 	for _, ref := range refs {
 		if _, err := fmt.Fprintf(r.stdin, "%s\n", ref); err != nil {
 			// Process died; clear it so the next call restarts, mirroring ReadObject.
-			_ = r.cmd.Process.Kill()
-			r.cmd = nil
+			r.killLocked()
 			return nil, fmt.Errorf("object reader write: %w", err)
 		}
 	}
@@ -138,8 +146,7 @@ func (r *objectReader) ReadObjectsBatch(refs []string) (map[string]string, error
 		content, found, err := r.readResponse(ref)
 		if err != nil {
 			// Stdout stream is broken; discard the process so the next call restarts.
-			_ = r.cmd.Process.Kill()
-			r.cmd = nil
+			r.killLocked()
 			return nil, err
 		}
 		if found {


### PR DESCRIPTION
## Summary

- `objectReader` (`internal/git/object_reader.go`) wraps a persistent `git cat-file --batch` process used by the batch metadata/blob-reading hot path.
- On any I/O failure (stdin write or stdout read), it killed the child process and cleared `r.cmd` to trigger a restart on the next call, but never closed `r.stdin` or waited on the process — leaking the pipe's write-end file descriptor and leaving a zombie process behind on every restart. This pattern was duplicated at three call sites (`ReadObject` and the two failure paths in `ReadObjectsBatch`).
- Adds a `killLocked` helper that closes `r.stdin`, kills the process, and waits on it before clearing `r.cmd`, and uses it at all three sites instead of the ad-hoc kill-and-clear.

## Test plan

- [x] `go build ./internal/git/...`
- [x] `go test ./internal/git/...` — `TestReadObjectsBatch_ClearsCmdOnWriteError` and `TestReadObjectsBatch_ClearsCmdOnReadError` (which already exercise the restart path) pass unmodified
- [x] `go vet ./internal/git/...`
- [x] `gofmt -l internal/git/object_reader.go` — no output


---
_Generated by [Claude Code](https://claude.ai/code/session_01PDshfxP8Q1Y7PBTNTqCcSh)_