### PR TITLE
fix(sync): skip foreign checkouts instead of failing the cleanup batch

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -27,6 +28,7 @@ type CleanBranchesResult struct {
 	BranchesWithNewParents []string
 	SkippedInWorktree      []string // branches that couldn't be deleted from worktree
 	SkippedUnpushed        []string // branches skipped due to unpushed local changes
+	SkippedCheckedOut      []string // branches checked out in the main working tree, which cannot be removed
 }
 
 // BranchDeletionPlan contains the planned branch deletions before execution
@@ -174,10 +176,12 @@ func ExecuteBranchDeletions(ctx *app.Context, plannedDeletion *BranchDeletionPla
 		plan, branchesWithNewParents, reparentMoves = buildDeletionPlan(ctx, filteredStatuses)
 	}
 
-	// Capture planned deletions before executeDeletions removes them from plan.branches
-	deletedBranches := make(map[string]string)
+	// Record each planned branch's reason before execution, which removes them
+	// from plan.branches. Only the names execution actually deleted are
+	// reported back, so a branch it declined to touch is not announced as gone.
+	reasons := make(map[string]string, len(plan.branches))
 	for name, info := range plan.branches {
-		deletedBranches[name] = info.reason
+		reasons[name] = info.reason
 	}
 
 	if err := applyReparentMoves(ctx, reparentMoves); err != nil {
@@ -185,14 +189,21 @@ func ExecuteBranchDeletions(ctx *app.Context, plannedDeletion *BranchDeletionPla
 	}
 
 	// Execute deletions
-	if err := executeDeletions(ctx, plan); err != nil {
+	deleted, skippedCheckedOut, err := executeDeletions(ctx, plan)
+	if err != nil {
 		return nil, err
+	}
+
+	deletedBranches := make(map[string]string, len(deleted))
+	for _, name := range deleted {
+		deletedBranches[name] = reasons[name]
 	}
 
 	return &CleanBranchesResult{
 		DeletedBranches:        deletedBranches,
 		BranchesWithNewParents: branchesWithNewParents,
 		SkippedInWorktree:      plannedDeletion.SkippedInWorktree,
+		SkippedCheckedOut:      skippedCheckedOut,
 	}, nil
 }
 
@@ -357,13 +368,21 @@ func buildDeletionPlan(ctx *app.Context, deleteStatuses engine.DeletionStatuses)
 	return plan, branchesWithNewParents, reparentMoves
 }
 
+// errMainWorktreeCheckout marks a branch that cannot be deleted because it is
+// checked out in the main working tree, which — unlike a linked worktree —
+// cannot be removed to free the branch.
+var errMainWorktreeCheckout = errors.New("checked out in the main working tree")
+
 // executeDeletions removes worktrees and then deletes every branch that can be
 // safely removed from the plan in one engine batch. The planning pass has
 // already reparented surviving children, so branches from different
 // topological layers can share a single ref update and engine rebuild.
