### PR TITLE
refactor: remove dead cache-warming revision batch call in merge planning

### DIFF
--- a/internal/actions/merge/plan.go
+++ b/internal/actions/merge/plan.go
@@ -296,11 +296,9 @@ func CollectMergeBranches(ctx context.Context, eng mergePlanEngine, splog output
 		}
 	}
 
-	// 4. Batch fetch metadata and revisions for all involved branches
+	// 4. Batch fetch metadata for all involved branches
 	involvedBranches := append(append([]string{}, allBranches...), upstackBranches...)
 	allMeta, _ := eng.BatchReadMetadataRaw(involvedBranches)
-	// We don't strictly need allRevisions here yet, but it's good for cache
-	_, _ = eng.GetRevisions(involvedBranches)
 
 	remoteCtx, cancelRemote := app.WithRemoteOperationTimeout(ctx)
 	defer cancelRemote()


### PR DESCRIPTION
## Summary

- `CollectMergeBranches` (`internal/actions/merge/plan.go`) called `eng.GetRevisions(involvedBranches)` and discarded both the result and any errors, with a comment claiming it was "good for cache."
- `GetRevisions` is a stateless passthrough straight to `git.BatchGetRevisions`, which just runs a single `git rev-parse` — there is no revision cache anywhere in this path for the call to warm (confirmed by reading `internal/engine/engine_branch_info.go` and `internal/git/runner.go`/`commit_info.go`). Per `.claude/rules/package-dependencies.md`'s branch-state guidance, the only caches that exist are the diff-stat/commit-count caches, keyed by content, not a global revision cache.
- The call was pure waste: it spawned an extra `git` subprocess on every merge-plan run for no benefit, and silently dropped any errors it returned.
- I searched the codebase for the same "discarded batch call kept around for a stale cache-warming comment" pattern and found no other occurrences — this was a one-off leftover.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/actions/merge/...`
- [x] `go test ./internal/actions/merge/...` (all passing)
- [x] `gofmt -l` clean on the changed file


---
_Generated by [Claude Code](https://claude.ai/code/session_01BoqE97zPLKRXHSZkyKstZu)_