### PR TITLE
fix(engine): worktree-anchor restack convergence, plus test coverage fix

### DIFF
--- a/internal/engine/rebase_validator.go
+++ b/internal/engine/rebase_validator.go
@@ -624,6 +624,19 @@ func (e *engineImpl) tryConflictFreeReplay(
 		if i+1 < len(commits) {
 			mergeBase = commits[i+1]
 		}
+		// mergeBase is this commit's original parent. When it already equals
+		// newBase, the commit is already correctly based -- reuse it as-is
+		// instead of minting an equivalent-but-different commit via
+		// commit-tree (a fresh commit object even with the same tree and
+		// parent, since the committer date isn't fixed). Without this, a
+		// spec whose upstream end is recomputed fresh every time it's
+		// planned -- as it is for a worktree-anchor child whose recorded
+		// parent revision never converges -- churns a new SHA on every
+		// restack even though nothing changed.
+		if mergeBase == newBase {
+			newBase = commits[i]
+			continue
+		}
 		newSHA, ok := e.replayCommitConflictFree(ctx, commits[i], mergeBase, newBase)
 		if !ok {
 			return "", false

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -522,6 +522,34 @@ func (e *engineImpl) applyValidatedRestack(
 		parentRev = rev
 	}
 
+	// The conflict-free replay path is idempotent: when nothing needed to
+	// change, newRev is the branch's own current SHA. Applying it anyway
+	// would still rewrite the branch ref and metadata and report a restack
+	// even though nothing moved. This matters most for a child of a worktree
+	// anchor: its recorded parent revision can never converge (the anchor
+	// doesn't fast-forward outside the restack set), so it gets re-planned on
+	// every run -- without this check, that would mint a fresh no-op commit
+	// SHA every time, force-pushing and re-triggering CI for no reason.
+	//
+	// Skip this only when the branch isn't being reparented: reparenting past
+	// a landed branch is a metadata-only move (the branch keeps its own
+	// commits unchanged, see .claude/rules/multiplayer-safety.md), so an
+	// unchanged newRev there is the expected, correct case -- and the parent
+	// branch name/revision update must still happen.
+	if !item.Reparented {
+		currentRev, ok := snap.revs[branchName]
+		if !ok {
+			var err error
+			currentRev, err = branch.GetRevision()
+			if err != nil {
+				return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to get current branch revision for %s: %w", branchName, err)
+			}
+		}
+		if currentRev == newRev {
+			return RestackBranchResult{Result: RestackUnneeded, RebasedBranchBase: parentRev}, nil
+		}
+	}
+
 	result, err := e.applyBranchAndMetadata(ctx, branch, item, newRev, parentRev, snap)
 	if err != nil {
 		return result, err

--- a/internal/integration/restack_worktree_anchor_test.go
+++ b/internal/integration/restack_worktree_anchor_test.go
@@ -22,8 +22,23 @@ import (
 // the branch, which .claude/rules/multiplayer-safety.md forbids: after a
 // restack, <trunk>..<branch> must equal exactly the branch's own commits.
 //
-// Restacking twice is what exposes it. One restack is fine, because the anchor
-// revision really is where the branch is based.
+// The stack goes two levels deep (anchor -> feature -> feature2) to broaden
+// coverage of the newly-reachable anchor path beyond a single child.
+//
+// The commit-count assertions below are not, by themselves, a regression
+// test for the replay bug -- verified by reverting internal/engine/restack_plan.go
+// to its pre-fix version and running this test with only those assertions
+// left in: it still passes, at both stack depths. A reverted build treats
+// the anchor as already landed (it is always an ancestor of trunk) and skips
+// it before ever reaching the fast-forward path, so it never moves; every
+// descendant then keeps comparing itself to that same stale anchor tip and
+// also gets skipped as "up to date". Nothing gets replayed, so the commit
+// counts stay right by accident. What actually catches the regression is the
+// bookkeeping asserted above -- the anchor failing to fast-forward to trunk,
+// and the child's recorded parent revision failing to track it -- confirmed
+// by the same revert, which fails there instead. The commit counts stay as
+// an integrity check on the stack's contents once a restack has genuinely
+// happened, not as the primary regression signal.
 func TestRestackWorktreeAnchorTracksTrunk(t *testing.T) {
 	t.Parallel()
 
@@ -35,9 +50,11 @@ func TestRestackWorktreeAnchorTracksTrunk(t *testing.T) {
 	sh.Run("worktree open my-wt")
 	worktreePath := strings.TrimSpace(sh.Output())
 
-	sh.InWorktree(worktreePath).
-		WriteFile("feature.txt", "feature").
+	wt := sh.InWorktree(worktreePath)
+	wt.WriteFile("feature.txt", "feature").
 		Run("create feature -m 'feat: feature'")
+	wt.WriteFile("feature2.txt", "feature2").
+		Run("create feature2 -m 'feat: feature2'")
 
 	anchorBranch := findWorktreeAnchor(t, sh)
 
@@ -54,8 +71,10 @@ func TestRestackWorktreeAnchorTracksTrunk(t *testing.T) {
 		require.Equal(t, trunkRev, recordedParentRev(t, sh, "feature"),
 			"%s: child's recorded parent revision must track trunk", stage)
 
-		// The invariant that actually protects the branch's contents.
+		// Integrity check once a restack has actually happened -- see the
+		// bookkeeping asserts above for what actually catches the regression.
 		sh.CommitCount("main", "feature", 1)
+		sh.CommitCount("main", "feature2", 2)
 	}
 
 	// Trunk advances and we restack. Correct even before the fix: the anchor

--- a/internal/integration/restack_worktree_anchor_test.go
+++ b/internal/integration/restack_worktree_anchor_test.go
@@ -92,6 +92,57 @@ func TestRestackWorktreeAnchorTracksTrunk(t *testing.T) {
 	assertTracksTrunk("after second restack")
 }
 
+// TestRestackUpstackConvergesForWorktreeAnchorChild covers #1491: `restack
+// --upstack` (and `--only`) on a child of a worktree anchor used to rewrite
+// the branch's commit on every run and never reach an up-to-date state, even
+// with no further trunk movement between runs. Contents stayed correct (no
+// replay), but each run minted a fresh SHA, which force-pushes on the next
+// submit, re-triggers CI, and detaches existing review threads from their
+// commits.
+//
+// Unlike TestRestackWorktreeAnchorTracksTrunk, this scope deliberately
+// excludes the anchor from the restack set (`--upstack` starts at feature),
+// so the anchor's ref never advances and the child's recorded parent
+// revision can never catch up to it. That keeps the branch "planned" forever
+// even once it is already correctly based, so what's under test is that the
+// conflict-free replay path stops minting a new commit once nothing is left
+// to replay.
+func TestRestackUpstackConvergesForWorktreeAnchorChild(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+	sh.SetWorktreeBasePath(t.TempDir())
+
+	sh.Run("worktree create my-wt")
+	sh.Run("worktree open my-wt")
+	worktreePath := strings.TrimSpace(sh.Output())
+
+	sh.InWorktree(worktreePath).
+		WriteFile("feature.txt", "feature").
+		Run("create feature -m 'feat: feature'")
+
+	// One trunk advance, then a real restack: feature actually needs to move.
+	sh.Checkout("main").
+		Commit("trunk1.txt", "chore: trunk commit 1").
+		Run("restack --branch feature --upstack")
+
+	sh.Git("rev-parse feature")
+	firstRev := strings.TrimSpace(sh.Output())
+
+	// No further trunk movement. Repeated restacks scoped to exclude the
+	// anchor must converge: same SHA, reported as already up to date.
+	for i := 2; i <= 3; i++ {
+		sh.Run("restack --branch feature --upstack").
+			OutputContains("up to date")
+
+		sh.Git("rev-parse feature")
+		require.Equal(t, firstRev, strings.TrimSpace(sh.Output()),
+			"run %d: feature's SHA must stay stable once it is already correctly based", i)
+	}
+
+	sh.CommitCount("main", "feature", 1)
+}
+
 // findWorktreeAnchor returns the name of the hidden worktree-anchor branch.
 func findWorktreeAnchor(t *testing.T, sh *TestShell) string {
 	t.Helper()


### PR DESCRIPTION
## Summary

This PR now contains two fixes from a scheduled issue-triage session, both stacked on the same branch per this session's configuration.

### fix(engine): make conflict-free replay idempotent for worktree-anchor children (#1491)

`restack --upstack` / `--only` on a child of a worktree anchor rewrote the branch's commit on every run and never converged, even with no further trunk movement between runs. Two things compound:

- The recorded parent revision can never catch up when the anchor is excluded from the restack set (it doesn't fast-forward outside it), so the branch stays "planned" on every restack.
- The conflict-free replay path unconditionally re-minted a commit via `commit-tree`, which produces a fresh SHA even when the tree and parent are unchanged (the committer date isn't fixed).

Fix: give the replay fast path an idempotency guard — when a commit's original parent already equals the new base, reuse the commit unchanged instead of recreating it. Complement that in `applyValidatedRestack`: when the validated result is the branch's own current SHA, report the branch as already up to date instead of writing a no-op ref/metadata update — except when the branch is being reparented, since reparenting past a landed branch is a metadata-only move that keeps the branch's commits unchanged by design, and needs its parent metadata written regardless. (That reparent carve-out was caught by the full test suite — an earlier version of this fix broke `TestRestackOnSyncedTrunkMatrix`'s rebase/squash reparent cases.)

Fixes #1491

### test(restack): broaden worktree-anchor coverage and correct its comment (#1499)

`TestRestackWorktreeAnchorTracksTrunk`'s comment claimed the `sh.CommitCount("main", "feature", 1)` assertion was "the invariant that actually protects the branch's contents." Reverting `internal/engine/restack_plan.go` to its pre-#1488 version and running the test with only that assertion left in shows it still passes: a reverted build treats the worktree anchor as already landed (it's always an ancestor of trunk) and skips it before it ever fast-forwards, so every descendant just keeps comparing itself to the same stale anchor tip and also gets skipped as "up to date" — nothing gets replayed, so the commit count stays right by accident.

What actually catches the regression, confirmed by the same revert, is the bookkeeping asserted above it: the anchor failing to fast-forward to trunk, and the child's recorded parent revision failing to track it. The comment now says so instead of overstating the commit-count check. Also deepens the stack to `anchor -> feature -> feature2`, broadening coverage of the newly-reachable anchor path to a case with an intermediate branch.

Fixes #1499

## Test plan

- [x] `go test ./internal/integration/ -run TestRestackUpstackConvergesForWorktreeAnchorChild -v` passes; fails with "restacked 1" instead of "up to date" when the fix is reverted, confirming it's load-bearing
- [x] `go test ./internal/integration/ -run TestRestackWorktreeAnchorTracksTrunk -v` passes
- [x] `go test ./internal/engine/... ./internal/integration/...` passes in full
- [x] `go test ./...` passes in full (one unrelated pre-existing failure in `internal/git` `TestGetRepoInfo/parses_HTTPS_URL`, reproduces on `main` with no changes — a sandbox git-remote-URL rewrite artifact, not caused by this PR)
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean