### PR TITLE
fix(restack): error on --branch with a nonexistent branch

### DIFF
--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -457,6 +457,11 @@ func planRestackBranchGroups(eng engine.BranchReader, opts RestackOptions) ([]re
 	if opts.AllStacks || len(opts.StackRoots) > 0 {
 		return branchGroupsForIndependentStacks(eng, opts)
 	}
+	// A typo'd --branch would otherwise produce an empty range and a silent
+	// "No branches to restack." success.
+	if !eng.BranchNames().Contains(opts.BranchName) {
+		return nil, fmt.Errorf("branch %s does not exist", opts.BranchName)
+	}
 	branch := eng.GetBranch(opts.BranchName)
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
 	branches := graph.Range(branch, opts.Scope).WithoutTrunk()

--- a/internal/actions/restack_test.go
+++ b/internal/actions/restack_test.go
@@ -114,6 +114,17 @@ func TestRestackAction(t *testing.T) {
 		require.Equal(t, len(conflictBranches), jsonHandler.Result.ConflictCount)
 	})
 
+	t.Run("planning errors on a nonexistent branch", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		_, err := PlanRestack(s.Context, RestackOptions{
+			BranchName: "does-not-exist",
+			Scope:      engine.StackRangeFull(),
+		})
+		require.ErrorContains(t, err, "branch does-not-exist does not exist")
+	})
+
 	t.Run("JSON restack reports conflicts without entering the workflow", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

planRestackBranchGroups built an empty range for an unknown branch
name, so 'stackit restack --branch typo' printed "No branches to
restack." and exited 0 — indistinguishable from an up-to-date stack.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785550649`.


* **PR #1545**
  * **PR #1550**
    * **PR #1546**
      * **PR #1549**
        * **PR #1548**
          * **PR #1547** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1551 by jonnii*