### PR TITLE
fix(worktree): identify the main worktree from git, not the caller

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -630,7 +630,7 @@ func removeWorktreeIfCheckedOut(ctx context.Context, branchName string, worktree
 	}
 
 	// Don't remove main worktree
-	if git.IsMainWorktree(worktreePath, eng.GetRepoRoot()) {
+	if worktrees.IsMain(worktreePath) {
 		out.Debug("Branch %s is in main worktree, not removing", branchName)
 		return "", nil
 	}

--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -457,8 +457,11 @@ func removeWorktreeForBranch(ctx context.Context, branchName string, worktrees g
 		return nil // Branch not in any worktree
 	}
 
-	// Don't remove main worktree
-	if git.IsMainWorktree(worktreePath, eng.GetRepoRoot()) {
+	// Don't remove the main worktree. This asks the worktree list rather than
+	// the engine: a consolidation merge runs these steps with an engine rooted
+	// in a temporary worktree, so comparing against its repo root would never
+	// match the user's main checkout and git would be asked to remove it.
+	if worktrees.IsMain(worktreePath) {
 		out.Debug("Branch %s is in main worktree, cannot remove", branchName)
 		return fmt.Errorf("branch %s is checked out in main worktree", branchName)
 	}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -73,10 +73,65 @@ type WorktreeList []Worktree
 // IsMainWorktree reports whether worktreePath is the repo's main worktree
 // (repoRoot), resolving symlinks on both sides for comparison (e.g. /var vs
 // /private/var on macOS).
+//
+// Only use this when repoRoot is known to be the main working tree. An engine
+// constructed inside a temporary worktree reports that worktree as its repo
+// root, which makes this answer "no" for the user's actual main checkout —
+// prefer WorktreeList.IsMain, which reads the answer from git instead of
+// trusting the caller's idea of where the repo lives.
 func IsMainWorktree(worktreePath, repoRoot string) bool {
-	resolvedWorktree, _ := filepath.EvalSymlinks(worktreePath)
-	resolvedRoot, _ := filepath.EvalSymlinks(repoRoot)
-	return resolvedWorktree == resolvedRoot
+	equal, known := samePath(worktreePath, repoRoot)
+	return known && equal
+}
+
+// samePath reports whether two paths name the same directory, and whether that
+// question could be answered at all. Resolving symlinks on both sides matters
+// on macOS, where /var and /private/var name the same place.
+//
+// The second return value exists because callers guard destructive operations
+// with this: previously both EvalSymlinks errors were discarded, so two
+// unresolvable paths yielded "" == "" and compared equal. Reporting "could not
+// tell" lets each caller pick the safe answer for its own operation.
+func samePath(a, b string) (equal, known bool) {
+	resolvedA, errA := filepath.EvalSymlinks(a)
+	resolvedB, errB := filepath.EvalSymlinks(b)
+	if errA != nil || errB != nil {
+		return false, false
+	}
+	return resolvedA == resolvedB, true
+}
+
+// MainPath returns the main working tree's path. `git worktree list` always
+// reports the main worktree first and linked worktrees after it, so the first
+// entry is authoritative regardless of which worktree the command ran from.
+func (l WorktreeList) MainPath() string {
+	if len(l) == 0 {
+		return ""
+	}
+	return l[0].Path
+}
+
+// IsMain reports whether path is the repo's main working tree, which can never
+// be removed with `git worktree remove`.
+//
+// Prefer this over IsMainWorktree for removal guards. IsMainWorktree compares
+// against whatever the caller believes the repo root to be, and an engine built
+// inside a temporary worktree believes it is that worktree — so the main
+// checkout does not match, the guard passes, and git is asked to remove the
+// user's working tree.
+//
+// Uncertainty resolves to true: with no list to compare against, or paths that
+// cannot be resolved, the caller must not proceed to remove.
+func (l WorktreeList) IsMain(path string) bool {
+	main := l.MainPath()
+	if main == "" {
+		return true
+	}
+	equal, known := samePath(path, main)
+	if !known {
+		return true
+	}
+	return equal
 }
 
 // PathForBranch returns the worktree path where branchName is checked out,

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -233,3 +233,55 @@ func TestWorktreeRegistry(t *testing.T) {
 		require.Equal(t, "/path/to/worktree2", metas["feature-2"].Path)
 	})
 }
