### PR TITLE
fix(worktree): sweep orphaned path registrations

### DIFF
--- a/internal/actions/checkout.go
+++ b/internal/actions/checkout.go
@@ -237,10 +237,15 @@ func getWorktreeSwitchInfo(ctx *app.Context, branch engine.Branch, branchName st
 		return "", nil, nil
 	}
 
-	if _, err := os.Stat(targetWorktree.Path); os.IsNotExist(err) {
-		ctx.Output.Warn("Worktree for stack %s is registered but path does not exist: %s",
-			output.BranchName(targetStackRoot), targetWorktree.Path)
-		ctx.Output.Tip("stackit worktree remove %s", targetStackRoot)
+	if _, err := os.Stat(targetWorktree.Path); err != nil {
+		if os.IsNotExist(err) {
+			ctx.Output.Warn("Worktree for stack %s is registered but path does not exist: %s",
+				output.BranchName(targetStackRoot), targetWorktree.Path)
+			ctx.Output.Tip("stackit worktree remove %s", targetStackRoot)
+			return "", nil, nil
+		}
+		ctx.Output.Warn("Cannot inspect worktree for stack %s at %s: %v",
+			output.BranchName(targetStackRoot), targetWorktree.Path, err)
 		return "", nil, nil
 	}
 

--- a/internal/actions/merge/multistack.go
+++ b/internal/actions/merge/multistack.go
@@ -95,6 +95,12 @@ func ExecuteMultiStack(ctx *app.Context, opts MultiStackOptions) (*MultiStackRes
 		IncludedStacks: worktreeResult.MergedStacks,
 		ExcludedStacks: worktreeResult.ConflictStacks,
 	}
+	consolidationCreated := false
+	defer func() {
+		if !consolidationCreated {
+			unlockConsolidatingStacks(ctx, eng, result.IncludedStacks)
+		}
+	}()
 
 	// 4.5. Generate branch name early and lock individual PRs before CI validation
 	// This indicates the PRs are part of a consolidation in progress
@@ -146,6 +152,7 @@ func ExecuteMultiStack(ctx *app.Context, opts MultiStackOptions) (*MultiStackRes
 				// Update result with binary search findings
 				result.IncludedStacks = searchResult.WorkingStacks
 				result.ExcludedStacks = append(result.ExcludedStacks, searchResult.FailedStacks...)
+				unlockExcludedMultiStackBranches(ctx, eng, searchResult.FailedStacks)
 
 				out.Success("Found %d stacks that pass CI together", len(result.IncludedStacks))
 			} else {
@@ -179,6 +186,8 @@ func ExecuteMultiStack(ctx *app.Context, opts MultiStackOptions) (*MultiStackRes
 	result.PRNumber = pr.Number
 	result.PRURL = pr.HTMLURL
 	result.BranchName = branchName
+	consolidationCreated = true
+	unlockExcludedMultiStackBranches(ctx, eng, result.ExcludedStacks)
 
 	out.Success("Created PR #%d: %s", pr.Number, pr.HTMLURL)
 	out.Debug("multistack: PR created successfully")
@@ -224,6 +233,34 @@ func ExecuteMultiStack(ctx *app.Context, opts MultiStackOptions) (*MultiStackRes
 
 	out.Debug("multistack: completed successfully")
 	return result, nil
+}
+
+// unlockConsolidatingStacks releases only locks created for multi-stack
+// consolidation. User locks and other workflow locks are intentionally left
+// untouched.
+func unlockConsolidatingStacks(ctx *app.Context, eng engine.Engine, stacks []MultiStackInfo) {
+	branches := engine.NewBranchesBuilder(0)
+	for _, stack := range stacks {
+		for _, name := range stack.AllBranches {
+			branch := eng.GetBranch(name)
+			if branch.GetLockReason() == engine.LockReasonConsolidating {
+				branches.Add(branch)
+			}
+		}
+	}
+	if selected := branches.Build(); len(selected) > 0 {
+		if _, err := eng.SetLocked(ctx.Context, selected, engine.LockReasonNone); err != nil {
+			ctx.Output.Warn("Failed to unlock excluded multi-stack branches: %v", err)
+		}
+	}
+}
+
+func unlockExcludedMultiStackBranches(ctx *app.Context, eng engine.Engine, excluded []MultiStackExcluded) {
+	stacks := make([]MultiStackInfo, 0, len(excluded))
+	for _, item := range excluded {
+		stacks = append(stacks, item.Stack)
+	}
+	unlockConsolidatingStacks(ctx, eng, stacks)
 }
 
 // validateBranchesMatchRemote checks that all branches in the stacks match their remote.

--- a/internal/actions/merge/multistack_pr.go
+++ b/internal/actions/merge/multistack_pr.go
@@ -33,7 +33,7 @@ func NewMultiStackPRCreator(ctx *app.Context, worktreeEng engine.Engine, worktre
 
 // GenerateMultiStackBranchName creates a unique branch name for the multi-stack PR
 func GenerateMultiStackBranchName() string {
-	return fmt.Sprintf("multi-stack/%s", time.Now().Format("20060102-150405"))
+	return fmt.Sprintf("multi-stack/%s-%d", time.Now().Format("20060102-150405"), time.Now().UnixNano())
 }
 
 // CreateAndPushBranch creates a named branch at the current HEAD and pushes it
@@ -41,6 +41,11 @@ func (p *MultiStackPRCreator) CreateAndPushBranch(ctx context.Context, branchNam
 	// Create a branch at current HEAD
 	if err := p.worktreeEng.CreateBranch(ctx, branchName, "HEAD"); err != nil {
 		return fmt.Errorf("failed to create branch %s: %w", branchName, err)
+	}
+	// Utility metadata tells sync that this generated delivery branch can be
+	// safely cleaned up once the consolidation has landed.
+	if err := p.worktreeEng.SetBranchType(p.worktreeEng.GetBranch(branchName), git.BranchTypeUtility); err != nil {
+		return fmt.Errorf("mark multi-stack branch %s as utility: %w", branchName, err)
 	}
 
 	// Checkout the new branch

--- a/internal/actions/merge/multistack_worktree.go
+++ b/internal/actions/merge/multistack_worktree.go
@@ -2,6 +2,7 @@ package merge
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/getstackit/stackit/internal/engine"
@@ -84,7 +85,8 @@ func (w *MultiStackWorktreeExecutor) ExecuteInWorktree(ctx context.Context, stac
 		if err := w.tryMergeStack(ctx, session.Engine, stack); err != nil {
 			w.output.Debug("Stack %s conflicts: %v", stack.RootBranch, err)
 			if resetErr := session.ResetToRef(ctx, baseline); resetErr != nil {
-				w.output.Debug("Failed to reset worktree after conflict: %v", resetErr)
+				session.Close()
+				return nil, fmt.Errorf("failed to reset merge worktree after %s conflict: %w", stack.RootBranch, resetErr)
 			}
 			result.ConflictStacks = append(result.ConflictStacks, MultiStackExcluded{
 				Stack:  stack,
@@ -129,7 +131,7 @@ func (w *MultiStackWorktreeExecutor) tryGlobalOctopusMerge(ctx context.Context, 
 		// Abort the merge if it's in progress
 		if eng.IsMergeInProgress(ctx) {
 			if abortErr := eng.MergeAbort(ctx); abortErr != nil {
-				w.output.Debug("Failed to abort merge: %v", abortErr)
+				return fmt.Errorf("global octopus merge failed: %w", errors.Join(err, abortErr))
 			}
 		}
 		return fmt.Errorf("global octopus merge failed: %w", err)
@@ -154,7 +156,7 @@ func (w *MultiStackWorktreeExecutor) tryMergeStack(ctx context.Context, eng engi
 		// Abort the merge if it's in progress
 		if eng.IsMergeInProgress(ctx) {
 			if abortErr := eng.MergeAbort(ctx); abortErr != nil {
-				w.output.Debug("Failed to abort merge: %v", abortErr)
+				return fmt.Errorf("conflict in stack %s: %w", stack.RootBranch, errors.Join(err, abortErr))
 			}
 		}
 		return fmt.Errorf("conflict in stack %s: %w", stack.RootBranch, err)

--- a/internal/actions/merge/worktree.go
+++ b/internal/actions/merge/worktree.go
@@ -64,7 +64,7 @@ func ExecuteInWorktree(ctx *app.Context, eng mergeExecuteEngine, opts ExecuteOpt
 	// Pull trunk in the worktree to ensure we have latest changes
 	pullResult, err := worktreeEng.PullTrunk(ctx.Context)
 	if err != nil {
-		out.Debug("Failed to pull trunk in worktree: %v", err)
+		return fmt.Errorf("failed to update trunk in merge worktree: %w", err)
 	} else if pullResult == engine.PullConflict {
 		if opts.Force {
 			out.Info("Trunk diverged from remote. Force-resetting trunk to match remote...")

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -119,7 +119,7 @@ func RemoveAction(ctx *app.Context, opts RemoveOptions) error {
 	if err != nil {
 		return err
 	}
-	if entry.NeedsRepair && (entry.RegistrationState != RegistrationStateInvalid || entry.Exists) {
+	if entry.NeedsRepair && (entry.RegistrationState != RegistrationStateInvalid || !entry.CanRemove) {
 		return fmt.Errorf("managed worktree %s cannot be removed because %s; %s", output.BranchName(entry.displayName()), output.Dim(entry.StatusMessage), repairHint(entry))
 	}
 	if entry.IsCurrent {
@@ -562,10 +562,6 @@ func PruneAction(ctx *app.Context, opts PruneOptions) (*PruneResult, error) {
 		// Clean up missing worktrees (directory deleted but registration remains)
 		if !wt.Exists {
 			if wt.NeedsRepair {
-				if opts.DryRun && wt.CanRemove {
-					result.Pruned = append(result.Pruned, name)
-					continue
-				}
 				result.Skipped = append(result.Skipped, SkippedEntry{
 					Name:   name,
 					Reason: wt.StatusMessage + "; " + repairHint(&wt),
@@ -799,7 +795,10 @@ func DetachAction(ctx *app.Context, opts DetachOptions) error {
 	if err != nil {
 		return err
 	}
-	if entry.NeedsRepair {
+	if entry.NeedsRepair && entry.RegistrationState != RegistrationStateInvalid {
+		return fmt.Errorf("managed worktree %s cannot be detached because %s; %s", output.BranchName(entry.displayName()), output.Dim(entry.StatusMessage), repairHint(entry))
+	}
+	if entry.NeedsRepair && !entry.CanDetach {
 		return fmt.Errorf("managed worktree %s cannot be detached because %s; %s", output.BranchName(entry.displayName()), output.Dim(entry.StatusMessage), repairHint(entry))
 	}
 
@@ -817,6 +816,23 @@ func DetachAction(ctx *app.Context, opts DetachOptions) error {
 	snapshot, err := snapshotWorktree(ctx, entry)
 	if err != nil {
 		return err
+	}
+	// An invalid registration cannot be reparented or repaired automatically
+	// when its checkout is detached or untracked. Detach still has a useful,
+	// safe meaning: remove the physical worktree and its stale registry entry.
+	if entry.NeedsRepair {
+		if entry.Exists {
+			if err := removeWorktreePath(ctx, entry.Path, opts.Force); err != nil {
+				return fmt.Errorf("failed to remove worktree at %s: %w", entry.Path, err)
+			}
+		} else if err := ctx.Engine.PruneWorktrees(ctx.Context); err != nil {
+			return fmt.Errorf("failed to prune stale worktree entries: %w", err)
+		}
+		if err := ctx.Engine.UnregisterWorktree(ctx.Context, entry.AnchorBranch); err != nil {
+			return fmt.Errorf("failed to unregister invalid worktree: %w", err)
+		}
+		out.Success("Detached invalid worktree %s", output.BranchName(entry.displayName()))
+		return nil
 	}
 
 	pathRemoved := false

--- a/internal/actions/worktree/entry.go
+++ b/internal/actions/worktree/entry.go
@@ -139,6 +139,7 @@ func inspectWorktreeEntry(ctx *app.Context, wt engine.WorktreeInfo, graph *engin
 	default:
 		entry.NeedsRepair = true
 		entry.StatusMessage = "registered anchor branch is missing"
+		entry.CanDetach = !entry.IsCurrent
 
 		if entry.CurrentBranch != "" {
 			currentBranch := ctx.Engine.GetBranch(entry.CurrentBranch)
@@ -152,8 +153,15 @@ func inspectWorktreeEntry(ctx *app.Context, wt engine.WorktreeInfo, graph *engin
 			}
 		}
 
-		if !entry.Exists {
+		switch {
+		case !entry.Exists:
 			entry.StatusMessage = "registration is stale and the directory is missing"
+			entry.CanRemove = !entry.IsCurrent
+		case entry.CurrentBranch == "":
+			entry.StatusMessage = "registration is invalid and worktree is detached"
+			entry.CanRemove = !entry.IsCurrent
+		case len(entry.RootBranches) == 0:
+			entry.StatusMessage = "registration is invalid and worktree branch is untracked"
 			entry.CanRemove = !entry.IsCurrent
 		}
 	}

--- a/internal/actions/worktree/repair.go
+++ b/internal/actions/worktree/repair.go
@@ -25,6 +25,11 @@ type RepairResult struct {
 }
 
 func RepairAction(ctx *app.Context, opts RepairOptions) (*RepairResult, error) {
+	if count, err := ctx.Engine.PruneOrphanedWorktreePathRefs(ctx.Context); err != nil {
+		return nil, err
+	} else if count > 0 {
+		ctx.Output.Info("Removed %d orphaned worktree path registration(s)", count)
+	}
 	listResult, err := listEntries(ctx, ListOptions(opts))
 	if err != nil {
 		return nil, err

--- a/internal/actions/worktree/repair.go
+++ b/internal/actions/worktree/repair.go
@@ -95,12 +95,18 @@ func repairEntry(ctx *app.Context, entry Entry) (RepairEntry, error) {
 		}
 
 		if entry.CurrentBranch == "" {
-			return RepairEntry{}, fmt.Errorf("cannot repair %s automatically because the worktree has no branch checked out", output.BranchName(entry.displayName()))
+			if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
+				return RepairEntry{}, fmt.Errorf("failed to remove detached invalid registration: %w", err)
+			}
+			return RepairEntry{Name: entry.displayName(), Action: "removed invalid detached registration"}, nil
 		}
 
 		currentBranch := ctx.Engine.GetBranch(entry.CurrentBranch)
 		if !currentBranch.IsTracked() {
-			return RepairEntry{}, fmt.Errorf("cannot repair %s automatically because %s is not tracked by stackit", output.BranchName(entry.displayName()), output.BranchName(entry.CurrentBranch))
+			if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
+				return RepairEntry{}, fmt.Errorf("failed to remove untracked invalid registration: %w", err)
+			}
+			return RepairEntry{Name: entry.displayName(), Action: "removed invalid untracked registration"}, nil
 		}
 
 		stackRootName := ctx.Engine.GetStackRootForBranch(currentBranch)

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -88,6 +88,36 @@ func (e *engineImpl) PruneWorktrees(ctx context.Context) error {
 	return nil
 }
 
+// PruneOrphanedWorktreePathRefs removes reverse worktree path claims with no
+// matching forward registration, left behind by interrupted legacy cleanup.
+func (e *engineImpl) PruneOrphanedWorktreePathRefs(ctx context.Context) (int, error) {
+	forward, err := e.git.ListRefs(git.WorktreeRefPrefix)
+	if err != nil {
+		return 0, fmt.Errorf("list worktree registrations: %w", err)
+	}
+	pathRefs, err := e.git.ListRefs(git.WorktreePathRefPrefix)
+	if err != nil {
+		return 0, fmt.Errorf("list worktree path registrations: %w", err)
+	}
+	forwardSHAs := make(map[string]bool, len(forward))
+	for _, sha := range forward {
+		forwardSHAs[sha] = true
+	}
+	orphaned := make([]string, 0)
+	for ref, sha := range pathRefs {
+		if !forwardSHAs[sha] {
+			orphaned = append(orphaned, ref)
+		}
+	}
+	if len(orphaned) == 0 {
+		return 0, nil
+	}
+	if err := e.git.DeleteRefsBatch(ctx, orphaned); err != nil {
+		return 0, fmt.Errorf("delete orphaned worktree path registrations: %w", err)
+	}
+	return len(orphaned), nil
+}
+
 // CreateTemporaryWorktree creates a temporary directory and adds a detached worktree
 func (e *engineImpl) CreateTemporaryWorktree(ctx context.Context, branch string, prefix string) (string, func(), error) {
 	return e.CreateTemporaryWorktreeWithOptions(ctx, branch, prefix, WorktreeCheckoutFull, WorktreePruneAuto)

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -290,6 +290,8 @@ type WorktreeOperations interface {
 	// manually calling PruneWorktrees() once, to avoid race conditions.
 	CreateTemporaryWorktreeSkipPrune(ctx context.Context, branch string, prefix string) (path string, cleanup func(), err error)
 	PruneWorktrees(ctx context.Context) error
+	// PruneOrphanedWorktreePathRefs removes stale reverse registration refs.
+	PruneOrphanedWorktreePathRefs(ctx context.Context) (int, error)
 }
 
 // WorktreeInfo represents information about a stackit-managed worktree

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -182,7 +182,9 @@ func (r *runner) RemoveWorktree(ctx context.Context, path string) error {
 }
 
 func (r *runner) ForceRemoveWorktree(ctx context.Context, path string) error {
-	_, err := r.RunGitCommandWithContext(ctx, "worktree", "remove", "--force", path)
+	// Git requires --force twice when the worktree is locked, in addition to
+	// using it to discard local changes.
+	_, err := r.RunGitCommandWithContext(ctx, "worktree", "remove", "--force", "--force", path)
 	if err != nil {
 		return fmt.Errorf("failed to remove worktree at %s: %w", path, err)
 	}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Make branch mutations safe when worktrees hold the branch**

Closes the worktree half of the reconciliation-safety audit: eighteen fixes so
that moving a branch ref can no longer corrupt, revert, or silently discard work
in a worktree that has that branch checked out.

The unifying rule: before any operation rewrites a ref, it must ask who
physically holds that branch. If the holder is dirty or uninspectable, hold the
branch back and say so; if it is clean, reset it to match the ref it now points
at; never move a ref out from under a checkout and report success.

**Data loss (P0)**

- **#1580, #1584, #1585** — `fold`, `absorb`, and `continue` no longer merge onto
  a detached HEAD, rewrite an ancestor, or move a rebased ref while another
  worktree holds the branch. `CheckoutBranch` stops silently falling back to
  detached HEAD, which was a latent trap for every checkout-then-mutate action.
- **#1584** — `git.Rebase` writes its result through a compare-and-swap, so a
  commit made in another worktree mid-pass can no longer be overwritten (and
  then wiped by a reset keyed on a stale clean-snapshot).
- **#1580** — `create -w` keeps the branch when only the worktree phase fails.
  It previously deleted the sole ref to the commit that had just consumed the
  staged changes, past the point a snapshot could recover it.
- **#1585** — `merge --force` resets trunk through a ref update instead of a
  branch checkout, so a temp worktree can no longer squat on `refs/heads/<trunk>`
  and block the main workspace.

**Reconciliation model**

- **#1573, #1574, #1577, #1593** — restack holds branches behind dirty or
  uninspectable worktrees, holds their descendants too, leaves held branches
  metadata untouched, and reports the hold rather than passing it off as
  "already up to date". Untracked files count: `git reset --hard` will overwrite
  an untracked file whose pathname the incoming commit contains.
- **#1597** — worktrees mid-rebase report no branch to porcelain, so they were
  invisible to every branch/worktree guard. They are now held.

**Lifecycle and ownership**

- **#1586, #1595** — `pluck` and `delete` enforce managed-worktree ownership like
  the other branch-scoped mutations.
- **#1588, #1592, #1594** — worktree cleanup prunes before deleting the anchor,
  recovers invalid registrations instead of dead-ending between `remove`,
  `repair`, and `detach`, and sweeps reverse path refs orphaned by older code
  that would otherwise block re-creating a worktree at that path forever.
- **#1571** — reverse registrations stay addressable through symlinked bases by
  resolving the deepest existing ancestor, so register and unregister agree.
- **#1592** — multi-stack merge tags and deletes its consolidation branch and
  unlocks excluded and failed stacks instead of stranding PR locks.

**Correctness and hardening**

- **#1572** — sync stops treating a deleted remote branch as proof the local tip
  was pushed, which discarded follow-up commits on closed PRs.
- **#1589** — `split` uses the stash-by-ref API rather than popping the shared
  cross-worktree `stash@{0}`; relative `gitdir:` pointers resolve against the
  right base.
- **#1596** — `tree --json` no longer emits hidden anchors as dangling parents.
- Worktree porcelain is parsed with `-z`, `ForceRemoveWorktree` passes `--force`
  twice so it can remove locked worktrees, and relative `worktree.basePath`
  resolves against the repo root in Go code as it already did in git.

**Notes**

Sync also skips hidden anchors when comparing PR bases, which was queueing a
GitHub 422 on every sync for every worktree stack root with a PR.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785934948`.


* **PR #1571**
  * **PR #1572**
    * **PR #1573**
      * **PR #1574**
        * **PR #1577**
          * **PR #1580**
            * **PR #1584**
              * **PR #1585**
                * **PR #1586**
                  * **PR #1588**
                    * **PR #1589**
                      * **PR #1592** 👈
                        * **PR #1593**
                          * **PR #1594**
                            * **PR #1595**
                              * **PR #1596**
                                * **PR #1597**
                                  * **PR #1599**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1601 by jonnii*