### PR TITLE
feat(cli): add a direct pull-request opener

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ stack-submit --stack         # Creates/updates all PRs in the stack
 | `stackit children` | Show the children of the current branch |
 | `stackit parent` | Show the parent of the current branch |
 | `stackit share` | Print the current stack as Slack-ready markdown for copy-paste |
+| `stackit pr [branch\|PR]` | Open a pull request in your default browser (`--stack` for the stack's root PR) |
 
 ### Branch Management
 | Command | Description |

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -1,0 +1,118 @@
+package actions
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/output"
+	"github.com/getstackit/stackit/internal/utils"
+)
+
+// PrOptions configures which pull request PrAction opens.
+type PrOptions struct {
+	// BranchOrPR selects the target: a branch name, a PR number, or empty
+	// for the current branch.
+	BranchOrPR string
+	// Stack, when true, resolves the root PR of the stack containing the
+	// target branch instead of the target branch's own PR.
+	Stack bool
+}
+
+// PrResult is the pull request PrAction resolved and opened.
+type PrResult struct {
+	BranchName string
+	PRNumber   int
+	URL        string
+}
+
+// PrAction resolves the pull request for a branch, a PR number, or the
+// current branch, optionally walking up to the root PR of the stack, and
+// opens it in the default browser.
+func PrAction(ctx *app.Context, opts PrOptions) (*PrResult, error) {
+	eng := ctx.Engine
+
+	branchName, result, err := resolvePrTarget(ctx, opts.BranchOrPR)
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Stack {
+		branchName, result, err = resolveStackRootPr(eng, branchName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := utils.OpenBrowser(result.URL); err != nil {
+		ctx.Output.Debug("failed to open browser: %v", err)
+	}
+	ctx.Output.Success("Opening %s (%s) in your browser: %s", output.PRNumber(result.PRNumber), output.BranchName(branchName), result.URL)
+
+	result.BranchName = branchName
+	return result, nil
+}
+
+// resolvePrTarget resolves branchOrPR (a branch name, a PR number, or empty
+// for the current branch) to a branch name and its pull request. PR numbers
+// are resolved via the GitHub API so branches never fetched locally (e.g. a
+// plain GitHub branch that never went through `stackit create`) still work.
+func resolvePrTarget(ctx *app.Context, branchOrPR string) (string, *PrResult, error) {
+	eng := ctx.Engine
+
+	if branchOrPR == "" {
+		current := eng.CurrentBranch()
+		if current == nil {
+			return "", nil, errors.ErrNotOnBranchNoBranchSpecified
+		}
+		return resolveTrackedBranchPr(eng, current.GetName())
+	}
+
+	if prNumber, err := strconv.Atoi(branchOrPR); err == nil {
+		gh, err := ctx.RequireGitHub()
+		if err != nil {
+			return "", nil, fmt.Errorf("cannot resolve PR #%d: %w", prNumber, err)
+		}
+		pr, err := gh.GetPullRequest(ctx.Context, prNumber)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to get PR #%d: %w", prNumber, err)
+		}
+		return pr.Head, &PrResult{PRNumber: pr.Number, URL: pr.HTMLURL}, nil
+	}
+
+	return resolveTrackedBranchPr(eng, branchOrPR)
+}
+
+// resolveStackRootPr walks up from branchName to the root of its stack (the
+// branch directly above trunk) and resolves that branch's pull request.
+func resolveStackRootPr(eng engine.Engine, branchName string) (string, *PrResult, error) {
+	root := eng.GetStackRootForBranch(eng.GetBranch(branchName))
+	if root == "" {
+		return "", nil, fmt.Errorf("%q is not part of a tracked stack", branchName)
+	}
+	return resolveTrackedBranchPr(eng, root)
+}
+
+// resolveTrackedBranchPr looks up the pull request for a branch tracked in
+// local stackit metadata.
+func resolveTrackedBranchPr(eng engine.Engine, branchName string) (string, *PrResult, error) {
+	branchObj := eng.GetBranch(branchName)
+	if branchObj.IsTrunk() {
+		return "", nil, fmt.Errorf("%q is the trunk branch and has no pull request", branchName)
+	}
+	if !branchObj.IsTracked() {
+		return "", nil, fmt.Errorf("%q is not tracked by stackit; run `stackit create` or `stackit track` first", branchName)
+	}
+
+	prInfo, err := branchObj.GetPrInfo()
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to read pull request info for %q: %w", branchName, err)
+	}
+	if prInfo == nil || prInfo.Number() == nil || prInfo.URL() == "" {
+		return "", nil, fmt.Errorf("%q has no associated pull request; run `stackit submit` first", branchName)
+	}
+
+	return branchName, &PrResult{PRNumber: *prInfo.Number(), URL: prInfo.URL()}, nil
+}

