### PR TITLE
fix(modify): take an undo snapshot before rewriting history

### DIFF
--- a/internal/actions/modify.go
+++ b/internal/actions/modify.go
@@ -64,6 +64,26 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) (err error) {
 	}
 	targetBranchObj := eng.GetBranch(targetBranchName)
 
+	// Take snapshot before modifying the repository. modify was the only
+	// history-rewriting action without one, so `stackit undo` / `abort` fell
+	// through to whatever unrelated command's snapshot happened to be latest --
+	// restoring the wrong branch, or deleting branches created since it. This
+	// matters most with --into, which rewrites a branch the user is not standing
+	// on and then restacks its whole subtree.
+	//
+	// Deliberately above the interactive-rebase branch: that path rewrites
+	// history too and needs the same safety net.
+	snapshotOpts := NewSnapshot("modify",
+		WithFlagValue("--into", opts.Into),
+		WithFlagValue("-m", opts.Message),
+		WithFlag(opts.CreateCommit, "--commit"),
+		WithFlag(opts.All, "--all"),
+		WithFlag(opts.Update, "--update"),
+		WithFlag(opts.Patch, "--patch"),
+		WithFlag(opts.InteractiveRebase, "--interactive-rebase"),
+	)
+	TakeBestEffortSnapshot(ctx, snapshotOpts)
+
 	// Handle interactive rebase separately
 	if opts.InteractiveRebase {
 		return interactiveRebaseAction(ctx, opts)

--- a/internal/integration/modify_test.go
+++ b/internal/integration/modify_test.go
@@ -2,6 +2,8 @@ package integration
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestModifyWorkflow(t *testing.T) {
@@ -189,6 +191,99 @@ func TestModifyInto(t *testing.T) {
 			OutputContains("checked out in worktree").
 			OutputContains(worktreeDir)
 
+		sh.OnBranch("c")
+	})
+
+	// #1497: modify took no undo snapshot, so `stackit abort` fell back to
+	// whatever unrelated command's snapshot happened to be latest (typically the
+	// last `create`) instead of the state right before this modify ran — landing
+	// on the wrong branch and, in the worst case, deleting branches created since
+	// that stale snapshot.
+	t.Run("abort after a conflict restacking upstack returns to the original branch", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// main -> a -> b -> d. d's own commit reverts b's change to file.txt,
+		// so file.txt is identical between a and d: checking out a to amend
+		// it hits no local-changes conflict. b's original edit to the same
+		// line still conflicts when b is replayed onto the amended a.
+		sh.WriteFile("file.txt", "L1\nL2\nL3\n").
+			Run("create a -m 'Add a'").
+			OnBranch("a")
+		sh.WriteFile("file.txt", "L1\nL2-changed\nL3\n").
+			Run("create b -m 'Add b'").
+			OnBranch("b")
+		sh.WriteFile("file.txt", "L1\nL2\nL3\n").
+			Run("create d -m 'Add d'").
+			OnBranch("d")
+
+		sh.WriteFile("file.txt", "L1\nL2-AMENDED\nL3\n")
+		sh.Git("add file.txt")
+		sh.RunExpectError("modify --into a -n").
+			OutputContains("conflict")
+
+		sh.Run("abort --force").
+			OutputContains("Successfully aborted")
+
+		sh.OnBranch("d")
+		sh.HasBranches("a", "b", "d", "main")
+		sh.Git("show a:file.txt").OutputContains("L1\nL2\nL3\n")
+	})
+}
+
+// TestModifyUndo covers the success-path counterpart to the abort test above:
+// with a snapshot in place, `stackit undo` can roll a completed modify back.
+func TestModifyUndo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("undo restores the pre-amend commit", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.Write("a", "original content").
+			Run("create feature-a -m 'Feature A'").
+			OnBranch("feature-a")
+
+		before := sh.Git("rev-parse feature-a").Output()
+
+		sh.Modify("a_extra", "extra content").
+			OutputContains("Amended commit")
+
+		after := sh.Git("rev-parse feature-a").Output()
+		require.NotEqual(t, before, after, "modify should have amended the commit")
+
+		sh.UndoLatest()
+
+		require.Equal(t, before, sh.Git("rev-parse feature-a").Output(),
+			"undo should restore the pre-amend commit")
+	})
+
+	t.Run("undo restores both branches after modify --into", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3().
+			OnBranch("c")
+
+		beforeA := sh.Git("rev-parse a").Output()
+		beforeB := sh.Git("rev-parse b").Output()
+
+		sh.Write("a_extra", "extra content for a").
+			Run("modify --into a -n").
+			OutputContains("Amended commit in a").
+			OnBranch("c")
+
+		require.NotEqual(t, beforeA, sh.Git("rev-parse a").Output(),
+			"modify --into should have amended the target branch")
+		require.NotEqual(t, beforeB, sh.Git("rev-parse b").Output(),
+			"restacking upstack branches should have moved b")
+
+		sh.UndoLatest()
+
+		require.Equal(t, beforeA, sh.Git("rev-parse a").Output(),
+			"undo should restore the target branch's pre-amend commit")
+		require.Equal(t, beforeB, sh.Git("rev-parse b").Output(),
+			"undo should restore the restacked branch's pre-restack commit")
 		sh.OnBranch("c")
 	})
 }


### PR DESCRIPTION

modify was the only history-rewriting action without a snapshot — create,
squash, absorb, fold, split, rename, move, flatten and restack all take one.
Without it, `stackit undo` / `stackit abort` fell through to whatever unrelated
command's snapshot happened to be latest, restoring the wrong branch or
deleting branches created since it. Closes #1497.

This also fixes the `abort` half of #1494: after a conflict during the upstack
restack, `abort --force` now returns to the branch the user ran `modify --into`
from instead of leaving them on the amended target. The `continue` path is not
covered here.

The snapshot sits above the interactive-rebase early return, since that path
rewrites history too and needs the same net.

Salvaged from #1504 and #1511, which both bundled this with the shell-completion
fix that landed separately in #1505. Flag set follows create's convention of
labelling staging flags (they change what gets amended); --interactive-rebase is
included because the snapshot covers that path.