### PR TITLE
Merging 6 PRs

### DIFF
--- a/docs/absorb.md
+++ b/docs/absorb.md
@@ -150,6 +150,14 @@ warns when descendants of the rewritten commits are left un-restacked
 ("Skipped restacking N branches...") and points at `stackit restack --upstack`
 to finish the job.
 
+The follow-up restack runs in continue-on-conflict mode, never the interactive
+conflict workflow: a conflicted stack is held back and absorb finishes on a
+clean worktree, pointing at `stackit restack` to resolve. This is deliberate —
+the absorbed hunks are already committed by that point, and ending mid-rebase
+would make the deferred stash restore pop stashes onto a conflicted worktree
+(and its failure path would re-stage already-absorbed hunks, duplicating
+them).
+
 Implementation: `internal/actions/absorb/restack.go`
 
 ## Conflict and Recovery

--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -410,6 +410,13 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return fmt.Errorf("failed to refresh engine after absorb: %w", err)
 	}
 
+	// The rewrite is complete: the staged hunks now live in commits. Flip the
+	// restore flag BEFORE the follow-up restack — if anything below fails, the
+	// deferred restore must take the success path. The failure path re-stages
+	// the original hunks, which would duplicate content that is already
+	// committed.
+	absorbSucceeded = true
+
 	// Restack branches according to mode
 	if oldestModifiedBranch != "" {
 		// Rebuild graph with fresh engine state
@@ -417,8 +424,35 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		upstackBranches := selectRestackBranches(graph, eng, opts.Restack, currentBranch.GetName(), oldestModifiedBranch, currentScope)
 
 		if len(upstackBranches) > 0 {
-			if err := actions.RestackBranches(ctx, upstackBranches); err != nil {
+			// ConflictModeContinue, not EnterWorkflow: entering the conflict
+			// workflow would return with the repo mid-rebase, and the deferred
+			// stash restore would then pop stashes and apply patches onto a
+			// conflicted worktree. Continue mode holds conflicted stacks back,
+			// so absorb always finishes on a clean worktree; the user resolves
+			// with 'stackit restack'.
+			var conflicted, blocked []string
+			if err := actions.RestackBranchesWithHandler(ctx, upstackBranches, func(p actions.RestackProgress) {
+				switch p.Result {
+				case engine.RestackDone:
+					out.Info("Restacked %s on %s.",
+						output.BranchName(p.Branch),
+						output.BranchName(eng.GetBranch(p.Branch).GetParentOrTrunk()))
+				case engine.RestackConflict:
+					conflicted = append(conflicted, p.Branch)
+				case engine.RestackBlocked:
+					blocked = append(blocked, p.Branch)
+				}
+			}, actions.ConflictModeContinue); err != nil {
 				return fmt.Errorf("failed to restack upstack branches: %w", err)
+			}
+			if len(conflicted) > 0 {
+				if len(blocked) > 0 {
+					out.Warn("Absorbed changes are committed, but restacking %s hit conflicts; %d dependent %s left in place. Run 'stackit restack' to rebase and resolve.",
+						strings.Join(conflicted, ", "), len(blocked), actions.Pluralize("branch", len(blocked)))
+				} else {
+					out.Warn("Absorbed changes are committed, but restacking %s hit conflicts. Run 'stackit restack' to rebase and resolve.",
+						strings.Join(conflicted, ", "))
+				}
 			}
 		}
 
@@ -436,7 +470,6 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		}
 	}
 
