### PR TITLE
fix(modify): give actionable guidance when --into hits conflicting staged files

### DIFF
--- a/internal/actions/modify.go
+++ b/internal/actions/modify.go
@@ -96,6 +96,9 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) (err error) {
 
 	if targetBranchName != originalBranchName {
 		if err := eng.CheckoutBranch(gctx, targetBranchObj); err != nil {
+			if git.IsLocalChangesError(err) {
+				return fmt.Errorf("cannot modify %s because your staged changes conflict with it; commit or stash them first, or use 'stackit absorb' to route the change to the commit that should own it", targetBranchName)
+			}
 			return fmt.Errorf("failed to checkout %s: %w", targetBranchName, err)
 		}
 		out.Info("Modifying downstack branch %s.", output.CurrentBranch(targetBranchName))

--- a/internal/integration/modify_test.go
+++ b/internal/integration/modify_test.go
@@ -194,6 +194,30 @@ func TestModifyInto(t *testing.T) {
 		sh.OnBranch("c")
 	})
 
+	t.Run("gives actionable guidance instead of a raw git error on conflicting staged files", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		sh.CreateLinearStack3().
+			OnBranch("c")
+
+		// Diverge the shared file between a and c: amend b's commit so the
+		// file differs between a's HEAD and c's HEAD, then stage yet another
+		// conflicting version on c. Checking out from c to a then requires
+		// overwriting the staged change, which git refuses to do silently.
+		sh.Checkout("b").
+			Modify("a.txt", "b's version of the shared file")
+
+		sh.Checkout("c").
+			Write("a.txt", "c's conflicting staged version").
+			RunExpectError("modify --into a -n").
+			OutputContains("stackit absorb").
+			OnBranch("c")
+
+		sh.Git("diff --cached --name-only").
+			OutputContains("a.txt_test.txt")
+	})
+
 	// #1497: modify took no undo snapshot, so `stackit abort` fell back to
 	// whatever unrelated command's snapshot happened to be latest (typically the
 	// last `create`) instead of the state right before this modify ran — landing


### PR DESCRIPTION

Closes #1498. Staging a change to a file whose content differs between the
current branch and the --into target is the normal case for amending a
downstack branch, and it surfaced git's raw wording:

  error: Your local changes to the following files would be overwritten by
  checkout: shared.txt

It already failed safe — HEAD stays put and the staged change survives — but
the message named no stackit remedy. Detect it with git.IsLocalChangesError and
point at stash or `stackit absorb`, which is the command built for routing a
working change to the commit that should own it.

Salvaged from #1513, rebased onto main after #1527 changed the same function.