### PR TITLE
fix(git): compare-and-swap metadata writes

### DIFF
--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -262,7 +262,7 @@ func (r *runner) ReadMetadata(branchName string) (*Meta, error) {
 
 	// Pass the ref name directly to cat-file --batch: it resolves ref → blob in one
 	// step, replacing the two rev-parse subprocesses GetRef previously spawned.
-	content, found, err := r.objects.ReadObject(refName)
+	content, sha, found, err := r.objects.ReadObjectWithSHA(refName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read metadata for %s: %w", branchName, err)
 	}
@@ -277,7 +277,9 @@ func (r *runner) ReadMetadata(branchName string) (*Meta, error) {
 		return nil, fmt.Errorf("failed to unmarshal metadata for %s: %w", branchName, err)
 	}
 
-	r.metadataCache.Put(branchName, &meta)
+	// Remember which blob this came from so WriteMetadata can refuse to
+	// overwrite a different one.
+	r.metadataCache.PutWithSHA(branchName, &meta, sha)
 	return &meta, nil
 }
 
@@ -293,11 +295,45 @@ func (r *runner) WriteMetadata(branchName string, meta *Meta) error {
 	}
 
 	refName := fmt.Sprintf("%s%s", MetadataRefPrefix, branchName)
-	if err := r.UpdateRef(refName, sha); err != nil {
-		return fmt.Errorf("failed to write metadata ref: %w", err)
+	if err := r.updateMetadataRefCAS(refName, branchName, sha); err != nil {
+		return err
 	}
 
-	r.metadataCache.Put(branchName, meta)
+	r.metadataCache.PutWithSHA(branchName, meta, sha)
+	return nil
+}
+
+// updateMetadataRefCAS writes a metadata ref, requiring it to still hold the
+// blob this process last read.
+//
+// Without the expectation, two stackit processes in different worktrees that
+// both read a branch's metadata and then wrote it would silently keep only the
+// second write. Failing is the right outcome: the caller based its new metadata
+// on state that no longer exists, so applying it would drop whatever the other
+// process recorded.
+//
+// An unknown expectation (never read in this process, or invalidated since)
+// falls back to an unconditional write, which is what creating metadata for a
+// newly tracked branch needs.
+func (r *runner) updateMetadataRefCAS(refName, branchName, newSHA string) error {
+	expected := r.metadataCache.SHAFor(branchName)
+	if expected == "" {
+		if err := r.UpdateRef(refName, newSHA); err != nil {
+			return fmt.Errorf("failed to write metadata ref: %w", err)
+		}
+		return nil
+	}
+	if expected == newSHA {
+		return nil // Identical content; nothing to write.
+	}
+	err := r.UpdateRefsBatch(context.Background(), []RefUpdate{{
+		RefName: refName,
+		NewSHA:  newSHA,
+		OldSHA:  expected,
+	}})
+	if err != nil {
+		return fmt.Errorf("failed to write metadata ref for %s (another process changed it; re-run to pick up their change): %w", branchName, err)
+	}
 	return nil
 }
 
