### PR TITLE
fix(worktree): recover invalid registrations safely

### DIFF
--- a/docs/worktree.md
+++ b/docs/worktree.md
@@ -36,6 +36,20 @@ Git worktrees let you check out multiple branches simultaneously in separate dir
 
 **Default location:** Worktrees are created in a sibling directory named `{repo}-stacks/`. For example, if your repo is at `~/projects/myapp`, worktrees go to `~/projects/myapp-stacks/`.
 
+### Ownership and reconciliation
+
+Branch-scoped content operations — including `create`, `modify`, `absorb`,
+`fold`, `squash`, `split`, `move`, and `reorder` — must run in the worktree
+that owns the stack. This ensures an edit is made in the working tree the user
+is actually viewing.
+
+`sync` and `restack` are whole-repository reconcilers and may run from any
+worktree. They never check out a foreign branch. Before either moves a ref,
+Stackit inspects every physical checkout: a clean holder is reset to the new
+ref, while a dirty or uninspectable holder (and its descendants) is held back
+and reported. This applies to ordinary Git worktrees too, not only worktrees
+registered with Stackit.
+
 ---
 
 ## Warm starts

--- a/internal/actions/checkout.go
+++ b/internal/actions/checkout.go
@@ -237,10 +237,15 @@ func getWorktreeSwitchInfo(ctx *app.Context, branch engine.Branch, branchName st
 		return "", nil, nil
 	}
 
-	if _, err := os.Stat(targetWorktree.Path); os.IsNotExist(err) {
-		ctx.Output.Warn("Worktree for stack %s is registered but path does not exist: %s",
-			output.BranchName(targetStackRoot), targetWorktree.Path)
-		ctx.Output.Tip("stackit worktree remove %s", targetStackRoot)
+	if _, err := os.Stat(targetWorktree.Path); err != nil {
+		if os.IsNotExist(err) {
+			ctx.Output.Warn("Worktree for stack %s is registered but path does not exist: %s",
+				output.BranchName(targetStackRoot), targetWorktree.Path)
+			ctx.Output.Tip("stackit worktree remove %s", targetStackRoot)
+			return "", nil, nil
+		}
+		ctx.Output.Warn("Cannot inspect worktree for stack %s at %s: %v",
+			output.BranchName(targetStackRoot), targetWorktree.Path, err)
 		return "", nil, nil
 	}
 

--- a/internal/actions/create/create.go
+++ b/internal/actions/create/create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/utils"
 )
 
@@ -305,25 +306,23 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 		// Checkout back to trunk first so we can create the worktree for the branch
 		trunkBranch := eng.Trunk()
 		if err := eng.CheckoutBranch(ctx.Context, trunkBranch); err != nil {
-			_ = eng.DeleteBranch(ctx.Context, branch)
 			h.OnStep(StepWorktree, handler.StatusFailed, err.Error())
-			return Result{}, fmt.Errorf("failed to checkout trunk before creating worktree: %w", err)
-		}
+			out.Warn("Created %s, but could not create its worktree: %v", output.BranchName(branchName), err)
+		} else {
+			created, err := worktree.CreateAnchoredWorktreeForBranch(ctx, branchName, branchName, opts.Scope)
+			if err != nil {
+				h.OnStep(StepWorktree, handler.StatusFailed, err.Error())
+				out.Warn("Created %s, but could not create its worktree: %v", output.BranchName(branchName), err)
+			} else {
+				worktreePath = created.Path
+				h.OnStep(StepWorktree, handler.StatusCompleted, fmt.Sprintf("Created worktree at %s", worktreePath))
+				out.Info("Created worktree at %s", worktreePath)
+			}
 
-		created, err := worktree.CreateAnchoredWorktreeForBranch(ctx, branchName, branchName, opts.Scope)
-		if err != nil {
-			// Clean up branch on worktree failure
-			_ = eng.DeleteBranch(ctx.Context, branch)
-			h.OnStep(StepWorktree, handler.StatusFailed, err.Error())
-			return Result{}, fmt.Errorf("failed to create worktree: %w", err)
-		}
-		worktreePath = created.Path
-		h.OnStep(StepWorktree, handler.StatusCompleted, fmt.Sprintf("Created worktree at %s", worktreePath))
-		out.Info("Created worktree at %s", worktreePath)
-
-		// Run post-create hooks in the worktree
-		if hookErr := worktree.RunPostCreateHooks(ctx, worktreePath); hookErr != nil {
-			out.Warn("Post-create hooks failed: %v", hookErr)
+			// Run post-create hooks in the worktree
+			if hookErr := worktree.RunPostCreateHooks(ctx, worktreePath); hookErr != nil {
+				out.Warn("Post-create hooks failed: %v", hookErr)
+			}
 		}
 	}
 

--- a/internal/actions/fold/fold_test.go
+++ b/internal/actions/fold/fold_test.go
@@ -47,6 +47,33 @@ func TestFoldAction(t *testing.T) {
 		require.Contains(t, logOutput, "change on branch2")
 	})
 
+	t.Run("refuses when parent is checked out in another worktree", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"branch1": "main",
+				"branch2": "branch1",
+			})
+		s.Checkout("branch2")
+		branch2Before, err := s.Engine.GetBranch("branch2").GetRevision()
+		require.NoError(t, err)
+
+		worktreePath := filepath.Join(t.TempDir(), "parent")
+		require.NoError(t, s.Scene.Repo.RunGitCommand("worktree", "add", worktreePath, "branch1"))
+		t.Cleanup(func() { _ = s.Scene.Repo.RunGitCommand("worktree", "remove", "--force", worktreePath) })
+
+		err = Action(s.Context, Options{Keep: false}, nil)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to checkout parent branch")
+
+		branch2After, err := s.Engine.GetBranch("branch2").GetRevision()
+		require.NoError(t, err)
+		require.Equal(t, branch2Before, branch2After, "fold must not delete or rewrite its branch")
+		current, err := s.Scene.Repo.CurrentBranchName()
+		require.NoError(t, err)
+		require.Equal(t, "branch2", current, "fold must not leave the caller detached")
+	})
+
 	t.Run("reparents children when folding branch", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).

