### PR TITLE
feat: consolidate restack conflict reporting into one actionable block

### DIFF
--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -23,6 +23,7 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
 	"github.com/getstackit/stackit/internal/output"
 )
 
@@ -540,7 +541,7 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 		return fmt.Errorf("failed to print conflict status: %w", err)
 	}
 
-	return fmt.Errorf("restack stopped due to conflict on %s", firstConflict)
+	return errors.NewConflictWorkflowError(firstConflict)
 }
 
 // validateBranchAncestry performs pre-flight checks on branch ancestry relationships.

--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -87,7 +87,9 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 		if err := PrintConflictStatus(ctx, branchName); err != nil {
 			return fmt.Errorf("failed to print conflict status: %w", err)
 		}
-		return fmt.Errorf("rebase conflict is not yet resolved")
+		// PrintConflictStatus already told the user what to do; return the
+		// silenced conflict-workflow error so cobra doesn't reprint it.
+		return errors.NewConflictWorkflowError(branchName)
 	}
 
 	// Success - checkout the branch (rebase leaves us in detached HEAD)

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -3,7 +3,6 @@ package sync
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/getstackit/stackit/internal/actions"
@@ -514,27 +513,6 @@ func plural(count int) string {
 		return ""
 	}
 	return "s"
-}
-
-// FormatSummaryString returns the full summary as a string
-func FormatSummaryString(summary Summary) string {
-	if summary.UpToDate {
-		return "Everything is up to date!"
-	}
-
-	parts := FormatSummaryParts(summary)
-	if len(parts) == 0 {
-		return ""
-	}
-
-	result := "Summary: " + strings.Join(parts, ", ")
-
-	// Add actionable advice for conflicts
-	if len(summary.ConflictBranches) > 0 {
-		result += fmt.Sprintf("\n   Run 'st restack %s' to resolve and continue", summary.ConflictBranches[0])
-	}
-
-	return result
 }
 
 // pluralES returns "es" if count != 1, otherwise empty string (for "branch" -> "branches")

