### PR TITLE
feat(modify): modify a downstack branch directly

### DIFF
--- a/internal/actions/modify.go
+++ b/internal/actions/modify.go
@@ -1,11 +1,13 @@
 package actions
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/getstackit/stackit/internal/actions/validation"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/utils"
@@ -28,10 +30,14 @@ type ModifyOptions struct {
 
 	// Interactive rebase
 	InteractiveRebase bool // Start interactive rebase on branch commits
+
+	// Into targets a downstack ancestor of the current branch instead of the
+	// current branch itself. Empty means "modify the current branch".
+	Into string
 }
 
 // ModifyAction performs the modify operation
-func ModifyAction(ctx *app.Context, opts ModifyOptions) error {
+func ModifyAction(ctx *app.Context, opts ModifyOptions) (err error) {
 	eng := ctx.Engine
 	out := ctx.Output
 	gctx := ctx.Context
@@ -40,8 +46,23 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) error {
 	if err := validation.ModifyBranchChain(eng, "modify").Validate(); err != nil {
 		return err
 	}
-	currentBranch := eng.CurrentBranch().GetName()
-	currentBranchObj := eng.GetBranch(currentBranch)
+	originalBranchName := eng.CurrentBranch().GetName()
+
+	if opts.Into != "" && opts.InteractiveRebase {
+		return fmt.Errorf("--into cannot be combined with --interactive-rebase")
+	}
+
+	targetBranchName := originalBranchName
+	if opts.Into != "" {
+		if err := validateModifyIntoTarget(eng, originalBranchName, opts.Into); err != nil {
+			return err
+		}
+		if err := ensureModifyTargetNotCheckedOutElsewhere(gctx, eng, opts.Into); err != nil {
+			return err
+		}
+		targetBranchName = opts.Into
+	}
+	targetBranchObj := eng.GetBranch(targetBranchName)
 
 	// Handle interactive rebase separately
 	if opts.InteractiveRebase {
@@ -53,9 +74,29 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) error {
 		return err
 	}
 
+	if targetBranchName != originalBranchName {
+		if err := eng.CheckoutBranch(gctx, targetBranchObj); err != nil {
+			return fmt.Errorf("failed to checkout %s: %w", targetBranchName, err)
+		}
+		out.Info("Modifying downstack branch %s.", output.CurrentBranch(targetBranchName))
+		defer func() {
+			// A conflict workflow deliberately leaves HEAD detached (see
+			// EnterConflictWorkflow); forcing a checkout back here would
+			// defeat that safety measure. `stackit continue`/`abort` own
+			// recovery from that state instead.
+			var conflictErr *errors.ConflictWorkflowError
+			if errors.As(err, &conflictErr) {
+				return
+			}
+			if checkoutErr := eng.CheckoutBranch(gctx, eng.GetBranch(originalBranchName)); checkoutErr != nil {
+				out.Error("Failed to return to %s: %v", originalBranchName, checkoutErr)
+			}
+		}()
+	}
+
 	// Check if branch is empty when amending
 	if !opts.CreateCommit {
-		isEmpty, err := eng.IsBranchEmpty(gctx, currentBranch)
+		isEmpty, err := eng.IsBranchEmpty(gctx, targetBranchName)
 		if err != nil {
 			return fmt.Errorf("failed to check if branch is empty: %w", err)
 		}
@@ -121,14 +162,15 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) error {
 
 	// Log success
 	if opts.CreateCommit {
-		out.Info("Created new commit in %s.", output.CurrentBranch(currentBranch))
+		out.Info("Created new commit in %s.", output.CurrentBranch(targetBranchName))
 	} else {
-		out.Info("Amended commit in %s.", output.CurrentBranch(currentBranch))
+		out.Info("Amended commit in %s.", output.CurrentBranch(targetBranchName))
 	}
 
-	// Restack upstack branches
+	// Restack upstack branches (rooted at the target so descendants of a
+	// downstack --into target, including the original current branch, are covered)
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
-	upstackBranches := graph.Range(currentBranchObj, engine.StackRange{RecursiveChildren: true})
+	upstackBranches := graph.Range(targetBranchObj, engine.StackRange{RecursiveChildren: true})
 
 	if len(upstackBranches) > 0 {
 		out.Info("Restacking %d upstack branch(es)...", len(upstackBranches))
@@ -137,6 +179,46 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) error {
 		}
 	}
 
+	return nil
+}
+
+// validateModifyIntoTarget ensures --into targets a genuine, modifiable
+// downstack ancestor of the current branch.
+func validateModifyIntoTarget(eng engine.Engine, currentBranchName, targetName string) error {
+	if !eng.BranchNames().Contains(targetName) {
+		return fmt.Errorf("branch %s does not exist", targetName)
+	}
+	if targetName == currentBranchName {
+		return fmt.Errorf("--into %s is the current branch; run modify without --into instead", targetName)
+	}
+
+	if err := (validation.Chain{
+		validation.BranchMustNotBeTrunk(eng, targetName),
+		validation.BranchMustBeTracked(eng, targetName),
+		validation.BranchMustBeModifiable(eng, targetName),
+	}).Validate(); err != nil {
+		return err
+	}
+
+	graph := eng.Graph(engine.SortStrategyAlphabetical)
+	downstack := graph.Downstack(eng.GetBranch(currentBranchName), false)
+	if !downstack.Contains(targetName) {
+		return fmt.Errorf("branch %s is not a downstack ancestor of %s", targetName, currentBranchName)
+	}
+	return nil
+}
+
+// ensureModifyTargetNotCheckedOutElsewhere refuses to modify a branch that is
+// checked out in another worktree, pointing the user at that worktree instead
+// of silently detaching HEAD there (which is what a plain CheckoutBranch would do).
+func ensureModifyTargetNotCheckedOutElsewhere(ctx context.Context, eng engine.Engine, targetName string) error {
+	worktrees, err := eng.ListWorktrees(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check worktrees: %w", err)
+	}
+	if path := worktrees.PathForBranch(targetName); path != "" {
+		return fmt.Errorf("branch %s is checked out in worktree %s; run 'stackit modify' from there, or 'cd %s && stackit modify'", targetName, path, path)
+	}
 	return nil
 }
 

--- a/internal/cli/branch/modify.go
+++ b/internal/cli/branch/modify.go
@@ -16,6 +16,7 @@ func NewModifyCmd() *cobra.Command {
 		commit            bool
 		edit              bool
 		interactiveRebase bool
+		into              string
 		message           string
 		messageFile       string
 		noEdit            bool
@@ -40,7 +41,8 @@ Examples:
   stackit modify -a -e                    # Stage all and amend (opens editor)
   stackit modify -p                       # Interactive patch staging then amend
   stackit modify -c -a -m "New commit"    # Create new commit instead of amending
-  stackit modify --interactive-rebase     # Interactive rebase on branch commits`,
+  stackit modify --interactive-rebase     # Interactive rebase on branch commits
+  stackit modify -a --into feature-a      # Amend a downstack ancestor without checking it out`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
@@ -64,6 +66,7 @@ Examples:
 					ResetAuthor:       resetAuthor,
 					Verbose:           verbose,
 					InteractiveRebase: interactiveRebase,
+					Into:              into,
 				})
 			})
 		},
