### PR TITLE
fix(git): resolve remote revision against the configured remote

### DIFF
--- a/internal/git/commit_info.go
+++ b/internal/git/commit_info.go
@@ -102,11 +102,11 @@ func (r *runner) getRevision(branchName string) (string, error) {
 }
 
 func (r *runner) getRemoteRevision(branchName string) (string, error) {
-	// Use the bare "origin/<branch>" form so git's normal ref lookup order
+	// Use the bare "<remote>/<branch>" form so git's normal ref lookup order
 	// applies (refs/heads/, refs/remotes/, etc.). Tests sometimes mock the
 	// remote SHA by creating a local branch named "origin/<branch>" and
 	// rely on that fallback resolving via refs/heads/.
-	return r.resolveRefSHA("origin/" + branchName)
+	return r.resolveRefSHA(r.getRemote() + "/" + branchName)
 }
 
 func (r *runner) batchGetRevisions(branchNames []string) (map[string]string, []error) {

--- a/internal/git/commit_info_test.go
+++ b/internal/git/commit_info_test.go
@@ -46,3 +46,20 @@ func TestBatchCommitInfo_Empty(t *testing.T) {
 	got := runner.BatchCommitInfo(nil)
 	require.Empty(t, got)
 }
+
+func TestGetRemoteRevision_UsesConfiguredRemote(t *testing.T) {
+	t.Parallel()
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+
+	// Point main's configured remote at a name other than "origin" and stand
+	// in a local branch for that remote's tracking ref.
+	require.NoError(t, scene.Repo.RunGitCommand("config", "branch.main.remote", "upstream"))
+	mainSHA, err := scene.Repo.GetRevision("main")
+	require.NoError(t, err)
+	require.NoError(t, scene.Repo.RunGitCommand("branch", "upstream/main", mainSHA))
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	got, err := runner.GetRemoteRevision("main")
+	require.NoError(t, err)
+	require.Equal(t, mainSHA, got)
+}


### PR DESCRIPTION
## Summary

- `getRemoteRevision` hardcoded the `"origin/<branch>"` ref form, ignoring the remote actually configured for the branch (`branch.<name>.remote`)
- On repos where the tracked remote isn't named `origin` (fork workflows, custom remote names), resolution silently failed — and callers swallow that error, degrading `ReadBranchRemoteStatuses` (used by submit/sync/merge/lock/clean/worktree, 16+ call sites) and skipping the frozen-branch remote reset in restack
- Resolve against `getRemote()` instead, matching the convention already used everywhere else remote refs are built (`TrunkRemoteState`, `ReadBranchRemoteStatuses`, `pull`, `sync`)

## Test plan

- [x] Added `TestGetRemoteRevision_UsesConfiguredRemote`, which configures a non-`origin` remote name and verifies resolution follows it (fails without the fix, passes with it)
- [x] `go test ./internal/git/...` (all pass except a pre-existing, unrelated `TestGetRepoInfo/parses_HTTPS_URL` failure caused by this sandbox's URL rewrite config — reproduces identically on `main`)
- [x] `go test ./internal/engine/...` passes
- [x] `go build ./...`, `go vet ./internal/git/...`, `gofmt -l` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsVsQxteicm7fXwgauyQU7)_