### PR TITLE
fix(create): inherit scope from the --onto target, not the current branch

### DIFF
--- a/internal/actions/create/create.go
+++ b/internal/actions/create/create.go
@@ -165,12 +165,20 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 	}
 
 	// Determine branch
+	// The branch's parent is --onto's target when given, otherwise the current
+	// branch. Resolved once, up front, so scope inheritance below and the
+	// tracking/Result parent further down agree on the same parent.
+	parentBranch := currentBranch
+	if opts.Onto != "" {
+		parentBranch = opts.Onto
+	}
+
 	// Use provided scope if given, otherwise inherit from parent
 	var scopeToUse string
 	if opts.Scope != "" {
 		scopeToUse = opts.Scope
 	} else {
-		parentScope := eng.GetScope(eng.GetBranch(currentBranch))
+		parentScope := eng.GetScope(eng.GetBranch(parentBranch))
 		scopeToUse = parentScope.String()
 	}
 
@@ -207,10 +215,8 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 	// checkout, so the divergence point stackit records is the target's tip
 	// rather than a merge-base that could wander into unrelated history the
 	// current branch happens to share with the target.
-	parentBranch := currentBranch
 	h.OnStep(StepBranchCreate, handler.StatusStarted, fmt.Sprintf("Creating branch %s", branchName))
 	if opts.Onto != "" {
-		parentBranch = opts.Onto
 		ontoBranch := eng.GetBranch(opts.Onto)
 		ontoSHA, err := ontoBranch.GetRevision()
 		if err != nil {

--- a/internal/integration/create_onto_test.go
+++ b/internal/integration/create_onto_test.go
@@ -65,6 +65,27 @@ func TestCreateOnto(t *testing.T) {
 		shW.OnBranch("shared")
 	})
 
+	t.Run("inherits scope from the --onto target, not the current branch", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Run("config set branch.pattern \"{scope}/{message}\"")
+
+		// branch-a (current) carries scope JIRA-1; branch-b (--onto target)
+		// carries a different scope, JIRA-2.
+		sh.Write("a", "content a").Run("create branch-a -m 'a' --scope JIRA-1")
+		sh.Checkout("main")
+		sh.Write("b", "content b").Run("create branch-b -m 'b' --scope JIRA-2")
+		sh.Checkout("branch-a")
+
+		// No explicit branch name, so it's generated from the pattern. The
+		// generated name must use branch-b's scope, not branch-a's, since
+		// branch-b is the real parent.
+		sh.Write("c", "content c").Run("create --onto branch-b -m 'child feature'")
+
+		sh.OnBranch("JIRA-2/child-feature")
+		sh.ExpectBranchParent("JIRA-2/child-feature", "branch-b")
+	})
+
 	t.Run("errors for a nonexistent target", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)


### PR DESCRIPTION
## Summary

Fixes #1495.

Stacked on #1519 (unrelated restack fix landed first on the same base branch).

`stackit create --onto <target>` resolved the inherited scope from the **current** branch instead of the `--onto` target. Branching from a scoped branch onto a differently-scoped (or unscoped) target picked up the wrong scope, which flowed into the generated branch name (when the configured branch pattern contains `{scope}`) and the PR title prefix. Recorded metadata scope was already correct — when no `--scope` is passed, metadata inherits from the real tracked parent (`opts.Onto`) — only the scope used for branch-name generation read the wrong branch.

### Fix

`internal/actions/create/create.go`: resolve `parentBranch` once, up front (current branch, or `opts.Onto` when given), and use it for both scope inheritance and the tracking/`Result` parent further down, so the two can no longer disagree. This mirrors the fix suggested in the issue.

### Test plan

- [x] Added a `TestCreateOnto` subtest: branch-a (current) and branch-b (`--onto` target) carry different scopes with a `{scope}`-containing branch pattern configured; the generated child branch name must use branch-b's scope. Verified it fails against the pre-fix code (`JIRA-1/child-feature` instead of `JIRA-2/child-feature`) and passes with the fix.
- [x] `go test ./internal/actions/create/...`
- [x] `go test ./internal/integration/...`
- [x] `go vet` / `gofmt` clean

---

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01H5cyAgdcYFoyiMxsLw3fPD)_