@@ -74,6 +77,7 @@ Examples:
 	cmd.Flags().BoolVarP(&commit, "commit", "c", false, "Create a new commit instead of amending the current commit. If this branch has no commits, this command always creates a new commit.")
 	cmd.Flags().BoolVarP(&edit, "edit", "e", false, "Open an editor to edit the commit message.")
 	cmd.Flags().BoolVar(&interactiveRebase, "interactive-rebase", false, "Ignore all other flags and start a git interactive rebase on the commits in this branch.")
+	cmd.Flags().StringVar(&into, "into", "", "Modify a downstack ancestor branch instead of the current branch, without checking it out first.")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "The message for the new or amended commit. If passed, no editor is opened.")
 	cmd.Flags().StringVarP(&messageFile, "message-file", "F", "", "Read commit message from a file (use \"-\" for stdin). Mutually exclusive with --message.")
 	cmd.Flags().BoolVarP(&noEdit, "no-edit", "n", false, "Don't modify the existing commit message. Takes precedence over --edit.")
@@ -81,6 +85,8 @@ Examples:
 	cmd.Flags().BoolVar(&resetAuthor, "reset-author", false, "Set the author of the commit to the current user if amending.")
 	cmd.Flags().BoolVarP(&update, "update", "u", false, "Stage all updates to tracked files before committing.")
 	cmd.Flags().CountVarP(&verbose, "verbose", "v", "Show unified diff between the HEAD commit and what would be committed at the bottom of the commit message template.")
+
+	_ = cmd.RegisterFlagCompletionFunc("into", common.CompleteBranches)
 
 	return cmd
 }

--- a/internal/integration/modify_test.go
+++ b/internal/integration/modify_test.go
@@ -98,3 +98,97 @@ func TestModifyWorkflow(t *testing.T) {
 		sh.Checkout("feature-c").Run("info").OutputContains("feature-c")
 	})
 }
