### PR TITLE
feat: make restack output terse and outcome-focused

### DIFF
--- a/apps/st-tui/main.go
+++ b/apps/st-tui/main.go
@@ -60,7 +60,7 @@ func runSubmitScenario(out output.Output, name string, delay time.Duration) {
 		printUsage(os.Stderr)
 		os.Exit(2)
 	}
-	runner, handler := stack.NewSubmitUI(out, output.NewNullLogger(), false)
+	runner, handler := stack.NewSubmitUI(out, output.NewNullLogger(), stack.SubmitCompact)
 	if runner != nil {
 		defer runner.Cleanup()
 	}

--- a/internal/cli/stack/restack_test.go
+++ b/internal/cli/stack/restack_test.go
@@ -157,8 +157,6 @@ func TestRestackCommand(t *testing.T) {
 
 		normalized := testhelpers.NormalizeOutput(string(output))
 		expected := testhelpers.NormalizeOutput(`
-  ✓ feature (current) up to date
-
 ✨ Everything is up to date!
 		`)
 		require.Equal(t, expected, normalized, "output format should match expected structure")
@@ -215,9 +213,6 @@ No branches to restack.
 
 		normalized := testhelpers.NormalizeOutput(string(output))
 		expected := testhelpers.NormalizeOutput(`
-  ✓ branch1 up to date
-  ✓ branch2 (current) up to date
-
 ✨ Everything is up to date!
 `)
 		require.Equal(t, expected, normalized, "output format should match expected structure")
@@ -261,9 +256,6 @@ No branches to restack.
 
 		normalized := testhelpers.NormalizeOutput(string(output))
 		expected := testhelpers.NormalizeOutput(`
-  ✓ branch1 (current) up to date
-  ✓ branch2 up to date
-
 ✨ Everything is up to date!
 `)
 		require.Equal(t, expected, normalized, "output format should match expected structure")
@@ -298,8 +290,6 @@ No branches to restack.
 
 		normalized := testhelpers.NormalizeOutput(string(output))
 		expected := testhelpers.NormalizeOutput(`
-  ✓ branch1 up to date
-
 ✨ Everything is up to date!
 `)
 		require.Equal(t, expected, normalized, "output format should match expected structure")

--- a/internal/cli/stack/submit.go
+++ b/internal/cli/stack/submit.go
@@ -158,7 +158,11 @@ func executeSubmit(cmd *cobra.Command, f *submitFlags) error {
 		// starts lazily (when the submission phase begins), so calling Action
 		// unconditionally no longer flashes the TUI when there's nothing to do.
 		// A dry run's whole output IS the plan, so it always prints verbose.
-		runner, handler := NewSubmitUI(ctx.Output, ctx.Logger, f.verbose || f.dryRun)
+		verbosity := SubmitCompact
+		if f.verbose || f.dryRun {
+			verbosity = SubmitVerbose
+		}
+		runner, handler := NewSubmitUI(ctx.Output, ctx.Logger, verbosity)
 		defer runner.Cleanup()
 		return submit.Action(ctx, opts, handler)
 	})

--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -15,21 +15,33 @@ import (
 	"github.com/getstackit/stackit/internal/tui/style"
 )
 
+// SubmitVerbosity selects how much per-branch detail the submit handlers emit.
+type SubmitVerbosity int
+
+const (
+	// SubmitCompact prints an outcome-focused summary (the default UX).
+	SubmitCompact SubmitVerbosity = iota
+	// SubmitVerbose retains the full branch-by-branch plan and result list.
+	SubmitVerbose
+)
+
+func (v SubmitVerbosity) verbose() bool { return v == SubmitVerbose }
+
 // NewSubmitUI creates a runner and handler pair for submit operations.
 // The runner manages terminal state; the handler processes events.
 // Caller must defer runner.Cleanup() to restore terminal on exit.
