### PR TITLE
feat(cli): add `stackit pr` to open a pull request in the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ stack-submit --stack         # Creates/updates all PRs in the stack
 | `stackit children` | Show the children of the current branch |
 | `stackit parent` | Show the parent of the current branch |
 | `stackit share` | Print the current stack as Slack-ready markdown for copy-paste |
+| `stackit pr [branch\|PR]` | Open a pull request in the default browser (`--stack` opens the root PR of the stack) |
 
 ### Branch Management
 | Command | Description |

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -1,0 +1,76 @@
+package actions
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/utils"
+)
+
+// PROptions configures PRAction.
+type PROptions struct {
+	// Stack opens the root pull request of the stack (the branch directly
+	// above trunk) instead of the resolved branch's own pull request.
+	Stack bool
+}
+
+// PRAction resolves branchOrPR to a pull request URL and opens it in the
+// default browser. branchOrPR may be a branch name, a PR number, or empty
+// (defaults to the current branch).
+func PRAction(ctx *app.Context, branchOrPR string, opts PROptions) error {
+	eng := ctx.Engine
+
+	targetBranch, prURL, err := resolvePRTarget(ctx, branchOrPR)
+	if err != nil {
+		return err
+	}
+
+	if opts.Stack {
+		if rootBranch := shareStackBase(eng, targetBranch); rootBranch != targetBranch {
+			targetBranch = rootBranch
+			prURL = ""
+		}
+	}
+
+	if prURL == "" {
+		prInfo, infoErr := eng.GetBranch(targetBranch).GetPrInfo()
+		if infoErr != nil || prInfo == nil || prInfo.URL() == "" {
+			return fmt.Errorf("branch %q has no associated pull request; run `stackit submit` first", targetBranch)
+		}
+		prURL = prInfo.URL()
+	}
+
+	if err := utils.OpenBrowser(prURL); err != nil {
+		return fmt.Errorf("failed to open %s in the browser: %w", prURL, err)
+	}
+
+	ctx.Output.Info("Opened %s", prURL)
+	return nil
+}
+
+// resolvePRTarget resolves branchOrPR to a branch name. When branchOrPR is a
+// PR number, it also returns the PR's URL directly from GitHub so callers
+// don't need local metadata for a branch that may not be tracked.
+func resolvePRTarget(ctx *app.Context, branchOrPR string) (branchName, prURL string, err error) {
+	if branchOrPR == "" {
+		name, err := ResolveBranchName(ctx.Engine, "")
+		return name, "", err
+	}
+
+	prNum, convErr := strconv.Atoi(branchOrPR)
+	if convErr != nil {
+		return branchOrPR, "", nil
+	}
+
+	if _, err := ctx.RequireGitHub(); err != nil {
+		return "", "", fmt.Errorf("cannot resolve PR #%d: %w", prNum, err)
+	}
+	remoteCtx, cancel := ctx.RemoteOperationContext()
+	defer cancel()
+	pr, err := ctx.GitHub().GetPullRequest(remoteCtx, prNum)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get PR #%d: %w", prNum, err)
+	}
+	return pr.Head, pr.HTMLURL, nil
+}

