### PR TITLE
fix(sync): preserve closed branches with deleted remotes

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -251,9 +251,15 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (engi
 		// Check if local branch has unpushed changes relative to remote
 		branch := eng.GetBranch(name)
 		remoteStatus := remoteStatuses[name]
-		if remoteStatus.Ahead() || remoteStatus.Diverged() {
+		// A missing remote branch cannot prove that the local tip was pushed.
+		// This is common after a closed PR's remote branch is deleted; treating
+		// it as clean would make non-interactive sync discard local follow-up
+		// commits without a prompt. Preserve the branch until an explicit user
+		// action decides otherwise.
+		if remoteStatus.Ahead() || remoteStatus.Diverged() ||
+			(status.Kind == engine.DeletionReasonClosedPR && remoteStatus.MissingRemote()) {
 			status.HasUnpushedChanges = true
-			ctx.Logger.Info("identifyBranchesToDelete branch has unpushed changes branch=%v ahead=%v diverged=%v", name, remoteStatus.Ahead(), remoteStatus.Diverged())
+			ctx.Logger.Info("identifyBranchesToDelete branch has unpushed or unverifiable changes branch=%v ahead=%v diverged=%v missingRemote=%v", name, remoteStatus.Ahead(), remoteStatus.Diverged(), remoteStatus.MissingRemote())
 		}
 
 		deleteStatuses[name] = status

--- a/internal/actions/clean_branches_test.go
+++ b/internal/actions/clean_branches_test.go
@@ -297,6 +297,46 @@ func TestCleanBranches(t *testing.T) {
 		require.True(t, plan.UnpushedBranches["branch1"], "branch1 should be marked as having unpushed changes")
 	})
 
+	t.Run("marks a closed PR with a deleted remote branch as unpushed", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"branch1": "main",
+			})
+
+		_, err := s.Scene.Repo.CreateBareRemote("origin")
+		require.NoError(t, err)
+		require.NoError(t, s.Scene.Repo.PushBranch("origin", "main"))
+		require.NoError(t, s.Scene.Repo.PushBranch("origin", "branch1"))
+
+		s.Checkout("branch1").CommitChange("follow-up.txt", "local-only follow-up").Checkout("main")
+		require.NoError(t, s.Scene.Repo.RunGitCommand("push", "origin", "--delete", "branch1"))
+		require.NoError(t, s.Engine.UpsertPrInfo(context.Background(), s.Engine.GetBranch("branch1"), testhelpers.NewTestPrInfoClosed(1)))
+
+		plan, err := actions.PlanBranchDeletions(s.Context, actions.CleanBranchesOptions{Force: true})
+		require.NoError(t, err)
+		require.Contains(t, plan.BranchesToDelete, "branch1")
+		require.True(t, plan.UnpushedBranches["branch1"], "missing remote must preserve unverifiable local work")
+	})
+
+	t.Run("does not mark a merged PR with a deleted remote branch as unpushed", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{"branch1": "main"})
+
+		_, err := s.Scene.Repo.CreateBareRemote("origin")
+		require.NoError(t, err)
+		require.NoError(t, s.Scene.Repo.PushBranch("origin", "main"))
+		require.NoError(t, s.Scene.Repo.PushBranch("origin", "branch1"))
+		require.NoError(t, s.Scene.Repo.RunGitCommand("push", "origin", "--delete", "branch1"))
+		require.NoError(t, s.Engine.UpsertPrInfo(context.Background(), s.Engine.GetBranch("branch1"), testhelpers.NewTestPrInfoMerged(1, "main")))
+
+		plan, err := actions.PlanBranchDeletions(s.Context, actions.CleanBranchesOptions{Force: true})
+		require.NoError(t, err)
+		require.Contains(t, plan.BranchesToDelete, "branch1")
+		require.False(t, plan.UnpushedBranches["branch1"])
+	})
+
 	t.Run("planning does not reparent surviving children", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).

--- a/internal/actions/sync/github_sync.go
+++ b/internal/actions/sync/github_sync.go
@@ -205,13 +205,7 @@ func PushParentsToGitHub(ctx *app.Context, result *GitHubSyncResult, dirtyAnchor
 		}
 
 		// Get local parent
