### PR TITLE
refactor(engine): return DeletionStatuses from GetDeletionStatuses

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -47,7 +47,7 @@ type BranchDeletionPlan struct {
 	// internal plan for execution
 	plan           *deletionPlan
 	reparentMoves  []plannedReparentMove
-	deleteStatuses map[string]engine.DeletionStatus
+	deleteStatuses engine.DeletionStatuses
 }
 
 // branchDeletionInfo stores information about a branch marked for deletion
@@ -154,12 +154,12 @@ func ExecuteBranchDeletions(ctx *app.Context, plannedDeletion *BranchDeletionPla
 
 	// If branchesToDelete filter is provided, remove branches not in the filter
 	if branchesToDelete != nil {
-		filteredStatuses := make(map[string]engine.DeletionStatus)
+		filteredStatuses := make(engine.DeletionStatuses)
 		for name := range plannedDeletion.plan.branches {
 			if !branchesToDelete[name] {
 				continue
 			}
-			status := plannedDeletion.deleteStatuses[name]
+			status := plannedDeletion.deleteStatuses.For(name)
 			if !status.SafeToDelete {
 				info := plannedDeletion.plan.branches[name]
 				status = engine.DeletionStatus{
@@ -199,7 +199,7 @@ func ExecuteBranchDeletions(ctx *app.Context, plannedDeletion *BranchDeletionPla
 // identifyBranchesToDelete pre-calculates deletion status for all tracked branches.
 // Returns the branches to delete, any branches that were skipped due to being in a worktree,
 // and which branches are utility branches (e.g., consolidated merge branches).
-func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[string]engine.DeletionStatus, []string, map[string]bool, error) {
+func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (engine.DeletionStatuses, []string, map[string]bool, error) {
 	eng := ctx.Engine
 	c := ctx.Context
 
@@ -219,14 +219,14 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[
 		return nil, nil, nil, fmt.Errorf("failed to get deletion statuses: %w", err)
 	}
 
-	deleteStatuses := make(map[string]engine.DeletionStatus) // name -> status
-	utilityBranches := make(map[string]bool)                 // branches that are utility type
+	deleteStatuses := make(engine.DeletionStatuses) // name -> status
+	utilityBranches := make(map[string]bool)        // branches that are utility type
 	var skippedInWorktree []string
 	remoteStatuses := opts.RemoteStatuses
 	if remoteStatuses == nil {
 		branchesNeedingRemoteStatus := engine.NewBranchesBuilder(len(candidateNames))
 		for _, name := range candidateNames {
-			if statuses[name].SafeToDelete {
+			if statuses.For(name).SafeToDelete {
 				branchesNeedingRemoteStatus.Add(eng.GetBranch(name))
 			}
 		}
@@ -236,7 +236,7 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[
 	}
 
 	for _, name := range candidateNames {
-		status := statuses[name]
+		status := statuses.For(name)
 		if !status.SafeToDelete {
 			continue
 		}
@@ -274,7 +274,7 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (map[
 
 // buildDeletionPlan constructs the deletion hierarchy and records parent updates
 // for surviving branches. It does not mutate branch metadata.
-func buildDeletionPlan(ctx *app.Context, deleteStatuses map[string]engine.DeletionStatus) (*deletionPlan, []string, []plannedReparentMove) {
+func buildDeletionPlan(ctx *app.Context, deleteStatuses engine.DeletionStatuses) (*deletionPlan, []string, []plannedReparentMove) {
 	eng := ctx.Engine
 	out := ctx.Output
 
@@ -479,7 +479,7 @@ func getParentName(branch engine.Branch) string {
 // corresponding refs/heads/<name>. The most common cause is the user
 // running `git branch -D <merged-branch>` directly instead of letting
 // stackit clean up.
-func appendStrandedRoots(eng engine.Engine, graph *engine.StackGraph, deleteStatuses map[string]engine.DeletionStatus, queue []string) []string {
+func appendStrandedRoots(eng engine.Engine, graph *engine.StackGraph, deleteStatuses engine.DeletionStatuses, queue []string) []string {
 	trunkName := eng.Trunk().GetName()
 	branchNames := eng.BranchNames()
 

--- a/internal/actions/delete/delete.go
+++ b/internal/actions/delete/delete.go
@@ -87,7 +87,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) (Result, error) {
 	// Confirm if not forced and not merged/closed
 	if !opts.Force {
 		for _, b := range toDelete {
-			status := statuses[b.GetName()]
+			status := statuses.For(b.GetName())
 			if !status.SafeToDelete {
 				// If handler is interactive, prompt for confirmation
 				if handler.IsInteractive() {
@@ -167,7 +167,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) (Result, error) {
 	return Result{MainRepoDirForSwitch: mainRepoDirForSwitch}, nil
 }
 
-func preReparentChildrenWithPreservedDivergence(ctx *app.Context, toDelete engine.Branches, statuses map[string]engine.DeletionStatus) ([]string, error) {
+func preReparentChildrenWithPreservedDivergence(ctx *app.Context, toDelete engine.Branches, statuses engine.DeletionStatuses) ([]string, error) {
 	eng := ctx.Engine
 	gctx := ctx.Context
 	out := ctx.Output
@@ -184,7 +184,7 @@ func preReparentChildrenWithPreservedDivergence(ctx *app.Context, toDelete engin
 
 	for _, deleted := range toDelete {
 		deletedName := deleted.GetName()
-		status := statuses[deletedName]
+		status := statuses.For(deletedName)
 		if !shouldPreserveDivergenceOnDelete(status.Kind) {
 			continue
 		}

--- a/internal/engine/engine_branch_status.go
+++ b/internal/engine/engine_branch_status.go
@@ -425,8 +425,8 @@ func (e *engineImpl) BatchIsBranchEmpty(branchNames []string) BranchNameSet {
 // GetDeletionStatuses checks deletion status for multiple branches in a single batch.
 // It batch-fetches metadata, revisions, and merged status, then evaluates the canonical
 // deletion policy for each branch.
-func (e *engineImpl) GetDeletionStatuses(ctx context.Context, branchNames []string) (map[string]DeletionStatus, error) {
-	results := make(map[string]DeletionStatus, len(branchNames))
+func (e *engineImpl) GetDeletionStatuses(ctx context.Context, branchNames []string) (DeletionStatuses, error) {
+	results := make(DeletionStatuses, len(branchNames))
 	if len(branchNames) == 0 {
 		return results, nil
 	}
@@ -479,8 +479,8 @@ func (e *engineImpl) loadDeletionStatusInputs(ctx context.Context, branchNames [
 	}, nil
 }
 
-func (e *engineImpl) evaluateDeletionStatuses(ctx context.Context, branchNames []string, inputs *deletionStatusInputs) map[string]DeletionStatus {
-	results := make(map[string]DeletionStatus, len(branchNames))
+func (e *engineImpl) evaluateDeletionStatuses(ctx context.Context, branchNames []string, inputs *deletionStatusInputs) DeletionStatuses {
+	results := make(DeletionStatuses, len(branchNames))
 
 	// Evaluate each branch
 	for _, name := range branchNames {

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -56,7 +56,7 @@ type BranchStatus interface {
 	// BatchIsBranchEmpty reports emptiness for many branches, resolving all tree
 	// SHAs in one batched rev-parse instead of a diff per branch.
 	BatchIsBranchEmpty(branchNames []string) BranchNameSet
-	GetDeletionStatuses(ctx context.Context, branchNames []string) (map[string]DeletionStatus, error)
+	GetDeletionStatuses(ctx context.Context, branchNames []string) (DeletionStatuses, error)
 	GetScope(branch Branch) Scope
 	GetStackDescription(branch Branch) *git.StackDescription
 	IsLocked(branch Branch) bool

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -199,6 +199,17 @@ type DeletionStatus struct {
 	HasUnpushedChanges bool               // Local branch is ahead of or diverged from remote
 }
 
+// DeletionStatuses maps branch name -> deletion status, as returned by
+// GetDeletionStatuses.
+type DeletionStatuses map[string]DeletionStatus
+
+// For returns the deletion status for a branch. A branch absent from the map
+// returns the zero DeletionStatus (SafeToDelete=false), so an unknown branch is
+// never treated as safe to delete. Safe to call on a nil map.
+func (s DeletionStatuses) For(name string) DeletionStatus {
+	return s[name]
+}
+
 // DeletionReasonKind is a machine-readable reason for branch deletion eligibility.
 type DeletionReasonKind string
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

GetDeletionStatuses returned a bare map[string]DeletionStatus, and its five
read sites across sync, clean_branches, and delete handled the missing-key case
inconsistently — some guarded with , ok, others raw-indexed and relied on the
zero value.

Introduce a DeletionStatuses map alias with a nil-safe .For(name) accessor that
returns the zero DeletionStatus (SafeToDelete=false) for an unknown branch, so an
absent branch is never treated as safe to delete. Route the raw zero-value reads
through .For; guarded , ok reads and the internal writes keep working since the
alias is still a map. The map is threaded through several clean_branches helpers,
whose signatures now use engine.DeletionStatuses for consistency.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785066547`.


* **PR #1457**
  * **PR #1458** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1460 by jonnii*