### PR TITLE
perf(shippable): share remote-status fetch across AnalyzeAll's stacks

### DIFF
--- a/internal/shippable/analyzer.go
+++ b/internal/shippable/analyzer.go
@@ -52,13 +52,16 @@ func (a *Analyzer) AnalyzeAll(ctx context.Context) (*AnalysisResult, error) {
 		statusMap = make(github.ChecksByBranch)
 	}
 
-	// Analyze each stack
+	// Analyze each stack, sharing one remote-status provider so remote SHAs
+	// are listed once for the whole run instead of once per stack.
+	remoteStatuses := a.remoteStatusProviderFor(ctx, stacks)
+
 	result := &AnalysisResult{
 		Stacks: make([]Stack, 0, len(stacks)),
 	}
 
 	for _, stack := range stacks {
-		analyzed := a.analyzeStack(ctx, stack, statusMap)
+		analyzed := a.analyzeStack(ctx, stack, statusMap, remoteStatuses)
 		result.Stacks = append(result.Stacks, analyzed)
 
 		// Update counts
@@ -93,12 +96,36 @@ func (a *Analyzer) AnalyzeStack(ctx context.Context, stack merge.MultiStackInfo)
 		statusMap = make(github.ChecksByBranch)
 	}
 
-	analyzed := a.analyzeStack(ctx, stack, statusMap)
+	remoteStatuses := a.remoteStatusProviderFor(ctx, []merge.MultiStackInfo{stack})
+	analyzed := a.analyzeStack(ctx, stack, statusMap, remoteStatuses)
 	return &analyzed, nil
 }
 
+// remoteStatusProviderFor builds a single remote-status provider shared across
+// the given stacks, so remote branch SHAs are listed once for all of them
+// instead of once per stack. Only branches with updateable PRs need remote
+// status; missing and draft PRs return before the not-pushed check, so
+// incomplete stacks stay offline.
+func (a *Analyzer) remoteStatusProviderFor(ctx context.Context, stacks []merge.MultiStackInfo) *branchRemoteStatusProvider {
+	var remoteStatusBranches engine.Branches
+	for _, stack := range stacks {
+		for _, branchName := range stack.AllBranches {
+			branch := a.eng.GetBranch(branchName)
+			prInfo, err := branch.GetPrInfo()
+			if err == nil && prInfo != nil && prInfo.Number() != nil && !prInfo.IsDraft() {
+				remoteStatusBranches = append(remoteStatusBranches, branch)
+			}
+		}
+	}
+	return &branchRemoteStatusProvider{
+		ctx:      ctx,
+		eng:      a.eng,
+		branches: remoteStatusBranches,
+	}
+}
+
 // analyzeStack performs the actual analysis of a single stack.