+
+func TestModifyInto(t *testing.T) {
+	t.Parallel()
+
+	t.Run("amends a downstack ancestor without checking it out, then returns", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3().
+			OnBranch("c")
+
+		sh.Write("a_extra", "extra content for a").
+			Run("modify --into a -n").
+			OutputContains("Modifying downstack branch a").
+			OutputContains("Amended commit in a").
+			OutputContains("Restacking").
+			OnBranch("c")
+
+		sh.Git("show a:a_extra_test.txt").
+			OutputContains("extra content for a")
+
+		sh.Checkout("b").Run("info").OutputContains("b")
+		sh.Checkout("c").Run("info").OutputContains("c")
+	})
+
+	t.Run("with --commit creates a new commit on the target and restacks", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3().
+			OnBranch("c").
+			CommitCount("main", "a", 1)
+
+		sh.Write("a_extra", "extra content").
+			Run("modify --into a -c -m 'Additional work on A'").
+			OutputContains("Created new commit in a").
+			CommitCount("main", "a", 2).
+			OnBranch("c")
+	})
+
+	t.Run("refuses a target that is not a downstack ancestor", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateDiamondStack().
+			OnBranch("child2")
+
+		sh.Write("extra", "extra content").
+			RunExpectError("modify --into child1 -n").
+			OutputContains("not a downstack ancestor")
+	})
+
+	t.Run("refuses the current branch itself", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3().
+			OnBranch("c")
+
+		sh.Write("extra", "extra content").
+			RunExpectError("modify --into c -n").
+			OutputContains("is the current branch")
+	})
+
+	t.Run("refuses a nonexistent branch", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3().
+			OnBranch("c")
+
+		sh.Write("extra", "extra content").
+			RunExpectError("modify --into does-not-exist -n").
+			OutputContains("does not exist")
+	})
+
+	t.Run("refuses a target checked out in another worktree", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3().
+			OnBranch("c")
+
+		worktreeDir := t.TempDir()
+		sh.Git("worktree add " + worktreeDir + " a")
+
+		sh.Write("extra", "extra content").
+			RunExpectError("modify --into a -n").
+			OutputContains("checked out in worktree").
+			OutputContains(worktreeDir)
+
+		sh.OnBranch("c")
+	})
+}


### PR DESCRIPTION
## Summary

Adds `stackit modify --into <branch>` so a small fix for review feedback on a downstack (ancestor) branch can be amended without first checking that branch out.

Closes #1472

## What changed

- `internal/actions/modify.go`: `ModifyOptions` gains an `Into` field. When set, `ModifyAction`:
  - validates the target is a tracked, modifiable, non-trunk branch that is a genuine downstack ancestor of the current branch (`validateModifyIntoTarget`, using the stack graph's `Downstack` traversal — not commit-ancestry, which can differ from metadata after manual git operations),
  - refuses a target already checked out in another worktree, pointing at that worktree's path instead of silently detaching HEAD there (`ensureModifyTargetNotCheckedOutElsewhere`) — this is the "no detached HEAD" safety invariant applied to a case that `Engine.CheckoutBranch` alone doesn't cover (it would otherwise fall back to a detached checkout),
  - checks out the target, performs the existing staging/message/edit/new-commit behavior unchanged, then restacks upstack from the target (which covers the original branch and its descendants too),
  - returns to the original branch afterward — unless restacking entered the conflict workflow, in which case the intentional detached-HEAD state is left alone for `stackit continue`/`stackit abort` to own, matching `EnterConflictWorkflow`'s existing invariant.
  - `--into` is rejected together with `--interactive-rebase` (that path only operates on the current branch).
- `internal/cli/branch/modify.go`: adds the `--into` flag (with branch-name completion) and an example line.
- `internal/integration/modify_test.go`: adds `TestModifyInto` covering amend-in-place, `--commit`, the not-a-downstack-ancestor rejection, targeting the current branch itself, a nonexistent branch, and a target checked out in another worktree.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/actions/... ./internal/cli/... ./internal/integration/...` (plus full `go test ./internal/...`; one pre-existing, unrelated failure in `internal/git` — `TestGetRepoInfo/parses_HTTPS_URL` — reproduces identically on `main` and is unrelated to this change)
- [x] `gofmt -l` clean on touched files
- (golangci-lint could not run in this sandbox — the pinned binary was built with go1.25 and this repo now targets go1.26; unrelated to this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MW97Jj1mmwmf78BAWYnH2N)_