-	absorbSucceeded = true
 	handler.Complete(Result{
 		Absorbed:    len(absorbedTargets),
 		Unabsorbed:  len(unabsorbedHunks),

--- a/internal/actions/absorb/absorb_test.go
+++ b/internal/actions/absorb/absorb_test.go
@@ -860,6 +860,65 @@ func TestAbsorbRestoresUnabsorbableTextHunkToWorktree(t *testing.T) {
 	require.NotContains(t, stashList, absorbStashStagedMarker)
 }
 
+// TestAbsorbRestackConflictKeepsCleanWorktree verifies that a conflicted
+// follow-up restack does not fail the absorb: the rewrite already committed
+// the hunks, so the conflicted stack is held back and absorb finishes on a
+// clean worktree. Before the fix the restack entered the conflict workflow,
+// absorb returned its error, and the deferred restore took the failure path —
+// re-staging already-absorbed hunks onto a mid-rebase worktree.
+func TestAbsorbRestackConflictKeepsCleanWorktree(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+	s.CreateBranch("branch-a")
+	s.TrackBranch("branch-a", "main")
+	aFile := filepath.Join(s.Scene.Dir, "a.txt")
+	require.NoError(t, os.WriteFile(aFile, []byte("a-line\n"), 0600))
+	conflictFile := filepath.Join(s.Scene.Dir, "conflict.txt")
+	require.NoError(t, os.WriteFile(conflictFile, []byte("base\n"), 0600))
+	s.RunGit("add", "a.txt", "conflict.txt")
+	s.RunGit("commit", "-m", "a: add files")
+
+	s.CreateBranch("branch-b")
+	s.TrackBranch("branch-b", "branch-a")
+	require.NoError(t, os.WriteFile(conflictFile, []byte("b-version\n"), 0600))
+	s.RunGit("add", "conflict.txt")
+	s.RunGit("commit", "-m", "b: change conflict file")
+
+	// Diverge branch-a so branch-b's replay conflicts during the restack.
+	s.Checkout("branch-a")
+	require.NoError(t, os.WriteFile(conflictFile, []byte("a-version\n"), 0600))
+	s.RunGit("add", "conflict.txt")
+	s.RunGit("commit", "-m", "a: conflicting change")
+	s.Rebuild()
+
+	// Stage a hunk that absorbs into branch-a's first commit.
+	require.NoError(t, os.WriteFile(aFile, []byte("a-line absorbed\n"), 0600))
+	s.RunGit("add", "a.txt")
+
+	err := Action(s.Context, Options{Force: true, Restack: RestackAll}, nil)
+	require.NoError(t, err)
+
+	// The absorbed hunk is committed on branch-a.
+	headA, err := s.Scene.Repo.RunGitCommandAndGetOutput("show", "branch-a:a.txt")
+	require.NoError(t, err)
+	require.Contains(t, headA, "a-line absorbed")
+
+	// The repo is clean: no rebase in progress, nothing staged (the absorbed
+	// hunk must NOT have been re-staged by the restore path), and no leftover
+	// absorb stashes.
+	require.False(t, s.Engine.Git().IsRebaseInProgress(context.Background()))
+	staged, err := s.Scene.Repo.RunGitCommandAndGetOutput("diff", "--cached")
+	require.NoError(t, err)
+	require.Empty(t, strings.TrimSpace(staged))
+	stashList, err := s.Scene.Repo.RunGitCommandAndGetOutput("stash", "list")
+	require.NoError(t, err)
+	require.NotContains(t, stashList, absorbStashMarker)
+
+	// branch-b was held back (still needs restack), not left mid-conflict.
+	require.NotEmpty(t, s.Engine.CurrentBranch())
+}
+
 // TestDropStagedStashIfRestored verifies the staged safety stash is dropped only
 // after the unabsorbable-hunk restore succeeds, and kept (as the recovery net)
 // when it fails. This mirrors the ordering guard in restoreStashedState.

--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -471,6 +471,20 @@ func reportRestackResult(ctx *app.Context, branch engine.Branch, result engine.R
 	}
 }
 
+// ResolveConflictWorkflow enters the conflict workflow from an interactive
+// "resolve conflicts now?" prompt by re-running the conflicted stack in
+// ConflictModeEnterWorkflow. The prompt paths run their initial restack in
+// ConflictModeContinue, which holds back the ENTIRE conflicted stack — the
+// conflict branch's ancestors included. Calling EnterConflictWorkflow directly
+// from that state would rebase the conflict branch against its never-moved
+// parent, find no conflict, and fail after detaching HEAD. Re-running in
+// EnterWorkflow mode applies the ancestors first (that mode is exempt from
+// per-stack atomicity on purpose) and then enters the conflict on top of them.
+// stackBranches must be the conflicted stack in topological order.
+func ResolveConflictWorkflow(ctx *app.Context, stackBranches engine.Branches) error {
+	return restackBranchesWithPlan(ctx, stackBranches, nil, nil, ConflictModeEnterWorkflow)
+}
+
 // EnterConflictWorkflow performs the rebase to enter conflict state and persists continuation state.
 // This helper is shared between RestackBranchesWithHandler (standalone mode) and sync.RunSync (sync mode).
 func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches engine.Branches) error {
@@ -483,6 +497,13 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 	// failed rebase's target, corrupting the branch. Detaching first ensures
 	// abort can only touch HEAD, never a branch ref. `st continue` already
 	// re-attaches to the conflict branch on success.
+	// reattach undoes the detach below when the workflow is NOT entered after
+	// all (rebase errored without leaving a conflict, or unexpectedly completed
+	// clean). Failing on a detached HEAD would strand the user off their
+	// branch, violating the no-detached-HEAD invariant. Best-effort and gated
+	// on no rebase being in progress: checkout would fail on an unmerged index
+	// anyway, and a live conflict is the one state where detached is correct.
+	reattach := func() {}
 	if currentBranch := ctx.Engine.CurrentBranch(); currentBranch != nil {
 		currentRev, revErr := ctx.Engine.GetCurrentRevision(ctx.Context)
 		if revErr != nil {
@@ -491,17 +512,25 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 		if detachErr := ctx.Engine.Detach(ctx.Context, currentRev); detachErr != nil {
 			return fmt.Errorf("failed to detach HEAD before conflict workflow: %w", detachErr)
 		}
+		originalBranch := *currentBranch
+		reattach = func() {
+			if !ctx.Engine.IsRebaseInProgress(ctx.Context) {
+				_ = ctx.Engine.CheckoutBranch(ctx.Context, originalBranch)
+			}
+		}
 	}
 
 	// Perform rebase to enter conflict state
 	conflictBranch := ctx.Engine.GetBranch(firstConflict)
 	batchResult, err := ctx.Engine.RestackBranches(ctx.Context, engine.BranchesOf(conflictBranch))
 	if err != nil {
+		reattach()
 		return fmt.Errorf("failed to enter conflict state for %s: %w", firstConflict, err)
 	}
 
 	// Verify we're actually in conflict state
 	if !ctx.Engine.IsRebaseInProgress(ctx.Context) {
+		reattach()
 		return fmt.Errorf("expected conflict on %s but rebase completed successfully", firstConflict)
 	}
 

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -174,10 +174,8 @@ func RestackAction(ctx *app.Context, plan *RestackPlan, handler handlers.Restack
 		handler = &handlers.NullRestackHandler{}
 	}
 
-	interactiveRererePrompt := ctx.Interactive && !ctx.Quiet && tui.IsTTY()
-	if _, jsonOutput := handler.(*handlers.JSONRestackHandler); jsonOutput {
-		interactiveRererePrompt = false
-	}
+	_, jsonOutput := handler.(*handlers.JSONRestackHandler)
+	interactiveRererePrompt := ctx.Interactive && !ctx.Quiet && tui.IsTTY() && !jsonOutput
 	pauser, _ := handler.(rerere.Pauser)
 	if _, err := rerere.EnsureEnabled(ctx.Context, ctx.Engine, interactiveRererePrompt, pauser); err != nil {
 		out.Warn("Failed to enable git rerere: %v", err)
@@ -204,8 +202,14 @@ func RestackAction(ctx *app.Context, plan *RestackPlan, handler handlers.Restack
 		return nil
 	}
 
+	// JSON output never enters the conflict workflow: EnterConflictWorkflow
+	// prints human conflict guidance into the stream that must stay parseable
+	// JSON, leaves the repo mid-rebase, and its error skipped OnRestackComplete
+	// — so the documented "conflict" status was unreachable and a routine
+	// conflict surfaced as status "error" with conflict_count 0. Report
+	// conflicts like --continue-on-conflict instead.
 	conflictMode := ConflictModeEnterWorkflow
-	if opts.ContinueOnConflict || promptForConflicts {
+	if opts.ContinueOnConflict || promptForConflicts || jsonOutput {
 		conflictMode = ConflictModeContinue
 	}
 

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -230,7 +230,11 @@ func RestackAction(ctx *app.Context, plan *RestackPlan, handler handlers.Restack
 			return fmt.Errorf("failed to prompt for conflict resolution: %w", err)
 		}
 		if resolve {
-			return EnterConflictWorkflow(ctx, conflicts[0], branchesForConflict(plan, conflicts[0]))
+			// The prompt run used ConflictModeContinue, which held back the
+			// whole conflicted stack — ancestors included. Re-run that stack
+			// in EnterWorkflow mode so ancestors are applied before entering
+			// the conflict; see ResolveConflictWorkflow.
+			return ResolveConflictWorkflow(ctx, branchesForConflict(plan, conflicts[0]))
 		}
 	}
 

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -457,6 +457,11 @@ func planRestackBranchGroups(eng engine.BranchReader, opts RestackOptions) ([]re
 	if opts.AllStacks || len(opts.StackRoots) > 0 {
 		return branchGroupsForIndependentStacks(eng, opts)
 	}
+	// A typo'd --branch would otherwise produce an empty range and a silent
+	// "No branches to restack." success.
+	if !eng.BranchNames().Contains(opts.BranchName) {
+		return nil, fmt.Errorf("branch %s does not exist", opts.BranchName)
+	}
 	branch := eng.GetBranch(opts.BranchName)
 	graph := eng.Graph(engine.SortStrategyAlphabetical)
 	branches := graph.Range(branch, opts.Scope).WithoutTrunk()

--- a/internal/actions/restack_test.go
+++ b/internal/actions/restack_test.go
@@ -114,6 +114,39 @@ func TestRestackAction(t *testing.T) {
 		require.Equal(t, len(conflictBranches), jsonHandler.Result.ConflictCount)
 	})
 
+	t.Run("JSON restack reports conflicts without entering the workflow", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		s.Checkout("main")
+		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("base", "conflict"))
+		s.CreateBranch("feature")
+		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("feature change", "conflict"))
+		s.TrackBranch("feature", "main")
+		s.Checkout("main")
+		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("main change", "conflict"))
+		s.Checkout("feature")
+
+		plan, err := PlanRestack(s.Context, RestackOptions{
+			BranchName: "feature",
+			Scope:      engine.StackRange{IncludeCurrent: true},
+		})
+		require.NoError(t, err)
+		require.True(t, plan.HasWork())
+
+		jsonHandler := handlers.NewJSONRestackHandler()
+		err = RestackAction(s.Context, plan, jsonHandler)
+
+		// A routine conflict is data, not an error: status "conflict" with
+		// the branch listed, and the repo left clean — never mid-rebase with
+		// human conflict guidance printed into the JSON stream.
+		require.NoError(t, err)
+		require.Equal(t, handlers.RestackJSONStatusConflict, jsonHandler.Result.Status)
+		require.Equal(t, 1, jsonHandler.Result.ConflictCount)
+		require.Equal(t, "feature", jsonHandler.Result.Conflicts[0].Branch)
+		require.False(t, s.Engine.Git().IsRebaseInProgress(context.Background()))
+	})
+
 	t.Run("resolving mid-stack conflict applies ancestors before entering workflow", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)

