### PR TITLE
Merging 4 PRs

### DIFF
--- a/internal/actions/absorb/absorb.go
+++ b/internal/actions/absorb/absorb.go
@@ -49,6 +49,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		return err
 	}
 	currentBranch := eng.CurrentBranch()
+	if err := actions.EnsureCanModifyHere(ctx, *currentBranch); err != nil {
+		return err
+	}
 	opts.Restack = NormalizeRestackMode(opts.Restack)
 	if err := opts.Restack.Validate(); err != nil {
 		return err

--- a/internal/actions/checkout_test.go
+++ b/internal/actions/checkout_test.go
@@ -1,6 +1,7 @@
 package actions_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,6 +27,10 @@ func TestCheckoutActionWorktreeSwitchIncludesTargetBranch(t *testing.T) {
 
 	result, err := actions.CheckoutAction(s.Context, actions.CheckoutOptions{BranchName: "feature"}, nil)
 	require.NoError(t, err)
-	require.Equal(t, s.Context.RepoRoot, result.WorktreeSwitchPath)
+	canonicalRepoRoot, err := filepath.EvalSymlinks(s.Context.RepoRoot)
+	require.NoError(t, err)
+	canonicalWorktreeSwitchPath, err := filepath.EvalSymlinks(result.WorktreeSwitchPath)
+	require.NoError(t, err)
+	require.Equal(t, canonicalRepoRoot, canonicalWorktreeSwitchPath)
 	require.Equal(t, "feature", result.TargetBranch)
 }

--- a/internal/actions/create/create.go
+++ b/internal/actions/create/create.go
@@ -58,6 +58,13 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 		return Result{}, err
 	}
 	currentBranch := eng.CurrentBranch().GetName()
+	requestedParent := currentBranch
+	if opts.Onto != "" {
+		requestedParent = opts.Onto
+	}
+	if ctx.InManagedWorktree && ctx.WorktreeInfo != nil && requestedParent == eng.Trunk().GetName() {
+		return Result{}, fmt.Errorf("cannot create a branch from trunk inside managed worktree %s; first check out a branch owned by this worktree", ctx.WorktreeInfo.Name)
+	}
 	if err := actions.EnsureCanModifyNamesHere(ctx, currentBranch); err != nil {
 		return Result{}, err
 	}
@@ -82,6 +89,9 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 			return Result{}, fmt.Errorf("--onto cannot be combined with --insert/-i")
 		}
 		if err := validateOntoTarget(eng, opts.Onto); err != nil {
+			return Result{}, err
+		}
+		if err := actions.EnsureCanModifyNamesHere(ctx, opts.Onto); err != nil {
 			return Result{}, err
 		}
 	}

--- a/internal/actions/create/create.go
+++ b/internal/actions/create/create.go
@@ -58,6 +58,9 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 		return Result{}, err
 	}
 	currentBranch := eng.CurrentBranch().GetName()
+	if err := actions.EnsureCanModifyNamesHere(ctx, currentBranch); err != nil {
+		return Result{}, err
+	}
 
 	h.Start(currentBranch)
 

--- a/internal/actions/create/create_test.go
+++ b/internal/actions/create/create_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
@@ -50,6 +51,20 @@ func TestCreateAction_Stdin(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, commits, expectedMessage)
 	})
+}
+
+func TestCreateAction_RefusesTrunkInManagedWorktree(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithInitialCommit()
+	s.Context.InManagedWorktree = true
+	s.Context.WorktreeInfo = &engine.WorktreeInfo{
+		Name:         "feature-wt",
+		AnchorBranch: "feature-wt-anchor",
+	}
+
+	_, err := Action(s.Context, Options{BranchName: "new-branch", Message: "test"}, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "cannot create a branch from trunk inside managed worktree feature-wt")
 }
 
 func TestCreateAction_Insert(t *testing.T) {

--- a/internal/actions/fold/fold.go
+++ b/internal/actions/fold/fold.go
@@ -114,6 +114,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 			return err
 		}
 	}
