### PR TITLE
fix(git): make the metadata compare-and-swap cover the batch read path

### DIFF
--- a/internal/git/metadata.go
+++ b/internal/git/metadata.go
@@ -182,19 +182,21 @@ func (r *runner) BatchReadMetadata(branchNames []string) (map[string]*Meta, map[
 	}
 
 	for i, name := range misses {
-		content := contents[refs[i]] // empty string when the ref is missing
-		if content == "" {
+		obj := contents[refs[i]] // zero value when the ref is missing
+		if obj.Content == "" {
 			empty := NewMeta()
 			r.metadataCache.Put(name, empty)
 			results[name] = empty
 			continue
 		}
 		var meta Meta
-		if unmarshalErr := json.Unmarshal([]byte(content), &meta); unmarshalErr != nil {
+		if unmarshalErr := json.Unmarshal([]byte(obj.Content), &meta); unmarshalErr != nil {
 			errs[name] = fmt.Errorf("failed to unmarshal metadata for %s: %w", name, unmarshalErr)
 			continue
 		}
-		r.metadataCache.Put(name, &meta)
+		// Record the blob this came from, the same way ReadMetadata does, so a
+		// later WriteMetadata compares against it instead of overwriting blind.
+		r.metadataCache.PutWithSHA(name, &meta, obj.SHA)
 		results[name] = &meta
 	}
 
@@ -231,17 +233,20 @@ func (r *runner) BatchReadLocalMetadata(branchNames []string) LocalMetaMap {
 	}
 
 	for i, name := range branchNames {
-		content := contents[refs[i]]
-		if content == "" {
+		obj := contents[refs[i]]
+		if obj.Content == "" {
 			results[name] = &LocalMeta{}
 			continue
 		}
 		var meta LocalMeta
-		if err := json.Unmarshal([]byte(content), &meta); err != nil {
+		if err := json.Unmarshal([]byte(obj.Content), &meta); err != nil {
 			// Non-critical; treat as missing
 			results[name] = &LocalMeta{}
 			continue
 		}
+		// Same reason as BatchReadMetadata: without the SHA, WriteLocalMetadata
+		// has nothing to compare against and falls back to a blind write.
+		r.metadataCache.PutLocalSHA(name, obj.SHA)
 		results[name] = &meta
 	}
 
@@ -323,15 +328,22 @@ func (r *runner) updateMetadataRefCAS(refName, branchName, newSHA string) error 
 		}
 		return nil
 	}
-	if expected == newSHA {
-		return nil // Identical content; nothing to write.
-	}
+	// Writing back what we read is still a write. expected is what *this*
+	// process last saw, not what the ref holds now, so short-circuiting here
+	// reported success for a ref another process may have moved in between —
+	// and the caller then cached metadata it never actually wrote. Let the
+	// compare-and-swap decide; it costs one update-ref.
 	err := r.UpdateRefsBatch(context.Background(), []RefUpdate{{
 		RefName: refName,
 		NewSHA:  newSHA,
 		OldSHA:  expected,
 	}})
 	if err != nil {
+		// The expectation is now known-stale. Dropping it forces the next read
+		// to come from disk: otherwise ReadMetadata answers from cache, recomputes
+		// the same expectation, and every retry in this process fails the same
+		// way — which the short-lived CLI hides but a long-lived server does not.
+		r.metadataCache.Delete(branchName)
 		return fmt.Errorf("failed to write metadata ref for %s (another process changed it; re-run to pick up their change): %w", branchName, err)
 	}
 	return nil
@@ -416,21 +428,26 @@ func (r *runner) WriteLocalMetadata(branchName string, meta *LocalMeta) error {
 	}
 
 	refName := fmt.Sprintf("%s%s", LocalMetadataRefPrefix, branchName)
-	if expected := r.metadataCache.LocalSHAFor(branchName); expected != "" && expected != sha {
+	// Mirrors updateMetadataRefCAS: an expectation we hold is compared even when
+	// the new content matches it, because "matches what I read" is not the same
+	// as "matches what is on disk now".
+	if expected := r.metadataCache.LocalSHAFor(branchName); expected != "" {
 		err := r.UpdateRefsBatch(context.Background(), []RefUpdate{{
 			RefName: refName,
 			NewSHA:  sha,
 			OldSHA:  expected,
 		}})
 		if err != nil {
+			r.metadataCache.Delete(branchName)
 			return fmt.Errorf("failed to write local metadata ref for %s (another process changed it; re-run to pick up their change): %w", branchName, err)
 		}
 		r.metadataCache.PutLocalSHA(branchName, sha)
-	} else if err := r.UpdateRef(refName, sha); err != nil {
-		return fmt.Errorf("failed to write local metadata ref: %w", err)
-	} else {
-		r.metadataCache.PutLocalSHA(branchName, sha)
+		return nil
 	}
+	if err := r.UpdateRef(refName, sha); err != nil {
+		return fmt.Errorf("failed to write local metadata ref: %w", err)
+	}
+	r.metadataCache.PutLocalSHA(branchName, sha)
 
 	return nil
 }

--- a/internal/git/metadata_cas_test.go
+++ b/internal/git/metadata_cas_test.go
@@ -54,6 +54,81 @@ func TestMetadataWriteCompareAndSwap(t *testing.T) {
 		require.Equal(t, "first-parent", *latest.GetParentBranchName())
 	})
 
+	// The guard is worthless if it only covers the read path almost nothing
+	// uses. Engine graph loads go through BatchReadMetadata, which warmed the
+	// cache without a SHA — so every command that read a stack and then wrote
+	// to it had no expectation to compare against and fell back to a blind
+	// update-ref. This is the same scenario as "stale write is rejected",
+	// seeded the way real commands seed it.
+	t.Run("stale write is rejected after a batch read", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+
+		first := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+		second := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+
+		main := "main"
+		require.NoError(t, first.WriteMetadata("feature", git.NewMeta().WithParentBranchName(&main)))
+
+		firstBatch, errs := first.BatchReadMetadata([]string{"feature"})
+		require.Empty(t, errs)
+		secondBatch, errs := second.BatchReadMetadata([]string{"feature"})
+		require.Empty(t, errs)
+
+		firstParent := "first-parent"
+		require.NoError(t, first.WriteMetadata("feature", firstBatch["feature"].WithParentBranchName(&firstParent)))
+
+		secondParent := "second-parent"
+		err := second.WriteMetadata("feature", secondBatch["feature"].WithParentBranchName(&secondParent))
+		require.Error(t, err, "a write based on superseded state must not silently win")
+		require.Contains(t, err.Error(), "another process changed it")
+
+		latest, err := first.ReadMetadata("feature")
+		require.NoError(t, err)
+		require.Equal(t, "first-parent", *latest.GetParentBranchName())
+	})
+
+	// A failed compare-and-swap leaves the process holding an expectation that
+	// is known-stale. Keeping it meant a re-read answered from cache, recomputed
+	// the same expectation, and failed identically forever — invisible in the
+	// short-lived CLI, a wedge in the long-lived server.
+	t.Run("a rejected write does not wedge later writes", func(t *testing.T) {
+		t.Parallel()
+		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+
+		first := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+		second := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+
+		main := "main"
+		require.NoError(t, first.WriteMetadata("feature", git.NewMeta().WithParentBranchName(&main)))
+
+		fromSecond, err := second.ReadMetadata("feature")
+		require.NoError(t, err)
+
+		fromFirst, err := first.ReadMetadata("feature")
+		require.NoError(t, err)
+		firstParent := "first-parent"
+		require.NoError(t, first.WriteMetadata("feature", fromFirst.WithParentBranchName(&firstParent)))
+
+		secondParent := "second-parent"
+		require.Error(t, second.WriteMetadata("feature", fromSecond.WithParentBranchName(&secondParent)))
+
+		// Re-reading in the same process must see the winner, not the stale
+		// cached copy, and the retry must then be allowed through.
+		fresh, err := second.ReadMetadata("feature")
+		require.NoError(t, err)
+		require.Equal(t, "first-parent", *fresh.GetParentBranchName())
+		require.NoError(t, second.WriteMetadata("feature", fresh.WithParentBranchName(&secondParent)))
+
+		// Read through a third runner: first still holds its own cached copy
+		// from before second's write, which is ordinary cache staleness and not
+		// what this case is about.
+		third := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+		latest, err := third.ReadMetadata("feature")
+		require.NoError(t, err)
+		require.Equal(t, "second-parent", *latest.GetParentBranchName())
+	})
+
 	t.Run("write after re-reading succeeds", func(t *testing.T) {
 		t.Parallel()
 		scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)

--- a/internal/git/object_reader.go
+++ b/internal/git/object_reader.go
@@ -136,10 +136,23 @@ func (r *objectReader) ReadObjectWithSHA(ref string) (content, sha string, found
 	return content, sha, found, err
 }
 
+// BatchObject is one object's content together with the SHA the ref resolved
+// to. Callers that intend to write the ref back keep the SHA so they can detect
+// another process having written it in between.
+type BatchObject struct {
+	Content string
+	SHA     string
+}
+
 // ReadObjectsBatch sends all refs in one burst and reads all responses in order.
 // More efficient than N individual ReadObject calls: one lock acquisition, one
 // write loop, one read loop, zero per-item subprocess overhead.
-func (r *objectReader) ReadObjectsBatch(refs []string) (map[string]string, error) {
+//
+// The SHA comes back alongside the content because the batch path is the one
+// almost every command actually uses. Dropping it left those reads with no
+// compare-and-swap expectation to write against, so the lost-update guard only
+// ever engaged for the rare single-branch ReadMetadata caller.
+func (r *objectReader) ReadObjectsBatch(refs []string) (map[string]BatchObject, error) {
 	if len(refs) == 0 {
 		return nil, nil
 	}
@@ -157,16 +170,16 @@ func (r *objectReader) ReadObjectsBatch(refs []string) (map[string]string, error
 			return nil, fmt.Errorf("object reader write: %w", err)
 		}
 	}
-	results := make(map[string]string, len(refs))
+	results := make(map[string]BatchObject, len(refs))
 	for _, ref := range refs {
-		content, _, found, err := r.readResponse(ref)
+		content, sha, found, err := r.readResponse(ref)
 		if err != nil {
 			// Stdout stream is broken; discard the process so the next call restarts.
 			r.killLocked()
 			return nil, err
 		}
 		if found {
-			results[ref] = content
+			results[ref] = BatchObject{Content: content, SHA: sha}
 		}
 	}
 	return results, nil


### PR DESCRIPTION

b7c00f2d made metadata writes compare against the blob the process last
read, but only ReadMetadata recorded that blob. Engine graph loads go
through BatchReadMetadata, which warmed the cache with a plain Put and no
SHA — so for essentially every command the expectation was empty and the
write fell back to an unconditional update-ref. The guard covered the one
read path almost nothing uses, and its test passed only because it used
that path.

ReadObjectsBatch already had the SHA from cat-file and discarded it;
return it and record it, for both shared and local metadata. Two callers,
both here.

Also stop treating a write of unchanged content as a no-op. The
expectation is what this process last read, not what the ref holds now,
so short-circuiting reported success for a ref another process may have
moved — and then cached metadata that was never written.

On a rejected write, drop the cache entry. The expectation is known-stale
at that point, and keeping it meant a re-read answered from cache,
recomputed the same expectation, and failed identically forever: harmless
in the short-lived CLI, a wedge in the long-lived server.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1622**
  * **PR #1623**
    * **PR #1624**
      * **PR #1625**
        * **PR #1626**
          * **PR #1627** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->