### PR TITLE
fix(git): let worktree unregistration survive unreadable metadata

### DIFF
--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -362,9 +362,15 @@ func (r *runner) DeleteWorktreeMeta(ctx context.Context, stackRoot string) error
 		return r.DeleteRef(ctx, refName)
 	}
 
+	// A metadata blob we cannot read or parse tells us nothing about which
+	// reverse path ref to retire, but it must not make the registration
+	// undeletable — that would leave remove, detach, prune and sync's orphan
+	// cleanup with no way to retire it short of a manual `git update-ref -d`.
+	// Drop the forward ref regardless; PruneOrphanedWorktreePathRefs sweeps the
+	// reverse claim once this ref is gone.
 	meta, err := r.ReadWorktreeMeta(stackRoot)
 	if err != nil {
-		return err
+		meta = nil
 	}
 	updates := []RefUpdate{{RefName: refName, OldSHA: sha, IsDelete: true}}
 	if meta != nil {

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -150,6 +150,35 @@ func TestWorktreeRegistry(t *testing.T) {
 		}))
 	})
 
+	// A registration whose metadata blob cannot be parsed must still be
+	// deletable. Propagating the read error made the ref undeletable through
+	// every stackit path that retires one — remove, detach, prune, and sync's
+	// orphan cleanup — leaving a manual `git update-ref -d` as the only exit
+	// from a state the repair work in this area exists to recover from.
+	t.Run("deletes a registration whose metadata cannot be parsed", func(t *testing.T) {
+		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
+		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+
+		require.NoError(t, runner.WriteWorktreeMeta(context.Background(), "corrupt", &git.WorktreeMeta{
+			Path:         filepath.Join(t.TempDir(), "worktree"),
+			AnchorBranch: "corrupt",
+		}))
+
+		// Point the registration at a blob that is not valid metadata.
+		garbage, err := runner.CreateBlob("this is not json")
+		require.NoError(t, err)
+		require.NoError(t, runner.UpdateRef("refs/stackit/worktrees/corrupt", garbage))
+
+		_, readErr := runner.ReadWorktreeMeta("corrupt")
+		require.Error(t, readErr, "precondition: metadata must be unreadable")
+
+		require.NoError(t, runner.DeleteWorktreeMeta(context.Background(), "corrupt"))
+
+		meta, err := runner.ReadWorktreeMeta("corrupt")
+		require.NoError(t, err)
+		require.Nil(t, meta)
+	})
+
 	t.Run("write and read worktree metadata", func(t *testing.T) {
 		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)
 		runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)


### PR DESCRIPTION

DeleteWorktreeMeta started reading the metadata blob so it could retire
the reverse path ref in the same transaction, and propagated a read or
parse failure to the caller. A corrupt or truncated blob then made the
registration undeletable through every path that retires one — worktree
remove, detach, prune, and sync's orphaned-worktree cleanup — leaving a
manual `git update-ref -d` as the only way out.

That is the opposite of what the surrounding repair and prune work is
for: these paths exist to recover from damaged registrations, so they
must not themselves require intact metadata. Unreadable metadata only
means we cannot tell which reverse ref to retire, so drop the forward
ref regardless and let PruneOrphanedWorktreePathRefs sweep the reverse
claim once the forward ref is gone.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1622**
  * **PR #1623**
    * **PR #1624**
      * **PR #1625** 👈
        * **PR #1626**
          * **PR #1627**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->