### PR TITLE
fix(engine): never hold trunk-rooted branches behind a dirty trunk worktree

### DIFF
--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -527,9 +527,17 @@ func skipDirtyWorktreeStacks(ctx *app.Context, groups []restackBranchGroup) []re
 	// them. Untracked files hold it only when one occupies a path the incoming
 	// commit also writes, which is the only case a hard reset destroys.
 	dirtyBranches := make(map[string]bool)
+	trunk := eng.Trunk().GetName()
 	if worktrees, err := eng.ListWorktrees(ctx.Context); err == nil {
 		for _, wt := range worktrees {
 			if wt.Branch == "" || dirtyAnchors[wt.Branch] {
+				continue
+			}
+			// Trunk is never restacked and its worktree is never reset, so a
+			// dirty trunk checkout holds nothing. Warning about it told users
+			// to stash work that was never at risk, for a restack that went on
+			// to succeed in full.
+			if wt.Branch == trunk {
 				continue
 			}
 			if eng.WorktreeRebaseInProgress(ctx.Context, wt.Path) {

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -140,23 +140,37 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 	dirtyWorktrees := make(map[string]bool, len(worktrees))
 	untrackedByWorktree := make(map[string][]string)
 	heldBranches := make(BranchNameSet)
+
+	e.mu.RLock()
+	trunk := e.trunk
+	e.mu.RUnlock()
+
+	// A dirty worktree holds the branch it has checked out, because restacking
+	// that branch would reset the worktree and discard the work. Trunk is the
+	// exception: restack never moves trunk's ref and never resets trunk's
+	// worktree, so there is nothing to protect — while holding it would
+	// propagate through branchHeldBack's ancestry walk and silently hold every
+	// trunk-rooted branch in the repository. Marking the worktree dirty still
+	// stops any reset of it.
+	hold := func(branch string) {
+		if branch != "" && branch != trunk {
+			heldBranches[branch] = true
+		}
+	}
+
 	for _, worktree := range worktrees {
 		path := worktree.Path
 		tracked, trackedErr := e.git.WorktreeHasTrackedChanges(ctx, path)
 		if trackedErr != nil || tracked {
 			dirtyWorktrees[path] = true
-			if worktree.Branch != "" {
-				heldBranches[worktree.Branch] = true
-			}
+			hold(worktree.Branch)
 			continue
 		}
 		untracked, untrackedErr := e.git.GetUntrackedFilesIn(ctx, path)
 		if untrackedErr != nil {
 			// Cannot tell what is there, so no reset is safe.
 			dirtyWorktrees[path] = true
-			if worktree.Branch != "" {
-				heldBranches[worktree.Branch] = true
-			}
+			hold(worktree.Branch)
 			continue
 		}
 		if len(untracked) > 0 {

--- a/internal/integration/restack_dirty_trunk_worktree_test.go
+++ b/internal/integration/restack_dirty_trunk_worktree_test.go
@@ -1,0 +1,86 @@
+package integration
+
+import (
+	"testing"
+)
+
+// A dirty worktree holds the branch it has checked out, because restacking that
+// branch would reset the worktree and discard the work. Trunk is the exception:
+// restack never moves trunk's ref and never resets trunk's worktree, so there is
+// nothing to protect.
+//
+// Holding it anyway was not a conservative no-op. `branchHeldBack` walks a
+// branch's parent chain and stops at the first held ancestor, and every stacked
+// branch's chain terminates at trunk — so one uncommitted tracked change in a
+// worktree parked on trunk held every trunk-rooted branch in the repository,
+// and the commands reported success while doing nothing.
+
+// TestRestackProceedsWhenTrunkWorktreeIsDirty covers the restack command, which
+// at least printed a warning — but then claimed "Everything is up to date!" and
+// exited 0 with the stack still unrestacked.
+func TestRestackProceedsWhenTrunkWorktreeIsDirty(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+	sh.CreateLinearStack3()
+
+	// Trunk advances so the stack genuinely needs restacking, and leaves a
+	// tracked file on trunk for the next step to dirty.
+	sh.Checkout("main").
+		WriteFile("trunk1.txt", "trunk content").
+		Git("commit -m 'chore: trunk commit'")
+
+	// Uncommitted tracked work in the worktree that holds trunk. Restack never
+	// touches this worktree, so it is not at risk either way.
+	sh.WriteUnstaged("trunk1.txt", "work in progress on trunk")
+
+	sh.Run("restack --all-stacks")
+
+	// Every branch restacked onto the new trunk. Asserted against the refs
+	// rather than by checking each branch out, so the assertion is about the
+	// restack and not about whether checkout tolerates the dirty trunk file.
+	for _, branch := range []string{"a", "b", "c"} {
+		sh.Git("ls-tree " + branch + " -- trunk1.txt").
+			OutputContains("trunk1.txt")
+	}
+
+	// And the uncommitted work on trunk survived untouched.
+	sh.Git("status --porcelain").OutputContains("trunk1.txt")
+	sh.Git("show :trunk1.txt").OutputContains("trunk content")
+}
+
+// TestModifyRestacksChildrenWhenTrunkWorktreeIsDirty covers the silent half.
+//
+// modify, sync, squash, absorb, split and reorder go straight to
+// engine.RestackBranches and never reach the restack command's warning, so this
+// reported "b up to date" for a branch it had left stale — the shape that gets
+// a stale child submitted.
+func TestModifyRestacksChildrenWhenTrunkWorktreeIsDirty(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+	sh.CreateLinearStack3()
+
+	// The main worktree stays parked on trunk with uncommitted tracked work —
+	// the ordinary state after `stackit create -w`, which checks the main repo
+	// back out to trunk. Work happens in a sibling worktree on `a`.
+	sh.Checkout("main").
+		WriteFile("trunk1.txt", "trunk content").
+		Git("commit -m 'chore: trunk commit'").
+		WriteUnstaged("trunk1.txt", "work in progress on trunk")
+
+	worktreeDir := t.TempDir()
+	sh.Git("worktree add " + worktreeDir + " a")
+	wt := sh.InWorktree(worktreeDir)
+
+	// Amending a must restack b onto it.
+	wt.Write("a_extra", "more work on a").
+		Run("modify -a -n")
+
+	aRev := sh.Git("rev-parse a").Output()
+	sh.Git("merge-base --is-ancestor a b")
+
+	// b must contain the amended a. If the hold fired, b still points at the
+	// pre-amend a and this is the stale state modify claimed was up to date.
+	sh.Git("log b --format=%H").OutputContains(aRev)
+}


### PR DESCRIPTION

restackBranches recorded every dirty worktree's checked-out branch in
heldBranches, trunk included. branchHeldBack walks a branch's parent
chain and returns held on the first hit, and every stacked branch's chain
terminates at trunk — so one uncommitted tracked change in a worktree
parked on trunk held every trunk-rooted branch in the repository.

The hold buys nothing there: restack never moves trunk's ref and never
resets trunk's worktree, which is the only thing the hold protects
against. Marking the worktree dirty still suppresses any reset of it.

The reporting made it worse than a conservative no-op. restack printed a
skip warning and then "Everything is up to date!", exiting 0 with the
stack unrestacked. modify, sync, squash, absorb, split and reorder go
straight to engine.RestackBranches and never reach that warning, so they
reported "b up to date" for a branch left stale — the shape that gets a
stale child submitted. The trigger is routine: `stackit create -w`
leaves the main repo checked out on trunk.

Also stop the restack command warning about a dirty trunk worktree. It
only ever filtered trunk out of a restack group trunk is never in, so it
told users to stash work that was never at risk for a restack that went
on to succeed in full.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1622**
  * **PR #1623** 👈
    * **PR #1624**
      * **PR #1625**
        * **PR #1626**
          * **PR #1627**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->