--- a/internal/actions/pr_test.go
+++ b/internal/actions/pr_test.go
@@ -1,0 +1,119 @@
+package actions_test
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v89/github"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+func TestPrAction(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resolves the current branch's pull request", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithLinearStack3()
+
+		require.NoError(t, s.Engine.UpsertPrInfo(s.Context.Context, s.Engine.GetBranch("c"), engine.NewPrInfo(
+			new(9), "Add c", "", git.PRStateOpen, "b", "https://github.com/acme/widgets/pull/9", false,
+		)))
+
+		result, err := actions.PrAction(s.Context, actions.PrOptions{})
+		require.NoError(t, err)
+		require.Equal(t, "c", result.BranchName)
+		require.Equal(t, 9, result.PRNumber)
+		require.Equal(t, "https://github.com/acme/widgets/pull/9", result.URL)
+	})
+
+	t.Run("resolves an explicit branch's pull request", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithLinearStack3()
+
+		require.NoError(t, s.Engine.UpsertPrInfo(s.Context.Context, s.Engine.GetBranch("a"), engine.NewPrInfo(
+			new(1), "Add a", "", git.PRStateOpen, "main", "https://github.com/acme/widgets/pull/1", false,
+		)))
+
+		result, err := actions.PrAction(s.Context, actions.PrOptions{BranchOrPR: "a"})
+		require.NoError(t, err)
+		require.Equal(t, "a", result.BranchName)
+		require.Equal(t, 1, result.PRNumber)
+	})
+
+	t.Run("--stack resolves the root pull request of the stack", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithLinearStack3()
+
+		require.NoError(t, s.Engine.UpsertPrInfo(s.Context.Context, s.Engine.GetBranch("a"), engine.NewPrInfo(
+			new(1), "Add a", "", git.PRStateOpen, "main", "https://github.com/acme/widgets/pull/1", false,
+		)))
+		require.NoError(t, s.Engine.UpsertPrInfo(s.Context.Context, s.Engine.GetBranch("c"), engine.NewPrInfo(
+			new(3), "Add c", "", git.PRStateOpen, "b", "https://github.com/acme/widgets/pull/3", false,
+		)))
+
+		result, err := actions.PrAction(s.Context, actions.PrOptions{Stack: true})
+		require.NoError(t, err)
+		require.Equal(t, "a", result.BranchName)
+		require.Equal(t, 1, result.PRNumber)
+	})
+
+	t.Run("resolves a PR number via the GitHub API", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+
+		ghConfig := testhelpers.NewMockGitHubServerConfig()
+		pr := &github.PullRequest{
+			Number:  new(123),
+			Head:    &github.PullRequestBranch{Ref: new("feature-a")},
+			Base:    &github.PullRequestBranch{Ref: new("main")},
+			Title:   new("Feature A"),
+			HTMLURL: new("https://github.com/acme/widgets/pull/123"),
+		}
+		ghConfig.PRs["feature-a"] = pr
+		ghConfig.CreatedPRs = append(ghConfig.CreatedPRs, pr)
+		ghClient, owner, repo := testhelpers.NewMockGitHubClient(t, ghConfig)
+		s.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(ghClient, owner, repo, ghConfig)
+
+		result, err := actions.PrAction(s.Context, actions.PrOptions{BranchOrPR: "123"})
+		require.NoError(t, err)
+		require.Equal(t, 123, result.PRNumber)
+		require.Equal(t, "https://github.com/acme/widgets/pull/123", result.URL)
+	})
+
+	t.Run("errors on trunk", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithLinearStack3()
+		s.Checkout("main")
+
+		_, err := actions.PrAction(s.Context, actions.PrOptions{})
+		require.ErrorContains(t, err, "trunk branch")
+	})
+
+	t.Run("errors when the branch is not tracked", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithLinearStack3()
+
+		_, err := actions.PrAction(s.Context, actions.PrOptions{BranchOrPR: "does-not-exist"})
+		require.ErrorContains(t, err, "not tracked")
+	})
+
+	t.Run("errors when the branch has no pull request", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithLinearStack3()
+
+		_, err := actions.PrAction(s.Context, actions.PrOptions{BranchOrPR: "a"})
+		require.ErrorContains(t, err, "no associated pull request")
+	})
+}

