### PR TITLE
fix(github): surface rerequest-review API failures instead of discarding them

### DIFF
--- a/internal/github/pr_operations.go
+++ b/internal/github/pr_operations.go
@@ -177,14 +177,18 @@ func UpdatePullRequest(ctx context.Context, client *github.Client, runner GitCom
 			}
 			if len(reviewers) > 0 || len(teamReviewers) > 0 {
 				// Remove and re-add reviewers
-				_, _ = client.PullRequests.RemoveReviewers(ctx, repo.Owner, repo.Name, prNumber, github.ReviewersRequest{
+				if _, err := client.PullRequests.RemoveReviewers(ctx, repo.Owner, repo.Name, prNumber, github.ReviewersRequest{
 					Reviewers:     reviewers,
 					TeamReviewers: teamReviewers,
-				})
-				_, _, _ = client.PullRequests.RequestReviewers(ctx, repo.Owner, repo.Name, prNumber, github.ReviewersRequest{
+				}); err != nil {
+					warnings = append(warnings, fmt.Sprintf("failed to remove reviewers for rerequest: %v", err))
+				}
+				if _, _, err := client.PullRequests.RequestReviewers(ctx, repo.Owner, repo.Name, prNumber, github.ReviewersRequest{
 					Reviewers:     reviewers,
 					TeamReviewers: teamReviewers,
-				})
+				}); err != nil {
+					warnings = append(warnings, fmt.Sprintf("failed to re-add reviewers: %v", err))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

`UpdatePullRequest`'s `--rerequest-review` handling silently discarded the errors from `RemoveReviewers` and `RequestReviewers`:

```go
_, _ = client.PullRequests.RemoveReviewers(...)
_, _, _ = client.PullRequests.RequestReviewers(...)
```

This is inconsistent with the sibling `applyPRMetadata` helper in the same file, which converts the same class of GitHub API errors (failed reviewer/label/assignee calls) into `warnings` that are returned and surfaced to the user. If a rerequest failed — rate limit, permissions, network — the user got no signal that reviewers weren't actually re-requested.

## Changes

- `internal/github/pr_operations.go`: capture the `RemoveReviewers`/`RequestReviewers` errors and append them to the existing `warnings` slice, matching the established pattern in `applyPRMetadata`.

Searched the rest of `internal/github` for the same discarded-error shape (`_, _ = client.` / `_, _, _ = client.`) — this was the only occurrence.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/github/...`
- [x] `go vet ./internal/github/...`
- [x] `gofmt -l` clean on the changed file

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7zKfGHry7aZ6DLt3KZULw)_