### PR TITLE
fix(restack): report unsafe worktree holds

### DIFF
--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -503,11 +503,19 @@ func skipDirtyWorktreeStacks(ctx *app.Context, groups []restackBranchGroup) []re
 	dirtyAnchors := make(map[string]bool)
 	if managed, err := eng.ListManagedWorktrees(); err == nil {
 		for _, wt := range managed {
-			if hasChanges, _ := eng.WorktreeHasUncommittedChanges(ctx.Context, wt.Path); hasChanges {
+			hasChanges, inspectErr := eng.WorktreeHasUncommittedChanges(ctx.Context, wt.Path)
+			if inspectErr != nil {
+				ctx.Output.Warn("Holding stack rooted at %s because worktree %s could not be inspected: %v", wt.AnchorBranch, wt.Path, inspectErr)
+				dirtyAnchors[wt.AnchorBranch] = true
+				continue
+			}
+			if hasChanges {
 				dirtyAnchors[wt.AnchorBranch] = true
 				ctx.Output.Warn("Skipping stack rooted at %s (worktree %s has uncommitted changes)", wt.AnchorBranch, wt.Path)
 			}
 		}
+	} else {
+		ctx.Output.Warn("Could not inspect managed worktrees; holding no known stacks: %v", err)
 	}
 
 	// Tracked changes only here: an untracked file cannot be destroyed by the
@@ -518,11 +526,19 @@ func skipDirtyWorktreeStacks(ctx *app.Context, groups []restackBranchGroup) []re
 			if wt.Branch == "" || dirtyAnchors[wt.Branch] {
 				continue
 			}
-			if hasChanges, _ := eng.WorktreeHasTrackedChanges(ctx.Context, wt.Path); hasChanges {
+			hasChanges, inspectErr := eng.WorktreeHasTrackedChanges(ctx.Context, wt.Path)
+			if inspectErr != nil {
+				ctx.Output.Warn("Holding %s because worktree %s could not be inspected: %v", wt.Branch, wt.Path, inspectErr)
+				dirtyBranches[wt.Branch] = true
+				continue
+			}
+			if hasChanges {
 				dirtyBranches[wt.Branch] = true
 				ctx.Output.Warn("Skipping %s (worktree %s has uncommitted changes; commit or stash them, then restack again)", wt.Branch, wt.Path)
 			}
 		}
+	} else {
+		ctx.Output.Warn("Could not inspect Git worktrees; restack safety checks were incomplete: %v", err)
 	}
 
 	if len(dirtyAnchors) == 0 && len(dirtyBranches) == 0 {

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -367,7 +367,10 @@ func (e *engineImpl) GetStackRootForBranch(branch Branch) string {
 
 	current := branchName
 	visited := make(map[string]bool)
-	for {
+	// Metadata should be acyclic, but cap the walk as a second line of
+	// defense against malformed or concurrently changing parent metadata.
+	maxSteps := e.BranchNames().Len() + 1
+	for range maxSteps {
 		if visited[current] {
 			return ""
 		}
@@ -395,6 +398,7 @@ func (e *engineImpl) GetStackRootForBranch(branch Branch) string {
 
 		current = parent
 	}
+	return ""
 }
 
 // IsInManagedWorktree checks if the current directory is a stackit-managed worktree.

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -196,7 +196,8 @@ func (r *runner) ForceRemoveWorktree(ctx context.Context, path string) error {
 // up many branches should call this once and reuse the result rather than
 // invoking git per branch — see WorktreeList.PathForBranch.
 func (r *runner) ListWorktrees(ctx context.Context) (WorktreeList, error) {
-	output, err := r.RunGitCommandWithContext(ctx, "worktree", "list", "--porcelain")
+	// -z is required because worktree paths may legally contain newlines.
+	output, err := r.RunGitCommandWithContext(ctx, "worktree", "list", "--porcelain", "-z")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list worktrees: %w", err)
 	}
@@ -213,7 +214,7 @@ func (r *runner) ListWorktrees(ctx context.Context) (WorktreeList, error) {
 		}
 		current = Worktree{}
 	}
-	for line := range strings.SplitSeq(output, "\n") {
+	for line := range strings.SplitSeq(output, "\x00") {
 		switch {
 		case line == "":
 			flush()
@@ -328,37 +329,11 @@ func (r *runner) DeleteWorktreeMeta(ctx context.Context, stackRoot string) error
 // GetWorktreePathForBranch returns the worktree path where a branch is checked out.
 // Returns empty string if the branch is not checked out in any worktree.
 func (r *runner) GetWorktreePathForBranch(ctx context.Context, branchName string) (string, error) {
-	output, err := r.RunGitCommandWithContext(ctx, "worktree", "list", "--porcelain")
+	worktrees, err := r.ListWorktrees(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to list worktrees: %w", err)
 	}
-
-	if output == "" {
-		return "", nil
-	}
-
-	// Parse porcelain output to find worktree with this branch
-	// Format:
-	// worktree /path/to/worktree
-	// HEAD abc123
-	// branch refs/heads/branchname
-	// (blank line)
-	lines := strings.Split(output, "\n")
-	var currentWorktree string
-	targetRef := "refs/heads/" + branchName
-
-	for _, line := range lines {
-		if after, ok := strings.CutPrefix(line, "worktree "); ok {
-			currentWorktree = after
-		} else if after, ok := strings.CutPrefix(line, "branch "); ok {
-			branch := after
-			if branch == targetRef && currentWorktree != "" {
-				return currentWorktree, nil
-			}
-		}
-	}
-
-	return "", nil
+	return worktrees.PathForBranch(branchName), nil
 }
 
 // ResetWorktreeWorkingDir resets a worktree's working directory to match HEAD.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Make branch mutations safe when worktrees hold the branch**

Closes the worktree half of the reconciliation-safety audit: eighteen fixes so
that moving a branch ref can no longer corrupt, revert, or silently discard work
in a worktree that has that branch checked out.

The unifying rule: before any operation rewrites a ref, it must ask who
physically holds that branch. If the holder is dirty or uninspectable, hold the
branch back and say so; if it is clean, reset it to match the ref it now points
at; never move a ref out from under a checkout and report success.

**Data loss (P0)**

- **#1580, #1584, #1585** — `fold`, `absorb`, and `continue` no longer merge onto
  a detached HEAD, rewrite an ancestor, or move a rebased ref while another
  worktree holds the branch. `CheckoutBranch` stops silently falling back to
  detached HEAD, which was a latent trap for every checkout-then-mutate action.
- **#1584** — `git.Rebase` writes its result through a compare-and-swap, so a
  commit made in another worktree mid-pass can no longer be overwritten (and
  then wiped by a reset keyed on a stale clean-snapshot).
- **#1580** — `create -w` keeps the branch when only the worktree phase fails.
  It previously deleted the sole ref to the commit that had just consumed the
  staged changes, past the point a snapshot could recover it.
- **#1585** — `merge --force` resets trunk through a ref update instead of a
  branch checkout, so a temp worktree can no longer squat on `refs/heads/<trunk>`
  and block the main workspace.

**Reconciliation model**

- **#1573, #1574, #1577, #1593** — restack holds branches behind dirty or
  uninspectable worktrees, holds their descendants too, leaves held branches
  metadata untouched, and reports the hold rather than passing it off as
  "already up to date". Untracked files count: `git reset --hard` will overwrite
  an untracked file whose pathname the incoming commit contains.
- **#1597** — worktrees mid-rebase report no branch to porcelain, so they were
  invisible to every branch/worktree guard. They are now held.

**Lifecycle and ownership**

- **#1586, #1595** — `pluck` and `delete` enforce managed-worktree ownership like
  the other branch-scoped mutations.
- **#1588, #1592, #1594** — worktree cleanup prunes before deleting the anchor,
  recovers invalid registrations instead of dead-ending between `remove`,
  `repair`, and `detach`, and sweeps reverse path refs orphaned by older code
  that would otherwise block re-creating a worktree at that path forever.
- **#1571** — reverse registrations stay addressable through symlinked bases by
  resolving the deepest existing ancestor, so register and unregister agree.
- **#1592** — multi-stack merge tags and deletes its consolidation branch and
  unlocks excluded and failed stacks instead of stranding PR locks.

**Correctness and hardening**

- **#1572** — sync stops treating a deleted remote branch as proof the local tip
  was pushed, which discarded follow-up commits on closed PRs.
- **#1589** — `split` uses the stash-by-ref API rather than popping the shared
  cross-worktree `stash@{0}`; relative `gitdir:` pointers resolve against the
  right base.
- **#1596** — `tree --json` no longer emits hidden anchors as dangling parents.
- Worktree porcelain is parsed with `-z`, `ForceRemoveWorktree` passes `--force`
  twice so it can remove locked worktrees, and relative `worktree.basePath`
  resolves against the repo root in Go code as it already did in git.

**Notes**

Sync also skips hidden anchors when comparing PR bases, which was queueing a
GitHub 422 on every sync for every worktree stack root with a PR.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785934948`.


* **PR #1571**
  * **PR #1572**
    * **PR #1573**
      * **PR #1574**
        * **PR #1577**
          * **PR #1580**
            * **PR #1584**
              * **PR #1585**
                * **PR #1586**
                  * **PR #1588**
                    * **PR #1589**
                      * **PR #1592**
                        * **PR #1593** 👈
                          * **PR #1594**
                            * **PR #1595**
                              * **PR #1596**
                                * **PR #1597**
                                  * **PR #1599**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1601 by jonnii*