### PR TITLE
fix(continue): preserve concurrent branch updates

### DIFF
--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -522,6 +522,11 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 
 	// Perform rebase to enter conflict state
 	conflictBranch := ctx.Engine.GetBranch(firstConflict)
+	expectedBranchRevision, err := conflictBranch.GetRevision()
+	if err != nil {
+		reattach()
+		return fmt.Errorf("failed to get branch revision before conflict workflow: %w", err)
+	}
 	batchResult, err := ctx.Engine.RestackBranches(ctx.Context, engine.BranchesOf(conflictBranch))
 	if err != nil {
 		reattach()
@@ -557,9 +562,10 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 
 	// Persist continuation state
 	continuation := &config.ContinuationState{
-		BranchesToRestack:     remainingBranches,
-		RebasedBranchBase:     rebasedBranchBase,
-		CurrentBranchOverride: firstConflict,
+		BranchesToRestack:      remainingBranches,
+		RebasedBranchBase:      rebasedBranchBase,
+		CurrentBranchOverride:  firstConflict,
+		ExpectedBranchRevision: expectedBranchRevision,
 	}
 
 	if err := config.PersistContinuationState(ctx.RepoRoot, continuation); err != nil {

--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -51,6 +51,11 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 			BranchesToRestack:     []string{},
 			CurrentBranchOverride: currentBranch.GetName(),
 		}
+		expectedBranchRevision, err := currentBranch.GetRevision()
+		if err != nil {
+			return fmt.Errorf("failed to get current branch revision: %w", err)
+		}
+		continuation.ExpectedBranchRevision = expectedBranchRevision
 	}
 
 	// Stage all changes if --all flag is set
@@ -61,9 +66,7 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 	}
 
 	// Continue the rebase
-	// No expected revision recorded: ContinueRebase falls back to the branch's
-	// current tip, which still rejects a write racing this one.
-	result, err := eng.ContinueRebase(ctx.Context, continuation.CurrentBranchOverride, continuation.RebasedBranchBase, "")
+	result, err := eng.ContinueRebase(ctx.Context, continuation.CurrentBranchOverride, continuation.RebasedBranchBase, continuation.ExpectedBranchRevision)
 	if err != nil {
 		return fmt.Errorf("failed to continue rebase: %w", err)
 	}

