### PR TITLE
feat(worktree): add safe warm-start copy core

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/go-github/v89 v89.0.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/mattn/go-isatty v0.0.24
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/sahilm/fuzzy v0.1.3
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -191,6 +191,8 @@ github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
 github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/sahilm/fuzzy v0.1.3 h1:juByESSS32nVD81vr6tHmKmA/8zde7gE+x5CLxrzXPU=
 github.com/sahilm/fuzzy v0.1.3/go.mod h1:au6//VbVSqu6DFrkL2CfjlJ5iURpNCPeE+1GwY3XsT8=
 github.com/shirou/gopsutil/v4 v4.26.6 h1:Mzr/npDtQC/xpeEuQKHZt8Zo9CmPvhTj8nkR8w5TLDs=
@@ -206,6 +208,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
 github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=

--- a/internal/actions/worktree/warm_start.go
+++ b/internal/actions/worktree/warm_start.go
@@ -1,0 +1,166 @@
+package worktree
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	ignore "github.com/sabhiram/go-gitignore"
+)
+
+// WorktreeIncludeFile is the repository-root file that selects ignored files
+// which may be copied into a newly-created worktree. Its patterns use
+// .gitignore syntax, but a match alone is insufficient: callers must pass
+// only files already known to be ignored by Git.
+const WorktreeIncludeFile = ".worktreeinclude"
+
+// WarmStartResult describes files copied into a new worktree. Paths are
+// relative to the source worktree and sorted for deterministic output.
+type WarmStartResult struct {
+	Enabled         bool
+	Copied          []string
+	SkippedExisting []string
+}
+
+// CopyIncludedIgnoredFiles copies selected ignored regular files from sourceRoot
+// to destinationRoot. ignoredPaths must be repository-relative paths that Git
+// has already classified as ignored; this function deliberately does not infer
+// ignore state from .worktreeinclude itself.
+//
+// Existing destination files are never overwritten. Symlinks and non-regular
+// files are skipped so a project-controlled include file cannot cause Stackit
+// to follow a path outside either worktree.
+func CopyIncludedIgnoredFiles(sourceRoot, destinationRoot string, ignoredPaths []string) (WarmStartResult, error) {
+	includePath := filepath.Join(sourceRoot, WorktreeIncludeFile)
+	matcher, err := ignore.CompileIgnoreFile(includePath)
+	if os.IsNotExist(err) {
+		return WarmStartResult{}, nil
+	}
+	if err != nil {
+		return WarmStartResult{}, fmt.Errorf("read %s: %w", WorktreeIncludeFile, err)
+	}
+
+	result := WarmStartResult{Enabled: true}
+	for _, path := range uniqueSortedPaths(ignoredPaths) {
+		relativePath, err := warmStartRelativePath(path)
+		if err != nil {
+			return WarmStartResult{}, err
+		}
+		if !matcher.MatchesPath(filepath.ToSlash(relativePath)) {
+			continue
+		}
+
+		sourcePath := filepath.Join(sourceRoot, relativePath)
+		if err := ensureWarmStartParents(sourceRoot, relativePath, false); err != nil {
+			return WarmStartResult{}, err
+		}
+		info, err := os.Lstat(sourcePath)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return WarmStartResult{}, fmt.Errorf("inspect warm-start source %s: %w", relativePath, err)
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+
+		destinationPath := filepath.Join(destinationRoot, relativePath)
+		if _, err := os.Lstat(destinationPath); err == nil {
+			result.SkippedExisting = append(result.SkippedExisting, relativePath)
+			continue
+		} else if !os.IsNotExist(err) {
+			return WarmStartResult{}, fmt.Errorf("inspect warm-start destination %s: %w", relativePath, err)
+		}
+		if err := ensureWarmStartParents(destinationRoot, relativePath, true); err != nil {
+			return WarmStartResult{}, err
+		}
+
+		if err := copyWarmStartFile(sourcePath, destinationPath, info.Mode().Perm()); err != nil {
+			return WarmStartResult{}, fmt.Errorf("copy warm-start file %s: %w", relativePath, err)
+		}
+		result.Copied = append(result.Copied, relativePath)
+	}
+
+	return result, nil
+}
+
+func uniqueSortedPaths(paths []string) []string {
+	paths = slices.Clone(paths)
+	slices.Sort(paths)
+	return slices.Compact(paths)
+}
+
+func warmStartRelativePath(path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return "", fmt.Errorf("warm-start path must be relative: %s", path)
+	}
+
+	cleaned := filepath.Clean(path)
+	if cleaned == "." || cleaned == ".." || filepath.IsAbs(cleaned) {
+		return "", fmt.Errorf("invalid warm-start path: %s", path)
+	}
+	if strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("warm-start path escapes repository: %s", path)
+	}
+
+	return cleaned, nil
+}
+
+func copyWarmStartFile(sourcePath, destinationPath string, mode os.FileMode) (err error) {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = source.Close() }()
+
+	destination, err := os.OpenFile(destinationPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		closeErr := destination.Close()
+		if err == nil && closeErr != nil {
+			err = closeErr
+		}
+		if err != nil {
+			_ = os.Remove(destinationPath)
+		}
+	}()
+
+	_, err = io.Copy(destination, source)
+	return err
+}
+
+func ensureWarmStartParents(root, relativePath string, create bool) error {
+	directory := filepath.Dir(relativePath)
+	if directory == "." {
+		return nil
+	}
+
+	current := root
+	for _, component := range strings.Split(directory, string(filepath.Separator)) {
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		if os.IsNotExist(err) && create {
+			if err := os.Mkdir(current, 0o750); err != nil && !os.IsExist(err) {
+				return fmt.Errorf("create warm-start directory %s: %w", current, err)
+			}
+			info, err = os.Lstat(current)
+		}
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("inspect warm-start directory %s: %w", current, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("warm-start path has unsafe parent directory: %s", current)
+		}
+	}
+
+	return nil
+}

