### PR TITLE
fix(engine): sync the sibling worktree when continue moves a branch ref

### DIFF
--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -97,9 +97,23 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 		return errors.NewConflictWorkflowError(branchName)
 	}
 
-	// Success - checkout the branch (rebase leaves us in detached HEAD)
+	// Success - checkout the branch (rebase leaves us in detached HEAD).
+	//
+	// A branch checked out in another worktree cannot be attached here, and
+	// since CheckoutBranch stopped falling back to a detached checkout that is
+	// now a hard error. Failing the whole command for it abandons the branches
+	// still queued in BranchesToRestack and leaves the continuation state on
+	// disk, so the resolved conflict has to be redone. Report where the branch
+	// lives and carry on with the rest of the stack instead.
 	if err := eng.CheckoutBranch(ctx.Context, eng.GetBranch(result.BranchName)); err != nil {
-		return fmt.Errorf("failed to checkout branch %s: %w", result.BranchName, err)
+		otherWorktree := ""
+		if worktrees, listErr := eng.ListWorktrees(ctx.Context); listErr == nil {
+			otherWorktree = worktrees.PathForBranch(result.BranchName)
+		}
+		if otherWorktree == "" {
+			return fmt.Errorf("failed to checkout branch %s: %w", result.BranchName, err)
+		}
+		out.Warn("Updated %s, which is checked out in worktree %s; staying where you are.", result.BranchName, otherWorktree)
 	}
 
 	out.Info("Resolved rebase conflict for %s.", output.CurrentBranch(result.BranchName))

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -320,9 +320,23 @@ func (e *engineImpl) ContinueRebase(ctx context.Context, branchName string, reba
 			return ContinueRebaseResult{BranchName: branchName}, fmt.Errorf("failed to get expected branch revision for %s: %w", branchName, err)
 		}
 	}
+	// Moving the ref is only half the operation: a worktree holding this branch
+	// is still on the pre-rebase content, and `git status` there reports the
+	// rebased commit's files as deleted — which the next `stackit modify -a` in
+	// that worktree commits, silently reverting the rebase. restackBranch resets
+	// the branch's worktree for exactly this reason; the continue path moved its
+	// ref without doing so.
+	//
+	// Resolved before the ref moves; see branchWorktreeResetTarget for why.
+	worktreeToReset := e.branchWorktreeResetTarget(ctx, branchName)
+
 	err = e.git.UpdateBranchRefCAS(ctx, branchName, newRev, expectedBranchRevision)
 	if err != nil {
 		return ContinueRebaseResult{BranchName: branchName}, fmt.Errorf("failed to update branch reference %s: %w", branchName, err)
+	}
+
+	if worktreeToReset != "" {
+		_ = e.git.ResetWorktreeWorkingDir(ctx, worktreeToReset) //nolint:errcheck // best-effort
 	}
 
 	// Update metadata

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -35,6 +35,34 @@ func (e *engineImpl) resetWorktreeIfClean(ctx context.Context, worktreePath stri
 	_ = e.git.ResetWorktreeWorkingDir(ctx, worktreePath) //nolint:errcheck // best-effort
 }
 
+// branchWorktreeResetTarget resolves the worktree holding branchName and
+// reports whether it is safe to reset once the branch's ref moves. It is the
+// one-off equivalent of the restack snapshot's dirtyWorktrees for paths that
+// move a single ref outside a restack pass.
+//
+// This MUST be called before the ref moves. Asking afterwards compares the
+// worktree's now-stale content against its own new ref, which always reads as
+// dirty and silently disables the reset — the same trap resetWorktreeIfClean
+// documents for the batch path.
+//
+// Best-effort: a worktree that cannot be inspected returns "" and is left
+// alone, since a reset is what would discard uncommitted work.
+func (e *engineImpl) branchWorktreeResetTarget(ctx context.Context, branchName string) string {
+	worktrees, err := e.git.ListWorktrees(ctx)
+	if err != nil {
+		return ""
+	}
+	worktreePath := worktrees.PathForBranch(branchName)
+	if worktreePath == "" {
+		return ""
+	}
+	dirty, err := e.git.WorktreeHasTrackedChanges(ctx, worktreePath)
+	if err != nil || dirty {
+		return ""
+	}
+	return worktreePath
+}
+
 // restackSnapshot bundles the branch-keyed state captured once per restack
 // pass so per-branch steps don't re-read metadata, revisions, worktrees, or
 // metadata-ref SHAs from git. It is mutated in place as branches are rebased

