### PR TITLE
fix: shell completion for create --onto/pr, plus their untested error paths

### DIFF
--- a/internal/cli/branch/create.go
+++ b/internal/cli/branch/create.go
@@ -115,5 +115,7 @@ Examples:
 	cmd.Flags().CountVarP(&verbose, "verbose", "v", "Show unified diff between the HEAD commit and what would be committed at the bottom of the commit message template. If specified twice, show in addition the unified diff between what would be committed and the worktree files")
 	cmd.Flags().BoolVarP(&worktree, "worktree", "w", false, "Create a dedicated worktree for this stack (only valid when creating a new stack from trunk)")
 
+	_ = cmd.RegisterFlagCompletionFunc("onto", common.CompleteBranches)
+
 	return cmd
 }

--- a/internal/cli/navigation/pr.go
+++ b/internal/cli/navigation/pr.go
@@ -26,8 +26,9 @@ Examples:
   stackit pr feature-x        # Open feature-x's PR
   stackit pr 1234             # Open PR #1234
   stackit pr --stack          # Open the root PR of the current stack`,
-		SilenceUsage: true,
-		Args:         cobra.MaximumNArgs(1),
+		ValidArgsFunction: common.CompleteBranches,
+		SilenceUsage:      true,
+		Args:              cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return common.RunReadOnlyCurrentBranch(cmd, func(ctx *app.Context) error {
 				target := ""

--- a/internal/integration/create_onto_test.go
+++ b/internal/integration/create_onto_test.go
@@ -94,6 +94,18 @@ func TestCreateOnto(t *testing.T) {
 			OutputContains("locked")
 	})
 
+	t.Run("errors for a worktree anchor target", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.SetWorktreeBasePath(t.TempDir())
+
+		sh.Run("worktree create my-wt")
+		anchorBranch := findWorktreeAnchor(t, sh)
+
+		sh.RunExpectError("create branch-x --onto " + anchorBranch + " -m 'feat: x' --allow-empty").
+			OutputContains("cannot create a branch onto worktree anchor")
+	})
+
 	t.Run("errors when combined with --worktree", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)

--- a/internal/integration/pr_test.go
+++ b/internal/integration/pr_test.go
@@ -78,4 +78,25 @@ func TestPrCommand(t *testing.T) {
 
 		sh.RunExpectError("pr 999").OutputContains("no tracked branch found")
 	})
+
+	t.Run("errors when HEAD is detached", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Git("checkout --detach main")
+
+		sh.RunExpectError("pr").OutputContains("not on a branch")
+	})
+
+	t.Run("--stack errors when the stack root has no PR", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// main -> a -> b -> c, currently on c. Only c has a PR; the stack
+		// root (a) does not.
+		sh.CreateLinearStack3()
+		sh.SetPrMetadata("c", PRMetadata{Number: 3, URL: "https://github.com/owner/repo/pull/3"})
+
+		sh.RunExpectError("pr --stack").OutputContains("no associated pull request")
+	})
 }


### PR DESCRIPTION
## Summary

**#1503** — missing shell completion:
- `create --onto` had no `RegisterFlagCompletionFunc`, unlike every other branch-valued flag (`move --onto`, `pluck --onto`, `track --parent`, `up --to`, `modify --into`).
- `pr`'s positional `[branch|number]` argument had no `ValidArgsFunction`, unlike every other positional-branch command (`checkout`, `info`, `track`, `delete`).
- Both are wired to the existing `common.CompleteBranches` helper, matching the established convention.

**#1501** — untested error branches in the two new features:
- `create --onto <worktree-anchor>` now has a subtest covering the `cannot create a branch onto worktree anchor` rejection, using the existing `findWorktreeAnchor` helper.
- `pr` now has a subtest covering `errors.ErrNotOnBranch` (detached HEAD).
- `pr --stack` now has a subtest covering the case where the resolved stack root has no PR.

Each new assertion was verified load-bearing by temporarily reverting the corresponding source check and confirming the new subtest fails (not just that it runs).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` on changed files (clean)
- [x] `go test ./internal/integration/ -run 'TestPrCommand|TestCreateOnto' -v` — all pass
- [x] Manually reverted each of the three source checks and confirmed the corresponding new subtest fails

Fixes #1503
Fixes #1501

🤖 Generated with [Claude Code](https://claude.com/claude-code)
