### PR TITLE
perf(restack): skip undo snapshot when no branch needs rebasing

### DIFF
--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -142,15 +142,20 @@ func RestackAction(ctx *app.Context, plan *RestackPlan, handler handlers.Restack
 
 	ctx.Logger.Info("restack started branchCount=%v", branchCount)
 
-	// Take snapshot before modifying the repository
-	snapshotOpts := NewSnapshot("restack",
-		WithArg(opts.BranchName),
-		WithFlag(opts.AllStacks, "--all-stacks"),
-		WithFlagValue("--stacks", strings.Join(opts.StackRoots, ",")),
-		WithFlag(opts.ContinueOnConflict, "--continue-on-conflict"),
-		WithFlag(opts.Parallel, "--parallel"),
-	)
-	TakeBestEffortSnapshot(ctx, snapshotOpts)
+	// Take snapshot before modifying the repository. Skip it when no branch
+	// actually needs a rebase: an up-to-date restack mutates nothing, so there
+	// is nothing to undo and the snapshot is pure overhead (it hits every no-op
+	// restack, and sync runs restack often).
+	if plan.HasWork() {
+		snapshotOpts := NewSnapshot("restack",
+			WithArg(opts.BranchName),
+			WithFlag(opts.AllStacks, "--all-stacks"),
+			WithFlagValue("--stacks", strings.Join(opts.StackRoots, ",")),
+			WithFlag(opts.ContinueOnConflict, "--continue-on-conflict"),
+			WithFlag(opts.Parallel, "--parallel"),
+		)
+		TakeBestEffortSnapshot(ctx, snapshotOpts)
+	}
 
 	// If no handler provided, use NullRestackHandler (silent)
 	if handler == nil {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

RestackAction gated the undo snapshot on BranchCount != 0, but took it even
when every resolved branch was already up-to-date. An up-to-date restack
mutates nothing, so there is nothing to undo and the snapshot (disk + git
work) is pure overhead. It hits every no-op restack, and sync runs restack
often. Gate TakeBestEffortSnapshot on plan.HasWork() instead.

HasWork() reads the per-group engine plans, which PlanRestack populates for
every non-empty group regardless of parallel mode, so the signal is reliable
even when parallel workers recompute their plans in-worktree.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785067446`.


* **PR #1453** 👈
  * **PR #1454**
    * **PR #1455**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1461 by jonnii*