### PR TITLE
fix(git): resolve current-branch casing against the ref list

### DIFF
--- a/internal/actions/validation/validators.go
+++ b/internal/actions/validation/validators.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/errors"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // Validator validates a single precondition.
@@ -263,7 +264,8 @@ func ValidateTargetBranch(eng BranchValidationEngine, sourceName, targetName, op
 
 	// Target must exist - check if it's trunk, tracked, or at least a git branch
 	if !targetBranch.IsTrunk() && !targetBranch.IsTracked() && !eng.BranchNames().Contains(targetName) {
-		return fmt.Errorf("branch %s does not exist", targetName)
+		return fmt.Errorf("branch %s does not exist%s", targetName,
+			git.CaseMismatchHint(targetName, eng.BranchNames().Names()))
 	}
 
 	if targetBranch.IsWorktreeAnchor() {

--- a/internal/engine/branch_tracking.go
+++ b/internal/engine/branch_tracking.go
@@ -22,6 +22,7 @@ func (e *engineImpl) TrackBranch(ctx context.Context, branchName string, parentB
 	// Update current branch if it changed
 	if current, err := e.git.GetCurrentBranch(); err == nil {
 		e.currentBranch = current
+		e.normalizeCurrentBranchLocked()
 	}
 
 	// Validate branch exists
@@ -36,8 +37,9 @@ func (e *engineImpl) TrackBranch(ctx context.Context, branchName string, parentB
 		e.state.setBranches(branches)
 		branchExists = slices.Contains(e.state.branches, branchName)
 		if !branchExists {
+			hint := git.CaseMismatchHint(branchName, e.state.branches)
 			e.mu.Unlock()
-			return fmt.Errorf("branch %s does not exist", branchName)
+			return fmt.Errorf("branch %s does not exist%s", branchName, hint)
 		}
 	}
 
@@ -54,8 +56,9 @@ func (e *engineImpl) TrackBranch(ctx context.Context, branchName string, parentB
 			e.state.setBranches(branches)
 			parentExists = slices.Contains(e.state.branches, parentBranchName)
 			if !parentExists {
+				hint := git.CaseMismatchHint(parentBranchName, e.state.branches)
 				e.mu.Unlock()
-				return fmt.Errorf("parent branch %s does not exist", parentBranchName)
+				return fmt.Errorf("parent branch %s does not exist%s", parentBranchName, hint)
 			}
 		}
 	}

--- a/internal/engine/current_branch_case_test.go
+++ b/internal/engine/current_branch_case_test.go
@@ -1,0 +1,76 @@
+package engine_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// Issue #1532: on case-insensitive filesystems `refs/heads/Claude/x` and
+// `refs/heads/claude/x` are the same file, so HEAD can record a casing that
+// for-each-ref never reports. Every current-branch lookup then misses and
+// stackit reports the branch you are standing on as nonexistent.
+//
+// The divergence itself — HEAD naming a ref with different casing than the one
+// on disk — is reproducible on a case-sensitive filesystem by pointing HEAD at
+// the other spelling directly, so this covers the resolution on Linux CI.
+func TestCurrentBranchResolvesRefCasing(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HEAD casing is realigned with the on-disk ref", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.CreateBranch("claude/feature").Commit("feature change")
+
+		s.RunGit("symbolic-ref", "HEAD", "refs/heads/Claude/feature")
+		s.Rebuild()
+
+		current := s.Engine.CurrentBranch()
+		require.NotNil(t, current)
+		require.Equal(t, "claude/feature", current.GetName())
+	})
+
+	t.Run("matching casing is left untouched", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.CreateBranch("claude/feature").Commit("feature change")
+
+		current := s.Engine.CurrentBranch()
+		require.NotNil(t, current)
+		require.Equal(t, "claude/feature", current.GetName())
+	})
+
+	t.Run("track succeeds on a branch HEAD spells differently", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.CreateBranch("claude/feature").Commit("feature change")
+
+		s.RunGit("symbolic-ref", "HEAD", "refs/heads/Claude/feature")
+		s.Rebuild()
+
+		name, err := s.Engine.ValidateOnBranch()
+		require.NoError(t, err)
+		require.Equal(t, "claude/feature", name)
+
+		require.NoError(t, s.Engine.TrackBranch(context.Background(), name, "main"))
+		parent := s.Engine.GetBranch(name).GetParent()
+		require.NotNil(t, parent)
+		require.Equal(t, "main", parent.GetName())
+	})
+}
+
+func TestTrackBranchReportsCaseMismatch(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.CreateBranch("claude/feature").Commit("feature change")
+	s.Checkout("main")
+
+	err := s.Engine.TrackBranch(context.Background(), "Claude/feature", "main")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "claude/feature")
+	require.Contains(t, err.Error(), "differ only in case")
+}

