### PR TITLE
fix(test): tolerate files vanishing during template copy

### DIFF
--- a/testhelpers/git_repo.go
+++ b/testhelpers/git_repo.go
@@ -16,6 +16,14 @@ const textFileName = "test.txt"
 func copyDir(src, dst string) error {
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			// Git housekeeping (maintenance/auto-gc) creates and removes lock
+			// files such as .git/objects/maintenance.lock inside the template
+			// while we walk it. A file that vanished between readdir and lstat
+			// is nothing we need to copy, and failing the whole clone over it
+			// makes every template-backed test flaky.
+			if os.IsNotExist(err) {
+				return nil
+			}
 			return err
 		}
 
@@ -33,6 +41,11 @@ func copyDir(src, dst string) error {
 		// Copy file
 		srcFile, err := os.Open(path) //nolint:gosec // G122: test helper, no symlink risk
 		if err != nil {
+			// Same race as above: the file survived lstat but was removed
+			// before we opened it.
+			if os.IsNotExist(err) {
+				return nil
+			}
 			return err
 		}
 		defer func() { _ = srcFile.Close() }()


### PR DESCRIPTION

Git housekeeping creates and removes lock files such as
.git/objects/maintenance.lock inside the shared template repo while
copyDir walks it. filepath.Walk surfaces the failed lstat to the
callback, which returned it and failed the whole clone, so any test
backed by a template repo could fail with

  failed to copy from template: lstat .../maintenance.lock:
  no such file or directory

A full run hit 12 such failures across three packages, all passing on
re-run and on a different set of tests each time. A file that vanished
mid-walk is nothing we need to copy, so skip it rather than aborting.
The same race exists between lstat and open, so guard both.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1622** 👈
  * **PR #1623**
    * **PR #1624**
      * **PR #1625**
        * **PR #1626**
          * **PR #1627**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->