### PR TITLE
perf(absorb): drop redundant pre-staging staged-changes probe

### DIFF
--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -67,12 +67,6 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	// Build a StackGraph for efficient traversals
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
 
-	// Check if there are staged changes (before handling flags)
-	_, err := eng.HasStagedChanges(ctx.Context)
-	if err != nil {
-		return fmt.Errorf("failed to check staged changes: %w", err)
-	}
-
 	// Handle staging flags. Unlike create/modify, --all stages tracked changes
 	// only (git add -u): untracked files can never be absorbed. When combined
 	// with --patch, --all wins, matching the pre-existing precedence.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The pre-staging HasStagedChanges call discarded its result (_, err :=) and
only checked the error; the real decision is made by the re-check after
staging flags are applied. It was a pure wasted git subprocess with no
behavioral effect. Delete it.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785067446`.


* **PR #1453**
  * **PR #1454** 👈
    * **PR #1455**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1461 by jonnii*