### PR TITLE
fix(git): preserve explicit stash and gitdir paths

### DIFF
--- a/internal/actions/split/split_file.go
+++ b/internal/actions/split/split_file.go
@@ -19,6 +19,7 @@ type splitByFileEngine interface {
 	engine.BranchReader
 	engine.BranchWriter
 	engine.StackRewriter
+	splitStashEngine
 }
 
 // splitByFileOptions contains options for the splitByFile operation
@@ -222,6 +223,10 @@ func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []s
 		_ = eng.ForceCheckoutBranch(ctx, branchToSplit)
 		return nil, fmt.Errorf("failed to stash staged changes: %w", err)
 	}
+	stashRef, err := splitStashRef(ctx, eng, stashName)
+	if err != nil {
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit, err)
+	}
 
 	// Track stash state for cleanup.
 	// Note: cleanupStash is called during error recovery, so we intentionally
@@ -230,7 +235,7 @@ func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []s
 	stashPopped := false
 	cleanupStash := func() {
 		if !stashPopped {
-			_ = eng.StashPop(ctx)
+			_ = eng.StashPopRef(ctx, stashRef)
 			stashPopped = true
 		}
 	}
@@ -278,7 +283,7 @@ func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []s
 	}
 
 	// Pop the stash to get the parent branch changes
-	if err := eng.StashPop(ctx); err != nil {
+	if err := eng.StashPopRef(ctx, stashRef); err != nil {
 		return nil, fmt.Errorf("failed to pop stash: %w. Recovery: check 'git stash list' for pending stash, resolve any conflicts manually", err)
 	}
 	stashPopped = true
@@ -406,6 +411,10 @@ func splitByFileAbove(ctx context.Context, branchToSplit engine.Branch, newBranc
 		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit,
 			fmt.Errorf("failed to stash staged changes: %w", err))
 	}
+	stashRef, err := splitStashRef(ctx, eng, stashName)
+	if err != nil {
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit, err)
+	}
 
 	// Track stash state for cleanup.
 	// Note: cleanupStash is called during error recovery, so we intentionally
