### PR TITLE
perf(engine): add scoped RebuildBranches and use it in absorb

### DIFF
--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -361,6 +361,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	// Track the oldest modified branch to know where to start restacking from
 	var oldestModifiedBranch string
+	var modifiedBranches []string
 
 	// Get branches in topological order (bottom-up)
 	allBranches := eng.AllBranches()
@@ -375,6 +376,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		if oldestModifiedBranch == "" {
 			oldestModifiedBranch = branch.GetName()
 		}
+		modifiedBranches = append(modifiedBranches, branch.GetName())
 
 		// Apply all hunks for this branch together
 		if err := eng.ApplyHunksToBranch(ctx.Context, branch, branchHunks); err != nil {
@@ -399,9 +401,12 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	// Absorb rewrites history via raw git operations (cherry-pick + reset on
 	// every modified branch), which engine doesn't observe through its own
-	// mutation paths. Rebuild reconciles cached ParentBranchRevision and
-	// branch tips with the post-rewrite state on disk.
-	if err := eng.Rebuild(""); err != nil {
+	// mutation paths. Refresh reconciles cached ParentBranchRevision and branch
+	// tips with the post-rewrite state on disk. Only the branches we applied
+	// hunks to changed, so a scoped rebuild suffices — it invalidates the
+	// metadata cache (so the follow-up restack reads fresh) without re-reading
+	// every branch in the repo.
+	if err := eng.RebuildBranches(modifiedBranches); err != nil {
 		return fmt.Errorf("failed to refresh engine after absorb: %w", err)
 	}
 

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -375,3 +375,58 @@ func (e *engineImpl) Rebuild(newTrunkName string) error {
 
 	return e.rebuild()
 }
+
+// RebuildBranches refreshes cached state for only the named branches, re-reading
+// their shared + local metadata and merging the result into the existing graph.
+// Unlike Rebuild it does not list every branch in the repo or re-read every
+// branch's metadata — use it after an operation that rewrote history or metadata
+// on a known set of branches (e.g. absorb) and left the rest of the graph alone.
+//
+// Because it merges rather than resets, it forces a full load first: a scoped
+// merge into a partially-loaded state would look complete while silently
+// omitting the untouched branches. It does not change the trunk, the branch
+// list, or the current branch — callers that add/remove branches or move HEAD
+// must use Rebuild. A named branch whose metadata no longer marks it tracked is
+// dropped from state, mirroring what a full rebuild would conclude.
+func (e *engineImpl) RebuildBranches(branchNames []string) error {
+	if len(branchNames) == 0 {
+		return nil
+	}
+
+	// The merge layers onto the complete graph, so both tiers must be loaded
+	// before we take the write lock (ensure* must not run under e.mu).
+	e.ensureSharedLoaded()
+	e.ensureLocalLoaded()
+
+	// Invalidate the metadata cache so the re-reads below observe writes made by
+	// the operation that just ran (e.g. absorb's raw cherry-pick/reset), not a
+	// stale pre-operation snapshot.
+	e.git.ClearMetadataCache()
+
+	allMeta, _ := e.batchReadMetadata(branchNames)
+	allLocalMeta := e.batchReadLocalMetadata(branchNames)
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	for _, name := range branchNames {
+		if name == e.trunk {
+			continue // Trunk is never tracked.
+		}
+
+		meta := allMeta[name]
+		if meta == nil || meta.GetParentBranchName() == nil || *meta.GetParentBranchName() == name {
+			// No parent metadata (untracked, deleted, or self-parenting) → drop,
+			// matching applySharedMetadata's skip-then-absent behavior.
+			e.state.removeBranch(name)
+			continue
+		}
+
+		e.state.updateBranchStateFromMeta(name, meta)
+		if lm := allLocalMeta[name]; lm != nil {
+			e.state.updateBranchStateFromLocalMeta(name, lm)
+		}
+	}
+
+	return nil
+}

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -628,6 +628,87 @@ func TestRebuild(t *testing.T) {
 	})
 }
 
