### PR TITLE
fix(restack): hold descendants behind unsafe worktrees

### DIFF
--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -145,18 +145,12 @@ func RestackAction(ctx *app.Context, plan *RestackPlan, handler handlers.Restack
 
 	ctx.Logger.Info("restack started branchCount=%v", branchCount)
 
-	// Parallel mode dispatches each group to a worktree that recomputes its own
-	// plan, so the plan resolved here does not decide what those workers do.
+	// Restack is repository reconciliation, like sync: it may run from any
+	// worktree, but the engine holds branches whose checked-out worktree is
+	// dirty or cannot be inspected. Content-editing actions keep the ownership
+	// guard; applying it here would make unrelated main-repo stacks an
+	// all-or-nothing casualty of one managed worktree.
 	parallelDispatch := opts.Parallel && len(plan.groups) > 1
-	if !parallelDispatch {
-		branches := engine.Branches{}
-		for _, group := range plan.groups {
-			branches = branches.Concat(group.sortedBranches)
-		}
-		if err := EnsureCanModifyHere(ctx, branches...); err != nil {
-			return err
-		}
-	}
 
 	// Take snapshot before modifying the repository. Skip it when no branch
 	// actually needs a rebase: an up-to-date restack mutates nothing, so there

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -115,6 +115,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 	// check; the snapshot is stable across the restack loop since we don't
 	// add or remove worktrees here.
 	worktrees, err := e.git.ListWorktrees(ctx)
+	worktreeInspectionFailed := err != nil
 	if err != nil {
 		worktrees = git.WorktreeList{}
 	}
@@ -134,9 +135,15 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 	// the new commit's files as deleted, and the next `stackit modify -a`
 	// commits that deletion into the stack.
 	dirtyWorktrees := make(map[string]bool, len(worktrees))
-	for _, path := range worktrees.Paths() {
-		if dirty, dirtyErr := e.git.WorktreeHasTrackedChanges(ctx, path); dirtyErr == nil && dirty {
+	heldBranches := make(BranchNameSet)
+	for _, worktree := range worktrees {
+		dirty, dirtyErr := e.git.WorktreeHasTrackedChanges(ctx, worktree.Path)
+		if dirtyErr != nil || dirty {
+			path := worktree.Path
 			dirtyWorktrees[path] = true
+			if worktree.Branch != "" {
+				heldBranches[worktree.Branch] = true
+			}
 		}
 	}
 
@@ -152,7 +159,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 			metaRefSHAs[strings.TrimPrefix(refName, git.MetadataRefPrefix)] = sha
 		}
 	}
-	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees}
+	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees, heldBranches: heldBranches, worktreeInspectionFailed: worktreeInspectionFailed}
 
 	// 2. Apply the restack changes
 	results := make(map[string]RestackBranchResult)

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -60,6 +60,34 @@ type restackSnapshot struct {
 	// deliberately excluded — see resetWorktreeIfClean for why, and for why this
 	// can't be checked lazily.
 	dirtyWorktrees map[string]bool
+	// heldBranches contains every branch whose checked-out worktree was dirty
+	// or could not be inspected before this pass. Descendants of these branches
+	// must be held too: a validated child may otherwise be built on the target
+	// SHA of a parent that was ultimately not allowed to move.
+	heldBranches BranchNameSet
+	// worktreeInspectionFailed means the physical checkout map is unknown, so
+	// no ref move is safe for this pass.
+	worktreeInspectionFailed bool
+}
+
+func (e *engineImpl) branchHeldBack(branch Branch, snap *restackSnapshot) bool {
+	if snap.worktreeInspectionFailed {
+		return true
+	}
+	for current := branch.GetName(); current != ""; {
+		if snap.heldBranches.Contains(current) {
+			return true
+		}
+		e.mu.RLock()
+		state := e.readState(current)
+		trunk := e.trunk
+		e.mu.RUnlock()
+		if state == nil || state.Parent == "" || current == trunk {
+			return false
+		}
+		current = state.Parent
+	}
+	return false
 }
 
 // branchRev returns branch's revision from the pass snapshot, falling back to a
