### PR TITLE
fix(restack): hold on untracked files only when they would be overwritten

### DIFF
--- a/docs/plans/worktree-audit-todo.md
+++ b/docs/plans/worktree-audit-todo.md
@@ -1,0 +1,151 @@
+# Worktree Audit — Open Items
+
+Status after the verification pass of 2026-08-05. The fix stacks that landed on main
+(reconciliation safety, the 18-branch checkout-safety stack, and the follow-ups through
+`8f32c6a2`) closed the entire previous P0 list and nearly all of P1/P2: fold's
+detached-HEAD loss, `create -w` branch deletion, absorb's unguarded rewrite, the rebase
+ref CAS, `merge --force` trunk checkout, multi-stack leaks/locks, autoClean orphaning,
+remove ordering, the refusal triangle, orphaned path-ref sweep, prune dry-run, batch
+abort, delete/pluck guards, tree JSON anchors, split stash refs, gitdir resolution,
+locked-worktree force removal, relative `basePath`, the anchor-base 422 loop, and the
+`PullTrunk` swallow. Verified per commit; regressions and residuals below are what's
+left. Line numbers as of the verification; re-check before fixing.
+
+## High
+
+- [ ] **A dirty trunk worktree silently holds every restack, engine-wide.**
+  `restackBranches` puts *any* dirty worktree's branch into `heldBranches` with no trunk
+  exclusion (`internal/engine/engine_sync.go:133-143`), and `branchHeldBack`
+  (`internal/engine/restack_impl.go:68-103`) checks membership *before* its trunk
+  termination — so a main worktree parked on `main` with one untracked scratch file
+  propagates "held" to every trunk-rooted branch. `modify`, `sync --restack`, absorb's
+  follow-up restack etc. all silently return `RestackUnneeded` for everything (no held
+  reporting outside the `restack` command). Holding is wrong here: restack never moves
+  trunk's ref. Empirically confirmed with a probe test. Fix: exclude trunk when building
+  `heldBranches`, or terminate the ancestry walk on trunk before the `Contains` check.
+
+- [ ] **`continue` after a conflicted restack of a branch checked out in a sibling
+  worktree corrupts the sibling and strands the remaining restacks.**
+  Despite `d06d105a`'s title, `ContinueRebase`
+  (`internal/engine/engine_sync.go:265-313`) still has no
+  `PathForBranch`/`ResetWorktreeWorkingDir` after its CAS ref move — the original
+  finding, unimplemented; the `3cbbb4b0` test covers the *parent* in a sibling worktree,
+  not the rebased branch itself. A clean sibling checkout keeps pre-rebase content under
+  the moved ref (next `modify -a` there commits the revert). Compounding fallout from
+  `569b6981`: `internal/actions/continue.go:101`'s `CheckoutBranch` now hard-fails for a
+  foreign-checkout branch, abandoning `BranchesToRestack`, leaving continuation state
+  behind, and leaving the user detached. Fix: reset the branch's worktree after the CAS
+  move (mirror `restackBranch`), and skip/soften the final checkout when the branch
+  lives elsewhere.
+
+## Medium
+
+- [ ] **`create -w` runs post-create hooks in the main repo when worktree creation fails.**
+  Introduced by `076e6316` (the branch-preservation fix): on `CreateAnchoredWorktreeForBranch`
+  failure, execution falls through to `RunPostCreateHooks(ctx, worktreePath)` with
+  `worktreePath == ""` (`internal/actions/create/create.go:322-325`) → hooks (e.g.
+  `pnpm install`) execute in the process CWD on trunk. Move the hooks call inside the
+  success branch.
+
+- [ ] **Metadata CAS gaps (in-flight commit `b7c00f2d` — fix before submit).**
+  All in `internal/git/metadata.go`: (a) `WriteLocalMetadata` (~:419) lacks the
+  `expected == sha` early return `WriteMetadata` has — a no-op local save from a stale
+  reader silently reverts a concurrent write, the exact bug the commit targets; (b) CAS
+  failure doesn't invalidate the in-process cache entry, so cache-first re-reads return
+  superseded meta and retries fail forever in a long-lived engine (server); (c)
+  `ReadLocalMetadata`'s not-found path (~:393) doesn't clear a stale cached SHA, so
+  writes CAS against a deleted ref persistently fail in-process. Also note: batch-read →
+  write flows carry no expectation (safe fallback, last-writer-wins) — document or
+  extend later.
+
+- [ ] **Mid-rebase worktree holds only cover the `restack` command.**
+  `bca90c07` wired `WorktreeRebaseInProgress` into `skipDirtyWorktreeStacks`
+  (`internal/actions/restack.go:506,534`) but the engine snapshot still keys
+  `heldBranches` on `worktree.Branch != ""` (`internal/engine/engine_sync.go:133-143`) —
+  a mid-rebase worktree reports `Branch == ""`, so modify/sync/squash/absorb-driven
+  restacks can move the ref of a branch being rebased elsewhere (the user's later
+  `continue` CAS-fails; resolved rebase stranded detached, reflog recovery). Sync's
+  `SkipReasonForWorktree` (`internal/actions/sync/worktree_cleanup.go:29-43`) also
+  doesn't check rebase-in-progress. Add rebase detection to the engine snapshot (hold
+  the worktree's branch when determinable from the rebase state, or hold the whole
+  anchor stack) and to sync's gate.
+
+- [ ] **Sync never reports engine-level holds.**
+  `3ec80337` fixed reporting for the `restack` command only. Branch-level engine holds
+  surface as bare `RestackUnneeded` → `EventCompleted` in
+  `internal/actions/sync/restack.go:100-110`, indistinguishable from up-to-date.
+  `RestackBranchResult` carries no "held" marker, so no consumer can distinguish. Add a
+  held marker + reason to the result and report it in sync (this also serves the
+  dirty-trunk item above once trunk is excluded).
+
+- [ ] **Absorb aborts mid-loop when a later target is held, then restores duplicated hunks.**
+  When target k of n is held (`internal/actions/absorb/absorb.go:385-387`), targets
+  1..k−1 keep their rewritten commits and the failure restore pops the *full* staged
+  stash — re-staging hunks already committed (duplication on next absorb/restack). The
+  recovery path is pre-existing, but the hold made it a common entry. Cheap fix:
+  pre-check all target branches' worktrees before rewriting anything (also removes the
+  per-target `ListWorktrees` N+1).
+
+- [ ] **Multi-stack failure unlocks are local-only.**
+  The consolidation lock is pushed to remote metadata + PR bodies at lock time
+  (`internal/actions/merge/multistack.go:350`), but the failure/excluded-stack unlocks
+  only run `eng.SetLocked` locally (`multistack.go:241-256`). Until the user's next
+  sync, teammates see phantom `LockReasonConsolidating` locks and stale PR-body notices.
+  Fail-safe direction, but violates the lock-immediacy rationale in reverse — push the
+  unlock like `lock`/`unlock` do.
+
+- [ ] **Split's stash pop still races: positional ref resolved at push time, popped later.**
+  `60907466` made pops ref-qualified, but `splitStashRef`
+  (`internal/actions/split/stash.go:17-29`) resolves `stash@{N}` once right after push;
+  indices are shared across worktrees and shift on any stash traffic, so a concurrent
+  stash during the split still pops the wrong entry. Re-resolve the marker immediately
+  before each pop. Also: when `splitStashRef` errors, the pushed stash is left behind
+  without mention.
+
+## Low
+
+- [ ] **Orphaned path-ref sweep can delete a live ref registered concurrently.**
+  `internal/engine/engine_worktree.go:99-118` lists forward refs before path refs and
+  deletes via unguarded `DeleteRefsBatch`; a `worktree create` committing its atomic
+  pair between the two lists gets its fresh path ref classified as orphaned. Manual
+  `repair` only, so low. Fix: list path refs first, and/or delete with OldSHA guards.
+- [ ] **Sync-time divergence report nags unmanaged-worktree users.**
+  In-flight `0eb35b3e` surfaces `OwnershipWarnings` on every sync, including "checked
+  out in unmanaged worktree Y" rows that no guard acts on — a recurring warning for a
+  legitimate workflow, with no dedup. Consider restricting the sync-time report to
+  managed-owner mismatches.
+- [ ] **`resetWorktreeIfClean` snapshot TOCTOU.** Uncommitted edits made in a sibling
+  worktree after the pass's up-front dirty snapshot but before that branch's reset are
+  destroyed (commits are now CAS-safe; working-tree edits in the window are not).
+  Narrow; hard to close under the snapshot design — consider a re-probe just before
+  reset.
+- [ ] **`ResetTrunkToRemote` has zero test coverage** despite the rewrite
+  (`internal/engine/pull.go:92-165`). Add main-checkout-clean / main-checkout-dirty /
+  detached-engine cases.
+- [ ] **Double ref-write in `restackBranch`.** `git.Rebase` CAS-moves the ref, then
+  `restackBranch` writes it again (no-op) in `UpdateRefsBatchWithLog`
+  (`internal/engine/restack_impl.go:565-570`), and `resetWorktreeIfClean` at :548 is
+  correct only because the ref already moved inside `Rebase`. Consolidate or comment.
+- [ ] **`foreach` capability change from `569b6981`.** Branches checked out in other
+  worktrees previously ran detached; now they error per-branch. Honest but a
+  regression for read-only foreach use — consider an explicit detached mode.
+- [ ] **Cosmetics/info:** `sync/branch_cleaning.go:154` "checked out here" wording is
+  wrong from a linked worktree; `worktreePathUsable` stranded `getWorktreeSwitchInfo`'s
+  doc comment (`internal/actions/checkout.go:190-196`); `fc702272`'s message doesn't
+  match its diff (content landed in `e6404bda`); registering over an orphaned path ref
+  says "failed to register worktree" without pointing at `worktree repair`; `create -w`
+  from *inside* a managed worktree resolves a relative basePath against the worktree
+  root rather than the main repo; warm-start treats any mkdir errno as a per-file skip
+  and repeats warnings per file under a broken prefix; `foreach.go:511` passes
+  `appCtx.Context` where siblings use the local `ctx`.
+
+## Suggested next steps
+
+1. Fix the two Highs together (both in `engine_sync.go` / continue path): trunk
+   exclusion for `heldBranches`, sibling reset in `ContinueRebase`, soften
+   `continue.go`'s final checkout.
+2. Patch the in-flight stack before submit: metadata CAS gaps (`b7c00f2d`), hooks
+   fall-through (`076e6316` follow-up fits the same stack), sync divergence noise.
+3. Fold the mid-rebase engine snapshot + sync held-reporting into one "engine hold
+   completeness" branch.
+4. Long tail as convenient.

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -523,8 +523,9 @@ func skipDirtyWorktreeStacks(ctx *app.Context, groups []restackBranchGroup) []re
 		ctx.Output.Warn("Could not inspect managed worktrees; holding no known stacks: %v", err)
 	}
 