--- a/internal/actions/restack_test.go
+++ b/internal/actions/restack_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/getstackit/stackit/internal/engine"
+	stackiterrors "github.com/getstackit/stackit/internal/errors"
 	"github.com/getstackit/stackit/internal/handlers"
 	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
@@ -111,6 +112,52 @@ func TestRestackAction(t *testing.T) {
 			conflictBranches,
 		)
 		require.Equal(t, len(conflictBranches), jsonHandler.Result.ConflictCount)
+	})
+
+	t.Run("resolving mid-stack conflict applies ancestors before entering workflow", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		s.Checkout("main")
+		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("base", "conflict"))
+
+		// a rebases cleanly; b (child of a) conflicts with the trunk change.
+		s.CreateBranch("a")
+		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("a change", "afile"))
+		s.TrackBranch("a", "main")
+
+		s.CreateBranch("b")
+		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("b change", "conflict"))
+		s.TrackBranch("b", "a")
+
+		s.Checkout("main")
+		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("main change", "conflict"))
+		s.Checkout("b")
+
+		plan, err := PlanRestack(s.Context, RestackOptions{
+			BranchName: "b",
+			Scope:      engine.StackRangeFull(),
+		})
+		require.NoError(t, err)
+		require.True(t, plan.HasWork())
+
+		handler := &promptRestackHandler{resolveConflicts: true}
+		err = RestackAction(s.Context, plan, handler)
+		require.True(t, handler.prompted)
+		require.Equal(t, []string{"b"}, handler.conflicts)
+
+		// Answering "yes" must actually enter the conflict workflow: the
+		// held-back ancestors get applied first, then b's rebase stops in
+		// conflict state. Before the fix this errored with "expected conflict
+		// on b but rebase completed successfully" and left HEAD detached.
+		require.ErrorIs(t, err, stackiterrors.ErrConflictWorkflow)
+		require.True(t, s.Engine.Git().IsRebaseInProgress(context.Background()))
+
+		mainRev, err := s.Engine.GetRevision(engine.NewBranch("main", nil))
+		require.NoError(t, err)
+		isAncestor, err := s.Engine.Git().IsAncestor(context.Background(), mainRev, "a")
+		require.NoError(t, err)
+		require.True(t, isAncestor, "ancestor a must be restacked onto the new trunk before entering the conflict workflow")
 	})
 
 	t.Run("interactive restack prompts before entering conflict workflow", func(t *testing.T) {

--- a/internal/actions/restack_test.go
+++ b/internal/actions/restack_test.go
@@ -114,6 +114,17 @@ func TestRestackAction(t *testing.T) {
 		require.Equal(t, len(conflictBranches), jsonHandler.Result.ConflictCount)
 	})
 
+	t.Run("planning errors on a nonexistent branch", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+
+		_, err := PlanRestack(s.Context, RestackOptions{
+			BranchName: "does-not-exist",
+			Scope:      engine.StackRangeFull(),
+		})
+		require.ErrorContains(t, err, "branch does-not-exist does not exist")
+	})
+
 	t.Run("JSON restack reports conflicts without entering the workflow", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)

