### PR TITLE
refactor: remove dead migration-shim wrapper functions

### DIFF
--- a/internal/actions/merge/multistack_discover.go
+++ b/internal/actions/merge/multistack_discover.go
@@ -4,9 +4,6 @@ import (
 	"github.com/getstackit/stackit/internal/engine"
 )
 
-// FormatStackLabel is retained for callers that have not migrated to MultiStackInfo.Label.
-func FormatStackLabel(stack MultiStackInfo) string { return stack.Label() }
-
 // DiscoverStacks returns all independent stacks rooted at trunk.
 // Each stack is represented by its root branch (direct child of trunk)
 // and includes all branches in the stack in topological order.

--- a/internal/actions/merge/plan.go
+++ b/internal/actions/merge/plan.go
@@ -128,9 +128,6 @@ func (branches MergeBranches) AllAreLeaves(graph *engine.StackGraph) bool {
 	return true
 }
 
-// AnyPRHasChecks is retained for callers that have not migrated to MergeBranches.AnyHasChecks.
-func AnyPRHasChecks(branches []BranchMergeInfo) bool { return MergeBranches(branches).AnyHasChecks() }
-
 // BranchNames returns the names of all branches to be merged, in order.
 func (p *Plan) BranchNames() []string {
 	names := make([]string, len(p.BranchesToMerge))

--- a/internal/actions/pr_updates.go
+++ b/internal/actions/pr_updates.go
@@ -48,12 +48,6 @@ func FetchPRContentForBranches(ctx *app.Context, branches []string) map[int]gith
 	return content
 }
 
-// UpdateBranchPRMetadata updates PR title and body footer for a single branch.
-func UpdateBranchPRMetadata(ctx *app.Context, name string) {
-	current := FetchPRContentForBranches(ctx, []string{name})
-	UpdateBranchPRMetadataWithContent(ctx, name, current)
-}
-
 // UpdateBranchPRMetadataWithContent updates PR title and body footer for a single
 // branch, using PR content pre-fetched in bulk by FetchPRContentForBranches. If
 // the branch's PR is not present in current (a batch miss or fetch failure), it

--- a/internal/pr/sections.go
+++ b/internal/pr/sections.go
@@ -101,11 +101,6 @@ func ShouldShowNavigation(opts NavigationOptions, branch string, eng engine.Bran
 	}
 }
 
-// CreatePRBodyFooter creates a PR body footer with dependency tree using default options.
-func CreatePRBodyFooter(branch string, eng engine.BranchReader) string {
-	return CreatePRBodyFooterWithOptions(branch, eng, DefaultNavigationOptions())
-}
-
 // CreatePRBodyFooterWithOptions creates a PR body footer with dependency tree using custom options.
 // Returns empty string if neither navigation nor description should be shown.
 // The footer includes both the stack description and the navigation tree in a combined section.


### PR DESCRIPTION
## Summary

- Removes four exported wrapper functions that were explicitly left behind during earlier refactors "for callers that have not migrated" to their replacements, but no such callers remain anywhere in the codebase:
  - `FormatStackLabel` (`internal/actions/merge/multistack_discover.go`) → superseded by `MultiStackInfo.Label()`
  - `AnyPRHasChecks` (`internal/actions/merge/plan.go`) → superseded by `MergeBranches.AnyHasChecks()`
  - `UpdateBranchPRMetadata` (`internal/actions/pr_updates.go`) → superseded by the batched `UpdateStackPRMetadata` / `UpdateBranchPRMetadataWithContent`
  - `CreatePRBodyFooter` (`internal/pr/sections.go`) → superseded by `CreatePRBodyFooterWithOptions`

Verified via whole-program dead-code analysis (`golang.org/x/tools/cmd/deadcode` against both CLI and server entry points) plus a full-repo grep that none of these have remaining callers in production code or tests. Each is a pure passthrough to its replacement, so this is a behavior-neutral deletion.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/actions/... ./internal/pr/... ./internal/github/...`
- [x] `go test ./internal/actions/... ./internal/pr/...` (all packages pass)
- [x] `gofmt -l` on changed files (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfrAfPw14VRpGZsJTGkAPz)_