### PR TITLE
fix: clear cached cat-file process on ReadObject read failure

### DIFF
--- a/internal/git/object_reader.go
+++ b/internal/git/object_reader.go
@@ -117,7 +117,13 @@ func (r *objectReader) ReadObject(ref string) (string, bool, error) {
 			return "", false, fmt.Errorf("object reader write after restart: %w", err)
 		}
 	}
-	return r.readResponse(ref)
+	content, found, err := r.readResponse(ref)
+	if err != nil {
+		// Stdout stream is broken; discard the process so the next call
+		// restarts, mirroring ReadObjectsBatch.
+		r.killLocked()
+	}
+	return content, found, err
 }
 
 // ReadObjectsBatch sends all refs in one burst and reads all responses in order.

--- a/internal/git/object_reader_internal_test.go
+++ b/internal/git/object_reader_internal_test.go
@@ -1,6 +1,8 @@
 package git
 
 import (
+	"bufio"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -66,6 +68,49 @@ func TestReadObjectsBatch_ClearsCmdOnWriteError(t *testing.T) {
 	results2, err := reader.ReadObjectsBatch([]string{"HEAD"})
 	require.NoError(t, err, "ReadObjectsBatch must succeed after restarting the process")
 	require.NotEmpty(t, results2)
+}
+
+// erroringReader always fails, simulating a broken stdout stream.
+type erroringReader struct{}
+
+func (erroringReader) Read([]byte) (int, error) { return 0, io.ErrClosedPipe }
+
+// TestReadObject_ClearsCmdOnReadError verifies that ReadObject, like
+// ReadObjectsBatch, clears r.cmd when the stdout stream breaks, so a
+// single bad read doesn't permanently poison the shared process for every
+// later call. The stdout reader is swapped out directly (rather than
+// killing the process) so the write path stays healthy and the test
+// isolates ReadObject's read-error branch from its separate write-retry
+// logic.
+func TestReadObject_ClearsCmdOnReadError(t *testing.T) {
+	t.Parallel()
+
+	dir := initTestRepo(t)
+
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	require.NoError(t, err)
+	headSHA := strings.TrimSpace(string(out))
+
+	reader := newObjectReader(func() (string, error) { return dir, nil })
+
+	// Warm up so the process is running.
+	_, found, err := reader.ReadObject(headSHA)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	reader.mu.Lock()
+	reader.stdout = bufio.NewReader(erroringReader{})
+	reader.mu.Unlock()
+
+	_, _, err = reader.ReadObject(headSHA)
+	require.Error(t, err, "ReadObject must return an error when stdout is broken")
+	require.Nil(t, reader.cmd, "r.cmd must be nil after stdout read failure")
+
+	// Recovery: the next call restarts cleanly.
+	content2, found2, err := reader.ReadObject(headSHA)
+	require.NoError(t, err, "ReadObject must recover after clearing the dead process")
+	require.True(t, found2)
+	require.NotEmpty(t, content2)
 }
 
 // TestReadObjectsBatch_ClearsCmdOnReadError verifies that a broken stdout


### PR DESCRIPTION
## Summary

- `objectReader` wraps one persistent `git cat-file --batch` process shared by every single-object git read (`ReadLocalMetadata`, stack metadata, blob reads, etc).
- `ReadObjectsBatch` correctly discards the process (`killLocked`) whenever `readResponse` fails, so the next call restarts cleanly — see its comment "Stdout stream is broken; discard the process so the next call restarts."
- `ReadObject` was missing this on its read-error path: it just returned `r.readResponse(ref)` directly. If that read fails (broken pipe, unexpected EOF, or a desynced/malformed header), `r.cmd` stays non-nil, so the *next* call skips restarting and writes a new query into the same desynced stdin/stdout pair — silently poisoning every subsequent single-object read for the rest of the CLI invocation.
- This fixes `ReadObject` to mirror `ReadObjectsBatch`: on a `readResponse` error, discard the process so the next call restarts fresh.
- Added `TestReadObject_ClearsCmdOnReadError`, mirroring the existing `TestReadObjectsBatch_ClearsCmdOnReadError`, which injects a broken stdout reader (isolating the read-error path from `ReadObject`'s separate write-retry logic) and asserts `r.cmd` is cleared and the next call recovers.
- Checked for the same missing-cleanup pattern elsewhere (`rg "readResponse|killLocked"`) — this is the only call site, so no other locations need the fix.

## Test plan

- [x] `go test ./internal/git/... -run TestReadObject` — new and existing object-reader tests pass
- [x] `go test ./internal/git/...` — full package passes (one pre-existing, unrelated failure in `TestGetRepoInfo` due to sandbox git URL rewriting, reproduces identically on `main`)
- [x] `go vet ./internal/git/...` and `gofmt -l` clean on changed files


---
_Generated by [Claude Code](https://claude.ai/code/session_016binqvnW2qxeNr9Mg1uaTx)_