### PR TITLE
feat(cli): add a direct pull-request opener

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ stack-submit --stack         # Creates/updates all PRs in the stack
 | `stackit children` | Show the children of the current branch |
 | `stackit parent` | Show the parent of the current branch |
 | `stackit share` | Print the current stack as Slack-ready markdown for copy-paste |
+| `stackit pr [branch|number]` | Open a pull request in the default browser (`--stack` for the stack's root PR) |
 
 ### Branch Management
 | Command | Description |

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -1,0 +1,100 @@
+package actions
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/utils"
+)
+
+// OpenPROptions configures which pull request to open.
+type OpenPROptions struct {
+	// Target is a branch name or PR number from the command line. Empty means
+	// the current branch.
+	Target string
+	// Stack opens the root PR of the target's stack instead of the target
+	// branch's own PR.
+	Stack bool
+}
+
+// OpenPRAction resolves the pull request opts identifies and opens it in the
+// default browser.
+func OpenPRAction(ctx *app.Context, opts OpenPROptions) error {
+	eng := ctx.Engine
+
+	branchName, err := resolvePRBranch(eng, opts.Target)
+	if err != nil {
+		return err
+	}
+
+	if opts.Stack {
+		if root := eng.GetStackRootForBranch(eng.GetBranch(branchName)); root != "" {
+			branchName = root
+		}
+	}
+
+	prInfo, err := eng.GetBranch(branchName).GetPrInfo()
+	if err != nil {
+		return fmt.Errorf("reading pull request info for %q: %w", branchName, err)
+	}
+	if prInfo == nil || prInfo.URL() == "" {
+		return fmt.Errorf("%q has no associated pull request; run 'stackit submit' first", branchName)
+	}
+
+	ctx.Output.Info("Opening %s", prInfo.URL())
+	// Best-effort: environments without a browser (SSH, headless CI) still get
+	// the URL printed above, mirroring submit's --web behavior.
+	if err := utils.OpenBrowser(prInfo.URL()); err != nil {
+		ctx.Output.Debug("Failed to open browser: %v", err)
+	}
+	return nil
+}
+
+// resolvePRBranch turns target into a branch name. An empty target resolves to
+// the current branch; a numeric target resolves to whichever tracked branch
+// has that PR number; anything else is used as a branch name directly.
+func resolvePRBranch(eng engine.Engine, target string) (string, error) {
+	if target == "" {
+		current := eng.CurrentBranch()
+		if current == nil {
+			return "", errors.ErrNotOnBranch
+		}
+		return current.GetName(), nil
+	}
+
+	number, convErr := strconv.Atoi(target)
+	if convErr != nil {
+		if !eng.BranchNames().Contains(target) {
+			return "", fmt.Errorf("branch %q not found: %w", target, errors.ErrBranchNotFound)
+		}
+		return target, nil
+	}
+
+	branchName, found := findBranchByPRNumber(eng, number)
+	if !found {
+		return "", fmt.Errorf("no tracked branch found for pull request #%d", number)
+	}
+	return branchName, nil
+}
+
+// findBranchByPRNumber searches tracked branches for the one whose recorded PR
+// number matches number, reading all metadata in a single batched pass rather
+// than once per branch.
+func findBranchByPRNumber(eng engine.Engine, number int) (string, bool) {
+	branchNames := eng.AllBranches().Names()
+	metas, _ := eng.BatchReadMetadataRaw(branchNames)
+	for _, name := range branchNames {
+		meta := metas[name]
+		if meta == nil {
+			continue
+		}
+		prInfo := meta.GetPrInfo()
+		if prInfo != nil && prInfo.Number != nil && *prInfo.Number == number {
+			return name, true
+		}
+	}
+	return "", false
+}