--- a/internal/cli/navigation/pr.go
+++ b/internal/cli/navigation/pr.go
@@ -1,0 +1,51 @@
+package navigation
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+)
+
+// NewPrCmd creates the pr command.
+func NewPrCmd() *cobra.Command {
+	var stack bool
+
+	cmd := &cobra.Command{
+		Use:   "pr [branch|PR]",
+		Short: "Open a pull request in your default browser",
+		Long: `Open the pull request for a branch, a PR number, or the current branch in
+your default browser.
+
+With no argument, opens the current branch's pull request. Pass a branch name
+or a PR number to open a specific one. Pass --stack to open the root pull
+request of the stack instead of the target branch's own PR.
+
+Examples:
+  stackit pr                  # open the current branch's pull request
+  stackit pr feature-x        # open feature-x's pull request
+  stackit pr 1234             # open PR #1234
+  stackit pr --stack          # open the root pull request of the current stack
+  stackit pr feature-x --stack   # open the root pull request of feature-x's stack`,
+		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			branchOrPR := ""
+			if len(args) > 0 {
+				branchOrPR = args[0]
+			}
+			return common.Run(cmd, func(ctx *app.Context) error {
+				_, err := actions.PrAction(ctx, actions.PrOptions{
+					BranchOrPR: branchOrPR,
+					Stack:      stack,
+				})
+				return err
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&stack, "stack", false, "Open the root pull request of the stack instead of the target branch's own PR")
+
+	return cmd
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -115,6 +115,7 @@ Commit:  ` + commit + `
 	rootCmd.AddCommand(navigation.NewParentCmd())
 	rootCmd.AddCommand(branch.NewPopCmd())
 	rootCmd.AddCommand(stack.NewPluckCmd())
+	rootCmd.AddCommand(navigation.NewPrCmd())
 	rootCmd.AddCommand(newRebaseCmd())
 	rootCmd.AddCommand(branch.NewRenameCmd())
 	rootCmd.AddCommand(stack.NewReorderCmd())

--- a/internal/integration/pr_test.go
+++ b/internal/integration/pr_test.go
@@ -1,0 +1,82 @@
+package integration
+
+import (
+	"testing"
+)
+
+// TestPrCommand verifies that `stackit pr` resolves the pull request for a
+// branch, the current branch, or the root of a stack, and opens it in the
+// browser (best-effort — the tests only assert on the printed URL).
+func TestPrCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("opens the current branch's pull request", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3()
+		sh.SetPrMetadata("c", PRMetadata{Number: 42, State: "OPEN", URL: "https://github.com/acme/widgets/pull/42"})
+
+		sh.Run("pr").
+			OutputContains("#42").
+			OutputContains("https://github.com/acme/widgets/pull/42")
+	})
+
+	t.Run("opens the pull request for an explicit branch", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3()
+		sh.SetPrMetadata("a", PRMetadata{Number: 7, State: "OPEN", URL: "https://github.com/acme/widgets/pull/7"})
+		sh.Checkout("main")
+
+		sh.Run("pr a").
+			OutputContains("#7").
+			OutputContains("https://github.com/acme/widgets/pull/7")
+	})
+
+	t.Run("--stack opens the root pull request of the stack", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// main -> a -> b -> c, currently on c.
+		sh.CreateLinearStack3()
+		sh.SetPrMetadata("a", PRMetadata{Number: 1, State: "OPEN", URL: "https://github.com/acme/widgets/pull/1"})
+		sh.SetPrMetadata("c", PRMetadata{Number: 3, State: "OPEN", URL: "https://github.com/acme/widgets/pull/3"})
+
+		sh.Run("pr --stack").
+			OutputContains("#1").
+			OutputContains("https://github.com/acme/widgets/pull/1")
+	})
+
+	t.Run("errors on trunk", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3()
+		sh.Checkout("main")
+
+		sh.RunExpectError("pr").
+			OutputContains("trunk branch")
+	})
+
+	t.Run("errors when the branch is not tracked", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3()
+
+		sh.RunExpectError("pr does-not-exist").
+			OutputContains("not tracked")
+	})
+
+	t.Run("errors when the branch has no pull request", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3()
+
+		sh.RunExpectError("pr a").
+			OutputContains("no associated pull request")
+	})
+}


### PR DESCRIPTION
## Summary

Adds `stackit pr [branch|PR]` to open the relevant pull request in the default browser, closing #1470.

- With no argument, opens the current branch's pull request, resolved from local stackit metadata (no network call).
- Accepts an explicit branch name, or a PR number (resolved via the GitHub API, so it also works for branches never fetched locally).
- `--stack` walks up to the root of the stack and opens its PR instead of the target branch's own PR.
- Gives an actionable error when the target is trunk, isn't tracked by stackit, or has no associated PR.
- Registered under `internal/cli/navigation` alongside other read-only, informational commands (`log`, `share`, `tree`).

## Test plan

- [x] `internal/actions/pr_test.go` — unit tests covering current-branch resolution, explicit branch, `--stack` root resolution, PR-number resolution via a mocked GitHub API, and the trunk/untracked/no-PR error paths.
- [x] `internal/integration/pr_test.go` — end-to-end CLI coverage for the same cases via `TestShellInProcess`.
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` (2.11.3) clean on the touched packages.
- [x] `go test ./internal/...` passes (one pre-existing, unrelated failure in `internal/git` caused by this sandbox's proxy git config rewriting URLs — reproduces on `main` without this change).
- [x] `stackit pr --help` reviewed manually for wording/examples.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BSNYfU7njZyfzmrXZdD5wZ)_