### PR TITLE
fix(engine): fast-forward worktree anchors on the non-plan restack path

### DIFF
--- a/internal/engine/restack_anchor_nonplan_test.go
+++ b/internal/engine/restack_anchor_nonplan_test.go
@@ -1,0 +1,85 @@
+package engine_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// These cover the non-plan RestackBranches path — the one reached by
+// `continue`, `delete`, `squash`, `absorb`, `pluck` and `insert`, as opposed to
+// the `restack` command's PlanRestack path. #1488 fixed worktree-anchor
+// handling only in the plan; this is the sibling path (#1493).
+//
+// A faithful anchor is built by hand rather than with WithStack: a real
+// worktree anchor holds no commits of its own (it marks where trunk was when
+// the worktree was created), and WithStack commits on every branch it makes.
+// That difference is the whole bug — a commit-less anchor is an ancestor of
+// trunk, so the landed check treats it as already merged.
+func withWorktreeAnchor(t *testing.T, s *scenario.Scenario, name string) {
+	t.Helper()
+	s.CreateBranchFromQuiet(name, "main").Rebuild()
+	s.TrackBranch(name, "main")
+	require.NoError(t, s.Engine.SetBranchType(s.Engine.GetBranch(name), git.BranchTypeWorktreeAnchor))
+}
+
+// TestRestackBranchesFastForwardsWorktreeAnchor covers the ordering half of
+// #1493. An anchor holds no commits, so it is always an ancestor of trunk and
+// branchLanded reports it as landed — returning "unneeded" before the
+// fast-forward handler further down is ever reached. The anchor then never
+// moves, and every consumer measuring a child against it drifts with each
+// trunk advance.
+func TestRestackBranchesFastForwardsWorktreeAnchor(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	withWorktreeAnchor(t, s, "anchor")
+
+	oldSHA, err := s.Engine.GetBranch("anchor").GetRevision()
+	require.NoError(t, err)
+
+	s.Checkout("main").Commit("main update").Rebuild()
+	trunkSHA, err := s.Engine.Trunk().GetRevision()
+	require.NoError(t, err)
+	require.NotEqual(t, oldSHA, trunkSHA)
+
+	_, err = s.Engine.RestackBranches(context.Background(), engine.BranchesOf(s.Engine.GetBranch("anchor")))
+	require.NoError(t, err)
+
+	anchorSHA, err := s.Scene.Repo.GetBranchSHA("anchor")
+	require.NoError(t, err)
+	require.Equal(t, trunkSHA, anchorSHA,
+		"anchor must fast-forward to trunk on the non-plan path too")
+}
+
+// TestRestackBranchesDoesNotReplayTrunkOntoAnchorChild covers the rebase-range
+// half. Restacking a child of an anchor rebases onto trunk's tip but measures
+// the other end of the range against the stale anchor, so trunk commits can
+// fall inside the replay range. .claude/rules/multiplayer-safety.md requires
+// <trunk>..<branch> to equal exactly the branch's own commits.
+//
+// Two rounds: one restack alone is fine, because the recorded revision really
+// is where the branch is based. The second is where a stale anchor bites.
+func TestRestackBranchesDoesNotReplayTrunkOntoAnchorChild(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	withWorktreeAnchor(t, s, "anchor")
+
+	s.CreateBranchFromQuiet("feature", "anchor").
+		CommitChange("feature", "feat: feature").
+		Rebuild()
+	s.TrackBranch("feature", "anchor")
+
+	for round, msg := range []string{"trunk one", "trunk two"} {
+		s.Checkout("main").Commit(msg).Rebuild()
+
+		_, err := s.Engine.RestackBranches(context.Background(), engine.BranchesOf(s.Engine.GetBranch("feature")))
+		require.NoError(t, err)
+
+		require.Equal(t, 1, s.BranchCommitCount("feature"),
+			"round %d: feature must contain only its own commit, not replayed trunk commits", round+1)
+	}
+}

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -50,6 +50,84 @@ type restackSnapshot struct {
 	dirtyWorktrees map[string]bool
 }
 
