### PR TITLE
fix(delete): enforce managed worktree ownership

### DIFF
--- a/internal/actions/delete/delete.go
+++ b/internal/actions/delete/delete.go
@@ -4,6 +4,7 @@ package delete
 import (
 	"fmt"
 	"os"
+	"slices"
 
 	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/actions/validation"
@@ -73,6 +74,15 @@ func Action(ctx *app.Context, opts Options, handler Handler) (Result, error) {
 	if opts.Downstack {
 		downstack := graph.Range(branch, engine.StackRange{RecursiveParents: true})
 		toDelete = downstack.Concat(toDelete)
+	}
+
+	// Deletion rewrites metadata and can reparent surviving children, so it has
+	// the same worktree-ownership boundary as other stack mutations. A caller
+	// operating from the owning managed worktree still passes this check, which
+	// preserves delete's deliberate full-stack worktree cleanup below.
+	managedCleanupAnchors, err := managedCleanupAnchors(ctx, toDelete)
+	if err != nil {
+		return Result{}, err
 	}
 
 	handler.Start(len(toDelete))
@@ -149,6 +159,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) (Result, error) {
 
 	// Cleanup worktrees and get path if user was in a deleted worktree
 	var mainRepoDirForSwitch string
+	deletedStackRoots = mergeUniqueBranchNames(deletedStackRoots, managedCleanupAnchors)
 	if len(deletedStackRoots) > 0 {
 		mainRepoDirForSwitch = cleanupWorktreesForDeletedStacks(ctx, deletedStackRoots)
 	}
@@ -165,6 +176,64 @@ func Action(ctx *app.Context, opts Options, handler Handler) (Result, error) {
 
 	handler.Complete(len(toDelete), 0)
 	return Result{MainRepoDirForSwitch: mainRepoDirForSwitch}, nil
+}
+
+// managedCleanupAnchors enforces normal worktree ownership unless a caller in
+// the main repository is deleting every non-anchor branch owned by a managed
+// worktree. That full-stack deletion is delete's intentional cleanup workflow:
+// it removes the worktree registration after removing its stack.
+func managedCleanupAnchors(ctx *app.Context, toDelete engine.Branches) ([]string, error) {
+	selected := make(map[string]bool, len(toDelete))
+	for _, branch := range toDelete {
+		selected[branch.GetName()] = true
+	}
+
+	anchors := make(map[string]bool)
+	for _, branch := range toDelete {
+		owner, err := ctx.Engine.OwningWorktree(branch)
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine worktree ownership for branch %s: %w", branch.GetName(), err)
+		}
+		if owner != nil {
+			anchors[owner.AnchorBranch] = true
+		}
+	}
+
+	cleanup := make([]string, 0, len(anchors))
+	for anchor := range anchors {
+		complete := !ctx.InManagedWorktree
+		for _, candidate := range ctx.Engine.AllBranches() {
+			if candidate.IsWorktreeAnchor() {
+				continue
+			}
+			owner, err := ctx.Engine.OwningWorktree(candidate)
+			if err != nil {
+				return nil, fmt.Errorf("cannot determine worktree ownership for branch %s: %w", candidate.GetName(), err)
+			}
+			if owner != nil && owner.AnchorBranch == anchor && !selected[candidate.GetName()] {
+				complete = false
+				break
+			}
+		}
+		if complete {
+			cleanup = append(cleanup, anchor)
+		}
+	}
+
+	guarded := make([]engine.Branch, 0, len(toDelete))
+	for _, branch := range toDelete {
+		owner, err := ctx.Engine.OwningWorktree(branch)
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine worktree ownership for branch %s: %w", branch.GetName(), err)
+		}
+		if owner == nil || !anchors[owner.AnchorBranch] || !slices.Contains(cleanup, owner.AnchorBranch) {
+			guarded = append(guarded, branch)
+		}
+	}
+	if err := actions.EnsureCanModifyHere(ctx, guarded...); err != nil {
+		return nil, err
+	}
+	return cleanup, nil
 }
 
 func preReparentChildrenWithPreservedDivergence(ctx *app.Context, toDelete engine.Branches, statuses engine.DeletionStatuses) ([]string, error) {

--- a/internal/actions/delete/delete_test.go
+++ b/internal/actions/delete/delete_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
@@ -190,6 +191,26 @@ func TestDelete(t *testing.T) {
 	})
 }
 
