### PR TITLE
refactor: drop unused params from newUICmd

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -131,7 +131,7 @@ Commit:  ` + commit + `
 	rootCmd.AddCommand(stack.NewSubmitCmd())
 	rootCmd.AddCommand(stack.NewSyncCmd())
 	rootCmd.AddCommand(navigation.NewTopCmd())
-	rootCmd.AddCommand(newUICmd(version, commit, date))
+	rootCmd.AddCommand(newUICmd())
 	rootCmd.AddCommand(newTrackCmd())
 	rootCmd.AddCommand(newUntrackCmd())
 	rootCmd.AddCommand(navigation.NewTrunkCmd())

--- a/internal/cli/ui.go
+++ b/internal/cli/ui.go
@@ -9,7 +9,7 @@ import (
 )
 
 // newUICmd creates the ui command
-func newUICmd(_, _, _ string) *cobra.Command {
+func newUICmd() *cobra.Command {
 	var runLocalCI bool
 
 	cmd := &cobra.Command{


### PR DESCRIPTION
## Summary
- `newUICmd` took `version`, `commit`, and `date` string parameters but discarded all three with blank identifiers — the `ui` command's `RunE` (via `dashboard.RunShippable`) never uses them.
- Removes the unused parameters and updates the single call site in `root.go`, following the project's own code-style rule to remove unused parameters entirely rather than discard them with `_`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `go test ./internal/cli/...` passes

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Kzvpzj5mh9Q5kVgzwBjtw8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kzvpzj5mh9Q5kVgzwBjtw8)_