### PR TITLE
docs: add modify --into to README, escape table pipes, fix --interactive-rebase help

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,13 +255,13 @@ stack-submit --stack         # Creates/updates all PRs in the stack
 | `stackit children` | Show the children of the current branch |
 | `stackit parent` | Show the parent of the current branch |
 | `stackit share` | Print the current stack as Slack-ready markdown for copy-paste |
-| `stackit pr [branch|number]` | Open a pull request in the default browser (`--stack` for the stack's root PR) |
+| `stackit pr [branch\|number]` | Open a pull request in the default browser (`--stack` for the stack's root PR) |
 
 ### Branch Management
 | Command | Description |
 |:---|:---|
 | `stackit create [name]` | Create a new branch on top of current (use `-w` to create with worktree, `--onto <branch>` to target a specific parent without checking it out) |
-| `stackit modify` | Amend the current commit (like `git commit --amend`) |
+| `stackit modify` | Amend the current commit (like `git commit --amend`; use `--into <branch>` to amend a downstack ancestor without checking it out) |
 | `stackit absorb` | Intelligently amend changes to the correct commits in the stack |
 | `stackit split` | Split commits into branches (by commit, hunk, or file; use `--above` for upstack) |
 | `stackit squash` | Squash all commits on the current branch |
@@ -294,7 +294,7 @@ stack-submit --stack         # Creates/updates all PRs in the stack
 |:---|:---|
 | `stackit flatten` | Move branches closer to trunk where possible |
 | `stackit restack` | Rebase branches to ensure proper ancestry (`--branch X --upstack`, `--all-stacks`, `--stacks root1,root2`, `--parallel`) |
-| `stackit get [branch|PR]` | Sync a stack or specific PR from remote |
+| `stackit get [branch\|PR]` | Sync a stack or specific PR from remote |
 | `stackit foreach` | Run a shell command on each branch (`--upstack`, `--all-stacks`, `--stacks`, `--parallel`) |
 | `stackit submit` | Push branches and create/update GitHub PRs (alias: `ss` for `--stack`) |
 | `stackit sync` | Pull trunk, delete merged branches, and restack |

--- a/internal/cli/branch/modify.go
+++ b/internal/cli/branch/modify.go
@@ -76,7 +76,7 @@ Examples:
 	cmd.Flags().BoolVarP(&all, "all", "a", false, "Stage all changes before committing.")
 	cmd.Flags().BoolVarP(&commit, "commit", "c", false, "Create a new commit instead of amending the current commit. If this branch has no commits, this command always creates a new commit.")
 	cmd.Flags().BoolVarP(&edit, "edit", "e", false, "Open an editor to edit the commit message.")
-	cmd.Flags().BoolVar(&interactiveRebase, "interactive-rebase", false, "Ignore all other flags and start a git interactive rebase on the commits in this branch.")
+	cmd.Flags().BoolVar(&interactiveRebase, "interactive-rebase", false, "Start a git interactive rebase on the commits in this branch. Ignores the staging/message flags; cannot be combined with --into.")
 	cmd.Flags().StringVar(&into, "into", "", "Modify a downstack ancestor branch instead of the current branch, without checking it out first.")
 	cmd.Flags().StringVarP(&message, "message", "m", "", "The message for the new or amended commit. If passed, no editor is opened.")
 	cmd.Flags().StringVarP(&messageFile, "message-file", "F", "", "Read commit message from a file (use \"-\" for stdin). Mutually exclusive with --message.")


### PR DESCRIPTION
## Summary

Fixes #1502.

Re-submitted as a standalone docs-only PR: these three hunks were originally written in #1518, which was closed because it bundled them with an unrelated engine fix (now merged separately via #1520). Per the maintainer's comment on #1502, lifting the hunks verbatim into their own PR.

Three small documentation gaps from the `v0.23.0..b2ee8445` release, found by a pre-release review:

1. **README command reference never mentioned `stackit modify --into`**, even though `create --onto` and `pr` from the same release both got rows.
2. **Unescaped `|` inside inline code breaks two GFM table rows** — `` `stackit pr [branch|number]` `` and `` `stackit get [branch|PR]` `` each render as extra cells instead of literal text. Escaped to match the repo's existing convention (`` `stack-submit [--stack \| --draft]` ``).
3. **`--interactive-rebase` help text was inaccurate** — it said it "ignores all other flags," but the code now rejects being combined with `--into` instead of ignoring it.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/cli/branch/...`


---
_Generated by [Claude Code](https://claude.ai/code/session_01WhWnY8e33DhaqB9EP5m1QA)_