### PR TITLE
fix(merge): leave main-worktree checkouts to post-merge cleanup

### DIFF
--- a/internal/actions/merge/execute.go
+++ b/internal/actions/merge/execute.go
@@ -2,6 +2,7 @@ package merge
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/getstackit/stackit/internal/app"
@@ -393,8 +394,17 @@ func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecut
 		if branch.IsTracked() {
 			// Check if branch is checked out in a worktree and remove it first
 			// Git refuses to delete a branch that is checked out in any worktree
-			if err := removeWorktreeForBranch(ctx.Context, step.BranchName, worktrees, eng, out); err != nil {
-				out.Warn("Failed to remove worktree for branch %s: %v", step.BranchName, err)
+			removeErr := removeWorktreeForBranch(ctx.Context, step.BranchName, worktrees, eng, out)
+			if errors.Is(removeErr, errBranchInMainWorktree) {
+				// Nothing to warn about: the branch cannot be deleted from here,
+				// but the post-merge trunk sync runs in that working tree and
+				// deletes it there, switching HEAD to trunk first. Attempting it
+				// now only produces two failures the user cannot act on.
+				out.Debug("Branch %s is checked out in a main working tree; leaving it to post-merge cleanup", step.BranchName)
+				return nil
+			}
+			if removeErr != nil {
+				out.Warn("Failed to remove worktree for branch %s: %v", step.BranchName, removeErr)
 				// Continue anyway - deletion might still work if worktree is gone
 			}
 
@@ -445,6 +455,11 @@ func executeStep(ctx *app.Context, step PlanStep, stepIndex int, eng mergeExecut
 	return nil
 }
 
+// errBranchInMainWorktree marks a branch whose checkout cannot be freed here:
+// it lives in a main working tree, which cannot be removed, and which is not
+// this engine's own HEAD during a consolidation merge.
+var errBranchInMainWorktree = errors.New("branch is checked out in a main working tree")
+
 // removeWorktreeForBranch removes any worktree that has the given branch checked out.
 // This is necessary because git refuses to delete a branch that is checked out in any worktree.
 // Returns nil if no worktree exists or if removal succeeds.
@@ -463,7 +478,7 @@ func removeWorktreeForBranch(ctx context.Context, branchName string, worktrees g
 	// match the user's main checkout and git would be asked to remove it.
 	if worktrees.IsMain(worktreePath) {
 		out.Debug("Branch %s is in main worktree, cannot remove", branchName)
-		return fmt.Errorf("branch %s is checked out in main worktree", branchName)
+		return fmt.Errorf("%w: %s", errBranchInMainWorktree, worktreePath)
 	}
 
 	out.Debug("Removing worktree at %s for branch %s", worktreePath, branchName)

--- a/internal/actions/merge/remove_worktree_test.go
+++ b/internal/actions/merge/remove_worktree_test.go
@@ -1,0 +1,79 @@
+package merge
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/internal/output"
+)
+
+// recordingRemoveEngine records RemoveWorktree calls so a test can assert that
+// a destructive call was never attempted.
+type recordingRemoveEngine struct {
+	mergeExecuteEngine
+	removed []string
+}
+
+func (e *recordingRemoveEngine) RemoveWorktree(_ context.Context, path string) error {
+	e.removed = append(e.removed, path)
+	return nil
+}
+
+// TestRemoveWorktreeForBranch covers freeing a branch's checkout before the
+// merge plan deletes it.
+//
+// A consolidation merge runs its steps with an engine rooted in a temporary
+// worktree. The main-worktree guard used to compare the candidate path against
+// that engine's repo root, so the user's main checkout never matched and
+// `git worktree remove <main repo>` was attempted — git refuses, but only after
+// the attempt, and the branch delete that followed then failed too. Both showed
+// up as warnings about a failure the user could do nothing about.
+func TestRemoveWorktreeForBranch(t *testing.T) {
+	t.Parallel()
+
+	mainRepo := t.TempDir()
+	linked := t.TempDir()
+	worktrees := git.WorktreeList{
+		{Path: mainRepo, Branch: "landed"},
+		{Path: linked, Branch: "feature"},
+	}
+	out := output.NewNullOutput()
+
+	t.Run("refuses the main working tree without calling git", func(t *testing.T) {
+		t.Parallel()
+		eng := &recordingRemoveEngine{}
+
+		err := removeWorktreeForBranch(context.Background(), "landed", worktrees, eng, out)
+
+		require.ErrorIs(t, err, errBranchInMainWorktree,
+			"caller relies on this sentinel to defer the branch to post-merge cleanup")
+		require.Empty(t, eng.removed, "must not ask git to remove a main working tree")
+	})
+
+	t.Run("removes a linked worktree", func(t *testing.T) {
+		t.Parallel()
+		eng := &recordingRemoveEngine{}
+
+		require.NoError(t, removeWorktreeForBranch(context.Background(), "feature", worktrees, eng, out))
+		require.Equal(t, []string{linked}, eng.removed)
+	})
+
+	t.Run("branch in no worktree needs nothing removed", func(t *testing.T) {
+		t.Parallel()
+		eng := &recordingRemoveEngine{}
+
+		require.NoError(t, removeWorktreeForBranch(context.Background(), "untouched", worktrees, eng, out))
+		require.Empty(t, eng.removed)
+	})
+
+	t.Run("sentinel is distinguishable from a real removal failure", func(t *testing.T) {
+		t.Parallel()
+		// The caller treats only the sentinel as "not a problem"; anything else
+		// still warns.
+		require.False(t, errors.Is(errors.New("failed to remove worktree"), errBranchInMainWorktree))
+	})
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

A branch checked out in a main working tree cannot be deleted from a
consolidation merge: that worktree cannot be removed to free it, and it is not
the merge engine's own HEAD, so nothing switches it to trunk. The step tried
anyway and emitted two warnings for a failure the user could not act on —
"failed to remove worktree" followed by "failed to delete branch".

Nothing was actually wrong. The trunk sync that runs right after the merge
deletes the branch from that working tree, switching HEAD to trunk first. Skip
the attempt and say so at debug level instead.

Observed on both of the last two ships, where the branch was reported as two
failures and then deleted seconds later by the cleanup phase.

<hr/>

<!-- STACKIT-SECTION-START -->
**Stop misreading worktrees you cannot act on or cannot see into**

Two more from the worktree audit's open list, both about a check that drew the
wrong conclusion from a worktree it could not handle.

**A failure that was not one**

- **#1608** — a branch checked out in a main working tree cannot be deleted by
  a consolidation merge: that worktree cannot be removed to free it, and it is
  not the merge engine's own HEAD, so nothing switches it to trunk. The step
  tried regardless and emitted two warnings — "failed to remove worktree", then
  "failed to delete branch" — for something the user could do nothing about.
  Nothing was wrong: the trunk sync immediately after deletes the branch from
  that working tree. Observed on both of the last two ships, warned about and
  then silently succeeding seconds later. The step now defers and says so at
  debug level.

**A probe whose error meant the opposite of what was assumed**

- **#1609** — sync discarded the dirty probe's error, so a worktree git could
  not read came back "clean" and its stack was restacked anyway. The probe
  fails when something is holding the worktree — an index.lock from a
  concurrent stackit or an agent, unreadable permissions — which is exactly
  when moving refs under that checkout is least safe. The engine already fails
  closed here; this closes the same hole at the action layer.

  A missing directory is deliberately not lumped in: there is no working tree
  left to protect, and counting it as unsafe would disable the orphan cleanup
  whose whole job is retiring that registration. An existing test caught this,
  which is why the two cases are now distinguished explicitly.

  Sync and its --dry-run preview read one decision now, the same divergence

**Still open**

The phantom-conflict diagnosis for held branches, actionable dead-worktree
errors, ownership divergence at mutation time, metadata compare-and-swap, and
the warm-start group.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785978752`.


* **PR #1608** 👈
  * **PR #1609**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1610 by jonnii*