+	if err := actions.EnsureCanModifyHere(ctx, currentBranchObj, parentBranch); err != nil {
+		return err
+	}
 
 	// Prohibit folding branches with different scopes
 	if !parentBranch.IsTrunk() {

--- a/internal/actions/modify.go
+++ b/internal/actions/modify.go
@@ -64,6 +64,9 @@ func ModifyAction(ctx *app.Context, opts ModifyOptions) (err error) {
 		targetBranchName = opts.Into
 	}
 	targetBranchObj := eng.GetBranch(targetBranchName)
+	if err := EnsureCanModifyNamesHere(ctx, originalBranchName, targetBranchName); err != nil {
+		return err
+	}
 
 	// Take snapshot before modifying the repository. modify was the only
 	// history-rewriting action without one, so `stackit undo` / `abort` fell

--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -66,6 +66,9 @@ func Action(ctx *app.Context, opts Options, h Handler) error {
 	if err != nil {
 		return err
 	}
+	if err := actions.EnsureCanModifyHere(ctx, plan.descendants.Concat(engine.BranchesOf(plan.ontoBranch))...); err != nil {
+		return err
+	}
 
 	if opts.DryRun {
 		return dryRun(ctx, plan.source, plan.oldParentName, plan.onto, plan.sourceBranch, plan.descendants, plan.rebaseSpecs)

--- a/internal/actions/reorder.go
+++ b/internal/actions/reorder.go
@@ -65,6 +65,9 @@ func ReorderAction(ctx *app.Context) error {
 				branch.GetName(), branch.IsTrunk(), branch.IsTracked())
 		}
 	}
+	if err := EnsureCanModifyNamesHere(ctx, branches...); err != nil {
+		return fmt.Errorf("cannot reorder stack: %w", err)
+	}
 	out.Debug("reorder: filtered to %d reorderable branches: %v", len(branches), branches)
 
 	// Minimum requirements: need at least 2 branches to reorder

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -148,6 +148,15 @@ func RestackAction(ctx *app.Context, plan *RestackPlan, handler handlers.Restack
 	// Parallel mode dispatches each group to a worktree that recomputes its own
 	// plan, so the plan resolved here does not decide what those workers do.
 	parallelDispatch := opts.Parallel && len(plan.groups) > 1
+	if !parallelDispatch {
+		branches := engine.Branches{}
+		for _, group := range plan.groups {
+			branches = branches.Concat(group.sortedBranches)
+		}
+		if err := EnsureCanModifyHere(ctx, branches...); err != nil {
+			return err
+		}
+	}
 
 	// Take snapshot before modifying the repository. Skip it when no branch
 	// actually needs a rebase: an up-to-date restack mutates nothing, so there

--- a/internal/actions/split/split.go
+++ b/internal/actions/split/split.go
@@ -108,6 +108,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	if err := currentBranch.EnsureCanModify(); err != nil {
 		return err
 	}
+	if err := actions.EnsureCanModifyHere(ctx, *currentBranch); err != nil {
+		return err
+	}
 
 	// Check for uncommitted tracked changes
 	hasUnstaged, err := eng.HasUnstagedChanges(context)

--- a/internal/actions/squash.go
+++ b/internal/actions/squash.go
@@ -30,6 +30,9 @@ func SquashAction(ctx *app.Context, opts SquashOptions) error {
 	if err := currentBranch.EnsureCanModify(); err != nil {
 		return err
 	}
+	if err := EnsureCanModifyHere(ctx, *currentBranch); err != nil {
+		return err
+	}
 
 	// Log entry point for diagnostics
 	ctx.Logger.Info("squash started branch=%v", currentBranch.GetName())

--- a/internal/actions/sync/worktree_cleanup_test.go
+++ b/internal/actions/sync/worktree_cleanup_test.go
@@ -88,6 +88,10 @@ func TestSyncCleansOrphanedWorktrees(t *testing.T) {
 		wt, err := s.Engine.GetWorktreeForStack("missing-anchor")
 		require.NoError(t, err)
 		assert.NotNil(t, wt, "registration should be preserved when physical worktree removal fails")
-		assert.Equal(t, worktreePath, wt.Path)
+		canonicalWorktreePath, err := filepath.EvalSymlinks(worktreePath)
+		require.NoError(t, err)
+		canonicalRegisteredPath, err := filepath.EvalSymlinks(wt.Path)
+		require.NoError(t, err)
+		assert.Equal(t, canonicalWorktreePath, canonicalRegisteredPath)
 	})
 }

--- a/internal/actions/track/action.go
+++ b/internal/actions/track/action.go
@@ -3,6 +3,7 @@ package track
 import (
 	"fmt"
 
+	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/output"
 )
@@ -23,6 +24,17 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	eng := ctx.Engine
 	branchName := opts.BranchName
+	if branchName == "" {
+		currentBranch := eng.CurrentBranch()
+		if currentBranch != nil {
+			branchName = currentBranch.GetName()
+		}
+	}
+	if branchName != "" {
+		if err := actions.EnsureCanModifyNamesHere(ctx, branchName); err != nil {
+			return err
+		}
+	}
 
 	// Opportunistically configure the metadata fetch refspec so a plain
 	// `git fetch` keeps pulling branch metadata. Local, idempotent, and a no-op

--- a/internal/actions/worktree/actions_test.go
+++ b/internal/actions/worktree/actions_test.go
@@ -2,6 +2,7 @@ package worktree_test
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -176,7 +177,11 @@ func TestOpenAction(t *testing.T) {
 			AnchorBranch: "feature-stack",
 		})
 		require.NoError(t, err)
-		require.Equal(t, repoRoot, path)
+		canonicalRepoRoot, err := filepath.EvalSymlinks(repoRoot)
+		require.NoError(t, err)
+		canonicalPath, err := filepath.EvalSymlinks(path)
+		require.NoError(t, err)
+		require.Equal(t, canonicalRepoRoot, canonicalPath)
 
 		// Clean up
 		_ = s.Engine.UnregisterWorktree(s.Context, "feature-stack")
@@ -341,7 +346,11 @@ func TestRepairAction(t *testing.T) {
 		repaired, err := s.Engine.GetWorktreeForStack(result.Repaired[0].AnchorBranch)
 		require.NoError(t, err)
 		require.NotNil(t, repaired)
-		require.Equal(t, worktreeDir, repaired.Path)
+		canonicalWorktreeDir, err := filepath.EvalSymlinks(worktreeDir)
+		require.NoError(t, err)
+		canonicalRepairedPath, err := filepath.EvalSymlinks(repaired.Path)
+		require.NoError(t, err)
+		require.Equal(t, canonicalWorktreeDir, canonicalRepairedPath)
 		require.True(t, s.Engine.GetBranch(result.Repaired[0].AnchorBranch).IsWorktreeAnchor())
 		require.Equal(t, result.Repaired[0].AnchorBranch, s.Engine.GetBranch("feature").GetParent().GetName())
 

--- a/internal/actions/worktree/actions_test.go
+++ b/internal/actions/worktree/actions_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/getstackit/stackit/internal/actions/worktree"
@@ -66,6 +67,29 @@ func TestListAction(t *testing.T) {
 		require.Equal(t, []string{"feature"}, result.Worktrees[0].RootBranches)
 
 		_ = s.Engine.UnregisterWorktree(s.Context, "feature")
+	})
+
+	t.Run("reports branch checked out outside its owning worktree", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+		s.CreateBranch("feature").Commit("feature change")
+		s.TrackBranch("feature", "main")
+		s.Checkout("main")
+
+		worktreeDir := t.TempDir()
+		require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", worktreeDir, "feature-wt"))
+		t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
+
+		// Simulate raw `git checkout feature` from the main repository, bypassing
+		// Stackit's checkout redirect.
+		s.Checkout("feature")
+
+		result, err := worktree.ListAction(s.Context, worktree.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, result.OwnershipWarnings, 1)
+		assert.Contains(t, result.OwnershipWarnings[0], "branch feature belongs to managed worktree feature-wt")
+		assert.Contains(t, result.OwnershipWarnings[0], "but is checked out at")
 	})
 }
 