--- a/internal/actions/debug.go
+++ b/internal/actions/debug.go
@@ -81,10 +81,11 @@ type BranchInfo struct {
 
 // ContinuationStateInfo represents continuation state
 type ContinuationStateInfo struct {
-	BranchesToRestack     []string `json:"branches_to_restack,omitempty"`
-	BranchesToSync        []string `json:"branches_to_sync,omitempty"`
-	CurrentBranchOverride string   `json:"current_branch_override,omitempty"`
-	RebasedBranchBase     string   `json:"rebased_branch_base,omitempty"`
+	BranchesToRestack      []string `json:"branches_to_restack,omitempty"`
+	BranchesToSync         []string `json:"branches_to_sync,omitempty"`
+	CurrentBranchOverride  string   `json:"current_branch_override,omitempty"`
+	RebasedBranchBase      string   `json:"rebased_branch_base,omitempty"`
+	ExpectedBranchRevision string   `json:"expected_branch_revision,omitempty"`
 }
 
 // RepositoryInfo represents basic repository information
@@ -191,10 +192,11 @@ func DebugAction(ctx *app.Context, opts DebugOptions) error {
 	contState, err := config.GetContinuationState(repoRoot)
 	if err == nil && contState != nil {
 		continuationState = &ContinuationStateInfo{
-			BranchesToRestack:     contState.BranchesToRestack,
-			BranchesToSync:        contState.BranchesToSync,
-			CurrentBranchOverride: contState.CurrentBranchOverride,
-			RebasedBranchBase:     contState.RebasedBranchBase,
+			BranchesToRestack:      contState.BranchesToRestack,
+			BranchesToSync:         contState.BranchesToSync,
+			CurrentBranchOverride:  contState.CurrentBranchOverride,
+			RebasedBranchBase:      contState.RebasedBranchBase,
+			ExpectedBranchRevision: contState.ExpectedBranchRevision,
 		}
 	}
 

--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -319,6 +319,10 @@ func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecut
 		// if the parent has been merged/deleted
 		branch := eng.GetBranch(step.BranchName)
 		out.Debug("Executing StepRestack for branch %s", step.BranchName)
+		expectedBranchRevision, err := branch.GetRevision()
+		if err != nil {
+			return fmt.Errorf("failed to get branch revision before restack: %w", err)
+		}
 		batchResult, err := eng.RestackBranches(ctx.Context, engine.BranchesOf(branch))
 		result := batchResult.Results[step.BranchName]
 		if err != nil {
@@ -360,8 +364,9 @@ func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecut
 				currentBranchName = currentBranch.GetName()
 			}
 			continuation := &config.ContinuationState{
-				RebasedBranchBase:     result.RebasedBranchBase,
-				CurrentBranchOverride: currentBranchName,
+				RebasedBranchBase:      result.RebasedBranchBase,
+				CurrentBranchOverride:  currentBranchName,
+				ExpectedBranchRevision: expectedBranchRevision,
 			}
 			if err := config.PersistContinuationState(repoRoot, continuation); err != nil {
 				return fmt.Errorf("failed to persist continuation: %w", err)

--- a/internal/actions/restack_test.go
+++ b/internal/actions/restack_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/engine"
 	stackiterrors "github.com/getstackit/stackit/internal/errors"
 	"github.com/getstackit/stackit/internal/handlers"
@@ -173,6 +174,8 @@ func TestRestackAction(t *testing.T) {
 		s.CreateBranch("b")
 		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("b change", "conflict"))
 		s.TrackBranch("b", "a")
+		bBefore, err := s.Engine.GetRevision(engine.NewBranch("b", nil))
+		require.NoError(t, err)
 
 		s.Checkout("main")
 		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("main change", "conflict"))
@@ -196,6 +199,10 @@ func TestRestackAction(t *testing.T) {
 		// on b but rebase completed successfully" and left HEAD detached.
 		require.ErrorIs(t, err, stackiterrors.ErrConflictWorkflow)
 		require.True(t, s.Engine.Git().IsRebaseInProgress(context.Background()))
+
+		continuation, err := config.GetContinuationState(s.Scene.Dir)
+		require.NoError(t, err)
+		require.Equal(t, bBefore, continuation.ExpectedBranchRevision)
 
 		mainRev, err := s.Engine.GetRevision(engine.NewBranch("main", nil))
 		require.NoError(t, err)

--- a/internal/config/continuation.go
+++ b/internal/config/continuation.go
@@ -15,6 +15,10 @@ type ContinuationState struct {
 	BranchesToSync        []string `json:"branchesToSync,omitempty"` // For future sync command
 	CurrentBranchOverride string   `json:"currentBranchOverride,omitempty"`
 	RebasedBranchBase     string   `json:"rebasedBranchBase,omitempty"`
+	// ExpectedBranchRevision is the branch tip before a conflict-driven rebase.
+	// Continue uses it as a compare-and-swap guard so it cannot overwrite work
+	// that another worktree added while the conflict was being resolved.
+	ExpectedBranchRevision string `json:"expectedBranchRevision,omitempty"`
 	// ReturnToBranch is the branch the interrupted command should leave the
 	// user on once the conflict workflow finishes, when that differs from the
 	// branch being rebased. `modify --into` sets it: it amends a downstack

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -15,7 +15,7 @@ const (
 )
 
 // resetWorktreeIfClean resets a worktree's working directory to match its
-// branch ref's new content, unless the worktree had changes to TRACKED files
+// branch ref's new content, unless the worktree had local changes
 // before this restack pass touched anything. dirtyWorktrees is captured once
 // up front (see restackSnapshot.dirtyWorktrees) rather than checked here,
 // because by the time any branch's reset runs, restack has already moved that
@@ -24,11 +24,7 @@ const (
 // dirty, silently disabling the reset for every branch, not just genuinely
 // dirty ones.
 //
-// Untracked files must not count: `git reset --hard` cannot destroy them, so
-// treating them as dirty suppresses a reset that was never a threat and leaves
-// the worktree holding the old commit's content under a moved ref.
-//
-// Skipping the reset on a worktree with real tracked changes leaves it out of
+// Skipping the reset on a worktree with changes leaves it out of
 // sync with its ref rather than discarding the user's work. That state is still
 // a footgun — `git status` shows the new commit's files as deleted — so callers
 // should avoid moving the ref at all in that case; see skipDirtyWorktreeStacks.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
**Make branch mutations safe when worktrees hold the branch**

Closes the worktree half of the reconciliation-safety audit: eighteen fixes so
that moving a branch ref can no longer corrupt, revert, or silently discard work
in a worktree that has that branch checked out.

The unifying rule: before any operation rewrites a ref, it must ask who
physically holds that branch. If the holder is dirty or uninspectable, hold the
branch back and say so; if it is clean, reset it to match the ref it now points
at; never move a ref out from under a checkout and report success.

**Data loss (P0)**

- **#1580, #1584, #1585** — `fold`, `absorb`, and `continue` no longer merge onto
  a detached HEAD, rewrite an ancestor, or move a rebased ref while another
  worktree holds the branch. `CheckoutBranch` stops silently falling back to
  detached HEAD, which was a latent trap for every checkout-then-mutate action.
- **#1584** — `git.Rebase` writes its result through a compare-and-swap, so a
  commit made in another worktree mid-pass can no longer be overwritten (and
  then wiped by a reset keyed on a stale clean-snapshot).
- **#1580** — `create -w` keeps the branch when only the worktree phase fails.
  It previously deleted the sole ref to the commit that had just consumed the
  staged changes, past the point a snapshot could recover it.
- **#1585** — `merge --force` resets trunk through a ref update instead of a
  branch checkout, so a temp worktree can no longer squat on `refs/heads/<trunk>`
  and block the main workspace.

**Reconciliation model**

- **#1573, #1574, #1577, #1593** — restack holds branches behind dirty or
  uninspectable worktrees, holds their descendants too, leaves held branches
  metadata untouched, and reports the hold rather than passing it off as
  "already up to date". Untracked files count: `git reset --hard` will overwrite
  an untracked file whose pathname the incoming commit contains.
- **#1597** — worktrees mid-rebase report no branch to porcelain, so they were
  invisible to every branch/worktree guard. They are now held.

**Lifecycle and ownership**

- **#1586, #1595** — `pluck` and `delete` enforce managed-worktree ownership like
  the other branch-scoped mutations.
- **#1588, #1592, #1594** — worktree cleanup prunes before deleting the anchor,
  recovers invalid registrations instead of dead-ending between `remove`,
  `repair`, and `detach`, and sweeps reverse path refs orphaned by older code
  that would otherwise block re-creating a worktree at that path forever.
- **#1571** — reverse registrations stay addressable through symlinked bases by
  resolving the deepest existing ancestor, so register and unregister agree.
- **#1592** — multi-stack merge tags and deletes its consolidation branch and
  unlocks excluded and failed stacks instead of stranding PR locks.

**Correctness and hardening**

- **#1572** — sync stops treating a deleted remote branch as proof the local tip
  was pushed, which discarded follow-up commits on closed PRs.
- **#1589** — `split` uses the stash-by-ref API rather than popping the shared
  cross-worktree `stash@{0}`; relative `gitdir:` pointers resolve against the
  right base.
- **#1596** — `tree --json` no longer emits hidden anchors as dangling parents.
- Worktree porcelain is parsed with `-z`, `ForceRemoveWorktree` passes `--force`
  twice so it can remove locked worktrees, and relative `worktree.basePath`
  resolves against the repo root in Go code as it already did in git.

**Notes**

Sync also skips hidden anchors when comparing PR bases, which was queueing a
GitHub 422 on every sync for every worktree stack root with a PR.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785934948`.


* **PR #1571**
  * **PR #1572**
    * **PR #1573**
      * **PR #1574**
        * **PR #1577**
          * **PR #1580**
            * **PR #1584**
              * **PR #1585**
                * **PR #1586**
                  * **PR #1588**
                    * **PR #1589**
                      * **PR #1592**
                        * **PR #1593**
                          * **PR #1594**
                            * **PR #1595**
                              * **PR #1596**
                                * **PR #1597**
                                  * **PR #1599** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1601 by jonnii*