### PR TITLE
fix(worktree): guard stack mutations by owning worktree

### DIFF
--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -49,6 +49,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return err
 	}
 	currentBranch := eng.CurrentBranch()
+	if err := actions.EnsureCanModifyHere(ctx, *currentBranch); err != nil {
+		return err
+	}
 	opts.Restack = NormalizeRestackMode(opts.Restack)
 	if err := opts.Restack.Validate(); err != nil {
 		return err

--- a/internal/actions/create/create.go
+++ b/internal/actions/create/create.go
@@ -58,6 +58,9 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 		return Result{}, err
 	}
 	currentBranch := eng.CurrentBranch().GetName()
+	if err := actions.EnsureCanModifyNamesHere(ctx, currentBranch); err != nil {
+		return Result{}, err
+	}
 
 	h.Start(currentBranch)
 

--- a/internal/actions/fold/fold.go
+++ b/internal/actions/fold/fold.go
@@ -114,6 +114,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 			return err
 		}
 	}
+	if err := actions.EnsureCanModifyHere(ctx, currentBranchObj, parentBranch); err != nil {
+		return err
+	}
 
 	// Prohibit folding branches with different scopes
 	if !parentBranch.IsTrunk() {

--- a/internal/actions/modify.go
+++ b/internal/actions/modify.go
@@ -64,6 +64,9 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) (err error) {
 		targetBranchName = opts.Into
 	}
 	targetBranchObj := eng.GetBranch(targetBranchName)
+	if err := EnsureCanModifyNamesHere(ctx, originalBranchName, targetBranchName); err != nil {
+		return err
+	}
 
 	// Take snapshot before modifying the repository. modify was the only
 	// history-rewriting action without one, so `stackit undo` / `abort` fell

--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -66,6 +66,9 @@ func Action(ctx *app.Context, opts Options, h Handler) error {
 	if err != nil {
 		return err
 	}
+	if err := actions.EnsureCanModifyHere(ctx, plan.descendants.Concat(engine.BranchesOf(plan.ontoBranch))...); err != nil {
+		return err
+	}
 
 	if opts.DryRun {
 		return dryRun(ctx, plan.source, plan.oldParentName, plan.onto, plan.sourceBranch, plan.descendants, plan.rebaseSpecs)

--- a/internal/actions/reorder.go
+++ b/internal/actions/reorder.go
@@ -65,6 +65,9 @@ func ReorderAction(ctx *app.Context) error {
 				branch.GetName(), branch.IsTrunk(), branch.IsTracked())
 		}
 	}
+	if err := EnsureCanModifyNamesHere(ctx, branches...); err != nil {
+		return fmt.Errorf("cannot reorder stack: %w", err)
+	}
 	out.Debug("reorder: filtered to %d reorderable branches: %v", len(branches), branches)
 
 	// Minimum requirements: need at least 2 branches to reorder

--- a/internal/actions/split/split.go
+++ b/internal/actions/split/split.go
@@ -108,6 +108,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	if err := currentBranch.EnsureCanModify(); err != nil {
 		return err
 	}
+	if err := actions.EnsureCanModifyHere(ctx, *currentBranch); err != nil {
+		return err
+	}
 
 	// Check for uncommitted tracked changes
 	hasUnstaged, err := eng.HasUnstagedChanges(context)

