### PR TITLE
fix(sync): treat an uninspectable worktree as unsafe

### DIFF
--- a/internal/actions/sync/skip_reason_test.go
+++ b/internal/actions/sync/skip_reason_test.go
@@ -1,0 +1,62 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type stubInspector struct {
+	hasChanges bool
+	err        error
+}
+
+func (s stubInspector) WorktreeHasUncommittedChanges(context.Context, string) (bool, error) {
+	return s.hasChanges, s.err
+}
+
+// TestSkipReasonForWorktree pins the decision sync and its --dry-run preview
+// both read before touching a managed worktree's stack.
+//
+// The dirty probe's error used to be discarded, so a worktree git could not
+// read — an index.lock held by a concurrent process, unreadable permissions —
+// came back "clean" and the restack moved refs under a checkout whose contents
+// were unknown. That is exactly the state the skip exists to prevent.
+func TestSkipReasonForWorktree(t *testing.T) {
+	t.Parallel()
+
+	existing := t.TempDir()
+
+	t.Run("clean worktree is safe", func(t *testing.T) {
+		t.Parallel()
+		require.Empty(t, SkipReasonForWorktree(context.Background(), stubInspector{}, existing))
+	})
+
+	t.Run("dirty worktree is skipped", func(t *testing.T) {
+		t.Parallel()
+		reason := SkipReasonForWorktree(context.Background(), stubInspector{hasChanges: true}, existing)
+		require.Contains(t, reason, "uncommitted changes")
+	})
+
+	t.Run("uninspectable worktree is skipped", func(t *testing.T) {
+		t.Parallel()
+		reason := SkipReasonForWorktree(context.Background(),
+			stubInspector{err: errors.New("index.lock exists")}, existing)
+		require.Contains(t, reason, "cannot inspect")
+		require.Contains(t, reason, "index.lock")
+	})
+
+	t.Run("missing directory is not skipped", func(t *testing.T) {
+		t.Parallel()
+		// Nothing left to protect, and skipping would block the orphan cleanup
+		// whose whole job is retiring this registration. The probe would fail
+		// here, so this must not be lumped in with uninspectable worktrees.
+		missing := filepath.Join(t.TempDir(), "gone")
+		reason := SkipReasonForWorktree(context.Background(),
+			stubInspector{err: errors.New("no such file or directory")}, missing)
+		require.Empty(t, reason)
+	})
+}

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -65,13 +65,15 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	managedWorktrees, err := eng.ListManagedWorktrees()
 	if err == nil {
 		for _, wt := range managedWorktrees {
-			if hasChanges, _ := eng.WorktreeHasUncommittedChanges(gctx, wt.Path); hasChanges {
-				if dirtyAnchors == nil {
-					dirtyAnchors = make(dirtyAnchorSet)
-				}
-				dirtyAnchors[wt.AnchorBranch] = true
-				out.Warn("Skipping stack rooted at %s (worktree has uncommitted changes)", wt.AnchorBranch)
+			reason := SkipReasonForWorktree(gctx, eng, wt.Path)
+			if reason == "" {
+				continue
 			}
+			if dirtyAnchors == nil {
+				dirtyAnchors = make(dirtyAnchorSet)
+			}
+			dirtyAnchors[wt.AnchorBranch] = true
+			out.Warn("Skipping stack rooted at %s (%s)", wt.AnchorBranch, reason)
 		}
 	}
 

--- a/internal/actions/sync/worktree_cleanup.go
+++ b/internal/actions/sync/worktree_cleanup.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -9,6 +11,37 @@ import (
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/git"
 )
+
+// WorktreeInspector is the narrow dependency SkipReasonForWorktree needs.
+type WorktreeInspector interface {
+	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)
+}
+
+// SkipReasonForWorktree returns why a managed worktree's stack must be left
+// alone this pass, or "" when it is safe to touch. Both sync and its --dry-run
+// preview call this, so the preview cannot promise work the run then skips.
+//
+// A failed inspection counts as unsafe. The probe fails when git cannot read
+// the worktree — an index.lock held by another process, unreadable permissions
+// — and reading that as clean would move refs under a checkout whose contents
+// are unknown, which is exactly what the skip exists to prevent.
+//
+// A missing directory is the one exception: there is no working tree left to
+// protect, and treating it as unsafe would block the orphan cleanup that exists
+// to retire its registration.
+func SkipReasonForWorktree(ctx context.Context, eng WorktreeInspector, worktreePath string) string {
+	if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
+		return ""
+	}
+	hasChanges, inspectErr := eng.WorktreeHasUncommittedChanges(ctx, worktreePath)
+	switch {
+	case inspectErr != nil:
+		return fmt.Sprintf("cannot inspect worktree at %s: %v", worktreePath, inspectErr)
+	case hasChanges:
+		return "worktree has uncommitted changes"
+	}
+	return ""
+}
 
 // WorktreeCleanupResult contains the results of worktree cleanup
 type WorktreeCleanupResult struct {

--- a/internal/cli/stack/sync.go
+++ b/internal/cli/stack/sync.go
@@ -215,11 +215,11 @@ func computeSyncDryRun(ctx context.Context, eng engine.Engine, opts sync.Options
 		}
 	}
 
