### PR TITLE
fix(worktree): make dead-worktree guidance actionable

### DIFF
--- a/internal/actions/checkout.go
+++ b/internal/actions/checkout.go
@@ -190,6 +190,28 @@ func printBranchInfo(ctx *app.Context, branch engine.Branch) {
 // getWorktreeSwitchInfo checks if the target branch belongs to a stack with a worktree,
 // or if we need to switch back to the main repo from a worktree.
 // Returns (switchPath, rerunArgs, fallbackTips) - all empty if no worktree switch is needed.
+// worktreePathUsable reports whether a registered worktree can actually be
+// switched to, warning when it cannot. Both switch directions check this: a
+// registration whose directory is gone must not be offered as a destination
+// from the main repo or from another worktree.
+func worktreePathUsable(ctx *app.Context, stackRoot, path string) bool {
+	_, err := os.Stat(path)
+	switch {
+	case err == nil:
+		return true
+	case os.IsNotExist(err):
+		ctx.Output.Warn("Worktree for stack %s is registered but path does not exist: %s",
+			output.BranchName(stackRoot), path)
+		// detach, not remove: remove refuses for any stack that still has
+		// branches, which is every stack worth checking out.
+		ctx.Output.Tip("stackit worktree detach %s", stackRoot)
+	default:
+		ctx.Output.Warn("Cannot inspect worktree for stack %s at %s: %v",
+			output.BranchName(stackRoot), path, err)
+	}
+	return false
+}
+
 func getWorktreeSwitchInfo(ctx *app.Context, branch engine.Branch, branchName string) (string, []string, []string) {
 	targetStackRoot := ctx.Engine.GetStackRootForBranch(branch)
 
@@ -206,11 +228,12 @@ func getWorktreeSwitchInfo(ctx *app.Context, branch engine.Branch, branchName st
 		} else if targetStackRoot != currentStackRoot {
 			// Target is in a different stack - check if that stack has a worktree
 			targetWorktree, err := ctx.Engine.GetWorktreeForStack(targetStackRoot)
-			if err == nil && targetWorktree != nil {
+			switch {
+			case err == nil && targetWorktree != nil && worktreePathUsable(ctx, targetStackRoot, targetWorktree.Path):
 				switchTarget = targetWorktree.Path
 				targetStack = targetStackRoot
-			} else {
-				// Target stack has no worktree - switch to main repo
+			default:
+				// Target stack has no usable worktree - switch to main repo
 				switchTarget = ctx.WorktreeInfo.MainRepoDir
 			}
 		}
@@ -237,15 +260,7 @@ func getWorktreeSwitchInfo(ctx *app.Context, branch engine.Branch, branchName st
 		return "", nil, nil
 	}
 
-	if _, err := os.Stat(targetWorktree.Path); err != nil {
-		if os.IsNotExist(err) {
-			ctx.Output.Warn("Worktree for stack %s is registered but path does not exist: %s",
-				output.BranchName(targetStackRoot), targetWorktree.Path)
-			ctx.Output.Tip("stackit worktree remove %s", targetStackRoot)
-			return "", nil, nil
-		}
-		ctx.Output.Warn("Cannot inspect worktree for stack %s at %s: %v",
-			output.BranchName(targetStackRoot), targetWorktree.Path, err)
+	if !worktreePathUsable(ctx, targetStackRoot, targetWorktree.Path) {
 		return "", nil, nil
 	}
 

--- a/internal/actions/worktree_ownership.go
+++ b/internal/actions/worktree_ownership.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"fmt"
+	"os"
 	"slices"
 
 	"github.com/getstackit/stackit/internal/app"
@@ -41,6 +42,19 @@ func EnsureCanModifyHere(ctx *app.Context, branches ...engine.Branch) error {
 
 		if ctx.InManagedWorktree && ctx.WorktreeInfo != nil && ctx.WorktreeInfo.AnchorBranch == owner.AnchorBranch {
 			continue
+		}
+
+		// "cd there" is only useful advice if "there" still exists. A worktree
+		// whose directory was deleted leaves the branch owned by a path the
+		// user cannot go to, and the way out is detaching the registration —
+		// not a cd that will fail.
+		if _, statErr := os.Stat(owner.Path); statErr != nil {
+			if os.IsNotExist(statErr) {
+				return fmt.Errorf("branch %s belongs to worktree %s, whose directory no longer exists (%s); run 'stackit worktree detach %s' to release it, or 'stackit worktree list' to review",
+					branchName, worktreeDisplayName(owner), owner.Path, worktreeDisplayName(owner))
+			}
+			return fmt.Errorf("branch %s belongs to worktree %s, which cannot be inspected at %s: %w; 'stackit worktree list' shows the current state",
+				branchName, worktreeDisplayName(owner), owner.Path, statErr)
 		}
 
 		return fmt.Errorf("branch %s belongs to worktree %s; run this command from there: cd %s", branchName, worktreeDisplayName(owner), owner.Path)

--- a/internal/actions/worktree_ownership_test.go
+++ b/internal/actions/worktree_ownership_test.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,14 +18,33 @@ func TestEnsureCanModifyHere(t *testing.T) {
 	s.WithInitialCommit()
 	s.CreateBranch("feature").Commit("feature change")
 	s.TrackBranch("feature", "main")
-	require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature", "/tmp/feature-worktree", "feature-wt"))
+	worktreePath := t.TempDir()
+	require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature", worktreePath, "feature-wt"))
 	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
 
 	t.Run("refuses managed stack mutation from main repository", func(t *testing.T) {
 		err := EnsureCanModifyHere(s.Context, s.Engine.GetBranch("feature"))
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "belongs to worktree feature-wt")
-		assert.ErrorContains(t, err, "cd /tmp/feature-worktree")
+		assert.ErrorContains(t, err, "cd "+worktreePath)
+	})
+
+	// Telling someone to cd into a directory that no longer exists strands
+	// them: the branch is owned by a path they cannot go to, and only detaching
+	// the registration releases it.
+	t.Run("points at detach when the worktree directory is gone", func(t *testing.T) {
+		gone := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		gone.WithInitialCommit()
+		gone.CreateBranch("feature").Commit("feature change")
+		gone.TrackBranch("feature", "main")
+		missing := filepath.Join(t.TempDir(), "deleted-worktree")
+		require.NoError(t, gone.Engine.RegisterWorktreeWithName(context.Background(), "feature", missing, "feature-wt"))
+
+		err := EnsureCanModifyHere(gone.Context, gone.Engine.GetBranch("feature"))
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "no longer exists")
+		assert.ErrorContains(t, err, "worktree detach feature-wt")
+		assert.NotContains(t, err.Error(), "cd "+missing)
 	})
 
 	t.Run("allows mutation from owning worktree", func(t *testing.T) {
@@ -32,7 +52,7 @@ func TestEnsureCanModifyHere(t *testing.T) {
 		ctx.InManagedWorktree = true
 		ctx.WorktreeInfo = &engine.WorktreeInfo{
 			Name:         "feature-wt",
-			Path:         "/tmp/feature-worktree",
+			Path:         worktreePath,
 			AnchorBranch: "feature",
 		}
 		require.NoError(t, EnsureCanModifyHere(&ctx, s.Engine.GetBranch("feature")))
@@ -43,7 +63,7 @@ func TestEnsureCanModifyHere(t *testing.T) {
 		ctx.InManagedWorktree = true
 		ctx.WorktreeInfo = &engine.WorktreeInfo{
 			Name:         "feature-wt",
-			Path:         "/tmp/feature-worktree",
+			Path:         worktreePath,
 			AnchorBranch: "feature",
 			MainRepoDir:  s.Context.RepoRoot,
 		}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Every refusal involving a worktree assumed its directory was still there.

The ownership guard told users to `cd` into the owning worktree without ever
checking it existed, so a deleted directory produced advice that could only
fail — and the branch stayed unusable, because only detaching the registration
releases it. It now names detach for a missing directory, and points at
`worktree list` when the path cannot be inspected at all.

Checkout's stale-path tip named `worktree remove`, which refuses for any stack
that still has branches — that is, every stack worth checking out. It names
detach now.

Checkout also only validated the destination when switching from the main repo.
Switching between worktrees offered a registered-but-missing directory as a
destination with no check at all; both directions share one check now.

<hr/>

<!-- STACKIT-SECTION-START -->
**Close out the worktree audit, and stop holding restacks for harmless files**

The last of the worktree audit's open items, plus one behavior change the audit
did not ask for.

**Concurrency and cancellation**

- **#1611** — metadata writes are compare-and-swap. Two stackit processes in
  different worktrees that both read a branch and then wrote it kept only the
  second write; whatever the first recorded was silently gone. Metadata refs
  point straight at a blob and cat-file already reports that blob's SHA — it was
  being parsed and discarded. A write based on state another process replaced
  now fails and says so.
- **#1612** — worktree registration and post-create hooks ran with
  context.Background(), ignoring cancellation. AttachAction also discarded the
  error from restoring your original branch, leaving you somewhere you did not
  ask to be without saying so.

**Guidance that assumed the worktree was still there**

- **#1613** — the ownership guard told users to `cd` into the owning worktree
  without checking it existed, so a deleted directory produced advice that could
  only fail, for a branch only detach can release. Checkout's stale-path tip
  named `worktree remove`, which refuses for any stack that still has branches.
  Checkout also only validated the destination when switching from the main
  repo, not between worktrees.
- **#1614** — a branch held back reports RestackUnneeded, the same status as a
  branch that needed no work, so the conflict workflow concluded the rebase had
  succeeded and said so. It now names why the branch is held, and where.
- **#1615** — ownership divergence was only reported by `worktree list`, a
  command nobody runs until they already suspect something. Sync reports it.

**Warm start**

- **#1616** — one unplaceable file aborted worktree creation entirely, because
  any warm-start error makes the caller tear the worktree down. The mundane case
  is a tracked file occupying a name the include file also wants as a directory.
  It is reported and skipped now; a symlinked parent stays a hard failure, since
  that is how a project-controlled include file could steer a copy outside the
  worktree. Directory checks are memoized, and the docs now say plainly that
  warm-started files have no backup anywhere.

**The rule that was too broad**

- **#1617** — restack held a branch whenever its worktree had any untracked
  file. `git reset --hard` overwrites an untracked file only when the incoming
  commit contains that same path; every other one survives. Holding on all of
  them stopped restacks for the ordinary state of having written a new file and
  not staged it. Now it holds only on a real collision. Tracked changes still
  hold unconditionally, and anything unanswerable still holds.

This required the same rule in two places: the engine decides per branch, but
`restack` runs its own filter first, and changing only the engine left the
command unaffected while sync and modify quietly got the new behavior.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785983482`.


* **PR #1611**
  * **PR #1612**
    * **PR #1613** 👈
      * **PR #1614**
        * **PR #1615**
          * **PR #1616**
            * **PR #1617**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1618 by jonnii*