--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -69,6 +69,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	// Get source's direct children (they will be reparented to grandparent)
 	children := graph.ChildBranches(sourceBranch)
+	if err := actions.EnsureCanModifyHere(ctx, append(engine.BranchesOf(sourceBranch, ontoBranch), children...)...); err != nil {
+		return err
+	}
 
 	// Cycle detection: ensure onto is not a descendant of source
 	if graph.IsDescendant(sourceBranch, ontoBranch) {

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -145,18 +145,12 @@ func RestackAction(ctx *app.Context, plan *RestackPlan, handler handlers.Restack
 
 	ctx.Logger.Info("restack started branchCount=%v", branchCount)
 
-	// Parallel mode dispatches each group to a worktree that recomputes its own
-	// plan, so the plan resolved here does not decide what those workers do.
+	// Restack is repository reconciliation, like sync: it may run from any
+	// worktree, but the engine holds branches whose checked-out worktree is
+	// dirty or cannot be inspected. Content-editing actions keep the ownership
+	// guard; applying it here would make unrelated main-repo stacks an
+	// all-or-nothing casualty of one managed worktree.
 	parallelDispatch := opts.Parallel && len(plan.groups) > 1
-	if !parallelDispatch {
-		branches := engine.Branches{}
-		for _, group := range plan.groups {
-			branches = branches.Concat(group.sortedBranches)
-		}
-		if err := EnsureCanModifyHere(ctx, branches...); err != nil {
-			return err
-		}
-	}
 
 	// Take snapshot before modifying the repository. Skip it when no branch
 	// actually needs a rebase: an up-to-date restack mutates nothing, so there

--- a/internal/actions/split/split_file.go
+++ b/internal/actions/split/split_file.go
@@ -19,6 +19,7 @@ type splitByFileEngine interface {
 	engine.BranchReader
 	engine.BranchWriter
 	engine.StackRewriter
+	splitStashEngine
 }
 
 // splitByFileOptions contains options for the splitByFile operation
@@ -222,6 +223,10 @@ func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []s
 		_ = eng.ForceCheckoutBranch(ctx, branchToSplit)
 		return nil, fmt.Errorf("failed to stash staged changes: %w", err)
 	}
+	stashRef, err := splitStashRef(ctx, eng, stashName)
+	if err != nil {
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit, err)
+	}
 
 	// Track stash state for cleanup.
 	// Note: cleanupStash is called during error recovery, so we intentionally
@@ -230,7 +235,7 @@ func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []s
 	stashPopped := false
 	cleanupStash := func() {
 		if !stashPopped {
-			_ = eng.StashPop(ctx)
+			_ = eng.StashPopRef(ctx, stashRef)
 			stashPopped = true
 		}
 	}
@@ -278,7 +283,7 @@ func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []s
 	}
 
 	// Pop the stash to get the parent branch changes
-	if err := eng.StashPop(ctx); err != nil {
+	if err := eng.StashPopRef(ctx, stashRef); err != nil {
 		return nil, fmt.Errorf("failed to pop stash: %w. Recovery: check 'git stash list' for pending stash, resolve any conflicts manually", err)
 	}
 	stashPopped = true
@@ -406,6 +411,10 @@ func splitByFileAbove(ctx context.Context, branchToSplit engine.Branch, newBranc
 		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit,
 			fmt.Errorf("failed to stash staged changes: %w", err))
 	}
+	stashRef, err := splitStashRef(ctx, eng, stashName)
+	if err != nil {
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit, err)
+	}
 
 	// Track stash state for cleanup.
 	// Note: cleanupStash is called during error recovery, so we intentionally
