### PR TITLE
fix(engine): harden restack internals against crashes and deadlocks

### DIFF
--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -137,8 +137,14 @@ func (e *engineImpl) shouldReparentBranch(ctx context.Context, parentBranchName 
 	}
 
 	// Worktree anchor branches should never be reparented - they are permanent parents
-	// for their stacks, even though they may be at trunk HEAD
-	if e.IsWorktreeAnchor(e.GetBranch(parentBranchName)) {
+	// for their stacks, even though they may be at trunk HEAD.
+	//
+	// Callers hold e.mu, so read the branch type via readState directly:
+	// IsWorktreeAnchor goes through GetBranchType, which re-acquires e.mu.RLock
+	// (deadlock if a writer is queued between the two RLocks) and may take
+	// e.mu.Lock via ensureBranchSharedLoaded — a self-deadlock on a
+	// lazily-loaded engine.
+	if state := e.readState(parentBranchName); state != nil && state.BranchType == git.BranchTypeWorktreeAnchor {
 		return false
 	}
 

--- a/internal/engine/rebase_validator.go
+++ b/internal/engine/rebase_validator.go
@@ -388,6 +388,13 @@ func (e *engineImpl) processValidationLevel(
 	for _, spec := range level.specs {
 		wg.Add(1)
 		go func(spec RebaseSpec) {
+			// wg.Done must be the FIRST defer registered so it runs LAST
+			// (defers are LIFO): the panic-recovery defer below sends on
+			// results, and the collector closes that channel once wg.Wait
+			// returns. Done firing before the send would let the close race
+			// the send — a panic in the last goroutine of a level would then
+			// crash the process on a closed channel instead of being reported.
+			defer wg.Done()
 			// Panic recovery at outermost level to ensure cleanup always happens
 			defer func() {
 				if r := recover(); r != nil {
@@ -399,7 +406,6 @@ func (e *engineImpl) processValidationLevel(
 					}
 				}
 			}()
-			defer wg.Done()
 
 			// Check parent context before acquiring semaphore so an outer cancel
 			// (e.g. user Ctrl+C) short-circuits queued siblings.

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -90,7 +90,7 @@ func AutoContinueRerereRebase(ctx context.Context, r Runner, originalErr error) 
 
 		unmergedFiles, err := applyRerereToUnmerged(ctx, r)
 		if err != nil {
-			return outcome, nil, originalErr
+			return outcome, nil, fmt.Errorf("failed to read unmerged files during rerere auto-continue: %s (rebase error: %w)", err.Error(), originalErr)
 		}
 		if len(unmergedFiles) > 0 {
 			return outcome, unmergedFiles, nil


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Three small robustness fixes in the restack machinery:

- rebase validator: register wg.Done before the panic-recovery defer.
  Defers run LIFO, so the recovery send on the results channel could
  race the collector's close(results) after Done fired — a panic in the
  last goroutine of a level crashed the process on a closed channel
  instead of being reported as a validation failure.

- shouldReparentBranch: read the parent's branch type via readState
  instead of IsWorktreeAnchor. Callers hold e.mu, and IsWorktreeAnchor
  re-acquires the lock (deadlock with a queued writer) and can take the
  write lock via lazy loading (self-deadlock on lazily-loaded engines).

- AutoContinueRerereRebase: report the actual error when reading
  unmerged files fails instead of misattributing the failure to the
  original rebase error.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785550649`.


* **PR #1545**
  * **PR #1550** 👈
    * **PR #1546**
      * **PR #1549**
        * **PR #1548**
          * **PR #1547**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1551 by jonnii*