### PR TITLE
fix(restack): hold back branches whose worktree has uncommitted changes

### DIFF
--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -457,35 +457,59 @@ func planRestackBranchGroups(eng engine.BranchReader, opts RestackOptions) ([]re
 	}}, nil
 }
 
-// skipDirtyWorktreeStacks drops every branch whose stack is rooted at a managed
-// worktree with uncommitted changes, warning once per skipped stack.
+// skipDirtyWorktreeStacks drops branches that cannot be restacked without
+// leaving a worktree out of sync with its own branch ref, warning once for each.
 //
-// Restacking such a stack fast-forwards the anchor's ref, but the working-directory
-// reset that would realign the anchor's worktree is deliberately suppressed while
-// that worktree is dirty (it would discard the user's uncommitted edits). The
-// worktree is then left reporting trunk's new files as deleted, so a `git add -A`
-// there would commit a revert of trunk. Leaving the stack alone until the worktree
-// is clean avoids that state entirely, and it self-heals on the next restack once
-// the user commits or stashes.
+// Moving a branch's ref is only half the operation: the worktree holding that
+// branch has to be reset to match. That reset is suppressed while the worktree
+// has uncommitted tracked changes, because it would discard them — which leaves
+// the worktree on the old commit's content under a moved ref. `git status` then
+// reports the new commit's files as deleted, and the next `stackit modify -a`
+// commits that deletion into the stack. Not restacking at all is the safe
+// outcome, and it self-heals once the user commits or stashes.
 //
