### PR TITLE
feat(worktree): warm-start new worktrees

### DIFF
--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -464,6 +464,15 @@ func createAnchoredWorktree(ctx *app.Context, eng engine.Engine, repoRoot string
 	}
 	worktreeCreated = true
 
+	warmStart, err := warmStartWorktree(ctx.Context, eng, repoRoot, worktreePath)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("failed to warm-start worktree: %w", err)
+	}
+	if warmStart.Enabled && len(warmStart.Copied) > 0 {
+		out.Info("Warm-started worktree with %d ignored file(s)", len(warmStart.Copied))
+	}
+
 	if err := eng.RegisterWorktreeWithName(anchorBranchName, worktreePath, opts.Name); err != nil {
 		cleanup()
 		return nil, fmt.Errorf("failed to register worktree: %w", err)

--- a/internal/actions/worktree/warm_start.go
+++ b/internal/actions/worktree/warm_start.go
@@ -1,6 +1,7 @@
 package worktree
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -9,6 +10,8 @@ import (
 	"strings"
 
 	ignore "github.com/sabhiram/go-gitignore"
+
+	"github.com/getstackit/stackit/internal/engine"
 )
 
 // WorktreeIncludeFile is the repository-root file that selects ignored files
@@ -23,6 +26,20 @@ type WarmStartResult struct {
 	Enabled         bool
 	Copied          []string
 	SkippedExisting []string
+}
+
+func warmStartWorktree(ctx context.Context, eng engine.Engine, sourceRoot, destinationRoot string) (WarmStartResult, error) {
+	if _, err := os.Stat(filepath.Join(sourceRoot, WorktreeIncludeFile)); os.IsNotExist(err) {
+		return WarmStartResult{}, nil
+	} else if err != nil {
+		return WarmStartResult{}, fmt.Errorf("inspect %s: %w", WorktreeIncludeFile, err)
+	}
+
+	ignoredPaths, err := eng.ListIgnoredFiles(ctx, sourceRoot)
+	if err != nil {
+		return WarmStartResult{}, err
+	}
+	return CopyIncludedIgnoredFiles(sourceRoot, destinationRoot, ignoredPaths)
 }
 
 // CopyIncludedIgnoredFiles copies selected ignored regular files from sourceRoot

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -75,6 +75,10 @@ func (d *demoGitRunner) GetGitCommonDir() (string, error) {
 	return "/demo/repo/.git", nil
 }
 
+func (d *demoGitRunner) ListIgnoredFiles(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
 func (d *demoGitRunner) EnsureMetadataRefspecConfigured() error {
 	return nil
 }

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -67,6 +67,11 @@ func (e *engineImpl) WorktreeHasTrackedChanges(ctx context.Context, worktreePath
 	return e.git.WorktreeHasTrackedChanges(ctx, worktreePath)
 }
 
+// ListIgnoredFiles returns every ignored, untracked file in a worktree.
+func (e *engineImpl) ListIgnoredFiles(ctx context.Context, worktreePath string) ([]string, error) {
+	return e.git.ListIgnoredFiles(ctx, worktreePath)
+}
+
 // PruneWorktrees removes stale worktree entries from .git/worktrees.
 // This cleans up worktree information for worktrees whose working directory
 // has been deleted or is otherwise unavailable.

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -280,6 +280,7 @@ type WorktreeOperations interface {
 	GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error)
 	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)
 	WorktreeHasTrackedChanges(ctx context.Context, worktreePath string) (bool, error)
+	ListIgnoredFiles(ctx context.Context, worktreePath string) ([]string, error)
 	CreateTemporaryWorktree(ctx context.Context, branch string, prefix string) (path string, cleanup func(), err error)
 	// CreateTemporaryWorktreeSkipPrune is like CreateTemporaryWorktree but skips the automatic
 	// PruneWorktrees() call. Use this when creating multiple worktrees in parallel after

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -212,6 +212,9 @@ type WorktreeOperations interface {
 	ResetWorktreeWorkingDir(ctx context.Context, worktreePath string) error
 	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)
 	WorktreeHasTrackedChanges(ctx context.Context, worktreePath string) (bool, error)
+	// ListIgnoredFiles returns repository-relative paths that Git currently
+	// classifies as ignored in the requested worktree.
+	ListIgnoredFiles(ctx context.Context, worktreePath string) ([]string, error)
 }
 
 // WorktreeRegistryOperations handles stackit-managed worktree tracking (local-only refs).

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -389,6 +389,25 @@ func (r *runner) WorktreeHasTrackedChanges(ctx context.Context, worktreePath str
 	return strings.TrimSpace(out) != "", nil
 }
 
