### PR TITLE
refactor: extract shared git hook install/uninstall logic

### DIFF
--- a/internal/actions/integrations/hook_install.go
+++ b/internal/actions/integrations/hook_install.go
@@ -1,0 +1,121 @@
+// Package integrations provides functionality for integrating Stackit with external tools and hooks.
+package integrations
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/getstackit/stackit/internal/output"
+)
+
+// installHook installs a git hook at .git/hooks/<hookName>, appending the
+// marker command to an existing hook file or writing the template if none
+// exists yet. displayName is used in log messages (e.g. "Pre-commit").
+func installHook(repoRoot, hookName, marker, template, displayName string, out output.Output) error {
+	hooksDir := filepath.Join(repoRoot, ".git", "hooks")
+	hookPath := filepath.Join(hooksDir, hookName)
+
+	if err := os.MkdirAll(hooksDir, 0750); err != nil {
+		return fmt.Errorf("failed to create hooks directory: %w", err)
+	}
+
+	if _, err := os.Stat(hookPath); err == nil {
+		content, err := os.ReadFile(hookPath)
+		if err == nil && strings.Contains(string(content), marker) {
+			out.Info(fmt.Sprintf("%s hook is already installed.", displayName))
+			return nil
+		}
+
+		// If it exists but doesn't have our command, append
+		f, err := os.OpenFile(hookPath, os.O_APPEND|os.O_WRONLY, 0600)
+		if err != nil {
+			return fmt.Errorf("failed to open existing %s hook: %w", hookName, err)
+		}
+		defer func() { _ = f.Close() }()
+
+		if _, err := f.WriteString(fmt.Sprintf("\n# Added by Stackit\n%s\n", marker)); err != nil {
+			return fmt.Errorf("failed to append to %s hook: %w", hookName, err)
+		}
+		out.Info(fmt.Sprintf("Appended Stackit verification to existing %s hook.", strings.ToLower(displayName)))
+	} else {
+		// #nosec G306 - Git hooks need to be executable
+		if err := os.WriteFile(hookPath, []byte(template), 0750); err != nil {
+			return fmt.Errorf("failed to write %s hook: %w", hookName, err)
+		}
+		out.Info(fmt.Sprintf("Installed Stackit %s hook.", strings.ToLower(displayName)))
+	}
+
+	return nil
+}
+
+// uninstallHook removes the Stackit marker command from .git/hooks/<hookName>,
+// deleting the file entirely if only a shebang would remain. displayName is
+// used in log messages (e.g. "Pre-commit").
+func uninstallHook(out output.Output, repoRoot, hookName, marker, displayName string) error {
+	hooksDir := filepath.Join(repoRoot, ".git", "hooks")
+	hookPath := filepath.Join(hooksDir, hookName)
+
+	if _, err := os.Stat(hookPath); os.IsNotExist(err) {
+		out.Info(fmt.Sprintf("%s hook is not installed.", displayName))
+		return nil
+	}
+
+	content, err := os.ReadFile(hookPath)
+	if err != nil {
+		return fmt.Errorf("failed to read %s hook: %w", hookName, err)
+	}
+
+	lines := strings.Split(string(content), "\n")
+	newLines := make([]string, 0, len(lines))
+	removed := false
+
+	for i := range lines {
+		line := lines[i]
+		if strings.Contains(line, marker) {
+			removed = true
+			// Check if previous line was our comment or if it's the "# Added by Stackit" comment
+			if i > 0 && len(newLines) > 0 && (strings.Contains(lines[i-1], "Installed by Stackit") || strings.Contains(lines[i-1], "Added by Stackit")) {
+				newLines = newLines[:len(newLines)-1]
+			}
+			continue
+		}
+		newLines = append(newLines, line)
+	}
+
+	if !removed {
+		out.Info(fmt.Sprintf("Stackit verification not found in %s hook.", strings.ToLower(displayName)))
+		return nil
+	}
+
+	// Check if only shebang is left or if it's empty
+	isOnlyShebang := true
+	for _, line := range newLines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#!") {
+			continue
+		}
+		isOnlyShebang = false
+		break
+	}
+
+	if isOnlyShebang {
+		if err := os.Remove(hookPath); err != nil {
+			return fmt.Errorf("failed to remove %s hook: %w", hookName, err)
+		}
+		out.Info(fmt.Sprintf("Removed Stackit %s hook.", strings.ToLower(displayName)))
+	} else {
+		// Write back modified content
+		newContent := strings.Join(newLines, "\n")
+		// Clean up trailing/leading newlines that might have been left behind
+		newContent = strings.TrimSpace(newContent) + "\n"
+		// #nosec G306 - Git hooks need to be executable
+		if err := os.WriteFile(hookPath, []byte(newContent), 0750); err != nil {
+			return fmt.Errorf("failed to write %s hook: %w", hookName, err)
+		}
+		out.Info(fmt.Sprintf("Removed Stackit verification from existing %s hook.", strings.ToLower(displayName)))
+	}
+
+	return nil
+}

