### PR TITLE
fix(restack): diagnose a held branch instead of a phantom conflict

### DIFF
--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -536,6 +536,12 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 	// Verify we're actually in conflict state
 	if !ctx.Engine.IsRebaseInProgress(ctx.Context) {
 		reattach()
+		// A held branch reports RestackUnneeded, exactly like a branch that was
+		// already up to date, so "the rebase succeeded" is the wrong diagnosis
+		// and sends the user looking for a conflict that never started.
+		if reason := heldWorktreeReason(ctx, firstConflict); reason != "" {
+			return fmt.Errorf("cannot resolve the conflict on %s: it was held back because %s; resolve that, then re-run", firstConflict, reason)
+		}
 		return fmt.Errorf("expected conflict on %s but rebase completed successfully", firstConflict)
 	}
 

--- a/internal/actions/held_worktree_reason_test.go
+++ b/internal/actions/held_worktree_reason_test.go
@@ -1,0 +1,63 @@
+package actions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// TestHeldWorktreeReason covers the lookup behind the conflict-workflow
+// diagnosis.
+//
+// Restack holds a branch whose worktree it cannot safely reset, and reports the
+// hold as RestackUnneeded — indistinguishable from "already up to date". When a
+// caller expected a rebase to start, that produced "expected conflict on X but
+// rebase completed successfully", which describes the opposite of what happened
+// and points nowhere near the fix (the other worktree).
+func TestHeldWorktreeReason(t *testing.T) {
+	t.Parallel()
+
+	setup := func(t *testing.T) (*scenario.Scenario, string) {
+		t.Helper()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+		s.CreateBranch("feature").Commit("feature change")
+		s.TrackBranch("feature", "main")
+		s.Checkout("main")
+
+		// A real second checkout of feature, so ListWorktrees reports it.
+		worktreePath := filepath.Join(t.TempDir(), "feature-checkout")
+		s.RunGit("worktree", "add", worktreePath, "feature")
+		t.Cleanup(func() { s.RunGit("worktree", "remove", "--force", worktreePath) })
+		return s, worktreePath
+	}
+
+	t.Run("clean checkout holds nothing", func(t *testing.T) {
+		t.Parallel()
+		s, _ := setup(t)
+		require.Empty(t, heldWorktreeReason(s.Context, "feature"))
+	})
+
+	t.Run("uncommitted changes are reported", func(t *testing.T) {
+		t.Parallel()
+		s, worktreePath := setup(t)
+		require.NoError(t, os.WriteFile(filepath.Join(worktreePath, "scratch.txt"), []byte("wip"), 0o600))
+
+		reason := heldWorktreeReason(s.Context, "feature")
+		require.Contains(t, reason, "uncommitted changes")
+		require.Contains(t, reason, worktreePath,
+			"the reason must name the worktree to act on, not just the branch")
+	})
+
+	t.Run("branch with no checkout holds nothing", func(t *testing.T) {
+		t.Parallel()
+		s, _ := setup(t)
+		require.Empty(t, heldWorktreeReason(s.Context, "main"))
+		require.Empty(t, heldWorktreeReason(s.Context, "does-not-exist"))
+	})
+}

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -663,3 +663,36 @@ func handleRestackProgress(
 		}
 	}
 }
