### PR TITLE
feat(cli): add stackit pr command to open pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ stack-submit --stack         # Creates/updates all PRs in the stack
 | `stackit children` | Show the children of the current branch |
 | `stackit parent` | Show the parent of the current branch |
 | `stackit share` | Print the current stack as Slack-ready markdown for copy-paste |
+| `stackit pr [branch|PR]` | Open a pull request in the default browser (`--stack` for the stack's root PR) |
 
 ### Branch Management
 | Command | Description |

--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -1,0 +1,84 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/errors"
+)
+
+// PROpenOptions configures how the target pull request is resolved.
+type PROpenOptions struct {
+	// BranchOrPR selects the pull request: a branch name, a PR number, or
+	// empty to use the current branch.
+	BranchOrPR string
+	// Stack, when true, resolves to the root pull request of the stack (the
+	// branch directly above trunk) instead of BranchOrPR's own pull request.
+	Stack bool
+}
+
+// PRResult is the pull request resolved by PROpenAction.
+type PRResult struct {
+	Branch string
+	Number *int
+	URL    string
+}
+
+// PROpenAction resolves the pull request for a branch name, a PR number, or
+// the current branch, so the caller can open it. It prefers local metadata
+// (no network) and only calls GitHub when local metadata doesn't have the
+// pull request yet, or when the argument is a PR number.
+func PROpenAction(ctx *app.Context, opts PROpenOptions) (*PRResult, error) {
+	eng := ctx.Engine
+	remoteCtx, cancel := ctx.RemoteOperationContext()
+	defer cancel()
+
+	branchName := opts.BranchOrPR
+	if branchName == "" {
+		current := eng.CurrentBranch()
+		if current == nil {
+			return nil, errors.ErrNotOnBranch
+		}
+		branchName = current.GetName()
+	} else if prNum, convErr := strconv.Atoi(branchName); convErr == nil {
+		gh, err := ctx.RequireGitHub()
+		if err != nil {
+			return nil, fmt.Errorf("cannot resolve PR #%d: %w", prNum, err)
+		}
+		pr, err := gh.GetPullRequest(remoteCtx, prNum)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get PR #%d: %w", prNum, err)
+		}
+		if !opts.Stack {
+			return &PRResult{Branch: pr.Head, Number: &pr.Number, URL: pr.HTMLURL}, nil
+		}
+		branchName = pr.Head
+	}
+
+	if opts.Stack {
+		branchName = shareStackBase(eng, branchName)
+	}
+
+	return resolvePRForBranch(ctx, remoteCtx, branchName)
+}
+
+// resolvePRForBranch resolves the pull request for a known branch name,
+// preferring cached local metadata over a GitHub call.
+func resolvePRForBranch(ctx *app.Context, remoteCtx context.Context, branchName string) (*PRResult, error) {
+	branch := ctx.Engine.GetBranch(branchName)
+	if prInfo, err := branch.GetPrInfo(); err == nil && prInfo != nil && prInfo.URL() != "" {
+		return &PRResult{Branch: branchName, Number: prInfo.Number(), URL: prInfo.URL()}, nil
+	}
+
+	gh := ctx.GitHub()
+	if gh == nil {
+		return nil, fmt.Errorf("no pull request found for %q", branchName)
+	}
+	pr, err := gh.GetPullRequestByBranch(remoteCtx, branchName)
+	if err != nil || pr == nil {
+		return nil, fmt.Errorf("no pull request found for %q", branchName)
+	}
+	return &PRResult{Branch: branchName, Number: &pr.Number, URL: pr.HTMLURL}, nil
+}

