### PR TITLE
fix(create): preserve branches when worktree setup fails

### DIFF
--- a/internal/actions/create/create.go
+++ b/internal/actions/create/create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/utils"
 )
 
@@ -305,25 +306,23 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 		// Checkout back to trunk first so we can create the worktree for the branch
 		trunkBranch := eng.Trunk()
 		if err := eng.CheckoutBranch(ctx.Context, trunkBranch); err != nil {
-			_ = eng.DeleteBranch(ctx.Context, branch)
 			h.OnStep(StepWorktree, handler.StatusFailed, err.Error())
-			return Result{}, fmt.Errorf("failed to checkout trunk before creating worktree: %w", err)
-		}
+			out.Warn("Created %s, but could not create its worktree: %v", output.BranchName(branchName), err)
+		} else {
+			created, err := worktree.CreateAnchoredWorktreeForBranch(ctx, branchName, branchName, opts.Scope)
+			if err != nil {
+				h.OnStep(StepWorktree, handler.StatusFailed, err.Error())
+				out.Warn("Created %s, but could not create its worktree: %v", output.BranchName(branchName), err)
+			} else {
+				worktreePath = created.Path
+				h.OnStep(StepWorktree, handler.StatusCompleted, fmt.Sprintf("Created worktree at %s", worktreePath))
+				out.Info("Created worktree at %s", worktreePath)
+			}
 
-		created, err := worktree.CreateAnchoredWorktreeForBranch(ctx, branchName, branchName, opts.Scope)
-		if err != nil {
-			// Clean up branch on worktree failure
-			_ = eng.DeleteBranch(ctx.Context, branch)
-			h.OnStep(StepWorktree, handler.StatusFailed, err.Error())
-			return Result{}, fmt.Errorf("failed to create worktree: %w", err)
-		}
-		worktreePath = created.Path
-		h.OnStep(StepWorktree, handler.StatusCompleted, fmt.Sprintf("Created worktree at %s", worktreePath))
-		out.Info("Created worktree at %s", worktreePath)
-
-		// Run post-create hooks in the worktree
-		if hookErr := worktree.RunPostCreateHooks(ctx, worktreePath); hookErr != nil {
-			out.Warn("Post-create hooks failed: %v", hookErr)
+			// Run post-create hooks in the worktree
+			if hookErr := worktree.RunPostCreateHooks(ctx, worktreePath); hookErr != nil {
+				out.Warn("Post-create hooks failed: %v", hookErr)
+			}
 		}
 	}
 

--- a/internal/actions/fold/fold_test.go
+++ b/internal/actions/fold/fold_test.go
@@ -47,6 +47,33 @@ func TestFoldAction(t *testing.T) {
 		require.Contains(t, logOutput, "change on branch2")
 	})
 
+	t.Run("refuses when parent is checked out in another worktree", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"branch1": "main",
+				"branch2": "branch1",
+			})
+		s.Checkout("branch2")
+		branch2Before, err := s.Engine.GetBranch("branch2").GetRevision()
+		require.NoError(t, err)
+
+		worktreePath := filepath.Join(t.TempDir(), "parent")
+		require.NoError(t, s.Scene.Repo.RunGitCommand("worktree", "add", worktreePath, "branch1"))
+		t.Cleanup(func() { _ = s.Scene.Repo.RunGitCommand("worktree", "remove", "--force", worktreePath) })
+
+		err = Action(s.Context, Options{Keep: false}, nil)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to checkout parent branch")
+
+		branch2After, err := s.Engine.GetBranch("branch2").GetRevision()
+		require.NoError(t, err)
+		require.Equal(t, branch2Before, branch2After, "fold must not delete or rewrite its branch")
+		current, err := s.Scene.Repo.CurrentBranchName()
+		require.NoError(t, err)
+		require.Equal(t, "branch2", current, "fold must not leave the caller detached")
+	})
+
 	t.Run("reparents children when folding branch", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).

--- a/internal/cli/common/directives.go
+++ b/internal/cli/common/directives.go
@@ -34,8 +34,11 @@ func HandleCheckoutResult(out output.Output, result actions.CheckoutResult) bool
 	return false
 }
 
