### PR TITLE
fix: use BatchIsBranchEmpty instead of per-branch checks in doctor

### DIFF
--- a/internal/actions/doctor/stack_state.go
+++ b/internal/actions/doctor/stack_state.go
@@ -113,7 +113,7 @@ func checkStackState(ctx context.Context, eng engine.Engine, handler Handler, wa
 	}
 
 	// Check for empty branches (branches with no commits vs their parent)
-	emptyBranches := checkEmptyBranches(ctx, eng)
+	emptyBranches := checkEmptyBranches(eng)
 	if len(emptyBranches) > 0 {
 		warnings += len(emptyBranches)
 		branchList := strings.Join(emptyBranches, ", ")
@@ -126,23 +126,23 @@ func checkStackState(ctx context.Context, eng engine.Engine, handler Handler, wa
 }
 
 // checkEmptyBranches finds branches that have no commits compared to their parent
-func checkEmptyBranches(ctx context.Context, eng engine.Engine) []string {
-	var emptyBranches []string
+func checkEmptyBranches(eng engine.Engine) []string {
 	trunk := eng.Trunk()
 	trunkName := trunk.GetName()
 
-	for _, branch := range eng.AllBranches() {
-		branchName := branch.GetName()
-		if branchName == trunkName {
-			continue
+	allBranches := eng.AllBranches()
+	branchNames := make([]string, 0, len(allBranches))
+	for _, branch := range allBranches {
+		if branch.GetName() != trunkName {
+			branchNames = append(branchNames, branch.GetName())
 		}
+	}
 
-		isEmpty, err := eng.IsBranchEmpty(ctx, branchName)
-		if err != nil {
-			// Skip branches we can't check
-			continue
-		}
-		if isEmpty {
+	emptyStatuses := eng.BatchIsBranchEmpty(branchNames)
+
+	var emptyBranches []string
+	for _, branchName := range branchNames {
+		if emptyStatuses[branchName] {
 			emptyBranches = append(emptyBranches, branchName)
 		}
 	}

--- a/internal/actions/doctor/stack_state_test.go
+++ b/internal/actions/doctor/stack_state_test.go
@@ -1,0 +1,25 @@
+package doctor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+func TestCheckEmptyBranches(t *testing.T) {
+	t.Parallel()
+
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		CreateBranch("withchanges").
+		CommitChange("file1", "real change").
+		Checkout("main").
+		CreateBranch("nochanges").
+		Checkout("main")
+
+	empty := checkEmptyBranches(s.Engine)
+
+	require.ElementsMatch(t, []string{"nochanges"}, empty)
+}


### PR DESCRIPTION
## Summary

- `doctor`'s empty-branch check called `IsBranchEmpty` once per branch, each doing a separate `git diff`.
- `BatchIsBranchEmpty` already exists and resolves all branch/parent tree SHAs in a single batched rev-parse (it's already used by `submit`) — `doctor` was the one caller that had been missed.
- Switched `checkEmptyBranches` to collect branch names once and call `BatchIsBranchEmpty` a single time instead of looping `IsBranchEmpty` per branch.
- Added a unit test for `checkEmptyBranches` since none previously existed.

This is a pure read-only refactor with no behavior change — output is identical, just fewer git subprocess calls on repos with many branches.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/actions/doctor/...` (including new `TestCheckEmptyBranches`)
- [x] `gofmt -l` clean on changed files


---
_Generated by [Claude Code](https://claude.ai/code/session_01U1z1v8HCtfi1UTet9HoGry)_