--- a/internal/actions/pr_test.go
+++ b/internal/actions/pr_test.go
@@ -1,0 +1,112 @@
+package actions_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-github/v89/github"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/utils"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// withCapturedBrowser overrides utils.OpenBrowser for the duration of a test
+// so PRAction doesn't shell out to a real browser launcher. It returns a
+// pointer to the URL that was "opened".
+func withCapturedBrowser(t *testing.T) *string {
+	t.Helper()
+	opened := new(string)
+	orig := utils.OpenBrowser
+	utils.OpenBrowser = func(url string) error {
+		*opened = url
+		return nil
+	}
+	t.Cleanup(func() { utils.OpenBrowser = orig })
+	return opened
+}
+
+// Subtests below intentionally don't call t.Parallel(): they all override the
+// package-level utils.OpenBrowser var via withCapturedBrowser, which would
+// race if they ran concurrently.
+func TestPRAction(t *testing.T) {
+	t.Parallel()
+
+	t.Run("opens the current branch's PR when no argument given", func(t *testing.T) {
+		opened := withCapturedBrowser(t)
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithLinearStack3().Checkout("b")
+
+		err := s.Engine.UpsertPrInfo(context.Background(), s.Engine.GetBranch("b"), testhelpers.NewTestPrInfoFull(2, "", "", "OPEN", "a", "https://github.com/o/r/pull/2", false))
+		require.NoError(t, err)
+
+		require.NoError(t, actions.PRAction(s.Context, "", actions.PROptions{}))
+		require.Equal(t, "https://github.com/o/r/pull/2", *opened)
+	})
+
+	t.Run("opens an explicit branch's PR", func(t *testing.T) {
+		opened := withCapturedBrowser(t)
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithLinearStack3().Checkout("c")
+
+		err := s.Engine.UpsertPrInfo(context.Background(), s.Engine.GetBranch("a"), testhelpers.NewTestPrInfoFull(1, "", "", "OPEN", "main", "https://github.com/o/r/pull/1", false))
+		require.NoError(t, err)
+
+		require.NoError(t, actions.PRAction(s.Context, "a", actions.PROptions{}))
+		require.Equal(t, "https://github.com/o/r/pull/1", *opened)
+	})
+
+	t.Run("errors with an actionable message when the branch has no PR", func(t *testing.T) {
+		withCapturedBrowser(t)
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithLinearStack3().Checkout("b")
+
+		err := actions.PRAction(s.Context, "", actions.PROptions{})
+		require.ErrorContains(t, err, `"b" has no associated pull request`)
+		require.ErrorContains(t, err, "stackit submit")
+	})
+
+	t.Run("--stack opens the root PR of the stack", func(t *testing.T) {
+		opened := withCapturedBrowser(t)
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithLinearStack3().Checkout("c")
+
+		err := s.Engine.UpsertPrInfo(context.Background(), s.Engine.GetBranch("a"), testhelpers.NewTestPrInfoFull(1, "", "", "OPEN", "main", "https://github.com/o/r/pull/1", false))
+		require.NoError(t, err)
+
+		require.NoError(t, actions.PRAction(s.Context, "c", actions.PROptions{Stack: true}))
+		require.Equal(t, "https://github.com/o/r/pull/1", *opened)
+	})
+
+	t.Run("resolves a PR number directly from GitHub", func(t *testing.T) {
+		opened := withCapturedBrowser(t)
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+
+		ghConfig := testhelpers.NewMockGitHubServerConfig()
+		pr := &github.PullRequest{
+			Number:  new(123),
+			Head:    &github.PullRequestBranch{Ref: new("feature-a")},
+			Base:    &github.PullRequestBranch{Ref: new("main")},
+			Title:   new("Feature A"),
+			HTMLURL: new("https://github.com/o/r/pull/123"),
+		}
+		ghConfig.CreatedPRs = append(ghConfig.CreatedPRs, pr)
+		ghClient, owner, repo := testhelpers.NewMockGitHubClient(t, ghConfig)
+		s.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(ghClient, owner, repo, ghConfig)
+
+		require.NoError(t, actions.PRAction(s.Context, "123", actions.PROptions{}))
+		require.Equal(t, "https://github.com/o/r/pull/123", *opened)
+	})
+
+	t.Run("errors when resolving a PR number without a GitHub client", func(t *testing.T) {
+		withCapturedBrowser(t)
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+
+		err := actions.PRAction(s.Context, "123", actions.PROptions{})
+		require.ErrorContains(t, err, "cannot resolve PR #123")
+	})
+}