-// CompleteCheckout handles a CheckoutAction result, including the fallback
-// checkout path when shell integration cannot switch worktrees for the caller.
+// CompleteCheckout handles a CheckoutAction result, including a worktree switch
+// when shell integration is available. Without shell integration, retain the
+// regular-checkout fallback only when the target is not already checked out in
+// another worktree; Git permits a branch to be checked out by only one
+// worktree at a time.
 func CompleteCheckout(ctx *app.Context, result actions.CheckoutResult, fallbackOpts actions.CheckoutOptions, handler actions.CheckoutHandler) error {
 	if HandleCheckoutResult(ctx.Output, result) {
 		return nil
@@ -44,15 +47,20 @@ func CompleteCheckout(ctx *app.Context, result actions.CheckoutResult, fallbackO
 		return nil
 	}
 
+	worktrees, err := ctx.Engine.ListWorktrees(ctx.Context)
+	if err == nil && worktrees.PathForBranch(result.TargetBranch) != "" {
+		return nil
+	}
+
 	if !fallbackOpts.CheckoutTrunk {
 		fallbackOpts.BranchName = result.TargetBranch
 	}
 	fallbackOpts.SkipWorktreeSwitch = true
-	_, err := actions.CheckoutAction(ctx, fallbackOpts, handler)
+	_, err = actions.CheckoutAction(ctx, fallbackOpts, handler)
 	return err
 }
 
-// Checkout runs CheckoutAction and completes any worktree-switch fallback.
+// Checkout runs CheckoutAction and completes any worktree switch.
 func Checkout(ctx *app.Context, opts actions.CheckoutOptions, handler actions.CheckoutHandler) (actions.CheckoutResult, error) {
 	result, err := actions.CheckoutAction(ctx, opts, handler)
 	if err != nil {

--- a/internal/engine/branch_mutations.go
+++ b/internal/engine/branch_mutations.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/getstackit/stackit/internal/git"
 )
@@ -342,16 +341,6 @@ func (e *engineImpl) DeleteBranches(ctx context.Context, branches Branches) ([]s
 func (e *engineImpl) CheckoutBranch(ctx context.Context, branch Branch) error {
 	branchName := branch.GetName()
 	if err := e.git.CheckoutBranch(ctx, branchName); err != nil {
-		// If it's already used by another worktree, try checking out detached
-		if branchCheckedOutInAnotherWorktree(err) {
-			if err := e.git.CheckoutDetached(ctx, branchName); err != nil {
-				return err
-			}
-			e.mu.Lock()
-			e.currentBranch = "" // Detached HEAD
-			e.mu.Unlock()
-			return nil
-		}
 		return err
 	}
 
@@ -359,15 +348,6 @@ func (e *engineImpl) CheckoutBranch(ctx context.Context, branch Branch) error {
 	e.currentBranch = branchName
 	e.mu.Unlock()
 	return nil
-}
-
-func branchCheckedOutInAnotherWorktree(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "already used by worktree") ||
-		strings.Contains(msg, "is already checked out")
 }
 
 // UpdateBranchRef updates a branch reference to point to a new revision


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Make branch mutations safe when worktrees hold the branch**

Closes the worktree half of the reconciliation-safety audit: eighteen fixes so
that moving a branch ref can no longer corrupt, revert, or silently discard work
in a worktree that has that branch checked out.

The unifying rule: before any operation rewrites a ref, it must ask who
physically holds that branch. If the holder is dirty or uninspectable, hold the
branch back and say so; if it is clean, reset it to match the ref it now points
at; never move a ref out from under a checkout and report success.

**Data loss (P0)**

- **#1580, #1584, #1585** — `fold`, `absorb`, and `continue` no longer merge onto
  a detached HEAD, rewrite an ancestor, or move a rebased ref while another
  worktree holds the branch. `CheckoutBranch` stops silently falling back to
  detached HEAD, which was a latent trap for every checkout-then-mutate action.
- **#1584** — `git.Rebase` writes its result through a compare-and-swap, so a
  commit made in another worktree mid-pass can no longer be overwritten (and
  then wiped by a reset keyed on a stale clean-snapshot).
- **#1580** — `create -w` keeps the branch when only the worktree phase fails.
  It previously deleted the sole ref to the commit that had just consumed the
  staged changes, past the point a snapshot could recover it.
- **#1585** — `merge --force` resets trunk through a ref update instead of a
  branch checkout, so a temp worktree can no longer squat on `refs/heads/<trunk>`
  and block the main workspace.

**Reconciliation model**

- **#1573, #1574, #1577, #1593** — restack holds branches behind dirty or
  uninspectable worktrees, holds their descendants too, leaves held branches
  metadata untouched, and reports the hold rather than passing it off as
  "already up to date". Untracked files count: `git reset --hard` will overwrite
  an untracked file whose pathname the incoming commit contains.
- **#1597** — worktrees mid-rebase report no branch to porcelain, so they were
  invisible to every branch/worktree guard. They are now held.

**Lifecycle and ownership**

- **#1586, #1595** — `pluck` and `delete` enforce managed-worktree ownership like
  the other branch-scoped mutations.
- **#1588, #1592, #1594** — worktree cleanup prunes before deleting the anchor,
  recovers invalid registrations instead of dead-ending between `remove`,
  `repair`, and `detach`, and sweeps reverse path refs orphaned by older code
  that would otherwise block re-creating a worktree at that path forever.
- **#1571** — reverse registrations stay addressable through symlinked bases by
  resolving the deepest existing ancestor, so register and unregister agree.
- **#1592** — multi-stack merge tags and deletes its consolidation branch and
  unlocks excluded and failed stacks instead of stranding PR locks.

**Correctness and hardening**

- **#1572** — sync stops treating a deleted remote branch as proof the local tip
  was pushed, which discarded follow-up commits on closed PRs.
- **#1589** — `split` uses the stash-by-ref API rather than popping the shared
  cross-worktree `stash@{0}`; relative `gitdir:` pointers resolve against the
  right base.
- **#1596** — `tree --json` no longer emits hidden anchors as dangling parents.
- Worktree porcelain is parsed with `-z`, `ForceRemoveWorktree` passes `--force`
  twice so it can remove locked worktrees, and relative `worktree.basePath`
  resolves against the repo root in Go code as it already did in git.

**Notes**

Sync also skips hidden anchors when comparing PR bases, which was queueing a
GitHub 422 on every sync for every worktree stack root with a PR.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785934948`.


* **PR #1571**
  * **PR #1572**
    * **PR #1573**
      * **PR #1574**
        * **PR #1577**
          * **PR #1580** 👈
            * **PR #1584**
              * **PR #1585**
                * **PR #1586**
                  * **PR #1588**
                    * **PR #1589**
                      * **PR #1592**
                        * **PR #1593**
                          * **PR #1594**
                            * **PR #1595**
                              * **PR #1596**
                                * **PR #1597**
                                  * **PR #1599**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1601 by jonnii*