### PR TITLE
refactor: remove redundant per-branch commit-count/diff-stats accessors

### DIFF
--- a/internal/actions/delete/delete_test.go
+++ b/internal/actions/delete/delete_test.go
@@ -186,9 +186,7 @@ func TestDelete(t *testing.T) {
 		require.NotNil(t, parent)
 		require.Equal(t, "main", parent.GetName())
 
-		commitCount, err := s.Engine.GetCommitCount(s.Engine.GetBranch("branch2"))
-		require.NoError(t, err)
-		require.Equal(t, 1, commitCount)
+		require.Equal(t, 1, s.BranchCommitCount("branch2"))
 	})
 }
 

--- a/internal/actions/info.go
+++ b/internal/actions/info.go
@@ -332,12 +332,11 @@ func outputBranchInfoJSON(ctx *app.Context, branch engine.Branch) error {
 		info.CommitMessages = commits
 	}
 
-	// Diff stats
-	added, deleted, err := branch.GetDiffStats()
-	if err == nil {
-		info.DiffStats.Additions = added
-		info.DiffStats.Deletions = deleted
-	}
+	// Diff stats — resolved via the batched reader over a single-branch set,
+	// rather than a per-branch accessor.
+	diff := eng.BatchDiffStats(engine.BranchesOf(branch))[branchName]
+	info.DiffStats.Additions = diff.Added
+	info.DiffStats.Deletions = diff.Deleted
 
 	// Files changed — measured against the branch's divergence point, the same
 	// base GetDiffStats uses above, so the file count stays consistent with the

--- a/internal/engine/branch.go
+++ b/internal/engine/branch.go
@@ -97,16 +97,6 @@ func (b Branch) GetRevision() (string, error) {
 	return b.reader.GetRevision(b)
 }
 
-// GetCommitCount returns the number of commits for this branch
-func (b Branch) GetCommitCount() (int, error) {
-	return b.reader.GetCommitCount(b)
-}
-
-// GetDiffStats returns the number of lines added and deleted for this branch
-func (b Branch) GetDiffStats() (added int, deleted int, err error) {
-	return b.reader.GetDiffStats(b)
-}
-
 // GetAllCommits returns commits for this branch in various formats
 func (b Branch) GetAllCommits(format CommitFormat) ([]string, error) {
 	return b.reader.GetAllCommits(b, format)

--- a/internal/engine/branch_view_test.go
+++ b/internal/engine/branch_view_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
 
-// TestBatchBranchStats asserts the batched stats match the per-branch accessors
-// they replace, so annotation builders can read from the batch instead of
-// warming the engine-global caches.
+// TestBatchBranchStats asserts the batched stats match an independent raw-git
+// oracle (commit count and diff numstat against each branch's parent), so
+// annotation builders can rely on the batch reader as the single source.
 func TestBatchBranchStats(t *testing.T) {
 	t.Parallel()
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
@@ -36,11 +36,13 @@ func TestBatchBranchStats(t *testing.T) {
 			continue
 		}
 
-		wantCount, err := s.Engine.GetCommitCount(b)
+		parent := b.GetParent().GetName()
+
+		wantCount, err := s.Scene.Repo.GetCommitCount(parent, name)
 		require.NoError(t, err)
 		require.Equal(t, wantCount, stat.CommitCount, "CommitCount for %s", name)
 
-		wantAdded, wantDeleted, err := s.Engine.GetDiffStats(b)
+		wantAdded, wantDeleted, err := s.Scene.Repo.GetDiffStats(parent, name)
 		require.NoError(t, err)
 		require.Equal(t, wantAdded, stat.LinesAdded, "LinesAdded for %s", name)
 		require.Equal(t, wantDeleted, stat.LinesDeleted, "LinesDeleted for %s", name)
@@ -93,7 +95,7 @@ func TestPerConcernBatchReaders(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, wantDiv, divergence[name], "divergence for %s", name)
 
-		wantAdded, wantDeleted, err := s.Engine.GetDiffStats(b)
+		wantAdded, wantDeleted, err := s.Scene.Repo.GetDiffStats(b.GetParent().GetName(), name)
 		require.NoError(t, err)
 		require.Equal(t, engine.DiffStat{Added: wantAdded, Deleted: wantDeleted}, diffs[name], "diff for %s", name)
 
@@ -126,8 +128,9 @@ func TestCommitsFallBackToParentTipWithoutStoredDivergence(t *testing.T) {
 	require.NoError(t, err)
 
 	// Without the fallback, GetAllCommits walks b's whole history to the repo
-	// root while GetCommitCount walks only parent..b, so the two disagree.
-	count, err := s.Engine.GetCommitCount(b)
+	// root while a parent..b walk covers only b's own commits, so the two
+	// disagree. The raw-git count against the parent tip is the oracle here.
+	count, err := s.Scene.Repo.GetCommitCount(b.GetParent().GetName(), "b")
 	require.NoError(t, err)
 	require.Equal(t, count, len(commits),
 		"commit messages and count must use the same base when no divergence is stored")

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -46,16 +46,6 @@ func (e *engineImpl) BatchDivergencePoints(branches Branches) map[string]string 
 	})
 }
 
