### PR TITLE
fix(engine): stop restack discarding uncommitted worktree edits

### DIFF
--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -103,6 +103,20 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 		worktrees = git.WorktreeList{}
 	}
 
+	// Snapshot which of those worktrees have uncommitted changes before any
+	// branch in this pass is touched. This must happen up front: restacking a
+	// branch moves its ref before its worktree gets reset, so checking
+	// dirtiness lazily at reset time would compare the worktree's now-stale
+	// content against its own new ref and read as dirty every time, not just
+	// when the user actually had uncommitted work. Bounded by worktree count,
+	// not branch count, so this stays a handful of calls even for a large stack.
+	dirtyWorktrees := make(map[string]bool, len(worktrees))
+	for _, path := range worktrees.Paths() {
+		if dirty, dirtyErr := e.git.WorktreeHasUncommittedChanges(ctx, path); dirtyErr == nil && dirty {
+			dirtyWorktrees[path] = true
+		}
+	}
+
 	// Snapshot every metadata ref's SHA once via a single in-process iterator
 	// (git.ListRefs). The previous code called GetRef per branch in three
 	// places (frozen path, anchor path, regular rebase) plus applyBranchAndMetadata
@@ -115,7 +129,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 			metaRefSHAs[strings.TrimPrefix(refName, git.MetadataRefPrefix)] = sha
 		}
 	}
-	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs}
+	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees}
 
 	// 2. Apply the restack changes
 	results := make(map[string]RestackBranchResult)

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -14,6 +14,27 @@ const (
 	reflogRestackAnchor = "stackit: restack (anchor)"
 )
 
+// resetWorktreeIfClean resets a worktree's working directory to match its
+// branch ref's new content, unless the worktree had uncommitted changes
+// before this restack pass touched anything. dirtyWorktrees is captured once
+// up front (see restackSnapshot.dirtyWorktrees) rather than checked here,
+// because by the time any branch's reset runs, restack has already moved that
+// branch's ref — checking dirtiness at that point would compare the
+// worktree's now-stale content against its own new ref and always read as
+// dirty, silently disabling the reset for every branch, not just genuinely
+// dirty ones.
+//
+// Skipping the reset on a worktree that was genuinely dirty beforehand leaves
+// it briefly out of sync with its ref rather than discarding the uncommitted
+// changes — the same tradeoff sync makes when deciding whether to touch a
+// stack rooted at a dirty managed worktree.
+func (e *engineImpl) resetWorktreeIfClean(ctx context.Context, worktreePath string, snap *restackSnapshot) {
+	if snap.dirtyWorktrees[worktreePath] {
+		return
+	}
+	_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
+}
+
 // restackSnapshot bundles the branch-keyed state captured once per restack
 // pass so per-branch steps don't re-read metadata, revisions, worktrees, or
 // metadata-ref SHAs from git. It is mutated in place as branches are rebased
@@ -23,6 +44,10 @@ type restackSnapshot struct {
 	revs        RevisionMap
 	worktrees   git.WorktreeList
 	metaRefSHAs map[string]string
+	// dirtyWorktrees records, per worktree path, whether it had uncommitted
+	// changes before this restack pass began. Captured once up front — see
+	// resetWorktreeIfClean for why it can't be checked lazily.
+	dirtyWorktrees map[string]bool
 }
 
 // restackBranch rebases a branch onto its parent
@@ -133,11 +158,8 @@ func (e *engineImpl) restackBranch(
 				}
 			} else {
 				// If the branch is checked out in a different worktree, reset that worktree.
-				// This is best-effort: sync checks for uncommitted changes before proceeding,
-				// so failure here just means the worktree may be briefly out of sync with HEAD.
-				// The ResetWorktreeWorkingDir command itself is logged via debugLog.
 				if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" {
-					_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
+					e.resetWorktreeIfClean(ctx, worktreePath, snap)
 				}
 			}
 
@@ -205,10 +227,8 @@ func (e *engineImpl) restackBranch(
 			}
 		} else {
 			// If the branch is checked out in a different worktree, reset that worktree.
-			// This is best-effort: sync checks for uncommitted changes before proceeding,
-			// so failure here just means the worktree may be briefly out of sync with HEAD.
 			if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" {
-				_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
+				e.resetWorktreeIfClean(ctx, worktreePath, snap)
 			}
 		}
 
@@ -404,10 +424,8 @@ func (e *engineImpl) restackBranch(
 	// If this branch is checked out in a worktree, reset that worktree's working directory
 	// to match the new branch content. Without this, the worktree would have stale content
 	// that appears as staged changes reverting the rebased commits.
-	// This is best-effort: sync checks for uncommitted changes before proceeding,
-	// so failure here just means the worktree may be briefly out of sync with HEAD.
 	if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" {
-		_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
+		e.resetWorktreeIfClean(ctx, worktreePath, snap)
 	}
 
 	metadataSHA, err := e.git.CreateBlob(string(metadataJSON))
@@ -603,7 +621,7 @@ func (e *engineImpl) applyBranchAndMetadata(
 	}
 
 	if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" {
