### PR TITLE
fix(modify): translate raw checkout error for --into conflicts

### DIFF
--- a/internal/actions/modify.go
+++ b/internal/actions/modify.go
@@ -76,6 +76,9 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) (err error) {
 
 	if targetBranchName != originalBranchName {
 		if err := eng.CheckoutBranch(gctx, targetBranchObj); err != nil {
+			if git.IsLocalChangesError(err) {
+				return fmt.Errorf("cannot modify %s because your staged changes conflict with it; commit or stash them first, or use 'stackit absorb' to route the change to the commit that should own it", targetBranchName)
+			}
 			return fmt.Errorf("failed to checkout %s: %w", targetBranchName, err)
 		}
 		out.Info("Modifying downstack branch %s.", output.CurrentBranch(targetBranchName))

--- a/internal/integration/modify_test.go
+++ b/internal/integration/modify_test.go
@@ -191,4 +191,28 @@ func TestModifyInto(t *testing.T) {
 
 		sh.OnBranch("c")
 	})
+
+	t.Run("gives actionable guidance instead of a raw git error on conflicting staged files", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3().
+			OnBranch("c")
+
+		// Diverge the shared file between a and c: amend b's commit so the
+		// file differs between a's HEAD and c's HEAD, then stage yet another
+		// conflicting version on c. Checking out from c to a then requires
+		// overwriting the staged change, which git refuses to do silently.
+		sh.Checkout("b").
+			Modify("a.txt", "b's version of the shared file")
+
+		sh.Checkout("c").
+			Write("a.txt", "c's conflicting staged version").
+			RunExpectError("modify --into a -n").
+			OutputContains("stackit absorb").
+			OnBranch("c")
+
+		sh.Git("diff --cached --name-only").
+			OutputContains("a.txt_test.txt")
+	})
 }


### PR DESCRIPTION
## Summary
- `modify --into <target>` surfaced git's raw `error: Your local changes to the following files would be overwritten by checkout` message when the staged change conflicts with the target branch's version of a file. This is the flag's most likely real-world failure mode (amending a downstack branch that touches the same file), so translate it into stackit guidance: commit/stash the change, or use `stackit absorb` to route it to the commit that should own it.
- `internal/actions/modify.go`: detect the failure with the existing `git.IsLocalChangesError` helper (already used by `checkout`) before falling back to the generic "failed to checkout" wrap.

Fails safe both before and after this change — HEAD stays on the original branch and the staged change is preserved either way. This only changes the message.

Fixes #1498

## Test plan
- [x] Added `TestModifyInto/gives_actionable_guidance_instead_of_a_raw_git_error_on_conflicting_staged_files` — diverges a shared file between the `--into` target and the current branch, stages a further conflicting change, and asserts the failure mentions `stackit absorb`, stays on the original branch, and leaves the staged change intact. Confirmed this test fails with the old raw-git-error message before the fix.
- [x] `go test ./internal/actions/... ./internal/integration/...`
- [x] `go build ./...`
- [x] `gofmt -l` clean on changed files

---
_Generated by [Claude Code](https://claude.ai/code/session_014NUPmYSDTUd7MkQRqejQcR)_