### PR TITLE
fix: preserve uncommitted worktree changes during restack; docs cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,13 +255,13 @@ stack-submit --stack         # Creates/updates all PRs in the stack
 | `stackit children` | Show the children of the current branch |
 | `stackit parent` | Show the parent of the current branch |
 | `stackit share` | Print the current stack as Slack-ready markdown for copy-paste |
-| `stackit pr [branch|number]` | Open a pull request in the default browser (`--stack` for the stack's root PR) |
+| `stackit pr [branch\|number]` | Open a pull request in the default browser (`--stack` for the stack's root PR) |
 
 ### Branch Management
 | Command | Description |
 |:---|:---|
 | `stackit create [name]` | Create a new branch on top of current (use `-w` to create with worktree, `--onto <branch>` to target a specific parent without checking it out) |
-| `stackit modify` | Amend the current commit (like `git commit --amend`) |
+| `stackit modify` | Amend the current commit (like `git commit --amend`; use `--into <branch>` to amend a downstack ancestor without checking it out) |
 | `stackit absorb` | Intelligently amend changes to the correct commits in the stack |
 | `stackit split` | Split commits into branches (by commit, hunk, or file; use `--above` for upstack) |
 | `stackit squash` | Squash all commits on the current branch |
@@ -294,7 +294,7 @@ stack-submit --stack         # Creates/updates all PRs in the stack
 |:---|:---|
 | `stackit flatten` | Move branches closer to trunk where possible |
 | `stackit restack` | Rebase branches to ensure proper ancestry (`--branch X --upstack`, `--all-stacks`, `--stacks root1,root2`, `--parallel`) |
-| `stackit get [branch|PR]` | Sync a stack or specific PR from remote |
+| `stackit get [branch\|PR]` | Sync a stack or specific PR from remote |
 | `stackit foreach` | Run a shell command on each branch (`--upstack`, `--all-stacks`, `--stacks`, `--parallel`) |
 | `stackit submit` | Push branches and create/update GitHub PRs (alias: `ss` for `--stack`) |
 | `stackit sync` | Pull trunk, delete merged branches, and restack |

--- a/internal/cli/branch/modify.go
+++ b/internal/cli/branch/modify.go
@@ -76,7 +76,7 @@ Examples:
 	cmd.Flags().BoolVarP(&all, "all", "a", false, "Stage all changes before committing.")
 	cmd.Flags().BoolVarP(&commit, "commit", "c", false, "Create a new commit instead of amending the current commit. If this branch has no commits, this command always creates a new commit.")
 	cmd.Flags().BoolVarP(&edit, "edit", "e", false, "Open an editor to edit the commit message.")
-	cmd.Flags().BoolVar(&interactiveRebase, "interactive-rebase", false, "Ignore all other flags and start a git interactive rebase on the commits in this branch.")
+	cmd.Flags().BoolVar(&interactiveRebase, "interactive-rebase", false, "Start a git interactive rebase on the commits in this branch. Ignores the staging/message flags; cannot be combined with --into.")
 	cmd.Flags().StringVar(&into, "into", "", "Modify a downstack ancestor branch instead of the current branch, without checking it out first.")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "The message for the new or amended commit. If passed, no editor is opened.")
 	cmd.Flags().StringVarP(&messageFile, "message-file", "F", "", "Read commit message from a file (use \"-\" for stdin). Mutually exclusive with --message.")

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -25,6 +25,36 @@ type restackSnapshot struct {
 	metaRefSHAs map[string]string
 }
 
+// worktreeIsClean reports whether worktreePath currently has no uncommitted
+// changes. An empty path (the branch isn't checked out in any worktree)
+// counts as clean, since there is nothing to reset either way. Callers must
+// snapshot this *before* mutating the branch's ref: once the ref moves, the
+// worktree's files necessarily differ from the new HEAD, so checking
+// afterward would always report dirty.
+func (e *engineImpl) worktreeIsClean(ctx context.Context, worktreePath string) bool {
+	if worktreePath == "" {
+		return true
+	}
+	dirty, err := e.git.WorktreeHasUncommittedChanges(ctx, worktreePath)
+	return err == nil && !dirty
+}
+
+// resetWorktreeIfWasClean resets worktreePath's working directory to match
+// its newly-updated branch ref, but only when wasClean (captured by
+// worktreeIsClean *before* the branch ref was mutated) says the worktree had
+// no uncommitted changes beforehand. A worktree that really was dirty is left
+// untouched rather than force-reset: it will show as out of sync with HEAD
+// until the user commits or stashes, which is the same "best-effort"
+// staleness already accepted here, instead of silently discarding work that
+// exists nowhere else (no commit, no stash, not covered by undo snapshots —
+// see the data-loss report this guards against).
+func (e *engineImpl) resetWorktreeIfWasClean(ctx context.Context, worktreePath string, wasClean bool) {
+	if worktreePath == "" || !wasClean {
+		return
+	}
+	_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
+}
+
 // restackBranch rebases a branch onto its parent
 // If the parent has been merged/deleted, it will automatically reparent to the nearest valid ancestor.
 // snap is the point-in-time state captured by the caller — passing it avoids
@@ -72,6 +102,11 @@ func (e *engineImpl) restackBranch(
 	if e.branchLanded(ctx, branchName, parent, squashCache) {
 		return RestackBranchResult{Result: RestackUnneeded}, nil
 	}
+
+	// Snapshot worktree cleanliness now, before anything below moves this
+	// branch's ref. See worktreeIsClean.
+	worktreePath := snap.worktrees.PathForBranch(branchName)
+	worktreeWasClean := e.worktreeIsClean(ctx, worktreePath)
 
 	if e.IsFrozen(branch) {
 		// For frozen branches, we update via hard reset to remote instead of rebase
@@ -132,13 +167,10 @@ func (e *engineImpl) restackBranch(
 					return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to reset working tree for frozen branch %s: %w", branchName, err)
 				}
 			} else {
-				// If the branch is checked out in a different worktree, reset that worktree.
-				// This is best-effort: sync checks for uncommitted changes before proceeding,
-				// so failure here just means the worktree may be briefly out of sync with HEAD.
-				// The ResetWorktreeWorkingDir command itself is logged via debugLog.
-				if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" {
-					_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
-				}
+				// If the branch is checked out in a different worktree, reset that
+				// worktree — but only if it had no uncommitted changes before this
+				// ref update. See resetWorktreeIfWasClean.
+				e.resetWorktreeIfWasClean(ctx, worktreePath, worktreeWasClean)
 			}
 
 			return RestackBranchResult{
@@ -204,12 +236,10 @@ func (e *engineImpl) restackBranch(
 				return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to reset working tree for anchor %s: %w", branchName, err)
 			}
 		} else {
-			// If the branch is checked out in a different worktree, reset that worktree.
-			// This is best-effort: sync checks for uncommitted changes before proceeding,
-			// so failure here just means the worktree may be briefly out of sync with HEAD.
-			if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" {
-				_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
-			}
+			// If the branch is checked out in a different worktree, reset that
+			// worktree — but only if it had no uncommitted changes before this
+			// ref update. See resetWorktreeIfWasClean.
+			e.resetWorktreeIfWasClean(ctx, worktreePath, worktreeWasClean)
 		}
 
 		return RestackBranchResult{
@@ -403,12 +433,10 @@ func (e *engineImpl) restackBranch(
 	}
 	// If this branch is checked out in a worktree, reset that worktree's working directory
 	// to match the new branch content. Without this, the worktree would have stale content
-	// that appears as staged changes reverting the rebased commits.
-	// This is best-effort: sync checks for uncommitted changes before proceeding,
-	// so failure here just means the worktree may be briefly out of sync with HEAD.
-	if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" {
-		_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
-	}
+	// that appears as staged changes reverting the rebased commits. Only done when the
+	// worktree had no uncommitted changes before the rebase moved this branch's ref — see
+	// resetWorktreeIfWasClean.
+	e.resetWorktreeIfWasClean(ctx, worktreePath, worktreeWasClean)
 
 	metadataSHA, err := e.git.CreateBlob(string(metadataJSON))
 	if err != nil {
@@ -573,6 +601,11 @@ func (e *engineImpl) applyBranchAndMetadata(
 		}
 	}
 