-		_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
+		e.resetWorktreeIfClean(ctx, worktreePath, snap)
 	}
 
 	if snap.meta != nil {

--- a/internal/integration/restack_worktree_anchor_test.go
+++ b/internal/integration/restack_worktree_anchor_test.go
@@ -2,6 +2,8 @@ package integration
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -71,6 +73,47 @@ func TestRestackWorktreeAnchorTracksTrunk(t *testing.T) {
 		Commit("trunk2.txt", "chore: trunk commit 2").
 		Run("restack --all-stacks")
 	assertTracksTrunk("after second restack")
+}
+
+// TestRestackWorktreeAnchorPreservesUncommittedChanges covers the regression
+// from #1490: `worktree create` with no root branch checks out the anchor
+// itself in the new worktree, and #1488 made the anchor reachable by restack
+// for the first time (it used to be skipped by the landed check). Restacking
+// fast-forwards the anchor and then unconditionally ran `git reset --hard` on
+// its worktree to match, discarding any uncommitted edit sitting there with no
+// prompt, no warning, and no recovery path.
+func TestRestackWorktreeAnchorPreservesUncommittedChanges(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+	sh.SetWorktreeBasePath(t.TempDir())
+
+	// No --root-branch: the new worktree checks out the anchor directly.
+	sh.Run("worktree create my-wt")
+	sh.Run("worktree open my-wt")
+	worktreePath := strings.TrimSpace(sh.Output())
+
+	// Edit a tracked file inside the worktree and leave it uncommitted — the
+	// shape of work that tends to live in a freshly created worktree.
+	const uncommitted = "uncommitted edit"
+	sh.InWorktree(worktreePath).WriteFile("init_test.txt", uncommitted)
+
+	// Trunk advances elsewhere, giving the anchor somewhere to fast-forward to.
+	sh.Checkout("main").Commit("trunk1.txt", "chore: trunk commit 1")
+
+	sh.Run("restack --all-stacks")
+
+	anchorBranch := findWorktreeAnchor(t, sh)
+	sh.Git("rev-parse main")
+	trunkRev := strings.TrimSpace(sh.Output())
+	sh.Git("rev-parse " + anchorBranch)
+	require.Equal(t, trunkRev, strings.TrimSpace(sh.Output()),
+		"anchor should still fast-forward to trunk even when its worktree is dirty")
+
+	content, err := os.ReadFile(filepath.Join(worktreePath, "init_test.txt"))
+	require.NoError(t, err)
+	require.Equal(t, uncommitted, string(content),
+		"restack must not discard uncommitted changes in the anchor's worktree")
 }
 
 // findWorktreeAnchor returns the name of the hidden worktree-anchor branch.


### PR DESCRIPTION
## Summary

Closes #1490.

`stackit restack` unconditionally ran `git reset --hard HEAD` in a managed worktree after moving that worktree's branch ref, discarding any uncommitted changes with no prompt, no warning, and no recovery path.

The worktree-anchor case is a regression introduced by #1488: before that fix, a worktree anchor was always skipped by the landed check (an anchor is always an ancestor of trunk), so `RestackPlanApplyAnchor` was unreachable and the reset never ran against an anchor's worktree. `stackit worktree create` with no `--root-branch` checks out the *anchor* directly in the new worktree, so a freshly created worktree with an uncommitted edit — exactly where work tends to live — could lose that edit on the very next restack. The same unconditional reset also existed for regular (non-anchor) branches before this change.

## Root cause

`internal/engine/restack_impl.go` called `e.git.ResetWorktreeWorkingDir` (`git -C <path> reset --hard HEAD`) at four call sites with no check that the worktree was clean.

## Fix

Snapshot which managed worktrees have uncommitted changes **once, up front**, before any branch in a restack pass is touched (`internal/engine/engine_sync.go`), and skip the working-directory reset for any worktree that was already dirty. The reset is still attempted for every clean worktree, so normal restacks behave exactly as before.

This has to happen up front rather than lazily at reset time: by the time any branch's reset runs, restack has already moved that branch's ref (either via `git rebase`'s internal ref update, or via the atomic `UpdateRefsBatchWithLog` for the frozen/anchor fast-forward paths). Checking dirtiness at that point would compare the worktree's now-stale content against its own *new* ref, which always reads as "dirty" — that first version of the fix broke restack/sync/modify for every worktree, not just genuinely dirty ones, which the full test suite caught.

Skipping the reset on a genuinely dirty worktree leaves it briefly out of sync with its ref rather than discarding the user's uncommitted changes — the same tradeoff `sync` already makes when deciding whether to touch a stack rooted at a dirty managed worktree.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/engine/... ./internal/integration/...` and `gofmt -l` on changed files (clean)
- [x] New `TestRestackWorktreeAnchorPreservesUncommittedChanges` in `internal/integration/restack_worktree_anchor_test.go`: reproduces #1490 exactly (worktree anchor checked out via `worktree create` with no root branch, uncommitted edit, trunk advances, `restack --all-stacks`) — fails on the pre-fix code (edit reverted to "initial") and passes with the fix (edit preserved, anchor still fast-forwards to trunk)
- [x] `go test ./internal/engine/... ./internal/integration/...` — all passing
- [x] Full `go test ./...` — all green except one pre-existing, unrelated failure (`internal/git` `TestGetRepoInfo/parses_HTTPS_URL`, reproduces identically on `main` with no changes — a sandbox git-config artifact, not something this PR touches)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BzoGSbFe3oQeH31Pf3Nj2a)_