--- a/internal/actions/squash.go
+++ b/internal/actions/squash.go
@@ -30,6 +30,9 @@ func SquashAction(ctx *app.Context, opts SquashOptions) error {
 	if err := currentBranch.EnsureCanModify(); err != nil {
 		return err
 	}
+	if err := EnsureCanModifyHere(ctx, *currentBranch); err != nil {
+		return err
+	}
 
 	// Log entry point for diagnostics
 	ctx.Logger.Info("squash started branch=%v", currentBranch.GetName())

--- a/internal/actions/worktree_ownership.go
+++ b/internal/actions/worktree_ownership.go
@@ -1,0 +1,70 @@
+package actions
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+)
+
+// EnsureCanModifyHere refuses to mutate a stack from anywhere other than its
+// managed worktree. The ownership relation is derived from the branch's stack
+// root, while the invocation location comes from the command context.
+//
+// Branch-level mutation checks deliberately do not live in engine.Branch:
+// Branch has no command context, and the same branch can be valid in one
+// worktree and invalid in another.
+func EnsureCanModifyHere(ctx *app.Context, branches ...engine.Branch) error {
+	seen := make(map[string]struct{}, len(branches))
+	for _, branch := range branches {
+		branchName := branch.GetName()
+		if branchName == "" {
+			continue
+		}
+		if _, ok := seen[branchName]; ok {
+			continue
+		}
+		seen[branchName] = struct{}{}
+
+		owner, err := ctx.Engine.OwningWorktree(branch)
+		if err != nil {
+			return fmt.Errorf("cannot determine worktree ownership for branch %s: %w", branchName, err)
+		}
+
+		if owner == nil {
+			if ctx.InManagedWorktree {
+				return fmt.Errorf("branch %s belongs to the main repository stack; run this command from %s", branchName, ctx.WorktreeInfo.MainRepoDir)
+			}
+			continue
+		}
+
+		if ctx.InManagedWorktree && ctx.WorktreeInfo != nil && ctx.WorktreeInfo.AnchorBranch == owner.AnchorBranch {
+			continue
+		}
+
+		return fmt.Errorf("branch %s belongs to worktree %s; run this command from there: cd %s", branchName, worktreeDisplayName(owner), owner.Path)
+	}
+
+	return nil
+}
+
+func worktreeDisplayName(worktree *engine.WorktreeInfo) string {
+	if worktree.Name != "" {
+		return worktree.Name
+	}
+	return worktree.AnchorBranch
+}
+
+// EnsureCanModifyNamesHere is the convenient form for operations that resolve
+// their targets as branch names before constructing a plan.
+func EnsureCanModifyNamesHere(ctx *app.Context, branchNames ...string) error {
+	uniqueNames := slices.Compact(slices.Sorted(slices.Values(branchNames)))
+	branches := make([]engine.Branch, 0, len(uniqueNames))
+	for _, name := range uniqueNames {
+		if name != "" {
+			branches = append(branches, ctx.Engine.GetBranch(name))
+		}
+	}
+	return EnsureCanModifyHere(ctx, branches...)
+}

--- a/internal/actions/worktree_ownership_test.go
+++ b/internal/actions/worktree_ownership_test.go
@@ -1,0 +1,53 @@
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+func TestEnsureCanModifyHere(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithInitialCommit()
+	s.CreateBranch("feature").Commit("feature change")
+	s.TrackBranch("feature", "main")
+	require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", "/tmp/feature-worktree", "feature-wt"))
+	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
+
+	t.Run("refuses managed stack mutation from main repository", func(t *testing.T) {
+		err := EnsureCanModifyHere(s.Context, s.Engine.GetBranch("feature"))
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "belongs to worktree feature-wt")
+		assert.ErrorContains(t, err, "cd /tmp/feature-worktree")
+	})
+
+	t.Run("allows mutation from owning worktree", func(t *testing.T) {
+		ctx := *s.Context
+		ctx.InManagedWorktree = true
+		ctx.WorktreeInfo = &engine.WorktreeInfo{
+			Name:         "feature-wt",
+			Path:         "/tmp/feature-worktree",
+			AnchorBranch: "feature",
+		}
+		require.NoError(t, EnsureCanModifyHere(&ctx, s.Engine.GetBranch("feature")))
+	})
+
+	t.Run("refuses main stack mutation from a managed worktree", func(t *testing.T) {
+		ctx := *s.Context
+		ctx.InManagedWorktree = true
+		ctx.WorktreeInfo = &engine.WorktreeInfo{
+			Name:         "feature-wt",
+			Path:         "/tmp/feature-worktree",
+			AnchorBranch: "feature",
+			MainRepoDir:  s.Context.RepoRoot,
+		}
+		err := EnsureCanModifyHere(&ctx, s.Engine.Trunk())
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "belongs to the main repository stack")
+	})
+}

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -243,6 +243,26 @@ func (e *engineImpl) GetWorktreeForStack(stackRoot string) (*WorktreeInfo, error
 	}, nil
 }
 