--- a/internal/actions/pr_test.go
+++ b/internal/actions/pr_test.go
@@ -1,0 +1,139 @@
+package actions_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-github/v89/github"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+func TestPROpenAction(t *testing.T) {
+	t.Parallel()
+
+	t.Run("errors when not on a branch and no target given", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.RunGit("checkout", "--detach", "main")
+
+		_, err := actions.PROpenAction(s.Context, actions.PROpenOptions{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not on a branch")
+	})
+
+	t.Run("resolves from local metadata without calling GitHub", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit().
+			CreateBranch("feature-a").
+			Commit("a1").
+			TrackBranch("feature-a", "main")
+
+		branch := s.Engine.GetBranch("feature-a")
+		prInfo := testhelpers.NewTestPrInfoFull(42, "Feature A", "", "OPEN", "main", "https://github.com/owner/repo/pull/42", false)
+		require.NoError(t, s.Engine.UpsertPrInfo(context.Background(), branch, prInfo))
+
+		result, err := actions.PROpenAction(s.Context, actions.PROpenOptions{BranchOrPR: "feature-a"})
+		require.NoError(t, err)
+		require.Equal(t, "feature-a", result.Branch)
+		require.Equal(t, 42, *result.Number)
+		require.Equal(t, "https://github.com/owner/repo/pull/42", result.URL)
+	})
+
+	t.Run("falls back to GitHub when local metadata has no PR", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit().
+			CreateBranch("feature-a").
+			Commit("a1").
+			TrackBranch("feature-a", "main")
+
+		ghConfig := testhelpers.NewMockGitHubServerConfig()
+		pr := &github.PullRequest{
+			Number:  new(7),
+			Head:    &github.PullRequestBranch{Ref: new("feature-a")},
+			Base:    &github.PullRequestBranch{Ref: new("main")},
+			Title:   new("Feature A"),
+			HTMLURL: new("https://github.com/owner/repo/pull/7"),
+		}
+		ghConfig.PRs["feature-a"] = pr
+		ghClient, owner, repo := testhelpers.NewMockGitHubClient(t, ghConfig)
+		s.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(ghClient, owner, repo, ghConfig)
+
+		result, err := actions.PROpenAction(s.Context, actions.PROpenOptions{BranchOrPR: "feature-a"})
+		require.NoError(t, err)
+		require.Equal(t, 7, *result.Number)
+		require.Equal(t, "https://github.com/owner/repo/pull/7", result.URL)
+	})
+
+	t.Run("errors when no pull request exists anywhere", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit().
+			CreateBranch("feature-a").
+			Commit("a1").
+			TrackBranch("feature-a", "main")
+
+		_, err := actions.PROpenAction(s.Context, actions.PROpenOptions{BranchOrPR: "feature-a"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `no pull request found for "feature-a"`)
+	})
+
+	t.Run("resolves a PR number via GitHub", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+
+		ghConfig := testhelpers.NewMockGitHubServerConfig()
+		pr := &github.PullRequest{
+			Number:  new(123),
+			Head:    &github.PullRequestBranch{Ref: new("feature-a")},
+			Base:    &github.PullRequestBranch{Ref: new("main")},
+			Title:   new("Feature A"),
+			HTMLURL: new("https://github.com/owner/repo/pull/123"),
+		}
+		ghConfig.CreatedPRs = append(ghConfig.CreatedPRs, pr)
+		ghClient, owner, repo := testhelpers.NewMockGitHubClient(t, ghConfig)
+		s.Context.GitHubClient = testhelpers.NewMockGitHubClientInterface(ghClient, owner, repo, ghConfig)
+
+		result, err := actions.PROpenAction(s.Context, actions.PROpenOptions{BranchOrPR: "123"})
+		require.NoError(t, err)
+		require.Equal(t, "feature-a", result.Branch)
+		require.Equal(t, 123, *result.Number)
+		require.Equal(t, "https://github.com/owner/repo/pull/123", result.URL)
+	})
+
+	t.Run("errors resolving a PR number without a GitHub client", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+
+		_, err := actions.PROpenAction(s.Context, actions.PROpenOptions{BranchOrPR: "123"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cannot resolve PR #123")
+	})
+
+	t.Run("--stack resolves to the root branch of the stack", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit().
+			CreateBranch("feature-a").
+			Commit("a1").
+			CreateBranch("feature-b").
+			Commit("b1").
+			TrackBranch("feature-a", "main").
+			TrackBranch("feature-b", "feature-a")
+
+		rootPR := testhelpers.NewTestPrInfoFull(1, "Feature A", "", "OPEN", "main", "https://github.com/owner/repo/pull/1", false)
+		require.NoError(t, s.Engine.UpsertPrInfo(context.Background(), s.Engine.GetBranch("feature-a"), rootPR))
+
+		result, err := actions.PROpenAction(s.Context, actions.PROpenOptions{BranchOrPR: "feature-b", Stack: true})
+		require.NoError(t, err)
+		require.Equal(t, "feature-a", result.Branch)
+		require.Equal(t, "https://github.com/owner/repo/pull/1", result.URL)
+	})
+}