+	// Snapshot worktree cleanliness now, before the ref update below moves
+	// this branch's ref. See worktreeIsClean.
+	worktreePath := snap.worktrees.PathForBranch(branchName)
+	worktreeWasClean := e.worktreeIsClean(ctx, worktreePath)
+
 	oldBranchSHA, err := branch.GetRevision()
 	if err != nil {
 		return RestackBranchResult{Result: RestackConflict, RebasedBranchBase: parentRev}, fmt.Errorf("failed to get current branch revision for %s: %w", branchName, err)
@@ -602,9 +635,7 @@ func (e *engineImpl) applyBranchAndMetadata(
 		return RestackBranchResult{Result: RestackConflict, RebasedBranchBase: parentRev}, fmt.Errorf("failed to update refs atomically: %w", err)
 	}
 
-	if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" {
-		_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
-	}
+	e.resetWorktreeIfWasClean(ctx, worktreePath, worktreeWasClean)
 
 	if snap.meta != nil {
 		snap.meta[branchName] = updatedMeta

--- a/internal/integration/restack_worktree_dirty_test.go
+++ b/internal/integration/restack_worktree_dirty_test.go
@@ -1,0 +1,58 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRestackPreservesUncommittedChangesInWorktreeAnchor guards against a data-loss
+// regression: restack used to run `git reset --hard HEAD` unconditionally against a
+// managed worktree after moving its branch ref, discarding any uncommitted changes
+// with no prompt, no warning, and no recovery path (the content lives in no git
+// object, no stash, and undo snapshots only record refs).
+//
+// `stackit worktree create` with no --root-branch checks out the hidden anchor
+// branch directly in the new worktree. Restacking that anchor (to fast-forward it
+// to trunk) used to reset the worktree's working directory unconditionally, even
+// when the user had uncommitted edits sitting there — exactly where uncommitted
+// work tends to live in a freshly created worktree.
+func TestRestackPreservesUncommittedChangesInWorktreeAnchor(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+	sh.SetWorktreeBasePath(t.TempDir())
+
+	sh.Run("worktree create my-wt")
+	sh.Run("worktree open my-wt")
+	worktreePath := strings.TrimSpace(sh.Output())
+
+	// Leave uncommitted, staged content in the worktree without creating any
+	// branch under the anchor — the worktree stays checked out on the anchor
+	// itself, matching `worktree create` with no --root-branch.
+	sh.InWorktree(worktreePath).WriteFile("dirty.txt", "uncommitted work")
+
+	anchorBranch := findWorktreeAnchor(t, sh)
+
+	// Trunk advances, then restack fast-forwards the anchor to trunk.
+	sh.Checkout("main").
+		Commit("trunk1.txt", "chore: trunk commit").
+		Run("restack --all-stacks")
+
+	// The anchor still tracks trunk...
+	sh.Git("rev-parse main")
+	trunkRev := strings.TrimSpace(sh.Output())
+	sh.Git("rev-parse " + anchorBranch)
+	require.Equal(t, trunkRev, strings.TrimSpace(sh.Output()), "anchor must still fast-forward to trunk")
+
+	// ...but the uncommitted work in its worktree must survive untouched.
+	content, err := os.ReadFile(filepath.Join(worktreePath, "dirty.txt"))
+	require.NoError(t, err, "uncommitted file must not be deleted by restack")
+	require.Equal(t, "uncommitted work", string(content), "uncommitted file content must be preserved")
+
+	wtShell := sh.InWorktree(worktreePath).Git("status --porcelain")
+	require.Contains(t, wtShell.Output(), "dirty.txt", "worktree must still report the uncommitted change")
+}


### PR DESCRIPTION
## Summary

Two independent fixes from the same pre-release review batch, landed on this branch per the automated routine's single-branch setup.

### 1. Fixes #1490 — restack destroyed uncommitted worktree changes

`restack` unconditionally ran `git reset --hard HEAD` against a managed worktree after moving its branch ref, discarding any uncommitted changes with no prompt, no warning, and no recovery path — the content lives in no git object, no stash, and undo snapshots only record refs.

`stackit worktree create` with no `--root-branch` checks out the hidden anchor branch directly in the new worktree — exactly where uncommitted work tends to live right after creating a worktree. Restacking that anchor to fast-forward it to trunk (the new anchor-restack path from #1488) was enough to trigger the unconditional reset and silently destroy the edit.

**Fix:** snapshot each worktree's cleanliness *before* its branch ref is mutated, and skip the working-directory reset when it was dirty beforehand, at all four `ResetWorktreeWorkingDir` call sites in `internal/engine/restack_impl.go` (frozen branches, worktree anchors, the general rebase path, and the validated-plan apply path).

The cleanliness check must happen before the ref moves, not after: once a branch's ref is updated, the checked-out worktree's files necessarily differ from the new HEAD, so checking afterward would always read as dirty regardless of whether the user had made any real edits. (An earlier version of this fix checked after the ref move and broke an existing squash-merge restack test for exactly this reason.)

A worktree found dirty is left untouched rather than force-reset — it shows as out of sync with HEAD until the user commits or stashes, the same best-effort staleness already accepted for reset failures on this path, instead of silently losing work.

**Test plan:**
- Added `TestRestackPreservesUncommittedChangesInWorktreeAnchor` (`internal/integration/restack_worktree_dirty_test.go`), reproducing the issue's repro. Verified it fails without the fix (destroyed file) and passes with it, while the anchor still fast-forwards to trunk.
- `go test ./internal/engine/...`, `go test ./internal/integration/...` (full suite) — pass
- `go build ./...`, `go vet ./...` — clean

### 2. Fixes #1502 — three small documentation gaps

- README command reference never mentioned `stackit modify --into`, even though `create --onto` and `pr` from the same release both got rows.
- Two command reference rows (`` `stackit pr [branch|number]` `` and `` `stackit get [branch|PR]` ``) had an unescaped `|` inside inline code, which GFM splits into extra table cells instead of rendering literally.
- `--interactive-rebase`'s help text still said it ignores other flags, but it now rejects being combined with `--into` instead.

**Test plan:**
- `go build ./...`, `go test ./internal/cli/branch/...` — pass
