### PR TITLE
feat(pr): explain stacked PRs in the PR body footer

### DIFF
--- a/internal/pr/sections.go
+++ b/internal/pr/sections.go
@@ -148,6 +148,14 @@ func renderNavigationContent(branch string, eng engine.BranchReader, opts Naviga
 			fmt.Fprintf(&content, "**Scope**: %s\n\n", scope.String())
 		}
 
+		// Explain what a stacked PR means when this PR targets another PR's branch
+		// rather than trunk — merging it in the GitHub UI lands it on the parent, not trunk.
+		if parent := branchObj.GetParent(); parent != nil && !parent.IsTrunk() {
+			fmt.Fprintf(&content,
+				"> ⚠️ **Stacked PR**: based on `%s`, not `%s`. Merging here in the GitHub UI merges into `%s` — the PRs below must land first. Run `st merge` to merge the stack in order.\n\n",
+				parent.GetName(), eng.Trunk().GetName(), parent.GetName())
+		}
+
 		// Add notice if present in PrInfo
 		prInfo, _ := branchObj.GetPrInfo()
 		if prInfo != nil {

--- a/internal/pr/sections_test.go
+++ b/internal/pr/sections_test.go
@@ -127,6 +127,44 @@ func TestCreatePRBodyFooter(t *testing.T) {
 	})
 }
 
+func TestStackedPRNotice(t *testing.T) {
+	t.Parallel()
+
+	newStack := func(t *testing.T) *scenario.Scenario {
+		t.Helper()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit().
+			CreateBranch("feature-a").
+			Commit("a1").
+			TrackBranch("feature-a", "main").
+			CreateBranch("feature-b").
+			Commit("b1").
+			TrackBranch("feature-b", "feature-a")
+
+		prNum := 1
+		require.NoError(t, s.Engine.UpsertPrInfo(context.Background(), s.Engine.GetBranch("feature-a"),
+			engine.NewPrInfo(&prNum, "Title A", "Body A", "OPEN", "main", "http://pr/1", false)))
+		prNum2 := 2
+		require.NoError(t, s.Engine.UpsertPrInfo(context.Background(), s.Engine.GetBranch("feature-b"),
+			engine.NewPrInfo(&prNum2, "Title B", "Body B", "OPEN", "feature-a", "http://pr/2", false)))
+		return s
+	}
+
+	opts := NavigationOptions{When: "always", Marker: "👈"}
+
+	t.Run("shown when the PR is based on another branch", func(t *testing.T) {
+		t.Parallel()
+		footer := CreatePRBodyFooterWithOptions("feature-b", newStack(t).Engine, opts)
+		assert.Contains(t, footer, "**Stacked PR**: based on `feature-a`, not `main`")
+	})
+
+	t.Run("hidden when the PR is based on trunk", func(t *testing.T) {
+		t.Parallel()
+		footer := CreatePRBodyFooterWithOptions("feature-a", newStack(t).Engine, opts)
+		assert.NotContains(t, footer, "**Stacked PR**")
+	})
+}
+
 func TestShouldShowNavigation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION

The footer already warned when a PR was part of a stack merge, but never
explained what being stacked means or what merging in the GitHub UI would
do. Reviewers landing on a child PR had no way to tell it targets its
parent rather than trunk.

Shown only when the base is a non-trunk branch, so bottom PRs are
unaffected. Rides on the existing navigation.when config rather than
adding a key of its own.

Closes #372

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1488**
  * **PR #1489** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->