### PR TITLE
feat(create): create a branch onto an explicit parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ stack-submit --stack         # Creates/updates all PRs in the stack
 ### Branch Management
 | Command | Description |
 |:---|:---|
-| `stackit create [name]` | Create a new branch on top of current (use `-w` to create with worktree) |
+| `stackit create [name]` | Create a new branch on top of current (use `-w` to create with worktree, `--onto <branch>` to target a specific parent without checking it out) |
 | `stackit modify` | Amend the current commit (like `git commit --amend`) |
 | `stackit absorb` | Intelligently amend changes to the correct commits in the stack |
 | `stackit split` | Split commits into branches (by commit, hunk, or file; use `--above` for upstack) |

--- a/internal/actions/create/create.go
+++ b/internal/actions/create/create.go
@@ -30,6 +30,10 @@ type Options struct {
 	// SelectedChildren is used to specify which children to move during insert
 	// in non-interactive mode (mostly for tests)
 	SelectedChildren []string
+	// Onto creates the branch as a tracked child of this branch instead of the
+	// current branch, without checking it out. Mutually exclusive with
+	// Worktree and Insert.
+	Onto string
 	// Worktree creates a dedicated worktree for this stack (only valid from trunk)
 	Worktree bool
 	// AllowEmpty permits creating a branch with no commit when the working tree
@@ -64,11 +68,27 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 		}
 	}
 
+	// Validate --onto: it replaces the implicit "parent is the current
+	// branch" behavior, so it can't be combined with flags that also depend
+	// on that assumption.
+	if opts.Onto != "" {
+		if opts.Worktree {
+			return Result{}, fmt.Errorf("--onto cannot be combined with --worktree/-w")
+		}
+		if opts.Insert {
+			return Result{}, fmt.Errorf("--onto cannot be combined with --insert/-i")
+		}
+		if err := validateOntoTarget(eng, opts.Onto); err != nil {
+			return Result{}, err
+		}
+	}
+
 	// Take snapshot before modifying the repository
 	snapshotOpts := actions.NewSnapshot("create",
 		actions.WithArg(opts.BranchName),
 		actions.WithFlagValue("-m", opts.Message),
 		actions.WithFlagValue("--scope", opts.Scope),
+		actions.WithFlagValue("--onto", opts.Onto),
 		actions.WithFlag(opts.All, "--all"),
 		actions.WithFlag(opts.Insert, "--insert"),
 		actions.WithFlag(opts.Patch, "--patch"),
@@ -182,9 +202,36 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 		return Result{}, fmt.Errorf("branch %s already exists", branchName)
 	}
 
-	// Create and checkout new branch
+	// Create and checkout new branch. With --onto, the branch is created at
+	// the target's tip SHA (not current HEAD) and tracked immediately, before
+	// checkout, so the divergence point stackit records is the target's tip
+	// rather than a merge-base that could wander into unrelated history the
+	// current branch happens to share with the target.
+	parentBranch := currentBranch
 	h.OnStep(StepBranchCreate, handler.StatusStarted, fmt.Sprintf("Creating branch %s", branchName))
-	if err := eng.CreateAndCheckoutBranch(ctx.Context, branch); err != nil {
+	if opts.Onto != "" {
+		parentBranch = opts.Onto
+		ontoBranch := eng.GetBranch(opts.Onto)
+		ontoSHA, err := ontoBranch.GetRevision()
+		if err != nil {
+			h.OnStep(StepBranchCreate, handler.StatusFailed, err.Error())
+			return Result{}, fmt.Errorf("failed to resolve %s: %w", opts.Onto, err)
+		}
+		if err := eng.CreateBranch(ctx.Context, branchName, ontoSHA); err != nil {
+			h.OnStep(StepBranchCreate, handler.StatusFailed, err.Error())
+			return Result{}, fmt.Errorf("failed to create branch: %w", err)
+		}
+		if err := eng.TrackBranch(ctx.Context, branchName, opts.Onto); err != nil {
+			_ = eng.DeleteBranch(ctx.Context, branch)
+			h.OnStep(StepBranchCreate, handler.StatusFailed, err.Error())
+			return Result{}, fmt.Errorf("failed to track branch: %w", err)
+		}
+		if err := eng.CheckoutBranch(ctx.Context, branch); err != nil {
+			_ = eng.DeleteBranch(ctx.Context, branch)
+			h.OnStep(StepBranchCreate, handler.StatusFailed, err.Error())
+			return Result{}, fmt.Errorf("failed to check out %s onto %s: %w", branchName, opts.Onto, err)
+		}
+	} else if err := eng.CreateAndCheckoutBranch(ctx.Context, branch); err != nil {
 		h.OnStep(StepBranchCreate, handler.StatusFailed, err.Error())
 		return Result{}, fmt.Errorf("failed to create branch: %w", err)
 	}
@@ -207,14 +254,19 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 		h.OnStep(StepCommit, handler.StatusSkipped, "No staged changes")
 	}
 
