### PR TITLE
fix: shell completion for create/pr, and give modify an undo snapshot

### DIFF
--- a/internal/actions/modify.go
+++ b/internal/actions/modify.go
@@ -64,6 +64,21 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) (err error) {
 	}
 	targetBranchObj := eng.GetBranch(targetBranchName)
 
+	// Take snapshot before modifying the repository. Without this, `stackit
+	// abort` falls back to whatever unrelated command's snapshot happens to
+	// be latest, which can restore the wrong current branch or even delete
+	// branches created since (see #1497). This matters more with --into,
+	// which amends a branch other than the one the user is standing on.
+	snapshotOpts := NewSnapshot("modify",
+		WithFlagValue("--into", opts.Into),
+		WithFlagValue("-m", opts.Message),
+		WithFlag(opts.CreateCommit, "--commit"),
+		WithFlag(opts.All, "--all"),
+		WithFlag(opts.Update, "--update"),
+		WithFlag(opts.Patch, "--patch"),
+	)
+	TakeBestEffortSnapshot(ctx, snapshotOpts)
+
 	// Handle interactive rebase separately
 	if opts.InteractiveRebase {
 		return interactiveRebaseAction(ctx, opts)

--- a/internal/cli/branch/create.go
+++ b/internal/cli/branch/create.go
@@ -115,5 +115,7 @@ Examples:
 	cmd.Flags().CountVarP(&verbose, "verbose", "v", "Show unified diff between the HEAD commit and what would be committed at the bottom of the commit message template. If specified twice, show in addition the unified diff between what would be committed and the worktree files")
 	cmd.Flags().BoolVarP(&worktree, "worktree", "w", false, "Create a dedicated worktree for this stack (only valid when creating a new stack from trunk)")
 
+	_ = cmd.RegisterFlagCompletionFunc("onto", common.CompleteBranches)
+
 	return cmd
 }

--- a/internal/cli/navigation/pr.go
+++ b/internal/cli/navigation/pr.go
@@ -26,8 +26,9 @@ Examples:
   stackit pr feature-x        # Open feature-x's PR
   stackit pr 1234             # Open PR #1234
   stackit pr --stack          # Open the root PR of the current stack`,
-		SilenceUsage: true,
-		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage:      true,
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: common.CompleteBranches,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return common.RunReadOnlyCurrentBranch(cmd, func(ctx *app.Context) error {
 				target := ""

--- a/internal/integration/modify_test.go
+++ b/internal/integration/modify_test.go
@@ -191,4 +191,40 @@ func TestModifyInto(t *testing.T) {
 
 		sh.OnBranch("c")
 	})
+
+	// Regression test for #1494/#1497: modify took no undo snapshot, so
+	// `stackit abort` fell back to whatever unrelated command's snapshot
+	// happened to be latest (typically the last `create`) instead of the
+	// state right before this modify ran — landing on the wrong branch and,
+	// in the worst case, deleting branches created since that stale snapshot.
+	t.Run("abort after a conflict restacking upstack returns to the original branch", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// main -> a -> b -> d. d's own commit reverts b's change to file.txt,
+		// so file.txt is identical between a and d: checking out a to amend
+		// it hits no local-changes conflict. b's original edit to the same
+		// line still conflicts when b is replayed onto the amended a.
+		sh.WriteFile("file.txt", "L1\nL2\nL3\n").
+			Run("create a -m 'Add a'").
+			OnBranch("a")
+		sh.WriteFile("file.txt", "L1\nL2-changed\nL3\n").
+			Run("create b -m 'Add b'").
+			OnBranch("b")
+		sh.WriteFile("file.txt", "L1\nL2\nL3\n").
+			Run("create d -m 'Add d'").
+			OnBranch("d")
+
+		sh.WriteFile("file.txt", "L1\nL2-AMENDED\nL3\n")
+		sh.Git("add file.txt")
+		sh.RunExpectError("modify --into a -n").
+			OutputContains("conflict")
+
+		sh.Run("abort --force").
+			OutputContains("Successfully aborted")
+
+		sh.OnBranch("d")
+		sh.HasBranches("a", "b", "d", "main")
+		sh.Git("show a:file.txt").OutputContains("L1\nL2\nL3\n")
+	})
 }


### PR DESCRIPTION
## Summary

Two independent, small fixes found by a pre-release review of `v0.23.0..b2ee8445`:

**1. Shell completion** (`internal/cli/branch/create.go`, `internal/cli/navigation/pr.go`)
- Register `common.CompleteBranches` for `create --onto`, matching every other branch-valued flag (`move --onto`, `pluck --onto`, `track --parent`, `up --to`, `modify --into`).
- Add `ValidArgsFunction: common.CompleteBranches` to `pr`'s positional branch argument, matching `checkout`, `info`, `track`, and `delete`.

Fixes #1503

**2. `modify` takes no undo snapshot** (`internal/actions/modify.go`)
- `modify` was the only history-rewriting action with no undo snapshot (`create`, `squash`, `absorb`, `fold`, `split`, `rename`, `move`, `flatten`, and `restack` all take one).
- Without it, `stackit abort` fell back to whatever unrelated command's snapshot happened to be latest instead of the state right before `modify` ran.
- This matters more with `--into`: aborting a conflict hit while amending a downstack ancestor landed on whatever branch a stale snapshot recorded as current — and could even **delete branches created since that snapshot was taken**. Confirmed with a repro building a 3-branch linear stack, amending the root via `--into`, hitting a conflict on restack, then running `stackit abort`: it deleted the most-recently-created branch and left HEAD on an unrelated branch.
- Fix: `modify` now takes its own `NewSnapshot("modify", ...)` before mutating, matching the established pattern used by every other action, so `stackit abort` correctly restores to the branch the user was actually on.

Fixes #1497
Fixes #1494

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/actions/... ./internal/cli/branch/... ./internal/cli/navigation/... ./internal/integration/...`
- [x] `go test ./internal/actions/... ./internal/integration/... ./internal/engine/...` (all passing)
- [x] Added `TestModifyInto/abort_after_a_conflict_restacking_upstack_returns_to_the_original_branch`, which reproduces the conflict-then-abort scenario and asserts the original branch is restored and no branches are lost
