### PR TITLE
fix(restack): keep held descendants' metadata unchanged

### DIFF
--- a/docs/worktree.md
+++ b/docs/worktree.md
@@ -36,6 +36,20 @@ Git worktrees let you check out multiple branches simultaneously in separate dir
 
 **Default location:** Worktrees are created in a sibling directory named `{repo}-stacks/`. For example, if your repo is at `~/projects/myapp`, worktrees go to `~/projects/myapp-stacks/`.
 
+### Ownership and reconciliation
+
+Branch-scoped content operations — including `create`, `modify`, `absorb`,
+`fold`, `squash`, `split`, `move`, and `reorder` — must run in the worktree
+that owns the stack. This ensures an edit is made in the working tree the user
+is actually viewing.
+
+`sync` and `restack` are whole-repository reconcilers and may run from any
+worktree. They never check out a foreign branch. Before either moves a ref,
+Stackit inspects every physical checkout: a clean holder is reset to the new
+ref, while a dirty or uninspectable holder (and its descendants) is held back
+and reported. This applies to ordinary Git worktrees too, not only worktrees
+registered with Stackit.
+
 ---
 
 ## Warm starts

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -115,6 +115,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 	// check; the snapshot is stable across the restack loop since we don't
 	// add or remove worktrees here.
 	worktrees, err := e.git.ListWorktrees(ctx)
+	worktreeInspectionFailed := err != nil
 	if err != nil {
 		worktrees = git.WorktreeList{}
 	}
@@ -127,16 +128,19 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 	// when the user actually had uncommitted work. Bounded by worktree count,
 	// not branch count, so this stays a handful of calls even for a large stack.
 	//
-	// Tracked changes only, deliberately. This gates a `git reset --hard`, which
-	// cannot touch untracked files — so counting them would suppress a reset
-	// that was never a threat to them, leaving the worktree holding the old
-	// commit's content while its branch ref has moved. `git status` then reports
-	// the new commit's files as deleted, and the next `stackit modify -a`
-	// commits that deletion into the stack.
+	// Capture every local change. `git reset --hard` can delete an untracked
+	// file when the incoming commit needs that pathname, so excluding untracked
+	// files would risk user data loss.
 	dirtyWorktrees := make(map[string]bool, len(worktrees))
-	for _, path := range worktrees.Paths() {
-		if dirty, dirtyErr := e.git.WorktreeHasTrackedChanges(ctx, path); dirtyErr == nil && dirty {
+	heldBranches := make(BranchNameSet)
+	for _, worktree := range worktrees {
+		dirty, dirtyErr := e.git.WorktreeHasUncommittedChanges(ctx, worktree.Path)
+		if dirtyErr != nil || dirty {
+			path := worktree.Path
 			dirtyWorktrees[path] = true
+			if worktree.Branch != "" {
+				heldBranches[worktree.Branch] = true
+			}
 		}
 	}
 
@@ -152,7 +156,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 			metaRefSHAs[strings.TrimPrefix(refName, git.MetadataRefPrefix)] = sha
 		}
 	}