+// ListIgnoredFiles returns every ignored, untracked file in worktreePath as a
+// repository-relative path. --exclude-standard ensures this has Git's actual
+// ignore semantics, rather than treating a warm-start include file as another
+// source of ignored paths.
+func (r *runner) ListIgnoredFiles(ctx context.Context, worktreePath string) ([]string, error) {
+	out, err := r.RunGitCommandRawWithContext(ctx,
+		"-C", worktreePath,
+		"ls-files", "--others", "--ignored", "--exclude-standard", "-z",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list ignored files in worktree %s: %w", worktreePath, err)
+	}
+
+	paths := strings.Split(out, "\x00")
+	paths = slices.DeleteFunc(paths, func(path string) bool { return path == "" })
+	slices.Sort(paths)
+	return paths, nil
+}
+
 // GetWorktreeCurrentBranch returns the name of the branch currently checked out in a worktree.
 // Returns empty string if the worktree is in detached HEAD state. Real failures
 // (worktree missing, repo corruption, context cancellation) are surfaced — git

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -13,6 +13,20 @@ import (
 )
 
 func TestWorktree(t *testing.T) {
+	t.Run("lists ignored files", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+		require.NoError(t, os.WriteFile(filepath.Join(scene.Repo.Dir, ".gitignore"), []byte(".env\ncache/\n"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(scene.Repo.Dir, ".env"), []byte("secret"), 0o600))
+		require.NoError(t, os.MkdirAll(filepath.Join(scene.Repo.Dir, "cache"), 0o750))
+		require.NoError(t, os.WriteFile(filepath.Join(scene.Repo.Dir, "cache", "data"), []byte("cached"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(scene.Repo.Dir, "tracked.txt"), []byte("tracked"), 0o600))
+
+		ignored, err := runner.ListIgnoredFiles(context.Background(), scene.Repo.Dir)
+		require.NoError(t, err)
+		require.Equal(t, []string{".env", "cache/data"}, ignored)
+	})
+
 	t.Run("add and remove worktree", func(t *testing.T) {
 		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
 		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)

--- a/internal/integration/worktree_comprehensive_test.go
+++ b/internal/integration/worktree_comprehensive_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/getstackit/stackit/internal/cli/common"
 )
 
@@ -107,6 +109,26 @@ func TestWorktreeBasicOperations(t *testing.T) {
 		if meta.ParentBranchName == nil || *meta.ParentBranchName != wt.AnchorBranch {
 			t.Fatalf("expected first branch parent %s, got %#v", wt.AnchorBranch, meta.ParentBranchName)
 		}
+	})
+
+	run("warm-starts explicitly included ignored files", func(t *testing.T, sh *TestShell) {
+		sh.WriteFile(".gitignore", ".env\n.warm-cache\n.other-cache\n").
+			WriteFile(".worktreeinclude", ".env\n.warm-cache\n").
+			Git("add .gitignore .worktreeinclude").
+			Git("commit -m 'configure warm start'")
+		sh.WriteUnstaged(".env", "secret").
+			WriteUnstaged(".warm-cache", "cached").
+			WriteUnstaged(".other-cache", "not copied").
+			Run("worktree create warm-start")
+
+		worktreePath := sh.GetWorktreePath("warm-start")
+		contents, err := os.ReadFile(filepath.Join(worktreePath, ".env"))
+		require.NoError(t, err)
+		require.Equal(t, "secret", string(contents))
+		contents, err = os.ReadFile(filepath.Join(worktreePath, ".warm-cache"))
+		require.NoError(t, err)
+		require.Equal(t, "cached", string(contents))
+		require.NoFileExists(t, filepath.Join(worktreePath, ".other-cache"))
 	})
 
 	run("worktree run returns child process exit code", func(t *testing.T, sh *TestShell) {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Copy explicitly included Git-ignored files into new managed worktrees before
their setup hooks run, and roll creation back if initialization fails.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785719814`.


* **PR #1566**
  * **PR #1567** 👈
    * **PR #1568**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1570 by jonnii*