--- a/internal/engine/engine_impl.go
+++ b/internal/engine/engine_impl.go
@@ -150,6 +150,7 @@ func NewEngineForWorktree(opts WorktreeEngineOptions) (Engine, error) {
 		currentBranch = ""
 	}
 	e.currentBranch = currentBranch
+	e.normalizeCurrentBranchLocked()
 
 	// Worktree snapshots are built only from fully-loaded parent engines (see
 	// SnapshotForWorktree), so the worktree engine starts with both gates open.
@@ -234,8 +235,19 @@ func (e *engineImpl) loadBranchList() error {
 	}
 	e.mu.Lock()
 	e.state.setBranches(branches)
+	e.normalizeCurrentBranchLocked()
 	e.mu.Unlock()
 	return nil
+}
+
+// normalizeCurrentBranchLocked realigns e.currentBranch with the casing the ref
+// carries in refs/heads. See git.ResolveBranchNameCase for why HEAD and the
+// branch list can disagree. Callers must hold e.mu for writing.
+func (e *engineImpl) normalizeCurrentBranchLocked() {
+	if e.currentBranch == "" {
+		return
+	}
+	e.currentBranch = git.ResolveBranchNameCase(e.currentBranch, e.state.branches)
 }
 
 // ensureSharedLoaded reads shared metadata for all known branches and applies

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -46,6 +46,7 @@ func (e *engineImpl) applyRebuild(branches []string, currentBranch string, allMe
 	if currentBranch != "" {
 		e.currentBranch = currentBranch
 	}
+	e.normalizeCurrentBranchLocked()
 	e.sharedLoaded.Store(true)
 	e.localLoaded.Store(true)
 }

