### PR TITLE
fix: restore info remote timeout and cover the compact submit path

### DIFF
--- a/internal/actions/info.go
+++ b/internal/actions/info.go
@@ -84,12 +84,7 @@ func refreshRemoteMetadataForBranchInfo(ctx context.Context, eng engine.Engine, 
 		return
 	}
 
-	if err := eng.LoadRemoteMetadataCache(); err != nil {
-		debugBranchInfof(debug, "Failed to load remote metadata cache: %v", err)
-		return
-	}
-
-	if err := eng.ApplyRemoteMetadataIfExists(branchName); err != nil {
+	if err := eng.ApplyRemoteMetadataForBranches(ctx, []string{branchName}); err != nil {
 		debugBranchInfof(debug, "Failed to apply remote metadata for %s: %v", branchName, err)
 	}
 }

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -64,7 +64,10 @@ If no branch is specified and --stack is not provided, displays information abou
 					opts.BranchName = args[0]
 				}
 
-				info, err := actions.QueryBranchInfo(ctx.Context, ctx.Engine, opts, ctx.Output)
+				remoteCtx, cancel := ctx.RemoteOperationContext()
+				defer cancel()
+
+				info, err := actions.QueryBranchInfo(remoteCtx, ctx.Engine, opts, ctx.Output)
 				if err != nil {
 					return err
 				}

--- a/internal/cli/stack/submit_handlers_test.go
+++ b/internal/cli/stack/submit_handlers_test.go
@@ -337,3 +337,84 @@ func TestSimpleSubmitHandlerPrintsOutcomeWhenNothingSubmitted(t *testing.T) {
 
 	require.Contains(t, out.String(), "All PRs up to date")
 }
+
+// SubmitCompact is the default verbosity, so the assertions below cover what
+// every non-verbose user sees. Each compact branch in the handler is the "else"
+// of a check the SubmitVerbose tests above exercise from the other side.
+func TestSimpleSubmitHandlerCompactReportsOutcomeNotPerBranchRows(t *testing.T) {
+	t.Parallel()
+
+	out := output.NewTestOutput()
+	handler := NewSimpleSubmitHandler(out, SubmitCompact)
+	updated := "jonnii/20260511011552/update-me"
+	created := "jonnii/20260511011552/add-feature"
+	prNumber := 42
+
+	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+		Branches:    []string{updated, created},
+		TrunkBranch: "main",
+	}})
+	handler.OnEvent(submitAction.BranchPlanEvent{BranchName: updated, Action: "update", PRNumber: &prNumber})
+	handler.OnEvent(submitAction.BranchPlanEvent{BranchName: created, Action: "create"})
+	handler.OnEvent(submitAction.PlanningCompleteEvent{})
+	handler.OnEvent(submitAction.SubmissionStartEvent{
+		Branches: []submitAction.BranchInfo{
+			{Name: updated, Action: "update"},
+			{Name: created, Action: "create"},
+		},
+	})
+	handler.OnEvent(submitAction.BranchProgressEvent{
+		BranchName: updated,
+		Status:     submitAction.StatusDone,
+		URL:        "https://github.com/getstackit/stackit/pull/42",
+	})
+	handler.OnEvent(submitAction.BranchProgressEvent{
+		BranchName: created,
+		Status:     submitAction.StatusDone,
+		URL:        "https://github.com/getstackit/stackit/pull/51",
+	})
+	handler.OnEvent(submitAction.CompletionEvent{
+		Outcome:  submitAction.OutcomeComplete,
+		Message:  "Submit complete",
+		Duration: 2 * time.Second,
+	})
+
+	got := ansi.Strip(out.String())
+	require.Contains(t, got, "● Will open 1 PR · update 1 PR")
+	require.Contains(t, got, "Submitting 2 PRs...")
+	require.Contains(t, got, "✓ Opened 1 PR · updated 1 PR")
+	// Only the created PR's URL is worth pasting; the updated one is not.
+	require.Contains(t, got, "https://github.com/getstackit/stackit/pull/51")
+	require.NotContains(t, got, "https://github.com/getstackit/stackit/pull/42")
+	// The per-branch audit trail belongs to --verbose.
+	require.NotContains(t, got, "Submit plan")
+	require.NotContains(t, got, "Will submit (2)")
+	require.NotContains(t, got, "update-me #42 updated")
+	require.NotContains(t, got, "add-feature #51 created")
+}
+
+func TestSimpleSubmitHandlerCompactStaysSilentWhenNothingToSubmit(t *testing.T) {
+	t.Parallel()
+
+	out := output.NewTestOutput()
+	handler := NewSimpleSubmitHandler(out, SubmitCompact)
+	branch := "jonnii/20260511011552/up-to-date-branch"
+
+	handler.OnEvent(submitAction.StackDisplayEvent{Stack: submitAction.StackSnapshot{
+		Branches:      []string{branch},
+		CurrentBranch: branch,
+		TrunkBranch:   "main",
+	}})
+	handler.OnEvent(submitAction.BranchPlanEvent{
+		BranchName: branch,
+		Skipped:    true,
+		SkipReason: "no changes",
+	})
+	handler.OnEvent(submitAction.CompletionEvent{Outcome: submitAction.OutcomeUpToDate, Message: "Nothing to submit"})
+
+	got := ansi.Strip(out.String())
+	// An all-skipped plan has no work to describe, so compactSummary is empty
+	// and the outcome line carries the whole message.
+	require.NotContains(t, got, "●")
+	require.Contains(t, got, "Nothing to submit")
+}

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -418,7 +418,16 @@ func (e *engineImpl) RebuildBranches(branchNames []string) error {
 		if meta == nil || meta.GetParentBranchName() == nil || *meta.GetParentBranchName() == name {
 			// No parent metadata (untracked, deleted, or self-parenting) → drop,
 			// matching applySharedMetadata's skip-then-absent behavior.
+			//
+			// removeBranch also deletes this branch's own child edges, but a full
+			// rebuild would keep them: applySharedMetadata derives childrenMap from
+			// every branch's parent metadata, so children that still name this
+			// branch as their parent survive the drop. Preserve them.
+			children := e.state.childrenMap[name]
 			e.state.removeBranch(name)
+			if len(children) > 0 {
+				e.state.childrenMap[name] = children
+			}
 			continue
 		}
 

--- a/internal/engine/engine_impl_test.go
+++ b/internal/engine/engine_impl_test.go
@@ -688,6 +688,23 @@ func TestRebuildBranches(t *testing.T) {
 		require.NotContains(t, descendantsOf(s.Engine, "a"), "b")
 	})
 