+func TestRebuildBranches(t *testing.T) {
+	t.Parallel()
+
+	// descendantsOf walks the childrenMap-backed traversal and returns each
+	// branch's depth below start. This is the accessor that breaks if a scoped
+	// rebuild leaves childrenMap inconsistent.
+	descendantsOf := func(eng engine.Engine, start string) map[string]int {
+		got := map[string]int{}
+		for b, depth := range eng.BranchesDepthFirst(eng.GetBranch(start)) {
+			got[b.GetName()] = depth
+		}
+		return got
+	}
+
+	t.Run("reparent merges without disturbing the rest of the graph", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithLinearStack("a", "b", "c") // main -> a -> b -> c
+
+		// Externally reparent b onto main (as a raw metadata write the engine
+		// did not observe through its own mutation path).
+		main := "main"
+		meta, err := s.Engine.Git().ReadMetadata("b")
+		require.NoError(t, err)
+		require.NoError(t, s.Engine.Git().WriteMetadata("b", meta.WithParentBranchName(&main)))
+
+		// Engine still shows the pre-write graph until we refresh.
+		require.Equal(t, "a", s.Engine.GetBranch("b").GetParent().GetName())
+
+		require.NoError(t, s.Engine.RebuildBranches([]string{"b"}))
+
+		// b now parents onto main; a and c are untouched.
+		require.Equal(t, "main", s.Engine.GetBranch("b").GetParent().GetName())
+		require.Equal(t, "main", s.Engine.GetBranch("a").GetParent().GetName())
+		require.Equal(t, "b", s.Engine.GetBranch("c").GetParent().GetName())
+
+		// childrenMap is consistent: a lost b, main gained b, b keeps c.
+		fromMain := descendantsOf(s.Engine, "main")
+		require.Equal(t, 1, fromMain["a"], "a stays a direct child of main")
+		require.Equal(t, 1, fromMain["b"], "b is now a direct child of main")
+		require.Equal(t, 2, fromMain["c"], "c stays under b")
+		// The traversal includes the start node at depth 0, so a with no
+		// children yields only itself.
+		require.Equal(t, map[string]int{"a": 0}, descendantsOf(s.Engine, "a"), "a has no children after b moved off")
+	})
+
+	t.Run("drops a branch that became untracked", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithLinearStack("a", "b") // main -> a -> b
+
+		require.NoError(t, s.Engine.Git().DeleteMetadata(context.Background(), "b"))
+
+		require.NoError(t, s.Engine.RebuildBranches([]string{"b"}))
+
+		require.False(t, s.Engine.GetBranch("b").IsTracked(), "b is no longer tracked")
+		// a's children no longer include b.
+		require.NotContains(t, descendantsOf(s.Engine, "a"), "b")
+	})
+
+	t.Run("only refreshes the listed branches", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithLinearStack("a", "b") // main -> a -> b
+
+		// Reparent a onto main->... actually change a's recorded parent revision
+		// externally, then rebuild only b. a must stay as the engine last saw it.
+		newRev := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+		metaA, err := s.Engine.Git().ReadMetadata("a")
+		require.NoError(t, err)
+		require.NoError(t, s.Engine.Git().WriteMetadata("a", metaA.WithParentBranchRevision(&newRev)))
+
+		require.NoError(t, s.Engine.RebuildBranches([]string{"b"}))
+
+		// a was not in the list, so its cached state is unchanged (still tracked
+		// under main, no surprise refresh).
+		require.Equal(t, "main", s.Engine.GetBranch("a").GetParent().GetName())
+		require.True(t, s.Engine.GetBranch("a").IsTracked())
+	})
+}
+
 func TestCreateBranchUpdatesBranchInventory(t *testing.T) {
 	t.Parallel()
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -319,6 +319,9 @@ type WorktreeRegistry interface {
 type Initializer interface {
 	Reset(newTrunkName string) error
 	Rebuild(newTrunkName string) error
+	// RebuildBranches refreshes cached state for only the named branches,
+	// merging into the existing graph instead of re-reading every branch.
+	RebuildBranches(branchNames []string) error
 }
 
 // BranchWriter is a composite interface for backward compatibility


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

engine.rebuild() re-reads the branch list and every branch metadata ref in
the repo even when an operation only touched a handful of branches. Absorb hit
this: after rewriting history on the branches it absorbed into, it called
Rebuild("") to reconcile the engine, re-reading all N branches to refresh K.

Add RebuildBranches([]string): it re-reads only the named branches shared +
local metadata and merges the result into the existing graph via the same
updateBranchStateFromMeta primitive transactions already use, so childrenMap
edges are maintained on reparent. Because it merges rather than resets, it
forces a full load first (a scoped merge into a partially-loaded state would
look complete while omitting untouched branches) and never touches the trunk,
branch list, or current branch. A named branch whose metadata no longer marks
it tracked is dropped, matching what a full rebuild would conclude.

Wire absorb to pass the branches it applied hunks to. It still ClearMetadataCache
so the follow-up restack reads fresh, but skips the repo-wide metadata reload.

TestRebuildBranches covers the reparent merge (asserting childrenMap
consistency through the childrenMap-backed BranchesDepthFirst traversal),
dropping a branch that became untracked, and the scoping contract that only
listed branches are refreshed.

untrack is left on the full rebuild: it deletes-and-reparents rather than
refreshing in place, and its per-branch N+1 was already removed by
UntrackBranches, so it is a lower-value, higher-risk follow-up.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785067446`.


* **PR #1453**
  * **PR #1454**
    * **PR #1455** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1461 by jonnii*