-	// Track the branch with current branch as parent
-	h.OnStep(StepTracking, handler.StatusStarted, "Setting up branch tracking")
-	if err := eng.TrackBranch(ctx.Context, branchName, currentBranch); err != nil {
-		// Log error but don't fail - branch is created, just not tracked
-		h.OnStep(StepTracking, handler.StatusFailed, err.Error())
-		out.Info("Warning: failed to track branch: %v", err)
-	} else {
-		h.OnStep(StepTracking, handler.StatusCompleted, "Branch tracked")
+	// Track the branch with its parent. With --onto, tracking already happened
+	// before checkout (see above) so the divergence point is correct; here we
+	// only need to track the common case, where the parent is the branch we
+	// started from.
+	if opts.Onto == "" {
+		h.OnStep(StepTracking, handler.StatusStarted, "Setting up branch tracking")
+		if err := eng.TrackBranch(ctx.Context, branchName, currentBranch); err != nil {
+			// Log error but don't fail - branch is created, just not tracked
+			h.OnStep(StepTracking, handler.StatusFailed, err.Error())
+			out.Info("Warning: failed to track branch: %v", err)
+		} else {
+			h.OnStep(StepTracking, handler.StatusCompleted, "Branch tracked")
+		}
 	}
 
 	// Opportunistically configure the metadata fetch refspec so a plain
@@ -225,7 +277,7 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 		out.Debug("Failed to configure metadata refspec: %v", err)
 	}
 
-	ctx.Logger.Info("branch created name=%v parent=%v hasCommit=%v", branchName, currentBranch, hasStaged)
+	ctx.Logger.Info("branch created name=%v parent=%v hasCommit=%v", branchName, parentBranch, hasStaged)
 
 	// Create worktree if requested
 	var worktreePath string
@@ -291,7 +343,7 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 
 	result := Result{
 		BranchName:   branchName,
-		ParentBranch: currentBranch,
+		ParentBranch: parentBranch,
 		HasCommit:    hasStaged,
 		WorktreePath: worktreePath,
 	}
@@ -317,4 +369,27 @@ func determineBranch(ctx *app.Context, opts *Options, commitMessage string, scop
 	}
 
 	return ctx.Engine.GetBranch(branchName), nil
+}
+
+// validateOntoTarget checks that --onto refers to a branch the new branch can
+// be safely parented on: it must exist, be trunk or a stackit-tracked branch
+// (not a plain untracked git branch), not be a worktree anchor, and not be
+// locked or frozen.
+func validateOntoTarget(eng engine.Engine, ontoName string) error {
+	ontoBranch := eng.GetBranch(ontoName)
+
+	if ontoBranch.IsWorktreeAnchor() {
+		return fmt.Errorf("cannot create a branch onto worktree anchor %q; use 'stackit create' inside that worktree instead", ontoName)
+	}
+
+	switch {
+	case ontoBranch.IsTrunk():
+		return nil
+	case ontoBranch.IsTracked():
+		return ontoBranch.EnsureCanModify()
+	case eng.BranchNames().Contains(ontoName):
+		return fmt.Errorf("branch %q is not tracked by stackit; track it first with 'stackit track', or choose a tracked branch", ontoName)
+	default:
+		return fmt.Errorf("branch %q does not exist", ontoName)
+	}
 }