--- a/internal/engine/engine_reader.go
+++ b/internal/engine/engine_reader.go
@@ -54,6 +54,10 @@ func (e *engineImpl) CurrentBranch() *Branch {
 
 	e.mu.Lock()
 	e.currentBranch = current
+	// HEAD echoes the casing requested at checkout time, which can differ from
+	// the ref on disk on case-insensitive filesystems. Realign against the
+	// branch list we already hold so downstream lookups don't miss.
+	e.normalizeCurrentBranchLocked()
 	e.mu.Unlock()
 
 	e.mu.RLock()

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -15,6 +15,63 @@ func (r *runner) GetCurrentBranch() (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
+// ResolveBranchNameCase reconciles a branch name reported by HEAD with the
+// casing the ref actually carries in refs/heads.
+//
+// On case-insensitive filesystems (macOS and Windows defaults) loose refs
+// `refs/heads/Claude/x` and `refs/heads/claude/x` are the same file, so
+// whichever casing created the directory first wins on disk. HEAD, however,
+// stores the name verbatim as requested at checkout time, so
+// `git symbolic-ref --short HEAD` can echo back a casing that for-each-ref
+// never reports. Every lookup of the current branch against the branch list
+// then misses, and stackit reports the branch you are standing on as
+// nonexistent.
+//
+// The exact match always wins, so this is a no-op on case-sensitive
+// filesystems. The case-insensitive fallback engages only when the exact name
+// is absent from branchNames and exactly one candidate differs by case alone —
+// a case-insensitive filesystem cannot hold two such refs, so a unique match
+// there is the ref HEAD meant.
+//
+// Caveat: on a case-sensitive filesystem an unborn branch (`git checkout
+// --orphan Feature`) whose name differs only in case from an existing branch
+// resolves to that existing branch. Harmless in practice, and the alternative
+// costs a git call on every current-branch read.
+func ResolveBranchNameCase(name string, branchNames []string) string {
+	if name == "" || slices.Contains(branchNames, name) {
+		return name
+	}
+
+	match := ""
+	for _, candidate := range branchNames {
+		if !strings.EqualFold(candidate, name) {
+			continue
+		}
+		if match != "" {
+			// Ambiguous: only possible on a case-sensitive filesystem, where
+			// HEAD's casing is authoritative anyway.
+			return name
+		}
+		match = candidate
+	}
+	if match == "" {
+		return name
+	}
+	return match
+}
+
+// CaseMismatchHint returns a parenthetical explaining that name is absent from
+// branchNames only because of casing, or "" when casing is not the problem.
+// Turns "branch X does not exist" — reported for a branch the user can see —
+// into a message that names both spellings.
+func CaseMismatchHint(name string, branchNames []string) string {
+	if resolved := ResolveBranchNameCase(name, branchNames); resolved != name {
+		return fmt.Sprintf(" (a branch named %s exists; the names differ only in case, "+
+			"which git cannot distinguish on case-insensitive filesystems)", resolved)
+	}
+	return ""
+}
+
 func (r *runner) GetAllBranchNames(ctx context.Context) ([]string, error) {
 	branches, err := r.allBranchHashes(ctx)
 	if err != nil {

--- a/internal/git/branches_test.go
+++ b/internal/git/branches_test.go
@@ -1,0 +1,94 @@
+package git_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/git"
+)
+
+// Reproduces the case-insensitive-filesystem divergence from issue #1532
+// without needing such a filesystem: HEAD reports one casing, for-each-ref
+// reports another.
+func TestResolveBranchNameCase(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		head     string
+		branches []string
+		expected string
+	}{
+		{
+			name:     "exact match is returned unchanged",
+			head:     "claude/feature",
+			branches: []string{"main", "claude/feature"},
+			expected: "claude/feature",
+		},
+		{
+			name:     "HEAD casing maps onto the on-disk ref casing",
+			head:     "Claude/20260730021014/translate-raw-checkout-error",
+			branches: []string{"main", "claude/20260730021014/translate-raw-checkout-error"},
+			expected: "claude/20260730021014/translate-raw-checkout-error",
+		},
+		{
+			name:     "exact match wins over a case-insensitive candidate",
+			head:     "Feature",
+			branches: []string{"feature", "Feature"},
+			expected: "Feature",
+		},
+		{
+			name:     "unknown branch is returned unchanged",
+			head:     "missing",
+			branches: []string{"main", "feature"},
+			expected: "missing",
+		},
+		{
+			name:     "ambiguous case-insensitive candidates leave HEAD authoritative",
+			head:     "FEATURE",
+			branches: []string{"feature", "Feature"},
+			expected: "FEATURE",
+		},
+		{
+			name:     "empty name is returned unchanged",
+			head:     "",
+			branches: []string{"main"},
+			expected: "",
+		},
+		{
+			name:     "empty branch list is returned unchanged",
+			head:     "feature",
+			branches: nil,
+			expected: "feature",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, git.ResolveBranchNameCase(tt.head, tt.branches))
+		})
+	}
+}
+
+func TestCaseMismatchHint(t *testing.T) {
+	t.Parallel()
+
+	t.Run("names the on-disk casing when only case differs", func(t *testing.T) {
+		t.Parallel()
+		hint := git.CaseMismatchHint("Claude/feature", []string{"main", "claude/feature"})
+		require.Contains(t, hint, "claude/feature")
+		require.Contains(t, hint, "differ only in case")
+	})
+
+	t.Run("empty when the branch exists", func(t *testing.T) {
+		t.Parallel()
+		require.Empty(t, git.CaseMismatchHint("feature", []string{"main", "feature"}))
+	})
+
+	t.Run("empty when no case-insensitive candidate exists", func(t *testing.T) {
+		t.Parallel()
+		require.Empty(t, git.CaseMismatchHint("missing", []string{"main", "feature"}))
+	})
+}