--- a/internal/actions/worktree/warm_start_test.go
+++ b/internal/actions/worktree/warm_start_test.go
@@ -1,0 +1,119 @@
+package worktree
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyIncludedIgnoredFiles(t *testing.T) {
+	source := t.TempDir()
+	destination := t.TempDir()
+
+	writeWarmStartFile(t, source, WorktreeIncludeFile, ".env\ncache/\n!cache/keep.txt\n")
+	writeWarmStartFile(t, source, ".env", "secret")
+	writeWarmStartFile(t, source, "cache/data.txt", "cached")
+	writeWarmStartFile(t, source, "cache/keep.txt", "do not copy")
+	writeWarmStartFile(t, source, "other.txt", "not selected")
+
+	result, err := CopyIncludedIgnoredFiles(source, destination, []string{
+		"other.txt", "cache/keep.txt", ".env", "cache/data.txt", "cache/data.txt",
+	})
+	require.NoError(t, err)
+	require.True(t, result.Enabled)
+	require.Equal(t, []string{".env", "cache/data.txt"}, result.Copied)
+	require.Empty(t, result.SkippedExisting)
+
+	requireWarmStartFile(t, destination, ".env", "secret")
+	requireWarmStartFile(t, destination, "cache/data.txt", "cached")
+	require.NoFileExists(t, filepath.Join(destination, "cache", "keep.txt"))
+	require.NoFileExists(t, filepath.Join(destination, "other.txt"))
+}
+
+func TestCopyIncludedIgnoredFilesDoesNotOverwriteExistingFiles(t *testing.T) {
+	source := t.TempDir()
+	destination := t.TempDir()
+	writeWarmStartFile(t, source, WorktreeIncludeFile, ".env\n")
+	writeWarmStartFile(t, source, ".env", "source")
+	writeWarmStartFile(t, destination, ".env", "destination")
+
+	result, err := CopyIncludedIgnoredFiles(source, destination, []string{".env"})
+	require.NoError(t, err)
+	require.True(t, result.Enabled)
+	require.Empty(t, result.Copied)
+	require.Equal(t, []string{".env"}, result.SkippedExisting)
+	requireWarmStartFile(t, destination, ".env", "destination")
+}
+
+func TestCopyIncludedIgnoredFilesPreservesExecutableMode(t *testing.T) {
+	source := t.TempDir()
+	destination := t.TempDir()
+	writeWarmStartFile(t, source, WorktreeIncludeFile, "bin/tool\n")
+	writeWarmStartFile(t, source, "bin/tool", "#!/bin/sh\n")
+	require.NoError(t, os.Chmod(filepath.Join(source, "bin", "tool"), 0o755))
+
+	_, err := CopyIncludedIgnoredFiles(source, destination, []string{"bin/tool"})
+	require.NoError(t, err)
+
+	info, err := os.Stat(filepath.Join(destination, "bin", "tool"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+}
+
+func TestCopyIncludedIgnoredFilesSkipsSymlinks(t *testing.T) {
+	source := t.TempDir()
+	destination := t.TempDir()
+	writeWarmStartFile(t, source, WorktreeIncludeFile, "linked\n")
+	writeWarmStartFile(t, source, "real.txt", "real")
+	require.NoError(t, os.Symlink("real.txt", filepath.Join(source, "linked")))
+
+	result, err := CopyIncludedIgnoredFiles(source, destination, []string{"linked"})
+	require.NoError(t, err)
+	require.Empty(t, result.Copied)
+	require.NoFileExists(t, filepath.Join(destination, "linked"))
+}
+
+func TestCopyIncludedIgnoredFilesRefusesSymlinkDestinationParents(t *testing.T) {
+	source := t.TempDir()
+	destination := t.TempDir()
+	outside := t.TempDir()
+	writeWarmStartFile(t, source, WorktreeIncludeFile, "config/secret\n")
+	writeWarmStartFile(t, source, "config/secret", "secret")
+	require.NoError(t, os.Symlink(outside, filepath.Join(destination, "config")))
+
+	_, err := CopyIncludedIgnoredFiles(source, destination, []string{"config/secret"})
+	require.ErrorContains(t, err, "unsafe parent directory")
+	require.NoFileExists(t, filepath.Join(outside, "secret"))
+}
+
+func TestCopyIncludedIgnoredFilesRejectsEscapingPaths(t *testing.T) {
+	source := t.TempDir()
+	destination := t.TempDir()
+	writeWarmStartFile(t, source, WorktreeIncludeFile, "*\n")
+
+	_, err := CopyIncludedIgnoredFiles(source, destination, []string{"../outside"})
+	require.ErrorContains(t, err, "escapes repository")
+}
+
+func TestCopyIncludedIgnoredFilesWithoutIncludeFileIsDisabled(t *testing.T) {
+	result, err := CopyIncludedIgnoredFiles(t.TempDir(), t.TempDir(), []string{".env"})
+	require.NoError(t, err)
+	require.False(t, result.Enabled)
+	require.Empty(t, result.Copied)
+}
+
+func writeWarmStartFile(t *testing.T, root, relativePath, contents string) {
+	t.Helper()
+	path := filepath.Join(root, relativePath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+}
+
+func requireWarmStartFile(t *testing.T, root, relativePath, expected string) {
+	t.Helper()
+	contents, err := os.ReadFile(filepath.Join(root, relativePath))
+	require.NoError(t, err)
+	require.Equal(t, expected, string(contents))
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Add .worktreeinclude matching and non-overwriting copies for Git-ignored
regular files. The worktree creation integration follows separately.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785719814`.


* **PR #1566** 👈
  * **PR #1567**
    * **PR #1568**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1570 by jonnii*