--- a/internal/cli/navigation/pr.go
+++ b/internal/cli/navigation/pr.go
@@ -1,0 +1,59 @@
+package navigation
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/getstackit/stackit/internal/actions"
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/cli/common"
+	"github.com/getstackit/stackit/internal/utils"
+)
+
+// NewPrCmd creates the pr command.
+func NewPrCmd() *cobra.Command {
+	var stack bool
+
+	cmd := &cobra.Command{
+		Use:   "pr [branch|PR]",
+		Short: "Open a pull request in the default browser",
+		Long: `Open the pull request for a branch, a PR number, or the current branch in
+your default browser.
+
+Examples:
+  stackit pr                 # Open the current branch's pull request
+  stackit pr feature-x       # Open the pull request for a specific branch
+  stackit pr 123             # Open pull request #123
+  stackit pr --stack         # Open the root pull request of the current stack`,
+		ValidArgsFunction: common.CompleteBranches,
+		SilenceUsage:      true,
+		Args:              cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			branchOrPR := ""
+			if len(args) > 0 {
+				branchOrPR = args[0]
+			}
+
+			return common.Run(cmd, func(ctx *app.Context) error {
+				result, err := actions.PROpenAction(ctx, actions.PROpenOptions{
+					BranchOrPR: branchOrPR,
+					Stack:      stack,
+				})
+				if err != nil {
+					return err
+				}
+
+				ctx.Output.Info("Opening %s", result.URL)
+				if err := utils.OpenBrowser(result.URL); err != nil {
+					return fmt.Errorf("failed to open browser: %w", err)
+				}
+				return nil
+			})
+		},
+	}
+
+	cmd.Flags().BoolVarP(&stack, "stack", "s", false, "Open the root pull request of the current stack")
+
+	return cmd
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -115,6 +115,7 @@ Commit:  ` + commit + `
 	rootCmd.AddCommand(navigation.NewParentCmd())
 	rootCmd.AddCommand(branch.NewPopCmd())
 	rootCmd.AddCommand(stack.NewPluckCmd())
+	rootCmd.AddCommand(navigation.NewPrCmd())
 	rootCmd.AddCommand(newRebaseCmd())
 	rootCmd.AddCommand(branch.NewRenameCmd())
 	rootCmd.AddCommand(stack.NewReorderCmd())

--- a/internal/integration/pr_test.go
+++ b/internal/integration/pr_test.go
@@ -1,0 +1,51 @@
+package integration
+
+import "testing"
+
+// TestPrCommand verifies error paths for `stackit pr`. Success paths (a
+// resolved pull request opened in the browser) are covered at the action
+// level in internal/actions/pr_test.go, since opening a real browser isn't
+// something CI/sandboxed environments can exercise.
+func TestPrCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("errors when the current branch has no pull request", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.CreateLinearStack3()
+
+		sh.RunExpectError("pr").OutputContains(`no pull request found for "c"`)
+	})
+
+	t.Run("errors when an explicit branch has no pull request", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.CreateLinearStack3()
+
+		sh.RunExpectError("pr b").OutputContains(`no pull request found for "b"`)
+	})
+
+	t.Run("--stack resolves to the root branch of the stack", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.CreateLinearStack3()
+
+		sh.RunExpectError("pr --stack").OutputContains(`no pull request found for "a"`)
+	})
+
+	t.Run("errors resolving a PR number without a configured remote", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.CreateLinearStack3()
+
+		sh.RunExpectError("pr 123").OutputContains("cannot resolve PR #123")
+	})
+
+	t.Run("rejects more than one argument", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.CreateLinearStack3()
+
+		sh.RunExpectError("pr a b")
+	})
+}


### PR DESCRIPTION
## Summary

Implements #1470: adds `stackit pr [branch|PR]` to open a pull request in the default browser.

- No argument → opens the current branch's pull request.
- A branch name → opens that branch's pull request.
- A PR number → resolves the PR via GitHub and opens it.
- `--stack` / `-s` → opens the root pull request of the current stack (the branch directly above trunk).
- Resolution prefers cached local metadata (no network) and only calls GitHub when local metadata doesn't have the PR yet.
- Gives an actionable error when the target has no associated pull request, or when a PR-number lookup needs GitHub but no client is configured.
- Works without a TTY (`--no-interactive`), since it doesn't prompt.

## Implementation notes

- `internal/actions/pr.go`: `PROpenAction` resolves the branch/PR/URL; it does not touch the browser, so it's fully unit-testable without any UI/OS dependency.
- `internal/cli/navigation/pr.go`: the CLI command calls the action then `utils.OpenBrowser` (existing helper, already used by `submit --web`).
- Registered in `internal/cli/root.go` and documented in the README's Navigation command table.

## Test plan

- [x] `internal/actions/pr_test.go` — unit coverage for: not-on-a-branch, local-metadata resolution (no GitHub call), GitHub fallback when local metadata is empty, no-PR-found error, PR-number resolution via GitHub, PR-number without a GitHub client, and `--stack` resolving to the stack root.
- [x] `internal/integration/pr_test.go` — CLI-level coverage for the error paths (no PR found, `--stack` root resolution, PR-number without a configured remote, rejecting extra args). Success paths that open a real browser aren't exercised at this layer since CI/sandboxed environments have no browser opener — see the action-level tests instead.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` on changed files, and `go test ./internal/actions/... ./internal/cli/... ./internal/integration/...` all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EcBmdW2TdDykvCAk8oc5W7)_