--- a/internal/cli/branch/absorb_test.go
+++ b/internal/cli/branch/absorb_test.go
@@ -352,7 +352,9 @@ func TestAbsorbComplex(t *testing.T) {
 		output, err := cmd.CombinedOutput()
 
 		require.Error(t, err, "absorb should fail during restack. Output: %s", string(output))
-		require.Contains(t, string(output), "failed to restack", "should report restack failure")
+		// The conflict-workflow error is silenced (instructions are printed
+		// instead), so assert on the printed conflict status.
+		require.Contains(t, string(output), "Hit conflict restacking branchB", "should report restack conflict")
 
 		// In case of restack conflict, stackit stays in rebase mode (detached HEAD)
 		rebaseDir := scene.Dir + "/.git/rebase-merge"

--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -60,6 +60,11 @@ func RunWithOptions(cmd *cobra.Command, opts app.GlobalOptions, fn func(ctx *app
 	// and failure both. Their errors are surfaced as warnings (non-blocking).
 	_ = RunCommandHooks(ctx, cmd, PhasePost)
 	if err != nil {
+		// The conflict workflow already printed full resolution instructions;
+		// silence cobra's "Error: ..." reprint but keep the non-zero exit.
+		if errors.Is(err, errors.ErrConflictWorkflow) {
+			cmd.SilenceErrors = true
+		}
 		return HandleCommandError(err)
 	}
 	return nil

--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -302,10 +302,10 @@ func (h *SimpleSyncHandler) printSummary(summary syncAction.Summary) {
 		h.Output.Info("✅ Summary: %s", strings.Join(parts, ", "))
 	}
 
-	// Print actionable advice for conflicts
-	if len(summary.ConflictBranches) > 0 {
+	// Print actionable advice for every conflict, not just the first
+	for _, conflict := range summary.ConflictBranches {
 		h.Output.Info("  Run %s to resolve and continue",
-			style.ColorCyan(fmt.Sprintf("st restack %s", summary.ConflictBranches[0])))
+			style.ColorCyan(fmt.Sprintf("st restack %s", conflict)))
 	}
 }
 
@@ -581,17 +581,17 @@ func (h *InteractiveSyncHandler) formatSummary(summary syncAction.Summary) strin
 
 	parts := syncAction.FormatSummaryParts(summary)
 
-	result := ""
+	var lines []string
 	if len(parts) > 0 {
-		result = "✅ Summary: " + strings.Join(parts, ", ")
+		lines = append(lines, "✅ Summary: "+strings.Join(parts, ", "))
 	}
 
-	// Add actionable advice for conflicts
-	if len(summary.ConflictBranches) > 0 {
-		result += fmt.Sprintf("\n   Run 'st restack %s' to resolve and continue", summary.ConflictBranches[0])
+	// Add actionable advice for every conflict, not just the first
+	for _, conflict := range summary.ConflictBranches {
+		lines = append(lines, fmt.Sprintf("   Run 'st restack %s' to resolve and continue", conflict))
 	}
 
-	return result
+	return strings.Join(lines, "\n")
 }
 
 // OnRestackStart implements RestackHandler for standalone restack operations
@@ -764,16 +764,15 @@ func (h *InteractiveSyncHandler) PromptOrphanedMetadata(info engine.OrphanedMeta
 func describeRestackConflicts(out output.Output, conflictBranches []string) {
 	out.Newline()
 	// out.Warn already prefixes "⚠️ "; don't hardcode another one here.
-	out.Warn("Found conflicts in %d %s during restack:",
+	out.Warn("Found conflicts in %d %s during restack; branches without conflicts were restacked.",
 		len(conflictBranches),
 		map[bool]string{true: "branch", false: "branches"}[len(conflictBranches) == 1])
+	// Bullets are detail lines, not warnings — use Info so they don't each
+	// pick up a ⚠️ prefix.
+	out.Info("Resolve each with:")
 	for _, name := range conflictBranches {
-		// Bullets are detail lines, not warnings — use Info so they don't each
-		// pick up a ⚠️ prefix.
-		out.Info("  • %s", style.ColorBranchName(name))
+		out.Info("  • %s", style.ColorCyan("st restack "+name))
 	}
-	out.Newline()
-	out.Info("Branches that could be restacked cleanly have been restacked.")
 	out.Newline()
 }
 

--- a/internal/cli/stack/testdata/sync/full_sync.golden
+++ b/internal/cli/stack/testdata/sync/full_sync.golden
@@ -18,10 +18,9 @@
   ✓ Restacked feat-ui (PR #202) on feat-api → c3d4e5f
   ⚠ Skipped feat-report (PR #203) (conflict)
 
-⚠️  Found conflicts in 1 branch during restack:
-  • feat-report
-
-Branches that could be restacked cleanly have been restacked.
+⚠️  Found conflicts in 1 branch during restack; branches without conflicts were restacked.
+Resolve each with:
+  • st restack feat-report
 
 ? Resolve conflicts now? [y/N]
 › user answers: no

--- a/internal/cli/stack/testdata/sync/restack_conflict_declined.golden
+++ b/internal/cli/stack/testdata/sync/restack_conflict_declined.golden
@@ -2,10 +2,9 @@
   ✓ Restacked feat-api (PR #201) on main → b2c3d4e
   ⚠ Skipped feat-ui (PR #202) (conflict)
 
-⚠️  Found conflicts in 1 branch during restack:
-  • feat-ui
-
-Branches that could be restacked cleanly have been restacked.
+⚠️  Found conflicts in 1 branch during restack; branches without conflicts were restacked.
+Resolve each with:
+  • st restack feat-ui
 
 ? Resolve conflicts now? [y/N]
 › user answers: no

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -43,6 +43,11 @@ var (
 	// ErrCanceled indicates that an interactive operation was canceled by the user
 	ErrCanceled = errors.New("canceled")
 
+	// ErrConflictWorkflow indicates a command entered the conflict-resolution
+	// workflow. Resolution instructions have already been printed, so CLI
+	// adapters should exit non-zero without printing this error again.
+	ErrConflictWorkflow = errors.New("conflict workflow entered")
+
 	// ErrBack indicates that the user wants to go back to the previous step
 	ErrBack = errors.New("back")
 )
@@ -103,6 +108,28 @@ func NewBranchModificationError(branchName string, lockReason git.LockReason, fr
 		LockReason: lockReason,
 		IsFrozen:   frozen,
 	}
+}
+
+// ConflictWorkflowError reports that a restack stopped inside the conflict
+// workflow on a specific branch. The user-facing resolution instructions were
+// printed before this error was returned; it exists to carry the non-zero exit
+// code (and the message for JSON output) without a duplicate terminal print.
+type ConflictWorkflowError struct {
+	BranchName string
+}
+
+func (e *ConflictWorkflowError) Error() string {
+	return fmt.Sprintf("restack stopped due to conflict on %s", e.BranchName)
+}
+
+// Is returns true if the target error is ErrConflictWorkflow
+func (e *ConflictWorkflowError) Is(target error) bool {
+	return target == ErrConflictWorkflow
+}
+
+// NewConflictWorkflowError creates a new ConflictWorkflowError
+func NewConflictWorkflowError(branchName string) *ConflictWorkflowError {
+	return &ConflictWorkflowError{BranchName: branchName}
 }
 
 // RebaseConflictError represents an error when a rebase encounters a conflict

--- a/internal/integration/resiliency_test.go
+++ b/internal/integration/resiliency_test.go
@@ -54,9 +54,11 @@ func TestRestackWithStaleMetadataButMatchingParentRev(t *testing.T) {
 
 	// The bug manifests as "expected conflict on A but rebase completed successfully"
 	// which means the rebase was skipped entirely due to the early-exit check.
-	// The fix should make the rebase actually happen and hit a conflict.
+	// The fix should make the rebase actually happen and hit a conflict. The
+	// conflict-workflow error itself is no longer echoed by cobra (instructions
+	// are printed instead), so assert on the printed conflict status.
 	sh.OutputNotContains("rebase completed successfully").
-		OutputContains("restack stopped due to conflict")
+		OutputContains("Hit conflict restacking A")
 }
 
 // TestRestackWorktreeAnchoredBranchAgainstAdvancedTrunk reproduces the bug where


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Restack conflicts were reported three times with contradicting tone: per-branch skip lines, a summary block, and a trailing cobra 'Error: restack stopped due to conflict' that read like a crash right after saying clean branches were restacked. The conflict block now leads with a copy-pasteable 'st restack <branch>' command per conflict, summary advice covers every conflict instead of only the first, and the conflict-workflow error is a typed error (errors.ConflictWorkflowError) that keeps the non-zero exit and JSON message but suppresses cobra's duplicate print — the printed resolution instructions are the last word. Also removes the dead FormatSummaryString.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1784862381`.


* **PR #1416**
  * **PR #1417**
    * **PR #1418**
      * **PR #1419**
        * **PR #1420**
          * **PR #1443** 👈
            * **PR #1445**
              * **PR #1446**
                * **PR #1447**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1448 by jonnii*