### PR TITLE
fix(restack): hold worktrees mid-rebase

### DIFF
--- a/internal/actions/move/move_test.go
+++ b/internal/actions/move/move_test.go
@@ -573,6 +573,13 @@ func TestMoveAction(t *testing.T) {
 		writeAndCommit(t, s, "conflict.txt", "branch2 content\n", "branch2 change")
 		s.TrackBranch("branch2", "main")
 
+		// Keep the new parent checked out elsewhere while the conflict is
+		// resolved. Continue must not treat this sibling worktree as a reason
+		// to abandon the interrupted rebase or fail its final checkout.
+		sibling := filepath.Join(t.TempDir(), "branch1-sibling")
+		s.RunGit("worktree", "add", sibling, "branch1")
+		t.Cleanup(func() { _ = s.Scene.Repo.RunGitCommand("worktree", "remove", "--force", sibling) })
+
 		// Attempt to move branch2 onto branch1 — this will conflict on conflict.txt.
 		// The interactive handler opts to proceed and resolve manually.
 		h := &interactiveTestHandler{proceed: true}

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -503,6 +503,11 @@ func skipDirtyWorktreeStacks(ctx *app.Context, groups []restackBranchGroup) []re
 	dirtyAnchors := make(map[string]bool)
 	if managed, err := eng.ListManagedWorktrees(); err == nil {
 		for _, wt := range managed {
+			if eng.WorktreeRebaseInProgress(ctx.Context, wt.Path) {
+				dirtyAnchors[wt.AnchorBranch] = true
+				ctx.Output.Warn("Holding stack rooted at %s (worktree %s has a rebase in progress)", wt.AnchorBranch, wt.Path)
+				continue
+			}
 			hasChanges, inspectErr := eng.WorktreeHasUncommittedChanges(ctx.Context, wt.Path)
 			if inspectErr != nil {
 				ctx.Output.Warn("Holding stack rooted at %s because worktree %s could not be inspected: %v", wt.AnchorBranch, wt.Path, inspectErr)
@@ -518,15 +523,20 @@ func skipDirtyWorktreeStacks(ctx *app.Context, groups []restackBranchGroup) []re
 		ctx.Output.Warn("Could not inspect managed worktrees; holding no known stacks: %v", err)
 	}
 
-	// Tracked changes only here: an untracked file cannot be destroyed by the
-	// reset, so it is no reason to hold a branch back.
+	// A hard reset can remove an untracked file when the incoming commit needs
+	// that pathname, so any local change must hold the branch back.
 	dirtyBranches := make(map[string]bool)
 	if worktrees, err := eng.ListWorktrees(ctx.Context); err == nil {
 		for _, wt := range worktrees {
 			if wt.Branch == "" || dirtyAnchors[wt.Branch] {
 				continue
 			}
-			hasChanges, inspectErr := eng.WorktreeHasTrackedChanges(ctx.Context, wt.Path)
+			if eng.WorktreeRebaseInProgress(ctx.Context, wt.Path) {
+				dirtyBranches[wt.Branch] = true
+				ctx.Output.Warn("Holding %s (worktree %s has a rebase in progress)", wt.Branch, wt.Path)
+				continue
+			}
+			hasChanges, inspectErr := eng.WorktreeHasUncommittedChanges(ctx.Context, wt.Path)
 			if inspectErr != nil {
 				ctx.Output.Warn("Holding %s because worktree %s could not be inspected: %v", wt.Branch, wt.Path, inspectErr)
 				dirtyBranches[wt.Branch] = true

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -67,6 +67,11 @@ func (e *engineImpl) WorktreeHasTrackedChanges(ctx context.Context, worktreePath
 	return e.git.WorktreeHasTrackedChanges(ctx, worktreePath)
 }
 
+// WorktreeRebaseInProgress checks the target worktree's own git directory.
+func (e *engineImpl) WorktreeRebaseInProgress(ctx context.Context, worktreePath string) bool {
+	return git.NewRunnerWithPath(worktreePath, nil).IsRebaseInProgress(ctx)
+}
+
 // ListIgnoredFiles returns every ignored, untracked file in a worktree.
 func (e *engineImpl) ListIgnoredFiles(ctx context.Context, worktreePath string) ([]string, error) {
 	return e.git.ListIgnoredFiles(ctx, worktreePath)

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -283,6 +283,8 @@ type WorktreeOperations interface {
 	GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error)
 	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)
 	WorktreeHasTrackedChanges(ctx context.Context, worktreePath string) (bool, error)
+	// WorktreeRebaseInProgress reports whether a rebase is active in worktreePath.
+	WorktreeRebaseInProgress(ctx context.Context, worktreePath string) bool
 	ListIgnoredFiles(ctx context.Context, worktreePath string) ([]string, error)
 	CreateTemporaryWorktree(ctx context.Context, branch string, prefix string) (path string, cleanup func(), err error)
 	// CreateTemporaryWorktreeSkipPrune is like CreateTemporaryWorktree but skips the automatic


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Make branch mutations safe when worktrees hold the branch**

Closes the worktree half of the reconciliation-safety audit: eighteen fixes so
that moving a branch ref can no longer corrupt, revert, or silently discard work
in a worktree that has that branch checked out.

The unifying rule: before any operation rewrites a ref, it must ask who
physically holds that branch. If the holder is dirty or uninspectable, hold the
branch back and say so; if it is clean, reset it to match the ref it now points
at; never move a ref out from under a checkout and report success.

**Data loss (P0)**

- **#1580, #1584, #1585** — `fold`, `absorb`, and `continue` no longer merge onto
  a detached HEAD, rewrite an ancestor, or move a rebased ref while another
  worktree holds the branch. `CheckoutBranch` stops silently falling back to
  detached HEAD, which was a latent trap for every checkout-then-mutate action.
- **#1584** — `git.Rebase` writes its result through a compare-and-swap, so a
  commit made in another worktree mid-pass can no longer be overwritten (and
  then wiped by a reset keyed on a stale clean-snapshot).
- **#1580** — `create -w` keeps the branch when only the worktree phase fails.
  It previously deleted the sole ref to the commit that had just consumed the
  staged changes, past the point a snapshot could recover it.
- **#1585** — `merge --force` resets trunk through a ref update instead of a
  branch checkout, so a temp worktree can no longer squat on `refs/heads/<trunk>`
  and block the main workspace.

**Reconciliation model**

- **#1573, #1574, #1577, #1593** — restack holds branches behind dirty or
  uninspectable worktrees, holds their descendants too, leaves held branches
  metadata untouched, and reports the hold rather than passing it off as
  "already up to date". Untracked files count: `git reset --hard` will overwrite
  an untracked file whose pathname the incoming commit contains.
- **#1597** — worktrees mid-rebase report no branch to porcelain, so they were
  invisible to every branch/worktree guard. They are now held.

**Lifecycle and ownership**

- **#1586, #1595** — `pluck` and `delete` enforce managed-worktree ownership like
  the other branch-scoped mutations.
- **#1588, #1592, #1594** — worktree cleanup prunes before deleting the anchor,
  recovers invalid registrations instead of dead-ending between `remove`,
  `repair`, and `detach`, and sweeps reverse path refs orphaned by older code
  that would otherwise block re-creating a worktree at that path forever.
- **#1571** — reverse registrations stay addressable through symlinked bases by
  resolving the deepest existing ancestor, so register and unregister agree.
- **#1592** — multi-stack merge tags and deletes its consolidation branch and
  unlocks excluded and failed stacks instead of stranding PR locks.

**Correctness and hardening**

- **#1572** — sync stops treating a deleted remote branch as proof the local tip
  was pushed, which discarded follow-up commits on closed PRs.
- **#1589** — `split` uses the stash-by-ref API rather than popping the shared
  cross-worktree `stash@{0}`; relative `gitdir:` pointers resolve against the
  right base.
- **#1596** — `tree --json` no longer emits hidden anchors as dangling parents.
- Worktree porcelain is parsed with `-z`, `ForceRemoveWorktree` passes `--force`
  twice so it can remove locked worktrees, and relative `worktree.basePath`
  resolves against the repo root in Go code as it already did in git.

**Notes**

Sync also skips hidden anchors when comparing PR bases, which was queueing a
GitHub 422 on every sync for every worktree stack root with a PR.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785934948`.


* **PR #1571**
  * **PR #1572**
    * **PR #1573**
      * **PR #1574**
        * **PR #1577**
          * **PR #1580**
            * **PR #1584**
              * **PR #1585**
                * **PR #1586**
                  * **PR #1588**
                    * **PR #1589**
                      * **PR #1592**
                        * **PR #1593**
                          * **PR #1594**
                            * **PR #1595**
                              * **PR #1596**
                                * **PR #1597** 👈
                                  * **PR #1599**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1601 by jonnii*