### PR TITLE
fix(restack): report conflicts as JSON instead of entering the workflow

### DIFF
--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -174,10 +174,8 @@ func RestackAction(ctx *app.Context, plan *RestackPlan, handler handlers.Restack
 		handler = &handlers.NullRestackHandler{}
 	}
 
-	interactiveRererePrompt := ctx.Interactive && !ctx.Quiet && tui.IsTTY()
-	if _, jsonOutput := handler.(*handlers.JSONRestackHandler); jsonOutput {
-		interactiveRererePrompt = false
-	}
+	_, jsonOutput := handler.(*handlers.JSONRestackHandler)
+	interactiveRererePrompt := ctx.Interactive && !ctx.Quiet && tui.IsTTY() && !jsonOutput
 	pauser, _ := handler.(rerere.Pauser)
 	if _, err := rerere.EnsureEnabled(ctx.Context, ctx.Engine, interactiveRererePrompt, pauser); err != nil {
 		out.Warn("Failed to enable git rerere: %v", err)
@@ -204,8 +202,14 @@ func RestackAction(ctx *app.Context, plan *RestackPlan, handler handlers.Restack
 		return nil
 	}
 
+	// JSON output never enters the conflict workflow: EnterConflictWorkflow
+	// prints human conflict guidance into the stream that must stay parseable
+	// JSON, leaves the repo mid-rebase, and its error skipped OnRestackComplete
+	// — so the documented "conflict" status was unreachable and a routine
+	// conflict surfaced as status "error" with conflict_count 0. Report
+	// conflicts like --continue-on-conflict instead.
 	conflictMode := ConflictModeEnterWorkflow
-	if opts.ContinueOnConflict || promptForConflicts {
+	if opts.ContinueOnConflict || promptForConflicts || jsonOutput {
 		conflictMode = ConflictModeContinue
 	}
 

--- a/internal/actions/restack_test.go
+++ b/internal/actions/restack_test.go
@@ -114,6 +114,39 @@ func TestRestackAction(t *testing.T) {
 		require.Equal(t, len(conflictBranches), jsonHandler.Result.ConflictCount)
 	})
 
+	t.Run("JSON restack reports conflicts without entering the workflow", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		s.Checkout("main")
+		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("base", "conflict"))
+		s.CreateBranch("feature")
+		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("feature change", "conflict"))
+		s.TrackBranch("feature", "main")
+		s.Checkout("main")
+		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("main change", "conflict"))
+		s.Checkout("feature")
+
+		plan, err := PlanRestack(s.Context, RestackOptions{
+			BranchName: "feature",
+			Scope:      engine.StackRange{IncludeCurrent: true},
+		})
+		require.NoError(t, err)
+		require.True(t, plan.HasWork())
+
+		jsonHandler := handlers.NewJSONRestackHandler()
+		err = RestackAction(s.Context, plan, jsonHandler)
+
+		// A routine conflict is data, not an error: status "conflict" with
+		// the branch listed, and the repo left clean — never mid-rebase with
+		// human conflict guidance printed into the JSON stream.
+		require.NoError(t, err)
+		require.Equal(t, handlers.RestackJSONStatusConflict, jsonHandler.Result.Status)
+		require.Equal(t, 1, jsonHandler.Result.ConflictCount)
+		require.Equal(t, "feature", jsonHandler.Result.Conflicts[0].Branch)
+		require.False(t, s.Engine.Git().IsRebaseInProgress(context.Background()))
+	})
+
 	t.Run("resolving mid-stack conflict applies ancestors before entering workflow", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

restack --json fell into ConflictModeEnterWorkflow on conflict: it
printed colored human conflict guidance into the stream that must stay
parseable JSON, left the repo mid-rebase on a detached HEAD, and the
error return skipped OnRestackComplete — so the documented "conflict"
status was unreachable and a routine conflict surfaced as status
"error" with conflict_count 0.

Treat JSON output like --continue-on-conflict: conflicted stacks are
held back and reported in the conflicts list with status "conflict",
and the output stream carries nothing but JSON.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785550649`.


* **PR #1545**
  * **PR #1550**
    * **PR #1546**
      * **PR #1549** 👈
        * **PR #1548**
          * **PR #1547**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1551 by jonnii*