### PR TITLE
refactor: dedupe shortSHA helpers into utils.ShortRevision

### DIFF
--- a/internal/actions/merge/plan.go
+++ b/internal/actions/merge/plan.go
@@ -474,7 +474,7 @@ func formatBranchRemoteDifference(status engine.BranchRemoteStatus) string {
 		return "(branch not found locally)"
 	}
 
-	localShort := shortSHA(status.LocalSha)
+	localShort := utils.ShortRevision(status.LocalSha, 0)
 	if status.RemoteSha == "" {
 		return fmt.Sprintf("local: %s (branch not found on remote)", localShort)
 	}
@@ -482,7 +482,7 @@ func formatBranchRemoteDifference(status engine.BranchRemoteStatus) string {
 		return ""
 	}
 
-	remoteShort := shortSHA(status.RemoteSha)
+	remoteShort := utils.ShortRevision(status.RemoteSha, 0)
 	switch {
 	case status.Behind():
 		return fmt.Sprintf("local is behind remote (local: %s, remote: %s)", localShort, remoteShort)
@@ -493,13 +493,6 @@ func formatBranchRemoteDifference(status engine.BranchRemoteStatus) string {
 	default:
 		return fmt.Sprintf("local: %s, remote: %s", localShort, remoteShort)
 	}
-}
-
-func shortSHA(sha string) string {
-	if len(sha) > 7 {
-		return sha[:7]
-	}
-	return sha
 }
 
 // BuildMergePlan builds a Plan with strategy-specific steps from collected branch data.

