### PR TITLE
fix(engine): don't rebase branches that are already correctly based

### DIFF
--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -306,11 +306,11 @@ func holdBackConflictedStacks(eng engine.BranchReader, success engine.Branches, 
 // apply now, ones that conflicted, and ones blocked behind a conflict, using
 // the validation result as the source of truth instead of position-in-specs
 // arithmetic. A branch is applied only if its action proves it's safe:
-// Frozen/Anchor branches don't touch a rebase worktree at all, and Validated
-// branches need a confirmed SHA. Every planned branch lands in exactly one of
-// the three buckets so none silently disappears from reporting — a Validated
-// branch with no SHA that isn't in the failed set was skipped because an
-// ancestor failed, and is classified blocked.
+// Frozen/Anchor/MetadataRefresh branches don't touch a rebase worktree at
+// all, and Validated branches need a confirmed SHA. Every planned branch
+// lands in exactly one of the three buckets so none silently disappears from
+// reporting — a Validated branch with no SHA that isn't in the failed set was
+// skipped because an ancestor failed, and is classified blocked.
 func classifyValidatedBranches(branches engine.Branches, plan *engine.RestackPlan, validation *engine.RebaseValidation) (success engine.Branches, conflicts, blocked []string) {
 	if plan == nil || validation == nil {
 		return nil, nil, nil
@@ -331,7 +331,7 @@ func classifyValidatedBranches(branches engine.Branches, plan *engine.RestackPla
 		}
 
 		switch item.Action {
-		case engine.RestackPlanApplyFrozen, engine.RestackPlanApplyAnchor:
+		case engine.RestackPlanApplyFrozen, engine.RestackPlanApplyAnchor, engine.RestackPlanApplyMetadataRefresh:
 			builder.Add(branch)
 		case engine.RestackPlanApplyValidated:
 			switch {

--- a/internal/engine/rebase_validator_test.go
+++ b/internal/engine/rebase_validator_test.go
@@ -648,6 +648,110 @@ func TestRestackBranchesWithValidatedPlanAppliesAnchorBranch(t *testing.T) {
 	require.Equal(t, trunkSHA, anchorSHA)
 }
 
+// TestPlanRestackRefreshesMetadataWithoutRebaseWhenRecordedRevisionMissing
+// covers a legacy on-disk stack: the branch is already correctly based on
+// its parent, but parentBranchRevision was never recorded. Before this
+// behavior existed, the strengthened up-to-date check planned a full rebase
+// purely to fix the record, minting a new SHA for no content change.
+func TestPlanRestackRefreshesMetadataWithoutRebaseWhenRecordedRevisionMissing(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{
+			"parent": "main",
+			"child":  "parent",
+		})
+
+	parentRev, err := s.Engine.GetBranch("parent").GetRevision()
+	require.NoError(t, err)
+	childSHA, err := s.Scene.Repo.GetBranchSHA("child")
+	require.NoError(t, err)
+
+	meta, err := s.Engine.Git().ReadMetadata("child")
+	require.NoError(t, err)
+	require.NoError(t, s.Engine.Git().WriteMetadata("child", meta.WithParentBranchRevision(nil)))
+	require.NoError(t, s.Engine.Rebuild("main"))
+
+	child := s.Engine.GetBranch("child")
+	plan, err := s.Engine.PlanRestack(context.Background(), engine.BranchesOf(child))
+	require.NoError(t, err)
+	require.Empty(t, plan.Specs, "child is already correctly based on parent; no rebase should be planned")
+	require.True(t, plan.ApplyMap["child"])
+	require.Equal(t, engine.RestackPlanApplyMetadataRefresh, plan.Items["child"].Action)
+
+	validation := &engine.RebaseValidation{Success: true, NewSHAs: map[string]string{}, RerereResolved: map[string]int{}}
+	result, err := s.Engine.RestackBranchesWithValidatedPlan(context.Background(), engine.BranchesOf(child), validation, plan, nil)
+	require.NoError(t, err)
+	require.Equal(t, engine.RestackUnneeded, result.Results["child"].Result)
+
+	newChildSHA, err := s.Scene.Repo.GetBranchSHA("child")
+	require.NoError(t, err)
+	require.Equal(t, childSHA, newChildSHA, "restack must not mint a new SHA when nothing needed replaying")
+
+	updatedMeta, err := s.Engine.Git().ReadMetadata("child")
+	require.NoError(t, err)
+	require.NotNil(t, updatedMeta.GetParentBranchRevision())
+	require.Equal(t, parentRev, *updatedMeta.GetParentBranchRevision(), "recorded parent revision should catch up")
+
+	// A second restack should now find the record fully caught up.
+	plan2, err := s.Engine.PlanRestack(context.Background(), engine.BranchesOf(child))
+	require.NoError(t, err)
+	require.True(t, plan2.Items["child"].Skip)
+	require.Equal(t, engine.RestackUnneeded, plan2.PlannedResults["child"].Result)
+}
+
+// TestPlanRestackRefreshesMetadataAfterManualRebaseOutsideStackit covers the
+// other trigger from #1492: a child rebased outside stackit with raw git.
+// The branch ends up correctly based on its parent's current tip, but the
+// recorded parent revision in metadata still points at the parent's pre-amend
+// SHA, which is no longer an ancestor of the branch.
+func TestPlanRestackRefreshesMetadataAfterManualRebaseOutsideStackit(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{
+			"a": "main",
+			"b": "a",
+		})
+
+	oldARev, err := s.Engine.GetBranch("a").GetRevision()
+	require.NoError(t, err)
+
+	// Amend "a" outside stackit so its tip moves without stackit updating
+	// "b"'s recorded parent revision. The message must actually change --
+	// otherwise an amend moments after the original commit can produce a
+	// byte-identical (and thus identically-SHA'd) commit object.
+	s.Checkout("a").RunGit("commit", "--amend", "-m", "a, amended outside stackit")
+	newARev, err := s.Engine.GetBranch("a").GetRevision()
+	require.NoError(t, err)
+	require.NotEqual(t, oldARev, newARev)
+
+	// Manually rebase "b" onto the new tip of "a" with raw git, bypassing
+	// stackit entirely -- "b" ends up correctly based on "a", but its
+	// recorded parent revision still names the pre-amend SHA.
+	s.RunGit("rebase", "--onto", "a", oldARev, "b")
+	require.NoError(t, s.Engine.Rebuild("main"))
+
+	bSHA, err := s.Scene.Repo.GetBranchSHA("b")
+	require.NoError(t, err)
+
+	b := s.Engine.GetBranch("b")
+	plan, err := s.Engine.PlanRestack(context.Background(), engine.BranchesOf(b))
+	require.NoError(t, err)
+	require.Empty(t, plan.Specs, "b is already correctly based on a; no rebase should replay its commits")
+	require.Equal(t, engine.RestackPlanApplyMetadataRefresh, plan.Items["b"].Action)
+
+	validation := &engine.RebaseValidation{Success: true, NewSHAs: map[string]string{}, RerereResolved: map[string]int{}}
+	result, err := s.Engine.RestackBranchesWithValidatedPlan(context.Background(), engine.BranchesOf(b), validation, plan, nil)
+	require.NoError(t, err)
+	require.Equal(t, engine.RestackUnneeded, result.Results["b"].Result)
+
+	newBSHA, err := s.Scene.Repo.GetBranchSHA("b")
+	require.NoError(t, err)
+	require.Equal(t, bSHA, newBSHA, "restack must not mint a new SHA when the branch was already correctly based")
+
+	meta, err := s.Engine.Git().ReadMetadata("b")
+	require.NoError(t, err)
+	require.NotNil(t, meta.GetParentBranchRevision())
+	require.Equal(t, newARev, *meta.GetParentBranchRevision(), "recorded parent revision should catch up to a's current tip")
+}
+
 func TestRestackBranchesWithValidatedPlanReparentsMergedParent(t *testing.T) {
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
 		WithStack(map[string]string{

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -499,6 +499,8 @@ func (e *engineImpl) restackBranchWithValidatedRebase(
 	switch item.Action {
 	case RestackPlanApplyFrozen, RestackPlanApplyAnchor:
 		return e.applyPlannedRefUpdate(ctx, branch, item, snap)
+	case RestackPlanApplyMetadataRefresh:
+		return e.applyMetadataRefresh(ctx, branch, item, snap)
 	case RestackPlanApplyValidated:
 		return e.applyValidatedRestack(ctx, branch, validation, item, snap)
 	default:
@@ -571,6 +573,58 @@ func (e *engineImpl) applyPlannedRefUpdate(
 	}
 
 	return e.applyBranchAndMetadata(ctx, branch, item, item.TargetRev, parentRev, snap)
+}
+
+// applyMetadataRefresh corrects a branch's recorded parent revision without
+// touching its branch ref or working tree. It runs when planRestackBranch
+// finds the branch already sitting exactly on its parent's tip but the
+// recorded parentBranchRevision has drifted (never set, or stale from manual
+// git operations) — nothing needs to be rebased, only the record fixed, so
+// only the metadata ref moves and the result reports RestackUnneeded.
+func (e *engineImpl) applyMetadataRefresh(
+	ctx context.Context,
+	branch Branch,
+	item RestackPlanItem,
+	snap *restackSnapshot,
+) (RestackBranchResult, error) {
+	branchName := branch.GetName()
+	meta := snap.meta.Get(branchName)
+	if meta == nil {
+		var err error
+		meta, err = e.readMetadata(branchName)
+		if err != nil {
+			return RestackBranchResult{Result: RestackConflict, RebasedBranchBase: item.ParentRev}, fmt.Errorf("failed to read metadata: %w", err)
+		}
+	}
+
+	oldMetadataSHA := snap.metaRefSHAs[branchName]
+	parentRev := item.ParentRev
+	updatedMeta := meta.WithParentBranchRevision(&parentRev)
+	metadataJSON, err := json.Marshal(updatedMeta)
+	if err != nil {
+		return RestackBranchResult{Result: RestackConflict, RebasedBranchBase: parentRev}, fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	metadataSHA, err := e.git.CreateBlob(string(metadataJSON))
+	if err != nil {
+		return RestackBranchResult{Result: RestackConflict, RebasedBranchBase: parentRev}, fmt.Errorf("failed to prepare metadata blob: %w", err)
+	}
+
+	updates := []git.RefUpdate{
+		{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
+	}
+	if err := e.git.UpdateRefsBatchWithLog(ctx, updates, reflogRestack); err != nil {
+		return RestackBranchResult{Result: RestackConflict, RebasedBranchBase: parentRev}, fmt.Errorf("failed to update metadata ref: %w", err)
+	}
+
+	if snap.meta != nil {
+		snap.meta[branchName] = updatedMeta
+	}
+
+	return RestackBranchResult{
+		Result:            RestackUnneeded,
+		RebasedBranchBase: parentRev,
+	}, nil
 }
 
 func (e *engineImpl) applyBranchAndMetadata(

--- a/internal/engine/restack_plan.go
+++ b/internal/engine/restack_plan.go
@@ -238,26 +238,38 @@ func (e *engineImpl) planRestackBranch(ctx context.Context, branch Branch, plann
 	}
 	item.ParentRev = parentRev
 
-	// Only skip when the recorded parent revision already agrees with the
-	// resolved one. A branch that needs no rebase never reaches a path that
-	// rewrites its metadata, so a recorded revision that has fallen behind can
-	// never catch up on its own — it just keeps drifting, and everything that
-	// reads it (tree commit counts and diffs, "restack suggested") drifts with
-	// it. This bites children of a worktree anchor, whose parent revision
-	// resolves to trunk while the metadata still holds whatever the anchor
-	// pointed at. Planning them keeps the no-op rebase that refreshes the
-	// record; the rebase itself has nothing to replay.
+	// A branch can already sit exactly on its parent's tip (parentRev ==
+	// oldParentRev) while its recorded parent revision has still drifted —
+	// never set, stale from manual git operations, or (for a worktree
+	// anchor's children) resolved to trunk while the metadata still holds
+	// whatever the anchor pointed at. A branch that needs no rebase never
+	// reaches a path that rewrites its metadata on its own, so a drifted
+	// record can never catch up by itself — it just keeps drifting, and
+	// everything that reads it (tree commit counts and diffs, "restack
+	// suggested") drifts with it.
+	//
+	// The two needs are handled separately rather than folded into one
+	// rebase: a branch that is not actually based where it should be gets a
+	// real rebase, but a branch that's already correctly based only gets its
+	// metadata corrected. Rebasing purely to fix the record would replay the
+	// branch's own commits onto themselves, minting a fresh SHA on every
+	// restack for no content change — forcing unnecessary force-pushes, CI
+	// re-runs, and detached review comments.
 	recordedRev := ""
 	if rev := meta.GetParentBranchRevision(); rev != nil {
 		recordedRev = *rev
 	}
-	upToDate := parentRev == oldParentRev && oldParentRev == recordedRev
-	if upToDate && !plannedBranches.Contains(parentName) && !item.Reparented {
+	correctlyBased := parentRev == oldParentRev
+	skippable := !plannedBranches.Contains(parentName) && !item.Reparented
+	switch {
+	case correctlyBased && oldParentRev == recordedRev && skippable:
 		item.Skip = true
 		item.SkipResult = RestackBranchResult{
 			Result:            RestackUnneeded,
 			RebasedBranchBase: parentRev,
 		}
+	case correctlyBased && skippable:
+		item.Action = RestackPlanApplyMetadataRefresh
 	}
 
 	return item, true

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -385,6 +385,11 @@ const (
 	RestackPlanApplyFrozen
 	// RestackPlanApplyAnchor updates a worktree anchor to trunk.
 	RestackPlanApplyAnchor
+	// RestackPlanApplyMetadataRefresh corrects a branch's recorded parent
+	// revision without moving its branch ref — used when the branch is
+	// already correctly based on its parent but the recorded revision has
+	// drifted.
+	RestackPlanApplyMetadataRefresh
 )
 
 // RestackPlanItem describes how a branch should be handled during restack.


### PR DESCRIPTION
## Summary

Closes #1492.

`PlanRestack`'s strengthened up-to-date check (`internal/engine/restack_plan.go`) required the recorded `parentBranchRevision` in metadata to agree with the resolved parent revision, on top of the branch already sitting exactly on its parent's tip:

```go
upToDate := parentRev == oldParentRev && oldParentRev == recordedRev
```

Previously it was just `parentRev == oldParentRev`. The added clause means a branch gets a full rebase planned whenever the *recorded* revision is missing or stale — even though the branch's actual position is already correct — replaying the branch's own commits onto themselves for no reason. That mints a fresh SHA on every restack, forcing unnecessary force-pushes, CI re-runs, and detaching existing review comments from their commits.

Two triggers, both reproduced in the added tests:
1. A child rebased outside stackit with raw git (the branch is now correctly based, but the metadata record still points at the pre-rebase parent SHA).
2. A legacy on-disk stack where `parentBranchRevision` was never recorded.

## Fix

Split "needs a rebase" from "needs a metadata refresh":

- A branch that is **not** actually based where it should be (`parentRev != oldParentRev`) still gets a real rebase — unchanged behavior.
- A branch that **is** correctly based, but whose recorded revision has drifted, now gets a new `RestackPlanApplyMetadataRefresh` plan action instead of `RestackPlanApplyValidated`. This only moves the branch's metadata ref (correcting `parentBranchRevision`) — no rebase validation runs, no `RebaseSpec` is built, and the branch's own ref is untouched. The result reports `RestackUnneeded`, not `RestackDone`.
- Fully up-to-date branches (recorded revision already agrees) are unaffected — still skipped entirely, as before.

`classifyValidatedBranches` (`internal/actions/common.go`) treats the new action like `Frozen`/`Anchor`: safe to apply immediately, no rebase worktree needed.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/engine/... ./internal/actions/...` and `gofmt -l` (clean)
- [x] Two new engine tests in `internal/engine/rebase_validator_test.go`:
  - `TestPlanRestackRefreshesMetadataWithoutRebaseWhenRecordedRevisionMissing` — legacy stack, `parentBranchRevision` unset
  - `TestPlanRestackRefreshesMetadataAfterManualRebaseOutsideStackit` — reproduces the exact "child rebased outside stackit" repro from the issue (amend parent, manually `git rebase --onto`)
  - Both assert: no `RebaseSpec` is planned, the branch's SHA is unchanged after apply, the result is `RestackUnneeded`, and the recorded parent revision catches up. Verified both fail against the pre-fix `upToDate` check and pass with the fix.
- [x] `go test ./internal/engine/... ./internal/actions/... ./internal/integration/...` — all passing


---
_Generated by [Claude Code](https://claude.ai/code/session_01BzoGSbFe3oQeH31Pf3Nj2a)_