### PR TITLE
fix(info): restore trunk styling on the Parent and Children lines

### DIFF
--- a/internal/actions/info.go
+++ b/internal/actions/info.go
@@ -29,16 +29,19 @@ type BranchDiffStats struct {
 
 // BranchInfoResult contains structured data for `stackit info` on a single branch.
 type BranchInfoResult struct {
-	Name             string
-	IsCurrent        bool
-	IsTrunk          bool
-	IsLocked         bool
-	IsFrozen         bool
-	NeedsRestack     bool
-	Scope            string
-	CommitDate       string
-	Parent           string
-	Children         []string
+	Name         string
+	IsCurrent    bool
+	IsTrunk      bool
+	IsLocked     bool
+	IsFrozen     bool
+	NeedsRestack bool
+	Scope        string
+	CommitDate   string
+	Parent       string
+	Children     []string
+	// Trunk is the repository's trunk branch name, so renderers can style a
+	// trunk parent or child without re-resolving it from the engine.
+	Trunk            string
 	PR               *BranchInfoPR
 	CommitMessages   []string
 	DiffStats        BranchDiffStats
@@ -102,6 +105,7 @@ func buildBranchInfoResult(ctx context.Context, eng engine.Engine, branchName st
 		IsFrozen:       branch.IsFrozen(),
 		NeedsRestack:   !isTrunk && !branch.IsBranchUpToDate(),
 		Scope:          branch.GetScope().String(),
+		Trunk:          eng.Trunk().GetName(),
 		CommitMessages: []string{},
 		Children:       []string{},
 	}

--- a/internal/actions/info_test.go
+++ b/internal/actions/info_test.go
@@ -71,6 +71,9 @@ func TestQueryBranchInfo(t *testing.T) {
 		require.False(t, info.IsTrunk)
 		require.Equal(t, "PROJ-123", info.Scope)
 		require.Equal(t, "main", info.Parent)
+		// Renderers need the trunk name to style a trunk parent; resolving it
+		// again from the engine is not their job.
+		require.Equal(t, "main", info.Trunk)
 		require.Contains(t, info.Children, "child")
 		require.Contains(t, strings.Join(info.CommitMessages, "\n"), "feature change")
 		require.GreaterOrEqual(t, info.DiffStats.FilesChanged, 1)
@@ -94,6 +97,28 @@ func TestQueryBranchInfo(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, info.PatchOutput)
 		require.Empty(t, info.DiffOutput)
+	})
+
+	// GetScope resolves the inheritance-breaking sentinel ("none"/"clear") to an
+	// empty scope, so the sentinel never reaches a consumer as a scope name.
+	// This is why the renderer can gate purely on Scope being non-empty.
+	t.Run("resolves the inheritance-breaking scope sentinel to empty", func(t *testing.T) {
+		s := scenario.NewScenario(t, testhelpers.InitialCommitSceneSetup)
+
+		require.NoError(t, s.Scene.Repo.CreateAndCheckoutBranch("feature"))
+		require.NoError(t, s.Scene.Repo.CreateChange("feature change", "feature.txt", false))
+		require.NoError(t, s.Scene.Repo.RunGitCommand("add", "."))
+		require.NoError(t, s.Scene.Repo.RunGitCommand("commit", "-m", "feature change"))
+		s.Rebuild()
+		require.NoError(t, s.Engine.TrackBranch(context.Background(), "feature", "main"))
+		require.NoError(t, s.Engine.SetScope(context.Background(), s.Engine.GetBranch("feature"), engine.None()))
+
+		info, err := QueryBranchInfo(context.Background(), s.Engine, BranchInfoQueryOptions{
+			BranchName: "feature",
+		}, nil)
+		require.NoError(t, err)
+
+		require.Empty(t, info.Scope, "the sentinel is a directive, not a scope name")
 	})
 
 	t.Run("errors for a missing branch", func(t *testing.T) {

--- a/internal/cli/info_render.go
+++ b/internal/cli/info_render.go
@@ -88,15 +88,17 @@ func renderBranchInfoText(info actions.BranchInfoResult, opts branchInfoRenderOp
 		}
 	}
 
+	isTrunkName := func(name string) bool { return info.Trunk != "" && name == info.Trunk }
+
 	if info.Parent != "" {
 		outputLines = append(outputLines, "")
-		outputLines = append(outputLines, fmt.Sprintf("%s: %s", style.ColorCyan("Parent"), style.ColorBranchNameWithTrunk(info.Parent, false, false)))
+		outputLines = append(outputLines, fmt.Sprintf("%s: %s", style.ColorCyan("Parent"), style.ColorBranchNameWithTrunk(info.Parent, false, isTrunkName(info.Parent))))
 	}
 
 	if len(info.Children) > 0 {
 		outputLines = append(outputLines, fmt.Sprintf("%s:", style.ColorCyan("Children")))
 		for _, child := range info.Children {
-			outputLines = append(outputLines, fmt.Sprintf("▸ %s", style.ColorBranchNameWithTrunk(child, false, false)))
+			outputLines = append(outputLines, fmt.Sprintf("▸ %s", style.ColorBranchNameWithTrunk(child, false, isTrunkName(child))))
 		}
 	}
 

--- a/internal/cli/info_test.go
+++ b/internal/cli/info_test.go
@@ -371,4 +371,27 @@ func TestInfoCommand(t *testing.T) {
 		require.NoError(t, err, "info command failed: %s", output)
 		require.Contains(t, output, "\"scope\": \"api\"")
 	})
+
+	t.Run("info shows no scope tag for the inheritance-breaking sentinel", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.InitialCommitSceneSetup).WithInProcess(true)
+
+		if err := s.Scene.Repo.CreateChange("feature change", "test", false); err != nil {
+			t.Fatal(err)
+		}
+		s.RunCli("create", "feature", "-m", "feature change")
+		// Documented usage: "Use 'none' or 'clear' as the scope name to
+		// explicitly break the inheritance chain."
+		s.RunCli("scope", "none")
+
+		output, err := s.RunCliAndGetOutput("info")
+		require.NoError(t, err, "info command failed: %s", output)
+		require.NotContains(t, output, "[none]", "the sentinel is a directive, not a scope tag")
+
+		// GetScope resolves the sentinel to empty, so it never surfaces as a
+		// scope name in either rendering.
+		jsonOutput, err := s.RunCliAndGetOutput("info", "--json")
+		require.NoError(t, err, "info command failed: %s", jsonOutput)
+		require.Contains(t, jsonOutput, "\"scope\": \"\"")
+	})
 }


### PR DESCRIPTION

The info query/render split flattened parent and child branches to plain
strings, so the renderer had no is-trunk flag left to pass and hardcoded false.
A trunk parent -- the common case for a branch stacked directly on main --
rendered in the ordinary branch color instead of the trunk color.

Carrying the trunk name on the result restores it for both lines without the
renderer reaching back into the engine.

Also pins the scope sentinel behavior while here. GetScope already resolves
"none"/"clear" to an empty scope, so the sentinel never reaches a renderer as a
scope name -- the pre-split IsNone check was dead code and the current
non-empty gate is equivalent. Worth a test so a future reader does not
rediscover that the hard way.