### PR TITLE
feat: show created PR URLs in default submit output

### DIFF
--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -464,6 +464,9 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 				if summary := submitComponent.FormatOutcomeSummary(h.submitItems(), ev.Duration); summary != "" {
 					h.Output.Info("%s", summary)
 				}
+				if urls := submitComponent.FormatCreatedURLs(h.submitItems()); urls != "" {
+					h.Output.Info("%s", urls)
+				}
 				return
 			}
 			if summary := h.completionSummary(); summary != "" {

--- a/internal/tui/components/submit/format.go
+++ b/internal/tui/components/submit/format.go
@@ -377,6 +377,24 @@ func FormatOutcomeSummary(items []Item, elapsed time.Duration) string {
 	return line
 }
 
+// FormatCreatedURLs lists the URLs of newly created PRs, one indented "#N  url"
+// line each. Updated PRs are omitted — they rarely need their URL re-pasted,
+// matching the per-branch and solo output. Returns "" when nothing was created.
+func FormatCreatedURLs(items []Item) string {
+	rows := make([]string, 0, len(items))
+	for _, item := range items {
+		if item.Status != StatusDone || item.Action != ActionCreate || item.URL == "" {
+			continue
+		}
+		if ref := PRRef(item); ref != "" {
+			rows = append(rows, fmt.Sprintf("  %s  %s", ref, item.URL))
+		} else {
+			rows = append(rows, "  "+item.URL)
+		}
+	}
+	return strings.Join(rows, "\n")
+}
+
 func pluralPR(count int) string {
 	if count == 1 {
 		return "PR"

--- a/internal/tui/components/submit/format_test.go
+++ b/internal/tui/components/submit/format_test.go
@@ -209,6 +209,20 @@ func TestFormatOutcomeSummary(t *testing.T) {
 	require.Empty(t, FormatOutcomeSummary(nil, time.Second))
 }
 
+func TestFormatCreatedURLs(t *testing.T) {
+	t.Parallel()
+
+	items := []Item{
+		{BranchName: "a", Action: ActionCreate, Status: StatusDone, URL: "https://github.com/o/r/pull/1"},
+		{BranchName: "b", Action: ActionUpdate, Status: StatusDone, URL: "https://github.com/o/r/pull/2"},
+		{BranchName: "c", Action: ActionCreate, Status: StatusError, URL: "https://github.com/o/r/pull/3"},
+	}
+
+	// Only the created, done PR is listed — not the updated or failed one.
+	require.Equal(t, "  #1  https://github.com/o/r/pull/1", FormatCreatedURLs(items))
+	require.Empty(t, FormatCreatedURLs(items[1:2]))
+}
+
 func TestFormatFailureSummaryWithoutErrorDetail(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -106,6 +106,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		summary := m.completionSummary()
 		if !m.Verbose {
 			summary = FormatOutcomeSummary(m.Items, msg.Elapsed)
+			if urls := FormatCreatedURLs(m.Items); urls != "" {
+				if summary != "" {
+					summary += "\n"
+				}
+				summary += urls
+			}
 			if failures := FormatFailureSummary(m.Items); failures != "" {
 				if summary != "" {
 					summary += "\n\n"


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The compact (non-verbose) submit summary printed only a count line, so a
stack submit surfaced no PR URLs anywhere. List each newly created PR's
URL under the outcome summary, matching the solo/verbose behavior.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1784862381`.


* **PR #1416**
  * **PR #1417**
    * **PR #1418**
      * **PR #1419**
        * **PR #1420**
          * **PR #1443**
            * **PR #1445** 👈
              * **PR #1446**
                * **PR #1447**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1448 by jonnii*