-func NewSubmitUI(out output.Output, logger output.Logger, verbose bool) (*tui.Runner, submit.Handler) {
+func NewSubmitUI(out output.Output, logger output.Logger, verbosity SubmitVerbosity) (*tui.Runner, submit.Handler) {
 	if tui.IsTTY() {
 		model := submitComponent.NewModel(nil)
-		model.Verbose = verbose
+		model.Verbose = verbosity.verbose()
 		runner := tui.NewRunner(model, out, logger)
 		// Start lazily when the submission phase begins rather than here: the
 		// stack and plan print as plain lines, so a submit that turns out to
 		// have nothing to do never flashes the bubbletea startup/teardown
 		// sequence. See InteractiveSubmitHandler.OnEvent.
-		return runner, NewInteractiveSubmitHandler(runner, model, out, verbose)
+		return runner, NewInteractiveSubmitHandler(runner, model, out, verbosity)
 	}
-	return nil, NewSimpleSubmitHandler(out, verbose)
+	return nil, NewSimpleSubmitHandler(out, verbosity)
 }
 
 // maxNamedSkipGroup is the largest skipped-branch group that still lists its
@@ -332,16 +344,10 @@ type branchItem struct {
 }
 
 // NewSimpleSubmitHandler creates a new simple submit handler
-func NewSimpleSubmitHandler(out output.Output, verbose ...bool) *SimpleSubmitHandler {
-	// Keep direct constructor callers (notably renderer tests and the TUI lab)
-	// detailed by default. The command always passes its explicit mode.
-	showVerbose := true
-	if len(verbose) > 0 {
-		showVerbose = verbose[0]
-	}
+func NewSimpleSubmitHandler(out output.Output, verbosity SubmitVerbosity) *SimpleSubmitHandler {
 	return &SimpleSubmitHandler{
 		BaseHandler: common.NewBaseHandler(out),
-		plan:        planPrinter{out: out, verbose: showVerbose},
+		plan:        planPrinter{out: out, verbose: verbosity.verbose()},
 		items:       make(map[string]*branchItem),
 	}
 }
@@ -576,12 +582,8 @@ type InteractiveSubmitHandler struct {
 }
 
 // NewInteractiveSubmitHandler creates a new interactive submit handler
-func NewInteractiveSubmitHandler(runner *tui.Runner, model *submitComponent.Model, out output.Output, verbose ...bool) *InteractiveSubmitHandler {
-	showVerbose := true
-	if len(verbose) > 0 {
-		showVerbose = verbose[0]
-	}
-	return &InteractiveSubmitHandler{runner: runner, model: model, out: out, plan: planPrinter{out: out, verbose: showVerbose}}
+func NewInteractiveSubmitHandler(runner *tui.Runner, model *submitComponent.Model, out output.Output, verbosity SubmitVerbosity) *InteractiveSubmitHandler {
+	return &InteractiveSubmitHandler{runner: runner, model: model, out: out, plan: planPrinter{out: out, verbose: verbosity.verbose()}}
 }
 
 // OnEvent handles events from the submit action

--- a/internal/cli/stack/submit_handlers_test.go
+++ b/internal/cli/stack/submit_handlers_test.go
@@ -17,7 +17,7 @@ func TestSimpleSubmitHandlerStreamsOneListWithURLsOnCreates(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 	updated := "jonnii/20260511011552/guard-runner.repoRoot-reads-with-repoMu-to-fix"
 	created := "jonnii/20260511011552/add-feature"
 
@@ -54,7 +54,7 @@ func TestSimpleSubmitHandlerPreservesURLAcrossFooterSync(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 	branch := "jonnii/20260511011552/guard-runner.repoRoot-reads-with-repoMu-to-fix"
 
 	handler.OnEvent(submitAction.SubmissionStartEvent{
@@ -88,7 +88,7 @@ func TestSimpleSubmitHandlerMergesPlanIntoStackList(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 	current := "jonnii/20260511011552/current-branch"
 	skipped := "jonnii/20260511011552/skipped-branch"
 
@@ -125,7 +125,7 @@ func TestSimpleSubmitHandlerPrintsClosingSummary(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 
 	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
 		Branches:    []string{"create-me", "update-me", "skip-me"},
@@ -150,7 +150,7 @@ func TestPlanPrinterCollapsesLargeSkipGroups(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 
 	branches := []string{"active-one", "skip-a", "skip-b", "skip-c", "skip-d"}
 	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
@@ -180,7 +180,7 @@ func TestInteractiveSubmitHandlerPrintsPlanWithoutStartingTUI(t *testing.T) {
 	out := output.NewTestOutput()
 	// A nil runner stands in for a TUI that was never started; every runner
 	// method is nil-safe. Plan output must not depend on the TUI running.
-	handler := NewInteractiveSubmitHandler(nil, submitComponent.NewModel(nil), out)
+	handler := NewInteractiveSubmitHandler(nil, submitComponent.NewModel(nil), out, SubmitVerbose)
 	branch := "jonnii/20260511011552/up-to-date-branch"
 
 	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
@@ -209,7 +209,7 @@ func TestPlanPrinterShowsPRNumbersAndEmptyAnnotation(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 	prNumber := 1189
 
 	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
@@ -240,7 +240,7 @@ func TestSimpleSubmitHandlerSoloSubmitDropsStackFraming(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 	branch := "jonnii/20260511011552/tighten-submit-output"
 
 	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
@@ -277,7 +277,7 @@ func TestSimpleSubmitHandlerOnTrunkGuidance(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 
 	handler.OnEvent(submitAction.CompletionEvent{
 		Outcome: submitAction.OutcomeOnTrunk,
@@ -294,7 +294,7 @@ func TestSimpleSubmitHandlerPrintsBranchWarnings(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 
 	handler.OnEvent(submitAction.BranchWarningEvent{
 		BranchName: "jonnii/20260511011552/add-feature",
@@ -308,7 +308,7 @@ func TestSimpleSubmitHandlerStaysQuietOnFailureOutcome(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 
 	// The CLI prints the returned error; the handler must not double-report.
 	handler.OnEvent(submitAction.CompletionEvent{Outcome: submitAction.OutcomeFailed, Message: "Submit failed"})
@@ -320,7 +320,7 @@ func TestSimpleSubmitHandlerPrintsOutcomeWhenNothingSubmitted(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 	branch := "jonnii/20260511011552/up-to-date-branch"
 
 	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{

--- a/internal/cli/stack/submit_scenarios_test.go
+++ b/internal/cli/stack/submit_scenarios_test.go
@@ -15,7 +15,7 @@ func TestSubmitScenarioReplayUsesProductionHandler(t *testing.T) {
 	require.True(t, found)
 
 	out := output.NewTestOutput()
-	scenario.Replay(NewSimpleSubmitHandler(out), 0)
+	scenario.Replay(NewSimpleSubmitHandler(out, SubmitVerbose), 0)
 	got := ansi.Strip(out.String())
 
 	assert.Contains(t, got, "Submitting 2 branches")
@@ -38,7 +38,7 @@ func TestSubmitScenarioSSReplay(t *testing.T) {
 	require.True(t, found)
 
 	out := output.NewTestOutput()
-	scenario.Replay(NewSimpleSubmitHandler(out), 0)
+	scenario.Replay(NewSimpleSubmitHandler(out, SubmitVerbose), 0)
 	got := ansi.Strip(out.String())
 
 	assert.Contains(t, got, "Will submit (1)")
@@ -69,7 +69,7 @@ func TestSubmitScenarioSpecialCases(t *testing.T) {
 			require.True(t, found)
 
 			out := output.NewTestOutput()
-			scenario.Replay(NewSimpleSubmitHandler(out), 0)
+			scenario.Replay(NewSimpleSubmitHandler(out, SubmitVerbose), 0)
 			assert.Contains(t, ansi.Strip(out.String()), tt.want)
 		})
 	}

--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -42,6 +42,11 @@ type SimpleSyncHandler struct {
 	totalOps  int
 	currentOp int
 	headers   *utils.LazyHeaders[syncAction.Phase]
+
+	// restack-only state: standalone restack suppresses already-current rows
+	// and reports them as a count in the summary instead.
+	restackUpToDate int
+	restackPrinted  bool
 }
 
 // NewSimpleSyncHandler creates a new SimpleSyncHandler
@@ -317,6 +322,14 @@ func (h *SimpleSyncHandler) OnRestackStart(_ int) {
 
 // OnRestackBranch implements RestackHandler for standalone restack operations
 func (h *SimpleSyncHandler) OnRestackBranch(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, reparented bool, oldParent, newParent string, rerereResolvedCount int) {
+	// Already-current branches are the expected default; suppress their rows
+	// and fold them into the summary count so only movement and problems print.
+	if isPlainUpToDate(result, lockReason, frozen, reparented) {
+		h.restackUpToDate++
+		return
+	}
+	h.restackPrinted = true
+
 	// Log reparenting info if applicable
 	if reparented {
 		h.Output.Info("Reparented %s from %s to %s (parent was merged/deleted).",
@@ -354,14 +367,18 @@ func (h *SimpleSyncHandler) OnRestackBranch(branch string, result syncAction.Res
 
 // OnRestackComplete implements RestackHandler for standalone restack operations
 func (h *SimpleSyncHandler) OnRestackComplete(restacked, skipped int, conflicts, blocked []string) {
-	h.Output.Newline()
+	// Only separate from prior rows when some actually printed; a pure no-op
+	// prints just the one-line summary with no leading blank.
+	if h.restackPrinted {
+		h.Output.Newline()
+	}
 
 	if restacked == 0 && skipped == 0 && len(blocked) == 0 {
 		h.Output.Info("✨ Everything is up to date!")
 		return
 	}
 
-	if summary := formatRestackSummaryLine(restacked, skipped, len(blocked)); summary != "" {
+	if summary := formatRestackSummaryLine(restacked, skipped, len(blocked), h.restackUpToDate); summary != "" {
 		h.Output.Info("✅ Summary: %s", summary)
 	}
 
@@ -377,9 +394,9 @@ func (h *SimpleSyncHandler) OnRestackComplete(restacked, skipped int, conflicts,
 const reasonBlockedByConflict = "(blocked by conflict in stack)"
 
 // formatRestackSummaryLine renders the shared "restacked N, skipped M
-// (conflict), blocked K" summary used by both restack handlers. Returns ""
-// when there is nothing to summarize.
-func formatRestackSummaryLine(restacked, skipped, blocked int) string {
+// (conflict), blocked K, P already current" summary used by both restack
+// handlers. Returns "" when there is nothing to summarize.
+func formatRestackSummaryLine(restacked, skipped, blocked, upToDate int) string {
 	parts := []string{}
 	if restacked > 0 {
 		parts = append(parts, fmt.Sprintf("restacked %d", restacked))
@@ -390,7 +407,18 @@ func formatRestackSummaryLine(restacked, skipped, blocked int) string {
 	if blocked > 0 {
 		parts = append(parts, fmt.Sprintf("blocked %d", blocked))
 	}
+	if upToDate > 0 {
+		parts = append(parts, fmt.Sprintf("%d already current", upToDate))
+	}
 	return strings.Join(parts, ", ")
+}
+
+// isPlainUpToDate reports whether a restack result is a no-op with nothing
+// worth showing — the branch was already current, not locked, frozen, or
+// reparented. Standalone restack suppresses these rows and folds them into the
+// summary count instead.
+func isPlainUpToDate(result syncAction.RestackResult, lockReason engine.LockReason, frozen, reparented bool) bool {
+	return result == syncAction.RestackUnneeded && !lockReason.IsLocked() && !frozen && !reparented
 }
 
 // InteractiveSyncHandler provides bubbletea TUI for TTY environments
@@ -403,6 +431,10 @@ type InteractiveSyncHandler struct {
 	totalOps     int
 	completedOps int
 	currentPhase syncAction.Phase
+
+	// restack-only: count of already-current branches whose rows were
+	// suppressed, reported as a summary count instead.
+	restackUpToDate int
 }
 
 // NewInteractiveSyncHandler creates a new InteractiveSyncHandler
@@ -614,6 +646,15 @@ func (h *InteractiveSyncHandler) OnRestackStart(branchCount int) {
 func (h *InteractiveSyncHandler) OnRestackBranch(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, reparented bool, oldParent, newParent string, rerereResolvedCount int) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+
+	// Already-current branches are the expected default; skip their rows but
+	// still advance the progress bar and count them for the summary.
+	if isPlainUpToDate(result, lockReason, frozen, reparented) {
+		h.restackUpToDate++
+		h.completedOps++
+		h.runner.Send(syncComponent.ProgressTickMsg{Completed: h.completedOps, Total: h.totalOps})
+		return
+	}
 
 	// Build detail message
 	detail, mark := h.formatRestackDetail(branch, result, newRev, prNumber, lockReason, frozen, isCurrent, parent, rerereResolvedCount)
@@ -850,7 +891,7 @@ func (h *InteractiveSyncHandler) formatRestackSummary(restacked, skipped int, co
 	}
 
 	result := ""
-	if summary := formatRestackSummaryLine(restacked, skipped, len(blocked)); summary != "" {
+	if summary := formatRestackSummaryLine(restacked, skipped, len(blocked), h.restackUpToDate); summary != "" {
 		result = "✅ Summary: " + summary
 	}
 

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -103,8 +103,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case ProgressCompleteMsg:
 		m.Done = true
-		summary := m.completionSummary()
-		if !m.Verbose {
+		var summary string
+		if m.Verbose {
+			summary = m.completionSummary()
+			// The solo summary already names the single result; a count line
+			// would just restate it.
+			if !m.Solo && summary != "" {
+				if closing := FormatClosingSummary(m.Items, msg.Skipped, msg.Elapsed); closing != "" {
+					summary += "\n\n" + closing
+				}
+			}
+		} else {
 			summary = FormatOutcomeSummary(m.Items, msg.Elapsed)
 			if urls := FormatCreatedURLs(m.Items); urls != "" {
 				if summary != "" {
@@ -117,13 +126,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					summary += "\n\n"
 				}
 				summary += failures
-			}
-		}
-		// The solo summary already names the single result; a count line would
-		// just restate it.
-		if m.Verbose && !m.Solo && summary != "" {
-			if closing := FormatClosingSummary(m.Items, msg.Skipped, msg.Elapsed); closing != "" {
-				summary += "\n\n" + closing
 			}
 		}
 		if summary != "" {
@@ -179,16 +181,16 @@ func (m *Model) content() string {
 	return b.String()
 }
 
-// completionSummary is the output persisted to the terminal when the TUI
-// exits. After a submission it lists every branch's final result (including
-// failures); when nothing was submitted (dry run, all up to date) it falls
-// back to the final plan view, which would otherwise be erased with the
+// completionSummary is the verbose-mode output persisted to the terminal when
+// the TUI exits. After a submission it lists every branch's final result
+// (including failures); when nothing was submitted (dry run, all up to date) it
+// falls back to the final plan view, which would otherwise be erased with the
 // progress display. Warnings are appended in either case so they survive the
-// screen clear.
+// screen clear. Compact mode builds its own summary inline in the
+// ProgressCompleteMsg handler and does not call this.
 func (m *Model) completionSummary() string {
 	var summary string
-	switch {
-	case m.Verbose && m.Solo:
+	if m.Solo {
 		summary = FormatSoloSummary(m.Items)
 		if failures := FormatFailureSummary(m.Items); failures != "" {
 			if summary != "" {
@@ -196,10 +198,8 @@ func (m *Model) completionSummary() string {
 			}
 			summary += failures
 		}
-	case m.Verbose:
+	} else {
 		summary = FormatFinalList(m.Items)
-	default:
-		summary = FormatOutcomeSummary(m.Items, 0)
 	}
 	if summary == "" {
 		return m.content()


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Standalone restack listed one "up to date" row per branch even when
nothing moved, so an all-current stack printed N redundant rows above a
footer already saying everything was up to date.

Suppress already-current rows and fold them into the summary as a count
("N already current"). A pure no-op now prints just the one-line footer;
a mixed restack shows only the branches that moved plus problems
(conflicts, blocked, locked, frozen). Applies to both the streaming and
TUI restack handlers; sync output is unchanged.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1784862381`.


* **PR #1416**
  * **PR #1417**
    * **PR #1418**
      * **PR #1419**
        * **PR #1420**
          * **PR #1443**
            * **PR #1445**
              * **PR #1446**
                * **PR #1447** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1448 by jonnii*