--- a/internal/actions/sync/restack.go
+++ b/internal/actions/sync/restack.go
@@ -145,6 +145,28 @@ func restackBranches(ctx *app.Context, branchesToRestack []string, restackScope 
 	return nil
 }
 
+// conflictStackBranches returns the full stack containing branchName (ancestors
+// and descendants, trunk excluded) in topological order — the branch set
+// ResolveConflictWorkflow needs to apply the held-back ancestors before
+// entering the conflict.
+func conflictStackBranches(ctx *app.Context, branchName string) engine.Branches {
+	nav := ctx.Navigator()
+	branch := nav.GetBranch(branchName)
+	graph := ctx.Engine.Graph(engine.SortStrategyAlphabetical)
+	stack := graph.Range(branch, engine.StackRange{
+		RecursiveParents:  true,
+		IncludeCurrent:    true,
+		RecursiveChildren: true,
+	})
+	builder := engine.NewBranchesBuilder(len(stack))
+	for _, b := range stack {
+		if b.IsTracked() && !b.IsTrunk() {
+			builder.Add(b)
+		}
+	}
+	return nav.SortBranchesTopologically(builder.Build())
+}
+
 // getPRNumber returns the PR number for a branch if it has one
 func getPRNumber(eng engine.BranchStatus, branchName string) *int {
 	branch := eng.GetBranch(branchName)

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -286,10 +286,14 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		}
 
 		if resolve {
-			// User wants to resolve conflicts - enter conflict workflow for the first conflict
+			// User wants to resolve conflicts. The restack above ran in
+			// ConflictModeContinue, which held back the whole conflicted stack
+			// — ancestors included — so re-run that stack in EnterWorkflow
+			// mode (applies ancestors, then enters the conflict) rather than
+			// jumping straight to the conflict branch; see
+			// actions.ResolveConflictWorkflow.
 			firstConflict := summary.ConflictBranches[0]
-			allBranches := ctx.Navigator().AllBranches()
-			return actions.EnterConflictWorkflow(ctx, firstConflict, allBranches)
+			return actions.ResolveConflictWorkflow(ctx, conflictStackBranches(ctx, firstConflict))
 		}
 		// User chose to skip conflicts - continue with summary
 	}

