### PR TITLE
fix(absorb): never enter the conflict workflow from the post-absorb restack

### DIFF
--- a/docs/absorb.md
+++ b/docs/absorb.md
@@ -150,6 +150,14 @@ warns when descendants of the rewritten commits are left un-restacked
 ("Skipped restacking N branches...") and points at `stackit restack --upstack`
 to finish the job.
 
+The follow-up restack runs in continue-on-conflict mode, never the interactive
+conflict workflow: a conflicted stack is held back and absorb finishes on a
+clean worktree, pointing at `stackit restack` to resolve. This is deliberate —
+the absorbed hunks are already committed by that point, and ending mid-rebase
+would make the deferred stash restore pop stashes onto a conflicted worktree
+(and its failure path would re-stage already-absorbed hunks, duplicating
+them).
+
 Implementation: `internal/actions/absorb/restack.go`
 
 ## Conflict and Recovery

--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -410,6 +410,13 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return fmt.Errorf("failed to refresh engine after absorb: %w", err)
 	}
 
+	// The rewrite is complete: the staged hunks now live in commits. Flip the
+	// restore flag BEFORE the follow-up restack — if anything below fails, the
+	// deferred restore must take the success path. The failure path re-stages
+	// the original hunks, which would duplicate content that is already
+	// committed.
+	absorbSucceeded = true
+
 	// Restack branches according to mode
 	if oldestModifiedBranch != "" {
 		// Rebuild graph with fresh engine state
@@ -417,8 +424,35 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		upstackBranches := selectRestackBranches(graph, eng, opts.Restack, currentBranch.GetName(), oldestModifiedBranch, currentScope)
 
 		if len(upstackBranches) > 0 {
-			if err := actions.RestackBranches(ctx, upstackBranches); err != nil {
+			// ConflictModeContinue, not EnterWorkflow: entering the conflict
+			// workflow would return with the repo mid-rebase, and the deferred
+			// stash restore would then pop stashes and apply patches onto a
+			// conflicted worktree. Continue mode holds conflicted stacks back,
+			// so absorb always finishes on a clean worktree; the user resolves
+			// with 'stackit restack'.
+			var conflicted, blocked []string
+			if err := actions.RestackBranchesWithHandler(ctx, upstackBranches, func(p actions.RestackProgress) {
+				switch p.Result {
+				case engine.RestackDone:
+					out.Info("Restacked %s on %s.",
+						output.BranchName(p.Branch),
+						output.BranchName(eng.GetBranch(p.Branch).GetParentOrTrunk()))
+				case engine.RestackConflict:
+					conflicted = append(conflicted, p.Branch)
+				case engine.RestackBlocked:
+					blocked = append(blocked, p.Branch)
+				}
+			}, actions.ConflictModeContinue); err != nil {
 				return fmt.Errorf("failed to restack upstack branches: %w", err)
+			}
+			if len(conflicted) > 0 {
+				if len(blocked) > 0 {
+					out.Warn("Absorbed changes are committed, but restacking %s hit conflicts; %d dependent %s left in place. Run 'stackit restack' to rebase and resolve.",
+						strings.Join(conflicted, ", "), len(blocked), actions.Pluralize("branch", len(blocked)))
+				} else {
+					out.Warn("Absorbed changes are committed, but restacking %s hit conflicts. Run 'stackit restack' to rebase and resolve.",
+						strings.Join(conflicted, ", "))
+				}
 			}
 		}
 
@@ -436,7 +470,6 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		}
 	}
 