-	// A hard reset can remove an untracked file when the incoming commit needs
-	// that pathname, so any local change must hold the branch back.
+	// Changes to tracked files always hold the branch: the reset would discard
+	// them. Untracked files hold it only when one occupies a path the incoming
+	// commit also writes, which is the only case a hard reset destroys.
 	dirtyBranches := make(map[string]bool)
 	if worktrees, err := eng.ListWorktrees(ctx.Context); err == nil {
 		for _, wt := range worktrees {
@@ -536,7 +537,7 @@ func skipDirtyWorktreeStacks(ctx *app.Context, groups []restackBranchGroup) []re
 				ctx.Output.Warn("Holding %s (worktree %s has a rebase in progress)", wt.Branch, wt.Path)
 				continue
 			}
-			hasChanges, inspectErr := eng.WorktreeHasUncommittedChanges(ctx.Context, wt.Path)
+			hasChanges, inspectErr := eng.WorktreeHasTrackedChanges(ctx.Context, wt.Path)
 			if inspectErr != nil {
 				ctx.Output.Warn("Holding %s because worktree %s could not be inspected: %v", wt.Branch, wt.Path, inspectErr)
 				dirtyBranches[wt.Branch] = true
@@ -545,6 +546,20 @@ func skipDirtyWorktreeStacks(ctx *app.Context, groups []restackBranchGroup) []re
 			if hasChanges {
 				dirtyBranches[wt.Branch] = true
 				ctx.Output.Warn("Skipping %s (worktree %s has uncommitted changes; commit or stash them, then restack again)", wt.Branch, wt.Path)
+				continue
+			}
+			// Untracked files only hold the branch when one of them occupies a
+			// path the incoming commit also writes — the only case a hard reset
+			// would destroy. Holding on any untracked file at all would stop a
+			// restack for the ordinary state of having written a new file and
+			// not staged it yet.
+			if collides, known := eng.UntrackedCollision(ctx.Context, wt.Branch); collides || !known {
+				dirtyBranches[wt.Branch] = true
+				if known {
+					ctx.Output.Warn("Skipping %s (an untracked file in worktree %s would be overwritten by the incoming commit; move or commit it, then restack again)", wt.Branch, wt.Path)
+				} else {
+					ctx.Output.Warn("Holding %s because untracked files in worktree %s could not be checked against the incoming commit", wt.Branch, wt.Path)
+				}
 			}
 		}
 	} else {

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -807,3 +807,11 @@ func (d *demoGitRunner) WriteStackMetaBlob(_ *git.StackMeta) (string, error) {
 func (d *demoGitRunner) GetStackMetaRefSHA(_ string) string {
 	return ""
 }
+
+func (d *demoGitRunner) TreeContainsAnyPath(_ context.Context, _ string, _ []string) (bool, bool) {
+	return false, true
+}
+
+func (d *demoGitRunner) GetUntrackedFilesIn(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -128,19 +128,39 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 	// when the user actually had uncommitted work. Bounded by worktree count,
 	// not branch count, so this stays a handful of calls even for a large stack.
 	//
-	// Capture every local change. `git reset --hard` can delete an untracked
-	// file when the incoming commit needs that pathname, so excluding untracked
-	// files would risk user data loss.
+	// Changes to tracked files hold their branch unconditionally: the reset
+	// would discard them.
+	//
+	// Untracked files are recorded but not decided here. `git reset --hard`
+	// overwrites an untracked file only when the incoming commit contains that
+	// same path, and leaves every other untracked file untouched — so holding
+	// on any untracked file at all stops a restack for the ordinary state of
+	// having written a new file and not staged it yet. The collision is checked
+	// per branch once its incoming tree is known; see untrackedCollisionHold.
 	dirtyWorktrees := make(map[string]bool, len(worktrees))
+	untrackedByWorktree := make(map[string][]string)
 	heldBranches := make(BranchNameSet)
 	for _, worktree := range worktrees {
-		dirty, dirtyErr := e.git.WorktreeHasUncommittedChanges(ctx, worktree.Path)
-		if dirtyErr != nil || dirty {
-			path := worktree.Path
+		path := worktree.Path
+		tracked, trackedErr := e.git.WorktreeHasTrackedChanges(ctx, path)
+		if trackedErr != nil || tracked {
 			dirtyWorktrees[path] = true
 			if worktree.Branch != "" {
 				heldBranches[worktree.Branch] = true
 			}
+			continue
+		}
+		untracked, untrackedErr := e.git.GetUntrackedFilesIn(ctx, path)
+		if untrackedErr != nil {
+			// Cannot tell what is there, so no reset is safe.
+			dirtyWorktrees[path] = true
+			if worktree.Branch != "" {
+				heldBranches[worktree.Branch] = true
+			}
+			continue
+		}
+		if len(untracked) > 0 {
+			untrackedByWorktree[path] = untracked
 		}
 	}
 
@@ -156,7 +176,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 			metaRefSHAs[strings.TrimPrefix(refName, git.MetadataRefPrefix)] = sha
 		}
 	}
-	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees, heldBranches: heldBranches, worktreeInspectionFailed: worktreeInspectionFailed}
+	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees, untrackedByWorktree: untrackedByWorktree, heldBranches: heldBranches, worktreeInspectionFailed: worktreeInspectionFailed}
 
 	// 2. Apply the restack changes
 	results := make(map[string]RestackBranchResult)

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -461,3 +461,44 @@ func (e *engineImpl) IsInManagedWorktree() (bool, *WorktreeInfo, error) {
 	// It's a worktree but not managed by stackit
 	return false, nil, nil
 }
