### PR TITLE
Close out the worktree audit, and stop holding restacks for harmless files

### DIFF
--- a/docs/plans/worktree-audit-todo.md
+++ b/docs/plans/worktree-audit-todo.md
@@ -1,0 +1,151 @@
+# Worktree Audit — Open Items
+
+Status after the verification pass of 2026-08-05. The fix stacks that landed on main
+(reconciliation safety, the 18-branch checkout-safety stack, and the follow-ups through
+`8f32c6a2`) closed the entire previous P0 list and nearly all of P1/P2: fold's
+detached-HEAD loss, `create -w` branch deletion, absorb's unguarded rewrite, the rebase
+ref CAS, `merge --force` trunk checkout, multi-stack leaks/locks, autoClean orphaning,
+remove ordering, the refusal triangle, orphaned path-ref sweep, prune dry-run, batch
+abort, delete/pluck guards, tree JSON anchors, split stash refs, gitdir resolution,
+locked-worktree force removal, relative `basePath`, the anchor-base 422 loop, and the
+`PullTrunk` swallow. Verified per commit; regressions and residuals below are what's
+left. Line numbers as of the verification; re-check before fixing.
+
+## High
+
+- [ ] **A dirty trunk worktree silently holds every restack, engine-wide.**
+  `restackBranches` puts *any* dirty worktree's branch into `heldBranches` with no trunk
+  exclusion (`internal/engine/engine_sync.go:133-143`), and `branchHeldBack`
+  (`internal/engine/restack_impl.go:68-103`) checks membership *before* its trunk
+  termination — so a main worktree parked on `main` with one untracked scratch file
+  propagates "held" to every trunk-rooted branch. `modify`, `sync --restack`, absorb's
+  follow-up restack etc. all silently return `RestackUnneeded` for everything (no held
+  reporting outside the `restack` command). Holding is wrong here: restack never moves
+  trunk's ref. Empirically confirmed with a probe test. Fix: exclude trunk when building
+  `heldBranches`, or terminate the ancestry walk on trunk before the `Contains` check.
+
+- [ ] **`continue` after a conflicted restack of a branch checked out in a sibling
+  worktree corrupts the sibling and strands the remaining restacks.**
+  Despite `d06d105a`'s title, `ContinueRebase`
+  (`internal/engine/engine_sync.go:265-313`) still has no
+  `PathForBranch`/`ResetWorktreeWorkingDir` after its CAS ref move — the original
+  finding, unimplemented; the `3cbbb4b0` test covers the *parent* in a sibling worktree,
+  not the rebased branch itself. A clean sibling checkout keeps pre-rebase content under
+  the moved ref (next `modify -a` there commits the revert). Compounding fallout from
+  `569b6981`: `internal/actions/continue.go:101`'s `CheckoutBranch` now hard-fails for a
+  foreign-checkout branch, abandoning `BranchesToRestack`, leaving continuation state
+  behind, and leaving the user detached. Fix: reset the branch's worktree after the CAS
+  move (mirror `restackBranch`), and skip/soften the final checkout when the branch
+  lives elsewhere.
+
+## Medium
+
+- [ ] **`create -w` runs post-create hooks in the main repo when worktree creation fails.**
+  Introduced by `076e6316` (the branch-preservation fix): on `CreateAnchoredWorktreeForBranch`
+  failure, execution falls through to `RunPostCreateHooks(ctx, worktreePath)` with
+  `worktreePath == ""` (`internal/actions/create/create.go:322-325`) → hooks (e.g.
+  `pnpm install`) execute in the process CWD on trunk. Move the hooks call inside the
+  success branch.
+
+- [ ] **Metadata CAS gaps (in-flight commit `b7c00f2d` — fix before submit).**
+  All in `internal/git/metadata.go`: (a) `WriteLocalMetadata` (~:419) lacks the
+  `expected == sha` early return `WriteMetadata` has — a no-op local save from a stale
+  reader silently reverts a concurrent write, the exact bug the commit targets; (b) CAS
+  failure doesn't invalidate the in-process cache entry, so cache-first re-reads return
+  superseded meta and retries fail forever in a long-lived engine (server); (c)
+  `ReadLocalMetadata`'s not-found path (~:393) doesn't clear a stale cached SHA, so
+  writes CAS against a deleted ref persistently fail in-process. Also note: batch-read →
+  write flows carry no expectation (safe fallback, last-writer-wins) — document or
+  extend later.
+
+- [ ] **Mid-rebase worktree holds only cover the `restack` command.**
+  `bca90c07` wired `WorktreeRebaseInProgress` into `skipDirtyWorktreeStacks`
+  (`internal/actions/restack.go:506,534`) but the engine snapshot still keys
+  `heldBranches` on `worktree.Branch != ""` (`internal/engine/engine_sync.go:133-143`) —
+  a mid-rebase worktree reports `Branch == ""`, so modify/sync/squash/absorb-driven
+  restacks can move the ref of a branch being rebased elsewhere (the user's later
+  `continue` CAS-fails; resolved rebase stranded detached, reflog recovery). Sync's
+  `SkipReasonForWorktree` (`internal/actions/sync/worktree_cleanup.go:29-43`) also
+  doesn't check rebase-in-progress. Add rebase detection to the engine snapshot (hold
+  the worktree's branch when determinable from the rebase state, or hold the whole
+  anchor stack) and to sync's gate.
+
+- [ ] **Sync never reports engine-level holds.**
+  `3ec80337` fixed reporting for the `restack` command only. Branch-level engine holds
+  surface as bare `RestackUnneeded` → `EventCompleted` in
+  `internal/actions/sync/restack.go:100-110`, indistinguishable from up-to-date.
+  `RestackBranchResult` carries no "held" marker, so no consumer can distinguish. Add a
+  held marker + reason to the result and report it in sync (this also serves the
+  dirty-trunk item above once trunk is excluded).
+
+- [ ] **Absorb aborts mid-loop when a later target is held, then restores duplicated hunks.**
+  When target k of n is held (`internal/actions/absorb/absorb.go:385-387`), targets
+  1..k−1 keep their rewritten commits and the failure restore pops the *full* staged
+  stash — re-staging hunks already committed (duplication on next absorb/restack). The
+  recovery path is pre-existing, but the hold made it a common entry. Cheap fix:
+  pre-check all target branches' worktrees before rewriting anything (also removes the
+  per-target `ListWorktrees` N+1).
+
+- [ ] **Multi-stack failure unlocks are local-only.**
+  The consolidation lock is pushed to remote metadata + PR bodies at lock time
+  (`internal/actions/merge/multistack.go:350`), but the failure/excluded-stack unlocks
+  only run `eng.SetLocked` locally (`multistack.go:241-256`). Until the user's next
+  sync, teammates see phantom `LockReasonConsolidating` locks and stale PR-body notices.
+  Fail-safe direction, but violates the lock-immediacy rationale in reverse — push the
+  unlock like `lock`/`unlock` do.
+
+- [ ] **Split's stash pop still races: positional ref resolved at push time, popped later.**
+  `60907466` made pops ref-qualified, but `splitStashRef`
+  (`internal/actions/split/stash.go:17-29`) resolves `stash@{N}` once right after push;
+  indices are shared across worktrees and shift on any stash traffic, so a concurrent
+  stash during the split still pops the wrong entry. Re-resolve the marker immediately
+  before each pop. Also: when `splitStashRef` errors, the pushed stash is left behind
+  without mention.
+
+## Low
+
+- [ ] **Orphaned path-ref sweep can delete a live ref registered concurrently.**
+  `internal/engine/engine_worktree.go:99-118` lists forward refs before path refs and
+  deletes via unguarded `DeleteRefsBatch`; a `worktree create` committing its atomic
+  pair between the two lists gets its fresh path ref classified as orphaned. Manual
+  `repair` only, so low. Fix: list path refs first, and/or delete with OldSHA guards.
+- [ ] **Sync-time divergence report nags unmanaged-worktree users.**
+  In-flight `0eb35b3e` surfaces `OwnershipWarnings` on every sync, including "checked
+  out in unmanaged worktree Y" rows that no guard acts on — a recurring warning for a
+  legitimate workflow, with no dedup. Consider restricting the sync-time report to
+  managed-owner mismatches.
+- [ ] **`resetWorktreeIfClean` snapshot TOCTOU.** Uncommitted edits made in a sibling
+  worktree after the pass's up-front dirty snapshot but before that branch's reset are
+  destroyed (commits are now CAS-safe; working-tree edits in the window are not).
+  Narrow; hard to close under the snapshot design — consider a re-probe just before
+  reset.
+- [ ] **`ResetTrunkToRemote` has zero test coverage** despite the rewrite
+  (`internal/engine/pull.go:92-165`). Add main-checkout-clean / main-checkout-dirty /
+  detached-engine cases.
+- [ ] **Double ref-write in `restackBranch`.** `git.Rebase` CAS-moves the ref, then
+  `restackBranch` writes it again (no-op) in `UpdateRefsBatchWithLog`
+  (`internal/engine/restack_impl.go:565-570`), and `resetWorktreeIfClean` at :548 is
+  correct only because the ref already moved inside `Rebase`. Consolidate or comment.
+- [ ] **`foreach` capability change from `569b6981`.** Branches checked out in other
+  worktrees previously ran detached; now they error per-branch. Honest but a
+  regression for read-only foreach use — consider an explicit detached mode.
+- [ ] **Cosmetics/info:** `sync/branch_cleaning.go:154` "checked out here" wording is
+  wrong from a linked worktree; `worktreePathUsable` stranded `getWorktreeSwitchInfo`'s
+  doc comment (`internal/actions/checkout.go:190-196`); `fc702272`'s message doesn't
+  match its diff (content landed in `e6404bda`); registering over an orphaned path ref
+  says "failed to register worktree" without pointing at `worktree repair`; `create -w`
+  from *inside* a managed worktree resolves a relative basePath against the worktree
+  root rather than the main repo; warm-start treats any mkdir errno as a per-file skip
+  and repeats warnings per file under a broken prefix; `foreach.go:511` passes
+  `appCtx.Context` where siblings use the local `ctx`.
+
+## Suggested next steps
+
+1. Fix the two Highs together (both in `engine_sync.go` / continue path): trunk
+   exclusion for `heldBranches`, sibling reset in `ContinueRebase`, soften
+   `continue.go`'s final checkout.
+2. Patch the in-flight stack before submit: metadata CAS gaps (`b7c00f2d`), hooks
+   fall-through (`076e6316` follow-up fits the same stack), sync divergence noise.
+3. Fold the mid-rebase engine snapshot + sync held-reporting into one "engine hold
+   completeness" branch.
+4. Long tail as convenient.

--- a/docs/worktree.md
+++ b/docs/worktree.md
@@ -79,11 +79,26 @@ Safety rules:
 - A pattern cannot copy a tracked file: it must also be ignored by Git.
 - Existing files in the destination are never overwritten.
 - Symlinks and non-regular files are skipped.
-- A warm-start failure aborts worktree creation and rolls it back, rather than
-  giving an agent a partially initialized workspace.
+- A file that cannot be placed — because a tracked file already occupies a
+  directory name its path needs — is reported and skipped. The rest of the warm
+  start still runs, and the worktree is still created.
+- A symlinked parent directory in the destination aborts worktree creation and
+  rolls it back. `.worktreeinclude` is project-controlled, so this is the path
+  by which a warm start could be steered into writing outside the worktree.
 
 Treat `.worktreeinclude` as an explicit local-data allowlist. In particular,
 include secrets only when every managed worktree is allowed to receive them.
+
+### Warm-started files are not backed up
+
+Warm-started files are ignored by Git, so nothing else has a copy of them.
+`worktree remove` and `worktree prune` delete the worktree directory and
+everything in it, including every warm-started file — a `.env` you edited in
+that worktree is gone with it, with no Git history to recover it from.
+
+`worktree detach` removes the worktree while keeping its branches, but it also
+removes the directory. If a warm-started file has diverged from the copy in
+your main repository and you want to keep it, copy it out first.
 
 ---
 

