### PR TITLE
Make worktree cleanup guards match what actually happens

### DIFF
--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -27,6 +28,7 @@ type CleanBranchesResult struct {
 	BranchesWithNewParents []string
 	SkippedInWorktree      []string // branches that couldn't be deleted from worktree
 	SkippedUnpushed        []string // branches skipped due to unpushed local changes
+	SkippedCheckedOut      []string // branches checked out in the main working tree, which cannot be removed
 }
 
 // BranchDeletionPlan contains the planned branch deletions before execution
@@ -174,10 +176,12 @@ func ExecuteBranchDeletions(ctx *app.Context, plannedDeletion *BranchDeletionPla
 		plan, branchesWithNewParents, reparentMoves = buildDeletionPlan(ctx, filteredStatuses)
 	}
 
-	// Capture planned deletions before executeDeletions removes them from plan.branches
-	deletedBranches := make(map[string]string)
+	// Record each planned branch's reason before execution, which removes them
+	// from plan.branches. Only the names execution actually deleted are
+	// reported back, so a branch it declined to touch is not announced as gone.
+	reasons := make(map[string]string, len(plan.branches))
 	for name, info := range plan.branches {
-		deletedBranches[name] = info.reason
+		reasons[name] = info.reason
 	}
 
 	if err := applyReparentMoves(ctx, reparentMoves); err != nil {
@@ -185,14 +189,21 @@ func ExecuteBranchDeletions(ctx *app.Context, plannedDeletion *BranchDeletionPla
 	}
 
 	// Execute deletions
-	if err := executeDeletions(ctx, plan); err != nil {
+	deleted, skippedCheckedOut, err := executeDeletions(ctx, plan)
+	if err != nil {
 		return nil, err
+	}
+
+	deletedBranches := make(map[string]string, len(deleted))
+	for _, name := range deleted {
+		deletedBranches[name] = reasons[name]
 	}
 
 	return &CleanBranchesResult{
 		DeletedBranches:        deletedBranches,
 		BranchesWithNewParents: branchesWithNewParents,
 		SkippedInWorktree:      plannedDeletion.SkippedInWorktree,
+		SkippedCheckedOut:      skippedCheckedOut,
 	}, nil
 }
 
@@ -357,13 +368,21 @@ func buildDeletionPlan(ctx *app.Context, deleteStatuses engine.DeletionStatuses)
 	return plan, branchesWithNewParents, reparentMoves
 }
 
+// errMainWorktreeCheckout marks a branch that cannot be deleted because it is
+// checked out in the main working tree, which — unlike a linked worktree —
+// cannot be removed to free the branch.
+var errMainWorktreeCheckout = errors.New("checked out in the main working tree")
+
 // executeDeletions removes worktrees and then deletes every branch that can be
 // safely removed from the plan in one engine batch. The planning pass has
 // already reparented surviving children, so branches from different
 // topological layers can share a single ref update and engine rebuild.
