### PR TITLE
fix(engine): don't silently bypass optimistic locking on restack

### DIFF
--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -373,7 +373,16 @@ func (e *engineImpl) restackBranch(
 	}
 
 	// Get current SHAs for optimistic locking
-	oldBranchSHA, _ := branch.GetRevision()
+	oldBranchSHA, err := branch.GetRevision()
+	if err != nil {
+		return RestackBranchResult{
+			Result:            RestackConflict,
+			RebasedBranchBase: parentRev,
+			Reparented:        reparented,
+			OldParent:         oldParent,
+			NewParent:         parent,
+		}, fmt.Errorf("failed to get current branch revision for %s: %w", branchName, err)
+	}
 	oldMetadataSHA := snap.metaRefSHAs[branchName]
 
 	// Prepare metadata update
@@ -564,7 +573,10 @@ func (e *engineImpl) applyBranchAndMetadata(
 		}
 	}
 
-	oldBranchSHA, _ := branch.GetRevision()
+	oldBranchSHA, err := branch.GetRevision()
+	if err != nil {
+		return RestackBranchResult{Result: RestackConflict, RebasedBranchBase: parentRev}, fmt.Errorf("failed to get current branch revision for %s: %w", branchName, err)
+	}
 	oldMetadataSHA := snap.metaRefSHAs[branchName]
 
 	updatedMeta := meta.WithParentBranchRevision(&parentRev)


### PR DESCRIPTION
## Summary

- `restackBranch` and `applyBranchAndMetadata` in `internal/engine/restack_impl.go` discarded the error from `branch.GetRevision()` when capturing the branch's current SHA for the optimistic-locking ref update (`oldBranchSHA, _ := branch.GetRevision()`).
- On error, `oldBranchSHA` silently became `""`. `UpdateRefsBatch` (`internal/git/runner.go`) treats an empty `OldSHA` as "skip verification" rather than "expect empty ref" — so a transient read failure would silently disable the compare-and-swap check these functions rely on to detect concurrent modification, instead of failing the restack as `RestackConflict` like every other error path in these same functions.
- Both call sites now propagate the error and return `RestackConflict` with a wrapped error, matching the existing error-handling style used elsewhere in these functions.

I also checked for the same discarded-`GetRevision()`-into-`OldSHA` pattern elsewhere in the codebase (`internal/engine/rebase_validator.go:495`); that occurrence feeds a best-effort SHA-remapping cache rather than a ref-update CAS check, so it doesn't share this bug and was left as-is.

## Test plan

- [x] `go build ./internal/engine/...`
- [x] `go vet ./internal/engine/...`
- [x] `go test ./internal/engine/...` (all passing)
- [x] `gofmt -l` on the changed file (clean)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FKfNfHW2JecNAWsoLRUSyo)_