### PR TITLE
refactor(st-tui): move TUI lab fixtures out of the shipped CLI binary

### DIFF
--- a/apps/st-tui/main.go
+++ b/apps/st-tui/main.go
@@ -40,7 +40,7 @@ func main() {
 }
 
 func runSyncScenario(out output.Output, name string, delay time.Duration) {
-	scenario, found := stack.LookupSyncScenario(name)
+	scenario, found := LookupSyncScenario(name)
 	if !found {
 		_, _ = fmt.Fprintf(os.Stderr, "unknown sync scenario %q\n\n", name)
 		printUsage(os.Stderr)
@@ -54,7 +54,7 @@ func runSyncScenario(out output.Output, name string, delay time.Duration) {
 }
 
 func runSubmitScenario(out output.Output, name string, delay time.Duration) {
-	scenario, found := stack.LookupSubmitScenario(name)
+	scenario, found := LookupSubmitScenario(name)
 	if !found {
 		_, _ = fmt.Fprintf(os.Stderr, "unknown submit scenario %q\n\n", name)
 		printUsage(os.Stderr)
@@ -71,14 +71,14 @@ func printUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "Usage: st-tui [--delay duration] <command> <scenario>")
 	_, _ = fmt.Fprintln(w, "")
 	_, _ = fmt.Fprintln(w, "Sync scenarios:")
-	for _, name := range stack.SyncScenarioNames() {
-		scenario, _ := stack.LookupSyncScenario(name)
+	for _, name := range SyncScenarioNames() {
+		scenario, _ := LookupSyncScenario(name)
 		_, _ = fmt.Fprintf(w, "  %-10s %s\n", name, scenario.Description)
 	}
 	_, _ = fmt.Fprintln(w, "")
 	_, _ = fmt.Fprintln(w, "Submit scenarios:")
-	for _, name := range stack.SubmitScenarioNames() {
-		scenario, _ := stack.LookupSubmitScenario(name)
+	for _, name := range SubmitScenarioNames() {
+		scenario, _ := LookupSubmitScenario(name)
 		_, _ = fmt.Fprintf(w, "  %-10s %s\n", name, scenario.Description)
 	}
 	_, _ = fmt.Fprintln(w, "")

--- a/apps/st-tui/submit_scenarios.go
+++ b/apps/st-tui/submit_scenarios.go
@@ -1,4 +1,4 @@
-package stack
+package main
 
 import (
 	"errors"

--- a/apps/st-tui/submit_scenarios_test.go
+++ b/apps/st-tui/submit_scenarios_test.go
@@ -1,4 +1,4 @@
-package stack
+package main
 
 import (
 	"testing"
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/getstackit/stackit/internal/cli/stack"
 	"github.com/getstackit/stackit/internal/output"
 )
 
@@ -15,7 +16,7 @@ func TestSubmitScenarioReplayUsesProductionHandler(t *testing.T) {
 	require.True(t, found)
 
 	out := output.NewTestOutput()
-	scenario.Replay(NewSimpleSubmitHandler(out, SubmitVerbose), 0)
+	scenario.Replay(stack.NewSimpleSubmitHandler(out, stack.SubmitVerbose), 0)
 	got := ansi.Strip(out.String())
 
 	assert.Contains(t, got, "Submitting 2 branches")
@@ -38,7 +39,7 @@ func TestSubmitScenarioSSReplay(t *testing.T) {
 	require.True(t, found)
 
 	out := output.NewTestOutput()
-	scenario.Replay(NewSimpleSubmitHandler(out, SubmitVerbose), 0)
+	scenario.Replay(stack.NewSimpleSubmitHandler(out, stack.SubmitVerbose), 0)
 	got := ansi.Strip(out.String())
 
 	assert.Contains(t, got, "Will submit (1)")
@@ -69,7 +70,7 @@ func TestSubmitScenarioSpecialCases(t *testing.T) {
 			require.True(t, found)
 
 			out := output.NewTestOutput()
-			scenario.Replay(NewSimpleSubmitHandler(out, SubmitVerbose), 0)
+			scenario.Replay(stack.NewSimpleSubmitHandler(out, stack.SubmitVerbose), 0)
 			assert.Contains(t, ansi.Strip(out.String()), tt.want)
 		})
 	}

--- a/apps/st-tui/sync_scenarios.go
+++ b/apps/st-tui/sync_scenarios.go
@@ -1,4 +1,4 @@
-package stack
+package main
 
 import (
 	"time"

--- a/apps/st-tui/sync_scenarios_test.go
+++ b/apps/st-tui/sync_scenarios_test.go
@@ -1,4 +1,4 @@
-package stack
+package main
 
 import (
 	"testing"
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/getstackit/stackit/internal/cli/stack"
 	"github.com/getstackit/stackit/internal/output"
 )
 
@@ -15,7 +16,7 @@ func TestSyncScenarioReplayUsesProductionHandler(t *testing.T) {
 	require.True(t, found)
 
 	out := output.NewTestOutput()
-	scenario.Replay(NewSimpleSyncHandler(out), 0)
+	scenario.Replay(stack.NewSimpleSyncHandler(out), 0)
 	got := ansi.Strip(out.String())
 
 	assert.Contains(t, got, "main fast-forwarded to a1b2c3d")


### PR DESCRIPTION

SubmitScenarios and SyncScenarios lived in internal/cli/stack, which apps/cli
imports for the real submit and sync commands. Because they are package-level
slice literals rather than constants, the compiler builds them in a generated
init function, and a linked package init is always reachable from main -- so
the linker could not prune them. Every stackit invocation allocated the fake
stack fixtures at startup.

Moving them into apps/st-tui, their only consumer, drops ~17KB from the CLI
binary and removes the startup work. The lab binary already imported
internal/cli/stack for the production handlers, so no new package is needed.