### PR TITLE
perf(test): drop unused WithRemote from sync dry-run JSON subtests

### DIFF
--- a/internal/integration/json_output_test.go
+++ b/internal/integration/json_output_test.go
@@ -171,7 +171,7 @@ func TestJSONOutput(t *testing.T) {
 
 	t.Run("sync --dry-run --json outputs valid JSON", func(t *testing.T) {
 		t.Parallel()
-		sh := NewTestShellInProcess(t, WithRemote())
+		sh := NewTestShellInProcess(t)
 
 		// Create a stack
 		sh.Write("feature_a", "content a").
@@ -192,7 +192,7 @@ func TestJSONOutput(t *testing.T) {
 
 	t.Run("sync --dry-run --json --restack reports stack roots for would_restack branches", func(t *testing.T) {
 		t.Parallel()
-		sh := NewTestShellInProcess(t, WithRemote())
+		sh := NewTestShellInProcess(t)
 
 		// Build two independent stacks rooted at trunk:
 		//   main -> alpha-root -> alpha-child


### PR DESCRIPTION

Dry-run never hits the network, so the remote clone is dead setup.
Coverage guard: 7259 blocks preserved.