### PR TITLE
feat: apply restack atomically per stack and report blocked branches

### DIFF
--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -58,7 +58,7 @@ type Restacker interface {
 // juggling a long positional parameter list.
 type RestackProgress struct {
 	Branch              string               // the branch being processed
-	Result              engine.RestackResult // Done, Unneeded, or Conflict
+	Result              engine.RestackResult // Done, Unneeded, Conflict, or Blocked
 	NewRev              string               // new revision if restacked (empty otherwise)
 	RerereResolvedCount int                  // number of rebase continuations handled by git rerere
 	Conflict            bool                 // true if this is a conflict
@@ -147,17 +147,31 @@ func restackBranchesWithPlan(ctx *app.Context, branches engine.Branches, prePlan
 
 	// Check if validation failed due to a system error (not a conflict)
 	if !validation.Success {
-		if validation.ErrorType == engine.ValidationErrorSystem {
-			return fmt.Errorf("validation failed for %s: %s", validation.FailedBranch, validation.ErrorMessage)
-		}
-		// Else: conflict - continue with conflict workflow
-		// Log conflicting files for debugging
-		if len(validation.ConflictingFiles) > 0 {
-			ctx.Logger.Debug("conflict detected during validation branch=%v files=%v", validation.FailedBranch, validation.ConflictingFiles)
+		for _, f := range validation.Failed {
+			if f.ErrorType == engine.ValidationErrorSystem {
+				return fmt.Errorf("validation failed for %s: %s", f.Branch, f.ErrorMessage)
+			}
+			// Else: conflict - continue with conflict workflow
+			// Log conflicting files for debugging
+			if len(f.ConflictingFiles) > 0 {
+				ctx.Logger.Debug("conflict detected during validation branch=%v files=%v", f.Branch, f.ConflictingFiles)
+			}
 		}
 	}
 
-	successBranches, conflictBranches := classifyValidatedBranches(branches, plan, validation)
+	successBranches, conflictBranches, blockedBranches := classifyValidatedBranches(branches, plan, validation)
+
+	// Non-interactive restacks apply stacks atomically: a conflict anywhere in
+	// an independent stack holds back the whole stack. Applying only part of a
+	// stack would move a parent without its children, turning a benign
+	// "behind trunk" state into "child not restacked on parent" — which
+	// downstream tooling (submit validation) treats as a hard error.
+	// The conflict workflow is exempt: it applies up to the conflict on
+	// purpose so the user resolves on top of the restacked parent, and
+	// 'stackit continue' finishes the rest of the stack.
+	if mode == ConflictModeContinue && len(conflictBranches) > 0 {
+		successBranches, blockedBranches = holdBackConflictedStacks(ctx.Engine, successBranches, conflictBranches, blockedBranches)
+	}
 
 	// For standalone mode, enter conflict workflow on first conflict
 	if mode == ConflictModeEnterWorkflow && len(conflictBranches) > 0 {
@@ -225,13 +239,9 @@ func restackBranchesWithPlan(ctx *app.Context, branches engine.Branches, prePlan
 	}
 	reportPlannedResults(ctx, branches, plannedResults, callback)
 
-	// Report conflicts via callback for sync mode
-	if mode == ConflictModeContinue && len(conflictBranches) > 0 {
-		currentBranch := ctx.Engine.CurrentBranch()
-		currentBranchName := ""
-		if currentBranch != nil {
-			currentBranchName = currentBranch.GetName()
-		}
+	// Report conflicts and blocked branches via callback for sync mode
+	if mode == ConflictModeContinue && (len(conflictBranches) > 0 || len(blockedBranches) > 0) {
+		currentBranchName := getCurrentBranchName(ctx.Engine)
 
 		for _, branchName := range conflictBranches {
 			if callback != nil {
@@ -243,25 +253,70 @@ func restackBranchesWithPlan(ctx *app.Context, branches engine.Branches, prePlan
 				})
 			}
 		}
+		for _, branchName := range blockedBranches {
+			if callback != nil {
+				callback(RestackProgress{
+					Branch:    branchName,
+					Result:    engine.RestackBlocked,
+					IsCurrent: branchName == currentBranchName,
+				})
+			}
+		}
 	}
 
 	return nil
 }
 
+// holdBackConflictedStacks enforces per-stack atomicity: any branch whose
+// independent stack (rooted at a child of trunk) contains a validation
+// conflict is moved from the apply set into the blocked set. Returns the
+// filtered apply set and the extended blocked list.
+func holdBackConflictedStacks(eng engine.BranchReader, success engine.Branches, conflicts, blocked []string) (engine.Branches, []string) {
+	graph := eng.Graph(engine.SortStrategyAlphabetical)
+	trunk := eng.Trunk().GetName()
+	rootOf := func(name string) string {
+		cur := name
+		for {
+			node := graph.GetNode(cur)
+			if node == nil || node.Parent == "" || node.Parent == trunk {
+				return cur
+			}
+			cur = node.Parent
+		}
+	}
+
+	conflictedRoots := make(map[string]bool, len(conflicts))
+	for _, name := range conflicts {
+		conflictedRoots[rootOf(name)] = true
+	}
+
+	kept := engine.NewBranchesBuilder(len(success))
+	for _, branch := range success {
+		if conflictedRoots[rootOf(branch.GetName())] {
+			blocked = append(blocked, branch.GetName())
+			continue
+		}
+		kept.Add(branch)
+	}
+	return kept.Build(), blocked
+}
+
 // classifyValidatedBranches splits the planned branches into ones safe to
-// apply now and ones to surface as conflicts, using the validation result as
-// the source of truth instead of position-in-specs arithmetic. The earlier
-// position-based split was racy: when multiple sibling specs at the same
-// depth validate in parallel and one fails, validation.FailedBranch is
-// whichever failure arrives first on the results channel — non-deterministic.
-// Alphabetically-earlier canceled siblings would then satisfy `pos < failedPos`
-// and end up in successBranches without a matching entry in NewSHAs, and the
-// engine would error with "missing validated SHA for X". Here we apply a
-// branch only if its action proves it's safe: Frozen/Anchor branches don't
-// touch a rebase worktree at all, and Validated branches need a confirmed SHA.
-func classifyValidatedBranches(branches engine.Branches, plan *engine.RestackPlan, validation *engine.RebaseValidation) (success engine.Branches, conflicts []string) {
+// apply now, ones that conflicted, and ones blocked behind a conflict, using
+// the validation result as the source of truth instead of position-in-specs
+// arithmetic. A branch is applied only if its action proves it's safe:
+// Frozen/Anchor branches don't touch a rebase worktree at all, and Validated
+// branches need a confirmed SHA. Every planned branch lands in exactly one of
+// the three buckets so none silently disappears from reporting — a Validated
+// branch with no SHA that isn't in the failed set was skipped because an
+// ancestor failed, and is classified blocked.
+func classifyValidatedBranches(branches engine.Branches, plan *engine.RestackPlan, validation *engine.RebaseValidation) (success engine.Branches, conflicts, blocked []string) {
 	if plan == nil || validation == nil {
-		return nil, nil
+		return nil, nil, nil
+	}
+	failed := make(map[string]bool, len(validation.Failed))
+	for _, f := range validation.Failed {
+		failed[f.Branch] = true
 	}
 	builder := engine.NewBranchesBuilder(len(branches))
 	for _, branch := range branches {
@@ -278,17 +333,17 @@ func classifyValidatedBranches(branches engine.Branches, plan *engine.RestackPla
 		case engine.RestackPlanApplyFrozen, engine.RestackPlanApplyAnchor:
 			builder.Add(branch)
 		case engine.RestackPlanApplyValidated:
-			if _, hasSHA := validation.NewSHAs[branchName]; hasSHA {
+			switch {
+			case validation.NewSHAs[branchName] != "":
 				builder.Add(branch)
-			} else if branchName == validation.FailedBranch {
+			case failed[branchName]:
 				conflicts = append(conflicts, branchName)
+			default:
+				blocked = append(blocked, branchName)
 			}
-			// Otherwise the branch was canceled — a sibling at the same depth
-			// failed first, or validation never reached this depth. Leave it
-			// for the next restack pass.
 		}
 	}
-	return builder.Build(), conflicts
+	return builder.Build(), conflicts, blocked
 }
 
 func getCurrentBranchName(eng engine.BranchReader) string {

--- a/internal/actions/common_test.go
+++ b/internal/actions/common_test.go
@@ -182,13 +182,14 @@ func TestClassifyValidatedBranches(t *testing.T) {
 			NewSHAs: map[string]string{"a": "sha-a", "b": "sha-b"},
 		}
 
-		success, conflicts := classifyValidatedBranches(
+		success, conflicts, blocked := classifyValidatedBranches(
 			engine.BranchesOf(mkBranch("a"), mkBranch("b")),
 			plan,
 			validation,
 		)
 
 		require.Empty(t, conflicts)
+		require.Empty(t, blocked)
 		require.Len(t, success, 2)
 		require.Equal(t, "a", success[0].GetName())
 		require.Equal(t, "b", success[1].GetName())
@@ -205,43 +206,47 @@ func TestClassifyValidatedBranches(t *testing.T) {
 			NewSHAs: map[string]string{},
 		}
 
-		success, conflicts := classifyValidatedBranches(
+		success, conflicts, blocked := classifyValidatedBranches(
 			engine.BranchesOf(mkBranch("frozen"), mkBranch("anchor")),
 			plan,
 			validation,
 		)
 
 		require.Empty(t, conflicts)
+		require.Empty(t, blocked)
 		require.Len(t, success, 2)
 	})
 
 	// Regression: when sibling validations race in parallel and one fails,
-	// canceled siblings have no NewSHA. The previous position-based logic
-	// would put an alphabetically-earlier canceled sibling into success
+	// unattempted branches have no NewSHA. The previous position-based logic
+	// would put an alphabetically-earlier unattempted sibling into success
 	// (its position in specs was < the failed branch's position) and the
 	// engine then errored with "missing validated SHA for X". The fix
 	// classifies by capability: only branches with a confirmed NewSHA
-	// (or a no-validation action) are eligible.
-	t.Run("canceled sibling at same depth is dropped, not added to success", func(t *testing.T) {
+	// (or a no-validation action) are eligible; branches with neither a SHA
+	// nor a recorded failure are reported blocked, never silently dropped.
+	t.Run("unattempted branch is classified blocked, not added to success", func(t *testing.T) {
 		t.Parallel()
 		plan := mkPlan(map[string]engine.RestackPlanAction{
-			"alpha-canceled": engine.RestackPlanApplyValidated,
-			"beta-conflict":  engine.RestackPlanApplyValidated,
-			"gamma-ok":       engine.RestackPlanApplyValidated,
+			"alpha-blocked": engine.RestackPlanApplyValidated,
+			"beta-conflict": engine.RestackPlanApplyValidated,
+			"gamma-ok":      engine.RestackPlanApplyValidated,
 		})
 		validation := &engine.RebaseValidation{
 			Success:      false,
 			FailedBranch: "beta-conflict",
+			Failed:       []engine.FailedRebase{{Branch: "beta-conflict", ErrorType: engine.ValidationErrorConflict}},
 			NewSHAs:      map[string]string{"gamma-ok": "sha-gamma"},
 		}
 
-		success, conflicts := classifyValidatedBranches(
-			engine.BranchesOf(mkBranch("alpha-canceled"), mkBranch("beta-conflict"), mkBranch("gamma-ok")),
+		success, conflicts, blocked := classifyValidatedBranches(
+			engine.BranchesOf(mkBranch("alpha-blocked"), mkBranch("beta-conflict"), mkBranch("gamma-ok")),
 			plan,
 			validation,
 		)
 
 		require.Equal(t, []string{"beta-conflict"}, conflicts)
+		require.Equal(t, []string{"alpha-blocked"}, blocked)
 		require.Len(t, success, 1, "only gamma-ok (with confirmed NewSHA) should succeed")
 		require.Equal(t, "gamma-ok", success[0].GetName())
 	})
@@ -256,13 +261,14 @@ func TestClassifyValidatedBranches(t *testing.T) {
 			NewSHAs: map[string]string{"a": "sha-a"},
 		}
 
-		success, conflicts := classifyValidatedBranches(
+		success, conflicts, blocked := classifyValidatedBranches(
 			engine.BranchesOf(mkBranch("a"), mkBranch("not-in-plan")),
 			plan,
 			validation,
 		)
 
 		require.Empty(t, conflicts)
+		require.Empty(t, blocked)
 		require.Len(t, success, 1)
 		require.Equal(t, "a", success[0].GetName())
 	})

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -357,7 +357,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 
 	// Restack if requested
 	var restacked, skipped int
-	var conflicts []string
+	var conflicts, blocked []string
 	if opts.Restack {
 		uniqueBranches := engine.NewBranchesBuilder(len(branchesToSync))
 		seen := make(map[string]bool)
@@ -404,13 +404,16 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 					skipped++
 					conflicts = append(conflicts, p.Branch)
 					handler.OnRestackBranch(p.Branch, handlers.RestackConflict, "", prNumber, p.LockReason, p.Frozen, p.IsCurrent, parentName, p.Reparented, p.OldParent, p.NewParent, p.RerereResolvedCount)
+				case engine.RestackBlocked:
+					blocked = append(blocked, p.Branch)
+					handler.OnRestackBranch(p.Branch, handlers.RestackBlocked, "", prNumber, p.LockReason, p.Frozen, p.IsCurrent, parentName, p.Reparented, p.OldParent, p.NewParent, p.RerereResolvedCount)
 				}
 			}, ConflictModeEnterWorkflow); err != nil {
-				handler.OnRestackComplete(restacked, skipped, conflicts)
+				handler.OnRestackComplete(restacked, skipped, conflicts, blocked)
 				return fmt.Errorf("restack failed: %w", err)
 			}
 
-			handler.OnRestackComplete(restacked, skipped, conflicts)
+			handler.OnRestackComplete(restacked, skipped, conflicts, blocked)
 		}
 	}
 

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -170,7 +170,7 @@ func RestackAction(ctx *app.Context, plan *RestackPlan, handler handlers.Restack
 	handler.OnRestackStart(branchCount)
 
 	var restacked, skipped int
-	var conflicts []string
+	var conflicts, blocked []string
 	prompter, promptForConflicts := conflictPrompter(handler, opts)
 
 	// Parallel mode: dispatch independent stack groups to separate worktrees.
@@ -178,9 +178,9 @@ func RestackAction(ctx *app.Context, plan *RestackPlan, handler handlers.Restack
 	// so each worker computes its own plan inside its worktree.
 	if opts.Parallel && len(plan.groups) > 1 {
 		var err error
-		restacked, skipped, conflicts, err = restackGroupsParallel(ctx, opts, plan.groups, handler)
-		ctx.Logger.Info("restack completed (parallel) restacked=%v skipped=%v conflicts=%v", restacked, skipped, len(conflicts))
-		handler.OnRestackComplete(restacked, skipped, conflicts)
+		restacked, skipped, conflicts, blocked, err = restackGroupsParallel(ctx, opts, plan.groups, handler)
+		ctx.Logger.Info("restack completed (parallel) restacked=%v skipped=%v conflicts=%v blocked=%v", restacked, skipped, len(conflicts), len(blocked))
+		handler.OnRestackComplete(restacked, skipped, conflicts, blocked)
 		if err != nil {
 			return fmt.Errorf("restack failed: %w", err)
 		}
@@ -197,7 +197,7 @@ func RestackAction(ctx *app.Context, plan *RestackPlan, handler handlers.Restack
 		groupRoot := group.rootBranch
 		progress := func(p RestackProgress) {
 			p.StackRoot = groupRoot
-			handleRestackProgress(eng, handler, p, &restacked, &skipped, &conflicts)
+			handleRestackProgress(eng, handler, p, &restacked, &skipped, &conflicts, &blocked)
 		}
 
 		if err := restackBranchesWithPlan(ctx, group.sortedBranches, group.enginePlan, progress, conflictMode); err != nil {
@@ -205,7 +205,7 @@ func RestackAction(ctx *app.Context, plan *RestackPlan, handler handlers.Restack
 		}
 	}
 
-	ctx.Logger.Info("restack completed restacked=%v skipped=%v conflicts=%v", restacked, skipped, len(conflicts))
+	ctx.Logger.Info("restack completed restacked=%v skipped=%v conflicts=%v blocked=%v", restacked, skipped, len(conflicts), len(blocked))
 
 	if promptForConflicts && len(conflicts) > 0 {
 		resolve, err := prompter.PromptResolveConflicts(conflicts)
@@ -217,7 +217,7 @@ func RestackAction(ctx *app.Context, plan *RestackPlan, handler handlers.Restack
 		}
 	}
 
-	handler.OnRestackComplete(restacked, skipped, conflicts)
+	handler.OnRestackComplete(restacked, skipped, conflicts, blocked)
 	return nil
 }
 
@@ -253,6 +253,7 @@ type parallelResultCollector struct {
 	restacked int
 	skipped   int
 	conflicts []string
+	blocked   []string
 	errs      []error
 }
 
@@ -260,7 +261,7 @@ type parallelResultCollector struct {
 func (c *parallelResultCollector) recordProgress(p RestackProgress) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	handleRestackProgress(c.eng, c.handler, p, &c.restacked, &c.skipped, &c.conflicts)
+	handleRestackProgress(c.eng, c.handler, p, &c.restacked, &c.skipped, &c.conflicts, &c.blocked)
 }
 
 // recordGroupFailure attributes every branch in a failed group to the handler
@@ -277,7 +278,7 @@ func (c *parallelResultCollector) recordGroupFailure(group restackPlannedGroup, 
 			Result:    engine.RestackConflict,
 			Conflict:  true,
 			StackRoot: group.rootBranch,
-		}, &c.restacked, &c.skipped, &c.conflicts)
+		}, &c.restacked, &c.skipped, &c.conflicts, &c.blocked)
 	}
 }
 
@@ -312,7 +313,7 @@ func restackGroupsParallel(
 	opts RestackOptions,
 	groups []restackPlannedGroup,
 	handler handlers.RestackHandler,
-) (restacked, skipped int, conflicts []string, err error) {
+) (restacked, skipped int, conflicts, blocked []string, err error) {
 	eng := ctx.Engine
 
 	numJobs := opts.Jobs
@@ -382,7 +383,7 @@ func restackGroupsParallel(
 		ctx.Logger.Warn("failed to rebuild engine after parallel restack: %v", err)
 	}
 
-	return collector.restacked, collector.skipped, collector.conflicts, collector.joinedError()
+	return collector.restacked, collector.skipped, collector.conflicts, collector.blocked, collector.joinedError()
 }
 
 // guardUnpushedTrunk refuses to restack when the local trunk has commits that
@@ -483,6 +484,7 @@ func handleRestackProgress(
 	restacked *int,
 	skipped *int,
 	conflicts *[]string,
+	blocked *[]string,
 ) {
 	res := handlers.RestackDone
 	switch p.Result {
@@ -495,6 +497,9 @@ func handleRestackProgress(
 		*skipped++
 		*conflicts = append(*conflicts, p.Branch)
 		res = handlers.RestackConflict
+	case engine.RestackBlocked:
+		*blocked = append(*blocked, p.Branch)
+		res = handlers.RestackBlocked
 	}
 
 	// Determine parent name for consistent output

--- a/internal/actions/sync/restack.go
+++ b/internal/actions/sync/restack.go
@@ -122,6 +122,19 @@ func restackBranches(ctx *app.Context, branchesToRestack []string, restackScope 
 					IsCurrent:  p.IsCurrent,
 					Parent:     parentName,
 				})
+			case engine.RestackBlocked:
+				summary.BranchesBlocked++
+				handler.EmitEvent(Event{
+					Phase:      PhaseRestack,
+					Type:       EventSkipped,
+					Branch:     p.Branch,
+					PRNumber:   prNumber,
+					Message:    "(blocked by conflict in stack)",
+					LockReason: p.LockReason,
+					Frozen:     p.Frozen,
+					IsCurrent:  p.IsCurrent,
+					Parent:     parentName,
+				})
 			}
 		}, actions.ConflictModeContinue); err != nil {
 			return fmt.Errorf("failed to restack branches: %w", err)

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -311,6 +311,7 @@ const (
 	RestackDone     = handlers.RestackDone
 	RestackUnneeded = handlers.RestackUnneeded
 	RestackConflict = handlers.RestackConflict
+	RestackBlocked  = handlers.RestackBlocked
 )
 
 // RestackResult is an alias for handlers.RestackResult
@@ -374,6 +375,7 @@ type Summary struct {
 	BranchesDeleted   int      // Number of branches deleted
 	BranchesSkipped   int      // Number of branches skipped (due to conflicts)
 	ConflictBranches  []string // Names of branches that conflicted
+	BranchesBlocked   int      // Number of branches left untouched because their stack conflicted
 	UpToDate          bool     // Everything was already current
 	WorktreesCleaned  int      // Number of orphaned worktrees cleaned up
 	SkippedStacks     []string // Stacks skipped due to dirty worktrees
@@ -382,8 +384,8 @@ type Summary struct {
 // HasChanges returns true if any operations were performed
 func (s *Summary) HasChanges() bool {
 	return s.TrunkUpdated || s.BranchesSynced > 0 || s.BranchesRestacked > 0 ||
-		s.BranchesDeleted > 0 || s.BranchesSkipped > 0 || s.WorktreesCleaned > 0 ||
-		len(s.SkippedStacks) > 0
+		s.BranchesDeleted > 0 || s.BranchesSkipped > 0 || s.BranchesBlocked > 0 ||
+		s.WorktreesCleaned > 0 || len(s.SkippedStacks) > 0
 }
 
 // Handler abstracts TTY vs non-TTY output for sync operations
@@ -495,6 +497,9 @@ func FormatSummaryParts(summary Summary) []string {
 	}
 	if summary.BranchesSkipped > 0 {
 		parts = append(parts, fmt.Sprintf("skipped %d (conflict)", summary.BranchesSkipped))
+	}
+	if summary.BranchesBlocked > 0 {
+		parts = append(parts, fmt.Sprintf("blocked %d", summary.BranchesBlocked))
 	}
 	if len(summary.SkippedStacks) > 0 {
 		parts = append(parts, fmt.Sprintf("skipped %d stack%s (dirty worktree)", len(summary.SkippedStacks), plural(len(summary.SkippedStacks))))

--- a/internal/actions/sync/sync_test.go
+++ b/internal/actions/sync/sync_test.go
@@ -134,7 +134,7 @@ func TestSyncAction(t *testing.T) {
 			ExpectBranchFixed("GC2")
 	})
 
-	t.Run("partial success in branching restack (one child succeeds, one fails)", func(t *testing.T) {
+	t.Run("branching restack with a conflicted sibling holds back the whole stack", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewRemoteScenario(t)
 
@@ -178,9 +178,10 @@ func TestSyncAction(t *testing.T) {
 		// Should NOT error - conflicts are detected via validation and skipped
 		require.NoError(t, err)
 
-		// 0-Success should have been restacked successfully
-		s.ExpectBranchFixed("0-Success")
-		// 1-Failure should NOT be fixed (conflict detected via validation)
+		// The stack is applied atomically: 1-Failure's conflict holds back its
+		// clean sibling too, so the stack stays internally consistent and a
+		// later restack (after resolving) moves it as one unit.
+		s.ExpectBranchNotFixed("0-Success")
 		s.ExpectBranchNotFixed("1-Failure")
 	})
 

--- a/internal/cli/branch/get_handlers.go
+++ b/internal/cli/branch/get_handlers.go
@@ -210,15 +210,19 @@ func (h *SimpleGetHandler) OnRestackBranch(branch string, result handlers.Restac
 		h.Output.Warn("  Skipped %s%s (conflict)",
 			style.ColorBranchNameIf(branch, isCurrent),
 			prInfo)
+	case handlers.RestackBlocked:
+		h.Output.Warn("  Skipped %s%s (blocked by conflict in stack)",
+			style.ColorBranchNameIf(branch, isCurrent),
+			prInfo)
 	}
 }
 
 // OnRestackComplete implements RestackHandler for restack phase
-func (h *SimpleGetHandler) OnRestackComplete(restacked, skipped int, conflicts []string) {
+func (h *SimpleGetHandler) OnRestackComplete(restacked, skipped int, conflicts, blocked []string) {
 	h.Lock()
 	defer h.Unlock()
 
-	if restacked == 0 && skipped == 0 {
+	if restacked == 0 && skipped == 0 && len(blocked) == 0 {
 		return // No restack summary needed if nothing happened
 	}
 
@@ -229,13 +233,16 @@ func (h *SimpleGetHandler) OnRestackComplete(restacked, skipped int, conflicts [
 	if skipped > 0 {
 		parts = append(parts, fmt.Sprintf("skipped %d (conflict)", skipped))
 	}
+	if len(blocked) > 0 {
+		parts = append(parts, fmt.Sprintf("blocked %d", len(blocked)))
+	}
 
 	if len(parts) > 0 {
 		h.Output.Info("  %s", strings.Join(parts, ", "))
 	}
 
-	if len(conflicts) > 0 {
+	for _, conflict := range conflicts {
 		h.Output.Info("  Run %s to resolve and continue",
-			style.ColorCyan(fmt.Sprintf("st restack %s", conflicts[0])))
+			style.ColorCyan(fmt.Sprintf("st restack %s", conflict)))
 	}
 }

--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -344,20 +344,42 @@ func (h *SimpleSyncHandler) OnRestackBranch(branch string, result syncAction.Res
 	case syncAction.RestackConflict:
 		event.Type = syncAction.EventSkipped
 		event.Conflict = true
+	case syncAction.RestackBlocked:
+		event.Type = syncAction.EventSkipped
+		event.Message = reasonBlockedByConflict
 	}
 
 	h.printRestackEvent(event)
 }
 
 // OnRestackComplete implements RestackHandler for standalone restack operations
-func (h *SimpleSyncHandler) OnRestackComplete(restacked, skipped int, conflicts []string) {
+func (h *SimpleSyncHandler) OnRestackComplete(restacked, skipped int, conflicts, blocked []string) {
 	h.Output.Newline()
 
-	if restacked == 0 && skipped == 0 {
+	if restacked == 0 && skipped == 0 && len(blocked) == 0 {
 		h.Output.Info("✨ Everything is up to date!")
 		return
 	}
 
+	if summary := formatRestackSummaryLine(restacked, skipped, len(blocked)); summary != "" {
+		h.Output.Info("✅ Summary: %s", summary)
+	}
+
+	for _, conflict := range conflicts {
+		h.Output.Info("  Run %s to resolve and continue",
+			style.ColorCyan(fmt.Sprintf("st restack %s", conflict)))
+	}
+}
+
+// reasonBlockedByConflict annotates branches held back because another branch
+// in their stack conflicted. The stack is applied atomically, so these were
+// left untouched rather than restacked onto a moved parent.
+const reasonBlockedByConflict = "(blocked by conflict in stack)"
+
+// formatRestackSummaryLine renders the shared "restacked N, skipped M
+// (conflict), blocked K" summary used by both restack handlers. Returns ""
+// when there is nothing to summarize.
+func formatRestackSummaryLine(restacked, skipped, blocked int) string {
 	parts := []string{}
 	if restacked > 0 {
 		parts = append(parts, fmt.Sprintf("restacked %d", restacked))
@@ -365,15 +387,10 @@ func (h *SimpleSyncHandler) OnRestackComplete(restacked, skipped int, conflicts 
 	if skipped > 0 {
 		parts = append(parts, fmt.Sprintf("skipped %d (conflict)", skipped))
 	}
-
-	if len(parts) > 0 {
-		h.Output.Info("✅ Summary: %s", strings.Join(parts, ", "))
+	if blocked > 0 {
+		parts = append(parts, fmt.Sprintf("blocked %d", blocked))
 	}
-
-	if len(conflicts) > 0 {
-		h.Output.Info("  Run %s to resolve and continue",
-			style.ColorCyan(fmt.Sprintf("st restack %s", conflicts[0])))
-	}
+	return strings.Join(parts, ", ")
 }
 
 // InteractiveSyncHandler provides bubbletea TUI for TTY environments
@@ -656,17 +673,19 @@ func (h *InteractiveSyncHandler) formatRestackDetail(branch string, result syncA
 		return fmt.Sprintf("%s%s %s", displayName, prInfo, reason), syncComponent.MarkDone
 	case syncAction.RestackConflict:
 		return fmt.Sprintf("Skipped %s%s (conflict)", displayName, prInfo), syncComponent.MarkWarn
+	case syncAction.RestackBlocked:
+		return fmt.Sprintf("Skipped %s%s %s", displayName, prInfo, reasonBlockedByConflict), syncComponent.MarkWarn
 	}
 	return "", syncComponent.MarkDone
 }
 
 // OnRestackComplete implements RestackHandler for standalone restack operations
-func (h *InteractiveSyncHandler) OnRestackComplete(restacked, skipped int, conflicts []string) {
+func (h *InteractiveSyncHandler) OnRestackComplete(restacked, skipped int, conflicts, blocked []string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	// Build summary message
-	summaryMsg := h.formatRestackSummary(restacked, skipped, conflicts)
+	summaryMsg := h.formatRestackSummary(restacked, skipped, conflicts, blocked)
 
 	// Send complete message
 	h.runner.Send(syncComponent.CompleteMsg{Summary: summaryMsg})
@@ -826,26 +845,18 @@ func (h *InteractiveSyncHandler) PromptBranchDeletions(branches map[string]strin
 }
 
 // formatRestackSummary formats the restack summary
-func (h *InteractiveSyncHandler) formatRestackSummary(restacked, skipped int, conflicts []string) string {
-	if restacked == 0 && skipped == 0 {
+func (h *InteractiveSyncHandler) formatRestackSummary(restacked, skipped int, conflicts, blocked []string) string {
+	if restacked == 0 && skipped == 0 && len(blocked) == 0 {
 		return "✨ Everything is up to date!"
 	}
 
-	parts := []string{}
-	if restacked > 0 {
-		parts = append(parts, fmt.Sprintf("restacked %d", restacked))
-	}
-	if skipped > 0 {
-		parts = append(parts, fmt.Sprintf("skipped %d (conflict)", skipped))
-	}
-
 	result := ""
-	if len(parts) > 0 {
-		result = "✅ Summary: " + strings.Join(parts, ", ")
+	if summary := formatRestackSummaryLine(restacked, skipped, len(blocked)); summary != "" {
+		result = "✅ Summary: " + summary
 	}
 
-	if len(conflicts) > 0 {
-		result += fmt.Sprintf("\n   Run 'st restack %s' to resolve and continue", conflicts[0])
+	for _, conflict := range conflicts {
+		result += fmt.Sprintf("\n   Run 'st restack %s' to resolve and continue", conflict)
 	}
 
 	return result

--- a/internal/cli/stack/sync_handlers_test.go
+++ b/internal/cli/stack/sync_handlers_test.go
@@ -180,7 +180,7 @@ func TestInteractiveSyncHandler_OnRestackComplete(t *testing.T) {
 	model := syncComponent.NewModel(0)
 	handler := NewInteractiveSyncHandler(mockRunner, model, output.NewNullOutput(), output.NewNullLogger())
 
-	handler.OnRestackComplete(5, 2, nil)
+	handler.OnRestackComplete(5, 2, nil, nil)
 
 	// Verify that OnRestackComplete sends a CompleteMsg
 	messages := mockRunner.Messages()

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -329,6 +329,9 @@ const (
 	RestackUnneeded
 	// RestackConflict indicates a conflict occurred during restack
 	RestackConflict
+	// RestackBlocked indicates the branch was not restacked because another
+	// branch in its stack conflicted; it is untouched and needs a later pass
+	RestackBlocked
 )
 
 // RestackBranchResult represents the result of restacking a branch, including the rebased branch base

--- a/internal/handlers/restack.go
+++ b/internal/handlers/restack.go
@@ -18,6 +18,9 @@ const (
 	RestackUnneeded RestackResult = "unneeded"
 	// RestackConflict indicates the branch had a conflict
 	RestackConflict RestackResult = "conflict"
+	// RestackBlocked indicates the branch was left untouched because another
+	// branch in its stack conflicted
+	RestackBlocked RestackResult = "blocked"
 )
 
 // RestackHandler abstracts TTY vs non-TTY output for restack operations
@@ -29,8 +32,9 @@ type RestackHandler interface {
 	// OnRestackBranch is called for each branch during restack
 	OnRestackBranch(branch string, result RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, reparented bool, oldParent, newParent string, rerereResolvedCount int)
 
-	// OnRestackComplete is called when restack finishes
-	OnRestackComplete(restacked, skipped int, conflicts []string)
+	// OnRestackComplete is called when restack finishes. blocked lists
+	// branches left untouched because their stack contained a conflict.
+	OnRestackComplete(restacked, skipped int, conflicts, blocked []string)
 }
 
 // NullRestackHandler is a no-op handler for testing or when output is not needed
@@ -44,7 +48,7 @@ func (h *NullRestackHandler) OnRestackBranch(_ string, _ RestackResult, _ string
 }
 
 // OnRestackComplete implements RestackHandler.
-func (h *NullRestackHandler) OnRestackComplete(_, _ int, _ []string) {}
+func (h *NullRestackHandler) OnRestackComplete(_, _ int, _, _ []string) {}
 
 // RestackJSONStatus represents the aggregate outcome of a JSON restack operation.
 type RestackJSONStatus string
@@ -62,10 +66,12 @@ type RestackJSONResult struct {
 	Restacked     []RestackBranchInfo   `json:"restacked,omitempty"`
 	Skipped       []string              `json:"skipped,omitempty"`
 	Conflicts     []RestackConflictInfo `json:"conflicts,omitempty"`
+	Blocked       []string              `json:"blocked,omitempty"`     // Branches left untouched because their stack contained a conflict
 	StackRoots    []string              `json:"stack_roots,omitempty"` // Deduped independent stack roots that were processed
 	TotalCount    int                   `json:"total_count"`
 	RestackCount  int                   `json:"restack_count"`
 	ConflictCount int                   `json:"conflict_count"`
+	BlockedCount  int                   `json:"blocked_count,omitempty"`
 }
 
 // RestackBranchInfo represents info about a restacked branch
@@ -130,15 +136,18 @@ func (h *JSONRestackHandler) OnRestackBranch(branch string, result RestackResult
 			Branch: branch,
 			Parent: parent,
 		})
+	case RestackBlocked:
+		h.Result.Blocked = append(h.Result.Blocked, branch)
 	}
 }
 
 // OnRestackComplete implements RestackHandler.
-func (h *JSONRestackHandler) OnRestackComplete(restacked, _ int, _ []string) {
+func (h *JSONRestackHandler) OnRestackComplete(restacked, _ int, _, _ []string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.Result.RestackCount = restacked
 	h.Result.ConflictCount = len(h.Result.Conflicts)
+	h.Result.BlockedCount = len(h.Result.Blocked)
 
 	if h.Result.ConflictCount > 0 {
 		h.Result.Status = RestackJSONStatusConflict

--- a/internal/handlers/restack_test.go
+++ b/internal/handlers/restack_test.go
@@ -23,7 +23,7 @@ func TestJSONRestackHandler(t *testing.T) {
 		handler.OnRestackBranch("branch-a", RestackDone, "abc123", &prNum, engine.LockReasonNone, false, false, "main", false, "", "", 2)
 		handler.OnRestackBranch("branch-b", RestackDone, "def456", nil, engine.LockReasonNone, false, false, "branch-a", false, "", "", 0)
 
-		handler.OnRestackComplete(2, 0, nil)
+		handler.OnRestackComplete(2, 0, nil, nil)
 
 		require.Equal(t, RestackJSONStatusSuccess, handler.Result.Status)
 		require.Len(t, handler.Result.Restacked, 2)
@@ -46,7 +46,7 @@ func TestJSONRestackHandler(t *testing.T) {
 		handler.OnRestackBranch("branch-a", RestackUnneeded, "", nil, engine.LockReasonNone, false, false, "main", false, "", "", 0)
 		handler.OnRestackBranch("branch-b", RestackUnneeded, "", nil, engine.LockReasonNone, false, false, "branch-a", false, "", "", 0)
 
-		handler.OnRestackComplete(0, 2, nil)
+		handler.OnRestackComplete(0, 2, nil, nil)
 
 		require.Equal(t, RestackJSONStatusSuccess, handler.Result.Status)
 		require.Empty(t, handler.Result.Restacked)
@@ -65,7 +65,7 @@ func TestJSONRestackHandler(t *testing.T) {
 		handler.OnRestackBranch("branch-a", RestackDone, "abc123", nil, engine.LockReasonNone, false, false, "main", false, "", "", 0)
 		handler.OnRestackBranch("branch-b", RestackConflict, "", nil, engine.LockReasonNone, false, false, "branch-a", false, "", "", 0)
 
-		handler.OnRestackComplete(1, 0, []string{"branch-b"})
+		handler.OnRestackComplete(1, 0, []string{"branch-b"}, nil)
 
 		require.Equal(t, RestackJSONStatusConflict, handler.Result.Status)
 		require.Len(t, handler.Result.Restacked, 1)
@@ -94,7 +94,7 @@ func TestJSONRestackHandler(t *testing.T) {
 		handler := NewJSONRestackHandler()
 		handler.OnRestackStart(1)
 		handler.OnRestackBranch("branch-a", RestackConflict, "", nil, engine.LockReasonNone, false, false, "main", false, "", "", 0)
-		handler.OnRestackComplete(0, 0, []string{"branch-a"})
+		handler.OnRestackComplete(0, 0, []string{"branch-a"}, nil)
 
 		handler.SetError(errors.New("restack stopped due to conflict on branch-a"))
 
@@ -118,7 +118,7 @@ func TestJSONRestackHandler(t *testing.T) {
 		handler.OnRestackBranch("beta", RestackConflict, "", nil, engine.LockReasonNone, false, false, "main", false, "", "", 0)
 		handler.SetLastBranchStackRoot("beta", "beta")
 
-		handler.OnRestackComplete(2, 0, []string{"beta"})
+		handler.OnRestackComplete(2, 0, []string{"beta"}, nil)
 
 		// Per-branch annotation
 		require.Equal(t, "alpha", handler.Result.Restacked[0].StackRoot)
@@ -134,7 +134,7 @@ func TestJSONRestackHandler(t *testing.T) {
 
 		handler := NewJSONRestackHandler()
 		handler.OnRestackStart(1)
-		handler.OnRestackComplete(0, 1, nil)
+		handler.OnRestackComplete(0, 1, nil, nil)
 
 		// Call SetError with nil
 		handler.SetError(nil)

--- a/internal/integration/restack_atomic_stack_test.go
+++ b/internal/integration/restack_atomic_stack_test.go
@@ -1,0 +1,68 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRestackAppliesStacksAtomically locks in per-stack atomicity for
+// non-interactive restacks: a conflict anywhere in an independent stack holds
+// back the ENTIRE stack (even members that would rebase cleanly), while
+// unrelated stacks restack fully.
+//
+// Without atomicity, restack would move b1 onto the new trunk but leave its
+// conflicted child b2 behind, converting a benign "behind trunk" state into
+// "child not restacked on parent" — which submit validation treats as a hard
+// error. Holding the whole stack back keeps it internally consistent.
+func TestRestackAppliesStacksAtomically(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t)
+
+	// Seed a shared file on main that stack B will conflict on.
+	sh.WriteFile("shared.txt", "base\n").
+		Git("commit -m 'add shared file'")
+
+	// Stack A (clean): main -> a1 -> a2, files disjoint from trunk's edit.
+	sh.WriteFile("a1.txt", "a1\n").
+		Run("create a1 -m 'a1'").
+		OnBranch("a1")
+	sh.WriteFile("a2.txt", "a2\n").
+		Run("create a2 -m 'a2'").
+		OnBranch("a2")
+
+	// Stack B: main -> b1 (clean) -> b2 (rewrites the shared line).
+	sh.Checkout("main")
+	sh.WriteFile("b1.txt", "b1\n").
+		Run("create b1 -m 'b1'").
+		OnBranch("b1")
+	sh.WriteFile("shared.txt", "base\nB2\n").
+		Run("create b2 -m 'b2'").
+		OnBranch("b2")
+
+	// Trunk advances with an edit that conflicts with b2 only.
+	sh.Checkout("main")
+	sh.WriteFile("shared.txt", "base\nMAIN\n").
+		Git("commit -m 'trunk edit on shared line'")
+
+	mainRev := sh.revParse("main")
+	b1Orig := sh.revParse("b1")
+	b2Orig := sh.revParse("b2")
+
+	// Every branch is accounted for in the output: restacked, conflicted, blocked.
+	sh.Run("restack --continue-on-conflict").
+		OutputContains("Restacked a1").
+		OutputContains("Restacked a2").
+		OutputContains("(conflict)").
+		OutputContains("blocked by conflict in stack").
+		OutputContains("restacked 2, skipped 1 (conflict), blocked 1")
+
+	// Stack A restacked fully onto the new trunk.
+	require.Equal(t, mainRev, sh.revParse("main"), "trunk itself must not move")
+	require.Equal(t, mainRev, sh.revParse("a1^"), "a1 must sit directly on the new trunk tip")
+
+	// Stack B is untouched end to end: the conflicted b2 AND its clean parent b1.
+	require.Equal(t, b1Orig, sh.revParse("b1"),
+		"b1 must be held back: applying it without its conflicted child would split the stack")
+	require.Equal(t, b2Orig, sh.revParse("b2"), "conflicted b2 must not move")
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Non-interactive restacks (multi-stack, sync, --continue-on-conflict) now hold back an entire independent stack when any branch in it conflicts, instead of moving the clean part and stranding the rest. Partially applying a stack moved a parent without its children, turning a benign behind-trunk state into 'child not restacked on parent', which submit treats as a hard error. The interactive conflict workflow is unchanged: it still applies up to the conflict so the user resolves on top of the restacked parent.

Branches held back this way are now reported as blocked instead of silently vanishing: every planned branch appears in the output, summaries show a blocked count, JSON output carries blocked branches, and the completion hint lists a restack command for every conflict rather than just the first.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1784415895`.


* **PR #1430** 👈
  * **PR #1431**
    * **PR #1432**

**Previously based on:**
* ~~PR #1429~~ (merged)

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1434 by jonnii*