-// GetCommitCount returns the number of commits for a branch.
-// Results are cached by (base, head) SHA pair.
-func (e *engineImpl) GetCommitCount(branch Branch) (int, error) {
-	base, branchRev, err := e.resolveBranchComparisonRevisions(branch.GetName())
-	if err != nil {
-		return 0, err
-	}
-	return e.commitCountBetween(git.RevRange{Base: base, Head: branchRev})
-}
-
 // commitCountBetween returns the commit count in (base, head], using the
 // (base, head)-keyed cache. It takes pre-resolved revisions so batched callers
 // need not re-resolve a branch's head.
@@ -77,16 +67,6 @@ func (e *engineImpl) commitCountBetween(rr git.RevRange) (int, error) {
 	count, _ := strconv.Atoi(strings.TrimSpace(out))
 	e.commitCountCache.Store(cacheKey, count)
 	return count, nil
-}
-
-// GetDiffStats returns diff stats for a branch.
-// Results are cached by (base, head) SHA pair.
-func (e *engineImpl) GetDiffStats(branch Branch) (int, int, error) {
-	base, branchRev, err := e.resolveBranchComparisonRevisions(branch.GetName())
-	if err != nil {
-		return 0, 0, err
-	}
-	return e.diffStatsBetween(git.RevRange{Base: base, Head: branchRev})
 }
 
 // diffStatsBetween returns the additions/deletions between two revisions, using
@@ -125,39 +105,6 @@ func (e *engineImpl) diffStatsBetween(rr git.RevRange) (int, int, error) {
 
 	e.diffStatsCache.Store(cacheKey, [2]int{added, deleted})
 	return added, deleted, nil
-}
-
-func (e *engineImpl) resolveBranchComparisonRevisions(branchName string) (base, branchRev string, err error) {
-	e.mu.RLock()
-	trunk := e.trunk
-	state := e.readState(branchName)
-	e.mu.RUnlock()
-
-	parent := trunk
-	if state != nil {
-		parent = state.Parent
-	}
-
-	// Get base revision (stored parent revision). An empty stored revision is
-	// treated as unset and falls back to the parent's current tip, matching
-	// statBase, which the batched diff-stat/commit-count readers use.
-	meta, err := e.readMetadata(branchName)
-	if rev := meta.GetParentBranchRevision(); err == nil && rev != nil && *rev != "" {
-		base = *rev
-	} else {
-		baseRev, err := e.git.GetRevision(parent)
-		if err != nil {
-			return "", "", err
-		}
-		base = baseRev
-	}
-
-	branchRev, err = e.git.GetRevision(branchName)
-	if err != nil {
-		return "", "", err
-	}
-
-	return base, branchRev, nil
 }
 
 // GetRecentTrunkCommits returns the most recent commits on the trunk branch,
@@ -204,7 +151,7 @@ func (e *engineImpl) GetAllCommits(branch Branch, format CommitFormat) ([]string
 	// current tip when none is recorded. Falling back to the parent tip — not an
 	// empty base, which lists the branch's entire history back to the repo root —
 	// keeps the result to the branch's own commits and consistent with the base
-	// GetDiffStats / GetCommitCount use.
+	// the batched diff-stat / commit-count readers use (statBase).
 	var baseRevision string
 	if rev := meta.GetParentBranchRevision(); rev != nil && *rev != "" {
 		baseRevision = *rev

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -88,8 +88,6 @@ type BranchInfo interface {
 	GetCommitDate(branch Branch) (time.Time, error)
 	GetCommitAuthor(branch Branch) (string, error)
 	GetRevision(branch Branch) (string, error)
-	GetCommitCount(branch Branch) (int, error)
-	GetDiffStats(branch Branch) (added int, deleted int, err error)
 	GetAllCommits(branch Branch, format CommitFormat) ([]string, error)
 	GetParentCommitSHA(commitSHA string) (string, error)
 	GetCommitSHA(branchName string, offset int) (string, error)

--- a/internal/integration/restack_squash_merge_test.go
+++ b/internal/integration/restack_squash_merge_test.go
@@ -70,9 +70,7 @@ func TestSquashMergeMultiCommitParent(t *testing.T) {
 	require.Equal(t, mainName, sh.Engine.GetBranch("child").GetParent().GetName())
 
 	// Child must keep ONLY its own commit — parent's 3 commits must not replay.
-	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("child"))
-	require.NoError(t, err)
-	require.Equal(t, 1, cCount, "child should not inherit parent's squashed commits")
+	require.Equal(t, 1, sh.BranchCommitCount("child"), "child should not inherit parent's squashed commits")
 
 	requireCleanWorkingTree(t, sh)
 }
@@ -120,9 +118,7 @@ func TestRestackAfterMultiCommitSquashParentDeleted(t *testing.T) {
 	sh.Rebuild()
 	require.Equal(t, mainName, sh.Engine.GetBranch("child").GetParent().GetName())
 
-	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("child"))
-	require.NoError(t, err)
-	require.Equal(t, 1, cCount, "child should not inherit parent's squashed commits")
+	require.Equal(t, 1, sh.BranchCommitCount("child"), "child should not inherit parent's squashed commits")
 
 	requireCleanWorkingTree(t, sh)
 }
@@ -173,9 +169,7 @@ func TestRestackDetectsSquashMergeWithStalePRState(t *testing.T) {
 	require.Equal(t, mainName, sh.Engine.GetBranch("child").GetParent().GetName(),
 		"child should reparent to main when the squash scan detects the parent merged")
 
-	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("child"))
-	require.NoError(t, err)
-	require.Equal(t, 1, cCount, "child should keep only its own commit")
+	require.Equal(t, 1, sh.BranchCommitCount("child"), "child should keep only its own commit")
 
 	requireCleanWorkingTree(t, sh)
 }
