### PR TITLE
fix(pr): stop pr integration tests from launching a real browser

### DIFF
--- a/internal/actions/pr.go
+++ b/internal/actions/pr.go
@@ -20,6 +20,20 @@ type OpenPROptions struct {
 	Stack bool
 }
 
+// openBrowser is the function OpenPRAction uses to open a URL in the user's
+// default browser. Overridable via SetBrowserOpener so tests don't launch
+// real browser windows.
+var openBrowser = utils.OpenBrowser
+
+// SetBrowserOpener overrides the function OpenPRAction uses to open a URL in
+// the browser. Intended for tests; pass nil to restore the default.
+func SetBrowserOpener(fn func(url string) error) {
+	if fn == nil {
+		fn = utils.OpenBrowser
+	}
+	openBrowser = fn
+}
+
 // OpenPRAction resolves the pull request opts identifies and opens it in the
 // default browser.
 func OpenPRAction(ctx *app.Context, opts OpenPROptions) error {
@@ -47,7 +61,7 @@ func OpenPRAction(ctx *app.Context, opts OpenPROptions) error {
 	ctx.Output.Info("Opening %s", prInfo.URL())
 	// Best-effort: environments without a browser (SSH, headless CI) still get
 	// the URL printed above, mirroring submit's --web behavior.
-	if err := utils.OpenBrowser(prInfo.URL()); err != nil {
+	if err := openBrowser(prInfo.URL()); err != nil {
 		ctx.Output.Debug("Failed to open browser: %v", err)
 	}
 	return nil

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 
+	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/utils"
 	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/inprocess"
@@ -46,6 +47,9 @@ func init() {
 		res := runner.Run(workDir, args...)
 		return res.Output, res.Err
 	})
+	// Integration tests run the CLI in-process; never launch a real browser
+	// window for `stackit pr`.
+	actions.SetBrowserOpener(func(string) error { return nil })
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- `OpenPRAction` called `utils.OpenBrowser` unconditionally. The `pr` integration tests run the CLI in-process with no `PATH`/`BROWSER` stub, so every `go test -run TestPrCommand` run launched real browser windows (four times, on the developer's machine and in CI).
- Route the call through an overridable `openBrowser` package var (`actions.SetBrowserOpener`) rather than gating on interactivity, so the production path stays unconditional — exactly as it behaves today. The integration test harness installs a no-op opener once in its `init()` (`internal/integration/helpers_test.go`), covering every test that runs the CLI in-process, not just `pr`'s.
- `submit`'s browser-opening path is unaffected — it's already gated behind `--web`/config and never fires in tests.

Fixes #1496

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/actions/... ./internal/integration/...`
- [x] `gofmt -l` on changed files (clean)
- [x] `go test ./internal/actions/...`
- [x] `go test ./internal/integration/...` (full suite, including `TestPrCommand`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKmnLM8tzFfotHAS32jQsU)_