### PR DESCRIPTION
Fixes #1532.

## Problem

On case-insensitive filesystems (macOS, Windows), `refs/heads/Claude/x` and `refs/heads/claude/x` are the same loose-ref file, so whichever casing creates the directory first wins on disk. But `git symbolic-ref --short HEAD` echoes back the name **as requested at checkout time**, while `for-each-ref` reports the ref **as it exists on disk**. When those disagree, every lookup of the current branch against the branch list misses and stackit reports the branch you are standing on as nonexistent — blocking `track`, `restack`, and anything else that resolves the current branch.

## Fix

Reconcile the two names in the engine, where the branch list is already in memory — so this costs **no extra git calls**, in line with the batch/N+1 rules in `.claude/rules/code-style.md`. (The issue suggested localizing to `internal/git/branches.go`; doing the reconciliation there would have meant a `for-each-ref` or `show-ref` on every current-branch read, so the pure resolution helper lives in `internal/git` and the engine — which already holds the list — applies it.)

- `git.ResolveBranchNameCase(name, branchNames)` — pure helper. Exact match always wins, so it is a no-op on case-sensitive filesystems. The case-insensitive fallback engages only when the exact name is absent and exactly one candidate differs by case alone; a case-insensitive filesystem cannot hold two such refs, so a unique match there is the ref HEAD meant. Ambiguous matches leave HEAD authoritative.
- `engineImpl.normalizeCurrentBranchLocked()` applies it everywhere `currentBranch` is read from git: `CurrentBranch()` (which re-reads HEAD on every call), `applyRebuild`, `loadBranchList`, `NewEngineForWorktree`, and `TrackBranch`'s refresh.

The remaining `e.currentBranch` assignments (split, undo, branch mutations) set names stackit itself supplied, and `CurrentBranch()` re-normalizes on every read regardless.

## Clearer error

`git.CaseMismatchHint` appends the on-disk spelling when casing is the only difference, so "branch X does not exist" for a branch the user can plainly see becomes self-explaining. Wired into `TrackBranch` (branch and parent) and `validation.ValidateTargetBranch`.

## Tests

The issue notes this needs a case-insensitive filesystem to reproduce. The underlying divergence — HEAD naming a ref with different casing than the one on disk — is reproducible on Linux by pointing HEAD at the other spelling directly, so the fix is covered on CI both ways:

- `internal/git/branches_test.go` — table-driven unit tests for `ResolveBranchNameCase` (exact match, case remap, exact-wins-over-fuzzy, unknown branch, ambiguous, empty inputs) and `CaseMismatchHint`.
- `internal/engine/current_branch_case_test.go` — engine-level coverage via `git symbolic-ref HEAD refs/heads/Claude/feature` against an on-disk `claude/feature`: `CurrentBranch()` and `ValidateOnBranch()` realign, `TrackBranch` succeeds on the branch that previously reported "does not exist", matching casing is untouched, and the case-mismatch hint appears in the error.

Verified the new engine tests fail without the fix (`Claude/feature` vs `claude/feature`) and pass with it. These tests are filesystem-agnostic — they exercise the same path on macOS.

## Validation

`gofmt`, `go vet`, and the full `go test ./...` suite pass. One pre-existing failure, `TestGetRepoInfo/parses_HTTPS_URL`, is unrelated — it reproduces on a clean tree and is caused by a sandbox-level git `insteadOf` URL rewrite. `golangci-lint` could not run in this environment (the installed binary is built with Go 1.25 against a 1.26 target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018W2uJGQ7uamemKso4XeFZW

---
_Generated by [Claude Code](https://claude.ai/code/session_018W2uJGQ7uamemKso4XeFZW)_