### PR TITLE
fix(engine): stop restack replaying trunk onto worktree-anchor stacks

### DIFF
--- a/internal/engine/restack_plan.go
+++ b/internal/engine/restack_plan.go
@@ -35,6 +35,13 @@ func (e *engineImpl) PlanRestack(ctx context.Context, branches Branches) (*Resta
 			continue
 		}
 		plan.ApplyMap[item.Branch] = true
+		if item.Action == RestackPlanApplyAnchor {
+			// A moved anchor has to invalidate its children exactly like any
+			// other moved parent. Without this they stay "up to date" against
+			// the anchor's previous tip, so their recorded parent revision
+			// never catches up and every consumer reading it keeps drifting.
+			plan.BranchMap[item.Branch] = true
+		}
 		if item.Action == RestackPlanApplyValidated {
 			specNewParent := item.NewParent
 			if parentItem, ok := plan.Items[item.NewParent]; ok && parentItem.Action == RestackPlanApplyAnchor && parentItem.TargetRev != "" {
@@ -92,6 +99,34 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 		}
 	}
 
+	// Worktree anchors are handled before the landed check below. An anchor
+	// holds no commits of its own -- it marks where trunk was when the worktree
+	// was created -- so it is always an ancestor of trunk and the landed check
+	// would always skip it. Skipping it means it never fast-forwards, and every
+	// consumer that measures a child against its recorded parent (restack
+	// ranges, tree commit counts and diffs) drifts further from reality with
+	// each trunk advance.
+	if branch.IsWorktreeAnchor() {
+		trunkRev, ok := e.planRev(revMap, e.trunk)
+		if !ok {
+			return item, false
+		}
+		anchorRev, ok := e.planRev(revMap, branchName)
+		if !ok {
+			return item, false
+		}
+		if anchorRev == trunkRev {
+			item.Skip = true
+			item.SkipResult = RestackBranchResult{Result: RestackUnneeded}
+			return item, true
+		}
+		item.Action = RestackPlanApplyAnchor
+		item.NewParent = e.trunk
+		item.ParentRev = trunkRev
+		item.TargetRev = trunkRev
+		return item, true
+	}
+
 	// If this branch has already landed, do not rebase it during restack. This
 	// covers merged PR metadata for all GitHub methods, plus Git-detected merge,
 	// rebase, and multi-commit squash histories on trunk even when the merged
@@ -129,27 +164,6 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 		return item, true
 	}
 
-	if branch.IsWorktreeAnchor() {
-		trunkRev, ok := e.planRev(revMap, e.trunk)
-		if !ok {
-			return item, false
-		}
-		anchorRev, ok := e.planRev(revMap, branchName)
-		if !ok {
-			return item, false
-		}
-		if anchorRev == trunkRev {
-			item.Skip = true
-			item.SkipResult = RestackBranchResult{Result: RestackUnneeded}
-			return item, true
-		}
-		item.Action = RestackPlanApplyAnchor
-		item.NewParent = e.trunk
-		item.ParentRev = trunkRev
-		item.TargetRev = trunkRev
-		return item, true
-	}
-
 	e.mu.RLock()
 	needsReparent := state != nil && e.shouldReparentBranch(ctx, state.Parent, nil, squashCache)
 	if needsReparent {
@@ -174,20 +188,34 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 		oldParentRev = *rev
 	}
 
+	// A worktree anchor is never the branch's real rebase base: children of an
+	// anchor are rebased onto trunk's tip below. Measure the other end of the
+	// range against trunk too, or the two ends sit on different bases. The
+	// anchor's recorded revision goes stale as soon as trunk advances, and the
+	// is-ancestor check below cannot detect that: a stale anchor revision is an
+	// ancestor of trunk, so it stays an ancestor of a branch sitting on trunk.
+	// Trusting it keeps every trunk commit since the anchor was created inside
+	// the replay range.
+	rebaseBase := parentName
+	if e.IsWorktreeAnchor(e.GetBranch(parentName)) {
+		rebaseBase = e.trunk
+		oldParentRev = ""
+	}
+
 	if oldParentRev != "" {
 		isAncestor, err := e.git.IsAncestor(ctx, oldParentRev, branchName)
 		if err != nil {
 			isAncestor = false
 		}
 		if !isAncestor {
-			mergeBase, err := e.git.GetMergeBase(ctx, branchName, parentName)
+			mergeBase, err := e.git.GetMergeBase(ctx, branchName, rebaseBase)
 			if err != nil {
 				return item, false
 			}
 			oldParentRev = mergeBase
 		}
 	} else {
-		mergeBase, err := e.git.GetMergeBase(ctx, branchName, parentName)
+		mergeBase, err := e.git.GetMergeBase(ctx, branchName, rebaseBase)
 		if err != nil {
 			return item, false
 		}
@@ -210,7 +238,21 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 	}
 	item.ParentRev = parentRev
 
