### PR TITLE
Merging 9 PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ stackit-web
 .gocache/
 .golangci-cache/
 st-tui
+!apps/st-tui/
 
 tmp/
 node_modules/

--- a/apps/st-tui/main.go
+++ b/apps/st-tui/main.go
@@ -21,32 +21,64 @@ func main() {
 	}
 
 	args := flags.Args()
-	if len(args) != 2 || args[0] != "sync" {
-		printUsage(os.Stderr)
-		os.Exit(2)
-	}
-
-	scenario, found := stack.LookupSyncScenario(args[1])
-	if !found {
-		_, _ = fmt.Fprintf(os.Stderr, "unknown sync scenario %q\n\n", args[1])
+	if len(args) != 2 {
 		printUsage(os.Stderr)
 		os.Exit(2)
 	}
 
 	out := output.NewDefaultOutput()
+	switch args[0] {
+	case "sync":
+		runSyncScenario(out, args[1], *delay)
+	case "submit":
+		runSubmitScenario(out, args[1], *delay)
+	default:
+		_, _ = fmt.Fprintf(os.Stderr, "unknown command %q\n\n", args[0])
+		printUsage(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+func runSyncScenario(out output.Output, name string, delay time.Duration) {
+	scenario, found := stack.LookupSyncScenario(name)
+	if !found {
+		_, _ = fmt.Fprintf(os.Stderr, "unknown sync scenario %q\n\n", name)
+		printUsage(os.Stderr)
+		os.Exit(2)
+	}
 	runner, handler := stack.NewSyncUI(out, output.NewNullLogger())
 	if runner != nil {
 		defer runner.Cleanup()
 	}
-	scenario.Replay(handler, *delay)
+	scenario.Replay(handler, delay)
+}
+
+func runSubmitScenario(out output.Output, name string, delay time.Duration) {
+	scenario, found := stack.LookupSubmitScenario(name)
+	if !found {
+		_, _ = fmt.Fprintf(os.Stderr, "unknown submit scenario %q\n\n", name)
+		printUsage(os.Stderr)
+		os.Exit(2)
+	}
+	runner, handler := stack.NewSubmitUI(out, output.NewNullLogger())
+	if runner != nil {
+		defer runner.Cleanup()
+	}
+	scenario.Replay(handler, delay)
 }
 
 func printUsage(w io.Writer) {
-	_, _ = fmt.Fprintln(w, "Usage: st-tui [--delay duration] sync <scenario>")
+	_, _ = fmt.Fprintln(w, "Usage: st-tui [--delay duration] <command> <scenario>")
 	_, _ = fmt.Fprintln(w, "")
 	_, _ = fmt.Fprintln(w, "Sync scenarios:")
 	for _, name := range stack.SyncScenarioNames() {
 		scenario, _ := stack.LookupSyncScenario(name)
+		_, _ = fmt.Fprintf(w, "  %-10s %s\n", name, scenario.Description)
+	}
+	_, _ = fmt.Fprintln(w, "")
+	_, _ = fmt.Fprintln(w, "Submit scenarios:")
+	for _, name := range stack.SubmitScenarioNames() {
+		scenario, _ := stack.LookupSubmitScenario(name)
 		_, _ = fmt.Fprintf(w, "  %-10s %s\n", name, scenario.Description)
 	}
 	_, _ = fmt.Fprintln(w, "")

--- a/apps/st-tui/main.go
+++ b/apps/st-tui/main.go
@@ -60,7 +60,7 @@ func runSubmitScenario(out output.Output, name string, delay time.Duration) {
 		printUsage(os.Stderr)
 		os.Exit(2)
 	}
-	runner, handler := stack.NewSubmitUI(out, output.NewNullLogger(), false)
+	runner, handler := stack.NewSubmitUI(out, output.NewNullLogger(), stack.SubmitCompact)
 	if runner != nil {
 		defer runner.Cleanup()
 	}

--- a/apps/st-tui/main.go
+++ b/apps/st-tui/main.go
@@ -60,7 +60,7 @@ func runSubmitScenario(out output.Output, name string, delay time.Duration) {
 		printUsage(os.Stderr)
 		os.Exit(2)
 	}
-	runner, handler := stack.NewSubmitUI(out, output.NewNullLogger())
+	runner, handler := stack.NewSubmitUI(out, output.NewNullLogger(), false)
 	if runner != nil {
 		defer runner.Cleanup()
 	}

--- a/apps/st-tui/main.go
+++ b/apps/st-tui/main.go
@@ -1,0 +1,54 @@
+// Package main replays deterministic command scenarios through Stackit's real TUIs.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/getstackit/stackit/internal/cli/stack"
+	"github.com/getstackit/stackit/internal/output"
+)
+
+func main() {
+	flags := flag.NewFlagSet("st-tui", flag.ExitOnError)
+	delay := flags.Duration("delay", 700*time.Millisecond, "delay between action events")
+	flags.Usage = func() { printUsage(flags.Output()) }
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		return
+	}
+
+	args := flags.Args()
+	if len(args) != 2 || args[0] != "sync" {
+		printUsage(os.Stderr)
+		os.Exit(2)
+	}
+
+	scenario, found := stack.LookupSyncScenario(args[1])
+	if !found {
+		_, _ = fmt.Fprintf(os.Stderr, "unknown sync scenario %q\n\n", args[1])
+		printUsage(os.Stderr)
+		os.Exit(2)
+	}
+
+	out := output.NewDefaultOutput()
+	runner, handler := stack.NewSyncUI(out, output.NewNullLogger())
+	if runner != nil {
+		defer runner.Cleanup()
+	}
+	scenario.Replay(handler, *delay)
+}
+
+func printUsage(w io.Writer) {
+	_, _ = fmt.Fprintln(w, "Usage: st-tui [--delay duration] sync <scenario>")
+	_, _ = fmt.Fprintln(w, "")
+	_, _ = fmt.Fprintln(w, "Sync scenarios:")
+	for _, name := range stack.SyncScenarioNames() {
+		scenario, _ := stack.LookupSyncScenario(name)
+		_, _ = fmt.Fprintf(w, "  %-10s %s\n", name, scenario.Description)
+	}
+	_, _ = fmt.Fprintln(w, "")
+	_, _ = fmt.Fprintln(w, "Use --delay 0 to replay a scenario without pauses.")
+}

--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -23,6 +23,7 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
 	"github.com/getstackit/stackit/internal/output"
 )
 
@@ -540,7 +541,7 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 		return fmt.Errorf("failed to print conflict status: %w", err)
 	}
 
-	return fmt.Errorf("restack stopped due to conflict on %s", firstConflict)
+	return errors.NewConflictWorkflowError(firstConflict)
 }
 
 // validateBranchAncestry performs pre-flight checks on branch ancestry relationships.

--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -87,7 +87,9 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 		if err := PrintConflictStatus(ctx, branchName); err != nil {
 			return fmt.Errorf("failed to print conflict status: %w", err)
 		}
-		return fmt.Errorf("rebase conflict is not yet resolved")
+		// PrintConflictStatus already told the user what to do; return the
+		// silenced conflict-workflow error so cobra doesn't reprint it.
+		return errors.NewConflictWorkflowError(branchName)
 	}
 
 	// Success - checkout the branch (rebase leaves us in detached HEAD)

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -3,7 +3,6 @@ package sync
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/getstackit/stackit/internal/actions"
@@ -514,27 +513,6 @@ func plural(count int) string {
 		return ""
 	}
 	return "s"
-}
-
-// FormatSummaryString returns the full summary as a string
-func FormatSummaryString(summary Summary) string {
-	if summary.UpToDate {
-		return "Everything is up to date!"
-	}
-
-	parts := FormatSummaryParts(summary)
-	if len(parts) == 0 {
-		return ""
-	}
-
-	result := "Summary: " + strings.Join(parts, ", ")
-
-	// Add actionable advice for conflicts
-	if len(summary.ConflictBranches) > 0 {
-		result += fmt.Sprintf("\n   Run 'st restack %s' to resolve and continue", summary.ConflictBranches[0])
-	}
-
-	return result
 }
 
 // pluralES returns "es" if count != 1, otherwise empty string (for "branch" -> "branches")

