### PR TITLE
fix(git): require Git 2.36 explicitly instead of degrading to a silent no-op

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,7 +721,7 @@ Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for gui
 
 ### Requirements
 
-- **Git 2.25+**
+- **Git 2.36+** (`git worktree list -z`, used by every stack operation to see which branches are checked out where)
 - **GitHub CLI (`gh`)** for PR operations
 - **Go 1.26+** (if building from source)
 - **tmux** (required by overmind)

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -114,10 +114,16 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 	// `git worktree list` N times for the "reset other worktree's working dir"
 	// check; the snapshot is stable across the restack loop since we don't
 	// add or remove worktrees here.
+	//
+	// A failure here is fatal rather than conservative. Without the checkout map
+	// no ref move is safe, so branchHeldBack holds every branch — and a held
+	// branch returns RestackUnneeded, which every caller renders as "up to
+	// date". That turned an unreadable worktree list into commands reporting
+	// success while leaving the whole stack unrestacked, with only the restack
+	// command printing a warning and modify/sync/squash/absorb printing nothing.
 	worktrees, err := e.git.ListWorktrees(ctx)
-	worktreeInspectionFailed := err != nil
 	if err != nil {
-		worktrees = git.WorktreeList{}
+		return RestackBatchResult{}, fmt.Errorf("cannot restack without inspecting Git worktrees: %w", err)
 	}
 
 	// Snapshot which of those worktrees have tracked-file changes before any
@@ -190,7 +196,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 			metaRefSHAs[strings.TrimPrefix(refName, git.MetadataRefPrefix)] = sha
 		}
 	}
-	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees, untrackedByWorktree: untrackedByWorktree, heldBranches: heldBranches, worktreeInspectionFailed: worktreeInspectionFailed}
+	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees, untrackedByWorktree: untrackedByWorktree, heldBranches: heldBranches}
 
 	// 2. Apply the restack changes
 	results := make(map[string]RestackBranchResult)

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -102,9 +102,6 @@ type restackSnapshot struct {
 	// must be held too: a validated child may otherwise be built on the target
 	// SHA of a parent that was ultimately not allowed to move.
 	heldBranches BranchNameSet
-	// worktreeInspectionFailed means the physical checkout map is unknown, so
-	// no ref move is safe for this pass.
-	worktreeInspectionFailed bool
 }
 
 // untrackedCollisionHold decides whether a worktree holding only untracked
@@ -171,9 +168,6 @@ func (e *engineImpl) holdBranch(ctx context.Context, branch Branch, snap *restac
 }
 
 func (e *engineImpl) branchHeldBack(branch Branch, snap *restackSnapshot) bool {
-	if snap.worktreeInspectionFailed {
-		return true
-	}
 	current := branch.GetName()
 	visited := make(map[string]bool)
 	// Metadata should be acyclic, but cap the walk as a second line of defense

--- a/internal/engine/restack_worktree_inspection_test.go
+++ b/internal/engine/restack_worktree_inspection_test.go
@@ -1,0 +1,52 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/git"
+)
+
+// blindWorktreeRunner wraps a real git.Runner and fails ListWorktrees, standing
+// in for any repo where the physical checkout map cannot be read — most
+// concretely a Git older than 2.36, which does not accept `worktree list -z`.
+type blindWorktreeRunner struct {
+	git.Runner
+}
+
+func (r *blindWorktreeRunner) ListWorktrees(context.Context) (git.WorktreeList, error) {
+	return nil, errors.New("injected: cannot list worktrees")
+}
+
+// TestRestackFailsLoudlyWhenWorktreesCannotBeInspected covers the reporting half
+// of the worktree guard.
+//
+// Without the checkout map, no ref move is safe, so every branch is held — and a
+// held branch returns RestackUnneeded, which callers render as "up to date".
+// That turned an unreadable worktree list into modify/sync/squash/absorb
+// reporting success while leaving the entire stack unrestacked. Refusing is the
+// only honest answer; the one thing this must not do is claim there was nothing
+// to do.
+func TestRestackFailsLoudlyWhenWorktreesCannotBeInspected(t *testing.T) {
+	t.Parallel()
+
+	dir, realGit := newOptimisticLockTestRepo(t)
+	ctx := context.Background()
+
+	trackingEngine, err := NewEngine(Options{RepoRoot: dir, Trunk: "main", Git: realGit})
+	require.NoError(t, err)
+	trackingImpl, ok := trackingEngine.(*engineImpl)
+	require.True(t, ok)
+	require.NoError(t, trackingImpl.TrackBranch(ctx, "feature", "main"))
+
+	blindGit := &blindWorktreeRunner{Runner: realGit}
+	eng, err := NewEngine(Options{RepoRoot: dir, Trunk: "main", Git: blindGit})
+	require.NoError(t, err)
+
+	_, err = eng.RestackBranches(ctx, BranchesFromNames(eng, []string{"feature"}))
+	require.Error(t, err, "an uninspectable worktree list must not be reported as nothing to do")
+	require.Contains(t, err.Error(), "inspecting Git worktrees")
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -252,6 +252,12 @@ func (r *runner) ForceRemoveWorktree(ctx context.Context, path string) error {
 // invoking git per branch — see WorktreeList.PathForBranch.
 func (r *runner) ListWorktrees(ctx context.Context) (WorktreeList, error) {
 	// -z is required because worktree paths may legally contain newlines.
+	// `git worktree list` only learned it in 2.36, and every caller treats an
+	// inspection failure as "no ref move is safe", so on an older git this
+	// would otherwise present as commands quietly declining to do anything.
+	if !r.isGitVersionAtLeast(ctx, 2, 36) {
+		return nil, fmt.Errorf("git worktree list -z requires Git 2.36 or later; please upgrade your Git installation")
+	}
 	output, err := r.RunGitCommandWithContext(ctx, "worktree", "list", "--porcelain", "-z")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list worktrees: %w", err)


### PR DESCRIPTION

3ec80337 added -z to `git worktree list --porcelain` so worktree paths
containing newlines parse correctly. That option landed in Git 2.36, while
README documented the requirement as Git 2.25+ — and the failure was
invisible. ListWorktrees errored, restackBranches recorded
worktreeInspectionFailed, branchHeldBack held every branch, and a held
branch returns RestackUnneeded, which callers render as "up to date". On
Ubuntu 22.04 (Git 2.34) `stackit modify` amended a branch and then
reported its stale children as current.

Check the version up front so the cause is named, and make an
uninspectable worktree list fatal to the restack rather than conservative.
Holding every branch was never a safe degradation: it did nothing and said
it had succeeded, and only the restack command printed a warning — modify,
sync, squash and absorb reach the engine directly and printed nothing. With
the hard error, worktreeInspectionFailed can no longer be set, so the flag
and its branchHeldBack check go away with it.

Document the real floor in README.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #1628**
  * **PR #1629** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->