+func TestDeleteRespectsManagedWorktreeOwnership(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.CreateBranch("feature").Commit("feature change")
+	s.TrackBranch("feature", "main")
+	s.CreateBranch("feature-child").Commit("child change")
+	s.TrackBranch("feature-child", "feature")
+	require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", "/tmp/feature-worktree", "feature-wt"))
+	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
+
+	_, err := Action(s.Context, Options{BranchName: "feature", Force: true}, nil)
+	require.ErrorContains(t, err, "belongs to worktree feature-wt")
+
+	ctx := *s.Context
+	ctx.InManagedWorktree = true
+	ctx.WorktreeInfo = &engine.WorktreeInfo{Name: "feature-wt", Path: "/tmp/feature-worktree", AnchorBranch: "feature"}
+	_, err = Action(&ctx, Options{BranchName: "feature", Upstack: true, Force: true}, nil)
+	require.NoError(t, err)
+}
+
 func TestDeleteCleansUpWorktrees(t *testing.T) {
 	t.Parallel()
 	t.Run("cleans worktree when stack root is deleted", func(t *testing.T) {
@@ -248,7 +269,7 @@ func TestDeleteCleansUpWorktrees(t *testing.T) {
 			BranchName: "child-branch",
 			Force:      true,
 		}, nil)
-		require.NoError(t, err)
+		require.ErrorContains(t, err, "belongs to worktree")
 
 		// Verify worktree registration is preserved
 		wt, err = s.Engine.GetWorktreeForStack("stack-root")


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Make branch mutations safe when worktrees hold the branch**

Closes the worktree half of the reconciliation-safety audit: eighteen fixes so
that moving a branch ref can no longer corrupt, revert, or silently discard work
in a worktree that has that branch checked out.

The unifying rule: before any operation rewrites a ref, it must ask who
physically holds that branch. If the holder is dirty or uninspectable, hold the
branch back and say so; if it is clean, reset it to match the ref it now points
at; never move a ref out from under a checkout and report success.

**Data loss (P0)**

- **#1580, #1584, #1585** — `fold`, `absorb`, and `continue` no longer merge onto
  a detached HEAD, rewrite an ancestor, or move a rebased ref while another
  worktree holds the branch. `CheckoutBranch` stops silently falling back to
  detached HEAD, which was a latent trap for every checkout-then-mutate action.
- **#1584** — `git.Rebase` writes its result through a compare-and-swap, so a
  commit made in another worktree mid-pass can no longer be overwritten (and
  then wiped by a reset keyed on a stale clean-snapshot).
- **#1580** — `create -w` keeps the branch when only the worktree phase fails.
  It previously deleted the sole ref to the commit that had just consumed the
  staged changes, past the point a snapshot could recover it.
- **#1585** — `merge --force` resets trunk through a ref update instead of a
  branch checkout, so a temp worktree can no longer squat on `refs/heads/<trunk>`
  and block the main workspace.

**Reconciliation model**

- **#1573, #1574, #1577, #1593** — restack holds branches behind dirty or
  uninspectable worktrees, holds their descendants too, leaves held branches
  metadata untouched, and reports the hold rather than passing it off as
  "already up to date". Untracked files count: `git reset --hard` will overwrite
  an untracked file whose pathname the incoming commit contains.
- **#1597** — worktrees mid-rebase report no branch to porcelain, so they were
  invisible to every branch/worktree guard. They are now held.

**Lifecycle and ownership**

- **#1586, #1595** — `pluck` and `delete` enforce managed-worktree ownership like
  the other branch-scoped mutations.
- **#1588, #1592, #1594** — worktree cleanup prunes before deleting the anchor,
  recovers invalid registrations instead of dead-ending between `remove`,
  `repair`, and `detach`, and sweeps reverse path refs orphaned by older code
  that would otherwise block re-creating a worktree at that path forever.
- **#1571** — reverse registrations stay addressable through symlinked bases by
  resolving the deepest existing ancestor, so register and unregister agree.
- **#1592** — multi-stack merge tags and deletes its consolidation branch and
  unlocks excluded and failed stacks instead of stranding PR locks.

**Correctness and hardening**

- **#1572** — sync stops treating a deleted remote branch as proof the local tip
  was pushed, which discarded follow-up commits on closed PRs.
- **#1589** — `split` uses the stash-by-ref API rather than popping the shared
  cross-worktree `stash@{0}`; relative `gitdir:` pointers resolve against the
  right base.
- **#1596** — `tree --json` no longer emits hidden anchors as dangling parents.
- Worktree porcelain is parsed with `-z`, `ForceRemoveWorktree` passes `--force`
  twice so it can remove locked worktrees, and relative `worktree.basePath`
  resolves against the repo root in Go code as it already did in git.

**Notes**

Sync also skips hidden anchors when comparing PR bases, which was queueing a
GitHub 422 on every sync for every worktree stack root with a PR.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785934948`.


* **PR #1571**
  * **PR #1572**
    * **PR #1573**
      * **PR #1574**
        * **PR #1577**
          * **PR #1580**
            * **PR #1584**
              * **PR #1585**
                * **PR #1586**
                  * **PR #1588**
                    * **PR #1589**
                      * **PR #1592**
                        * **PR #1593**
                          * **PR #1594**
                            * **PR #1595** 👈
                              * **PR #1596**
                                * **PR #1597**
                                  * **PR #1599**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1601 by jonnii*