@@ -249,9 +243,7 @@ func TestSyncKeepsUnmergedBranchWithPRNumber(t *testing.T) {
 	require.Contains(t, branches, "feature",
 		"an unmerged branch must not be deleted just because it has a PR number")
 
-	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("feature"))
-	require.NoError(t, err)
-	require.Equal(t, 1, cCount, "feature must keep its own unlanded commit")
+	require.Equal(t, 1, sh.BranchCommitCount("feature"), "feature must keep its own unlanded commit")
 
 	requireCleanWorkingTree(t, sh)
 }
@@ -309,9 +301,7 @@ func TestSquashMergedSiblingKeepsOwnCommit(t *testing.T) {
 		"sibling B must never be reset to A's stale pre-merge tip (issue #1345 data loss)")
 
 	// B keeps exactly its own commit on top of main.
-	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("branch-b"))
-	require.NoError(t, err)
-	require.Equal(t, 1, cCount, "sibling B must keep only its own commit")
+	require.Equal(t, 1, sh.BranchCommitCount("branch-b"), "sibling B must keep only its own commit")
 
 	requireCleanWorkingTree(t, sh)
 }
@@ -357,9 +347,7 @@ func TestRestackAfterMultiCommitSquashWithoutSync(t *testing.T) {
 		"child should reparent to main past the merged parent")
 
 	// Child must keep ONLY its own commit — parent's 3 commits must not replay.
-	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("child"))
-	require.NoError(t, err)
-	require.Equal(t, 1, cCount, "child should not inherit parent's squashed commits")
+	require.Equal(t, 1, sh.BranchCommitCount("child"), "child should not inherit parent's squashed commits")
 
 	requireCleanWorkingTree(t, sh)
 }

--- a/internal/integration/sync_test.go
+++ b/internal/integration/sync_test.go
@@ -393,13 +393,8 @@ func TestSyncSquashMergedRootPreservesChildCommitBoundaries(t *testing.T) {
 
 	// Core regression assertions: B and C keep their own commit boundaries.
 	// If A commits were replayed into B/C, these counts would be inflated.
-	bCount, err := eng.GetCommitCount(eng.GetBranch("branch-b"))
-	require.NoError(t, err)
-	require.Equal(t, 1, bCount)
-
-	cCount, err := eng.GetCommitCount(eng.GetBranch("branch-c"))
-	require.NoError(t, err)
-	require.Equal(t, 1, cCount)
+	require.Equal(t, 1, sh.BranchCommitCount("branch-b"))
+	require.Equal(t, 1, sh.BranchCommitCount("branch-c"))
 
 	sh.ExpectBranchFixed("branch-b").
 		ExpectBranchFixed("branch-c")
@@ -715,9 +710,7 @@ func TestSquashMergeMiddleOfStack(t *testing.T) {
 	require.Equal(t, "main", sh.Engine.GetBranch("branch-a").GetParent().GetName())
 
 	// C keeps its own commits — A's squash content shouldn't replay into C.
-	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("branch-c"))
-	require.NoError(t, err)
-	require.Equal(t, 1, cCount)
+	require.Equal(t, 1, sh.BranchCommitCount("branch-c"))
 }
 
 // TestSquashMergeMultipleAdjacentMergedInOneSync covers when both A and B
