### PR TITLE
test: cover the untested error paths in create --onto and pr

### DIFF
--- a/internal/integration/create_onto_test.go
+++ b/internal/integration/create_onto_test.go
@@ -94,6 +94,18 @@ func TestCreateOnto(t *testing.T) {
 			OutputContains("locked")
 	})
 
+	t.Run("errors for a worktree anchor target", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.SetWorktreeBasePath(t.TempDir())
+
+		sh.Run("worktree create my-wt")
+		anchorBranch := findWorktreeAnchor(t, sh)
+
+		sh.RunExpectError("create branch-x --onto " + anchorBranch + " -m 'feat: x' --allow-empty").
+			OutputContains("cannot create a branch onto worktree anchor")
+	})
+
 	t.Run("errors when combined with --worktree", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)

--- a/internal/integration/pr_test.go
+++ b/internal/integration/pr_test.go
@@ -78,4 +78,25 @@ func TestPrCommand(t *testing.T) {
 
 		sh.RunExpectError("pr 999").OutputContains("no tracked branch found")
 	})
+
+	t.Run("errors when HEAD is detached", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Git("checkout --detach main")
+
+		sh.RunExpectError("pr").OutputContains("not on a branch")
+	})
+
+	t.Run("--stack errors when the stack root has no PR", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// main -> a -> b -> c, currently on c. Only c has a PR; the stack
+		// root (a) does not.
+		sh.CreateLinearStack3()
+		sh.SetPrMetadata("c", PRMetadata{Number: 3, URL: "https://github.com/owner/repo/pull/3"})
+
+		sh.RunExpectError("pr --stack").OutputContains("no associated pull request")
+	})
 }


### PR DESCRIPTION

Closes the three gaps in #1501:

- create --onto rejecting a worktree-anchor target (create.go:379-382), the
  one validateOntoTarget branch create_onto_test.go did not reach
- pr on a detached HEAD (pr.go:63)
- pr --stack when the resolved stack root has no PR (pr.go:33-45)

Salvaged from #1507, which bundled these with the shell-completion fix that
landed separately in #1505.