### PR TITLE
refactor(tui): replace BranchStyle's positional bools with an options struct

### DIFF
--- a/internal/tui/style/formatter.go
+++ b/internal/tui/style/formatter.go
@@ -73,13 +73,13 @@ func FormatShortLine(line string, circleIndex, arrowIndex int, isCurrent bool, o
 
 // ColorBranchName colors a branch name that is not the current branch.
 func ColorBranchName(branchName string) string {
-	return BranchStyle(false, false, false).Render(branchName)
+	return BranchStyle(BranchStyleOpts{}).Render(branchName)
 }
 
 // ColorCurrentBranch colors the checked-out branch and appends its
 // " (current)" marker.
 func ColorCurrentBranch(branchName string) string {
-	return BranchStyle(true, false, false).Render(branchName + " (current)")
+	return BranchStyle(BranchStyleOpts{IsCurrent: true}).Render(branchName + " (current)")
 }
 
 // ColorBranchNameIf renders the current-branch style (with the " (current)"
@@ -99,25 +99,32 @@ func ColorBranchNameWithTrunk(branchName string, isCurrent bool, isTrunk bool) s
 	if isCurrent {
 		name += " (current)"
 	}
-	return BranchStyle(isCurrent, isTrunk, false).Render(name)
+	return BranchStyle(BranchStyleOpts{IsCurrent: isCurrent, IsTrunk: isTrunk}).Render(name)
 }
 
 // ColorBranchNamePlain colors a branch name by current/trunk status without
 // appending the " (current)" marker, for callers that already convey
 // currency another way (e.g. a leading cursor or row highlight).
 func ColorBranchNamePlain(branchName string, isCurrent, isTrunk bool) string {
-	return BranchStyle(isCurrent, isTrunk, false).Render(branchName)
+	return BranchStyle(BranchStyleOpts{IsCurrent: isCurrent, IsTrunk: isTrunk}).Render(branchName)
+}
+
+// BranchStyleOpts configures the appearance BranchStyle renders.
+type BranchStyleOpts struct {
+	IsCurrent bool
+	IsTrunk   bool
+	IsDim     bool
 }
 
 // BranchStyle returns the unified style for a branch name
-func BranchStyle(isCurrent, isTrunk, isDim bool) lipgloss.Style {
-	if isDim {
+func BranchStyle(opts BranchStyleOpts) lipgloss.Style {
+	if opts.IsDim {
 		return lipgloss.NewStyle().Foreground(colorDimValue())
 	}
-	if isCurrent {
+	if opts.IsCurrent {
 		return lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Bold(true) // Bold Green
 	}
-	if isTrunk {
+	if opts.IsTrunk {
 		// Distinct color for main/trunk: Pink (205)
 		return lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
 	}

--- a/internal/tui/style/theme.go
+++ b/internal/tui/style/theme.go
@@ -70,7 +70,7 @@ func DefaultCommonStyles() CommonStyles {
 		Bold:    lipgloss.NewStyle().Bold(true),
 		Dim:     DimStyle(),
 		Subtle:  SubtleStyle(),
-		Branch:  BranchStyle(false, false, false),
+		Branch:  BranchStyle(BranchStyleOpts{}),
 		URL:     DimStyle(),
 		Spinner: lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPrimary)),
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -78,7 +78,7 @@ func NewSubmitTUIModel(items []submit.Item, submitFunc func(idx int) tea.Cmd) Su
 			spinnerStyle: lipgloss.NewStyle().Foreground(lipgloss.Color("205")),
 			doneStyle:    lipgloss.NewStyle().Foreground(lipgloss.Color("42")),
 			errorStyle:   lipgloss.NewStyle().Foreground(lipgloss.Color("196")),
-			branchStyle:  style.BranchStyle(false, false, false).Bold(true),
+			branchStyle:  style.BranchStyle(style.BranchStyleOpts{}).Bold(true),
 			urlStyle:     style.DimStyle(),
 			dimStyle:     style.SubtleStyle(),
 		},


### PR DESCRIPTION
## Summary
- `BranchStyle(isCurrent, isTrunk, isDim bool)` was called with bare boolean literals at every call site (e.g. `BranchStyle(true, false, false)`, `BranchStyle(false, false, false)`), which is exactly the unclear-boolean-parameter anti-pattern flagged in this repo's own `.claude/rules/code-style.md`.
- Replaced the three positional bools with a `BranchStyleOpts{IsCurrent, IsTrunk, IsDim bool}` struct so every call site is self-documenting (e.g. `BranchStyle(BranchStyleOpts{IsCurrent: true})` instead of `BranchStyle(true, false, false)`).
- Updated all 6 call sites across `internal/tui/style/formatter.go`, `internal/tui/style/theme.go`, and `internal/tui/tui.go`. No behavior change.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/tui/...`
- [x] `go test ./internal/tui/...` (all pass)
- [x] `gofmt -l` on changed files (clean)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVKBQRtRqoyjjVYUDQCeiV)_