+
+// UntrackedCollision reports whether untracked files in the worktree holding
+// branchName would be destroyed by restacking it.
+//
+// `git reset --hard` overwrites an untracked file only when the incoming commit
+// contains that same path; every other untracked file survives untouched. The
+// incoming tree is the branch's base — its own commits cannot introduce a
+// colliding path, or the file would be tracked rather than untracked.
+//
+// known is false when the question could not be answered, which callers must
+// treat as unsafe rather than as "no collision".
+func (e *engineImpl) UntrackedCollision(ctx context.Context, branchName string) (collides, known bool) {
+	worktrees, err := e.git.ListWorktrees(ctx)
+	if err != nil {
+		return false, false
+	}
+	worktreePath := worktrees.PathForBranch(branchName)
+	if worktreePath == "" {
+		return false, true
+	}
+	untracked, err := e.git.GetUntrackedFilesIn(ctx, worktreePath)
+	if err != nil {
+		return false, false
+	}
+	if len(untracked) == 0 {
+		return false, true
+	}
+
+	e.mu.RLock()
+	state := e.readState(branchName)
+	parent := e.trunk
+	e.mu.RUnlock()
+	if state != nil && state.Parent != "" {
+		parent = state.Parent
+	}
+	baseRev, err := e.GetBranch(parent).GetRevision()
+	if err != nil || baseRev == "" {
+		return false, false
+	}
+	return e.git.TreeContainsAnyPath(ctx, baseRev, untracked)
+}

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -283,6 +283,7 @@ type WorktreeOperations interface {
 	GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error)
 	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)
 	WorktreeHasTrackedChanges(ctx context.Context, worktreePath string) (bool, error)