--- a/internal/cli/branch/create.go
+++ b/internal/cli/branch/create.go
@@ -18,6 +18,7 @@ func NewCreateCmd() *cobra.Command {
 		insert      bool
 		message     string
 		messageFile string
+		onto        string
 		patch       bool
 		scope       string
 		update      bool
@@ -37,10 +38,16 @@ If you have any unstaged changes, you will be asked whether you'd like to stage 
 as a "forgot to stage" mistake and rejected — stage them, pass --all, or pass
 --allow-empty to create an empty branch anyway.
 
+Use --onto to create the branch as a child of a specific branch instead of
+the current one, without checking that branch out first. This also works
+when the target is checked out in another worktree. --onto cannot be
+combined with --worktree/-w or --insert/-i.
+
 Examples:
   stackit create -m "feat: add login"             # Inline message
   stackit create feature -F /tmp/msg              # Read message from a file
-  printf "feat: add login" | stackit create -F -  # Read message from stdin`,
+  printf "feat: add login" | stackit create -F -  # Read message from stdin
+  stackit create feature --onto main -m "feat: x" # Branch onto main directly`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
@@ -66,6 +73,7 @@ Examples:
 					Scope:         scope,
 					All:           all,
 					Insert:        insert,
+					Onto:          onto,
 					Patch:         patch,
 					Update:        update,
 					Verbose:       verbose,
@@ -100,6 +108,7 @@ Examples:
 	cmd.Flags().BoolVarP(&insert, "insert", "i", false, "Insert this branch between the current branch and its child. If there are multiple children, prompts you to select which should be moved onto the new branch")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "Specify a commit message")
 	cmd.Flags().StringVarP(&messageFile, "message-file", "F", "", "Read commit message from a file (use \"-\" for stdin). Mutually exclusive with --message.")
+	cmd.Flags().StringVar(&onto, "onto", "", "Create the branch as a tracked child of this branch, without checking it out first. Cannot be combined with --worktree/-w or --insert/-i.")
 	cmd.Flags().BoolVarP(&patch, "patch", "p", false, "Pick hunks to stage before committing")
 	cmd.Flags().StringVar(&scope, "scope", "", "Set a scope (e.g., Jira ticket ID, Linear ID) for the new branch. If not provided, inherits from parent branch")
 	cmd.Flags().BoolVarP(&update, "update", "u", false, "Stage all updates to tracked files before creating the branch")

--- a/internal/integration/create_onto_test.go
+++ b/internal/integration/create_onto_test.go
@@ -1,0 +1,118 @@
+package integration
+
+import (
+	"testing"
+)
+
+// TestCreateOnto verifies `stackit create --onto <branch>` creates a branch
+// tracked as a child of the target, built directly on the target's tip
+// rather than the current branch's history.
+func TestCreateOnto(t *testing.T) {
+	t.Parallel()
+
+	t.Run("branches onto an unrelated tracked branch, not the current branch", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// main -> branch-a (current), main -> branch-b (onto target). Siblings.
+		sh.Write("a", "content a").Run("create branch-a -m 'feat: a'")
+		sh.Checkout("main")
+		sh.Write("b", "content b").Run("create branch-b -m 'feat: b'")
+		sh.Checkout("branch-a")
+
+		sh.Write("c", "content c").Run("create branch-c --onto branch-b -m 'feat: c'")
+
+		sh.OnBranch("branch-c")
+		sh.ExpectBranchParent("branch-c", "branch-b")
+		// Exactly the one new commit sits on top of branch-b — none of
+		// branch-a's own history leaked in via a wide merge-base.
+		sh.CommitCount("branch-b", "branch-c", 1)
+	})
+
+	t.Run("branches onto trunk directly", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("a", "content a").Run("create branch-a -m 'feat: a'")
+
+		sh.Write("d", "content d").Run("create branch-d --onto main -m 'feat: d'")
+
+		sh.OnBranch("branch-d")
+		sh.ExpectBranchParent("branch-d", "main")
+		sh.CommitCount("main", "branch-d", 1)
+	})
+
+	t.Run("works when the target is checked out in another worktree", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.SetWorktreeBasePath(t.TempDir())
+
+		// Anchor "shared" in its own worktree so it's checked out elsewhere.
+		sh.Write("shared.txt", "shared content").Run("create shared -w -m 'feat: shared'")
+		sh.OnBranch("main")
+		worktreePath := sh.GetWorktreePath("shared")
+		shW := sh.InWorktree(worktreePath)
+		shW.OnBranch("shared")
+
+		// From the main worktree, branch onto "shared" without disturbing it.
+		sh.Write("e", "content e").Run("create branch-e --onto shared -m 'feat: e'")
+
+		sh.OnBranch("branch-e")
+		sh.ExpectBranchParent("branch-e", "shared")
+		sh.CommitCount("shared", "branch-e", 1)
+
+		// The other worktree's checkout is untouched.
+		shW.OnBranch("shared")
+	})
+
+	t.Run("errors for a nonexistent target", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.RunExpectError("create branch-x --onto does-not-exist -m 'feat: x' --allow-empty").
+			OutputContains("does not exist")
+	})
+
+	t.Run("errors for an untracked target", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Git("branch plain-branch")
+
+		sh.RunExpectError("create branch-x --onto plain-branch -m 'feat: x' --allow-empty").
+			OutputContains("not tracked by stackit")
+	})
+
+	t.Run("errors for a locked target", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("a", "content a").Run("create branch-a -m 'feat: a'")
+		sh.Run("lock branch-a")
+
+		sh.RunExpectError("create branch-x --onto branch-a -m 'feat: x' --allow-empty").
+			OutputContains("locked")
+	})
+
+	t.Run("errors when combined with --worktree", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("a", "content a").Run("create branch-a -m 'feat: a'")
+		sh.Checkout("main")
+
+		sh.RunExpectError("create branch-x --onto branch-a -w -m 'feat: x' --allow-empty").
+			OutputContains("cannot be combined")
+	})
+
+	t.Run("errors when combined with --insert", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("a", "content a").Run("create branch-a -m 'feat: a'")
+		sh.Checkout("main")
+
+		sh.RunExpectError("create branch-x --onto branch-a -i -m 'feat: x' --allow-empty").
+			OutputContains("cannot be combined")
+	})
+}