-	absorbSucceeded = true
 	handler.Complete(Result{
 		Absorbed:    len(absorbedTargets),
 		Unabsorbed:  len(unabsorbedHunks),

--- a/internal/actions/absorb/absorb_test.go
+++ b/internal/actions/absorb/absorb_test.go
@@ -860,6 +860,65 @@ func TestAbsorbRestoresUnabsorbableTextHunkToWorktree(t *testing.T) {
 	require.NotContains(t, stashList, absorbStashStagedMarker)
 }
 
+// TestAbsorbRestackConflictKeepsCleanWorktree verifies that a conflicted
+// follow-up restack does not fail the absorb: the rewrite already committed
+// the hunks, so the conflicted stack is held back and absorb finishes on a
+// clean worktree. Before the fix the restack entered the conflict workflow,
+// absorb returned its error, and the deferred restore took the failure path —
+// re-staging already-absorbed hunks onto a mid-rebase worktree.
+func TestAbsorbRestackConflictKeepsCleanWorktree(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+	s.CreateBranch("branch-a")
+	s.TrackBranch("branch-a", "main")
+	aFile := filepath.Join(s.Scene.Dir, "a.txt")
+	require.NoError(t, os.WriteFile(aFile, []byte("a-line\n"), 0600))
+	conflictFile := filepath.Join(s.Scene.Dir, "conflict.txt")
+	require.NoError(t, os.WriteFile(conflictFile, []byte("base\n"), 0600))
+	s.RunGit("add", "a.txt", "conflict.txt")
+	s.RunGit("commit", "-m", "a: add files")
+
+	s.CreateBranch("branch-b")
+	s.TrackBranch("branch-b", "branch-a")
+	require.NoError(t, os.WriteFile(conflictFile, []byte("b-version\n"), 0600))
+	s.RunGit("add", "conflict.txt")
+	s.RunGit("commit", "-m", "b: change conflict file")
+
+	// Diverge branch-a so branch-b's replay conflicts during the restack.
+	s.Checkout("branch-a")
+	require.NoError(t, os.WriteFile(conflictFile, []byte("a-version\n"), 0600))
+	s.RunGit("add", "conflict.txt")
+	s.RunGit("commit", "-m", "a: conflicting change")
+	s.Rebuild()
+
+	// Stage a hunk that absorbs into branch-a's first commit.
+	require.NoError(t, os.WriteFile(aFile, []byte("a-line absorbed\n"), 0600))
+	s.RunGit("add", "a.txt")
+
+	err := Action(s.Context, Options{Force: true, Restack: RestackAll}, nil)
+	require.NoError(t, err)
+
+	// The absorbed hunk is committed on branch-a.
+	headA, err := s.Scene.Repo.RunGitCommandAndGetOutput("show", "branch-a:a.txt")
+	require.NoError(t, err)
+	require.Contains(t, headA, "a-line absorbed")
+
+	// The repo is clean: no rebase in progress, nothing staged (the absorbed
+	// hunk must NOT have been re-staged by the restore path), and no leftover
+	// absorb stashes.
+	require.False(t, s.Engine.Git().IsRebaseInProgress(context.Background()))
+	staged, err := s.Scene.Repo.RunGitCommandAndGetOutput("diff", "--cached")
+	require.NoError(t, err)
+	require.Empty(t, strings.TrimSpace(staged))
+	stashList, err := s.Scene.Repo.RunGitCommandAndGetOutput("stash", "list")
+	require.NoError(t, err)
+	require.NotContains(t, stashList, absorbStashMarker)
+
+	// branch-b was held back (still needs restack), not left mid-conflict.
+	require.NotEmpty(t, s.Engine.CurrentBranch())
+}
+
 // TestDropStagedStashIfRestored verifies the staged safety stash is dropped only
 // after the unabsorbable-hunk restore succeeds, and kept (as the recovery net)
 // when it fails. This mirrors the ordering guard in restoreStashedState.

--- a/internal/cli/branch/absorb_test.go
+++ b/internal/cli/branch/absorb_test.go
@@ -304,7 +304,7 @@ func TestAbsorbComplex(t *testing.T) {
 		t.Fatal("stackit binary not built")
 	}
 
-	t.Run("absorb failure during restack preserves work and reports error", func(t *testing.T) {
+	t.Run("restack conflict after absorb holds the stack back and stays clean", func(t *testing.T) {
 		t.Parallel()
 		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
 			// Create branch A
@@ -346,27 +346,33 @@ func TestAbsorbComplex(t *testing.T) {
 			return nil
 		})
 
-		// Run absorb. It should successfully absorb into branchA, but then fail during restack of branchB
+		// Run absorb. It absorbs into branchA; the follow-up restack of branchB
+		// conflicts, so branchB is held back and absorb still succeeds — the
+		// hunks are already committed, and entering the conflict workflow here
+		// would leave the repo mid-rebase while the deferred stash restore
+		// re-staged already-absorbed content.
 		cmd := exec.Command(binaryPath, "absorb", "--force")
 		cmd.Dir = scene.Dir
 		output, err := cmd.CombinedOutput()
 
-		require.Error(t, err, "absorb should fail during restack. Output: %s", string(output))
-		// The conflict-workflow error is silenced (instructions are printed
-		// instead), so assert on the printed conflict status.
-		require.Contains(t, string(output), "Hit conflict restacking branchB", "should report restack conflict")
+		require.NoError(t, err, "absorb must succeed despite the restack conflict. Output: %s", string(output))
+		require.Contains(t, string(output), "hit conflicts", "should report the held-back restack conflict")
+		require.Contains(t, string(output), "stackit restack", "should point at restack to resolve")
 
-		// In case of restack conflict, stackit stays in rebase mode (detached HEAD)
-		rebaseDir := scene.Dir + "/.git/rebase-merge"
-		if _, err := os.Stat(rebaseDir); os.IsNotExist(err) {
-			rebaseDir = scene.Dir + "/.git/rebase-apply"
+		// The repo must be clean: no rebase in progress, nothing staged.
+		for _, dir := range []string{"/.git/rebase-merge", "/.git/rebase-apply"} {
+			_, statErr := os.Stat(scene.Dir + dir)
+			require.True(t, os.IsNotExist(statErr), "must not be mid-rebase (%s exists)", dir)
 		}
-		_, err = os.Stat(rebaseDir)
-		require.NoError(t, err, "should be in middle of rebase")
+		staged := exec.Command("git", "diff", "--cached", "--quiet")
+		staged.Dir = scene.Dir
+		require.NoError(t, staged.Run(), "nothing may be re-staged after absorb")
 
-		// Clean up for next tests
-		cmd = exec.Command("git", "rebase", "--abort")
-		cmd.Dir = scene.Dir
-		_ = cmd.Run()
+		// The absorbed change is committed on branchA.
+		show := exec.Command("git", "show", "branchA:conflict.txt")
+		show.Dir = scene.Dir
+		content, err := show.CombinedOutput()
+		require.NoError(t, err)
+		require.Contains(t, string(content), "line 1 modified", "absorbed hunk must be committed")
 	})
 }


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

When the restack following a successful absorb rewrite hit a conflict,
it entered the interactive conflict workflow and returned its error, so
absorb took its failure path: the deferred stash restore popped the
staged safety stash (or re-staged the captured hunks), duplicating
content that was already committed — on top of a worktree left
mid-rebase with conflict markers. 'stackit continue --all' would then
sweep the duplicates into a rebase commit.

Two changes close this:

- absorbSucceeded now flips right after the rewrite lands (before the
  restack), so no later failure can route the restore onto the
  re-stage-everything path.
- The follow-up restack runs in ConflictModeContinue: a conflicted
  stack is held back, absorb finishes on a clean worktree, and the user
  is pointed at 'stackit restack' to rebase and resolve.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785550649`.


* **PR #1545**
  * **PR #1550**
    * **PR #1546**
      * **PR #1549**
        * **PR #1548** 👈
          * **PR #1547**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1551 by jonnii*