### PR TITLE
fix(restack): skip stacks whose worktree has uncommitted changes

### DIFF
--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -100,6 +100,9 @@ func PlanRestack(ctx *app.Context, opts RestackOptions) (*RestackPlan, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Drop dirty-worktree stacks before the guard so a restack that has nothing
+	// left to move is a no-op rather than a guard error.
+	rawGroups = skipDirtyWorktreeStacks(ctx, rawGroups)
 	if err := guardUnpushedTrunk(ctx, eng, rawGroups); err != nil {
 		return nil, err
 	}
@@ -452,6 +455,53 @@ func planRestackBranchGroups(eng engine.BranchReader, opts RestackOptions) ([]re
 	return []restackBranchGroup{{
 		branches: branches,
 	}}, nil
+}
+
+// skipDirtyWorktreeStacks drops every branch whose stack is rooted at a managed
+// worktree with uncommitted changes, warning once per skipped stack.
+//
+// Restacking such a stack fast-forwards the anchor's ref, but the working-directory
+// reset that would realign the anchor's worktree is deliberately suppressed while
+// that worktree is dirty (it would discard the user's uncommitted edits). The
+// worktree is then left reporting trunk's new files as deleted, so a `git add -A`
+// there would commit a revert of trunk. Leaving the stack alone until the worktree
+// is clean avoids that state entirely, and it self-heals on the next restack once
+// the user commits or stashes.
+//
+// Deliberately mirrors — rather than shares — sync's dirtyAnchorSet handling in
+// internal/actions/sync/sync.go: that type is package-private to sync, and
+// exporting it would mean touching every sync call site.
+func skipDirtyWorktreeStacks(ctx *app.Context, groups []restackBranchGroup) []restackBranchGroup {
+	eng := ctx.Engine
+	worktrees, err := eng.ListManagedWorktrees()
+	if err != nil || len(worktrees) == 0 {
+		return groups
+	}
+
+	dirtyAnchors := make(map[string]bool)
+	for _, wt := range worktrees {
+		if hasChanges, _ := eng.WorktreeHasUncommittedChanges(ctx.Context, wt.Path); hasChanges {
+			dirtyAnchors[wt.AnchorBranch] = true
+			ctx.Output.Warn("Skipping stack rooted at %s (worktree has uncommitted changes)", wt.AnchorBranch)
+		}
+	}
+	if len(dirtyAnchors) == 0 {
+		return groups
+	}
+
+	kept := make([]restackBranchGroup, 0, len(groups))
+	for _, g := range groups {
+		builder := engine.NewBranchesBuilder(len(g.branches))
+		for _, branch := range g.branches {
+			if !dirtyAnchors[eng.GetStackRootForBranch(branch)] {
+				builder.Add(branch)
+			}
+		}
+		if built := builder.Build(); len(built) > 0 {
+			kept = append(kept, restackBranchGroup{rootBranch: g.rootBranch, branches: built})
+		}
+	}
+	return kept
 }
 
 func branchGroupsForIndependentStacks(eng engine.BranchReader, opts RestackOptions) ([]restackBranchGroup, error) {

--- a/internal/integration/restack_worktree_anchor_test.go
+++ b/internal/integration/restack_worktree_anchor_test.go
@@ -82,6 +82,10 @@ func TestRestackWorktreeAnchorTracksTrunk(t *testing.T) {
 // fast-forwards the anchor and then unconditionally ran `git reset --hard` on
 // its worktree to match, discarding any uncommitted edit sitting there with no
 // prompt, no warning, and no recovery path.
+//
+// Restack now skips the whole stack while its worktree is dirty, so the anchor
+// stays put rather than moving to trunk without its working directory following.
+// See TestRestackWorktreeAnchorSkipsDirtyStack for that half.
 func TestRestackWorktreeAnchorPreservesUncommittedChanges(t *testing.T) {
 	t.Parallel()
 
@@ -103,17 +107,50 @@ func TestRestackWorktreeAnchorPreservesUncommittedChanges(t *testing.T) {
 
 	sh.Run("restack --all-stacks")
 
-	anchorBranch := findWorktreeAnchor(t, sh)
-	sh.Git("rev-parse main")
-	trunkRev := strings.TrimSpace(sh.Output())
-	sh.Git("rev-parse " + anchorBranch)
-	require.Equal(t, trunkRev, strings.TrimSpace(sh.Output()),
-		"anchor should still fast-forward to trunk even when its worktree is dirty")
-
 	content, err := os.ReadFile(filepath.Join(worktreePath, "init_test.txt"))
 	require.NoError(t, err)
 	require.Equal(t, uncommitted, string(content),
 		"restack must not discard uncommitted changes in the anchor's worktree")
+}
+
+// TestRestackWorktreeAnchorSkipsDirtyStack covers the other half of #1490:
+// suppressing only the working-directory reset would still fast-forward the
+// anchor's ref, leaving its worktree holding the old trunk content. `git status`
+// there then reports trunk's new files as deleted, so a `git add -A` in that
+// worktree would commit a revert of trunk. Restack instead skips the stack
+// entirely — visibly — until the worktree is clean, matching what sync already
+// does (internal/actions/sync/sync.go).
+func TestRestackWorktreeAnchorSkipsDirtyStack(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+	sh.SetWorktreeBasePath(t.TempDir())
+
+	sh.Run("worktree create my-wt")
+	sh.Run("worktree open my-wt")
+	worktreePath := strings.TrimSpace(sh.Output())
+
+	anchorBranch := findWorktreeAnchor(t, sh)
+	sh.Git("rev-parse " + anchorBranch)
+	anchorRevBefore := strings.TrimSpace(sh.Output())
+
+	sh.InWorktree(worktreePath).WriteFile("dirty.txt", "uncommitted work")
+
+	sh.Checkout("main").
+		Commit("trunk1.txt", "chore: trunk commit 1").
+		Run("restack --all-stacks").
+		OutputContains("worktree has uncommitted changes")
+
+	// The anchor is left where it was rather than moving to trunk without its
+	// working directory.
+	sh.Git("rev-parse " + anchorBranch)
+	require.Equal(t, anchorRevBefore, strings.TrimSpace(sh.Output()),
+		"dirty anchor must not be fast-forwarded while its worktree has uncommitted changes")
+
+	// And the uncommitted work is still there.
+	content, err := os.ReadFile(filepath.Join(worktreePath, "dirty.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "uncommitted work", string(content))
 }
 
 // findWorktreeAnchor returns the name of the hidden worktree-anchor branch.


### PR DESCRIPTION

#1520 closed the data-loss path in #1490 by gating restack's working-directory
reset on a dirty-status snapshot. But gating only the reset left the other half:
the anchor's ref still fast-forwarded to trunk while its worktree kept the old
content on disk. `git status` in that worktree then reported trunk's new files
as deleted, so a `git add -A` there would commit a revert of trunk.

Skip the whole stack while its worktree is dirty instead, warning once per
skipped stack, matching what sync has always done. Two placement notes:

- The filter lives in the actions layer, not the engine plan, because
  internal/engine cannot import output and so cannot explain the skip. This
  also puts it next to guardUnpushedTrunk, the other restack-path guard.
- It runs before that guard, so a restack left with nothing to move is a no-op
  rather than a guard error.

This deliberately reverses one assertion added by #1520 — a dirty anchor no
longer fast-forwards — while keeping its content-preservation half.