### PR TITLE
Make branch mutations safe when worktrees hold the branch

### DIFF
--- a/docs/worktree.md
+++ b/docs/worktree.md
@@ -36,6 +36,20 @@ Git worktrees let you check out multiple branches simultaneously in separate dir
 
 **Default location:** Worktrees are created in a sibling directory named `{repo}-stacks/`. For example, if your repo is at `~/projects/myapp`, worktrees go to `~/projects/myapp-stacks/`.
 
+### Ownership and reconciliation
+
+Branch-scoped content operations — including `create`, `modify`, `absorb`,
+`fold`, `squash`, `split`, `move`, and `reorder` — must run in the worktree
+that owns the stack. This ensures an edit is made in the working tree the user
+is actually viewing.
+
+`sync` and `restack` are whole-repository reconcilers and may run from any
+worktree. They never check out a foreign branch. Before either moves a ref,
+Stackit inspects every physical checkout: a clean holder is reset to the new
+ref, while a dirty or uninspectable holder (and its descendants) is held back
+and reported. This applies to ordinary Git worktrees too, not only worktrees
+registered with Stackit.
+
 ---
 
 ## Warm starts

--- a/internal/actions/checkout.go
+++ b/internal/actions/checkout.go
@@ -237,10 +237,15 @@ func getWorktreeSwitchInfo(ctx *app.Context, branch engine.Branch, branchName st
 		return "", nil, nil
 	}
 
-	if _, err := os.Stat(targetWorktree.Path); os.IsNotExist(err) {
-		ctx.Output.Warn("Worktree for stack %s is registered but path does not exist: %s",
-			output.BranchName(targetStackRoot), targetWorktree.Path)
-		ctx.Output.Tip("stackit worktree remove %s", targetStackRoot)
+	if _, err := os.Stat(targetWorktree.Path); err != nil {
+		if os.IsNotExist(err) {
+			ctx.Output.Warn("Worktree for stack %s is registered but path does not exist: %s",
+				output.BranchName(targetStackRoot), targetWorktree.Path)
+			ctx.Output.Tip("stackit worktree remove %s", targetStackRoot)
+			return "", nil, nil
+		}
+		ctx.Output.Warn("Cannot inspect worktree for stack %s at %s: %v",
+			output.BranchName(targetStackRoot), targetWorktree.Path, err)
 		return "", nil, nil
 	}
 

--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -251,9 +251,15 @@ func identifyBranchesToDelete(ctx *app.Context, opts CleanBranchesOptions) (engi
 		// Check if local branch has unpushed changes relative to remote
 		branch := eng.GetBranch(name)
 		remoteStatus := remoteStatuses[name]
-		if remoteStatus.Ahead() || remoteStatus.Diverged() {
+		// A missing remote branch cannot prove that the local tip was pushed.
+		// This is common after a closed PR's remote branch is deleted; treating
+		// it as clean would make non-interactive sync discard local follow-up
+		// commits without a prompt. Preserve the branch until an explicit user
+		// action decides otherwise.
+		if remoteStatus.Ahead() || remoteStatus.Diverged() ||
+			(status.Kind == engine.DeletionReasonClosedPR && remoteStatus.MissingRemote()) {
 			status.HasUnpushedChanges = true
-			ctx.Logger.Info("identifyBranchesToDelete branch has unpushed changes branch=%v ahead=%v diverged=%v", name, remoteStatus.Ahead(), remoteStatus.Diverged())
+			ctx.Logger.Info("identifyBranchesToDelete branch has unpushed or unverifiable changes branch=%v ahead=%v diverged=%v missingRemote=%v", name, remoteStatus.Ahead(), remoteStatus.Diverged(), remoteStatus.MissingRemote())
 		}
 
 		deleteStatuses[name] = status

--- a/internal/actions/clean_branches_test.go
+++ b/internal/actions/clean_branches_test.go
@@ -297,6 +297,46 @@ func TestCleanBranches(t *testing.T) {
 		require.True(t, plan.UnpushedBranches["branch1"], "branch1 should be marked as having unpushed changes")
 	})
 
+	t.Run("marks a closed PR with a deleted remote branch as unpushed", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"branch1": "main",
+			})
+
+		_, err := s.Scene.Repo.CreateBareRemote("origin")
+		require.NoError(t, err)
+		require.NoError(t, s.Scene.Repo.PushBranch("origin", "main"))
+		require.NoError(t, s.Scene.Repo.PushBranch("origin", "branch1"))
+
+		s.Checkout("branch1").CommitChange("follow-up.txt", "local-only follow-up").Checkout("main")
+		require.NoError(t, s.Scene.Repo.RunGitCommand("push", "origin", "--delete", "branch1"))
+		require.NoError(t, s.Engine.UpsertPrInfo(context.Background(), s.Engine.GetBranch("branch1"), testhelpers.NewTestPrInfoClosed(1)))
+
+		plan, err := actions.PlanBranchDeletions(s.Context, actions.CleanBranchesOptions{Force: true})
+		require.NoError(t, err)
+		require.Contains(t, plan.BranchesToDelete, "branch1")
+		require.True(t, plan.UnpushedBranches["branch1"], "missing remote must preserve unverifiable local work")
+	})
+
+	t.Run("does not mark a merged PR with a deleted remote branch as unpushed", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{"branch1": "main"})
+
+		_, err := s.Scene.Repo.CreateBareRemote("origin")
+		require.NoError(t, err)
+		require.NoError(t, s.Scene.Repo.PushBranch("origin", "main"))
+		require.NoError(t, s.Scene.Repo.PushBranch("origin", "branch1"))
+		require.NoError(t, s.Scene.Repo.RunGitCommand("push", "origin", "--delete", "branch1"))
+		require.NoError(t, s.Engine.UpsertPrInfo(context.Background(), s.Engine.GetBranch("branch1"), testhelpers.NewTestPrInfoMerged(1, "main")))
+
+		plan, err := actions.PlanBranchDeletions(s.Context, actions.CleanBranchesOptions{Force: true})
+		require.NoError(t, err)
+		require.Contains(t, plan.BranchesToDelete, "branch1")
+		require.False(t, plan.UnpushedBranches["branch1"])
+	})
+
 	t.Run("planning does not reparent surviving children", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).

--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -522,6 +522,11 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 
 	// Perform rebase to enter conflict state
 	conflictBranch := ctx.Engine.GetBranch(firstConflict)
+	expectedBranchRevision, err := conflictBranch.GetRevision()
+	if err != nil {
+		reattach()
+		return fmt.Errorf("failed to get branch revision before conflict workflow: %w", err)
+	}
 	batchResult, err := ctx.Engine.RestackBranches(ctx.Context, engine.BranchesOf(conflictBranch))
 	if err != nil {
 		reattach()
@@ -557,9 +562,10 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 
 	// Persist continuation state
 	continuation := &config.ContinuationState{
-		BranchesToRestack:     remainingBranches,
-		RebasedBranchBase:     rebasedBranchBase,
-		CurrentBranchOverride: firstConflict,
+		BranchesToRestack:      remainingBranches,
+		RebasedBranchBase:      rebasedBranchBase,
+		CurrentBranchOverride:  firstConflict,
+		ExpectedBranchRevision: expectedBranchRevision,
 	}
 
 	if err := config.PersistContinuationState(ctx.RepoRoot, continuation); err != nil {

--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -51,6 +51,11 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 			BranchesToRestack:     []string{},
 			CurrentBranchOverride: currentBranch.GetName(),
 		}
+		expectedBranchRevision, err := currentBranch.GetRevision()
+		if err != nil {
+			return fmt.Errorf("failed to get current branch revision: %w", err)
+		}
+		continuation.ExpectedBranchRevision = expectedBranchRevision
 	}
 
 	// Stage all changes if --all flag is set
@@ -61,9 +66,7 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 	}
 
 	// Continue the rebase
-	// No expected revision recorded: ContinueRebase falls back to the branch's
-	// current tip, which still rejects a write racing this one.
-	result, err := eng.ContinueRebase(ctx.Context, continuation.CurrentBranchOverride, continuation.RebasedBranchBase, "")
+	result, err := eng.ContinueRebase(ctx.Context, continuation.CurrentBranchOverride, continuation.RebasedBranchBase, continuation.ExpectedBranchRevision)
 	if err != nil {
 		return fmt.Errorf("failed to continue rebase: %w", err)
 	}

--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -61,7 +61,9 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 	}
 
 	// Continue the rebase
-	result, err := eng.ContinueRebase(ctx.Context, continuation.CurrentBranchOverride, continuation.RebasedBranchBase)
+	// No expected revision recorded: ContinueRebase falls back to the branch's
+	// current tip, which still rejects a write racing this one.
+	result, err := eng.ContinueRebase(ctx.Context, continuation.CurrentBranchOverride, continuation.RebasedBranchBase, "")
 	if err != nil {
 		return fmt.Errorf("failed to continue rebase: %w", err)
 	}

--- a/internal/actions/create/create.go
+++ b/internal/actions/create/create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/output"
 	"github.com/getstackit/stackit/internal/utils"
 )
 
@@ -305,25 +306,23 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 		// Checkout back to trunk first so we can create the worktree for the branch
 		trunkBranch := eng.Trunk()
 		if err := eng.CheckoutBranch(ctx.Context, trunkBranch); err != nil {
-			_ = eng.DeleteBranch(ctx.Context, branch)
 			h.OnStep(StepWorktree, handler.StatusFailed, err.Error())
-			return Result{}, fmt.Errorf("failed to checkout trunk before creating worktree: %w", err)
-		}
+			out.Warn("Created %s, but could not create its worktree: %v", output.BranchName(branchName), err)
+		} else {
+			created, err := worktree.CreateAnchoredWorktreeForBranch(ctx, branchName, branchName, opts.Scope)
+			if err != nil {
+				h.OnStep(StepWorktree, handler.StatusFailed, err.Error())
+				out.Warn("Created %s, but could not create its worktree: %v", output.BranchName(branchName), err)
+			} else {
+				worktreePath = created.Path
+				h.OnStep(StepWorktree, handler.StatusCompleted, fmt.Sprintf("Created worktree at %s", worktreePath))
+				out.Info("Created worktree at %s", worktreePath)
+			}
 
-		created, err := worktree.CreateAnchoredWorktreeForBranch(ctx, branchName, branchName, opts.Scope)
-		if err != nil {
-			// Clean up branch on worktree failure
-			_ = eng.DeleteBranch(ctx.Context, branch)
-			h.OnStep(StepWorktree, handler.StatusFailed, err.Error())
-			return Result{}, fmt.Errorf("failed to create worktree: %w", err)
-		}
-		worktreePath = created.Path
-		h.OnStep(StepWorktree, handler.StatusCompleted, fmt.Sprintf("Created worktree at %s", worktreePath))
-		out.Info("Created worktree at %s", worktreePath)
-
-		// Run post-create hooks in the worktree
-		if hookErr := worktree.RunPostCreateHooks(ctx, worktreePath); hookErr != nil {
-			out.Warn("Post-create hooks failed: %v", hookErr)
+			// Run post-create hooks in the worktree
+			if hookErr := worktree.RunPostCreateHooks(ctx, worktreePath); hookErr != nil {
+				out.Warn("Post-create hooks failed: %v", hookErr)
+			}
 		}
 	}
 

