### PR TITLE
fix(worktree): keep warm start from failing the whole worktree

### DIFF
--- a/docs/worktree.md
+++ b/docs/worktree.md
@@ -79,11 +79,26 @@ Safety rules:
 - A pattern cannot copy a tracked file: it must also be ignored by Git.
 - Existing files in the destination are never overwritten.
 - Symlinks and non-regular files are skipped.
-- A warm-start failure aborts worktree creation and rolls it back, rather than
-  giving an agent a partially initialized workspace.
+- A file that cannot be placed — because a tracked file already occupies a
+  directory name its path needs — is reported and skipped. The rest of the warm
+  start still runs, and the worktree is still created.
+- A symlinked parent directory in the destination aborts worktree creation and
+  rolls it back. `.worktreeinclude` is project-controlled, so this is the path
+  by which a warm start could be steered into writing outside the worktree.
 
 Treat `.worktreeinclude` as an explicit local-data allowlist. In particular,
 include secrets only when every managed worktree is allowed to receive them.
+
+### Warm-started files are not backed up
+
+Warm-started files are ignored by Git, so nothing else has a copy of them.
+`worktree remove` and `worktree prune` delete the worktree directory and
+everything in it, including every warm-started file — a `.env` you edited in
+that worktree is gone with it, with no Git history to recover it from.
+
+`worktree detach` removes the worktree while keeping its branches, but it also
+removes the directory. If a warm-started file has diverged from the copy in
+your main repository and you want to keep it, copy it out first.
 
 ---
 

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -481,6 +481,9 @@ func createAnchoredWorktree(ctx *app.Context, eng engine.Engine, repoRoot string
 	if warmStart.Enabled && len(warmStart.Copied) > 0 {
 		out.Info("Warm-started worktree with %d ignored file(s)", len(warmStart.Copied))
 	}
+	for _, skip := range warmStart.SkippedUnsafe {
+		out.Warn("Did not warm-start %s: %s (selected by %s)", skip.Path, skip.Reason, WorktreeIncludeFile)
+	}
 
 	if err := eng.RegisterWorktreeWithName(ctx.Context, anchorBranchName, worktreePath, opts.Name); err != nil {
 		cleanup()

--- a/internal/actions/worktree/warm_start.go
+++ b/internal/actions/worktree/warm_start.go
@@ -2,6 +2,7 @@ package worktree
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -26,7 +27,22 @@ type WarmStartResult struct {
 	Enabled         bool
 	Copied          []string
 	SkippedExisting []string
+	// SkippedUnsafe lists files that could not be placed because something on
+	// their path is not a plain directory — most often a tracked file on trunk
+	// occupying a name the include file also selects as a directory.
+	SkippedUnsafe []WarmStartSkip
 }
+
+// WarmStartSkip records one file warm start declined to copy, and why.
+type WarmStartSkip struct {
+	Path   string
+	Reason string
+}
+
+// errWarmStartSkip marks a per-file problem. Warm start is an optimization:
+// one unplaceable file must not fail worktree creation, which is what an error
+// return does — the caller tears the whole worktree down.
+var errWarmStartSkip = errors.New("warm-start path cannot be used")
 
 func warmStartWorktree(ctx context.Context, eng engine.Engine, sourceRoot, destinationRoot string) (WarmStartResult, error) {
 	if _, err := os.Stat(filepath.Join(sourceRoot, WorktreeIncludeFile)); os.IsNotExist(err) {
@@ -61,6 +77,12 @@ func CopyIncludedIgnoredFiles(sourceRoot, destinationRoot string, ignoredPaths [
 	}
 
 	result := WarmStartResult{Enabled: true}
+	// Verified directories are remembered per root. Files selected for warm
+	// start share long prefixes — node_modules/... being the motivating case —
+	// and re-walking every component of every path costs one Lstat per
+	// component per file.
+	sourceVerified := map[string]bool{}
+	destinationVerified := map[string]bool{}
 	for _, path := range uniqueSortedPaths(ignoredPaths) {
 		relativePath, err := warmStartRelativePath(path)
 		if err != nil {
@@ -71,7 +93,11 @@ func CopyIncludedIgnoredFiles(sourceRoot, destinationRoot string, ignoredPaths [
 		}
 
 		sourcePath := filepath.Join(sourceRoot, relativePath)
-		if err := ensureWarmStartParents(sourceRoot, relativePath, false); err != nil {
+		if err := ensureWarmStartParents(sourceRoot, relativePath, false, sourceVerified); err != nil {
+			if skip, ok := asWarmStartSkip(relativePath, err); ok {
+				result.SkippedUnsafe = append(result.SkippedUnsafe, skip)
+				continue
+			}
 			return WarmStartResult{}, err
 		}
 		info, err := os.Lstat(sourcePath)
@@ -85,15 +111,23 @@ func CopyIncludedIgnoredFiles(sourceRoot, destinationRoot string, ignoredPaths [
 			continue
 		}
 
+		// Validate the destination's parents before stat-ing the destination
+		// itself: if a component is a plain file, that stat fails with a
+		// platform-specific "not a directory" errno rather than "does not
+		// exist", and the path check reports the same condition portably.
 		destinationPath := filepath.Join(destinationRoot, relativePath)
+		if err := ensureWarmStartParents(destinationRoot, relativePath, true, destinationVerified); err != nil {
+			if skip, ok := asWarmStartSkip(relativePath, err); ok {
+				result.SkippedUnsafe = append(result.SkippedUnsafe, skip)
+				continue
+			}
+			return WarmStartResult{}, err
+		}
 		if _, err := os.Lstat(destinationPath); err == nil {
 			result.SkippedExisting = append(result.SkippedExisting, relativePath)
 			continue
 		} else if !os.IsNotExist(err) {
 			return WarmStartResult{}, fmt.Errorf("inspect warm-start destination %s: %w", relativePath, err)
-		}
-		if err := ensureWarmStartParents(destinationRoot, relativePath, true); err != nil {
-			return WarmStartResult{}, err
 		}
 
 		if err := copyWarmStartFile(sourcePath, destinationPath, info.Mode().Perm()); err != nil {
@@ -152,7 +186,22 @@ func copyWarmStartFile(sourcePath, destinationPath string, mode os.FileMode) (er
 	return err
 }
 
-func ensureWarmStartParents(root, relativePath string, create bool) error {
+// asWarmStartSkip converts a per-file refusal into a recorded skip. Anything
+// else is a real failure and stays an error.
+func asWarmStartSkip(relativePath string, err error) (WarmStartSkip, bool) {
+	if !errors.Is(err, errWarmStartSkip) {
+		return WarmStartSkip{}, false
+	}
+	return WarmStartSkip{Path: relativePath, Reason: err.Error()}, true
+}
+
+// ensureWarmStartParents verifies (and optionally creates) every directory
+// leading to relativePath under root.
+//
+// verified memoizes directories already checked under this root for this run.
+// Warm-start sets share deep prefixes, so without it each file re-Lstats every
+// component of its path on both roots.
+func ensureWarmStartParents(root, relativePath string, create bool, verified map[string]bool) error {
 	directory := filepath.Dir(relativePath)
 	if directory == "." {
 		return nil
@@ -161,10 +210,16 @@ func ensureWarmStartParents(root, relativePath string, create bool) error {
 	current := root
 	for _, component := range strings.Split(directory, string(filepath.Separator)) {
 		current = filepath.Join(current, component)
+		if verified[current] {
+			continue
+		}
 		info, err := os.Lstat(current)
 		if os.IsNotExist(err) && create {
-			if err := os.Mkdir(current, 0o750); err != nil && !os.IsExist(err) {
-				return fmt.Errorf("create warm-start directory %s: %w", current, err)
+			if mkErr := os.Mkdir(current, 0o750); mkErr != nil && !os.IsExist(mkErr) {
+				// Most often a tracked file already occupies this name, which
+				// is a conflict with this one file's path — not a reason to
+				// abandon the worktree.
+				return fmt.Errorf("%w: cannot create directory %s: %w", errWarmStartSkip, current, mkErr)
 			}
 			info, err = os.Lstat(current)
 		}
@@ -174,9 +229,20 @@ func ensureWarmStartParents(root, relativePath string, create bool) error {
 		if err != nil {
 			return fmt.Errorf("inspect warm-start directory %s: %w", current, err)
 		}
-		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		// A symlink stays a hard failure. The include file is project-controlled,
+		// so a symlinked parent is how a warm start would be steered into
+		// writing outside the worktree — that is worth refusing loudly, not
+		// noting and moving on.
+		if info.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("warm-start path has unsafe parent directory: %s", current)
 		}
+		// A plain file occupying a directory name is mundane by comparison: a
+		// tracked file on trunk whose name the include file also selects as a
+		// directory. Only this one file is unplaceable.
+		if !info.IsDir() {
+			return fmt.Errorf("%w: %s is a file, not a directory", errWarmStartSkip, current)
+		}
+		verified[current] = true
 	}
 
 	return nil

--- a/internal/actions/worktree/warm_start_test.go
+++ b/internal/actions/worktree/warm_start_test.go
@@ -117,3 +117,61 @@ func requireWarmStartFile(t *testing.T, root, relativePath, expected string) {
 	require.NoError(t, err)
 	require.Equal(t, expected, string(contents))
 }
+
+// TestCopyIncludedIgnoredFilesSkipsFileOccupyingDirectoryName covers a warm-start
+// selection that cannot be placed because a tracked file already owns the name.
+//
+// Any warm-start error tears down the whole worktree — the caller cleans up on
+// failure — so one unplaceable file used to cost the entire `create -w`. Warm
+// start is an optimization; it reports the file and continues.
+func TestCopyIncludedIgnoredFilesSkipsFileOccupyingDirectoryName(t *testing.T) {
+	source := t.TempDir()
+	destination := t.TempDir()
+	writeWarmStartFile(t, source, WorktreeIncludeFile, "config/secret\nkeep.env\n")
+	writeWarmStartFile(t, source, "config/secret", "secret")
+	writeWarmStartFile(t, source, "keep.env", "kept")
+
+	// Trunk carries a tracked file named "config", so the directory the include
+	// file wants cannot exist.
+	writeWarmStartFile(t, destination, "config", "tracked file on trunk")
+
+	result, err := CopyIncludedIgnoredFiles(source, destination, []string{"config/secret", "keep.env"})
+	require.NoError(t, err, "one unplaceable file must not fail the whole warm start")
+
+	require.Len(t, result.SkippedUnsafe, 1)
+	require.Equal(t, "config/secret", result.SkippedUnsafe[0].Path)
+	require.Contains(t, result.SkippedUnsafe[0].Reason, "not a directory")
+
+	// Everything else still gets copied.
+	require.Equal(t, []string{"keep.env"}, result.Copied)
+	require.FileExists(t, filepath.Join(destination, "keep.env"))
+
+	// The tracked file is untouched.
+	contents, err := os.ReadFile(filepath.Join(destination, "config"))
+	require.NoError(t, err)
+	require.Equal(t, "tracked file on trunk", string(contents))
+}
+
+// TestCopyIncludedIgnoredFilesVerifiesEachDirectoryOnce guards the memoization
+// that keeps deep warm-start sets (node_modules being the motivating case) from
+// re-walking every path component for every file.
+func TestCopyIncludedIgnoredFilesVerifiesEachDirectoryOnce(t *testing.T) {
+	source := t.TempDir()
+	destination := t.TempDir()
+	writeWarmStartFile(t, source, WorktreeIncludeFile, "deps/**\n")
+
+	names := []string{"a", "b", "c", "d"}
+	paths := make([]string, 0, len(names))
+	for _, name := range names {
+		relativePath := filepath.Join("deps", "nested", "deeper", name)
+		writeWarmStartFile(t, source, relativePath, name)
+		paths = append(paths, filepath.ToSlash(relativePath))
+	}
+
+	result, err := CopyIncludedIgnoredFiles(source, destination, paths)
+	require.NoError(t, err)
+	require.Len(t, result.Copied, 4)
+	for _, name := range []string{"a", "b", "c", "d"} {
+		require.FileExists(t, filepath.Join(destination, "deps", "nested", "deeper", name))
+	}
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Three warm-start follow-ups.

A file that cannot be placed used to abort worktree creation entirely: any
warm-start error makes the caller tear the new worktree down. The mundane case
is a tracked file on trunk occupying a name the include file also selects as a
directory — one unplaceable file, costing the whole `create -w`. Report it and
carry on. A symlinked parent stays a hard failure: the include file is
project-controlled, so that is the path by which a warm start could be steered
into writing outside the worktree.

Verified directories are now memoized per root. Warm-start sets share deep
prefixes — node_modules being the motivating example, and the one the docs lead
with — and every file was re-walking every component of its path on both roots.

Documented that warm-started files have no backup anywhere: they are ignored by
Git, so remove/prune/detach delete them with the directory and nothing can
recover them.

<hr/>

<!-- STACKIT-SECTION-START -->
**Close out the worktree audit, and stop holding restacks for harmless files**

The last of the worktree audit's open items, plus one behavior change the audit
did not ask for.

**Concurrency and cancellation**

- **#1611** — metadata writes are compare-and-swap. Two stackit processes in
  different worktrees that both read a branch and then wrote it kept only the
  second write; whatever the first recorded was silently gone. Metadata refs
  point straight at a blob and cat-file already reports that blob's SHA — it was
  being parsed and discarded. A write based on state another process replaced
  now fails and says so.
- **#1612** — worktree registration and post-create hooks ran with
  context.Background(), ignoring cancellation. AttachAction also discarded the
  error from restoring your original branch, leaving you somewhere you did not
  ask to be without saying so.

**Guidance that assumed the worktree was still there**

- **#1613** — the ownership guard told users to `cd` into the owning worktree
  without checking it existed, so a deleted directory produced advice that could
  only fail, for a branch only detach can release. Checkout's stale-path tip
  named `worktree remove`, which refuses for any stack that still has branches.
  Checkout also only validated the destination when switching from the main
  repo, not between worktrees.
- **#1614** — a branch held back reports RestackUnneeded, the same status as a
  branch that needed no work, so the conflict workflow concluded the rebase had
  succeeded and said so. It now names why the branch is held, and where.
- **#1615** — ownership divergence was only reported by `worktree list`, a
  command nobody runs until they already suspect something. Sync reports it.

**Warm start**

- **#1616** — one unplaceable file aborted worktree creation entirely, because
  any warm-start error makes the caller tear the worktree down. The mundane case
  is a tracked file occupying a name the include file also wants as a directory.
  It is reported and skipped now; a symlinked parent stays a hard failure, since
  that is how a project-controlled include file could steer a copy outside the
  worktree. Directory checks are memoized, and the docs now say plainly that
  warm-started files have no backup anywhere.

**The rule that was too broad**

- **#1617** — restack held a branch whenever its worktree had any untracked
  file. `git reset --hard` overwrites an untracked file only when the incoming
  commit contains that same path; every other one survives. Holding on all of
  them stopped restacks for the ordinary state of having written a new file and
  not staged it. Now it holds only on a real collision. Tracked changes still
  hold unconditionally, and anything unanswerable still holds.

This required the same rule in two places: the engine decides per branch, but
`restack` runs its own filter first, and changing only the engine left the
command unaffected while sync and modify quietly got the new behavior.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785983482`.


* **PR #1611**
  * **PR #1612**
    * **PR #1613**
      * **PR #1614**
        * **PR #1615**
          * **PR #1616** 👈
            * **PR #1617**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1618 by jonnii*