--- a/internal/actions/integrations/hook_install.go
+++ b/internal/actions/integrations/hook_install.go
@@ -35,7 +35,7 @@ func installHook(repoRoot, hookName, marker, template, displayName string, out o
 		}
 		defer func() { _ = f.Close() }()
 
-		if _, err := f.WriteString(fmt.Sprintf("\n# Added by Stackit\n%s\n", marker)); err != nil {
+		if _, err := fmt.Fprintf(f, "\n# Added by Stackit\n%s\n", marker); err != nil {
 			return fmt.Errorf("failed to append to %s hook: %w", hookName, err)
 		}
 		out.Info(fmt.Sprintf("Appended Stackit verification to existing %s hook.", strings.ToLower(displayName)))

--- a/internal/actions/integrations/precommit.go
+++ b/internal/actions/integrations/precommit.go
@@ -2,14 +2,16 @@
 package integrations
 
 import (
-	"fmt"
 	"io"
-	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/output"
+)
+
+const (
+	precommitHookName    = "pre-commit"
+	precommitMarker      = "stackit precommit verify"
+	precommitDisplayName = "Pre-commit"
 )
 
 const precommitHookTemplate = `#!/bin/bash
@@ -19,55 +21,14 @@ stackit precommit verify
 
 // PrecommitInstallAction installs the pre-commit hook
 func PrecommitInstallAction(ctx *app.Context) error {
-	return installPrecommitHook(ctx.RepoRoot, ctx.Output)
+	return installHook(ctx.RepoRoot, precommitHookName, precommitMarker, precommitHookTemplate, precommitDisplayName, ctx.Output)
 }
 
 // PrecommitInstallActionWithOutput installs the pre-commit hook with a custom writer.
 // This is a convenience function for use during init where we don't have an app.Context.
 func PrecommitInstallActionWithOutput(repoRoot string, writer io.Writer) error {
 	out := output.NewConsoleOutput(writer, false)
-	return installPrecommitHook(repoRoot, out)
-}
-
-// installPrecommitHook is the core implementation for installing the pre-commit hook.
-func installPrecommitHook(repoRoot string, out output.Output) error {
-	hooksDir := filepath.Join(repoRoot, ".git", "hooks")
-	hookPath := filepath.Join(hooksDir, "pre-commit")
-
-	// Ensure hooks directory exists
-	if err := os.MkdirAll(hooksDir, 0750); err != nil {
-		return fmt.Errorf("failed to create hooks directory: %w", err)
-	}
-
-	// Check if hook already exists
-	if _, err := os.Stat(hookPath); err == nil {
-		content, err := os.ReadFile(hookPath)
-		if err == nil && strings.Contains(string(content), "stackit precommit verify") {
-			out.Info("Pre-commit hook is already installed.")
-			return nil
-		}
-
-		// If it exists but doesn't have our command, append
-		f, err := os.OpenFile(hookPath, os.O_APPEND|os.O_WRONLY, 0600)
-		if err != nil {
-			return fmt.Errorf("failed to open existing pre-commit hook: %w", err)
-		}
-		defer func() { _ = f.Close() }()
-
-		if _, err := f.WriteString("\n# Added by Stackit\nstackit precommit verify\n"); err != nil {
-			return fmt.Errorf("failed to append to pre-commit hook: %w", err)
-		}
-		out.Info("Appended Stackit verification to existing pre-commit hook.")
-	} else {
-		// Create new hook
-		// #nosec G306 - Git hooks need to be executable
-		if err := os.WriteFile(hookPath, []byte(precommitHookTemplate), 0750); err != nil {
-			return fmt.Errorf("failed to write pre-commit hook: %w", err)
-		}
-		out.Info("Installed Stackit pre-commit hook.")
-	}
-
-	return nil
+	return installHook(repoRoot, precommitHookName, precommitMarker, precommitHookTemplate, precommitDisplayName, out)
 }
 
 // PrecommitVerifyAction checks if the current branch can be modified
@@ -86,70 +47,5 @@ func PrecommitVerifyAction(ctx *app.Context) error {
 
 // PrecommitUninstallAction uninstalls the pre-commit hook
 func PrecommitUninstallAction(ctx *app.Context) error {
-	repoRoot := ctx.RepoRoot
-	hooksDir := filepath.Join(repoRoot, ".git", "hooks")
-	hookPath := filepath.Join(hooksDir, "pre-commit")
-
-	// Check if hook exists
-	if _, err := os.Stat(hookPath); os.IsNotExist(err) {
-		ctx.Output.Info("Pre-commit hook is not installed.")
-		return nil
-	}
-
-	content, err := os.ReadFile(hookPath)
-	if err != nil {
-		return fmt.Errorf("failed to read pre-commit hook: %w", err)
-	}
-
-	lines := strings.Split(string(content), "\n")
-	newLines := make([]string, 0, len(lines))
-	removed := false
-
-	for i := range lines {
-		line := lines[i]
-		if strings.Contains(line, "stackit precommit verify") {
-			removed = true
-			// Check if previous line was our comment or if it's the "# Added by Stackit" comment
-			if i > 0 && len(newLines) > 0 && (strings.Contains(lines[i-1], "Installed by Stackit") || strings.Contains(lines[i-1], "Added by Stackit")) {
-				newLines = newLines[:len(newLines)-1]
-			}
-			continue
-		}
-		newLines = append(newLines, line)
-	}
-
-	if !removed {
-		ctx.Output.Info("Stackit verification not found in pre-commit hook.")
-		return nil
-	}
-
-	// Check if only shebang is left or if it's empty
-	isOnlyShebang := true
-	for _, line := range newLines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || strings.HasPrefix(trimmed, "#!") {
-			continue
-		}
-		isOnlyShebang = false
-		break
-	}
-
-	if isOnlyShebang {
-		if err := os.Remove(hookPath); err != nil {
-			return fmt.Errorf("failed to remove pre-commit hook: %w", err)
-		}
-		ctx.Output.Info("Removed Stackit pre-commit hook.")
-	} else {
-		// Write back modified content
-		newContent := strings.Join(newLines, "\n")
-		// Clean up trailing/leading newlines that might have been left behind
-		newContent = strings.TrimSpace(newContent) + "\n"
-		// #nosec G306 - Git hooks need to be executable
-		if err := os.WriteFile(hookPath, []byte(newContent), 0750); err != nil {
-			return fmt.Errorf("failed to write pre-commit hook: %w", err)
-		}
-		ctx.Output.Info("Removed Stackit verification from existing pre-commit hook.")
-	}
-
-	return nil
+	return uninstallHook(ctx.Output, ctx.RepoRoot, precommitHookName, precommitMarker, precommitDisplayName)
 }

--- a/internal/actions/integrations/prepush.go
+++ b/internal/actions/integrations/prepush.go
@@ -6,11 +6,16 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/output"
+)
+
+const (
+	prepushHookName    = "pre-push"
+	prepushMarker      = "stackit prepush verify"
+	prepushDisplayName = "Pre-push"
 )
 
 const prepushHookTemplate = `#!/bin/bash
@@ -20,55 +25,14 @@ stackit prepush verify
 
 // PrepushInstallAction installs the pre-push hook
 func PrepushInstallAction(ctx *app.Context) error {
-	return installPrepushHook(ctx.RepoRoot, ctx.Output)
+	return installHook(ctx.RepoRoot, prepushHookName, prepushMarker, prepushHookTemplate, prepushDisplayName, ctx.Output)
 }
 
 // PrepushInstallActionWithOutput installs the pre-push hook with a custom writer.
 // This is a convenience function for use during init where we don't have an app.Context.
 func PrepushInstallActionWithOutput(repoRoot string, writer io.Writer) error {
 	out := output.NewConsoleOutput(writer, false)
-	return installPrepushHook(repoRoot, out)
-}
-
-// installPrepushHook is the core implementation for installing the pre-push hook.
-func installPrepushHook(repoRoot string, out output.Output) error {
-	hooksDir := filepath.Join(repoRoot, ".git", "hooks")
-	hookPath := filepath.Join(hooksDir, "pre-push")
-
-	// Ensure hooks directory exists
-	if err := os.MkdirAll(hooksDir, 0750); err != nil {
-		return fmt.Errorf("failed to create hooks directory: %w", err)
-	}
-
-	// Check if hook already exists
-	if _, err := os.Stat(hookPath); err == nil {
-		content, err := os.ReadFile(hookPath)
-		if err == nil && strings.Contains(string(content), "stackit prepush verify") {
-			out.Info("Pre-push hook is already installed.")
-			return nil
-		}
-
-		// If it exists but doesn't have our command, append
-		f, err := os.OpenFile(hookPath, os.O_APPEND|os.O_WRONLY, 0600)
-		if err != nil {
-			return fmt.Errorf("failed to open existing pre-push hook: %w", err)
-		}
-		defer func() { _ = f.Close() }()
-
-		if _, err := f.WriteString("\n# Added by Stackit\nstackit prepush verify\n"); err != nil {
-			return fmt.Errorf("failed to append to pre-push hook: %w", err)
-		}
-		out.Info("Appended Stackit verification to existing pre-push hook.")
-	} else {
-		// Create new hook
-		// #nosec G306 - Git hooks need to be executable
-		if err := os.WriteFile(hookPath, []byte(prepushHookTemplate), 0750); err != nil {
-			return fmt.Errorf("failed to write pre-push hook: %w", err)
-		}
-		out.Info("Installed Stackit pre-push hook.")
-	}
-
-	return nil
+	return installHook(repoRoot, prepushHookName, prepushMarker, prepushHookTemplate, prepushDisplayName, out)
 }
 
 // PrepushVerifyAction verifies that branches being pushed are not locked.
@@ -125,70 +89,5 @@ func PrepushVerifyFromReader(ctx *app.Context, reader io.Reader) error {
 
 // PrepushUninstallAction uninstalls the pre-push hook
 func PrepushUninstallAction(ctx *app.Context) error {
-	repoRoot := ctx.RepoRoot
-	hooksDir := filepath.Join(repoRoot, ".git", "hooks")
-	hookPath := filepath.Join(hooksDir, "pre-push")
-
-	// Check if hook exists
-	if _, err := os.Stat(hookPath); os.IsNotExist(err) {
-		ctx.Output.Info("Pre-push hook is not installed.")
-		return nil
-	}
-
-	content, err := os.ReadFile(hookPath)
-	if err != nil {
-		return fmt.Errorf("failed to read pre-push hook: %w", err)
-	}
-
-	lines := strings.Split(string(content), "\n")
-	newLines := make([]string, 0, len(lines))
-	removed := false
-
-	for i := range lines {
-		line := lines[i]
-		if strings.Contains(line, "stackit prepush verify") {
-			removed = true
-			// Check if previous line was our comment
-			if i > 0 && len(newLines) > 0 && (strings.Contains(lines[i-1], "Installed by Stackit") || strings.Contains(lines[i-1], "Added by Stackit")) {
-				newLines = newLines[:len(newLines)-1]
-			}
-			continue
-		}
-		newLines = append(newLines, line)
-	}
-
-	if !removed {
-		ctx.Output.Info("Stackit verification not found in pre-push hook.")
-		return nil
-	}
-
-	// Check if only shebang is left or if it's empty
-	isOnlyShebang := true
-	for _, line := range newLines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || strings.HasPrefix(trimmed, "#!") {
-			continue
-		}
-		isOnlyShebang = false
-		break
-	}
-
-	if isOnlyShebang {
-		if err := os.Remove(hookPath); err != nil {
-			return fmt.Errorf("failed to remove pre-push hook: %w", err)
-		}
-		ctx.Output.Info("Removed Stackit pre-push hook.")
-	} else {
-		// Write back modified content
-		newContent := strings.Join(newLines, "\n")
-		// Clean up trailing/leading newlines that might have been left behind
-		newContent = strings.TrimSpace(newContent) + "\n"
-		// #nosec G306 - Git hooks need to be executable
-		if err := os.WriteFile(hookPath, []byte(newContent), 0750); err != nil {
-			return fmt.Errorf("failed to write pre-push hook: %w", err)
-		}
-		ctx.Output.Info("Removed Stackit verification from existing pre-push hook.")
-	}
-
-	return nil
+	return uninstallHook(ctx.Output, ctx.RepoRoot, prepushHookName, prepushMarker, prepushDisplayName)
 }


### PR DESCRIPTION
## Summary
- `internal/actions/integrations/precommit.go` and `prepush.go` each implemented nearly byte-for-byte identical logic for installing and uninstalling a git hook (create hooks dir, check-if-already-installed, append-vs-create for install; strip the marker line and its preceding comment, remove the file if only a shebang remains, otherwise rewrite for uninstall).
- Extracted the shared logic into `internal/actions/integrations/hook_install.go` as `installHook`/`uninstallHook`, parameterized by hook name, marker string, template, and display name.
- `precommit.go` and `prepush.go` are now thin wrappers that pass their hook-specific constants; the genuinely different `*VerifyAction` functions are untouched.
- No behavior change: verified manually against a real repo that install (create/append/already-installed) and uninstall (remove-file/rewrite/not-found) produce identical output and hook file contents for both hook types.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/actions/integrations/...`
- [x] Manual smoke test: installed/uninstalled both pre-commit and pre-push hooks against a real git repo, covering create, already-installed, append-to-existing, remove-when-only-shebang-remains, and rewrite-when-content-remains paths — output messages and file contents matched the pre-refactor behavior exactly.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dov5YTHxocrbS94KczwjdK)_