### PR TITLE
refactor: add ColorBranchNamePlain to finish boolean-free branch styling pass

### DIFF
--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -162,7 +162,7 @@ func (p *planPrinter) printSoloLine(ev submit.BranchPlanEvent) {
 
 	if ev.Skipped {
 		p.out.Info("%s → %s %s",
-			style.BranchStyle(ev.IsCurrent, false, false).Render(name),
+			style.ColorBranchNamePlain(name, ev.IsCurrent, false),
 			style.ColorBranchNameWithTrunk(base, false, base == p.trunk),
 			style.ColorDim("— "+ev.SkipReason))
 		return
@@ -172,7 +172,7 @@ func (p *planPrinter) printSoloLine(ev submit.BranchPlanEvent) {
 	if ev.PRNumber != nil {
 		action = fmt.Sprintf("%s %s", action, style.ColorYellow(fmt.Sprintf("#%d", *ev.PRNumber)))
 	}
-	line := fmt.Sprintf("%s → %s  %s", style.BranchStyle(ev.IsCurrent, false, false).Render(name), style.ColorBranchNameWithTrunk(base, false, base == p.trunk), colorAction(ev.Action, action))
+	line := fmt.Sprintf("%s → %s  %s", style.ColorBranchNamePlain(name, ev.IsCurrent, false), style.ColorBranchNameWithTrunk(base, false, base == p.trunk), colorAction(ev.Action, action))
 	if ev.Empty {
 		line += " " + style.ColorDim("(empty)")
 	}
@@ -200,7 +200,7 @@ func (p *planPrinter) pad(name string, dim bool, current bool) string {
 	if dim {
 		return style.ColorDim(padded)
 	}
-	return style.BranchStyle(current, false, false).Render(padded)
+	return style.ColorBranchNamePlain(padded, current, false)
 }
 
 // skippedCount is the number of plan rows that were skipped.

--- a/internal/tui/components/tree/tree.go
+++ b/internal/tui/components/tree/tree.go
@@ -972,7 +972,7 @@ func (r *StackTreeRenderer) getInfoLines(args treeRenderArgs) []string {
 	// TRUNK: minimal single line
 	if isTrunk {
 		branchName := args.branchName
-		coloredBranchName := style.BranchStyle(isCurrent, true, false).Render(branchName)
+		coloredBranchName := style.ColorBranchNamePlain(branchName, isCurrent, true)
 		if isSelected {
 			coloredBranchName = style.Selection().Render(" " + branchName + " ")
 		} else if !matchesSearch && args.searchQuery != "" {
@@ -1001,7 +1001,7 @@ func (r *StackTreeRenderer) getInfoLines(args treeRenderArgs) []string {
 
 	// LINE 1: Symbol + Branch Name (bold if current) + SHA + Scope + Actionable Warnings
 	branchName := args.branchName
-	coloredBranchName := style.BranchStyle(isCurrent, isTrunk, false).Render(branchName)
+	coloredBranchName := style.ColorBranchNamePlain(branchName, isCurrent, isTrunk)
 
 	switch {
 	case isSelected && !isNonSelectable:

--- a/internal/tui/style/formatter.go
+++ b/internal/tui/style/formatter.go
@@ -102,6 +102,13 @@ func ColorBranchNameWithTrunk(branchName string, isCurrent bool, isTrunk bool) s
 	return BranchStyle(isCurrent, isTrunk, false).Render(name)
 }
 
+// ColorBranchNamePlain colors a branch name by current/trunk status without
+// appending the " (current)" marker, for callers that already convey
+// currency another way (e.g. a leading cursor or row highlight).
+func ColorBranchNamePlain(branchName string, isCurrent, isTrunk bool) string {
+	return BranchStyle(isCurrent, isTrunk, false).Render(branchName)
+}
+
 // BranchStyle returns the unified style for a branch name
 func BranchStyle(isCurrent, isTrunk, isDim bool) lipgloss.Style {
 	if isDim {


### PR DESCRIPTION
## Summary

- Five call sites (`internal/cli/stack/submit_handlers.go` x3, `internal/tui/components/tree/tree.go` x2) called `style.BranchStyle(isCurrent, isTrunk, false).Render(name)` directly — the unclear three-bool shape the codebase's `code-style.md` rule warns against, and one the project has already been mechanically fixing at other call sites via `ColorBranchName`/`ColorCurrentBranch`/`ColorBranchNameWithTrunk`.
- Those existing wrappers don't fit here because they all unconditionally append a `" (current)"` marker; these five callers already convey current-ness another way (a leading cursor/highlight), so they'd fallen back to the raw `BranchStyle(...).Render(...)` call.
- Adds `style.ColorBranchNamePlain(branchName, isCurrent, isTrunk)` — colors by current/trunk status with no marker appended — and switches the five call sites to use it.

No behavior change: `ColorBranchNamePlain` is a thin wrapper around the same `BranchStyle(...).Render(...)` call each site made before.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/tui/... ./internal/cli/...`
- [x] `go test ./internal/tui/style/... ./internal/tui/components/tree/... ./internal/cli/stack/...` (all pass)
- [x] `gofmt -l` on changed files (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018paGcrMHfvWF15AiD5TDN3)_