### PR TITLE
fix: restack worktree-anchored branch onto trunk, not stale anchor

### DIFF
--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -274,6 +274,24 @@ func (e *engineImpl) restackBranch(
 		}
 	}
 
+	// A worktree anchor is a hidden marker at trunk. When a branch parented
+	// under an anchor is restacked in isolation (e.g. EnterConflictWorkflow
+	// restacking just the conflict branch), the anchor ref can still lag trunk
+	// because it isn't part of this restack set. PlanRestack substitutes trunk
+	// for a stale anchor parent (see restack_plan.go); restackBranch must too.
+	// Without it, parentRev stays at the anchor's stale tip, the check below
+	// finds parentRev == oldParentRev and skips the rebase as "unneeded" — while
+	// validation (which used trunk) predicted a conflict. That mismatch trips
+	// EnterConflictWorkflow's "expected conflict but rebase completed
+	// successfully" assertion and leaves the branch un-restacked.
+	rebaseOnto := parent
+	if e.IsWorktreeAnchor(parentBranch) {
+		if trunkRev, trunkErr := e.Trunk().GetRevision(); trunkErr == nil && trunkRev != parentRev {
+			parentRev = trunkRev
+			rebaseOnto = trunkRev
+		}
+	}
+
 	// Get metadata (read once to avoid duplicate disk I/O)
 	meta := snap.meta.Get(branchName)
 	if meta == nil {
@@ -319,7 +337,7 @@ func (e *engineImpl) restackBranch(
 	}
 
 	// Perform rebase
-	gitResult, err := e.git.Rebase(ctx, branchName, parent, oldParentRev)
+	gitResult, err := e.git.Rebase(ctx, branchName, rebaseOnto, oldParentRev)
 	if err != nil {
 		return RestackBranchResult{
 			Result:              RestackConflict,

--- a/internal/integration/resiliency_test.go
+++ b/internal/integration/resiliency_test.go
@@ -59,6 +59,54 @@ func TestRestackWithStaleMetadataButMatchingParentRev(t *testing.T) {
 		OutputContains("restack stopped due to conflict")
 }
 
+// TestRestackWorktreeAnchoredBranchAgainstAdvancedTrunk reproduces the bug where
+// restacking a worktree-anchored branch onto an advanced trunk fails with
+// "expected conflict on <branch> but rebase completed successfully".
+//
+// A worktree stack is rooted under a hidden anchor branch that sits at trunk.
+// When trunk advances with a change that conflicts with the worktree branch's
+// own commit, pre-flight validation (which resolves the branch's base past the
+// hidden anchor to the *new* trunk tip) correctly predicts a conflict. But the
+// conflict-entry path re-plans the restack for that single branch in isolation,
+// resolving its base to the anchor's *stale* tip, so the real rebase is a clean
+// no-op. Validation and execution disagree, and the assertion in
+// EnterConflictWorkflow fires.
+//
+// Correct behavior: the restack either cleanly reparents past the anchor or
+// stops at the real conflict — never reports "rebase completed successfully"
+// after validation predicted a conflict.
+func TestRestackWorktreeAnchoredBranchAgainstAdvancedTrunk(t *testing.T) {
+	t.Parallel()
+	sh := NewTestShellInProcess(t)
+	sh.SetWorktreeBasePath(t.TempDir())
+
+	// 1. Seed trunk with the shared file both sides will touch.
+	sh.WriteFile("shared.txt", "base").Git("commit -m 'seed shared file'")
+
+	// 2. Create a worktree-anchored branch whose commit changes shared.txt.
+	//    `create -w` makes the real branch, inserts a hidden anchor at trunk,
+	//    reparents the branch under the anchor, and opens the worktree on it.
+	sh.WriteFile("shared.txt", "feature version").
+		Run("create feature -w -m 'feature changes shared'")
+
+	// 3. Advance trunk with a conflicting change to the same file.
+	sh.Checkout("main").
+		WriteFile("shared.txt", "main version").
+		Git("commit -m 'main also changes shared'")
+
+	// 4. Restack the worktree stack against the advanced trunk. Validation
+	//    predicts a real conflict; the buggy path instead completes a no-op
+	//    rebase onto the stale anchor.
+	sh.RunExpectError("restack --all-stacks")
+
+	// The bug manifests as "expected conflict ... but rebase completed
+	// successfully" — the branch was skipped as a no-op onto its stale anchor.
+	// The fix rebases onto trunk (the anchor's logical position), so the real
+	// conflict surfaces and the normal resolve/continue workflow engages.
+	sh.OutputNotContains("rebase completed successfully").
+		OutputContains("conflict")
+}
+
 func TestResiliencyStaleParentSHA(t *testing.T) {
 	t.Parallel()
 	shell := NewTestShellInProcess(t)


### PR DESCRIPTION

Restacking a branch parented under a hidden worktree anchor onto an
advanced trunk aborted with "expected conflict ... but rebase completed
successfully" and left the branch un-restacked.

Two paths resolved the rebase base differently. PlanRestack (pre-flight
validation) substitutes trunk for a stale anchor parent and predicts the
conflict, but restackBranch (the real rebase in EnterConflictWorkflow)
used the anchor's stale ref, saw parentRev == oldParentRev, and skipped
the rebase as unneeded. Validation said "conflict", execution said "clean
no-op", so EnterConflictWorkflow's assertion fired and rolled back.

Mirror PlanRestack's anchor->trunk substitution in restackBranch so the
branch rebases onto trunk (the anchor's logical position). Execution now
matches validation: the real conflict surfaces and the normal
resolve/continue workflow engages.