### PR TITLE
perf(api): batch commit date/author lookups in branch mapping

### DIFF
--- a/internal/api/handlers/branches.go
+++ b/internal/api/handlers/branches.go
@@ -63,12 +63,13 @@ func (h *BranchesHandler) listBranches(w http.ResponseWriter, r *http.Request, e
 		checksMap, _ = entry.GitHub.BatchGetPRChecksStatus(r.Context(), names)
 	}
 
-	// One remote listing, one stats pass, and one commits pass for all
-	// branches instead of one of each per branch.
+	// One remote listing, one stats pass, one commits pass, and one commit-info
+	// pass for all branches instead of one of each per branch.
 	branchSet := engine.BranchesOf(branches...)
 	remoteStatuses := entry.Engine.ReadBranchRemoteStatuses(r.Context(), branchSet)
 	stats := entry.Engine.BatchBranchStats(branchSet)
 	commitsByBranch := entry.Engine.BatchCommits(branchSet, engine.CommitFormatReadableWithDate)
+	commitInfoByBranch := entry.Engine.BatchCommitInfo(branchSet)
 
 	responses := make([]httpcontract.BranchResponse, 0, len(branches))
 	for _, branch := range branches {
@@ -77,7 +78,8 @@ func (h *BranchesHandler) listBranches(w http.ResponseWriter, r *http.Request, e
 			continue
 		}
 		checks := checksMap.Get(branch.GetName())
-		responses = append(responses, httpcontract.MapBranch(entry.Engine, branch, node, checks, remoteStatuses.ForBranch(branch), stats[branch.GetName()], commitsByBranch[branch.GetName()]))
+		name := branch.GetName()
+		responses = append(responses, httpcontract.MapBranch(entry.Engine, branch, node, checks, remoteStatuses.ForBranch(branch), stats[name], commitsByBranch[name], commitInfoByBranch[name]))
 	}
 
 	writeJSON(w, responses)
@@ -107,6 +109,7 @@ func (h *BranchesHandler) getBranch(w http.ResponseWriter, r *http.Request, entr
 	remoteStatus := entry.Engine.ReadBranchRemoteStatuses(r.Context(), branchSet).ForBranch(branch)
 	stat := entry.Engine.BatchBranchStats(branchSet)[branchName]
 	commits := entry.Engine.BatchCommits(branchSet, engine.CommitFormatReadableWithDate)[branchName]
-	resp := httpcontract.MapBranch(entry.Engine, branch, node, checks, remoteStatus, stat, commits)
+	commitInfo := entry.Engine.BatchCommitInfo(branchSet)[branchName]
+	resp := httpcontract.MapBranch(entry.Engine, branch, node, checks, remoteStatus, stat, commits, commitInfo)
 	writeJSON(w, resp)
 }

--- a/internal/contracts/http/mappers.go
+++ b/internal/contracts/http/mappers.go
@@ -13,11 +13,11 @@ import (
 )
 
 // MapBranch converts an engine Branch and its StackNode into an API BranchResponse.
