### PR TITLE
refactor: extract IsMainWorktree helper to remove duplication

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -3,7 +3,6 @@ package actions
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -624,11 +623,8 @@ func removeWorktreeIfCheckedOut(ctx context.Context, branchName string, worktree
 		return "", nil // Branch not in any worktree
 	}
 
-	// Don't remove main worktree (resolve symlinks for comparison, e.g., /var vs /private/var on macOS)
-	repoRoot := eng.GetRepoRoot()
-	resolvedWorktree, _ := filepath.EvalSymlinks(worktreePath)
-	resolvedRoot, _ := filepath.EvalSymlinks(repoRoot)
-	if resolvedWorktree == resolvedRoot {
+	// Don't remove main worktree
+	if git.IsMainWorktree(worktreePath, eng.GetRepoRoot()) {
 		out.Debug("Branch %s is in main worktree, not removing", branchName)
 		return "", nil
 	}

--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -3,7 +3,6 @@ package merge
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/config"
@@ -453,11 +452,8 @@ func removeWorktreeForBranch(ctx context.Context, branchName string, worktrees g
 		return nil // Branch not in any worktree
 	}
 
-	// Don't remove main worktree (resolve symlinks for comparison, e.g., /var vs /private/var on macOS)
-	repoRoot := eng.GetRepoRoot()
-	resolvedWorktree, _ := filepath.EvalSymlinks(worktreePath)
-	resolvedRoot, _ := filepath.EvalSymlinks(repoRoot)
-	if resolvedWorktree == resolvedRoot {
+	// Don't remove main worktree
+	if git.IsMainWorktree(worktreePath, eng.GetRepoRoot()) {
 		out.Debug("Branch %s is in main worktree, cannot remove", branchName)
 		return fmt.Errorf("branch %s is checked out in main worktree", branchName)
 	}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -22,6 +23,15 @@ type Worktree struct {
 // invocation. Callers should pass it down per-batch instead of calling
 // ListWorktrees per branch — see PathForBranch for the common lookup.
 type WorktreeList []Worktree
+
+// IsMainWorktree reports whether worktreePath is the repo's main worktree
+// (repoRoot), resolving symlinks on both sides for comparison (e.g. /var vs
+// /private/var on macOS).
+func IsMainWorktree(worktreePath, repoRoot string) bool {
+	resolvedWorktree, _ := filepath.EvalSymlinks(worktreePath)
+	resolvedRoot, _ := filepath.EvalSymlinks(repoRoot)
+	return resolvedWorktree == resolvedRoot
+}
 
 // PathForBranch returns the worktree path where branchName is checked out,
 // or "" if no worktree currently has it.

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -75,6 +75,41 @@ func TestWorktree(t *testing.T) {
 	})
 }
 
+func TestIsMainWorktree(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	root, err := filepath.EvalSymlinks(tmpDir)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		worktreePath string
+		repoRoot     string
+		expected     bool
+	}{
+		{
+			name:         "same path is main worktree",
+			worktreePath: root,
+			repoRoot:     root,
+			expected:     true,
+		},
+		{
+			name:         "different path is not main worktree",
+			worktreePath: filepath.Join(root, "linked"),
+			repoRoot:     root,
+			expected:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, git.IsMainWorktree(tt.worktreePath, tt.repoRoot))
+		})
+	}
+}
+
 func TestWorktreeRegistry(t *testing.T) {
 	t.Run("write and read worktree metadata", func(t *testing.T) {
 		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)


### PR DESCRIPTION
## Summary

- `removeWorktreeIfCheckedOut` (`internal/actions/clean_branches.go`) and `removeWorktreeForBranch` (`internal/actions/merge/execute.go`) each independently resolved symlinks (via `filepath.EvalSymlinks`) to detect whether a worktree path is the repo's main worktree — identical logic, including the same comment, duplicated verbatim in two files.
- Extracted a single `git.IsMainWorktree(worktreePath, repoRoot string) bool` helper in `internal/git/worktree.go` and updated both call sites to use it.
- Added a table-driven unit test (`TestIsMainWorktree`) covering the same-path and different-path cases.

This removes drift risk: if the symlink-resolution edge case is ever fixed in one place (e.g. handling `EvalSymlinks` errors), the other site no longer silently keeps the old behavior.

No behavior change — pure extraction of existing logic into a shared, tested helper.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/git/... ./internal/actions/... ./internal/actions/merge/...` (all pass; one pre-existing, unrelated `TestGetRepoInfo` failure reproduces identically on `main` and is due to the sandbox's git URL rewrite, not this change)
- [x] `gofmt -l` clean on all touched files


---
_Generated by [Claude Code](https://claude.ai/code/session_01BJbUrL5kVhwq98QAnegvoa)_