### PR TITLE
fix(engine): stop continue from destroying untracked files in a sibling worktree

### DIFF
--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -103,8 +103,10 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 	// since CheckoutBranch stopped falling back to a detached checkout that is
 	// now a hard error. Failing the whole command for it abandons the branches
 	// still queued in BranchesToRestack and leaves the continuation state on
-	// disk, so the resolved conflict has to be redone. Report where the branch
-	// lives and carry on with the rest of the stack instead.
+	// disk, so the resolved conflict has to be redone. Carry on with the rest of
+	// the stack instead — but do not leave the user silently detached, which is
+	// where `git rebase` left HEAD and how commits get orphaned.
+	attached := true
 	if err := eng.CheckoutBranch(ctx.Context, eng.GetBranch(result.BranchName)); err != nil {
 		otherWorktree := ""
 		if worktrees, listErr := eng.ListWorktrees(ctx.Context); listErr == nil {
@@ -113,10 +115,16 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 		if otherWorktree == "" {
 			return fmt.Errorf("failed to checkout branch %s: %w", result.BranchName, err)
 		}
-		out.Warn("Updated %s, which is checked out in worktree %s; staying where you are.", result.BranchName, otherWorktree)
+		attached = false
+		out.Warn("Updated %s, but it is checked out in worktree %s so it cannot be checked out here: %v",
+			result.BranchName, otherWorktree, err)
 	}
 
-	out.Info("Resolved rebase conflict for %s.", output.CurrentBranch(result.BranchName))
+	if attached {
+		out.Info("Resolved rebase conflict for %s.", output.CurrentBranch(result.BranchName))
+	} else {
+		out.Info("Resolved rebase conflict for %s.", output.BranchName(result.BranchName))
+	}
 	if result.RerereResolvedCount > 0 {
 		printRerereResolved(ctx, result.RerereResolvedCount)
 	}
@@ -136,8 +144,25 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 	// you end up. Unset for every other command, which correctly leaves the
 	// user on the branch they just resolved.
 	if continuation.ReturnToBranch != "" && continuation.ReturnToBranch != result.BranchName {
-		if err := eng.CheckoutBranch(ctx.Context, eng.GetBranch(continuation.ReturnToBranch)); err != nil {
+		if err := eng.CheckoutBranch(ctx.Context, eng.GetBranch(continuation.ReturnToBranch)); err == nil {
+			attached = true
+		} else {
 			out.Error("Failed to return to %s: %v", continuation.ReturnToBranch, err)
+		}
+	}
+
+	// The rebase left HEAD detached and the branch could not be checked out
+	// here, so land on a real branch rather than returning success from a
+	// detached HEAD, where the user's next commit belongs to nothing. Trunk is
+	// the one branch that is always present; if it too is held elsewhere, say
+	// plainly where the user ended up instead of implying they are on a branch.
+	if !attached {
+		trunk := eng.Trunk()
+		if err := eng.CheckoutBranch(ctx.Context, trunk); err == nil {
+			out.Info("Switched to %s; %s lives in its own worktree.",
+				output.BranchName(trunk.GetName()), output.BranchName(result.BranchName))
+		} else {
+			out.Warn("HEAD is detached here. Run 'stackit checkout <branch>' to get back onto a branch.")
 		}
 	}
 

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -60,6 +60,16 @@ func (e *engineImpl) branchWorktreeResetTarget(ctx context.Context, branchName s
 	if err != nil || dirty {
 		return ""
 	}
+	// Tracked changes are not the only thing a reset destroys.
+	// WorktreeHasTrackedChanges deliberately ignores untracked files, so it
+	// cannot see the one case `git reset --hard` does overwrite them: an
+	// untracked file sitting at a path the incoming tree also contains. That
+	// file was never in git, so there is no reflog or stash to recover it from.
+	// The batch path guards this through untrackedCollisionHold; this one-off
+	// path has to ask the same question.
+	if collides, known := e.UntrackedCollision(ctx, branchName); collides || !known {
+		return ""
+	}
 	return worktreePath
 }
 

--- a/internal/integration/continue_sibling_worktree_test.go
+++ b/internal/integration/continue_sibling_worktree_test.go
@@ -1,7 +1,12 @@
 package integration
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestContinueResetsRebasedBranchSiblingWorktree covers the half of the
@@ -50,4 +55,56 @@ func TestContinueResetsRebasedBranchSiblingWorktree(t *testing.T) {
 		OutputNotContains(" M ")
 
 	wt.Git("diff HEAD --stat").OutputNotContains("common.txt")
+
+	// The rebased branch is checked out elsewhere, so it cannot be attached
+	// here — but the command must still land the user on a branch. Returning
+	// success from the detached HEAD `git rebase` left behind means their next
+	// commit belongs to nothing.
+	sh.Git("symbolic-ref -q HEAD").OutputContains("refs/heads/")
+}
+
+// TestContinueDoesNotDestroyUntrackedFileInSiblingWorktree covers the hazard the
+// sibling-worktree reset introduced.
+//
+// `git reset --hard` leaves untracked files alone except in one case: when the
+// incoming tree contains a file at that same path, it is overwritten. The file
+// was never in git, so there is no reflog, stash or snapshot to recover it. The
+// batch restack path guards this through untrackedCollisionHold; the one-off
+// reset on the continue path must ask the same question.
+func TestContinueDoesNotDestroyUntrackedFileInSiblingWorktree(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+
+	sh.WriteFile("common.txt", "base").Run("create a -m 'a'")
+	sh.WriteFile("common.txt", "base\nb content").Run("create b -m 'b'")
+
+	worktreeDir := t.TempDir()
+	sh.Checkout("a")
+	sh.Git("worktree add " + worktreeDir + " b")
+	wt := sh.InWorktree(worktreeDir)
+
+	// Amend a so restacking b conflicts AND so the incoming tree introduces
+	// shared.txt — the path the sibling worktree is about to hold untracked.
+	sh.WriteFile("common.txt", "base\na conflicting change").
+		WriteFile("shared.txt", "from a").
+		Git("commit --amend --no-edit")
+
+	sh.RunExpectError("restack --upstack").
+		OutputContains("conflict")
+
+	// While resolving, the user writes an untracked file in the sibling
+	// worktree at exactly that path.
+	wt.WriteUnstaged("shared.txt", "PRECIOUS UNSAVED WORK")
+
+	sh.WriteFile("common.txt", "base\na conflicting change\nb content").
+		Run("continue")
+
+	// It must survive. Holding the reset leaves the worktree stale, which is
+	// recoverable; overwriting this file is not.
+	wt.Git("status --porcelain").OutputContains("shared.txt")
+	content, err := os.ReadFile(filepath.Join(worktreeDir, "shared.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "PRECIOUS UNSAVED WORK", strings.TrimSpace(string(content)),
+		"untracked file in sibling worktree was destroyed by continue")
 }


### PR DESCRIPTION

d7ed3e7d added a reset of the rebased branch's worktree, gated only on
WorktreeHasTrackedChanges. That helper ignores untracked files on the
premise that a reset cannot harm them, which is false in exactly one
case: `git reset --hard` overwrites an untracked file whose path the
incoming tree also contains. The file was never in git, so there is no
reflog, stash or snapshot to recover it from.

The batch restack path already guards this through untrackedCollisionHold;
the one-off continue path was given the tracked check but not that one, so
resolving a conflict on a branch checked out elsewhere could silently
replace a file the user had just written there. Ask the same question via
the existing UntrackedCollision helper, which compares the untracked paths
against the branch's incoming base. Holding the reset leaves the worktree
stale, which is recoverable; overwriting the file is not.

Also stop reporting success from a detached HEAD. When the branch lives in
another worktree it cannot be attached here, and the command printed
"staying where you are" plus a "(current)" label while leaving HEAD
detached and exiting 0 — so the next commit in that worktree would belong
to no branch. Surface the underlying checkout error, drop the false label,
and land on trunk; if even that is held elsewhere, say plainly that HEAD is
detached and how to get back.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1628** 👈
  * **PR #1629**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->