### PR TITLE
fix(worktree): decide prune once for both dry-run and the real run

### DIFF
--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -559,80 +559,23 @@ func PruneAction(ctx *app.Context, opts PruneOptions) (*PruneResult, error) {
 	for _, wt := range listResult.Worktrees {
 		name := wt.displayName()
 
-		// Clean up missing worktrees (directory deleted but registration remains)
-		if !wt.Exists {
-			if wt.NeedsRepair {
-				result.Skipped = append(result.Skipped, SkippedEntry{
-					Name:   name,
-					Reason: wt.StatusMessage + "; " + repairHint(&wt),
-				})
-				continue
-			}
-			if opts.DryRun {
-				result.Pruned = append(result.Pruned, name)
-				continue
-			}
-
-			// Unregister and delete anchor branch
-			if err := RemoveAction(ctx, RemoveOptions{
-				AnchorBranch: wt.AnchorBranch,
-				Force:        true, // Force since directory is missing
-			}); err != nil {
-				result.Skipped = append(result.Skipped, SkippedEntry{
-					Name:   name,
-					Reason: fmt.Sprintf("cleanup failed: %v", err),
-				})
-				continue
-			}
-			result.Pruned = append(result.Pruned, name)
+		// One decision drives both modes. Deciding separately is what let
+		// --dry-run promise removals the real run then refused.
+		if reason := pruneRefusal(&wt, listResult.CurrentAnchor); reason != "" {
+			result.Skipped = append(result.Skipped, SkippedEntry{Name: name, Reason: reason})
 			continue
 		}
 
-		if wt.NeedsRepair {
-			result.Skipped = append(result.Skipped, SkippedEntry{
-				Name:   name,
-				Reason: wt.StatusMessage + "; " + repairHint(&wt),
-			})
-			continue
-		}
-
-		// Skip worktrees with stacked branches
-		if len(wt.RootBranches) > 0 {
-			result.Skipped = append(result.Skipped, SkippedEntry{
-				Name:   name,
-				Reason: fmt.Sprintf("has %d stacked branches", wt.StackSize),
-			})
-			continue
-		}
-
-		// Skip worktrees with uncommitted changes
-		if wt.IsDirty {
-			result.Skipped = append(result.Skipped, SkippedEntry{
-				Name:   name,
-				Reason: "has uncommitted changes",
-			})
-			continue
-		}
-
-		// Skip if we're currently in this worktree
-		if listResult.CurrentAnchor != "" && wt.AnchorBranch == listResult.CurrentAnchor {
-			result.Skipped = append(result.Skipped, SkippedEntry{
-				Name:   name,
-				Reason: "currently in this worktree",
-			})
-			continue
-		}
-
-		// This worktree is empty and can be pruned
 		if opts.DryRun {
 			result.Pruned = append(result.Pruned, name)
 			continue
 		}
 
-		// Actually remove the worktree
 		if err := RemoveAction(ctx, RemoveOptions{
 			AnchorBranch: wt.AnchorBranch,
-			Force:        false,
+			// A missing directory has nothing to preserve, and a worktree that
+			// still exists has already been refused above if it was dirty.
+			Force: !wt.Exists,
 		}); err != nil {
 			result.Skipped = append(result.Skipped, SkippedEntry{
 				Name:   name,
@@ -645,6 +588,33 @@ func PruneAction(ctx *app.Context, opts PruneOptions) (*PruneResult, error) {
 	}
 
 	return result, nil
+}
+
+// pruneRefusal returns why a worktree cannot be pruned, or "" when it can.
+//
+// The first three checks mirror RemoveAction's own guards, because prune
+// executes through RemoveAction: anything it would reject must be reported as
+// skipped rather than counted as pruned. The rest are prune's own policy —
+// it never discards work, even though RemoveAction would with Force.
+func pruneRefusal(wt *Entry, currentAnchor string) string {
+	switch {
+	case wt.NeedsRepair && (wt.RegistrationState != RegistrationStateInvalid || !wt.CanRemove):
+		// An invalid registration that RemoveAction can still clean up is
+		// pruned rather than sent to `worktree repair`, which cannot fix it.
+		return wt.StatusMessage + "; " + repairHint(wt)
+	case currentAnchor != "" && wt.AnchorBranch == currentAnchor:
+		return "currently in this worktree"
+	case len(wt.RootBranches) > 0:
+		// Checked in both modes now: a registration whose directory is gone but
+		// whose stack still has branches was reported prunable, then rejected
+		// by RemoveAction. Carry RemoveAction's guidance so the refusal still
+		// says what to do about it.
+		return fmt.Sprintf("has %d stacked branches; use 'stackit worktree detach %s' to remove the worktree while keeping them",
+			wt.StackSize, wt.displayName())
+	case wt.Exists && wt.IsDirty:
+		return "has uncommitted changes"
+	}
+	return ""
 }
 
 // AttachOptions contains options for the attach action

--- a/internal/actions/worktree/prune_test.go
+++ b/internal/actions/worktree/prune_test.go
@@ -1,0 +1,91 @@
+package worktree
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPruneRefusal pins the decision that both `worktree prune` and
+// `worktree prune --dry-run` read.
+//
+// The two modes used to decide separately, so --dry-run listed worktrees the
+// real run then refused: a registration whose directory was gone but whose
+// stack still had branches was reported prunable and then rejected by
+// RemoveAction's root-branches guard, and an invalid registration that
+// RemoveAction can clean up was sent to `worktree repair`, which cannot fix it.
+func TestPruneRefusal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		entry         Entry
+		currentAnchor string
+		refused       bool
+	}{
+		{
+			name:  "empty healthy worktree is prunable",
+			entry: Entry{AnchorBranch: "anchor", Exists: true},
+		},
+		{
+			name:  "missing directory is prunable",
+			entry: Entry{AnchorBranch: "anchor"},
+		},
+		{
+			name: "missing directory with stacked branches is refused",
+			// Reported prunable by --dry-run, then refused by the real run.
+			entry:   Entry{AnchorBranch: "anchor", RootBranches: []string{"feature"}, StackSize: 1},
+			refused: true,
+		},
+		{
+			name: "removable invalid registration is prunable",
+			// repairHint sends users to a command that cannot fix this state,
+			// but RemoveAction handles it.
+			entry: Entry{
+				AnchorBranch:      "anchor",
+				NeedsRepair:       true,
+				RegistrationState: RegistrationStateInvalid,
+				CanRemove:         true,
+			},
+		},
+		{
+			name: "unrepairable registration is refused",
+			entry: Entry{
+				AnchorBranch:      "anchor",
+				Exists:            true,
+				NeedsRepair:       true,
+				RegistrationState: RegistrationStateLegacy,
+				StatusMessage:     "registration is legacy",
+			},
+			refused: true,
+		},
+		{
+			name:          "current worktree is refused",
+			entry:         Entry{AnchorBranch: "anchor", Exists: true},
+			currentAnchor: "anchor",
+			refused:       true,
+		},
+		{
+			name:    "dirty worktree is refused",
+			entry:   Entry{AnchorBranch: "anchor", Exists: true, IsDirty: true},
+			refused: true,
+		},
+		{
+			name: "dirty flag on a missing directory does not refuse",
+			// Nothing on disk to protect: the flag is stale.
+			entry: Entry{AnchorBranch: "anchor", IsDirty: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			reason := pruneRefusal(&tt.entry, tt.currentAnchor)
+			if tt.refused {
+				require.NotEmpty(t, reason, "expected a refusal reason")
+				return
+			}
+			require.Empty(t, reason)
+		})
+	}
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

`worktree prune --dry-run` and `worktree prune` evaluated separately, so the
preview promised removals the real run then refused. A registration whose
directory was gone but whose stack still had branches was listed as prunable
and then rejected by RemoveAction's root-branches guard; an invalid
registration that RemoveAction can clean up was instead sent to
`worktree repair`, which cannot fix that state.

Both modes now read one decision, so they cannot disagree again: the refusal
check mirrors RemoveAction's guards, then applies prune's own policy of never
discarding work. The root-branches refusal carries RemoveAction's guidance to
use `worktree detach`, which was previously only visible after the real run
failed.

<hr/>

<!-- STACKIT-SECTION-START -->
**Make worktree cleanup guards match what actually happens**

Follow-on to the worktree reconciliation-safety stack, from the open items in
that audit plus one bug the audit missed — caught live while shipping it.

Each fix here is the same shape: a guard or a preview that disagreed with what
the operation went on to do.

**The guard that asked the wrong object**

- **#1602** — cleanup checked "is this the main working tree?" by comparing
  against the engine's repo root. A consolidation merge runs its steps with an
  engine rooted in a temporary worktree, so the user's main checkout never
  matched, the guard passed, and git was asked to remove it. Observed during
  `merge ship`: "fatal: is a main working tree", followed by a failed branch
  delete. Main-worktree identity now comes from the worktree list, which git
  always reports main-first, so the answer no longer depends on where the
  command runs from. Unresolvable paths resolve to "this is main" so removal
  never proceeds on something that could not be checked.

**The batch that failed whole instead of skipping one**

- **#1603** — a merged branch checked out in a main working tree that is not
  yours (syncing from a linked worktree, or the temp worktree mid-ship) was
  reported ready to delete. Refs are deleted in one atomic batch, so git
  rejected every branch over that one and nothing was cleaned. It is now
  skipped individually. Deleting the engine's own HEAD still works, because
  DeleteBranches checks out trunk first when the batch contains it.
  Also: results were built from the plan before execution, so branches
  execution declined to touch were still announced as deleted.

**The preview that promised what the run refused**

- **#1604** — `prune --dry-run` and `prune` evaluated separately. A
  registration whose directory was gone but whose stack still had branches was
  listed as prunable, then rejected; an invalid registration that RemoveAction
  can clean up was sent to `worktree repair`, which cannot fix it. Both modes
  read one decision now, and the refusal carries the `worktree detach` guidance
  that previously appeared only after the real run failed.

**The orderings that failed toward the invisible state**

- **#1605** — `RemoveAction` unregistered before deleting the anchor, so an
  interruption between them left an anchor branch with no registration:
  invisible to every worktree command, unreachable by repair. Detach already
  fails the other way, leaving something the user can see and act on. Remove
  now matches, and restores the anchor on rollback.
- **#1606** — the held-branch ancestry walk had no visited set and no step
  limit, so a parent loop hung the whole restack pass. Concurrent metadata
  rewrites are a likelier cause than corruption, since the walk re-reads state
  per iteration rather than from one snapshot. A cycle now resolves to "held":
  metadata that cannot say what a branch is stacked on is not safe to rebase
  onto.

**Still open**

The phantom-conflict diagnosis for held branches, actionable dead-worktree
errors, ownership divergence at mutation time, warm-start follow-ups, and the
P3 tail.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785972991`.


* **PR #1602**
  * **PR #1603**
    * **PR #1604** 👈
      * **PR #1605**
        * **PR #1606**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1607 by jonnii*