### PR TITLE
fix(tree): omit dangling worktree anchors from JSON

### DIFF
--- a/internal/actions/tree.go
+++ b/internal/actions/tree.go
@@ -386,8 +386,10 @@ func BuildTreeJSON(ctx *app.Context, opts TreeOptions) TreeJSONResult {
 				NeedsRestack: !statuses.IsUpToDate(branch) && !branch.IsTrunk(),
 			}
 
-			// Parent
-			if parent := branch.GetParent(); parent != nil {
+			// Worktree anchors are an implementation detail. JSON consumers only
+			// receive visible branches, so walk past anchors to avoid emitting a
+			// parent that does not exist in the result.
+			if parent := visibleTreeParent(branch); parent != nil {
 				info.Parent = parent.GetName()
 			}
 
@@ -397,11 +399,8 @@ func BuildTreeJSON(ctx *app.Context, opts TreeOptions) TreeJSONResult {
 			}
 
 			// Children
-			children := graph.ChildBranches(branch)
-			for _, child := range children {
-				if !child.IsWorktreeAnchor() {
-					info.Children = append(info.Children, child.GetName())
-				}
+			for _, child := range visibleTreeChildren(graph, branch) {
+				info.Children = append(info.Children, child.GetName())
 			}
 
 			// Commits and diff stats from the batched stats resolved above.
@@ -474,4 +473,28 @@ func BuildTreeJSON(ctx *app.Context, opts TreeOptions) TreeJSONResult {
 	})
 
 	return result
+}
+
+func visibleTreeParent(branch engine.Branch) *engine.Branch {
+	parent := branch.GetParent()
+	for parent != nil && parent.IsWorktreeAnchor() {
+		parent = parent.GetParent()
+	}
+	return parent
+}
+
+func visibleTreeChildren(graph *engine.StackGraph, branch engine.Branch) engine.Branches {
+	children := engine.NewBranchesBuilder(0)
+	var collect func(engine.Branch)
+	collect = func(parent engine.Branch) {
+		for _, child := range graph.ChildBranches(parent) {
+			if child.IsWorktreeAnchor() {
+				collect(child)
+				continue
+			}
+			children.Add(child)
+		}
+	}
+	collect(branch)
+	return children.Build()
 }

--- a/internal/actions/tree_test.go
+++ b/internal/actions/tree_test.go
@@ -1,0 +1,31 @@
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+func TestBuildTreeJSONHidesAnchorParents(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.CreateBranch("anchor").Commit("anchor")
+	s.TrackBranch("anchor", "main")
+	require.NoError(t, s.Engine.SetBranchType(s.Engine.GetBranch("anchor"), git.BranchTypeWorktreeAnchor))
+	s.CreateBranch("feature").Commit("feature")
+	s.TrackBranch("feature", "anchor")
+
+	result := BuildTreeJSON(s.Context, TreeOptions{})
+	info := make(map[string]TreeBranchInfo, len(result.Branches))
+	for _, branch := range result.Branches {
+		info[branch.Name] = branch
+	}
+
+	_, anchorPresent := info["anchor"]
+	require.False(t, anchorPresent)
+	require.Equal(t, "main", info["feature"].Parent)
+	require.Contains(t, info["main"].Children, "feature")
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Make branch mutations safe when worktrees hold the branch**

Closes the worktree half of the reconciliation-safety audit: eighteen fixes so
that moving a branch ref can no longer corrupt, revert, or silently discard work
in a worktree that has that branch checked out.

The unifying rule: before any operation rewrites a ref, it must ask who
physically holds that branch. If the holder is dirty or uninspectable, hold the
branch back and say so; if it is clean, reset it to match the ref it now points
at; never move a ref out from under a checkout and report success.

**Data loss (P0)**

- **#1580, #1584, #1585** — `fold`, `absorb`, and `continue` no longer merge onto
  a detached HEAD, rewrite an ancestor, or move a rebased ref while another
  worktree holds the branch. `CheckoutBranch` stops silently falling back to
  detached HEAD, which was a latent trap for every checkout-then-mutate action.
- **#1584** — `git.Rebase` writes its result through a compare-and-swap, so a
  commit made in another worktree mid-pass can no longer be overwritten (and
  then wiped by a reset keyed on a stale clean-snapshot).
- **#1580** — `create -w` keeps the branch when only the worktree phase fails.
  It previously deleted the sole ref to the commit that had just consumed the
  staged changes, past the point a snapshot could recover it.
- **#1585** — `merge --force` resets trunk through a ref update instead of a
  branch checkout, so a temp worktree can no longer squat on `refs/heads/<trunk>`
  and block the main workspace.

**Reconciliation model**

- **#1573, #1574, #1577, #1593** — restack holds branches behind dirty or
  uninspectable worktrees, holds their descendants too, leaves held branches
  metadata untouched, and reports the hold rather than passing it off as
  "already up to date". Untracked files count: `git reset --hard` will overwrite
  an untracked file whose pathname the incoming commit contains.
- **#1597** — worktrees mid-rebase report no branch to porcelain, so they were
  invisible to every branch/worktree guard. They are now held.

**Lifecycle and ownership**

- **#1586, #1595** — `pluck` and `delete` enforce managed-worktree ownership like
  the other branch-scoped mutations.
- **#1588, #1592, #1594** — worktree cleanup prunes before deleting the anchor,
  recovers invalid registrations instead of dead-ending between `remove`,
  `repair`, and `detach`, and sweeps reverse path refs orphaned by older code
  that would otherwise block re-creating a worktree at that path forever.
- **#1571** — reverse registrations stay addressable through symlinked bases by
  resolving the deepest existing ancestor, so register and unregister agree.
- **#1592** — multi-stack merge tags and deletes its consolidation branch and
  unlocks excluded and failed stacks instead of stranding PR locks.

**Correctness and hardening**

- **#1572** — sync stops treating a deleted remote branch as proof the local tip
  was pushed, which discarded follow-up commits on closed PRs.
- **#1589** — `split` uses the stash-by-ref API rather than popping the shared
  cross-worktree `stash@{0}`; relative `gitdir:` pointers resolve against the
  right base.
- **#1596** — `tree --json` no longer emits hidden anchors as dangling parents.
- Worktree porcelain is parsed with `-z`, `ForceRemoveWorktree` passes `--force`
  twice so it can remove locked worktrees, and relative `worktree.basePath`
  resolves against the repo root in Go code as it already did in git.

**Notes**

Sync also skips hidden anchors when comparing PR bases, which was queueing a
GitHub 422 on every sync for every worktree stack root with a PR.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785934948`.


* **PR #1571**
  * **PR #1572**
    * **PR #1573**
      * **PR #1574**
        * **PR #1577**
          * **PR #1580**
            * **PR #1584**
              * **PR #1585**
                * **PR #1586**
                  * **PR #1588**
                    * **PR #1589**
                      * **PR #1592**
                        * **PR #1593**
                          * **PR #1594**
                            * **PR #1595**
                              * **PR #1596** 👈
                                * **PR #1597**
                                  * **PR #1599**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1601 by jonnii*