### PR TITLE
docs: reconcile docs with current code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ stackit submit             # Update PRs
 ```
 apps/
 ├── cli/        CLI entry point
-├── api/        HTTP API + embedded static web assets
+├── server/     HTTP API + embedded static web assets
 ├── st-tui/     TUI storyboard binary
 └── web/        Next.js frontend (see docs/web.md)
     ├── src/app/         Pages and layouts

--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ stack-submit --stack         # Creates/updates all PRs in the stack
 | `stackit github install` | Install GitHub Action CI checks for branch locking |
 | `stackit precommit install` | Install git pre-commit hook for branch state validation |
 | `stackit precommit uninstall` | Remove the git pre-commit hook |
+| `stackit prepush install` | Install git pre-push hook for branch state validation (also `uninstall`, `verify`) |
 
 ### Utilities & System
 | Command | Description |
@@ -318,6 +319,7 @@ stack-submit --stack         # Creates/updates all PRs in the stack
 | `stackit info` | Show detailed info about the current branch |
 | `stackit track` / `untrack` | Manually start/stop tracking a branch with stackit |
 | `stackit config` | Manage stackit configuration |
+| `stackit ui` | Open the shippable work dashboard in the local web UI |
 | `stackit debug` | Dump debugging information about recent commands and stack state |
 | `stackit continue` / `abort` | Continue or abort an interrupted operation (like a rebase) |
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -54,7 +54,7 @@ git config --local --add stackit.trunks develop
 |-----|------|---------|-------------|
 | `stackit.trunk` | string | `main` | Primary trunk branch |
 | `stackit.trunks` | string[] | `[]` | Additional trunk branches |
-| `stackit.branch.pattern` | string | `{username}/{date}/{message}` | Branch naming template |
+| `stackit.branch.pattern` | string | `{username}/{date}/{message}` | Branch naming template (placeholders: `{username}`, `{date}`, `{message}`, `{scope}`) |
 | `stackit.submit.footer` | bool | `true` | Include PR footer in descriptions |
 | `stackit.submit.draft` | bool | `false` | Create PRs as drafts by default |
 | `stackit.submit.web` | string | `never` | When to open PRs in browser (always/created/never) |
@@ -70,6 +70,10 @@ git config --local --add stackit.trunks develop
 | `stackit.ci.timeout` | int | `600` | CI command timeout in seconds |
 | `stackit.split.hunkSelector` | string | `tui` | Hunk selector mode (tui/git) |
 | `stackit.maxConcurrency` | int | `0` | Max concurrent operations (0 = auto) |
+| `stackit.navigation.when` | string | `multiple` | When to show the PR navigation footer (always/never/multiple) |
+| `stackit.navigation.location` | string | `body` | Where to render navigation (body/comment/none) |
+| `stackit.navigation.marker` | string | `👈` | Marker for the current branch in the navigation footer |
+| `stackit.navigation.showMerged` | bool | `true` | Include merged branches in the navigation footer |
 | `stackit.hooks.approvedPostWorktreeCreate` | string[] | `[]` | Approved post-worktree hooks |
 
 ### Code Location
@@ -218,7 +222,7 @@ The table below shows all options available in `.stackit.yaml`. The "Team Fallba
 |--------|------|---------|-------------|---------------|
 | `trunk` | string | `main` | Primary trunk branch | Yes |
 | `trunks` | string[] | `[]` | Additional trunk branches (merged with git config) | Yes (additive) |
-| `branch.pattern` | string | `{username}/{date}/{message}` | Branch naming template | Yes |
+| `branch.pattern` | string | `{username}/{date}/{message}` | Branch naming template (placeholders: `{username}`, `{date}`, `{message}`, `{scope}`) | Yes |
 | `submit.footer` | bool | `true` | Include PR footer | Yes |
 | `submit.draft` | bool | `false` | Create PRs as drafts by default | Yes |
 | `submit.web` | string | `never` | Open PRs in browser (always/created/never) | Yes |
@@ -234,6 +238,10 @@ The table below shows all options available in `.stackit.yaml`. The "Team Fallba
 | `worktree.autoClean` | bool | `true` | Auto-remove clean, empty managed worktrees during sync | Yes |
 | `split.hunkSelector` | string | `tui` | Hunk selector mode (tui/git) | Yes |
 | `maxConcurrency` | int | `0` | Max concurrent operations (0 = auto) | Yes |
+| `navigation.when` | string | `multiple` | When to show the PR navigation footer (always/never/multiple) | Yes |
+| `navigation.location` | string | `body` | Where to render navigation (body/comment/none) | Yes |
+| `navigation.marker` | string | `👈` | Marker for the current branch in the navigation footer | Yes |
+| `navigation.showMerged` | bool | `true` | Include merged branches in the navigation footer | Yes |
 | `hooks.<phase>` | string[] | `[]` | Lifecycle hook commands per phase (e.g. `pre-modify`, `post-submit`, `post-worktree-create`); see `docs/hooks.md` | No (requires approval) |
 
 ### Layered Configuration Example
@@ -265,13 +273,18 @@ internal/config/
 
 ```go
 type ProjectConfig struct {
-    Trunk  string       `yaml:"trunk,omitempty"`
-    Trunks []string     `yaml:"trunks,omitempty"`
-    Branch BranchConfig `yaml:"branch,omitempty"`
-    Submit SubmitConfig `yaml:"submit,omitempty"`
-    Merge  MergeConfig  `yaml:"merge,omitempty"`
-    CI     CIConfig     `yaml:"ci,omitempty"`
-    Hooks  HooksConfig  `yaml:"hooks,omitempty"`
+    Trunk          string           `yaml:"trunk,omitempty"`
+    Trunks         []string         `yaml:"trunks,omitempty"`
+    Branch         BranchConfig     `yaml:"branch,omitempty"`
+    Submit         SubmitConfig     `yaml:"submit,omitempty"`
+    Merge          MergeConfig      `yaml:"merge,omitempty"`
+    CI             CIConfig         `yaml:"ci,omitempty"`
+    Undo           UndoConfig       `yaml:"undo,omitempty"`
+    Worktree       WorktreeConfig   `yaml:"worktree,omitempty"`
+    Split          SplitConfig      `yaml:"split,omitempty"`
+    Hooks          HooksConfig      `yaml:"hooks,omitempty"`
+    MaxConcurrency *int             `yaml:"maxConcurrency,omitempty"`
+    Navigation     NavigationConfig `yaml:"navigation,omitempty"`
 }
 
 // Load from repo root

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,14 +1,18 @@
 # Deploying stackit-server
 