### PR DESCRIPTION
## Summary

Adds `stackit create --onto <parent>` to create a tracked child branch on an explicit parent branch without checking it out first, per #1471.

Stacked on #1476 (this session's other open PR) since it was the current branch when this issue's webhook fired — normal stackit stacking, not a dependency between the two features.

## Design

The branch is created **directly at the target's tip SHA** (`eng.CreateBranch(ctx, branchName, ontoSHA)`), tracked immediately (`eng.TrackBranch`), and only then checked out (`eng.CheckoutBranch`) — never touching the target's own checkout state.

This matters more than it looks: an earlier version of this implementation did the "obvious" thing — create+commit on the current branch as usual, then reparent+restack onto the target. That's unsound whenever the current branch has its own unrelated history: `TrackBranch` computes divergence via `DivergenceRecompute` (a fresh merge-base against the declared parent), so tracking a branch whose actual git parent is the current branch's tip, but whose *declared* parent is some unrelated target, can compute a merge-base far up the tree (e.g. all the way back to trunk) — silently pulling the current branch's own accumulated commits into what should be a single new commit. Building directly at the target's SHA sidesteps this: the new commit's actual git parent *is* the target's tip, so the merge-base is trivially correct regardless of what the current branch's history looks like.

## Acceptance criteria (from #1471)

- [x] New branch is created and tracked as a child of `--onto`.
- [x] Works when the target is checked out in another worktree (never checks it out — see design above; covered by an integration test).
- [x] Existing staging, message, patch, scope behavior is unchanged (only the branch-creation/tracking steps are touched).
- [x] `--worktree` behavior is unchanged (rejects combining `--onto` with `--worktree`, since both assume different things about where the new branch starts).
- [x] `--onto` also rejected combined with `--insert` (insert assumes the new branch stays a child of the *current* branch, which `--onto` breaks).
- [x] Invalid, untracked, locked, and frozen targets fail with actionable errors (`validateOntoTarget` in `internal/actions/create/create.go`).
- [x] Integration coverage for multi-worktree use, plus the other validation/error paths.

## Test plan

- [x] `go build ./...`
- [x] `go vet` + `gofmt -l` on changed files (clean)
- [x] New `internal/integration/create_onto_test.go`: onto an unrelated tracked branch (commit-count assertion proves no history leakage), onto trunk, onto a branch checked out in another worktree, nonexistent/untracked/locked target errors, `--worktree`/`--insert` combination errors — all passing
- [x] Full `go test ./...` — all green except one pre-existing, unrelated failure (`internal/git` `TestGetRepoInfo/parses_HTTPS_URL`, reproduces on `main` with no changes — looks like a git-config artifact of this sandbox, not something this PR touches)

---
_Generated by [Claude Code](https://claude.ai/code/session_011CgsKcS8AWhqjvt5XsVqcU)_