--- a/internal/cli/navigation/pr.go
+++ b/internal/cli/navigation/pr.go
@@ -1,0 +1,47 @@
+package navigation
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+)
+
+// NewPRCmd creates the pr command.
+func NewPRCmd() *cobra.Command {
+	var stack bool
+
+	cmd := &cobra.Command{
+		Use:   "pr [branch|PR]",
+		Short: "Open a pull request in the default browser",
+		Long: `Open the pull request for a branch or PR number in the default browser.
+
+With no argument, opens the current branch's pull request. Accepts either a
+branch name or a pull request number.
+
+Examples:
+  stackit pr                # Open the current branch's pull request
+  stackit pr feature-x      # Open the pull request for branch feature-x
+  stackit pr 1234           # Open pull request #1234
+  stackit pr --stack        # Open the root pull request of the current stack`,
+		SilenceUsage: true,
+		Args:         cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return common.Run(cmd, func(ctx *app.Context) error {
+				branchOrPR := ""
+				if len(args) > 0 {
+					branchOrPR = args[0]
+				}
+
+				return actions.PRAction(ctx, branchOrPR, actions.PROptions{
+					Stack: stack,
+				})
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&stack, "stack", false, "Open the root pull request of the stack instead of the resolved branch's own pull request")
+
+	return cmd
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -114,6 +114,7 @@ Commit:  ` + commit + `
 	rootCmd.AddCommand(stack.NewMoveCmd())
 	rootCmd.AddCommand(navigation.NewParentCmd())
 	rootCmd.AddCommand(branch.NewPopCmd())
+	rootCmd.AddCommand(navigation.NewPRCmd())
 	rootCmd.AddCommand(stack.NewPluckCmd())
 	rootCmd.AddCommand(newRebaseCmd())
 	rootCmd.AddCommand(branch.NewRenameCmd())

--- a/internal/integration/pr_test.go
+++ b/internal/integration/pr_test.go
@@ -1,0 +1,88 @@
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/utils"
+	"github.com/getstackit/stackit/testhelpers"
+)
+
+// withCapturedBrowser overrides utils.OpenBrowser for the duration of a test
+// so the pr command doesn't shell out to a real browser launcher. It returns
+// a pointer to the URL that was "opened".
+//
+// Callers must not run this subtest with t.Parallel(): utils.OpenBrowser is a
+// package-level var, so concurrent overrides would race.
+func withCapturedBrowser(t *testing.T) *string {
+	t.Helper()
+	opened := new(string)
+	orig := utils.OpenBrowser
+	utils.OpenBrowser = func(url string) error {
+		*opened = url
+		return nil
+	}
+	t.Cleanup(func() { utils.OpenBrowser = orig })
+	return opened
+}
+
+// setPrInfo writes PR metadata for a branch directly to the repo at dir,
+// independent of the TestShell's own (already-built) engine instance.
+func setPrInfo(t *testing.T, dir, branch string, prInfo *engine.PrInfo) {
+	t.Helper()
+	eng, err := engine.NewEngine(engine.Options{RepoRoot: dir, Trunk: "main"})
+	require.NoError(t, err)
+	require.NoError(t, eng.UpsertPrInfo(context.Background(), eng.GetBranch(branch), prInfo))
+}
+
+// TestPRCommand verifies that `stackit pr` resolves the right pull request
+// and opens it in the browser.
+func TestPRCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("opens the current branch's PR", func(t *testing.T) {
+		opened := withCapturedBrowser(t)
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3()
+		setPrInfo(t, sh.Dir(), "c", testhelpers.NewTestPrInfoFull(3, "", "", "OPEN", "b", "https://github.com/o/r/pull/3", false))
+
+		sh.Run("pr")
+		require.Equal(t, "https://github.com/o/r/pull/3", *opened)
+	})
+
+	t.Run("opens an explicit branch's PR", func(t *testing.T) {
+		opened := withCapturedBrowser(t)
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3()
+		setPrInfo(t, sh.Dir(), "a", testhelpers.NewTestPrInfoFull(1, "", "", "OPEN", "main", "https://github.com/o/r/pull/1", false))
+
+		sh.Run("pr a")
+		require.Equal(t, "https://github.com/o/r/pull/1", *opened)
+	})
+
+	t.Run("--stack opens the root PR of the stack", func(t *testing.T) {
+		opened := withCapturedBrowser(t)
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3()
+		setPrInfo(t, sh.Dir(), "a", testhelpers.NewTestPrInfoFull(1, "", "", "OPEN", "main", "https://github.com/o/r/pull/1", false))
+
+		sh.Run("pr c --stack")
+		require.Equal(t, "https://github.com/o/r/pull/1", *opened)
+	})
+
+	t.Run("errors with an actionable message when there is no PR", func(t *testing.T) {
+		withCapturedBrowser(t)
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3()
+
+		sh.RunExpectError("pr").
+			OutputContains("has no associated pull request")
+	})
+}

--- a/internal/utils/browser.go
+++ b/internal/utils/browser.go
@@ -1,0 +1,6 @@
+package utils
+
+// OpenBrowser opens a URL in the user's default browser. It is a package
+// variable (rather than a plain function) so tests can override it instead
+// of shelling out to a real browser launcher.
+var OpenBrowser = openBrowser

--- a/internal/utils/browser_darwin.go
+++ b/internal/utils/browser_darwin.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 )
 