-func (a *Analyzer) analyzeStack(ctx context.Context, stack merge.MultiStackInfo, statusMap github.ChecksByBranch) Stack {
+func (a *Analyzer) analyzeStack(ctx context.Context, stack merge.MultiStackInfo, statusMap github.ChecksByBranch, remoteStatuses *branchRemoteStatusProvider) Stack {
 	result := Stack{
 		Stack:       stack,
 		ApprovalOK:  true,
@@ -115,22 +142,6 @@ func (a *Analyzer) analyzeStack(ctx context.Context, stack merge.MultiStackInfo,
 			// Fall back to commit subject (DefaultPRTitle returns commit subject or branch name)
 			result.PRTitle = rootBranch.DefaultPRTitle()
 		}
-	}
-
-	// Only branches with updateable PRs need remote status. Missing and draft
-	// PRs return before the not-pushed check, so keep incomplete stacks offline.
-	remoteStatusBranches := make(engine.Branches, 0, len(stack.AllBranches))
-	for _, branchName := range stack.AllBranches {
-		branch := a.eng.GetBranch(branchName)
-		prInfo, err := branch.GetPrInfo()
-		if err == nil && prInfo != nil && prInfo.Number() != nil && !prInfo.IsDraft() {
-			remoteStatusBranches = append(remoteStatusBranches, branch)
-		}
-	}
-	remoteStatuses := &branchRemoteStatusProvider{
-		ctx:      ctx,
-		eng:      a.eng,
-		branches: remoteStatusBranches,
 	}
 
 	// Check each branch in the stack

--- a/internal/shippable/analyzer.go
+++ b/internal/shippable/analyzer.go
@@ -61,7 +61,7 @@ func (a *Analyzer) AnalyzeAll(ctx context.Context) (*AnalysisResult, error) {
 	}
 
 	for _, stack := range stacks {
-		analyzed := a.analyzeStack(ctx, stack, statusMap, remoteStatuses)
+		analyzed := a.analyzeStack(stack, statusMap, remoteStatuses)
 		result.Stacks = append(result.Stacks, analyzed)
 
 		// Update counts
@@ -97,7 +97,7 @@ func (a *Analyzer) AnalyzeStack(ctx context.Context, stack merge.MultiStackInfo)
 	}
 
 	remoteStatuses := a.remoteStatusProviderFor(ctx, []merge.MultiStackInfo{stack})
-	analyzed := a.analyzeStack(ctx, stack, statusMap, remoteStatuses)
+	analyzed := a.analyzeStack(stack, statusMap, remoteStatuses)
 	return &analyzed, nil
 }
 
@@ -125,7 +125,7 @@ func (a *Analyzer) remoteStatusProviderFor(ctx context.Context, stacks []merge.M
 }
 
 // analyzeStack performs the actual analysis of a single stack.
-func (a *Analyzer) analyzeStack(ctx context.Context, stack merge.MultiStackInfo, statusMap github.ChecksByBranch, remoteStatuses *branchRemoteStatusProvider) Stack {
+func (a *Analyzer) analyzeStack(stack merge.MultiStackInfo, statusMap github.ChecksByBranch, remoteStatuses *branchRemoteStatusProvider) Stack {
 	result := Stack{
 		Stack:       stack,
 		ApprovalOK:  true,

--- a/internal/shippable/analyzer_test.go
+++ b/internal/shippable/analyzer_test.go
@@ -99,3 +99,20 @@ func TestAnalyzerReadsRemoteStatusOnceForUpdateStack(t *testing.T) {
 	require.Equal(t, int64(1), counting.fetchRemoteShas.Load(),
 		"update stacks should read remote branch status once for the whole stack")
 }
+
+func TestAnalyzeAllReadsRemoteStatusOnceAcrossStacks(t *testing.T) {
+	t.Parallel()
+
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+		WithStack(map[string]string{"P1": "main", "P2": "main"})
+	analyzer, eng, counting := newCountingAnalyzer(t, s.Scene.Dir)
+	require.NoError(t, eng.UpsertPrInfo(context.Background(), eng.GetBranch("P1"), testhelpers.NewTestPrInfo(101)))
+	require.NoError(t, eng.UpsertPrInfo(context.Background(), eng.GetBranch("P2"), testhelpers.NewTestPrInfo(102)))
+
+	result, err := analyzer.AnalyzeAll(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, result.Stacks, 2)
+	require.Equal(t, int64(1), counting.fetchRemoteShas.Load(),
+		"AnalyzeAll should read remote branch status once for all stacks, not once per stack")
+}


### PR DESCRIPTION
## Summary

- `AnalyzeAll` already batches GitHub CI/PR status once for all stacks (`BatchGetPRChecksStatus`), but it called `analyzeStack` in a loop over stacks, and each `analyzeStack` call built its own lazy remote-status provider. That provider's first access triggers `ReadBranchRemoteStatuses` → `FetchRemoteShas`, which runs a full `git ls-remote` of the remote — not a cheap call.
- For a repo with N shippable stacks, this meant N full remote listings per `AnalyzeAll` run instead of 1, even though the data (all remote heads) is identical every time. This path is hit by the auto-refreshing `stackit ship` dashboard TUI and `stackit stack merge status`, so the redundant network round trips repeat on every refresh.
- Fixed by extracting `remoteStatusProviderFor`, which builds one remote-status provider over the union of branches across a set of stacks. `AnalyzeAll` now builds a single shared provider once for all discovered stacks; the single-stack `AnalyzeStack` API is unchanged in behavior — it still scopes the provider to just that one stack's branches.
- No public API changes: `AnalyzeAll(ctx)` and `AnalyzeStack(ctx, stack)` keep their existing signatures. Only the unexported `analyzeStack` helper gained a parameter.

## Test plan

- [x] Added `TestAnalyzeAllReadsRemoteStatusOnceAcrossStacks`, which asserts `FetchRemoteShas` is called exactly once when `AnalyzeAll` analyzes two independent stacks (previously this would have been 2 calls).
- [x] `go test ./internal/shippable/...` passes, including the existing `TestAnalyzerReadsRemoteStatusOnceForUpdateStack` and `TestAnalyzerSkipsRemoteStatusForIncompleteStacks` tests, confirming single-stack behavior is unchanged.
- [x] `go test ./internal/cli/stack/merge/...` passes (consumer of `AnalyzeAll`).
- [x] `go build ./...` and `go vet ./internal/shippable/...` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPAm7uTJXwCA3w9Z4vxHe4)_