--- a/internal/actions/worktree/entry.go
+++ b/internal/actions/worktree/entry.go
@@ -3,6 +3,8 @@ package worktree
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"slices"
 
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
@@ -26,6 +28,10 @@ const (
 type ListResult struct {
 	Worktrees     []Entry
 	CurrentAnchor string // Anchor branch of the worktree we're currently in (if any)
+	// OwnershipWarnings report branches whose physical checkout location does
+	// not agree with Stackit's derived ownership model. They are warnings so
+	// `worktree list` remains useful for diagnosing a damaged repository.
+	OwnershipWarnings []string `json:"ownership_warnings,omitempty"`
 }
 
 // Entry represents a single managed worktree
@@ -179,7 +185,82 @@ func listEntries(ctx *app.Context, opts ListOptions) (*ListResult, error) {
 		result.Worktrees = append(result.Worktrees, entry)
 	}
 
+	result.OwnershipWarnings = ownershipWarnings(ctx)
+
 	return result, nil
+}
+
+func ownershipWarnings(ctx *app.Context) []string {
+	gitWorktrees, err := ctx.Engine.ListWorktrees(ctx.Context)
+	if err != nil {
+		return []string{fmt.Sprintf("could not inspect Git worktrees for ownership conflicts: %v", err)}
+	}
+
+	mainRepoPath, err := canonicalPath(ctx.Engine.GetRepoRoot())
+	if err != nil {
+		return []string{fmt.Sprintf("could not canonicalize the main repository path: %v", err)}
+	}
+
+	warnings := make([]string, 0)
+	for _, gitWorktree := range gitWorktrees {
+		if gitWorktree.Branch == "" {
+			// Porcelain does not identify the branch for detached worktrees, so
+			// it cannot establish stack ownership without a more expensive
+			// commit-membership scan.
+			continue
+		}
+
+		actualPath, pathErr := canonicalPath(gitWorktree.Path)
+		if pathErr != nil {
+			warnings = append(warnings, fmt.Sprintf("could not canonicalize Git worktree path %s: %v", gitWorktree.Path, pathErr))
+			continue
+		}
+
+		owner, ownerErr := ctx.Engine.OwningWorktree(ctx.Engine.GetBranch(gitWorktree.Branch))
+		if ownerErr != nil {
+			warnings = append(warnings, fmt.Sprintf("could not determine owner for branch %s checked out at %s: %v", gitWorktree.Branch, gitWorktree.Path, ownerErr))
+			continue
+		}
+		if owner == nil {
+			if actualPath != mainRepoPath {
+				warnings = append(warnings, fmt.Sprintf("branch %s is checked out in unmanaged worktree %s", gitWorktree.Branch, gitWorktree.Path))
+			}
+			continue
+		}
+
+		expectedPath, expectedPathErr := canonicalPath(owner.Path)
+		if expectedPathErr != nil {
+			warnings = append(warnings, fmt.Sprintf("could not canonicalize registered path %s for branch %s: %v", owner.Path, gitWorktree.Branch, expectedPathErr))
+			continue
+		}
+		if actualPath != expectedPath {
+			warnings = append(warnings, fmt.Sprintf("branch %s belongs to managed worktree %s (%s) but is checked out at %s", gitWorktree.Branch, worktreeDisplayName(owner), owner.Path, gitWorktree.Path))
+		}
+	}
+
+	return slices.Compact(slices.Sorted(slices.Values(warnings)))
+}
+
+func canonicalPath(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolvedPath, err := filepath.EvalSymlinks(absPath)
+	if err == nil {
+		return filepath.Clean(resolvedPath), nil
+	}
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+	return filepath.Clean(absPath), nil
+}
+
+func worktreeDisplayName(worktree *engine.WorktreeInfo) string {
+	if worktree.Name != "" {
+		return worktree.Name
+	}
+	return worktree.AnchorBranch
 }
 
 // ListAction lists all managed worktrees