@@ -414,7 +423,7 @@ func splitByFileAbove(ctx context.Context, branchToSplit engine.Branch, newBranc
 	stashPopped := false
 	cleanupStash := func() {
 		if !stashPopped {
-			_ = eng.StashPop(ctx)
+			_ = eng.StashPopRef(ctx, stashRef)
 			stashPopped = true
 		}
 	}
@@ -482,7 +491,7 @@ func splitByFileAbove(ctx context.Context, branchToSplit engine.Branch, newBranc
 	}
 
 	// Pop the stash to get the extract changes back
-	if err := eng.StashPop(ctx); err != nil {
+	if err := eng.StashPopRef(ctx, stashRef); err != nil {
 		cleanupChildBranch()
 		_ = eng.CheckoutBranch(ctx, branchToSplit)
 		return nil, fmt.Errorf("failed to pop stash: %w. Recovery: check 'git stash list' for pending stash, resolve any conflicts manually", err)

--- a/internal/actions/split/split_hunk.go
+++ b/internal/actions/split/split_hunk.go
@@ -31,6 +31,7 @@ type splitByHunkEngine interface {
 	engine.BranchWriter
 	engine.PRManager
 	engine.StackRewriter
+	splitStashEngine
 }
 
 // splitByHunkWithHandler splits a branch by interactively staging hunks using an InteractiveHandler.
@@ -402,12 +403,16 @@ func splitByHunkBelowWithPatch(ctx *app.Context, branchToSplit engine.Branch, en
 	if err != nil {
 		return fmt.Errorf("failed to stash staged changes: %w", err)
 	}
+	stashRef, err := splitStashRef(gitCtx, eng, stashName)
+	if err != nil {
+		return err
+	}
 
 	// Track stash state for cleanup
 	stashPopped := false
 	cleanupStash := func() {
 		if !stashPopped {
-			_ = eng.StashPop(gitCtx)
+			_ = eng.StashPopRef(gitCtx, stashRef)
 			stashPopped = true
 		}
 	}
@@ -439,7 +444,7 @@ func splitByHunkBelowWithPatch(ctx *app.Context, branchToSplit engine.Branch, en
 	}
 
 	// Pop the stash to get the parent branch changes
-	if err := eng.StashPop(gitCtx); err != nil {
+	if err := eng.StashPopRef(gitCtx, stashRef); err != nil {
 		return fmt.Errorf("failed to pop stash: %w. Recovery: run 'git stash pop' to restore changes", err)
 	}
 	stashPopped = true
@@ -692,12 +697,16 @@ func splitByHunkAbove(ctx *app.Context, branchToSplit engine.Branch, eng splitBy
 	if err != nil {
 		return fmt.Errorf("failed to stash staged changes: %w", err)
 	}
+	stashRef, err := splitStashRef(gitCtx, eng, stashName)
+	if err != nil {
+		return err
+	}
 
 	// Track stash state for cleanup - once stash is pushed, we need to pop it on any error
 	stashPopped := false
 	cleanupStash := func() {
 		if !stashPopped {
-			_ = eng.StashPop(gitCtx)
+			_ = eng.StashPopRef(gitCtx, stashRef)
 			stashPopped = true
 		}
 	}
@@ -743,7 +752,7 @@ func splitByHunkAbove(ctx *app.Context, branchToSplit engine.Branch, eng splitBy
 	}
 
 	// Pop the stash to get the extract changes back
-	if err := eng.StashPop(gitCtx); err != nil {
+	if err := eng.StashPopRef(gitCtx, stashRef); err != nil {
 		// Stash pop failed - this leaves the repo in a partially completed state.
 		// The original branch has been updated and the child branch exists but has no commit.
 		// Provide guidance on how to recover.

--- a/internal/actions/split/stash.go
+++ b/internal/actions/split/stash.go
@@ -1,0 +1,29 @@
+package split
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type splitStashEngine interface {
+	StashList(context.Context) (string, error)
+	StashPopRef(context.Context, string) error
+}
+
+// splitStashRef returns the exact ref created for this split operation. A
+// split must never fall back to stash@{0}: users may create another stash
+// while recovering from an error, and popping that stash loses their work.
+func splitStashRef(ctx context.Context, eng splitStashEngine, marker string) (string, error) {
+	list, err := eng.StashList(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list stashes: %w", err)
+	}
+	for line := range strings.SplitSeq(list, "\n") {
+		ref, message, ok := strings.Cut(line, ":")
+		if ok && strings.Contains(message, marker) {
+			return strings.TrimSpace(ref), nil
+		}
+	}
+	return "", fmt.Errorf("split stash %q was not found", marker)
+}

--- a/internal/git/gitdir.go
+++ b/internal/git/gitdir.go
@@ -56,9 +56,11 @@ func resolveGitDir(repoRoot string) string {
 	}
 	gitDir = strings.TrimSpace(gitDir)
 	if !filepath.IsAbs(gitDir) {
-		gitDir = filepath.Join(repoRoot, gitDir)
+		// A relative gitdir is relative to the .git file, which may be in an
+		// ancestor when the caller supplied a repository subdirectory.
+		gitDir = filepath.Join(filepath.Dir(gitPath), gitDir)
 	}
-	return gitDir
+	return filepath.Clean(gitDir)
 }
 
 func findDotGit(path string) string {


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Make branch mutations safe when worktrees hold the branch**

Closes the worktree half of the reconciliation-safety audit: eighteen fixes so
that moving a branch ref can no longer corrupt, revert, or silently discard work
in a worktree that has that branch checked out.

The unifying rule: before any operation rewrites a ref, it must ask who
physically holds that branch. If the holder is dirty or uninspectable, hold the
branch back and say so; if it is clean, reset it to match the ref it now points
at; never move a ref out from under a checkout and report success.

**Data loss (P0)**

- **#1580, #1584, #1585** — `fold`, `absorb`, and `continue` no longer merge onto
  a detached HEAD, rewrite an ancestor, or move a rebased ref while another
  worktree holds the branch. `CheckoutBranch` stops silently falling back to
  detached HEAD, which was a latent trap for every checkout-then-mutate action.
- **#1584** — `git.Rebase` writes its result through a compare-and-swap, so a
  commit made in another worktree mid-pass can no longer be overwritten (and
  then wiped by a reset keyed on a stale clean-snapshot).
- **#1580** — `create -w` keeps the branch when only the worktree phase fails.
  It previously deleted the sole ref to the commit that had just consumed the
  staged changes, past the point a snapshot could recover it.
- **#1585** — `merge --force` resets trunk through a ref update instead of a
  branch checkout, so a temp worktree can no longer squat on `refs/heads/<trunk>`
  and block the main workspace.

**Reconciliation model**

- **#1573, #1574, #1577, #1593** — restack holds branches behind dirty or
  uninspectable worktrees, holds their descendants too, leaves held branches
  metadata untouched, and reports the hold rather than passing it off as
  "already up to date". Untracked files count: `git reset --hard` will overwrite
  an untracked file whose pathname the incoming commit contains.
- **#1597** — worktrees mid-rebase report no branch to porcelain, so they were
  invisible to every branch/worktree guard. They are now held.

**Lifecycle and ownership**

- **#1586, #1595** — `pluck` and `delete` enforce managed-worktree ownership like
  the other branch-scoped mutations.
- **#1588, #1592, #1594** — worktree cleanup prunes before deleting the anchor,
  recovers invalid registrations instead of dead-ending between `remove`,
  `repair`, and `detach`, and sweeps reverse path refs orphaned by older code
  that would otherwise block re-creating a worktree at that path forever.
- **#1571** — reverse registrations stay addressable through symlinked bases by
  resolving the deepest existing ancestor, so register and unregister agree.
- **#1592** — multi-stack merge tags and deletes its consolidation branch and
  unlocks excluded and failed stacks instead of stranding PR locks.

**Correctness and hardening**

- **#1572** — sync stops treating a deleted remote branch as proof the local tip
  was pushed, which discarded follow-up commits on closed PRs.
- **#1589** — `split` uses the stash-by-ref API rather than popping the shared
  cross-worktree `stash@{0}`; relative `gitdir:` pointers resolve against the
  right base.
- **#1596** — `tree --json` no longer emits hidden anchors as dangling parents.
- Worktree porcelain is parsed with `-z`, `ForceRemoveWorktree` passes `--force`
  twice so it can remove locked worktrees, and relative `worktree.basePath`
  resolves against the repo root in Go code as it already did in git.

**Notes**

Sync also skips hidden anchors when comparing PR bases, which was queueing a
GitHub 422 on every sync for every worktree stack root with a PR.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785934948`.


* **PR #1571**
  * **PR #1572**
    * **PR #1573**
      * **PR #1574**
        * **PR #1577**
          * **PR #1580**
            * **PR #1584**
              * **PR #1585**
                * **PR #1586**
                  * **PR #1588**
                    * **PR #1589** 👈
                      * **PR #1592**
                        * **PR #1593**
                          * **PR #1594**
                            * **PR #1595**
                              * **PR #1596**
                                * **PR #1597**
                                  * **PR #1599**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1601 by jonnii*