--- a/internal/actions/checkout.go
+++ b/internal/actions/checkout.go
@@ -190,6 +190,28 @@ func printBranchInfo(ctx *app.Context, branch engine.Branch) {
 // getWorktreeSwitchInfo checks if the target branch belongs to a stack with a worktree,
 // or if we need to switch back to the main repo from a worktree.
 // Returns (switchPath, rerunArgs, fallbackTips) - all empty if no worktree switch is needed.
+// worktreePathUsable reports whether a registered worktree can actually be
+// switched to, warning when it cannot. Both switch directions check this: a
+// registration whose directory is gone must not be offered as a destination
+// from the main repo or from another worktree.
+func worktreePathUsable(ctx *app.Context, stackRoot, path string) bool {
+	_, err := os.Stat(path)
+	switch {
+	case err == nil:
+		return true
+	case os.IsNotExist(err):
+		ctx.Output.Warn("Worktree for stack %s is registered but path does not exist: %s",
+			output.BranchName(stackRoot), path)
+		// detach, not remove: remove refuses for any stack that still has
+		// branches, which is every stack worth checking out.
+		ctx.Output.Tip("stackit worktree detach %s", stackRoot)
+	default:
+		ctx.Output.Warn("Cannot inspect worktree for stack %s at %s: %v",
+			output.BranchName(stackRoot), path, err)
+	}
+	return false
+}
+
 func getWorktreeSwitchInfo(ctx *app.Context, branch engine.Branch, branchName string) (string, []string, []string) {
 	targetStackRoot := ctx.Engine.GetStackRootForBranch(branch)
 
@@ -206,11 +228,12 @@ func getWorktreeSwitchInfo(ctx *app.Context, branch engine.Branch, branchName st
 		} else if targetStackRoot != currentStackRoot {
 			// Target is in a different stack - check if that stack has a worktree
 			targetWorktree, err := ctx.Engine.GetWorktreeForStack(targetStackRoot)
-			if err == nil && targetWorktree != nil {
+			switch {
+			case err == nil && targetWorktree != nil && worktreePathUsable(ctx, targetStackRoot, targetWorktree.Path):
 				switchTarget = targetWorktree.Path
 				targetStack = targetStackRoot
-			} else {
-				// Target stack has no worktree - switch to main repo
+			default:
+				// Target stack has no usable worktree - switch to main repo
 				switchTarget = ctx.WorktreeInfo.MainRepoDir
 			}
 		}
@@ -237,15 +260,7 @@ func getWorktreeSwitchInfo(ctx *app.Context, branch engine.Branch, branchName st
 		return "", nil, nil
 	}
 
-	if _, err := os.Stat(targetWorktree.Path); err != nil {
-		if os.IsNotExist(err) {
-			ctx.Output.Warn("Worktree for stack %s is registered but path does not exist: %s",
-				output.BranchName(targetStackRoot), targetWorktree.Path)
-			ctx.Output.Tip("stackit worktree remove %s", targetStackRoot)
-			return "", nil, nil
-		}
-		ctx.Output.Warn("Cannot inspect worktree for stack %s at %s: %v",
-			output.BranchName(targetStackRoot), targetWorktree.Path, err)
+	if !worktreePathUsable(ctx, targetStackRoot, targetWorktree.Path) {
 		return "", nil, nil
 	}
 

--- a/internal/actions/checkout_test.go
+++ b/internal/actions/checkout_test.go
@@ -1,6 +1,7 @@
 package actions_test
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestCheckoutActionWorktreeSwitchIncludesTargetBranch(t *testing.T) {
 			"feature": "main",
 		})
 
-	err := s.Engine.RegisterWorktree("feature", s.Context.RepoRoot)
+	err := s.Engine.RegisterWorktree(context.Background(), "feature", s.Context.RepoRoot)
 	require.NoError(t, err)
 	defer func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") }()
 

--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -536,6 +536,12 @@ func EnterConflictWorkflow(ctx *app.Context, firstConflict string, allBranches e
 	// Verify we're actually in conflict state
 	if !ctx.Engine.IsRebaseInProgress(ctx.Context) {
 		reattach()
+		// A held branch reports RestackUnneeded, exactly like a branch that was
+		// already up to date, so "the rebase succeeded" is the wrong diagnosis
+		// and sends the user looking for a conflict that never started.
+		if reason := heldWorktreeReason(ctx, firstConflict); reason != "" {
+			return fmt.Errorf("cannot resolve the conflict on %s: it was held back because %s; resolve that, then re-run", firstConflict, reason)
+		}
 		return fmt.Errorf("expected conflict on %s but rebase completed successfully", firstConflict)
 	}
 

--- a/internal/actions/delete/delete_test.go
+++ b/internal/actions/delete/delete_test.go
@@ -198,7 +198,7 @@ func TestDeleteRespectsManagedWorktreeOwnership(t *testing.T) {
 	s.TrackBranch("feature", "main")
 	s.CreateBranch("feature-child").Commit("child change")
 	s.TrackBranch("feature-child", "feature")
-	require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", "/tmp/feature-worktree", "feature-wt"))
+	require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature", "/tmp/feature-worktree", "feature-wt"))
 	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
 
 	_, err := Action(s.Context, Options{BranchName: "feature", Force: true}, nil)
@@ -222,7 +222,7 @@ func TestDeleteCleansUpWorktrees(t *testing.T) {
 		s.TrackBranch("feature-branch", "main")
 
 		// Register a fake worktree for this stack root
-		err := s.Engine.RegisterWorktree("feature-branch", "/tmp/fake-worktree-path")
+		err := s.Engine.RegisterWorktree(context.Background(), "feature-branch", "/tmp/fake-worktree-path")
 		require.NoError(t, err)
 
 		// Verify worktree is registered
@@ -255,7 +255,7 @@ func TestDeleteCleansUpWorktrees(t *testing.T) {
 		s.TrackBranch("child-branch", "stack-root")
 
 		// Register a worktree for the stack root
-		err := s.Engine.RegisterWorktree("stack-root", "/tmp/fake-worktree-path")
+		err := s.Engine.RegisterWorktree(context.Background(), "stack-root", "/tmp/fake-worktree-path")
 		require.NoError(t, err)
 
 		// Verify worktree is registered
@@ -288,7 +288,7 @@ func TestDeleteCleansUpWorktrees(t *testing.T) {
 		s.TrackBranch("child-branch", "stack-root")
 
 		// Register a worktree for the stack root
-		err := s.Engine.RegisterWorktree("stack-root", "/tmp/fake-worktree-path")
+		err := s.Engine.RegisterWorktree(context.Background(), "stack-root", "/tmp/fake-worktree-path")
 		require.NoError(t, err)
 
 		// Verify worktree is registered

--- a/internal/actions/foreach/foreach.go
+++ b/internal/actions/foreach/foreach.go
@@ -508,7 +508,7 @@ func executeCommandOnBranch(ctx context.Context, appCtx *app.Context, branch eng
 	defer cleanup()
 
 	// Run post-worktree-create hooks (pre-resolved, no prompting)
-	worktree.RunResolvedHooks(hooks, worktreePath, appCtx.Output)
+	worktree.RunResolvedHooks(appCtx.Context, hooks, worktreePath, appCtx.Output)
 
 	var output strings.Builder
 	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", fullCommand)

--- a/internal/actions/held_worktree_reason_test.go
+++ b/internal/actions/held_worktree_reason_test.go
@@ -1,0 +1,63 @@
+package actions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// TestHeldWorktreeReason covers the lookup behind the conflict-workflow
+// diagnosis.
+//
+// Restack holds a branch whose worktree it cannot safely reset, and reports the
+// hold as RestackUnneeded — indistinguishable from "already up to date". When a
+// caller expected a rebase to start, that produced "expected conflict on X but
+// rebase completed successfully", which describes the opposite of what happened
+// and points nowhere near the fix (the other worktree).
+func TestHeldWorktreeReason(t *testing.T) {
+	t.Parallel()
+
+	setup := func(t *testing.T) (*scenario.Scenario, string) {
+		t.Helper()
+		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		s.WithInitialCommit()
+		s.CreateBranch("feature").Commit("feature change")
+		s.TrackBranch("feature", "main")
+		s.Checkout("main")
+
+		// A real second checkout of feature, so ListWorktrees reports it.
+		worktreePath := filepath.Join(t.TempDir(), "feature-checkout")
+		s.RunGit("worktree", "add", worktreePath, "feature")
+		t.Cleanup(func() { s.RunGit("worktree", "remove", "--force", worktreePath) })
+		return s, worktreePath
+	}
+
+	t.Run("clean checkout holds nothing", func(t *testing.T) {
+		t.Parallel()
+		s, _ := setup(t)
+		require.Empty(t, heldWorktreeReason(s.Context, "feature"))
+	})
+
+	t.Run("uncommitted changes are reported", func(t *testing.T) {
+		t.Parallel()
+		s, worktreePath := setup(t)
+		require.NoError(t, os.WriteFile(filepath.Join(worktreePath, "scratch.txt"), []byte("wip"), 0o600))
+
+		reason := heldWorktreeReason(s.Context, "feature")
+		require.Contains(t, reason, "uncommitted changes")
+		require.Contains(t, reason, worktreePath,
+			"the reason must name the worktree to act on, not just the branch")
+	})
+
+	t.Run("branch with no checkout holds nothing", func(t *testing.T) {
+		t.Parallel()
+		s, _ := setup(t)
+		require.Empty(t, heldWorktreeReason(s.Context, "main"))
+		require.Empty(t, heldWorktreeReason(s.Context, "does-not-exist"))
+	})
+}

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -663,3 +663,36 @@ func handleRestackProgress(
 		}
 	}
 }
+
+// heldWorktreeReason returns why branchName's own checkout blocks a restack, or
+// "" when nothing does.
+//
+// Restack holds a branch whose worktree it cannot safely reset, and a held
+// branch is reported as RestackUnneeded — the same status as a branch that
+// needed no work. Callers that expected a rebase to start need to tell those
+// apart, because the remedy lives in the other worktree.
+//
+// Only the branch's own checkout is examined. A branch held because an ancestor
+// is held returns "", and the caller falls back to its generic message.
+func heldWorktreeReason(ctx *app.Context, branchName string) string {
+	eng := ctx.Engine
+	worktrees, err := eng.ListWorktrees(ctx.Context)
+	if err != nil {
+		return ""
+	}
+	path := worktrees.PathForBranch(branchName)
+	if path == "" {
+		return ""
+	}
+	if eng.WorktreeRebaseInProgress(ctx.Context, path) {
+		return fmt.Sprintf("worktree %s has a rebase in progress", path)
+	}
+	hasChanges, inspectErr := eng.WorktreeHasUncommittedChanges(ctx.Context, path)
+	switch {
+	case inspectErr != nil:
+		return fmt.Sprintf("worktree %s could not be inspected: %v", path, inspectErr)
+	case hasChanges:
+		return fmt.Sprintf("worktree %s has uncommitted changes", path)
+	}
+	return ""
+}

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -523,8 +523,9 @@ func skipDirtyWorktreeStacks(ctx *app.Context, groups []restackBranchGroup) []re
 		ctx.Output.Warn("Could not inspect managed worktrees; holding no known stacks: %v", err)
 	}
 
-	// A hard reset can remove an untracked file when the incoming commit needs
-	// that pathname, so any local change must hold the branch back.
+	// Changes to tracked files always hold the branch: the reset would discard
+	// them. Untracked files hold it only when one occupies a path the incoming
+	// commit also writes, which is the only case a hard reset destroys.
 	dirtyBranches := make(map[string]bool)
 	if worktrees, err := eng.ListWorktrees(ctx.Context); err == nil {
 		for _, wt := range worktrees {
@@ -536,7 +537,7 @@ func skipDirtyWorktreeStacks(ctx *app.Context, groups []restackBranchGroup) []re
 				ctx.Output.Warn("Holding %s (worktree %s has a rebase in progress)", wt.Branch, wt.Path)
 				continue
 			}
-			hasChanges, inspectErr := eng.WorktreeHasUncommittedChanges(ctx.Context, wt.Path)
+			hasChanges, inspectErr := eng.WorktreeHasTrackedChanges(ctx.Context, wt.Path)
 			if inspectErr != nil {
 				ctx.Output.Warn("Holding %s because worktree %s could not be inspected: %v", wt.Branch, wt.Path, inspectErr)
 				dirtyBranches[wt.Branch] = true
@@ -545,6 +546,20 @@ func skipDirtyWorktreeStacks(ctx *app.Context, groups []restackBranchGroup) []re
 			if hasChanges {
 				dirtyBranches[wt.Branch] = true
 				ctx.Output.Warn("Skipping %s (worktree %s has uncommitted changes; commit or stash them, then restack again)", wt.Branch, wt.Path)
+				continue
+			}
+			// Untracked files only hold the branch when one of them occupies a
+			// path the incoming commit also writes — the only case a hard reset
+			// would destroy. Holding on any untracked file at all would stop a
+			// restack for the ordinary state of having written a new file and
+			// not staged it yet.
+			if collides, known := eng.UntrackedCollision(ctx.Context, wt.Branch); collides || !known {
+				dirtyBranches[wt.Branch] = true
+				if known {
+					ctx.Output.Warn("Skipping %s (an untracked file in worktree %s would be overwritten by the incoming commit; move or commit it, then restack again)", wt.Branch, wt.Path)
+				} else {
+					ctx.Output.Warn("Holding %s because untracked files in worktree %s could not be checked against the incoming commit", wt.Branch, wt.Path)
+				}
 			}
 		}
 	} else {

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/getstackit/stackit/internal/actions"
 	"github.com/getstackit/stackit/internal/actions/handler"
+	"github.com/getstackit/stackit/internal/actions/worktree"
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
 	"github.com/getstackit/stackit/internal/handlers"
@@ -75,6 +76,15 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 			dirtyAnchors[wt.AnchorBranch] = true
 			out.Warn("Skipping stack rooted at %s (%s)", wt.AnchorBranch, reason)
 		}
+	}
+
+	// Report branches checked out somewhere other than the worktree owning
+	// their stack. Sync is the command licensed to touch every stack, so it is
+	// the one place divergence reliably gets seen — previously it surfaced only
+	// if someone happened to run `worktree list`, while the guards that refuse
+	// mutations because of it said nothing about where to look.
+	for _, warning := range worktree.OwnershipWarnings(ctx) {
+		out.Warn("%s", warning)
 	}
 
 	// Calculate total operations for progress (rough estimate)

--- a/internal/actions/sync/worktree_cleanup_test.go
+++ b/internal/actions/sync/worktree_cleanup_test.go
@@ -1,6 +1,7 @@
 package sync_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,7 +24,7 @@ func TestSyncCleansOrphanedWorktrees(t *testing.T) {
 		s.TrackBranch("feature-branch", "main")
 
 		// Register a fake worktree for this branch (we won't actually create the worktree dir)
-		err := s.Engine.RegisterWorktree("feature-branch", "/tmp/fake-worktree-path")
+		err := s.Engine.RegisterWorktree(context.Background(), "feature-branch", "/tmp/fake-worktree-path")
 		require.NoError(t, err)
 
 		// Verify worktree is registered
@@ -56,7 +57,7 @@ func TestSyncCleansOrphanedWorktrees(t *testing.T) {
 		s.TrackBranch("feature-branch", "main")
 
 		// Register a worktree for this branch
-		err := s.Engine.RegisterWorktree("feature-branch", "/tmp/fake-worktree-path")
+		err := s.Engine.RegisterWorktree(context.Background(), "feature-branch", "/tmp/fake-worktree-path")
 		require.NoError(t, err)
 
 		// Go back to main and run sync
@@ -78,7 +79,7 @@ func TestSyncCleansOrphanedWorktrees(t *testing.T) {
 		worktreePath := filepath.Join(t.TempDir(), "not-a-git-worktree")
 		require.NoError(t, os.MkdirAll(worktreePath, 0o755))
 
-		err := s.Engine.RegisterWorktree("missing-anchor", worktreePath)
+		err := s.Engine.RegisterWorktree(context.Background(), "missing-anchor", worktreePath)
 		require.NoError(t, err)
 
 		handler := &sync.NullHandler{}

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -481,6 +481,9 @@ func createAnchoredWorktree(ctx *app.Context, eng engine.Engine, repoRoot string
 	if warmStart.Enabled && len(warmStart.Copied) > 0 {
 		out.Info("Warm-started worktree with %d ignored file(s)", len(warmStart.Copied))
 	}
+	for _, skip := range warmStart.SkippedUnsafe {
+		out.Warn("Did not warm-start %s: %s (selected by %s)", skip.Path, skip.Reason, WorktreeIncludeFile)
+	}
 
 	if err := eng.RegisterWorktreeWithName(ctx.Context, anchorBranchName, worktreePath, opts.Name); err != nil {
 		cleanup()

--- a/internal/actions/worktree/actions.go
+++ b/internal/actions/worktree/actions.go
@@ -75,7 +75,7 @@ func snapshotWorktree(ctx *app.Context, entry *Entry) (*worktreeSnapshot, error)
 }
 
 func restoreWorktreeRegistration(ctx *app.Context, snapshot *worktreeSnapshot) error {
-	return ctx.Engine.RegisterWorktreeWithName(snapshot.Info.AnchorBranch, snapshot.Info.Path, snapshot.Info.Name)
+	return ctx.Engine.RegisterWorktreeWithName(ctx.Context, snapshot.Info.AnchorBranch, snapshot.Info.Path, snapshot.Info.Name)
 }
 
 func restoreWorktreePath(ctx *app.Context, snapshot *worktreeSnapshot) error {
@@ -482,7 +482,7 @@ func createAnchoredWorktree(ctx *app.Context, eng engine.Engine, repoRoot string
 		out.Info("Warm-started worktree with %d ignored file(s)", len(warmStart.Copied))
 	}
 
-	if err := eng.RegisterWorktreeWithName(anchorBranchName, worktreePath, opts.Name); err != nil {
+	if err := eng.RegisterWorktreeWithName(ctx.Context, anchorBranchName, worktreePath, opts.Name); err != nil {
 		cleanup()
 		return nil, fmt.Errorf("failed to register worktree: %w", err)
 	}
@@ -737,7 +737,12 @@ func AttachAction(ctx *app.Context, opts AttachOptions) (*AttachResult, error) {
 	})
 	if err != nil {
 		if needsCheckout && currentBranch != nil {
-			_ = eng.CheckoutBranch(ctx.Context, *currentBranch)
+			// Attach checked out trunk to free the stack root. Failing to get
+			// back leaves the user somewhere they did not ask to be, which they
+			// need to know about even though the attach error is the headline.
+			if restoreErr := eng.CheckoutBranch(ctx.Context, *currentBranch); restoreErr != nil {
+				out.Warn("Could not return to %s: %v", output.BranchName(currentBranch.GetName()), restoreErr)
+			}
 		}
 		return nil, err
 	}

--- a/internal/actions/worktree/actions_test.go
+++ b/internal/actions/worktree/actions_test.go
@@ -32,7 +32,7 @@ func TestListAction(t *testing.T) {
 		s.WithInitialCommit()
 
 		// Register a fake worktree
-		err := s.Engine.RegisterWorktree("feature-stack", "/tmp/fake-worktree")
+		err := s.Engine.RegisterWorktree(context.Background(), "feature-stack", "/tmp/fake-worktree")
 		require.NoError(t, err)
 
 		result, err := worktree.ListAction(s.Context, worktree.ListOptions{})
@@ -57,7 +57,7 @@ func TestListAction(t *testing.T) {
 		require.NoError(t, s.Engine.TrackBranch(context.Background(), "feature", "main"))
 
 		worktreeDir := t.TempDir()
-		require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", worktreeDir, "feature"))
+		require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature", worktreeDir, "feature"))
 
 		result, err := worktree.ListAction(s.Context, worktree.ListOptions{})
 		require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestListAction(t *testing.T) {
 		s.Checkout("main")
 
 		worktreeDir := t.TempDir()
-		require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", worktreeDir, "feature-wt"))
+		require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature", worktreeDir, "feature-wt"))
 		t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
 
 		// Simulate raw `git checkout feature` from the main repository, bypassing
@@ -114,7 +114,7 @@ func TestRemoveAction(t *testing.T) {
 		s.WithInitialCommit()
 
 		// Register a fake worktree (path doesn't exist)
-		err := s.Engine.RegisterWorktree("feature-stack", "/tmp/nonexistent-worktree")
+		err := s.Engine.RegisterWorktree(context.Background(), "feature-stack", "/tmp/nonexistent-worktree")
 		require.NoError(t, err)
 
 		// Verify it's registered
@@ -139,7 +139,7 @@ func TestRemoveAction(t *testing.T) {
 		s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 		s.WithInitialCommit()
 
-		err := s.Engine.RegisterWorktree("feature-stack", "/tmp/nonexistent-worktree")
+		err := s.Engine.RegisterWorktree(context.Background(), "feature-stack", "/tmp/nonexistent-worktree")
 		require.NoError(t, err)
 
 		err = worktree.RemoveAction(s.Context, worktree.RemoveOptions{
@@ -174,7 +174,7 @@ func TestOpenAction(t *testing.T) {
 		s.WithInitialCommit()
 
 		// Register a fake worktree with non-existent path
-		err := s.Engine.RegisterWorktree("feature-stack", "/tmp/nonexistent-path-12345")
+		err := s.Engine.RegisterWorktree(context.Background(), "feature-stack", "/tmp/nonexistent-path-12345")
 		require.NoError(t, err)
 
 		_, err = worktree.OpenAction(s.Context, worktree.OpenOptions{
@@ -194,7 +194,7 @@ func TestOpenAction(t *testing.T) {
 
 		// Use a path that exists (the repo root)
 		repoRoot := s.Context.RepoRoot
-		err := s.Engine.RegisterWorktree("feature-stack", repoRoot)
+		err := s.Engine.RegisterWorktree(context.Background(), "feature-stack", repoRoot)
 		require.NoError(t, err)
 
 		path, err := worktree.OpenAction(s.Context, worktree.OpenOptions{
@@ -354,7 +354,7 @@ func TestRepairAction(t *testing.T) {
 		require.NoError(t, s.Engine.TrackBranch(context.Background(), "feature", "main"))
 
 		worktreeDir := t.TempDir()
-		require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", worktreeDir, "legacy-wt"))
+		require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature", worktreeDir, "legacy-wt"))
 
 		result, err := worktree.RepairAction(s.Context, worktree.RepairOptions{NameOrBranch: "legacy-wt"})
 		require.NoError(t, err)

--- a/internal/actions/worktree/entry.go
+++ b/internal/actions/worktree/entry.go
@@ -193,12 +193,16 @@ func listEntries(ctx *app.Context, opts ListOptions) (*ListResult, error) {
 		result.Worktrees = append(result.Worktrees, entry)
 	}
 
-	result.OwnershipWarnings = ownershipWarnings(ctx)
+	result.OwnershipWarnings = OwnershipWarnings(ctx)
 
 	return result, nil
 }
 
-func ownershipWarnings(ctx *app.Context) []string {
+// OwnershipWarnings reports branches whose physical checkout location does not
+// match the worktree that owns their stack. Exported so commands that mutate
+// across the whole repository — sync in particular — can surface divergence at
+// the time it matters, not only when someone happens to run `worktree list`.
+func OwnershipWarnings(ctx *app.Context) []string {
 	gitWorktrees, err := ctx.Engine.ListWorktrees(ctx.Context)
 	if err != nil {
 		return []string{fmt.Sprintf("could not inspect Git worktrees for ownership conflicts: %v", err)}

--- a/internal/actions/worktree/hooks.go
+++ b/internal/actions/worktree/hooks.go
@@ -34,8 +34,11 @@ func ResolveApprovedHooks(ctx *app.Context) ([]string, error) {
 
 // RunResolvedHooks executes a pre-resolved list of hooks in the given directory.
 // Failures are warned, not blocking — matches the existing worktree behavior.
-func RunResolvedHooks(hookCmds []string, worktreePath string, out output.Output) {
-	_ = hooks.Run(context.Background(), hookCmds, hooks.RunOptions{
+//
+// The caller's context is honored so Ctrl-C interrupts a hook instead of
+// waiting out its timeout.
+func RunResolvedHooks(ctx context.Context, hookCmds []string, worktreePath string, out output.Output) {
+	_ = hooks.Run(ctx, hookCmds, hooks.RunOptions{
 		Dir:      worktreePath,
 		Blocking: false,
 		Output:   out,
@@ -50,7 +53,7 @@ func RunPostCreateHooks(ctx *app.Context, worktreePath string) error {
 	if err != nil {
 		return err
 	}
-	RunResolvedHooks(approved, worktreePath, ctx.Output)
+	RunResolvedHooks(ctx.Context, approved, worktreePath, ctx.Output)
 	return nil
 }
 

--- a/internal/actions/worktree/repair.go
+++ b/internal/actions/worktree/repair.go
@@ -167,8 +167,8 @@ func moveRegistration(ctx *app.Context, from engine.WorktreeInfo, toAnchor strin
 	if err := ctx.Engine.UnregisterWorktree(ctx.Context, from.AnchorBranch); err != nil {
 		return fmt.Errorf("failed to remove stale registration %s: %w", output.BranchName(from.AnchorBranch), err)
 	}
-	if err := ctx.Engine.RegisterWorktreeWithName(toAnchor, from.Path, from.Name); err != nil {
-		if restoreErr := ctx.Engine.RegisterWorktreeWithName(from.AnchorBranch, from.Path, from.Name); restoreErr != nil {
+	if err := ctx.Engine.RegisterWorktreeWithName(ctx.Context, toAnchor, from.Path, from.Name); err != nil {
+		if restoreErr := ctx.Engine.RegisterWorktreeWithName(ctx.Context, from.AnchorBranch, from.Path, from.Name); restoreErr != nil {
 			return fmt.Errorf("failed to register worktree under anchor %s: %w (also failed to restore %s: %w)", toAnchor, err, output.BranchName(from.AnchorBranch), restoreErr)
 		}
 		return fmt.Errorf("failed to register worktree under anchor %s: %w", toAnchor, err)
@@ -219,7 +219,7 @@ func convertLegacyRegistration(ctx *app.Context, wtInfo engine.WorktreeInfo, roo
 			_ = ctx.Engine.UnregisterWorktree(ctx.Context, anchorBranchName)
 		}
 		if legacyUnregistered {
-			_ = ctx.Engine.RegisterWorktreeWithName(wtInfo.AnchorBranch, wtInfo.Path, wtInfo.Name)
+			_ = ctx.Engine.RegisterWorktreeWithName(ctx.Context, wtInfo.AnchorBranch, wtInfo.Path, wtInfo.Name)
 		}
 		if rootReparented {
 			_ = ctx.Engine.ReparentBranch(ctx.Context, ctx.Engine.GetBranch(rootBranchName), ctx.Engine.GetBranch(originalParent))
@@ -256,7 +256,7 @@ func convertLegacyRegistration(ctx *app.Context, wtInfo engine.WorktreeInfo, roo
 		return "", fmt.Errorf("failed to remove legacy registration %s: %w", output.BranchName(wtInfo.AnchorBranch), err)
 	}
 	legacyUnregistered = true
-	if err := ctx.Engine.RegisterWorktreeWithName(anchorBranchName, wtInfo.Path, wtInfo.Name); err != nil {
+	if err := ctx.Engine.RegisterWorktreeWithName(ctx.Context, anchorBranchName, wtInfo.Path, wtInfo.Name); err != nil {
 		cleanup()
 		return "", fmt.Errorf("failed to register worktree under anchor %s: %w", output.BranchName(anchorBranchName), err)
 	}

--- a/internal/actions/worktree/warm_start.go
+++ b/internal/actions/worktree/warm_start.go
@@ -2,6 +2,7 @@ package worktree
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -26,7 +27,22 @@ type WarmStartResult struct {
 	Enabled         bool
 	Copied          []string
 	SkippedExisting []string
+	// SkippedUnsafe lists files that could not be placed because something on
+	// their path is not a plain directory — most often a tracked file on trunk
+	// occupying a name the include file also selects as a directory.
+	SkippedUnsafe []WarmStartSkip
 }
+
+// WarmStartSkip records one file warm start declined to copy, and why.
+type WarmStartSkip struct {
+	Path   string
+	Reason string
+}
+
+// errWarmStartSkip marks a per-file problem. Warm start is an optimization:
+// one unplaceable file must not fail worktree creation, which is what an error
+// return does — the caller tears the whole worktree down.
+var errWarmStartSkip = errors.New("warm-start path cannot be used")
 
 func warmStartWorktree(ctx context.Context, eng engine.Engine, sourceRoot, destinationRoot string) (WarmStartResult, error) {
 	if _, err := os.Stat(filepath.Join(sourceRoot, WorktreeIncludeFile)); os.IsNotExist(err) {
@@ -61,6 +77,12 @@ func CopyIncludedIgnoredFiles(sourceRoot, destinationRoot string, ignoredPaths [
 	}
 
 	result := WarmStartResult{Enabled: true}
+	// Verified directories are remembered per root. Files selected for warm
+	// start share long prefixes — node_modules/... being the motivating case —
+	// and re-walking every component of every path costs one Lstat per
+	// component per file.
+	sourceVerified := map[string]bool{}
+	destinationVerified := map[string]bool{}
 	for _, path := range uniqueSortedPaths(ignoredPaths) {
 		relativePath, err := warmStartRelativePath(path)
 		if err != nil {
@@ -71,7 +93,11 @@ func CopyIncludedIgnoredFiles(sourceRoot, destinationRoot string, ignoredPaths [
 		}
 
 		sourcePath := filepath.Join(sourceRoot, relativePath)
-		if err := ensureWarmStartParents(sourceRoot, relativePath, false); err != nil {
+		if err := ensureWarmStartParents(sourceRoot, relativePath, false, sourceVerified); err != nil {
+			if skip, ok := asWarmStartSkip(relativePath, err); ok {
+				result.SkippedUnsafe = append(result.SkippedUnsafe, skip)
+				continue
+			}
 			return WarmStartResult{}, err
 		}
 		info, err := os.Lstat(sourcePath)
@@ -85,15 +111,23 @@ func CopyIncludedIgnoredFiles(sourceRoot, destinationRoot string, ignoredPaths [
 			continue
 		}
 
+		// Validate the destination's parents before stat-ing the destination
+		// itself: if a component is a plain file, that stat fails with a
+		// platform-specific "not a directory" errno rather than "does not
+		// exist", and the path check reports the same condition portably.
 		destinationPath := filepath.Join(destinationRoot, relativePath)
+		if err := ensureWarmStartParents(destinationRoot, relativePath, true, destinationVerified); err != nil {
+			if skip, ok := asWarmStartSkip(relativePath, err); ok {
+				result.SkippedUnsafe = append(result.SkippedUnsafe, skip)
+				continue
+			}
+			return WarmStartResult{}, err
+		}
 		if _, err := os.Lstat(destinationPath); err == nil {
 			result.SkippedExisting = append(result.SkippedExisting, relativePath)
 			continue
 		} else if !os.IsNotExist(err) {
 			return WarmStartResult{}, fmt.Errorf("inspect warm-start destination %s: %w", relativePath, err)
-		}
-		if err := ensureWarmStartParents(destinationRoot, relativePath, true); err != nil {
-			return WarmStartResult{}, err
 		}
 
 		if err := copyWarmStartFile(sourcePath, destinationPath, info.Mode().Perm()); err != nil {
@@ -152,7 +186,22 @@ func copyWarmStartFile(sourcePath, destinationPath string, mode os.FileMode) (er
 	return err
 }
 
-func ensureWarmStartParents(root, relativePath string, create bool) error {
+// asWarmStartSkip converts a per-file refusal into a recorded skip. Anything
+// else is a real failure and stays an error.
+func asWarmStartSkip(relativePath string, err error) (WarmStartSkip, bool) {
+	if !errors.Is(err, errWarmStartSkip) {
+		return WarmStartSkip{}, false
+	}
+	return WarmStartSkip{Path: relativePath, Reason: err.Error()}, true
+}
+
+// ensureWarmStartParents verifies (and optionally creates) every directory
+// leading to relativePath under root.
+//
+// verified memoizes directories already checked under this root for this run.
+// Warm-start sets share deep prefixes, so without it each file re-Lstats every
+// component of its path on both roots.
+func ensureWarmStartParents(root, relativePath string, create bool, verified map[string]bool) error {
 	directory := filepath.Dir(relativePath)
 	if directory == "." {
 		return nil
@@ -161,10 +210,16 @@ func ensureWarmStartParents(root, relativePath string, create bool) error {
 	current := root
 	for _, component := range strings.Split(directory, string(filepath.Separator)) {
 		current = filepath.Join(current, component)
+		if verified[current] {
+			continue
+		}
 		info, err := os.Lstat(current)
 		if os.IsNotExist(err) && create {
-			if err := os.Mkdir(current, 0o750); err != nil && !os.IsExist(err) {
-				return fmt.Errorf("create warm-start directory %s: %w", current, err)
+			if mkErr := os.Mkdir(current, 0o750); mkErr != nil && !os.IsExist(mkErr) {
+				// Most often a tracked file already occupies this name, which
+				// is a conflict with this one file's path — not a reason to
+				// abandon the worktree.
+				return fmt.Errorf("%w: cannot create directory %s: %w", errWarmStartSkip, current, mkErr)
 			}
 			info, err = os.Lstat(current)
 		}
@@ -174,9 +229,20 @@ func ensureWarmStartParents(root, relativePath string, create bool) error {
 		if err != nil {
 			return fmt.Errorf("inspect warm-start directory %s: %w", current, err)
 		}
-		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		// A symlink stays a hard failure. The include file is project-controlled,
+		// so a symlinked parent is how a warm start would be steered into
+		// writing outside the worktree — that is worth refusing loudly, not
+		// noting and moving on.
+		if info.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("warm-start path has unsafe parent directory: %s", current)
 		}
+		// A plain file occupying a directory name is mundane by comparison: a
+		// tracked file on trunk whose name the include file also selects as a
+		// directory. Only this one file is unplaceable.
+		if !info.IsDir() {
+			return fmt.Errorf("%w: %s is a file, not a directory", errWarmStartSkip, current)
+		}
+		verified[current] = true
 	}
 
 	return nil

--- a/internal/actions/worktree/warm_start_test.go
+++ b/internal/actions/worktree/warm_start_test.go
@@ -117,3 +117,61 @@ func requireWarmStartFile(t *testing.T, root, relativePath, expected string) {
 	require.NoError(t, err)
 	require.Equal(t, expected, string(contents))
 }
+
+// TestCopyIncludedIgnoredFilesSkipsFileOccupyingDirectoryName covers a warm-start
+// selection that cannot be placed because a tracked file already owns the name.
+//
+// Any warm-start error tears down the whole worktree — the caller cleans up on
+// failure — so one unplaceable file used to cost the entire `create -w`. Warm
+// start is an optimization; it reports the file and continues.
+func TestCopyIncludedIgnoredFilesSkipsFileOccupyingDirectoryName(t *testing.T) {
+	source := t.TempDir()
+	destination := t.TempDir()
+	writeWarmStartFile(t, source, WorktreeIncludeFile, "config/secret\nkeep.env\n")
+	writeWarmStartFile(t, source, "config/secret", "secret")
+	writeWarmStartFile(t, source, "keep.env", "kept")
+
+	// Trunk carries a tracked file named "config", so the directory the include
+	// file wants cannot exist.
+	writeWarmStartFile(t, destination, "config", "tracked file on trunk")
+
+	result, err := CopyIncludedIgnoredFiles(source, destination, []string{"config/secret", "keep.env"})
+	require.NoError(t, err, "one unplaceable file must not fail the whole warm start")
+
+	require.Len(t, result.SkippedUnsafe, 1)
+	require.Equal(t, "config/secret", result.SkippedUnsafe[0].Path)
+	require.Contains(t, result.SkippedUnsafe[0].Reason, "not a directory")
+
+	// Everything else still gets copied.
+	require.Equal(t, []string{"keep.env"}, result.Copied)
+	require.FileExists(t, filepath.Join(destination, "keep.env"))
+
+	// The tracked file is untouched.
+	contents, err := os.ReadFile(filepath.Join(destination, "config"))
+	require.NoError(t, err)
+	require.Equal(t, "tracked file on trunk", string(contents))
+}
+
+// TestCopyIncludedIgnoredFilesVerifiesEachDirectoryOnce guards the memoization
+// that keeps deep warm-start sets (node_modules being the motivating case) from
+// re-walking every path component for every file.
+func TestCopyIncludedIgnoredFilesVerifiesEachDirectoryOnce(t *testing.T) {
+	source := t.TempDir()
+	destination := t.TempDir()
+	writeWarmStartFile(t, source, WorktreeIncludeFile, "deps/**\n")
+
+	names := []string{"a", "b", "c", "d"}
+	paths := make([]string, 0, len(names))
+	for _, name := range names {
+		relativePath := filepath.Join("deps", "nested", "deeper", name)
+		writeWarmStartFile(t, source, relativePath, name)
+		paths = append(paths, filepath.ToSlash(relativePath))
+	}
+
+	result, err := CopyIncludedIgnoredFiles(source, destination, paths)
+	require.NoError(t, err)
+	require.Len(t, result.Copied, 4)
+	for _, name := range []string{"a", "b", "c", "d"} {
+		require.FileExists(t, filepath.Join(destination, "deps", "nested", "deeper", name))
+	}
+}

--- a/internal/actions/worktree_ownership.go
+++ b/internal/actions/worktree_ownership.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"fmt"
+	"os"
 	"slices"
 
 	"github.com/getstackit/stackit/internal/app"
@@ -41,6 +42,19 @@ func EnsureCanModifyHere(ctx *app.Context, branches ...engine.Branch) error {
 
 		if ctx.InManagedWorktree && ctx.WorktreeInfo != nil && ctx.WorktreeInfo.AnchorBranch == owner.AnchorBranch {
 			continue
+		}
+
+		// "cd there" is only useful advice if "there" still exists. A worktree
+		// whose directory was deleted leaves the branch owned by a path the
+		// user cannot go to, and the way out is detaching the registration —
+		// not a cd that will fail.
+		if _, statErr := os.Stat(owner.Path); statErr != nil {
+			if os.IsNotExist(statErr) {
+				return fmt.Errorf("branch %s belongs to worktree %s, whose directory no longer exists (%s); run 'stackit worktree detach %s' to release it, or 'stackit worktree list' to review",
+					branchName, worktreeDisplayName(owner), owner.Path, worktreeDisplayName(owner))
+			}
+			return fmt.Errorf("branch %s belongs to worktree %s, which cannot be inspected at %s: %w; 'stackit worktree list' shows the current state",
+				branchName, worktreeDisplayName(owner), owner.Path, statErr)
 		}
 
 		return fmt.Errorf("branch %s belongs to worktree %s; run this command from there: cd %s", branchName, worktreeDisplayName(owner), owner.Path)

--- a/internal/actions/worktree_ownership_test.go
+++ b/internal/actions/worktree_ownership_test.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,7 +17,7 @@ func TestEnsureCanModifyHere(t *testing.T) {
 	s.WithInitialCommit()
 	s.CreateBranch("feature").Commit("feature change")
 	s.TrackBranch("feature", "main")
-	require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", "/tmp/feature-worktree", "feature-wt"))
+	require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature", "/tmp/feature-worktree", "feature-wt"))
 	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
 
 	t.Run("refuses managed stack mutation from main repository", func(t *testing.T) {

--- a/internal/actions/worktree_ownership_test.go
+++ b/internal/actions/worktree_ownership_test.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,14 +18,33 @@ func TestEnsureCanModifyHere(t *testing.T) {
 	s.WithInitialCommit()
 	s.CreateBranch("feature").Commit("feature change")
 	s.TrackBranch("feature", "main")
-	require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature", "/tmp/feature-worktree", "feature-wt"))
+	worktreePath := t.TempDir()
+	require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature", worktreePath, "feature-wt"))
 	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
 
 	t.Run("refuses managed stack mutation from main repository", func(t *testing.T) {
 		err := EnsureCanModifyHere(s.Context, s.Engine.GetBranch("feature"))
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "belongs to worktree feature-wt")
-		assert.ErrorContains(t, err, "cd /tmp/feature-worktree")
+		assert.ErrorContains(t, err, "cd "+worktreePath)
+	})
+
+	// Telling someone to cd into a directory that no longer exists strands
+	// them: the branch is owned by a path they cannot go to, and only detaching
+	// the registration releases it.
+	t.Run("points at detach when the worktree directory is gone", func(t *testing.T) {
+		gone := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+		gone.WithInitialCommit()
+		gone.CreateBranch("feature").Commit("feature change")
+		gone.TrackBranch("feature", "main")
+		missing := filepath.Join(t.TempDir(), "deleted-worktree")
+		require.NoError(t, gone.Engine.RegisterWorktreeWithName(context.Background(), "feature", missing, "feature-wt"))
+
+		err := EnsureCanModifyHere(gone.Context, gone.Engine.GetBranch("feature"))
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "no longer exists")
+		assert.ErrorContains(t, err, "worktree detach feature-wt")
+		assert.NotContains(t, err.Error(), "cd "+missing)
 	})
 
 	t.Run("allows mutation from owning worktree", func(t *testing.T) {
@@ -32,7 +52,7 @@ func TestEnsureCanModifyHere(t *testing.T) {
 		ctx.InManagedWorktree = true
 		ctx.WorktreeInfo = &engine.WorktreeInfo{
 			Name:         "feature-wt",
-			Path:         "/tmp/feature-worktree",
+			Path:         worktreePath,
 			AnchorBranch: "feature",
 		}
 		require.NoError(t, EnsureCanModifyHere(&ctx, s.Engine.GetBranch("feature")))
@@ -43,7 +63,7 @@ func TestEnsureCanModifyHere(t *testing.T) {
 		ctx.InManagedWorktree = true
 		ctx.WorktreeInfo = &engine.WorktreeInfo{
 			Name:         "feature-wt",
-			Path:         "/tmp/feature-worktree",
+			Path:         worktreePath,
 			AnchorBranch: "feature",
 			MainRepoDir:  s.Context.RepoRoot,
 		}

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -807,3 +807,11 @@ func (d *demoGitRunner) WriteStackMetaBlob(_ *git.StackMeta) (string, error) {
 func (d *demoGitRunner) GetStackMetaRefSHA(_ string) string {
 	return ""
 }
+
+func (d *demoGitRunner) TreeContainsAnyPath(_ context.Context, _ string, _ []string) (bool, bool) {
+	return false, true
+}
+
+func (d *demoGitRunner) GetUntrackedFilesIn(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -732,7 +732,7 @@ func (d *demoGitRunner) ReadWorktreeMeta(_ string) (*git.WorktreeMeta, error) {
 	return nil, nil
 }
 
-func (d *demoGitRunner) WriteWorktreeMeta(_ string, _ *git.WorktreeMeta) error {
+func (d *demoGitRunner) WriteWorktreeMeta(_ context.Context, _ string, _ *git.WorktreeMeta) error {
 	return nil
 }
 

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -128,19 +128,39 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 	// when the user actually had uncommitted work. Bounded by worktree count,
 	// not branch count, so this stays a handful of calls even for a large stack.
 	//
-	// Capture every local change. `git reset --hard` can delete an untracked
-	// file when the incoming commit needs that pathname, so excluding untracked
-	// files would risk user data loss.
+	// Changes to tracked files hold their branch unconditionally: the reset
+	// would discard them.
+	//
+	// Untracked files are recorded but not decided here. `git reset --hard`
+	// overwrites an untracked file only when the incoming commit contains that
+	// same path, and leaves every other untracked file untouched — so holding
+	// on any untracked file at all stops a restack for the ordinary state of
+	// having written a new file and not staged it yet. The collision is checked
+	// per branch once its incoming tree is known; see untrackedCollisionHold.
 	dirtyWorktrees := make(map[string]bool, len(worktrees))
+	untrackedByWorktree := make(map[string][]string)
 	heldBranches := make(BranchNameSet)
 	for _, worktree := range worktrees {
-		dirty, dirtyErr := e.git.WorktreeHasUncommittedChanges(ctx, worktree.Path)
-		if dirtyErr != nil || dirty {
-			path := worktree.Path
+		path := worktree.Path
+		tracked, trackedErr := e.git.WorktreeHasTrackedChanges(ctx, path)
+		if trackedErr != nil || tracked {
 			dirtyWorktrees[path] = true
 			if worktree.Branch != "" {
 				heldBranches[worktree.Branch] = true
 			}
+			continue
+		}
+		untracked, untrackedErr := e.git.GetUntrackedFilesIn(ctx, path)
+		if untrackedErr != nil {
+			// Cannot tell what is there, so no reset is safe.
+			dirtyWorktrees[path] = true
+			if worktree.Branch != "" {
+				heldBranches[worktree.Branch] = true
+			}
+			continue
+		}
+		if len(untracked) > 0 {
+			untrackedByWorktree[path] = untracked
 		}
 	}
 
@@ -156,7 +176,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 			metaRefSHAs[strings.TrimPrefix(refName, git.MetadataRefPrefix)] = sha
 		}
 	}
-	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees, heldBranches: heldBranches, worktreeInspectionFailed: worktreeInspectionFailed}
+	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees, untrackedByWorktree: untrackedByWorktree, heldBranches: heldBranches, worktreeInspectionFailed: worktreeInspectionFailed}
 
 	// 2. Apply the restack changes
 	results := make(map[string]RestackBranchResult)

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -461,3 +461,44 @@ func (e *engineImpl) IsInManagedWorktree() (bool, *WorktreeInfo, error) {
 	// It's a worktree but not managed by stackit
 	return false, nil, nil
 }
+
+// UntrackedCollision reports whether untracked files in the worktree holding
+// branchName would be destroyed by restacking it.
+//
+// `git reset --hard` overwrites an untracked file only when the incoming commit
+// contains that same path; every other untracked file survives untouched. The
+// incoming tree is the branch's base — its own commits cannot introduce a
+// colliding path, or the file would be tracked rather than untracked.
+//
+// known is false when the question could not be answered, which callers must
+// treat as unsafe rather than as "no collision".
+func (e *engineImpl) UntrackedCollision(ctx context.Context, branchName string) (collides, known bool) {
+	worktrees, err := e.git.ListWorktrees(ctx)
+	if err != nil {
+		return false, false
+	}
+	worktreePath := worktrees.PathForBranch(branchName)
+	if worktreePath == "" {
+		return false, true
+	}
+	untracked, err := e.git.GetUntrackedFilesIn(ctx, worktreePath)
+	if err != nil {
+		return false, false
+	}
+	if len(untracked) == 0 {
+		return false, true
+	}
+
+	e.mu.RLock()
+	state := e.readState(branchName)
+	parent := e.trunk
+	e.mu.RUnlock()
+	if state != nil && state.Parent != "" {
+		parent = state.Parent
+	}
+	baseRev, err := e.GetBranch(parent).GetRevision()
+	if err != nil || baseRev == "" {
+		return false, false
+	}
+	return e.git.TreeContainsAnyPath(ctx, baseRev, untracked)
+}

--- a/internal/engine/engine_worktree.go
+++ b/internal/engine/engine_worktree.go
@@ -237,12 +237,12 @@ func (e *engineImpl) addWorktreeWithRetryLocked(ctx context.Context, path string
 }
 
 // RegisterWorktree registers a worktree for a stack root in local git refs
-func (e *engineImpl) RegisterWorktree(stackRoot string, path string) error {
-	return e.RegisterWorktreeWithName(stackRoot, path, "")
+func (e *engineImpl) RegisterWorktree(ctx context.Context, stackRoot string, path string) error {
+	return e.RegisterWorktreeWithName(ctx, stackRoot, path, "")
 }
 
 // RegisterWorktreeWithName registers a worktree with a user-friendly name
-func (e *engineImpl) RegisterWorktreeWithName(anchorBranch string, path string, name string) error {
+func (e *engineImpl) RegisterWorktreeWithName(ctx context.Context, anchorBranch string, path string, name string) error {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return fmt.Errorf("failed to get absolute worktree path: %w", err)
@@ -280,7 +280,7 @@ func (e *engineImpl) RegisterWorktreeWithName(anchorBranch string, path string, 
 		MainRepoDir:  e.repoRoot,
 	}
 
-	return e.git.WriteWorktreeMeta(anchorBranch, meta)
+	return e.git.WriteWorktreeMeta(ctx, anchorBranch, meta)
 }
 
 // UnregisterWorktree removes worktree registration for a stack root

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -308,9 +308,9 @@ type WorktreeInfo struct {
 // WorktreeRegistry handles stackit-managed worktree tracking
 type WorktreeRegistry interface {
 	// RegisterWorktree registers a worktree for a stack root
-	RegisterWorktree(stackRoot string, path string) error
+	RegisterWorktree(ctx context.Context, stackRoot string, path string) error
 	// RegisterWorktreeWithName registers a worktree with a user-friendly name
-	RegisterWorktreeWithName(anchorBranch string, path string, name string) error
+	RegisterWorktreeWithName(ctx context.Context, anchorBranch string, path string, name string) error
 	// UnregisterWorktree removes worktree registration for a stack root
 	UnregisterWorktree(ctx context.Context, stackRoot string) error
 	// GetWorktreeForStack returns worktree info for a stack root, or nil if none

--- a/internal/engine/interfaces.go
+++ b/internal/engine/interfaces.go
@@ -283,6 +283,7 @@ type WorktreeOperations interface {
 	GetWorktreeCurrentBranch(ctx context.Context, worktreePath string) (string, error)
 	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)
 	WorktreeHasTrackedChanges(ctx context.Context, worktreePath string) (bool, error)
+	UntrackedCollision(ctx context.Context, branchName string) (collides, known bool)
 	// WorktreeRebaseInProgress reports whether a rebase is active in worktreePath.
 	WorktreeRebaseInProgress(ctx context.Context, worktreePath string) bool
 	ListIgnoredFiles(ctx context.Context, worktreePath string) ([]string, error)

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -55,6 +55,10 @@ type restackSnapshot struct {
 	// local changes before this restack pass began. This cannot be checked
 	// lazily; see resetWorktreeIfClean for why.
 	dirtyWorktrees map[string]bool
+	// untrackedByWorktree holds the untracked (non-ignored) paths found in
+	// worktrees that had no tracked changes. Whether those hold their branch
+	// depends on the incoming tree, which is only known per branch.
+	untrackedByWorktree map[string][]string
 	// heldBranches contains every branch whose checked-out worktree was dirty
 	// or could not be inspected before this pass. Descendants of these branches
 	// must be held too: a validated child may otherwise be built on the target
@@ -63,6 +67,69 @@ type restackSnapshot struct {
 	// worktreeInspectionFailed means the physical checkout map is unknown, so
 	// no ref move is safe for this pass.
 	worktreeInspectionFailed bool
+}
+
+// untrackedCollisionHold decides whether a worktree holding only untracked
+// files must still hold its branch back.
+//
+// `git reset --hard` silently overwrites an untracked file whose path the
+// incoming commit also contains, and leaves every other untracked file alone.
+// So the question is not "are there untracked files" — which is the ordinary
+// state of having written a new file and not staged it — but "does any of them
+// collide with what is about to land".
+//
+// The incoming tree is the branch's new base. A branch's own commits cannot
+// introduce a colliding path: if they did, the file would be tracked rather
+// than untracked. Parents are restacked before their children, so by the time
+// this runs the parent ref already holds the tree that is about to arrive.
+//
+// The decision is recorded in the snapshot: a held branch must also hold its
+// descendants, and its worktree must not be reset afterwards.
+func (e *engineImpl) untrackedCollisionHold(ctx context.Context, branch Branch, snap *restackSnapshot) bool {
+	branchName := branch.GetName()
+	worktreePath := snap.worktrees.PathForBranch(branchName)
+	if worktreePath == "" {
+		return false
+	}
+	untracked := snap.untrackedByWorktree[worktreePath]
+	if len(untracked) == 0 {
+		return false
+	}
+
+	hold := func() bool {
+		snap.dirtyWorktrees[worktreePath] = true
+		snap.heldBranches[branchName] = true
+		return true
+	}
+
+	e.mu.RLock()
+	state := e.readState(branchName)
+	parent := e.trunk
+	e.mu.RUnlock()
+	if state != nil && state.Parent != "" {
+		parent = state.Parent
+	}
+	baseRev, err := e.GetBranch(parent).GetRevision()
+	if err != nil || baseRev == "" {
+		// Cannot see what is about to land, so cannot rule out a collision.
+		return hold()
+	}
+
+	collides, known := e.git.TreeContainsAnyPath(ctx, baseRev, untracked)
+	if !known || collides {
+		return hold()
+	}
+	return false
+}
+
+// holdBranch is the single hold decision every restack path consults: an
+// ancestor already held, or this branch's own worktree holding something the
+// incoming tree would destroy.
+func (e *engineImpl) holdBranch(ctx context.Context, branch Branch, snap *restackSnapshot) bool {
+	if e.branchHeldBack(branch, snap) {
+		return true
+	}
+	return e.untrackedCollisionHold(ctx, branch, snap)
 }
 
 func (e *engineImpl) branchHeldBack(branch Branch, snap *restackSnapshot) bool {
@@ -264,7 +331,7 @@ func (e *engineImpl) restackBranch(
 	// which warns and is reached solely by the `restack` command) so that every
 	// caller of RestackBranches inherits it — modify, sync, squash, absorb,
 	// delete, split, reorder, pluck and insert all arrive here directly.
-	if e.branchHeldBack(branch, snap) {
+	if e.holdBranch(ctx, branch, snap) {
 		return RestackBranchResult{Result: RestackUnneeded}, nil
 	}
 
@@ -712,7 +779,7 @@ func (e *engineImpl) applyMetadataRefresh(
 	// Metadata records the parent SHA consumed by later planning, so advancing
 	// it past a held parent would create the same phantom-parent state as a ref
 	// move. A held branch and every descendant must remain completely unchanged.
-	if e.branchHeldBack(branch, snap) {
+	if e.holdBranch(ctx, branch, snap) {
 		return RestackBranchResult{Result: RestackUnneeded, RebasedBranchBase: item.ParentRev}, nil
 	}
 	meta := snap.meta.Get(branchName)
@@ -770,7 +837,7 @@ func (e *engineImpl) applyBranchAndMetadata(
 	// Hold the branch back instead. This is the plan path, reached by every
 	// caller of actions.RestackBranches (modify, squash, absorb, delete, split,
 	// reorder, pluck) as well as the `restack` command.
-	if e.branchHeldBack(branch, snap) {
+	if e.holdBranch(ctx, branch, snap) {
 		return RestackBranchResult{Result: RestackUnneeded, RebasedBranchBase: parentRev}, nil
 	}
 

--- a/internal/engine/worktree_test.go
+++ b/internal/engine/worktree_test.go
@@ -35,7 +35,7 @@ func TestWorktreeRegistry_StackRootForBranch(t *testing.T) {
 	s.TrackBranch("branch2", "branch1")
 
 	// Register a worktree for branch1 (as if it were the stack root)
-	err := s.Engine.RegisterWorktree("branch1", "/tmp/test-worktree-branch1")
+	err := s.Engine.RegisterWorktree(context.Background(), "branch1", "/tmp/test-worktree-branch1")
 	require.NoError(t, err)
 
 	// Stack root for branch2 should be branch1 (the first branch whose parent is trunk)
@@ -61,7 +61,7 @@ func TestWorktreeRegistry_OwningWorktree(t *testing.T) {
 	s.CreateBranch("feature-child").Commit("feature child change")
 	s.TrackBranch("feature-child", "feature")
 
-	require.NoError(t, s.Engine.RegisterWorktreeWithName("feature", "/tmp/feature-worktree", "feature"))
+	require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature", "/tmp/feature-worktree", "feature"))
 	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
 
 	owner, err := s.Engine.OwningWorktree(s.Engine.GetBranch("feature-child"))
@@ -79,14 +79,14 @@ func TestWorktreeRegistry_RejectsDuplicatePathAndAnchor(t *testing.T) {
 	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
 	s.WithInitialCommit()
 
-	require.NoError(t, s.Engine.RegisterWorktreeWithName("feature-a", "/tmp/shared-worktree", "feature-a"))
+	require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature-a", "/tmp/shared-worktree", "feature-a"))
 	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature-a") })
 
-	err := s.Engine.RegisterWorktreeWithName("feature-b", "/tmp/shared-worktree", "feature-b")
+	err := s.Engine.RegisterWorktreeWithName(context.Background(), "feature-b", "/tmp/shared-worktree", "feature-b")
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "already registered to anchor feature-a")
 
-	err = s.Engine.RegisterWorktreeWithName("feature-a", "/tmp/other-worktree", "feature-a")
+	err = s.Engine.RegisterWorktreeWithName(context.Background(), "feature-a", "/tmp/other-worktree", "feature-a")
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "anchor feature-a is already registered")
 }

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -244,6 +244,8 @@ type RefOperations interface {
 	GetRef(name string) (string, error)
 	UpdateRef(name, sha string) error
 	UpdateRefWithLog(ctx context.Context, refName, sha, message string) error
+	GetUntrackedFilesIn(ctx context.Context, worktreePath string) ([]string, error)
+	TreeContainsAnyPath(ctx context.Context, rev string, paths []string) (collides, known bool)
 	UpdateRefsBatch(ctx context.Context, updates []RefUpdate) error
 	UpdateRefsBatchWithLog(ctx context.Context, updates []RefUpdate, reflogMessage string) error
 	DeleteRefsBatch(ctx context.Context, refNames []string) error

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -227,7 +227,7 @@ type WorktreeOperations interface {
 // WorktreeRegistryOperations handles stackit-managed worktree tracking (local-only refs).
 type WorktreeRegistryOperations interface {
 	ReadWorktreeMeta(stackRoot string) (*WorktreeMeta, error)
-	WriteWorktreeMeta(stackRoot string, meta *WorktreeMeta) error
+	WriteWorktreeMeta(ctx context.Context, stackRoot string, meta *WorktreeMeta) error
 	DeleteWorktreeMeta(ctx context.Context, stackRoot string) error
 	ListWorktreeMetas() (map[string]*WorktreeMeta, error)
 }

--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -262,7 +262,7 @@ func (r *runner) ReadMetadata(branchName string) (*Meta, error) {
 
 	// Pass the ref name directly to cat-file --batch: it resolves ref → blob in one
 	// step, replacing the two rev-parse subprocesses GetRef previously spawned.
-	content, found, err := r.objects.ReadObject(refName)
+	content, sha, found, err := r.objects.ReadObjectWithSHA(refName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read metadata for %s: %w", branchName, err)
 	}
@@ -277,7 +277,9 @@ func (r *runner) ReadMetadata(branchName string) (*Meta, error) {
 		return nil, fmt.Errorf("failed to unmarshal metadata for %s: %w", branchName, err)
 	}
 
-	r.metadataCache.Put(branchName, &meta)
+	// Remember which blob this came from so WriteMetadata can refuse to
+	// overwrite a different one.
+	r.metadataCache.PutWithSHA(branchName, &meta, sha)
 	return &meta, nil
 }
 
@@ -293,11 +295,45 @@ func (r *runner) WriteMetadata(branchName string, meta *Meta) error {
 	}
 
 	refName := fmt.Sprintf("%s%s", MetadataRefPrefix, branchName)
-	if err := r.UpdateRef(refName, sha); err != nil {
-		return fmt.Errorf("failed to write metadata ref: %w", err)
+	if err := r.updateMetadataRefCAS(refName, branchName, sha); err != nil {
+		return err
 	}
 
-	r.metadataCache.Put(branchName, meta)
+	r.metadataCache.PutWithSHA(branchName, meta, sha)
+	return nil
+}
+
+// updateMetadataRefCAS writes a metadata ref, requiring it to still hold the
+// blob this process last read.
+//
+// Without the expectation, two stackit processes in different worktrees that
+// both read a branch's metadata and then wrote it would silently keep only the
+// second write. Failing is the right outcome: the caller based its new metadata
+// on state that no longer exists, so applying it would drop whatever the other
+// process recorded.
+//
+// An unknown expectation (never read in this process, or invalidated since)
+// falls back to an unconditional write, which is what creating metadata for a
+// newly tracked branch needs.
+func (r *runner) updateMetadataRefCAS(refName, branchName, newSHA string) error {
+	expected := r.metadataCache.SHAFor(branchName)
+	if expected == "" {
+		if err := r.UpdateRef(refName, newSHA); err != nil {
+			return fmt.Errorf("failed to write metadata ref: %w", err)
+		}
+		return nil
+	}
+	if expected == newSHA {
+		return nil // Identical content; nothing to write.
+	}
+	err := r.UpdateRefsBatch(context.Background(), []RefUpdate{{
+		RefName: refName,
+		NewSHA:  newSHA,
+		OldSHA:  expected,
+	}})
+	if err != nil {
+		return fmt.Errorf("failed to write metadata ref for %s (another process changed it; re-run to pick up their change): %w", branchName, err)
+	}
 	return nil
 }
 
@@ -350,13 +386,15 @@ func (r *runner) RenameMetadata(oldName, newName string) error {
 func (r *runner) ReadLocalMetadata(branchName string) (*LocalMeta, error) {
 	refName := fmt.Sprintf("%s%s", LocalMetadataRefPrefix, branchName)
 
-	content, found, err := r.objects.ReadObject(refName)
+	content, sha, found, err := r.objects.ReadObjectWithSHA(refName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read local metadata for %s: %w", branchName, err)
 	}
 	if !found || content == "" {
 		return &LocalMeta{}, nil
 	}
+	// Remember the blob so WriteLocalMetadata can refuse to clobber a different one.
+	r.metadataCache.PutLocalSHA(branchName, sha)
 
 	var meta LocalMeta
 	if err := json.Unmarshal([]byte(content), &meta); err != nil {
@@ -378,8 +416,20 @@ func (r *runner) WriteLocalMetadata(branchName string, meta *LocalMeta) error {
 	}
 
 	refName := fmt.Sprintf("%s%s", LocalMetadataRefPrefix, branchName)
-	if err := r.UpdateRef(refName, sha); err != nil {
+	if expected := r.metadataCache.LocalSHAFor(branchName); expected != "" && expected != sha {
+		err := r.UpdateRefsBatch(context.Background(), []RefUpdate{{
+			RefName: refName,
+			NewSHA:  sha,
+			OldSHA:  expected,
+		}})
+		if err != nil {
+			return fmt.Errorf("failed to write local metadata ref for %s (another process changed it; re-run to pick up their change): %w", branchName, err)
+		}
+		r.metadataCache.PutLocalSHA(branchName, sha)
+	} else if err := r.UpdateRef(refName, sha); err != nil {
 		return fmt.Errorf("failed to write local metadata ref: %w", err)
+	} else {
+		r.metadataCache.PutLocalSHA(branchName, sha)
 	}
 
 	return nil

--- a/internal/git/metadata_cache.go
+++ b/internal/git/metadata_cache.go
@@ -11,6 +11,12 @@ import (
 // without deep copying.
 type metadataCache struct {
 	entries sync.Map // map[string]*Meta
+	refSHAs sync.Map // map[string]string — ref SHA each entry was read from
+
+	// localRefSHAs tracks the same thing for local-metadata refs. Local
+	// metadata is not cached (its values are read fresh), but its writes still
+	// need something to compare against.
+	localRefSHAs sync.Map // map[string]string
 
 	// Instrumentation counters. Updated with atomics to stay lock-free on the
 	// hot Get path. Exposed via Summary() for logging and tests.
@@ -57,15 +63,62 @@ func (c *metadataCache) Put(branchName string, meta *Meta) {
 	c.entries.Store(branchName, meta)
 }
 
+// PutWithSHA stores the metadata along with the ref SHA it was read from, so a
+// later write of the same branch can require the ref to still hold that value.
+func (c *metadataCache) PutWithSHA(branchName string, meta *Meta, sha string) {
+	c.entries.Store(branchName, meta)
+	if sha == "" {
+		c.refSHAs.Delete(branchName)
+		return
+	}
+	c.refSHAs.Store(branchName, sha)
+}
+
+// SHAFor returns the ref SHA this process last read for the branch, or "" when
+// it has not read one. Writers treat "" as "no expectation to enforce" rather
+// than "the ref is absent", because the branch may simply never have been read
+// in this process.
+func (c *metadataCache) SHAFor(branchName string) string {
+	value, ok := c.refSHAs.Load(branchName)
+	if !ok {
+		return ""
+	}
+	sha, _ := value.(string)
+	return sha
+}
+
+// PutLocalSHA records the ref SHA a branch's local metadata was read from.
+func (c *metadataCache) PutLocalSHA(branchName, sha string) {
+	if sha == "" {
+		c.localRefSHAs.Delete(branchName)
+		return
+	}
+	c.localRefSHAs.Store(branchName, sha)
+}
+
+// LocalSHAFor returns the local-metadata ref SHA this process last read, or "".
+func (c *metadataCache) LocalSHAFor(branchName string) string {
+	value, ok := c.localRefSHAs.Load(branchName)
+	if !ok {
+		return ""
+	}
+	sha, _ := value.(string)
+	return sha
+}
+
 // Delete removes the cached metadata for the given branch.
 func (c *metadataCache) Delete(branchName string) {
 	c.entries.Delete(branchName)
+	c.refSHAs.Delete(branchName)
+	c.localRefSHAs.Delete(branchName)
 }
 
 // Clear removes all entries from the cache.
 // Used during Rebuild to ensure stale metadata from external changes is not retained.
 func (c *metadataCache) Clear() {
 	c.entries.Clear()
+	c.refSHAs.Clear()
+	c.localRefSHAs.Clear()
 }
 
 // InvalidateForRefs clears cached metadata for any refs in the given batch
@@ -74,7 +127,10 @@ func (c *metadataCache) Clear() {
 func (c *metadataCache) InvalidateForRefs(updates []RefUpdate) {
 	for _, update := range updates {
 		if branchName, ok := strings.CutPrefix(update.RefName, MetadataRefPrefix); ok {
-			c.entries.Delete(branchName)
+			c.Delete(branchName)
+		}
+		if branchName, ok := strings.CutPrefix(update.RefName, LocalMetadataRefPrefix); ok {
+			c.localRefSHAs.Delete(branchName)
 		}
 	}
 }
@@ -84,7 +140,10 @@ func (c *metadataCache) InvalidateForRefs(updates []RefUpdate) {
 func (c *metadataCache) InvalidateForRefNames(refNames []string) {
 	for _, refName := range refNames {
 		if branchName, ok := strings.CutPrefix(refName, MetadataRefPrefix); ok {
-			c.entries.Delete(branchName)
+			c.Delete(branchName)
+		}
+		if branchName, ok := strings.CutPrefix(refName, LocalMetadataRefPrefix); ok {
+			c.localRefSHAs.Delete(branchName)
 		}
 	}
 }

--- a/internal/git/metadata_cas_test.go
+++ b/internal/git/metadata_cas_test.go
@@ -1,0 +1,97 @@
+package git_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/git"
+	"github.com/getstackit/stackit/testhelpers"
+)
+
+// TestMetadataWriteCompareAndSwap covers two stackit processes writing the same
+// branch's metadata.
+//
+// Both runners read the same state, then both write. The writes used to be
+// unconditional `update-ref`, so the second silently discarded whatever the
+// first recorded — a parent change, a PR number, a scope. Each runner now
+// remembers the blob it read and requires the ref to still hold it, so the
+// stale write fails loudly instead.
+func TestMetadataWriteCompareAndSwap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("stale write is rejected", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+
+		// Two runners stand in for two processes against the same repo.
+		first := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+		second := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+
+		main := "main"
+		require.NoError(t, first.WriteMetadata("feature", git.NewMeta().WithParentBranchName(&main)))
+
+		// Both read the same starting point.
+		fromFirst, err := first.ReadMetadata("feature")
+		require.NoError(t, err)
+		fromSecond, err := second.ReadMetadata("feature")
+		require.NoError(t, err)
+		require.Equal(t, "main", *fromSecond.GetParentBranchName())
+
+		// First writes.
+		firstParent := "first-parent"
+		require.NoError(t, first.WriteMetadata("feature", fromFirst.WithParentBranchName(&firstParent)))
+
+		// Second writes based on what it read before that.
+		secondParent := "second-parent"
+		err = second.WriteMetadata("feature", fromSecond.WithParentBranchName(&secondParent))
+		require.Error(t, err, "a write based on superseded state must not silently win")
+		require.Contains(t, err.Error(), "another process changed it")
+
+		// The first write survives.
+		latest, err := first.ReadMetadata("feature")
+		require.NoError(t, err)
+		require.Equal(t, "first-parent", *latest.GetParentBranchName())
+	})
+
+	t.Run("write after re-reading succeeds", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+		first := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+		second := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+
+		main := "main"
+		require.NoError(t, first.WriteMetadata("feature", git.NewMeta().WithParentBranchName(&main)))
+
+		fromFirst, err := first.ReadMetadata("feature")
+		require.NoError(t, err)
+		firstParent := "first-parent"
+		require.NoError(t, first.WriteMetadata("feature", fromFirst.WithParentBranchName(&firstParent)))
+
+		// Re-reading picks up the new blob, so the follow-up write is based on
+		// current state and is allowed.
+		fresh, err := second.ReadMetadata("feature")
+		require.NoError(t, err)
+		require.Equal(t, "first-parent", *fresh.GetParentBranchName())
+		secondParent := "second-parent"
+		require.NoError(t, second.WriteMetadata("feature", fresh.WithParentBranchName(&secondParent)))
+
+		latest, err := second.ReadMetadata("feature")
+		require.NoError(t, err)
+		require.Equal(t, "second-parent", *latest.GetParentBranchName())
+	})
+
+	t.Run("first write of a branch needs no expectation", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+
+		// Never read: tracking a new branch must not require one.
+		main := "main"
+		require.NoError(t, runner.WriteMetadata("brand-new", git.NewMeta().WithParentBranchName(&main)))
+
+		stored, err := runner.ReadMetadata("brand-new")
+		require.NoError(t, err)
+		require.Equal(t, "main", *stored.GetParentBranchName())
+	})
+}

--- a/internal/git/object_reader.go
+++ b/internal/git/object_reader.go
@@ -68,62 +68,72 @@ func (r *objectReader) killLocked() {
 }
 
 // readResponse reads one response from stdout. Caller must hold r.mu.
-func (r *objectReader) readResponse(ref string) (string, bool, error) {
+func (r *objectReader) readResponse(ref string) (content, sha string, found bool, err error) {
 	header, err := r.stdout.ReadString('\n')
 	if err != nil {
-		return "", false, fmt.Errorf("object reader read header for %s: %w", ref, err)
+		return "", "", false, fmt.Errorf("object reader read header for %s: %w", ref, err)
 	}
 	header = strings.TrimSuffix(header, "\n")
 
 	// Missing: "<ref> missing"
 	if strings.HasSuffix(header, " missing") {
-		return "", false, nil
+		return "", "", false, nil
 	}
 
 	// Present: "<sha> <type> <size>"
 	parts := strings.Fields(header)
 	if len(parts) != 3 {
-		return "", false, fmt.Errorf("object reader unexpected header %q for %s", header, ref)
+		return "", "", false, fmt.Errorf("object reader unexpected header %q for %s", header, ref)
 	}
 	size, err := strconv.Atoi(parts[2])
 	if err != nil {
-		return "", false, fmt.Errorf("object reader bad size in header %q: %w", header, err)
+		return "", "", false, fmt.Errorf("object reader bad size in header %q: %w", header, err)
 	}
 
 	// Read exactly size bytes + the trailing newline git appends after each object
 	buf := make([]byte, size+1)
 	if _, err := io.ReadFull(r.stdout, buf); err != nil {
-		return "", false, fmt.Errorf("object reader read body for %s: %w", ref, err)
+		return "", "", false, fmt.Errorf("object reader read body for %s: %w", ref, err)
 	}
-	return string(buf[:size]), true, nil
+	// parts[0] is the resolved object's SHA. Metadata refs point straight at a
+	// blob, so this is the value a later compare-and-swap update must match.
+	return string(buf[:size]), parts[0], true, nil
 }
 
 // ReadObject reads one object by ref name or SHA, restarting the process once on I/O failure.
 func (r *objectReader) ReadObject(ref string) (string, bool, error) {
+	content, _, found, err := r.ReadObjectWithSHA(ref)
+	return content, found, err
+}
+
+// ReadObjectWithSHA is ReadObject plus the resolved object's SHA. Callers that
+// intend to write the ref back use the SHA to detect another process having
+// written it in between.
+func (r *objectReader) ReadObjectWithSHA(ref string) (content, sha string, found bool, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.cmd == nil {
 		if err := r.start(); err != nil {
-			return "", false, err
+			return "", "", false, err
 		}
 	}
 	if _, err := fmt.Fprintf(r.stdin, "%s\n", ref); err != nil {
 		// Process died; restart and retry once
 		r.killLocked()
 		if startErr := r.start(); startErr != nil {
-			return "", false, startErr
+			return "", "", false, startErr
 		}
 		if _, err := fmt.Fprintf(r.stdin, "%s\n", ref); err != nil {
-			return "", false, fmt.Errorf("object reader write after restart: %w", err)
+			return "", "", false, fmt.Errorf("object reader write after restart: %w", err)
 		}
 	}
-	content, found, err := r.readResponse(ref)
+	content, sha, found, err = r.readResponse(ref)
 	if err != nil {
 		// Stdout stream is broken; discard the process so the next call
 		// restarts, mirroring ReadObjectsBatch.
 		r.killLocked()
 	}
-	return content, found, err
+	return content, sha, found, err
 }
 
 // ReadObjectsBatch sends all refs in one burst and reads all responses in order.
@@ -149,7 +159,7 @@ func (r *objectReader) ReadObjectsBatch(refs []string) (map[string]string, error
 	}
 	results := make(map[string]string, len(refs))
 	for _, ref := range refs {
-		content, found, err := r.readResponse(ref)
+		content, _, found, err := r.readResponse(ref)
 		if err != nil {
 			// Stdout stream is broken; discard the process so the next call restarts.
 			r.killLocked()

--- a/internal/git/staging.go
+++ b/internal/git/staging.go
@@ -106,6 +106,20 @@ func (r *runner) listUntrackedFiles(ctx context.Context) ([]string, error) {
 	return splitNulTerminated(out), nil
 }
 
+// GetUntrackedFilesIn returns untracked, non-ignored files in an arbitrary
+// worktree, as repository-relative paths. Ignored files are excluded, so
+// gitignored build output never counts as work to protect.
+func (r *runner) GetUntrackedFilesIn(ctx context.Context, worktreePath string) ([]string, error) {
+	out, err := r.RunGitCommandRawWithContext(ctx,
+		"-C", worktreePath,
+		"ls-files", "--others", "--exclude-standard", "-z",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list untracked files in %s: %w", worktreePath, err)
+	}
+	return splitNulTerminated(out), nil
+}
+
 func (r *runner) ParseStagedHunks(ctx context.Context) ([]Hunk, error) {
 	diffOutput, err := r.RunGitCommandRawWithContext(ctx, "diff", "--cached")
 	if err != nil {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -501,3 +501,34 @@ func (r *runner) ListWorktreeMetas() (map[string]*WorktreeMeta, error) {
 
 	return result, nil
 }
+
+// maxUntrackedCollisionPaths bounds how many paths TreeContainsAnyPath will ask
+// git about in one invocation. Beyond this the caller is expected to fall back
+// to a conservative answer rather than build an unbounded argv.
+const maxUntrackedCollisionPaths = 200
+
+// TreeContainsAnyPath reports whether rev's tree contains any of paths.
+//
+// This answers the only question that makes an untracked file unsafe during a
+// restack: `git reset --hard` silently overwrites an untracked file whose path
+// the incoming commit also contains, and leaves every other untracked file
+// alone. Paths are repository-relative.
+//
+// The second return reports whether the question could be answered at all.
+// Callers guard destructive work with this, so "unknown" must not read as "no
+// collision".
+func (r *runner) TreeContainsAnyPath(ctx context.Context, rev string, paths []string) (collides, known bool) {
+	if rev == "" || len(paths) == 0 {
+		return false, true
+	}
+	if len(paths) > maxUntrackedCollisionPaths {
+		return false, false
+	}
+
+	args := append([]string{"ls-tree", "-r", "-z", "--name-only", rev, "--"}, paths...)
+	out, err := r.RunGitCommandRawWithContext(ctx, args...)
+	if err != nil {
+		return false, false
+	}
+	return strings.TrimSpace(strings.ReplaceAll(out, "\x00", "")) != "", true
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -325,7 +325,7 @@ func (r *runner) ReadWorktreeMeta(stackRoot string) (*WorktreeMeta, error) {
 }
 
 // WriteWorktreeMeta writes worktree metadata for a stack root to local git refs
-func (r *runner) WriteWorktreeMeta(stackRoot string, meta *WorktreeMeta) error {
+func (r *runner) WriteWorktreeMeta(ctx context.Context, stackRoot string, meta *WorktreeMeta) error {
 	jsonData, err := json.Marshal(meta)
 	if err != nil {
 		return fmt.Errorf("failed to marshal worktree metadata: %w", err)
@@ -346,7 +346,7 @@ func (r *runner) WriteWorktreeMeta(stackRoot string, meta *WorktreeMeta) error {
 		{RefName: fmt.Sprintf("%s%s", WorktreeRefPrefix, stackRoot), NewSHA: sha, OldSHA: zeroSHA},
 		{RefName: worktreePathRef(meta.Path), NewSHA: sha, OldSHA: zeroSHA},
 	}
-	if err := r.UpdateRefsBatch(context.Background(), updates); err != nil {
+	if err := r.UpdateRefsBatch(ctx, updates); err != nil {
 		return fmt.Errorf("failed to register worktree metadata refs: %w", err)
 	}
 

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -134,7 +134,7 @@ func TestWorktreeRegistry(t *testing.T) {
 		require.NoError(t, os.Symlink(targetBase, linkBase))
 		worktreePath := filepath.Join(linkBase, "worktree")
 
-		require.NoError(t, runner.WriteWorktreeMeta("first", &git.WorktreeMeta{
+		require.NoError(t, runner.WriteWorktreeMeta(context.Background(), "first", &git.WorktreeMeta{
 			Path:         worktreePath,
 			AnchorBranch: "first",
 		}))
@@ -144,7 +144,7 @@ func TestWorktreeRegistry(t *testing.T) {
 
 		// Re-registration at the same path must not collide with an orphaned
 		// reverse path ref hashed with a different spelling.
-		require.NoError(t, runner.WriteWorktreeMeta("second", &git.WorktreeMeta{
+		require.NoError(t, runner.WriteWorktreeMeta(context.Background(), "second", &git.WorktreeMeta{
 			Path:         worktreePath,
 			AnchorBranch: "second",
 		}))
@@ -160,7 +160,7 @@ func TestWorktreeRegistry(t *testing.T) {
 			AnchorBranch: "feature-branch",
 			MainRepoDir:  scene.Repo.Dir,
 		}
-		err := runner.WriteWorktreeMeta("feature-branch", meta)
+		err := runner.WriteWorktreeMeta(context.Background(), "feature-branch", meta)
 		require.NoError(t, err)
 
 		// Read it back
@@ -191,7 +191,7 @@ func TestWorktreeRegistry(t *testing.T) {
 			Path:         "/path/to/worktree",
 			AnchorBranch: "feature-branch",
 		}
-		err := runner.WriteWorktreeMeta("feature-branch", meta)
+		err := runner.WriteWorktreeMeta(context.Background(), "feature-branch", meta)
 		require.NoError(t, err)
 
 		// Delete it
@@ -213,14 +213,14 @@ func TestWorktreeRegistry(t *testing.T) {
 			Path:         "/path/to/worktree1",
 			AnchorBranch: "feature-1",
 		}
-		err := runner.WriteWorktreeMeta("feature-1", meta1)
+		err := runner.WriteWorktreeMeta(context.Background(), "feature-1", meta1)
 		require.NoError(t, err)
 
 		meta2 := &git.WorktreeMeta{
 			Path:         "/path/to/worktree2",
 			AnchorBranch: "feature-2",
 		}
-		err = runner.WriteWorktreeMeta("feature-2", meta2)
+		err = runner.WriteWorktreeMeta(context.Background(), "feature-2", meta2)
 		require.NoError(t, err)
 
 		// List all

--- a/internal/integration/restack_dirty_maintree_test.go
+++ b/internal/integration/restack_dirty_maintree_test.go
@@ -4,26 +4,19 @@ import (
 	"testing"
 )
 
-// TestRestackWithUntrackedFileHoldsBranchAndLeavesNoStagedRevert covers the
-// untracked half of the dirty-worktree hold.
+// TestRestackWithHarmlessUntrackedFileProceeds covers the ordinary state of
+// having written a new file and not staged it yet.
 //
-// The reset that realigns a worktree after its branch ref moves is gated on the
-// worktree being clean, so that it cannot discard uncommitted work. Untracked
-// files count: `git reset --hard` overwrites an untracked file whose pathname
-// the incoming commit also contains, so skipping the reset is not enough — the
-// ref must not move either, or the worktree ends up holding the old commit's
-// content under a new ref and `stackit modify -a` commits the revert.
-//
-// So a stray untracked file holds the branch back rather than being restacked
-// around it. The file survives, the ref stays put, and nothing is staged.
-func TestRestackWithUntrackedFileHoldsBranchAndLeavesNoStagedRevert(t *testing.T) {
+// `git reset --hard` overwrites an untracked file only when the incoming commit
+// contains that same path, and leaves every other untracked file alone. Holding
+// the branch for any untracked file at all stopped restacks for a state most
+// working repositories are in most of the time.
+func TestRestackWithHarmlessUntrackedFileProceeds(t *testing.T) {
 	t.Parallel()
 
 	sh := NewTestShellInProcess(t)
 
 	sh.CreateLinearStack3().Checkout("a")
-	sh.Git("rev-parse a")
-	revBefore := sh.Output()
 
 	// Trunk advances so the stack genuinely needs restacking. WriteFile stages
 	// under the exact name, which the assertions below rely on.
@@ -32,25 +25,57 @@ func TestRestackWithUntrackedFileHoldsBranchAndLeavesNoStagedRevert(t *testing.T
 		Git("commit -m 'chore: trunk commit'").
 		Checkout("a")
 
-	// A single untracked file — a scratch note, a build artifact, anything not
-	// in .gitignore.
+	// An untracked file at a path trunk knows nothing about. Nothing incoming
+	// can overwrite it.
 	sh.WriteUnstaged("scratch.txt", "scratch note")
 
 	sh.Run("restack --upstack")
 
-	// The branch must not have moved: holding it back is what keeps the
-	// worktree and its ref consistent.
-	sh.Git("rev-parse a")
-	if sh.Output() != revBefore {
-		t.Fatalf("branch a moved despite its worktree having an untracked file:\nbefore %safter  %s", revBefore, sh.Output())
-	}
+	// The restack happened: trunk's commit is now in this branch's history.
+	sh.Git("ls-tree HEAD -- trunk1.txt").OutputContains("trunk1.txt")
 
-	// The only thing git should report is the untracked file itself. A "D " or
-	// " D" entry here means trunk's content was left staged for deletion.
+	// The untracked file survived, and no staged revert was left behind.
 	sh.Git("status --porcelain").
 		OutputContains("?? scratch.txt").
 		OutputNotContains(" D ").
 		OutputNotContains("D  ")
+}
+
+// TestRestackHoldsBranchWhenUntrackedFileWouldBeOverwritten covers the case the
+// hold actually exists for.
+//
+// The incoming commit adds a file at the same path as an untracked file in the
+// worktree. `git reset --hard` overwrites it silently, and since the file was
+// never in Git there is nothing to recover it from — so the branch is held
+// instead and the ref does not move.
+func TestRestackHoldsBranchWhenUntrackedFileWouldBeOverwritten(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+
+	sh.CreateLinearStack3().Checkout("a")
+	sh.Git("rev-parse a")
+	revBefore := sh.Output()
+
+	// Trunk advances by adding a file the worktree also has, untracked.
+	sh.Checkout("main").
+		WriteFile("collide.txt", "from trunk").
+		Git("commit -m 'chore: trunk adds collide.txt'").
+		Checkout("a")
+
+	sh.WriteUnstaged("collide.txt", "my uncommitted work")
+
+	sh.Run("restack --upstack").
+		OutputContains("would be overwritten")
+
+	// The branch must not have moved.
+	sh.Git("rev-parse a")
+	if sh.Output() != revBefore {
+		t.Fatalf("branch a moved even though restacking it would overwrite an untracked file:\nbefore %safter  %s", revBefore, sh.Output())
+	}
+
+	// And the file still holds the user's content, not trunk's.
+	sh.Git("status --porcelain").OutputContains("?? collide.txt")
 }
 
 // TestRestackSkipsBranchWithTrackedChangesInItsWorktree covers the other half.


### PR DESCRIPTION
**Close out the worktree audit, and stop holding restacks for harmless files**

The last of the worktree audit's open items, plus one behavior change the audit
did not ask for.

**Concurrency and cancellation**

- **#1611** — metadata writes are compare-and-swap. Two stackit processes in
  different worktrees that both read a branch and then wrote it kept only the
  second write; whatever the first recorded was silently gone. Metadata refs
  point straight at a blob and cat-file already reports that blob's SHA — it was
  being parsed and discarded. A write based on state another process replaced
  now fails and says so.
- **#1612** — worktree registration and post-create hooks ran with
  context.Background(), ignoring cancellation. AttachAction also discarded the
  error from restoring your original branch, leaving you somewhere you did not
  ask to be without saying so.

**Guidance that assumed the worktree was still there**

- **#1613** — the ownership guard told users to `cd` into the owning worktree
  without checking it existed, so a deleted directory produced advice that could
  only fail, for a branch only detach can release. Checkout's stale-path tip
  named `worktree remove`, which refuses for any stack that still has branches.
  Checkout also only validated the destination when switching from the main
  repo, not between worktrees.
- **#1614** — a branch held back reports RestackUnneeded, the same status as a
  branch that needed no work, so the conflict workflow concluded the rebase had
  succeeded and said so. It now names why the branch is held, and where.
- **#1615** — ownership divergence was only reported by `worktree list`, a
  command nobody runs until they already suspect something. Sync reports it.

**Warm start**

- **#1616** — one unplaceable file aborted worktree creation entirely, because
  any warm-start error makes the caller tear the worktree down. The mundane case
  is a tracked file occupying a name the include file also wants as a directory.
  It is reported and skipped now; a symlinked parent stays a hard failure, since
  that is how a project-controlled include file could steer a copy outside the
  worktree. Directory checks are memoized, and the docs now say plainly that
  warm-started files have no backup anywhere.

**The rule that was too broad**

- **#1617** — restack held a branch whenever its worktree had any untracked
  file. `git reset --hard` overwrites an untracked file only when the incoming
  commit contains that same path; every other one survives. Holding on all of
  them stopped restacks for the ordinary state of having written a new file and
  not staged it. Now it holds only on a real collision. Tracked changes still
  hold unconditionally, and anything unanswerable still holds.

This required the same rule in two places: the engine decides per branch, but
`restack` runs its own filter first, and changing only the engine left the
command unaffected while sync and modify quietly got the new behavior.

This PR merges the following changes:

1. **#1611** fix(git): compare-and-swap metadata writes
2. **#1612** fix(worktree): honor cancellation and report a failed checkout restore
3. **#1613** fix(worktree): make dead-worktree guidance actionable
4. **#1614** fix(restack): diagnose a held branch instead of a phantom conflict
5. **#1615** fix(sync): report ownership divergence where it gets seen
6. **#1616** fix(worktree): keep warm start from failing the whole worktree
7. **#1617** fix(restack): hold on untracked files only when they would be overwritten

### Stack

```
main
  └─ jonnii/20260806013619/compare-and-swap-metadata-writes (#1611)
    └─ jonnii/20260806013947/honor-cancellation-and-report-a-failed-checkout (#1612)
      └─ jonnii/20260806014405/make-dead-worktree-guidance-actionable (#1613)
        └─ jonnii/20260806014843/diagnose-a-held-branch-instead-of-a-phantom (#1614)
          └─ jonnii/20260806015043/report-ownership-divergence-where-it-gets-seen (#1615)
            └─ jonnii/20260806015612/keep-warm-start-from-failing-the-whole-worktree (#1616)
              └─ jonnii/20260806022551/hold-on-untracked-files-only-when-they-would-be (#1617)
```

Stackit-Stack-Size: 7
Stackit-PRs: 1611,1612,1613,1614,1615,1616,1617