+// restackWorktreeAnchor fast-forwards a worktree anchor to trunk instead of
+// rebasing it. handled is false for any branch that isn't an anchor, so callers
+// fall through to the normal path.
+//
+// An anchor carries no commits of its own, so there is nothing to replay: the
+// ref and its recorded parent revision are moved to trunk in one atomic update.
+func (e *engineImpl) restackWorktreeAnchor(
+	ctx context.Context,
+	branch Branch,
+	snap *restackSnapshot,
+) (result RestackBranchResult, handled bool, err error) {
+	if !e.IsWorktreeAnchor(branch) {
+		return RestackBranchResult{}, false, nil
+	}
+	branchName := branch.GetName()
+
+	trunkRev, err := e.Trunk().GetRevision()
+	if err != nil {
+		return RestackBranchResult{Result: RestackConflict}, true, fmt.Errorf("failed to get trunk revision for anchor %s: %w", branchName, err)
+	}
+
+	anchorRev, err := branch.GetRevision()
+	if err != nil {
+		return RestackBranchResult{Result: RestackConflict}, true, fmt.Errorf("failed to get anchor revision for %s: %w", branchName, err)
+	}
+
+	// If already at trunk, nothing to do
+	if anchorRev == trunkRev {
+		return RestackBranchResult{Result: RestackUnneeded}, true, nil
+	}
+
+	// Get current metadata SHA for optimistic locking
+	oldMetadataSHA := snap.metaRefSHAs[branchName]
+
+	// Prepare metadata update with new parent revision
+	meta, err := e.readMetadata(branchName)
+	if err != nil {
+		meta = git.NewMeta()
+	}
+	meta = meta.WithParentBranchRevision(&trunkRev)
+	metadataJSON, err := json.Marshal(meta)
+	if err != nil {
+		return RestackBranchResult{Result: RestackConflict}, true, fmt.Errorf("failed to marshal metadata for anchor %s: %w", branchName, err)
+	}
+	metadataSHA, err := e.git.CreateBlob(string(metadataJSON))
+	if err != nil {
+		return RestackBranchResult{Result: RestackConflict}, true, fmt.Errorf("failed to prepare metadata blob for anchor %s: %w", branchName, err)
+	}
+
+	// Atomic update of both branch ref and metadata ref
+	updates := []git.RefUpdate{
+		{RefName: fmt.Sprintf("refs/heads/%s", branchName), NewSHA: trunkRev, OldSHA: anchorRev},
+		{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
+	}
+	if err := e.git.UpdateRefsBatchWithLog(ctx, updates, reflogRestackAnchor); err != nil {
+		return RestackBranchResult{Result: RestackConflict}, true, fmt.Errorf("failed to update refs atomically for anchor %s: %w", branchName, err)
+	}
+
+	// If the anchor branch is currently checked out in this context, reset the working tree
+	current := e.CurrentBranch()
+	if current != nil && current.GetName() == branchName {
+		if err := e.git.HardReset(ctx, "HEAD"); err != nil {
+			return RestackBranchResult{Result: RestackConflict}, true, fmt.Errorf("failed to reset working tree for anchor %s: %w", branchName, err)
+		}
+	} else {
+		// If the branch is checked out in a different worktree, reset that worktree.
+		if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" {
+			e.resetWorktreeIfClean(ctx, worktreePath, snap)
+		}
+	}
+
+	return RestackBranchResult{
+		Result:            RestackDone,
+		RebasedBranchBase: trunkRev,
+		NewRev:            trunkRev,
+	}, true, nil
+}
+
 // restackBranch rebases a branch onto its parent
 // If the parent has been merged/deleted, it will automatically reparent to the nearest valid ancestor.
 // snap is the point-in-time state captured by the caller — passing it avoids
