### PR TITLE
fix(cli): add missing shell completion for create --onto and pr

### DIFF
--- a/internal/cli/branch/create.go
+++ b/internal/cli/branch/create.go
@@ -115,5 +115,7 @@ Examples:
 	cmd.Flags().CountVarP(&verbose, "verbose", "v", "Show unified diff between the HEAD commit and what would be committed at the bottom of the commit message template. If specified twice, show in addition the unified diff between what would be committed and the worktree files")
 	cmd.Flags().BoolVarP(&worktree, "worktree", "w", false, "Create a dedicated worktree for this stack (only valid when creating a new stack from trunk)")
 
+	_ = cmd.RegisterFlagCompletionFunc("onto", common.CompleteBranches)
+
 	return cmd
 }

--- a/internal/cli/navigation/pr.go
+++ b/internal/cli/navigation/pr.go
@@ -26,8 +26,9 @@ Examples:
   stackit pr feature-x        # Open feature-x's PR
   stackit pr 1234             # Open PR #1234
   stackit pr --stack          # Open the root PR of the current stack`,
-		SilenceUsage: true,
-		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage:      true,
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: common.CompleteBranches,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return common.RunReadOnlyCurrentBranch(cmd, func(ctx *app.Context) error {
 				target := ""


### PR DESCRIPTION
## Summary
- `stackit create --onto <branch>` now registers `common.CompleteBranches` for the `--onto` flag, matching every other branch-valued flag (`move --onto`, `pluck --onto`, `track --parent`, `up --to`, `modify --into`).
- `stackit pr [branch|number]` now registers `common.CompleteBranches` as its `ValidArgsFunction`, matching the other positional-branch commands (`checkout`, `info`, `track`, `delete`).

Both features already work without completion — this is polish only, no behavior change.

Fixes #1503

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/cli/branch/... ./internal/cli/navigation/...`
- [x] `go test ./internal/cli/branch/... ./internal/cli/navigation/...`
- [x] `gofmt -l` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_012xwXUpd9dt3gxA4RXWxquG)_