### PR TITLE
perf(submit): avoid per-branch worktree metadata lookups

### DIFF
--- a/internal/actions/submit/submit.go
+++ b/internal/actions/submit/submit.go
@@ -165,6 +165,17 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	scopeMap := make(map[string]string)
 	worktreeMap := make(map[string]string)
 
+	// Look up managed worktrees once and index by stack root, rather than
+	// calling GetWorktreeForStack per branch (each call reads a git ref plus
+	// a blob). Branches sharing a stack root would otherwise repeat the same
+	// lookup.
+	worktreeByStackRoot := make(map[string]string)
+	if worktrees, err := ctx.Worktree().ListManagedWorktrees(); err == nil {
+		for _, wt := range worktrees {
+			worktreeByStackRoot[wt.AnchorBranch] = wt.Path
+		}
+	}
+
 	for i, branchName := range branches {
 		branch := branchObjs[i]
 		fixedMap[branchName] = statuses.IsUpToDate(branch)
@@ -172,10 +183,8 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 		// Check if this branch belongs to a stack with a managed worktree.
 		stackRoot := ctx.Worktree().GetStackRootForBranch(branch)
-		if stackRoot != "" {
-			if wtInfo, err := ctx.Worktree().GetWorktreeForStack(stackRoot); err == nil && wtInfo != nil {
-				worktreeMap[branchName] = wtInfo.Path
-			}
+		if path, ok := worktreeByStackRoot[stackRoot]; ok {
+			worktreeMap[branchName] = path
 		}
 	}
 


### PR DESCRIPTION
## Summary
- `submit`'s stack-display loop called `GetWorktreeForStack` once per branch to populate the worktree map. Each call reads a git ref plus a blob, so every branch sharing a stack root repeated the identical lookup — an N+1 for any stack with a managed worktree.
- List managed worktrees once up front and index by stack root (`AnchorBranch`), then do an O(1) map lookup per branch instead. This mirrors the `GetWorktreeData`/`WorktreeByStackRoot` pattern already used in `internal/tui/tree_renderer.go` for the same problem.
- Behavior-preserving: same data is produced, just without the redundant subprocess spawns.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/actions/submit/...`
- [x] `go test ./internal/actions/submit/...`
- [x] `go test ./internal/integration/... -run TestWorktree` (covers `submit` + managed-worktree interaction)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SeYqMTTxR125xuFDQ38vHZ)_