### PR TITLE
fix(worktree): enforce unique worktree registrations

### DIFF
--- a/internal/actions/checkout_test.go
+++ b/internal/actions/checkout_test.go
@@ -1,6 +1,7 @@
 package actions_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,6 +27,10 @@ func TestCheckoutActionWorktreeSwitchIncludesTargetBranch(t *testing.T) {
 
 	result, err := actions.CheckoutAction(s.Context, actions.CheckoutOptions{BranchName: "feature"}, nil)
 	require.NoError(t, err)
-	require.Equal(t, s.Context.RepoRoot, result.WorktreeSwitchPath)
+	canonicalRepoRoot, err := filepath.EvalSymlinks(s.Context.RepoRoot)
+	require.NoError(t, err)
+	canonicalWorktreeSwitchPath, err := filepath.EvalSymlinks(result.WorktreeSwitchPath)
+	require.NoError(t, err)
+	require.Equal(t, canonicalRepoRoot, canonicalWorktreeSwitchPath)
 	require.Equal(t, "feature", result.TargetBranch)
 }

--- a/internal/actions/sync/worktree_cleanup_test.go
+++ b/internal/actions/sync/worktree_cleanup_test.go
@@ -88,6 +88,10 @@ func TestSyncCleansOrphanedWorktrees(t *testing.T) {
 		wt, err := s.Engine.GetWorktreeForStack("missing-anchor")
 		require.NoError(t, err)
 		assert.NotNil(t, wt, "registration should be preserved when physical worktree removal fails")
-		assert.Equal(t, worktreePath, wt.Path)
+		canonicalWorktreePath, err := filepath.EvalSymlinks(worktreePath)
+		require.NoError(t, err)
+		canonicalRegisteredPath, err := filepath.EvalSymlinks(wt.Path)
+		require.NoError(t, err)
+		assert.Equal(t, canonicalWorktreePath, canonicalRegisteredPath)
 	})
 }

--- a/internal/actions/worktree/actions_test.go
+++ b/internal/actions/worktree/actions_test.go
@@ -2,6 +2,7 @@ package worktree_test
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -176,7 +177,11 @@ func TestOpenAction(t *testing.T) {
 			AnchorBranch: "feature-stack",
 		})
 		require.NoError(t, err)
-		require.Equal(t, repoRoot, path)
+		canonicalRepoRoot, err := filepath.EvalSymlinks(repoRoot)
+		require.NoError(t, err)
+		canonicalPath, err := filepath.EvalSymlinks(path)
+		require.NoError(t, err)
+		require.Equal(t, canonicalRepoRoot, canonicalPath)
 
 		// Clean up
 		_ = s.Engine.UnregisterWorktree(s.Context, "feature-stack")
