### PR TITLE
fix: register shell completion for create --onto and pr's branch arg

### DIFF
--- a/internal/cli/branch/create.go
+++ b/internal/cli/branch/create.go
@@ -115,5 +115,7 @@ Examples:
 	cmd.Flags().CountVarP(&verbose, "verbose", "v", "Show unified diff between the HEAD commit and what would be committed at the bottom of the commit message template. If specified twice, show in addition the unified diff between what would be committed and the worktree files")
 	cmd.Flags().BoolVarP(&worktree, "worktree", "w", false, "Create a dedicated worktree for this stack (only valid when creating a new stack from trunk)")
 
+	_ = cmd.RegisterFlagCompletionFunc("onto", common.CompleteBranches)
+
 	return cmd
 }

--- a/internal/cli/navigation/pr.go
+++ b/internal/cli/navigation/pr.go
@@ -26,8 +26,9 @@ Examples:
   stackit pr feature-x        # Open feature-x's PR
   stackit pr 1234             # Open PR #1234
   stackit pr --stack          # Open the root PR of the current stack`,
-		SilenceUsage: true,
-		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage:      true,
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: common.CompleteBranches,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return common.RunReadOnlyCurrentBranch(cmd, func(ctx *app.Context) error {
 				target := ""


### PR DESCRIPTION
## Summary
- Register branch completion for `create --onto` (`internal/cli/branch/create.go`), matching every other branch-valued flag in the codebase (`move --onto`, `pluck --onto`, `track --parent`, `up --to`, `modify --into`).
- Add a `ValidArgsFunction` for `pr`'s positional branch/PR-number argument (`internal/cli/navigation/pr.go`), matching `checkout`, `info`, `track`, and `delete`.

Both flags/args already worked correctly without completion — this is shell-completion polish only, no behavior change.

Fixes #1503

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/cli/...`
- [x] `go test ./internal/cli/...` (all packages pass)
- [x] `gofmt -l` clean on changed files

---
_Generated by [Claude Code](https://claude.ai/code/session_014NUPmYSDTUd7MkQRqejQcR)_