### PR TITLE
fix(worktree): make cleanup lifecycle safe

### DIFF
--- a/internal/actions/sync/worktree_cleanup.go
+++ b/internal/actions/sync/worktree_cleanup.go
@@ -7,6 +7,7 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // WorktreeCleanupResult contains the results of worktree cleanup
@@ -59,6 +60,14 @@ func cleanOrphanedWorktrees(ctx *app.Context, dirtyAnchors dirtyAnchorSet) *Work
 
 	// Check each anchored worktree and remove it once it is clean and empty.
 	for _, wt := range worktrees {
+		// The main worktree is never disposable, even if an invalid
+		// registration makes it look like an empty managed worktree. Skipping
+		// this candidate lets cleanup continue for the rest of the batch.
+		if git.IsMainWorktree(wt.Path, wt.MainRepoDir) {
+			ctx.Output.Debug("Skipping cleanup for main worktree %s", wt.Path)
+			continue
+		}
+
 		// Skip dirty worktrees - don't clean up while there are uncommitted changes
 		if dirtyAnchors[wt.AnchorBranch] {
 			continue
@@ -96,10 +105,13 @@ func cleanOrphanedWorktrees(ctx *app.Context, dirtyAnchors dirtyAnchorSet) *Work
 			continue
 		}
 
-		if unregErr := ctx.Engine.UnregisterWorktree(ctx.Context, wt.AnchorBranch); unregErr != nil {
+		// Removing a directory can leave Git's administrative worktree entry
+		// behind. Prune it before deleting the anchor; an anchor deleted first
+		// is not recoverable from a later unregister failure.
+		if pruneErr := ctx.Engine.PruneWorktrees(ctx.Context); pruneErr != nil {
 			result.Errors = append(result.Errors,
-				"failed to unregister worktree for "+wt.AnchorBranch+": "+unregErr.Error())
-			ctx.Output.Debug("Failed to unregister worktree for %s: %v", wt.AnchorBranch, unregErr)
+				"failed to prune stale worktree entries for "+wt.AnchorBranch+": "+pruneErr.Error())
+			ctx.Output.Debug("Failed to prune stale worktree entries for %s: %v", wt.AnchorBranch, pruneErr)
 			continue
 		}
 
@@ -110,6 +122,13 @@ func cleanOrphanedWorktrees(ctx *app.Context, dirtyAnchors dirtyAnchorSet) *Work
 				ctx.Output.Debug("Failed to delete anchor branch %s: %v", wt.AnchorBranch, deleteErr)
 				continue
 			}
+		}
+
+		if unregErr := ctx.Engine.UnregisterWorktree(ctx.Context, wt.AnchorBranch); unregErr != nil {
+			result.Errors = append(result.Errors,
+				"failed to unregister worktree for "+wt.AnchorBranch+": "+unregErr.Error())
+			ctx.Output.Debug("Failed to unregister worktree for %s: %v", wt.AnchorBranch, unregErr)
+			continue
 		}
 		result.RemovedWorktrees = append(result.RemovedWorktrees, wt.AnchorBranch)
 	}

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -510,6 +510,10 @@ func worktreePathForName(repoRoot string, name string) string {
 	if basePath == "" {
 		repoName := filepath.Base(repoRoot)
 		basePath = filepath.Join(filepath.Dir(repoRoot), repoName+"-stacks")
+	} else if !filepath.IsAbs(basePath) {
+		// Configuration lives with the repository, so relative worktree bases
+		// must not depend on the directory from which stackit was invoked.
+		basePath = filepath.Join(repoRoot, basePath)
 	}
 
 	return filepath.Join(basePath, name)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Make branch mutations safe when worktrees hold the branch**

Closes the worktree half of the reconciliation-safety audit: eighteen fixes so
that moving a branch ref can no longer corrupt, revert, or silently discard work
in a worktree that has that branch checked out.

The unifying rule: before any operation rewrites a ref, it must ask who
physically holds that branch. If the holder is dirty or uninspectable, hold the
branch back and say so; if it is clean, reset it to match the ref it now points
at; never move a ref out from under a checkout and report success.

**Data loss (P0)**

- **#1580, #1584, #1585** — `fold`, `absorb`, and `continue` no longer merge onto
  a detached HEAD, rewrite an ancestor, or move a rebased ref while another
  worktree holds the branch. `CheckoutBranch` stops silently falling back to
  detached HEAD, which was a latent trap for every checkout-then-mutate action.
- **#1584** — `git.Rebase` writes its result through a compare-and-swap, so a
  commit made in another worktree mid-pass can no longer be overwritten (and
  then wiped by a reset keyed on a stale clean-snapshot).
- **#1580** — `create -w` keeps the branch when only the worktree phase fails.
  It previously deleted the sole ref to the commit that had just consumed the
  staged changes, past the point a snapshot could recover it.
- **#1585** — `merge --force` resets trunk through a ref update instead of a
  branch checkout, so a temp worktree can no longer squat on `refs/heads/<trunk>`
  and block the main workspace.

**Reconciliation model**

- **#1573, #1574, #1577, #1593** — restack holds branches behind dirty or
  uninspectable worktrees, holds their descendants too, leaves held branches
  metadata untouched, and reports the hold rather than passing it off as
  "already up to date". Untracked files count: `git reset --hard` will overwrite
  an untracked file whose pathname the incoming commit contains.
- **#1597** — worktrees mid-rebase report no branch to porcelain, so they were
  invisible to every branch/worktree guard. They are now held.

**Lifecycle and ownership**

- **#1586, #1595** — `pluck` and `delete` enforce managed-worktree ownership like
  the other branch-scoped mutations.
- **#1588, #1592, #1594** — worktree cleanup prunes before deleting the anchor,
  recovers invalid registrations instead of dead-ending between `remove`,
  `repair`, and `detach`, and sweeps reverse path refs orphaned by older code
  that would otherwise block re-creating a worktree at that path forever.
- **#1571** — reverse registrations stay addressable through symlinked bases by
  resolving the deepest existing ancestor, so register and unregister agree.
- **#1592** — multi-stack merge tags and deletes its consolidation branch and
  unlocks excluded and failed stacks instead of stranding PR locks.

**Correctness and hardening**

- **#1572** — sync stops treating a deleted remote branch as proof the local tip
  was pushed, which discarded follow-up commits on closed PRs.
- **#1589** — `split` uses the stash-by-ref API rather than popping the shared
  cross-worktree `stash@{0}`; relative `gitdir:` pointers resolve against the
  right base.
- **#1596** — `tree --json` no longer emits hidden anchors as dangling parents.
- Worktree porcelain is parsed with `-z`, `ForceRemoveWorktree` passes `--force`
  twice so it can remove locked worktrees, and relative `worktree.basePath`
  resolves against the repo root in Go code as it already did in git.

**Notes**

Sync also skips hidden anchors when comparing PR bases, which was queueing a
GitHub 422 on every sync for every worktree stack root with a PR.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785934948`.


* **PR #1571**
  * **PR #1572**
    * **PR #1573**
      * **PR #1574**
        * **PR #1577**
          * **PR #1580**
            * **PR #1584**
              * **PR #1585**
                * **PR #1586**
                  * **PR #1588** 👈
                    * **PR #1589**
                      * **PR #1592**
                        * **PR #1593**
                          * **PR #1594**
                            * **PR #1595**
                              * **PR #1596**
                                * **PR #1597**
                                  * **PR #1599**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1601 by jonnii*