### PR TITLE
fix(create): inherit scope from the --onto target, not the current branch

### DIFF
--- a/internal/actions/create/create.go
+++ b/internal/actions/create/create.go
@@ -165,12 +165,20 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 	}
 
 	// Determine branch
+	// The branch's parent is --onto's target when given, otherwise the current
+	// branch. Resolved once, up front, so scope inheritance below and the
+	// tracking/Result parent further down agree on the same parent.
+	parentBranch := currentBranch
+	if opts.Onto != "" {
+		parentBranch = opts.Onto
+	}
+
 	// Use provided scope if given, otherwise inherit from parent
 	var scopeToUse string
 	if opts.Scope != "" {
 		scopeToUse = opts.Scope
 	} else {
-		parentScope := eng.GetScope(eng.GetBranch(currentBranch))
+		parentScope := eng.GetScope(eng.GetBranch(parentBranch))
 		scopeToUse = parentScope.String()
 	}
 
@@ -207,10 +215,8 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 	// checkout, so the divergence point stackit records is the target's tip
 	// rather than a merge-base that could wander into unrelated history the
 	// current branch happens to share with the target.
-	parentBranch := currentBranch
 	h.OnStep(StepBranchCreate, handler.StatusStarted, fmt.Sprintf("Creating branch %s", branchName))
 	if opts.Onto != "" {
-		parentBranch = opts.Onto
 		ontoBranch := eng.GetBranch(opts.Onto)
 		ontoSHA, err := ontoBranch.GetRevision()
 		if err != nil {

--- a/internal/integration/create_onto_test.go
+++ b/internal/integration/create_onto_test.go
@@ -65,6 +65,27 @@ func TestCreateOnto(t *testing.T) {
 		shW.OnBranch("shared")
 	})
 
+	t.Run("inherits scope from the --onto target, not the current branch", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+		sh.Run("config set branch.pattern \"{scope}/{message}\"")
+
+		// branch-a (current) carries scope JIRA-1; branch-b (--onto target)
+		// carries a different scope, JIRA-2.
+		sh.Write("a", "content a").Run("create branch-a -m 'a' --scope JIRA-1")
+		sh.Checkout("main")
+		sh.Write("b", "content b").Run("create branch-b -m 'b' --scope JIRA-2")
+		sh.Checkout("branch-a")
+
+		// No explicit branch name, so it's generated from the pattern. The
+		// generated name must use branch-b's scope, not branch-a's, since
+		// branch-b is the real parent.
+		sh.Write("c", "content c").Run("create --onto branch-b -m 'child feature'")
+
+		sh.OnBranch("JIRA-2/child-feature")
+		sh.ExpectBranchParent("JIRA-2/child-feature", "branch-b")
+	})
+
 	t.Run("errors for a nonexistent target", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)


### PR DESCRIPTION

Closes #1495. Scope resolution read the current branch while the new branch's
actual parent is --onto's target, so branching from a scoped branch onto a
differently-scoped one picked up the wrong scope. That fed the {scope} branch
pattern and the PR title prefix. Recorded metadata scope was unaffected — with
no --scope it inherits from the real parent.

Resolve the parent once, before scope resolution, so scope inheritance and the
tracking/Result parent agree instead of being derived separately.

Salvaged from #1522, rebased onto main. That PR's CI only ran the two
lightweight checks — Build, Lint, Test and Web never started — so it never had
a real green run.