### PR TITLE
fix(merge): reset trunk safely from detached worktrees

### DIFF
--- a/internal/engine/pull.go
+++ b/internal/engine/pull.go
@@ -114,27 +114,45 @@ func (e *engineImpl) ResetTrunkToRemote(ctx context.Context) error {
 		return fmt.Errorf("failed to get remote SHA: %w", err)
 	}
 
-	// Checkout trunk
-	trunkBranch := e.Trunk()
-	if err := e.CheckoutBranch(ctx, trunkBranch); err != nil {
-		return fmt.Errorf("failed to checkout trunk: %w", err)
+	oldTrunk, err := e.git.GetRevision(trunk)
+	if err != nil {
+		return fmt.Errorf("failed to get local trunk revision: %w", err)
 	}
-
-	// Hard reset to remote
-	if err := e.git.HardReset(ctx, remoteSha); err != nil {
-		// Try to switch back
-		if currentBranch != "" {
-			currentBranchObj := e.GetBranch(currentBranch)
-			_ = e.CheckoutBranch(ctx, currentBranchObj)
+	worktrees, err := e.git.ListWorktrees(ctx)
+	if err != nil {
+		return fmt.Errorf("refusing to reset trunk: cannot inspect worktrees: %w", err)
+	}
+	trunkWorktree := worktrees.PathForBranch(trunk)
+	if trunkWorktree != "" {
+		dirty, statusErr := e.git.WorktreeHasUncommittedChanges(ctx, trunkWorktree)
+		if statusErr != nil {
+			return fmt.Errorf("refusing to reset trunk: cannot inspect worktree %s: %w", trunkWorktree, statusErr)
 		}
-		return fmt.Errorf("failed to reset trunk: %w", err)
+		if dirty {
+			return fmt.Errorf("refusing to reset trunk: worktree %s has uncommitted changes", trunkWorktree)
+		}
 	}
 
-	// Switch back to original branch
-	if currentBranch != "" && currentBranch != trunk {
-		currentBranchObj := e.GetBranch(currentBranch)
-		if err := e.CheckoutBranch(ctx, currentBranchObj); err != nil {
-			return fmt.Errorf("failed to switch back: %w", err)
+	// Never check out the shared trunk in an analysis worktree. Move the ref
+	// with a CAS, then synchronize its clean holder; if this engine is itself
+	// detached, advance only its detached HEAD to the same remote revision.
+	if err := e.git.UpdateBranchRefCAS(ctx, trunk, remoteSha, oldTrunk); err != nil {
+		return fmt.Errorf("failed to reset trunk ref: %w", err)
+	}
+	if currentBranch == trunk {
+		if err := e.git.HardReset(ctx, "HEAD"); err != nil {
+			return fmt.Errorf("reset trunk ref but failed to reset current worktree: %w", err)
+		}
+	} else {
+		if trunkWorktree != "" {
+			if err := e.git.ResetWorktreeWorkingDir(ctx, trunkWorktree); err != nil {
+				return fmt.Errorf("reset trunk ref but failed to reset clean worktree %s: %w", trunkWorktree, err)
+			}
+		}
+		if currentBranch == "" {
+			if err := e.git.HardReset(ctx, remoteSha); err != nil {
+				return fmt.Errorf("reset trunk ref but failed to advance detached worktree: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Make branch mutations safe when worktrees hold the branch**

Closes the worktree half of the reconciliation-safety audit: eighteen fixes so
that moving a branch ref can no longer corrupt, revert, or silently discard work
in a worktree that has that branch checked out.

The unifying rule: before any operation rewrites a ref, it must ask who
physically holds that branch. If the holder is dirty or uninspectable, hold the
branch back and say so; if it is clean, reset it to match the ref it now points
at; never move a ref out from under a checkout and report success.

**Data loss (P0)**

- **#1580, #1584, #1585** — `fold`, `absorb`, and `continue` no longer merge onto
  a detached HEAD, rewrite an ancestor, or move a rebased ref while another
  worktree holds the branch. `CheckoutBranch` stops silently falling back to
  detached HEAD, which was a latent trap for every checkout-then-mutate action.
- **#1584** — `git.Rebase` writes its result through a compare-and-swap, so a
  commit made in another worktree mid-pass can no longer be overwritten (and
  then wiped by a reset keyed on a stale clean-snapshot).
- **#1580** — `create -w` keeps the branch when only the worktree phase fails.
  It previously deleted the sole ref to the commit that had just consumed the
  staged changes, past the point a snapshot could recover it.
- **#1585** — `merge --force` resets trunk through a ref update instead of a
  branch checkout, so a temp worktree can no longer squat on `refs/heads/<trunk>`
  and block the main workspace.

**Reconciliation model**

- **#1573, #1574, #1577, #1593** — restack holds branches behind dirty or
  uninspectable worktrees, holds their descendants too, leaves held branches
  metadata untouched, and reports the hold rather than passing it off as
  "already up to date". Untracked files count: `git reset --hard` will overwrite
  an untracked file whose pathname the incoming commit contains.
- **#1597** — worktrees mid-rebase report no branch to porcelain, so they were
  invisible to every branch/worktree guard. They are now held.

**Lifecycle and ownership**

- **#1586, #1595** — `pluck` and `delete` enforce managed-worktree ownership like
  the other branch-scoped mutations.
- **#1588, #1592, #1594** — worktree cleanup prunes before deleting the anchor,
  recovers invalid registrations instead of dead-ending between `remove`,
  `repair`, and `detach`, and sweeps reverse path refs orphaned by older code
  that would otherwise block re-creating a worktree at that path forever.
- **#1571** — reverse registrations stay addressable through symlinked bases by
  resolving the deepest existing ancestor, so register and unregister agree.
- **#1592** — multi-stack merge tags and deletes its consolidation branch and
  unlocks excluded and failed stacks instead of stranding PR locks.

**Correctness and hardening**

- **#1572** — sync stops treating a deleted remote branch as proof the local tip
  was pushed, which discarded follow-up commits on closed PRs.
- **#1589** — `split` uses the stash-by-ref API rather than popping the shared
  cross-worktree `stash@{0}`; relative `gitdir:` pointers resolve against the
  right base.
- **#1596** — `tree --json` no longer emits hidden anchors as dangling parents.
- Worktree porcelain is parsed with `-z`, `ForceRemoveWorktree` passes `--force`
  twice so it can remove locked worktrees, and relative `worktree.basePath`
  resolves against the repo root in Go code as it already did in git.

**Notes**

Sync also skips hidden anchors when comparing PR bases, which was queueing a
GitHub 422 on every sync for every worktree stack root with a PR.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785934948`.


* **PR #1571**
  * **PR #1572**
    * **PR #1573**
      * **PR #1574**
        * **PR #1577**
          * **PR #1580**
            * **PR #1584**
              * **PR #1585** 👈
                * **PR #1586**
                  * **PR #1588**
                    * **PR #1589**
                      * **PR #1592**
                        * **PR #1593**
                          * **PR #1594**
                            * **PR #1595**
                              * **PR #1596**
                                * **PR #1597**
                                  * **PR #1599**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1601 by jonnii*