+// OwningWorktree returns the managed worktree for branch's stack. Stack
+// ownership is derived from the stack root, which is the worktree anchor for
+// stacks that have been attached to a managed worktree.
+func (e *engineImpl) OwningWorktree(branch Branch) (*WorktreeInfo, error) {
+	stackRoot := e.GetStackRootForBranch(branch)
+	if stackRoot == "" {
+		return nil, nil
+	}
+
+	worktree, err := e.GetWorktreeForStack(stackRoot)
+	if err != nil || worktree == nil {
+		return worktree, err
+	}
+	if worktree.AnchorBranch != stackRoot {
+		return nil, fmt.Errorf("invalid worktree registration for stack %s: metadata anchor is %s", stackRoot, worktree.AnchorBranch)
+	}
+
+	return worktree, nil
+}
+
 // ListManagedWorktrees returns all stackit-managed worktrees, sorted by stack root name
 func (e *engineImpl) ListManagedWorktrees() ([]WorktreeInfo, error) {
 	metas, err := e.git.ListWorktreeMetas()

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -307,6 +307,11 @@ type WorktreeRegistry interface {
 	UnregisterWorktree(ctx context.Context, stackRoot string) error
 	// GetWorktreeForStack returns worktree info for a stack root, or nil if none
 	GetWorktreeForStack(stackRoot string) (*WorktreeInfo, error)
+	// OwningWorktree returns the managed worktree that owns branch's stack, or
+	// nil when the branch belongs to an ordinary stack in the main repository.
+	// A malformed registration is returned as an error rather than being treated
+	// as unowned, so callers can fail closed before mutating the stack.
+	OwningWorktree(branch Branch) (*WorktreeInfo, error)
 	// ListManagedWorktrees returns all stackit-managed worktrees
 	ListManagedWorktrees() ([]WorktreeInfo, error)
 	// GetStackRootForBranch returns the stack root for a given branch

--- a/internal/engine/worktree_test.go
+++ b/internal/engine/worktree_test.go
@@ -52,6 +52,29 @@ func TestWorktreeRegistry_StackRootForBranch(t *testing.T) {
 	_ = s.Engine.UnregisterWorktree(s.Context, "branch1")
 }
 
+func TestWorktreeRegistry_OwningWorktree(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithInitialCommit()
+
+	s.CreateBranch("feature").Commit("feature change")
+	s.TrackBranch("feature", "main")
+	s.CreateBranch("feature-child").Commit("feature child change")
+	s.TrackBranch("feature-child", "feature")
+
+	require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", "/tmp/feature-worktree", "feature"))
+	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
+
+	owner, err := s.Engine.OwningWorktree(s.Engine.GetBranch("feature-child"))
+	require.NoError(t, err)
+	require.NotNil(t, owner)
+	assert.Equal(t, "feature", owner.AnchorBranch)
+	assert.Equal(t, "/tmp/feature-worktree", owner.Path)
+
+	owner, err = s.Engine.OwningWorktree(s.Engine.Trunk())
+	require.NoError(t, err)
+	assert.Nil(t, owner)
+}
+
 func TestCreateTemporaryWorktree(t *testing.T) {
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 

--- a/internal/integration/worktree_comprehensive_test.go
+++ b/internal/integration/worktree_comprehensive_test.go
@@ -467,11 +467,9 @@ func TestWorktreeRestackOperations(t *testing.T) {
 		shW.WriteFile("b.txt", "b").Run("create b -m 'branch b'")
 		shW.WriteFile("c.txt", "c").Run("create c -m 'branch c'")
 
-		// Modify root branch from main repo to trigger restack
-		sh.Checkout("feature").
-			WriteFile("feature-update.txt", "update").
-			Run("modify -n").
-			Checkout("main")
+		// Advance trunk from the main repository to trigger the restack.
+		sh.WriteFile("trunk-update.txt", "update").
+			Git("commit -m 'trunk update'")
 
 		// Restack from main
 		sh.Run("restack")
@@ -485,9 +483,9 @@ func TestWorktreeRestackOperations(t *testing.T) {
 		})
 
 		// Worktree should have the updated content
-		shW.Git("ls-files feature-update.txt")
+		shW.Git("ls-files trunk-update.txt")
 		if shW.Output() == "" {
-			t.Error("feature-update.txt should exist in worktree after restack")
+			t.Error("trunk-update.txt should exist in worktree after restack")
 		}
 	})
 
@@ -561,7 +559,7 @@ func TestWorktreeModifyOperations(t *testing.T) {
 		}
 	})
 
