### PR TITLE
docs(test): stop overclaiming replay-invariant coverage in worktree-anchor test

### DIFF
--- a/internal/integration/restack_worktree_anchor_test.go
+++ b/internal/integration/restack_worktree_anchor_test.go
@@ -22,8 +22,23 @@ import (
 // the branch, which .claude/rules/multiplayer-safety.md forbids: after a
 // restack, <trunk>..<branch> must equal exactly the branch's own commits.
 //
-// Restacking twice is what exposes it. One restack is fine, because the anchor
-// revision really is where the branch is based.
+// Restacking twice is what exposes the drift in the two bookkeeping asserts
+// below (the anchor fast-forwarding, and the child's recorded parent revision
+// tracking trunk): pre-fix, those fail on the second restack because the
+// anchor never moved and the recorded revision never caught up.
+//
+// The final sh.CommitCount assert is the invariant that actually protects the
+// branch's contents, but this scenario alone does not exercise it as
+// regression coverage: git silently drops an already-applied commit from a
+// rebase todo when its patch already matches history on the new base (the
+// "skipped previously applied commit" optimization), which is exactly what
+// happens to the widened-but-unchanged trunk commits replayed here. The
+// widening only becomes visible in the commit count once a replayed trunk
+// commit's patch no longer matches what is already on trunk — the shape a
+// squash or rebase merge produces — which is a separate scenario this test
+// does not construct. Do not treat CommitCount passing here as proof the
+// replay-widening bug (the data-loss shape, not just the bookkeeping) stays
+// fixed; the bookkeeping asserts are what is load-bearing in this test.
 func TestRestackWorktreeAnchorTracksTrunk(t *testing.T) {
 	t.Parallel()
 
@@ -54,7 +69,8 @@ func TestRestackWorktreeAnchorTracksTrunk(t *testing.T) {
 		require.Equal(t, trunkRev, recordedParentRev(t, sh, "feature"),
 			"%s: child's recorded parent revision must track trunk", stage)
 
-		// The invariant that actually protects the branch's contents.
+		// Sanity check only in this scenario -- see the type comment on why
+		// this does not independently prove the replay-widening bug is fixed.
 		sh.CommitCount("main", "feature", 1)
 	}
 
@@ -65,8 +81,8 @@ func TestRestackWorktreeAnchorTracksTrunk(t *testing.T) {
 		Run("restack --all-stacks")
 	assertTracksTrunk("after first restack")
 
-	// Trunk advances again. This is where the stale anchor used to widen the
-	// replay range to cover every trunk commit since the worktree was created.
+	// Trunk advances again. This is where the stale anchor and recorded
+	// revision used to fail to catch up (see the type comment).
 	sh.Checkout("main").
 		Commit("trunk2.txt", "chore: trunk commit 2").
 		Run("restack --all-stacks")


### PR DESCRIPTION
Fixes #1499.

`TestRestackWorktreeAnchorTracksTrunk`'s final assert was commented as "the invariant that actually protects the branch's contents," implying it is regression coverage for the replay/widening bug fixed in #1488. It is not.

## Investigation

I verified empirically, two ways, that this scenario's `sh.CommitCount("main", "feature", 1)` passes even without the #1488 fix:

1. Reverted `internal/engine/restack_plan.go` to its pre-#1488 shape (commit `2c61e8e~1`) in a scratch worktree and ran the existing test — it fails, but only at the "anchor must fast-forward to trunk" bookkeeping assert. Neutering just that assert (and the recorded-parent-revision assert next to it) makes the test pass against the pre-fix engine, exactly as the issue described.
2. Manually reproduced the actual data-loss shape from #1488's commit message (a replayed trunk commit whose patch no longer matches, i.e. squash/rebase-merge shaped) against a pre-fix binary — `main..feature` genuinely widens to include a stale trunk commit there. Reproducing the same steps against the post-fix binary requires rewriting a trunk commit the anchor has *already* fast-forwarded onto, which is a different, invalid precondition (rewriting shared history a ref already depends on) rather than a clean isolated repro of this bug. I could not construct a scenario that (a) is a legitimate restack sequence, (b) fails pre-fix, and (c) passes post-fix, without modeling actual squash/rebase-merge semantics, which is a materially bigger effort and arguably belongs with the existing squash/rebase-merge-detection test suites instead.

So I went with the issue's second suggested option: reword the comments instead of adding a test that wouldn't actually prove what it claims.

## Change

Reworded the type-level comment and the two touched inline comments to state plainly:
- The two bookkeeping asserts (anchor fast-forwarding, recorded parent revision tracking trunk) are what this test actually catches pre-fix.
- The `CommitCount` assert, while it's the invariant that matters in production, isn't independently exercised as regression coverage by this scenario — git's "skip already-applied commit" optimization silently absorbs the widened-but-unchanged replay range here. It only becomes visible once a replayed commit's patch stops matching, which is a squash/rebase-merge shape this test doesn't construct.

No behavior change — comments only. Verified `go build`, `go vet ./internal/integration/...`, and `go test ./internal/integration/ -run TestRestackWorktreeAnchor` (both worktree-anchor tests) pass.

## Test plan

- [x] `go vet ./internal/integration/...`
- [x] `go test ./internal/integration/ -run TestRestackWorktreeAnchor` — both `TestRestackWorktreeAnchorTracksTrunk` and `TestRestackWorktreeAnchoredBranchAgainstAdvancedTrunk` pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pi1N35G9PV8hcSdmYYATej)_