@@ -92,6 +170,17 @@ func (e *engineImpl) restackBranch(
 	lockReason := e.GetLockReason(branch)
 	if lockReason.IsLocked() && lockReason != LockReasonDraining {
 		return RestackBranchResult{Result: RestackUnneeded, LockReason: lockReason}, nil
+	}
+
+	// Worktree anchors are handled before the landed check, mirroring
+	// planRestackBranch. An anchor holds no commits of its own -- it marks where
+	// trunk was when the worktree was created -- so it is always an ancestor of
+	// trunk and branchLanded always reports it as landed. Checking that first
+	// meant the anchor returned "unneeded" before ever reaching the
+	// fast-forward below, so it never moved, and every consumer that measures a
+	// child against its recorded parent drifted further with each trunk advance.
+	if anchorResult, handled, err := e.restackWorktreeAnchor(ctx, branch, snap); handled {
+		return anchorResult, err
 	}
 
 	if e.branchLanded(ctx, branchName, parent, squashCache) {
@@ -171,72 +260,6 @@ func (e *engineImpl) restackBranch(
 		}
 
 		return RestackBranchResult{Result: RestackUnneeded, Frozen: true}, nil
-	}
-
-	// Handle worktree anchor branches: fast-forward to trunk instead of rebase
-	if e.IsWorktreeAnchor(branch) {
-		// Get trunk's current SHA
-		trunkRev, err := e.Trunk().GetRevision()
-		if err != nil {
-			return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to get trunk revision for anchor %s: %w", branchName, err)
-		}
-
-		// Get anchor's current SHA
-		anchorRev, err := branch.GetRevision()
-		if err != nil {
-			return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to get anchor revision for %s: %w", branchName, err)
-		}
-
-		// If already at trunk, nothing to do
-		if anchorRev == trunkRev {
-			return RestackBranchResult{Result: RestackUnneeded}, nil
-		}
-
-		// Get current metadata SHA for optimistic locking
-		oldMetadataSHA := snap.metaRefSHAs[branchName]
-
-		// Prepare metadata update with new parent revision
-		meta, err := e.readMetadata(branchName)
-		if err != nil {
-			meta = git.NewMeta()
-		}
-		meta = meta.WithParentBranchRevision(&trunkRev)
-		metadataJSON, err := json.Marshal(meta)
-		if err != nil {
-			return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to marshal metadata for anchor %s: %w", branchName, err)
-		}
-		metadataSHA, err := e.git.CreateBlob(string(metadataJSON))
-		if err != nil {
-			return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to prepare metadata blob for anchor %s: %w", branchName, err)
-		}
-
-		// Atomic update of both branch ref and metadata ref
-		updates := []git.RefUpdate{
-			{RefName: fmt.Sprintf("refs/heads/%s", branchName), NewSHA: trunkRev, OldSHA: anchorRev},
-			{RefName: fmt.Sprintf("%s%s", git.MetadataRefPrefix, branchName), NewSHA: metadataSHA, OldSHA: oldMetadataSHA},
-		}
-		if err := e.git.UpdateRefsBatchWithLog(ctx, updates, reflogRestackAnchor); err != nil {
-			return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to update refs atomically for anchor %s: %w", branchName, err)
-		}
-
-		// If the anchor branch is currently checked out in this context, reset the working tree
-		current := e.CurrentBranch()
-		if current != nil && current.GetName() == branchName {
-			if err := e.git.HardReset(ctx, "HEAD"); err != nil {
-				return RestackBranchResult{Result: RestackConflict}, fmt.Errorf("failed to reset working tree for anchor %s: %w", branchName, err)
-			}
-		} else {
-			// If the branch is checked out in a different worktree, reset that worktree.
-			if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" {
-				e.resetWorktreeIfClean(ctx, worktreePath, snap)
-			}
-		}
-
-		return RestackBranchResult{
-			Result:            RestackDone,
-			RebasedBranchBase: trunkRev,
-			NewRev:            trunkRev,
-		}, nil
 	}
 
 	// Track reparenting info


### PR DESCRIPTION

Partially addresses #1493. #1488 moved the worktree-anchor handler above the
landed check in planRestackBranch; restackBranch — the path taken by continue,
delete, squash, absorb, pluck and insert — kept the old ordering.

An anchor holds no commits of its own, so it is always an ancestor of trunk and
branchLanded always reports it as landed. It therefore returned "unneeded"
before ever reaching the fast-forward below, and the anchor never moved. Every
consumer that measures a child against its recorded parent then drifts further
with each trunk advance. Mirror the plan's ordering and extract the block into
restackWorktreeAnchor so both paths read the same way.

The fast-forward test fails without this change, with the anchor sitting at its
pre-restack SHA.

Note on the other half of #1493 — the claim that this path also widens the
rebase range by taking the merge base against the stale anchor at
restack_impl.go:337/343. I could not reproduce it, and TestRestackBranchesDoes
NotReplayTrunkOntoAnchorChild passes with and without any change there. The
existing trunk substitution above already moves parentRev and the rebase target
to trunk, and the merge-base operand only matters when the recorded revision is
not an ancestor of the branch — in which case merge-base against the anchor and
against trunk coincide, since the branch descends from the anchor's commit. The
test is kept as coverage for the invariant; #1493 stays open for that half
rather than being closed on an unproven fix.

Both tests build a commit-less anchor by hand. WithStack commits on every
branch it creates, which makes its "anchor" a non-ancestor of trunk and hides
the bug entirely — that difference is the whole point.