### PR TITLE
fix(engine): guard worktree reset against uncommitted changes during restack

### DIFF
--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/utils"
 )
 
 // RestackBranches implements a hybrid batch approach for performance:
@@ -103,6 +105,23 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 		worktrees = git.WorktreeList{}
 	}
 
+	// Snapshot each worktree's dirty status once, before any branch ref in
+	// this pass moves. A branch's ref updates before its worktree's working
+	// directory is reset, so checking dirtiness afterward would see the
+	// worktree legitimately out of sync with its new HEAD and misreport that
+	// staleness as user edits. Checked up front, per worktree rather than per
+	// branch, and bounded by utils.Run rather than one goroutine per worktree.
+	dirtyWorktrees := make(map[string]bool, len(worktrees))
+	if len(worktrees) > 0 {
+		var dirtyMu sync.Mutex
+		utils.Run(worktrees, func(wt git.Worktree) {
+			dirty, _ := e.git.WorktreeHasUncommittedChanges(ctx, wt.Path)
+			dirtyMu.Lock()
+			dirtyWorktrees[wt.Path] = dirty
+			dirtyMu.Unlock()
+		})
+	}
+
 	// Snapshot every metadata ref's SHA once via a single in-process iterator
 	// (git.ListRefs). The previous code called GetRef per branch in three
 	// places (frozen path, anchor path, regular rebase) plus applyBranchAndMetadata
@@ -115,7 +134,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 			metaRefSHAs[strings.TrimPrefix(refName, git.MetadataRefPrefix)] = sha
 		}
 	}
-	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs}
+	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, dirtyWorktrees: dirtyWorktrees, metaRefSHAs: metaRefSHAs}
 
 	// 2. Apply the restack changes
 	results := make(map[string]RestackBranchResult)

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -14,15 +14,37 @@ const (
 	reflogRestackAnchor = "stackit: restack (anchor)"
 )
 
+// resetWorktreeWorkingDirIfClean resets a worktree's working directory to
+// match its branch's new HEAD after a ref update, but only when the worktree
+// was clean *before* the restack pass touched anything. A worktree that had
+// uncommitted changes is left untouched: resetting it would discard the
+// user's in-progress edits with no prompt, no warning, and no recovery path.
+// Dirtiness must come from snap.dirtyWorktrees (checked once, up front) and
+// not a live check here — by the time a branch's ref is updated, its
+// worktree's on-disk content is legitimately stale relative to the new HEAD,
+// which git.WorktreeHasUncommittedChanges would misreport as user edits.
+// Leaving a clean worktree briefly out of sync with HEAD on error is the
+// existing best-effort tradeoff for this call.
+func (e *engineImpl) resetWorktreeWorkingDirIfClean(ctx context.Context, snap *restackSnapshot, worktreePath string) {
+	if worktreePath == "" {
+		return
+	}
+	if snap.dirtyWorktrees[worktreePath] {
+		return
+	}
+	_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
+}
+
 // restackSnapshot bundles the branch-keyed state captured once per restack
 // pass so per-branch steps don't re-read metadata, revisions, worktrees, or
 // metadata-ref SHAs from git. It is mutated in place as branches are rebased
 // so later branches in the same pass observe the updated values.
 type restackSnapshot struct {
-	meta        MetaMap
-	revs        RevisionMap
-	worktrees   git.WorktreeList
-	metaRefSHAs map[string]string
+	meta           MetaMap
+	revs           RevisionMap
+	worktrees      git.WorktreeList
+	dirtyWorktrees map[string]bool
+	metaRefSHAs    map[string]string
 }
 
 // restackBranch rebases a branch onto its parent
@@ -132,13 +154,9 @@ func (e *engineImpl) restackBranch(
 					return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to reset working tree for frozen branch %s: %w", branchName, err)
 				}
 			} else {
-				// If the branch is checked out in a different worktree, reset that worktree.
-				// This is best-effort: sync checks for uncommitted changes before proceeding,
-				// so failure here just means the worktree may be briefly out of sync with HEAD.
-				// The ResetWorktreeWorkingDir command itself is logged via debugLog.
-				if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" {
-					_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
-				}
+				// If the branch is checked out in a different worktree, reset that
+				// worktree unless it has uncommitted changes.
+				e.resetWorktreeWorkingDirIfClean(ctx, snap, snap.worktrees.PathForBranch(branchName))
 			}
 
 			return RestackBranchResult{
@@ -204,12 +222,9 @@ func (e *engineImpl) restackBranch(
 				return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to reset working tree for anchor %s: %w", branchName, err)
 			}
 		} else {
-			// If the branch is checked out in a different worktree, reset that worktree.
-			// This is best-effort: sync checks for uncommitted changes before proceeding,
-			// so failure here just means the worktree may be briefly out of sync with HEAD.
-			if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" {
-				_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
-			}
+			// If the branch is checked out in a different worktree, reset that
+			// worktree unless it has uncommitted changes.
+			e.resetWorktreeWorkingDirIfClean(ctx, snap, snap.worktrees.PathForBranch(branchName))
 		}
 
 		return RestackBranchResult{
@@ -401,14 +416,12 @@ func (e *engineImpl) restackBranch(
 			NewParent:         parent,
 		}, fmt.Errorf("failed to marshal metadata: %w", err)
 	}