-		currentParent := branch.GetParent()
-		localParentName := ""
-		if currentParent == nil {
-			localParentName = eng.Trunk().GetName()
-		} else {
-			localParentName = currentParent.GetName()
-		}
+		localParentName := githubParentName(eng, branch)
 
 		if prInfo.Base == localParentName {
 			continue
@@ -255,4 +249,23 @@ func PushParentsToGitHub(ctx *app.Context, result *GitHubSyncResult, dirtyAnchor
 	return &ParentsToGitHubResult{
 		BranchesUpdated: updated,
 	}, nil
+}
+
+// githubParentName skips hidden worktree anchors: they are local bookkeeping
+// branches and can never be valid GitHub PR bases.
+func githubParentName(nav engine.StackNavigator, branch engine.Branch) string {
+	parent := branch.GetParent()
+	visited := make(map[string]bool)
+	for parent != nil {
+		name := parent.GetName()
+		if visited[name] {
+			break
+		}
+		visited[name] = true
+		if !parent.IsWorktreeAnchor() {
+			return name
+		}
+		parent = parent.GetParent()
+	}
+	return nav.Trunk().GetName()
 }

--- a/internal/integration/sync_test.go
+++ b/internal/integration/sync_test.go
@@ -120,7 +120,7 @@ func TestSync(t *testing.T) {
 		meta, err := eng.Git().ReadMetadata(mergeBranch)
 		require.NoError(t, err)
 		prNum := 100
-		state := git.PRStateClosed
+		state := git.PRStateMerged
 		base := mainBranchName
 		meta = meta.WithPrInfo(&git.PrInfoPersistence{
 			Number: &prNum,


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Make branch mutations safe when worktrees hold the branch**

Closes the worktree half of the reconciliation-safety audit: eighteen fixes so
that moving a branch ref can no longer corrupt, revert, or silently discard work
in a worktree that has that branch checked out.

The unifying rule: before any operation rewrites a ref, it must ask who
physically holds that branch. If the holder is dirty or uninspectable, hold the
branch back and say so; if it is clean, reset it to match the ref it now points
at; never move a ref out from under a checkout and report success.

**Data loss (P0)**

- **#1580, #1584, #1585** — `fold`, `absorb`, and `continue` no longer merge onto
  a detached HEAD, rewrite an ancestor, or move a rebased ref while another
  worktree holds the branch. `CheckoutBranch` stops silently falling back to
  detached HEAD, which was a latent trap for every checkout-then-mutate action.
- **#1584** — `git.Rebase` writes its result through a compare-and-swap, so a
  commit made in another worktree mid-pass can no longer be overwritten (and
  then wiped by a reset keyed on a stale clean-snapshot).
- **#1580** — `create -w` keeps the branch when only the worktree phase fails.
  It previously deleted the sole ref to the commit that had just consumed the
  staged changes, past the point a snapshot could recover it.
- **#1585** — `merge --force` resets trunk through a ref update instead of a
  branch checkout, so a temp worktree can no longer squat on `refs/heads/<trunk>`
  and block the main workspace.

**Reconciliation model**

- **#1573, #1574, #1577, #1593** — restack holds branches behind dirty or
  uninspectable worktrees, holds their descendants too, leaves held branches
  metadata untouched, and reports the hold rather than passing it off as
  "already up to date". Untracked files count: `git reset --hard` will overwrite
  an untracked file whose pathname the incoming commit contains.
- **#1597** — worktrees mid-rebase report no branch to porcelain, so they were
  invisible to every branch/worktree guard. They are now held.

**Lifecycle and ownership**

- **#1586, #1595** — `pluck` and `delete` enforce managed-worktree ownership like
  the other branch-scoped mutations.
- **#1588, #1592, #1594** — worktree cleanup prunes before deleting the anchor,
  recovers invalid registrations instead of dead-ending between `remove`,
  `repair`, and `detach`, and sweeps reverse path refs orphaned by older code
  that would otherwise block re-creating a worktree at that path forever.
- **#1571** — reverse registrations stay addressable through symlinked bases by
  resolving the deepest existing ancestor, so register and unregister agree.
- **#1592** — multi-stack merge tags and deletes its consolidation branch and
  unlocks excluded and failed stacks instead of stranding PR locks.

**Correctness and hardening**

- **#1572** — sync stops treating a deleted remote branch as proof the local tip
  was pushed, which discarded follow-up commits on closed PRs.
- **#1589** — `split` uses the stash-by-ref API rather than popping the shared
  cross-worktree `stash@{0}`; relative `gitdir:` pointers resolve against the
  right base.
- **#1596** — `tree --json` no longer emits hidden anchors as dangling parents.
- Worktree porcelain is parsed with `-z`, `ForceRemoveWorktree` passes `--force`
  twice so it can remove locked worktrees, and relative `worktree.basePath`
  resolves against the repo root in Go code as it already did in git.

**Notes**

Sync also skips hidden anchors when comparing PR bases, which was queueing a
GitHub 422 on every sync for every worktree stack root with a PR.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785934948`.


* **PR #1571**
  * **PR #1572** 👈
    * **PR #1573**
      * **PR #1574**
        * **PR #1577**
          * **PR #1580**
            * **PR #1584**
              * **PR #1585**
                * **PR #1586**
                  * **PR #1588**
                    * **PR #1589**
                      * **PR #1592**
                        * **PR #1593**
                          * **PR #1594**
                            * **PR #1595**
                              * **PR #1596**
                                * **PR #1597**
                                  * **PR #1599**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1601 by jonnii*