### PR TITLE
perf(get): batch-freeze new branches in a single transaction

### DIFF
--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -250,6 +250,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 	// Track statistics for summary
 	var branchesCreated, branchesUpdated int
 	branchFrozenStatus := make(map[string]bool) // branch -> is frozen
+	branchesToFreeze := engine.NewBranchesBuilder(len(branchesToSync))
 
 	// Fetch PR info for branches in parallel if possible
 	if ctx.GitHub() != nil {
@@ -300,9 +301,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 			isFrozen := !opts.Unfrozen
 			branchFrozenStatus[branchName] = isFrozen
 			if isFrozen {
-				if _, err := eng.SetFrozen(ctx, engine.BranchesOf(eng.GetBranch(branchName)), true); err != nil {
-					out.Debug("Failed to freeze new branch %s: %v", branchName, err)
-				}
+				branchesToFreeze.Add(eng.GetBranch(branchName))
 			}
 			branchesCreated++
 
@@ -342,6 +341,12 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 				PRNumber: branchPRInfo[branchName],
 				IsNew:    false,
 			})
+		}
+	}
+
+	if freezeSet := branchesToFreeze.Build(); len(freezeSet) > 0 {
+		if _, err := eng.SetFrozen(ctx, freezeSet, true); err != nil {
+			out.Debug("Failed to freeze new branches: %v", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- `GetAction` (`internal/actions/get.go`) called `eng.SetFrozen` once per newly-created branch inside the sync loop, even though `SetFrozen` is documented as a batch API — it stages every update inside a single transaction (retry loop, batch metadata read, one commit).
- Every other production caller (`freeze.go`, `unfreeze.go`) already passes the full branch set in one call. `get.go` was the one place reinventing a per-item loop, matching the N+1 anti-pattern this codebase's style rules explicitly call out.
- With N newly-tracked branches (e.g. `stackit get --downstack` on a long chain), this paid N full transaction round-trips instead of 1.

## Change

Collect the branches that get frozen while the sync loop runs, then issue a single `eng.SetFrozen` call with the full batch after the loop completes. Behavior is unchanged — same branches end up frozen, same debug logging on failure — just one transaction instead of N.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/...`
- [x] `gofmt -l internal/actions/get.go` (clean)
- [x] `go test ./internal/actions/...` (all pass, including `TestGetAction`)
- [x] `go test ./internal/integration/... -run TestGet` (all pass, including force/metadata-discovery cases)


---
_Generated by [Claude Code](https://claude.ai/code/session_0162eAXP2jrSsrMFHBuQQQwc)_