-	// If this branch is checked out in a worktree, reset that worktree's working directory
-	// to match the new branch content. Without this, the worktree would have stale content
-	// that appears as staged changes reverting the rebased commits.
-	// This is best-effort: sync checks for uncommitted changes before proceeding,
-	// so failure here just means the worktree may be briefly out of sync with HEAD.
-	if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" {
-		_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
-	}
+	// If this branch is checked out in a worktree, reset that worktree's working
+	// directory to match the new branch content, unless it has uncommitted
+	// changes. Without this, a clean worktree would have stale content that
+	// appears as staged changes reverting the rebased commits; a dirty one is
+	// left alone rather than having its in-progress edits discarded.
+	e.resetWorktreeWorkingDirIfClean(ctx, snap, snap.worktrees.PathForBranch(branchName))
 
 	metadataSHA, err := e.git.CreateBlob(string(metadataJSON))
 	if err != nil {
@@ -602,9 +615,7 @@ func (e *engineImpl) applyBranchAndMetadata(
 		return RestackBranchResult{Result: RestackConflict, RebasedBranchBase: parentRev}, fmt.Errorf("failed to update refs atomically: %w", err)
 	}
 
-	if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" {
-		_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
-	}
+	e.resetWorktreeWorkingDirIfClean(ctx, snap, snap.worktrees.PathForBranch(branchName))
 
 	if snap.meta != nil {
 		snap.meta[branchName] = updatedMeta

--- a/internal/integration/restack_worktree_anchor_test.go
+++ b/internal/integration/restack_worktree_anchor_test.go
@@ -2,6 +2,8 @@ package integration
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -71,6 +73,37 @@ func TestRestackWorktreeAnchorTracksTrunk(t *testing.T) {
 		Commit("trunk2.txt", "chore: trunk commit 2").
 		Run("restack --all-stacks")
 	assertTracksTrunk("after second restack")
+}
+
+// TestRestackDoesNotDestroyUncommittedAnchorWorktreeChanges covers the data-loss
+// regression from fast-forwarding a worktree anchor: `worktree create` with no
+// --root-branch checks out the anchor itself, and restacking that anchor used
+// to run an unconditional `git reset --hard` in its worktree. An uncommitted
+// edit sitting there — exactly what a freshly created worktree tends to hold —
+// was silently discarded with no prompt and no recovery path.
+func TestRestackDoesNotDestroyUncommittedAnchorWorktreeChanges(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+	sh.SetWorktreeBasePath(t.TempDir())
+
+	sh.Run("worktree create my-wt")
+	sh.Run("worktree open my-wt")
+	worktreePath := strings.TrimSpace(sh.Output())
+
+	// Edit a tracked file in the anchor's worktree without committing.
+	trackedFile := filepath.Join(worktreePath, "init_test.txt")
+	require.NoError(t, os.WriteFile(trackedFile, []byte("uncommitted edit"), 0o644))
+
+	// Trunk advances, then restack fast-forwards the anchor to trunk.
+	sh.Checkout("main").
+		Commit("trunk1.txt", "chore: trunk commit").
+		Run("restack --all-stacks")
+
+	content, err := os.ReadFile(trackedFile)
+	require.NoError(t, err)
+	require.Equal(t, "uncommitted edit", string(content),
+		"restack must not discard uncommitted changes in a worktree-anchor's worktree")
 }
 
 // findWorktreeAnchor returns the name of the hidden worktree-anchor branch.


### PR DESCRIPTION
## Summary

Fixes #1490.

`restack` runs an unconditional `git reset --hard HEAD` in a branch's worktree after moving that branch's ref, with no check for uncommitted changes. Since #1488 made worktree anchors reachable by the restack apply path (anchors used to be skipped entirely by the landed check), and `stackit worktree create` with no `--root-branch` checks out the anchor itself, restacking a stack whose anchor-checked-out worktree has an uncommitted edit silently destroys that edit — no prompt, no warning, no recovery path. The same unconditional reset existed at three more call sites for regular/frozen branches, predating this release.

### Fix

- `restackSnapshot` now precomputes a `dirtyWorktrees` map once per restack pass, before any branch ref in the pass is updated — checked up front via a bounded `utils.Run` pass over the worktree list (mirrors how `sync` already gathers dirty-worktree state), not live at reset time. A live check after the ref move would see the worktree's on-disk content as legitimately stale relative to its new HEAD and misreport that staleness as user edits.
- All four `ResetWorktreeWorkingDir` call sites in `internal/engine/restack_impl.go` (frozen path, anchor path, regular rebase, and the shared plan-apply path) now go through a new `resetWorktreeWorkingDirIfClean` helper that skips the reset when the target worktree was dirty going in.
- The branch ref itself still advances as intended (this is the correct new anchor fast-forward behavior from #1488) — only the destructive working-directory reset is skipped, so no data is lost.

### Test plan

- [x] Added `TestRestackDoesNotDestroyUncommittedAnchorWorktreeChanges`, which reproduces the issue's repro (worktree checked out at the anchor, uncommitted edit, trunk advances, `restack --all-stacks`) and asserts the edit survives. Verified it fails against the pre-fix code (edit destroyed) and passes with the fix.
- [x] `go test ./internal/engine/...`
- [x] `go test ./internal/integration/...` (full suite, including `TestRestackWorktreeAnchorTracksTrunk`, `TestWorktreeWorkingDirAfterRestack`, `TestSyncWithMultipleWorktrees`, and the squash-merge restack tests that regressed on an earlier version of this fix)
- [x] `go vet` / `gofmt` clean

---

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01H5cyAgdcYFoyiMxsLw3fPD)_