### PR TITLE
fix(continue): synchronize rebased sibling worktrees

### DIFF
--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -61,7 +61,9 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 	}
 
 	// Continue the rebase
-	result, err := eng.ContinueRebase(ctx.Context, continuation.CurrentBranchOverride, continuation.RebasedBranchBase)
+	// No expected revision recorded: ContinueRebase falls back to the branch's
+	// current tip, which still rejects a write racing this one.
+	result, err := eng.ContinueRebase(ctx.Context, continuation.CurrentBranchOverride, continuation.RebasedBranchBase, "")
 	if err != nil {
 		return fmt.Errorf("failed to continue rebase: %w", err)
 	}

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -151,6 +151,10 @@ func (d *demoGitRunner) UpdateBranchRef(_ context.Context, _, _ string) error {
 	return nil
 }
 
+func (d *demoGitRunner) UpdateBranchRefCAS(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
 func (d *demoGitRunner) GetRemoteRevision(_ string) (string, error) {
 	return "remote-rev", nil
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -50,7 +50,7 @@ type SyncManager interface {
 	RestackBranchesWithProgress(ctx context.Context, branches Branches, progress RestackBranchProgressFunc) (RestackBatchResult, error)
 	RestackBranchesWithValidatedRebases(ctx context.Context, branches Branches, validation *RebaseValidation, progress RestackBranchProgressFunc) (RestackBatchResult, error)
 	RestackBranchesWithValidatedPlan(ctx context.Context, branches Branches, validation *RebaseValidation, plan *RestackPlan, progress RestackBranchProgressFunc) (RestackBatchResult, error)
-	ContinueRebase(ctx context.Context, branchName string, rebasedBranchBase string) (ContinueRebaseResult, error)
+	ContinueRebase(ctx context.Context, branchName string, rebasedBranchBase string, expectedBranchRevision string) (ContinueRebaseResult, error)
 	Rebase(ctx context.Context, branchName, upstream, oldUpstream string) (RestackResult, error)
 
 	// Validation

--- a/internal/engine/engine_absorb.go
+++ b/internal/engine/engine_absorb.go
@@ -17,6 +17,24 @@ func (e *engineImpl) ApplyHunksToBranch(ctx context.Context, branch Branch, hunk
 	}
 
 	branchName := branch.GetName()
+	oldTip, err := branch.GetRevision()
+	if err != nil {
+		return fmt.Errorf("failed to get branch revision for %s: %w", branchName, err)
+	}
+	worktrees, err := e.git.ListWorktrees(ctx)
+	if err != nil {
+		return fmt.Errorf("refusing to rewrite %s: cannot inspect worktrees: %w", branchName, err)
+	}
+	worktreePath := worktrees.PathForBranch(branchName)
+	if worktreePath != "" {
+		dirty, statusErr := e.git.WorktreeHasUncommittedChanges(ctx, worktreePath)
+		if statusErr != nil {
+			return fmt.Errorf("refusing to rewrite %s: cannot inspect worktree %s: %w", branchName, worktreePath, statusErr)
+		}
+		if dirty {
+			return fmt.Errorf("refusing to rewrite %s: worktree %s has uncommitted changes", branchName, worktreePath)
+		}
+	}
 
 	// Save current state to restore later
 	originalRef, _ := e.git.GetCurrentBranchOrSHA(ctx)
@@ -143,8 +161,13 @@ func (e *engineImpl) ApplyHunksToBranch(ctx context.Context, branch Branch, hunk
 	newTip = strings.TrimSpace(newTip)
 
 	// Update branch to point to new tip
-	if err := e.git.UpdateBranchRef(ctx, branchName, newTip); err != nil {
+	if err := e.git.UpdateBranchRefCAS(ctx, branchName, newTip, oldTip); err != nil {
 		return fmt.Errorf("failed to update branch %s: %w", branchName, err)
+	}
+	if worktreePath != "" {
+		if err := e.git.ResetWorktreeWorkingDir(ctx, worktreePath); err != nil {
+			return fmt.Errorf("updated %s but failed to reset clean worktree %s: %w", branchName, worktreePath, err)
+		}
 	}
 
 	return nil

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -262,7 +262,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 }
 
 // ContinueRebase continues an in-progress rebase
-func (e *engineImpl) ContinueRebase(ctx context.Context, branchName string, rebasedBranchBase string) (ContinueRebaseResult, error) {
+func (e *engineImpl) ContinueRebase(ctx context.Context, branchName string, rebasedBranchBase string, expectedBranchRevision string) (ContinueRebaseResult, error) {
 	// Call git rebase --continue
 	result, err := e.git.RebaseContinue(ctx)
 	if err != nil {
@@ -280,7 +280,13 @@ func (e *engineImpl) ContinueRebase(ctx context.Context, branchName string, reba
 	}
 
 	// Update the branch reference to the new rebased commit
-	err = e.git.UpdateBranchRef(ctx, branchName, newRev)
+	if expectedBranchRevision == "" {
+		expectedBranchRevision, err = e.git.GetRevision(branchName)
+		if err != nil {
+			return ContinueRebaseResult{BranchName: branchName}, fmt.Errorf("failed to get expected branch revision for %s: %w", branchName, err)
+		}
+	}
+	err = e.git.UpdateBranchRefCAS(ctx, branchName, newRev, expectedBranchRevision)
 	if err != nil {
 		return ContinueRebaseResult{BranchName: branchName}, fmt.Errorf("failed to update branch reference %s: %w", branchName, err)
 	}

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -200,6 +200,24 @@ func (r *runner) UpdateBranchRef(ctx context.Context, branchName, revision strin
 	return nil
 }
 
+func (r *runner) UpdateBranchRefCAS(ctx context.Context, branchName, revision, expectedOld string) error {
+	sha, err := r.resolveRefSHA(revision)
+	if err != nil {
+		return fmt.Errorf("failed to resolve revision %s: %w", revision, err)
+	}
+	if expectedOld == "" {
+		return fmt.Errorf("expected old revision is required when updating branch %s", branchName)
+	}
+	if err := r.UpdateRefsBatch(ctx, []RefUpdate{{
+		RefName: "refs/heads/" + branchName,
+		NewSHA:  sha,
+		OldSHA:  expectedOld,
+	}}); err != nil {
+		return fmt.Errorf("failed to compare-and-swap branch ref: %w", err)
+	}
+	return nil
+}
+
 func (r *runner) GetCurrentBranchOrSHA(ctx context.Context) (string, error) {
 	branch, err := r.GetCurrentBranch()
 	if err == nil {

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -70,6 +70,10 @@ type BranchWriter interface {
 	DeleteBranch(ctx context.Context, branchName string) error
 	RenameBranch(ctx context.Context, oldName, newName string) error
 	UpdateBranchRef(ctx context.Context, branchName, revision string) error
+	// UpdateBranchRefCAS moves a branch only if it still names expectedOld.
+	// Callers that prepared commits from a detached snapshot use this to avoid
+	// overwriting concurrent work from another worktree.
+	UpdateBranchRefCAS(ctx context.Context, branchName, revision, expectedOld string) error
 }
 
 // CommitReader provides read access to commit and revision information.

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -28,10 +28,14 @@ type RebaseOutcome struct {
 
 func (r *runner) Rebase(ctx context.Context, branchName, upstream, oldUpstream string) (RebaseOutcome, error) {
 	outcome := RebaseOutcome{Result: RebaseDone}
+	oldRev, err := r.GetRevision(branchName)
+	if err != nil {
+		return RebaseOutcome{Result: RebaseConflict}, fmt.Errorf("failed to get revision before rebase: %w", err)
+	}
 
 	// Use detached HEAD to avoid "already used by worktree" errors
 	// We use branchName~0 to force a detached checkout of the branch tip
-	_, err := r.RunGitCommandWithContext(ctx, "rebase", "--onto", upstream, oldUpstream, branchName+"~0")
+	_, err = r.RunGitCommandWithContext(ctx, "rebase", "--onto", upstream, oldUpstream, branchName+"~0")
 	if err != nil {
 		if r.IsRebaseInProgress(ctx) {
 			autoOutcome, autoErr := r.continueRerereResolvedRebase(ctx, err)
@@ -53,7 +57,7 @@ func (r *runner) Rebase(ctx context.Context, branchName, upstream, oldUpstream s
 		return RebaseOutcome{Result: RebaseConflict, RerereResolvedCount: outcome.RerereResolvedCount}, fmt.Errorf("failed to get revision after rebase: %w", err)
 	}
 
-	if err := r.UpdateBranchRef(ctx, branchName, newRev); err != nil {
+	if err := r.UpdateBranchRefCAS(ctx, branchName, newRev, oldRev); err != nil {
 		return RebaseOutcome{Result: RebaseConflict, RerereResolvedCount: outcome.RerereResolvedCount}, fmt.Errorf("failed to update branch ref %s: %w", branchName, err)
 	}
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Make branch mutations safe when worktrees hold the branch**

Closes the worktree half of the reconciliation-safety audit: eighteen fixes so
that moving a branch ref can no longer corrupt, revert, or silently discard work
in a worktree that has that branch checked out.

The unifying rule: before any operation rewrites a ref, it must ask who
physically holds that branch. If the holder is dirty or uninspectable, hold the
branch back and say so; if it is clean, reset it to match the ref it now points
at; never move a ref out from under a checkout and report success.

**Data loss (P0)**

- **#1580, #1584, #1585** — `fold`, `absorb`, and `continue` no longer merge onto
  a detached HEAD, rewrite an ancestor, or move a rebased ref while another
  worktree holds the branch. `CheckoutBranch` stops silently falling back to
  detached HEAD, which was a latent trap for every checkout-then-mutate action.
- **#1584** — `git.Rebase` writes its result through a compare-and-swap, so a
  commit made in another worktree mid-pass can no longer be overwritten (and
  then wiped by a reset keyed on a stale clean-snapshot).
- **#1580** — `create -w` keeps the branch when only the worktree phase fails.
  It previously deleted the sole ref to the commit that had just consumed the
  staged changes, past the point a snapshot could recover it.
- **#1585** — `merge --force` resets trunk through a ref update instead of a
  branch checkout, so a temp worktree can no longer squat on `refs/heads/<trunk>`
  and block the main workspace.

**Reconciliation model**

- **#1573, #1574, #1577, #1593** — restack holds branches behind dirty or
  uninspectable worktrees, holds their descendants too, leaves held branches
  metadata untouched, and reports the hold rather than passing it off as
  "already up to date". Untracked files count: `git reset --hard` will overwrite
  an untracked file whose pathname the incoming commit contains.
- **#1597** — worktrees mid-rebase report no branch to porcelain, so they were
  invisible to every branch/worktree guard. They are now held.

**Lifecycle and ownership**

- **#1586, #1595** — `pluck` and `delete` enforce managed-worktree ownership like
  the other branch-scoped mutations.
- **#1588, #1592, #1594** — worktree cleanup prunes before deleting the anchor,
  recovers invalid registrations instead of dead-ending between `remove`,
  `repair`, and `detach`, and sweeps reverse path refs orphaned by older code
  that would otherwise block re-creating a worktree at that path forever.
- **#1571** — reverse registrations stay addressable through symlinked bases by
  resolving the deepest existing ancestor, so register and unregister agree.
- **#1592** — multi-stack merge tags and deletes its consolidation branch and
  unlocks excluded and failed stacks instead of stranding PR locks.

**Correctness and hardening**

- **#1572** — sync stops treating a deleted remote branch as proof the local tip
  was pushed, which discarded follow-up commits on closed PRs.
- **#1589** — `split` uses the stash-by-ref API rather than popping the shared
  cross-worktree `stash@{0}`; relative `gitdir:` pointers resolve against the
  right base.
- **#1596** — `tree --json` no longer emits hidden anchors as dangling parents.
- Worktree porcelain is parsed with `-z`, `ForceRemoveWorktree` passes `--force`
  twice so it can remove locked worktrees, and relative `worktree.basePath`
  resolves against the repo root in Go code as it already did in git.

**Notes**

Sync also skips hidden anchors when comparing PR bases, which was queueing a
GitHub 422 on every sync for every worktree stack root with a PR.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785934948`.


* **PR #1571**
  * **PR #1572**
    * **PR #1573**
      * **PR #1574**
        * **PR #1577**
          * **PR #1580**
            * **PR #1584** 👈
              * **PR #1585**
                * **PR #1586**
                  * **PR #1588**
                    * **PR #1589**
                      * **PR #1592**
                        * **PR #1593**
                          * **PR #1594**
                            * **PR #1595**
                              * **PR #1596**
                                * **PR #1597**
                                  * **PR #1599**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1601 by jonnii*