### PR TITLE
fix(cli/actions): shell completion for create --onto/pr, and modify undo snapshot

### DIFF
--- a/internal/actions/modify.go
+++ b/internal/actions/modify.go
@@ -64,6 +64,18 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) (err error) {
 	}
 	targetBranchObj := eng.GetBranch(targetBranchName)
 
+	// Take snapshot before modifying the repository
+	snapshotOpts := NewSnapshot("modify",
+		WithFlagValue("--into", opts.Into),
+		WithFlagValue("-m", opts.Message),
+		WithFlag(opts.CreateCommit, "--commit"),
+		WithFlag(opts.Edit, "--edit"),
+		WithFlag(opts.NoEdit, "--no-edit"),
+		WithFlag(opts.ResetAuthor, "--reset-author"),
+		WithFlag(opts.InteractiveRebase, "--interactive-rebase"),
+	)
+	TakeBestEffortSnapshot(ctx, snapshotOpts)
+
 	// Handle interactive rebase separately
 	if opts.InteractiveRebase {
 		return interactiveRebaseAction(ctx, opts)

--- a/internal/cli/branch/create.go
+++ b/internal/cli/branch/create.go
@@ -115,5 +115,7 @@ Examples:
 	cmd.Flags().CountVarP(&verbose, "verbose", "v", "Show unified diff between the HEAD commit and what would be committed at the bottom of the commit message template. If specified twice, show in addition the unified diff between what would be committed and the worktree files")
 	cmd.Flags().BoolVarP(&worktree, "worktree", "w", false, "Create a dedicated worktree for this stack (only valid when creating a new stack from trunk)")
 
+	_ = cmd.RegisterFlagCompletionFunc("onto", common.CompleteBranches)
+
 	return cmd
 }

--- a/internal/cli/navigation/pr.go
+++ b/internal/cli/navigation/pr.go
@@ -26,8 +26,9 @@ Examples:
   stackit pr feature-x        # Open feature-x's PR
   stackit pr 1234             # Open PR #1234
   stackit pr --stack          # Open the root PR of the current stack`,
-		SilenceUsage: true,
-		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage:      true,
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: common.CompleteBranches,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return common.RunReadOnlyCurrentBranch(cmd, func(ctx *app.Context) error {
 				target := ""

--- a/internal/integration/modify_test.go
+++ b/internal/integration/modify_test.go
@@ -2,6 +2,8 @@ package integration
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestModifyWorkflow(t *testing.T) {
@@ -189,6 +191,61 @@ func TestModifyInto(t *testing.T) {
 			OutputContains("checked out in worktree").
 			OutputContains(worktreeDir)
 
+		sh.OnBranch("c")
+	})
+}
+
+func TestModifyUndo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("undo restores the pre-amend commit", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("a", "original content").
+			Run("create feature-a -m 'Feature A'").
+			OnBranch("feature-a")
+
+		before := sh.Git("rev-parse feature-a").Output()
+
+		sh.Modify("a_extra", "extra content").
+			OutputContains("Amended commit")
+
+		after := sh.Git("rev-parse feature-a").Output()
+		require.NotEqual(t, before, after, "modify should have amended the commit")
+
+		sh.UndoLatest()
+
+		require.Equal(t, before, sh.Git("rev-parse feature-a").Output(),
+			"undo should restore the pre-amend commit")
+	})
+
+	t.Run("undo restores both branches after modify --into", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3().
+			OnBranch("c")
+
+		beforeA := sh.Git("rev-parse a").Output()
+		beforeB := sh.Git("rev-parse b").Output()
+
+		sh.Write("a_extra", "extra content for a").
+			Run("modify --into a -n").
+			OutputContains("Amended commit in a").
+			OnBranch("c")
+
+		require.NotEqual(t, beforeA, sh.Git("rev-parse a").Output(),
+			"modify --into should have amended the target branch")
+		require.NotEqual(t, beforeB, sh.Git("rev-parse b").Output(),
+			"restacking upstack branches should have moved b")
+
+		sh.UndoLatest()
+
+		require.Equal(t, beforeA, sh.Git("rev-parse a").Output(),
+			"undo should restore the target branch's pre-amend commit")
+		require.Equal(t, beforeB, sh.Git("rev-parse b").Output(),
+			"undo should restore the restacked branch's pre-restack commit")
 		sh.OnBranch("c")
 	})
 }


### PR DESCRIPTION
## Summary

Two small, independent fixes from the pre-release review batch (issues opened in this repo):

**#1503 — missing shell completion**
- `create --onto` registers no flag completion; every other branch-valued flag does (`move --onto`, `pluck --onto`, `track --parent`, `up --to`, `modify --into`). Added `cmd.RegisterFlagCompletionFunc("onto", common.CompleteBranches)`.
- `pr`'s positional `[branch|number]` argument has no `ValidArgsFunction`, while every other positional-branch command does (`checkout`, `info`, `track`, `delete`). Added `ValidArgsFunction: common.CompleteBranches`.

**#1497 — modify takes no undo snapshot**
- `ModifyAction` was the one history-rewriting action with no `NewSnapshot` call (unlike create/squash/absorb/fold/split/rename/move/flatten/restack). The `--into` flag widens the blast radius: a mistyped `--into` target amends a commit on a branch the user wasn't standing on and restacks its whole subtree, with only the reflog to recover from.
- Added a snapshot before the checkout, covering both the plain-modify and `--into` paths, plus an integration test (`TestModifyUndo`) asserting undo restores the pre-amend commit and the restacked upstack branch. Verified the new test fails without the fix.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/cli/...`
- [x] `go test ./internal/cli/...`
- [x] `go test ./internal/actions/... ./internal/integration/...`
- [x] Confirmed `TestModifyUndo` fails against the pre-fix code and passes with the fix
- [x] `gofmt -l` on changed files (clean)
