### PR TITLE
fix(merge): push what drain's post-merge restack changed

### DIFF
--- a/internal/cli/stack/merge/drain.go
+++ b/internal/cli/stack/merge/drain.go
@@ -9,11 +9,13 @@ import (
 
 	"github.com/getstackit/stackit/internal/actions"
 	mergeAction "github.com/getstackit/stackit/internal/actions/merge"
+	"github.com/getstackit/stackit/internal/actions/submit"
 	"github.com/getstackit/stackit/internal/actions/sync"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/cli/common"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/tui"
 )
 
@@ -268,6 +270,29 @@ func runMergeDrain(ctx *app.Context, opts mergeDrainOptions) error {
 		if len(drainHandler.summary.ConflictBranches) > 0 {
 			return fmt.Errorf("restack conflict in %s — resolve before continuing drain", drainHandler.summary.ConflictBranches[0])
 		}
+
+		// Publish what the restack just changed. The restack rewrote each
+		// remaining branch onto the new trunk and reparented the next one off
+		// the branch that just merged, and both of those live only locally
+		// until pushed. Leaving them behind strands the drain:
+		//
+		//   - The metadata ref still names the merged (now deleted) parent, so a
+		//     stack-order CI check reads a stale parent and reports the next PR
+		//     as "not at the bottom of the stack". That leaves the PR in an
+		//     unstable state and automerge refuses it, so the drain stalls on
+		//     its second PR and every one after.
+		//   - The remote branch still points at the pre-restack commits, so the
+		//     PR shows a diff against the old base — including the changes that
+		//     just merged.
+		//
+		// GitHub retargets the PR base itself when the base branch is deleted,
+		// which makes the PR *look* correct while both of the above are still
+		// wrong.
+		if len(restackScope) > 0 {
+			if pushErr := pushDrainedBranches(ctx, restackScope); pushErr != nil {
+				return fmt.Errorf("post-merge push failed after PR #%d: %w", bottomPR.PRNumber, pushErr)
+			}
+		}
 	}
 
 	out.Newline()