@@ -223,7 +251,7 @@ func (e *engineImpl) restackBranch(
 	// which warns and is reached solely by the `restack` command) so that every
 	// caller of RestackBranches inherits it — modify, sync, squash, absorb,
 	// delete, split, reorder, pluck and insert all arrive here directly.
-	if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" && snap.dirtyWorktrees[worktreePath] {
+	if e.branchHeldBack(branch, snap) {
 		return RestackBranchResult{Result: RestackUnneeded}, nil
 	}
 
@@ -723,7 +751,7 @@ func (e *engineImpl) applyBranchAndMetadata(
 	// Hold the branch back instead. This is the plan path, reached by every
 	// caller of actions.RestackBranches (modify, squash, absorb, delete, split,
 	// reorder, pluck) as well as the `restack` command.
-	if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" && snap.dirtyWorktrees[worktreePath] {
+	if e.branchHeldBack(branch, snap) {
 		return RestackBranchResult{Result: RestackUnneeded, RebasedBranchBase: parentRev}, nil
 	}
 

--- a/internal/git/pull.go
+++ b/internal/git/pull.go
@@ -69,26 +69,27 @@ func (r *runner) UpdateBranchFromRemote(ctx context.Context, remote, branchName 
 	if err == nil && isRemoteAhead {
 		// Save current branch/detached HEAD immediately before mutating refs.
 		currentBranch, err := r.GetCurrentBranch()
-		var currentRev string
 		if err != nil {
 			currentBranch = ""
-			currentRev, _ = r.GetCurrentRevision(ctx)
 		}
 
-		// Before updating the ref, check if this branch is checked out in another worktree.
-		// update-ref is global and will affect all worktrees, so we need to sync any
-		// worktree that has this branch checked out to avoid corrupting its index/working tree.
-		//
-		// IMPORTANT: We must check for uncommitted changes BEFORE the update-ref,
-		// because after update-ref the worktree will appear to have inverse changes
-		// (old content vs new HEAD), which would cause the check to fail.
-		var otherWorktreePath string
-		var otherWorktreeClean bool
-		if currentBranch != branchName {
-			otherWorktreePath, _ = r.GetWorktreePathForBranch(ctx, branchName)
-			if otherWorktreePath != "" {
-				hasChanges, err := r.WorktreeHasUncommittedChanges(ctx, otherWorktreePath)
-				otherWorktreeClean = err == nil && !hasChanges
+		// A ref update is global, but the checked-out worktree's index and
+		// working directory are local. Never move a checked-out branch unless
+		// its holder is known clean and can be reset immediately afterwards.
+		// Importantly, an inspection failure is unsafe too: it must not silently
+		// turn into a ref move that strands an unknown worktree on old content.
+		worktrees, err := r.ListWorktrees(ctx)
+		if err != nil {
+			return PullConflict, fmt.Errorf("refusing to update %s: cannot inspect worktrees: %w", branchName, err)
+		}
+		worktreePath := worktrees.PathForBranch(branchName)
+		if worktreePath != "" {
+			hasChanges, statusErr := r.WorktreeHasTrackedChanges(ctx, worktreePath)
+			if statusErr != nil {
+				return PullConflict, fmt.Errorf("refusing to update %s: cannot inspect worktree %s: %w", branchName, worktreePath, statusErr)
+			}
+			if hasChanges {
+				return PullConflict, fmt.Errorf("refusing to update %s: worktree %s has uncommitted tracked changes", branchName, worktreePath)
 			}
 		}
 
@@ -107,15 +108,14 @@ func (r *runner) UpdateBranchFromRemote(ctx context.Context, remote, branchName 
 		// so hard reset is safe here.
 		if currentBranch == branchName {
 			_ = r.HardReset(ctx, "HEAD")
-		} else if currentRev != "" {
-			_ = r.CheckoutDetached(ctx, currentRev)
 		}
 
-		// If this branch is checked out in another worktree that was clean before
-		// the update-ref, we need to reset that worktree to match the new HEAD.
-		// Otherwise the worktree's index/working tree will appear as inverse changes.
-		if otherWorktreePath != "" && otherWorktreeClean {
-			_ = r.ResetWorktreeWorkingDir(ctx, otherWorktreePath)
+		// If this branch is checked out in another clean worktree, reset it to
+		// match the ref we just moved. The clean check above makes this safe.
+		if worktreePath != "" && currentBranch != branchName {
+			if err := r.ResetWorktreeWorkingDir(ctx, worktreePath); err != nil {
+				return PullConflict, fmt.Errorf("updated %s but failed to reset clean worktree %s: %w", branchName, worktreePath, err)
+			}
 		}
 
 		return PullDone, nil

--- a/internal/integration/worktree_comprehensive_test.go
+++ b/internal/integration/worktree_comprehensive_test.go
@@ -476,7 +476,7 @@ func TestWorktreeRestackOperations(t *testing.T) {
 		})
 	}
 
-	run("restack from main rejects worktree branches", func(t *testing.T, sh *TestShell) {
+	run("restack from main reconciles worktree branches", func(t *testing.T, sh *TestShell) {
 		// Create stack in worktree
 		sh.WriteFile("feature.txt", "feature").
 			Run("create feature -w -m 'feature branch'")
@@ -489,7 +489,7 @@ func TestWorktreeRestackOperations(t *testing.T) {
 		shW.WriteFile("b.txt", "b").Run("create b -m 'branch b'")
 		shW.WriteFile("c.txt", "c").Run("create c -m 'branch c'")
 
-		sh.RunExpectError("restack").OutputContains("belongs to worktree")
+		sh.Run("restack").OutputNotContains("belongs to worktree")
 		shW.OnBranch("c")
 	})
 


### PR DESCRIPTION


<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1571**
  * **PR #1572**
    * **PR #1573**
      * **PR #1574**
        * **PR #1575** 👈
          * **PR #1576**
            * **PR #1577**
              * **PR #1581**
                * **PR #1580**
                  * **PR #1582**
                    * **PR #1583**
                      * **PR #1584**
                        * **PR #1585**
                          * **PR #1586**
                            * **PR #1588**
                              * **PR #1589**
                                * **PR #1590**
                                  * **PR #1591**
                                    * **PR #1592**
                                      * **PR #1593**
                                        * **PR #1594**
                                          * **PR #1595**
                                            * **PR #1596**
                                              * **PR #1597**
                                                * **PR #1598**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->