### PR TITLE
fix: make the Git 2.36 requirement discoverable and stop it misfiring

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to Stackit! This document outlines t
 
 ### Prerequisites
 
-- **Git 2.25+**
+- **Git 2.36+**
 - **GitHub CLI (`gh`)** for PR operations
 - **[mise](https://mise.jdx.dev/)** - Tool version manager and task runner
 

--- a/doc/src/start/index.md
+++ b/doc/src/start/index.md
@@ -18,7 +18,7 @@ Welcome to stackit! This guide will help you get up and running with stacked cha
 
 Make sure you have:
 
-- **Git 2.25+** installed
+- **Git 2.36+** installed (`git worktree list -z`, used by every stack operation to see which branches are checked out where)
 - **GitHub CLI (`gh`)** for PR operations
 - A GitHub repository to work with
 

--- a/internal/actions/continue.go
+++ b/internal/actions/continue.go
@@ -128,6 +128,7 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 	if result.RerereResolvedCount > 0 {
 		printRerereResolved(ctx, result.RerereResolvedCount)
 	}
+	reportUnresetWorktree(out, result)
 
 	// Continue with remaining branches to restack
 	if len(continuation.BranchesToRestack) > 0 {
@@ -172,4 +173,22 @@ func ContinueAction(ctx *app.Context, opts ContinueOptions) error {
 	}
 
 	return nil
+}
+
+// reportUnresetWorktree tells the user about a worktree left holding pre-rebase
+// content under a ref that has since moved.
+//
+// Nothing else will surface this. The worktree is not the one they are standing
+// in, `git status` there reports the rebased commit's files as deleted, and the
+// next `stackit modify -a` run in it commits that deletion — silently reverting
+// the rebase they just resolved. The remedy lives in a directory they are not
+// looking at, so name it.
+func reportUnresetWorktree(out output.Output, result engine.ContinueRebaseResult) {
+	if result.UnresetWorktree == "" {
+		return
+	}
+	out.Warn("Worktree %s still has %s checked out at the pre-rebase content because %s.",
+		result.UnresetWorktree, result.BranchName, result.UnresetReason)
+	out.Warn("Commit or discard the changes there, then run 'git reset --hard %s' in that worktree.",
+		result.BranchName)
 }

--- a/internal/actions/doctor/environment.go
+++ b/internal/actions/doctor/environment.go
@@ -12,14 +12,31 @@ import (
 
 // checkEnvironment performs environment-related checks
 func checkEnvironment(runner git.Runner, handler Handler, warnings int, errors int) (int, int) {
-	// Check git version
+	// Check git version. The floor is not cosmetic: below it ListWorktrees
+	// fails, and every ref-moving command inspects worktrees first — so a git
+	// that is merely present but too old leaves the user with a tool that
+	// refuses to do anything. Reporting it as passed here is how that turns into
+	// a bug report instead of an upgrade.
 	gitVersion, err := exec.Command("git", "version").Output()
-	if err != nil {
+	switch {
+	case err != nil:
 		errors++
 		handler.OnCheck("git", CheckError, "git is not installed or not in PATH")
-	} else {
+	default:
 		version := strings.TrimSpace(string(gitVersion))
-		handler.OnCheck("git", CheckPassed, version)
+		major, minor, versionErr := runner.GitVersion(context.Background())
+		switch {
+		case versionErr != nil:
+			warnings++
+			handler.OnCheck("git", CheckWarning, fmt.Sprintf("%s (could not determine version: %v)", version, versionErr))
+		case !git.AtLeast(major, minor, git.MinGitMajor, git.MinGitMinor):
+			errors++
+			handler.OnCheck("git", CheckError, fmt.Sprintf(
+				"%s is too old; stackit requires Git %d.%d or later. Stack operations will fail until you upgrade.",
+				version, git.MinGitMajor, git.MinGitMinor))
+		default:
+			handler.OnCheck("git", CheckPassed, version)
+		}
 	}
 
 	// Check gh CLI

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -31,6 +31,12 @@ func (d *demoGitRunner) GetRemote() string {
 	return "origin"
 }
 
+// GitVersion reports a version new enough to clear every feature gate, since
+// demo mode never shells out to git.
+func (d *demoGitRunner) GitVersion(_ context.Context) (int, int, error) {
+	return git.MinGitMajor, git.MinGitMinor, nil
+}
+
 func (d *demoGitRunner) FetchRemoteShas(_ context.Context, _ string) (map[string]string, error) {
 	return make(map[string]string), nil
 }

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -334,15 +334,15 @@ func (e *engineImpl) ContinueRebase(ctx context.Context, branchName string, reba
 	// ref without doing so.
 	//
 	// Resolved before the ref moves; see branchWorktreeResetTarget for why.
-	worktreeToReset := e.branchWorktreeResetTarget(ctx, branchName)
+	reset := e.branchWorktreeResetTarget(ctx, branchName)
 
 	err = e.git.UpdateBranchRefCAS(ctx, branchName, newRev, expectedBranchRevision)
 	if err != nil {
 		return ContinueRebaseResult{BranchName: branchName}, fmt.Errorf("failed to update branch reference %s: %w", branchName, err)
 	}
 
-	if worktreeToReset != "" {
-		_ = e.git.ResetWorktreeWorkingDir(ctx, worktreeToReset) //nolint:errcheck // best-effort
+	if reset.ResetPath != "" {
+		_ = e.git.ResetWorktreeWorkingDir(ctx, reset.ResetPath) //nolint:errcheck // best-effort
 	}
 
 	// Update metadata
@@ -361,6 +361,8 @@ func (e *engineImpl) ContinueRebase(ctx context.Context, branchName string, reba
 		Result:              int(git.RebaseDone),
 		BranchName:          branchName,
 		RerereResolvedCount: result.RerereResolvedCount,
+		UnresetWorktree:     reset.HeldPath,
+		UnresetReason:       reset.HeldReason,
 	}, nil
 }
 

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -45,20 +45,28 @@ func (e *engineImpl) resetWorktreeIfClean(ctx context.Context, worktreePath stri
 // dirty and silently disables the reset — the same trap resetWorktreeIfClean
 // documents for the batch path.
 //
-// Best-effort: a worktree that cannot be inspected returns "" and is left
-// alone, since a reset is what would discard uncommitted work.
-func (e *engineImpl) branchWorktreeResetTarget(ctx context.Context, branchName string) string {
+// Best-effort: a worktree that cannot be inspected is left alone, since a reset
+// is what would discard uncommitted work.
+//
+// Declining to reset is not a silent outcome. The ref still moves, so that
+// worktree is left holding pre-move content under a moved ref — the divergence
+// the user's next `stackit modify -a` commits as a deletion. The reason is
+// returned so the caller can say so; see worktreeResetDecision.
+func (e *engineImpl) branchWorktreeResetTarget(ctx context.Context, branchName string) worktreeResetDecision {
 	worktrees, err := e.git.ListWorktrees(ctx)
 	if err != nil {
-		return ""
+		return worktreeResetDecision{}
 	}
 	worktreePath := worktrees.PathForBranch(branchName)
 	if worktreePath == "" {
-		return ""
+		return worktreeResetDecision{}
 	}
 	dirty, err := e.git.WorktreeHasTrackedChanges(ctx, worktreePath)
-	if err != nil || dirty {
-		return ""
+	switch {
+	case err != nil:
+		return worktreeResetDecision{HeldPath: worktreePath, HeldReason: fmt.Sprintf("it could not be inspected: %v", err)}
+	case dirty:
+		return worktreeResetDecision{HeldPath: worktreePath, HeldReason: "it has uncommitted changes"}
 	}
 	// Tracked changes are not the only thing a reset destroys.
 	// WorktreeHasTrackedChanges deliberately ignores untracked files, so it
@@ -67,10 +75,22 @@ func (e *engineImpl) branchWorktreeResetTarget(ctx context.Context, branchName s
 	// file was never in git, so there is no reflog or stash to recover it from.
 	// The batch path guards this through untrackedCollisionHold; this one-off
 	// path has to ask the same question.
-	if collides, known := e.UntrackedCollision(ctx, branchName); collides || !known {
-		return ""
+	switch collides, known := e.UntrackedCollision(ctx, branchName); {
+	case !known:
+		return worktreeResetDecision{HeldPath: worktreePath, HeldReason: "its untracked files could not be inspected"}
+	case collides:
+		return worktreeResetDecision{HeldPath: worktreePath, HeldReason: "an untracked file there would be overwritten"}
 	}
-	return worktreePath
+	return worktreeResetDecision{ResetPath: worktreePath}
+}
+
+// worktreeResetDecision is the outcome of branchWorktreeResetTarget: either a
+// worktree that is safe to reset once the ref moves, or one that was left
+// diverged and why. Both are empty when no worktree holds the branch.
+type worktreeResetDecision struct {
+	ResetPath  string
+	HeldPath   string
+	HeldReason string
 }
 
 // restackSnapshot bundles the branch-keyed state captured once per restack

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -421,6 +421,14 @@ type ContinueRebaseResult struct {
 	Result              int    // git.RebaseResult value (0 = RebaseDone, 1 = RebaseConflict)
 	BranchName          string // Only set if Result is RebaseDone
 	RerereResolvedCount int    // Number of rebase continuations handled by git rerere
+
+	// UnresetWorktree is a worktree holding BranchName that was left on
+	// pre-rebase content because resetting it would have discarded work. Its ref
+	// moved anyway — refusing that would throw away the conflict resolution the
+	// user just performed — so the divergence is real and only the user can
+	// clear it. Empty when nothing was held.
+	UnresetWorktree string
+	UnresetReason   string
 }
 
 // SubmitAction says whether submitting a branch will create a new PR or

--- a/internal/git/runner.go
+++ b/internal/git/runner.go
@@ -417,6 +417,9 @@ type Runner interface {
 	MetadataOperations
 	StackMetadataOperations
 
+	// Environment
+	GitVersion(ctx context.Context) (major, minor int, err error)
+
 	// Raw command execution
 	RunGitCommandWithContext(ctx context.Context, args ...string) (string, error)
 	RunGitCommandRawWithContext(ctx context.Context, args ...string) (string, error)
@@ -472,8 +475,9 @@ type runner struct {
 	// Started lazily on first use; lives for the lifetime of the runner.
 	objects *objectReader
 
-	// Cached git version info
-	gitVersionOnce   sync.Once
+	// Cached git version info. Guarded by a mutex rather than a sync.Once so a
+	// failed probe can be retried — see GitVersion.
+	gitVersionMu     sync.Mutex
 	gitVersionMajor  int
 	gitVersionMinor  int
 	gitVersionParsed bool

--- a/internal/git/stash.go
+++ b/internal/git/stash.go
@@ -3,8 +3,6 @@ package git
 import (
 	"context"
 	"fmt"
-	"regexp"
-	"strconv"
 	"strings"
 )
 
@@ -25,8 +23,8 @@ func (r *runner) StashPush(ctx context.Context, message string) (string, error) 
 // Note: The --staged flag requires Git 2.35 or later.
 func (r *runner) StashPushStaged(ctx context.Context, message string) (string, error) {
 	// Check Git version first - --staged requires Git 2.35+
-	if !r.isGitVersionAtLeast(ctx, 2, 35) {
-		return "", fmt.Errorf("git stash --staged requires Git 2.35 or later; please upgrade your Git installation")
+	if err := r.requireGitVersion(ctx, 2, 35, "git stash --staged"); err != nil {
+		return "", err
 	}
 
 	args := []string{"stash", gitCmdPush, "--staged"}
@@ -38,55 +36,6 @@ func (r *runner) StashPushStaged(ctx context.Context, message string) (string, e
 		return "", fmt.Errorf("stash push --staged failed: %w", err)
 	}
 	return output, nil
-}
-
-// isGitVersionAtLeast checks if the installed Git version is at least major.minor.
-// The version is cached after the first check to avoid repeated git --version calls.
-func (r *runner) isGitVersionAtLeast(ctx context.Context, major, minor int) bool {
-	r.gitVersionOnce.Do(func() {
-		r.parseGitVersion(ctx)
-	})
-
-	if !r.gitVersionParsed {
-		return false // Assume old version if parsing failed
-	}
-
-	if r.gitVersionMajor > major {
-		return true
-	}
-	if r.gitVersionMajor == major && r.gitVersionMinor >= minor {
-		return true
-	}
-	return false
-}
-
-// parseGitVersion parses and caches the Git version.
-func (r *runner) parseGitVersion(ctx context.Context) {
-	output, err := r.RunGitCommandWithContext(ctx, "--version")
-	if err != nil {
-		return // Leave gitVersionParsed as false
-	}
-
-	// Parse "git version X.Y.Z" format
-	// Examples: "git version 2.39.2", "git version 2.35.1.windows.2"
-	re := regexp.MustCompile(`git version (\d+)\.(\d+)`)
-	matches := re.FindStringSubmatch(strings.TrimSpace(output))
-	if len(matches) < 3 {
-		return
-	}
-
-	gitMajor, err := strconv.Atoi(matches[1])
-	if err != nil {
-		return
-	}
-	gitMinor, err := strconv.Atoi(matches[2])
-	if err != nil {
-		return
-	}
-
-	r.gitVersionMajor = gitMajor
-	r.gitVersionMinor = gitMinor
-	r.gitVersionParsed = true
 }
 
 // StashDrop drops the stash entry at ref. It refuses an empty ref: bare

--- a/internal/git/version.go
+++ b/internal/git/version.go
@@ -1,0 +1,105 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// MinGitMajor and MinGitMinor are the oldest Git that can run stackit's stack
+// operations. ListWorktrees needs `git worktree list -z`, which arrived in
+// 2.36, and every ref-moving command inspects worktrees before it moves
+// anything.
+const (
+	MinGitMajor = 2
+	MinGitMinor = 36
+)
+
+var gitVersionPattern = regexp.MustCompile(`git version (\d+)\.(\d+)`)
+
+// AtLeast reports whether the version major.minor is at least
+// wantMajor.wantMinor. Shared so the feature gates and `stackit doctor` cannot
+// disagree about what "too old" means.
+func AtLeast(major, minor, wantMajor, wantMinor int) bool {
+	return major > wantMajor || (major == wantMajor && minor >= wantMinor)
+}
+
+// GitVersion reports the installed Git's major and minor version.
+//
+// A successful probe is cached for the runner's lifetime. A failed one is
+// deliberately not: `git --version` can fail for reasons that say nothing about
+// the installed version — a canceled context, a working directory that no
+// longer exists — and caching that would make every later check report a
+// perfectly modern Git as too old. In the CLI that means one bad probe poisons
+// the command; in the long-lived server it poisons the repo's runner until the
+// process restarts.
+func (r *runner) GitVersion(ctx context.Context) (major, minor int, err error) {
+	r.gitVersionMu.Lock()
+	defer r.gitVersionMu.Unlock()
+
+	if r.gitVersionParsed {
+		return r.gitVersionMajor, r.gitVersionMinor, nil
+	}
+
+	major, minor, err = r.probeGitVersion(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	r.gitVersionMajor, r.gitVersionMinor, r.gitVersionParsed = major, minor, true
+	return major, minor, nil
+}
+
+func (r *runner) probeGitVersion(ctx context.Context) (int, int, error) {
+	output, err := r.RunGitCommandWithContext(ctx, "--version")
+	if err != nil {
+		return 0, 0, fmt.Errorf("could not run git --version: %w", err)
+	}
+	return parseGitVersion(output)
+}
+
+// parseGitVersion pulls major.minor out of `git --version` output.
+// Examples: "git version 2.39.2", "git version 2.35.1.windows.2".
+func parseGitVersion(output string) (int, int, error) {
+	reported := strings.TrimSpace(output)
+	matches := gitVersionPattern.FindStringSubmatch(reported)
+	if len(matches) < 3 {
+		return 0, 0, fmt.Errorf("could not parse a version out of %q", reported)
+	}
+
+	major, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("could not parse major version out of %q: %w", reported, err)
+	}
+	minor, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return 0, 0, fmt.Errorf("could not parse minor version out of %q: %w", reported, err)
+	}
+
+	return major, minor, nil
+}
+
+// requireGitVersion reports why feature cannot run on the installed Git, or nil
+// when it can.
+//
+// "could not determine the version" and "the version is too old" are reported
+// differently on purpose. Telling someone on Git 2.49 to upgrade because their
+// context was canceled sends them down entirely the wrong path, and these
+// gates now sit in front of ListWorktrees — which nearly every stack command
+// calls before it moves a ref.
+func (r *runner) requireGitVersion(ctx context.Context, major, minor int, feature string) error {
+	haveMajor, haveMinor, err := r.GitVersion(ctx)
+	if err != nil {
+		return fmt.Errorf("%s requires Git %d.%d or later, but the installed version could not be determined: %w",
+			feature, major, minor, err)
+	}
+
+	if AtLeast(haveMajor, haveMinor, major, minor) {
+		return nil
+	}
+
+	return fmt.Errorf("%s requires Git %d.%d or later (found %d.%d); please upgrade your Git installation",
+		feature, major, minor, haveMajor, haveMinor)
+}

--- a/internal/git/version_test.go
+++ b/internal/git/version_test.go
@@ -1,0 +1,104 @@
+package git
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGitVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		output  string
+		major   int
+		minor   int
+		wantErr bool
+	}{
+		{name: "plain", output: "git version 2.39.2", major: 2, minor: 39},
+		{name: "windows suffix", output: "git version 2.35.1.windows.2", major: 2, minor: 35},
+		{name: "apple suffix", output: "git version 2.39.5 (Apple Git-154)", major: 2, minor: 39},
+		{name: "trailing newline", output: "git version 2.36.0\n", major: 2, minor: 36},
+		{name: "two-component version", output: "git version 3.0", major: 3, minor: 0},
+		{name: "empty", output: "", wantErr: true},
+		{name: "unrelated output", output: "command not found", wantErr: true},
+		{name: "no minor component", output: "git version 2", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			major, minor, err := parseGitVersion(tt.output)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.major, major)
+			require.Equal(t, tt.minor, minor)
+		})
+	}
+}
+
+func TestAtLeast(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, AtLeast(2, 36, 2, 36), "equal meets the minimum")
+	require.True(t, AtLeast(2, 49, 2, 36), "same major, higher minor")
+	require.True(t, AtLeast(3, 0, 2, 36), "higher major with lower minor still passes")
+	require.False(t, AtLeast(2, 35, 2, 36), "same major, lower minor")
+	require.False(t, AtLeast(1, 99, 2, 36), "lower major with higher minor still fails")
+}
+
+// The version gate sits in front of ListWorktrees, which nearly every stack
+// command calls before moving a ref. A parse that stops matching the installed
+// git's output would take the whole tool down, so pin it against the real one.
+func TestGitVersionClearsMinimum(t *testing.T) {
+	t.Parallel()
+
+	r := &runner{}
+	major, minor, err := r.GitVersion(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, r.requireGitVersion(context.Background(), MinGitMajor, MinGitMinor, "test"),
+		"installed git %d.%d is below the minimum this test suite assumes", major, minor)
+}
+
+func TestRequireGitVersionDistinguishesTooOldFromUnknown(t *testing.T) {
+	t.Parallel()
+
+	r := &runner{}
+
+	// Too old: name the versions so the user knows what they have.
+	err := r.requireGitVersion(context.Background(), 99, 0, "git future-feature")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires Git 99.0 or later")
+	require.Contains(t, err.Error(), "please upgrade")
+
+	// Unknown: a probe failure must NOT be reported as an old git. Point the
+	// runner at a directory with no git to force the probe to fail.
+	broken := &runner{repoRoot: "/nonexistent-stackit-version-probe"}
+	brokenErr := broken.requireGitVersion(context.Background(), MinGitMajor, MinGitMinor, "git worktree list -z")
+	require.Error(t, brokenErr)
+	require.Contains(t, brokenErr.Error(), "could not be determined")
+	require.NotContains(t, brokenErr.Error(), "please upgrade")
+}
+
+// A failed probe must not be cached: latching it would make every later check
+// report a perfectly modern git as too old for the runner's lifetime.
+func TestGitVersionDoesNotCacheFailure(t *testing.T) {
+	t.Parallel()
+
+	r := &runner{repoRoot: "/nonexistent-stackit-version-probe"}
+	_, _, err := r.GitVersion(context.Background())
+	require.Error(t, err)
+	require.False(t, r.gitVersionParsed, "a failed probe must not be cached")
+
+	// Same runner, now able to reach git: the earlier failure must not persist.
+	r.repoRoot = ""
+	major, _, err := r.GitVersion(context.Background())
+	require.NoError(t, err, "a failed probe must be retried, not latched")
+	require.Positive(t, major)
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -255,8 +255,8 @@ func (r *runner) ListWorktrees(ctx context.Context) (WorktreeList, error) {
 	// `git worktree list` only learned it in 2.36, and every caller treats an
 	// inspection failure as "no ref move is safe", so on an older git this
 	// would otherwise present as commands quietly declining to do anything.
-	if !r.isGitVersionAtLeast(ctx, 2, 36) {
-		return nil, fmt.Errorf("git worktree list -z requires Git 2.36 or later; please upgrade your Git installation")
+	if err := r.requireGitVersion(ctx, MinGitMajor, MinGitMinor, "git worktree list -z"); err != nil {
+		return nil, err
 	}
 	output, err := r.RunGitCommandWithContext(ctx, "worktree", "list", "--porcelain", "-z")
 	if err != nil {

--- a/internal/integration/continue_sibling_worktree_test.go
+++ b/internal/integration/continue_sibling_worktree_test.go
@@ -98,7 +98,13 @@ func TestContinueDoesNotDestroyUntrackedFileInSiblingWorktree(t *testing.T) {
 	wt.WriteUnstaged("shared.txt", "PRECIOUS UNSAVED WORK")
 
 	sh.WriteFile("common.txt", "base\na conflicting change\nb content").
-		Run("continue")
+		Run("continue").
+		// Holding the reset is the safe call, but the ref still moved — so that
+		// worktree is now diverged and only the user can clear it. Saying
+		// nothing leaves them to discover it via a `modify -a` that commits the
+		// divergence as a deletion.
+		OutputContains(worktreeDir).
+		OutputContains("untracked file")
 
 	// It must survive. Holding the reset leaves the worktree stale, which is
 	// recoverable; overwriting this file is not.
@@ -107,4 +113,44 @@ func TestContinueDoesNotDestroyUntrackedFileInSiblingWorktree(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "PRECIOUS UNSAVED WORK", strings.TrimSpace(string(content)),
 		"untracked file in sibling worktree was destroyed by continue")
+}
+
+// TestContinueReportsUnresetDirtySiblingWorktree covers the common hold reason:
+// the sibling worktree has uncommitted tracked changes, so it cannot be reset.
+//
+// The ref moves regardless — refusing it would discard the conflict resolution
+// the user just performed — so the divergence is real. A held branch that is
+// never mentioned is indistinguishable from one that needed no work, and the
+// remedy lives in a directory the user is not looking at.
+func TestContinueReportsUnresetDirtySiblingWorktree(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+
+	sh.WriteFile("common.txt", "base").Run("create a -m 'a'")
+	sh.WriteFile("common.txt", "base\nb content").Run("create b -m 'b'")
+
+	worktreeDir := t.TempDir()
+	sh.Checkout("a")
+	sh.Git("worktree add " + worktreeDir + " b")
+	wt := sh.InWorktree(worktreeDir)
+
+	sh.WriteFile("common.txt", "base\na conflicting change").
+		Git("commit --amend --no-edit")
+
+	sh.RunExpectError("restack --upstack").OutputContains("conflict")
+
+	// Uncommitted tracked work in the sibling, which a reset would destroy.
+	wt.WriteUnstaged("common.txt", "base\nb content\nwork in progress")
+
+	sh.WriteFile("common.txt", "base\na conflicting change\nb content").
+		Run("continue").
+		OutputContains(worktreeDir).
+		OutputContains("uncommitted changes")
+
+	// The work is still there.
+	content, err := os.ReadFile(filepath.Join(worktreeDir, "common.txt"))
+	require.NoError(t, err)
+	require.Contains(t, string(content), "work in progress",
+		"uncommitted work in sibling worktree was destroyed by continue")
 }


### PR DESCRIPTION

Pre-release feedback on the v0.24.0..HEAD range. Four fixes, all in the
blast radius of this release's one hard breaking change.

The Git version probe failed closed and latched under a sync.Once: a
`git --version` that failed for any reason — a canceled context, a
missing working directory — cached "too old" for the runner's lifetime.
Since ListWorktrees now gates on 2.36 and nearly every stack command
inspects worktrees before moving a ref, that turned one bad probe into
"please upgrade your Git" on a perfectly modern Git, for the rest of the
process. Worse in the server, where a runner outlives the request. The
probe now caches only success, retries failure, and reports "could not
determine the version" separately from "the version is too old".

`stackit doctor` reported git as passed on any version, so the one tool
README points broken users at actively signalled their environment was
fine while every stack operation refused to run. It now fails the check
below the minimum, sharing the comparison with the feature gates so the
two cannot disagree.

The docs site and CONTRIBUTING still advertised Git 2.25+. README was
updated when the floor moved; these two were missed, and the install
page is what a new user reads before hitting the error.

Separately, `continue` moved a branch ref while declining to reset the
sibling worktree holding it, and said nothing. Declining is the right
call — the reset is what would destroy uncommitted work — but the ref
moves regardless, so that worktree is left on pre-rebase content under a
moved ref. `git status` there reports the rebased commit's files as
deleted and the next `modify -a` commits that deletion, silently
reverting the rebase. The remedy lives in a directory the user is not
looking at, so name it and say what to run.