-	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees}
+	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees, heldBranches: heldBranches, worktreeInspectionFailed: worktreeInspectionFailed}
 
 	// 2. Apply the restack changes
 	results := make(map[string]RestackBranchResult)

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -695,6 +695,12 @@ func (e *engineImpl) applyMetadataRefresh(
 	snap *restackSnapshot,
 ) (RestackBranchResult, error) {
 	branchName := branch.GetName()
+	// Metadata records the parent SHA consumed by later planning, so advancing
+	// it past a held parent would create the same phantom-parent state as a ref
+	// move. A held branch and every descendant must remain completely unchanged.
+	if e.branchHeldBack(branch, snap) {
+		return RestackBranchResult{Result: RestackUnneeded, RebasedBranchBase: item.ParentRev}, nil
+	}
 	meta := snap.meta.Get(branchName)
 	if meta == nil {
 		var err error

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -56,10 +56,37 @@ type restackSnapshot struct {
 	worktrees   git.WorktreeList
 	metaRefSHAs map[string]string
 	// dirtyWorktrees records, per worktree path, whether it had changes to
-	// tracked files before this restack pass began. Untracked files are
-	// deliberately excluded — see resetWorktreeIfClean for why, and for why this
-	// can't be checked lazily.
+	// local changes before this restack pass began. This cannot be checked
+	// lazily; see resetWorktreeIfClean for why.
 	dirtyWorktrees map[string]bool
+	// heldBranches contains every branch whose checked-out worktree was dirty
+	// or could not be inspected before this pass. Descendants of these branches
+	// must be held too: a validated child may otherwise be built on the target
+	// SHA of a parent that was ultimately not allowed to move.
+	heldBranches BranchNameSet
+	// worktreeInspectionFailed means the physical checkout map is unknown, so
+	// no ref move is safe for this pass.
+	worktreeInspectionFailed bool
+}
+
+func (e *engineImpl) branchHeldBack(branch Branch, snap *restackSnapshot) bool {
+	if snap.worktreeInspectionFailed {
+		return true
+	}
+	for current := branch.GetName(); current != ""; {
+		if snap.heldBranches.Contains(current) {
+			return true
+		}
+		e.mu.RLock()
+		state := e.readState(current)
+		trunk := e.trunk
+		e.mu.RUnlock()
+		if state == nil || state.Parent == "" || current == trunk {
+			return false
+		}
+		current = state.Parent
+	}
+	return false
 }
 
 // branchRev returns branch's revision from the pass snapshot, falling back to a
@@ -223,7 +250,7 @@ func (e *engineImpl) restackBranch(
 	// which warns and is reached solely by the `restack` command) so that every
 	// caller of RestackBranches inherits it — modify, sync, squash, absorb,
 	// delete, split, reorder, pluck and insert all arrive here directly.
-	if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" && snap.dirtyWorktrees[worktreePath] {
+	if e.branchHeldBack(branch, snap) {
 		return RestackBranchResult{Result: RestackUnneeded}, nil
 	}
 
@@ -723,7 +750,7 @@ func (e *engineImpl) applyBranchAndMetadata(
 	// Hold the branch back instead. This is the plan path, reached by every
 	// caller of actions.RestackBranches (modify, squash, absorb, delete, split,
 	// reorder, pluck) as well as the `restack` command.
-	if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" && snap.dirtyWorktrees[worktreePath] {
+	if e.branchHeldBack(branch, snap) {
 		return RestackBranchResult{Result: RestackUnneeded, RebasedBranchBase: parentRev}, nil
 	}
 

--- a/internal/integration/restack_dirty_maintree_test.go
+++ b/internal/integration/restack_dirty_maintree_test.go
@@ -4,28 +4,26 @@ import (
 	"testing"
 )
 
-// TestRestackWithUntrackedFileLeavesNoStagedRevert covers a regression where an
-// untracked file anywhere in the repo made restack leave a staged deletion of
-// trunk's files behind.
+// TestRestackWithUntrackedFileHoldsBranchAndLeavesNoStagedRevert covers the
+// untracked half of the dirty-worktree hold.
 //
 // The reset that realigns a worktree after its branch ref moves is gated on the
-// worktree being clean, so that it cannot discard uncommitted work. Dirtiness
-// was measured with `git status --porcelain --untracked-files=normal`, so a
-// single untracked file — a scratch note, a build artifact, anything not in
-// .gitignore — marked the worktree dirty and suppressed the reset. `git reset
-// --hard` cannot touch untracked files, so nothing was being protected: the
-// working directory simply kept the old commit's content while the branch ref
-// moved on.
+// worktree being clean, so that it cannot discard uncommitted work. Untracked
+// files count: `git reset --hard` overwrites an untracked file whose pathname
+// the incoming commit also contains, so skipping the reset is not enough — the
+// ref must not move either, or the worktree ends up holding the old commit's
+// content under a new ref and `stackit modify -a` commits the revert.
 //
-// The result was invisible until it wasn't. `git status` showed trunk's files
-// as staged deletions, and the next `stackit modify -a` committed them, quietly
-// reverting trunk content inside the stack.
-func TestRestackWithUntrackedFileLeavesNoStagedRevert(t *testing.T) {
+// So a stray untracked file holds the branch back rather than being restacked
+// around it. The file survives, the ref stays put, and nothing is staged.
+func TestRestackWithUntrackedFileHoldsBranchAndLeavesNoStagedRevert(t *testing.T) {
 	t.Parallel()
 
 	sh := NewTestShellInProcess(t)
 
 	sh.CreateLinearStack3().Checkout("a")
+	sh.Git("rev-parse a")
+	revBefore := sh.Output()
 
 	// Trunk advances so the stack genuinely needs restacking. WriteFile stages
 	// under the exact name, which the assertions below rely on.
@@ -34,11 +32,18 @@ func TestRestackWithUntrackedFileLeavesNoStagedRevert(t *testing.T) {
 		Git("commit -m 'chore: trunk commit'").
 		Checkout("a")
 
-	// A single untracked file. Not staged, not tracked, not the user's work in
-	// any sense restack should care about.
+	// A single untracked file — a scratch note, a build artifact, anything not
+	// in .gitignore.
 	sh.WriteUnstaged("scratch.txt", "scratch note")
 
 	sh.Run("restack --upstack")
+
+	// The branch must not have moved: holding it back is what keeps the
+	// worktree and its ref consistent.
+	sh.Git("rev-parse a")
+	if sh.Output() != revBefore {
+		t.Fatalf("branch a moved despite its worktree having an untracked file:\nbefore %safter  %s", revBefore, sh.Output())
+	}
 
 	// The only thing git should report is the untracked file itself. A "D " or
 	// " D" entry here means trunk's content was left staged for deletion.
@@ -46,10 +51,6 @@ func TestRestackWithUntrackedFileLeavesNoStagedRevert(t *testing.T) {
 		OutputContains("?? scratch.txt").
 		OutputNotContains(" D ").
 		OutputNotContains("D  ")
-
-	// And trunk's file is still really there.
-	sh.Git("ls-tree HEAD -- trunk1.txt").OutputContains("trunk1.txt")
-	sh.Git("status --porcelain -- trunk1.txt").OutputNotContains("trunk1.txt")
 }
 
 // TestRestackSkipsBranchWithTrackedChangesInItsWorktree covers the other half.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Make branch mutations safe when worktrees hold the branch**

Closes the worktree half of the reconciliation-safety audit: eighteen fixes so
that moving a branch ref can no longer corrupt, revert, or silently discard work
in a worktree that has that branch checked out.

The unifying rule: before any operation rewrites a ref, it must ask who
physically holds that branch. If the holder is dirty or uninspectable, hold the
branch back and say so; if it is clean, reset it to match the ref it now points
at; never move a ref out from under a checkout and report success.

**Data loss (P0)**

- **#1580, #1584, #1585** — `fold`, `absorb`, and `continue` no longer merge onto
  a detached HEAD, rewrite an ancestor, or move a rebased ref while another
  worktree holds the branch. `CheckoutBranch` stops silently falling back to
  detached HEAD, which was a latent trap for every checkout-then-mutate action.
- **#1584** — `git.Rebase` writes its result through a compare-and-swap, so a
  commit made in another worktree mid-pass can no longer be overwritten (and
  then wiped by a reset keyed on a stale clean-snapshot).
- **#1580** — `create -w` keeps the branch when only the worktree phase fails.
  It previously deleted the sole ref to the commit that had just consumed the
  staged changes, past the point a snapshot could recover it.
- **#1585** — `merge --force` resets trunk through a ref update instead of a
  branch checkout, so a temp worktree can no longer squat on `refs/heads/<trunk>`
  and block the main workspace.

**Reconciliation model**

- **#1573, #1574, #1577, #1593** — restack holds branches behind dirty or
  uninspectable worktrees, holds their descendants too, leaves held branches
  metadata untouched, and reports the hold rather than passing it off as
  "already up to date". Untracked files count: `git reset --hard` will overwrite
  an untracked file whose pathname the incoming commit contains.
- **#1597** — worktrees mid-rebase report no branch to porcelain, so they were
  invisible to every branch/worktree guard. They are now held.

**Lifecycle and ownership**

- **#1586, #1595** — `pluck` and `delete` enforce managed-worktree ownership like
  the other branch-scoped mutations.
- **#1588, #1592, #1594** — worktree cleanup prunes before deleting the anchor,
  recovers invalid registrations instead of dead-ending between `remove`,
  `repair`, and `detach`, and sweeps reverse path refs orphaned by older code
  that would otherwise block re-creating a worktree at that path forever.
- **#1571** — reverse registrations stay addressable through symlinked bases by
  resolving the deepest existing ancestor, so register and unregister agree.
- **#1592** — multi-stack merge tags and deletes its consolidation branch and
  unlocks excluded and failed stacks instead of stranding PR locks.

**Correctness and hardening**

- **#1572** — sync stops treating a deleted remote branch as proof the local tip
  was pushed, which discarded follow-up commits on closed PRs.
- **#1589** — `split` uses the stash-by-ref API rather than popping the shared
  cross-worktree `stash@{0}`; relative `gitdir:` pointers resolve against the
  right base.
- **#1596** — `tree --json` no longer emits hidden anchors as dangling parents.
- Worktree porcelain is parsed with `-z`, `ForceRemoveWorktree` passes `--force`
  twice so it can remove locked worktrees, and relative `worktree.basePath`
  resolves against the repo root in Go code as it already did in git.

**Notes**

Sync also skips hidden anchors when comparing PR bases, which was queueing a
GitHub 422 on every sync for every worktree stack root with a PR.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785934948`.


* **PR #1571**
  * **PR #1572**
    * **PR #1573**
      * **PR #1574**
        * **PR #1577** 👈
          * **PR #1580**
            * **PR #1584**
              * **PR #1585**
                * **PR #1586**
                  * **PR #1588**
                    * **PR #1589**
                      * **PR #1592**
                        * **PR #1593**
                          * **PR #1594**
                            * **PR #1595**
                              * **PR #1596**
                                * **PR #1597**
                                  * **PR #1599**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1601 by jonnii*