### PR TITLE
refactor: drop the submit progress bar

### DIFF
--- a/internal/tui/components/submit/format_test.go
+++ b/internal/tui/components/submit/format_test.go
@@ -292,23 +292,6 @@ func TestModelCompletionSummaryPrefersSubmissionResults(t *testing.T) {
 	require.NotContains(t, summary, "Submitting")
 }
 
-func TestModelCompactModeShowsDeterminateProgress(t *testing.T) {
-	t.Parallel()
-
-	m := NewModel([]Item{
-		{BranchName: "feature-1", Action: ActionUpdate, Status: StatusDone},
-		{BranchName: "feature-2", Action: ActionCreate, Status: StatusSubmitting},
-		{BranchName: "feature-3", Action: ActionCreate, Status: StatusPending},
-	})
-	m.Verbose = false
-
-	content := stripANSIEscape(m.content())
-	require.Contains(t, content, "Submitting 3 PRs")
-	require.Contains(t, content, "1/3 complete")
-	require.Contains(t, content, "███")
-	require.Contains(t, content, "░")
-}
-
 func stripANSIEscape(s string) string {
 	return ansiPattern.ReplaceAllString(s, "")
 }

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -153,10 +153,6 @@ func (m *Model) content() string {
 	header := m.header()
 	if header != "" {
 		b.WriteString(header)
-		if !m.Verbose {
-			b.WriteString("  ")
-			b.WriteString(m.progress())
-		}
 		b.WriteString("\n\n")
 	}
 
@@ -181,31 +177,6 @@ func (m *Model) content() string {
 	}
 
 	return b.String()
-}
-
-// progress renders a compact, determinate progress indicator for the default
-// interactive submit view. Branch rows still identify the active operation;
-// this line answers the higher-level question of how much of the stack is
-// finished. Verbose mode intentionally keeps the existing audit-oriented
-// layout unchanged.
-func (m *Model) progress() string {
-	total := len(m.Items)
-	if total == 0 {
-		return ""
-	}
-
-	completed := 0
-	for _, item := range m.Items {
-		if item.Status == StatusDone || item.Status == StatusError {
-			completed++
-		}
-	}
-
-	const width = 10
-	filled := width * completed / total
-	bar := m.Styles.DoneStyle.Render(strings.Repeat("█", filled)) +
-		m.Styles.DimStyle.Render(strings.Repeat("░", width-filled))
-	return fmt.Sprintf("%s %d/%d complete", bar, completed, total)
 }
 
 // completionSummary is the output persisted to the terminal when the TUI


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The per-branch rows already show completion via their status icons, so
the determinate bar just restated the count — and rendered a pointless
0/1 -> 1/1 for solo submits. Remove it.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1784862381`.


* **PR #1416**
  * **PR #1417**
    * **PR #1418**
      * **PR #1419**
        * **PR #1420**
          * **PR #1443**
            * **PR #1445**
              * **PR #1446** 👈
                * **PR #1447**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1448 by jonnii*