-// OpenBrowser opens a URL in the default browser on macOS
-func OpenBrowser(url string) error {
+// openBrowser opens a URL in the default browser on macOS
+func openBrowser(url string) error {
 	return exec.Command("open", url).Run()
 }

--- a/internal/utils/browser_linux.go
+++ b/internal/utils/browser_linux.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 )
 
-// OpenBrowser opens a URL in the default browser on Linux
-func OpenBrowser(url string) error {
+// openBrowser opens a URL in the default browser on Linux
+func openBrowser(url string) error {
 	return exec.Command("xdg-open", url).Run()
 }

--- a/internal/utils/browser_windows.go
+++ b/internal/utils/browser_windows.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 )
 
-// OpenBrowser opens a URL in the default browser on Windows
-func OpenBrowser(url string) error {
+// openBrowser opens a URL in the default browser on Windows
+func openBrowser(url string) error {
 	return exec.Command("cmd", "/c", "start", url).Run()
 }


### PR DESCRIPTION
## Summary

Closes #1470. Adds `stackit pr [branch|PR] [--stack]` to open the relevant pull request in the default browser.

- With no argument, opens the current branch's pull request.
- Accepts either a branch name or a pull request number (resolved directly via GitHub, so it works even when the branch isn't tracked locally).
- `--stack` opens the root pull request of the stack instead (the branch directly above trunk).
- Gives an actionable error (`branch %q has no associated pull request; run 'stackit submit' first`) when there's nothing to open.
- No prompts are involved, so it behaves the same interactively or with `--no-interactive`.

As part of this, `utils.OpenBrowser` (previously a plain per-OS function) is now a package-level variable so tests can override it instead of shelling out to a real browser launcher — this was needed for both the new unit and integration tests, and doesn't change behavior for existing callers (`submit`).

## Test plan

- [x] `internal/actions/pr_test.go` — unit tests covering: current-branch resolution, explicit branch, `--stack` root-PR resolution, PR-number resolution via a mocked GitHub client, and the two error paths (no PR, no GitHub client for a numeric PR).
- [x] `internal/integration/pr_test.go` — CLI-level integration tests for `stackit pr`, `stackit pr <branch>`, `stackit pr --stack`, and the no-PR error message.
- [x] `go build ./...`, `go vet ./internal/actions/... ./internal/cli/... ./internal/utils/... ./internal/integration/...`
- [x] `go test ./internal/actions/... ./internal/cli/... ./internal/utils/... ./internal/integration/...` (all pass)
- [x] Manually built the CLI and checked `stackit pr --help` output
- [x] Updated `README.md` Command Reference (Navigation section)

---

Generated by an automated issue-triage routine.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012uL3dzXZkiQgUmSmo3jaY6

---
_Generated by [Claude Code](https://claude.ai/code/session_012uL3dzXZkiQgUmSmo3jaY6)_