--- a/internal/integration/continue_sibling_worktree_test.go
+++ b/internal/integration/continue_sibling_worktree_test.go
@@ -1,0 +1,53 @@
+package integration
+
+import (
+	"testing"
+)
+
+// TestContinueResetsRebasedBranchSiblingWorktree covers the half of the
+// worktree-sync contract that the continue path skipped.
+//
+// restackBranch resets a branch's worktree after moving its ref, because moving
+// the ref alone leaves that worktree on the pre-rebase content: `git status`
+// there reports the rebased commit's files as deleted, and the next
+// `stackit modify -a` in that worktree commits the deletion, silently reverting
+// the rebase. ContinueRebase moved the ref the same way but never reset, so
+// every conflict resolved on a branch checked out elsewhere left that worktree
+// diverged.
+func TestContinueResetsRebasedBranchSiblingWorktree(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+
+	// main -> a -> b, with b parked in its own worktree the way someone
+	// building two branches at once would have it.
+	sh.WriteFile("common.txt", "base").Run("create a -m 'a'")
+	sh.WriteFile("common.txt", "base\nb content").Run("create b -m 'b'")
+
+	worktreeDir := t.TempDir()
+	sh.Checkout("a")
+	sh.Git("worktree add " + worktreeDir + " b")
+	wt := sh.InWorktree(worktreeDir)
+
+	// Amend a so restacking b conflicts.
+	sh.WriteFile("common.txt", "base\na conflicting change").
+		Git("commit --amend --no-edit")
+
+	sh.RunExpectError("restack --upstack").
+		OutputContains("conflict")
+
+	// Resolve and continue. b's ref moves here, in the main worktree, while b
+	// itself is checked out in the sibling.
+	sh.WriteFile("common.txt", "base\na conflicting change\nb content").
+		Run("continue")
+
+	// The sibling worktree must match b's new tip. If the reset was skipped it
+	// still holds the pre-rebase tree, and status reports the rebased content
+	// as modified or deleted.
+	wt.Git("status --porcelain").
+		OutputNotContains("D  ").
+		OutputNotContains(" D ").
+		OutputNotContains(" M ")
+
+	wt.Git("diff HEAD --stat").OutputNotContains("common.txt")
+}


### PR DESCRIPTION

ContinueRebase moved the rebased branch's ref and stopped there. A
worktree holding that branch kept the pre-rebase content, so `git status`
there reported the rebased commit's files as deleted and the next
`stackit modify -a` in that worktree committed the deletion — silently
reverting the rebase. restackBranch resets the branch's worktree for
exactly this reason; the continue path never did.

The worktree and its dirtiness are resolved before the ref moves. Asking
afterwards compares the worktree's now-stale content against its own new
ref, which always reads as dirty and silently disables the reset — the
same trap resetWorktreeIfClean documents for the batch path.

Continue also hard-failed on the final checkout for such a branch, since
569b6981 removed CheckoutBranch's detached fallback. That abandoned
every branch still queued in BranchesToRestack and left the continuation
state on disk, so a resolved conflict had to be redone. Report where the
branch lives and carry on with the rest of the stack.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1622**
  * **PR #1623**
    * **PR #1624**
      * **PR #1625**
        * **PR #1626** 👈
          * **PR #1627**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->