@@ -341,7 +346,11 @@ func TestRepairAction(t *testing.T) {
 		repaired, err := s.Engine.GetWorktreeForStack(result.Repaired[0].AnchorBranch)
 		require.NoError(t, err)
 		require.NotNil(t, repaired)
-		require.Equal(t, worktreeDir, repaired.Path)
+		canonicalWorktreeDir, err := filepath.EvalSymlinks(worktreeDir)
+		require.NoError(t, err)
+		canonicalRepairedPath, err := filepath.EvalSymlinks(repaired.Path)
+		require.NoError(t, err)
+		require.Equal(t, canonicalWorktreeDir, canonicalRepairedPath)
 		require.True(t, s.Engine.GetBranch(result.Repaired[0].AnchorBranch).IsWorktreeAnchor())
 		require.Equal(t, result.Repaired[0].AnchorBranch, s.Engine.GetBranch("feature").GetParent().GetName())
 

--- a/internal/actions/worktree/repair.go
+++ b/internal/actions/worktree/repair.go
@@ -120,11 +120,11 @@ func repairEntry(ctx *app.Context, entry Entry) (RepairEntry, error) {
 			if existing != nil && existing.Path != wtInfo.Path {
 				return RepairEntry{}, fmt.Errorf("cannot repair %s automatically because anchor %s is already registered to %s", output.BranchName(entry.displayName()), output.BranchName(stackRootName), existing.Path)
 			}
-			if err := ctx.Engine.RegisterWorktreeWithName(stackRootName, wtInfo.Path, wtInfo.Name); err != nil {
-				return RepairEntry{}, fmt.Errorf("failed to register worktree under anchor %s: %w", stackRootName, err)
-			}
-			if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
-				_ = ctx.Engine.UnregisterWorktree(ctx.Context, stackRootName)
+			if existing == nil {
+				if err := moveRegistration(ctx, *wtInfo, stackRootName); err != nil {
+					return RepairEntry{}, err
+				}
+			} else if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
 				return RepairEntry{}, fmt.Errorf("failed to remove stale registration %s: %w", output.BranchName(wtInfo.AnchorBranch), err)
 			}
 			return RepairEntry{
@@ -146,6 +146,23 @@ func repairEntry(ctx *app.Context, entry Entry) (RepairEntry, error) {
 	}
 
 	return RepairEntry{}, fmt.Errorf("registration is already healthy")
+}
+
+// moveRegistration transfers a registration after the caller has established
+// that the destination anchor is safe. The registry's reverse path claim is
+// exclusive, so the old claim must be removed before creating the new one.
+// Restore the old registration if the replacement fails.
+func moveRegistration(ctx *app.Context, from engine.WorktreeInfo, toAnchor string) error {
+	if err := ctx.Engine.UnregisterWorktree(ctx.Context, from.AnchorBranch); err != nil {
+		return fmt.Errorf("failed to remove stale registration %s: %w", output.BranchName(from.AnchorBranch), err)
+	}
+	if err := ctx.Engine.RegisterWorktreeWithName(toAnchor, from.Path, from.Name); err != nil {
+		if restoreErr := ctx.Engine.RegisterWorktreeWithName(from.AnchorBranch, from.Path, from.Name); restoreErr != nil {
+			return fmt.Errorf("failed to register worktree under anchor %s: %w (also failed to restore %s: %w)", toAnchor, err, output.BranchName(from.AnchorBranch), restoreErr)
+		}
+		return fmt.Errorf("failed to register worktree under anchor %s: %w", toAnchor, err)
+	}
+	return nil
 }
 
 func convertLegacyRegistration(ctx *app.Context, wtInfo engine.WorktreeInfo, rootBranchName string) (string, error) {
@@ -185,9 +202,13 @@ func convertLegacyRegistration(ctx *app.Context, wtInfo engine.WorktreeInfo, roo
 	anchorCreated := true
 	rootReparented := false
 	registered := false
+	legacyUnregistered := false
 	cleanup := func() {
 		if registered {
 			_ = ctx.Engine.UnregisterWorktree(ctx.Context, anchorBranchName)
+		}
+		if legacyUnregistered {
+			_ = ctx.Engine.RegisterWorktreeWithName(wtInfo.AnchorBranch, wtInfo.Path, wtInfo.Name)
 		}
 		if rootReparented {
 			_ = ctx.Engine.ReparentBranch(ctx.Context, ctx.Engine.GetBranch(rootBranchName), ctx.Engine.GetBranch(originalParent))
@@ -216,14 +237,18 @@ func convertLegacyRegistration(ctx *app.Context, wtInfo engine.WorktreeInfo, roo
 		return "", fmt.Errorf("failed to reparent %s under anchor %s: %w", output.BranchName(rootBranchName), output.BranchName(anchorBranchName), err)
 	}
 	rootReparented = true
+	// The path's reverse registration claim is intentionally exclusive. Remove
+	// the legacy forward claim before creating the anchored one; cleanup restores
+	// it if the new registration cannot be written.
+	if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
+		cleanup()
+		return "", fmt.Errorf("failed to remove legacy registration %s: %w", output.BranchName(wtInfo.AnchorBranch), err)
+	}
+	legacyUnregistered = true
 	if err := ctx.Engine.RegisterWorktreeWithName(anchorBranchName, wtInfo.Path, wtInfo.Name); err != nil {
 		cleanup()
 		return "", fmt.Errorf("failed to register worktree under anchor %s: %w", output.BranchName(anchorBranchName), err)
 	}
 	registered = true
-	if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
-		cleanup()
-		return "", fmt.Errorf("failed to remove legacy registration %s: %w", output.BranchName(wtInfo.AnchorBranch), err)
-	}
 	return anchorBranchName, nil
 }

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -203,9 +203,29 @@ func (e *engineImpl) RegisterWorktree(stackRoot string, path string) error {
 
 // RegisterWorktreeWithName registers a worktree with a user-friendly name
 func (e *engineImpl) RegisterWorktreeWithName(anchorBranch string, path string, name string) error {
-	absPath, err := filepath.Abs(path)
+	absPath, err := canonicalWorktreePath(path)
 	if err != nil {
-		return fmt.Errorf("failed to get absolute path: %w", err)
+		return fmt.Errorf("failed to canonicalize worktree path: %w", err)
+	}
+
+	if existing, err := e.GetWorktreeForStack(anchorBranch); err != nil {
+		return fmt.Errorf("failed to check existing worktree registration: %w", err)
+	} else if existing != nil {
+		return fmt.Errorf("worktree anchor %s is already registered at %s", anchorBranch, existing.Path)
+	}
+
+	worktrees, err := e.ListManagedWorktrees()
+	if err != nil {
+		return fmt.Errorf("failed to list worktree registrations: %w", err)
+	}
+	for _, worktree := range worktrees {
+		worktreePath, pathErr := canonicalWorktreePath(worktree.Path)
+		if pathErr != nil {
+			return fmt.Errorf("failed to canonicalize registered worktree path %s: %w", worktree.Path, pathErr)
+		}
+		if worktreePath == absPath && worktree.AnchorBranch != anchorBranch {
+			return fmt.Errorf("worktree path %s is already registered to anchor %s", absPath, worktree.AnchorBranch)
+		}
 	}
 
 	meta := &git.WorktreeMeta{
@@ -217,6 +237,21 @@ func (e *engineImpl) RegisterWorktreeWithName(anchorBranch string, path string, 
 	}
 
 	return e.git.WriteWorktreeMeta(anchorBranch, meta)
+}
+
+func canonicalWorktreePath(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolvedPath, err := filepath.EvalSymlinks(absPath)
+	if err == nil {
+		return filepath.Clean(resolvedPath), nil
+	}
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+	return filepath.Clean(absPath), nil
 }
 
 // UnregisterWorktree removes worktree registration for a stack root

--- a/internal/engine/worktree_test.go
+++ b/internal/engine/worktree_test.go
@@ -75,6 +75,22 @@ func TestWorktreeRegistry_OwningWorktree(t *testing.T) {
 	assert.Nil(t, owner)
 }
 
+func TestWorktreeRegistry_RejectsDuplicatePathAndAnchor(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithInitialCommit()
+
+	require.NoError(t, s.Engine.RegisterWorktreeWithName("feature-a", "/tmp/shared-worktree", "feature-a"))
+	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature-a") })
+
+	err := s.Engine.RegisterWorktreeWithName("feature-b", "/tmp/shared-worktree", "feature-b")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "already registered to anchor feature-a")
+
+	err = s.Engine.RegisterWorktreeWithName("feature-a", "/tmp/other-worktree", "feature-a")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "anchor feature-a is already registered")
+}
+
 func TestCreateTemporaryWorktree(t *testing.T) {
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -12,6 +13,17 @@ import (
 
 // WorktreeRefPrefix is the prefix for Git refs where worktree metadata is stored (local-only)
 const WorktreeRefPrefix = "refs/stackit/worktrees/"
+
+// WorktreePathRefPrefix is a reverse index from canonical worktree path to
+// its anchor registration. Keeping this alongside WorktreeRefPrefix lets a
+// single update-ref transaction enforce both directions of the ownership
+// invariant.
+const WorktreePathRefPrefix = "refs/stackit/worktree-paths/"
+
+func worktreePathRef(path string) string {
+	hash := sha256.Sum256([]byte(path))
+	return fmt.Sprintf("%s%x", WorktreePathRefPrefix, hash)
+}
 
 // Worktree represents a single entry from `git worktree list`.
 type Worktree struct {
@@ -232,9 +244,18 @@ func (r *runner) WriteWorktreeMeta(stackRoot string, meta *WorktreeMeta) error {
 		return fmt.Errorf("failed to create worktree metadata blob: %w", err)
 	}
 
-	refName := fmt.Sprintf("%s%s", WorktreeRefPrefix, stackRoot)
-	if err := r.UpdateRef(refName, sha); err != nil {
-		return fmt.Errorf("failed to write worktree metadata ref: %w", err)
+	// Both refs are created only when absent. The forward ref protects one
+	// anchor from receiving two registrations; the reverse ref protects one
+	// path from being claimed by two anchors. update-ref applies the pair
+	// atomically, so a competing registration loses cleanly instead of creating
+	// an ambiguous ownership state.
+	zeroSHA := strings.Repeat("0", len(sha))
+	updates := []RefUpdate{
+		{RefName: fmt.Sprintf("%s%s", WorktreeRefPrefix, stackRoot), NewSHA: sha, OldSHA: zeroSHA},
+		{RefName: worktreePathRef(meta.Path), NewSHA: sha, OldSHA: zeroSHA},
+	}
+	if err := r.UpdateRefsBatch(context.Background(), updates); err != nil {
+		return fmt.Errorf("failed to register worktree metadata refs: %w", err)
 	}
 
 	return nil
@@ -243,7 +264,30 @@ func (r *runner) WriteWorktreeMeta(stackRoot string, meta *WorktreeMeta) error {
 // DeleteWorktreeMeta deletes worktree metadata for a stack root
 func (r *runner) DeleteWorktreeMeta(ctx context.Context, stackRoot string) error {
 	refName := fmt.Sprintf("%s%s", WorktreeRefPrefix, stackRoot)
-	return r.DeleteRef(ctx, refName)
+	sha, err := r.GetRef(refName)
+	if err != nil {
+		// Preserve DeleteRef's idempotent behavior for absent legacy metadata.
+		return r.DeleteRef(ctx, refName)
+	}
+
+	meta, err := r.ReadWorktreeMeta(stackRoot)
+	if err != nil {
+		return err
+	}
+	updates := []RefUpdate{{RefName: refName, OldSHA: sha, IsDelete: true}}
+	if meta != nil {
+		pathRef := worktreePathRef(meta.Path)
+		if pathSHA, pathErr := r.GetRef(pathRef); pathErr == nil {
+			if pathSHA != sha {
+				return fmt.Errorf("worktree path index for %s does not match its anchor registration", meta.Path)
+			}
+			updates = append(updates, RefUpdate{RefName: pathRef, OldSHA: sha, IsDelete: true})
+		}
+	}
+	if err := r.UpdateRefsBatch(ctx, updates); err != nil {
+		return fmt.Errorf("failed to unregister worktree metadata refs: %w", err)
+	}
+	return nil
 }
 
 // GetWorktreePathForBranch returns the worktree path where a branch is checked out.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785685261`.


* **PR #1553**
  * **PR #1554** 👈
    * **PR #1555**
      * **PR #1556**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1563 by jonnii*