@@ -414,7 +423,7 @@ func splitByFileAbove(ctx context.Context, branchToSplit engine.Branch, newBranc
 	stashPopped := false
 	cleanupStash := func() {
 		if !stashPopped {
-			_ = eng.StashPop(ctx)
+			_ = eng.StashPopRef(ctx, stashRef)
 			stashPopped = true
 		}
 	}
@@ -482,7 +491,7 @@ func splitByFileAbove(ctx context.Context, branchToSplit engine.Branch, newBranc
 	}
 
 	// Pop the stash to get the extract changes back
-	if err := eng.StashPop(ctx); err != nil {
+	if err := eng.StashPopRef(ctx, stashRef); err != nil {
 		cleanupChildBranch()
 		_ = eng.CheckoutBranch(ctx, branchToSplit)
 		return nil, fmt.Errorf("failed to pop stash: %w. Recovery: check 'git stash list' for pending stash, resolve any conflicts manually", err)

--- a/internal/actions/split/split_hunk.go
+++ b/internal/actions/split/split_hunk.go
@@ -31,6 +31,7 @@ type splitByHunkEngine interface {
 	engine.BranchWriter
 	engine.PRManager
 	engine.StackRewriter
+	splitStashEngine
 }
 
 // splitByHunkWithHandler splits a branch by interactively staging hunks using an InteractiveHandler.
@@ -402,12 +403,16 @@ func splitByHunkBelowWithPatch(ctx *app.Context, branchToSplit engine.Branch, en
 	if err != nil {
 		return fmt.Errorf("failed to stash staged changes: %w", err)
 	}
+	stashRef, err := splitStashRef(gitCtx, eng, stashName)
+	if err != nil {
+		return err
+	}
 
 	// Track stash state for cleanup
 	stashPopped := false
 	cleanupStash := func() {
 		if !stashPopped {
-			_ = eng.StashPop(gitCtx)
+			_ = eng.StashPopRef(gitCtx, stashRef)
 			stashPopped = true
 		}
 	}
@@ -439,7 +444,7 @@ func splitByHunkBelowWithPatch(ctx *app.Context, branchToSplit engine.Branch, en
 	}
 
 	// Pop the stash to get the parent branch changes
-	if err := eng.StashPop(gitCtx); err != nil {
+	if err := eng.StashPopRef(gitCtx, stashRef); err != nil {
 		return fmt.Errorf("failed to pop stash: %w. Recovery: run 'git stash pop' to restore changes", err)
 	}
 	stashPopped = true
@@ -692,12 +697,16 @@ func splitByHunkAbove(ctx *app.Context, branchToSplit engine.Branch, eng splitBy
 	if err != nil {
 		return fmt.Errorf("failed to stash staged changes: %w", err)
 	}
+	stashRef, err := splitStashRef(gitCtx, eng, stashName)
+	if err != nil {
+		return err
+	}
 
 	// Track stash state for cleanup - once stash is pushed, we need to pop it on any error
 	stashPopped := false
 	cleanupStash := func() {
 		if !stashPopped {
-			_ = eng.StashPop(gitCtx)
+			_ = eng.StashPopRef(gitCtx, stashRef)
 			stashPopped = true
 		}
 	}
@@ -743,7 +752,7 @@ func splitByHunkAbove(ctx *app.Context, branchToSplit engine.Branch, eng splitBy
 	}
 
 	// Pop the stash to get the extract changes back
-	if err := eng.StashPop(gitCtx); err != nil {
+	if err := eng.StashPopRef(gitCtx, stashRef); err != nil {
 		// Stash pop failed - this leaves the repo in a partially completed state.
 		// The original branch has been updated and the child branch exists but has no commit.
 		// Provide guidance on how to recover.

--- a/internal/actions/split/stash.go
+++ b/internal/actions/split/stash.go
@@ -1,0 +1,29 @@
+package split
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type splitStashEngine interface {
+	StashList(context.Context) (string, error)
+	StashPopRef(context.Context, string) error
+}
+
+// splitStashRef returns the exact ref created for this split operation. A
+// split must never fall back to stash@{0}: users may create another stash
+// while recovering from an error, and popping that stash loses their work.
+func splitStashRef(ctx context.Context, eng splitStashEngine, marker string) (string, error) {
+	list, err := eng.StashList(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list stashes: %w", err)
+	}
+	for line := range strings.SplitSeq(list, "\n") {
+		ref, message, ok := strings.Cut(line, ":")
+		if ok && strings.Contains(message, marker) {
+			return strings.TrimSpace(ref), nil
+		}
+	}
+	return "", fmt.Errorf("split stash %q was not found", marker)
+}

--- a/internal/actions/sync/worktree_cleanup.go
+++ b/internal/actions/sync/worktree_cleanup.go
@@ -7,6 +7,7 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // WorktreeCleanupResult contains the results of worktree cleanup
@@ -59,6 +60,14 @@ func cleanOrphanedWorktrees(ctx *app.Context, dirtyAnchors dirtyAnchorSet) *Work
 
 	// Check each anchored worktree and remove it once it is clean and empty.
 	for _, wt := range worktrees {
+		// The main worktree is never disposable, even if an invalid
+		// registration makes it look like an empty managed worktree. Skipping
+		// this candidate lets cleanup continue for the rest of the batch.
+		if git.IsMainWorktree(wt.Path, wt.MainRepoDir) {
+			ctx.Output.Debug("Skipping cleanup for main worktree %s", wt.Path)
+			continue
+		}
+
 		// Skip dirty worktrees - don't clean up while there are uncommitted changes
 		if dirtyAnchors[wt.AnchorBranch] {
 			continue
@@ -96,10 +105,13 @@ func cleanOrphanedWorktrees(ctx *app.Context, dirtyAnchors dirtyAnchorSet) *Work
 			continue
 		}
 
-		if unregErr := ctx.Engine.UnregisterWorktree(ctx.Context, wt.AnchorBranch); unregErr != nil {
+		// Removing a directory can leave Git's administrative worktree entry
+		// behind. Prune it before deleting the anchor; an anchor deleted first
+		// is not recoverable from a later unregister failure.
+		if pruneErr := ctx.Engine.PruneWorktrees(ctx.Context); pruneErr != nil {
 			result.Errors = append(result.Errors,
-				"failed to unregister worktree for "+wt.AnchorBranch+": "+unregErr.Error())
-			ctx.Output.Debug("Failed to unregister worktree for %s: %v", wt.AnchorBranch, unregErr)
+				"failed to prune stale worktree entries for "+wt.AnchorBranch+": "+pruneErr.Error())
+			ctx.Output.Debug("Failed to prune stale worktree entries for %s: %v", wt.AnchorBranch, pruneErr)
 			continue
 		}
 
@@ -110,6 +122,13 @@ func cleanOrphanedWorktrees(ctx *app.Context, dirtyAnchors dirtyAnchorSet) *Work
 				ctx.Output.Debug("Failed to delete anchor branch %s: %v", wt.AnchorBranch, deleteErr)
 				continue
 			}
+		}
+
+		if unregErr := ctx.Engine.UnregisterWorktree(ctx.Context, wt.AnchorBranch); unregErr != nil {
+			result.Errors = append(result.Errors,
+				"failed to unregister worktree for "+wt.AnchorBranch+": "+unregErr.Error())
+			ctx.Output.Debug("Failed to unregister worktree for %s: %v", wt.AnchorBranch, unregErr)
+			continue
 		}
 		result.RemovedWorktrees = append(result.RemovedWorktrees, wt.AnchorBranch)
 	}

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -119,7 +119,7 @@ func RemoveAction(ctx *app.Context, opts RemoveOptions) error {
 	if err != nil {
 		return err
 	}
-	if entry.NeedsRepair && (entry.RegistrationState != RegistrationStateInvalid || entry.Exists) {
+	if entry.NeedsRepair && (entry.RegistrationState != RegistrationStateInvalid || !entry.CanRemove) {
 		return fmt.Errorf("managed worktree %s cannot be removed because %s; %s", output.BranchName(entry.displayName()), output.Dim(entry.StatusMessage), repairHint(entry))
 	}
 	if entry.IsCurrent {
@@ -562,10 +562,6 @@ func PruneAction(ctx *app.Context, opts PruneOptions) (*PruneResult, error) {
 		// Clean up missing worktrees (directory deleted but registration remains)
 		if !wt.Exists {
 			if wt.NeedsRepair {
-				if opts.DryRun && wt.CanRemove {
-					result.Pruned = append(result.Pruned, name)
-					continue
-				}
 				result.Skipped = append(result.Skipped, SkippedEntry{
 					Name:   name,
 					Reason: wt.StatusMessage + "; " + repairHint(&wt),
@@ -799,7 +795,10 @@ func DetachAction(ctx *app.Context, opts DetachOptions) error {
 	if err != nil {
 		return err
 	}
-	if entry.NeedsRepair {
+	if entry.NeedsRepair && entry.RegistrationState != RegistrationStateInvalid {
+		return fmt.Errorf("managed worktree %s cannot be detached because %s; %s", output.BranchName(entry.displayName()), output.Dim(entry.StatusMessage), repairHint(entry))
+	}
+	if entry.NeedsRepair && !entry.CanDetach {
 		return fmt.Errorf("managed worktree %s cannot be detached because %s; %s", output.BranchName(entry.displayName()), output.Dim(entry.StatusMessage), repairHint(entry))
 	}
 
@@ -817,6 +816,23 @@ func DetachAction(ctx *app.Context, opts DetachOptions) error {
 	snapshot, err := snapshotWorktree(ctx, entry)
 	if err != nil {
 		return err
+	}
+	// An invalid registration cannot be reparented or repaired automatically
+	// when its checkout is detached or untracked. Detach still has a useful,
+	// safe meaning: remove the physical worktree and its stale registry entry.
+	if entry.NeedsRepair {
+		if entry.Exists {
+			if err := removeWorktreePath(ctx, entry.Path, opts.Force); err != nil {
+				return fmt.Errorf("failed to remove worktree at %s: %w", entry.Path, err)
+			}
+		} else if err := ctx.Engine.PruneWorktrees(ctx.Context); err != nil {
+			return fmt.Errorf("failed to prune stale worktree entries: %w", err)
+		}
+		if err := ctx.Engine.UnregisterWorktree(ctx.Context, entry.AnchorBranch); err != nil {
+			return fmt.Errorf("failed to unregister invalid worktree: %w", err)
+		}
+		out.Success("Detached invalid worktree %s", output.BranchName(entry.displayName()))
+		return nil
 	}
 
 	pathRemoved := false

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -510,6 +510,10 @@ func worktreePathForName(repoRoot string, name string) string {
 	if basePath == "" {
 		repoName := filepath.Base(repoRoot)
 		basePath = filepath.Join(filepath.Dir(repoRoot), repoName+"-stacks")
+	} else if !filepath.IsAbs(basePath) {
+		// Configuration lives with the repository, so relative worktree bases
+		// must not depend on the directory from which stackit was invoked.
+		basePath = filepath.Join(repoRoot, basePath)
 	}
 
 	return filepath.Join(basePath, name)

--- a/internal/actions/worktree/entry.go
+++ b/internal/actions/worktree/entry.go
@@ -139,6 +139,7 @@ func inspectWorktreeEntry(ctx *app.Context, wt engine.WorktreeInfo, graph *engin
 	default:
 		entry.NeedsRepair = true
 		entry.StatusMessage = "registered anchor branch is missing"
+		entry.CanDetach = !entry.IsCurrent
 
 		if entry.CurrentBranch != "" {
 			currentBranch := ctx.Engine.GetBranch(entry.CurrentBranch)
@@ -152,8 +153,15 @@ func inspectWorktreeEntry(ctx *app.Context, wt engine.WorktreeInfo, graph *engin
 			}
 		}
 
-		if !entry.Exists {
+		switch {
+		case !entry.Exists:
 			entry.StatusMessage = "registration is stale and the directory is missing"
+			entry.CanRemove = !entry.IsCurrent
+		case entry.CurrentBranch == "":
+			entry.StatusMessage = "registration is invalid and worktree is detached"
+			entry.CanRemove = !entry.IsCurrent
+		case len(entry.RootBranches) == 0:
+			entry.StatusMessage = "registration is invalid and worktree branch is untracked"
 			entry.CanRemove = !entry.IsCurrent
 		}
 	}

--- a/internal/actions/worktree/repair.go
+++ b/internal/actions/worktree/repair.go
@@ -95,12 +95,18 @@ func repairEntry(ctx *app.Context, entry Entry) (RepairEntry, error) {
 		}
 
 		if entry.CurrentBranch == "" {
-			return RepairEntry{}, fmt.Errorf("cannot repair %s automatically because the worktree has no branch checked out", output.BranchName(entry.displayName()))
+			if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
+				return RepairEntry{}, fmt.Errorf("failed to remove detached invalid registration: %w", err)
+			}
+			return RepairEntry{Name: entry.displayName(), Action: "removed invalid detached registration"}, nil
 		}
 
 		currentBranch := ctx.Engine.GetBranch(entry.CurrentBranch)
 		if !currentBranch.IsTracked() {
-			return RepairEntry{}, fmt.Errorf("cannot repair %s automatically because %s is not tracked by stackit", output.BranchName(entry.displayName()), output.BranchName(entry.CurrentBranch))
+			if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
+				return RepairEntry{}, fmt.Errorf("failed to remove untracked invalid registration: %w", err)
+			}
+			return RepairEntry{Name: entry.displayName(), Action: "removed invalid untracked registration"}, nil
 		}
 
 		stackRootName := ctx.Engine.GetStackRootForBranch(currentBranch)

--- a/internal/cli/common/directives.go
+++ b/internal/cli/common/directives.go
@@ -34,8 +34,11 @@ func HandleCheckoutResult(out output.Output, result actions.CheckoutResult) bool
 	return false
 }
 
-// CompleteCheckout handles a CheckoutAction result, including the fallback
-// checkout path when shell integration cannot switch worktrees for the caller.
+// CompleteCheckout handles a CheckoutAction result, including a worktree switch
+// when shell integration is available. Without shell integration, retain the
+// regular-checkout fallback only when the target is not already checked out in
+// another worktree; Git permits a branch to be checked out by only one
+// worktree at a time.
 func CompleteCheckout(ctx *app.Context, result actions.CheckoutResult, fallbackOpts actions.CheckoutOptions, handler actions.CheckoutHandler) error {
 	if HandleCheckoutResult(ctx.Output, result) {
 		return nil
@@ -44,15 +47,20 @@ func CompleteCheckout(ctx *app.Context, result actions.CheckoutResult, fallbackO
 		return nil
 	}
 
+	worktrees, err := ctx.Engine.ListWorktrees(ctx.Context)
+	if err == nil && worktrees.PathForBranch(result.TargetBranch) != "" {
+		return nil
+	}
+
 	if !fallbackOpts.CheckoutTrunk {
 		fallbackOpts.BranchName = result.TargetBranch
 	}
 	fallbackOpts.SkipWorktreeSwitch = true
-	_, err := actions.CheckoutAction(ctx, fallbackOpts, handler)
+	_, err = actions.CheckoutAction(ctx, fallbackOpts, handler)
 	return err
 }
 
-// Checkout runs CheckoutAction and completes any worktree-switch fallback.
+// Checkout runs CheckoutAction and completes any worktree switch.
 func Checkout(ctx *app.Context, opts actions.CheckoutOptions, handler actions.CheckoutHandler) (actions.CheckoutResult, error) {
 	result, err := actions.CheckoutAction(ctx, opts, handler)
 	if err != nil {

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -151,6 +151,10 @@ func (d *demoGitRunner) UpdateBranchRef(_ context.Context, _, _ string) error {
 	return nil
 }
 
+func (d *demoGitRunner) UpdateBranchRefCAS(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
 func (d *demoGitRunner) GetRemoteRevision(_ string) (string, error) {
 	return "remote-rev", nil
 }

--- a/internal/engine/branch_mutations.go
+++ b/internal/engine/branch_mutations.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/getstackit/stackit/internal/git"
 )
@@ -342,16 +341,6 @@ func (e *engineImpl) DeleteBranches(ctx context.Context, branches Branches) ([]s
 func (e *engineImpl) CheckoutBranch(ctx context.Context, branch Branch) error {
 	branchName := branch.GetName()
 	if err := e.git.CheckoutBranch(ctx, branchName); err != nil {
-		// If it's already used by another worktree, try checking out detached
-		if branchCheckedOutInAnotherWorktree(err) {
-			if err := e.git.CheckoutDetached(ctx, branchName); err != nil {
-				return err
-			}
-			e.mu.Lock()
-			e.currentBranch = "" // Detached HEAD
-			e.mu.Unlock()
-			return nil
-		}
 		return err
 	}
 
@@ -359,15 +348,6 @@ func (e *engineImpl) CheckoutBranch(ctx context.Context, branch Branch) error {
 	e.currentBranch = branchName
 	e.mu.Unlock()
 	return nil
-}
-
-func branchCheckedOutInAnotherWorktree(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "already used by worktree") ||
-		strings.Contains(msg, "is already checked out")
 }
 
 // UpdateBranchRef updates a branch reference to point to a new revision

--- a/internal/engine/engine_absorb.go
+++ b/internal/engine/engine_absorb.go
@@ -17,6 +17,24 @@ func (e *engineImpl) ApplyHunksToBranch(ctx context.Context, branch Branch, hunk
 	}
 
 	branchName := branch.GetName()
+	oldTip, err := branch.GetRevision()
+	if err != nil {
+		return fmt.Errorf("failed to get branch revision for %s: %w", branchName, err)
+	}
+	worktrees, err := e.git.ListWorktrees(ctx)
+	if err != nil {
+		return fmt.Errorf("refusing to rewrite %s: cannot inspect worktrees: %w", branchName, err)
+	}
+	worktreePath := worktrees.PathForBranch(branchName)
+	if worktreePath != "" {
+		dirty, statusErr := e.git.WorktreeHasTrackedChanges(ctx, worktreePath)
+		if statusErr != nil {
+			return fmt.Errorf("refusing to rewrite %s: cannot inspect worktree %s: %w", branchName, worktreePath, statusErr)
+		}
+		if dirty {
+			return fmt.Errorf("refusing to rewrite %s: worktree %s has uncommitted tracked changes", branchName, worktreePath)
+		}
+	}
 
 	// Save current state to restore later
 	originalRef, _ := e.git.GetCurrentBranchOrSHA(ctx)
@@ -143,8 +161,13 @@ func (e *engineImpl) ApplyHunksToBranch(ctx context.Context, branch Branch, hunk
 	newTip = strings.TrimSpace(newTip)
 
 	// Update branch to point to new tip
-	if err := e.git.UpdateBranchRef(ctx, branchName, newTip); err != nil {
+	if err := e.git.UpdateBranchRefCAS(ctx, branchName, newTip, oldTip); err != nil {
 		return fmt.Errorf("failed to update branch %s: %w", branchName, err)
+	}
+	if worktreePath != "" {
+		if err := e.git.ResetWorktreeWorkingDir(ctx, worktreePath); err != nil {
+			return fmt.Errorf("updated %s but failed to reset clean worktree %s: %w", branchName, worktreePath, err)
+		}
 	}
 
 	return nil

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -115,6 +115,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 	// check; the snapshot is stable across the restack loop since we don't
 	// add or remove worktrees here.
 	worktrees, err := e.git.ListWorktrees(ctx)
+	worktreeInspectionFailed := err != nil
 	if err != nil {
 		worktrees = git.WorktreeList{}
 	}
@@ -134,9 +135,15 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 	// the new commit's files as deleted, and the next `stackit modify -a`
 	// commits that deletion into the stack.
 	dirtyWorktrees := make(map[string]bool, len(worktrees))
-	for _, path := range worktrees.Paths() {
-		if dirty, dirtyErr := e.git.WorktreeHasTrackedChanges(ctx, path); dirtyErr == nil && dirty {
+	heldBranches := make(BranchNameSet)
+	for _, worktree := range worktrees {
+		dirty, dirtyErr := e.git.WorktreeHasTrackedChanges(ctx, worktree.Path)
+		if dirtyErr != nil || dirty {
+			path := worktree.Path
 			dirtyWorktrees[path] = true
+			if worktree.Branch != "" {
+				heldBranches[worktree.Branch] = true
+			}
 		}
 	}
 
@@ -152,7 +159,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 			metaRefSHAs[strings.TrimPrefix(refName, git.MetadataRefPrefix)] = sha
 		}
 	}
-	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees}
+	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees, heldBranches: heldBranches, worktreeInspectionFailed: worktreeInspectionFailed}
 
 	// 2. Apply the restack changes
 	results := make(map[string]RestackBranchResult)

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -266,6 +266,21 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 
 // ContinueRebase continues an in-progress rebase
 func (e *engineImpl) ContinueRebase(ctx context.Context, branchName string, rebasedBranchBase string) (ContinueRebaseResult, error) {
+	worktrees, err := e.git.ListWorktrees(ctx)
+	if err != nil {
+		return ContinueRebaseResult{BranchName: branchName}, fmt.Errorf("refusing to continue rebase for %s: cannot inspect worktrees: %w", branchName, err)
+	}
+	worktreePath := worktrees.PathForBranch(branchName)
+	if worktreePath != "" {
+		dirty, statusErr := e.git.WorktreeHasTrackedChanges(ctx, worktreePath)
+		if statusErr != nil {
+			return ContinueRebaseResult{BranchName: branchName}, fmt.Errorf("refusing to continue rebase for %s: cannot inspect worktree %s: %w", branchName, worktreePath, statusErr)
+		}
+		if dirty {
+			return ContinueRebaseResult{BranchName: branchName}, fmt.Errorf("refusing to continue rebase for %s: worktree %s has uncommitted tracked changes", branchName, worktreePath)
+		}
+	}
+
 	// Call git rebase --continue
 	result, err := e.git.RebaseContinue(ctx)
 	if err != nil {
@@ -286,6 +301,11 @@ func (e *engineImpl) ContinueRebase(ctx context.Context, branchName string, reba
 	err = e.git.UpdateBranchRef(ctx, branchName, newRev)
 	if err != nil {
 		return ContinueRebaseResult{BranchName: branchName}, fmt.Errorf("failed to update branch reference %s: %w", branchName, err)
+	}
+	if worktreePath != "" {
+		if err := e.git.ResetWorktreeWorkingDir(ctx, worktreePath); err != nil {
+			return ContinueRebaseResult{BranchName: branchName}, fmt.Errorf("updated branch %s but failed to reset clean worktree %s: %w", branchName, worktreePath, err)
+		}
 	}
 
 	// Update metadata

--- a/internal/engine/pull.go
+++ b/internal/engine/pull.go
@@ -114,27 +114,45 @@ func (e *engineImpl) ResetTrunkToRemote(ctx context.Context) error {
 		return fmt.Errorf("failed to get remote SHA: %w", err)
 	}
 
-	// Checkout trunk
-	trunkBranch := e.Trunk()
-	if err := e.CheckoutBranch(ctx, trunkBranch); err != nil {
-		return fmt.Errorf("failed to checkout trunk: %w", err)
+	oldTrunk, err := e.git.GetRevision(trunk)
+	if err != nil {
+		return fmt.Errorf("failed to get local trunk revision: %w", err)
 	}
-
-	// Hard reset to remote
-	if err := e.git.HardReset(ctx, remoteSha); err != nil {
-		// Try to switch back
-		if currentBranch != "" {
-			currentBranchObj := e.GetBranch(currentBranch)
-			_ = e.CheckoutBranch(ctx, currentBranchObj)
+	worktrees, err := e.git.ListWorktrees(ctx)
+	if err != nil {
+		return fmt.Errorf("refusing to reset trunk: cannot inspect worktrees: %w", err)
+	}
+	trunkWorktree := worktrees.PathForBranch(trunk)
+	if trunkWorktree != "" {
+		dirty, statusErr := e.git.WorktreeHasTrackedChanges(ctx, trunkWorktree)
+		if statusErr != nil {
+			return fmt.Errorf("refusing to reset trunk: cannot inspect worktree %s: %w", trunkWorktree, statusErr)
 		}
-		return fmt.Errorf("failed to reset trunk: %w", err)
+		if dirty {
+			return fmt.Errorf("refusing to reset trunk: worktree %s has uncommitted tracked changes", trunkWorktree)
+		}
 	}
 
-	// Switch back to original branch
-	if currentBranch != "" && currentBranch != trunk {
-		currentBranchObj := e.GetBranch(currentBranch)
-		if err := e.CheckoutBranch(ctx, currentBranchObj); err != nil {
-			return fmt.Errorf("failed to switch back: %w", err)
+	// Never check out the shared trunk in an analysis worktree. Move the ref
+	// with a CAS, then synchronize its clean holder; if this engine is itself
+	// detached, advance only its detached HEAD to the same remote revision.
+	if err := e.git.UpdateBranchRefCAS(ctx, trunk, remoteSha, oldTrunk); err != nil {
+		return fmt.Errorf("failed to reset trunk ref: %w", err)
+	}
+	if currentBranch == trunk {
+		if err := e.git.HardReset(ctx, "HEAD"); err != nil {
+			return fmt.Errorf("reset trunk ref but failed to reset current worktree: %w", err)
+		}
+	} else {
+		if trunkWorktree != "" {
+			if err := e.git.ResetWorktreeWorkingDir(ctx, trunkWorktree); err != nil {
+				return fmt.Errorf("reset trunk ref but failed to reset clean worktree %s: %w", trunkWorktree, err)
+			}
+		}
+		if currentBranch == "" {
+			if err := e.git.HardReset(ctx, remoteSha); err != nil {
+				return fmt.Errorf("reset trunk ref but failed to advance detached worktree: %w", err)
+			}
 		}
 	}
 

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -60,6 +60,34 @@ type restackSnapshot struct {
 	// deliberately excluded — see resetWorktreeIfClean for why, and for why this
 	// can't be checked lazily.
 	dirtyWorktrees map[string]bool
+	// heldBranches contains every branch whose checked-out worktree was dirty
+	// or could not be inspected before this pass. Descendants of these branches
+	// must be held too: a validated child may otherwise be built on the target
+	// SHA of a parent that was ultimately not allowed to move.
+	heldBranches BranchNameSet
+	// worktreeInspectionFailed means the physical checkout map is unknown, so
+	// no ref move is safe for this pass.
+	worktreeInspectionFailed bool
+}
+
+func (e *engineImpl) branchHeldBack(branch Branch, snap *restackSnapshot) bool {
+	if snap.worktreeInspectionFailed {
+		return true
+	}
+	for current := branch.GetName(); current != ""; {
+		if snap.heldBranches.Contains(current) {
+			return true
+		}
+		e.mu.RLock()
+		state := e.readState(current)
+		trunk := e.trunk
+		e.mu.RUnlock()
+		if state == nil || state.Parent == "" || current == trunk {
+			return false
+		}
+		current = state.Parent
+	}
+	return false
 }
 
 // branchRev returns branch's revision from the pass snapshot, falling back to a
@@ -223,7 +251,7 @@ func (e *engineImpl) restackBranch(
 	// which warns and is reached solely by the `restack` command) so that every
 	// caller of RestackBranches inherits it — modify, sync, squash, absorb,
 	// delete, split, reorder, pluck and insert all arrive here directly.
-	if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" && snap.dirtyWorktrees[worktreePath] {
+	if e.branchHeldBack(branch, snap) {
 		return RestackBranchResult{Result: RestackUnneeded}, nil
 	}
 
@@ -723,7 +751,7 @@ func (e *engineImpl) applyBranchAndMetadata(
 	// Hold the branch back instead. This is the plan path, reached by every
 	// caller of actions.RestackBranches (modify, squash, absorb, delete, split,
 	// reorder, pluck) as well as the `restack` command.
-	if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" && snap.dirtyWorktrees[worktreePath] {
+	if e.branchHeldBack(branch, snap) {
 		return RestackBranchResult{Result: RestackUnneeded, RebasedBranchBase: parentRev}, nil
 	}
 

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -696,6 +696,12 @@ func (e *engineImpl) applyMetadataRefresh(
 	snap *restackSnapshot,
 ) (RestackBranchResult, error) {
 	branchName := branch.GetName()
+	// Metadata records the parent SHA consumed by later planning, so advancing
+	// it past a held parent would create the same phantom-parent state as a ref
+	// move. A held branch and every descendant must remain completely unchanged.
+	if e.branchHeldBack(branch, snap) {
+		return RestackBranchResult{Result: RestackUnneeded, RebasedBranchBase: item.ParentRev}, nil
+	}
 	meta := snap.meta.Get(branchName)
 	if meta == nil {
 		var err error

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -200,6 +200,24 @@ func (r *runner) UpdateBranchRef(ctx context.Context, branchName, revision strin
 	return nil
 }
 
+func (r *runner) UpdateBranchRefCAS(ctx context.Context, branchName, revision, expectedOld string) error {
+	sha, err := r.resolveRefSHA(revision)
+	if err != nil {
+		return fmt.Errorf("failed to resolve revision %s: %w", revision, err)
+	}
+	if expectedOld == "" {
+		return fmt.Errorf("expected old revision is required when updating branch %s", branchName)
+	}
+	if err := r.UpdateRefsBatch(ctx, []RefUpdate{{
+		RefName: "refs/heads/" + branchName,
+		NewSHA:  sha,
+		OldSHA:  expectedOld,
+	}}); err != nil {
+		return fmt.Errorf("failed to compare-and-swap branch ref: %w", err)
+	}
+	return nil
+}
+
 func (r *runner) GetCurrentBranchOrSHA(ctx context.Context) (string, error) {
 	branch, err := r.GetCurrentBranch()
 	if err == nil {

--- a/internal/git/gitdir.go
+++ b/internal/git/gitdir.go
@@ -56,9 +56,11 @@ func resolveGitDir(repoRoot string) string {
 	}
 	gitDir = strings.TrimSpace(gitDir)
 	if !filepath.IsAbs(gitDir) {
-		gitDir = filepath.Join(repoRoot, gitDir)
+		// A relative gitdir is relative to the .git file, which may be in an
+		// ancestor when the caller supplied a repository subdirectory.
+		gitDir = filepath.Join(filepath.Dir(gitPath), gitDir)
 	}
-	return gitDir
+	return filepath.Clean(gitDir)
 }
 
 func findDotGit(path string) string {

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -70,6 +70,10 @@ type BranchWriter interface {
 	DeleteBranch(ctx context.Context, branchName string) error
 	RenameBranch(ctx context.Context, oldName, newName string) error
 	UpdateBranchRef(ctx context.Context, branchName, revision string) error
+	// UpdateBranchRefCAS moves a branch only if it still names expectedOld.
+	// Callers that prepared commits from a detached snapshot use this to avoid
+	// overwriting concurrent work from another worktree.
+	UpdateBranchRefCAS(ctx context.Context, branchName, revision, expectedOld string) error
 }
 
 // CommitReader provides read access to commit and revision information.

--- a/internal/git/pull.go
+++ b/internal/git/pull.go
@@ -69,26 +69,27 @@ func (r *runner) UpdateBranchFromRemote(ctx context.Context, remote, branchName 
 	if err == nil && isRemoteAhead {
 		// Save current branch/detached HEAD immediately before mutating refs.
 		currentBranch, err := r.GetCurrentBranch()
-		var currentRev string
 		if err != nil {
 			currentBranch = ""
-			currentRev, _ = r.GetCurrentRevision(ctx)
 		}
 
-		// Before updating the ref, check if this branch is checked out in another worktree.
-		// update-ref is global and will affect all worktrees, so we need to sync any
-		// worktree that has this branch checked out to avoid corrupting its index/working tree.
-		//
-		// IMPORTANT: We must check for uncommitted changes BEFORE the update-ref,
-		// because after update-ref the worktree will appear to have inverse changes
-		// (old content vs new HEAD), which would cause the check to fail.
-		var otherWorktreePath string
-		var otherWorktreeClean bool
-		if currentBranch != branchName {
-			otherWorktreePath, _ = r.GetWorktreePathForBranch(ctx, branchName)
-			if otherWorktreePath != "" {
-				hasChanges, err := r.WorktreeHasUncommittedChanges(ctx, otherWorktreePath)
-				otherWorktreeClean = err == nil && !hasChanges
+		// A ref update is global, but the checked-out worktree's index and
+		// working directory are local. Never move a checked-out branch unless
+		// its holder is known clean and can be reset immediately afterwards.
+		// Importantly, an inspection failure is unsafe too: it must not silently
+		// turn into a ref move that strands an unknown worktree on old content.
+		worktrees, err := r.ListWorktrees(ctx)
+		if err != nil {
+			return PullConflict, fmt.Errorf("refusing to update %s: cannot inspect worktrees: %w", branchName, err)
+		}
+		worktreePath := worktrees.PathForBranch(branchName)
+		if worktreePath != "" {
+			hasChanges, statusErr := r.WorktreeHasTrackedChanges(ctx, worktreePath)
+			if statusErr != nil {
+				return PullConflict, fmt.Errorf("refusing to update %s: cannot inspect worktree %s: %w", branchName, worktreePath, statusErr)
+			}
+			if hasChanges {
+				return PullConflict, fmt.Errorf("refusing to update %s: worktree %s has uncommitted tracked changes", branchName, worktreePath)
 			}
 		}
 
@@ -107,15 +108,14 @@ func (r *runner) UpdateBranchFromRemote(ctx context.Context, remote, branchName 
 		// so hard reset is safe here.
 		if currentBranch == branchName {
 			_ = r.HardReset(ctx, "HEAD")
-		} else if currentRev != "" {
-			_ = r.CheckoutDetached(ctx, currentRev)
 		}
 
-		// If this branch is checked out in another worktree that was clean before
-		// the update-ref, we need to reset that worktree to match the new HEAD.
-		// Otherwise the worktree's index/working tree will appear as inverse changes.
-		if otherWorktreePath != "" && otherWorktreeClean {
-			_ = r.ResetWorktreeWorkingDir(ctx, otherWorktreePath)
+		// If this branch is checked out in another clean worktree, reset it to
+		// match the ref we just moved. The clean check above makes this safe.
+		if worktreePath != "" && currentBranch != branchName {
+			if err := r.ResetWorktreeWorkingDir(ctx, worktreePath); err != nil {
+				return PullConflict, fmt.Errorf("updated %s but failed to reset clean worktree %s: %w", branchName, worktreePath, err)
+			}
 		}
 
 		return PullDone, nil

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -28,10 +28,14 @@ type RebaseOutcome struct {
 
 func (r *runner) Rebase(ctx context.Context, branchName, upstream, oldUpstream string) (RebaseOutcome, error) {
 	outcome := RebaseOutcome{Result: RebaseDone}
+	oldRev, err := r.GetRevision(branchName)
+	if err != nil {
+		return RebaseOutcome{Result: RebaseConflict}, fmt.Errorf("failed to get revision before rebase: %w", err)
+	}
 
 	// Use detached HEAD to avoid "already used by worktree" errors
 	// We use branchName~0 to force a detached checkout of the branch tip
-	_, err := r.RunGitCommandWithContext(ctx, "rebase", "--onto", upstream, oldUpstream, branchName+"~0")
+	_, err = r.RunGitCommandWithContext(ctx, "rebase", "--onto", upstream, oldUpstream, branchName+"~0")
 	if err != nil {
 		if r.IsRebaseInProgress(ctx) {
 			autoOutcome, autoErr := r.continueRerereResolvedRebase(ctx, err)
@@ -53,7 +57,7 @@ func (r *runner) Rebase(ctx context.Context, branchName, upstream, oldUpstream s
 		return RebaseOutcome{Result: RebaseConflict, RerereResolvedCount: outcome.RerereResolvedCount}, fmt.Errorf("failed to get revision after rebase: %w", err)
 	}
 
-	if err := r.UpdateBranchRef(ctx, branchName, newRev); err != nil {
+	if err := r.UpdateBranchRefCAS(ctx, branchName, newRev, oldRev); err != nil {
 		return RebaseOutcome{Result: RebaseConflict, RerereResolvedCount: outcome.RerereResolvedCount}, fmt.Errorf("failed to update branch ref %s: %w", branchName, err)
 	}
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -182,7 +182,9 @@ func (r *runner) RemoveWorktree(ctx context.Context, path string) error {
 }
 
 func (r *runner) ForceRemoveWorktree(ctx context.Context, path string) error {
-	_, err := r.RunGitCommandWithContext(ctx, "worktree", "remove", "--force", path)
+	// Git requires --force twice when the worktree is locked, in addition to
+	// using it to discard local changes.
+	_, err := r.RunGitCommandWithContext(ctx, "worktree", "remove", "--force", "--force", path)
 	if err != nil {
 		return fmt.Errorf("failed to remove worktree at %s: %w", path, err)
 	}

--- a/internal/integration/worktree_comprehensive_test.go
+++ b/internal/integration/worktree_comprehensive_test.go
@@ -476,7 +476,7 @@ func TestWorktreeRestackOperations(t *testing.T) {
 		})
 	}
 
-	run("restack from main rejects worktree branches", func(t *testing.T, sh *TestShell) {
+	run("restack from main reconciles worktree branches", func(t *testing.T, sh *TestShell) {
 		// Create stack in worktree
 		sh.WriteFile("feature.txt", "feature").
 			Run("create feature -w -m 'feature branch'")
@@ -489,7 +489,7 @@ func TestWorktreeRestackOperations(t *testing.T) {
 		shW.WriteFile("b.txt", "b").Run("create b -m 'branch b'")
 		shW.WriteFile("c.txt", "c").Run("create c -m 'branch c'")
 
-		sh.RunExpectError("restack").OutputContains("belongs to worktree")
+		sh.Run("restack").OutputNotContains("belongs to worktree")
 		shW.OnBranch("c")
 	})
 


### PR DESCRIPTION


<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1571**
  * **PR #1572**
    * **PR #1573**
      * **PR #1574**
        * **PR #1575**
          * **PR #1576**
            * **PR #1577**
              * **PR #1581**
                * **PR #1580**
                  * **PR #1582**
                    * **PR #1583**
                      * **PR #1584**
                        * **PR #1585**
                          * **PR #1586**
                            * **PR #1588**
                              * **PR #1589**
                                * **PR #1590** 👈
                                  * **PR #1591**
                                    * **PR #1592**
                                      * **PR #1593**
                                        * **PR #1594**
                                          * **PR #1595**
                                            * **PR #1596**
                                              * **PR #1597**
                                                * **PR #1598**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->