-This guide covers running the hosted multi-repo `stackit-server` container.
-At the time of writing the container ships **Phase 1 + Phase 6** from
-[`docs/plans/server/README.md`](plans/server/README.md): multiple repos,
-served via a config file, with no authentication yet. OAuth, clone-from-URL,
-and per-user repo scoping arrive in later phases.
+This guide covers running the hosted `stackit-server` container. The server
+runs in one of two shapes:
 
-Treat the container as a single-tenant deployment behind your own
-authentication (a tunnel like Tailscale, an oauth2-proxy, etc.) until the
-auth phases land.
+- **Multi-tenant** (`-database-url` + `-repos-root`): logged-in users add their
+  own repos through the web app; the server clones them with a GitHub App
+  installation token and keeps them synced. Requires GitHub OAuth and a GitHub
+  App. See [Repository onboarding](#repository-onboarding).
+- **Single-repo** (`-cwd`): serve one already-checked-out repo, typically a
+  local dev server via `mise run dev`. No database.
+
+A write-capable deploy must sit behind an access control — the built-in GitHub
+OAuth gate or an external gateway. To expose a repo publicly without write
+access, run in [read-only mode](#read-only-public-mode).
 
 ## Image
 
@@ -26,30 +30,17 @@ All tags are multi-arch (`linux/amd64`, `linux/arm64`).
 
 ## Configuration
 
-The container reads its repo list from a JSON file. Mount a volume at `/data`
-(or anywhere) and point `-repos-config` at a file inside it.
+Where the server gets its repos depends on how you start it:
 
-```json
-{
-  "repos": [
-    { "id": "stackit",  "displayName": "Stackit",  "path": "/data/repos/stackit" },
-    { "id": "myapp",    "displayName": "My App",    "path": "/data/repos/myapp" }
-  ]
-}
-```
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `id` | yes | URL-safe identifier (`[a-zA-Z0-9_-]+`) used in `/api/v1/repos/{id}/...` routes |
-| `path` | yes | Absolute path inside the container to a git working tree |
-| `displayName` | no | Human label shown in the web UI; defaults to `id` |
-| `remote` | no | Git remote name; defaults to `origin` |
-
-For DB-backed deployments (`-database-url`), repos can instead be added at
-runtime by logged-in users — the server clones and initializes them for you.
-See [Repository onboarding](#repository-onboarding). You can still pre-seed
-repos by inserting rows directly; a row with an empty `added_by` is shared
-with every authenticated user.
+- **`-database-url` (DB-backed, multi-repo).** Repos live in Postgres and are
+  added at runtime by logged-in users — the server clones and initializes them
+  for you into `-repos-root/<owner>/<name>`. See
+  [Repository onboarding](#repository-onboarding). You can pre-seed repos by
+  inserting rows directly; a row with an empty `added_by` is shared with every
+  authenticated user. Routes are keyed by `owner`/`repo`:
+  `/api/v1/repos/{owner}/{repo}/...`.
+- **`-cwd` (single-repo shortcut).** Serve the one repo discovered from that
+  path. Ignored when `-database-url` is set. Handy for a local dev server.
 
 ### Environment
 
@@ -338,7 +329,7 @@ The container is safe to run on a public hostname **only** behind:
    GitHub OAuth gate (`STACKIT_GITHUB_*` + an allowlist) or an external
    gateway (Tailscale, Cloudflare Access, an oauth2-proxy sidecar). Without
    one, any caller can trigger
-   `POST /api/v1/repos/{id}/stacks/{branch}/submit`, which pushes branches
+   `POST /api/v1/repos/{owner}/{repo}/stacks/{branch}/submit`, which pushes branches
    and creates PRs using the container's GitHub credentials. To expose a
    repo publicly *without* this risk, run in
    [read-only mode](#read-only-public-mode), which removes the write
@@ -391,7 +382,7 @@ can be ingested by any structured log pipeline.
 | `login` | `GET /auth/callback` after a successful exchange | `actor`, `user_id`, `target` (post-login URL), `request_id` |
 | `denied` | `GET /auth/callback` for non-allowlisted users | `actor`, `request_id` |
 | `logout` | `POST /auth/logout` | `actor`, `request_id` |
-| `submit` | `POST /api/v1/repos/{id}/stacks/{branch}/submit` | `actor`, `repo`, `branch`, `request_id` |
+| `submit` | `POST /api/v1/repos/{owner}/{repo}/stacks/{branch}/submit` | `actor`, `repo`, `branch`, `request_id` |
 
 Every request also carries a `X-Request-ID` response header with the
 same value used as `request_id` in the audit lines. Pass it through
@@ -418,21 +409,19 @@ and on bursts of `audit action=submit` from a single `actor`.
 curl https://stackit.example.com/api/v1/repos \
   -H "Cookie: stackit_session=$STACKIT_SESSION"
 
-curl -X POST https://stackit.example.com/api/v1/repos/default/stacks/main/submit \
+curl -X POST https://stackit.example.com/api/v1/repos/getstackit/stackit/stacks/main/submit \
   -H "Cookie: stackit_session=$STACKIT_SESSION" \
   -H "X-Stackit-CSRF: 1"
 ```
 
 ## Local smoke test
 
+The quickest end-to-end check serves a single pre-cloned repo via `-cwd`:
+
 ```bash
-# Clone something into ./data/repos/ first
-mkdir -p data/repos
-git clone https://github.com/getstackit/stackit data/repos/stackit
-(cd data/repos/stackit && stackit init)
-cat > data/repos.json <<'EOF'
-{ "repos": [ { "id": "stackit", "path": "/data/repos/stackit" } ] }
-EOF
+# Clone and initialize something to serve
+git clone https://github.com/getstackit/stackit data/stackit
+(cd data/stackit && stackit init)
 
 # STACKIT_ENV=production binds 0.0.0.0 so the -p mapping can reach the
 # server inside the container; STACKIT_READ_ONLY=1 exposes it without
@@ -442,32 +431,35 @@ docker run --rm -p 8080:8080 \
   -e STACKIT_READ_ONLY=1 \
   -v "$(pwd)/data:/data" \
   ghcr.io/getstackit/stackit-server:latest \
-  -repos-config /data/repos.json
+  -cwd /data/stackit
 
 # In another terminal:
 curl -s localhost:8080/api/v1/repos | jq
 open http://localhost:8080
 ```
 
+For the full multi-tenant flow, run with `-database-url` + `-repos-root` and add
+repos through the web app — see [Repository onboarding](#repository-onboarding).
+
 ## Railway
 
 1. **Service** — deploy from image `ghcr.io/getstackit/stackit-server:main`
    (or pin to `:latest` / `:vX.Y.Z`).
-2. **Volume** — mount at `/data`. Use at least a few GB; clones land here.
-3. **Variables** — set `STACKIT_ENV=production` (binds `0.0.0.0` so Railway's
+2. **Volume** — mount at `/data`. Use at least a few GB; clones land here. Set
+   `STACKIT_REPOS_ROOT=/data/repos`.
+3. **Postgres** — add a Railway Postgres plugin and point `STACKIT_DATABASE_URL`
+   at it (Railway exposes a connection string variable you can reference).
+4. **Variables** — set `STACKIT_ENV=production` (binds `0.0.0.0` so Railway's
    router can reach the port, and enforces auth). Railway injects `PORT`
    automatically. Add the auth vars (`STACKIT_GITHUB_*`, `STACKIT_SESSION_KEY`,
-   an allowlist) for a write-capable deploy, or set `STACKIT_READ_ONLY=1` to
-   expose it read-only without auth.
-4. **Start command** — leave blank to use the image's `ENTRYPOINT`, then set
-   the **Command** (Railway's arg override) to:
-   ```
-   -repos-config /data/repos.json
-   ```
-5. **Seed the volume** — clone repos into `/data/repos/<id>/`, run
-   `stackit init` in each, and create `/data/repos.json`. Do this once via
-   a one-shot Railway shell session, then redeploy. (A `repo init` API
-   endpoint replaces this manual step in Phase 4.)
+   `STACKIT_BASE_URL`, an allowlist) and the GitHub App vars
+   (`STACKIT_GITHUB_APP_ID`, `STACKIT_GITHUB_APP_PRIVATE_KEY`) so users can
+   onboard repos. To expose a single repo read-only instead, skip the database
+   and set `STACKIT_READ_ONLY=1` with a `-cwd` command.
+5. **Start command** — leave blank to use the image's `ENTRYPOINT`. The DB +
+   repos-root vars are enough; no command override is needed. (Users add repos
+   at runtime through the web app — see
+   [Repository onboarding](#repository-onboarding).)
 
 ## Pushing a snapshot without a release
 
@@ -492,16 +484,13 @@ the per-arch images and a manifest under `$TAG` (default `dev`). Skip the
   configured to redeploy whenever the GHCR tag is updated.
 - Use `:<short-sha>` to roll back to a known-good commit.
 
-## What's not in this container yet
+## Known limitations
 
-These all land in later phases:
-
-- **GitHub OAuth** (Phase 3) — every request currently hits the server with
-  no identity, and there is no per-user repo scoping.
-- **Clone-from-URL** (Phase 4) — repos must be pre-cloned into the mounted
-  volume.
-- **Persistent registry** (Phase 2) — runtime `POST /api/v1/repos` is not
-  available; edits to `repos.json` require a restart.
-
-See [`docs/plans/server/README.md`](plans/server/README.md) for the full
-phase plan.
+- **Trusted-user onboarding.** Repo IDs are `<owner>-<name>` globally, so two
+  users onboarding the same repo collide (`409`). The model assumes everyone who
+  can sign in is trusted. See
+  [Repository onboarding](#repository-onboarding).
+- **Metadata-only pushes aren't webhook-driven.** GitHub sends push events for
+  `refs/heads/*` and `refs/tags/*` only, so a metadata-only change (e.g. from
+  `describe`) is caught by the interval loop, not webhooks. Keep the sync loop
+  on. See [Evented refresh](#evented-refresh-webhooks).

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -26,7 +26,7 @@ Stackit uses four ref namespaces:
 
 **Ref**: `refs/stackit/metadata/{branch-name}`
 
-**Source**: `internal/git/metadata.go:41-61`
+**Source**: `internal/git/metadata.go` (`Meta`)
 
 Branch metadata stores the relationship between branches and associated PR information.
 
@@ -87,7 +87,7 @@ Branch metadata stores the relationship between branches and associated PR infor
 
 **Ref**: `refs/stackit/local-metadata/{branch-name}`
 
-**Source**: `internal/git/metadata.go:82-87`
+**Source**: `internal/git/metadata.go` (`LocalMeta`)
 
 Local metadata is never pushed to remote. It stores per-machine state.
 
@@ -125,7 +125,7 @@ Local metadata is never pushed to remote. It stores per-machine state.
 
 **Ref**: `refs/stackit/stacks/{stack-id}`
 
-**Source**: `internal/git/stack_metadata.go:20-29`
+**Source**: `internal/git/stack_metadata.go` (`StackMeta`)
 
 Stack metadata stores information about an entire stack. It survives branch operations like merging the root branch, because it's stored separately from branch metadata.
 
@@ -181,7 +181,7 @@ The sanitized branch name:
 
 ### LockReason
 
-**Source**: `internal/git/metadata.go:13-23`
+**Source**: `internal/git/metadata.go` (`LockReason`)
 
 | Value | Description |
 |-------|-------------|
@@ -191,7 +191,7 @@ The sanitized branch name:
 
 ### BranchType
 
-**Source**: `internal/git/metadata.go:30-38`
+**Source**: `internal/git/metadata.go` (`BranchType`)
 
 | Value | Description |
 |-------|-------------|
@@ -201,7 +201,7 @@ The sanitized branch name:
 
 ### PrInfoPersistence
 
-**Source**: `internal/git/metadata.go:96-107`
+**Source**: `internal/git/metadata.go` (`PrInfoPersistence`)
 
 PR information persisted in branch metadata.
 
@@ -237,7 +237,7 @@ non-ancestor branch tip as proof that a merged PR still needs to be replayed.
 
 ### MergedParent
 
-**Source**: `internal/git/metadata.go:76-80`
+**Source**: `internal/git/metadata.go` (`MergedParent`)
 
 Records historical parent relationships when branches are reparented.
 
@@ -251,7 +251,7 @@ Limited to 5 entries (oldest entries dropped when limit exceeded).
 
 ### ModifiedBy
 
-**Source**: `internal/git/metadata.go:89-94`
+**Source**: `internal/git/metadata.go` (`ModifiedBy`)
 
 Tracks who last modified metadata.
 
@@ -265,7 +265,7 @@ Tracks who last modified metadata.
 
 ## Scope Inheritance
 
-**Source**: `internal/engine/types.go:57-155`
+**Source**: `internal/engine/types.go`
 
 Scopes are inherited from parent branches. When a branch doesn't have an explicit scope, Stackit walks up the parent chain until it finds one.
 

--- a/docs/plans/perf/track-untrack.md
+++ b/docs/plans/perf/track-untrack.md
@@ -53,14 +53,13 @@ of a commit" question. One `git rev-list --children <branchName>..HEAD` (or
 `git for-each-ref --contains <branchName-sha>`) gives all branches that contain
 the branch's tip in one process. N+1 → 1.
 
-#### 2. Hoist `GetRevision(branchName)` out of the candidate loop *(trivial)*
+#### 2. Hoist `GetRevision(branchName)` out of the candidate loop *(DONE)*
 
-`eng.GetRevision(eng.GetBranch(branchName))` is recomputed inside the loop
-(`action.go:182`) on every candidate even though `branchName` is invariant for
-the whole loop. `GetRevision` is **not** cached (it shells
-`git rev-parse` via `runner.getRevision` → `resolveRefSHA` each call —
-`internal/git/commit_info.go:56`), so this is N redundant rev-parse calls. Resolve
-it once before the loop.
+**Landed.** `branchRev` is now computed once before the candidate loop
+(`action.go`, "branchRev is loop-invariant"), instead of re-resolving
+`eng.GetRevision(eng.GetBranch(branchName))` on every candidate. `GetRevision`
+is still uncached (it shells `git rev-parse`), so hoisting removed N redundant
+rev-parse calls.
 
 > Note: win #1 subsumes this if implemented — the rev-list rewrite removes the
 > per-candidate merge-base/revision comparison entirely. Keep #2 only as the

--- a/docs/plans/server/README.md
+++ b/docs/plans/server/README.md
@@ -1,5 +1,24 @@
 # Hosted multi-tenant stackit-server
 
+> **Status: historical.** This plan shipped (5 of 6 phases; the sixth, the
+> container, also shipped). The **built system diverged from this spec** — read
+> [`docs/deploy.md`](../../deploy.md) for how it actually works, not this file.
+> Key divergences: persistence is **Postgres** (`internal/api/store`), not the
+> planned SQLite-on-a-volume; there is **no `users` table** — identity lives in a
+> signed session cookie with the GitHub token encrypted inside it; routing is
+> keyed by **`{owner}/{repo}`**, not an opaque repo ID; onboarding clones with a
+> **GitHub App installation token**, not the user's token; and the background
+> **sync loop + webhook receiver** (which this plan listed as out of scope)
+> shipped too. Kept for design context.
+>
+> **Residual work not yet built** (real, tracked here until moved to issues):
+> - `DELETE /api/v1/repos/{owner}/{repo}` — runtime repo removal. The store query
+>   exists (`store/queries/delete_repo.sql`); no HTTP handler calls it.
+> - Persisted per-user model + token-at-rest — today operator-seeded repos
+>   (`added_by == ""`) are shared with every authenticated user; only build this
+>   if offline per-user GitHub actions are needed.
+> - Repo-level ACLs beyond the coarse `added_by` shared/owned split.
+
 Plan for turning the single-repo dev server into a hosted multi-user service
 deployable to Railway as a public container image
 (`ghcr.io/getstackit/stackit-server`).

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -63,7 +63,7 @@ Use these rules:
 | 1 | `internal/actions/<name>/` | Implement or extend the reusable operation |
 | 2 | `internal/cli/stack/<name>.go` | Cobra command definition (`Long` should include examples) |
 | 3 | `internal/cli/stack/<name>_handlers.go` or related adapter files | Add prompt/progress/output handling if needed |
-| 4 | `internal/cli/stack/root.go` | Register command in parent |
+| 4 | `internal/cli/root.go` | Register the command on `rootCmd` via `AddCommand` |
 | 5 | Tests in respective packages | Use action tests for orchestration and CLI tests for flags/output |
 
 CLI commands should:

--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -321,6 +321,7 @@ Launches an interactive merge wizard. Requires a TTY (use `merge next` or `merge
 | Flag | Description |
 |------|-------------|
 | `--dry-run` | Show merge plan without executing |
+| `--yes`, `-y` | Skip prompts and route to `merge next` non-interactively |
 | `--force` | Skip validation checks (draft PRs, failing CI) |
 | `--wait` | Wait for merge to complete (default: fire-and-forget) |
 | `--scope` | Pre-select scope to merge (skips scope prompt) |
@@ -366,7 +367,7 @@ Merge all PRs in the stack bottom-up, waiting for each to complete.
 
 ### `stackit merge ship`
 
-Consolidate stack(s) into a single PR.
+Consolidate stack(s) into a single PR. Alias: `stackit merge squash`.
 
 | Flag | Description |
 |------|-------------|
@@ -462,7 +463,8 @@ merge next (again)
 
 ```
 merge ship
-  → CreateMergePlan(StrategyShip)
+  → CollectMergeBranches()
+  → BuildMergePlan(StrategyShip)
   → Action()
     → Execute()
       → ConsolidateMergeExecutor.Execute()
@@ -479,7 +481,7 @@ merge ship
 merge ship --stacks a,b,c
   → DiscoverStacks()
   → ExecuteMultiStack()
-    → CreateWorktreeSession()
+    → NewMultiStackWorktreeExecutor(...).ExecuteInWorktree()
     → Test global merge feasibility
     → If fails: binary search for working subset
     → Run local CI (unless --skip-local-ci)

--- a/docs/web.md
+++ b/docs/web.md
@@ -34,27 +34,35 @@ apps/web/
 │   │   └── globals.css         Global styles, CSS variables, animations
 │   ├── components/
 │   │   ├── app-shell.tsx       Path → picker vs per-repo view dispatcher
+│   │   ├── read-only-banner.tsx Banner shown in read-only mode
 │   │   ├── providers/
-│   │   │   ├── repo-provider.tsx   Main data context (repo, stacks, events)
-│   │   │   └── theme-provider.tsx  Light/dark/system theme context
+│   │   │   ├── repo-provider.tsx    Main data context (repo, stacks, events)
+│   │   │   ├── config-provider.tsx  Server config (singleRepo, readOnly, auth)
+│   │   │   ├── auth-provider.tsx    Current user / login state
+│   │   │   └── theme-provider.tsx   Light/dark/system theme context
 │   │   ├── ui/                 Reusable UI primitives (shadcn)
 │   │   ├── status/             Status badge components
 │   │   ├── stack-tree/         SVG tree visualization
 │   │   ├── branch-detail/      Branch info panel components
-│   │   ├── stack-column.tsx    Vertical stack of branch cards
-│   │   ├── stack-list.tsx      Stack list container
-│   │   ├── owner-swimlane.tsx  Horizontal owner grouping
-│   │   ├── swimlane-label.tsx  Owner header with avatar
-│   │   ├── recently-merged.tsx Trunk commit history
-│   │   └── event-feed.tsx      Activity feed
+│   │   ├── swimlane/           Swimlane grouping: owner-swimlane, stack-column,
+│   │   │                       stack-list, branch-card, swimlane-label
+│   │   ├── recently-merged/    Trunk commit history (recently-merged + items)
+│   │   ├── repo-picker/        Repo picker + add-repository form + repo-view
+│   │   └── layout/             header.tsx, event-feed.tsx
 │   ├── hooks/
 │   │   ├── use-confetti.ts     Confetti animation on PR merge
-│   │   └── use-previous.ts     Track previous state value
+│   │   └── use-url-selection.ts Sync selection state with the URL
 │   ├── lib/
 │   │   ├── api.ts              API client, fetch functions, type definitions
 │   │   ├── repo-route.ts       Parse/build GitHub-style /{owner}/{repo}/... URLs
 │   │   ├── use-sse.ts          SSE hook for real-time updates
 │   │   ├── diff-views.ts       View snapshot diffing for event detection
+│   │   ├── swimlane-grouping.ts Group stacks into owner swimlanes
+│   │   ├── branch-utils.ts     Branch helpers
+│   │   ├── stats.ts            Stack/branch stat computation
+│   │   ├── status-config.ts    CI/PR status → label/color mapping
+│   │   ├── github.ts           GitHub URL/link helpers
+│   │   ├── file-icons.tsx      File-type icons for diffs
 │   │   ├── utils.ts            cn() helper for class merging
 │   │   └── time.ts             Time formatting utilities
 │   └── test/
@@ -70,8 +78,9 @@ apps/web/
 
 ```
 layout.tsx
-└── ThemeProvider → RepoProvider → TooltipProvider
+└── ThemeProvider → TooltipProvider
     └── [[...slug]]/page.tsx → AppShell
+        └── ConfigProvider → AuthProvider → RepoProvider (per-repo view)
         ├── Header (repo info, refresh, theme toggle)
         ├── LeftPanel (scrollable)
         │   ├── OwnerSwimlane ("You")
@@ -242,7 +251,8 @@ Tests use **Vitest** with **jsdom** environment and **Testing Library**. Test fi
 ```
 src/lib/__tests__/api.test.ts
 src/lib/__tests__/utils.test.ts
-src/hooks/__tests__/use-previous.test.ts
+src/components/providers/__tests__/config-provider.test.tsx
+src/components/swimlane/__tests__/stack-column.test.ts
 src/components/stack-tree/__tests__/tree-layout.test.ts
 src/components/status/__tests__/status-badge.test.tsx
 ```


### PR DESCRIPTION

Fix staleness surfaced by a verification pass over the docs:
- deploy.md: drop the nonexistent -repos-config/repos.json mechanism for
  the real -database-url/-cwd sourcing; correct {id} routes to {owner}/{repo};
  rewrite the smoke test, Railway, and "not yet" sections for the shipped server
- web.md: correct moved component dirs, add Config/Auth providers, fix nesting
- config.md: document the navigation.* keys and fill in the ProjectConfig struct
- shipping.md: fix two wrong function names, add the squash alias and --yes flag
- metadata.md: drop drifting line-number citations, keep filename + type name
- README/AGENTS/recipes: prepush/ui commands, apps/server path, root.go path
- plans/server: mark historical with a residual-work list
- plans/perf/track-untrack: mark the landed GetRevision hoist as done