--- a/internal/cli/navigation/pr.go
+++ b/internal/cli/navigation/pr.go
@@ -1,0 +1,48 @@
+package navigation
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+)
+
+// NewPrCmd creates the pr command.
+func NewPrCmd() *cobra.Command {
+	var stack bool
+
+	cmd := &cobra.Command{
+		Use:   "pr [branch|number]",
+		Short: "Open a pull request in the default browser",
+		Long: `Open the pull request for a branch in the default browser.
+
+With no argument, opens the current branch's pull request. Accepts either a
+branch name or a pull-request number. Use --stack to open the root pull
+request of the stack instead of the target branch's own pull request.
+
+Examples:
+  stackit pr                  # Open the current branch's PR
+  stackit pr feature-x        # Open feature-x's PR
+  stackit pr 1234             # Open PR #1234
+  stackit pr --stack          # Open the root PR of the current stack`,
+		SilenceUsage: true,
+		Args:         cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return common.RunReadOnlyCurrentBranch(cmd, func(ctx *app.Context) error {
+				target := ""
+				if len(args) > 0 {
+					target = args[0]
+				}
+				return actions.OpenPRAction(ctx, actions.OpenPROptions{
+					Target: target,
+					Stack:  stack,
+				})
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&stack, "stack", false, "Open the root pull request of the current stack")
+
+	return cmd
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -114,6 +114,7 @@ Commit:  ` + commit + `
 	rootCmd.AddCommand(stack.NewMoveCmd())
 	rootCmd.AddCommand(navigation.NewParentCmd())
 	rootCmd.AddCommand(branch.NewPopCmd())
+	rootCmd.AddCommand(navigation.NewPrCmd())
 	rootCmd.AddCommand(stack.NewPluckCmd())
 	rootCmd.AddCommand(newRebaseCmd())
 	rootCmd.AddCommand(branch.NewRenameCmd())

--- a/internal/integration/pr_test.go
+++ b/internal/integration/pr_test.go
@@ -1,0 +1,81 @@
+package integration
+
+import (
+	"testing"
+)
+
+// TestPrCommand verifies that `stackit pr` resolves and prints the URL of the
+// relevant pull request for the current branch, an explicit branch, a PR
+// number, or the root of the current stack.
+func TestPrCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("opens the current branch's PR", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("a", "content a").Run("create branch-a -m 'feat: a'")
+		sh.SetPrMetadata("branch-a", PRMetadata{Number: 42, URL: "https://github.com/owner/repo/pull/42"})
+
+		sh.Run("pr").OutputContains("https://github.com/owner/repo/pull/42")
+	})
+
+	t.Run("opens a PR by branch name", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("a", "content a").Run("create branch-a -m 'feat: a'")
+		sh.SetPrMetadata("branch-a", PRMetadata{Number: 42, URL: "https://github.com/owner/repo/pull/42"})
+		sh.Checkout("main")
+
+		sh.Run("pr branch-a").OutputContains("https://github.com/owner/repo/pull/42")
+	})
+
+	t.Run("opens a PR by number", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("a", "content a").Run("create branch-a -m 'feat: a'")
+		sh.SetPrMetadata("branch-a", PRMetadata{Number: 42, URL: "https://github.com/owner/repo/pull/42"})
+		sh.Checkout("main")
+
+		sh.Run("pr 42").OutputContains("https://github.com/owner/repo/pull/42")
+	})
+
+	t.Run("--stack opens the root PR of the stack", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// main -> a -> b -> c, currently on c.
+		sh.CreateLinearStack3()
+		sh.SetPrMetadata("a", PRMetadata{Number: 1, URL: "https://github.com/owner/repo/pull/1"})
+		sh.SetPrMetadata("c", PRMetadata{Number: 3, URL: "https://github.com/owner/repo/pull/3"})
+
+		sh.Run("pr --stack").
+			OutputContains("https://github.com/owner/repo/pull/1").
+			OutputNotContains("https://github.com/owner/repo/pull/3")
+	})
+
+	t.Run("errors when the branch has no PR", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("a", "content a").Run("create branch-a -m 'feat: a'")
+
+		sh.RunExpectError("pr").OutputContains("no associated pull request")
+	})
+
+	t.Run("errors for an unknown branch", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.RunExpectError("pr does-not-exist").OutputContains("not found")
+	})
+
+	t.Run("errors for an unknown PR number", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.RunExpectError("pr 999").OutputContains("no tracked branch found")
+	})
+}


### PR DESCRIPTION
## Summary

Adds `stackit pr [branch|number] [--stack]` to open the relevant pull request in the default browser, per #1470.

- With no argument, opens the current branch's PR (via `RunReadOnlyCurrentBranch`, so it's cheap — no full metadata bootstrap).
- Accepts either a branch name or a PR number. A numeric argument is resolved against tracked branches' recorded PR numbers via a single batched metadata read (`BatchReadMetadataRaw`), not a per-branch lookup.
- `--stack` opens the root PR of the current stack, using the existing `GetStackRootForBranch` engine helper.
- Gives an actionable error when the target has no associated PR (`run 'stackit submit' first`) or the branch/PR number doesn't resolve.
- Doesn't require a TTY: the URL is always printed first, and a failure to launch a browser (e.g. over SSH, headless CI) is logged at debug level rather than failing the command — mirroring the existing `submit --web` behavior in `internal/actions/submit/submit.go`.

## Implementation notes

- `internal/actions/pr.go` — new `OpenPRAction`/`OpenPROptions`, following the same shape as the existing `ShareAction` (`internal/actions/share.go`).
- `internal/cli/navigation/pr.go` — new `NewPrCmd()`, registered in `internal/cli/root.go` alongside the other navigation commands.
- Reuses `internal/utils.OpenBrowser` (already used by `submit`), `engine.GetStackRootForBranch`, and `Branch.GetPrInfo()` — no new engine surface needed.
- README Navigation table updated with the new command.

## Test plan

- [x] `go build ./...`
- [x] `go vet` + `gofmt -l` on changed files (clean)
- [x] New integration tests in `internal/integration/pr_test.go`: current-branch PR, PR by branch name, PR by PR number, `--stack` root resolution, no-PR error, unknown-branch error, unknown-PR-number error — all passing
- [x] Full `internal/actions/...` and `internal/cli/...` package tests passing
- [x] Full `internal/integration/...` suite passing (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_011CgsKcS8AWhqjvt5XsVqcU)_