--- a/internal/actions/worktree/repair.go
+++ b/internal/actions/worktree/repair.go
@@ -120,11 +120,11 @@ func repairEntry(ctx *app.Context, entry Entry) (RepairEntry, error) {
 			if existing != nil && existing.Path != wtInfo.Path {
 				return RepairEntry{}, fmt.Errorf("cannot repair %s automatically because anchor %s is already registered to %s", output.BranchName(entry.displayName()), output.BranchName(stackRootName), existing.Path)
 			}
-			if err := ctx.Engine.RegisterWorktreeWithName(stackRootName, wtInfo.Path, wtInfo.Name); err != nil {
-				return RepairEntry{}, fmt.Errorf("failed to register worktree under anchor %s: %w", stackRootName, err)
-			}
-			if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
-				_ = ctx.Engine.UnregisterWorktree(ctx.Context, stackRootName)
+			if existing == nil {
+				if err := moveRegistration(ctx, *wtInfo, stackRootName); err != nil {
+					return RepairEntry{}, err
+				}
+			} else if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
 				return RepairEntry{}, fmt.Errorf("failed to remove stale registration %s: %w", output.BranchName(wtInfo.AnchorBranch), err)
 			}
 			return RepairEntry{
@@ -146,6 +146,23 @@ func repairEntry(ctx *app.Context, entry Entry) (RepairEntry, error) {
 	}
 
 	return RepairEntry{}, fmt.Errorf("registration is already healthy")
+}
+
+// moveRegistration transfers a registration after the caller has established
+// that the destination anchor is safe. The registry's reverse path claim is
+// exclusive, so the old claim must be removed before creating the new one.
+// Restore the old registration if the replacement fails.
+func moveRegistration(ctx *app.Context, from engine.WorktreeInfo, toAnchor string) error {
+	if err := ctx.Engine.UnregisterWorktree(ctx.Context, from.AnchorBranch); err != nil {
+		return fmt.Errorf("failed to remove stale registration %s: %w", output.BranchName(from.AnchorBranch), err)
+	}
+	if err := ctx.Engine.RegisterWorktreeWithName(toAnchor, from.Path, from.Name); err != nil {
+		if restoreErr := ctx.Engine.RegisterWorktreeWithName(from.AnchorBranch, from.Path, from.Name); restoreErr != nil {
+			return fmt.Errorf("failed to register worktree under anchor %s: %w (also failed to restore %s: %w)", toAnchor, err, output.BranchName(from.AnchorBranch), restoreErr)
+		}
+		return fmt.Errorf("failed to register worktree under anchor %s: %w", toAnchor, err)
+	}
+	return nil
 }
 
 func convertLegacyRegistration(ctx *app.Context, wtInfo engine.WorktreeInfo, rootBranchName string) (string, error) {
@@ -185,9 +202,13 @@ func convertLegacyRegistration(ctx *app.Context, wtInfo engine.WorktreeInfo, roo
 	anchorCreated := true
 	rootReparented := false
 	registered := false
+	legacyUnregistered := false
 	cleanup := func() {
 		if registered {
 			_ = ctx.Engine.UnregisterWorktree(ctx.Context, anchorBranchName)
+		}
+		if legacyUnregistered {
+			_ = ctx.Engine.RegisterWorktreeWithName(wtInfo.AnchorBranch, wtInfo.Path, wtInfo.Name)
 		}
 		if rootReparented {
 			_ = ctx.Engine.ReparentBranch(ctx.Context, ctx.Engine.GetBranch(rootBranchName), ctx.Engine.GetBranch(originalParent))
@@ -216,14 +237,18 @@ func convertLegacyRegistration(ctx *app.Context, wtInfo engine.WorktreeInfo, roo
 		return "", fmt.Errorf("failed to reparent %s under anchor %s: %w", output.BranchName(rootBranchName), output.BranchName(anchorBranchName), err)
 	}
 	rootReparented = true
+	// The path's reverse registration claim is intentionally exclusive. Remove
+	// the legacy forward claim before creating the anchored one; cleanup restores
+	// it if the new registration cannot be written.
+	if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
+		cleanup()
+		return "", fmt.Errorf("failed to remove legacy registration %s: %w", output.BranchName(wtInfo.AnchorBranch), err)
+	}
+	legacyUnregistered = true
 	if err := ctx.Engine.RegisterWorktreeWithName(anchorBranchName, wtInfo.Path, wtInfo.Name); err != nil {
 		cleanup()
 		return "", fmt.Errorf("failed to register worktree under anchor %s: %w", output.BranchName(anchorBranchName), err)
 	}
 	registered = true
-	if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
-		cleanup()
-		return "", fmt.Errorf("failed to remove legacy registration %s: %w", output.BranchName(wtInfo.AnchorBranch), err)
-	}
 	return anchorBranchName, nil
 }

--- a/internal/actions/worktree_ownership.go
+++ b/internal/actions/worktree_ownership.go
@@ -1,0 +1,70 @@
+package actions
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/getstackit/stackit/internal/app"
+	"github.com/getstackit/stackit/internal/engine"
+)
+
+// EnsureCanModifyHere refuses to mutate a stack from anywhere other than its
+// managed worktree. The ownership relation is derived from the branch's stack
+// root, while the invocation location comes from the command context.
+//
+// Branch-level mutation checks deliberately do not live in engine.Branch:
+// Branch has no command context, and the same branch can be valid in one
+// worktree and invalid in another.
+func EnsureCanModifyHere(ctx *app.Context, branches ...engine.Branch) error {
+	seen := make(map[string]struct{}, len(branches))
+	for _, branch := range branches {
+		branchName := branch.GetName()
+		if branchName == "" {
+			continue
+		}
+		if _, ok := seen[branchName]; ok {
+			continue
+		}
+		seen[branchName] = struct{}{}
+
+		owner, err := ctx.Engine.OwningWorktree(branch)
+		if err != nil {
+			return fmt.Errorf("cannot determine worktree ownership for branch %s: %w", branchName, err)
+		}
+
+		if owner == nil {
+			if ctx.InManagedWorktree {
+				return fmt.Errorf("branch %s belongs to the main repository stack; run this command from %s", branchName, ctx.WorktreeInfo.MainRepoDir)
+			}
+			continue
+		}
+
+		if ctx.InManagedWorktree && ctx.WorktreeInfo != nil && ctx.WorktreeInfo.AnchorBranch == owner.AnchorBranch {
+			continue
+		}
+
+		return fmt.Errorf("branch %s belongs to worktree %s; run this command from there: cd %s", branchName, worktreeDisplayName(owner), owner.Path)
+	}
+
+	return nil
+}
+
+func worktreeDisplayName(worktree *engine.WorktreeInfo) string {
+	if worktree.Name != "" {
+		return worktree.Name
+	}
+	return worktree.AnchorBranch
+}
+
+// EnsureCanModifyNamesHere is the convenient form for operations that resolve
+// their targets as branch names before constructing a plan.
+func EnsureCanModifyNamesHere(ctx *app.Context, branchNames ...string) error {
+	uniqueNames := slices.Compact(slices.Sorted(slices.Values(branchNames)))
+	branches := make([]engine.Branch, 0, len(uniqueNames))
+	for _, name := range uniqueNames {
+		if name != "" {
+			branches = append(branches, ctx.Engine.GetBranch(name))
+		}
+	}
+	return EnsureCanModifyHere(ctx, branches...)
+}

--- a/internal/actions/worktree_ownership_test.go
+++ b/internal/actions/worktree_ownership_test.go
@@ -1,0 +1,53 @@
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+func TestEnsureCanModifyHere(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithInitialCommit()
+	s.CreateBranch("feature").Commit("feature change")
+	s.TrackBranch("feature", "main")
+	require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", "/tmp/feature-worktree", "feature-wt"))
+	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
+
+	t.Run("refuses managed stack mutation from main repository", func(t *testing.T) {
+		err := EnsureCanModifyHere(s.Context, s.Engine.GetBranch("feature"))
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "belongs to worktree feature-wt")
+		assert.ErrorContains(t, err, "cd /tmp/feature-worktree")
+	})
+
+	t.Run("allows mutation from owning worktree", func(t *testing.T) {
+		ctx := *s.Context
+		ctx.InManagedWorktree = true
+		ctx.WorktreeInfo = &engine.WorktreeInfo{
+			Name:         "feature-wt",
+			Path:         "/tmp/feature-worktree",
+			AnchorBranch: "feature",
+		}
+		require.NoError(t, EnsureCanModifyHere(&ctx, s.Engine.GetBranch("feature")))
+	})
+
+	t.Run("refuses main stack mutation from a managed worktree", func(t *testing.T) {
+		ctx := *s.Context
+		ctx.InManagedWorktree = true
+		ctx.WorktreeInfo = &engine.WorktreeInfo{
+			Name:         "feature-wt",
+			Path:         "/tmp/feature-worktree",
+			AnchorBranch: "feature",
+			MainRepoDir:  s.Context.RepoRoot,
+		}
+		err := EnsureCanModifyHere(&ctx, s.Engine.Trunk())
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "belongs to the main repository stack")
+	})
+}

--- a/internal/cli/worktree/worktree.go
+++ b/internal/cli/worktree/worktree.go
@@ -235,6 +235,9 @@ Shows each worktree's name, root branch, stack size, registration health, and st
 					renderWorktreeEntry(ctx, wt, result.CurrentAnchor)
 					needsRepair = needsRepair || wt.NeedsRepair
 				}