+	t.Run("dropping an untracked branch keeps the children still parented to it", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithLinearStack("a", "b", "c") // main -> a -> b -> c
+
+		// Untrack the middle branch. c's metadata still names b as its parent,
+		// so a full rebuild would keep the b -> c edge; a scoped rebuild must
+		// not diverge by erasing it.
+		require.NoError(t, s.Engine.Git().DeleteMetadata(context.Background(), "b"))
+
+		require.NoError(t, s.Engine.RebuildBranches([]string{"b"}))
+
+		require.False(t, s.Engine.GetBranch("b").IsTracked(), "b is no longer tracked")
+		require.NotContains(t, descendantsOf(s.Engine, "a"), "b")
+		require.Equal(t, 1, descendantsOf(s.Engine, "b")["c"], "c is still a child of b")
+	})
+
 	t.Run("only refreshes the listed branches", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).


### PR DESCRIPTION

Three pre-release findings.

The info query/render split moved the untracked-branch metadata fetch onto the
unbounded root context and hand-rolled the cache/apply sequence, dropping
ConfigureRemoteMetadataSync so the metadata refspec was no longer ensured.
ApplyRemoteMetadataForBranches already owns that exact sequence, so calling it
restores the refspec step, and the CLI now passes RemoteOperationContext the
way the sibling --stack path always did.

SubmitCompact is the default verbosity, but every handler test asserted
SubmitVerbose, so the output most users see after upgrading had no coverage.
Adds two tests over the compact branches; both fail if flipped to verbose.

RebuildBranches dropped an untracked branch via removeBranch, which also erased
that branch its own child edges. A full rebuild derives childrenMap from every
branch parent metadata, so children still naming the dropped branch survive
there -- the scoped path now preserves them. Unreachable through absorb today,
but it diverged from the semantics the doc comment claims.