+
+// heldWorktreeReason returns why branchName's own checkout blocks a restack, or
+// "" when nothing does.
+//
+// Restack holds a branch whose worktree it cannot safely reset, and a held
+// branch is reported as RestackUnneeded — the same status as a branch that
+// needed no work. Callers that expected a rebase to start need to tell those
+// apart, because the remedy lives in the other worktree.
+//
+// Only the branch's own checkout is examined. A branch held because an ancestor
+// is held returns "", and the caller falls back to its generic message.
+func heldWorktreeReason(ctx *app.Context, branchName string) string {
+	eng := ctx.Engine
+	worktrees, err := eng.ListWorktrees(ctx.Context)
+	if err != nil {
+		return ""
+	}
+	path := worktrees.PathForBranch(branchName)
+	if path == "" {
+		return ""
+	}
+	if eng.WorktreeRebaseInProgress(ctx.Context, path) {
+		return fmt.Sprintf("worktree %s has a rebase in progress", path)
+	}
+	hasChanges, inspectErr := eng.WorktreeHasUncommittedChanges(ctx.Context, path)
+	switch {
+	case inspectErr != nil:
+		return fmt.Sprintf("worktree %s could not be inspected: %v", path, inspectErr)
+	case hasChanges:
+		return fmt.Sprintf("worktree %s has uncommitted changes", path)
+	}
+	return ""
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

When validation predicted a conflict on a branch that restack then held back,
the conflict workflow re-ran it, got RestackUnneeded — the same status a branch
that needed no work reports — and concluded the rebase had succeeded. It told
the user "expected conflict on X but rebase completed successfully", which
describes the opposite of what happened and points nowhere near the remedy,
which lives in another worktree.

Check why the branch is held and say so: uncommitted changes, a rebase in
progress, or a checkout that could not be inspected, named with the path to act
on. The generic message stays for every other cause.

<hr/>

<!-- STACKIT-SECTION-START -->
**Close out the worktree audit, and stop holding restacks for harmless files**

The last of the worktree audit's open items, plus one behavior change the audit
did not ask for.

**Concurrency and cancellation**

- **#1611** — metadata writes are compare-and-swap. Two stackit processes in
  different worktrees that both read a branch and then wrote it kept only the
  second write; whatever the first recorded was silently gone. Metadata refs
  point straight at a blob and cat-file already reports that blob's SHA — it was
  being parsed and discarded. A write based on state another process replaced
  now fails and says so.
- **#1612** — worktree registration and post-create hooks ran with
  context.Background(), ignoring cancellation. AttachAction also discarded the
  error from restoring your original branch, leaving you somewhere you did not
  ask to be without saying so.

**Guidance that assumed the worktree was still there**

- **#1613** — the ownership guard told users to `cd` into the owning worktree
  without checking it existed, so a deleted directory produced advice that could
  only fail, for a branch only detach can release. Checkout's stale-path tip
  named `worktree remove`, which refuses for any stack that still has branches.
  Checkout also only validated the destination when switching from the main
  repo, not between worktrees.
- **#1614** — a branch held back reports RestackUnneeded, the same status as a
  branch that needed no work, so the conflict workflow concluded the rebase had
  succeeded and said so. It now names why the branch is held, and where.
- **#1615** — ownership divergence was only reported by `worktree list`, a
  command nobody runs until they already suspect something. Sync reports it.

**Warm start**

- **#1616** — one unplaceable file aborted worktree creation entirely, because
  any warm-start error makes the caller tear the worktree down. The mundane case
  is a tracked file occupying a name the include file also wants as a directory.
  It is reported and skipped now; a symlinked parent stays a hard failure, since
  that is how a project-controlled include file could steer a copy outside the
  worktree. Directory checks are memoized, and the docs now say plainly that
  warm-started files have no backup anywhere.

**The rule that was too broad**

- **#1617** — restack held a branch whenever its worktree had any untracked
  file. `git reset --hard` overwrites an untracked file only when the incoming
  commit contains that same path; every other one survives. Holding on all of
  them stopped restacks for the ordinary state of having written a new file and
  not staged it. Now it holds only on a real collision. Tracked changes still
  hold unconditionally, and anything unanswerable still holds.

This required the same rule in two places: the engine decides per branch, but
`restack` runs its own filter first, and changing only the engine left the
command unaffected while sync and modify quietly got the new behavior.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785983482`.


* **PR #1611**
  * **PR #1612**
    * **PR #1613**
      * **PR #1614** 👈
        * **PR #1615**
          * **PR #1616**
            * **PR #1617**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1618 by jonnii*