--- a/internal/cli/branch/absorb_test.go
+++ b/internal/cli/branch/absorb_test.go
@@ -304,7 +304,7 @@ func TestAbsorbComplex(t *testing.T) {
 		t.Fatal("stackit binary not built")
 	}
 
-	t.Run("absorb failure during restack preserves work and reports error", func(t *testing.T) {
+	t.Run("restack conflict after absorb holds the stack back and stays clean", func(t *testing.T) {
 		t.Parallel()
 		scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
 			// Create branch A
@@ -346,27 +346,33 @@ func TestAbsorbComplex(t *testing.T) {
 			return nil
 		})
 
-		// Run absorb. It should successfully absorb into branchA, but then fail during restack of branchB
+		// Run absorb. It absorbs into branchA; the follow-up restack of branchB
+		// conflicts, so branchB is held back and absorb still succeeds — the
+		// hunks are already committed, and entering the conflict workflow here
+		// would leave the repo mid-rebase while the deferred stash restore
+		// re-staged already-absorbed content.
 		cmd := exec.Command(binaryPath, "absorb", "--force")
 		cmd.Dir = scene.Dir
 		output, err := cmd.CombinedOutput()
 
-		require.Error(t, err, "absorb should fail during restack. Output: %s", string(output))
-		// The conflict-workflow error is silenced (instructions are printed
-		// instead), so assert on the printed conflict status.
-		require.Contains(t, string(output), "Hit conflict restacking branchB", "should report restack conflict")
+		require.NoError(t, err, "absorb must succeed despite the restack conflict. Output: %s", string(output))
+		require.Contains(t, string(output), "hit conflicts", "should report the held-back restack conflict")
+		require.Contains(t, string(output), "stackit restack", "should point at restack to resolve")
 
-		// In case of restack conflict, stackit stays in rebase mode (detached HEAD)
-		rebaseDir := scene.Dir + "/.git/rebase-merge"
-		if _, err := os.Stat(rebaseDir); os.IsNotExist(err) {
-			rebaseDir = scene.Dir + "/.git/rebase-apply"
+		// The repo must be clean: no rebase in progress, nothing staged.
+		for _, dir := range []string{"/.git/rebase-merge", "/.git/rebase-apply"} {
+			_, statErr := os.Stat(scene.Dir + dir)
+			require.True(t, os.IsNotExist(statErr), "must not be mid-rebase (%s exists)", dir)
 		}
-		_, err = os.Stat(rebaseDir)
-		require.NoError(t, err, "should be in middle of rebase")
+		staged := exec.Command("git", "diff", "--cached", "--quiet")
+		staged.Dir = scene.Dir
+		require.NoError(t, staged.Run(), "nothing may be re-staged after absorb")
 
-		// Clean up for next tests
-		cmd = exec.Command("git", "rebase", "--abort")
-		cmd.Dir = scene.Dir
-		_ = cmd.Run()
+		// The absorbed change is committed on branchA.
+		show := exec.Command("git", "show", "branchA:conflict.txt")
+		show.Dir = scene.Dir
+		content, err := show.CombinedOutput()
+		require.NoError(t, err)
+		require.Contains(t, string(content), "line 1 modified", "absorbed hunk must be committed")
 	})
 }

--- a/internal/engine/engine_internal.go
+++ b/internal/engine/engine_internal.go
@@ -137,8 +137,14 @@ func (e *engineImpl) shouldReparentBranch(ctx context.Context, parentBranchName 
 	}
 
 	// Worktree anchor branches should never be reparented - they are permanent parents
-	// for their stacks, even though they may be at trunk HEAD
-	if e.IsWorktreeAnchor(e.GetBranch(parentBranchName)) {
+	// for their stacks, even though they may be at trunk HEAD.
+	//
+	// Callers hold e.mu, so read the branch type via readState directly:
+	// IsWorktreeAnchor goes through GetBranchType, which re-acquires e.mu.RLock
+	// (deadlock if a writer is queued between the two RLocks) and may take
+	// e.mu.Lock via ensureBranchSharedLoaded — a self-deadlock on a
+	// lazily-loaded engine.
+	if state := e.readState(parentBranchName); state != nil && state.BranchType == git.BranchTypeWorktreeAnchor {
 		return false
 	}
 

--- a/internal/engine/rebase_validator.go
+++ b/internal/engine/rebase_validator.go
@@ -388,6 +388,13 @@ func (e *engineImpl) processValidationLevel(
 	for _, spec := range level.specs {
 		wg.Add(1)
 		go func(spec RebaseSpec) {
+			// wg.Done must be the FIRST defer registered so it runs LAST
+			// (defers are LIFO): the panic-recovery defer below sends on
+			// results, and the collector closes that channel once wg.Wait
+			// returns. Done firing before the send would let the close race
+			// the send — a panic in the last goroutine of a level would then
+			// crash the process on a closed channel instead of being reported.
+			defer wg.Done()
 			// Panic recovery at outermost level to ensure cleanup always happens
 			defer func() {
 				if r := recover(); r != nil {
@@ -399,7 +406,6 @@ func (e *engineImpl) processValidationLevel(
 					}
 				}
 			}()
-			defer wg.Done()
 
 			// Check parent context before acquiring semaphore so an outer cancel
 			// (e.g. user Ctrl+C) short-circuits queued siblings.

--- a/internal/engine/restack_plan.go
+++ b/internal/engine/restack_plan.go
@@ -35,16 +35,22 @@ func (e *engineImpl) PlanRestack(ctx context.Context, branches Branches) (*Resta
 			continue
 		}
 		plan.ApplyMap[item.Branch] = true
-		if item.Action == RestackPlanApplyAnchor {
-			// A moved anchor has to invalidate its children exactly like any
-			// other moved parent. Without this they stay "up to date" against
-			// the anchor's previous tip, so their recorded parent revision
-			// never catches up and every consumer reading it keeps drifting.
+		if item.Action == RestackPlanApplyAnchor || item.Action == RestackPlanApplyFrozen {
+			// A moved anchor or frozen branch has to invalidate its children
+			// exactly like any other moved parent. Without this they stay "up
+			// to date" against the parent's previous tip, so their recorded
+			// parent revision never catches up and every consumer reading it
+			// keeps drifting. For frozen this matters when the remote ref
+			// advanced: the branch hard-resets to the remote SHA, and its
+			// children must follow in the same pass.
 			plan.BranchMap[item.Branch] = true
 		}
 		if item.Action == RestackPlanApplyValidated {
 			specNewParent := item.NewParent
-			if parentItem, ok := plan.Items[item.NewParent]; ok && parentItem.Action == RestackPlanApplyAnchor && parentItem.TargetRev != "" {
+			// Anchor and frozen parents move to a known TargetRev at apply
+			// time; validate their children against that revision, not the
+			// parent's current (stale) ref.
+			if parentItem, ok := plan.Items[item.NewParent]; ok && parentItem.TargetRev != "" {
 				specNewParent = parentItem.TargetRev
 			} else if e.IsWorktreeAnchor(e.GetBranch(item.NewParent)) && item.ParentRev != "" {
 				if parentRev, ok := e.planRev(revMap, item.NewParent); ok && parentRev != item.ParentRev {

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -90,7 +90,7 @@ func AutoContinueRerereRebase(ctx context.Context, r Runner, originalErr error) 
 
 		unmergedFiles, err := applyRerereToUnmerged(ctx, r)
 		if err != nil {
-			return outcome, nil, originalErr
+			return outcome, nil, fmt.Errorf("failed to read unmerged files during rerere auto-continue: %s (rebase error: %w)", err.Error(), originalErr)
 		}
 		if len(unmergedFiles) > 0 {
 			return outcome, unmergedFiles, nil

--- a/internal/integration/frozen_integration_test.go
+++ b/internal/integration/frozen_integration_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -197,6 +198,38 @@ func TestFrozenIntegration(t *testing.T) {
 
 		// Child should not be frozen
 		s.Run("info feature-b").OutputNotContains("(frozen)")
+	})
+
+	t.Run("remote advance restacks children in the same pass", func(t *testing.T) {
+		t.Parallel()
+		s := NewTestShellInProcess(t)
+
+		// Stack: main -> f -> c
+		s.Run("create f").
+			WriteFile("f.txt", "f1").
+			Git("commit -m 'F1'")
+		s.Run("create c").
+			WriteFile("c.txt", "c1").
+			Git("commit -m 'C1'")
+
+		// Teammate advances f's remote: build a commit on top of f without
+		// moving the local ref, then point origin/f at it.
+		s.Git("checkout --detach f").
+			WriteFile("f2.txt", "f2").
+			Git("commit -m 'F2'").
+			Git("update-ref refs/remotes/origin/f HEAD")
+		s.Checkout("c")
+		s.Run("freeze f")
+
+		s.Run("restack")
+
+		// f must hard-reset to its remote SHA, and c must follow onto the
+		// new f in the same restack pass — not report "up to date" against
+		// f's stale pre-reset tip.
+		remoteSHA := strings.TrimSpace(s.Git("rev-parse refs/remotes/origin/f").lastOutput)
+		localSHA := strings.TrimSpace(s.Git("rev-parse f").lastOutput)
+		require.Equal(t, remoteSHA, localSHA, "frozen branch must reset to its remote SHA")
+		s.Git("merge-base --is-ancestor f c")
 	})
 
 	t.Run("unfreeze allows modifications", func(t *testing.T) {


### PR DESCRIPTION
This PR merges the following changes:

1. **#1545** fix(engine): restack frozen-branch children in the same pass
2. **#1550** fix(engine): harden restack internals against crashes and deadlocks
3. **#1546** fix(restack): make the interactive conflict-resolve prompt work mid-stack
4. **#1549** fix(restack): report conflicts as JSON instead of entering the workflow
5. **#1548** fix(absorb): never enter the conflict workflow from the post-absorb restack
6. **#1547** fix(restack): error on --branch with a nonexistent branch

### Stack

```
main
  └─ jonnii/20260801012714/restack-frozen-branch-children-in-the-same-pass (#1545)
    └─ jonnii/20260801013001/harden-restack-internals-against-crashes-and (#1550)
      └─ jonnii/20260801014747/make-the-interactive-conflict-resolve-prompt-work (#1546)
        └─ jonnii/20260801014937/report-conflicts-as-JSON-instead-of-entering-the (#1549)
          └─ jonnii/20260801015535/never-enter-the-conflict-workflow-from-the (#1548)
            └─ jonnii/20260801015702/error-on-branch-with-a-nonexistent-branch (#1547)
```

Stackit-Stack-Size: 6
Stackit-PRs: 1545,1550,1546,1549,1548,1547