-	// Check for dirty worktrees
+	// Same decision sync itself makes, so the preview cannot disagree with the run.
 	managedWorktrees, err := eng.ListManagedWorktrees()
 	if err == nil {
 		for _, wt := range managedWorktrees {
-			if hasChanges, _ := eng.WorktreeHasUncommittedChanges(ctx, wt.Path); hasChanges {
+			if sync.SkipReasonForWorktree(ctx, eng, wt.Path) != "" {
 				plan.skipped = append(plan.skipped, wt.AnchorBranch)
 			}
 		}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The dirty probe's error was discarded, so a worktree git could not read came
back "clean" and its stack was restacked anyway. The probe fails when something
is holding the worktree — an index.lock from a concurrent stackit or an agent,
unreadable permissions — which is precisely when moving refs under that
checkout is least safe. The engine already fails closed here; this closes the
same hole at the action layer.

A missing directory stays safe to touch: there is no working tree left to
protect, and counting it as unsafe would block the orphan cleanup whose job is
retiring that registration.

Sync and its --dry-run preview now read one decision, so the preview cannot
promise work the run skips.

<hr/>

<!-- STACKIT-SECTION-START -->
**Stop misreading worktrees you cannot act on or cannot see into**

Two more from the worktree audit's open list, both about a check that drew the
wrong conclusion from a worktree it could not handle.

**A failure that was not one**

- **#1608** — a branch checked out in a main working tree cannot be deleted by
  a consolidation merge: that worktree cannot be removed to free it, and it is
  not the merge engine's own HEAD, so nothing switches it to trunk. The step
  tried regardless and emitted two warnings — "failed to remove worktree", then
  "failed to delete branch" — for something the user could do nothing about.
  Nothing was wrong: the trunk sync immediately after deletes the branch from
  that working tree. Observed on both of the last two ships, warned about and
  then silently succeeding seconds later. The step now defers and says so at
  debug level.

**A probe whose error meant the opposite of what was assumed**

- **#1609** — sync discarded the dirty probe's error, so a worktree git could
  not read came back "clean" and its stack was restacked anyway. The probe
  fails when something is holding the worktree — an index.lock from a
  concurrent stackit or an agent, unreadable permissions — which is exactly
  when moving refs under that checkout is least safe. The engine already fails
  closed here; this closes the same hole at the action layer.

  A missing directory is deliberately not lumped in: there is no working tree
  left to protect, and counting it as unsafe would disable the orphan cleanup
  whose whole job is retiring that registration. An existing test caught this,
  which is why the two cases are now distinguished explicitly.

  Sync and its --dry-run preview read one decision now, the same divergence

**Still open**

The phantom-conflict diagnosis for held branches, actionable dead-worktree
errors, ownership divergence at mutation time, metadata compare-and-swap, and
the warm-start group.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785978752`.


* **PR #1608**
  * **PR #1609** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1610 by jonnii*