### PR TITLE
fix(git): hold ref updates behind dirty worktrees

### DIFF
--- a/internal/git/pull.go
+++ b/internal/git/pull.go
@@ -69,26 +69,27 @@ func (r *runner) UpdateBranchFromRemote(ctx context.Context, remote, branchName 
 	if err == nil && isRemoteAhead {
 		// Save current branch/detached HEAD immediately before mutating refs.
 		currentBranch, err := r.GetCurrentBranch()
-		var currentRev string
 		if err != nil {
 			currentBranch = ""
-			currentRev, _ = r.GetCurrentRevision(ctx)
 		}
 
-		// Before updating the ref, check if this branch is checked out in another worktree.
-		// update-ref is global and will affect all worktrees, so we need to sync any
-		// worktree that has this branch checked out to avoid corrupting its index/working tree.
-		//
-		// IMPORTANT: We must check for uncommitted changes BEFORE the update-ref,
-		// because after update-ref the worktree will appear to have inverse changes
-		// (old content vs new HEAD), which would cause the check to fail.
-		var otherWorktreePath string
-		var otherWorktreeClean bool
-		if currentBranch != branchName {
-			otherWorktreePath, _ = r.GetWorktreePathForBranch(ctx, branchName)
-			if otherWorktreePath != "" {
-				hasChanges, err := r.WorktreeHasUncommittedChanges(ctx, otherWorktreePath)
-				otherWorktreeClean = err == nil && !hasChanges
+		// A ref update is global, but the checked-out worktree's index and
+		// working directory are local. Never move a checked-out branch unless
+		// its holder is known clean and can be reset immediately afterwards.
+		// Importantly, an inspection failure is unsafe too: it must not silently
+		// turn into a ref move that strands an unknown worktree on old content.
+		worktrees, err := r.ListWorktrees(ctx)
+		if err != nil {
+			return PullConflict, fmt.Errorf("refusing to update %s: cannot inspect worktrees: %w", branchName, err)
+		}
+		worktreePath := worktrees.PathForBranch(branchName)
+		if worktreePath != "" {
+			hasChanges, statusErr := r.WorktreeHasUncommittedChanges(ctx, worktreePath)
+			if statusErr != nil {
+				return PullConflict, fmt.Errorf("refusing to update %s: cannot inspect worktree %s: %w", branchName, worktreePath, statusErr)
+			}
+			if hasChanges {
+				return PullConflict, fmt.Errorf("refusing to update %s: worktree %s has uncommitted changes", branchName, worktreePath)
 			}
 		}
 
@@ -107,15 +108,14 @@ func (r *runner) UpdateBranchFromRemote(ctx context.Context, remote, branchName 
 		// so hard reset is safe here.
 		if currentBranch == branchName {
 			_ = r.HardReset(ctx, "HEAD")
-		} else if currentRev != "" {
-			_ = r.CheckoutDetached(ctx, currentRev)
 		}
 
-		// If this branch is checked out in another worktree that was clean before
-		// the update-ref, we need to reset that worktree to match the new HEAD.
-		// Otherwise the worktree's index/working tree will appear as inverse changes.
-		if otherWorktreePath != "" && otherWorktreeClean {
-			_ = r.ResetWorktreeWorkingDir(ctx, otherWorktreePath)
+		// If this branch is checked out in another clean worktree, reset it to
+		// match the ref we just moved. The clean check above makes this safe.
+		if worktreePath != "" && currentBranch != branchName {
+			if err := r.ResetWorktreeWorkingDir(ctx, worktreePath); err != nil {
+				return PullConflict, fmt.Errorf("updated %s but failed to reset clean worktree %s: %w", branchName, worktreePath, err)
+			}
 		}
 
 		return PullDone, nil


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Make branch mutations safe when worktrees hold the branch**

Closes the worktree half of the reconciliation-safety audit: eighteen fixes so
that moving a branch ref can no longer corrupt, revert, or silently discard work
in a worktree that has that branch checked out.

The unifying rule: before any operation rewrites a ref, it must ask who
physically holds that branch. If the holder is dirty or uninspectable, hold the
branch back and say so; if it is clean, reset it to match the ref it now points
at; never move a ref out from under a checkout and report success.

**Data loss (P0)**

- **#1580, #1584, #1585** — `fold`, `absorb`, and `continue` no longer merge onto
  a detached HEAD, rewrite an ancestor, or move a rebased ref while another
  worktree holds the branch. `CheckoutBranch` stops silently falling back to
  detached HEAD, which was a latent trap for every checkout-then-mutate action.
- **#1584** — `git.Rebase` writes its result through a compare-and-swap, so a
  commit made in another worktree mid-pass can no longer be overwritten (and
  then wiped by a reset keyed on a stale clean-snapshot).
- **#1580** — `create -w` keeps the branch when only the worktree phase fails.
  It previously deleted the sole ref to the commit that had just consumed the
  staged changes, past the point a snapshot could recover it.
- **#1585** — `merge --force` resets trunk through a ref update instead of a
  branch checkout, so a temp worktree can no longer squat on `refs/heads/<trunk>`
  and block the main workspace.

**Reconciliation model**

- **#1573, #1574, #1577, #1593** — restack holds branches behind dirty or
  uninspectable worktrees, holds their descendants too, leaves held branches
  metadata untouched, and reports the hold rather than passing it off as
  "already up to date". Untracked files count: `git reset --hard` will overwrite
  an untracked file whose pathname the incoming commit contains.
- **#1597** — worktrees mid-rebase report no branch to porcelain, so they were
  invisible to every branch/worktree guard. They are now held.

**Lifecycle and ownership**

- **#1586, #1595** — `pluck` and `delete` enforce managed-worktree ownership like
  the other branch-scoped mutations.
- **#1588, #1592, #1594** — worktree cleanup prunes before deleting the anchor,
  recovers invalid registrations instead of dead-ending between `remove`,
  `repair`, and `detach`, and sweeps reverse path refs orphaned by older code
  that would otherwise block re-creating a worktree at that path forever.
- **#1571** — reverse registrations stay addressable through symlinked bases by
  resolving the deepest existing ancestor, so register and unregister agree.
- **#1592** — multi-stack merge tags and deletes its consolidation branch and
  unlocks excluded and failed stacks instead of stranding PR locks.

**Correctness and hardening**

- **#1572** — sync stops treating a deleted remote branch as proof the local tip
  was pushed, which discarded follow-up commits on closed PRs.
- **#1589** — `split` uses the stash-by-ref API rather than popping the shared
  cross-worktree `stash@{0}`; relative `gitdir:` pointers resolve against the
  right base.
- **#1596** — `tree --json` no longer emits hidden anchors as dangling parents.
- Worktree porcelain is parsed with `-z`, `ForceRemoveWorktree` passes `--force`
  twice so it can remove locked worktrees, and relative `worktree.basePath`
  resolves against the repo root in Go code as it already did in git.

**Notes**

Sync also skips hidden anchors when comparing PR bases, which was queueing a
GitHub 422 on every sync for every worktree stack root with a PR.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785934948`.


* **PR #1571**
  * **PR #1572**
    * **PR #1573** 👈
      * **PR #1574**
        * **PR #1577**
          * **PR #1580**
            * **PR #1584**
              * **PR #1585**
                * **PR #1586**
                  * **PR #1588**
                    * **PR #1589**
                      * **PR #1592**
                        * **PR #1593**
                          * **PR #1594**
                            * **PR #1595**
                              * **PR #1596**
                                * **PR #1597**
                                  * **PR #1599**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1601 by jonnii*