### PR TITLE
fix(worktree): delete the anchor before unregistering it

### DIFF
--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -138,9 +138,15 @@ func RemoveAction(ctx *app.Context, opts RemoveOptions) error {
 	}
 
 	pathRemoved := false
+	anchorDeleted := false
 	unregistered := false
 	rollback := func(cause error) error {
 		var rollbackErrs []string
+		if anchorDeleted {
+			if err := restoreAnchorBranch(ctx, snapshot); err != nil {
+				rollbackErrs = append(rollbackErrs, err.Error())
+			}
+		}
 		if unregistered {
 			if err := restoreWorktreeRegistration(ctx, snapshot); err != nil {
 				rollbackErrs = append(rollbackErrs, err.Error())
@@ -172,20 +178,23 @@ func RemoveAction(ctx *app.Context, opts RemoveOptions) error {
 		}
 	}
 
-	if unregErr := ctx.Engine.UnregisterWorktree(ctx.Context, snapshot.Info.AnchorBranch); unregErr != nil {
-		if pathRemoved {
-			return rollback(fmt.Errorf("failed to unregister worktree: %w", unregErr))
-		}
-		return fmt.Errorf("failed to unregister worktree: %w", unregErr)
-	}
-	unregistered = true
-
+	// Delete the anchor before unregistering, the same order detach uses.
+	// Unregistering first means an interruption in between leaves an anchor
+	// branch with no registration — invisible to every worktree command and
+	// unreachable by repair. This order fails the other way: a leftover
+	// registration is visible in `worktree list` and can be repaired or removed.
 	if snapshot.AnchorExists {
 		if err := ctx.Engine.DeleteBranch(ctx.Context, ctx.Engine.GetBranch(snapshot.Info.AnchorBranch)); err != nil {
 			return rollback(fmt.Errorf("failed to delete anchor branch %s: %w", snapshot.Info.AnchorBranch, err))
 		}
+		anchorDeleted = true
 		out.Debug("Deleted anchor branch %s", snapshot.Info.AnchorBranch)
 	}
+
+	if unregErr := ctx.Engine.UnregisterWorktree(ctx.Context, snapshot.Info.AnchorBranch); unregErr != nil {
+		return rollback(fmt.Errorf("failed to unregister worktree: %w", unregErr))
+	}
+	unregistered = true
 
 	out.Success("Removed worktree for stack %s", output.BranchName(snapshot.Info.AnchorBranch))
 	return nil


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

RemoveAction unregistered the worktree and then deleted its anchor branch, so
an interruption between the two left an anchor with no registration: invisible
to every worktree command and unreachable by repair.

Detach already uses the opposite order, where the same interruption leaves a
registration the user can still see in `worktree list` and act on. Match it,
and restore the anchor on rollback as detach does.

<hr/>

<!-- STACKIT-SECTION-START -->
**Make worktree cleanup guards match what actually happens**

Follow-on to the worktree reconciliation-safety stack, from the open items in
that audit plus one bug the audit missed — caught live while shipping it.

Each fix here is the same shape: a guard or a preview that disagreed with what
the operation went on to do.

**The guard that asked the wrong object**

- **#1602** — cleanup checked "is this the main working tree?" by comparing
  against the engine's repo root. A consolidation merge runs its steps with an
  engine rooted in a temporary worktree, so the user's main checkout never
  matched, the guard passed, and git was asked to remove it. Observed during
  `merge ship`: "fatal: is a main working tree", followed by a failed branch
  delete. Main-worktree identity now comes from the worktree list, which git
  always reports main-first, so the answer no longer depends on where the
  command runs from. Unresolvable paths resolve to "this is main" so removal
  never proceeds on something that could not be checked.

**The batch that failed whole instead of skipping one**

- **#1603** — a merged branch checked out in a main working tree that is not
  yours (syncing from a linked worktree, or the temp worktree mid-ship) was
  reported ready to delete. Refs are deleted in one atomic batch, so git
  rejected every branch over that one and nothing was cleaned. It is now
  skipped individually. Deleting the engine's own HEAD still works, because
  DeleteBranches checks out trunk first when the batch contains it.
  Also: results were built from the plan before execution, so branches
  execution declined to touch were still announced as deleted.

**The preview that promised what the run refused**

- **#1604** — `prune --dry-run` and `prune` evaluated separately. A
  registration whose directory was gone but whose stack still had branches was
  listed as prunable, then rejected; an invalid registration that RemoveAction
  can clean up was sent to `worktree repair`, which cannot fix it. Both modes
  read one decision now, and the refusal carries the `worktree detach` guidance
  that previously appeared only after the real run failed.

**The orderings that failed toward the invisible state**

- **#1605** — `RemoveAction` unregistered before deleting the anchor, so an
  interruption between them left an anchor branch with no registration:
  invisible to every worktree command, unreachable by repair. Detach already
  fails the other way, leaving something the user can see and act on. Remove
  now matches, and restores the anchor on rollback.
- **#1606** — the held-branch ancestry walk had no visited set and no step
  limit, so a parent loop hung the whole restack pass. Concurrent metadata
  rewrites are a likelier cause than corruption, since the walk re-reads state
  per iteration rather than from one snapshot. A cycle now resolves to "held":
  metadata that cannot say what a branch is stacked on is not safe to rebase
  onto.

**Still open**

The phantom-conflict diagnosis for held branches, actionable dead-worktree
errors, ownership divergence at mutation time, warm-start follow-ups, and the
P3 tail.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785972991`.


* **PR #1602**
  * **PR #1603**
    * **PR #1604**
      * **PR #1605** 👈
        * **PR #1606**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1607 by jonnii*