### PR TITLE
fix(merge): make multi-stack cleanup safe

### DIFF
--- a/internal/actions/merge/multistack.go
+++ b/internal/actions/merge/multistack.go
@@ -95,6 +95,12 @@ func ExecuteMultiStack(ctx *app.Context, opts MultiStackOptions) (*MultiStackRes
 		IncludedStacks: worktreeResult.MergedStacks,
 		ExcludedStacks: worktreeResult.ConflictStacks,
 	}
+	consolidationCreated := false
+	defer func() {
+		if !consolidationCreated {
+			unlockConsolidatingStacks(ctx, eng, result.IncludedStacks)
+		}
+	}()
 
 	// 4.5. Generate branch name early and lock individual PRs before CI validation
 	// This indicates the PRs are part of a consolidation in progress
@@ -146,6 +152,7 @@ func ExecuteMultiStack(ctx *app.Context, opts MultiStackOptions) (*MultiStackRes
 				// Update result with binary search findings
 				result.IncludedStacks = searchResult.WorkingStacks
 				result.ExcludedStacks = append(result.ExcludedStacks, searchResult.FailedStacks...)
+				unlockExcludedMultiStackBranches(ctx, eng, searchResult.FailedStacks)
 
 				out.Success("Found %d stacks that pass CI together", len(result.IncludedStacks))
 			} else {
@@ -179,6 +186,8 @@ func ExecuteMultiStack(ctx *app.Context, opts MultiStackOptions) (*MultiStackRes
 	result.PRNumber = pr.Number
 	result.PRURL = pr.HTMLURL
 	result.BranchName = branchName
+	consolidationCreated = true
+	unlockExcludedMultiStackBranches(ctx, eng, result.ExcludedStacks)
 
 	out.Success("Created PR #%d: %s", pr.Number, pr.HTMLURL)
 	out.Debug("multistack: PR created successfully")
@@ -224,6 +233,34 @@ func ExecuteMultiStack(ctx *app.Context, opts MultiStackOptions) (*MultiStackRes
 
 	out.Debug("multistack: completed successfully")
 	return result, nil
+}
+
+// unlockConsolidatingStacks releases only locks created for multi-stack
+// consolidation. User locks and other workflow locks are intentionally left
+// untouched.
+func unlockConsolidatingStacks(ctx *app.Context, eng engine.Engine, stacks []MultiStackInfo) {
+	branches := engine.NewBranchesBuilder(0)
+	for _, stack := range stacks {
+		for _, name := range stack.AllBranches {
+			branch := eng.GetBranch(name)
+			if branch.GetLockReason() == engine.LockReasonConsolidating {
+				branches.Add(branch)
+			}
+		}
+	}
+	if selected := branches.Build(); len(selected) > 0 {
+		if _, err := eng.SetLocked(ctx.Context, selected, engine.LockReasonNone); err != nil {
+			ctx.Output.Warn("Failed to unlock excluded multi-stack branches: %v", err)
+		}
+	}
+}
+
+func unlockExcludedMultiStackBranches(ctx *app.Context, eng engine.Engine, excluded []MultiStackExcluded) {
+	stacks := make([]MultiStackInfo, 0, len(excluded))
+	for _, item := range excluded {
+		stacks = append(stacks, item.Stack)
+	}
+	unlockConsolidatingStacks(ctx, eng, stacks)
 }
 
 // validateBranchesMatchRemote checks that all branches in the stacks match their remote.

--- a/internal/actions/merge/multistack_pr.go
+++ b/internal/actions/merge/multistack_pr.go
@@ -33,7 +33,7 @@ func NewMultiStackPRCreator(ctx *app.Context, worktreeEng engine.Engine, worktre
 
 // GenerateMultiStackBranchName creates a unique branch name for the multi-stack PR
 func GenerateMultiStackBranchName() string {
-	return fmt.Sprintf("multi-stack/%s", time.Now().Format("20060102-150405"))
+	return fmt.Sprintf("multi-stack/%s-%d", time.Now().Format("20060102-150405"), time.Now().UnixNano())
 }
 
 // CreateAndPushBranch creates a named branch at the current HEAD and pushes it
@@ -41,6 +41,11 @@ func (p *MultiStackPRCreator) CreateAndPushBranch(ctx context.Context, branchNam
 	// Create a branch at current HEAD
 	if err := p.worktreeEng.CreateBranch(ctx, branchName, "HEAD"); err != nil {
 		return fmt.Errorf("failed to create branch %s: %w", branchName, err)
+	}
+	// Utility metadata tells sync that this generated delivery branch can be
+	// safely cleaned up once the consolidation has landed.
+	if err := p.worktreeEng.SetBranchType(p.worktreeEng.GetBranch(branchName), git.BranchTypeUtility); err != nil {
+		return fmt.Errorf("mark multi-stack branch %s as utility: %w", branchName, err)
 	}
 
 	// Checkout the new branch

--- a/internal/actions/merge/multistack_worktree.go
+++ b/internal/actions/merge/multistack_worktree.go
@@ -2,6 +2,7 @@ package merge
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/getstackit/stackit/internal/engine"
@@ -84,7 +85,8 @@ func (w *MultiStackWorktreeExecutor) ExecuteInWorktree(ctx context.Context, stac
 		if err := w.tryMergeStack(ctx, session.Engine, stack); err != nil {
 			w.output.Debug("Stack %s conflicts: %v", stack.RootBranch, err)
 			if resetErr := session.ResetToRef(ctx, baseline); resetErr != nil {
-				w.output.Debug("Failed to reset worktree after conflict: %v", resetErr)
+				session.Close()
+				return nil, fmt.Errorf("failed to reset merge worktree after %s conflict: %w", stack.RootBranch, resetErr)
 			}
 			result.ConflictStacks = append(result.ConflictStacks, MultiStackExcluded{
 				Stack:  stack,
@@ -129,7 +131,7 @@ func (w *MultiStackWorktreeExecutor) tryGlobalOctopusMerge(ctx context.Context, 
 		// Abort the merge if it's in progress
 		if eng.IsMergeInProgress(ctx) {
 			if abortErr := eng.MergeAbort(ctx); abortErr != nil {
-				w.output.Debug("Failed to abort merge: %v", abortErr)
+				return fmt.Errorf("global octopus merge failed: %w", errors.Join(err, abortErr))
 			}
 		}
 		return fmt.Errorf("global octopus merge failed: %w", err)
@@ -154,7 +156,7 @@ func (w *MultiStackWorktreeExecutor) tryMergeStack(ctx context.Context, eng engi
 		// Abort the merge if it's in progress
 		if eng.IsMergeInProgress(ctx) {
 			if abortErr := eng.MergeAbort(ctx); abortErr != nil {
-				w.output.Debug("Failed to abort merge: %v", abortErr)
+				return fmt.Errorf("conflict in stack %s: %w", stack.RootBranch, errors.Join(err, abortErr))
 			}
 		}
 		return fmt.Errorf("conflict in stack %s: %w", stack.RootBranch, err)

--- a/internal/actions/merge/worktree.go
+++ b/internal/actions/merge/worktree.go
@@ -64,7 +64,7 @@ func ExecuteInWorktree(ctx *app.Context, eng mergeExecuteEngine, opts ExecuteOpt
 	// Pull trunk in the worktree to ensure we have latest changes
 	pullResult, err := worktreeEng.PullTrunk(ctx.Context)
 	if err != nil {
-		out.Debug("Failed to pull trunk in worktree: %v", err)
+		return fmt.Errorf("failed to update trunk in merge worktree: %w", err)
 	} else if pullResult == engine.PullConflict {
 		if opts.Force {
 			out.Info("Trunk diverged from remote. Force-resetting trunk to match remote...")


### PR DESCRIPTION


<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1571**
  * **PR #1572**
    * **PR #1573**
      * **PR #1574**
        * **PR #1575**
          * **PR #1576**
            * **PR #1577**
              * **PR #1581**
                * **PR #1580**
                  * **PR #1582**
                    * **PR #1583**
                      * **PR #1584**
                        * **PR #1585**
                          * **PR #1586**
                            * **PR #1588**
                              * **PR #1589**
                                * **PR #1590**
                                  * **PR #1591** 👈
                                    * **PR #1592**
                                      * **PR #1593**
                                        * **PR #1594**
                                          * **PR #1595**
                                            * **PR #1596**
                                              * **PR #1597**
                                                * **PR #1598**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->