### PR TITLE
fix(engine): measure anchor-child rebase range against trunk, not the anchor

### DIFF
--- a/internal/engine/restack_anchor_nonplan_test.go
+++ b/internal/engine/restack_anchor_nonplan_test.go
@@ -83,3 +83,39 @@ func TestRestackBranchesDoesNotReplayTrunkOntoAnchorChild(t *testing.T) {
 			"round %d: feature must contain only its own commit, not replayed trunk commits", round+1)
 	}
 }
+
+// TestRestackBranchesMissingRecordedRevDoesNotReplayTrunk probes the remaining
+// half of #1493: the merge-base operand at restack_impl.go:337/343 is the stale
+// anchor rather than trunk. The `oldParentRev != ""` branch cannot reach it --
+// an anchor holds no commits, so its recorded revision is always a trunk commit
+// and therefore always an ancestor of a branch descended from trunk. The empty
+// branch can: with no recorded revision, merge-base is taken against the
+// anchor's stale tip while the rebase target is trunk, so every trunk commit
+// between the two falls inside the replay range.
+func TestRestackBranchesMissingRecordedRevDoesNotReplayTrunk(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	withWorktreeAnchor(t, s, "anchor")
+
+	s.CreateBranchFromQuiet("feature", "anchor").
+		CommitChange("feature", "feat: feature").
+		Rebuild()
+	s.TrackBranch("feature", "anchor")
+
+	// Trunk advances and feature is restacked onto it, leaving the anchor stale.
+	s.Checkout("main").Commit("trunk one").Rebuild()
+	_, err := s.Engine.RestackBranches(context.Background(), engine.BranchesOf(s.Engine.GetBranch("feature")))
+	require.NoError(t, err)
+
+	// Legacy on-disk stack: no recorded parent revision.
+	meta, err := s.Engine.Git().ReadMetadata("feature")
+	require.NoError(t, err)
+	require.NoError(t, s.Engine.Git().WriteMetadata("feature", meta.WithParentBranchRevision(nil)))
+	require.NoError(t, s.Engine.Rebuild("main"))
+
+	s.Checkout("main").Commit("trunk two").Rebuild()
+	_, err = s.Engine.RestackBranches(context.Background(), engine.BranchesOf(s.Engine.GetBranch("feature")))
+	require.NoError(t, err)
+
+	require.Equal(t, 1, s.BranchCommitCount("feature"),
+		"feature must contain only its own commit, not trunk commits replayed from a stale anchor merge-base")
+}

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -328,7 +328,16 @@ func (e *engineImpl) restackBranch(
 	// EnterConflictWorkflow's "expected conflict but rebase completed
 	// successfully" assertion and leaves the branch un-restacked.
 	rebaseOnto := parent
+	// Measure the other end of the replay range against trunk too. An anchor is
+	// never the branch's real rebase base, and its own revision is always a
+	// trunk commit -- so it stays an ancestor of any branch sitting on trunk and
+	// the is-ancestor check below cannot spot that it has gone stale. Taking the
+	// merge base against the anchor while rebasing onto trunk puts every trunk
+	// commit since the anchor was created inside the range, which
+	// .claude/rules/multiplayer-safety.md forbids. Mirrors planRestackBranch.
+	rebaseBase := parent
 	if e.IsWorktreeAnchor(parentBranch) {
+		rebaseBase = e.trunk
 		if trunkRev, trunkErr := e.Trunk().GetRevision(); trunkErr == nil && trunkRev != parentRev {
 			parentRev = trunkRev
 			rebaseOnto = trunkRev
@@ -357,13 +366,13 @@ func (e *engineImpl) restackBranch(
 	// This check MUST run before the early-exit checks to match buildRebaseSpecs behavior.
 	if oldParentRev != "" {
 		if isAncestor, _ := e.git.IsAncestor(ctx, oldParentRev, branchName); !isAncestor {
-			if mergeBase, err := e.git.GetMergeBase(ctx, branchName, parent); err == nil {
+			if mergeBase, err := e.git.GetMergeBase(ctx, branchName, rebaseBase); err == nil {
 				oldParentRev = mergeBase
 			}
 		}
 	} else {
 		// No old parent revision in metadata, try to find merge base
-		if mergeBase, err := e.git.GetMergeBase(ctx, branchName, parent); err == nil {
+		if mergeBase, err := e.git.GetMergeBase(ctx, branchName, rebaseBase); err == nil {
 			oldParentRev = mergeBase
 		}
 	}


### PR DESCRIPTION

Closes #1493. restackBranch rebased a worktree anchor's child onto trunk's tip
but took the other end of the replay range from a merge base against the stale
anchor, putting every trunk commit since the worktree was created inside the
range. .claude/rules/multiplayer-safety.md requires <trunk>..<branch> to hold
exactly the branch's own commits. #1488 fixed this in planRestackBranch; this is
the sibling non-plan path, reached by continue, delete, squash, absorb, pluck
and insert.

Reachable only through the missing-recorded-revision branch. An anchor holds no
commits, so its revision is always a trunk commit and therefore always an
ancestor of a branch sitting on trunk — the is-ancestor path can never fall
through to the merge base. With no recorded revision (a legacy on-disk stack,
the same class #1523 addressed on the plan side) the empty branch takes it, and
merge-base against the anchor genuinely differs from trunk.

The new test fails without the fix with feature holding 2 commits instead of 1 —
a replayed trunk commit.

My earlier note on #1493 said this half was unreproducible. That was wrong: I
had only probed the is-ancestor path, which is genuinely unreachable, and
concluded too early instead of enumerating both branches of the conditional.