+				for _, warning := range result.OwnershipWarnings {
+					ctx.Output.Warn("Ownership warning: %s", warning)
+				}
 				if needsRepair {
 					ctx.Output.Tip("Some managed worktrees need repair: stackit worktree repair")
 				}

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -203,7 +203,11 @@ func (e *engineImpl) RegisterWorktree(stackRoot string, path string) error {
 
 // RegisterWorktreeWithName registers a worktree with a user-friendly name
 func (e *engineImpl) RegisterWorktreeWithName(anchorBranch string, path string, name string) error {
-	absPath, err := canonicalWorktreePath(path)
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute worktree path: %w", err)
+	}
+	canonicalPath, err := canonicalWorktreePath(absPath)
 	if err != nil {
 		return fmt.Errorf("failed to canonicalize worktree path: %w", err)
 	}
@@ -223,7 +227,7 @@ func (e *engineImpl) RegisterWorktreeWithName(anchorBranch string, path string, 
 		if pathErr != nil {
 			return fmt.Errorf("failed to canonicalize registered worktree path %s: %w", worktree.Path, pathErr)
 		}
-		if worktreePath == absPath && worktree.AnchorBranch != anchorBranch {
+		if worktreePath == canonicalPath && worktree.AnchorBranch != anchorBranch {
 			return fmt.Errorf("worktree path %s is already registered to anchor %s", absPath, worktree.AnchorBranch)
 		}
 	}

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -203,9 +203,29 @@ func (e *engineImpl) RegisterWorktree(stackRoot string, path string) error {
 
 // RegisterWorktreeWithName registers a worktree with a user-friendly name
 func (e *engineImpl) RegisterWorktreeWithName(anchorBranch string, path string, name string) error {
-	absPath, err := filepath.Abs(path)
+	absPath, err := canonicalWorktreePath(path)
 	if err != nil {
-		return fmt.Errorf("failed to get absolute path: %w", err)
+		return fmt.Errorf("failed to canonicalize worktree path: %w", err)
+	}
+
+	if existing, err := e.GetWorktreeForStack(anchorBranch); err != nil {
+		return fmt.Errorf("failed to check existing worktree registration: %w", err)
+	} else if existing != nil {
+		return fmt.Errorf("worktree anchor %s is already registered at %s", anchorBranch, existing.Path)
+	}
+
+	worktrees, err := e.ListManagedWorktrees()
+	if err != nil {
+		return fmt.Errorf("failed to list worktree registrations: %w", err)
+	}
+	for _, worktree := range worktrees {
+		worktreePath, pathErr := canonicalWorktreePath(worktree.Path)
+		if pathErr != nil {
+			return fmt.Errorf("failed to canonicalize registered worktree path %s: %w", worktree.Path, pathErr)
+		}
+		if worktreePath == absPath && worktree.AnchorBranch != anchorBranch {
+			return fmt.Errorf("worktree path %s is already registered to anchor %s", absPath, worktree.AnchorBranch)
+		}
 	}
 
 	meta := &git.WorktreeMeta{
@@ -217,6 +237,21 @@ func (e *engineImpl) RegisterWorktreeWithName(anchorBranch string, path string, 
 	}
 
 	return e.git.WriteWorktreeMeta(anchorBranch, meta)
+}
+
+func canonicalWorktreePath(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolvedPath, err := filepath.EvalSymlinks(absPath)
+	if err == nil {
+		return filepath.Clean(resolvedPath), nil
+	}
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+	return filepath.Clean(absPath), nil
 }
 
 // UnregisterWorktree removes worktree registration for a stack root

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -243,6 +243,26 @@ func (e *engineImpl) GetWorktreeForStack(stackRoot string) (*WorktreeInfo, error
 	}, nil
 }
 
+// OwningWorktree returns the managed worktree for branch's stack. Stack
+// ownership is derived from the stack root, which is the worktree anchor for
+// stacks that have been attached to a managed worktree.
+func (e *engineImpl) OwningWorktree(branch Branch) (*WorktreeInfo, error) {
+	stackRoot := e.GetStackRootForBranch(branch)
+	if stackRoot == "" {
+		return nil, nil
+	}
+
+	worktree, err := e.GetWorktreeForStack(stackRoot)
+	if err != nil || worktree == nil {
+		return worktree, err
+	}
+	if worktree.AnchorBranch != stackRoot {
+		return nil, fmt.Errorf("invalid worktree registration for stack %s: metadata anchor is %s", stackRoot, worktree.AnchorBranch)
+	}
+
+	return worktree, nil
+}
+
 // ListManagedWorktrees returns all stackit-managed worktrees, sorted by stack root name
 func (e *engineImpl) ListManagedWorktrees() ([]WorktreeInfo, error) {
 	metas, err := e.git.ListWorktreeMetas()

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -307,6 +307,11 @@ type WorktreeRegistry interface {
 	UnregisterWorktree(ctx context.Context, stackRoot string) error
 	// GetWorktreeForStack returns worktree info for a stack root, or nil if none
 	GetWorktreeForStack(stackRoot string) (*WorktreeInfo, error)
+	// OwningWorktree returns the managed worktree that owns branch's stack, or
+	// nil when the branch belongs to an ordinary stack in the main repository.
+	// A malformed registration is returned as an error rather than being treated
+	// as unowned, so callers can fail closed before mutating the stack.
+	OwningWorktree(branch Branch) (*WorktreeInfo, error)
 	// ListManagedWorktrees returns all stackit-managed worktrees
 	ListManagedWorktrees() ([]WorktreeInfo, error)
 	// GetStackRootForBranch returns the stack root for a given branch

--- a/internal/engine/worktree_test.go
+++ b/internal/engine/worktree_test.go
@@ -75,6 +75,22 @@ func TestWorktreeRegistry_OwningWorktree(t *testing.T) {
 	assert.Nil(t, owner)
 }
 
+func TestWorktreeRegistry_RejectsDuplicatePathAndAnchor(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithInitialCommit()
+
+	require.NoError(t, s.Engine.RegisterWorktreeWithName("feature-a", "/tmp/shared-worktree", "feature-a"))
+	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature-a") })
+
+	err := s.Engine.RegisterWorktreeWithName("feature-b", "/tmp/shared-worktree", "feature-b")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "already registered to anchor feature-a")
+
+	err = s.Engine.RegisterWorktreeWithName("feature-a", "/tmp/other-worktree", "feature-a")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "anchor feature-a is already registered")
+}
+
 func TestCreateTemporaryWorktree(t *testing.T) {
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 

--- a/internal/engine/worktree_test.go
+++ b/internal/engine/worktree_test.go
@@ -52,6 +52,29 @@ func TestWorktreeRegistry_StackRootForBranch(t *testing.T) {
 	_ = s.Engine.UnregisterWorktree(s.Context, "branch1")
 }
 
+func TestWorktreeRegistry_OwningWorktree(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithInitialCommit()
+
+	s.CreateBranch("feature").Commit("feature change")
+	s.TrackBranch("feature", "main")
+	s.CreateBranch("feature-child").Commit("feature child change")
+	s.TrackBranch("feature-child", "feature")
+
+	require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", "/tmp/feature-worktree", "feature"))
+	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
+
+	owner, err := s.Engine.OwningWorktree(s.Engine.GetBranch("feature-child"))
+	require.NoError(t, err)
+	require.NotNil(t, owner)
+	assert.Equal(t, "feature", owner.AnchorBranch)
+	assert.Equal(t, "/tmp/feature-worktree", owner.Path)
+
+	owner, err = s.Engine.OwningWorktree(s.Engine.Trunk())
+	require.NoError(t, err)
+	assert.Nil(t, owner)
+}
+
 func TestCreateTemporaryWorktree(t *testing.T) {
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -297,10 +297,9 @@ func (r *runner) DeleteWorktreeMeta(ctx context.Context, stackRoot string) error
 	if meta != nil {
 		pathRef := worktreePathRef(meta.Path)
 		if pathSHA, pathErr := r.GetRef(pathRef); pathErr == nil {
-			if pathSHA != sha {
-				return fmt.Errorf("worktree path index for %s does not match its anchor registration", meta.Path)
+			if pathSHA == sha {
+				updates = append(updates, RefUpdate{RefName: pathRef, OldSHA: sha, IsDelete: true})
 			}
-			updates = append(updates, RefUpdate{RefName: pathRef, OldSHA: sha, IsDelete: true})
 		}
 	}
 	if err := r.UpdateRefsBatch(ctx, updates); err != nil {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -21,8 +22,26 @@ const WorktreeRefPrefix = "refs/stackit/worktrees/"
 const WorktreePathRefPrefix = "refs/stackit/worktree-paths/"
 
 func worktreePathRef(path string) string {
+	if canonicalPath, err := canonicalWorktreePath(path); err == nil {
+		path = canonicalPath
+	}
 	hash := sha256.Sum256([]byte(path))
 	return fmt.Sprintf("%s%x", WorktreePathRefPrefix, hash)
+}
+
+func canonicalWorktreePath(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolvedPath, err := filepath.EvalSymlinks(absPath)
+	if err == nil {
+		return filepath.Clean(resolvedPath), nil
+	}
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+	return filepath.Clean(absPath), nil
 }
 
 // Worktree represents a single entry from `git worktree list`.

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -12,6 +13,17 @@ import (
 
 // WorktreeRefPrefix is the prefix for Git refs where worktree metadata is stored (local-only)
 const WorktreeRefPrefix = "refs/stackit/worktrees/"
+
+// WorktreePathRefPrefix is a reverse index from canonical worktree path to
+// its anchor registration. Keeping this alongside WorktreeRefPrefix lets a
+// single update-ref transaction enforce both directions of the ownership
+// invariant.
+const WorktreePathRefPrefix = "refs/stackit/worktree-paths/"
+
+func worktreePathRef(path string) string {
+	hash := sha256.Sum256([]byte(path))
+	return fmt.Sprintf("%s%x", WorktreePathRefPrefix, hash)
+}
 
 // Worktree represents a single entry from `git worktree list`.
 type Worktree struct {
@@ -232,9 +244,18 @@ func (r *runner) WriteWorktreeMeta(stackRoot string, meta *WorktreeMeta) error {
 		return fmt.Errorf("failed to create worktree metadata blob: %w", err)
 	}
 
-	refName := fmt.Sprintf("%s%s", WorktreeRefPrefix, stackRoot)
-	if err := r.UpdateRef(refName, sha); err != nil {
-		return fmt.Errorf("failed to write worktree metadata ref: %w", err)
+	// Both refs are created only when absent. The forward ref protects one
+	// anchor from receiving two registrations; the reverse ref protects one
+	// path from being claimed by two anchors. update-ref applies the pair
+	// atomically, so a competing registration loses cleanly instead of creating
+	// an ambiguous ownership state.
+	zeroSHA := strings.Repeat("0", len(sha))
+	updates := []RefUpdate{
+		{RefName: fmt.Sprintf("%s%s", WorktreeRefPrefix, stackRoot), NewSHA: sha, OldSHA: zeroSHA},
+		{RefName: worktreePathRef(meta.Path), NewSHA: sha, OldSHA: zeroSHA},
+	}
+	if err := r.UpdateRefsBatch(context.Background(), updates); err != nil {
+		return fmt.Errorf("failed to register worktree metadata refs: %w", err)
 	}
 
 	return nil
@@ -243,7 +264,30 @@ func (r *runner) WriteWorktreeMeta(stackRoot string, meta *WorktreeMeta) error {
 // DeleteWorktreeMeta deletes worktree metadata for a stack root
 func (r *runner) DeleteWorktreeMeta(ctx context.Context, stackRoot string) error {
 	refName := fmt.Sprintf("%s%s", WorktreeRefPrefix, stackRoot)
-	return r.DeleteRef(ctx, refName)
+	sha, err := r.GetRef(refName)
+	if err != nil {
+		// Preserve DeleteRef's idempotent behavior for absent legacy metadata.
+		return r.DeleteRef(ctx, refName)
+	}
+
+	meta, err := r.ReadWorktreeMeta(stackRoot)
+	if err != nil {
+		return err
+	}
+	updates := []RefUpdate{{RefName: refName, OldSHA: sha, IsDelete: true}}
+	if meta != nil {
+		pathRef := worktreePathRef(meta.Path)
+		if pathSHA, pathErr := r.GetRef(pathRef); pathErr == nil {
+			if pathSHA != sha {
+				return fmt.Errorf("worktree path index for %s does not match its anchor registration", meta.Path)
+			}
+			updates = append(updates, RefUpdate{RefName: pathRef, OldSHA: sha, IsDelete: true})
+		}
+	}
+	if err := r.UpdateRefsBatch(ctx, updates); err != nil {
+		return fmt.Errorf("failed to unregister worktree metadata refs: %w", err)
+	}
+	return nil
 }
 
 // GetWorktreePathForBranch returns the worktree path where a branch is checked out.

--- a/internal/integration/create_onto_test.go
+++ b/internal/integration/create_onto_test.go
@@ -42,7 +42,7 @@ func TestCreateOnto(t *testing.T) {
 		sh.CommitCount("main", "branch-d", 1)
 	})
 
-	t.Run("works when the target is checked out in another worktree", func(t *testing.T) {
+	t.Run("rejects a target owned by another worktree", func(t *testing.T) {
 		t.Parallel()
 		sh := NewTestShellInProcess(t)
 		sh.SetWorktreeBasePath(t.TempDir())
@@ -54,14 +54,10 @@ func TestCreateOnto(t *testing.T) {
 		shW := sh.InWorktree(worktreePath)
 		shW.OnBranch("shared")
 
-		// From the main worktree, branch onto "shared" without disturbing it.
-		sh.Write("e", "content e").Run("create branch-e --onto shared -m 'feat: e'")
-
-		sh.OnBranch("branch-e")
-		sh.ExpectBranchParent("branch-e", "shared")
-		sh.CommitCount("shared", "branch-e", 1)
-
-		// The other worktree's checkout is untouched.
+		// Creating a child would mutate shared's stack, so it must be done from
+		// the worktree that owns shared.
+		sh.Write("e", "content e").RunExpectError("create branch-e --onto shared -m 'feat: e'").
+			OutputContains("belongs to worktree")
 		shW.OnBranch("shared")
 	})
 

--- a/internal/integration/resiliency_test.go
+++ b/internal/integration/resiliency_test.go
@@ -90,6 +90,8 @@ func TestRestackWorktreeAnchoredBranchAgainstAdvancedTrunk(t *testing.T) {
 	//    reparents the branch under the anchor, and opens the worktree on it.
 	sh.WriteFile("shared.txt", "feature version").
 		Run("create feature -w -m 'feature changes shared'")
+	worktreePath := sh.GetWorktreePath("feature")
+	anchorBranch := findWorktreeAnchor(t, sh)
 
 	// 3. Advance trunk with a conflicting change to the same file.
 	sh.Checkout("main").
@@ -99,13 +101,14 @@ func TestRestackWorktreeAnchoredBranchAgainstAdvancedTrunk(t *testing.T) {
 	// 4. Restack the worktree stack against the advanced trunk. Validation
 	//    predicts a real conflict; the buggy path instead completes a no-op
 	//    rebase onto the stale anchor.
-	sh.RunExpectError("restack --all-stacks")
+	worktree := sh.InWorktree(worktreePath)
+	worktree.RunExpectError("restack --branch " + anchorBranch + " --upstack")
 
 	// The bug manifests as "expected conflict ... but rebase completed
 	// successfully" — the branch was skipped as a no-op onto its stale anchor.
 	// The fix rebases onto trunk (the anchor's logical position), so the real
 	// conflict surfaces and the normal resolve/continue workflow engages.
-	sh.OutputNotContains("rebase completed successfully").
+	worktree.OutputNotContains("rebase completed successfully").
 		OutputContains("conflict")
 }
 

--- a/internal/integration/restack_worktree_anchor_test.go
+++ b/internal/integration/restack_worktree_anchor_test.go
@@ -83,14 +83,16 @@ func TestRestackWorktreeAnchorTracksTrunk(t *testing.T) {
 	// revision really is where the branch is based.
 	sh.Checkout("main").
 		Commit("trunk1.txt", "chore: trunk commit 1").
-		Run("restack --all-stacks")
+		OnBranch("main")
+	wt.Run("restack --branch " + anchorBranch + " --upstack")
 	assertTracksTrunk("after first restack")
 
 	// Trunk advances again. This is where the stale anchor used to widen the
 	// replay range to cover every trunk commit since the worktree was created.
 	sh.Checkout("main").
 		Commit("trunk2.txt", "chore: trunk commit 2").
-		Run("restack --all-stacks")
+		OnBranch("main")
+	wt.Run("restack --branch " + anchorBranch + " --upstack")
 	assertTracksTrunk("after second restack")
 }
 
@@ -200,14 +202,15 @@ func TestRestackUpstackConvergesForWorktreeAnchorChild(t *testing.T) {
 	sh.Run("worktree open my-wt")
 	worktreePath := strings.TrimSpace(sh.Output())
 
-	sh.InWorktree(worktreePath).
+	wt := sh.InWorktree(worktreePath)
+	wt.
 		WriteFile("feature.txt", "feature").
 		Run("create feature -m 'feat: feature'")
 
 	// One trunk advance, then a real restack: feature actually needs to move.
 	sh.Checkout("main").
-		Commit("trunk1.txt", "chore: trunk commit 1").
-		Run("restack --branch feature --upstack")
+		Commit("trunk1.txt", "chore: trunk commit 1")
+	wt.Run("restack --branch feature --upstack")
 
 	sh.Git("rev-parse feature")
 	firstRev := strings.TrimSpace(sh.Output())
@@ -215,7 +218,7 @@ func TestRestackUpstackConvergesForWorktreeAnchorChild(t *testing.T) {
 	// No further trunk movement. Repeated restacks scoped to exclude the
 	// anchor must converge: same SHA, reported as already up to date.
 	for i := 2; i <= 3; i++ {
-		sh.Run("restack --branch feature --upstack").
+		wt.Run("restack --branch feature --upstack").
 			OutputContains("up to date")
 
 		sh.Git("rev-parse feature")

--- a/internal/integration/worktree_comprehensive_test.go
+++ b/internal/integration/worktree_comprehensive_test.go
@@ -467,11 +467,9 @@ func TestWorktreeRestackOperations(t *testing.T) {
 		shW.WriteFile("b.txt", "b").Run("create b -m 'branch b'")
 		shW.WriteFile("c.txt", "c").Run("create c -m 'branch c'")
 
-		// Modify root branch from main repo to trigger restack
-		sh.Checkout("feature").
-			WriteFile("feature-update.txt", "update").
-			Run("modify -n").
-			Checkout("main")
+		// Advance trunk from the main repository to trigger the restack.
+		sh.WriteFile("trunk-update.txt", "update").
+			Git("commit -m 'trunk update'")
 
 		// Restack from main
 		sh.Run("restack")
@@ -485,9 +483,9 @@ func TestWorktreeRestackOperations(t *testing.T) {
 		})
 
 		// Worktree should have the updated content
-		shW.Git("ls-files feature-update.txt")
+		shW.Git("ls-files trunk-update.txt")
 		if shW.Output() == "" {
-			t.Error("feature-update.txt should exist in worktree after restack")
+			t.Error("trunk-update.txt should exist in worktree after restack")
 		}
 	})
 
@@ -561,7 +559,7 @@ func TestWorktreeModifyOperations(t *testing.T) {
 		}
 	})
 
-	run("modify parent from main repo restacks worktree children", func(t *testing.T, sh *TestShell) {
+	run("modify parent from main repo rejects worktree stack", func(t *testing.T, sh *TestShell) {
 		// Create stack in worktree
 		sh.WriteFile("feature.txt", "feature").
 			Run("create feature -w -m 'feature branch'")
@@ -572,24 +570,12 @@ func TestWorktreeModifyOperations(t *testing.T) {
 		// Create child in worktree
 		shW.WriteFile("child.txt", "child").Run("create child -m 'child branch'")
 
-		// Modify parent from main repo
+		// Modifying an owned branch from the main checkout must fail closed.
 		sh.Checkout("feature").
 			WriteFile("feature-from-main.txt", "from main").
-			Run("modify -n").
-			Checkout("main")
-
-		// Worktree child should have the modified file
-		shW.Checkout("child").
-			Git("ls-files feature-from-main.txt")
-		if shW.Output() == "" {
-			t.Error("worktree child should have feature-from-main.txt")
-		}
-
-		// Worktree should be clean
-		shW.Git("status --porcelain")
-		if output := shW.Output(); output != "" {
-			t.Errorf("Worktree should be clean, but has:\n%s", output)
-		}
+			RunExpectError("modify -n").
+			OutputContains("belongs to worktree")
+		shW.OnBranch("child")
 	})
 }
 
@@ -706,8 +692,8 @@ func TestWorktreeEdgeCases(t *testing.T) {
 
 		sh.Checkout("feature").
 			WriteFile("feature-update.txt", "update").
-			Run("modify -n").
-			Checkout("main")
+			RunExpectError("modify -n").
+			OutputContains("belongs to worktree")
 
 		dirtyFile := filepath.Join(worktreePath, "uncommitted.txt")
 		if _, err := os.Stat(dirtyFile); os.IsNotExist(err) {
@@ -794,12 +780,12 @@ func TestWorktreeMoveOperations(t *testing.T) {
 		shW1.WriteFile("child.txt", "child").
 			Run("create child -m 'child'")
 
-		// Move child to stack2 (use --onto for the target)
+		// Moving into a separately owned stack must be run from its worktree.
 		shW1.Checkout("child").
-			Run("move --onto stack2")
+			RunExpectError("move --onto stack2").
+			OutputContains("belongs to worktree")
 
-		// Verify new parent
-		sh.ExpectBranchParent("child", "stack2")
+		sh.ExpectBranchParent("child", "stack1")
 	})
 }
 
@@ -1018,24 +1004,13 @@ func TestWorktreeComplexScenarios(t *testing.T) {
 		// Worktree is on grandchild
 		shW.OnBranch("grandchild")
 
-		// Modify feature from main repo (not in worktree)
+		// Modifying feature from the main repo must be rejected even though the
+		// managed worktree is currently on a descendant.
 		sh.Checkout("feature").
 			WriteFile("feature-update.txt", "updated").
-			Run("modify -n").
-			Checkout("main")
-
-		// Worktree should still be on grandchild and have the update
-		shW.OnBranch("grandchild").
-			Git("ls-files feature-update.txt")
-		if shW.Output() == "" {
-			t.Error("Grandchild should have feature-update.txt after modify")
-		}
-
-		// Working directory should be clean
-		shW.Git("status --porcelain")
-		if shW.Output() != "" {
-			t.Errorf("Worktree should be clean: %s", shW.Output())
-		}
+			RunExpectError("modify -n").
+			OutputContains("belongs to worktree")
+		shW.OnBranch("grandchild")
 	})
 }
 

--- a/internal/integration/worktree_comprehensive_test.go
+++ b/internal/integration/worktree_comprehensive_test.go
@@ -454,7 +454,7 @@ func TestWorktreeRestackOperations(t *testing.T) {
 		})
 	}
 
-	run("restack from main updates worktree branches", func(t *testing.T, sh *TestShell) {
+	run("restack from main rejects worktree branches", func(t *testing.T, sh *TestShell) {
 		// Create stack in worktree
 		sh.WriteFile("feature.txt", "feature").
 			Run("create feature -w -m 'feature branch'")
@@ -467,26 +467,8 @@ func TestWorktreeRestackOperations(t *testing.T) {
 		shW.WriteFile("b.txt", "b").Run("create b -m 'branch b'")
 		shW.WriteFile("c.txt", "c").Run("create c -m 'branch c'")
 
-		// Advance trunk from the main repository to trigger the restack.
-		sh.WriteFile("trunk-update.txt", "update").
-			Git("commit -m 'trunk update'")
-
-		// Restack from main
-		sh.Run("restack")
-
-		// Verify stack structure maintained
-		sh.ExpectStackStructure(map[string]string{
-			"feature": "main",
-			"a":       "feature",
-			"b":       "a",
-			"c":       "b",
-		})
-
-		// Worktree should have the updated content
-		shW.Git("ls-files trunk-update.txt")
-		if shW.Output() == "" {
-			t.Error("trunk-update.txt should exist in worktree after restack")
-		}
+		sh.RunExpectError("restack").OutputContains("belongs to worktree")
+		shW.OnBranch("c")
 	})
 
 	run("restack from worktree works correctly", func(t *testing.T, sh *TestShell) {


### PR DESCRIPTION
This PR merges the following changes:

1. **#1553** fix(worktree): guard stack mutations by owning worktree
2. **#1554** fix(worktree): enforce unique worktree registrations
3. **#1555** fix(worktree): report ownership divergence
4. **#1556** fix(worktree): preserve registrations during repair

### Stack

```
main
  └─ jonnii/20260801023409/guard-stack-mutations-by-owning-worktree (#1553)
    └─ jonnii/20260801023633/enforce-unique-worktree-registrations (#1554)
      └─ jonnii/20260801024141/report-ownership-divergence (#1555)
        └─ jonnii/20260801024412/preserve-registrations-during-repair (#1556)
```

Stackit-Stack-Size: 4
Stackit-PRs: 1553,1554,1555,1556
