### PR TITLE
fix(worktree): keep reverse registrations stable through symlinks

### DIFF
--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -212,7 +212,7 @@ func (e *engineImpl) RegisterWorktreeWithName(anchorBranch string, path string, 
 	if err != nil {
 		return fmt.Errorf("failed to get absolute worktree path: %w", err)
 	}
-	canonicalPath, err := canonicalWorktreePath(absPath)
+	canonicalPath, err := git.CanonicalWorktreePath(absPath)
 	if err != nil {
 		return fmt.Errorf("failed to canonicalize worktree path: %w", err)
 	}
@@ -228,7 +228,7 @@ func (e *engineImpl) RegisterWorktreeWithName(anchorBranch string, path string, 
 		return fmt.Errorf("failed to list worktree registrations: %w", err)
 	}
 	for _, worktree := range worktrees {
-		worktreePath, pathErr := canonicalWorktreePath(worktree.Path)
+		worktreePath, pathErr := git.CanonicalWorktreePath(worktree.Path)
 		if pathErr != nil {
 			return fmt.Errorf("failed to canonicalize registered worktree path %s: %w", worktree.Path, pathErr)
 		}
@@ -246,21 +246,6 @@ func (e *engineImpl) RegisterWorktreeWithName(anchorBranch string, path string, 
 	}
 
 	return e.git.WriteWorktreeMeta(anchorBranch, meta)
-}
-
-func canonicalWorktreePath(path string) (string, error) {
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return "", err
-	}
-	resolvedPath, err := filepath.EvalSymlinks(absPath)
-	if err == nil {
-		return filepath.Clean(resolvedPath), nil
-	}
-	if !os.IsNotExist(err) {
-		return "", err
-	}
-	return filepath.Clean(absPath), nil
 }
 
 // UnregisterWorktree removes worktree registration for a stack root
@@ -407,19 +392,23 @@ func (e *engineImpl) IsInManagedWorktree() (bool, *WorktreeInfo, error) {
 		return false, nil, fmt.Errorf("failed to get absolute path: %w", err)
 	}
 