-func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
+//
+// Returns the branches actually deleted and those skipped because they are
+// checked out in the main working tree.
+func executeDeletions(ctx *app.Context, plan *deletionPlan) ([]string, []string, error) {
 	if len(plan.branches) == 0 {
-		return nil
+		return nil, nil, nil
 	}
 
 	eng := ctx.Engine
@@ -385,9 +404,16 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 	selectionStart := time.Now()
 	worktreesRemoved := 0
 	worktreesFailed := 0
+	var skippedCheckedOut []string
 	branchNames := selectBranchesForDeletion(plan, func(name string) bool {
 		removed, removeErr := removeWorktreeIfCheckedOut(c, name, worktrees, eng, out)
-		if removeErr != nil {
+		switch {
+		case errors.Is(removeErr, errMainWorktreeCheckout):
+			// Drop just this branch. Keeping it would fail the atomic ref
+			// batch and take every other branch's cleanup down with it.
+			skippedCheckedOut = append(skippedCheckedOut, name)
+			return false
+		case removeErr != nil:
 			out.Warn("Could not remove worktree for branch %s: %v", name, removeErr)
 			worktreesFailed++
 			return false
@@ -399,11 +425,11 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 	}, func(name string) string {
 		return getParentName(eng.GetBranch(name))
 	})
-	ctx.Logger.Info("select branches for cleanup completed durationMs=%d branchCount=%d worktreesRemoved=%d worktreesFailed=%d",
-		time.Since(selectionStart).Milliseconds(), len(branchNames), worktreesRemoved, worktreesFailed)
+	ctx.Logger.Info("select branches for cleanup completed durationMs=%d branchCount=%d worktreesRemoved=%d worktreesFailed=%d skippedCheckedOut=%d",
+		time.Since(selectionStart).Milliseconds(), len(branchNames), worktreesRemoved, worktreesFailed, len(skippedCheckedOut))
 
 	if len(branchNames) == 0 {
-		return nil
+		return nil, skippedCheckedOut, nil
 	}
 
 	branches := engine.NewBranchesBuilder(len(branchNames))
@@ -416,7 +442,7 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 	ctx.Logger.Info("engine delete branches completed durationMs=%d branchCount=%d ok=%v",
 		time.Since(engineStart).Milliseconds(), len(branchNames), engineErr == nil)
 	if engineErr != nil {
-		return fmt.Errorf("failed to delete branches [%s]: %w", strings.Join(branchNames, ", "), engineErr)
+		return nil, skippedCheckedOut, fmt.Errorf("failed to delete branches [%s]: %w", strings.Join(branchNames, ", "), engineErr)
 	}
 
 	pushStart := time.Now()
@@ -431,7 +457,7 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 		out.Info("Deleted branch %s", output.BranchName(name))
 	}
 
-	return nil
+	return branchNames, skippedCheckedOut, nil
 }
 
 // selectBranchesForDeletion resolves the deletion plan without mutating Git.
@@ -629,10 +655,19 @@ func removeWorktreeIfCheckedOut(ctx context.Context, branchName string, worktree
 		return "", nil // Branch not in any worktree
 	}
 
-	// Don't remove main worktree
+	// The main working tree can never be removed to free its branch.
 	if worktrees.IsMain(worktreePath) {
-		out.Debug("Branch %s is in main worktree, not removing", branchName)
-		return "", nil
+		// Unless it is where we are running: DeleteBranches checks out trunk
+		// when the batch contains its own HEAD, which frees the branch.
+		if git.IsMainWorktree(worktreePath, eng.GetRepoRoot()) {
+			out.Debug("Branch %s is checked out here; deletion will switch to trunk first", branchName)
+			return "", nil
+		}
+		// Someone else's checkout. Report it rather than claiming the branch is
+		// ready to delete: refs are deleted in one atomic batch, so git rejects
+		// the whole batch over this one branch and nothing gets cleaned.
+		out.Debug("Branch %s is checked out in the main worktree at %s, not removing", branchName, worktreePath)
+		return "", errMainWorktreeCheckout
 	}
 
 	out.Debug("Removing worktree at %s for branch %s", worktreePath, branchName)

--- a/internal/actions/clean_branches_test.go
+++ b/internal/actions/clean_branches_test.go
@@ -35,6 +35,17 @@ func (e *countingDeletionEngine) DeleteRemoteMetadataForBranches(ctx context.Con
 	return e.Engine.DeleteRemoteMetadataForBranches(ctx, branchNames)
 }
 
+// fixedWorktreeEngine reports a caller-supplied worktree list, so a test can
+// describe a checkout in a worktree other than the one it runs in.
+type fixedWorktreeEngine struct {
+	engine.Engine
+	list git.WorktreeList
+}
+
+func (e *fixedWorktreeEngine) ListWorktrees(context.Context) (git.WorktreeList, error) {
+	return e.list, nil
+}
+
 func TestCleanBranches(t *testing.T) {
 	t.Parallel()
 	t.Run("deletes merged branch and updates children", func(t *testing.T) {
@@ -114,6 +125,55 @@ func TestCleanBranches(t *testing.T) {
 		require.Equal(t, "main", parent3.GetName())
 		require.Contains(t, result.BranchesWithNewParents, "branch2")
 		require.Contains(t, result.BranchesWithNewParents, "branch3")
+	})
+
+	// A merged branch checked out in the *main* working tree cannot be deleted
+	// from anywhere else: that worktree cannot be removed to free the branch,
+	// and only the engine's own HEAD gets switched to trunk automatically.
+	//
+	// It used to be reported as ready to delete anyway. Refs are deleted in one
+	// atomic batch, so git rejected the entire batch over that single branch and
+	// every other merged branch stayed behind too, under one confusing error.
+	t.Run("skips branch checked out in another worktree without aborting the batch", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"branch1": "main",
+				"branch2": "main",
+			})
+
+		s.Checkout("main").
+			RunGit("merge", "branch1").
+			RunGit("merge", "branch2")
+		require.NoError(t, s.Engine.Rebuild("main"))
+
+		for i, name := range []string{"branch1", "branch2"} {
+			prInfo := testhelpers.NewTestPrInfoMerged(i+1, "main")
+			require.NoError(t, s.Engine.UpsertPrInfo(context.Background(), s.Engine.GetBranch(name), prInfo))
+		}
+
+		// Stand in for running from a linked worktree: the main working tree is
+		// somewhere else and has branch1 checked out.
+		s.Context.Engine = &fixedWorktreeEngine{
+			Engine: s.Engine,
+			list: git.WorktreeList{
+				{Path: t.TempDir(), Branch: "branch1"},
+				{Path: s.Scene.Repo.Dir, Branch: "main"},
+			},
+		}
+
+		result, err := actions.CleanBranches(s.Context, actions.CleanBranchesOptions{
+			Force: true,
+		})
+		require.NoError(t, err)
+
+		require.Contains(t, result.SkippedCheckedOut, "branch1")
+		require.True(t, s.Engine.GetBranch("branch1").IsTracked())
+		require.NotContains(t, result.DeletedBranches, "branch1")
+
+		// The rest of the batch still gets cleaned.
+		require.False(t, s.Engine.GetBranch("branch2").IsTracked())
+		require.Contains(t, result.DeletedBranches, "branch2")
 	})
 
 	t.Run("does not delete branch without PR when not merged", func(t *testing.T) {

--- a/internal/actions/sync/branch_cleaning.go
+++ b/internal/actions/sync/branch_cleaning.go
@@ -148,6 +148,13 @@ func cleanBranches(ctx *app.Context, opts *Options, dirtyAnchors dirtyAnchorSet,
 			output.CurrentBranch(name))
 	}
 
+	// Branches checked out in the main working tree cannot be freed by removing
+	// a worktree, so switching branches is the only way to clean them up.
+	for _, name := range result.SkippedCheckedOut {
+		ctx.Output.Warn("Cannot delete %s — it is checked out here. Switch branches, then sync again.",
+			output.CurrentBranch(name))
+	}
+
 	// Warn about branches skipped due to unpushed changes
 	for _, name := range result.SkippedUnpushed {
 		ctx.Output.Warn("Skipped %s — has unpushed local changes. Push first or delete manually with 'git branch -D %s'.",


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

A merged branch checked out in the main working tree of another location — the
main repo while you sync from a linked worktree, or your repo while a
consolidation merge runs in its temp worktree — was reported as ready to
delete. Ref deletions go out as one atomic batch, so git rejected all of them
over that single branch: nothing was cleaned, under one error naming every
branch in the batch.

Skip just that branch and carry on with the rest. Deleting the engine's own
HEAD still works as before, because DeleteBranches checks out trunk first when
the batch contains it.

Report only the branches execution actually deleted, too. The result was built
from the plan before execution ran, so any branch execution declined to touch
was still announced as deleted.

<hr/>

<!-- STACKIT-SECTION-START -->
**Make worktree cleanup guards match what actually happens**

Follow-on to the worktree reconciliation-safety stack, from the open items in
that audit plus one bug the audit missed — caught live while shipping it.

Each fix here is the same shape: a guard or a preview that disagreed with what
the operation went on to do.

**The guard that asked the wrong object**

- **#1602** — cleanup checked "is this the main working tree?" by comparing
  against the engine's repo root. A consolidation merge runs its steps with an
  engine rooted in a temporary worktree, so the user's main checkout never
  matched, the guard passed, and git was asked to remove it. Observed during
  `merge ship`: "fatal: is a main working tree", followed by a failed branch
  delete. Main-worktree identity now comes from the worktree list, which git
  always reports main-first, so the answer no longer depends on where the
  command runs from. Unresolvable paths resolve to "this is main" so removal
  never proceeds on something that could not be checked.

**The batch that failed whole instead of skipping one**

- **#1603** — a merged branch checked out in a main working tree that is not
  yours (syncing from a linked worktree, or the temp worktree mid-ship) was
  reported ready to delete. Refs are deleted in one atomic batch, so git
  rejected every branch over that one and nothing was cleaned. It is now
  skipped individually. Deleting the engine's own HEAD still works, because
  DeleteBranches checks out trunk first when the batch contains it.
  Also: results were built from the plan before execution, so branches
  execution declined to touch were still announced as deleted.

**The preview that promised what the run refused**

- **#1604** — `prune --dry-run` and `prune` evaluated separately. A
  registration whose directory was gone but whose stack still had branches was
  listed as prunable, then rejected; an invalid registration that RemoveAction
  can clean up was sent to `worktree repair`, which cannot fix it. Both modes
  read one decision now, and the refusal carries the `worktree detach` guidance
  that previously appeared only after the real run failed.

**The orderings that failed toward the invisible state**

- **#1605** — `RemoveAction` unregistered before deleting the anchor, so an
  interruption between them left an anchor branch with no registration:
  invisible to every worktree command, unreachable by repair. Detach already
  fails the other way, leaving something the user can see and act on. Remove
  now matches, and restores the anchor on rollback.
- **#1606** — the held-branch ancestry walk had no visited set and no step
  limit, so a parent loop hung the whole restack pass. Concurrent metadata
  rewrites are a likelier cause than corruption, since the walk re-reads state
  per iteration rather than from one snapshot. A cycle now resolves to "held":
  metadata that cannot say what a branch is stacked on is not safe to rebase
  onto.

**Still open**

The phantom-conflict diagnosis for held branches, actionable dead-worktree
errors, ownership divergence at mutation time, warm-start follow-ups, and the
P3 tail.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785972991`.


* **PR #1602**
  * **PR #1603** 👈
    * **PR #1604**
      * **PR #1605**
        * **PR #1606**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1607 by jonnii*