-func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
+//
+// Returns the branches actually deleted and those skipped because they are
+// checked out in the main working tree.
+func executeDeletions(ctx *app.Context, plan *deletionPlan) ([]string, []string, error) {
 	if len(plan.branches) == 0 {
-		return nil
+		return nil, nil, nil
 	}
 
 	eng := ctx.Engine
@@ -385,9 +404,16 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 	selectionStart := time.Now()
 	worktreesRemoved := 0
 	worktreesFailed := 0
+	var skippedCheckedOut []string
 	branchNames := selectBranchesForDeletion(plan, func(name string) bool {
 		removed, removeErr := removeWorktreeIfCheckedOut(c, name, worktrees, eng, out)
-		if removeErr != nil {
+		switch {
+		case errors.Is(removeErr, errMainWorktreeCheckout):
+			// Drop just this branch. Keeping it would fail the atomic ref
+			// batch and take every other branch's cleanup down with it.
+			skippedCheckedOut = append(skippedCheckedOut, name)
+			return false
+		case removeErr != nil:
 			out.Warn("Could not remove worktree for branch %s: %v", name, removeErr)
 			worktreesFailed++
 			return false
@@ -399,11 +425,11 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 	}, func(name string) string {
 		return getParentName(eng.GetBranch(name))
 	})
-	ctx.Logger.Info("select branches for cleanup completed durationMs=%d branchCount=%d worktreesRemoved=%d worktreesFailed=%d",
-		time.Since(selectionStart).Milliseconds(), len(branchNames), worktreesRemoved, worktreesFailed)
+	ctx.Logger.Info("select branches for cleanup completed durationMs=%d branchCount=%d worktreesRemoved=%d worktreesFailed=%d skippedCheckedOut=%d",
+		time.Since(selectionStart).Milliseconds(), len(branchNames), worktreesRemoved, worktreesFailed, len(skippedCheckedOut))
 
 	if len(branchNames) == 0 {
-		return nil
+		return nil, skippedCheckedOut, nil
 	}
 
 	branches := engine.NewBranchesBuilder(len(branchNames))
@@ -416,7 +442,7 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 	ctx.Logger.Info("engine delete branches completed durationMs=%d branchCount=%d ok=%v",
 		time.Since(engineStart).Milliseconds(), len(branchNames), engineErr == nil)
 	if engineErr != nil {
-		return fmt.Errorf("failed to delete branches [%s]: %w", strings.Join(branchNames, ", "), engineErr)
+		return nil, skippedCheckedOut, fmt.Errorf("failed to delete branches [%s]: %w", strings.Join(branchNames, ", "), engineErr)
 	}
 
 	pushStart := time.Now()
@@ -431,7 +457,7 @@ func executeDeletions(ctx *app.Context, plan *deletionPlan) error {
 		out.Info("Deleted branch %s", output.BranchName(name))
 	}
 
-	return nil
+	return branchNames, skippedCheckedOut, nil
 }
 
 // selectBranchesForDeletion resolves the deletion plan without mutating Git.
@@ -629,10 +655,19 @@ func removeWorktreeIfCheckedOut(ctx context.Context, branchName string, worktree
 		return "", nil // Branch not in any worktree
 	}
 
-	// Don't remove main worktree
+	// The main working tree can never be removed to free its branch.
 	if worktrees.IsMain(worktreePath) {
-		out.Debug("Branch %s is in main worktree, not removing", branchName)
-		return "", nil
+		// Unless it is where we are running: DeleteBranches checks out trunk
+		// when the batch contains its own HEAD, which frees the branch.
+		if git.IsMainWorktree(worktreePath, eng.GetRepoRoot()) {
+			out.Debug("Branch %s is checked out here; deletion will switch to trunk first", branchName)
+			return "", nil
+		}
+		// Someone else's checkout. Report it rather than claiming the branch is
+		// ready to delete: refs are deleted in one atomic batch, so git rejects
+		// the whole batch over this one branch and nothing gets cleaned.
+		out.Debug("Branch %s is checked out in the main worktree at %s, not removing", branchName, worktreePath)
+		return "", errMainWorktreeCheckout
 	}
 
 	out.Debug("Removing worktree at %s for branch %s", worktreePath, branchName)

--- a/internal/actions/clean_branches.go
+++ b/internal/actions/clean_branches.go
@@ -630,7 +630,7 @@ func removeWorktreeIfCheckedOut(ctx context.Context, branchName string, worktree
 	}
 
 	// Don't remove main worktree
-	if git.IsMainWorktree(worktreePath, eng.GetRepoRoot()) {
+	if worktrees.IsMain(worktreePath) {
 		out.Debug("Branch %s is in main worktree, not removing", branchName)
 		return "", nil
 	}

--- a/internal/actions/clean_branches_test.go
+++ b/internal/actions/clean_branches_test.go
@@ -35,6 +35,17 @@ func (e *countingDeletionEngine) DeleteRemoteMetadataForBranches(ctx context.Con
 	return e.Engine.DeleteRemoteMetadataForBranches(ctx, branchNames)
 }
 
+// fixedWorktreeEngine reports a caller-supplied worktree list, so a test can
+// describe a checkout in a worktree other than the one it runs in.
+type fixedWorktreeEngine struct {
+	engine.Engine
+	list git.WorktreeList
+}
+
+func (e *fixedWorktreeEngine) ListWorktrees(context.Context) (git.WorktreeList, error) {
+	return e.list, nil
+}
+
 func TestCleanBranches(t *testing.T) {
 	t.Parallel()
 	t.Run("deletes merged branch and updates children", func(t *testing.T) {
@@ -114,6 +125,55 @@ func TestCleanBranches(t *testing.T) {
 		require.Equal(t, "main", parent3.GetName())
 		require.Contains(t, result.BranchesWithNewParents, "branch2")
 		require.Contains(t, result.BranchesWithNewParents, "branch3")
+	})
+
+	// A merged branch checked out in the *main* working tree cannot be deleted
+	// from anywhere else: that worktree cannot be removed to free the branch,
+	// and only the engine's own HEAD gets switched to trunk automatically.
+	//
+	// It used to be reported as ready to delete anyway. Refs are deleted in one
+	// atomic batch, so git rejected the entire batch over that single branch and
+	// every other merged branch stayed behind too, under one confusing error.
+	t.Run("skips branch checked out in another worktree without aborting the batch", func(t *testing.T) {
+		t.Parallel()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup).
+			WithStack(map[string]string{
+				"branch1": "main",
+				"branch2": "main",
+			})
+
+		s.Checkout("main").
+			RunGit("merge", "branch1").
+			RunGit("merge", "branch2")
+		require.NoError(t, s.Engine.Rebuild("main"))
+
+		for i, name := range []string{"branch1", "branch2"} {
+			prInfo := testhelpers.NewTestPrInfoMerged(i+1, "main")
+			require.NoError(t, s.Engine.UpsertPrInfo(context.Background(), s.Engine.GetBranch(name), prInfo))
+		}
+
+		// Stand in for running from a linked worktree: the main working tree is
+		// somewhere else and has branch1 checked out.
+		s.Context.Engine = &fixedWorktreeEngine{
+			Engine: s.Engine,
+			list: git.WorktreeList{
+				{Path: t.TempDir(), Branch: "branch1"},
+				{Path: s.Scene.Repo.Dir, Branch: "main"},
+			},
+		}
+
+		result, err := actions.CleanBranches(s.Context, actions.CleanBranchesOptions{
+			Force: true,
+		})
+		require.NoError(t, err)
+
+		require.Contains(t, result.SkippedCheckedOut, "branch1")
+		require.True(t, s.Engine.GetBranch("branch1").IsTracked())
+		require.NotContains(t, result.DeletedBranches, "branch1")
+
+		// The rest of the batch still gets cleaned.
+		require.False(t, s.Engine.GetBranch("branch2").IsTracked())
+		require.Contains(t, result.DeletedBranches, "branch2")
 	})
 
 	t.Run("does not delete branch without PR when not merged", func(t *testing.T) {

--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -457,8 +457,11 @@ func removeWorktreeForBranch(ctx context.Context, branchName string, worktrees g
 		return nil // Branch not in any worktree
 	}
 
-	// Don't remove main worktree
-	if git.IsMainWorktree(worktreePath, eng.GetRepoRoot()) {
+	// Don't remove the main worktree. This asks the worktree list rather than
+	// the engine: a consolidation merge runs these steps with an engine rooted
+	// in a temporary worktree, so comparing against its repo root would never
+	// match the user's main checkout and git would be asked to remove it.
+	if worktrees.IsMain(worktreePath) {
 		out.Debug("Branch %s is in main worktree, cannot remove", branchName)
 		return fmt.Errorf("branch %s is checked out in main worktree", branchName)
 	}

--- a/internal/actions/sync/branch_cleaning.go
+++ b/internal/actions/sync/branch_cleaning.go
@@ -148,6 +148,13 @@ func cleanBranches(ctx *app.Context, opts *Options, dirtyAnchors dirtyAnchorSet,
 			output.CurrentBranch(name))
 	}
 
+	// Branches checked out in the main working tree cannot be freed by removing
+	// a worktree, so switching branches is the only way to clean them up.
+	for _, name := range result.SkippedCheckedOut {
+		ctx.Output.Warn("Cannot delete %s — it is checked out here. Switch branches, then sync again.",
+			output.CurrentBranch(name))
+	}
+
 	// Warn about branches skipped due to unpushed changes
 	for _, name := range result.SkippedUnpushed {
 		ctx.Output.Warn("Skipped %s — has unpushed local changes. Push first or delete manually with 'git branch -D %s'.",

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -138,9 +138,15 @@ func RemoveAction(ctx *app.Context, opts RemoveOptions) error {
 	}
 
 	pathRemoved := false
+	anchorDeleted := false
 	unregistered := false
 	rollback := func(cause error) error {
 		var rollbackErrs []string
+		if anchorDeleted {
+			if err := restoreAnchorBranch(ctx, snapshot); err != nil {
+				rollbackErrs = append(rollbackErrs, err.Error())
+			}
+		}
 		if unregistered {
 			if err := restoreWorktreeRegistration(ctx, snapshot); err != nil {
 				rollbackErrs = append(rollbackErrs, err.Error())
@@ -172,20 +178,23 @@ func RemoveAction(ctx *app.Context, opts RemoveOptions) error {
 		}
 	}
 
-	if unregErr := ctx.Engine.UnregisterWorktree(ctx.Context, snapshot.Info.AnchorBranch); unregErr != nil {
-		if pathRemoved {
-			return rollback(fmt.Errorf("failed to unregister worktree: %w", unregErr))
-		}
-		return fmt.Errorf("failed to unregister worktree: %w", unregErr)
-	}
-	unregistered = true
-
+	// Delete the anchor before unregistering, the same order detach uses.
+	// Unregistering first means an interruption in between leaves an anchor
+	// branch with no registration — invisible to every worktree command and
+	// unreachable by repair. This order fails the other way: a leftover
+	// registration is visible in `worktree list` and can be repaired or removed.
 	if snapshot.AnchorExists {
 		if err := ctx.Engine.DeleteBranch(ctx.Context, ctx.Engine.GetBranch(snapshot.Info.AnchorBranch)); err != nil {
 			return rollback(fmt.Errorf("failed to delete anchor branch %s: %w", snapshot.Info.AnchorBranch, err))
 		}
+		anchorDeleted = true
 		out.Debug("Deleted anchor branch %s", snapshot.Info.AnchorBranch)
 	}
+
+	if unregErr := ctx.Engine.UnregisterWorktree(ctx.Context, snapshot.Info.AnchorBranch); unregErr != nil {
+		return rollback(fmt.Errorf("failed to unregister worktree: %w", unregErr))
+	}
+	unregistered = true
 
 	out.Success("Removed worktree for stack %s", output.BranchName(snapshot.Info.AnchorBranch))
 	return nil

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -559,80 +559,23 @@ func PruneAction(ctx *app.Context, opts PruneOptions) (*PruneResult, error) {
 	for _, wt := range listResult.Worktrees {
 		name := wt.displayName()
 
-		// Clean up missing worktrees (directory deleted but registration remains)
-		if !wt.Exists {
-			if wt.NeedsRepair {
-				result.Skipped = append(result.Skipped, SkippedEntry{
-					Name:   name,
-					Reason: wt.StatusMessage + "; " + repairHint(&wt),
-				})
-				continue
-			}
-			if opts.DryRun {
-				result.Pruned = append(result.Pruned, name)
-				continue
-			}
-
-			// Unregister and delete anchor branch
-			if err := RemoveAction(ctx, RemoveOptions{
-				AnchorBranch: wt.AnchorBranch,
-				Force:        true, // Force since directory is missing
-			}); err != nil {
-				result.Skipped = append(result.Skipped, SkippedEntry{
-					Name:   name,
-					Reason: fmt.Sprintf("cleanup failed: %v", err),
-				})
-				continue
-			}
-			result.Pruned = append(result.Pruned, name)
+		// One decision drives both modes. Deciding separately is what let
+		// --dry-run promise removals the real run then refused.
+		if reason := pruneRefusal(&wt, listResult.CurrentAnchor); reason != "" {
+			result.Skipped = append(result.Skipped, SkippedEntry{Name: name, Reason: reason})
 			continue
 		}
 
-		if wt.NeedsRepair {
-			result.Skipped = append(result.Skipped, SkippedEntry{
-				Name:   name,
-				Reason: wt.StatusMessage + "; " + repairHint(&wt),
-			})
-			continue
-		}
-
-		// Skip worktrees with stacked branches
-		if len(wt.RootBranches) > 0 {
-			result.Skipped = append(result.Skipped, SkippedEntry{
-				Name:   name,
-				Reason: fmt.Sprintf("has %d stacked branches", wt.StackSize),
-			})
-			continue
-		}
-
-		// Skip worktrees with uncommitted changes
-		if wt.IsDirty {
-			result.Skipped = append(result.Skipped, SkippedEntry{
-				Name:   name,
-				Reason: "has uncommitted changes",
-			})
-			continue
-		}
-
-		// Skip if we're currently in this worktree
-		if listResult.CurrentAnchor != "" && wt.AnchorBranch == listResult.CurrentAnchor {
-			result.Skipped = append(result.Skipped, SkippedEntry{
-				Name:   name,
-				Reason: "currently in this worktree",
-			})
-			continue
-		}
-
-		// This worktree is empty and can be pruned
 		if opts.DryRun {
 			result.Pruned = append(result.Pruned, name)
 			continue
 		}
 
-		// Actually remove the worktree
 		if err := RemoveAction(ctx, RemoveOptions{
 			AnchorBranch: wt.AnchorBranch,
-			Force:        false,
+			// A missing directory has nothing to preserve, and a worktree that
+			// still exists has already been refused above if it was dirty.
+			Force: !wt.Exists,
 		}); err != nil {
 			result.Skipped = append(result.Skipped, SkippedEntry{
 				Name:   name,
@@ -645,6 +588,33 @@ func PruneAction(ctx *app.Context, opts PruneOptions) (*PruneResult, error) {
 	}
 
 	return result, nil
+}
+
+// pruneRefusal returns why a worktree cannot be pruned, or "" when it can.
+//
+// The first three checks mirror RemoveAction's own guards, because prune
+// executes through RemoveAction: anything it would reject must be reported as
+// skipped rather than counted as pruned. The rest are prune's own policy —
+// it never discards work, even though RemoveAction would with Force.
+func pruneRefusal(wt *Entry, currentAnchor string) string {
+	switch {
+	case wt.NeedsRepair && (wt.RegistrationState != RegistrationStateInvalid || !wt.CanRemove):
+		// An invalid registration that RemoveAction can still clean up is
+		// pruned rather than sent to `worktree repair`, which cannot fix it.
+		return wt.StatusMessage + "; " + repairHint(wt)
+	case currentAnchor != "" && wt.AnchorBranch == currentAnchor:
+		return "currently in this worktree"
+	case len(wt.RootBranches) > 0:
+		// Checked in both modes now: a registration whose directory is gone but
+		// whose stack still has branches was reported prunable, then rejected
+		// by RemoveAction. Carry RemoveAction's guidance so the refusal still
+		// says what to do about it.
+		return fmt.Sprintf("has %d stacked branches; use 'stackit worktree detach %s' to remove the worktree while keeping them",
+			wt.StackSize, wt.displayName())
+	case wt.Exists && wt.IsDirty:
+		return "has uncommitted changes"
+	}
+	return ""
 }
 
 // AttachOptions contains options for the attach action

--- a/internal/actions/worktree/prune_test.go
+++ b/internal/actions/worktree/prune_test.go
@@ -1,0 +1,91 @@
+package worktree
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPruneRefusal pins the decision that both `worktree prune` and
+// `worktree prune --dry-run` read.
+//
+// The two modes used to decide separately, so --dry-run listed worktrees the
+// real run then refused: a registration whose directory was gone but whose
+// stack still had branches was reported prunable and then rejected by
+// RemoveAction's root-branches guard, and an invalid registration that
+// RemoveAction can clean up was sent to `worktree repair`, which cannot fix it.
+func TestPruneRefusal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		entry         Entry
+		currentAnchor string
+		refused       bool
+	}{
+		{
+			name:  "empty healthy worktree is prunable",
+			entry: Entry{AnchorBranch: "anchor", Exists: true},
+		},
+		{
+			name:  "missing directory is prunable",
+			entry: Entry{AnchorBranch: "anchor"},
+		},
+		{
+			name: "missing directory with stacked branches is refused",
+			// Reported prunable by --dry-run, then refused by the real run.
+			entry:   Entry{AnchorBranch: "anchor", RootBranches: []string{"feature"}, StackSize: 1},
+			refused: true,
+		},
+		{
+			name: "removable invalid registration is prunable",
+			// repairHint sends users to a command that cannot fix this state,
+			// but RemoveAction handles it.
+			entry: Entry{
+				AnchorBranch:      "anchor",
+				NeedsRepair:       true,
+				RegistrationState: RegistrationStateInvalid,
+				CanRemove:         true,
+			},
+		},
+		{
+			name: "unrepairable registration is refused",
+			entry: Entry{
+				AnchorBranch:      "anchor",
+				Exists:            true,
+				NeedsRepair:       true,
+				RegistrationState: RegistrationStateLegacy,
+				StatusMessage:     "registration is legacy",
+			},
+			refused: true,
+		},
+		{
+			name:          "current worktree is refused",
+			entry:         Entry{AnchorBranch: "anchor", Exists: true},
+			currentAnchor: "anchor",
+			refused:       true,
+		},
+		{
+			name:    "dirty worktree is refused",
+			entry:   Entry{AnchorBranch: "anchor", Exists: true, IsDirty: true},
+			refused: true,
+		},
+		{
+			name: "dirty flag on a missing directory does not refuse",
+			// Nothing on disk to protect: the flag is stale.
+			entry: Entry{AnchorBranch: "anchor", IsDirty: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			reason := pruneRefusal(&tt.entry, tt.currentAnchor)
+			if tt.refused {
+				require.NotEmpty(t, reason, "expected a refusal reason")
+				return
+			}
+			require.Empty(t, reason)
+		})
+	}
+}

--- a/internal/engine/restack_held_walk_test.go
+++ b/internal/engine/restack_held_walk_test.go
@@ -1,0 +1,88 @@
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBranchHeldBackCyclicMetadata covers the ancestry walk that decides whether
+// a branch sits behind a held one.
+//
+// The walk followed Parent links with no visited set and no step limit, so a
+// parent loop in metadata — corrupt, or concurrently rewritten by another
+// stackit process mid-pass — spun forever and hung the entire restack.
+func TestBranchHeldBackCyclicMetadata(t *testing.T) {
+	t.Parallel()
+
+	newEngine := func(t *testing.T, states map[string]string) *engineImpl {
+		t.Helper()
+		dir, g := newOptimisticLockTestRepo(t)
+		eng, err := NewEngine(Options{RepoRoot: dir, Trunk: "main", Git: g})
+		require.NoError(t, err)
+		e, ok := eng.(*engineImpl)
+		require.True(t, ok)
+
+		e.mu.Lock()
+		for name, parent := range states {
+			e.state.branchState.Set(name, &BranchState{Parent: parent})
+		}
+		e.mu.Unlock()
+		return e
+	}
+
+	// The walk is capped by branch count, so a hang shows up as a test timeout
+	// rather than a wrong answer. Run it with a deadline to keep the failure
+	// legible instead of letting the whole package time out.
+	within := func(t *testing.T, fn func() bool) bool {
+		t.Helper()
+		done := make(chan bool, 1)
+		go func() { done <- fn() }()
+		select {
+		case got := <-done:
+			return got
+		case <-time.After(20 * time.Second):
+			t.Fatal("branchHeldBack did not terminate: the ancestry walk is unbounded")
+			return false
+		}
+	}
+
+	t.Run("cycle terminates and holds the branch", func(t *testing.T) {
+		t.Parallel()
+		e := newEngine(t, map[string]string{
+			"a": "b",
+			"b": "c",
+			"c": "a",
+		})
+		snap := &restackSnapshot{heldBranches: make(BranchNameSet)}
+
+		// Nothing is held, but the parent chain never reaches trunk. Metadata
+		// that cannot say what a branch is stacked on is not safe to build on.
+		held := within(t, func() bool { return e.branchHeldBack(NewBranch("a", nil), snap) })
+		require.True(t, held)
+	})
+
+	t.Run("self-parent terminates", func(t *testing.T) {
+		t.Parallel()
+		e := newEngine(t, map[string]string{"a": "a"})
+		snap := &restackSnapshot{heldBranches: make(BranchNameSet)}
+
+		held := within(t, func() bool { return e.branchHeldBack(NewBranch("a", nil), snap) })
+		require.True(t, held)
+	})
+
+	t.Run("acyclic chain still resolves normally", func(t *testing.T) {
+		t.Parallel()
+		e := newEngine(t, map[string]string{
+			"child":  "parent",
+			"parent": "main",
+		})
+
+		snap := &restackSnapshot{heldBranches: make(BranchNameSet)}
+		require.False(t, e.branchHeldBack(NewBranch("child", nil), snap))
+
+		snap.heldBranches["parent"] = true
+		require.True(t, e.branchHeldBack(NewBranch("child", nil), snap))
+	})
+}

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -69,7 +69,23 @@ func (e *engineImpl) branchHeldBack(branch Branch, snap *restackSnapshot) bool {
 	if snap.worktreeInspectionFailed {
 		return true
 	}
-	for current := branch.GetName(); current != ""; {
+	current := branch.GetName()
+	visited := make(map[string]bool)
+	// Metadata should be acyclic, but cap the walk as a second line of defense
+	// against malformed or concurrently changing parent metadata — a parent
+	// loop here would hang the whole restack pass. See GetStackRootForBranch,
+	// which guards its own walk the same way.
+	maxSteps := e.BranchNames().Len() + 1
+	for range maxSteps {
+		if current == "" {
+			return false
+		}
+		if visited[current] {
+			// A cycle means the metadata cannot be trusted to say what this
+			// branch is stacked on, so no ref move is safe: hold it.
+			return true
+		}
+		visited[current] = true
 		if snap.heldBranches.Contains(current) {
 			return true
 		}
@@ -82,7 +98,9 @@ func (e *engineImpl) branchHeldBack(branch Branch, snap *restackSnapshot) bool {
 		}
 		current = state.Parent
 	}
-	return false
+	// Ran out of steps without reaching trunk: the chain is longer than the
+	// branch count allows, so treat it as untrustworthy too.
+	return true
 }
 
 // branchRev returns branch's revision from the pass snapshot, falling back to a

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -73,10 +73,65 @@ type WorktreeList []Worktree
 // IsMainWorktree reports whether worktreePath is the repo's main worktree
 // (repoRoot), resolving symlinks on both sides for comparison (e.g. /var vs
 // /private/var on macOS).
+//
+// Only use this when repoRoot is known to be the main working tree. An engine
+// constructed inside a temporary worktree reports that worktree as its repo
+// root, which makes this answer "no" for the user's actual main checkout —
+// prefer WorktreeList.IsMain, which reads the answer from git instead of
+// trusting the caller's idea of where the repo lives.
 func IsMainWorktree(worktreePath, repoRoot string) bool {
-	resolvedWorktree, _ := filepath.EvalSymlinks(worktreePath)
-	resolvedRoot, _ := filepath.EvalSymlinks(repoRoot)
-	return resolvedWorktree == resolvedRoot
+	equal, known := samePath(worktreePath, repoRoot)
+	return known && equal
+}
+
+// samePath reports whether two paths name the same directory, and whether that
+// question could be answered at all. Resolving symlinks on both sides matters
+// on macOS, where /var and /private/var name the same place.
+//
+// The second return value exists because callers guard destructive operations
+// with this: previously both EvalSymlinks errors were discarded, so two
+// unresolvable paths yielded "" == "" and compared equal. Reporting "could not
+// tell" lets each caller pick the safe answer for its own operation.
+func samePath(a, b string) (equal, known bool) {
+	resolvedA, errA := filepath.EvalSymlinks(a)
+	resolvedB, errB := filepath.EvalSymlinks(b)
+	if errA != nil || errB != nil {
+		return false, false
+	}
+	return resolvedA == resolvedB, true
+}
+
+// MainPath returns the main working tree's path. `git worktree list` always
+// reports the main worktree first and linked worktrees after it, so the first
+// entry is authoritative regardless of which worktree the command ran from.
+func (l WorktreeList) MainPath() string {
+	if len(l) == 0 {
+		return ""
+	}
+	return l[0].Path
+}
+
+// IsMain reports whether path is the repo's main working tree, which can never
+// be removed with `git worktree remove`.
+//
+// Prefer this over IsMainWorktree for removal guards. IsMainWorktree compares
+// against whatever the caller believes the repo root to be, and an engine built
+// inside a temporary worktree believes it is that worktree — so the main
+// checkout does not match, the guard passes, and git is asked to remove the
+// user's working tree.
+//
+// Uncertainty resolves to true: with no list to compare against, or paths that
+// cannot be resolved, the caller must not proceed to remove.
+func (l WorktreeList) IsMain(path string) bool {
+	main := l.MainPath()
+	if main == "" {
+		return true
+	}
+	equal, known := samePath(path, main)
+	if !known {
+		return true
+	}
+	return equal
 }
 
 // PathForBranch returns the worktree path where branchName is checked out,

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -233,3 +233,55 @@ func TestWorktreeRegistry(t *testing.T) {
 		require.Equal(t, "/path/to/worktree2", metas["feature-2"].Path)
 	})
 }
+
+// TestWorktreeListIsMain covers the guard that stops a cleanup path from asking
+// git to remove the user's main working tree.
+//
+// The regression: the guard compared the candidate path against the *engine's*
+// repo root. A consolidation merge runs its steps with an engine rooted in a
+// temporary worktree, so the main checkout never matched, the guard passed, and
+// `git worktree remove <main repo>` was attempted (git refuses, but only after
+// the branch deletion that followed had already been derailed).
+func TestWorktreeListIsMain(t *testing.T) {
+	t.Parallel()
+
+	mainDir := t.TempDir()
+	linkedDir := t.TempDir()
+	list := git.WorktreeList{
+		{Path: mainDir, Branch: "main"},
+		{Path: linkedDir, Branch: "feature"},
+	}
+
+	t.Run("first entry is the main worktree", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, mainDir, list.MainPath())
+		require.True(t, list.IsMain(mainDir))
+		require.False(t, list.IsMain(linkedDir))
+	})
+
+	t.Run("main worktree is recognized regardless of any repo root", func(t *testing.T) {
+		t.Parallel()
+		// This is the actual bug: an unrelated directory standing in for the
+		// temporary merge worktree's repo root must not change the answer.
+		require.False(t, git.IsMainWorktree(mainDir, t.TempDir()))
+		require.True(t, list.IsMain(mainDir))
+	})
+
+	t.Run("unresolvable paths are treated as main", func(t *testing.T) {
+		t.Parallel()
+		missing := filepath.Join(t.TempDir(), "gone")
+		// Cannot prove it is not the main worktree, so removal must not proceed.
+		require.True(t, list.IsMain(missing))
+		require.True(t, git.WorktreeList{}.IsMain(mainDir))
+	})
+
+	t.Run("two unresolvable paths are not equal", func(t *testing.T) {
+		t.Parallel()
+		// Both EvalSymlinks calls used to be discarded, so "" == "" reported a
+		// false positive match between any two nonexistent paths.
+		require.False(t, git.IsMainWorktree(
+			filepath.Join(t.TempDir(), "gone-a"),
+			filepath.Join(t.TempDir(), "gone-b"),
+		))
+	})
+}


### PR DESCRIPTION
**Make worktree cleanup guards match what actually happens**

Follow-on to the worktree reconciliation-safety stack, from the open items in
that audit plus one bug the audit missed — caught live while shipping it.

Each fix here is the same shape: a guard or a preview that disagreed with what
the operation went on to do.

**The guard that asked the wrong object**

- **#1602** — cleanup checked "is this the main working tree?" by comparing
  against the engine's repo root. A consolidation merge runs its steps with an
  engine rooted in a temporary worktree, so the user's main checkout never
  matched, the guard passed, and git was asked to remove it. Observed during
  `merge ship`: "fatal: is a main working tree", followed by a failed branch
  delete. Main-worktree identity now comes from the worktree list, which git
  always reports main-first, so the answer no longer depends on where the
  command runs from. Unresolvable paths resolve to "this is main" so removal
  never proceeds on something that could not be checked.

**The batch that failed whole instead of skipping one**

- **#1603** — a merged branch checked out in a main working tree that is not
  yours (syncing from a linked worktree, or the temp worktree mid-ship) was
  reported ready to delete. Refs are deleted in one atomic batch, so git
  rejected every branch over that one and nothing was cleaned. It is now
  skipped individually. Deleting the engine's own HEAD still works, because
  DeleteBranches checks out trunk first when the batch contains it.
  Also: results were built from the plan before execution, so branches
  execution declined to touch were still announced as deleted.

**The preview that promised what the run refused**

- **#1604** — `prune --dry-run` and `prune` evaluated separately. A
  registration whose directory was gone but whose stack still had branches was
  listed as prunable, then rejected; an invalid registration that RemoveAction
  can clean up was sent to `worktree repair`, which cannot fix it. Both modes
  read one decision now, and the refusal carries the `worktree detach` guidance
  that previously appeared only after the real run failed.

**The orderings that failed toward the invisible state**

- **#1605** — `RemoveAction` unregistered before deleting the anchor, so an
  interruption between them left an anchor branch with no registration:
  invisible to every worktree command, unreachable by repair. Detach already
  fails the other way, leaving something the user can see and act on. Remove
  now matches, and restores the anchor on rollback.
- **#1606** — the held-branch ancestry walk had no visited set and no step
  limit, so a parent loop hung the whole restack pass. Concurrent metadata
  rewrites are a likelier cause than corruption, since the walk re-reads state
  per iteration rather than from one snapshot. A cycle now resolves to "held":
  metadata that cannot say what a branch is stacked on is not safe to rebase
  onto.

**Still open**

The phantom-conflict diagnosis for held branches, actionable dead-worktree
errors, ownership divergence at mutation time, warm-start follow-ups, and the
P3 tail.

This PR merges the following changes:

1. **#1602** fix(worktree): identify the main worktree from git, not the caller
2. **#1603** fix(sync): skip foreign checkouts instead of failing the cleanup batch
3. **#1604** fix(worktree): decide prune once for both dry-run and the real run
4. **#1605** fix(worktree): delete the anchor before unregistering it
5. **#1606** fix(engine): cap the held-branch ancestry walk

### Stack

```
main
  └─ jonnii/20260805131650/identify-the-main-worktree-from-git-not-the (#1602)
    └─ jonnii/20260805132304/skip-foreign-checkouts-instead-of-failing-the (#1603)
      └─ jonnii/20260805134842/decide-prune-once-for-both-dry-run-and-the-real (#1604)
        └─ jonnii/20260805135039/delete-the-anchor-before-unregistering-it (#1605)
          └─ jonnii/20260805135402/cap-the-held-branch-ancestry-walk (#1606)
```

Stackit-Stack-Size: 5
Stackit-PRs: 1602,1603,1604,1605,1606
