### PR TITLE
fix(engine): restack frozen-branch children in the same pass

### DIFF
--- a/internal/engine/restack_plan.go
+++ b/internal/engine/restack_plan.go
@@ -35,16 +35,22 @@ func (e *engineImpl) PlanRestack(ctx context.Context, branches Branches) (*Resta
 			continue
 		}
 		plan.ApplyMap[item.Branch] = true
-		if item.Action == RestackPlanApplyAnchor {
-			// A moved anchor has to invalidate its children exactly like any
-			// other moved parent. Without this they stay "up to date" against
-			// the anchor's previous tip, so their recorded parent revision
-			// never catches up and every consumer reading it keeps drifting.
+		if item.Action == RestackPlanApplyAnchor || item.Action == RestackPlanApplyFrozen {
+			// A moved anchor or frozen branch has to invalidate its children
+			// exactly like any other moved parent. Without this they stay "up
+			// to date" against the parent's previous tip, so their recorded
+			// parent revision never catches up and every consumer reading it
+			// keeps drifting. For frozen this matters when the remote ref
+			// advanced: the branch hard-resets to the remote SHA, and its
+			// children must follow in the same pass.
 			plan.BranchMap[item.Branch] = true
 		}
 		if item.Action == RestackPlanApplyValidated {
 			specNewParent := item.NewParent
-			if parentItem, ok := plan.Items[item.NewParent]; ok && parentItem.Action == RestackPlanApplyAnchor && parentItem.TargetRev != "" {
+			// Anchor and frozen parents move to a known TargetRev at apply
+			// time; validate their children against that revision, not the
+			// parent's current (stale) ref.
+			if parentItem, ok := plan.Items[item.NewParent]; ok && parentItem.TargetRev != "" {
 				specNewParent = parentItem.TargetRev
 			} else if e.IsWorktreeAnchor(e.GetBranch(item.NewParent)) && item.ParentRev != "" {
 				if parentRev, ok := e.planRev(revMap, item.NewParent); ok && parentRev != item.ParentRev {

--- a/internal/integration/frozen_integration_test.go
+++ b/internal/integration/frozen_integration_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -197,6 +198,38 @@ func TestFrozenIntegration(t *testing.T) {
 
 		// Child should not be frozen
 		s.Run("info feature-b").OutputNotContains("(frozen)")
+	})
+
+	t.Run("remote advance restacks children in the same pass", func(t *testing.T) {
+		t.Parallel()
+		s := NewTestShellInProcess(t)
+
+		// Stack: main -> f -> c
+		s.Run("create f").
+			WriteFile("f.txt", "f1").
+			Git("commit -m 'F1'")
+		s.Run("create c").
+			WriteFile("c.txt", "c1").
+			Git("commit -m 'C1'")
+
+		// Teammate advances f's remote: build a commit on top of f without
+		// moving the local ref, then point origin/f at it.
+		s.Git("checkout --detach f").
+			WriteFile("f2.txt", "f2").
+			Git("commit -m 'F2'").
+			Git("update-ref refs/remotes/origin/f HEAD")
+		s.Checkout("c")
+		s.Run("freeze f")
+
+		s.Run("restack")
+
+		// f must hard-reset to its remote SHA, and c must follow onto the
+		// new f in the same restack pass — not report "up to date" against
+		// f's stale pre-reset tip.
+		remoteSHA := strings.TrimSpace(s.Git("rev-parse refs/remotes/origin/f").lastOutput)
+		localSHA := strings.TrimSpace(s.Git("rev-parse f").lastOutput)
+		require.Equal(t, remoteSHA, localSHA, "frozen branch must reset to its remote SHA")
+		s.Git("merge-base --is-ancestor f c")
 	})
 
 	t.Run("unfreeze allows modifications", func(t *testing.T) {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

A frozen branch whose remote advanced hard-resets to its remote SHA at
apply time, but PlanRestack only added anchor and validated items to
plan.BranchMap. Children of the frozen branch therefore planned as
"up to date" against its stale pre-reset tip and were skipped, leaving
the stack needing a second restack pass that the first one reported as
clean.

Add frozen items to BranchMap like any other moved parent, and widen the
child-spec TargetRev substitution (previously anchor-only) so children
validate against the revision the parent will actually move to.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785550649`.


* **PR #1545** 👈
  * **PR #1550**
    * **PR #1546**
      * **PR #1549**
        * **PR #1548**
          * **PR #1547**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1551 by jonnii*