### PR TITLE
fix(sync): report ownership divergence where it gets seen

### DIFF
--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/actions/worktree"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/handlers"
@@ -75,6 +76,15 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 			dirtyAnchors[wt.AnchorBranch] = true
 			out.Warn("Skipping stack rooted at %s (%s)", wt.AnchorBranch, reason)
 		}
+	}
+
+	// Report branches checked out somewhere other than the worktree owning
+	// their stack. Sync is the command licensed to touch every stack, so it is
+	// the one place divergence reliably gets seen — previously it surfaced only
+	// if someone happened to run `worktree list`, while the guards that refuse
+	// mutations because of it said nothing about where to look.
+	for _, warning := range worktree.OwnershipWarnings(ctx) {
+		out.Warn("%s", warning)
 	}
 
 	// Calculate total operations for progress (rough estimate)

--- a/internal/actions/worktree/entry.go
+++ b/internal/actions/worktree/entry.go
@@ -193,12 +193,16 @@ func listEntries(ctx *app.Context, opts ListOptions) (*ListResult, error) {
 		result.Worktrees = append(result.Worktrees, entry)
 	}
 
-	result.OwnershipWarnings = ownershipWarnings(ctx)
+	result.OwnershipWarnings = OwnershipWarnings(ctx)
 
 	return result, nil
 }
 
-func ownershipWarnings(ctx *app.Context) []string {
+// OwnershipWarnings reports branches whose physical checkout location does not
+// match the worktree that owns their stack. Exported so commands that mutate
+// across the whole repository — sync in particular — can surface divergence at
+// the time it matters, not only when someone happens to run `worktree list`.
+func OwnershipWarnings(ctx *app.Context) []string {
 	gitWorktrees, err := ctx.Engine.ListWorktrees(ctx.Context)
 	if err != nil {
 		return []string{fmt.Sprintf("could not inspect Git worktrees for ownership conflicts: %v", err)}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

A branch checked out somewhere other than the worktree owning its stack was
only reported by `stackit worktree list` — a command nobody runs until they
already suspect something. Meanwhile the guards that refuse mutations because
of that divergence said nothing about where to look.

Sync is the command licensed to touch every stack, so it is where the divergence
reliably reaches the user. Report it there.

<hr/>

<!-- STACKIT-SECTION-START -->
**Close out the worktree audit, and stop holding restacks for harmless files**

The last of the worktree audit's open items, plus one behavior change the audit
did not ask for.

**Concurrency and cancellation**

- **#1611** — metadata writes are compare-and-swap. Two stackit processes in
  different worktrees that both read a branch and then wrote it kept only the
  second write; whatever the first recorded was silently gone. Metadata refs
  point straight at a blob and cat-file already reports that blob's SHA — it was
  being parsed and discarded. A write based on state another process replaced
  now fails and says so.
- **#1612** — worktree registration and post-create hooks ran with
  context.Background(), ignoring cancellation. AttachAction also discarded the
  error from restoring your original branch, leaving you somewhere you did not
  ask to be without saying so.

**Guidance that assumed the worktree was still there**

- **#1613** — the ownership guard told users to `cd` into the owning worktree
  without checking it existed, so a deleted directory produced advice that could
  only fail, for a branch only detach can release. Checkout's stale-path tip
  named `worktree remove`, which refuses for any stack that still has branches.
  Checkout also only validated the destination when switching from the main
  repo, not between worktrees.
- **#1614** — a branch held back reports RestackUnneeded, the same status as a
  branch that needed no work, so the conflict workflow concluded the rebase had
  succeeded and said so. It now names why the branch is held, and where.
- **#1615** — ownership divergence was only reported by `worktree list`, a
  command nobody runs until they already suspect something. Sync reports it.

**Warm start**

- **#1616** — one unplaceable file aborted worktree creation entirely, because
  any warm-start error makes the caller tear the worktree down. The mundane case
  is a tracked file occupying a name the include file also wants as a directory.
  It is reported and skipped now; a symlinked parent stays a hard failure, since
  that is how a project-controlled include file could steer a copy outside the
  worktree. Directory checks are memoized, and the docs now say plainly that
  warm-started files have no backup anywhere.

**The rule that was too broad**

- **#1617** — restack held a branch whenever its worktree had any untracked
  file. `git reset --hard` overwrites an untracked file only when the incoming
  commit contains that same path; every other one survives. Holding on all of
  them stopped restacks for the ordinary state of having written a new file and
  not staged it. Now it holds only on a real collision. Tracked changes still
  hold unconditionally, and anything unanswerable still holds.

This required the same rule in two places: the engine decides per branch, but
`restack` runs its own filter first, and changing only the engine left the
command unaffected while sync and modify quietly got the new behavior.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785983482`.


* **PR #1611**
  * **PR #1612**
    * **PR #1613**
      * **PR #1614**
        * **PR #1615** 👈
          * **PR #1616**
            * **PR #1617**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1618 by jonnii*