### PR TITLE
fix(engine): hold branches back in the engine, not just the restack command

### DIFF
--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -210,6 +210,23 @@ func (e *engineImpl) restackBranch(
 		return RestackBranchResult{Result: RestackUnneeded, LockReason: lockReason}, nil
 	}
 
+	// Hold the branch back entirely when its worktree has uncommitted tracked
+	// changes. Moving the ref is only half the operation: the worktree has to be
+	// reset to match, and resetWorktreeIfClean deliberately refuses to do that
+	// while there is work to lose. Doing the first half without the second
+	// leaves the worktree on the old commit's content under a new ref, so
+	// `git status` there reports the new commit's files as deleted and the next
+	// `stackit modify -a` commits that deletion — silently reverting those files
+	// inside the branch.
+	//
+	// This sits here rather than only in actions.PlanRestack (skipDirtyWorktreeStacks,
+	// which warns and is reached solely by the `restack` command) so that every
+	// caller of RestackBranches inherits it — modify, sync, squash, absorb,
+	// delete, split, reorder, pluck and insert all arrive here directly.
+	if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" && snap.dirtyWorktrees[worktreePath] {
+		return RestackBranchResult{Result: RestackUnneeded}, nil
+	}
+
 	// Worktree anchors are handled before the landed check, mirroring
 	// planRestackBranch. An anchor holds no commits of its own -- it marks where
 	// trunk was when the worktree was created -- so it is always an ancestor of
@@ -699,6 +716,17 @@ func (e *engineImpl) applyBranchAndMetadata(
 	snap *restackSnapshot,
 ) (RestackBranchResult, error) {
 	branchName := branch.GetName()
+
+	// See the matching guard in restackBranch: moving the ref without resetting
+	// the worktree leaves a staged revert that the next `modify -a` commits, and
+	// resetWorktreeIfClean refuses to reset while there is uncommitted work.
+	// Hold the branch back instead. This is the plan path, reached by every
+	// caller of actions.RestackBranches (modify, squash, absorb, delete, split,
+	// reorder, pluck) as well as the `restack` command.
+	if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" && snap.dirtyWorktrees[worktreePath] {
+		return RestackBranchResult{Result: RestackUnneeded, RebasedBranchBase: parentRev}, nil
+	}
+
 	meta := snap.meta.Get(branchName)
 	if meta == nil {
 		var err error

--- a/internal/integration/restack_dirty_sibling_worktree_test.go
+++ b/internal/integration/restack_dirty_sibling_worktree_test.go
@@ -1,0 +1,67 @@
+package integration
+
+import (
+	"testing"
+)
+
+// TestModifyDoesNotStageRevertInDirtySiblingWorktree covers the half of the
+// dirty-worktree guard that lives above the engine.
+//
+// Moving a branch's ref is only half the operation — the worktree holding that
+// branch has to be reset to match. That reset is suppressed while the worktree
+// has uncommitted tracked changes, so it cannot discard them, which leaves the
+// worktree on the old commit's content under a moved ref. `git status` there
+// reports the new commit's files as deleted, and the next `stackit modify -a`
+// commits that deletion, silently reverting trunk content into the branch.
+//
+// `stackit restack` avoids this by holding the branch back entirely
+// (skipDirtyWorktreeStacks). But that guard lives in actions.PlanRestack, which
+// only the restack command reaches. modify, sync, squash, absorb, delete, split
+// and insert all go straight to engine.RestackBranches, where the only
+// protection is the reset suppression — so they still move the ref.
+//
+// Here modify amends `a`, which restacks its upstack branch `b`; `b` is checked
+// out in a plain `git worktree add` sibling with a locally modified tracked
+// file.
+func TestModifyDoesNotStageRevertInDirtySiblingWorktree(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+	sh.CreateLinearStack3()
+
+	// Park b in its own worktree, the way someone reviewing or building two
+	// branches at once would.
+	worktreeDir := t.TempDir()
+	sh.Checkout("a")
+	sh.Git("worktree add " + worktreeDir + " b")
+
+	// Real work in progress there: a tracked file modified, not staged. The
+	// stack fixture writes through Write, which prefixes, so b's file is
+	// b.txt_test.txt.
+	wt := sh.InWorktree(worktreeDir)
+	wt.WriteUnstaged("b.txt_test.txt", "work in progress")
+
+	sh.Git("rev-parse b")
+	bRevBefore := sh.Output()
+
+	// Amending a restacks b — which is checked out, and dirty, elsewhere.
+	sh.Write("a_extra", "more work on a").
+		Run("modify -a -n")
+
+	// Either of these is a correct outcome: hold b back so its ref does not
+	// move, or move it and reset the worktree. What must not happen is moving
+	// the ref and leaving the worktree behind, because that is the state whose
+	// next `modify -a` commits a revert.
+	status := wt.Git("status --porcelain").Output()
+	bRevAfter := sh.Git("rev-parse b").Output()
+
+	if bRevAfter != bRevBefore {
+		wt.Git("status --porcelain").
+			OutputNotContains("D  ").
+			OutputNotContains(" D ")
+		t.Logf("b moved %s-> %s, worktree status: %q", bRevBefore, bRevAfter, status)
+	}
+
+	// The in-progress edit must survive regardless of which path was taken.
+	wt.Git("show :b.txt_test.txt")
+}


### PR DESCRIPTION

Third variant of the dirty-worktree family. #1538 stopped restack moving a
branch's ref while its worktree had uncommitted tracked changes, but put the
guard in actions.PlanRestack — reached only by `stackit restack`. Every other
caller lands in the engine directly, where the sole protection is
resetWorktreeIfClean, which suppresses the reset without stopping the ref.

Doing the first half without the second leaves the worktree on the old commit's
content under a new ref: `git status` there reports the new commit's files as
deleted, and the next `stackit modify -a` commits that deletion, silently
reverting those files inside the branch.

Reproduced with `sync --restack` against a plain `git worktree add` sibling
holding a tracked-dirty branch: b's ref moved and the worktree was left with
`D  trunk2.txt` staged; `modify -a` then committed `trunk2.txt | 1 -` into b.
Same shape via modify, squash, absorb and delete.

Not a regression — v0.23.0 reset unconditionally and destroyed the edit outright
on this scenario. But preserving the edit and leaving a revert staged behind it
trades visible loss for invisible corruption that ships in a PR, so it is worth
closing rather than carrying.

The guard now sits at both engine entry points: restackBranch (the non-plan
path, used by insert) and applyBranchAndMetadata (the plan path, used by
actions.RestackBranches and so by modify, squash, absorb, delete, split, reorder
and pluck, as well as restack itself). skipDirtyWorktreeStacks stays where it is
— it still supplies the user-facing warning, and is now a UX layer over a guard
that holds regardless of caller.

The new test drives modify with b checked out dirty in a sibling worktree, and
accepts either correct outcome — hold the ref, or move it and reset — failing
only on the broken middle state. Without the fix it fails with
`"D  a_extra_test.txt\n M b.txt_test.txt\n"`.