### PR TITLE
fix(absorb): protect checked-out rewritten branches

### DIFF
--- a/internal/engine/engine_absorb.go
+++ b/internal/engine/engine_absorb.go
@@ -17,6 +17,24 @@ func (e *engineImpl) ApplyHunksToBranch(ctx context.Context, branch Branch, hunk
 	}
 
 	branchName := branch.GetName()
+	oldTip, err := branch.GetRevision()
+	if err != nil {
+		return fmt.Errorf("failed to get branch revision for %s: %w", branchName, err)
+	}
+	worktrees, err := e.git.ListWorktrees(ctx)
+	if err != nil {
+		return fmt.Errorf("refusing to rewrite %s: cannot inspect worktrees: %w", branchName, err)
+	}
+	worktreePath := worktrees.PathForBranch(branchName)
+	if worktreePath != "" {
+		dirty, statusErr := e.git.WorktreeHasTrackedChanges(ctx, worktreePath)
+		if statusErr != nil {
+			return fmt.Errorf("refusing to rewrite %s: cannot inspect worktree %s: %w", branchName, worktreePath, statusErr)
+		}
+		if dirty {
+			return fmt.Errorf("refusing to rewrite %s: worktree %s has uncommitted tracked changes", branchName, worktreePath)
+		}
+	}
 
 	// Save current state to restore later
 	originalRef, _ := e.git.GetCurrentBranchOrSHA(ctx)
@@ -143,8 +161,13 @@ func (e *engineImpl) ApplyHunksToBranch(ctx context.Context, branch Branch, hunk
 	newTip = strings.TrimSpace(newTip)
 
 	// Update branch to point to new tip
-	if err := e.git.UpdateBranchRef(ctx, branchName, newTip); err != nil {
+	if err := e.git.UpdateBranchRefCAS(ctx, branchName, newTip, oldTip); err != nil {
 		return fmt.Errorf("failed to update branch %s: %w", branchName, err)
+	}
+	if worktreePath != "" {
+		if err := e.git.ResetWorktreeWorkingDir(ctx, worktreePath); err != nil {
+			return fmt.Errorf("updated %s but failed to reset clean worktree %s: %w", branchName, worktreePath, err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION


<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1571**
  * **PR #1572**
    * **PR #1573**
      * **PR #1574**
        * **PR #1575**
          * **PR #1576**
            * **PR #1577**
              * **PR #1581**
                * **PR #1580**
                  * **PR #1582**
                    * **PR #1583** 👈
                      * **PR #1584**
                        * **PR #1585**
                          * **PR #1586**
                            * **PR #1588**
                              * **PR #1589**
                                * **PR #1590**
                                  * **PR #1591**
                                    * **PR #1592**
                                      * **PR #1593**
                                        * **PR #1594**
                                          * **PR #1595**
                                            * **PR #1596**
                                              * **PR #1597**
                                                * **PR #1598**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->