### PR TITLE
fix(worktree): preserve registrations during repair

### DIFF
--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -297,10 +297,9 @@ func (r *runner) DeleteWorktreeMeta(ctx context.Context, stackRoot string) error
 	if meta != nil {
 		pathRef := worktreePathRef(meta.Path)
 		if pathSHA, pathErr := r.GetRef(pathRef); pathErr == nil {
-			if pathSHA != sha {
-				return fmt.Errorf("worktree path index for %s does not match its anchor registration", meta.Path)
+			if pathSHA == sha {
+				updates = append(updates, RefUpdate{RefName: pathRef, OldSHA: sha, IsDelete: true})
 			}
-			updates = append(updates, RefUpdate{RefName: pathRef, OldSHA: sha, IsDelete: true})
 		}
 	}
 	if err := r.UpdateRefsBatch(ctx, updates); err != nil {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785685261`.


* **PR #1553**
  * **PR #1554**
    * **PR #1555**
      * **PR #1556** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1563 by jonnii*