### PR TITLE
fix(modify): return to the original branch after a --into conflict

### DIFF
--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -110,6 +110,18 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 		}
 	}
 
+	// Return to the branch the interrupted command was invoked from, when it
+	// differs from the one that was rebased. `modify --into` records this: it
+	// amends a downstack ancestor without checking it out and promises to put
+	// you back, and resolving a conflict along the way must not change where
+	// you end up. Unset for every other command, which correctly leaves the
+	// user on the branch they just resolved.
+	if continuation.ReturnToBranch != "" && continuation.ReturnToBranch != result.BranchName {
+		if err := eng.CheckoutBranch(ctx.Context, eng.GetBranch(continuation.ReturnToBranch)); err != nil {
+			out.Error("Failed to return to %s: %v", continuation.ReturnToBranch, err)
+		}
+	}
+
 	// Clear continuation state
 	if err := config.ClearContinuationState(ctx.RepoRoot); err != nil {
 		out.Debug("Failed to clear continuation state: %v", err)

--- a/internal/actions/modify.go
+++ b/internal/actions/modify.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/actions/validation"
 	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/errors"
 	"github.com/getstackit/stackit/internal/git"
@@ -106,9 +107,12 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) (err error) {
 			// A conflict workflow deliberately leaves HEAD detached (see
 			// EnterConflictWorkflow); forcing a checkout back here would
 			// defeat that safety measure. `stackit continue`/`abort` own
-			// recovery from that state instead.
+			// recovery from that state instead — so hand them the branch to
+			// return to, or --into's "without checking it out, then returns"
+			// contract quietly stops holding the moment a restack conflicts.
 			var conflictErr *errors.ConflictWorkflowError
 			if errors.As(err, &conflictErr) {
+				recordConflictReturnBranch(ctx, originalBranchName)
 				return
 			}
 			if checkoutErr := eng.CheckoutBranch(gctx, eng.GetBranch(originalBranchName)); checkoutErr != nil {
@@ -203,6 +207,30 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) (err error) {
 	}
 
 	return nil
+}
+
+// recordConflictReturnBranch tells the conflict workflow which branch to leave
+// the user on once it finishes. The continuation state has just been written by
+// EnterConflictWorkflow, so this reads it back and adds the one field it could
+// not know about — the branch modify was invoked from, as opposed to the branch
+// being rebased.
+//
+// Best-effort on purpose: failing to record where to return is a worse outcome
+// to surface as a hard error than the conflict the user is already dealing
+// with, and `continue` falls back to the rebased branch when it is unset.
+func recordConflictReturnBranch(ctx *app.Context, branchName string) {
+	state, err := config.GetContinuationState(ctx.RepoRoot)
+	if err != nil {
+		ctx.Output.Debug("Failed to read continuation state to record return branch: %v", err)
+		return
+	}
+	if state.CurrentBranchOverride == branchName {
+		return
+	}
+	state.ReturnToBranch = branchName
+	if err := config.PersistContinuationState(ctx.RepoRoot, state); err != nil {
+		ctx.Output.Debug("Failed to record return branch %s: %v", branchName, err)
+	}
 }
 
 // validateModifyIntoTarget ensures --into targets a genuine, modifiable

--- a/internal/config/continuation.go
+++ b/internal/config/continuation.go
@@ -15,6 +15,14 @@ type ContinuationState struct {
 	BranchesToSync        []string `json:"branchesToSync,omitempty"` // For future sync command
 	CurrentBranchOverride string   `json:"currentBranchOverride,omitempty"`
 	RebasedBranchBase     string   `json:"rebasedBranchBase,omitempty"`
+	// ReturnToBranch is the branch the interrupted command should leave the
+	// user on once the conflict workflow finishes, when that differs from the
+	// branch being rebased. `modify --into` sets it: it amends a downstack
+	// ancestor without checking it out and promises to return you, and a
+	// conflict must not silently break that. Empty means "stay on the branch
+	// that was being rebased", which is the right default for every other
+	// command.
+	ReturnToBranch string `json:"returnToBranch,omitempty"`
 }
 
 // GetContinuationState reads the continuation state from disk

--- a/internal/integration/modify_test.go
+++ b/internal/integration/modify_test.go
@@ -253,6 +253,42 @@ func TestModifyInto(t *testing.T) {
 		sh.HasBranches("a", "b", "d", "main")
 		sh.Git("show a:file.txt").OutputContains("L1\nL2\nL3\n")
 	})
+
+	// #1494: --into promises to amend a downstack ancestor "without checking it
+	// out" and put you back. `continue` knew only about the branch it rebased,
+	// so resolving a conflict silently changed where you ended up — on the
+	// conflicted ancestor rather than the branch you started from.
+	t.Run("continue after a conflict restacking upstack returns to the original branch", func(t *testing.T) {
+		t.Parallel()
+		sh := NewTestShellInProcess(t)
+
+		// Same shape as the abort case above: d reverts b's change, so checking
+		// out a from d is clean while replaying b onto the amended a conflicts.
+		sh.WriteFile("file.txt", "L1\nL2\nL3\n").
+			Run("create a -m 'Add a'").
+			OnBranch("a")
+		sh.WriteFile("file.txt", "L1\nL2-changed\nL3\n").
+			Run("create b -m 'Add b'").
+			OnBranch("b")
+		sh.WriteFile("file.txt", "L1\nL2\nL3\n").
+			Run("create d -m 'Add d'").
+			OnBranch("d")
+
+		sh.WriteFile("file.txt", "L1\nL2-AMENDED\nL3\n")
+		sh.Git("add file.txt")
+		sh.RunExpectError("modify --into a -n").
+			OutputContains("conflict")
+
+		// Resolve in b's favor, keeping b's exact content so that d — whose own
+		// commit reverts b — still applies cleanly and the restack runs to
+		// completion rather than stopping on a second conflict.
+		sh.WriteFile("file.txt", "L1\nL2-changed\nL3\n")
+		sh.Git("add file.txt")
+		sh.Run("continue")
+
+		sh.OnBranch("d")
+		sh.Git("show a:file.txt").OutputContains("L1\nL2-AMENDED\nL3\n")
+	})
 }
 
 // TestModifyUndo covers the success-path counterpart to the abort test above:


### PR DESCRIPTION

Closes #1494. `modify --into` amends a downstack ancestor "without checking it
out" and puts you back afterwards. On the conflict path that quietly stopped
holding: `stackit continue` knew only about the branch it had rebased, so after
resolving you were left on the conflicted ancestor instead of where you started.

modify already has the seam. Its deferred handler detects ConflictWorkflowError
and skips the checkout-back on purpose, delegating recovery to continue/abort —
it now also records the branch to return to in the continuation state, and
continue honours it once the remaining restacks finish.

A new ReturnToBranch field carries it, rather than reusing CurrentBranchOverride,
which names the branch being rebased and is load-bearing for ContinueRebase.
Empty for every other command, which correctly leaves the user on the branch
they just resolved.

The abort half was already fixed by #1527's undo snapshot; both paths now have a
test. The new one fails without this change, landing on "b" instead of "d".