@@ -350,13 +386,15 @@ func (r *runner) RenameMetadata(oldName, newName string) error {
 func (r *runner) ReadLocalMetadata(branchName string) (*LocalMeta, error) {
 	refName := fmt.Sprintf("%s%s", LocalMetadataRefPrefix, branchName)
 
-	content, found, err := r.objects.ReadObject(refName)
+	content, sha, found, err := r.objects.ReadObjectWithSHA(refName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read local metadata for %s: %w", branchName, err)
 	}
 	if !found || content == "" {
 		return &LocalMeta{}, nil
 	}
+	// Remember the blob so WriteLocalMetadata can refuse to clobber a different one.
+	r.metadataCache.PutLocalSHA(branchName, sha)
 
 	var meta LocalMeta
 	if err := json.Unmarshal([]byte(content), &meta); err != nil {
@@ -378,8 +416,20 @@ func (r *runner) WriteLocalMetadata(branchName string, meta *LocalMeta) error {
 	}
 
 	refName := fmt.Sprintf("%s%s", LocalMetadataRefPrefix, branchName)
-	if err := r.UpdateRef(refName, sha); err != nil {
+	if expected := r.metadataCache.LocalSHAFor(branchName); expected != "" && expected != sha {
+		err := r.UpdateRefsBatch(context.Background(), []RefUpdate{{
+			RefName: refName,
+			NewSHA:  sha,
+			OldSHA:  expected,
+		}})
+		if err != nil {
+			return fmt.Errorf("failed to write local metadata ref for %s (another process changed it; re-run to pick up their change): %w", branchName, err)
+		}
+		r.metadataCache.PutLocalSHA(branchName, sha)
+	} else if err := r.UpdateRef(refName, sha); err != nil {
 		return fmt.Errorf("failed to write local metadata ref: %w", err)
+	} else {
+		r.metadataCache.PutLocalSHA(branchName, sha)
 	}
 
 	return nil

--- a/internal/git/metadata_cache.go
+++ b/internal/git/metadata_cache.go
@@ -11,6 +11,12 @@ import (
 // without deep copying.
 type metadataCache struct {
 	entries sync.Map // map[string]*Meta
+	refSHAs sync.Map // map[string]string — ref SHA each entry was read from
+
+	// localRefSHAs tracks the same thing for local-metadata refs. Local
+	// metadata is not cached (its values are read fresh), but its writes still
+	// need something to compare against.
+	localRefSHAs sync.Map // map[string]string
 
 	// Instrumentation counters. Updated with atomics to stay lock-free on the
 	// hot Get path. Exposed via Summary() for logging and tests.
@@ -57,15 +63,62 @@ func (c *metadataCache) Put(branchName string, meta *Meta) {
 	c.entries.Store(branchName, meta)
 }
 
+// PutWithSHA stores the metadata along with the ref SHA it was read from, so a
+// later write of the same branch can require the ref to still hold that value.
+func (c *metadataCache) PutWithSHA(branchName string, meta *Meta, sha string) {
+	c.entries.Store(branchName, meta)
+	if sha == "" {
+		c.refSHAs.Delete(branchName)
+		return
+	}
+	c.refSHAs.Store(branchName, sha)
+}
+
+// SHAFor returns the ref SHA this process last read for the branch, or "" when
+// it has not read one. Writers treat "" as "no expectation to enforce" rather
+// than "the ref is absent", because the branch may simply never have been read
+// in this process.
+func (c *metadataCache) SHAFor(branchName string) string {
+	value, ok := c.refSHAs.Load(branchName)
+	if !ok {
+		return ""
+	}
+	sha, _ := value.(string)
+	return sha
+}
+
+// PutLocalSHA records the ref SHA a branch's local metadata was read from.
+func (c *metadataCache) PutLocalSHA(branchName, sha string) {
+	if sha == "" {
+		c.localRefSHAs.Delete(branchName)
+		return
+	}
+	c.localRefSHAs.Store(branchName, sha)
+}
+
+// LocalSHAFor returns the local-metadata ref SHA this process last read, or "".
+func (c *metadataCache) LocalSHAFor(branchName string) string {
+	value, ok := c.localRefSHAs.Load(branchName)
+	if !ok {
+		return ""
+	}
+	sha, _ := value.(string)
+	return sha
+}
+
 // Delete removes the cached metadata for the given branch.
 func (c *metadataCache) Delete(branchName string) {
 	c.entries.Delete(branchName)
+	c.refSHAs.Delete(branchName)
+	c.localRefSHAs.Delete(branchName)
 }
 
 // Clear removes all entries from the cache.
 // Used during Rebuild to ensure stale metadata from external changes is not retained.
 func (c *metadataCache) Clear() {
 	c.entries.Clear()
+	c.refSHAs.Clear()
+	c.localRefSHAs.Clear()
 }
 
 // InvalidateForRefs clears cached metadata for any refs in the given batch
@@ -74,7 +127,10 @@ func (c *metadataCache) Clear() {
 func (c *metadataCache) InvalidateForRefs(updates []RefUpdate) {
 	for _, update := range updates {
 		if branchName, ok := strings.CutPrefix(update.RefName, MetadataRefPrefix); ok {
-			c.entries.Delete(branchName)
+			c.Delete(branchName)
+		}
+		if branchName, ok := strings.CutPrefix(update.RefName, LocalMetadataRefPrefix); ok {
+			c.localRefSHAs.Delete(branchName)
 		}
 	}
 }
@@ -84,7 +140,10 @@ func (c *metadataCache) InvalidateForRefs(updates []RefUpdate) {
 func (c *metadataCache) InvalidateForRefNames(refNames []string) {
 	for _, refName := range refNames {
 		if branchName, ok := strings.CutPrefix(refName, MetadataRefPrefix); ok {
-			c.entries.Delete(branchName)
+			c.Delete(branchName)
+		}
+		if branchName, ok := strings.CutPrefix(refName, LocalMetadataRefPrefix); ok {
+			c.localRefSHAs.Delete(branchName)
 		}
 	}
 }

--- a/internal/git/metadata_cas_test.go
+++ b/internal/git/metadata_cas_test.go
@@ -1,0 +1,97 @@
+package git_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+)
+
+// TestMetadataWriteCompareAndSwap covers two stackit processes writing the same
+// branch's metadata.
+//
+// Both runners read the same state, then both write. The writes used to be
+// unconditional `update-ref`, so the second silently discarded whatever the
+// first recorded — a parent change, a PR number, a scope. Each runner now
+// remembers the blob it read and requires the ref to still hold it, so the
+// stale write fails loudly instead.
+func TestMetadataWriteCompareAndSwap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("stale write is rejected", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+
+		// Two runners stand in for two processes against the same repo.
+		first := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+		second := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+
+		main := "main"
+		require.NoError(t, first.WriteMetadata("feature", git.NewMeta().WithParentBranchName(&main)))
+
+		// Both read the same starting point.
+		fromFirst, err := first.ReadMetadata("feature")
+		require.NoError(t, err)
+		fromSecond, err := second.ReadMetadata("feature")
+		require.NoError(t, err)
+		require.Equal(t, "main", *fromSecond.GetParentBranchName())
+
+		// First writes.
+		firstParent := "first-parent"
+		require.NoError(t, first.WriteMetadata("feature", fromFirst.WithParentBranchName(&firstParent)))
+
+		// Second writes based on what it read before that.
+		secondParent := "second-parent"
+		err = second.WriteMetadata("feature", fromSecond.WithParentBranchName(&secondParent))
+		require.Error(t, err, "a write based on superseded state must not silently win")
+		require.Contains(t, err.Error(), "another process changed it")
+
+		// The first write survives.
+		latest, err := first.ReadMetadata("feature")
+		require.NoError(t, err)
+		require.Equal(t, "first-parent", *latest.GetParentBranchName())
+	})
+
+	t.Run("write after re-reading succeeds", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+		first := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+		second := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+
+		main := "main"
+		require.NoError(t, first.WriteMetadata("feature", git.NewMeta().WithParentBranchName(&main)))
+
+		fromFirst, err := first.ReadMetadata("feature")
+		require.NoError(t, err)
+		firstParent := "first-parent"
+		require.NoError(t, first.WriteMetadata("feature", fromFirst.WithParentBranchName(&firstParent)))
+
+		// Re-reading picks up the new blob, so the follow-up write is based on
+		// current state and is allowed.
+		fresh, err := second.ReadMetadata("feature")
+		require.NoError(t, err)
+		require.Equal(t, "first-parent", *fresh.GetParentBranchName())
+		secondParent := "second-parent"
+		require.NoError(t, second.WriteMetadata("feature", fresh.WithParentBranchName(&secondParent)))
+
+		latest, err := second.ReadMetadata("feature")
+		require.NoError(t, err)
+		require.Equal(t, "second-parent", *latest.GetParentBranchName())
+	})
+
+	t.Run("first write of a branch needs no expectation", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+
+		// Never read: tracking a new branch must not require one.
+		main := "main"
+		require.NoError(t, runner.WriteMetadata("brand-new", git.NewMeta().WithParentBranchName(&main)))
+
+		stored, err := runner.ReadMetadata("brand-new")
+		require.NoError(t, err)
+		require.Equal(t, "main", *stored.GetParentBranchName())
+	})
+}

--- a/internal/git/object_reader.go
+++ b/internal/git/object_reader.go
@@ -68,62 +68,72 @@ func (r *objectReader) killLocked() {
 }
 
 // readResponse reads one response from stdout. Caller must hold r.mu.
-func (r *objectReader) readResponse(ref string) (string, bool, error) {
+func (r *objectReader) readResponse(ref string) (content, sha string, found bool, err error) {
 	header, err := r.stdout.ReadString('\n')
 	if err != nil {
-		return "", false, fmt.Errorf("object reader read header for %s: %w", ref, err)
+		return "", "", false, fmt.Errorf("object reader read header for %s: %w", ref, err)
 	}
 	header = strings.TrimSuffix(header, "\n")
 
 	// Missing: "<ref> missing"
 	if strings.HasSuffix(header, " missing") {
-		return "", false, nil
+		return "", "", false, nil
 	}
 
 	// Present: "<sha> <type> <size>"
 	parts := strings.Fields(header)
 	if len(parts) != 3 {
-		return "", false, fmt.Errorf("object reader unexpected header %q for %s", header, ref)
+		return "", "", false, fmt.Errorf("object reader unexpected header %q for %s", header, ref)
 	}
 	size, err := strconv.Atoi(parts[2])
 	if err != nil {
-		return "", false, fmt.Errorf("object reader bad size in header %q: %w", header, err)
+		return "", "", false, fmt.Errorf("object reader bad size in header %q: %w", header, err)
 	}
 
 	// Read exactly size bytes + the trailing newline git appends after each object
 	buf := make([]byte, size+1)
 	if _, err := io.ReadFull(r.stdout, buf); err != nil {
-		return "", false, fmt.Errorf("object reader read body for %s: %w", ref, err)
+		return "", "", false, fmt.Errorf("object reader read body for %s: %w", ref, err)
 	}
-	return string(buf[:size]), true, nil
+	// parts[0] is the resolved object's SHA. Metadata refs point straight at a
+	// blob, so this is the value a later compare-and-swap update must match.
+	return string(buf[:size]), parts[0], true, nil
 }
 
 // ReadObject reads one object by ref name or SHA, restarting the process once on I/O failure.
 func (r *objectReader) ReadObject(ref string) (string, bool, error) {
+	content, _, found, err := r.ReadObjectWithSHA(ref)
+	return content, found, err
+}
+
+// ReadObjectWithSHA is ReadObject plus the resolved object's SHA. Callers that
+// intend to write the ref back use the SHA to detect another process having
+// written it in between.
+func (r *objectReader) ReadObjectWithSHA(ref string) (content, sha string, found bool, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.cmd == nil {
 		if err := r.start(); err != nil {
-			return "", false, err
+			return "", "", false, err
 		}
 	}
 	if _, err := fmt.Fprintf(r.stdin, "%s\n", ref); err != nil {
 		// Process died; restart and retry once
 		r.killLocked()
 		if startErr := r.start(); startErr != nil {
-			return "", false, startErr
+			return "", "", false, startErr
 		}
 		if _, err := fmt.Fprintf(r.stdin, "%s\n", ref); err != nil {
-			return "", false, fmt.Errorf("object reader write after restart: %w", err)
+			return "", "", false, fmt.Errorf("object reader write after restart: %w", err)
 		}
 	}
-	content, found, err := r.readResponse(ref)
+	content, sha, found, err = r.readResponse(ref)
 	if err != nil {
 		// Stdout stream is broken; discard the process so the next call
 		// restarts, mirroring ReadObjectsBatch.
 		r.killLocked()
 	}
-	return content, found, err
+	return content, sha, found, err
 }
 
 // ReadObjectsBatch sends all refs in one burst and reads all responses in order.
@@ -149,7 +159,7 @@ func (r *objectReader) ReadObjectsBatch(refs []string) (map[string]string, error
 	}
 	results := make(map[string]string, len(refs))
 	for _, ref := range refs {
-		content, found, err := r.readResponse(ref)
+		content, _, found, err := r.readResponse(ref)
 		if err != nil {
 			// Stdout stream is broken; discard the process so the next call restarts.
 			r.killLocked()


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

WriteMetadata and WriteLocalMetadata wrote unconditionally, so two stackit
processes in different worktrees that both read a branch and then wrote it kept
only the second write. Whatever the first recorded — a parent change, a PR
number, a scope — was silently gone.

Metadata refs point straight at a blob, and cat-file already reports that
blob's SHA in its header; it was being parsed and discarded. Keep it, and
require the ref to still hold it when writing back. A write based on state
another process has already replaced now fails and says so, rather than
dropping their change.

An unknown expectation falls back to an unconditional write, which is what
creating metadata for a newly tracked branch needs.

<hr/>

<!-- STACKIT-SECTION-START -->
**Close out the worktree audit, and stop holding restacks for harmless files**

The last of the worktree audit's open items, plus one behavior change the audit
did not ask for.

**Concurrency and cancellation**

- **#1611** — metadata writes are compare-and-swap. Two stackit processes in
  different worktrees that both read a branch and then wrote it kept only the
  second write; whatever the first recorded was silently gone. Metadata refs
  point straight at a blob and cat-file already reports that blob's SHA — it was
  being parsed and discarded. A write based on state another process replaced
  now fails and says so.
- **#1612** — worktree registration and post-create hooks ran with
  context.Background(), ignoring cancellation. AttachAction also discarded the
  error from restoring your original branch, leaving you somewhere you did not
  ask to be without saying so.

**Guidance that assumed the worktree was still there**

- **#1613** — the ownership guard told users to `cd` into the owning worktree
  without checking it existed, so a deleted directory produced advice that could
  only fail, for a branch only detach can release. Checkout's stale-path tip
  named `worktree remove`, which refuses for any stack that still has branches.
  Checkout also only validated the destination when switching from the main
  repo, not between worktrees.
- **#1614** — a branch held back reports RestackUnneeded, the same status as a
  branch that needed no work, so the conflict workflow concluded the rebase had
  succeeded and said so. It now names why the branch is held, and where.
- **#1615** — ownership divergence was only reported by `worktree list`, a
  command nobody runs until they already suspect something. Sync reports it.

**Warm start**

- **#1616** — one unplaceable file aborted worktree creation entirely, because
  any warm-start error makes the caller tear the worktree down. The mundane case
  is a tracked file occupying a name the include file also wants as a directory.
  It is reported and skipped now; a symlinked parent stays a hard failure, since
  that is how a project-controlled include file could steer a copy outside the
  worktree. Directory checks are memoized, and the docs now say plainly that
  warm-started files have no backup anywhere.

**The rule that was too broad**

- **#1617** — restack held a branch whenever its worktree had any untracked
  file. `git reset --hard` overwrites an untracked file only when the incoming
  commit contains that same path; every other one survives. Holding on all of
  them stopped restacks for the ordinary state of having written a new file and
  not staged it. Now it holds only on a real collision. Tracked changes still
  hold unconditionally, and anything unanswerable still holds.

This required the same rule in two places: the engine decides per branch, but
`restack` runs its own filter first, and changing only the engine left the
command unaffected while sync and modify quietly got the new behavior.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785983482`.


* **PR #1611** 👈
  * **PR #1612**
    * **PR #1613**
      * **PR #1614**
        * **PR #1615**
          * **PR #1616**
            * **PR #1617**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1618 by jonnii*