### PR TITLE
fix(create): only run post-worktree-create hooks when a worktree exists

### DIFF
--- a/internal/actions/create/create.go
+++ b/internal/actions/create/create.go
@@ -317,11 +317,14 @@ func Action(ctx *app.Context, opts Options, h Handler) (Result, error) {
 				worktreePath = created.Path
 				h.OnStep(StepWorktree, handler.StatusCompleted, fmt.Sprintf("Created worktree at %s", worktreePath))
 				out.Info("Created worktree at %s", worktreePath)
-			}
 
-			// Run post-create hooks in the worktree
-			if hookErr := worktree.RunPostCreateHooks(ctx, worktreePath); hookErr != nil {
-				out.Warn("Post-create hooks failed: %v", hookErr)
+				// Only when a worktree actually exists. On the failure path
+				// above worktreePath is still empty, which os/exec resolves to
+				// the current directory — the user's main checkout, which the
+				// CheckoutBranch above just moved to trunk.
+				if hookErr := worktree.RunPostCreateHooks(ctx, worktreePath); hookErr != nil {
+					out.Warn("Post-create hooks failed: %v", hookErr)
+				}
 			}
 		}
 	}

--- a/internal/actions/worktree/hooks.go
+++ b/internal/actions/worktree/hooks.go
@@ -37,7 +37,16 @@ func ResolveApprovedHooks(ctx *app.Context) ([]string, error) {
 //
 // The caller's context is honored so Ctrl-C interrupts a hook instead of
 // waiting out its timeout.
+// An empty worktreePath is refused rather than passed through: os/exec treats
+// an empty Dir as the current directory, which for these hooks is the user's
+// main checkout — the one place they must never run.
 func RunResolvedHooks(ctx context.Context, hookCmds []string, worktreePath string, out output.Output) {
+	if worktreePath == "" {
+		if len(hookCmds) > 0 {
+			out.Warn("Skipped post-worktree-create hooks: no worktree directory to run them in")
+		}
+		return
+	}
 	_ = hooks.Run(ctx, hookCmds, hooks.RunOptions{
 		Dir:      worktreePath,
 		Blocking: false,

--- a/internal/actions/worktree/hooks_test.go
+++ b/internal/actions/worktree/hooks_test.go
@@ -1,0 +1,46 @@
+package worktree
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/output"
+)
+
+// post-worktree-create hooks are arbitrary user-configured shell commands whose
+// whole purpose is to mutate a fresh worktree. os/exec treats an empty Dir as
+// the current directory, so passing an empty worktree path through would run
+// them against the user's main checkout instead. The guard returns before
+// hooks.Run, and the warning is the observable proof it fired.
+func TestRunResolvedHooksWarnsWhenSkipped(t *testing.T) {
+	t.Parallel()
+
+	out := output.NewTestOutput()
+	RunResolvedHooks(context.Background(), []string{"echo hi"}, "", out)
+
+	require.Contains(t, out.String(), "Skipped post-worktree-create hooks")
+}
+
+// Nothing configured means nothing to warn about.
+func TestRunResolvedHooksSilentWithNoHooks(t *testing.T) {
+	t.Parallel()
+
+	out := output.NewTestOutput()
+	RunResolvedHooks(context.Background(), nil, "", out)
+
+	require.NotContains(t, out.String(), "Skipped post-worktree-create hooks")
+}
+
+// The ordinary path still runs the hook, in the directory it was given.
+func TestRunResolvedHooksRunsInWorktree(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	out := output.NewTestOutput()
+	RunResolvedHooks(context.Background(), []string{"touch ran.txt"}, dir, out)
+
+	require.FileExists(t, filepath.Join(dir, "ran.txt"))
+}


### PR DESCRIPTION

076e6316 turned worktree-setup failure into a warn-and-continue so the
branch survives, but left RunPostCreateHooks outside the success branch.
On that path worktreePath is still empty, and os/exec treats an empty
Dir as the current directory — so post-worktree-create hooks ran in the
user's main checkout, which the preceding CheckoutBranch had just moved
to trunk.

Those hooks are arbitrary configured commands whose purpose is to set up
a fresh worktree (dependency installs, cp .env, clean scripts). Running
them against the primary working tree is an unrequested mutation, and it
happens precisely when something already went wrong. The failure path
also became more reachable this release, which added exclusive reverse-
path registration and duplicate-anchor rejection.

Guard RunResolvedHooks against an empty directory too, so the same
footgun cannot return through another caller, and warn rather than
silently dropping hooks the user configured.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1622**
  * **PR #1623**
    * **PR #1624** 👈
      * **PR #1625**
        * **PR #1626**
          * **PR #1627**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->