### PR TITLE
fix(worktree): honor cancellation and report a failed checkout restore

### DIFF
--- a/internal/actions/checkout_test.go
+++ b/internal/actions/checkout_test.go
@@ -1,6 +1,7 @@
 package actions_test
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestCheckoutActionWorktreeSwitchIncludesTargetBranch(t *testing.T) {
 			"feature": "main",
 		})
 
-	err := s.Engine.RegisterWorktree("feature", s.Context.RepoRoot)
+	err := s.Engine.RegisterWorktree(context.Background(), "feature", s.Context.RepoRoot)
 	require.NoError(t, err)
 	defer func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") }()
 

--- a/internal/actions/delete/delete_test.go
+++ b/internal/actions/delete/delete_test.go
@@ -198,7 +198,7 @@ func TestDeleteRespectsManagedWorktreeOwnership(t *testing.T) {
 	s.TrackBranch("feature", "main")
 	s.CreateBranch("feature-child").Commit("child change")
 	s.TrackBranch("feature-child", "feature")
-	require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", "/tmp/feature-worktree", "feature-wt"))
+	require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature", "/tmp/feature-worktree", "feature-wt"))
 	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
 
 	_, err := Action(s.Context, Options{BranchName: "feature", Force: true}, nil)
@@ -222,7 +222,7 @@ func TestDeleteCleansUpWorktrees(t *testing.T) {
 		s.TrackBranch("feature-branch", "main")
 
 		// Register a fake worktree for this stack root
-		err := s.Engine.RegisterWorktree("feature-branch", "/tmp/fake-worktree-path")
+		err := s.Engine.RegisterWorktree(context.Background(), "feature-branch", "/tmp/fake-worktree-path")
 		require.NoError(t, err)
 
 		// Verify worktree is registered
@@ -255,7 +255,7 @@ func TestDeleteCleansUpWorktrees(t *testing.T) {
 		s.TrackBranch("child-branch", "stack-root")
 
 		// Register a worktree for the stack root
-		err := s.Engine.RegisterWorktree("stack-root", "/tmp/fake-worktree-path")
+		err := s.Engine.RegisterWorktree(context.Background(), "stack-root", "/tmp/fake-worktree-path")
 		require.NoError(t, err)
 
 		// Verify worktree is registered
@@ -288,7 +288,7 @@ func TestDeleteCleansUpWorktrees(t *testing.T) {
 		s.TrackBranch("child-branch", "stack-root")
 
 		// Register a worktree for the stack root
-		err := s.Engine.RegisterWorktree("stack-root", "/tmp/fake-worktree-path")
+		err := s.Engine.RegisterWorktree(context.Background(), "stack-root", "/tmp/fake-worktree-path")
 		require.NoError(t, err)
 
 		// Verify worktree is registered

--- a/internal/actions/foreach/foreach.go
+++ b/internal/actions/foreach/foreach.go
@@ -508,7 +508,7 @@ func executeCommandOnBranch(ctx context.Context, appCtx *app.Context, branch eng
 	defer cleanup()
 
 	// Run post-worktree-create hooks (pre-resolved, no prompting)
-	worktree.RunResolvedHooks(hooks, worktreePath, appCtx.Output)
+	worktree.RunResolvedHooks(appCtx.Context, hooks, worktreePath, appCtx.Output)
 
 	var output strings.Builder
 	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", fullCommand)

--- a/internal/actions/sync/worktree_cleanup_test.go
+++ b/internal/actions/sync/worktree_cleanup_test.go
@@ -1,6 +1,7 @@
 package sync_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,7 +24,7 @@ func TestSyncCleansOrphanedWorktrees(t *testing.T) {
 		s.TrackBranch("feature-branch", "main")
 
 		// Register a fake worktree for this branch (we won't actually create the worktree dir)
-		err := s.Engine.RegisterWorktree("feature-branch", "/tmp/fake-worktree-path")
+		err := s.Engine.RegisterWorktree(context.Background(), "feature-branch", "/tmp/fake-worktree-path")
 		require.NoError(t, err)
 
 		// Verify worktree is registered
@@ -56,7 +57,7 @@ func TestSyncCleansOrphanedWorktrees(t *testing.T) {
 		s.TrackBranch("feature-branch", "main")
 
 		// Register a worktree for this branch
-		err := s.Engine.RegisterWorktree("feature-branch", "/tmp/fake-worktree-path")
+		err := s.Engine.RegisterWorktree(context.Background(), "feature-branch", "/tmp/fake-worktree-path")
 		require.NoError(t, err)
 
 		// Go back to main and run sync
@@ -78,7 +79,7 @@ func TestSyncCleansOrphanedWorktrees(t *testing.T) {
 		worktreePath := filepath.Join(t.TempDir(), "not-a-git-worktree")
 		require.NoError(t, os.MkdirAll(worktreePath, 0o755))
 
-		err := s.Engine.RegisterWorktree("missing-anchor", worktreePath)
+		err := s.Engine.RegisterWorktree(context.Background(), "missing-anchor", worktreePath)
 		require.NoError(t, err)
 
 		handler := &sync.NullHandler{}

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -75,7 +75,7 @@ func snapshotWorktree(ctx *app.Context, entry *Entry) (*worktreeSnapshot, error)
 }
 
 func restoreWorktreeRegistration(ctx *app.Context, snapshot *worktreeSnapshot) error {
-	return ctx.Engine.RegisterWorktreeWithName(snapshot.Info.AnchorBranch, snapshot.Info.Path, snapshot.Info.Name)
+	return ctx.Engine.RegisterWorktreeWithName(ctx.Context, snapshot.Info.AnchorBranch, snapshot.Info.Path, snapshot.Info.Name)
 }
 
 func restoreWorktreePath(ctx *app.Context, snapshot *worktreeSnapshot) error {
@@ -482,7 +482,7 @@ func createAnchoredWorktree(ctx *app.Context, eng engine.Engine, repoRoot string
 		out.Info("Warm-started worktree with %d ignored file(s)", len(warmStart.Copied))
 	}
 
-	if err := eng.RegisterWorktreeWithName(anchorBranchName, worktreePath, opts.Name); err != nil {
+	if err := eng.RegisterWorktreeWithName(ctx.Context, anchorBranchName, worktreePath, opts.Name); err != nil {
 		cleanup()
 		return nil, fmt.Errorf("failed to register worktree: %w", err)
 	}
@@ -737,7 +737,12 @@ func AttachAction(ctx *app.Context, opts AttachOptions) (*AttachResult, error) {
 	})
 	if err != nil {
 		if needsCheckout && currentBranch != nil {
-			_ = eng.CheckoutBranch(ctx.Context, *currentBranch)
+			// Attach checked out trunk to free the stack root. Failing to get
+			// back leaves the user somewhere they did not ask to be, which they
+			// need to know about even though the attach error is the headline.
+			if restoreErr := eng.CheckoutBranch(ctx.Context, *currentBranch); restoreErr != nil {
+				out.Warn("Could not return to %s: %v", output.BranchName(currentBranch.GetName()), restoreErr)
+			}
 		}
 		return nil, err
 	}

--- a/internal/actions/worktree/actions_test.go
+++ b/internal/actions/worktree/actions_test.go
@@ -32,7 +32,7 @@ func TestListAction(t *testing.T) {
 		s.WithInitialCommit()
 
 		// Register a fake worktree
-		err := s.Engine.RegisterWorktree("feature-stack", "/tmp/fake-worktree")
+		err := s.Engine.RegisterWorktree(context.Background(), "feature-stack", "/tmp/fake-worktree")
 		require.NoError(t, err)
 
 		result, err := worktree.ListAction(s.Context, worktree.ListOptions{})
@@ -57,7 +57,7 @@ func TestListAction(t *testing.T) {
 		require.NoError(t, s.Engine.TrackBranch(context.Background(), "feature", "main"))
 
 		worktreeDir := t.TempDir()
-		require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", worktreeDir, "feature"))
+		require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature", worktreeDir, "feature"))
 
 		result, err := worktree.ListAction(s.Context, worktree.ListOptions{})
 		require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestListAction(t *testing.T) {
 		s.Checkout("main")
 
 		worktreeDir := t.TempDir()
-		require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", worktreeDir, "feature-wt"))
+		require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature", worktreeDir, "feature-wt"))
 		t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
 
 		// Simulate raw `git checkout feature` from the main repository, bypassing
@@ -114,7 +114,7 @@ func TestRemoveAction(t *testing.T) {
 		s.WithInitialCommit()
 
 		// Register a fake worktree (path doesn't exist)
-		err := s.Engine.RegisterWorktree("feature-stack", "/tmp/nonexistent-worktree")
+		err := s.Engine.RegisterWorktree(context.Background(), "feature-stack", "/tmp/nonexistent-worktree")
 		require.NoError(t, err)
 
 		// Verify it's registered
@@ -139,7 +139,7 @@ func TestRemoveAction(t *testing.T) {
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
-		err := s.Engine.RegisterWorktree("feature-stack", "/tmp/nonexistent-worktree")
+		err := s.Engine.RegisterWorktree(context.Background(), "feature-stack", "/tmp/nonexistent-worktree")
 		require.NoError(t, err)
 
 		err = worktree.RemoveAction(s.Context, worktree.RemoveOptions{
@@ -174,7 +174,7 @@ func TestOpenAction(t *testing.T) {
 		s.WithInitialCommit()
 
 		// Register a fake worktree with non-existent path
-		err := s.Engine.RegisterWorktree("feature-stack", "/tmp/nonexistent-path-12345")
+		err := s.Engine.RegisterWorktree(context.Background(), "feature-stack", "/tmp/nonexistent-path-12345")
 		require.NoError(t, err)
 
 		_, err = worktree.OpenAction(s.Context, worktree.OpenOptions{
@@ -194,7 +194,7 @@ func TestOpenAction(t *testing.T) {
 
 		// Use a path that exists (the repo root)
 		repoRoot := s.Context.RepoRoot
-		err := s.Engine.RegisterWorktree("feature-stack", repoRoot)
+		err := s.Engine.RegisterWorktree(context.Background(), "feature-stack", repoRoot)
 		require.NoError(t, err)
 
 		path, err := worktree.OpenAction(s.Context, worktree.OpenOptions{
@@ -354,7 +354,7 @@ func TestRepairAction(t *testing.T) {
 		require.NoError(t, s.Engine.TrackBranch(context.Background(), "feature", "main"))
 
 		worktreeDir := t.TempDir()
-		require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", worktreeDir, "legacy-wt"))
+		require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature", worktreeDir, "legacy-wt"))
 
 		result, err := worktree.RepairAction(s.Context, worktree.RepairOptions{NameOrBranch: "legacy-wt"})
 		require.NoError(t, err)

--- a/internal/actions/worktree/hooks.go
+++ b/internal/actions/worktree/hooks.go
@@ -34,8 +34,11 @@ func ResolveApprovedHooks(ctx *app.Context) ([]string, error) {
 
 // RunResolvedHooks executes a pre-resolved list of hooks in the given directory.
 // Failures are warned, not blocking — matches the existing worktree behavior.
-func RunResolvedHooks(hookCmds []string, worktreePath string, out output.Output) {
-	_ = hooks.Run(context.Background(), hookCmds, hooks.RunOptions{
+//
+// The caller's context is honored so Ctrl-C interrupts a hook instead of
+// waiting out its timeout.
+func RunResolvedHooks(ctx context.Context, hookCmds []string, worktreePath string, out output.Output) {
+	_ = hooks.Run(ctx, hookCmds, hooks.RunOptions{
 		Dir:      worktreePath,
 		Blocking: false,
 		Output:   out,
@@ -50,7 +53,7 @@ func RunPostCreateHooks(ctx *app.Context, worktreePath string) error {
 	if err != nil {
 		return err
 	}
-	RunResolvedHooks(approved, worktreePath, ctx.Output)
+	RunResolvedHooks(ctx.Context, approved, worktreePath, ctx.Output)
 	return nil
 }
 

--- a/internal/actions/worktree/repair.go
+++ b/internal/actions/worktree/repair.go
@@ -167,8 +167,8 @@ func moveRegistration(ctx *app.Context, from engine.WorktreeInfo, toAnchor strin
 	if err := ctx.Engine.UnregisterWorktree(ctx.Context, from.AnchorBranch); err != nil {
 		return fmt.Errorf("failed to remove stale registration %s: %w", output.BranchName(from.AnchorBranch), err)
 	}
-	if err := ctx.Engine.RegisterWorktreeWithName(toAnchor, from.Path, from.Name); err != nil {
-		if restoreErr := ctx.Engine.RegisterWorktreeWithName(from.AnchorBranch, from.Path, from.Name); restoreErr != nil {
+	if err := ctx.Engine.RegisterWorktreeWithName(ctx.Context, toAnchor, from.Path, from.Name); err != nil {
+		if restoreErr := ctx.Engine.RegisterWorktreeWithName(ctx.Context, from.AnchorBranch, from.Path, from.Name); restoreErr != nil {
 			return fmt.Errorf("failed to register worktree under anchor %s: %w (also failed to restore %s: %w)", toAnchor, err, output.BranchName(from.AnchorBranch), restoreErr)
 		}
 		return fmt.Errorf("failed to register worktree under anchor %s: %w", toAnchor, err)
@@ -219,7 +219,7 @@ func convertLegacyRegistration(ctx *app.Context, wtInfo engine.WorktreeInfo, roo
 			_ = ctx.Engine.UnregisterWorktree(ctx.Context, anchorBranchName)
 		}
 		if legacyUnregistered {
-			_ = ctx.Engine.RegisterWorktreeWithName(wtInfo.AnchorBranch, wtInfo.Path, wtInfo.Name)
+			_ = ctx.Engine.RegisterWorktreeWithName(ctx.Context, wtInfo.AnchorBranch, wtInfo.Path, wtInfo.Name)
 		}
 		if rootReparented {
 			_ = ctx.Engine.ReparentBranch(ctx.Context, ctx.Engine.GetBranch(rootBranchName), ctx.Engine.GetBranch(originalParent))
@@ -256,7 +256,7 @@ func convertLegacyRegistration(ctx *app.Context, wtInfo engine.WorktreeInfo, roo
 		return "", fmt.Errorf("failed to remove legacy registration %s: %w", output.BranchName(wtInfo.AnchorBranch), err)
 	}
 	legacyUnregistered = true
-	if err := ctx.Engine.RegisterWorktreeWithName(anchorBranchName, wtInfo.Path, wtInfo.Name); err != nil {
+	if err := ctx.Engine.RegisterWorktreeWithName(ctx.Context, anchorBranchName, wtInfo.Path, wtInfo.Name); err != nil {
 		cleanup()
 		return "", fmt.Errorf("failed to register worktree under anchor %s: %w", output.BranchName(anchorBranchName), err)
 	}

--- a/internal/actions/worktree_ownership_test.go
+++ b/internal/actions/worktree_ownership_test.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,7 +17,7 @@ func TestEnsureCanModifyHere(t *testing.T) {
 	s.WithInitialCommit()
 	s.CreateBranch("feature").Commit("feature change")
 	s.TrackBranch("feature", "main")
-	require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", "/tmp/feature-worktree", "feature-wt"))
+	require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature", "/tmp/feature-worktree", "feature-wt"))
 	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
 
 	t.Run("refuses managed stack mutation from main repository", func(t *testing.T) {

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -732,7 +732,7 @@ func (d *demoGitRunner) ReadWorktreeMeta(_ string) (*git.WorktreeMeta, error) {
 	return nil, nil
 }
 
-func (d *demoGitRunner) WriteWorktreeMeta(_ string, _ *git.WorktreeMeta) error {
+func (d *demoGitRunner) WriteWorktreeMeta(_ context.Context, _ string, _ *git.WorktreeMeta) error {
 	return nil
 }
 

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -237,12 +237,12 @@ func (e *engineImpl) addWorktreeWithRetryLocked(ctx context.Context, path string
 }
 
 // RegisterWorktree registers a worktree for a stack root in local git refs
-func (e *engineImpl) RegisterWorktree(stackRoot string, path string) error {
-	return e.RegisterWorktreeWithName(stackRoot, path, "")
+func (e *engineImpl) RegisterWorktree(ctx context.Context, stackRoot string, path string) error {
+	return e.RegisterWorktreeWithName(ctx, stackRoot, path, "")
 }
 
 // RegisterWorktreeWithName registers a worktree with a user-friendly name
-func (e *engineImpl) RegisterWorktreeWithName(anchorBranch string, path string, name string) error {
+func (e *engineImpl) RegisterWorktreeWithName(ctx context.Context, anchorBranch string, path string, name string) error {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return fmt.Errorf("failed to get absolute worktree path: %w", err)
@@ -280,7 +280,7 @@ func (e *engineImpl) RegisterWorktreeWithName(anchorBranch string, path string, 
 		MainRepoDir:  e.repoRoot,
 	}
 
-	return e.git.WriteWorktreeMeta(anchorBranch, meta)
+	return e.git.WriteWorktreeMeta(ctx, anchorBranch, meta)
 }
 
 // UnregisterWorktree removes worktree registration for a stack root

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -308,9 +308,9 @@ type WorktreeInfo struct {
 // WorktreeRegistry handles stackit-managed worktree tracking
 type WorktreeRegistry interface {
 	// RegisterWorktree registers a worktree for a stack root
-	RegisterWorktree(stackRoot string, path string) error
+	RegisterWorktree(ctx context.Context, stackRoot string, path string) error
 	// RegisterWorktreeWithName registers a worktree with a user-friendly name
-	RegisterWorktreeWithName(anchorBranch string, path string, name string) error
+	RegisterWorktreeWithName(ctx context.Context, anchorBranch string, path string, name string) error
 	// UnregisterWorktree removes worktree registration for a stack root
 	UnregisterWorktree(ctx context.Context, stackRoot string) error
 	// GetWorktreeForStack returns worktree info for a stack root, or nil if none

--- a/internal/engine/worktree_test.go
+++ b/internal/engine/worktree_test.go
@@ -35,7 +35,7 @@ func TestWorktreeRegistry_StackRootForBranch(t *testing.T) {
 	s.TrackBranch("branch2", "branch1")
 
 	// Register a worktree for branch1 (as if it were the stack root)
-	err := s.Engine.RegisterWorktree("branch1", "/tmp/test-worktree-branch1")
+	err := s.Engine.RegisterWorktree(context.Background(), "branch1", "/tmp/test-worktree-branch1")
 	require.NoError(t, err)
 
 	// Stack root for branch2 should be branch1 (the first branch whose parent is trunk)
@@ -61,7 +61,7 @@ func TestWorktreeRegistry_OwningWorktree(t *testing.T) {
 	s.CreateBranch("feature-child").Commit("feature child change")
 	s.TrackBranch("feature-child", "feature")
 
-	require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", "/tmp/feature-worktree", "feature"))
+	require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature", "/tmp/feature-worktree", "feature"))
 	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
 
 	owner, err := s.Engine.OwningWorktree(s.Engine.GetBranch("feature-child"))
@@ -79,14 +79,14 @@ func TestWorktreeRegistry_RejectsDuplicatePathAndAnchor(t *testing.T) {
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 	s.WithInitialCommit()
 
-	require.NoError(t, s.Engine.RegisterWorktreeWithName("feature-a", "/tmp/shared-worktree", "feature-a"))
+	require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature-a", "/tmp/shared-worktree", "feature-a"))
 	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature-a") })
 
-	err := s.Engine.RegisterWorktreeWithName("feature-b", "/tmp/shared-worktree", "feature-b")
+	err := s.Engine.RegisterWorktreeWithName(context.Background(), "feature-b", "/tmp/shared-worktree", "feature-b")
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "already registered to anchor feature-a")
 
-	err = s.Engine.RegisterWorktreeWithName("feature-a", "/tmp/other-worktree", "feature-a")
+	err = s.Engine.RegisterWorktreeWithName(context.Background(), "feature-a", "/tmp/other-worktree", "feature-a")
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "anchor feature-a is already registered")
 }

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -227,7 +227,7 @@ type WorktreeOperations interface {
 // WorktreeRegistryOperations handles stackit-managed worktree tracking (local-only refs).
 type WorktreeRegistryOperations interface {
 	ReadWorktreeMeta(stackRoot string) (*WorktreeMeta, error)
-	WriteWorktreeMeta(stackRoot string, meta *WorktreeMeta) error
+	WriteWorktreeMeta(ctx context.Context, stackRoot string, meta *WorktreeMeta) error
 	DeleteWorktreeMeta(ctx context.Context, stackRoot string) error
 	ListWorktreeMetas() (map[string]*WorktreeMeta, error)
 }

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -325,7 +325,7 @@ func (r *runner) ReadWorktreeMeta(stackRoot string) (*WorktreeMeta, error) {
 }
 
 // WriteWorktreeMeta writes worktree metadata for a stack root to local git refs
-func (r *runner) WriteWorktreeMeta(stackRoot string, meta *WorktreeMeta) error {
+func (r *runner) WriteWorktreeMeta(ctx context.Context, stackRoot string, meta *WorktreeMeta) error {
 	jsonData, err := json.Marshal(meta)
 	if err != nil {
 		return fmt.Errorf("failed to marshal worktree metadata: %w", err)
@@ -346,7 +346,7 @@ func (r *runner) WriteWorktreeMeta(stackRoot string, meta *WorktreeMeta) error {
 		{RefName: fmt.Sprintf("%s%s", WorktreeRefPrefix, stackRoot), NewSHA: sha, OldSHA: zeroSHA},
 		{RefName: worktreePathRef(meta.Path), NewSHA: sha, OldSHA: zeroSHA},
 	}
-	if err := r.UpdateRefsBatch(context.Background(), updates); err != nil {
+	if err := r.UpdateRefsBatch(ctx, updates); err != nil {
 		return fmt.Errorf("failed to register worktree metadata refs: %w", err)
 	}
 

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -134,7 +134,7 @@ func TestWorktreeRegistry(t *testing.T) {
 		require.NoError(t, os.Symlink(targetBase, linkBase))
 		worktreePath := filepath.Join(linkBase, "worktree")
 
-		require.NoError(t, runner.WriteWorktreeMeta("first", &git.WorktreeMeta{
+		require.NoError(t, runner.WriteWorktreeMeta(context.Background(), "first", &git.WorktreeMeta{
 			Path:         worktreePath,
 			AnchorBranch: "first",
 		}))
@@ -144,7 +144,7 @@ func TestWorktreeRegistry(t *testing.T) {
 
 		// Re-registration at the same path must not collide with an orphaned
 		// reverse path ref hashed with a different spelling.
-		require.NoError(t, runner.WriteWorktreeMeta("second", &git.WorktreeMeta{
+		require.NoError(t, runner.WriteWorktreeMeta(context.Background(), "second", &git.WorktreeMeta{
 			Path:         worktreePath,
 			AnchorBranch: "second",
 		}))
@@ -160,7 +160,7 @@ func TestWorktreeRegistry(t *testing.T) {
 			AnchorBranch: "feature-branch",
 			MainRepoDir:  scene.Repo.Dir,
 		}
-		err := runner.WriteWorktreeMeta("feature-branch", meta)
+		err := runner.WriteWorktreeMeta(context.Background(), "feature-branch", meta)
 		require.NoError(t, err)
 
 		// Read it back
@@ -191,7 +191,7 @@ func TestWorktreeRegistry(t *testing.T) {
 			Path:         "/path/to/worktree",
 			AnchorBranch: "feature-branch",
 		}
-		err := runner.WriteWorktreeMeta("feature-branch", meta)
+		err := runner.WriteWorktreeMeta(context.Background(), "feature-branch", meta)
 		require.NoError(t, err)
 
 		// Delete it
@@ -213,14 +213,14 @@ func TestWorktreeRegistry(t *testing.T) {
 			Path:         "/path/to/worktree1",
 			AnchorBranch: "feature-1",
 		}
-		err := runner.WriteWorktreeMeta("feature-1", meta1)
+		err := runner.WriteWorktreeMeta(context.Background(), "feature-1", meta1)
 		require.NoError(t, err)
 
 		meta2 := &git.WorktreeMeta{
 			Path:         "/path/to/worktree2",
 			AnchorBranch: "feature-2",
 		}
-		err = runner.WriteWorktreeMeta("feature-2", meta2)
+		err = runner.WriteWorktreeMeta(context.Background(), "feature-2", meta2)
 		require.NoError(t, err)
 
 		// List all


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Three loose ends in worktree plumbing.

Worktree registration wrote its refs with context.Background(), so the ref
update ignored cancellation and the caller's timeout. Thread the caller's
context through WriteWorktreeMeta and RegisterWorktree/RegisterWorktreeWithName.

Post-create hooks ran with context.Background() too, so Ctrl-C could not
interrupt one; only the 60s timeout bounded it.

AttachAction checks out trunk to free the stack root, and on failure restores
the original branch — but discarded the restore error. The attach failure is
the headline, yet a user left on a branch they did not ask for needs to know.
Warn instead of swallowing.

<hr/>

<!-- STACKIT-SECTION-START -->
**Close out the worktree audit, and stop holding restacks for harmless files**

The last of the worktree audit's open items, plus one behavior change the audit
did not ask for.

**Concurrency and cancellation**

- **#1611** — metadata writes are compare-and-swap. Two stackit processes in
  different worktrees that both read a branch and then wrote it kept only the
  second write; whatever the first recorded was silently gone. Metadata refs
  point straight at a blob and cat-file already reports that blob's SHA — it was
  being parsed and discarded. A write based on state another process replaced
  now fails and says so.
- **#1612** — worktree registration and post-create hooks ran with
  context.Background(), ignoring cancellation. AttachAction also discarded the
  error from restoring your original branch, leaving you somewhere you did not
  ask to be without saying so.

**Guidance that assumed the worktree was still there**

- **#1613** — the ownership guard told users to `cd` into the owning worktree
  without checking it existed, so a deleted directory produced advice that could
  only fail, for a branch only detach can release. Checkout's stale-path tip
  named `worktree remove`, which refuses for any stack that still has branches.
  Checkout also only validated the destination when switching from the main
  repo, not between worktrees.
- **#1614** — a branch held back reports RestackUnneeded, the same status as a
  branch that needed no work, so the conflict workflow concluded the rebase had
  succeeded and said so. It now names why the branch is held, and where.
- **#1615** — ownership divergence was only reported by `worktree list`, a
  command nobody runs until they already suspect something. Sync reports it.

**Warm start**

- **#1616** — one unplaceable file aborted worktree creation entirely, because
  any warm-start error makes the caller tear the worktree down. The mundane case
  is a tracked file occupying a name the include file also wants as a directory.
  It is reported and skipped now; a symlinked parent stays a hard failure, since
  that is how a project-controlled include file could steer a copy outside the
  worktree. Directory checks are memoized, and the docs now say plainly that
  warm-started files have no backup anywhere.

**The rule that was too broad**

- **#1617** — restack held a branch whenever its worktree had any untracked
  file. `git reset --hard` overwrites an untracked file only when the incoming
  commit contains that same path; every other one survives. Holding on all of
  them stopped restacks for the ordinary state of having written a new file and
  not staged it. Now it holds only on a real collision. Tracked changes still
  hold unconditionally, and anything unanswerable still holds.

This required the same rule in two places: the engine decides per branch, but
`restack` runs its own filter first, and changing only the engine left the
command unaffected while sync and modify quietly got the new behavior.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785983482`.


* **PR #1611**
  * **PR #1612** 👈
    * **PR #1613**
      * **PR #1614**
        * **PR #1615**
          * **PR #1616**
            * **PR #1617**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1618 by jonnii*