+	UntrackedCollision(ctx context.Context, branchName string) (collides, known bool)
 	// WorktreeRebaseInProgress reports whether a rebase is active in worktreePath.
 	WorktreeRebaseInProgress(ctx context.Context, worktreePath string) bool
 	ListIgnoredFiles(ctx context.Context, worktreePath string) ([]string, error)

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -55,6 +55,10 @@ type restackSnapshot struct {
 	// local changes before this restack pass began. This cannot be checked
 	// lazily; see resetWorktreeIfClean for why.
 	dirtyWorktrees map[string]bool
+	// untrackedByWorktree holds the untracked (non-ignored) paths found in
+	// worktrees that had no tracked changes. Whether those hold their branch
+	// depends on the incoming tree, which is only known per branch.
+	untrackedByWorktree map[string][]string
 	// heldBranches contains every branch whose checked-out worktree was dirty
 	// or could not be inspected before this pass. Descendants of these branches
 	// must be held too: a validated child may otherwise be built on the target
@@ -63,6 +67,69 @@ type restackSnapshot struct {
 	// worktreeInspectionFailed means the physical checkout map is unknown, so
 	// no ref move is safe for this pass.
 	worktreeInspectionFailed bool
+}
+
+// untrackedCollisionHold decides whether a worktree holding only untracked
+// files must still hold its branch back.
+//
+// `git reset --hard` silently overwrites an untracked file whose path the
+// incoming commit also contains, and leaves every other untracked file alone.
+// So the question is not "are there untracked files" — which is the ordinary
+// state of having written a new file and not staged it — but "does any of them
+// collide with what is about to land".
+//
+// The incoming tree is the branch's new base. A branch's own commits cannot
+// introduce a colliding path: if they did, the file would be tracked rather
+// than untracked. Parents are restacked before their children, so by the time
+// this runs the parent ref already holds the tree that is about to arrive.
+//
+// The decision is recorded in the snapshot: a held branch must also hold its
+// descendants, and its worktree must not be reset afterwards.
+func (e *engineImpl) untrackedCollisionHold(ctx context.Context, branch Branch, snap *restackSnapshot) bool {
+	branchName := branch.GetName()
+	worktreePath := snap.worktrees.PathForBranch(branchName)
+	if worktreePath == "" {
+		return false
+	}
+	untracked := snap.untrackedByWorktree[worktreePath]
+	if len(untracked) == 0 {
+		return false
+	}
+
+	hold := func() bool {
+		snap.dirtyWorktrees[worktreePath] = true
+		snap.heldBranches[branchName] = true
+		return true
+	}
+
+	e.mu.RLock()
+	state := e.readState(branchName)
+	parent := e.trunk
+	e.mu.RUnlock()
+	if state != nil && state.Parent != "" {
+		parent = state.Parent
+	}
+	baseRev, err := e.GetBranch(parent).GetRevision()
+	if err != nil || baseRev == "" {
+		// Cannot see what is about to land, so cannot rule out a collision.
+		return hold()
+	}
+
+	collides, known := e.git.TreeContainsAnyPath(ctx, baseRev, untracked)
+	if !known || collides {
+		return hold()
+	}
+	return false
+}
+
+// holdBranch is the single hold decision every restack path consults: an
+// ancestor already held, or this branch's own worktree holding something the
+// incoming tree would destroy.
+func (e *engineImpl) holdBranch(ctx context.Context, branch Branch, snap *restackSnapshot) bool {
+	if e.branchHeldBack(branch, snap) {
+		return true
+	}
+	return e.untrackedCollisionHold(ctx, branch, snap)
 }
 
 func (e *engineImpl) branchHeldBack(branch Branch, snap *restackSnapshot) bool {
@@ -264,7 +331,7 @@ func (e *engineImpl) restackBranch(
 	// which warns and is reached solely by the `restack` command) so that every
 	// caller of RestackBranches inherits it — modify, sync, squash, absorb,
 	// delete, split, reorder, pluck and insert all arrive here directly.
-	if e.branchHeldBack(branch, snap) {
+	if e.holdBranch(ctx, branch, snap) {
 		return RestackBranchResult{Result: RestackUnneeded}, nil
 	}
 
@@ -712,7 +779,7 @@ func (e *engineImpl) applyMetadataRefresh(
 	// Metadata records the parent SHA consumed by later planning, so advancing
 	// it past a held parent would create the same phantom-parent state as a ref
 	// move. A held branch and every descendant must remain completely unchanged.
-	if e.branchHeldBack(branch, snap) {
+	if e.holdBranch(ctx, branch, snap) {
 		return RestackBranchResult{Result: RestackUnneeded, RebasedBranchBase: item.ParentRev}, nil
 	}
 	meta := snap.meta.Get(branchName)
@@ -770,7 +837,7 @@ func (e *engineImpl) applyBranchAndMetadata(
 	// Hold the branch back instead. This is the plan path, reached by every
 	// caller of actions.RestackBranches (modify, squash, absorb, delete, split,
 	// reorder, pluck) as well as the `restack` command.
-	if e.branchHeldBack(branch, snap) {
+	if e.holdBranch(ctx, branch, snap) {
 		return RestackBranchResult{Result: RestackUnneeded, RebasedBranchBase: parentRev}, nil
 	}
 

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -244,6 +244,8 @@ type RefOperations interface {
 	GetRef(name string) (string, error)
 	UpdateRef(name, sha string) error
 	UpdateRefWithLog(ctx context.Context, refName, sha, message string) error
+	GetUntrackedFilesIn(ctx context.Context, worktreePath string) ([]string, error)
+	TreeContainsAnyPath(ctx context.Context, rev string, paths []string) (collides, known bool)
 	UpdateRefsBatch(ctx context.Context, updates []RefUpdate) error
 	UpdateRefsBatchWithLog(ctx context.Context, updates []RefUpdate, reflogMessage string) error
 	DeleteRefsBatch(ctx context.Context, refNames []string) error

--- a/internal/git/staging.go
+++ b/internal/git/staging.go
@@ -106,6 +106,20 @@ func (r *runner) listUntrackedFiles(ctx context.Context) ([]string, error) {
 	return splitNulTerminated(out), nil
 }
 
+// GetUntrackedFilesIn returns untracked, non-ignored files in an arbitrary
+// worktree, as repository-relative paths. Ignored files are excluded, so
+// gitignored build output never counts as work to protect.
+func (r *runner) GetUntrackedFilesIn(ctx context.Context, worktreePath string) ([]string, error) {
+	out, err := r.RunGitCommandRawWithContext(ctx,
+		"-C", worktreePath,
+		"ls-files", "--others", "--exclude-standard", "-z",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list untracked files in %s: %w", worktreePath, err)
+	}
+	return splitNulTerminated(out), nil
+}
+
 func (r *runner) ParseStagedHunks(ctx context.Context) ([]Hunk, error) {
 	diffOutput, err := r.RunGitCommandRawWithContext(ctx, "diff", "--cached")
 	if err != nil {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -501,3 +501,34 @@ func (r *runner) ListWorktreeMetas() (map[string]*WorktreeMeta, error) {
 
 	return result, nil
 }
+
+// maxUntrackedCollisionPaths bounds how many paths TreeContainsAnyPath will ask
+// git about in one invocation. Beyond this the caller is expected to fall back
+// to a conservative answer rather than build an unbounded argv.
+const maxUntrackedCollisionPaths = 200
+
+// TreeContainsAnyPath reports whether rev's tree contains any of paths.
+//
+// This answers the only question that makes an untracked file unsafe during a
+// restack: `git reset --hard` silently overwrites an untracked file whose path
+// the incoming commit also contains, and leaves every other untracked file
+// alone. Paths are repository-relative.
+//
+// The second return reports whether the question could be answered at all.
+// Callers guard destructive work with this, so "unknown" must not read as "no
+// collision".
+func (r *runner) TreeContainsAnyPath(ctx context.Context, rev string, paths []string) (collides, known bool) {
+	if rev == "" || len(paths) == 0 {
+		return false, true
+	}
+	if len(paths) > maxUntrackedCollisionPaths {
+		return false, false
+	}
+
+	args := append([]string{"ls-tree", "-r", "-z", "--name-only", rev, "--"}, paths...)
+	out, err := r.RunGitCommandRawWithContext(ctx, args...)
+	if err != nil {
+		return false, false
+	}
+	return strings.TrimSpace(strings.ReplaceAll(out, "\x00", "")) != "", true
+}

--- a/internal/integration/restack_dirty_maintree_test.go
+++ b/internal/integration/restack_dirty_maintree_test.go
@@ -4,26 +4,19 @@ import (
 	"testing"
 )
 
-// TestRestackWithUntrackedFileHoldsBranchAndLeavesNoStagedRevert covers the
-// untracked half of the dirty-worktree hold.
+// TestRestackWithHarmlessUntrackedFileProceeds covers the ordinary state of
+// having written a new file and not staged it yet.
 //
-// The reset that realigns a worktree after its branch ref moves is gated on the
-// worktree being clean, so that it cannot discard uncommitted work. Untracked
-// files count: `git reset --hard` overwrites an untracked file whose pathname
-// the incoming commit also contains, so skipping the reset is not enough — the
-// ref must not move either, or the worktree ends up holding the old commit's
-// content under a new ref and `stackit modify -a` commits the revert.
-//
-// So a stray untracked file holds the branch back rather than being restacked
-// around it. The file survives, the ref stays put, and nothing is staged.
-func TestRestackWithUntrackedFileHoldsBranchAndLeavesNoStagedRevert(t *testing.T) {
+// `git reset --hard` overwrites an untracked file only when the incoming commit
+// contains that same path, and leaves every other untracked file alone. Holding
+// the branch for any untracked file at all stopped restacks for a state most
+// working repositories are in most of the time.
+func TestRestackWithHarmlessUntrackedFileProceeds(t *testing.T) {
 	t.Parallel()
 
 	sh := NewTestShellInProcess(t)
 
 	sh.CreateLinearStack3().Checkout("a")
-	sh.Git("rev-parse a")
-	revBefore := sh.Output()
 
 	// Trunk advances so the stack genuinely needs restacking. WriteFile stages
 	// under the exact name, which the assertions below rely on.
@@ -32,25 +25,57 @@ func TestRestackWithUntrackedFileHoldsBranchAndLeavesNoStagedRevert(t *testing.T
 		Git("commit -m 'chore: trunk commit'").
 		Checkout("a")
 
-	// A single untracked file — a scratch note, a build artifact, anything not
-	// in .gitignore.
+	// An untracked file at a path trunk knows nothing about. Nothing incoming
+	// can overwrite it.
 	sh.WriteUnstaged("scratch.txt", "scratch note")
 
 	sh.Run("restack --upstack")
 
-	// The branch must not have moved: holding it back is what keeps the
-	// worktree and its ref consistent.
-	sh.Git("rev-parse a")
-	if sh.Output() != revBefore {
-		t.Fatalf("branch a moved despite its worktree having an untracked file:\nbefore %safter  %s", revBefore, sh.Output())
-	}
+	// The restack happened: trunk's commit is now in this branch's history.
+	sh.Git("ls-tree HEAD -- trunk1.txt").OutputContains("trunk1.txt")
 
-	// The only thing git should report is the untracked file itself. A "D " or
-	// " D" entry here means trunk's content was left staged for deletion.
+	// The untracked file survived, and no staged revert was left behind.
 	sh.Git("status --porcelain").
 		OutputContains("?? scratch.txt").
 		OutputNotContains(" D ").
 		OutputNotContains("D  ")
+}
+
+// TestRestackHoldsBranchWhenUntrackedFileWouldBeOverwritten covers the case the
+// hold actually exists for.
+//
+// The incoming commit adds a file at the same path as an untracked file in the
+// worktree. `git reset --hard` overwrites it silently, and since the file was
+// never in Git there is nothing to recover it from — so the branch is held
+// instead and the ref does not move.
+func TestRestackHoldsBranchWhenUntrackedFileWouldBeOverwritten(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+
+	sh.CreateLinearStack3().Checkout("a")
+	sh.Git("rev-parse a")
+	revBefore := sh.Output()
+
+	// Trunk advances by adding a file the worktree also has, untracked.
+	sh.Checkout("main").
+		WriteFile("collide.txt", "from trunk").
+		Git("commit -m 'chore: trunk adds collide.txt'").
+		Checkout("a")
+
+	sh.WriteUnstaged("collide.txt", "my uncommitted work")
+
+	sh.Run("restack --upstack").
+		OutputContains("would be overwritten")
+
+	// The branch must not have moved.
+	sh.Git("rev-parse a")
+	if sh.Output() != revBefore {
+		t.Fatalf("branch a moved even though restacking it would overwrite an untracked file:\nbefore %safter  %s", revBefore, sh.Output())
+	}
+
+	// And the file still holds the user's content, not trunk's.
+	sh.Git("status --porcelain").OutputContains("?? collide.txt")
 }
 
 // TestRestackSkipsBranchWithTrackedChangesInItsWorktree covers the other half.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Restack held a branch whenever its worktree had any untracked file, which is
the ordinary state of having written a new file and not staged it yet. Trunk
moves, you restack, and nothing happens — the branch and everything above it
are held until you commit or stash.

`git reset --hard` overwrites an untracked file only when the incoming commit
contains that same path; every other untracked file survives untouched. So the
question is not whether untracked files exist but whether any of them collides
with what is about to land. Gitignored files never counted here and still do
not.

The incoming tree is the branch's base — its own commits cannot introduce a
colliding path, or the file would be tracked. Parents restack before their
children, so the base ref already holds that tree when the check runs.

Changes to tracked files still hold unconditionally, and anything that cannot
be inspected or compared still holds: an unanswerable question is not a
no-collision answer.

<hr/>

<!-- STACKIT-SECTION-START -->
**Close out the worktree audit, and stop holding restacks for harmless files**

The last of the worktree audit's open items, plus one behavior change the audit
did not ask for.

**Concurrency and cancellation**

- **#1611** — metadata writes are compare-and-swap. Two stackit processes in
  different worktrees that both read a branch and then wrote it kept only the
  second write; whatever the first recorded was silently gone. Metadata refs
  point straight at a blob and cat-file already reports that blob's SHA — it was
  being parsed and discarded. A write based on state another process replaced
  now fails and says so.
- **#1612** — worktree registration and post-create hooks ran with
  context.Background(), ignoring cancellation. AttachAction also discarded the
  error from restoring your original branch, leaving you somewhere you did not
  ask to be without saying so.

**Guidance that assumed the worktree was still there**

- **#1613** — the ownership guard told users to `cd` into the owning worktree
  without checking it existed, so a deleted directory produced advice that could
  only fail, for a branch only detach can release. Checkout's stale-path tip
  named `worktree remove`, which refuses for any stack that still has branches.
  Checkout also only validated the destination when switching from the main
  repo, not between worktrees.
- **#1614** — a branch held back reports RestackUnneeded, the same status as a
  branch that needed no work, so the conflict workflow concluded the rebase had
  succeeded and said so. It now names why the branch is held, and where.
- **#1615** — ownership divergence was only reported by `worktree list`, a
  command nobody runs until they already suspect something. Sync reports it.

**Warm start**

- **#1616** — one unplaceable file aborted worktree creation entirely, because
  any warm-start error makes the caller tear the worktree down. The mundane case
  is a tracked file occupying a name the include file also wants as a directory.
  It is reported and skipped now; a symlinked parent stays a hard failure, since
  that is how a project-controlled include file could steer a copy outside the
  worktree. Directory checks are memoized, and the docs now say plainly that
  warm-started files have no backup anywhere.

**The rule that was too broad**

- **#1617** — restack held a branch whenever its worktree had any untracked
  file. `git reset --hard` overwrites an untracked file only when the incoming
  commit contains that same path; every other one survives. Holding on all of
  them stopped restacks for the ordinary state of having written a new file and
  not staged it. Now it holds only on a real collision. Tracked changes still
  hold unconditionally, and anything unanswerable still holds.

This required the same rule in two places: the engine decides per branch, but
`restack` runs its own filter first, and changing only the engine left the
command unaffected while sync and modify quietly got the new behavior.

#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1785983482`.


* **PR #1611**
  * **PR #1612**
    * **PR #1613**
      * **PR #1614**
        * **PR #1615**
          * **PR #1616**
            * **PR #1617** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1618 by jonnii*