@@ -759,9 +752,7 @@ func TestSquashMergeMultipleAdjacentMergedInOneSync(t *testing.T) {
 	require.Equal(t, mainName, sh.Engine.GetBranch("branch-c").GetParent().GetName())
 
 	// C should not have inherited A's or B's commits during restack.
-	cCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("branch-c"))
-	require.NoError(t, err)
-	require.Equal(t, 1, cCount)
+	require.Equal(t, 1, sh.BranchCommitCount("branch-c"))
 
 	requireCleanWorkingTree(t, sh)
 }
@@ -860,9 +851,7 @@ func TestSquashMergeSyncWhileOnChildOfMergedBranch(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "branch-b", strings.TrimSpace(headRef))
 
-	bCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("branch-b"))
-	require.NoError(t, err)
-	require.Equal(t, 1, bCount, "B should keep its single commit after restack onto trunk")
+	require.Equal(t, 1, sh.BranchCommitCount("branch-b"), "B should keep its single commit after restack onto trunk")
 
 	requireCleanWorkingTree(t, sh)
 }
@@ -1066,9 +1055,7 @@ func TestMergeCommitNotSquash(t *testing.T) {
 	require.Equal(t, mainName, sh.Engine.GetBranch("branch-b").GetParent().GetName())
 
 	// B's commit boundary must be preserved — A's commits are already in trunk.
-	bCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("branch-b"))
-	require.NoError(t, err)
-	require.Equal(t, 1, bCount, "B should have its own commit only, not a duplicate of A's")
+	require.Equal(t, 1, sh.BranchCommitCount("branch-b"), "B should have its own commit only, not a duplicate of A's")
 
 	requireCleanWorkingTree(t, sh)
 }
@@ -1113,9 +1100,7 @@ func TestUserLocallyAdvancedTrunkBeforeSync(t *testing.T) {
 
 	require.Equal(t, mainName, sh.Engine.GetBranch("branch-b").GetParent().GetName())
 
-	bCount, err := sh.Engine.GetCommitCount(sh.Engine.GetBranch("branch-b"))
-	require.NoError(t, err)
-	require.Equal(t, 1, bCount)
+	require.Equal(t, 1, sh.BranchCommitCount("branch-b"))
 
 	requireCleanWorkingTree(t, sh)
 }

--- a/testhelpers/git_repo.go
+++ b/testhelpers/git_repo.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -448,6 +449,27 @@ func (r *GitRepo) GetCommitCount(from, to string) (int, error) {
 		return 0, fmt.Errorf("failed to parse commit count: %w", err)
 	}
 	return count, nil
+}
+
+// GetDiffStats returns the total additions and deletions between two refs,
+// summed across all changed files (git diff --numstat from..to).
+func (r *GitRepo) GetDiffStats(from, to string) (added, deleted int, err error) {
+	output, err := r.runGitCommandAndGetOutput("diff", "--numstat", from+".."+to)
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		// Binary files report "-" for numstat; treat as zero.
+		a, _ := strconv.Atoi(fields[0])
+		d, _ := strconv.Atoi(fields[1])
+		added += a
+		deleted += d
+	}
+	return added, deleted, nil
 }
 
 // GetBranchSHA returns the SHA of a branch.

--- a/testhelpers/scenario/scenario.go
+++ b/testhelpers/scenario/scenario.go
@@ -329,6 +329,16 @@ func (s *Scenario) ExpectStackStructure(expected map[string]string) *Scenario {
 	return s
 }
 
+// BranchCommitCount returns the number of commits a branch carries relative to
+// its divergence base, resolved via the batched stats reader (BatchBranchStats).
+// It replaces the removed per-branch Engine.GetCommitCount accessor and uses the
+// same base resolution, so counts are unchanged.
+func (s *Scenario) BranchCommitCount(branch string) int {
+	s.T.Helper()
+	b := s.Engine.GetBranch(branch)
+	return s.Engine.BatchBranchStats(engine.BranchesOf(b))[branch].CommitCount
+}
+
 // ExpectBranchFixed asserts that a branch is considered "fixed" (no restack needed) by the engine.
 func (s *Scenario) ExpectBranchFixed(branch string) *Scenario {
 	s.T.Helper()


### PR DESCRIPTION
The batched readers (BatchBranchStats / BatchDiffStats) took over every
production call site, leaving the per-branch Engine.GetCommitCount and
Engine.GetDiffStats accessors (and their Branch wrappers) with no callers.
GetCommitCount was fully dead; GetDiffStats had a single remaining caller in
the info action, now migrated to BatchDiffStats over a single-branch set.

The orphaned resolveBranchComparisonRevisions helper is removed too: the
batched path resolves the same base via statBase, so counts and diffs are
unchanged.

Tests that used the deleted accessors as oracles now validate the batch
readers against an independent raw-git oracle (new testhelpers
GitRepo.GetDiffStats) or the Scenario.BranchCommitCount helper, which wraps
BatchBranchStats with identical base resolution.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GMi1x5pkwEdgPhTN8Y3wYh