--- a/internal/cli/navigation/log.go
+++ b/internal/cli/navigation/log.go
@@ -16,6 +16,7 @@ import (
 	"github.com/getstackit/stackit/internal/cli/common"
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // NewLogCmd creates the log command: a stack-aware view of trunk commit history.
@@ -193,7 +194,7 @@ func renderStackBand(stack stacklog.Result) string {
 			b.WriteString("\n  ")
 			b.WriteString(symbol)
 			b.WriteString(" ")
-			b.WriteString(output.Yellow(shortSHA(c.SHA)))
+			b.WriteString(output.Yellow(utils.ShortRevision(c.SHA, 0)))
 			b.WriteString("  ")
 			b.WriteString(c.Subject)
 			// The branch's own head ref is the header above; omit it here, but
@@ -210,7 +211,7 @@ func renderStackBand(stack stacklog.Result) string {
 // renderTrunkDivider draws the boundary between the stack and trunk history,
 // labeled with the trunk name, its short tip SHA, and any tags on the tip.
 func renderTrunkDivider(stack stacklog.Result) string {
-	label := output.Cyan(stack.TrunkName) + " " + output.Yellow(shortSHA(stack.TrunkTipSHA))
+	label := output.Cyan(stack.TrunkName) + " " + output.Yellow(utils.ShortRevision(stack.TrunkTipSHA, 0))
 	if deco := formatDecorations(stack.Decorations[stack.TrunkTipSHA], stack.TrunkName); deco != "" {
 		label += " " + deco
 	}
@@ -232,7 +233,7 @@ func renderLog(res trunklog.Result, decos map[string][]git.RefDecoration, exclud
 		if i > 0 {
 			b.WriteString("\n")
 		}
-		b.WriteString(output.Yellow(shortSHA(c.SHA)))
+		b.WriteString(output.Yellow(utils.ShortRevision(c.SHA, 0)))
 		b.WriteString("  ")
 		b.WriteString(c.Message)
 
@@ -367,12 +368,4 @@ func (m *logPagerModel) View() tea.View {
 	v := tea.NewView(title + "\n\n" + content)
 	v.AltScreen = true
 	return v
-}
-
-// shortSHA truncates a commit SHA to the conventional 7-character form.
-func shortSHA(sha string) string {
-	if len(sha) > 7 {
-		return sha[:7]
-	}
-	return sha
 }

--- a/internal/cli/navigation/log_json.go
+++ b/internal/cli/navigation/log_json.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/actions/trunklog"
 	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // logCommitJSON is the per-commit shape emitted by `stackit log --json`. It is a
@@ -42,7 +43,7 @@ func printLogJSON(out output.Output, res trunklog.Result) error {
 	}
 	for _, c := range res.Commits {
 		payload.Commits = append(payload.Commits, logCommitJSON{
-			SHA:           shortSHA(c.SHA),
+			SHA:           utils.ShortRevision(c.SHA, 0),
 			Message:       c.Message,
 			Author:        c.Author,
 			Date:          c.Date.Format(time.RFC3339),

--- a/internal/cli/stack/sync.go
+++ b/internal/cli/stack/sync.go
@@ -17,6 +17,7 @@ import (
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/tui/style"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // NewSyncCmd creates the sync command
@@ -156,7 +157,7 @@ func computeSyncDryRun(ctx context.Context, eng engine.Engine, opts sync.Options
 	remoteStatus := eng.ReadBranchRemoteStatuses(ctx, engine.BranchesOf(trunk)).ForBranch(trunk)
 	if remoteStatus.Behind() {
 		plan.pullBranch = trunk.GetName()
-		plan.pullRev = shortSHA(remoteStatus.RemoteSha)
+		plan.pullRev = utils.ShortRevision(remoteStatus.RemoteSha, 0)
 	}
 
 	// Collect candidate branches for deletion and restack checks
@@ -329,12 +330,4 @@ func dryRunSummaryLine(plan dryRunPlan) string {
 		return ""
 	}
 	return "would " + strings.Join(parts, ", ")
-}
-
-// shortSHA truncates a full git SHA to its 7-character short form for display.
-func shortSHA(sha string) string {
-	if len(sha) > 7 {
-		return sha[:7]
-	}
-	return sha
 }

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // MapBranch converts an engine Branch and its StackNode into an API BranchResponse.
@@ -241,13 +242,6 @@ func mapCommitsWithDate(lines []string) []CommitResponse {
 	return commits
 }
 
-func shortSHA(sha string) string {
-	if len(sha) > 7 {
-		return sha[:7]
-	}
-	return sha
-}
-
 // computeStackStatus determines the overall status of a stack.
 func computeStackStatus(graph *engine.StackGraph, branchNames []string) string {
 	allHavePR := true
@@ -300,7 +294,7 @@ func MapTrunkCommits(commits []git.RecentCommit, prTitles map[int]string) []Trun
 		// Message substitution and constituent-title selection are shared with
 		// the `stackit log` command via internal/git.
 		resp := TrunkCommitResponse{
-			SHA:           shortSHA(c.SHA),
+			SHA:           utils.ShortRevision(c.SHA, 0),
 			Message:       c.DisplayMessage(prTitles),
 			Author:        c.Author,
 			Date:          c.Date.Format(time.RFC3339),


### PR DESCRIPTION
## Summary

- Four packages (`internal/contracts/http`, `internal/cli/stack`, `internal/cli/navigation`, `internal/actions/merge`) each defined a byte-for-byte identical private `shortSHA` helper that truncates a SHA to 7 characters.
- All four are removed in favor of the existing, already-tested `utils.ShortRevision(rev, maxLen)` in `internal/utils`, which implements the same truncation.
- No behavior change — pure deduplication of duplicated logic across the codebase.

(Left `internal/actions/absorb/output.go`'s `shortSHA` alone since it intentionally truncates to 8 characters instead of 7, and the unrelated `shortSHA` local variable in `internal/engine/undo.go` which truncates to 12.)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/contracts/http/... ./internal/cli/stack/... ./internal/cli/navigation/... ./internal/actions/merge/... ./internal/utils/...`
- [x] Full suite `go test ./internal/...` (one pre-existing, unrelated failure in `internal/git` `TestGetRepoInfo/parses_HTTPS_URL`, reproduces identically on `main`)

---
_Generated by [Claude Code](https://claude.ai/code/session_018wevFoYhrpv84WRbWtbyQH)_