### PR TITLE
refactor(engine): return RevisionMap from BatchDivergencePoints

### DIFF
--- a/internal/actions/flatten/flatten.go
+++ b/internal/actions/flatten/flatten.go
@@ -343,7 +343,7 @@ func buildRebaseSpecsForAll(eng engine.Engine, plan *flattenPlan, branches engin
 		}
 
 		// Get the old upstream (divergence point)
-		oldUpstream, ok := divergence[branchName]
+		oldUpstream, ok := divergence.Rev(branchName)
 		if !ok {
 			continue
 		}
@@ -480,8 +480,10 @@ func buildFlattenPlan(ctx *app.Context, eng engine.Engine, branches engine.Branc
 		// Get current parent info
 		origParentName := b.GetParentOrTrunk()
 
-		// The branch's base (divergence point from parent)
-		oldUpstream := divergence[bName]
+		// The branch's base (divergence point from parent). bName is always in
+		// the map (the loop iterates the same branch set), so a missing key here
+		// would be a programming error, not the expected empty-divergence case.
+		oldUpstream, _ := divergence.Rev(bName)
 
 		// Try to find the best (closest to trunk) parent this branch can move to
 		newParent := findBestParent(ctx, eng, bName, oldUpstream, potentialParents, revisions)

--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -483,8 +483,8 @@ func BuildRebaseSpecs(eng engine.Engine, out output.Output, source, onto string,
 		}
 
 		// Get the old upstream (divergence point)
-		dOldUpstream := divergencePoints[d.GetName()]
-		if dOldUpstream == "" {
+		dOldUpstream, ok := divergencePoints.Rev(d.GetName())
+		if !ok || dOldUpstream == "" {
 			dOldUpstream = parentRev // Fallback
 		}
 

--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -136,8 +136,8 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	childDivPoints := eng.BatchDivergencePoints(children)
 	for _, child := range children {
 		// Get the old upstream (divergence point)
-		childOldUpstream := childDivPoints[child.GetName()]
-		if childOldUpstream == "" {
+		childOldUpstream, ok := childDivPoints.Rev(child.GetName())
+		if !ok || childOldUpstream == "" {
 			// Fallback to source revision if unavailable
 			childOldUpstream = sourceRev
 		}

--- a/internal/engine/branch_tracking.go
+++ b/internal/engine/branch_tracking.go
@@ -314,14 +314,15 @@ func (e *engineImpl) ReparentBranchesToParents(ctx context.Context, moves []Bran
 	for _, m := range moves {
 		// The batch reader returns "" where the individual lookup would error;
 		// reparenting must not proceed with an unknown divergence point.
-		if divPoints[m.Branch] == "" {
+		if rev, ok := divPoints.Rev(m.Branch); !ok || rev == "" {
 			return fmt.Errorf("failed to determine divergence point for %s", m.Branch)
 		}
 	}
 
 	for _, m := range moves {
 		newParent := e.GetBranch(m.NewParent)
-		if err := e.setParentPreservingDivergence(ctx, e.GetBranch(m.Branch), newParent, divPoints[m.Branch]); err != nil {
+		divPoint, _ := divPoints.Rev(m.Branch)
+		if err := e.setParentPreservingDivergence(ctx, e.GetBranch(m.Branch), newParent, divPoint); err != nil {
 			return fmt.Errorf("failed to reparent %s to %s: %w", m.Branch, m.NewParent, err)
 		}
 		if err := e.syncStackIDFromParent(ctx, e.GetBranch(m.Branch)); err != nil {

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -40,10 +40,10 @@ func (e *engineImpl) GetRevisions(branchNames []string) (RevisionMap, []error) {
 // BatchDivergencePoints returns each branch's divergence point keyed by branch
 // name, matching GetDivergencePoint (the stored parent revision when present,
 // else the parent's current tip) but resolving the whole set in one batched pass.
-func (e *engineImpl) BatchDivergencePoints(branches Branches) map[string]string {
-	return batchByBranch(e, branches, func(b Branch, head, parentRev, storedBase string) string {
+func (e *engineImpl) BatchDivergencePoints(branches Branches) RevisionMap {
+	return RevisionMap(batchByBranch(e, branches, func(b Branch, head, parentRev, storedBase string) string {
 		return statBase(parentRev, storedBase)
-	})
+	}))
 }
 
 // commitCountBetween returns the commit count in (base, head], using the

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -102,7 +102,7 @@ type BranchInfo interface {
 	GetDivergencePoint(branchName string) (string, error)
 	// BatchDivergencePoints returns the divergence point for every branch in one
 	// batched (git-free when metadata is cached) pass, keyed by branch name.
-	BatchDivergencePoints(branches Branches) map[string]string
+	BatchDivergencePoints(branches Branches) RevisionMap
 	// BatchDiffStats, BatchCommits, and BatchChangedFileCounts each resolve one
 	// per-branch concern across the whole set in a single batched pass, returning
 	// a value map.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

BatchDivergencePoints returned a bare map[string]string even though its value
is a branch-name -> commit SHA (the divergence-point revision) — exactly what
the existing RevisionMap type models, and what GetRevisions already returns.
The four call sites each hand-rolled the missing-key case three different ways,
overloading "" to mean both "absent" and "empty divergence".

Return RevisionMap and route every lookup through its nil-safe .Rev(name) accessor
so "present but empty" is distinguished from "absent" consistently. RevisionMap is
a map[string]string alias, so the change is drop-in at the type level; the call
sites in move, pluck, flatten, and branch_tracking now read through .Rev.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785066547`.


* **PR #1457** 👈
  * **PR #1458**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1460 by jonnii*