### PR TITLE
fix(engine): cap the held-branch ancestry walk

### DIFF
--- a/internal/engine/restack_held_walk_test.go
+++ b/internal/engine/restack_held_walk_test.go
@@ -1,0 +1,88 @@
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBranchHeldBackCyclicMetadata covers the ancestry walk that decides whether
+// a branch sits behind a held one.
+//
+// The walk followed Parent links with no visited set and no step limit, so a
+// parent loop in metadata — corrupt, or concurrently rewritten by another
+// stackit process mid-pass — spun forever and hung the entire restack.
+func TestBranchHeldBackCyclicMetadata(t *testing.T) {
+	t.Parallel()
+
+	newEngine := func(t *testing.T, states map[string]string) *engineImpl {
+		t.Helper()
+		dir, g := newOptimisticLockTestRepo(t)
+		eng, err := NewEngine(Options{RepoRoot: dir, Trunk: "main", Git: g})
+		require.NoError(t, err)
+		e, ok := eng.(*engineImpl)
+		require.True(t, ok)
+
+		e.mu.Lock()
+		for name, parent := range states {
+			e.state.branchState.Set(name, &BranchState{Parent: parent})
+		}
+		e.mu.Unlock()
+		return e
+	}
+
+	// The walk is capped by branch count, so a hang shows up as a test timeout
+	// rather than a wrong answer. Run it with a deadline to keep the failure
+	// legible instead of letting the whole package time out.
+	within := func(t *testing.T, fn func() bool) bool {
+		t.Helper()
+		done := make(chan bool, 1)
+		go func() { done <- fn() }()
+		select {
+		case got := <-done:
+			return got
+		case <-time.After(20 * time.Second):
+			t.Fatal("branchHeldBack did not terminate: the ancestry walk is unbounded")
+			return false
+		}
+	}
+
+	t.Run("cycle terminates and holds the branch", func(t *testing.T) {
+		t.Parallel()
+		e := newEngine(t, map[string]string{
+			"a": "b",
+			"b": "c",
+			"c": "a",
+		})
+		snap := &restackSnapshot{heldBranches: make(BranchNameSet)}
+
+		// Nothing is held, but the parent chain never reaches trunk. Metadata
+		// that cannot say what a branch is stacked on is not safe to build on.
+		held := within(t, func() bool { return e.branchHeldBack(NewBranch("a", nil), snap) })
+		require.True(t, held)
+	})
+
+	t.Run("self-parent terminates", func(t *testing.T) {
+		t.Parallel()
+		e := newEngine(t, map[string]string{"a": "a"})
+		snap := &restackSnapshot{heldBranches: make(BranchNameSet)}
+
+		held := within(t, func() bool { return e.branchHeldBack(NewBranch("a", nil), snap) })
+		require.True(t, held)
+	})
+
+	t.Run("acyclic chain still resolves normally", func(t *testing.T) {
+		t.Parallel()
+		e := newEngine(t, map[string]string{
+			"child":  "parent",
+			"parent": "main",
+		})
+
+		snap := &restackSnapshot{heldBranches: make(BranchNameSet)}
+		require.False(t, e.branchHeldBack(NewBranch("child", nil), snap))
+
+		snap.heldBranches["parent"] = true
+		require.True(t, e.branchHeldBack(NewBranch("child", nil), snap))
+	})
+}

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -69,7 +69,23 @@ func (e *engineImpl) branchHeldBack(branch Branch, snap *restackSnapshot) bool {
 	if snap.worktreeInspectionFailed {
 		return true
 	}
-	for current := branch.GetName(); current != ""; {
+	current := branch.GetName()
+	visited := make(map[string]bool)
+	// Metadata should be acyclic, but cap the walk as a second line of defense
+	// against malformed or concurrently changing parent metadata — a parent
+	// loop here would hang the whole restack pass. See GetStackRootForBranch,
+	// which guards its own walk the same way.
+	maxSteps := e.BranchNames().Len() + 1
+	for range maxSteps {
+		if current == "" {
+			return false
+		}
+		if visited[current] {
+			// A cycle means the metadata cannot be trusted to say what this
+			// branch is stacked on, so no ref move is safe: hold it.
+			return true
+		}
+		visited[current] = true
 		if snap.heldBranches.Contains(current) {
 			return true
 		}
@@ -82,7 +98,9 @@ func (e *engineImpl) branchHeldBack(branch Branch, snap *restackSnapshot) bool {
 		}
 		current = state.Parent
 	}
-	return false
+	// Ran out of steps without reaching trunk: the chain is longer than the
+	// branch count allows, so treat it as untrustworthy too.
+	return true
 }
 
 // branchRev returns branch's revision from the pass snapshot, falling back to a


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

branchHeldBack followed Parent links with no visited set and no step limit, so
a parent loop in metadata hung the entire restack pass. Corrupt metadata is one
way in; another stackit process rewriting parents concurrently is a likelier
one, since the walk reads state under a per-iteration lock rather than a single
consistent snapshot.

Cap the walk by branch count and track visited names, matching
GetStackRootForBranch. A cycle resolves to "held": metadata that cannot say
what a branch is stacked on is not something to rebase onto.

<hr/>

<!-- STACKIT-SECTION-START -->
**Make worktree cleanup guards match what actually happens**

Follow-on to the worktree reconciliation-safety stack, from the open items in
that audit plus one bug the audit missed — caught live while shipping it.

Each fix here is the same shape: a guard or a preview that disagreed with what
the operation went on to do.

**The guard that asked the wrong object**

- **#1602** — cleanup checked "is this the main working tree?" by comparing
  against the engine's repo root. A consolidation merge runs its steps with an
  engine rooted in a temporary worktree, so the user's main checkout never
  matched, the guard passed, and git was asked to remove it. Observed during
  `merge ship`: "fatal: is a main working tree", followed by a failed branch
  delete. Main-worktree identity now comes from the worktree list, which git
  always reports main-first, so the answer no longer depends on where the
  command runs from. Unresolvable paths resolve to "this is main" so removal
  never proceeds on something that could not be checked.

**The batch that failed whole instead of skipping one**

- **#1603** — a merged branch checked out in a main working tree that is not
  yours (syncing from a linked worktree, or the temp worktree mid-ship) was
  reported ready to delete. Refs are deleted in one atomic batch, so git
  rejected every branch over that one and nothing was cleaned. It is now
  skipped individually. Deleting the engine's own HEAD still works, because
  DeleteBranches checks out trunk first when the batch contains it.
  Also: results were built from the plan before execution, so branches
  execution declined to touch were still announced as deleted.

**The preview that promised what the run refused**

- **#1604** — `prune --dry-run` and `prune` evaluated separately. A
  registration whose directory was gone but whose stack still had branches was
  listed as prunable, then rejected; an invalid registration that RemoveAction
  can clean up was sent to `worktree repair`, which cannot fix it. Both modes
  read one decision now, and the refusal carries the `worktree detach` guidance
  that previously appeared only after the real run failed.

**The orderings that failed toward the invisible state**

- **#1605** — `RemoveAction` unregistered before deleting the anchor, so an
  interruption between them left an anchor branch with no registration:
  invisible to every worktree command, unreachable by repair. Detach already
  fails the other way, leaving something the user can see and act on. Remove
  now matches, and restores the anchor on rollback.
- **#1606** — the held-branch ancestry walk had no visited set and no step
  limit, so a parent loop hung the whole restack pass. Concurrent metadata
  rewrites are a likelier cause than corruption, since the walk re-reads state
  per iteration rather than from one snapshot. A cycle now resolves to "held":
  metadata that cannot say what a branch is stacked on is not safe to rebase
  onto.

**Still open**

The phantom-conflict diagnosis for held branches, actionable dead-worktree
errors, ownership divergence at mutation time, warm-start follow-ups, and the
P3 tail.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785972991`.


* **PR #1602**
  * **PR #1603**
    * **PR #1604**
      * **PR #1605**
        * **PR #1606** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1607 by jonnii*