-// Deliberately mirrors — rather than shares — sync's dirtyAnchorSet handling in
-// internal/actions/sync/sync.go: that type is package-private to sync, and
-// exporting it would mean touching every sync call site.
+// Two cases, because the unit that must be held back differs:
+//
+//   - A dirty *managed* worktree holds a whole stack, and its anchor is that
+//     stack's root, so the entire stack is dropped. This also matches what sync
+//     has always done (internal/actions/sync/sync.go).
+//   - Any other worktree — including the main one, which `stackit restack` is
+//     normally run from — holds a single branch, so only that branch is dropped.
+//     Its descendants stay: they are still correctly based on a branch that did
+//     not move, so restacking them is a no-op rather than a hazard.
+//
+// Deliberately mirrors — rather than shares — sync's dirtyAnchorSet handling:
+// that type is package-private to sync, and exporting it would mean touching
+// every sync call site.
 func skipDirtyWorktreeStacks(ctx *app.Context, groups []restackBranchGroup) []restackBranchGroup {
 	eng := ctx.Engine
-	worktrees, err := eng.ListManagedWorktrees()
-	if err != nil || len(worktrees) == 0 {
-		return groups
-	}
 
 	dirtyAnchors := make(map[string]bool)
-	for _, wt := range worktrees {
-		if hasChanges, _ := eng.WorktreeHasUncommittedChanges(ctx.Context, wt.Path); hasChanges {
-			dirtyAnchors[wt.AnchorBranch] = true
-			ctx.Output.Warn("Skipping stack rooted at %s (worktree has uncommitted changes)", wt.AnchorBranch)
+	if managed, err := eng.ListManagedWorktrees(); err == nil {
+		for _, wt := range managed {
+			if hasChanges, _ := eng.WorktreeHasUncommittedChanges(ctx.Context, wt.Path); hasChanges {
+				dirtyAnchors[wt.AnchorBranch] = true
+				ctx.Output.Warn("Skipping stack rooted at %s (worktree %s has uncommitted changes)", wt.AnchorBranch, wt.Path)
+			}
 		}
 	}
-	if len(dirtyAnchors) == 0 {
+
+	// Tracked changes only here: an untracked file cannot be destroyed by the
+	// reset, so it is no reason to hold a branch back.
+	dirtyBranches := make(map[string]bool)
+	if worktrees, err := eng.ListWorktrees(ctx.Context); err == nil {
+		for _, wt := range worktrees {
+			if wt.Branch == "" || dirtyAnchors[wt.Branch] {
+				continue
+			}
+			if hasChanges, _ := eng.WorktreeHasTrackedChanges(ctx.Context, wt.Path); hasChanges {
+				dirtyBranches[wt.Branch] = true
+				ctx.Output.Warn("Skipping %s (worktree %s has uncommitted changes; commit or stash them, then restack again)", wt.Branch, wt.Path)
+			}
+		}
+	}
+
+	if len(dirtyAnchors) == 0 && len(dirtyBranches) == 0 {
 		return groups
 	}
 
@@ -493,9 +517,10 @@ func skipDirtyWorktreeStacks(ctx *app.Context, groups []restackBranchGroup) []re
 	for _, g := range groups {
 		builder := engine.NewBranchesBuilder(len(g.branches))
 		for _, branch := range g.branches {
-			if !dirtyAnchors[eng.GetStackRootForBranch(branch)] {
-				builder.Add(branch)
+			if dirtyAnchors[eng.GetStackRootForBranch(branch)] || dirtyBranches[branch.GetName()] {
+				continue
 			}
+			builder.Add(branch)
 		}
 		if built := builder.Build(); len(built) > 0 {
 			kept = append(kept, restackBranchGroup{rootBranch: g.rootBranch, branches: built})

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -59,6 +59,14 @@ func (e *engineImpl) WorktreeHasUncommittedChanges(ctx context.Context, worktree
 	return e.git.WorktreeHasUncommittedChanges(ctx, worktreePath)
 }
 
+// WorktreeHasTrackedChanges reports whether the worktree at worktreePath has
+// staged or unstaged changes to tracked files, ignoring untracked ones. Use this
+// when the question is "would a hard reset destroy something", which untracked
+// files never answer yes to.
+func (e *engineImpl) WorktreeHasTrackedChanges(ctx context.Context, worktreePath string) (bool, error) {
+	return e.git.WorktreeHasTrackedChanges(ctx, worktreePath)
+}
+
 // PruneWorktrees removes stale worktree entries from .git/worktrees.
 // This cleans up worktree information for worktrees whose working directory
 // has been deleted or is otherwise unavailable.

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -279,6 +279,7 @@ type WorktreeOperations interface {
 	ForceRemoveWorktree(ctx context.Context, path string) error
 	GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error)
 	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)
+	WorktreeHasTrackedChanges(ctx context.Context, worktreePath string) (bool, error)
 	CreateTemporaryWorktree(ctx context.Context, branch string, prefix string) (path string, cleanup func(), err error)
 	// CreateTemporaryWorktreeSkipPrune is like CreateTemporaryWorktree but skips the automatic
 	// PruneWorktrees() call. Use this when creating multiple worktrees in parallel after

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -270,10 +270,12 @@ func (s *TestShell) WriteFile(filename, content string) *TestShell {
 	return s.Git("add " + filename)
 }
 
-// WriteUntracked creates a file and deliberately does NOT stage it, so it shows
-// up as untracked. Use it to assert that operations gated on a "dirty" worktree
-// treat untracked files differently from real uncommitted work.
-func (s *TestShell) WriteUntracked(filename, content string) *TestShell {
+// WriteUnstaged writes a file and deliberately does NOT stage it. On a new path
+// that leaves an untracked file; on an existing tracked path it leaves an
+// unstaged modification. Use it to assert that operations gated on a "dirty"
+// worktree distinguish the two — a hard reset can destroy the second but never
+// the first.
+func (s *TestShell) WriteUnstaged(filename, content string) *TestShell {
 	s.t.Helper()
 	filePath := filepath.Join(s.scene.Dir, filename)
 	err := os.WriteFile(filePath, []byte(content), 0644)

--- a/internal/integration/restack_dirty_maintree_test.go
+++ b/internal/integration/restack_dirty_maintree_test.go
@@ -36,7 +36,7 @@ func TestRestackWithUntrackedFileLeavesNoStagedRevert(t *testing.T) {
 
 	// A single untracked file. Not staged, not tracked, not the user's work in
 	// any sense restack should care about.
-	sh.WriteUntracked("scratch.txt", "scratch note")
+	sh.WriteUnstaged("scratch.txt", "scratch note")
 
 	sh.Run("restack --upstack")
 
@@ -50,4 +50,48 @@ func TestRestackWithUntrackedFileLeavesNoStagedRevert(t *testing.T) {
 	// And trunk's file is still really there.
 	sh.Git("ls-tree HEAD -- trunk1.txt").OutputContains("trunk1.txt")
 	sh.Git("status --porcelain -- trunk1.txt").OutputNotContains("trunk1.txt")
+}
+
+// TestRestackSkipsBranchWithTrackedChangesInItsWorktree covers the other half.
+//
+// When a worktree really does have uncommitted tracked changes, suppressing the
+// reset is correct — it protects the user's work — but moving the branch ref
+// anyway leaves exactly the state the suppression was meant to avoid: the
+// worktree holds the old commit's content under a new ref, so `git status`
+// reports the new commit's files as deleted and `stackit modify -a` commits the
+// revert.
+//
+// Restack holds that branch back instead, visibly, until the worktree is clean.
+func TestRestackSkipsBranchWithTrackedChangesInItsWorktree(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+
+	sh.CreateLinearStack3().Checkout("a")
+	sh.Git("rev-parse a")
+	revBefore := sh.Output()
+
+	sh.Checkout("main").
+		WriteFile("trunk1.txt", "trunk content").
+		Git("commit -m 'chore: trunk commit'").
+		Checkout("a")
+
+	// Modify a TRACKED file without staging it — real work in progress. The
+	// stack fixture writes through Write, which prefixes, so branch a's file is
+	// a.txt_test.txt.
+	sh.WriteUnstaged("a.txt_test.txt", "locally modified, uncommitted")
+
+	sh.Run("restack --upstack").
+		OutputContains("uncommitted changes")
+
+	// The branch must not have moved...
+	sh.Git("rev-parse a")
+	if sh.Output() != revBefore {
+		t.Fatalf("branch a moved despite its worktree having uncommitted changes:\nbefore %safter  %s", revBefore, sh.Output())
+	}
+
+	// ...and no staged revert of trunk was left behind.
+	sh.Git("status --porcelain").
+		OutputNotContains("D  ").
+		OutputNotContains(" D ")
 }

--- a/internal/integration/restack_worktree_anchor_test.go
+++ b/internal/integration/restack_worktree_anchor_test.go
@@ -158,7 +158,10 @@ func TestRestackWorktreeAnchorSkipsDirtyStack(t *testing.T) {
 	sh.Checkout("main").
 		Commit("trunk1.txt", "chore: trunk commit 1").
 		Run("restack --all-stacks").
-		OutputContains("worktree has uncommitted changes")
+		OutputContains("Skipping stack rooted at").
+		OutputContains("has uncommitted changes").
+		// The path is what tells the user where to go and clean up.
+		OutputContains(worktreePath)
 
 	// The anchor is left where it was rather than moving to trunk without its
 	// working directory.


### PR DESCRIPTION

Second half of the dirty-worktree fix. The previous commit stopped untracked
files from suppressing the working-directory reset. This one handles the case
where the suppression is correct — the worktree really does have tracked
changes — but moving the branch ref anyway reproduces the same broken state.

Suppressing the reset protects the user's edits, then leaves the worktree on the
old commit's content under a moved ref. `git status` reports the new commit's
files as deleted and `stackit modify -a` commits the revert. Measured before
this change, on a stack with a modified tracked file: the edit survived as
` M a.txt`, but `D  trunk.txt` was staged alongside it.

skipDirtyWorktreeStacks only inspected ListManagedWorktrees, so the main
worktree — where `stackit restack` is normally run — was never covered. It now
also walks ListWorktrees and drops any branch checked out in a worktree with
tracked changes.

The two cases hold back different units, deliberately. A managed worktree holds
a whole stack, so its anchor's stack is dropped, matching sync. Any other
worktree holds one branch, so only that branch is dropped; its descendants stay,
since they remain correctly based on a branch that did not move and restacking
them is a no-op.

The warning now names the worktree path and says what to do, rather than only
naming a hidden anchor branch the user has never seen. TestRestackWorktreeAnchor
SkipsDirtyStack's assertion is updated for the new wording and now also checks
the path is present.

The new test fails without this change: restack reports "restacked 3" instead of
skipping.