### PR TITLE
fix(restack): make the interactive conflict-resolve prompt work mid-stack

### DIFF
--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -471,6 +471,20 @@ func reportRestackResult(ctx *app.Context, branch engine.Branch, result engine.R
 	}
 }
 
+// ResolveConflictWorkflow enters the conflict workflow from an interactive
+// "resolve conflicts now?" prompt by re-running the conflicted stack in
+// ConflictModeEnterWorkflow. The prompt paths run their initial restack in
+// ConflictModeContinue, which holds back the ENTIRE conflicted stack — the
+// conflict branch's ancestors included. Calling EnterConflictWorkflow directly
+// from that state would rebase the conflict branch against its never-moved
+// parent, find no conflict, and fail after detaching HEAD. Re-running in
+// EnterWorkflow mode applies the ancestors first (that mode is exempt from
+// per-stack atomicity on purpose) and then enters the conflict on top of them.
+// stackBranches must be the conflicted stack in topological order.
+func ResolveConflictWorkflow(ctx *app.Context, stackBranches engine.Branches) error {
+	return restackBranchesWithPlan(ctx, stackBranches, nil, nil, ConflictModeEnterWorkflow)
+}
+
 // EnterConflictWorkflow performs the rebase to enter conflict state and persists continuation state.
 // This helper is shared between RestackBranchesWithHandler (standalone mode) and sync.RunSync (sync mode).
 func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches engine.Branches) error {
@@ -483,6 +497,13 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 	// failed rebase's target, corrupting the branch. Detaching first ensures
 	// abort can only touch HEAD, never a branch ref. `st continue` already
 	// re-attaches to the conflict branch on success.
+	// reattach undoes the detach below when the workflow is NOT entered after
+	// all (rebase errored without leaving a conflict, or unexpectedly completed
+	// clean). Failing on a detached HEAD would strand the user off their
+	// branch, violating the no-detached-HEAD invariant. Best-effort and gated
+	// on no rebase being in progress: checkout would fail on an unmerged index
+	// anyway, and a live conflict is the one state where detached is correct.
+	reattach := func() {}
 	if currentBranch := ctx.Engine.CurrentBranch(); currentBranch != nil {
 		currentRev, revErr := ctx.Engine.GetCurrentRevision(ctx.Context)
 		if revErr != nil {
@@ -491,17 +512,25 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 		if detachErr := ctx.Engine.Detach(ctx.Context, currentRev); detachErr != nil {
 			return fmt.Errorf("failed to detach HEAD before conflict workflow: %w", detachErr)
 		}
+		originalBranch := *currentBranch
+		reattach = func() {
+			if !ctx.Engine.IsRebaseInProgress(ctx.Context) {
+				_ = ctx.Engine.CheckoutBranch(ctx.Context, originalBranch)
+			}
+		}
 	}
 
 	// Perform rebase to enter conflict state
 	conflictBranch := ctx.Engine.GetBranch(firstConflict)
 	batchResult, err := ctx.Engine.RestackBranches(ctx.Context, engine.BranchesOf(conflictBranch))
 	if err != nil {
+		reattach()
 		return fmt.Errorf("failed to enter conflict state for %s: %w", firstConflict, err)
 	}
 
 	// Verify we're actually in conflict state
 	if !ctx.Engine.IsRebaseInProgress(ctx.Context) {
+		reattach()
 		return fmt.Errorf("expected conflict on %s but rebase completed successfully", firstConflict)
 	}
 

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -230,7 +230,11 @@ func RestackAction(ctx *app.Context, plan *RestackPlan, handler handlers.Restack
 			return fmt.Errorf("failed to prompt for conflict resolution: %w", err)
 		}
 		if resolve {
-			return EnterConflictWorkflow(ctx, conflicts[0], branchesForConflict(plan, conflicts[0]))
+			// The prompt run used ConflictModeContinue, which held back the
+			// whole conflicted stack — ancestors included. Re-run that stack
+			// in EnterWorkflow mode so ancestors are applied before entering
+			// the conflict; see ResolveConflictWorkflow.
+			return ResolveConflictWorkflow(ctx, branchesForConflict(plan, conflicts[0]))
 		}
 	}
 

--- a/internal/actions/restack_test.go
+++ b/internal/actions/restack_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/getstackit/stackit/internal/engine"
+	stackiterrors "github.com/getstackit/stackit/internal/errors"
 	"github.com/getstackit/stackit/internal/handlers"
 	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
@@ -111,6 +112,52 @@ func TestRestackAction(t *testing.T) {
 			conflictBranches,
 		)
 		require.Equal(t, len(conflictBranches), jsonHandler.Result.ConflictCount)
+	})
+
+	t.Run("resolving mid-stack conflict applies ancestors before entering workflow", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		s.Checkout("main")
+		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("base", "conflict"))
+
+		// a rebases cleanly; b (child of a) conflicts with the trunk change.
+		s.CreateBranch("a")
+		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("a change", "afile"))
+		s.TrackBranch("a", "main")
+
+		s.CreateBranch("b")
+		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("b change", "conflict"))
+		s.TrackBranch("b", "a")
+
+		s.Checkout("main")
+		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("main change", "conflict"))
+		s.Checkout("b")
+
+		plan, err := PlanRestack(s.Context, RestackOptions{
+			BranchName: "b",
+			Scope:      engine.StackRangeFull(),
+		})
+		require.NoError(t, err)
+		require.True(t, plan.HasWork())
+
+		handler := &promptRestackHandler{resolveConflicts: true}
+		err = RestackAction(s.Context, plan, handler)
+		require.True(t, handler.prompted)
+		require.Equal(t, []string{"b"}, handler.conflicts)
+
+		// Answering "yes" must actually enter the conflict workflow: the
+		// held-back ancestors get applied first, then b's rebase stops in
+		// conflict state. Before the fix this errored with "expected conflict
+		// on b but rebase completed successfully" and left HEAD detached.
+		require.ErrorIs(t, err, stackiterrors.ErrConflictWorkflow)
+		require.True(t, s.Engine.Git().IsRebaseInProgress(context.Background()))
+
+		mainRev, err := s.Engine.GetRevision(engine.NewBranch("main", nil))
+		require.NoError(t, err)
+		isAncestor, err := s.Engine.Git().IsAncestor(context.Background(), mainRev, "a")
+		require.NoError(t, err)
+		require.True(t, isAncestor, "ancestor a must be restacked onto the new trunk before entering the conflict workflow")
 	})
 
 	t.Run("interactive restack prompts before entering conflict workflow", func(t *testing.T) {

--- a/internal/actions/sync/restack.go
+++ b/internal/actions/sync/restack.go
@@ -145,6 +145,28 @@ func restackBranches(ctx *app.Context, branchesToRestack []string, restackScope 
 	return nil
 }
 
+// conflictStackBranches returns the full stack containing branchName (ancestors
+// and descendants, trunk excluded) in topological order — the branch set
+// ResolveConflictWorkflow needs to apply the held-back ancestors before
+// entering the conflict.
+func conflictStackBranches(ctx *app.Context, branchName string) engine.Branches {
+	nav := ctx.Navigator()
+	branch := nav.GetBranch(branchName)
+	graph := ctx.Engine.Graph(engine.SortStrategyAlphabetical)
+	stack := graph.Range(branch, engine.StackRange{
+		RecursiveParents:  true,
+		IncludeCurrent:    true,
+		RecursiveChildren: true,
+	})
+	builder := engine.NewBranchesBuilder(len(stack))
+	for _, b := range stack {
+		if b.IsTracked() && !b.IsTrunk() {
+			builder.Add(b)
+		}
+	}
+	return nav.SortBranchesTopologically(builder.Build())
+}
+
 // getPRNumber returns the PR number for a branch if it has one
 func getPRNumber(eng engine.BranchStatus, branchName string) *int {
 	branch := eng.GetBranch(branchName)

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -286,10 +286,14 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		}
 
 		if resolve {
-			// User wants to resolve conflicts - enter conflict workflow for the first conflict
+			// User wants to resolve conflicts. The restack above ran in
+			// ConflictModeContinue, which held back the whole conflicted stack
+			// — ancestors included — so re-run that stack in EnterWorkflow
+			// mode (applies ancestors, then enters the conflict) rather than
+			// jumping straight to the conflict branch; see
+			// actions.ResolveConflictWorkflow.
 			firstConflict := summary.ConflictBranches[0]
-			allBranches := ctx.Navigator().AllBranches()
-			return actions.EnterConflictWorkflow(ctx, firstConflict, allBranches)
+			return actions.ResolveConflictWorkflow(ctx, conflictStackBranches(ctx, firstConflict))
 		}
 		// User chose to skip conflicts - continue with summary
 	}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The interactive restack/sync prompt runs its restack pass in
ConflictModeContinue, where per-stack atomicity holds back the ENTIRE
conflicted stack — including the conflict branch's not-yet-rebased
ancestors. Answering "yes" to the resolve prompt then called
EnterConflictWorkflow directly, which rebases only the conflict branch:
its parent had never moved, the rebase completed trivially, and the flow
died with "expected conflict but rebase completed successfully" — after
detaching HEAD and without re-attaching. Only a conflict on a
trunk-rooted stack root ever worked.

Route the prompt's yes-path through a new ResolveConflictWorkflow
helper that re-runs the conflicted stack in ConflictModeEnterWorkflow,
which applies ancestors first (it is exempt from atomicity for exactly
this reason) and then enters the conflict on top of them. The sync path
now also passes the topologically-sorted conflicted stack instead of
AllBranches(), so continuation state no longer records unrelated
branches in arbitrary order.

Also re-attach HEAD on EnterConflictWorkflow's failure paths (rebase
errored without conflict, or completed unexpectedly clean) so no error
path strands the user on a detached HEAD.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785550649`.


* **PR #1545**
  * **PR #1550**
    * **PR #1546** 👈
      * **PR #1549**
        * **PR #1548**
          * **PR #1547**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1551 by jonnii*