--- a/internal/actions/debug.go
+++ b/internal/actions/debug.go
@@ -81,10 +81,11 @@ type BranchInfo struct {
 
 // ContinuationStateInfo represents continuation state
 type ContinuationStateInfo struct {
-	BranchesToRestack     []string `json:"branches_to_restack,omitempty"`
-	BranchesToSync        []string `json:"branches_to_sync,omitempty"`
-	CurrentBranchOverride string   `json:"current_branch_override,omitempty"`
-	RebasedBranchBase     string   `json:"rebased_branch_base,omitempty"`
+	BranchesToRestack      []string `json:"branches_to_restack,omitempty"`
+	BranchesToSync         []string `json:"branches_to_sync,omitempty"`
+	CurrentBranchOverride  string   `json:"current_branch_override,omitempty"`
+	RebasedBranchBase      string   `json:"rebased_branch_base,omitempty"`
+	ExpectedBranchRevision string   `json:"expected_branch_revision,omitempty"`
 }
 
 // RepositoryInfo represents basic repository information
@@ -191,10 +192,11 @@ func DebugAction(ctx *app.Context, opts DebugOptions) error {
 	contState, err := config.GetContinuationState(repoRoot)
 	if err == nil && contState != nil {
 		continuationState = &ContinuationStateInfo{
-			BranchesToRestack:     contState.BranchesToRestack,
-			BranchesToSync:        contState.BranchesToSync,
-			CurrentBranchOverride: contState.CurrentBranchOverride,
-			RebasedBranchBase:     contState.RebasedBranchBase,
+			BranchesToRestack:      contState.BranchesToRestack,
+			BranchesToSync:         contState.BranchesToSync,
+			CurrentBranchOverride:  contState.CurrentBranchOverride,
+			RebasedBranchBase:      contState.RebasedBranchBase,
+			ExpectedBranchRevision: contState.ExpectedBranchRevision,
 		}
 	}
 

--- a/internal/actions/delete/delete.go
+++ b/internal/actions/delete/delete.go
@@ -4,6 +4,7 @@ package delete
 import (
 	"fmt"
 	"os"
+	"slices"
 
 	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/actions/validation"
@@ -73,6 +74,15 @@ func Action(ctx *app.Context, opts Options, handler Handler) (Result, error) {
 	if opts.Downstack {
 		downstack := graph.Range(branch, engine.StackRange{RecursiveParents: true})
 		toDelete = downstack.Concat(toDelete)
+	}
+
+	// Deletion rewrites metadata and can reparent surviving children, so it has
+	// the same worktree-ownership boundary as other stack mutations. A caller
+	// operating from the owning managed worktree still passes this check, which
+	// preserves delete's deliberate full-stack worktree cleanup below.
+	managedCleanupAnchors, err := managedCleanupAnchors(ctx, toDelete)
+	if err != nil {
+		return Result{}, err
 	}
 
 	handler.Start(len(toDelete))
@@ -149,6 +159,7 @@ func Action(ctx *app.Context, opts Options, handler Handler) (Result, error) {
 
 	// Cleanup worktrees and get path if user was in a deleted worktree
 	var mainRepoDirForSwitch string
+	deletedStackRoots = mergeUniqueBranchNames(deletedStackRoots, managedCleanupAnchors)
 	if len(deletedStackRoots) > 0 {
 		mainRepoDirForSwitch = cleanupWorktreesForDeletedStacks(ctx, deletedStackRoots)
 	}
@@ -165,6 +176,64 @@ func Action(ctx *app.Context, opts Options, handler Handler) (Result, error) {
 
 	handler.Complete(len(toDelete), 0)
 	return Result{MainRepoDirForSwitch: mainRepoDirForSwitch}, nil
+}
+
+// managedCleanupAnchors enforces normal worktree ownership unless a caller in
+// the main repository is deleting every non-anchor branch owned by a managed
+// worktree. That full-stack deletion is delete's intentional cleanup workflow:
+// it removes the worktree registration after removing its stack.
+func managedCleanupAnchors(ctx *app.Context, toDelete engine.Branches) ([]string, error) {
+	selected := make(map[string]bool, len(toDelete))
+	for _, branch := range toDelete {
+		selected[branch.GetName()] = true
+	}
+
+	anchors := make(map[string]bool)
+	for _, branch := range toDelete {
+		owner, err := ctx.Engine.OwningWorktree(branch)
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine worktree ownership for branch %s: %w", branch.GetName(), err)
+		}
+		if owner != nil {
+			anchors[owner.AnchorBranch] = true
+		}
+	}
+
+	cleanup := make([]string, 0, len(anchors))
+	for anchor := range anchors {
+		complete := !ctx.InManagedWorktree
+		for _, candidate := range ctx.Engine.AllBranches() {
+			if candidate.IsWorktreeAnchor() {
+				continue
+			}
+			owner, err := ctx.Engine.OwningWorktree(candidate)
+			if err != nil {
+				return nil, fmt.Errorf("cannot determine worktree ownership for branch %s: %w", candidate.GetName(), err)
+			}
+			if owner != nil && owner.AnchorBranch == anchor && !selected[candidate.GetName()] {
+				complete = false
+				break
+			}
+		}
+		if complete {
+			cleanup = append(cleanup, anchor)
+		}
+	}
+
+	guarded := make([]engine.Branch, 0, len(toDelete))
+	for _, branch := range toDelete {
+		owner, err := ctx.Engine.OwningWorktree(branch)
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine worktree ownership for branch %s: %w", branch.GetName(), err)
+		}
+		if owner == nil || !anchors[owner.AnchorBranch] || !slices.Contains(cleanup, owner.AnchorBranch) {
+			guarded = append(guarded, branch)
+		}
+	}
+	if err := actions.EnsureCanModifyHere(ctx, guarded...); err != nil {
+		return nil, err
+	}
+	return cleanup, nil
 }
 
 func preReparentChildrenWithPreservedDivergence(ctx *app.Context, toDelete engine.Branches, statuses engine.DeletionStatuses) ([]string, error) {

--- a/internal/actions/delete/delete_test.go
+++ b/internal/actions/delete/delete_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/testhelpers"
 	"github.com/getstackit/stackit/testhelpers/scenario"
 )
@@ -190,6 +191,26 @@ func TestDelete(t *testing.T) {
 	})
 }
 
+func TestDeleteRespectsManagedWorktreeOwnership(t *testing.T) {
+	t.Parallel()
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.CreateBranch("feature").Commit("feature change")
+	s.TrackBranch("feature", "main")
+	s.CreateBranch("feature-child").Commit("child change")
+	s.TrackBranch("feature-child", "feature")
+	require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", "/tmp/feature-worktree", "feature-wt"))
+	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
+
+	_, err := Action(s.Context, Options{BranchName: "feature", Force: true}, nil)
+	require.ErrorContains(t, err, "belongs to worktree feature-wt")
+
+	ctx := *s.Context
+	ctx.InManagedWorktree = true
+	ctx.WorktreeInfo = &engine.WorktreeInfo{Name: "feature-wt", Path: "/tmp/feature-worktree", AnchorBranch: "feature"}
+	_, err = Action(&ctx, Options{BranchName: "feature", Upstack: true, Force: true}, nil)
+	require.NoError(t, err)
+}
+
 func TestDeleteCleansUpWorktrees(t *testing.T) {
 	t.Parallel()
 	t.Run("cleans worktree when stack root is deleted", func(t *testing.T) {
@@ -248,7 +269,7 @@ func TestDeleteCleansUpWorktrees(t *testing.T) {
 			BranchName: "child-branch",
 			Force:      true,
 		}, nil)
-		require.NoError(t, err)
+		require.ErrorContains(t, err, "belongs to worktree")
 
 		// Verify worktree registration is preserved
 		wt, err = s.Engine.GetWorktreeForStack("stack-root")

--- a/internal/actions/fold/fold_test.go
+++ b/internal/actions/fold/fold_test.go
@@ -47,6 +47,33 @@ func TestFoldAction(t *testing.T) {
 		require.Contains(t, logOutput, "change on branch2")
 	})
 
+	t.Run("refuses when parent is checked out in another worktree", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"branch1": "main",
+				"branch2": "branch1",
+			})
+		s.Checkout("branch2")
+		branch2Before, err := s.Engine.GetBranch("branch2").GetRevision()
+		require.NoError(t, err)
+
+		worktreePath := filepath.Join(t.TempDir(), "parent")
+		require.NoError(t, s.Scene.Repo.RunGitCommand("worktree", "add", worktreePath, "branch1"))
+		t.Cleanup(func() { _ = s.Scene.Repo.RunGitCommand("worktree", "remove", "--force", worktreePath) })
+
+		err = Action(s.Context, Options{Keep: false}, nil)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to checkout parent branch")
+
+		branch2After, err := s.Engine.GetBranch("branch2").GetRevision()
+		require.NoError(t, err)
+		require.Equal(t, branch2Before, branch2After, "fold must not delete or rewrite its branch")
+		current, err := s.Scene.Repo.CurrentBranchName()
+		require.NoError(t, err)
+		require.Equal(t, "branch2", current, "fold must not leave the caller detached")
+	})
+
 	t.Run("reparents children when folding branch", func(t *testing.T) {
 		t.Parallel()
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).

--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -319,6 +319,10 @@ func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecut
 		// if the parent has been merged/deleted
 		branch := eng.GetBranch(step.BranchName)
 		out.Debug("Executing StepRestack for branch %s", step.BranchName)
+		expectedBranchRevision, err := branch.GetRevision()
+		if err != nil {
+			return fmt.Errorf("failed to get branch revision before restack: %w", err)
+		}
 		batchResult, err := eng.RestackBranches(ctx.Context, engine.BranchesOf(branch))
 		result := batchResult.Results[step.BranchName]
 		if err != nil {
@@ -360,8 +364,9 @@ func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecut
 				currentBranchName = currentBranch.GetName()
 			}
 			continuation := &config.ContinuationState{
-				RebasedBranchBase:     result.RebasedBranchBase,
-				CurrentBranchOverride: currentBranchName,
+				RebasedBranchBase:      result.RebasedBranchBase,
+				CurrentBranchOverride:  currentBranchName,
+				ExpectedBranchRevision: expectedBranchRevision,
 			}
 			if err := config.PersistContinuationState(repoRoot, continuation); err != nil {
 				return fmt.Errorf("failed to persist continuation: %w", err)

--- a/internal/actions/merge/multistack.go
+++ b/internal/actions/merge/multistack.go
@@ -95,6 +95,12 @@ func ExecuteMultiStack(ctx *app.Context, opts MultiStackOptions) (*MultiStackRes
 		IncludedStacks: worktreeResult.MergedStacks,
 		ExcludedStacks: worktreeResult.ConflictStacks,
 	}
+	consolidationCreated := false
+	defer func() {
+		if !consolidationCreated {
+			unlockConsolidatingStacks(ctx, eng, result.IncludedStacks)
+		}
+	}()
 
 	// 4.5. Generate branch name early and lock individual PRs before CI validation
 	// This indicates the PRs are part of a consolidation in progress
@@ -146,6 +152,7 @@ func ExecuteMultiStack(ctx *app.Context, opts MultiStackOptions) (*MultiStackRes
 				// Update result with binary search findings
 				result.IncludedStacks = searchResult.WorkingStacks
 				result.ExcludedStacks = append(result.ExcludedStacks, searchResult.FailedStacks...)
+				unlockExcludedMultiStackBranches(ctx, eng, searchResult.FailedStacks)
 
 				out.Success("Found %d stacks that pass CI together", len(result.IncludedStacks))
 			} else {
@@ -179,6 +186,8 @@ func ExecuteMultiStack(ctx *app.Context, opts MultiStackOptions) (*MultiStackRes
 	result.PRNumber = pr.Number
 	result.PRURL = pr.HTMLURL
 	result.BranchName = branchName
+	consolidationCreated = true
+	unlockExcludedMultiStackBranches(ctx, eng, result.ExcludedStacks)
 
 	out.Success("Created PR #%d: %s", pr.Number, pr.HTMLURL)
 	out.Debug("multistack: PR created successfully")
@@ -224,6 +233,34 @@ func ExecuteMultiStack(ctx *app.Context, opts MultiStackOptions) (*MultiStackRes
 
 	out.Debug("multistack: completed successfully")
 	return result, nil
+}
+
+// unlockConsolidatingStacks releases only locks created for multi-stack
+// consolidation. User locks and other workflow locks are intentionally left
+// untouched.
+func unlockConsolidatingStacks(ctx *app.Context, eng engine.Engine, stacks []MultiStackInfo) {
+	branches := engine.NewBranchesBuilder(0)
+	for _, stack := range stacks {
+		for _, name := range stack.AllBranches {
+			branch := eng.GetBranch(name)
+			if branch.GetLockReason() == engine.LockReasonConsolidating {
+				branches.Add(branch)
+			}
+		}
+	}
+	if selected := branches.Build(); len(selected) > 0 {
+		if _, err := eng.SetLocked(ctx.Context, selected, engine.LockReasonNone); err != nil {
+			ctx.Output.Warn("Failed to unlock excluded multi-stack branches: %v", err)
+		}
+	}
+}
+
+func unlockExcludedMultiStackBranches(ctx *app.Context, eng engine.Engine, excluded []MultiStackExcluded) {
+	stacks := make([]MultiStackInfo, 0, len(excluded))
+	for _, item := range excluded {
+		stacks = append(stacks, item.Stack)
+	}
+	unlockConsolidatingStacks(ctx, eng, stacks)
 }
 
 // validateBranchesMatchRemote checks that all branches in the stacks match their remote.

--- a/internal/actions/merge/multistack_pr.go
+++ b/internal/actions/merge/multistack_pr.go
@@ -33,7 +33,7 @@ func NewMultiStackPRCreator(ctx *app.Context, worktreeEng engine.Engine, worktre
 
 // GenerateMultiStackBranchName creates a unique branch name for the multi-stack PR
 func GenerateMultiStackBranchName() string {
-	return fmt.Sprintf("multi-stack/%s", time.Now().Format("20060102-150405"))
+	return fmt.Sprintf("multi-stack/%s-%d", time.Now().Format("20060102-150405"), time.Now().UnixNano())
 }
 
 // CreateAndPushBranch creates a named branch at the current HEAD and pushes it
@@ -41,6 +41,11 @@ func (p *MultiStackPRCreator) CreateAndPushBranch(ctx context.Context, branchNam
 	// Create a branch at current HEAD
 	if err := p.worktreeEng.CreateBranch(ctx, branchName, "HEAD"); err != nil {
 		return fmt.Errorf("failed to create branch %s: %w", branchName, err)
+	}
+	// Utility metadata tells sync that this generated delivery branch can be
+	// safely cleaned up once the consolidation has landed.
+	if err := p.worktreeEng.SetBranchType(p.worktreeEng.GetBranch(branchName), git.BranchTypeUtility); err != nil {
+		return fmt.Errorf("mark multi-stack branch %s as utility: %w", branchName, err)
 	}
 
 	// Checkout the new branch

--- a/internal/actions/merge/multistack_worktree.go
+++ b/internal/actions/merge/multistack_worktree.go
@@ -2,6 +2,7 @@ package merge
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/getstackit/stackit/internal/engine"
@@ -84,7 +85,8 @@ func (w *MultiStackWorktreeExecutor) ExecuteInWorktree(ctx context.Context, stac
 		if err := w.tryMergeStack(ctx, session.Engine, stack); err != nil {
 			w.output.Debug("Stack %s conflicts: %v", stack.RootBranch, err)
 			if resetErr := session.ResetToRef(ctx, baseline); resetErr != nil {
-				w.output.Debug("Failed to reset worktree after conflict: %v", resetErr)
+				session.Close()
+				return nil, fmt.Errorf("failed to reset merge worktree after %s conflict: %w", stack.RootBranch, resetErr)
 			}
 			result.ConflictStacks = append(result.ConflictStacks, MultiStackExcluded{
 				Stack:  stack,
@@ -129,7 +131,7 @@ func (w *MultiStackWorktreeExecutor) tryGlobalOctopusMerge(ctx context.Context, 
 		// Abort the merge if it's in progress
 		if eng.IsMergeInProgress(ctx) {
 			if abortErr := eng.MergeAbort(ctx); abortErr != nil {
-				w.output.Debug("Failed to abort merge: %v", abortErr)
+				return fmt.Errorf("global octopus merge failed: %w", errors.Join(err, abortErr))
 			}
 		}
 		return fmt.Errorf("global octopus merge failed: %w", err)
@@ -154,7 +156,7 @@ func (w *MultiStackWorktreeExecutor) tryMergeStack(ctx context.Context, eng engi
 		// Abort the merge if it's in progress
 		if eng.IsMergeInProgress(ctx) {
 			if abortErr := eng.MergeAbort(ctx); abortErr != nil {
-				w.output.Debug("Failed to abort merge: %v", abortErr)
+				return fmt.Errorf("conflict in stack %s: %w", stack.RootBranch, errors.Join(err, abortErr))
 			}
 		}
 		return fmt.Errorf("conflict in stack %s: %w", stack.RootBranch, err)

--- a/internal/actions/merge/multistack_worktree.go
+++ b/internal/actions/merge/multistack_worktree.go
@@ -131,7 +131,7 @@ func (w *MultiStackWorktreeExecutor) tryGlobalOctopusMerge(ctx context.Context, 
 		// Abort the merge if it's in progress
 		if eng.IsMergeInProgress(ctx) {
 			if abortErr := eng.MergeAbort(ctx); abortErr != nil {
-				return fmt.Errorf("global octopus merge failed: %w", errors.Join(err, abortErr))
+				return fmt.Errorf("global octopus merge and cleanup failed: %w", errors.Join(err, fmt.Errorf("abort merge: %w", abortErr)))
 			}
 		}
 		return fmt.Errorf("global octopus merge failed: %w", err)
@@ -156,7 +156,7 @@ func (w *MultiStackWorktreeExecutor) tryMergeStack(ctx context.Context, eng engi
 		// Abort the merge if it's in progress
 		if eng.IsMergeInProgress(ctx) {
 			if abortErr := eng.MergeAbort(ctx); abortErr != nil {
-				return fmt.Errorf("conflict in stack %s: %w", stack.RootBranch, errors.Join(err, abortErr))
+				return fmt.Errorf("conflict in stack %s and cleanup failed: %w", stack.RootBranch, errors.Join(err, fmt.Errorf("abort merge: %w", abortErr)))
 			}
 		}
 		return fmt.Errorf("conflict in stack %s: %w", stack.RootBranch, err)

--- a/internal/actions/merge/worktree.go
+++ b/internal/actions/merge/worktree.go
@@ -64,7 +64,7 @@ func ExecuteInWorktree(ctx *app.Context, eng mergeExecuteEngine, opts ExecuteOpt
 	// Pull trunk in the worktree to ensure we have latest changes
 	pullResult, err := worktreeEng.PullTrunk(ctx.Context)
 	if err != nil {
-		out.Debug("Failed to pull trunk in worktree: %v", err)
+		return fmt.Errorf("failed to update trunk in merge worktree: %w", err)
 	} else if pullResult == engine.PullConflict {
 		if opts.Force {
 			out.Info("Trunk diverged from remote. Force-resetting trunk to match remote...")

--- a/internal/actions/move/move_test.go
+++ b/internal/actions/move/move_test.go
@@ -573,6 +573,13 @@ func TestMoveAction(t *testing.T) {
 		writeAndCommit(t, s, "conflict.txt", "branch2 content\n", "branch2 change")
 		s.TrackBranch("branch2", "main")
 
+		// Keep the new parent checked out elsewhere while the conflict is
+		// resolved. Continue must not treat this sibling worktree as a reason
+		// to abandon the interrupted rebase or fail its final checkout.
+		sibling := filepath.Join(t.TempDir(), "branch1-sibling")
+		s.RunGit("worktree", "add", sibling, "branch1")
+		t.Cleanup(func() { _ = s.Scene.Repo.RunGitCommand("worktree", "remove", "--force", sibling) })
+
 		// Attempt to move branch2 onto branch1 — this will conflict on conflict.txt.
 		// The interactive handler opts to proceed and resolve manually.
 		h := &interactiveTestHandler{proceed: true}

--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -69,6 +69,9 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 
 	// Get source's direct children (they will be reparented to grandparent)
 	children := graph.ChildBranches(sourceBranch)
+	if err := actions.EnsureCanModifyHere(ctx, append(engine.BranchesOf(sourceBranch, ontoBranch), children...)...); err != nil {
+		return err
+	}
 
 	// Cycle detection: ensure onto is not a descendant of source
 	if graph.IsDescendant(sourceBranch, ontoBranch) {

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -145,18 +145,12 @@ func RestackAction(ctx *app.Context, plan *RestackPlan, handler handlers.Restack
 
 	ctx.Logger.Info("restack started branchCount=%v", branchCount)
 
-	// Parallel mode dispatches each group to a worktree that recomputes its own
-	// plan, so the plan resolved here does not decide what those workers do.
+	// Restack is repository reconciliation, like sync: it may run from any
+	// worktree, but the engine holds branches whose checked-out worktree is
+	// dirty or cannot be inspected. Content-editing actions keep the ownership
+	// guard; applying it here would make unrelated main-repo stacks an
+	// all-or-nothing casualty of one managed worktree.
 	parallelDispatch := opts.Parallel && len(plan.groups) > 1
-	if !parallelDispatch {
-		branches := engine.Branches{}
-		for _, group := range plan.groups {
-			branches = branches.Concat(group.sortedBranches)
-		}
-		if err := EnsureCanModifyHere(ctx, branches...); err != nil {
-			return err
-		}
-	}
 
 	// Take snapshot before modifying the repository. Skip it when no branch
 	// actually needs a rebase: an up-to-date restack mutates nothing, so there

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -503,6 +503,11 @@ func skipDirtyWorktreeStacks(ctx *app.Context, groups []restackBranchGroup) []re
 	dirtyAnchors := make(map[string]bool)
 	if managed, err := eng.ListManagedWorktrees(); err == nil {
 		for _, wt := range managed {
+			if eng.WorktreeRebaseInProgress(ctx.Context, wt.Path) {
+				dirtyAnchors[wt.AnchorBranch] = true
+				ctx.Output.Warn("Holding stack rooted at %s (worktree %s has a rebase in progress)", wt.AnchorBranch, wt.Path)
+				continue
+			}
 			hasChanges, inspectErr := eng.WorktreeHasUncommittedChanges(ctx.Context, wt.Path)
 			if inspectErr != nil {
 				ctx.Output.Warn("Holding stack rooted at %s because worktree %s could not be inspected: %v", wt.AnchorBranch, wt.Path, inspectErr)
@@ -518,15 +523,20 @@ func skipDirtyWorktreeStacks(ctx *app.Context, groups []restackBranchGroup) []re
 		ctx.Output.Warn("Could not inspect managed worktrees; holding no known stacks: %v", err)
 	}
 
-	// Tracked changes only here: an untracked file cannot be destroyed by the
-	// reset, so it is no reason to hold a branch back.
+	// A hard reset can remove an untracked file when the incoming commit needs
+	// that pathname, so any local change must hold the branch back.
 	dirtyBranches := make(map[string]bool)
 	if worktrees, err := eng.ListWorktrees(ctx.Context); err == nil {
 		for _, wt := range worktrees {
 			if wt.Branch == "" || dirtyAnchors[wt.Branch] {
 				continue
 			}
-			hasChanges, inspectErr := eng.WorktreeHasTrackedChanges(ctx.Context, wt.Path)
+			if eng.WorktreeRebaseInProgress(ctx.Context, wt.Path) {
+				dirtyBranches[wt.Branch] = true
+				ctx.Output.Warn("Holding %s (worktree %s has a rebase in progress)", wt.Branch, wt.Path)
+				continue
+			}
+			hasChanges, inspectErr := eng.WorktreeHasUncommittedChanges(ctx.Context, wt.Path)
 			if inspectErr != nil {
 				ctx.Output.Warn("Holding %s because worktree %s could not be inspected: %v", wt.Branch, wt.Path, inspectErr)
 				dirtyBranches[wt.Branch] = true

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -503,11 +503,19 @@ func skipDirtyWorktreeStacks(ctx *app.Context, groups []restackBranchGroup) []re
 	dirtyAnchors := make(map[string]bool)
 	if managed, err := eng.ListManagedWorktrees(); err == nil {
 		for _, wt := range managed {
-			if hasChanges, _ := eng.WorktreeHasUncommittedChanges(ctx.Context, wt.Path); hasChanges {
+			hasChanges, inspectErr := eng.WorktreeHasUncommittedChanges(ctx.Context, wt.Path)
+			if inspectErr != nil {
+				ctx.Output.Warn("Holding stack rooted at %s because worktree %s could not be inspected: %v", wt.AnchorBranch, wt.Path, inspectErr)
+				dirtyAnchors[wt.AnchorBranch] = true
+				continue
+			}
+			if hasChanges {
 				dirtyAnchors[wt.AnchorBranch] = true
 				ctx.Output.Warn("Skipping stack rooted at %s (worktree %s has uncommitted changes)", wt.AnchorBranch, wt.Path)
 			}
 		}
+	} else {
+		ctx.Output.Warn("Could not inspect managed worktrees; holding no known stacks: %v", err)
 	}
 
 	// Tracked changes only here: an untracked file cannot be destroyed by the
@@ -518,11 +526,19 @@ func skipDirtyWorktreeStacks(ctx *app.Context, groups []restackBranchGroup) []re
 			if wt.Branch == "" || dirtyAnchors[wt.Branch] {
 				continue
 			}
-			if hasChanges, _ := eng.WorktreeHasTrackedChanges(ctx.Context, wt.Path); hasChanges {
+			hasChanges, inspectErr := eng.WorktreeHasTrackedChanges(ctx.Context, wt.Path)
+			if inspectErr != nil {
+				ctx.Output.Warn("Holding %s because worktree %s could not be inspected: %v", wt.Branch, wt.Path, inspectErr)
+				dirtyBranches[wt.Branch] = true
+				continue
+			}
+			if hasChanges {
 				dirtyBranches[wt.Branch] = true
 				ctx.Output.Warn("Skipping %s (worktree %s has uncommitted changes; commit or stash them, then restack again)", wt.Branch, wt.Path)
 			}
 		}
+	} else {
+		ctx.Output.Warn("Could not inspect Git worktrees; restack safety checks were incomplete: %v", err)
 	}
 
 	if len(dirtyAnchors) == 0 && len(dirtyBranches) == 0 {

--- a/internal/actions/restack_test.go
+++ b/internal/actions/restack_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/engine"
 	stackiterrors "github.com/getstackit/stackit/internal/errors"
 	"github.com/getstackit/stackit/internal/handlers"
@@ -173,6 +174,8 @@ func TestRestackAction(t *testing.T) {
 		s.CreateBranch("b")
 		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("b change", "conflict"))
 		s.TrackBranch("b", "a")
+		bBefore, err := s.Engine.GetRevision(engine.NewBranch("b", nil))
+		require.NoError(t, err)
 
 		s.Checkout("main")
 		require.NoError(t, s.Scene.Repo.CreateChangeAndCommit("main change", "conflict"))
@@ -196,6 +199,10 @@ func TestRestackAction(t *testing.T) {
 		// on b but rebase completed successfully" and left HEAD detached.
 		require.ErrorIs(t, err, stackiterrors.ErrConflictWorkflow)
 		require.True(t, s.Engine.Git().IsRebaseInProgress(context.Background()))
+
+		continuation, err := config.GetContinuationState(s.Scene.Dir)
+		require.NoError(t, err)
+		require.Equal(t, bBefore, continuation.ExpectedBranchRevision)
 
 		mainRev, err := s.Engine.GetRevision(engine.NewBranch("main", nil))
 		require.NoError(t, err)

--- a/internal/actions/split/split_file.go
+++ b/internal/actions/split/split_file.go
@@ -19,6 +19,7 @@ type splitByFileEngine interface {
 	engine.BranchReader
 	engine.BranchWriter
 	engine.StackRewriter
+	splitStashEngine
 }
 
 // splitByFileOptions contains options for the splitByFile operation
@@ -222,6 +223,10 @@ func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []s
 		_ = eng.ForceCheckoutBranch(ctx, branchToSplit)
 		return nil, fmt.Errorf("failed to stash staged changes: %w", err)
 	}
+	stashRef, err := splitStashRef(ctx, eng, stashName)
+	if err != nil {
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit, err)
+	}
 
 	// Track stash state for cleanup.
 	// Note: cleanupStash is called during error recovery, so we intentionally
@@ -230,7 +235,7 @@ func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []s
 	stashPopped := false
 	cleanupStash := func() {
 		if !stashPopped {
-			_ = eng.StashPop(ctx)
+			_ = eng.StashPopRef(ctx, stashRef)
 			stashPopped = true
 		}
 	}
@@ -278,7 +283,7 @@ func splitByFile(ctx context.Context, branchToSplit engine.Branch, pathspecs []s
 	}
 
 	// Pop the stash to get the parent branch changes
-	if err := eng.StashPop(ctx); err != nil {
+	if err := eng.StashPopRef(ctx, stashRef); err != nil {
 		return nil, fmt.Errorf("failed to pop stash: %w. Recovery: check 'git stash list' for pending stash, resolve any conflicts manually", err)
 	}
 	stashPopped = true
@@ -406,6 +411,10 @@ func splitByFileAbove(ctx context.Context, branchToSplit engine.Branch, newBranc
 		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit,
 			fmt.Errorf("failed to stash staged changes: %w", err))
 	}
+	stashRef, err := splitStashRef(ctx, eng, stashName)
+	if err != nil {
+		return nil, recoverToOriginalBranch(ctx, eng, branchToSplit, err)
+	}
 
 	// Track stash state for cleanup.
 	// Note: cleanupStash is called during error recovery, so we intentionally
@@ -414,7 +423,7 @@ func splitByFileAbove(ctx context.Context, branchToSplit engine.Branch, newBranc
 	stashPopped := false
 	cleanupStash := func() {
 		if !stashPopped {
-			_ = eng.StashPop(ctx)
+			_ = eng.StashPopRef(ctx, stashRef)
 			stashPopped = true
 		}
 	}
@@ -482,7 +491,7 @@ func splitByFileAbove(ctx context.Context, branchToSplit engine.Branch, newBranc
 	}
 
 	// Pop the stash to get the extract changes back
-	if err := eng.StashPop(ctx); err != nil {
+	if err := eng.StashPopRef(ctx, stashRef); err != nil {
 		cleanupChildBranch()
 		_ = eng.CheckoutBranch(ctx, branchToSplit)
 		return nil, fmt.Errorf("failed to pop stash: %w. Recovery: check 'git stash list' for pending stash, resolve any conflicts manually", err)

--- a/internal/actions/split/split_hunk.go
+++ b/internal/actions/split/split_hunk.go
@@ -31,6 +31,7 @@ type splitByHunkEngine interface {
 	engine.BranchWriter
 	engine.PRManager
 	engine.StackRewriter
+	splitStashEngine
 }
 
 // splitByHunkWithHandler splits a branch by interactively staging hunks using an InteractiveHandler.
@@ -402,12 +403,16 @@ func splitByHunkBelowWithPatch(ctx *app.Context, branchToSplit engine.Branch, en
 	if err != nil {
 		return fmt.Errorf("failed to stash staged changes: %w", err)
 	}
+	stashRef, err := splitStashRef(gitCtx, eng, stashName)
+	if err != nil {
+		return err
+	}
 
 	// Track stash state for cleanup
 	stashPopped := false
 	cleanupStash := func() {
 		if !stashPopped {
-			_ = eng.StashPop(gitCtx)
+			_ = eng.StashPopRef(gitCtx, stashRef)
 			stashPopped = true
 		}
 	}
@@ -439,7 +444,7 @@ func splitByHunkBelowWithPatch(ctx *app.Context, branchToSplit engine.Branch, en
 	}
 
 	// Pop the stash to get the parent branch changes
-	if err := eng.StashPop(gitCtx); err != nil {
+	if err := eng.StashPopRef(gitCtx, stashRef); err != nil {
 		return fmt.Errorf("failed to pop stash: %w. Recovery: run 'git stash pop' to restore changes", err)
 	}
 	stashPopped = true
@@ -692,12 +697,16 @@ func splitByHunkAbove(ctx *app.Context, branchToSplit engine.Branch, eng splitBy
 	if err != nil {
 		return fmt.Errorf("failed to stash staged changes: %w", err)
 	}
+	stashRef, err := splitStashRef(gitCtx, eng, stashName)
+	if err != nil {
+		return err
+	}
 
 	// Track stash state for cleanup - once stash is pushed, we need to pop it on any error
 	stashPopped := false
 	cleanupStash := func() {
 		if !stashPopped {
-			_ = eng.StashPop(gitCtx)
+			_ = eng.StashPopRef(gitCtx, stashRef)
 			stashPopped = true
 		}
 	}
@@ -743,7 +752,7 @@ func splitByHunkAbove(ctx *app.Context, branchToSplit engine.Branch, eng splitBy
 	}
 
 	// Pop the stash to get the extract changes back
-	if err := eng.StashPop(gitCtx); err != nil {
+	if err := eng.StashPopRef(gitCtx, stashRef); err != nil {
 		// Stash pop failed - this leaves the repo in a partially completed state.
 		// The original branch has been updated and the child branch exists but has no commit.
 		// Provide guidance on how to recover.

--- a/internal/actions/split/stash.go
+++ b/internal/actions/split/stash.go
@@ -1,0 +1,29 @@
+package split
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type splitStashEngine interface {
+	StashList(context.Context) (string, error)
+	StashPopRef(context.Context, string) error
+}
+
+// splitStashRef returns the exact ref created for this split operation. A
+// split must never fall back to stash@{0}: users may create another stash
+// while recovering from an error, and popping that stash loses their work.
+func splitStashRef(ctx context.Context, eng splitStashEngine, marker string) (string, error) {
+	list, err := eng.StashList(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list stashes: %w", err)
+	}
+	for line := range strings.SplitSeq(list, "\n") {
+		ref, message, ok := strings.Cut(line, ":")
+		if ok && strings.Contains(message, marker) {
+			return strings.TrimSpace(ref), nil
+		}
+	}
+	return "", fmt.Errorf("split stash %q was not found", marker)
+}

--- a/internal/actions/sync/github_sync.go
+++ b/internal/actions/sync/github_sync.go
@@ -205,13 +205,7 @@ func PushParentsToGitHub(ctx *app.Context, result *GitHubSyncResult, dirtyAnchor
 		}
 
 		// Get local parent
-		currentParent := branch.GetParent()
-		localParentName := ""
-		if currentParent == nil {
-			localParentName = eng.Trunk().GetName()
-		} else {
-			localParentName = currentParent.GetName()
-		}
+		localParentName := githubParentName(eng, branch)
 
 		if prInfo.Base == localParentName {
 			continue
@@ -255,4 +249,23 @@ func PushParentsToGitHub(ctx *app.Context, result *GitHubSyncResult, dirtyAnchor
 	return &ParentsToGitHubResult{
 		BranchesUpdated: updated,
 	}, nil
+}
+
+// githubParentName skips hidden worktree anchors: they are local bookkeeping
+// branches and can never be valid GitHub PR bases.
+func githubParentName(nav engine.StackNavigator, branch engine.Branch) string {
+	parent := branch.GetParent()
+	visited := make(map[string]bool)
+	for parent != nil {
+		name := parent.GetName()
+		if visited[name] {
+			break
+		}
+		visited[name] = true
+		if !parent.IsWorktreeAnchor() {
+			return name
+		}
+		parent = parent.GetParent()
+	}
+	return nav.Trunk().GetName()
 }

--- a/internal/actions/sync/worktree_cleanup.go
+++ b/internal/actions/sync/worktree_cleanup.go
@@ -7,6 +7,7 @@ import (
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/config"
 	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 // WorktreeCleanupResult contains the results of worktree cleanup
@@ -59,6 +60,14 @@ func cleanOrphanedWorktrees(ctx *app.Context, dirtyAnchors dirtyAnchorSet) *Work
 
 	// Check each anchored worktree and remove it once it is clean and empty.
 	for _, wt := range worktrees {
+		// The main worktree is never disposable, even if an invalid
+		// registration makes it look like an empty managed worktree. Skipping
+		// this candidate lets cleanup continue for the rest of the batch.
+		if git.IsMainWorktree(wt.Path, wt.MainRepoDir) {
+			ctx.Output.Debug("Skipping cleanup for main worktree %s", wt.Path)
+			continue
+		}
+
 		// Skip dirty worktrees - don't clean up while there are uncommitted changes
 		if dirtyAnchors[wt.AnchorBranch] {
 			continue
@@ -96,10 +105,13 @@ func cleanOrphanedWorktrees(ctx *app.Context, dirtyAnchors dirtyAnchorSet) *Work
 			continue
 		}
 
-		if unregErr := ctx.Engine.UnregisterWorktree(ctx.Context, wt.AnchorBranch); unregErr != nil {
+		// Removing a directory can leave Git's administrative worktree entry
+		// behind. Prune it before deleting the anchor; an anchor deleted first
+		// is not recoverable from a later unregister failure.
+		if pruneErr := ctx.Engine.PruneWorktrees(ctx.Context); pruneErr != nil {
 			result.Errors = append(result.Errors,
-				"failed to unregister worktree for "+wt.AnchorBranch+": "+unregErr.Error())
-			ctx.Output.Debug("Failed to unregister worktree for %s: %v", wt.AnchorBranch, unregErr)
+				"failed to prune stale worktree entries for "+wt.AnchorBranch+": "+pruneErr.Error())
+			ctx.Output.Debug("Failed to prune stale worktree entries for %s: %v", wt.AnchorBranch, pruneErr)
 			continue
 		}
 
@@ -110,6 +122,13 @@ func cleanOrphanedWorktrees(ctx *app.Context, dirtyAnchors dirtyAnchorSet) *Work
 				ctx.Output.Debug("Failed to delete anchor branch %s: %v", wt.AnchorBranch, deleteErr)
 				continue
 			}
+		}
+
+		if unregErr := ctx.Engine.UnregisterWorktree(ctx.Context, wt.AnchorBranch); unregErr != nil {
+			result.Errors = append(result.Errors,
+				"failed to unregister worktree for "+wt.AnchorBranch+": "+unregErr.Error())
+			ctx.Output.Debug("Failed to unregister worktree for %s: %v", wt.AnchorBranch, unregErr)
+			continue
 		}
 		result.RemovedWorktrees = append(result.RemovedWorktrees, wt.AnchorBranch)
 	}

--- a/internal/actions/tree.go
+++ b/internal/actions/tree.go
@@ -386,8 +386,10 @@ func BuildTreeJSON(ctx *app.Context, opts TreeOptions) TreeJSONResult {
 				NeedsRestack: !statuses.IsUpToDate(branch) && !branch.IsTrunk(),
 			}
 
-			// Parent
-			if parent := branch.GetParent(); parent != nil {
+			// Worktree anchors are an implementation detail. JSON consumers only
+			// receive visible branches, so walk past anchors to avoid emitting a
+			// parent that does not exist in the result.
+			if parent := visibleTreeParent(branch); parent != nil {
 				info.Parent = parent.GetName()
 			}
 
@@ -397,11 +399,8 @@ func BuildTreeJSON(ctx *app.Context, opts TreeOptions) TreeJSONResult {
 			}
 
 			// Children
-			children := graph.ChildBranches(branch)
-			for _, child := range children {
-				if !child.IsWorktreeAnchor() {
-					info.Children = append(info.Children, child.GetName())
-				}
+			for _, child := range visibleTreeChildren(graph, branch) {
+				info.Children = append(info.Children, child.GetName())
 			}
 
 			// Commits and diff stats from the batched stats resolved above.
@@ -474,4 +473,28 @@ func BuildTreeJSON(ctx *app.Context, opts TreeOptions) TreeJSONResult {
 	})
 
 	return result
+}
+
+func visibleTreeParent(branch engine.Branch) *engine.Branch {
+	parent := branch.GetParent()
+	for parent != nil && parent.IsWorktreeAnchor() {
+		parent = parent.GetParent()
+	}
+	return parent
+}
+
+func visibleTreeChildren(graph *engine.StackGraph, branch engine.Branch) engine.Branches {
+	children := engine.NewBranchesBuilder(0)
+	var collect func(engine.Branch)
+	collect = func(parent engine.Branch) {
+		for _, child := range graph.ChildBranches(parent) {
+			if child.IsWorktreeAnchor() {
+				collect(child)
+				continue
+			}
+			children.Add(child)
+		}
+	}
+	collect(branch)
+	return children.Build()
 }

--- a/internal/actions/tree_test.go
+++ b/internal/actions/tree_test.go
@@ -1,0 +1,31 @@
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+func TestBuildTreeJSONHidesAnchorParents(t *testing.T) {
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.CreateBranch("anchor").Commit("anchor")
+	s.TrackBranch("anchor", "main")
+	require.NoError(t, s.Engine.SetBranchType(s.Engine.GetBranch("anchor"), git.BranchTypeWorktreeAnchor))
+	s.CreateBranch("feature").Commit("feature")
+	s.TrackBranch("feature", "anchor")
+
+	result := BuildTreeJSON(s.Context, TreeOptions{})
+	info := make(map[string]TreeBranchInfo, len(result.Branches))
+	for _, branch := range result.Branches {
+		info[branch.Name] = branch
+	}
+
+	_, anchorPresent := info["anchor"]
+	require.False(t, anchorPresent)
+	require.Equal(t, "main", info["feature"].Parent)
+	require.Contains(t, info["main"].Children, "feature")
+}

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -119,7 +119,7 @@ func RemoveAction(ctx *app.Context, opts RemoveOptions) error {
 	if err != nil {
 		return err
 	}
-	if entry.NeedsRepair && (entry.RegistrationState != RegistrationStateInvalid || entry.Exists) {
+	if entry.NeedsRepair && (entry.RegistrationState != RegistrationStateInvalid || !entry.CanRemove) {
 		return fmt.Errorf("managed worktree %s cannot be removed because %s; %s", output.BranchName(entry.displayName()), output.Dim(entry.StatusMessage), repairHint(entry))
 	}
 	if entry.IsCurrent {
@@ -562,10 +562,6 @@ func PruneAction(ctx *app.Context, opts PruneOptions) (*PruneResult, error) {
 		// Clean up missing worktrees (directory deleted but registration remains)
 		if !wt.Exists {
 			if wt.NeedsRepair {
-				if opts.DryRun && wt.CanRemove {
-					result.Pruned = append(result.Pruned, name)
-					continue
-				}
 				result.Skipped = append(result.Skipped, SkippedEntry{
 					Name:   name,
 					Reason: wt.StatusMessage + "; " + repairHint(&wt),
@@ -799,7 +795,10 @@ func DetachAction(ctx *app.Context, opts DetachOptions) error {
 	if err != nil {
 		return err
 	}
-	if entry.NeedsRepair {
+	if entry.NeedsRepair && entry.RegistrationState != RegistrationStateInvalid {
+		return fmt.Errorf("managed worktree %s cannot be detached because %s; %s", output.BranchName(entry.displayName()), output.Dim(entry.StatusMessage), repairHint(entry))
+	}
+	if entry.NeedsRepair && !entry.CanDetach {
 		return fmt.Errorf("managed worktree %s cannot be detached because %s; %s", output.BranchName(entry.displayName()), output.Dim(entry.StatusMessage), repairHint(entry))
 	}
 
@@ -817,6 +816,23 @@ func DetachAction(ctx *app.Context, opts DetachOptions) error {
 	snapshot, err := snapshotWorktree(ctx, entry)
 	if err != nil {
 		return err
+	}
+	// An invalid registration cannot be reparented or repaired automatically
+	// when its checkout is detached or untracked. Detach still has a useful,
+	// safe meaning: remove the physical worktree and its stale registry entry.
+	if entry.NeedsRepair {
+		if entry.Exists {
+			if err := removeWorktreePath(ctx, entry.Path, opts.Force); err != nil {
+				return fmt.Errorf("failed to remove worktree at %s: %w", entry.Path, err)
+			}
+		} else if err := ctx.Engine.PruneWorktrees(ctx.Context); err != nil {
+			return fmt.Errorf("failed to prune stale worktree entries: %w", err)
+		}
+		if err := ctx.Engine.UnregisterWorktree(ctx.Context, entry.AnchorBranch); err != nil {
+			return fmt.Errorf("failed to unregister invalid worktree: %w", err)
+		}
+		out.Success("Detached invalid worktree %s", output.BranchName(entry.displayName()))
+		return nil
 	}
 
 	pathRemoved := false

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -510,6 +510,10 @@ func worktreePathForName(repoRoot string, name string) string {
 	if basePath == "" {
 		repoName := filepath.Base(repoRoot)
 		basePath = filepath.Join(filepath.Dir(repoRoot), repoName+"-stacks")
+	} else if !filepath.IsAbs(basePath) {
+		// Configuration lives with the repository, so relative worktree bases
+		// must not depend on the directory from which stackit was invoked.
+		basePath = filepath.Join(repoRoot, basePath)
 	}
 
 	return filepath.Join(basePath, name)

--- a/internal/actions/worktree/entry.go
+++ b/internal/actions/worktree/entry.go
@@ -139,6 +139,7 @@ func inspectWorktreeEntry(ctx *app.Context, wt engine.WorktreeInfo, graph *engin
 	default:
 		entry.NeedsRepair = true
 		entry.StatusMessage = "registered anchor branch is missing"
+		entry.CanDetach = !entry.IsCurrent
 
 		if entry.CurrentBranch != "" {
 			currentBranch := ctx.Engine.GetBranch(entry.CurrentBranch)
@@ -152,8 +153,15 @@ func inspectWorktreeEntry(ctx *app.Context, wt engine.WorktreeInfo, graph *engin
 			}
 		}
 
-		if !entry.Exists {
+		switch {
+		case !entry.Exists:
 			entry.StatusMessage = "registration is stale and the directory is missing"
+			entry.CanRemove = !entry.IsCurrent
+		case entry.CurrentBranch == "":
+			entry.StatusMessage = "registration is invalid and worktree is detached"
+			entry.CanRemove = !entry.IsCurrent
+		case len(entry.RootBranches) == 0:
+			entry.StatusMessage = "registration is invalid and worktree branch is untracked"
 			entry.CanRemove = !entry.IsCurrent
 		}
 	}

--- a/internal/actions/worktree/repair.go
+++ b/internal/actions/worktree/repair.go
@@ -25,6 +25,11 @@ type RepairResult struct {
 }
 
 func RepairAction(ctx *app.Context, opts RepairOptions) (*RepairResult, error) {
+	if count, err := ctx.Engine.PruneOrphanedWorktreePathRefs(ctx.Context); err != nil {
+		return nil, err
+	} else if count > 0 {
+		ctx.Output.Info("Removed %d orphaned worktree path registration(s)", count)
+	}
 	listResult, err := listEntries(ctx, ListOptions(opts))
 	if err != nil {
 		return nil, err

--- a/internal/actions/worktree/repair.go
+++ b/internal/actions/worktree/repair.go
@@ -95,12 +95,18 @@ func repairEntry(ctx *app.Context, entry Entry) (RepairEntry, error) {
 		}
 
 		if entry.CurrentBranch == "" {
-			return RepairEntry{}, fmt.Errorf("cannot repair %s automatically because the worktree has no branch checked out", output.BranchName(entry.displayName()))
+			if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
+				return RepairEntry{}, fmt.Errorf("failed to remove detached invalid registration: %w", err)
+			}
+			return RepairEntry{Name: entry.displayName(), Action: "removed invalid detached registration"}, nil
 		}
 
 		currentBranch := ctx.Engine.GetBranch(entry.CurrentBranch)
 		if !currentBranch.IsTracked() {
-			return RepairEntry{}, fmt.Errorf("cannot repair %s automatically because %s is not tracked by stackit", output.BranchName(entry.displayName()), output.BranchName(entry.CurrentBranch))
+			if err := ctx.Engine.UnregisterWorktree(ctx.Context, wtInfo.AnchorBranch); err != nil {
+				return RepairEntry{}, fmt.Errorf("failed to remove untracked invalid registration: %w", err)
+			}
+			return RepairEntry{Name: entry.displayName(), Action: "removed invalid untracked registration"}, nil
 		}
 
 		stackRootName := ctx.Engine.GetStackRootForBranch(currentBranch)

--- a/internal/cli/common/directives.go
+++ b/internal/cli/common/directives.go
@@ -34,8 +34,11 @@ func HandleCheckoutResult(out output.Output, result actions.CheckoutResult) bool
 	return false
 }
 
-// CompleteCheckout handles a CheckoutAction result, including the fallback
-// checkout path when shell integration cannot switch worktrees for the caller.
+// CompleteCheckout handles a CheckoutAction result, including a worktree switch
+// when shell integration is available. Without shell integration, retain the
+// regular-checkout fallback only when the target is not already checked out in
+// another worktree; Git permits a branch to be checked out by only one
+// worktree at a time.
 func CompleteCheckout(ctx *app.Context, result actions.CheckoutResult, fallbackOpts actions.CheckoutOptions, handler actions.CheckoutHandler) error {
 	if HandleCheckoutResult(ctx.Output, result) {
 		return nil
@@ -44,15 +47,20 @@ func CompleteCheckout(ctx *app.Context, result actions.CheckoutResult, fallbackO
 		return nil
 	}
 
+	worktrees, err := ctx.Engine.ListWorktrees(ctx.Context)
+	if err == nil && worktrees.PathForBranch(result.TargetBranch) != "" {
+		return nil
+	}
+
 	if !fallbackOpts.CheckoutTrunk {
 		fallbackOpts.BranchName = result.TargetBranch
 	}
 	fallbackOpts.SkipWorktreeSwitch = true
-	_, err := actions.CheckoutAction(ctx, fallbackOpts, handler)
+	_, err = actions.CheckoutAction(ctx, fallbackOpts, handler)
 	return err
 }
 
-// Checkout runs CheckoutAction and completes any worktree-switch fallback.
+// Checkout runs CheckoutAction and completes any worktree switch.
 func Checkout(ctx *app.Context, opts actions.CheckoutOptions, handler actions.CheckoutHandler) (actions.CheckoutResult, error) {
 	result, err := actions.CheckoutAction(ctx, opts, handler)
 	if err != nil {

--- a/internal/config/continuation.go
+++ b/internal/config/continuation.go
@@ -15,6 +15,10 @@ type ContinuationState struct {
 	BranchesToSync        []string `json:"branchesToSync,omitempty"` // For future sync command
 	CurrentBranchOverride string   `json:"currentBranchOverride,omitempty"`
 	RebasedBranchBase     string   `json:"rebasedBranchBase,omitempty"`
+	// ExpectedBranchRevision is the branch tip before a conflict-driven rebase.
+	// Continue uses it as a compare-and-swap guard so it cannot overwrite work
+	// that another worktree added while the conflict was being resolved.
+	ExpectedBranchRevision string `json:"expectedBranchRevision,omitempty"`
 	// ReturnToBranch is the branch the interrupted command should leave the
 	// user on once the conflict workflow finishes, when that differs from the
 	// branch being rebased. `modify --into` sets it: it amends a downstack

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -151,6 +151,10 @@ func (d *demoGitRunner) UpdateBranchRef(_ context.Context, _, _ string) error {
 	return nil
 }
 
+func (d *demoGitRunner) UpdateBranchRefCAS(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
 func (d *demoGitRunner) GetRemoteRevision(_ string) (string, error) {
 	return "remote-rev", nil
 }

--- a/internal/engine/branch_mutations.go
+++ b/internal/engine/branch_mutations.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/getstackit/stackit/internal/git"
 )
@@ -342,16 +341,6 @@ func (e *engineImpl) DeleteBranches(ctx context.Context, branches Branches) ([]s
 func (e *engineImpl) CheckoutBranch(ctx context.Context, branch Branch) error {
 	branchName := branch.GetName()
 	if err := e.git.CheckoutBranch(ctx, branchName); err != nil {
-		// If it's already used by another worktree, try checking out detached
-		if branchCheckedOutInAnotherWorktree(err) {
-			if err := e.git.CheckoutDetached(ctx, branchName); err != nil {
-				return err
-			}
-			e.mu.Lock()
-			e.currentBranch = "" // Detached HEAD
-			e.mu.Unlock()
-			return nil
-		}
 		return err
 	}
 
@@ -359,15 +348,6 @@ func (e *engineImpl) CheckoutBranch(ctx context.Context, branch Branch) error {
 	e.currentBranch = branchName
 	e.mu.Unlock()
 	return nil
-}
-
-func branchCheckedOutInAnotherWorktree(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "already used by worktree") ||
-		strings.Contains(msg, "is already checked out")
 }
 
 // UpdateBranchRef updates a branch reference to point to a new revision

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -50,7 +50,7 @@ type SyncManager interface {
 	RestackBranchesWithProgress(ctx context.Context, branches Branches, progress RestackBranchProgressFunc) (RestackBatchResult, error)
 	RestackBranchesWithValidatedRebases(ctx context.Context, branches Branches, validation *RebaseValidation, progress RestackBranchProgressFunc) (RestackBatchResult, error)
 	RestackBranchesWithValidatedPlan(ctx context.Context, branches Branches, validation *RebaseValidation, plan *RestackPlan, progress RestackBranchProgressFunc) (RestackBatchResult, error)
-	ContinueRebase(ctx context.Context, branchName string, rebasedBranchBase string) (ContinueRebaseResult, error)
+	ContinueRebase(ctx context.Context, branchName string, rebasedBranchBase string, expectedBranchRevision string) (ContinueRebaseResult, error)
 	Rebase(ctx context.Context, branchName, upstream, oldUpstream string) (RestackResult, error)
 
 	// Validation

--- a/internal/engine/engine_absorb.go
+++ b/internal/engine/engine_absorb.go
@@ -17,6 +17,24 @@ func (e *engineImpl) ApplyHunksToBranch(ctx context.Context, branch Branch, hunk
 	}
 
 	branchName := branch.GetName()
+	oldTip, err := branch.GetRevision()
+	if err != nil {
+		return fmt.Errorf("failed to get branch revision for %s: %w", branchName, err)
+	}
+	worktrees, err := e.git.ListWorktrees(ctx)
+	if err != nil {
+		return fmt.Errorf("refusing to rewrite %s: cannot inspect worktrees: %w", branchName, err)
+	}
+	worktreePath := worktrees.PathForBranch(branchName)
+	if worktreePath != "" {
+		dirty, statusErr := e.git.WorktreeHasUncommittedChanges(ctx, worktreePath)
+		if statusErr != nil {
+			return fmt.Errorf("refusing to rewrite %s: cannot inspect worktree %s: %w", branchName, worktreePath, statusErr)
+		}
+		if dirty {
+			return fmt.Errorf("refusing to rewrite %s: worktree %s has uncommitted changes", branchName, worktreePath)
+		}
+	}
 
 	// Save current state to restore later
 	originalRef, _ := e.git.GetCurrentBranchOrSHA(ctx)
@@ -143,8 +161,13 @@ func (e *engineImpl) ApplyHunksToBranch(ctx context.Context, branch Branch, hunk
 	newTip = strings.TrimSpace(newTip)
 
 	// Update branch to point to new tip
-	if err := e.git.UpdateBranchRef(ctx, branchName, newTip); err != nil {
+	if err := e.git.UpdateBranchRefCAS(ctx, branchName, newTip, oldTip); err != nil {
 		return fmt.Errorf("failed to update branch %s: %w", branchName, err)
+	}
+	if worktreePath != "" {
+		if err := e.git.ResetWorktreeWorkingDir(ctx, worktreePath); err != nil {
+			return fmt.Errorf("updated %s but failed to reset clean worktree %s: %w", branchName, worktreePath, err)
+		}
 	}
 
 	return nil

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -262,7 +262,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 }
 
 // ContinueRebase continues an in-progress rebase
-func (e *engineImpl) ContinueRebase(ctx context.Context, branchName string, rebasedBranchBase string) (ContinueRebaseResult, error) {
+func (e *engineImpl) ContinueRebase(ctx context.Context, branchName string, rebasedBranchBase string, expectedBranchRevision string) (ContinueRebaseResult, error) {
 	// Call git rebase --continue
 	result, err := e.git.RebaseContinue(ctx)
 	if err != nil {
@@ -280,7 +280,13 @@ func (e *engineImpl) ContinueRebase(ctx context.Context, branchName string, reba
 	}
 
 	// Update the branch reference to the new rebased commit
-	err = e.git.UpdateBranchRef(ctx, branchName, newRev)
+	if expectedBranchRevision == "" {
+		expectedBranchRevision, err = e.git.GetRevision(branchName)
+		if err != nil {
+			return ContinueRebaseResult{BranchName: branchName}, fmt.Errorf("failed to get expected branch revision for %s: %w", branchName, err)
+		}
+	}
+	err = e.git.UpdateBranchRefCAS(ctx, branchName, newRev, expectedBranchRevision)
 	if err != nil {
 		return ContinueRebaseResult{BranchName: branchName}, fmt.Errorf("failed to update branch reference %s: %w", branchName, err)
 	}

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -115,6 +115,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 	// check; the snapshot is stable across the restack loop since we don't
 	// add or remove worktrees here.
 	worktrees, err := e.git.ListWorktrees(ctx)
+	worktreeInspectionFailed := err != nil
 	if err != nil {
 		worktrees = git.WorktreeList{}
 	}
@@ -127,16 +128,19 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 	// when the user actually had uncommitted work. Bounded by worktree count,
 	// not branch count, so this stays a handful of calls even for a large stack.
 	//
-	// Tracked changes only, deliberately. This gates a `git reset --hard`, which
-	// cannot touch untracked files — so counting them would suppress a reset
-	// that was never a threat to them, leaving the worktree holding the old
-	// commit's content while its branch ref has moved. `git status` then reports
-	// the new commit's files as deleted, and the next `stackit modify -a`
-	// commits that deletion into the stack.
+	// Capture every local change. `git reset --hard` can delete an untracked
+	// file when the incoming commit needs that pathname, so excluding untracked
+	// files would risk user data loss.
 	dirtyWorktrees := make(map[string]bool, len(worktrees))
-	for _, path := range worktrees.Paths() {
-		if dirty, dirtyErr := e.git.WorktreeHasTrackedChanges(ctx, path); dirtyErr == nil && dirty {
+	heldBranches := make(BranchNameSet)
+	for _, worktree := range worktrees {
+		dirty, dirtyErr := e.git.WorktreeHasUncommittedChanges(ctx, worktree.Path)
+		if dirtyErr != nil || dirty {
+			path := worktree.Path
 			dirtyWorktrees[path] = true
+			if worktree.Branch != "" {
+				heldBranches[worktree.Branch] = true
+			}
 		}
 	}
 
@@ -152,7 +156,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 			metaRefSHAs[strings.TrimPrefix(refName, git.MetadataRefPrefix)] = sha
 		}
 	}
-	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees}
+	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees, heldBranches: heldBranches, worktreeInspectionFailed: worktreeInspectionFailed}
 
 	// 2. Apply the restack changes
 	results := make(map[string]RestackBranchResult)

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -67,6 +67,11 @@ func (e *engineImpl) WorktreeHasTrackedChanges(ctx context.Context, worktreePath
 	return e.git.WorktreeHasTrackedChanges(ctx, worktreePath)
 }
 
+// WorktreeRebaseInProgress checks the target worktree's own git directory.
+func (e *engineImpl) WorktreeRebaseInProgress(ctx context.Context, worktreePath string) bool {
+	return git.NewRunnerWithPath(worktreePath, nil).IsRebaseInProgress(ctx)
+}
+
 // ListIgnoredFiles returns every ignored, untracked file in a worktree.
 func (e *engineImpl) ListIgnoredFiles(ctx context.Context, worktreePath string) ([]string, error) {
 	return e.git.ListIgnoredFiles(ctx, worktreePath)

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -212,7 +212,7 @@ func (e *engineImpl) RegisterWorktreeWithName(anchorBranch string, path string, 
 	if err != nil {
 		return fmt.Errorf("failed to get absolute worktree path: %w", err)
 	}
-	canonicalPath, err := canonicalWorktreePath(absPath)
+	canonicalPath, err := git.CanonicalWorktreePath(absPath)
 	if err != nil {
 		return fmt.Errorf("failed to canonicalize worktree path: %w", err)
 	}
@@ -228,7 +228,7 @@ func (e *engineImpl) RegisterWorktreeWithName(anchorBranch string, path string, 
 		return fmt.Errorf("failed to list worktree registrations: %w", err)
 	}
 	for _, worktree := range worktrees {
-		worktreePath, pathErr := canonicalWorktreePath(worktree.Path)
+		worktreePath, pathErr := git.CanonicalWorktreePath(worktree.Path)
 		if pathErr != nil {
 			return fmt.Errorf("failed to canonicalize registered worktree path %s: %w", worktree.Path, pathErr)
 		}
@@ -246,21 +246,6 @@ func (e *engineImpl) RegisterWorktreeWithName(anchorBranch string, path string, 
 	}
 
 	return e.git.WriteWorktreeMeta(anchorBranch, meta)
-}
-
-func canonicalWorktreePath(path string) (string, error) {
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return "", err
-	}
-	resolvedPath, err := filepath.EvalSymlinks(absPath)
-	if err == nil {
-		return filepath.Clean(resolvedPath), nil
-	}
-	if !os.IsNotExist(err) {
-		return "", err
-	}
-	return filepath.Clean(absPath), nil
 }
 
 // UnregisterWorktree removes worktree registration for a stack root
@@ -407,19 +392,23 @@ func (e *engineImpl) IsInManagedWorktree() (bool, *WorktreeInfo, error) {
 		return false, nil, fmt.Errorf("failed to get absolute path: %w", err)
 	}
 
-	// List all managed worktrees and check if current path matches
+	canonicalCurrentPath, err := git.CanonicalWorktreePath(currentPath)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to canonicalize current worktree path: %w", err)
+	}
+
+	// List all managed worktrees and check if current path matches.
 	worktrees, err := e.ListManagedWorktrees()
 	if err != nil {
 		return false, nil, fmt.Errorf("failed to list managed worktrees: %w", err)
 	}
 
 	for _, wt := range worktrees {
-		// Compare paths (normalize both)
-		wtPath, err := filepath.Abs(wt.Path)
+		wtPath, err := git.CanonicalWorktreePath(wt.Path)
 		if err != nil {
 			continue
 		}
-		if wtPath == currentPath {
+		if wtPath == canonicalCurrentPath {
 			return true, &WorktreeInfo{
 				Name:         wt.Name,
 				Path:         wt.Path,

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -367,7 +367,10 @@ func (e *engineImpl) GetStackRootForBranch(branch Branch) string {
 
 	current := branchName
 	visited := make(map[string]bool)
-	for {
+	// Metadata should be acyclic, but cap the walk as a second line of
+	// defense against malformed or concurrently changing parent metadata.
+	maxSteps := e.BranchNames().Len() + 1
+	for range maxSteps {
 		if visited[current] {
 			return ""
 		}
@@ -395,6 +398,7 @@ func (e *engineImpl) GetStackRootForBranch(branch Branch) string {
 
 		current = parent
 	}
+	return ""
 }
 
 // IsInManagedWorktree checks if the current directory is a stackit-managed worktree.

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -88,6 +88,36 @@ func (e *engineImpl) PruneWorktrees(ctx context.Context) error {
 	return nil
 }
 
+// PruneOrphanedWorktreePathRefs removes reverse worktree path claims with no
+// matching forward registration, left behind by interrupted legacy cleanup.
+func (e *engineImpl) PruneOrphanedWorktreePathRefs(ctx context.Context) (int, error) {
+	forward, err := e.git.ListRefs(git.WorktreeRefPrefix)
+	if err != nil {
+		return 0, fmt.Errorf("list worktree registrations: %w", err)
+	}
+	pathRefs, err := e.git.ListRefs(git.WorktreePathRefPrefix)
+	if err != nil {
+		return 0, fmt.Errorf("list worktree path registrations: %w", err)
+	}
+	forwardSHAs := make(map[string]bool, len(forward))
+	for _, sha := range forward {
+		forwardSHAs[sha] = true
+	}
+	orphaned := make([]string, 0)
+	for ref, sha := range pathRefs {
+		if !forwardSHAs[sha] {
+			orphaned = append(orphaned, ref)
+		}
+	}
+	if len(orphaned) == 0 {
+		return 0, nil
+	}
+	if err := e.git.DeleteRefsBatch(ctx, orphaned); err != nil {
+		return 0, fmt.Errorf("delete orphaned worktree path registrations: %w", err)
+	}
+	return len(orphaned), nil
+}
+
 // CreateTemporaryWorktree creates a temporary directory and adds a detached worktree
 func (e *engineImpl) CreateTemporaryWorktree(ctx context.Context, branch string, prefix string) (string, func(), error) {
 	return e.CreateTemporaryWorktreeWithOptions(ctx, branch, prefix, WorktreeCheckoutFull, WorktreePruneAuto)

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -283,6 +283,8 @@ type WorktreeOperations interface {
 	GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error)
 	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)
 	WorktreeHasTrackedChanges(ctx context.Context, worktreePath string) (bool, error)
+	// WorktreeRebaseInProgress reports whether a rebase is active in worktreePath.
+	WorktreeRebaseInProgress(ctx context.Context, worktreePath string) bool
 	ListIgnoredFiles(ctx context.Context, worktreePath string) ([]string, error)
 	CreateTemporaryWorktree(ctx context.Context, branch string, prefix string) (path string, cleanup func(), err error)
 	// CreateTemporaryWorktreeSkipPrune is like CreateTemporaryWorktree but skips the automatic

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -290,6 +290,8 @@ type WorktreeOperations interface {
 	// manually calling PruneWorktrees() once, to avoid race conditions.
 	CreateTemporaryWorktreeSkipPrune(ctx context.Context, branch string, prefix string) (path string, cleanup func(), err error)
 	PruneWorktrees(ctx context.Context) error
+	// PruneOrphanedWorktreePathRefs removes stale reverse registration refs.
+	PruneOrphanedWorktreePathRefs(ctx context.Context) (int, error)
 }
 
 // WorktreeInfo represents information about a stackit-managed worktree

--- a/internal/engine/pull.go
+++ b/internal/engine/pull.go
@@ -114,27 +114,45 @@ func (e *engineImpl) ResetTrunkToRemote(ctx context.Context) error {
 		return fmt.Errorf("failed to get remote SHA: %w", err)
 	}
 
-	// Checkout trunk
-	trunkBranch := e.Trunk()
-	if err := e.CheckoutBranch(ctx, trunkBranch); err != nil {
-		return fmt.Errorf("failed to checkout trunk: %w", err)
+	oldTrunk, err := e.git.GetRevision(trunk)
+	if err != nil {
+		return fmt.Errorf("failed to get local trunk revision: %w", err)
 	}
-
-	// Hard reset to remote
-	if err := e.git.HardReset(ctx, remoteSha); err != nil {
-		// Try to switch back
-		if currentBranch != "" {
-			currentBranchObj := e.GetBranch(currentBranch)
-			_ = e.CheckoutBranch(ctx, currentBranchObj)
+	worktrees, err := e.git.ListWorktrees(ctx)
+	if err != nil {
+		return fmt.Errorf("refusing to reset trunk: cannot inspect worktrees: %w", err)
+	}
+	trunkWorktree := worktrees.PathForBranch(trunk)
+	if trunkWorktree != "" {
+		dirty, statusErr := e.git.WorktreeHasUncommittedChanges(ctx, trunkWorktree)
+		if statusErr != nil {
+			return fmt.Errorf("refusing to reset trunk: cannot inspect worktree %s: %w", trunkWorktree, statusErr)
 		}
-		return fmt.Errorf("failed to reset trunk: %w", err)
+		if dirty {
+			return fmt.Errorf("refusing to reset trunk: worktree %s has uncommitted changes", trunkWorktree)
+		}
 	}
 
-	// Switch back to original branch
-	if currentBranch != "" && currentBranch != trunk {
-		currentBranchObj := e.GetBranch(currentBranch)
-		if err := e.CheckoutBranch(ctx, currentBranchObj); err != nil {
-			return fmt.Errorf("failed to switch back: %w", err)
+	// Never check out the shared trunk in an analysis worktree. Move the ref
+	// with a CAS, then synchronize its clean holder; if this engine is itself
+	// detached, advance only its detached HEAD to the same remote revision.
+	if err := e.git.UpdateBranchRefCAS(ctx, trunk, remoteSha, oldTrunk); err != nil {
+		return fmt.Errorf("failed to reset trunk ref: %w", err)
+	}
+	if currentBranch == trunk {
+		if err := e.git.HardReset(ctx, "HEAD"); err != nil {
+			return fmt.Errorf("reset trunk ref but failed to reset current worktree: %w", err)
+		}
+	} else {
+		if trunkWorktree != "" {
+			if err := e.git.ResetWorktreeWorkingDir(ctx, trunkWorktree); err != nil {
+				return fmt.Errorf("reset trunk ref but failed to reset clean worktree %s: %w", trunkWorktree, err)
+			}
+		}
+		if currentBranch == "" {
+			if err := e.git.HardReset(ctx, remoteSha); err != nil {
+				return fmt.Errorf("reset trunk ref but failed to advance detached worktree: %w", err)
+			}
 		}
 	}
 

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -15,7 +15,7 @@ const (
 )
 
 // resetWorktreeIfClean resets a worktree's working directory to match its
-// branch ref's new content, unless the worktree had changes to TRACKED files
+// branch ref's new content, unless the worktree had local changes
 // before this restack pass touched anything. dirtyWorktrees is captured once
 // up front (see restackSnapshot.dirtyWorktrees) rather than checked here,
 // because by the time any branch's reset runs, restack has already moved that
@@ -24,11 +24,7 @@ const (
 // dirty, silently disabling the reset for every branch, not just genuinely
 // dirty ones.
 //
-// Untracked files must not count: `git reset --hard` cannot destroy them, so
-// treating them as dirty suppresses a reset that was never a threat and leaves
-// the worktree holding the old commit's content under a moved ref.
-//
-// Skipping the reset on a worktree with real tracked changes leaves it out of
+// Skipping the reset on a worktree with changes leaves it out of
 // sync with its ref rather than discarding the user's work. That state is still
 // a footgun — `git status` shows the new commit's files as deleted — so callers
 // should avoid moving the ref at all in that case; see skipDirtyWorktreeStacks.

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -695,6 +695,12 @@ func (e *engineImpl) applyMetadataRefresh(
 	snap *restackSnapshot,
 ) (RestackBranchResult, error) {
 	branchName := branch.GetName()
+	// Metadata records the parent SHA consumed by later planning, so advancing
+	// it past a held parent would create the same phantom-parent state as a ref
+	// move. A held branch and every descendant must remain completely unchanged.
+	if e.branchHeldBack(branch, snap) {
+		return RestackBranchResult{Result: RestackUnneeded, RebasedBranchBase: item.ParentRev}, nil
+	}
 	meta := snap.meta.Get(branchName)
 	if meta == nil {
 		var err error

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -56,10 +56,37 @@ type restackSnapshot struct {
 	worktrees   git.WorktreeList
 	metaRefSHAs map[string]string
 	// dirtyWorktrees records, per worktree path, whether it had changes to
-	// tracked files before this restack pass began. Untracked files are
-	// deliberately excluded — see resetWorktreeIfClean for why, and for why this
-	// can't be checked lazily.
+	// local changes before this restack pass began. This cannot be checked
+	// lazily; see resetWorktreeIfClean for why.
 	dirtyWorktrees map[string]bool
+	// heldBranches contains every branch whose checked-out worktree was dirty
+	// or could not be inspected before this pass. Descendants of these branches
+	// must be held too: a validated child may otherwise be built on the target
+	// SHA of a parent that was ultimately not allowed to move.
+	heldBranches BranchNameSet
+	// worktreeInspectionFailed means the physical checkout map is unknown, so
+	// no ref move is safe for this pass.
+	worktreeInspectionFailed bool
+}
+
+func (e *engineImpl) branchHeldBack(branch Branch, snap *restackSnapshot) bool {
+	if snap.worktreeInspectionFailed {
+		return true
+	}
+	for current := branch.GetName(); current != ""; {
+		if snap.heldBranches.Contains(current) {
+			return true
+		}
+		e.mu.RLock()
+		state := e.readState(current)
+		trunk := e.trunk
+		e.mu.RUnlock()
+		if state == nil || state.Parent == "" || current == trunk {
+			return false
+		}
+		current = state.Parent
+	}
+	return false
 }
 
 // branchRev returns branch's revision from the pass snapshot, falling back to a
@@ -223,7 +250,7 @@ func (e *engineImpl) restackBranch(
 	// which warns and is reached solely by the `restack` command) so that every
 	// caller of RestackBranches inherits it — modify, sync, squash, absorb,
 	// delete, split, reorder, pluck and insert all arrive here directly.
-	if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" && snap.dirtyWorktrees[worktreePath] {
+	if e.branchHeldBack(branch, snap) {
 		return RestackBranchResult{Result: RestackUnneeded}, nil
 	}
 
@@ -723,7 +750,7 @@ func (e *engineImpl) applyBranchAndMetadata(
 	// Hold the branch back instead. This is the plan path, reached by every
 	// caller of actions.RestackBranches (modify, squash, absorb, delete, split,
 	// reorder, pluck) as well as the `restack` command.
-	if worktreePath := snap.worktrees.PathForBranch(branchName); worktreePath != "" && snap.dirtyWorktrees[worktreePath] {
+	if e.branchHeldBack(branch, snap) {
 		return RestackBranchResult{Result: RestackUnneeded, RebasedBranchBase: parentRev}, nil
 	}
 

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -200,6 +200,24 @@ func (r *runner) UpdateBranchRef(ctx context.Context, branchName, revision strin
 	return nil
 }
 
+func (r *runner) UpdateBranchRefCAS(ctx context.Context, branchName, revision, expectedOld string) error {
+	sha, err := r.resolveRefSHA(revision)
+	if err != nil {
+		return fmt.Errorf("failed to resolve revision %s: %w", revision, err)
+	}
+	if expectedOld == "" {
+		return fmt.Errorf("expected old revision is required when updating branch %s", branchName)
+	}
+	if err := r.UpdateRefsBatch(ctx, []RefUpdate{{
+		RefName: "refs/heads/" + branchName,
+		NewSHA:  sha,
+		OldSHA:  expectedOld,
+	}}); err != nil {
+		return fmt.Errorf("failed to compare-and-swap branch ref: %w", err)
+	}
+	return nil
+}
+
 func (r *runner) GetCurrentBranchOrSHA(ctx context.Context) (string, error) {
 	branch, err := r.GetCurrentBranch()
 	if err == nil {

--- a/internal/git/gitdir.go
+++ b/internal/git/gitdir.go
@@ -56,9 +56,11 @@ func resolveGitDir(repoRoot string) string {
 	}
 	gitDir = strings.TrimSpace(gitDir)
 	if !filepath.IsAbs(gitDir) {
-		gitDir = filepath.Join(repoRoot, gitDir)
+		// A relative gitdir is relative to the .git file, which may be in an
+		// ancestor when the caller supplied a repository subdirectory.
+		gitDir = filepath.Join(filepath.Dir(gitPath), gitDir)
 	}
-	return gitDir
+	return filepath.Clean(gitDir)
 }
 
 func findDotGit(path string) string {

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -70,6 +70,10 @@ type BranchWriter interface {
 	DeleteBranch(ctx context.Context, branchName string) error
 	RenameBranch(ctx context.Context, oldName, newName string) error
 	UpdateBranchRef(ctx context.Context, branchName, revision string) error
+	// UpdateBranchRefCAS moves a branch only if it still names expectedOld.
+	// Callers that prepared commits from a detached snapshot use this to avoid
+	// overwriting concurrent work from another worktree.
+	UpdateBranchRefCAS(ctx context.Context, branchName, revision, expectedOld string) error
 }
 
 // CommitReader provides read access to commit and revision information.

--- a/internal/git/pull.go
+++ b/internal/git/pull.go
@@ -69,26 +69,27 @@ func (r *runner) UpdateBranchFromRemote(ctx context.Context, remote, branchName 
 	if err == nil && isRemoteAhead {
 		// Save current branch/detached HEAD immediately before mutating refs.
 		currentBranch, err := r.GetCurrentBranch()
-		var currentRev string
 		if err != nil {
 			currentBranch = ""
-			currentRev, _ = r.GetCurrentRevision(ctx)
 		}
 
-		// Before updating the ref, check if this branch is checked out in another worktree.
-		// update-ref is global and will affect all worktrees, so we need to sync any
-		// worktree that has this branch checked out to avoid corrupting its index/working tree.
-		//
-		// IMPORTANT: We must check for uncommitted changes BEFORE the update-ref,
-		// because after update-ref the worktree will appear to have inverse changes
-		// (old content vs new HEAD), which would cause the check to fail.
-		var otherWorktreePath string
-		var otherWorktreeClean bool
-		if currentBranch != branchName {
-			otherWorktreePath, _ = r.GetWorktreePathForBranch(ctx, branchName)
-			if otherWorktreePath != "" {
-				hasChanges, err := r.WorktreeHasUncommittedChanges(ctx, otherWorktreePath)
-				otherWorktreeClean = err == nil && !hasChanges
+		// A ref update is global, but the checked-out worktree's index and
+		// working directory are local. Never move a checked-out branch unless
+		// its holder is known clean and can be reset immediately afterwards.
+		// Importantly, an inspection failure is unsafe too: it must not silently
+		// turn into a ref move that strands an unknown worktree on old content.
+		worktrees, err := r.ListWorktrees(ctx)
+		if err != nil {
+			return PullConflict, fmt.Errorf("refusing to update %s: cannot inspect worktrees: %w", branchName, err)
+		}
+		worktreePath := worktrees.PathForBranch(branchName)
+		if worktreePath != "" {
+			hasChanges, statusErr := r.WorktreeHasUncommittedChanges(ctx, worktreePath)
+			if statusErr != nil {
+				return PullConflict, fmt.Errorf("refusing to update %s: cannot inspect worktree %s: %w", branchName, worktreePath, statusErr)
+			}
+			if hasChanges {
+				return PullConflict, fmt.Errorf("refusing to update %s: worktree %s has uncommitted changes", branchName, worktreePath)
 			}
 		}
 
@@ -107,15 +108,14 @@ func (r *runner) UpdateBranchFromRemote(ctx context.Context, remote, branchName 
 		// so hard reset is safe here.
 		if currentBranch == branchName {
 			_ = r.HardReset(ctx, "HEAD")
-		} else if currentRev != "" {
-			_ = r.CheckoutDetached(ctx, currentRev)
 		}
 
-		// If this branch is checked out in another worktree that was clean before
-		// the update-ref, we need to reset that worktree to match the new HEAD.
-		// Otherwise the worktree's index/working tree will appear as inverse changes.
-		if otherWorktreePath != "" && otherWorktreeClean {
-			_ = r.ResetWorktreeWorkingDir(ctx, otherWorktreePath)
+		// If this branch is checked out in another clean worktree, reset it to
+		// match the ref we just moved. The clean check above makes this safe.
+		if worktreePath != "" && currentBranch != branchName {
+			if err := r.ResetWorktreeWorkingDir(ctx, worktreePath); err != nil {
+				return PullConflict, fmt.Errorf("updated %s but failed to reset clean worktree %s: %w", branchName, worktreePath, err)
+			}
 		}
 
 		return PullDone, nil

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -28,10 +28,14 @@ type RebaseOutcome struct {
 
 func (r *runner) Rebase(ctx context.Context, branchName, upstream, oldUpstream string) (RebaseOutcome, error) {
 	outcome := RebaseOutcome{Result: RebaseDone}
+	oldRev, err := r.GetRevision(branchName)
+	if err != nil {
+		return RebaseOutcome{Result: RebaseConflict}, fmt.Errorf("failed to get revision before rebase: %w", err)
+	}
 
 	// Use detached HEAD to avoid "already used by worktree" errors
 	// We use branchName~0 to force a detached checkout of the branch tip
-	_, err := r.RunGitCommandWithContext(ctx, "rebase", "--onto", upstream, oldUpstream, branchName+"~0")
+	_, err = r.RunGitCommandWithContext(ctx, "rebase", "--onto", upstream, oldUpstream, branchName+"~0")
 	if err != nil {
 		if r.IsRebaseInProgress(ctx) {
 			autoOutcome, autoErr := r.continueRerereResolvedRebase(ctx, err)
@@ -53,7 +57,7 @@ func (r *runner) Rebase(ctx context.Context, branchName, upstream, oldUpstream s
 		return RebaseOutcome{Result: RebaseConflict, RerereResolvedCount: outcome.RerereResolvedCount}, fmt.Errorf("failed to get revision after rebase: %w", err)
 	}
 
-	if err := r.UpdateBranchRef(ctx, branchName, newRev); err != nil {
+	if err := r.UpdateBranchRefCAS(ctx, branchName, newRev, oldRev); err != nil {
 		return RebaseOutcome{Result: RebaseConflict, RerereResolvedCount: outcome.RerereResolvedCount}, fmt.Errorf("failed to update branch ref %s: %w", branchName, err)
 	}
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -22,26 +22,41 @@ const WorktreeRefPrefix = "refs/stackit/worktrees/"
 const WorktreePathRefPrefix = "refs/stackit/worktree-paths/"
 
 func worktreePathRef(path string) string {
-	if canonicalPath, err := canonicalWorktreePath(path); err == nil {
+	if canonicalPath, err := CanonicalWorktreePath(path); err == nil {
 		path = canonicalPath
 	}
 	hash := sha256.Sum256([]byte(path))
 	return fmt.Sprintf("%s%x", WorktreePathRefPrefix, hash)
 }
 
-func canonicalWorktreePath(path string) (string, error) {
+// CanonicalWorktreePath returns an absolute path with every existing path
+// component resolved. It deliberately resolves the deepest existing ancestor
+// instead of requiring the final worktree directory to exist: registration
+// happens after creation but unregistering often happens after removal. Using
+// the same canonical spelling in both cases keeps the reverse registration
+// ref addressable through symlinked bases such as /tmp on macOS.
+func CanonicalWorktreePath(path string) (string, error) {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return "", err
 	}
-	resolvedPath, err := filepath.EvalSymlinks(absPath)
-	if err == nil {
-		return filepath.Clean(resolvedPath), nil
+
+	for existing := absPath; ; existing = filepath.Dir(existing) {
+		resolvedPath, evalErr := filepath.EvalSymlinks(existing)
+		if evalErr == nil {
+			remainder, relErr := filepath.Rel(existing, absPath)
+			if relErr != nil {
+				return "", relErr
+			}
+			return filepath.Clean(filepath.Join(resolvedPath, remainder)), nil
+		}
+		if !os.IsNotExist(evalErr) {
+			return "", evalErr
+		}
+		if parent := filepath.Dir(existing); parent == existing {
+			return "", evalErr
+		}
 	}
-	if !os.IsNotExist(err) {
-		return "", err
-	}
-	return filepath.Clean(absPath), nil
 }
 
 // Worktree represents a single entry from `git worktree list`.

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -196,7 +196,8 @@ func (r *runner) ForceRemoveWorktree(ctx context.Context, path string) error {
 // up many branches should call this once and reuse the result rather than
 // invoking git per branch — see WorktreeList.PathForBranch.
 func (r *runner) ListWorktrees(ctx context.Context) (WorktreeList, error) {
-	output, err := r.RunGitCommandWithContext(ctx, "worktree", "list", "--porcelain")
+	// -z is required because worktree paths may legally contain newlines.
+	output, err := r.RunGitCommandWithContext(ctx, "worktree", "list", "--porcelain", "-z")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list worktrees: %w", err)
 	}
@@ -213,7 +214,7 @@ func (r *runner) ListWorktrees(ctx context.Context) (WorktreeList, error) {
 		}
 		current = Worktree{}
 	}
-	for line := range strings.SplitSeq(output, "\n") {
+	for line := range strings.SplitSeq(output, "\x00") {
 		switch {
 		case line == "":
 			flush()
@@ -328,37 +329,11 @@ func (r *runner) DeleteWorktreeMeta(ctx context.Context, stackRoot string) error
 // GetWorktreePathForBranch returns the worktree path where a branch is checked out.
 // Returns empty string if the branch is not checked out in any worktree.
 func (r *runner) GetWorktreePathForBranch(ctx context.Context, branchName string) (string, error) {
-	output, err := r.RunGitCommandWithContext(ctx, "worktree", "list", "--porcelain")
+	worktrees, err := r.ListWorktrees(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to list worktrees: %w", err)
 	}
-
-	if output == "" {
-		return "", nil
-	}
-
-	// Parse porcelain output to find worktree with this branch
-	// Format:
-	// worktree /path/to/worktree
-	// HEAD abc123
-	// branch refs/heads/branchname
-	// (blank line)
-	lines := strings.Split(output, "\n")
-	var currentWorktree string
-	targetRef := "refs/heads/" + branchName
-
-	for _, line := range lines {
-		if after, ok := strings.CutPrefix(line, "worktree "); ok {
-			currentWorktree = after
-		} else if after, ok := strings.CutPrefix(line, "branch "); ok {
-			branch := after
-			if branch == targetRef && currentWorktree != "" {
-				return currentWorktree, nil
-			}
-		}
-	}
-
-	return "", nil
+	return worktrees.PathForBranch(branchName), nil
 }
 
 // ResetWorktreeWorkingDir resets a worktree's working directory to match HEAD.

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -182,7 +182,9 @@ func (r *runner) RemoveWorktree(ctx context.Context, path string) error {
 }
 
 func (r *runner) ForceRemoveWorktree(ctx context.Context, path string) error {
-	_, err := r.RunGitCommandWithContext(ctx, "worktree", "remove", "--force", path)
+	// Git requires --force twice when the worktree is locked, in addition to
+	// using it to discard local changes.
+	_, err := r.RunGitCommandWithContext(ctx, "worktree", "remove", "--force", "--force", path)
 	if err != nil {
 		return fmt.Errorf("failed to remove worktree at %s: %w", path, err)
 	}

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -125,6 +125,31 @@ func TestIsMainWorktree(t *testing.T) {
 }
 
 func TestWorktreeRegistry(t *testing.T) {
+	t.Run("removes reverse path registration after symlinked worktree is gone", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+
+		targetBase := t.TempDir()
+		linkBase := filepath.Join(t.TempDir(), "linked-base")
+		require.NoError(t, os.Symlink(targetBase, linkBase))
+		worktreePath := filepath.Join(linkBase, "worktree")
+
+		require.NoError(t, runner.WriteWorktreeMeta("first", &git.WorktreeMeta{
+			Path:         worktreePath,
+			AnchorBranch: "first",
+		}))
+		// Match real cleanup ordering: by this point the worktree directory is
+		// gone, while its symlinked base still exists.
+		require.NoError(t, runner.DeleteWorktreeMeta(context.Background(), "first"))
+
+		// Re-registration at the same path must not collide with an orphaned
+		// reverse path ref hashed with a different spelling.
+		require.NoError(t, runner.WriteWorktreeMeta("second", &git.WorktreeMeta{
+			Path:         worktreePath,
+			AnchorBranch: "second",
+		}))
+	})
+
 	t.Run("write and read worktree metadata", func(t *testing.T) {
 		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
 		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)

--- a/internal/integration/restack_dirty_maintree_test.go
+++ b/internal/integration/restack_dirty_maintree_test.go
@@ -4,28 +4,26 @@ import (
 	"testing"
 )
 
-// TestRestackWithUntrackedFileLeavesNoStagedRevert covers a regression where an
-// untracked file anywhere in the repo made restack leave a staged deletion of
-// trunk's files behind.
+// TestRestackWithUntrackedFileHoldsBranchAndLeavesNoStagedRevert covers the
+// untracked half of the dirty-worktree hold.
 //
 // The reset that realigns a worktree after its branch ref moves is gated on the
-// worktree being clean, so that it cannot discard uncommitted work. Dirtiness
-// was measured with `git status --porcelain --untracked-files=normal`, so a
-// single untracked file — a scratch note, a build artifact, anything not in
-// .gitignore — marked the worktree dirty and suppressed the reset. `git reset
-// --hard` cannot touch untracked files, so nothing was being protected: the
-// working directory simply kept the old commit's content while the branch ref
-// moved on.
+// worktree being clean, so that it cannot discard uncommitted work. Untracked
+// files count: `git reset --hard` overwrites an untracked file whose pathname
+// the incoming commit also contains, so skipping the reset is not enough — the
+// ref must not move either, or the worktree ends up holding the old commit's
+// content under a new ref and `stackit modify -a` commits the revert.
 //
-// The result was invisible until it wasn't. `git status` showed trunk's files
-// as staged deletions, and the next `stackit modify -a` committed them, quietly
-// reverting trunk content inside the stack.
-func TestRestackWithUntrackedFileLeavesNoStagedRevert(t *testing.T) {
+// So a stray untracked file holds the branch back rather than being restacked
+// around it. The file survives, the ref stays put, and nothing is staged.
+func TestRestackWithUntrackedFileHoldsBranchAndLeavesNoStagedRevert(t *testing.T) {
 	t.Parallel()
 
 	sh := NewTestShellInProcess(t)
 
 	sh.CreateLinearStack3().Checkout("a")
+	sh.Git("rev-parse a")
+	revBefore := sh.Output()
 
 	// Trunk advances so the stack genuinely needs restacking. WriteFile stages
 	// under the exact name, which the assertions below rely on.
@@ -34,11 +32,18 @@ func TestRestackWithUntrackedFileLeavesNoStagedRevert(t *testing.T) {
 		Git("commit -m 'chore: trunk commit'").
 		Checkout("a")
 
-	// A single untracked file. Not staged, not tracked, not the user's work in
-	// any sense restack should care about.
+	// A single untracked file — a scratch note, a build artifact, anything not
+	// in .gitignore.
 	sh.WriteUnstaged("scratch.txt", "scratch note")
 
 	sh.Run("restack --upstack")
+
+	// The branch must not have moved: holding it back is what keeps the
+	// worktree and its ref consistent.
+	sh.Git("rev-parse a")
+	if sh.Output() != revBefore {
+		t.Fatalf("branch a moved despite its worktree having an untracked file:\nbefore %safter  %s", revBefore, sh.Output())
+	}
 
 	// The only thing git should report is the untracked file itself. A "D " or
 	// " D" entry here means trunk's content was left staged for deletion.
@@ -46,10 +51,6 @@ func TestRestackWithUntrackedFileLeavesNoStagedRevert(t *testing.T) {
 		OutputContains("?? scratch.txt").
 		OutputNotContains(" D ").
 		OutputNotContains("D  ")
-
-	// And trunk's file is still really there.
-	sh.Git("ls-tree HEAD -- trunk1.txt").OutputContains("trunk1.txt")
-	sh.Git("status --porcelain -- trunk1.txt").OutputNotContains("trunk1.txt")
 }
 
 // TestRestackSkipsBranchWithTrackedChangesInItsWorktree covers the other half.

--- a/internal/integration/sync_test.go
+++ b/internal/integration/sync_test.go
@@ -120,7 +120,7 @@ func TestSync(t *testing.T) {
 		meta, err := eng.Git().ReadMetadata(mergeBranch)
 		require.NoError(t, err)
 		prNum := 100
-		state := git.PRStateClosed
+		state := git.PRStateMerged
 		base := mainBranchName
 		meta = meta.WithPrInfo(&git.PrInfoPersistence{
 			Number: &prNum,

--- a/internal/integration/worktree_comprehensive_test.go
+++ b/internal/integration/worktree_comprehensive_test.go
@@ -476,7 +476,7 @@ func TestWorktreeRestackOperations(t *testing.T) {
 		})
 	}
 
-	run("restack from main rejects worktree branches", func(t *testing.T, sh *TestShell) {
+	run("restack from main reconciles worktree branches", func(t *testing.T, sh *TestShell) {
 		// Create stack in worktree
 		sh.WriteFile("feature.txt", "feature").
 			Run("create feature -w -m 'feature branch'")
@@ -489,7 +489,7 @@ func TestWorktreeRestackOperations(t *testing.T) {
 		shW.WriteFile("b.txt", "b").Run("create b -m 'branch b'")
 		shW.WriteFile("c.txt", "c").Run("create c -m 'branch c'")
 
-		sh.RunExpectError("restack").OutputContains("belongs to worktree")
+		sh.Run("restack").OutputNotContains("belongs to worktree")
 		shW.OnBranch("c")
 	})
 


### PR DESCRIPTION
**Make branch mutations safe when worktrees hold the branch**

Closes the worktree half of the reconciliation-safety audit: eighteen fixes so
that moving a branch ref can no longer corrupt, revert, or silently discard work
in a worktree that has that branch checked out.

The unifying rule: before any operation rewrites a ref, it must ask who
physically holds that branch. If the holder is dirty or uninspectable, hold the
branch back and say so; if it is clean, reset it to match the ref it now points
at; never move a ref out from under a checkout and report success.

**Data loss (P0)**

- **#1580, #1584, #1585** — `fold`, `absorb`, and `continue` no longer merge onto
  a detached HEAD, rewrite an ancestor, or move a rebased ref while another
  worktree holds the branch. `CheckoutBranch` stops silently falling back to
  detached HEAD, which was a latent trap for every checkout-then-mutate action.
- **#1584** — `git.Rebase` writes its result through a compare-and-swap, so a
  commit made in another worktree mid-pass can no longer be overwritten (and
  then wiped by a reset keyed on a stale clean-snapshot).
- **#1580** — `create -w` keeps the branch when only the worktree phase fails.
  It previously deleted the sole ref to the commit that had just consumed the
  staged changes, past the point a snapshot could recover it.
- **#1585** — `merge --force` resets trunk through a ref update instead of a
  branch checkout, so a temp worktree can no longer squat on `refs/heads/<trunk>`
  and block the main workspace.

**Reconciliation model**

- **#1573, #1574, #1577, #1593** — restack holds branches behind dirty or
  uninspectable worktrees, holds their descendants too, leaves held branches
  metadata untouched, and reports the hold rather than passing it off as
  "already up to date". Untracked files count: `git reset --hard` will overwrite
  an untracked file whose pathname the incoming commit contains.
- **#1597** — worktrees mid-rebase report no branch to porcelain, so they were
  invisible to every branch/worktree guard. They are now held.

**Lifecycle and ownership**

- **#1586, #1595** — `pluck` and `delete` enforce managed-worktree ownership like
  the other branch-scoped mutations.
- **#1588, #1592, #1594** — worktree cleanup prunes before deleting the anchor,
  recovers invalid registrations instead of dead-ending between `remove`,
  `repair`, and `detach`, and sweeps reverse path refs orphaned by older code
  that would otherwise block re-creating a worktree at that path forever.
- **#1571** — reverse registrations stay addressable through symlinked bases by
  resolving the deepest existing ancestor, so register and unregister agree.
- **#1592** — multi-stack merge tags and deletes its consolidation branch and
  unlocks excluded and failed stacks instead of stranding PR locks.

**Correctness and hardening**

- **#1572** — sync stops treating a deleted remote branch as proof the local tip
  was pushed, which discarded follow-up commits on closed PRs.
- **#1589** — `split` uses the stash-by-ref API rather than popping the shared
  cross-worktree `stash@{0}`; relative `gitdir:` pointers resolve against the
  right base.
- **#1596** — `tree --json` no longer emits hidden anchors as dangling parents.
- Worktree porcelain is parsed with `-z`, `ForceRemoveWorktree` passes `--force`
  twice so it can remove locked worktrees, and relative `worktree.basePath`
  resolves against the repo root in Go code as it already did in git.

**Notes**

Sync also skips hidden anchors when comparing PR bases, which was queueing a
GitHub 422 on every sync for every worktree stack root with a PR.

This PR merges the following changes:

1. **#1571** fix(worktree): keep reverse registrations stable through symlinks
2. **#1572** fix(sync): preserve closed branches with deleted remotes
3. **#1573** fix(git): hold ref updates behind dirty worktrees
4. **#1574** fix(restack): reconcile managed stacks from any worktree
5. **#1577** fix(restack): keep held descendants' metadata unchanged
6. **#1580** fix(create): preserve branches when worktree setup fails
7. **#1584** fix(continue): synchronize rebased sibling worktrees
8. **#1585** fix(merge): reset trunk safely from detached worktrees
9. **#1586** fix(pluck): enforce managed-worktree ownership
10. **#1588** fix(worktree): make cleanup lifecycle safe
11. **#1589** fix(git): preserve explicit stash and gitdir paths
12. **#1592** fix(worktree): sweep orphaned path registrations
13. **#1593** fix(restack): report unsafe worktree holds
14. **#1594** fix(worktree): expose orphaned path cleanup
15. **#1595** fix(delete): enforce managed worktree ownership
16. **#1596** fix(tree): omit dangling worktree anchors from JSON
17. **#1597** fix(restack): hold worktrees mid-rebase
18. **#1599** fix(continue): preserve concurrent branch updates

### Stack

```
main
  └─ jonnii/20260803015741/keep-reverse-registrations-stable-through-symlinks (#1571)
    └─ jonnii/20260803015753/preserve-closed-branches-with-deleted-remotes (#1572)
      └─ jonnii/20260803020016/hold-ref-updates-behind-dirty-worktrees (#1573)
        └─ jonnii/20260803020055/reconcile-managed-stacks-from-any-worktree (#1574)
          └─ jonnii/20260803020256/keep-held-descendants-metadata-unchanged (#1577)
            └─ jonnii/20260803111836/preserve-branches-when-worktree-setup-fails (#1580)
              └─ jonnii/20260803112628/synchronize-rebased-sibling-worktrees (#1584)
                └─ jonnii/20260803113748/reset-trunk-safely-from-detached-worktrees (#1585)
                  └─ jonnii/20260803113847/enforce-managed-worktree-ownership (#1586)
                    └─ jonnii/20260804104923/make-cleanup-lifecycle-safe (#1588)
                      └─ jonnii/20260804105120/preserve-explicit-stash-and-gitdir-paths (#1589)
                        └─ jonnii/20260804105453/sweep-orphaned-path-registrations (#1592)
                          └─ jonnii/20260804105632/report-unsafe-worktree-holds (#1593)
                            └─ jonnii/20260804160407/expose-orphaned-path-cleanup (#1594)
                              └─ jonnii/20260805022242/expose-orphaned-path-cleanup (#1595)
                                └─ jonnii/20260805022557/omit-dangling-worktree-anchors-from-JSON (#1596)
                                  └─ jonnii/20260805022935/hold-worktrees-mid-rebase (#1597)
                                    └─ jonnii/20260805110628/preserve-concurrent-branch-updates (#1599)
```

Stackit-Stack-Size: 18
Stackit-PRs: 1571,1572,1573,1574,1577,1580,1584,1585,1586,1588,1589,1592,1593,1594,1595,1596,1597,1599