-	run("modify parent from main repo restacks worktree children", func(t *testing.T, sh *TestShell) {
+	run("modify parent from main repo rejects worktree stack", func(t *testing.T, sh *TestShell) {
 		// Create stack in worktree
 		sh.WriteFile("feature.txt", "feature").
 			Run("create feature -w -m 'feature branch'")
@@ -572,24 +570,12 @@ func TestWorktreeModifyOperations(t *testing.T) {
 		// Create child in worktree
 		shW.WriteFile("child.txt", "child").Run("create child -m 'child branch'")
 
-		// Modify parent from main repo
+		// Modifying an owned branch from the main checkout must fail closed.
 		sh.Checkout("feature").
 			WriteFile("feature-from-main.txt", "from main").
-			Run("modify -n").
-			Checkout("main")
-
-		// Worktree child should have the modified file
-		shW.Checkout("child").
-			Git("ls-files feature-from-main.txt")
-		if shW.Output() == "" {
-			t.Error("worktree child should have feature-from-main.txt")
-		}
-
-		// Worktree should be clean
-		shW.Git("status --porcelain")
-		if output := shW.Output(); output != "" {
-			t.Errorf("Worktree should be clean, but has:\n%s", output)
-		}
+			RunExpectError("modify -n").
+			OutputContains("belongs to worktree")
+		shW.OnBranch("child")
 	})
 }
 
@@ -706,8 +692,8 @@ func TestWorktreeEdgeCases(t *testing.T) {
 
 		sh.Checkout("feature").
 			WriteFile("feature-update.txt", "update").
-			Run("modify -n").
-			Checkout("main")
+			RunExpectError("modify -n").
+			OutputContains("belongs to worktree")
 
 		dirtyFile := filepath.Join(worktreePath, "uncommitted.txt")
 		if _, err := os.Stat(dirtyFile); os.IsNotExist(err) {
@@ -794,12 +780,12 @@ func TestWorktreeMoveOperations(t *testing.T) {
 		shW1.WriteFile("child.txt", "child").
 			Run("create child -m 'child'")
 
-		// Move child to stack2 (use --onto for the target)
+		// Moving into a separately owned stack must be run from its worktree.
 		shW1.Checkout("child").
-			Run("move --onto stack2")
+			RunExpectError("move --onto stack2").
+			OutputContains("belongs to worktree")
 
-		// Verify new parent
-		sh.ExpectBranchParent("child", "stack2")
+		sh.ExpectBranchParent("child", "stack1")
 	})
 }
 
@@ -1018,24 +1004,13 @@ func TestWorktreeComplexScenarios(t *testing.T) {
 		// Worktree is on grandchild
 		shW.OnBranch("grandchild")
 
-		// Modify feature from main repo (not in worktree)
+		// Modifying feature from the main repo must be rejected even though the
+		// managed worktree is currently on a descendant.
 		sh.Checkout("feature").
 			WriteFile("feature-update.txt", "updated").
-			Run("modify -n").
-			Checkout("main")
-
-		// Worktree should still be on grandchild and have the update
-		shW.OnBranch("grandchild").
-			Git("ls-files feature-update.txt")
-		if shW.Output() == "" {
-			t.Error("Grandchild should have feature-update.txt after modify")
-		}
-
-		// Working directory should be clean
-		shW.Git("status --porcelain")
-		if shW.Output() != "" {
-			t.Errorf("Worktree should be clean: %s", shW.Output())
-		}
+			RunExpectError("modify -n").
+			OutputContains("belongs to worktree")
+		shW.OnBranch("grandchild")
 	})
 }
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785685261`.


* **PR #1553** 👈
  * **PR #1554**
    * **PR #1555**
      * **PR #1556**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1563 by jonnii*