-// remoteStatus, stat, and commits should each come from a single batch call
-// covering all branches being mapped in the current request
-// (ReadBranchRemoteStatuses, BatchBranchStats, BatchCommits), not per-branch
-// calls — per-branch reads spawn a git process per field per branch.
-func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.StackNode, checks *github.CheckStatus, remoteStatus engine.BranchRemoteStatus, stat engine.BranchStat, commits []string) BranchResponse {
+// remoteStatus, stat, commits, and commitInfo should each come from a single
+// batch call covering all branches being mapped in the current request
+// (ReadBranchRemoteStatuses, BatchBranchStats, BatchCommits, BatchCommitInfo),
+// not per-branch calls — per-branch reads spawn a git process per field per branch.
+func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.StackNode, checks *github.CheckStatus, remoteStatus engine.BranchRemoteStatus, stat engine.BranchStat, commits []string, commitInfo git.CommitInfo) BranchResponse {
 	resp := BranchResponse{
 		Name:         branch.GetName(),
 		Depth:        node.Depth,
@@ -45,13 +45,10 @@ func MapBranch(eng engine.BranchReader, branch engine.Branch, node *engine.Stack
 	resp.LinesAdded = stat.LinesAdded
 	resp.LinesDeleted = stat.LinesDeleted
 
-	if date, err := branch.GetCommitDate(); err == nil {
-		resp.CommitDate = date.Format(time.RFC3339)
+	if !commitInfo.Date.IsZero() {
+		resp.CommitDate = commitInfo.Date.Format(time.RFC3339)
 	}
-
-	if author, err := eng.GetCommitAuthor(branch); err == nil {
-		resp.CommitAuthor = author
-	}
+	resp.CommitAuthor = commitInfo.Author
 
 	// Map commits
 	if len(commits) > 0 {
@@ -155,17 +152,18 @@ func MapStackDetail(ctx context.Context, eng engine.BranchReader, graph *engine.
 		stackBranches = append(stackBranches, node.Branch)
 	}
 
-	// One remote listing, one stats pass, and one commits pass for the whole
-	// stack instead of one of each per branch.
+	// One remote listing, one stats pass, one commits pass, and one commit-info
+	// pass for the whole stack instead of one of each per branch.
 	remoteStatuses := eng.ReadBranchRemoteStatuses(ctx, stackBranches)
 	stats := eng.BatchBranchStats(stackBranches)
 	commitsByBranch := eng.BatchCommits(stackBranches, engine.CommitFormatReadableWithDate)
+	commitInfoByBranch := eng.BatchCommitInfo(stackBranches)
 
 	branches := make([]BranchResponse, 0, len(nodes))
 	for _, node := range nodes {
 		name := node.Branch.GetName()
 		checks := checksMap.Get(name)
-		br := MapBranch(eng, node.Branch, node, checks, remoteStatuses.ForBranch(node.Branch), stats[name], commitsByBranch[name])
+		br := MapBranch(eng, node.Branch, node, checks, remoteStatuses.ForBranch(node.Branch), stats[name], commitsByBranch[name], commitInfoByBranch[name])
 		if isAnchor {
 			// Anchor's direct children become display roots
 			if br.Parent == anchorName {

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -196,6 +196,16 @@ func (d *demoGitRunner) GetCommitAuthor(_ string) (string, error) {
 	return "Demo User", nil
 }
 
+func (d *demoGitRunner) BatchCommitInfo(branchNames []string) map[string]git.CommitInfo {
+	results := make(map[string]git.CommitInfo, len(branchNames))
+	for _, name := range branchNames {
+		date, _ := d.GetCommitDate(name)
+		author, _ := d.GetCommitAuthor(name)
+		results[name] = git.CommitInfo{Date: date, Author: author}
+	}
+	return results
+}
+
 func (d *demoGitRunner) GetCommitRange(_ context.Context, _, _, _ string) ([]string, error) {
 	return []string{"commit message"}, nil
 }

--- a/internal/engine/branch_view_test.go
+++ b/internal/engine/branch_view_test.go
@@ -105,6 +105,31 @@ func TestPerConcernBatchReaders(t *testing.T) {
 	}
 }
 
+// TestBatchCommitInfo asserts the batched commit info matches the per-branch
+// GetCommitDate/GetCommitAuthor accessors for every branch, including trunk.
+func TestBatchCommitInfo(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithLinearStack3()
+
+	branches := s.Engine.AllBranches()
+	info := s.Engine.BatchCommitInfo(branches)
+
+	for _, b := range branches {
+		name := b.GetName()
+		got, ok := info[name]
+		require.True(t, ok, "missing commit info for %s", name)
+
+		wantDate, err := s.Engine.GetCommitDate(b)
+		require.NoError(t, err)
+		require.True(t, wantDate.Equal(got.Date), "CommitDate for %s", name)
+
+		wantAuthor, err := s.Engine.GetCommitAuthor(b)
+		require.NoError(t, err)
+		require.Equal(t, wantAuthor, got.Author, "CommitAuthor for %s", name)
+	}
+}
+
 // TestCommitsFallBackToParentTipWithoutStoredDivergence verifies that a branch
 // with no recorded ParentBranchRevision lists only its own commits — measured
 // against the parent's current tip — rather than its entire history back to the

--- a/internal/engine/engine_branch_info.go
+++ b/internal/engine/engine_branch_info.go
@@ -21,6 +21,16 @@ func (e *engineImpl) GetCommitAuthor(branch Branch) (string, error) {
 	return e.git.GetCommitAuthor(branchName)
 }
 
+// BatchCommitInfo returns each branch's tip commit date and author, keyed by
+// branch name, resolved in one batched pass.
+func (e *engineImpl) BatchCommitInfo(branches Branches) map[string]git.CommitInfo {
+	names := make([]string, len(branches))
+	for i, b := range branches {
+		names[i] = b.GetName()
+	}
+	return e.git.BatchCommitInfo(names)
+}
+
 // GetRevision returns the SHA of a branch
 func (e *engineImpl) GetRevision(branch Branch) (string, error) {
 	branchName := branch.GetName()

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -87,6 +87,9 @@ type BranchStatus interface {
 type BranchInfo interface {
 	GetCommitDate(branch Branch) (time.Time, error)
 	GetCommitAuthor(branch Branch) (string, error)
+	// BatchCommitInfo resolves each branch's tip commit date and author in one
+	// batched pass instead of two `git log` processes per branch.
+	BatchCommitInfo(branches Branches) map[string]git.CommitInfo
 	GetRevision(branch Branch) (string, error)
 	GetAllCommits(branch Branch, format CommitFormat) ([]string, error)
 	GetParentCommitSHA(commitSHA string) (string, error)

--- a/internal/git/commit_info.go
+++ b/internal/git/commit_info.go
@@ -53,6 +53,50 @@ func (r *runner) getCommitAuthor(branchName string) (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
+// CommitInfo holds a branch tip commit's author date and author name.
+type CommitInfo struct {
+	Date   time.Time
+	Author string
+}
+
+// batchCommitInfo resolves each branch's tip commit date and author in one
+// `git for-each-ref` invocation instead of two `git log` processes per branch
+// (getCommitDate + getCommitAuthor). Branches with no matching ref are simply
+// absent from the result map rather than reported as errors, matching
+// for-each-ref's own behavior for unmatched patterns.
+func (r *runner) batchCommitInfo(branchNames []string) map[string]CommitInfo {
+	results := make(map[string]CommitInfo)
+	if len(branchNames) == 0 {
+		return results
+	}
+
+	args := []string{"for-each-ref", "--format=%(refname:short)\t%(authordate:iso-strict)\t%(authorname)"}
+	for _, name := range branchNames {
+		args = append(args, "refs/heads/"+name)
+	}
+
+	out, err := r.RunGitCommandWithContext(context.Background(), args...)
+	if err != nil {
+		return results
+	}
+
+	for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		date, err := time.Parse(time.RFC3339, parts[1])
+		if err != nil {
+			continue
+		}
+		results[parts[0]] = CommitInfo{Date: date, Author: parts[2]}
+	}
+	return results
+}
+
 func (r *runner) getRevision(branchName string) (string, error) {
 	return r.resolveRefSHA(branchName)
 }

--- a/internal/git/commit_info_test.go
+++ b/internal/git/commit_info_test.go
@@ -1,0 +1,48 @@
+package git_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+)
+
+func TestBatchCommitInfo(t *testing.T) {
+	t.Parallel()
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+
+	err := scene.Repo.CreateAndCheckoutBranch("branch1")
+	require.NoError(t, err)
+	err = scene.Repo.CreateChangeAndCommit("branch1 change", "b1")
+	require.NoError(t, err)
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+
+	wantMainDate, err := runner.GetCommitDate("main")
+	require.NoError(t, err)
+	wantMainAuthor, err := runner.GetCommitAuthor("main")
+	require.NoError(t, err)
+	wantBranch1Date, err := runner.GetCommitDate("branch1")
+	require.NoError(t, err)
+	wantBranch1Author, err := runner.GetCommitAuthor("branch1")
+	require.NoError(t, err)
+
+	got := runner.BatchCommitInfo([]string{"main", "branch1", "no-such-branch"})
+
+	require.Len(t, got, 2, "unmatched branch should be omitted, not errored")
+	require.True(t, wantMainDate.Equal(got["main"].Date))
+	require.Equal(t, wantMainAuthor, got["main"].Author)
+	require.True(t, wantBranch1Date.Equal(got["branch1"].Date))
+	require.Equal(t, wantBranch1Author, got["branch1"].Author)
+}
+
+func TestBatchCommitInfo_Empty(t *testing.T) {
+	t.Parallel()
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	got := runner.BatchCommitInfo(nil)
+	require.Empty(t, got)
+}

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -79,6 +79,9 @@ type CommitReader interface {
 	BatchGetRevisions(branchNames []string) (map[string]string, []error)
 	GetCommitDate(branchName string) (time.Time, error)
 	GetCommitAuthor(branchName string) (string, error)
+	// BatchCommitInfo resolves each branch's tip commit date and author in one
+	// `git for-each-ref` invocation instead of two `git log` processes per branch.
+	BatchCommitInfo(branchNames []string) map[string]CommitInfo
 	GetCommitRange(ctx context.Context, base, head, format string) ([]string, error)
 	GetCommitRangeSHAs(ctx context.Context, rr RevRange) ([]string, error)
 	GetCommitHistorySHAs(ctx context.Context, branchName string) ([]string, error)

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -743,6 +743,10 @@ func (r *runner) GetCommitAuthor(branchName string) (string, error) {
 	return r.getCommitAuthor(branchName)
 }
 
+func (r *runner) BatchCommitInfo(branchNames []string) map[string]CommitInfo {
+	return r.batchCommitInfo(branchNames)
+}
+
 func (r *runner) GetCommitRange(ctx context.Context, base, head, format string) ([]string, error) {
 	rangeArg := head
 	if base != "" {


### PR DESCRIPTION
## Summary

- `MapBranch` (`internal/contracts/http/mappers.go`) is the API server's per-branch response mapper. Its own doc comment already says every per-branch field must come from a single batched call for the whole request — but `branch.GetCommitDate()` and `eng.GetCommitAuthor(branch)` were missed, each shelling out its own `git log` process per branch, per request.
- Added `BatchCommitInfo`, which resolves the whole branch set's tip commit date + author with one `git for-each-ref` call, following the same shape as the existing `BatchGetRevisions`/`BatchBranchStats`/`BatchCommits` batch readers (git runner → engine → API layer).
- Threaded the new batched value through all three call sites that build `BranchResponse`s: `MapStackDetail`, and the list/get handlers in `internal/api/handlers/branches.go`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/git/... ./internal/engine/... ./internal/contracts/... ./internal/api/... ./internal/demo/...` (one pre-existing, unrelated failure in `TestGetRepoInfo/parses_HTTPS_URL` reproduces identically on `main`, unaffected by this change)
- [x] Added `TestBatchCommitInfo` in `internal/git` and `internal/engine`, asserting the batched result matches the existing single-branch accessors

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6YnZbHvrCDKjyURm2FKCJ)_