+
+// TestWorktreeListIsMain covers the guard that stops a cleanup path from asking
+// git to remove the user's main working tree.
+//
+// The regression: the guard compared the candidate path against the *engine's*
+// repo root. A consolidation merge runs its steps with an engine rooted in a
+// temporary worktree, so the main checkout never matched, the guard passed, and
+// `git worktree remove <main repo>` was attempted (git refuses, but only after
+// the branch deletion that followed had already been derailed).
+func TestWorktreeListIsMain(t *testing.T) {
+	t.Parallel()
+
+	mainDir := t.TempDir()
+	linkedDir := t.TempDir()
+	list := git.WorktreeList{
+		{Path: mainDir, Branch: "main"},
+		{Path: linkedDir, Branch: "feature"},
+	}
+
+	t.Run("first entry is the main worktree", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, mainDir, list.MainPath())
+		require.True(t, list.IsMain(mainDir))
+		require.False(t, list.IsMain(linkedDir))
+	})
+
+	t.Run("main worktree is recognized regardless of any repo root", func(t *testing.T) {
+		t.Parallel()
+		// This is the actual bug: an unrelated directory standing in for the
+		// temporary merge worktree's repo root must not change the answer.
+		require.False(t, git.IsMainWorktree(mainDir, t.TempDir()))
+		require.True(t, list.IsMain(mainDir))
+	})
+
+	t.Run("unresolvable paths are treated as main", func(t *testing.T) {
+		t.Parallel()
+		missing := filepath.Join(t.TempDir(), "gone")
+		// Cannot prove it is not the main worktree, so removal must not proceed.
+		require.True(t, list.IsMain(missing))
+		require.True(t, git.WorktreeList{}.IsMain(mainDir))
+	})
+
+	t.Run("two unresolvable paths are not equal", func(t *testing.T) {
+		t.Parallel()
+		// Both EvalSymlinks calls used to be discarded, so "" == "" reported a
+		// false positive match between any two nonexistent paths.
+		require.False(t, git.IsMainWorktree(
+			filepath.Join(t.TempDir(), "gone-a"),
+			filepath.Join(t.TempDir(), "gone-b"),
+		))
+	})
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Cleanup paths guarded `git worktree remove` with IsMainWorktree(path,
eng.GetRepoRoot()). A consolidation merge runs its steps with an engine rooted
in a temporary worktree, so the main checkout never matched, the guard passed,
and git was asked to remove the main working tree. Observed live during a
`merge ship`: "fatal: is a main working tree", followed by a failed branch
delete.

Read the answer from the worktree list instead — git always reports the main
worktree first — so the guard holds regardless of which worktree the command
runs from. Uncertainty resolves to "this is main" so removal never proceeds on
a path that could not be checked.

Also stop discarding both EvalSymlinks errors during path comparison, which
made any two unresolvable paths compare equal.

<hr/>

<!-- STACKIT-SECTION-START -->
**Make worktree cleanup guards match what actually happens**

Follow-on to the worktree reconciliation-safety stack, from the open items in
that audit plus one bug the audit missed — caught live while shipping it.

Each fix here is the same shape: a guard or a preview that disagreed with what
the operation went on to do.

**The guard that asked the wrong object**

- **#1602** — cleanup checked "is this the main working tree?" by comparing
  against the engine's repo root. A consolidation merge runs its steps with an
  engine rooted in a temporary worktree, so the user's main checkout never
  matched, the guard passed, and git was asked to remove it. Observed during
  `merge ship`: "fatal: is a main working tree", followed by a failed branch
  delete. Main-worktree identity now comes from the worktree list, which git
  always reports main-first, so the answer no longer depends on where the
  command runs from. Unresolvable paths resolve to "this is main" so removal
  never proceeds on something that could not be checked.

**The batch that failed whole instead of skipping one**

- **#1603** — a merged branch checked out in a main working tree that is not
  yours (syncing from a linked worktree, or the temp worktree mid-ship) was
  reported ready to delete. Refs are deleted in one atomic batch, so git
  rejected every branch over that one and nothing was cleaned. It is now
  skipped individually. Deleting the engine's own HEAD still works, because
  DeleteBranches checks out trunk first when the batch contains it.
  Also: results were built from the plan before execution, so branches
  execution declined to touch were still announced as deleted.

**The preview that promised what the run refused**

- **#1604** — `prune --dry-run` and `prune` evaluated separately. A
  registration whose directory was gone but whose stack still had branches was
  listed as prunable, then rejected; an invalid registration that RemoveAction
  can clean up was sent to `worktree repair`, which cannot fix it. Both modes
  read one decision now, and the refusal carries the `worktree detach` guidance
  that previously appeared only after the real run failed.

**The orderings that failed toward the invisible state**

- **#1605** — `RemoveAction` unregistered before deleting the anchor, so an
  interruption between them left an anchor branch with no registration:
  invisible to every worktree command, unreachable by repair. Detach already
  fails the other way, leaving something the user can see and act on. Remove
  now matches, and restores the anchor on rollback.
- **#1606** — the held-branch ancestry walk had no visited set and no step
  limit, so a parent loop hung the whole restack pass. Concurrent metadata
  rewrites are a likelier cause than corruption, since the walk re-reads state
  per iteration rather than from one snapshot. A cycle now resolves to "held":
  metadata that cannot say what a branch is stacked on is not safe to rebase
  onto.

**Still open**

The phantom-conflict diagnosis for held branches, actionable dead-worktree
errors, ownership divergence at mutation time, warm-start follow-ups, and the
P3 tail.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785972991`.


* **PR #1602** 👈
  * **PR #1603**
    * **PR #1604**
      * **PR #1605**
        * **PR #1606**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1607 by jonnii*