--- a/internal/cli/branch/absorb_test.go
+++ b/internal/cli/branch/absorb_test.go
@@ -352,7 +352,9 @@ func TestAbsorbComplex(t *testing.T) {
 		output, err := cmd.CombinedOutput()
 
 		require.Error(t, err, "absorb should fail during restack. Output: %s", string(output))
-		require.Contains(t, string(output), "failed to restack", "should report restack failure")
+		// The conflict-workflow error is silenced (instructions are printed
+		// instead), so assert on the printed conflict status.
+		require.Contains(t, string(output), "Hit conflict restacking branchB", "should report restack conflict")
 
 		// In case of restack conflict, stackit stays in rebase mode (detached HEAD)
 		rebaseDir := scene.Dir + "/.git/rebase-merge"

--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -60,6 +60,11 @@ func RunWithOptions(cmd *cobra.Command, opts app.GlobalOptions, fn func(ctx *app
 	// and failure both. Their errors are surfaced as warnings (non-blocking).
 	_ = RunCommandHooks(ctx, cmd, PhasePost)
 	if err != nil {
+		// The conflict workflow already printed full resolution instructions;
+		// silence cobra's "Error: ..." reprint but keep the non-zero exit.
+		if errors.Is(err, errors.ErrConflictWorkflow) {
+			cmd.SilenceErrors = true
+		}
 		return HandleCommandError(err)
 	}
 	return nil

--- a/internal/cli/stack/restack_test.go
+++ b/internal/cli/stack/restack_test.go
@@ -157,8 +157,6 @@ func TestRestackCommand(t *testing.T) {
 
 		normalized := testhelpers.NormalizeOutput(string(output))
 		expected := testhelpers.NormalizeOutput(`
-  ✓ feature (current) up to date
-
 ✨ Everything is up to date!
 		`)
 		require.Equal(t, expected, normalized, "output format should match expected structure")
@@ -215,9 +213,6 @@ No branches to restack.
 
 		normalized := testhelpers.NormalizeOutput(string(output))
 		expected := testhelpers.NormalizeOutput(`
-  ✓ branch1 up to date
-  ✓ branch2 (current) up to date
-
 ✨ Everything is up to date!
 `)
 		require.Equal(t, expected, normalized, "output format should match expected structure")
@@ -261,9 +256,6 @@ No branches to restack.
 
 		normalized := testhelpers.NormalizeOutput(string(output))
 		expected := testhelpers.NormalizeOutput(`
-  ✓ branch1 (current) up to date
-  ✓ branch2 up to date
-
 ✨ Everything is up to date!
 `)
 		require.Equal(t, expected, normalized, "output format should match expected structure")
@@ -298,8 +290,6 @@ No branches to restack.
 
 		normalized := testhelpers.NormalizeOutput(string(output))
 		expected := testhelpers.NormalizeOutput(`
-  ✓ branch1 up to date
-
 ✨ Everything is up to date!
 `)
 		require.Equal(t, expected, normalized, "output format should match expected structure")

--- a/internal/cli/stack/submit.go
+++ b/internal/cli/stack/submit.go
@@ -158,7 +158,11 @@ func executeSubmit(cmd *cobra.Command, f *submitFlags) error {
 		// starts lazily (when the submission phase begins), so calling Action
 		// unconditionally no longer flashes the TUI when there's nothing to do.
 		// A dry run's whole output IS the plan, so it always prints verbose.
-		runner, handler := NewSubmitUI(ctx.Output, ctx.Logger, f.verbose || f.dryRun)
+		verbosity := SubmitCompact
+		if f.verbose || f.dryRun {
+			verbosity = SubmitVerbose
+		}
+		runner, handler := NewSubmitUI(ctx.Output, ctx.Logger, verbosity)
 		defer runner.Cleanup()
 		return submit.Action(ctx, opts, handler)
 	})

--- a/internal/cli/stack/submit.go
+++ b/internal/cli/stack/submit.go
@@ -45,6 +45,7 @@ type submitFlags struct {
 	noLabels             bool
 	noAssignees          bool
 	jsonOutput           bool
+	verbose              bool
 }
 
 func addSubmitFlags(cmd *cobra.Command, f *submitFlags) {
@@ -77,6 +78,7 @@ func addSubmitFlags(cmd *cobra.Command, f *submitFlags) {
 	cmd.Flags().BoolVar(&f.noLabels, "no-labels", false, "Don't apply default labels from config.")
 	cmd.Flags().BoolVar(&f.noAssignees, "no-assignees", false, "Don't apply default assignees from config.")
 	cmd.Flags().BoolVar(&f.jsonOutput, "json", false, "Output the plan and per-branch results as JSON.")
+	cmd.Flags().BoolVar(&f.verbose, "verbose", false, "Show the full branch-by-branch submission plan and results.")
 }
 
 func executeSubmit(cmd *cobra.Command, f *submitFlags) error {
@@ -155,7 +157,8 @@ func executeSubmit(cmd *cobra.Command, f *submitFlags) error {
 		// Action is the single source of truth for what to submit. The runner
 		// starts lazily (when the submission phase begins), so calling Action
 		// unconditionally no longer flashes the TUI when there's nothing to do.
-		runner, handler := NewSubmitUI(ctx.Output, ctx.Logger)
+		// A dry run's whole output IS the plan, so it always prints verbose.
+		runner, handler := NewSubmitUI(ctx.Output, ctx.Logger, f.verbose || f.dryRun)
 		defer runner.Cleanup()
 		return submit.Action(ctx, opts, handler)
 	})

--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -15,21 +15,33 @@ import (
 	"github.com/getstackit/stackit/internal/tui/style"
 )
 
+// SubmitVerbosity selects how much per-branch detail the submit handlers emit.
+type SubmitVerbosity int
+
+const (
+	// SubmitCompact prints an outcome-focused summary (the default UX).
+	SubmitCompact SubmitVerbosity = iota
+	// SubmitVerbose retains the full branch-by-branch plan and result list.
+	SubmitVerbose
+)
+
+func (v SubmitVerbosity) verbose() bool { return v == SubmitVerbose }
+
 // NewSubmitUI creates a runner and handler pair for submit operations.
 // The runner manages terminal state; the handler processes events.
 // Caller must defer runner.Cleanup() to restore terminal on exit.
-func NewSubmitUI(out output.Output, logger output.Logger, verbose bool) (*tui.Runner, submit.Handler) {
+func NewSubmitUI(out output.Output, logger output.Logger, verbosity SubmitVerbosity) (*tui.Runner, submit.Handler) {
 	if tui.IsTTY() {
 		model := submitComponent.NewModel(nil)
-		model.Verbose = verbose
+		model.Verbose = verbosity.verbose()
 		runner := tui.NewRunner(model, out, logger)
 		// Start lazily when the submission phase begins rather than here: the
 		// stack and plan print as plain lines, so a submit that turns out to
 		// have nothing to do never flashes the bubbletea startup/teardown
 		// sequence. See InteractiveSubmitHandler.OnEvent.
-		return runner, NewInteractiveSubmitHandler(runner, model, out, verbose)
+		return runner, NewInteractiveSubmitHandler(runner, model, out, verbosity)
 	}
-	return nil, NewSimpleSubmitHandler(out, verbose)
+	return nil, NewSimpleSubmitHandler(out, verbosity)
 }
 
 // maxNamedSkipGroup is the largest skipped-branch group that still lists its
@@ -332,16 +344,10 @@ type branchItem struct {
 }
 
 // NewSimpleSubmitHandler creates a new simple submit handler
-func NewSimpleSubmitHandler(out output.Output, verbose ...bool) *SimpleSubmitHandler {
-	// Keep direct constructor callers (notably renderer tests and the TUI lab)
-	// detailed by default. The command always passes its explicit mode.
-	showVerbose := true
-	if len(verbose) > 0 {
-		showVerbose = verbose[0]
-	}
+func NewSimpleSubmitHandler(out output.Output, verbosity SubmitVerbosity) *SimpleSubmitHandler {
 	return &SimpleSubmitHandler{
 		BaseHandler: common.NewBaseHandler(out),
-		plan:        planPrinter{out: out, verbose: showVerbose},
+		plan:        planPrinter{out: out, verbose: verbosity.verbose()},
 		items:       make(map[string]*branchItem),
 	}
 }
@@ -576,12 +582,8 @@ type InteractiveSubmitHandler struct {
 }
 
 // NewInteractiveSubmitHandler creates a new interactive submit handler
-func NewInteractiveSubmitHandler(runner *tui.Runner, model *submitComponent.Model, out output.Output, verbose ...bool) *InteractiveSubmitHandler {
-	showVerbose := true
-	if len(verbose) > 0 {
-		showVerbose = verbose[0]
-	}
-	return &InteractiveSubmitHandler{runner: runner, model: model, out: out, plan: planPrinter{out: out, verbose: showVerbose}}
+func NewInteractiveSubmitHandler(runner *tui.Runner, model *submitComponent.Model, out output.Output, verbosity SubmitVerbosity) *InteractiveSubmitHandler {
+	return &InteractiveSubmitHandler{runner: runner, model: model, out: out, plan: planPrinter{out: out, verbose: verbosity.verbose()}}
 }
 
 // OnEvent handles events from the submit action

--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -464,6 +464,9 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 				if summary := submitComponent.FormatOutcomeSummary(h.submitItems(), ev.Duration); summary != "" {
 					h.Output.Info("%s", summary)
 				}
+				if urls := submitComponent.FormatCreatedURLs(h.submitItems()); urls != "" {
+					h.Output.Info("%s", urls)
+				}
 				return
 			}
 			if summary := h.completionSummary(); summary != "" {

--- a/internal/cli/stack/submit_handlers.go
+++ b/internal/cli/stack/submit_handlers.go
@@ -18,17 +18,18 @@ import (
 // NewSubmitUI creates a runner and handler pair for submit operations.
 // The runner manages terminal state; the handler processes events.
 // Caller must defer runner.Cleanup() to restore terminal on exit.
-func NewSubmitUI(out output.Output, logger output.Logger) (*tui.Runner, submit.Handler) {
+func NewSubmitUI(out output.Output, logger output.Logger, verbose bool) (*tui.Runner, submit.Handler) {
 	if tui.IsTTY() {
 		model := submitComponent.NewModel(nil)
+		model.Verbose = verbose
 		runner := tui.NewRunner(model, out, logger)
 		// Start lazily when the submission phase begins rather than here: the
 		// stack and plan print as plain lines, so a submit that turns out to
 		// have nothing to do never flashes the bubbletea startup/teardown
 		// sequence. See InteractiveSubmitHandler.OnEvent.
-		return runner, NewInteractiveSubmitHandler(runner, model, out)
+		return runner, NewInteractiveSubmitHandler(runner, model, out, verbose)
 	}
-	return nil, NewSimpleSubmitHandler(out)
+	return nil, NewSimpleSubmitHandler(out, verbose)
 }
 
 // maxNamedSkipGroup is the largest skipped-branch group that still lists its
@@ -41,6 +42,7 @@ const maxNamedSkipGroup = 3
 // the stack header and aligned columns.
 type planPrinter struct {
 	out       output.Output
+	verbose   bool
 	scopes    map[string]string
 	worktrees map[string]string
 	parents   map[string]string
@@ -96,6 +98,12 @@ func (p *planPrinter) Flush() {
 		return
 	}
 	p.printed = true
+	if !p.verbose {
+		if summary := p.compactSummary(); summary != "" {
+			p.out.Info("● %s", summary)
+		}
+		return
+	}
 
 	if p.solo {
 		p.printSoloLine(p.events[0])
@@ -126,6 +134,36 @@ func (p *planPrinter) Flush() {
 			p.printSkippedName(ev)
 		}
 	}
+}
+
+// compactSummary describes only the work that submit will perform. The
+// default submit output is an action summary, not a stack visualization; the
+// full branch-by-branch plan is available with --verbose.
+func (p *planPrinter) compactSummary() string {
+	var creates, updates int
+	for _, ev := range p.events {
+		if ev.Skipped {
+			continue
+		}
+		switch ev.Action {
+		case engine.SubmitActionCreate:
+			creates++
+		case engine.SubmitActionUpdate:
+			updates++
+		}
+	}
+
+	parts := make([]string, 0, 2)
+	if creates > 0 {
+		parts = append(parts, fmt.Sprintf("open %d %s", creates, pluralizePRs(creates)))
+	}
+	if updates > 0 {
+		parts = append(parts, fmt.Sprintf("update %d %s", updates, pluralizePRs(updates)))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "Will " + strings.Join(parts, " · ")
 }
 
 func (p *planPrinter) printActiveLine(ev submit.BranchPlanEvent) {
@@ -294,10 +332,16 @@ type branchItem struct {
 }
 
 // NewSimpleSubmitHandler creates a new simple submit handler
-func NewSimpleSubmitHandler(out output.Output) *SimpleSubmitHandler {
+func NewSimpleSubmitHandler(out output.Output, verbose ...bool) *SimpleSubmitHandler {
+	// Keep direct constructor callers (notably renderer tests and the TUI lab)
+	// detailed by default. The command always passes its explicit mode.
+	showVerbose := true
+	if len(verbose) > 0 {
+		showVerbose = verbose[0]
+	}
 	return &SimpleSubmitHandler{
 		BaseHandler: common.NewBaseHandler(out),
-		plan:        planPrinter{out: out},
+		plan:        planPrinter{out: out, verbose: showVerbose},
 		items:       make(map[string]*branchItem),
 	}
 }
@@ -339,11 +383,13 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 			}
 			h.order = append(h.order, branch.Name)
 		}
-		h.Output.Newline()
-		// A solo branch was already named in the plan line; the count header
-		// would just restate it.
-		if !h.plan.solo {
-			h.Output.Info("Submitting %d %s", len(ev.Branches), pluralizeBranches(len(ev.Branches)))
+		if h.plan.verbose {
+			h.Output.Newline()
+			if !h.plan.solo {
+				h.Output.Info("Submitting %d %s", len(ev.Branches), pluralizeBranches(len(ev.Branches)))
+			}
+		} else {
+			h.Output.Info("Submitting %d %s...", len(ev.Branches), pluralizePRs(len(ev.Branches)))
 		}
 
 	case submit.BranchProgressEvent:
@@ -374,8 +420,13 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 				return
 			}
 			item.reportedDone = true
-			// A solo branch reports its result in the completion summary
-			// (ref + URL together); a per-branch line here would duplicate it.
+			// Default output reports one final result rather than a noisy row per
+			// branch. Verbose mode retains the per-branch audit trail.
+			if !h.plan.verbose && !h.plan.solo {
+				return
+			}
+			// A solo branch reports its result in the completion summary (ref +
+			// URL together); a per-branch line here would duplicate it.
 			if h.plan.solo {
 				return
 			}
@@ -409,6 +460,12 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 		h.plan.Flush()
 		switch ev.Outcome {
 		case submit.OutcomeComplete:
+			if !h.plan.verbose {
+				if summary := submitComponent.FormatOutcomeSummary(h.submitItems(), ev.Duration); summary != "" {
+					h.Output.Info("%s", summary)
+				}
+				return
+			}
 			if summary := h.completionSummary(); summary != "" {
 				h.Output.Newline()
 				h.Output.Info("%s", summary)
@@ -429,7 +486,9 @@ func (h *SimpleSubmitHandler) OnEvent(e submit.Event) {
 		default:
 			// Dry run, all up to date, canceled, nothing to submit: print the
 			// outcome so the run doesn't end silently.
-			if ev.Message != "" {
+			if ev.Outcome == submit.OutcomeUpToDate && !h.plan.verbose {
+				h.Output.Info("✓ Nothing to submit")
+			} else if ev.Message != "" {
 				h.Output.Info("%s", ev.Message)
 			}
 		}
@@ -484,6 +543,13 @@ func (i *branchItem) toSubmitItem() submitComponent.Item {
 	}
 }
 
+func pluralizePRs(count int) string {
+	if count == 1 {
+		return "PR"
+	}
+	return "PRs"
+}
+
 func pluralizeBranches(count int) string {
 	if count == 1 {
 		return "branch"
@@ -507,8 +573,12 @@ type InteractiveSubmitHandler struct {
 }
 
 // NewInteractiveSubmitHandler creates a new interactive submit handler
-func NewInteractiveSubmitHandler(runner *tui.Runner, model *submitComponent.Model, out output.Output) *InteractiveSubmitHandler {
-	return &InteractiveSubmitHandler{runner: runner, model: model, out: out, plan: planPrinter{out: out}}
+func NewInteractiveSubmitHandler(runner *tui.Runner, model *submitComponent.Model, out output.Output, verbose ...bool) *InteractiveSubmitHandler {
+	showVerbose := true
+	if len(verbose) > 0 {
+		showVerbose = verbose[0]
+	}
+	return &InteractiveSubmitHandler{runner: runner, model: model, out: out, plan: planPrinter{out: out, verbose: showVerbose}}
 }
 
 // OnEvent handles events from the submit action
@@ -549,9 +619,9 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 			}
 		}
 		h.model.Items = items
-		// The plan already named a solo branch and printed its base, so the TUI
-		// drops the count header and the per-row branch name.
-		h.model.Solo = h.plan.solo
+		// Verbose mode retains the traditional solo plan line; default mode is
+		// self-contained and keeps the branch name in its progress row.
+		h.model.Solo = h.plan.verbose && h.plan.solo
 
 		// Start the TUI now that there's real submission work to animate.
 		// Idempotent, so later events that arrive after this are safe.
@@ -590,7 +660,9 @@ func (h *InteractiveSubmitHandler) OnEvent(e submit.Event) {
 				printOnTrunkGuidance(h.out, ev.Message)
 				return
 			}
-			if ev.Outcome != submit.OutcomeFailed && ev.Message != "" {
+			if ev.Outcome == submit.OutcomeUpToDate && !h.plan.verbose {
+				h.out.Info("✓ Nothing to submit")
+			} else if ev.Outcome != submit.OutcomeFailed && ev.Message != "" {
 				h.out.Info("%s", ev.Message)
 			}
 			return

--- a/internal/cli/stack/submit_handlers_test.go
+++ b/internal/cli/stack/submit_handlers_test.go
@@ -17,7 +17,7 @@ func TestSimpleSubmitHandlerStreamsOneListWithURLsOnCreates(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 	updated := "jonnii/20260511011552/guard-runner.repoRoot-reads-with-repoMu-to-fix"
 	created := "jonnii/20260511011552/add-feature"
 
@@ -54,7 +54,7 @@ func TestSimpleSubmitHandlerPreservesURLAcrossFooterSync(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 	branch := "jonnii/20260511011552/guard-runner.repoRoot-reads-with-repoMu-to-fix"
 
 	handler.OnEvent(submitAction.SubmissionStartEvent{
@@ -88,7 +88,7 @@ func TestSimpleSubmitHandlerMergesPlanIntoStackList(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 	current := "jonnii/20260511011552/current-branch"
 	skipped := "jonnii/20260511011552/skipped-branch"
 
@@ -125,7 +125,7 @@ func TestSimpleSubmitHandlerPrintsClosingSummary(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 
 	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
 		Branches:    []string{"create-me", "update-me", "skip-me"},
@@ -150,7 +150,7 @@ func TestPlanPrinterCollapsesLargeSkipGroups(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 
 	branches := []string{"active-one", "skip-a", "skip-b", "skip-c", "skip-d"}
 	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
@@ -180,7 +180,7 @@ func TestInteractiveSubmitHandlerPrintsPlanWithoutStartingTUI(t *testing.T) {
 	out := output.NewTestOutput()
 	// A nil runner stands in for a TUI that was never started; every runner
 	// method is nil-safe. Plan output must not depend on the TUI running.
-	handler := NewInteractiveSubmitHandler(nil, submitComponent.NewModel(nil), out)
+	handler := NewInteractiveSubmitHandler(nil, submitComponent.NewModel(nil), out, SubmitVerbose)
 	branch := "jonnii/20260511011552/up-to-date-branch"
 
 	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
@@ -209,7 +209,7 @@ func TestPlanPrinterShowsPRNumbersAndEmptyAnnotation(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 	prNumber := 1189
 
 	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
@@ -240,7 +240,7 @@ func TestSimpleSubmitHandlerSoloSubmitDropsStackFraming(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 	branch := "jonnii/20260511011552/tighten-submit-output"
 
 	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
@@ -277,7 +277,7 @@ func TestSimpleSubmitHandlerOnTrunkGuidance(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 
 	handler.OnEvent(submitAction.CompletionEvent{
 		Outcome: submitAction.OutcomeOnTrunk,
@@ -294,7 +294,7 @@ func TestSimpleSubmitHandlerPrintsBranchWarnings(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 
 	handler.OnEvent(submitAction.BranchWarningEvent{
 		BranchName: "jonnii/20260511011552/add-feature",
@@ -308,7 +308,7 @@ func TestSimpleSubmitHandlerStaysQuietOnFailureOutcome(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 
 	// The CLI prints the returned error; the handler must not double-report.
 	handler.OnEvent(submitAction.CompletionEvent{Outcome: submitAction.OutcomeFailed, Message: "Submit failed"})
@@ -320,7 +320,7 @@ func TestSimpleSubmitHandlerPrintsOutcomeWhenNothingSubmitted(t *testing.T) {
 	t.Parallel()
 
 	out := output.NewTestOutput()
-	handler := NewSimpleSubmitHandler(out)
+	handler := NewSimpleSubmitHandler(out, SubmitVerbose)
 	branch := "jonnii/20260511011552/up-to-date-branch"
 
 	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{

--- a/internal/cli/stack/submit_scenarios.go
+++ b/internal/cli/stack/submit_scenarios.go
@@ -1,6 +1,7 @@
 package stack
 
 import (
+	"errors"
 	"time"
 
 	submitAction "github.com/getstackit/stackit/internal/actions/submit"
@@ -96,6 +97,178 @@ var SubmitScenarios = []SubmitScenario{
 			submitAction.BranchProgressEvent{BranchName: "add-submit-TUI-lab-scenarios", Status: submitAction.StatusSubmitting},
 			submitAction.BranchProgressEvent{BranchName: "add-submit-TUI-lab-scenarios", Status: submitAction.StatusDone, URL: "https://github.com/getstackit/stackit/pull/1417"},
 			submitAction.CompletionEvent{Outcome: submitAction.OutcomeComplete, Duration: 5500 * time.Millisecond},
+		},
+	},
+	{
+		Name:        "ss-create-stack",
+		Description: "A three-PR stack where every branch is created in sequence.",
+		Events: []submitAction.Event{
+			submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+				Branches:      []string{"feat/api", "feat/web", "feat/cli"},
+				CurrentBranch: "feat/cli",
+				TrunkBranch:   "main",
+				ParentMap:     map[string]string{"feat/api": "main", "feat/web": "feat/api", "feat/cli": "feat/web"},
+				FixedMap:      map[string]bool{"feat/api": true, "feat/web": true, "feat/cli": true},
+			}},
+			submitAction.BranchPlanEvent{BranchName: "feat/api", Action: engine.SubmitActionCreate},
+			submitAction.BranchPlanEvent{BranchName: "feat/web", Action: engine.SubmitActionCreate},
+			submitAction.BranchPlanEvent{BranchName: "feat/cli", Action: engine.SubmitActionCreate, IsCurrent: true},
+			submitAction.PlanningCompleteEvent{},
+			submitAction.SubmissionStartEvent{Branches: []submitAction.BranchInfo{
+				{Name: "feat/api", Action: engine.SubmitActionCreate},
+				{Name: "feat/web", Action: engine.SubmitActionCreate},
+				{Name: "feat/cli", Action: engine.SubmitActionCreate},
+			}},
+			submitAction.BranchProgressEvent{BranchName: "feat/api", Status: submitAction.StatusSubmitting},
+			submitAction.BranchProgressEvent{BranchName: "feat/api", Status: submitAction.StatusDone, URL: "https://github.com/getstackit/stackit/pull/1420"},
+			submitAction.BranchProgressEvent{BranchName: "feat/web", Status: submitAction.StatusSubmitting},
+			submitAction.BranchProgressEvent{BranchName: "feat/web", Status: submitAction.StatusDone, URL: "https://github.com/getstackit/stackit/pull/1421"},
+			submitAction.BranchProgressEvent{BranchName: "feat/cli", Status: submitAction.StatusSubmitting},
+			submitAction.BranchProgressEvent{BranchName: "feat/cli", Status: submitAction.StatusDone, URL: "https://github.com/getstackit/stackit/pull/1422"},
+			submitAction.CompletionEvent{Outcome: submitAction.OutcomeComplete, Duration: 3 * time.Second},
+		},
+	},
+	{
+		Name:        "ss-mixed",
+		Description: "An existing PR update and a new current-branch PR in one stack.",
+		Events: []submitAction.Event{
+			submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+				Branches:      []string{"feat/api", "feat/web"},
+				CurrentBranch: "feat/web",
+				TrunkBranch:   "main",
+				ParentMap:     map[string]string{"feat/api": "main", "feat/web": "feat/api"},
+				FixedMap:      map[string]bool{"feat/api": true, "feat/web": true},
+			}},
+			submitAction.BranchPlanEvent{BranchName: "feat/api", Action: engine.SubmitActionUpdate, PRNumber: intPointer(50)},
+			submitAction.BranchPlanEvent{BranchName: "feat/web", Action: engine.SubmitActionCreate, IsCurrent: true},
+			submitAction.PlanningCompleteEvent{},
+			submitAction.SubmissionStartEvent{Branches: []submitAction.BranchInfo{
+				{Name: "feat/api", Action: engine.SubmitActionUpdate, PRNumber: intPointer(50)},
+				{Name: "feat/web", Action: engine.SubmitActionCreate},
+			}},
+			submitAction.BranchProgressEvent{BranchName: "feat/api", Status: submitAction.StatusSubmitting},
+			submitAction.BranchProgressEvent{BranchName: "feat/web", Status: submitAction.StatusSubmitting},
+			submitAction.BranchProgressEvent{BranchName: "feat/api", Status: submitAction.StatusDone, URL: "https://github.com/getstackit/stackit/pull/50"},
+			submitAction.BranchProgressEvent{BranchName: "feat/web", Status: submitAction.StatusDone, URL: "https://github.com/getstackit/stackit/pull/51"},
+			submitAction.CompletionEvent{Outcome: submitAction.OutcomeComplete, Duration: 2 * time.Second},
+		},
+	},
+	{
+		Name:        "ss-current",
+		Description: "A full stack where every PR is already current and no TUI starts.",
+		Events: []submitAction.Event{
+			submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+				Branches:      []string{"feat/api", "feat/web"},
+				CurrentBranch: "feat/web",
+				TrunkBranch:   "main",
+				ParentMap:     map[string]string{"feat/api": "main", "feat/web": "feat/api"},
+				FixedMap:      map[string]bool{"feat/api": true, "feat/web": true},
+			}},
+			submitAction.BranchPlanEvent{BranchName: "feat/api", Skipped: true, SkipReason: "no changes"},
+			submitAction.BranchPlanEvent{BranchName: "feat/web", IsCurrent: true, Skipped: true, SkipReason: "no changes"},
+			submitAction.PlanningCompleteEvent{},
+			submitAction.CompletionEvent{Outcome: submitAction.OutcomeUpToDate, Message: "All PRs up to date"},
+		},
+	},
+	{
+		Name:        "ss-update-only",
+		Description: "Update an existing PR while a new branch is skipped by --update-only.",
+		Events: []submitAction.Event{
+			submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+				Branches:      []string{"feat/api", "feat/web"},
+				CurrentBranch: "feat/web",
+				TrunkBranch:   "main",
+				ParentMap:     map[string]string{"feat/api": "main", "feat/web": "feat/api"},
+				FixedMap:      map[string]bool{"feat/api": true, "feat/web": true},
+			}},
+			submitAction.BranchPlanEvent{BranchName: "feat/api", Action: engine.SubmitActionUpdate, PRNumber: intPointer(50)},
+			submitAction.BranchPlanEvent{BranchName: "feat/web", Action: engine.SubmitActionCreate, IsCurrent: true, Skipped: true, SkipReason: "no existing PR"},
+			submitAction.PlanningCompleteEvent{},
+			submitAction.SubmissionStartEvent{Branches: []submitAction.BranchInfo{{Name: "feat/api", Action: engine.SubmitActionUpdate, PRNumber: intPointer(50)}}},
+			submitAction.BranchProgressEvent{BranchName: "feat/api", Status: submitAction.StatusSubmitting},
+			submitAction.BranchProgressEvent{BranchName: "feat/api", Status: submitAction.StatusDone, URL: "https://github.com/getstackit/stackit/pull/50"},
+			submitAction.CompletionEvent{Outcome: submitAction.OutcomeComplete, Duration: time.Second},
+		},
+	},
+	{
+		Name:        "ss-empty-canceled",
+		Description: "An empty current branch is shown in the plan, then submission is canceled.",
+		Events: []submitAction.Event{
+			submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+				Branches:      []string{"feat/placeholder"},
+				CurrentBranch: "feat/placeholder",
+				TrunkBranch:   "main",
+				ParentMap:     map[string]string{"feat/placeholder": "main"},
+				FixedMap:      map[string]bool{"feat/placeholder": true},
+			}},
+			submitAction.BranchPlanEvent{BranchName: "feat/placeholder", Action: engine.SubmitActionCreate, IsCurrent: true, Empty: true},
+			submitAction.PlanningCompleteEvent{},
+			submitAction.CompletionEvent{Outcome: submitAction.OutcomeCanceled, Message: "Submit canceled"},
+		},
+	},
+	{
+		Name:        "ss-restack",
+		Description: "A full-stack submit that performs its optional restack before planning.",
+		Events: []submitAction.Event{
+			submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+				Branches:      []string{"feat/api", "feat/web"},
+				CurrentBranch: "feat/web",
+				TrunkBranch:   "main",
+				ParentMap:     map[string]string{"feat/api": "main", "feat/web": "feat/api"},
+				FixedMap:      map[string]bool{"feat/api": false, "feat/web": false},
+			}},
+			submitAction.RestackEvent{Started: true},
+			submitAction.RestackEvent{Completed: true},
+			submitAction.BranchPlanEvent{BranchName: "feat/api", Action: engine.SubmitActionUpdate, PRNumber: intPointer(50)},
+			submitAction.BranchPlanEvent{BranchName: "feat/web", Action: engine.SubmitActionCreate, IsCurrent: true},
+			submitAction.PlanningCompleteEvent{},
+			submitAction.SubmissionStartEvent{Branches: []submitAction.BranchInfo{
+				{Name: "feat/api", Action: engine.SubmitActionUpdate, PRNumber: intPointer(50)},
+				{Name: "feat/web", Action: engine.SubmitActionCreate},
+			}},
+			submitAction.BranchProgressEvent{BranchName: "feat/api", Status: submitAction.StatusDone, URL: "https://github.com/getstackit/stackit/pull/50"},
+			submitAction.BranchProgressEvent{BranchName: "feat/web", Status: submitAction.StatusDone, URL: "https://github.com/getstackit/stackit/pull/51"},
+			submitAction.CompletionEvent{Outcome: submitAction.OutcomeComplete, Duration: 4 * time.Second},
+		},
+	},
+	{
+		Name:        "ss-dry-run",
+		Description: "A full-stack plan that exits before starting the submit TUI.",
+		Events: []submitAction.Event{
+			submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+				Branches:      []string{"feat/api", "feat/web"},
+				CurrentBranch: "feat/web",
+				TrunkBranch:   "main",
+				ParentMap:     map[string]string{"feat/api": "main", "feat/web": "feat/api"},
+				FixedMap:      map[string]bool{"feat/api": true, "feat/web": true},
+			}},
+			submitAction.BranchPlanEvent{BranchName: "feat/api", Action: engine.SubmitActionUpdate, PRNumber: intPointer(50)},
+			submitAction.BranchPlanEvent{BranchName: "feat/web", Action: engine.SubmitActionCreate, IsCurrent: true},
+			submitAction.PlanningCompleteEvent{},
+			submitAction.CompletionEvent{Outcome: submitAction.OutcomeDryRun, Message: "Dry run complete"},
+		},
+	},
+	{
+		Name:        "ss-failure",
+		Description: "One branch completes and a second branch fails during submission.",
+		Events: []submitAction.Event{
+			submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+				Branches:      []string{"feat/api", "feat/web"},
+				CurrentBranch: "feat/web",
+				TrunkBranch:   "main",
+				ParentMap:     map[string]string{"feat/api": "main", "feat/web": "feat/api"},
+				FixedMap:      map[string]bool{"feat/api": true, "feat/web": true},
+			}},
+			submitAction.BranchPlanEvent{BranchName: "feat/api", Action: engine.SubmitActionUpdate, PRNumber: intPointer(50)},
+			submitAction.BranchPlanEvent{BranchName: "feat/web", Action: engine.SubmitActionCreate, IsCurrent: true},
+			submitAction.PlanningCompleteEvent{},
+			submitAction.SubmissionStartEvent{Branches: []submitAction.BranchInfo{
+				{Name: "feat/api", Action: engine.SubmitActionUpdate, PRNumber: intPointer(50)},
+				{Name: "feat/web", Action: engine.SubmitActionCreate},
+			}},
+			submitAction.BranchProgressEvent{BranchName: "feat/api", Status: submitAction.StatusDone, URL: "https://github.com/getstackit/stackit/pull/50"},
+			submitAction.BranchProgressEvent{BranchName: "feat/web", Status: submitAction.StatusError, Error: errors.New("force-with-lease rejected the remote branch")},
+			submitAction.CompletionEvent{Outcome: submitAction.OutcomeFailed, Message: "Submit failed"},
 		},
 	},
 }

--- a/internal/cli/stack/submit_scenarios.go
+++ b/internal/cli/stack/submit_scenarios.go
@@ -1,0 +1,120 @@
+package stack
+
+import (
+	"time"
+
+	submitAction "github.com/getstackit/stackit/internal/actions/submit"
+	"github.com/getstackit/stackit/internal/engine"
+)
+
+// SubmitScenario is a deterministic replay of submit action events. It drives
+// the production Handler, preserving the command's lazy TUI startup and its
+// regular terminal output before and after the submission phase.
+type SubmitScenario struct {
+	Name        string
+	Description string
+	Events      []submitAction.Event
+}
+
+// Replay sends this scenario through a submit handler. delay makes the active
+// submission states visible; zero is useful for automated checks.
+func (s SubmitScenario) Replay(handler submitAction.Handler, delay time.Duration) {
+	for _, event := range s.Events {
+		handler.OnEvent(event)
+		pause(delay)
+	}
+}
+
+// SubmitScenarios are the named submit flows available in the local TUI lab.
+var SubmitScenarios = []SubmitScenario{
+	{
+		Name:        "success",
+		Description: "Update one PR, create another, and surface a non-fatal warning.",
+		Events: []submitAction.Event{
+			submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+				Branches:      []string{"feat/api", "feat/web"},
+				CurrentBranch: "feat/web",
+				TrunkBranch:   "main",
+				ParentMap:     map[string]string{"feat/api": "main", "feat/web": "feat/api"},
+				FixedMap:      map[string]bool{"feat/api": true, "feat/web": true},
+				ScopeMap:      map[string]string{"feat/api": "API", "feat/web": "WEB"},
+			}},
+			submitAction.BranchPlanEvent{BranchName: "feat/api", Action: engine.SubmitActionUpdate, PRNumber: intPointer(42)},
+			submitAction.BranchPlanEvent{BranchName: "feat/web", Action: engine.SubmitActionCreate, IsCurrent: true},
+			submitAction.PlanningCompleteEvent{},
+			submitAction.SubmissionStartEvent{Branches: []submitAction.BranchInfo{
+				{Name: "feat/api", Action: engine.SubmitActionUpdate, PRNumber: intPointer(42)},
+				{Name: "feat/web", Action: engine.SubmitActionCreate},
+			}},
+			submitAction.BranchProgressEvent{BranchName: "feat/api", Status: submitAction.StatusSubmitting},
+			submitAction.BranchProgressEvent{BranchName: "feat/api", Status: submitAction.StatusDone, URL: "https://github.com/getstackit/stackit/pull/42"},
+			submitAction.BranchProgressEvent{BranchName: "feat/web", Status: submitAction.StatusSubmitting},
+			submitAction.BranchWarningEvent{BranchName: "feat/web", Warning: "could not apply reviewer @octo"},
+			submitAction.BranchProgressEvent{BranchName: "feat/web", Status: submitAction.StatusDone, URL: "https://github.com/getstackit/stackit/pull/43"},
+			submitAction.CompletionEvent{Outcome: submitAction.OutcomeComplete, Duration: 2 * time.Second},
+		},
+	},
+	{
+		Name:        "current",
+		Description: "An all-current plan that never starts the submit TUI.",
+		Events: []submitAction.Event{
+			submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+				Branches:      []string{"feat/api"},
+				CurrentBranch: "feat/api",
+				TrunkBranch:   "main",
+				ParentMap:     map[string]string{"feat/api": "main"},
+				FixedMap:      map[string]bool{"feat/api": true},
+			}},
+			submitAction.BranchPlanEvent{BranchName: "feat/api", Skipped: true, SkipReason: "already up to date"},
+			submitAction.PlanningCompleteEvent{},
+			submitAction.CompletionEvent{Outcome: submitAction.OutcomeUpToDate, Message: "All pull requests are up to date"},
+		},
+	},
+	{
+		Name:        "ss",
+		Description: "An st ss run that creates the current PR and retains its unchanged parent.",
+		Events: []submitAction.Event{
+			submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+				Branches:      []string{"add-sync-TUI-lab", "add-submit-TUI-lab-scenarios"},
+				CurrentBranch: "add-submit-TUI-lab-scenarios",
+				TrunkBranch:   "main",
+				ParentMap: map[string]string{
+					"add-sync-TUI-lab":             "main",
+					"add-submit-TUI-lab-scenarios": "add-sync-TUI-lab",
+				},
+				FixedMap: map[string]bool{
+					"add-sync-TUI-lab":             true,
+					"add-submit-TUI-lab-scenarios": true,
+				},
+			}},
+			submitAction.BranchPlanEvent{BranchName: "add-sync-TUI-lab", Skipped: true, SkipReason: "no changes"},
+			submitAction.BranchPlanEvent{BranchName: "add-submit-TUI-lab-scenarios", Action: engine.SubmitActionCreate, IsCurrent: true},
+			submitAction.PlanningCompleteEvent{},
+			submitAction.SubmissionStartEvent{Branches: []submitAction.BranchInfo{
+				{Name: "add-submit-TUI-lab-scenarios", Action: engine.SubmitActionCreate},
+			}},
+			submitAction.BranchProgressEvent{BranchName: "add-submit-TUI-lab-scenarios", Status: submitAction.StatusSubmitting},
+			submitAction.BranchProgressEvent{BranchName: "add-submit-TUI-lab-scenarios", Status: submitAction.StatusDone, URL: "https://github.com/getstackit/stackit/pull/1417"},
+			submitAction.CompletionEvent{Outcome: submitAction.OutcomeComplete, Duration: 5500 * time.Millisecond},
+		},
+	},
+}
+
+// LookupSubmitScenario returns a named submit scenario.
+func LookupSubmitScenario(name string) (SubmitScenario, bool) {
+	for _, scenario := range SubmitScenarios {
+		if scenario.Name == name {
+			return scenario, true
+		}
+	}
+	return SubmitScenario{}, false
+}
+
+// SubmitScenarioNames returns scenario names in display order.
+func SubmitScenarioNames() []string {
+	names := make([]string, 0, len(SubmitScenarios))
+	for _, scenario := range SubmitScenarios {
+		names = append(names, scenario.Name)
+	}
+	return names
+}

--- a/internal/cli/stack/submit_scenarios_test.go
+++ b/internal/cli/stack/submit_scenarios_test.go
@@ -15,7 +15,7 @@ func TestSubmitScenarioReplayUsesProductionHandler(t *testing.T) {
 	require.True(t, found)
 
 	out := output.NewTestOutput()
-	scenario.Replay(NewSimpleSubmitHandler(out), 0)
+	scenario.Replay(NewSimpleSubmitHandler(out, SubmitVerbose), 0)
 	got := ansi.Strip(out.String())
 
 	assert.Contains(t, got, "Submitting 2 branches")
@@ -38,7 +38,7 @@ func TestSubmitScenarioSSReplay(t *testing.T) {
 	require.True(t, found)
 
 	out := output.NewTestOutput()
-	scenario.Replay(NewSimpleSubmitHandler(out), 0)
+	scenario.Replay(NewSimpleSubmitHandler(out, SubmitVerbose), 0)
 	got := ansi.Strip(out.String())
 
 	assert.Contains(t, got, "Will submit (1)")
@@ -69,7 +69,7 @@ func TestSubmitScenarioSpecialCases(t *testing.T) {
 			require.True(t, found)
 
 			out := output.NewTestOutput()
-			scenario.Replay(NewSimpleSubmitHandler(out), 0)
+			scenario.Replay(NewSimpleSubmitHandler(out, SubmitVerbose), 0)
 			assert.Contains(t, ansi.Strip(out.String()), tt.want)
 		})
 	}

--- a/internal/cli/stack/submit_scenarios_test.go
+++ b/internal/cli/stack/submit_scenarios_test.go
@@ -25,7 +25,10 @@ func TestSubmitScenarioReplayUsesProductionHandler(t *testing.T) {
 }
 
 func TestLookupSubmitScenario(t *testing.T) {
-	assert.Equal(t, []string{"success", "current", "ss"}, SubmitScenarioNames())
+	assert.Equal(t, []string{
+		"success", "current", "ss", "ss-create-stack", "ss-mixed", "ss-current",
+		"ss-update-only", "ss-empty-canceled", "ss-restack", "ss-dry-run", "ss-failure",
+	}, SubmitScenarioNames())
 	_, found := LookupSubmitScenario("missing")
 	assert.False(t, found)
 }
@@ -43,4 +46,31 @@ func TestSubmitScenarioSSReplay(t *testing.T) {
 	assert.Contains(t, got, "add-sync-TUI-lab")
 	assert.Contains(t, got, "add-submit-TUI-lab-scenarios #1417 created")
 	assert.Contains(t, got, "✓ 1 created, 1 unchanged (5.5s)")
+}
+
+func TestSubmitScenarioSpecialCases(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"ss-create-stack", "✓ 3 created (3.0s)"},
+		{"ss-mixed", "✓ 1 created, 1 updated (2.0s)"},
+		{"ss-current", "All PRs up to date"},
+		{"ss-update-only", "No existing PR (1)"},
+		{"ss-empty-canceled", "Submit canceled"},
+		{"ss-restack", "Restacking branches before submitting..."},
+		{"ss-dry-run", "Dry run complete"},
+		{"ss-failure", "force-with-lease rejected the remote branch"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scenario, found := LookupSubmitScenario(tt.name)
+			require.True(t, found)
+
+			out := output.NewTestOutput()
+			scenario.Replay(NewSimpleSubmitHandler(out), 0)
+			assert.Contains(t, ansi.Strip(out.String()), tt.want)
+		})
+	}
 }

--- a/internal/cli/stack/submit_scenarios_test.go
+++ b/internal/cli/stack/submit_scenarios_test.go
@@ -1,0 +1,46 @@
+package stack
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/output"
+)
+
+func TestSubmitScenarioReplayUsesProductionHandler(t *testing.T) {
+	scenario, found := LookupSubmitScenario("success")
+	require.True(t, found)
+
+	out := output.NewTestOutput()
+	scenario.Replay(NewSimpleSubmitHandler(out), 0)
+	got := ansi.Strip(out.String())
+
+	assert.Contains(t, got, "Submitting 2 branches")
+	assert.Contains(t, got, "feat/api #42 updated")
+	assert.Contains(t, got, "feat/web #43 created")
+	assert.Contains(t, got, "could not apply reviewer @octo")
+}
+
+func TestLookupSubmitScenario(t *testing.T) {
+	assert.Equal(t, []string{"success", "current", "ss"}, SubmitScenarioNames())
+	_, found := LookupSubmitScenario("missing")
+	assert.False(t, found)
+}
+
+func TestSubmitScenarioSSReplay(t *testing.T) {
+	scenario, found := LookupSubmitScenario("ss")
+	require.True(t, found)
+
+	out := output.NewTestOutput()
+	scenario.Replay(NewSimpleSubmitHandler(out), 0)
+	got := ansi.Strip(out.String())
+
+	assert.Contains(t, got, "Will submit (1)")
+	assert.Contains(t, got, "No changes (1)")
+	assert.Contains(t, got, "add-sync-TUI-lab")
+	assert.Contains(t, got, "add-submit-TUI-lab-scenarios #1417 created")
+	assert.Contains(t, got, "✓ 1 created, 1 unchanged (5.5s)")
+}

--- a/internal/cli/stack/submit_test.go
+++ b/internal/cli/stack/submit_test.go
@@ -33,8 +33,8 @@ func TestSubmitCommand(t *testing.T) {
 			return s.Repo.CheckoutBranch("branch-b")
 		})
 
-		// 1. Basic submit (downstack)
-		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--dry-run", "--no-edit", "--draft", "--no-interactive")
+		// 1. Basic submit (downstack). A dry run's whole output is the plan,
+		// so it always prints the detailed branch plan; --verbose is a no-op.
 		expected := testhelpers.NormalizeOutput(`
 Submit plan → main
 Will submit (2)
@@ -42,6 +42,10 @@ Will submit (2)
 ● branch-b → create (empty)
 Dry run complete
 `)
+		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--dry-run", "--no-edit", "--draft", "--no-interactive")
+		require.Equal(t, expected, testhelpers.NormalizeOutput(output))
+
+		output = runCliCommandSuccess(t, binaryPath, scene.Dir, "submit", "--dry-run", "--no-edit", "--draft", "--no-interactive", "--verbose")
 		require.Equal(t, expected, testhelpers.NormalizeOutput(output))
 
 		// 2. Submit --stack (full stack)
@@ -99,12 +103,7 @@ Dry run complete
 
 		output := runCliCommandSuccess(t, binaryPath, scene.Dir, "ss", "--no-edit", "--no-interactive")
 		expected := testhelpers.NormalizeOutput(`
-Submit plan → main
-No changes (3)
-  branch-a
-● branch-b
-  branch-c
-All PRs up to date
+✓ Nothing to submit
 `)
 		require.Equal(t, expected, testhelpers.NormalizeOutput(output))
 	})

--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -302,10 +302,10 @@ func (h *SimpleSyncHandler) printSummary(summary syncAction.Summary) {
 		h.Output.Info("✅ Summary: %s", strings.Join(parts, ", "))
 	}
 
-	// Print actionable advice for conflicts
-	if len(summary.ConflictBranches) > 0 {
+	// Print actionable advice for every conflict, not just the first
+	for _, conflict := range summary.ConflictBranches {
 		h.Output.Info("  Run %s to resolve and continue",
-			style.ColorCyan(fmt.Sprintf("st restack %s", summary.ConflictBranches[0])))
+			style.ColorCyan(fmt.Sprintf("st restack %s", conflict)))
 	}
 }
 
@@ -581,17 +581,17 @@ func (h *InteractiveSyncHandler) formatSummary(summary syncAction.Summary) strin
 
 	parts := syncAction.FormatSummaryParts(summary)
 
-	result := ""
+	var lines []string
 	if len(parts) > 0 {
-		result = "✅ Summary: " + strings.Join(parts, ", ")
+		lines = append(lines, "✅ Summary: "+strings.Join(parts, ", "))
 	}
 
-	// Add actionable advice for conflicts
-	if len(summary.ConflictBranches) > 0 {
-		result += fmt.Sprintf("\n   Run 'st restack %s' to resolve and continue", summary.ConflictBranches[0])
+	// Add actionable advice for every conflict, not just the first
+	for _, conflict := range summary.ConflictBranches {
+		lines = append(lines, fmt.Sprintf("   Run 'st restack %s' to resolve and continue", conflict))
 	}
 
-	return result
+	return strings.Join(lines, "\n")
 }
 
 // OnRestackStart implements RestackHandler for standalone restack operations
@@ -764,16 +764,15 @@ func (h *InteractiveSyncHandler) PromptOrphanedMetadata(info engine.OrphanedMeta
 func describeRestackConflicts(out output.Output, conflictBranches []string) {
 	out.Newline()
 	// out.Warn already prefixes "⚠️ "; don't hardcode another one here.
-	out.Warn("Found conflicts in %d %s during restack:",
+	out.Warn("Found conflicts in %d %s during restack; branches without conflicts were restacked.",
 		len(conflictBranches),
 		map[bool]string{true: "branch", false: "branches"}[len(conflictBranches) == 1])
+	// Bullets are detail lines, not warnings — use Info so they don't each
+	// pick up a ⚠️ prefix.
+	out.Info("Resolve each with:")
 	for _, name := range conflictBranches {
-		// Bullets are detail lines, not warnings — use Info so they don't each
-		// pick up a ⚠️ prefix.
-		out.Info("  • %s", style.ColorBranchName(name))
+		out.Info("  • %s", style.ColorCyan("st restack "+name))
 	}
-	out.Newline()
-	out.Info("Branches that could be restacked cleanly have been restacked.")
 	out.Newline()
 }
 

--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -42,6 +42,11 @@ type SimpleSyncHandler struct {
 	totalOps  int
 	currentOp int
 	headers   *utils.LazyHeaders[syncAction.Phase]
+
+	// restack-only state: standalone restack suppresses already-current rows
+	// and reports them as a count in the summary instead.
+	restackUpToDate int
+	restackPrinted  bool
 }
 
 // NewSimpleSyncHandler creates a new SimpleSyncHandler
@@ -317,6 +322,14 @@ func (h *SimpleSyncHandler) OnRestackStart(_ int) {
 
 // OnRestackBranch implements RestackHandler for standalone restack operations
 func (h *SimpleSyncHandler) OnRestackBranch(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, reparented bool, oldParent, newParent string, rerereResolvedCount int) {
+	// Already-current branches are the expected default; suppress their rows
+	// and fold them into the summary count so only movement and problems print.
+	if isPlainUpToDate(result, lockReason, frozen, reparented) {
+		h.restackUpToDate++
+		return
+	}
+	h.restackPrinted = true
+
 	// Log reparenting info if applicable
 	if reparented {
 		h.Output.Info("Reparented %s from %s to %s (parent was merged/deleted).",
@@ -354,14 +367,18 @@ func (h *SimpleSyncHandler) OnRestackBranch(branch string, result syncAction.Res
 
 // OnRestackComplete implements RestackHandler for standalone restack operations
 func (h *SimpleSyncHandler) OnRestackComplete(restacked, skipped int, conflicts, blocked []string) {
-	h.Output.Newline()
+	// Only separate from prior rows when some actually printed; a pure no-op
+	// prints just the one-line summary with no leading blank.
+	if h.restackPrinted {
+		h.Output.Newline()
+	}
 
 	if restacked == 0 && skipped == 0 && len(blocked) == 0 {
 		h.Output.Info("✨ Everything is up to date!")
 		return
 	}
 
-	if summary := formatRestackSummaryLine(restacked, skipped, len(blocked)); summary != "" {
+	if summary := formatRestackSummaryLine(restacked, skipped, len(blocked), h.restackUpToDate); summary != "" {
 		h.Output.Info("✅ Summary: %s", summary)
 	}
 
@@ -377,9 +394,9 @@ func (h *SimpleSyncHandler) OnRestackComplete(restacked, skipped int, conflicts,
 const reasonBlockedByConflict = "(blocked by conflict in stack)"
 
 // formatRestackSummaryLine renders the shared "restacked N, skipped M
-// (conflict), blocked K" summary used by both restack handlers. Returns ""
-// when there is nothing to summarize.
-func formatRestackSummaryLine(restacked, skipped, blocked int) string {
+// (conflict), blocked K, P already current" summary used by both restack
+// handlers. Returns "" when there is nothing to summarize.
+func formatRestackSummaryLine(restacked, skipped, blocked, upToDate int) string {
 	parts := []string{}
 	if restacked > 0 {
 		parts = append(parts, fmt.Sprintf("restacked %d", restacked))
@@ -390,7 +407,18 @@ func formatRestackSummaryLine(restacked, skipped, blocked int) string {
 	if blocked > 0 {
 		parts = append(parts, fmt.Sprintf("blocked %d", blocked))
 	}
+	if upToDate > 0 {
+		parts = append(parts, fmt.Sprintf("%d already current", upToDate))
+	}
 	return strings.Join(parts, ", ")
+}
+
+// isPlainUpToDate reports whether a restack result is a no-op with nothing
+// worth showing — the branch was already current, not locked, frozen, or
+// reparented. Standalone restack suppresses these rows and folds them into the
+// summary count instead.
+func isPlainUpToDate(result syncAction.RestackResult, lockReason engine.LockReason, frozen, reparented bool) bool {
+	return result == syncAction.RestackUnneeded && !lockReason.IsLocked() && !frozen && !reparented
 }
 
 // InteractiveSyncHandler provides bubbletea TUI for TTY environments
@@ -403,6 +431,10 @@ type InteractiveSyncHandler struct {
 	totalOps     int
 	completedOps int
 	currentPhase syncAction.Phase
+
+	// restack-only: count of already-current branches whose rows were
+	// suppressed, reported as a summary count instead.
+	restackUpToDate int
 }
 
 // NewInteractiveSyncHandler creates a new InteractiveSyncHandler
@@ -614,6 +646,15 @@ func (h *InteractiveSyncHandler) OnRestackStart(branchCount int) {
 func (h *InteractiveSyncHandler) OnRestackBranch(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, reparented bool, oldParent, newParent string, rerereResolvedCount int) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+
+	// Already-current branches are the expected default; skip their rows but
+	// still advance the progress bar and count them for the summary.
+	if isPlainUpToDate(result, lockReason, frozen, reparented) {
+		h.restackUpToDate++
+		h.completedOps++
+		h.runner.Send(syncComponent.ProgressTickMsg{Completed: h.completedOps, Total: h.totalOps})
+		return
+	}
 
 	// Build detail message
 	detail, mark := h.formatRestackDetail(branch, result, newRev, prNumber, lockReason, frozen, isCurrent, parent, rerereResolvedCount)
@@ -850,7 +891,7 @@ func (h *InteractiveSyncHandler) formatRestackSummary(restacked, skipped int, co
 	}
 
 	result := ""
-	if summary := formatRestackSummaryLine(restacked, skipped, len(blocked)); summary != "" {
+	if summary := formatRestackSummaryLine(restacked, skipped, len(blocked), h.restackUpToDate); summary != "" {
 		result = "✅ Summary: " + summary
 	}
 

--- a/internal/cli/stack/sync_scenarios.go
+++ b/internal/cli/stack/sync_scenarios.go
@@ -1,0 +1,116 @@
+package stack
+
+import (
+	"time"
+
+	syncAction "github.com/getstackit/stackit/internal/actions/sync"
+)
+
+// SyncScenario is a deterministic replay of the action events emitted by sync.
+// It drives the production Handler, not the Bubble Tea model directly, so its
+// terminal lifecycle and event formatting match the sync command.
+type SyncScenario struct {
+	Name        string
+	Description string
+	TotalOps    int
+	Events      []syncAction.Event
+	Summary     syncAction.Summary
+}
+
+// Replay sends this scenario through a sync handler. delay makes individual
+// command states visible in the terminal; zero is useful for automated checks.
+func (s SyncScenario) Replay(handler syncAction.Handler, delay time.Duration) {
+	handler.Start(s.TotalOps)
+	pause(delay)
+	for _, event := range s.Events {
+		handler.EmitEvent(event)
+		pause(delay)
+	}
+	handler.Complete(s.Summary)
+}
+
+// SyncScenarios are the named sync flows available in the local TUI lab.
+var SyncScenarios = []SyncScenario{
+	{
+		Name:        "success",
+		Description: "Trunk update, PR refresh, cleanup, and restack.",
+		TotalOps:    6,
+		Events: []syncAction.Event{
+			{Phase: syncAction.PhaseTrunk, Type: syncAction.EventStarted},
+			{Phase: syncAction.PhaseGitHub, Type: syncAction.EventStarted},
+			{Phase: syncAction.PhaseTrunk, Type: syncAction.EventCompleted, Branch: "main", NewRevision: "a1b2c3d"},
+			{Phase: syncAction.PhaseGitHub, Type: syncAction.EventProgress, Branch: "feat/api"},
+			{Phase: syncAction.PhaseGitHub, Type: syncAction.EventCompleted, Message: "Updated PR #42 for feat/api"},
+			{Phase: syncAction.PhaseBranches, Type: syncAction.EventStarted},
+			{Phase: syncAction.PhaseBranches, Type: syncAction.EventCompleted, Branch: "feat/api"},
+			{Phase: syncAction.PhaseClean, Type: syncAction.EventStarted},
+			{Phase: syncAction.PhaseClean, Type: syncAction.EventCompleted, Branch: "fix/merged", PRNumber: intPointer(39), Message: "after merge"},
+			{Phase: syncAction.PhaseRestack, Type: syncAction.EventStarted},
+			{Phase: syncAction.PhaseRestack, Type: syncAction.EventCompleted, Branch: "feat/web", PRNumber: intPointer(43), Parent: "feat/api", NewRevision: "d4e5f6a"},
+		},
+		Summary: syncAction.Summary{
+			TrunkUpdated:      true,
+			BranchesSynced:    1,
+			BranchesDeleted:   1,
+			BranchesRestacked: 1,
+		},
+	},
+	{
+		Name:        "diverged",
+		Description: "A remote branch diverges and an affected restack conflicts.",
+		TotalOps:    3,
+		Events: []syncAction.Event{
+			{Phase: syncAction.PhaseTrunk, Type: syncAction.EventStarted},
+			{Phase: syncAction.PhaseGitHub, Type: syncAction.EventStarted},
+			{Phase: syncAction.PhaseTrunk, Type: syncAction.EventCompleted, Branch: "main"},
+			{Phase: syncAction.PhaseBranches, Type: syncAction.EventStarted},
+			{Phase: syncAction.PhaseBranches, Type: syncAction.EventSkipped, Branch: "feat/api", Conflict: true},
+			{Phase: syncAction.PhaseRestack, Type: syncAction.EventStarted},
+			{Phase: syncAction.PhaseRestack, Type: syncAction.EventSkipped, Branch: "feat/web", PRNumber: intPointer(43), Conflict: true},
+		},
+		Summary: syncAction.Summary{
+			BranchesSkipped:  2,
+			ConflictBranches: []string{"feat/web"},
+		},
+	},
+	{
+		Name:        "current",
+		Description: "The lightweight no-op path where trunk is already current.",
+		TotalOps:    1,
+		Events: []syncAction.Event{
+			{Phase: syncAction.PhaseTrunk, Type: syncAction.EventStarted},
+			{Phase: syncAction.PhaseGitHub, Type: syncAction.EventStarted},
+			{Phase: syncAction.PhaseTrunk, Type: syncAction.EventCompleted, Branch: "main"},
+		},
+		Summary: syncAction.Summary{UpToDate: true},
+	},
+}
+
+// LookupSyncScenario returns a named sync scenario.
+func LookupSyncScenario(name string) (SyncScenario, bool) {
+	for _, scenario := range SyncScenarios {
+		if scenario.Name == name {
+			return scenario, true
+		}
+	}
+	return SyncScenario{}, false
+}
+
+// SyncScenarioNames returns scenario names in display order.
+func SyncScenarioNames() []string {
+	names := make([]string, 0, len(SyncScenarios))
+	for _, scenario := range SyncScenarios {
+		names = append(names, scenario.Name)
+	}
+	return names
+}
+
+func intPointer(value int) *int {
+	return &value
+}
+
+func pause(delay time.Duration) {
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+}

--- a/internal/cli/stack/sync_scenarios_test.go
+++ b/internal/cli/stack/sync_scenarios_test.go
@@ -1,0 +1,30 @@
+package stack
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/output"
+)
+
+func TestSyncScenarioReplayUsesProductionHandler(t *testing.T) {
+	scenario, found := LookupSyncScenario("success")
+	require.True(t, found)
+
+	out := output.NewTestOutput()
+	scenario.Replay(NewSimpleSyncHandler(out), 0)
+	got := ansi.Strip(out.String())
+
+	assert.Contains(t, got, "main fast-forwarded to a1b2c3d")
+	assert.Contains(t, got, "Restacked feat/web (PR #43) on feat/api → d4e5f6a")
+	assert.Contains(t, got, "✅ Summary: pulled trunk, synced 1 branch, restacked 1, deleted 1")
+}
+
+func TestLookupSyncScenario(t *testing.T) {
+	assert.Equal(t, []string{"success", "diverged", "current"}, SyncScenarioNames())
+	_, found := LookupSyncScenario("missing")
+	assert.False(t, found)
+}

--- a/internal/cli/stack/testdata/sync/full_sync.golden
+++ b/internal/cli/stack/testdata/sync/full_sync.golden
@@ -18,10 +18,9 @@
   ✓ Restacked feat-ui (PR #202) on feat-api → c3d4e5f
   ⚠ Skipped feat-report (PR #203) (conflict)
 
-⚠️  Found conflicts in 1 branch during restack:
-  • feat-report
-
-Branches that could be restacked cleanly have been restacked.
+⚠️  Found conflicts in 1 branch during restack; branches without conflicts were restacked.
+Resolve each with:
+  • st restack feat-report
 
 ? Resolve conflicts now? [y/N]
 › user answers: no

--- a/internal/cli/stack/testdata/sync/restack_conflict_declined.golden
+++ b/internal/cli/stack/testdata/sync/restack_conflict_declined.golden
@@ -2,10 +2,9 @@
   ✓ Restacked feat-api (PR #201) on main → b2c3d4e
   ⚠ Skipped feat-ui (PR #202) (conflict)
 
-⚠️  Found conflicts in 1 branch during restack:
-  • feat-ui
-
-Branches that could be restacked cleanly have been restacked.
+⚠️  Found conflicts in 1 branch during restack; branches without conflicts were restacked.
+Resolve each with:
+  • st restack feat-ui
 
 ? Resolve conflicts now? [y/N]
 › user answers: no

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -43,6 +43,11 @@ var (
 	// ErrCanceled indicates that an interactive operation was canceled by the user
 	ErrCanceled = errors.New("canceled")
 
+	// ErrConflictWorkflow indicates a command entered the conflict-resolution
+	// workflow. Resolution instructions have already been printed, so CLI
+	// adapters should exit non-zero without printing this error again.
+	ErrConflictWorkflow = errors.New("conflict workflow entered")
+
 	// ErrBack indicates that the user wants to go back to the previous step
 	ErrBack = errors.New("back")
 )
@@ -103,6 +108,28 @@ func NewBranchModificationError(branchName string, lockReason git.LockReason, fr
 		LockReason: lockReason,
 		IsFrozen:   frozen,
 	}
+}
+
+// ConflictWorkflowError reports that a restack stopped inside the conflict
+// workflow on a specific branch. The user-facing resolution instructions were
+// printed before this error was returned; it exists to carry the non-zero exit
+// code (and the message for JSON output) without a duplicate terminal print.
+type ConflictWorkflowError struct {
+	BranchName string
+}
+
+func (e *ConflictWorkflowError) Error() string {
+	return fmt.Sprintf("restack stopped due to conflict on %s", e.BranchName)
+}
+
+// Is returns true if the target error is ErrConflictWorkflow
+func (e *ConflictWorkflowError) Is(target error) bool {
+	return target == ErrConflictWorkflow
+}
+
+// NewConflictWorkflowError creates a new ConflictWorkflowError
+func NewConflictWorkflowError(branchName string) *ConflictWorkflowError {
+	return &ConflictWorkflowError{BranchName: branchName}
 }
 
 // RebaseConflictError represents an error when a rebase encounters a conflict

--- a/internal/integration/resiliency_test.go
+++ b/internal/integration/resiliency_test.go
@@ -54,9 +54,11 @@ func TestRestackWithStaleMetadataButMatchingParentRev(t *testing.T) {
 
 	// The bug manifests as "expected conflict on A but rebase completed successfully"
 	// which means the rebase was skipped entirely due to the early-exit check.
-	// The fix should make the rebase actually happen and hit a conflict.
+	// The fix should make the rebase actually happen and hit a conflict. The
+	// conflict-workflow error itself is no longer echoed by cobra (instructions
+	// are printed instead), so assert on the printed conflict status.
 	sh.OutputNotContains("rebase completed successfully").
-		OutputContains("restack stopped due to conflict")
+		OutputContains("Hit conflict restacking A")
 }
 
 // TestRestackWorktreeAnchoredBranchAgainstAdvancedTrunk reproduces the bug where

--- a/internal/tui/components/submit/format.go
+++ b/internal/tui/components/submit/format.go
@@ -377,6 +377,24 @@ func FormatOutcomeSummary(items []Item, elapsed time.Duration) string {
 	return line
 }
 
+// FormatCreatedURLs lists the URLs of newly created PRs, one indented "#N  url"
+// line each. Updated PRs are omitted — they rarely need their URL re-pasted,
+// matching the per-branch and solo output. Returns "" when nothing was created.
+func FormatCreatedURLs(items []Item) string {
+	rows := make([]string, 0, len(items))
+	for _, item := range items {
+		if item.Status != StatusDone || item.Action != ActionCreate || item.URL == "" {
+			continue
+		}
+		if ref := PRRef(item); ref != "" {
+			rows = append(rows, fmt.Sprintf("  %s  %s", ref, item.URL))
+		} else {
+			rows = append(rows, "  "+item.URL)
+		}
+	}
+	return strings.Join(rows, "\n")
+}
+
 func pluralPR(count int) string {
 	if count == 1 {
 		return "PR"

--- a/internal/tui/components/submit/format.go
+++ b/internal/tui/components/submit/format.go
@@ -333,6 +333,57 @@ func FormatClosingSummary(items []Item, skipped int, elapsed time.Duration) stri
 	return line
 }
 
+// FormatOutcomeSummary renders the compact completion message used by the
+// normal submit experience. It deliberately omits unchanged branches and the
+// per-branch audit trail; --verbose retains those details.
+func FormatOutcomeSummary(items []Item, elapsed time.Duration) string {
+	var created, updated, failed int
+	for _, item := range items {
+		switch {
+		case item.Status == StatusError:
+			failed++
+		case item.Status == StatusDone && item.Action == ActionCreate:
+			created++
+		case item.Status == StatusDone && item.Action == ActionUpdate:
+			updated++
+		}
+	}
+
+	parts := make([]string, 0, 3)
+	if created > 0 {
+		parts = append(parts, fmt.Sprintf("opened %d %s", created, pluralPR(created)))
+	}
+	if updated > 0 {
+		parts = append(parts, fmt.Sprintf("updated %d %s", updated, pluralPR(updated)))
+	}
+	if failed > 0 {
+		parts = append(parts, fmt.Sprintf("%d %s failed", failed, pluralPR(failed)))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+
+	icon := "✓"
+	if failed > 0 {
+		icon = "✗"
+	}
+	line := icon + " " + strings.ToUpper(parts[0][:1]) + parts[0][1:]
+	if len(parts) > 1 {
+		line += " · " + strings.Join(parts[1:], " · ")
+	}
+	if elapsed > 0 {
+		line += " (" + formatElapsed(elapsed) + ")"
+	}
+	return line
+}
+
+func pluralPR(count int) string {
+	if count == 1 {
+		return "PR"
+	}
+	return "PRs"
+}
+
 // formatElapsed renders a duration compactly: "6.2s" under a minute, "1m23s" above.
 func formatElapsed(d time.Duration) string {
 	if d < time.Minute {

--- a/internal/tui/components/submit/format_test.go
+++ b/internal/tui/components/submit/format_test.go
@@ -292,23 +292,6 @@ func TestModelCompletionSummaryPrefersSubmissionResults(t *testing.T) {
 	require.NotContains(t, summary, "Submitting")
 }
 
-func TestModelCompactModeShowsDeterminateProgress(t *testing.T) {
-	t.Parallel()
-
-	m := NewModel([]Item{
-		{BranchName: "feature-1", Action: ActionUpdate, Status: StatusDone},
-		{BranchName: "feature-2", Action: ActionCreate, Status: StatusSubmitting},
-		{BranchName: "feature-3", Action: ActionCreate, Status: StatusPending},
-	})
-	m.Verbose = false
-
-	content := stripANSIEscape(m.content())
-	require.Contains(t, content, "Submitting 3 PRs")
-	require.Contains(t, content, "1/3 complete")
-	require.Contains(t, content, "███")
-	require.Contains(t, content, "░")
-}
-
 func stripANSIEscape(s string) string {
 	return ansiPattern.ReplaceAllString(s, "")
 }

--- a/internal/tui/components/submit/format_test.go
+++ b/internal/tui/components/submit/format_test.go
@@ -194,6 +194,21 @@ func TestFormatClosingSummary(t *testing.T) {
 	require.Empty(t, FormatClosingSummary(nil, 0, time.Second))
 }
 
+func TestFormatOutcomeSummary(t *testing.T) {
+	t.Parallel()
+
+	items := []Item{
+		{BranchName: "a", Action: ActionCreate, Status: StatusDone},
+		{BranchName: "b", Action: ActionUpdate, Status: StatusDone},
+		{BranchName: "c", Action: ActionUpdate, Status: StatusError, Error: errors.New("boom")},
+	}
+
+	require.Equal(t,
+		"✗ Opened 1 PR · updated 1 PR · 1 PR failed (6.2s)",
+		FormatOutcomeSummary(items, 6200*time.Millisecond))
+	require.Empty(t, FormatOutcomeSummary(nil, time.Second))
+}
+
 func TestFormatFailureSummaryWithoutErrorDetail(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/components/submit/format_test.go
+++ b/internal/tui/components/submit/format_test.go
@@ -278,6 +278,23 @@ func TestModelCompletionSummaryPrefersSubmissionResults(t *testing.T) {
 	require.NotContains(t, summary, "Submitting")
 }
 
+func TestModelCompactModeShowsDeterminateProgress(t *testing.T) {
+	t.Parallel()
+
+	m := NewModel([]Item{
+		{BranchName: "feature-1", Action: ActionUpdate, Status: StatusDone},
+		{BranchName: "feature-2", Action: ActionCreate, Status: StatusSubmitting},
+		{BranchName: "feature-3", Action: ActionCreate, Status: StatusPending},
+	})
+	m.Verbose = false
+
+	content := stripANSIEscape(m.content())
+	require.Contains(t, content, "Submitting 3 PRs")
+	require.Contains(t, content, "1/3 complete")
+	require.Contains(t, content, "███")
+	require.Contains(t, content, "░")
+}
+
 func stripANSIEscape(s string) string {
 	return ansiPattern.ReplaceAllString(s, "")
 }

--- a/internal/tui/components/submit/format_test.go
+++ b/internal/tui/components/submit/format_test.go
@@ -209,6 +209,20 @@ func TestFormatOutcomeSummary(t *testing.T) {
 	require.Empty(t, FormatOutcomeSummary(nil, time.Second))
 }
 
+func TestFormatCreatedURLs(t *testing.T) {
+	t.Parallel()
+
+	items := []Item{
+		{BranchName: "a", Action: ActionCreate, Status: StatusDone, URL: "https://github.com/o/r/pull/1"},
+		{BranchName: "b", Action: ActionUpdate, Status: StatusDone, URL: "https://github.com/o/r/pull/2"},
+		{BranchName: "c", Action: ActionCreate, Status: StatusError, URL: "https://github.com/o/r/pull/3"},
+	}
+
+	// Only the created, done PR is listed — not the updated or failed one.
+	require.Equal(t, "  #1  https://github.com/o/r/pull/1", FormatCreatedURLs(items))
+	require.Empty(t, FormatCreatedURLs(items[1:2]))
+}
+
 func TestFormatFailureSummaryWithoutErrorDetail(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -106,6 +106,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		summary := m.completionSummary()
 		if !m.Verbose {
 			summary = FormatOutcomeSummary(m.Items, msg.Elapsed)
+			if urls := FormatCreatedURLs(m.Items); urls != "" {
+				if summary != "" {
+					summary += "\n"
+				}
+				summary += urls
+			}
 			if failures := FormatFailureSummary(m.Items); failures != "" {
 				if summary != "" {
 					summary += "\n\n"

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -103,8 +103,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case ProgressCompleteMsg:
 		m.Done = true
-		summary := m.completionSummary()
-		if !m.Verbose {
+		var summary string
+		if m.Verbose {
+			summary = m.completionSummary()
+			// The solo summary already names the single result; a count line
+			// would just restate it.
+			if !m.Solo && summary != "" {
+				if closing := FormatClosingSummary(m.Items, msg.Skipped, msg.Elapsed); closing != "" {
+					summary += "\n\n" + closing
+				}
+			}
+		} else {
 			summary = FormatOutcomeSummary(m.Items, msg.Elapsed)
 			if urls := FormatCreatedURLs(m.Items); urls != "" {
 				if summary != "" {
@@ -117,13 +126,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					summary += "\n\n"
 				}
 				summary += failures
-			}
-		}
-		// The solo summary already names the single result; a count line would
-		// just restate it.
-		if m.Verbose && !m.Solo && summary != "" {
-			if closing := FormatClosingSummary(m.Items, msg.Skipped, msg.Elapsed); closing != "" {
-				summary += "\n\n" + closing
 			}
 		}
 		if summary != "" {
@@ -179,16 +181,16 @@ func (m *Model) content() string {
 	return b.String()
 }
 
-// completionSummary is the output persisted to the terminal when the TUI
-// exits. After a submission it lists every branch's final result (including
-// failures); when nothing was submitted (dry run, all up to date) it falls
-// back to the final plan view, which would otherwise be erased with the
+// completionSummary is the verbose-mode output persisted to the terminal when
+// the TUI exits. After a submission it lists every branch's final result
+// (including failures); when nothing was submitted (dry run, all up to date) it
+// falls back to the final plan view, which would otherwise be erased with the
 // progress display. Warnings are appended in either case so they survive the
-// screen clear.
+// screen clear. Compact mode builds its own summary inline in the
+// ProgressCompleteMsg handler and does not call this.
 func (m *Model) completionSummary() string {
 	var summary string
-	switch {
-	case m.Verbose && m.Solo:
+	if m.Solo {
 		summary = FormatSoloSummary(m.Items)
 		if failures := FormatFailureSummary(m.Items); failures != "" {
 			if summary != "" {
@@ -196,10 +198,8 @@ func (m *Model) completionSummary() string {
 			}
 			summary += failures
 		}
-	case m.Verbose:
+	} else {
 		summary = FormatFinalList(m.Items)
-	default:
-		summary = FormatOutcomeSummary(m.Items, 0)
 	}
 	if summary == "" {
 		return m.content()

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -153,10 +153,6 @@ func (m *Model) content() string {
 	header := m.header()
 	if header != "" {
 		b.WriteString(header)
-		if !m.Verbose {
-			b.WriteString("  ")
-			b.WriteString(m.progress())
-		}
 		b.WriteString("\n\n")
 	}
 
@@ -181,31 +177,6 @@ func (m *Model) content() string {
 	}
 
 	return b.String()
-}
-
-// progress renders a compact, determinate progress indicator for the default
-// interactive submit view. Branch rows still identify the active operation;
-// this line answers the higher-level question of how much of the stack is
-// finished. Verbose mode intentionally keeps the existing audit-oriented
-// layout unchanged.
-func (m *Model) progress() string {
-	total := len(m.Items)
-	if total == 0 {
-		return ""
-	}
-
-	completed := 0
-	for _, item := range m.Items {
-		if item.Status == StatusDone || item.Status == StatusError {
-			completed++
-		}
-	}
-
-	const width = 10
-	filled := width * completed / total
-	bar := m.Styles.DoneStyle.Render(strings.Repeat("█", filled)) +
-		m.Styles.DimStyle.Render(strings.Repeat("░", width-filled))
-	return fmt.Sprintf("%s %d/%d complete", bar, completed, total)
 }
 
 // completionSummary is the output persisted to the terminal when the TUI

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -19,6 +19,7 @@ type Model struct {
 	Items          []Item
 	Warnings       []string      // formatted warning lines, rendered after the rows and persisted on exit
 	Solo           bool          // single-branch submit — drop the count header and per-row name
+	Verbose        bool          // retain the detailed final per-branch result list
 	spinner        spinner.Model // lowercase for custom style
 	Styles         Styles
 }
@@ -52,6 +53,7 @@ func NewModel(items []Item) *Model {
 
 	return &Model{
 		Items:   items,
+		Verbose: true,
 		spinner: s,
 		Styles:  DefaultStyles(),
 	}
@@ -102,9 +104,18 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ProgressCompleteMsg:
 		m.Done = true
 		summary := m.completionSummary()
+		if !m.Verbose {
+			summary = FormatOutcomeSummary(m.Items, msg.Elapsed)
+			if failures := FormatFailureSummary(m.Items); failures != "" {
+				if summary != "" {
+					summary += "\n\n"
+				}
+				summary += failures
+			}
+		}
 		// The solo summary already names the single result; a count line would
 		// just restate it.
-		if !m.Solo && summary != "" {
+		if m.Verbose && !m.Solo && summary != "" {
 			if closing := FormatClosingSummary(m.Items, msg.Skipped, msg.Elapsed); closing != "" {
 				summary += "\n\n" + closing
 			}
@@ -170,7 +181,8 @@ func (m *Model) content() string {
 // screen clear.
 func (m *Model) completionSummary() string {
 	var summary string
-	if m.Solo {
+	switch {
+	case m.Verbose && m.Solo:
 		summary = FormatSoloSummary(m.Items)
 		if failures := FormatFailureSummary(m.Items); failures != "" {
 			if summary != "" {
@@ -178,8 +190,10 @@ func (m *Model) completionSummary() string {
 			}
 			summary += failures
 		}
-	} else {
+	case m.Verbose:
 		summary = FormatFinalList(m.Items)
+	default:
+		summary = FormatOutcomeSummary(m.Items, 0)
 	}
 	if summary == "" {
 		return m.content()
@@ -200,7 +214,10 @@ func (m *Model) header() string {
 	if count == 0 {
 		return ""
 	}
-	return fmt.Sprintf("Submitting %d %s", count, pluralBranch(count))
+	if m.Verbose {
+		return fmt.Sprintf("Submitting %d %s", count, pluralBranch(count))
+	}
+	return fmt.Sprintf("Submitting %d %s", count, pluralPR(count))
 }
 
 func pluralBranch(count int) string {

--- a/internal/tui/components/submit/model.go
+++ b/internal/tui/components/submit/model.go
@@ -147,6 +147,10 @@ func (m *Model) content() string {
 	header := m.header()
 	if header != "" {
 		b.WriteString(header)
+		if !m.Verbose {
+			b.WriteString("  ")
+			b.WriteString(m.progress())
+		}
 		b.WriteString("\n\n")
 	}
 
@@ -171,6 +175,31 @@ func (m *Model) content() string {
 	}
 
 	return b.String()
+}
+
+// progress renders a compact, determinate progress indicator for the default
+// interactive submit view. Branch rows still identify the active operation;
+// this line answers the higher-level question of how much of the stack is
+// finished. Verbose mode intentionally keeps the existing audit-oriented
+// layout unchanged.
+func (m *Model) progress() string {
+	total := len(m.Items)
+	if total == 0 {
+		return ""
+	}
+
+	completed := 0
+	for _, item := range m.Items {
+		if item.Status == StatusDone || item.Status == StatusError {
+			completed++
+		}
+	}
+
+	const width = 10
+	filled := width * completed / total
+	bar := m.Styles.DoneStyle.Render(strings.Repeat("█", filled)) +
+		m.Styles.DimStyle.Render(strings.Repeat("░", width-filled))
+	return fmt.Sprintf("%s %d/%d complete", bar, completed, total)
 }
 
 // completionSummary is the output persisted to the terminal when the TUI


### PR DESCRIPTION
This PR merges the following changes:

1. **#1416** feat: add sync TUI lab
2. **#1417** feat: add submit TUI lab scenarios
3. **#1418** feat: add ss TUI lab scenarios
4. **#1419** feat: make submit output outcome-focused
5. **#1420** feat: show submit progress in the TUI
6. **#1443** feat: consolidate restack conflict reporting into one actionable block
7. **#1445** feat: show created PR URLs in default submit output
8. **#1446** refactor: drop the submit progress bar
9. **#1447** feat: make restack output terse and outcome-focused

### Stack

```
main
  └─ jonnii/20260711125919/add-sync-TUI-lab (#1416)
    └─ jonnii/20260711131101/add-submit-TUI-lab-scenarios (#1417)
      └─ jonnii/20260711132159/add-ss-TUI-lab-scenarios (#1418)
        └─ tighten-submit-default-output (#1419)
          └─ show-submit-tui-progress (#1420)
            └─ jonnii/20260723102957/consolidate-restack-conflict-reporting-into-one (#1443)
              └─ jonnii/20260724021443/show-created-PR-URLs-in-default-submit-output (#1445)
                └─ jonnii/20260724021451/drop-the-submit-progress-bar (#1446)
                  └─ jonnii/20260724022739/make-restack-output-terse-and-outcome-focused (#1447)
```

Stackit-Stack-Size: 9
Stackit-PRs: 1416,1417,1418,1419,1420,1443,1445,1446,1447