-	// List all managed worktrees and check if current path matches
+	canonicalCurrentPath, err := git.CanonicalWorktreePath(currentPath)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to canonicalize current worktree path: %w", err)
+	}
+
+	// List all managed worktrees and check if current path matches.
 	worktrees, err := e.ListManagedWorktrees()
 	if err != nil {
 		return false, nil, fmt.Errorf("failed to list managed worktrees: %w", err)
 	}
 
 	for _, wt := range worktrees {
-		// Compare paths (normalize both)
-		wtPath, err := filepath.Abs(wt.Path)
+		wtPath, err := git.CanonicalWorktreePath(wt.Path)
 		if err != nil {
 			continue
 		}
-		if wtPath == currentPath {
+		if wtPath == canonicalCurrentPath {
 			return true, &WorktreeInfo{
 				Name:         wt.Name,
 				Path:         wt.Path,

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -22,26 +22,41 @@ const WorktreeRefPrefix = "refs/stackit/worktrees/"
 const WorktreePathRefPrefix = "refs/stackit/worktree-paths/"
 
 func worktreePathRef(path string) string {
-	if canonicalPath, err := canonicalWorktreePath(path); err == nil {
+	if canonicalPath, err := CanonicalWorktreePath(path); err == nil {
 		path = canonicalPath
 	}
 	hash := sha256.Sum256([]byte(path))
 	return fmt.Sprintf("%s%x", WorktreePathRefPrefix, hash)
 }
 
-func canonicalWorktreePath(path string) (string, error) {
+// CanonicalWorktreePath returns an absolute path with every existing path
+// component resolved. It deliberately resolves the deepest existing ancestor
+// instead of requiring the final worktree directory to exist: registration
+// happens after creation but unregistering often happens after removal. Using
+// the same canonical spelling in both cases keeps the reverse registration
+// ref addressable through symlinked bases such as /tmp on macOS.
+func CanonicalWorktreePath(path string) (string, error) {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return "", err
 	}
-	resolvedPath, err := filepath.EvalSymlinks(absPath)
-	if err == nil {
-		return filepath.Clean(resolvedPath), nil
+
+	for existing := absPath; ; existing = filepath.Dir(existing) {
+		resolvedPath, evalErr := filepath.EvalSymlinks(existing)
+		if evalErr == nil {
+			remainder, relErr := filepath.Rel(existing, absPath)
+			if relErr != nil {
+				return "", relErr
+			}
+			return filepath.Clean(filepath.Join(resolvedPath, remainder)), nil
+		}
+		if !os.IsNotExist(evalErr) {
+			return "", evalErr
+		}
+		if parent := filepath.Dir(existing); parent == existing {
+			return "", evalErr
+		}
 	}
-	if !os.IsNotExist(err) {
-		return "", err
-	}
-	return filepath.Clean(absPath), nil
 }
 
 // Worktree represents a single entry from `git worktree list`.

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -125,6 +125,31 @@ func TestIsMainWorktree(t *testing.T) {
 }
 
 func TestWorktreeRegistry(t *testing.T) {
+	t.Run("removes reverse path registration after symlinked worktree is gone", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+
+		targetBase := t.TempDir()
+		linkBase := filepath.Join(t.TempDir(), "linked-base")
+		require.NoError(t, os.Symlink(targetBase, linkBase))
+		worktreePath := filepath.Join(linkBase, "worktree")
+
+		require.NoError(t, runner.WriteWorktreeMeta("first", &git.WorktreeMeta{
+			Path:         worktreePath,
+			AnchorBranch: "first",
+		}))
+		// Match real cleanup ordering: by this point the worktree directory is
+		// gone, while its symlinked base still exists.
+		require.NoError(t, runner.DeleteWorktreeMeta(context.Background(), "first"))
+
+		// Re-registration at the same path must not collide with an orphaned
+		// reverse path ref hashed with a different spelling.
+		require.NoError(t, runner.WriteWorktreeMeta("second", &git.WorktreeMeta{
+			Path:         worktreePath,
+			AnchorBranch: "second",
+		}))
+	})
+
 	t.Run("write and read worktree metadata", func(t *testing.T) {
 		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
 		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Make branch mutations safe when worktrees hold the branch**

Closes the worktree half of the reconciliation-safety audit: eighteen fixes so
that moving a branch ref can no longer corrupt, revert, or silently discard work
in a worktree that has that branch checked out.

The unifying rule: before any operation rewrites a ref, it must ask who
physically holds that branch. If the holder is dirty or uninspectable, hold the
branch back and say so; if it is clean, reset it to match the ref it now points
at; never move a ref out from under a checkout and report success.

**Data loss (P0)**

- **#1580, #1584, #1585** — `fold`, `absorb`, and `continue` no longer merge onto
  a detached HEAD, rewrite an ancestor, or move a rebased ref while another
  worktree holds the branch. `CheckoutBranch` stops silently falling back to
  detached HEAD, which was a latent trap for every checkout-then-mutate action.
- **#1584** — `git.Rebase` writes its result through a compare-and-swap, so a
  commit made in another worktree mid-pass can no longer be overwritten (and
  then wiped by a reset keyed on a stale clean-snapshot).
- **#1580** — `create -w` keeps the branch when only the worktree phase fails.
  It previously deleted the sole ref to the commit that had just consumed the
  staged changes, past the point a snapshot could recover it.
- **#1585** — `merge --force` resets trunk through a ref update instead of a
  branch checkout, so a temp worktree can no longer squat on `refs/heads/<trunk>`
  and block the main workspace.

**Reconciliation model**

- **#1573, #1574, #1577, #1593** — restack holds branches behind dirty or
  uninspectable worktrees, holds their descendants too, leaves held branches
  metadata untouched, and reports the hold rather than passing it off as
  "already up to date". Untracked files count: `git reset --hard` will overwrite
  an untracked file whose pathname the incoming commit contains.
- **#1597** — worktrees mid-rebase report no branch to porcelain, so they were
  invisible to every branch/worktree guard. They are now held.

**Lifecycle and ownership**

- **#1586, #1595** — `pluck` and `delete` enforce managed-worktree ownership like
  the other branch-scoped mutations.
- **#1588, #1592, #1594** — worktree cleanup prunes before deleting the anchor,
  recovers invalid registrations instead of dead-ending between `remove`,
  `repair`, and `detach`, and sweeps reverse path refs orphaned by older code
  that would otherwise block re-creating a worktree at that path forever.
- **#1571** — reverse registrations stay addressable through symlinked bases by
  resolving the deepest existing ancestor, so register and unregister agree.
- **#1592** — multi-stack merge tags and deletes its consolidation branch and
  unlocks excluded and failed stacks instead of stranding PR locks.

**Correctness and hardening**

- **#1572** — sync stops treating a deleted remote branch as proof the local tip
  was pushed, which discarded follow-up commits on closed PRs.
- **#1589** — `split` uses the stash-by-ref API rather than popping the shared
  cross-worktree `stash@{0}`; relative `gitdir:` pointers resolve against the
  right base.
- **#1596** — `tree --json` no longer emits hidden anchors as dangling parents.
- Worktree porcelain is parsed with `-z`, `ForceRemoveWorktree` passes `--force`
  twice so it can remove locked worktrees, and relative `worktree.basePath`
  resolves against the repo root in Go code as it already did in git.

**Notes**

Sync also skips hidden anchors when comparing PR bases, which was queueing a
GitHub 422 on every sync for every worktree stack root with a PR.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785934948`.


* **PR #1571** 👈
  * **PR #1572**
    * **PR #1573**
      * **PR #1574**
        * **PR #1577**
          * **PR #1580**
            * **PR #1584**
              * **PR #1585**
                * **PR #1586**
                  * **PR #1588**
                    * **PR #1589**
                      * **PR #1592**
                        * **PR #1593**
                          * **PR #1594**
                            * **PR #1595**
                              * **PR #1596**
                                * **PR #1597**
                                  * **PR #1599**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1601 by jonnii*