### PR TITLE
perf: hoist regexes to package-level vars instead of recompiling per call

### DIFF
--- a/internal/config/branch_pattern.go
+++ b/internal/config/branch_pattern.go
@@ -17,6 +17,27 @@ type BranchPattern string
 // DefaultBranchPattern is the default branch name pattern
 const DefaultBranchPattern BranchPattern = "{username}/{date}/{message}"
 
+var (
+	// placeholderRegex matches {placeholder} tokens in a branch pattern.
+	placeholderRegex = regexp.MustCompile(`\{[^}]+\}`)
+
+	// conventionalCommitPrefixRegex matches conventional commit prefixes like "feat:", "fix(scope):", etc.
+	// This is a duplicate of utils.conventionalCommitPrefixRegex to avoid import cycles.
+	conventionalCommitPrefixRegex = regexp.MustCompile(`^(feat|fix|chore|docs|style|refactor|perf|test|build|ci)(\([^)]+\))?:\s*`)
+
+	// branchNameIgnoreRegex matches trailing slashes and dots that should be removed.
+	// This is a duplicate of utils.BranchNameIgnoreRegex to avoid import cycles.
+	branchNameIgnoreRegex = regexp.MustCompile(`[/.]*$`)
+
+	// branchNameReplaceRegex matches characters that are not valid in branch names.
+	// This is a duplicate of utils.BranchNameReplaceRegex to avoid import cycles.
+	branchNameReplaceRegex = regexp.MustCompile(`[^-_/.a-zA-Z0-9]+`)
+
+	// branchNameHyphenRegex matches consecutive hyphens for collapsing.
+	// This is a duplicate of utils.branchNameHyphenRegex to avoid import cycles.
+	branchNameHyphenRegex = regexp.MustCompile(`-+`)
+)
+
 // NewBranchPattern creates a new BranchPattern from a string
 // Returns an error if the pattern is invalid (doesn't contain {message})
 func NewBranchPattern(pattern string) (BranchPattern, error) {
@@ -100,7 +121,6 @@ func (p BranchPattern) GetBranchName(ctx GitContext, commitMessage string, scope
 
 	// Scan pattern once to find which placeholders are present
 	// Use regex to find all {placeholder} patterns in one pass
-	placeholderRegex := regexp.MustCompile(`\{[^}]+\}`)
 	foundPlaceholders := make(map[string]bool)
 	for _, match := range placeholderRegex.FindAllString(pattern, -1) {
 		foundPlaceholders[match] = true
@@ -151,7 +171,7 @@ func (p BranchPattern) generateBranchNameFromMessage(message string) string {
 	subject := strings.TrimSpace(lines[0])
 
 	// Remove common prefixes like "feat:", "fix:", etc. if present (with optional scope)
-	subject = regexp.MustCompile(`^(feat|fix|chore|docs|style|refactor|perf|test|build|ci)(\([^)]+\))?:\s*`).ReplaceAllString(subject, "")
+	subject = conventionalCommitPrefixRegex.ReplaceAllString(subject, "")
 
 	// Truncate to a reasonable length for branch names (before sanitization)
 	// Aim for ~50 characters to leave room for username/date prefixes
@@ -179,16 +199,13 @@ func (p BranchPattern) sanitizeBranchName(name string) string {
 	const maxBranchNameByteLength = 234
 
 	// Remove trailing slashes and dots
-	branchNameIgnoreRegex := regexp.MustCompile(`[/.]*$`)
 	name = branchNameIgnoreRegex.ReplaceAllString(name, "")
 
 	// Replace invalid characters with hyphens
-	branchNameReplaceRegex := regexp.MustCompile(`[^-_/.a-zA-Z0-9]+`)
 	name = branchNameReplaceRegex.ReplaceAllString(name, "-")
 
 	// Remove multiple consecutive hyphens
-	hyphenRegex := regexp.MustCompile(`-+`)
-	name = hyphenRegex.ReplaceAllString(name, "-")
+	name = branchNameHyphenRegex.ReplaceAllString(name, "-")
 
 	// Trim leading/trailing hyphens
 	name = strings.Trim(name, "-")

--- a/internal/git/absorb.go
+++ b/internal/git/absorb.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"regexp"
 	"strings"
 )
 
@@ -39,8 +38,6 @@ func parseDiffHunks(diffOutput, targetFile string) []Hunk {
 
 	var hunks []Hunk
 	lines := strings.Split(diffOutput, "\n")
-
-	hunkHeaderRegex := regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@`)
 
 	var currentHunk *Hunk
 	var currentFile string

--- a/internal/git/hunk_split.go
+++ b/internal/git/hunk_split.go
@@ -6,6 +6,10 @@ import (
 	"strings"
 )
 
+// hunkHeaderWithSuffixRegex matches hunk headers and captures any trailing
+// section-heading text after the closing "@@" (e.g. "@@ -1,2 +1,3 @@ func Foo()").
+var hunkHeaderWithSuffixRegex = regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$`)
+
 // CanSplit returns true if the hunk has context lines between changes,
 // meaning it can be split into multiple smaller hunks.
 // A hunk is splittable only when there's at least one context line that separates
@@ -57,9 +61,6 @@ func (h Hunk) Split() (Hunks, error) {
 
 	lines := strings.Split(h.Content, "\n")
 
-	// Parse original hunk header
-	hunkHeaderRegex := regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$`)
-
 	var headerLine string
 	var headerSuffix string
 	var contentLines []string
@@ -68,7 +69,7 @@ func (h Hunk) Split() (Hunks, error) {
 	for i, line := range lines {
 		if strings.HasPrefix(line, "@@") {
 			headerLine = line
-			match := hunkHeaderRegex.FindStringSubmatch(line)
+			match := hunkHeaderWithSuffixRegex.FindStringSubmatch(line)
 			if len(match) > 5 {
 				headerSuffix = match[5]
 			}

--- a/internal/git/hunks.go
+++ b/internal/git/hunks.go
@@ -25,6 +25,10 @@ type Hunk struct {
 // Hunks is an ordered collection of diff hunks.
 type Hunks []Hunk
 
+// hunkHeaderRegex matches hunk headers: @@ -old_start,old_count +new_start,new_count @@
+// Example: @@ -10,5 +10,6 @@
+var hunkHeaderRegex = regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@`)
+
 // ParseDiffOutput parses a diff output into structured hunks
 func ParseDiffOutput(diffOutput string) (Hunks, error) {
 	if diffOutput == "" {
@@ -33,10 +37,6 @@ func ParseDiffOutput(diffOutput string) (Hunks, error) {
 
 	var hunks Hunks
 	lines := strings.Split(diffOutput, "\n")
-
-	// Regex to match hunk headers: @@ -old_start,old_count +new_start,new_count @@
-	// Example: @@ -10,5 +10,6 @@
-	hunkHeaderRegex := regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@`)
 
 	var currentHunk *Hunk
 	var currentFile string


### PR DESCRIPTION
## Summary

- `internal/config/branch_pattern.go` recompiled 4 regexes on every `sanitizeBranchName`/`generateBranchNameFromMessage`/`GetBranchName` call (up to ~9-11 `regexp.Compile` calls per branch-name generation). Hoisted them to package-level `var`s, mirroring the existing pattern already used in `internal/utils/utils.go` for the same patterns (the file's own comments note it's "a duplicate of utils... to avoid import cycles").
- `internal/git` had the identical hunk-header regex independently compiled inline in three files (`hunks.go`, `absorb.go`, `hunk_split.go`). `absorb.go`'s copy sits in `parseDiffHunks`, which runs once per staged hunk per candidate commit during `stackit absorb` — recompilation there scales with `hunks × commits`. Consolidated to two package-level vars (`hunkHeaderRegex` shared by `hunks.go`/`absorb.go`, and `hunkHeaderWithSuffixRegex` for `hunk_split.go`'s slightly different pattern).

No behavior change — pure refactor removing redundant `regexp.Compile` work on hot paths.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/config/...` — passes
- [x] `go test ./internal/git/...` (hunk/absorb/split-related tests) — all pass; one pre-existing, unrelated failure (`TestGetRepoInfo/parses_HTTPS_URL`) reproduces identically on `main` before this change and is caused by the sandbox's global git config, not this diff
- [x] `go vet ./internal/config/... ./internal/git/...` — clean
- [x] `gofmt -l` on changed files — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01BM4DCFcWXEwcurqvTS6SGC)_