@@ -284,6 +309,48 @@ type drainSyncHandler struct {
 
 // Complete captures the sync summary for conflict detection.
 func (h *drainSyncHandler) Complete(s sync.Summary) { h.summary = s }
+
+// pushDrainedBranches publishes the branches the post-merge restack rewrote, so
+// the remote matches what drain just did locally.
+//
+// Goes through submit rather than pushing refs directly: submit already pushes
+// branch heads with the right force-with-lease, pushes metadata refs, and
+// retargets each PR's base. UpdateOnly keeps it to branches that already have a
+// PR — a drain must never open one — and NoEdit keeps it silent about
+// titles and descriptions, which are not drain's business to change.
+func pushDrainedBranches(ctx *app.Context, branchNames []string) error {
+	return submit.Action(ctx, submit.Options{
+		// branchNames[0] is the next PR to merge and needs pushing itself, so
+		// the range has to include it as well as its descendants.
+		Branch:     branchNames[0],
+		StackRange: engine.StackRangeUpstack(true),
+		UpdateOnly: true,
+		NoEdit:     true,
+	}, &drainSubmitHandler{out: ctx.Output})
+}
+
+// drainSubmitHandler reports per-branch results of drain's nested submit without
+// prompting, mirroring lock's nested-submit handler.
+type drainSubmitHandler struct {
+	out output.Output
+}
+
+func (h *drainSubmitHandler) OnEvent(e submit.Event) {
+	if ev, ok := e.(submit.BranchProgressEvent); ok {
+		switch ev.Status {
+		case submit.StatusDone:
+			h.out.Info("  ✓ %s updated → %s", ev.BranchName, ev.URL)
+		case submit.StatusError:
+			h.out.Warn("  ✗ %s failed to update: %v", ev.BranchName, ev.Error)
+		}
+	}
+}
+
+func (h *drainSubmitHandler) Confirm(_ string, defaultYes bool) (bool, error) {
+	return defaultYes, nil
+}
+
+func (h *drainSubmitHandler) IsInteractive() bool { return false }
 
 // remainingBranchNames extracts branch names from a slice of MergeBranch.
 func remainingBranchNames(branches []mergeAction.BranchMergeInfo) []string {

--- a/internal/cli/stack/merge/drain_push_test.go
+++ b/internal/cli/stack/merge/drain_push_test.go
@@ -1,0 +1,161 @@
+package merge
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	gogithub "github.com/google/go-github/v89/github"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/github"
+	"github.com/getstackit/stackit/testhelpers"
+)
+
+// drainFakeMergeAPI stands in for the GitHub merge API. Three of the real
+// implementation's methods reach GitHub's GraphQL API by shelling out to `gh`
+// through the git runner, so a mock github.Client alone is not enough to drive
+// the drain loop — see newPRMergeAPI.
+//
+// mergePR simulates GitHub landing the PR: it fast-forwards the remote's main
+// to the merged branch, which is what makes the next loop iteration observe the
+// merge after drain syncs trunk.
+type drainFakeMergeAPI struct {
+	repo   *testhelpers.GitRepo
+	merged []string
+}
+
+func (f *drainFakeMergeAPI) getMergeableState(_ context.Context, _ git.Runner, _ string) (*github.PRMergeableState, error) {
+	return &github.PRMergeableState{State: git.PRStateOpen, Mergeable: true, MergeStateText: "CLEAN"}, nil
+}
+
+func (f *drainFakeMergeAPI) enableAutoMerge(_ context.Context, _ git.Runner, _ string, _ github.MergeMethod) error {
+	return nil
+}
+
+func (f *drainFakeMergeAPI) waitForPRMerge(_ context.Context, _ git.Runner, _ string, _, _ time.Duration) error {
+	return nil
+}
+
+func (f *drainFakeMergeAPI) waitForMergeable(_ context.Context, _ git.Runner, _ string, _, _ time.Duration) (*github.PRMergeableState, error) {
+	return &github.PRMergeableState{State: git.PRStateOpen, Mergeable: true, MergeStateText: "CLEAN"}, nil
+}
+
+func (f *drainFakeMergeAPI) mergePR(_ context.Context, branchName string, _ github.MergeMethod) error {
+	f.merged = append(f.merged, branchName)
+	// Land the branch on the remote's trunk, the way a real merge would.
+	return f.repo.RunGitCommand("push", "origin", branchName+":main")
+}
+
+// seedMockPR registers an open PR with the mock server under every lookup the
+// drain loop uses: by branch (planning) and by number (which needs a NodeID,
+// since drain refuses a PR without one).
+func seedMockPR(cfg *testhelpers.MockGitHubServerConfig, branch, base string, number int) {
+	pr := &gogithub.PullRequest{
+		Number:  gogithub.Ptr(number),
+		NodeID:  gogithub.Ptr(fmt.Sprintf("PR_node%d", number)),
+		State:   gogithub.Ptr("open"),
+		Title:   gogithub.Ptr("PR for " + branch),
+		HTMLURL: gogithub.Ptr(fmt.Sprintf("https://github.com/owner/repo/pull/%d", number)),
+		Head:    &gogithub.PullRequestBranch{Ref: gogithub.Ptr(branch)},
+		Base:    &gogithub.PullRequestBranch{Ref: gogithub.Ptr(base)},
+	}
+	cfg.PRs[branch] = pr
+	cfg.UpdatedPRs[number] = pr
+}
+
+// remoteMetadataParent reads the parent a branch's metadata records ON THE
+// REMOTE. Reading the local ref would hide the bug entirely: drain reparents
+// locally either way, and the whole failure is that the local change never
+// reaches the remote.
+func remoteMetadataParent(t *testing.T, repo *testhelpers.GitRepo, remoteDir, branch string) string {
+	t.Helper()
+
+	out, err := repo.RunGitCommandAndGetOutput("ls-remote", remoteDir, "refs/stackit/metadata/"+branch)
+	require.NoError(t, err)
+	if strings.TrimSpace(out) == "" {
+		return "" // no metadata ref pushed at all
+	}
+	sha := strings.Fields(strings.TrimSpace(out))[0]
+
+	// The blob is only fetchable once we have the object locally.
+	require.NoError(t, repo.RunGitCommand("fetch", remoteDir, "refs/stackit/metadata/"+branch))
+	blob, err := repo.RunGitCommandAndGetOutput("cat-file", "-p", sha)
+	require.NoError(t, err)
+
+	var meta struct {
+		ParentBranchName string `json:"parentBranchName"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(blob), &meta))
+	return meta.ParentBranchName
+}
+
+// TestDrainPushesRestackedBranchesToRemote covers the drain stall: after each
+// merge, drain restacks the remaining branches onto the new trunk and reparents
+// the next one off the branch that just merged, but published neither.
+//
+// The stale metadata ref is what breaks the drain in practice. A stack-order CI
+// check reads it, still sees the merged (deleted) parent, and reports the next
+// PR as "not at the bottom of the stack" — leaving it unstable so automerge
+// refuses it, one stall per remaining PR.
+func TestDrainPushesRestackedBranchesToRemote(t *testing.T) {
+	scene := testhelpers.NewRemoteSceneParallel(t)
+	repo := scene.Repo
+
+	remoteDir, err := repo.RunGitCommandAndGetOutput("remote", "get-url", "origin")
+	require.NoError(t, err)
+	remoteDir = strings.TrimSpace(remoteDir)
+
+	eng, err := engine.NewEngine(engine.Options{RepoRoot: scene.Dir, Trunk: "main", Git: git.NewRunnerWithPath(scene.Dir, nil)})
+	require.NoError(t, err)
+
+	// main -> a -> b, both with open PRs and both pushed.
+	for _, b := range []string{"a", "b"} {
+		require.NoError(t, repo.CreateAndCheckoutBranch(b))
+		require.NoError(t, repo.CreateChangeAndCommit("content "+b, b))
+	}
+	require.NoError(t, eng.Rebuild("main"))
+	require.NoError(t, eng.TrackBranch(context.Background(), "a", "main"))
+	require.NoError(t, eng.TrackBranch(context.Background(), "b", "a"))
+	require.NoError(t, eng.UpsertPrInfo(context.Background(), eng.GetBranch("a"), testhelpers.NewTestPrInfo(101)))
+	require.NoError(t, eng.UpsertPrInfo(context.Background(), eng.GetBranch("b"), testhelpers.NewTestPrInfo(102)))
+	require.NoError(t, repo.RunGitCommand("push", "origin", "a", "b"))
+	require.NoError(t, eng.PushMetadataForBranches(context.Background(), []string{"a", "b"}))
+
+	// Before draining, b's recorded parent on the remote is a.
+	require.Equal(t, "a", remoteMetadataParent(t, repo, remoteDir, "b"),
+		"precondition: b should start out parented on a")
+
+	fake := &drainFakeMergeAPI{repo: repo}
+	restore := newPRMergeAPI
+	newPRMergeAPI = func(*app.Context) prMergeAPI { return fake }
+	t.Cleanup(func() { newPRMergeAPI = restore })
+
+	ctx := app.NewContext(eng,
+		app.WithRepoRoot(scene.Dir),
+		app.WithWriter(&bytes.Buffer{}),
+	)
+	mockCfg := testhelpers.NewMockGitHubServerConfig()
+	seedMockPR(mockCfg, "a", "main", 101)
+	seedMockPR(mockCfg, "b", "a", 102)
+	mockClient, owner, mockRepo := testhelpers.NewMockGitHubClient(t, mockCfg)
+	ctx.GitHubClient = testhelpers.NewMockGitHubClientInterface(mockClient, owner, mockRepo, mockCfg)
+
+	require.NoError(t, repo.CheckoutBranch("b"))
+	err = runMergeDrain(ctx, mergeDrainOptions{yes: true, count: 1})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"a"}, fake.merged, "drain should have merged only the bottom PR")
+
+	// The point of the test: after a's merge, b was reparented onto main — and
+	// that has to be visible on the remote, not just locally.
+	require.Equal(t, "main", remoteMetadataParent(t, repo, remoteDir, "b"),
+		"b's metadata ref on the remote must record its new parent after drain restacks it")
+}

--- a/internal/cli/stack/merge/orchestrate.go
+++ b/internal/cli/stack/merge/orchestrate.go
@@ -92,8 +92,20 @@ func (d *defaultPRMergeAPI) mergePR(ctx context.Context, branchName string, meth
 //     - "not enabled on repo" + wait → poll until mergeable, then merge directly.
 //     - "not enabled on repo" + no wait → error with --wait suggestion.
 func orchestrateMerge(ctx *app.Context, opts orchestrateMergeOptions) (Outcome, error) {
-	api := &defaultPRMergeAPI{client: ctx.GitHub()}
+	api := newPRMergeAPI(ctx)
 	return doOrchestrateMerge(ctx.Context, ctx.Output, ctx.Engine.Git(), api, opts) //nolint:forbidigo // GitHub integration needs the git runner to run gh; not a domain bypass
+}
+
+// newPRMergeAPI builds the merge API for a run. It is a variable so tests can
+// drive the commands that own the merge loop — `merge next` and `merge drain` —
+// rather than only doOrchestrateMerge, which already takes a prMergeAPI directly.
+//
+// The seam has to be here rather than on the github.Client: three of the five
+// prMergeAPI methods reach GitHub's GraphQL API by shelling out to `gh` through
+// the git runner, not through the client, so injecting a mock client leaves
+// them talking to the real thing.
+var newPRMergeAPI = func(ctx *app.Context) prMergeAPI {
+	return &defaultPRMergeAPI{client: ctx.GitHub()}
 }
 
 // doOrchestrateMerge contains the core merge orchestration logic, accepting a prMergeAPI


### PR DESCRIPTION

Draining a stack of two or more PRs stalled after the first merge. Hit while
merging #1537/#1538: the second PR reported

  failed to enable automerge: Pull request is in unstable status

and needed a manual `stackit submit` to unblock, once per remaining PR.

After each merge, drain checks out trunk and runs a scoped sync + restack. That
rewrites every remaining branch onto the new trunk and reparents the next one
off the branch that just merged — both only locally. Neither was pushed, which
strands the drain two ways:

- The metadata ref still names the merged, now-deleted parent. The Check Stack
  Order workflow reads that ref and reports the next PR as "not at the bottom of
  the stack", which leaves it unstable and automerge refuses it.
- The remote branch still points at pre-restack commits, so the PR shows a diff
  against the old base, including the changes that just merged.

GitHub retargets a PR's base itself when the base branch is deleted, so the PR
looks correct while both of the above are still wrong — which is what made this
hard to see.

Publish through submit rather than pushing refs directly: it already pushes
branch heads with the right force-with-lease, pushes metadata refs, and
retargets PR bases. UpdateOnly keeps it to branches that already have a PR, so a
drain can never open one, and NoEdit keeps it away from titles and descriptions.
The range is StackRangeUpstack(true) because the next PR to merge needs pushing
itself, not just its descendants.

No automated test. The drain merge loop takes an app.Context and drives the
GitHub API inline, so it is only reachable with a live remote — every existing
drain test is --dry-run and stops before the merge. Testing this properly needs
the loop's steps injectable, the way doOrchestrateMerge already takes its API as
a parameter; that refactor is worth doing but is larger than the fix. Verified
by hand instead: the stall reproduced on a real two-PR drain, and `stackit
submit` — which is what this now runs automatically — cleared it.