-	if parentRev == oldParentRev && !plannedBranches.Contains(parentName) && !item.Reparented {
+	// Only skip when the recorded parent revision already agrees with the
+	// resolved one. A branch that needs no rebase never reaches a path that
+	// rewrites its metadata, so a recorded revision that has fallen behind can
+	// never catch up on its own — it just keeps drifting, and everything that
+	// reads it (tree commit counts and diffs, "restack suggested") drifts with
+	// it. This bites children of a worktree anchor, whose parent revision
+	// resolves to trunk while the metadata still holds whatever the anchor
+	// pointed at. Planning them keeps the no-op rebase that refreshes the
+	// record; the rebase itself has nothing to replay.
+	recordedRev := ""
+	if rev := meta.GetParentBranchRevision(); rev != nil {
+		recordedRev = *rev
+	}
+	upToDate := parentRev == oldParentRev && oldParentRev == recordedRev
+	if upToDate && !plannedBranches.Contains(parentName) && !item.Reparented {
 		item.Skip = true
 		item.SkipResult = RestackBranchResult{
 			Result:            RestackUnneeded,

--- a/internal/integration/restack_worktree_anchor_test.go
+++ b/internal/integration/restack_worktree_anchor_test.go
@@ -1,0 +1,103 @@
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRestackWorktreeAnchorTracksTrunk covers a stack living in a managed
+// worktree, which sits under a hidden worktree anchor.
+//
+// An anchor holds no commits of its own — it marks where trunk was when the
+// worktree was created — so it is always an ancestor of trunk. That made the
+// landed check skip it before it ever reached the fast-forward path, so the
+// anchor never moved. Two things then drift with every trunk advance: the
+// child's recorded parent revision (nothing invalidates it, because a skipped
+// anchor never counted as a moved parent), and the rebase range used to restack
+// the child, whose `upstream` end came from that stale revision while its `onto`
+// end was trunk's tip. The widening range replays trunk's own commits back onto
+// the branch, which .claude/rules/multiplayer-safety.md forbids: after a
+// restack, <trunk>..<branch> must equal exactly the branch's own commits.
+//
+// Restacking twice is what exposes it. One restack is fine, because the anchor
+// revision really is where the branch is based.
+func TestRestackWorktreeAnchorTracksTrunk(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+	sh.SetWorktreeBasePath(t.TempDir())
+
+	// A worktree-backed stack: `worktree create` inserts the hidden anchor.
+	sh.Run("worktree create my-wt")
+	sh.Run("worktree open my-wt")
+	worktreePath := strings.TrimSpace(sh.Output())
+
+	sh.InWorktree(worktreePath).
+		WriteFile("feature.txt", "feature").
+		Run("create feature -m 'feat: feature'")
+
+	anchorBranch := findWorktreeAnchor(t, sh)
+
+	assertTracksTrunk := func(stage string) {
+		t.Helper()
+
+		sh.Git("rev-parse main")
+		trunkRev := strings.TrimSpace(sh.Output())
+
+		sh.Git("rev-parse " + anchorBranch)
+		require.Equal(t, trunkRev, strings.TrimSpace(sh.Output()),
+			"%s: anchor must fast-forward to trunk, otherwise it pins a stale rebase base", stage)
+
+		require.Equal(t, trunkRev, recordedParentRev(t, sh, "feature"),
+			"%s: child's recorded parent revision must track trunk", stage)
+
+		// The invariant that actually protects the branch's contents.
+		sh.CommitCount("main", "feature", 1)
+	}
+
+	// Trunk advances and we restack. Correct even before the fix: the anchor
+	// revision really is where the branch is based.
+	sh.Checkout("main").
+		Commit("trunk1.txt", "chore: trunk commit 1").
+		Run("restack --all-stacks")
+	assertTracksTrunk("after first restack")
+
+	// Trunk advances again. This is where the stale anchor used to widen the
+	// replay range to cover every trunk commit since the worktree was created.
+	sh.Checkout("main").
+		Commit("trunk2.txt", "chore: trunk commit 2").
+		Run("restack --all-stacks")
+	assertTracksTrunk("after second restack")
+}
+
+// findWorktreeAnchor returns the name of the hidden worktree-anchor branch.
+func findWorktreeAnchor(t *testing.T, sh *TestShell) string {
+	t.Helper()
+
+	sh.Git("for-each-ref --format=%(refname:short) refs/heads/")
+	for _, branch := range strings.Fields(sh.Output()) {
+		if sh.isWorktreeAnchorBranch(branch) {
+			return branch
+		}
+	}
+
+	require.FailNow(t, "no worktree anchor branch found")
+	return ""
+}
+
+// recordedParentRev reads the parent revision stackit has recorded for a branch.
+func recordedParentRev(t *testing.T, sh *TestShell, branch string) string {
+	t.Helper()
+
+	sh.Git("rev-parse refs/stackit/metadata/" + branch)
+	sh.Git("cat-file -p " + strings.TrimSpace(sh.Output()))
+
+	var meta struct {
+		ParentBranchRevision string `json:"parentBranchRevision"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(sh.Output()), &meta))
+	return meta.ParentBranchRevision
+}


### PR DESCRIPTION

A stack in a managed worktree sits under a hidden anchor. Restacking such a
stack repeatedly replayed trunk history back onto the branch, violating the
invariant in .claude/rules/multiplayer-safety.md that <trunk>..<branch> holds
exactly the branch own commits. Observed on a real stack as a branch reported
at 210 commits and +16693/-8784 when it carries two, and as a rebase whose
todo listed 125 of trunk own commits.

Three faults compounded. The landed check ran before the anchor branch, and an
anchor is always an ancestor of trunk, so it was skipped as already landed and
the fast-forward path it exists for was unreachable. A child of an anchor then
had its rebase onto trunk tip while the other end of the range still came from
the anchor recorded revision, and the is-ancestor staleness guard cannot catch
that because a stale anchor revision stays an ancestor of a branch sitting on
trunk. Finally a branch needing no rebase never reaches a metadata write, so a
recorded revision that had fallen behind could never catch up.

Git patch-id dedup masks the replay whenever the trunk commits still match, so
the damage only surfaces once one does not, which is what squash and rebase
merges produce.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1488** 👈
  * **PR #1489**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->