### PR TITLE
fix(engine): don't let untracked files suppress the worktree reset

### DIFF
--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -509,6 +509,10 @@ func (d *demoGitRunner) WorktreeHasUncommittedChanges(_ context.Context, _ strin
 	return false, nil
 }
 
+func (d *demoGitRunner) WorktreeHasTrackedChanges(_ context.Context, _ string) (bool, error) {
+	return false, nil
+}
+
 func (d *demoGitRunner) UpdateRefWithLog(_ context.Context, _, _, _ string) error {
 	return nil
 }

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -103,16 +103,23 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 		worktrees = git.WorktreeList{}
 	}
 
-	// Snapshot which of those worktrees have uncommitted changes before any
+	// Snapshot which of those worktrees have tracked-file changes before any
 	// branch in this pass is touched. This must happen up front: restacking a
 	// branch moves its ref before its worktree gets reset, so checking
 	// dirtiness lazily at reset time would compare the worktree's now-stale
 	// content against its own new ref and read as dirty every time, not just
 	// when the user actually had uncommitted work. Bounded by worktree count,
 	// not branch count, so this stays a handful of calls even for a large stack.
+	//
+	// Tracked changes only, deliberately. This gates a `git reset --hard`, which
+	// cannot touch untracked files — so counting them would suppress a reset
+	// that was never a threat to them, leaving the worktree holding the old
+	// commit's content while its branch ref has moved. `git status` then reports
+	// the new commit's files as deleted, and the next `stackit modify -a`
+	// commits that deletion into the stack.
 	dirtyWorktrees := make(map[string]bool, len(worktrees))
 	for _, path := range worktrees.Paths() {
-		if dirty, dirtyErr := e.git.WorktreeHasUncommittedChanges(ctx, path); dirtyErr == nil && dirty {
+		if dirty, dirtyErr := e.git.WorktreeHasTrackedChanges(ctx, path); dirtyErr == nil && dirty {
 			dirtyWorktrees[path] = true
 		}
 	}

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -15,7 +15,7 @@ const (
 )
 
 // resetWorktreeIfClean resets a worktree's working directory to match its
-// branch ref's new content, unless the worktree had uncommitted changes
+// branch ref's new content, unless the worktree had changes to TRACKED files
 // before this restack pass touched anything. dirtyWorktrees is captured once
 // up front (see restackSnapshot.dirtyWorktrees) rather than checked here,
 // because by the time any branch's reset runs, restack has already moved that
@@ -24,10 +24,14 @@ const (
 // dirty, silently disabling the reset for every branch, not just genuinely
 // dirty ones.
 //
-// Skipping the reset on a worktree that was genuinely dirty beforehand leaves
-// it briefly out of sync with its ref rather than discarding the uncommitted
-// changes — the same tradeoff sync makes when deciding whether to touch a
-// stack rooted at a dirty managed worktree.
+// Untracked files must not count: `git reset --hard` cannot destroy them, so
+// treating them as dirty suppresses a reset that was never a threat and leaves
+// the worktree holding the old commit's content under a moved ref.
+//
+// Skipping the reset on a worktree with real tracked changes leaves it out of
+// sync with its ref rather than discarding the user's work. That state is still
+// a footgun — `git status` shows the new commit's files as deleted — so callers
+// should avoid moving the ref at all in that case; see skipDirtyWorktreeStacks.
 func (e *engineImpl) resetWorktreeIfClean(ctx context.Context, worktreePath string, snap *restackSnapshot) {
 	if snap.dirtyWorktrees[worktreePath] {
 		return
@@ -51,9 +55,10 @@ type restackSnapshot struct {
 	revs        RevisionMap
 	worktrees   git.WorktreeList
 	metaRefSHAs map[string]string
-	// dirtyWorktrees records, per worktree path, whether it had uncommitted
-	// changes before this restack pass began. Captured once up front — see
-	// resetWorktreeIfClean for why it can't be checked lazily.
+	// dirtyWorktrees records, per worktree path, whether it had changes to
+	// tracked files before this restack pass began. Untracked files are
+	// deliberately excluded — see resetWorktreeIfClean for why, and for why this
+	// can't be checked lazily.
 	dirtyWorktrees map[string]bool
 }
 

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -211,6 +211,7 @@ type WorktreeOperations interface {
 	GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error)
 	ResetWorktreeWorkingDir(ctx context.Context, worktreePath string) error
 	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)
+	WorktreeHasTrackedChanges(ctx context.Context, worktreePath string) (bool, error)
 }
 
 // WorktreeRegistryOperations handles stackit-managed worktree tracking (local-only refs).

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -306,6 +306,27 @@ func (r *runner) WorktreeHasUncommittedChanges(ctx context.Context, worktreePath
 	return strings.TrimSpace(out) != "", nil
 }
 
+// WorktreeHasTrackedChanges reports whether a worktree has staged or unstaged
+// changes to tracked files, ignoring untracked ones — equivalent to
+// `git status --porcelain --untracked-files=no` returning empty output.
+//
+// This is the right question when deciding whether a `git reset --hard` would
+// destroy something: reset never touches untracked files, so counting them as
+// "dirty" suppresses a reset that could not have harmed them. Use
+// WorktreeHasUncommittedChanges instead when deciding whether it is polite to
+// operate on someone's worktree at all, where a stray untracked file still
+// signals work in progress.
+func (r *runner) WorktreeHasTrackedChanges(ctx context.Context, worktreePath string) (bool, error) {
+	out, err := r.RunGitCommandRawWithContext(ctx,
+		"-C", worktreePath,
+		"status", "--porcelain", "--untracked-files=no",
+	)
+	if err != nil {
+		return false, fmt.Errorf("failed to check tracked status in worktree %s: %w", worktreePath, err)
+	}
+	return strings.TrimSpace(out) != "", nil
+}
+
 // GetWorktreeCurrentBranch returns the name of the branch currently checked out in a worktree.
 // Returns empty string if the worktree is in detached HEAD state. Real failures
 // (worktree missing, repo corruption, context cancellation) are surfaced — git

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -270,6 +270,17 @@ func (s *TestShell) WriteFile(filename, content string) *TestShell {
 	return s.Git("add " + filename)
 }
 
+// WriteUntracked creates a file and deliberately does NOT stage it, so it shows
+// up as untracked. Use it to assert that operations gated on a "dirty" worktree
+// treat untracked files differently from real uncommitted work.
+func (s *TestShell) WriteUntracked(filename, content string) *TestShell {
+	s.t.Helper()
+	filePath := filepath.Join(s.scene.Dir, filename)
+	err := os.WriteFile(filePath, []byte(content), 0644)
+	require.NoError(s.t, err, "failed to write file %s", filename)
+	return s
+}
+
 // SetWorktreeBasePath sets the worktree base path for this repo.
 func (s *TestShell) SetWorktreeBasePath(path string) *TestShell {
 	s.t.Helper()

--- a/internal/integration/restack_dirty_maintree_test.go
+++ b/internal/integration/restack_dirty_maintree_test.go
@@ -1,0 +1,53 @@
+package integration
+
+import (
+	"testing"
+)
+
+// TestRestackWithUntrackedFileLeavesNoStagedRevert covers a regression where an
+// untracked file anywhere in the repo made restack leave a staged deletion of
+// trunk's files behind.
+//
+// The reset that realigns a worktree after its branch ref moves is gated on the
+// worktree being clean, so that it cannot discard uncommitted work. Dirtiness
+// was measured with `git status --porcelain --untracked-files=normal`, so a
+// single untracked file — a scratch note, a build artifact, anything not in
+// .gitignore — marked the worktree dirty and suppressed the reset. `git reset
+// --hard` cannot touch untracked files, so nothing was being protected: the
+// working directory simply kept the old commit's content while the branch ref
+// moved on.
+//
+// The result was invisible until it wasn't. `git status` showed trunk's files
+// as staged deletions, and the next `stackit modify -a` committed them, quietly
+// reverting trunk content inside the stack.
+func TestRestackWithUntrackedFileLeavesNoStagedRevert(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+
+	sh.CreateLinearStack3().Checkout("a")
+
+	// Trunk advances so the stack genuinely needs restacking. WriteFile stages
+	// under the exact name, which the assertions below rely on.
+	sh.Checkout("main").
+		WriteFile("trunk1.txt", "trunk content").
+		Git("commit -m 'chore: trunk commit'").
+		Checkout("a")
+
+	// A single untracked file. Not staged, not tracked, not the user's work in
+	// any sense restack should care about.
+	sh.WriteUntracked("scratch.txt", "scratch note")
+
+	sh.Run("restack --upstack")
+
+	// The only thing git should report is the untracked file itself. A "D " or
+	// " D" entry here means trunk's content was left staged for deletion.
+	sh.Git("status --porcelain").
+		OutputContains("?? scratch.txt").
+		OutputNotContains(" D ").
+		OutputNotContains("D  ")
+
+	// And trunk's file is still really there.
+	sh.Git("ls-tree HEAD -- trunk1.txt").OutputContains("trunk1.txt")
+	sh.Git("status --porcelain -- trunk1.txt").OutputNotContains("trunk1.txt")
+}


### PR DESCRIPTION

Regression against v0.23.0, introduced by the dirty-worktree gate added for
#1490. A single untracked file anywhere in the repo made restack leave a staged
deletion of trunk's files behind.

The gate exists so the post-restack `git reset --hard` cannot discard
uncommitted work, and it measured dirtiness with `git status --porcelain
--untracked-files=normal`. `git worktree list` includes the main worktree, so
one stray scratch file, build artifact, or un-ignored editor file marked the
worktree dirty and suppressed the reset for the branch the user was standing on.
Nothing was protected by that: `reset --hard` never touches untracked files. The
working directory simply kept the old commit's content while its branch ref
moved on.

Measured, main -> a -> b with trunk advanced, standing on a, one untracked file:

  v0.23.0   git status after restack --upstack: `?? scratch.txt`, trunk file present
  before    `D  trunk.txt` staged deletion, trunk file gone from the worktree

The staged deletion is easy to miss, and the next `stackit modify -a` commits
it: reproduced `trunk.txt | 1 -` landing inside the user's commit, silently
reverting trunk content inside the stack.

Add WorktreeHasTrackedChanges (`--untracked-files=no`) and gate the reset on
that. WorktreeHasUncommittedChanges keeps its untracked-aware semantics for the
"is it polite to touch this worktree at all" decisions in sync and worktree
entry, where a stray file still signals work in progress.

The new test fails without this change with `"D  trunk1.txt\n?? scratch.txt\n"`.

A worktree with real tracked-file changes still has its reset suppressed and its
ref moved, which leaves the same shape on a narrower path. That half is the next
commit.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1537** 👈
  * **PR #1538**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->