### PR TITLE
fix(restack): restack clean descendants of dirty current branch

### DIFF
--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -196,7 +196,11 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 			metaRefSHAs[strings.TrimPrefix(refName, git.MetadataRefPrefix)] = sha
 		}
 	}
-	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees, untrackedByWorktree: untrackedByWorktree, heldBranches: heldBranches}
+	applyingBranches := make(BranchNameSet, len(branches))
+	for _, branch := range branches {
+		applyingBranches[branch.GetName()] = true
+	}
+	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees, untrackedByWorktree: untrackedByWorktree, heldBranches: heldBranches, applyingBranches: applyingBranches}
 
 	// 2. Apply the restack changes
 	results := make(map[string]RestackBranchResult)

--- a/internal/engine/restack_held_walk_test.go
+++ b/internal/engine/restack_held_walk_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -79,10 +80,16 @@ func TestBranchHeldBackCyclicMetadata(t *testing.T) {
 			"parent": "main",
 		})
 
-		snap := &restackSnapshot{heldBranches: make(BranchNameSet)}
+		snap := &restackSnapshot{heldBranches: make(BranchNameSet), applyingBranches: make(BranchNameSet)}
 		require.False(t, e.branchHeldBack(NewBranch("child", nil), snap))
 
 		snap.heldBranches["parent"] = true
+		require.False(t, e.branchHeldBack(NewBranch("child", nil), snap),
+			"a held ancestor that is not being applied already has its final ref")
+
+		snap.applyingBranches["parent"] = true
 		require.True(t, e.branchHeldBack(NewBranch("child", nil), snap))
+		require.False(t, e.holdBranchInOwnWorktree(context.Background(), NewBranch("child", nil), snap),
+			"ordinary rebases use the parent's current ref, so a held parent does not make its clean child unsafe")
 	})
 }

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -118,10 +118,15 @@ type restackSnapshot struct {
 	// depends on the incoming tree, which is only known per branch.
 	untrackedByWorktree map[string][]string
 	// heldBranches contains every branch whose checked-out worktree was dirty
-	// or could not be inspected before this pass. Descendants of these branches
-	// must be held too: a validated child may otherwise be built on the target
-	// SHA of a parent that was ultimately not allowed to move.
+	// or could not be inspected before this pass.
 	heldBranches BranchNameSet
+	// applyingBranches is the subset this restack pass will actually move. A
+	// held ancestor only blocks a validated child when it is in this set: then
+	// the child's plan may name the ancestor's would-be target SHA even though
+	// its ref was held back. A dirty current branch already amended by modify or
+	// squash is not being applied here, so descendants may safely use its
+	// current ref.
+	applyingBranches BranchNameSet
 }
 
 // untrackedCollisionHold decides whether a worktree holding only untracked
@@ -138,8 +143,9 @@ type restackSnapshot struct {
 // than untracked. Parents are restacked before their children, so by the time
 // this runs the parent ref already holds the tree that is about to arrive.
 //
-// The decision is recorded in the snapshot: a held branch must also hold its
-// descendants, and its worktree must not be reset afterwards.
+// The decision is recorded in the snapshot. If this branch is also being
+// applied in the validated plan, its descendants must be held; its worktree
+// must not be reset in either case.
 func (e *engineImpl) untrackedCollisionHold(ctx context.Context, branch Branch, snap *restackSnapshot) bool {
 	branchName := branch.GetName()
 	worktreePath := snap.worktrees.PathForBranch(branchName)
@@ -177,9 +183,22 @@ func (e *engineImpl) untrackedCollisionHold(ctx context.Context, branch Branch, 
 	return false
 }
 
-// holdBranch is the single hold decision every restack path consults: an
+// holdBranchInOwnWorktree is the hold decision for the ordinary rebase path.
+// That path rebases onto the parent's current ref, so a dirty ancestor does not
+// make this branch unsafe to move. Only this branch's own worktree can need
+// protection from the reset that follows its ref update.
+func (e *engineImpl) holdBranchInOwnWorktree(ctx context.Context, branch Branch, snap *restackSnapshot) bool {
+	if snap.heldBranches.Contains(branch.GetName()) {
+		return true
+	}
+	return e.untrackedCollisionHold(ctx, branch, snap)
+}
+
+// holdBranch is the hold decision for the validated-plan application path: an
 // ancestor already held, or this branch's own worktree holding something the
-// incoming tree would destroy.
+// incoming tree would destroy. A validated plan applies a parent's would-be
+// target SHA, so applying a child after holding its parent would record a
+// parent revision the child cannot actually be based on.
 func (e *engineImpl) holdBranch(ctx context.Context, branch Branch, snap *restackSnapshot) bool {
 	if e.branchHeldBack(branch, snap) {
 		return true
@@ -205,7 +224,7 @@ func (e *engineImpl) branchHeldBack(branch Branch, snap *restackSnapshot) bool {
 			return true
 		}
 		visited[current] = true
-		if snap.heldBranches.Contains(current) {
+		if snap.heldBranches.Contains(current) && snap.applyingBranches.Contains(current) {
 			return true
 		}
 		e.mu.RLock()
@@ -379,11 +398,12 @@ func (e *engineImpl) restackBranch(
 	// `stackit modify -a` commits that deletion — silently reverting those files
 	// inside the branch.
 	//
-	// This sits here rather than only in actions.PlanRestack (skipDirtyWorktreeStacks,
-	// which warns and is reached solely by the `restack` command) so that every
-	// caller of RestackBranches inherits it — modify, sync, squash, absorb,
-	// delete, split, reorder, pluck and insert all arrive here directly.
-	if e.holdBranch(ctx, branch, snap) {
+	// The validated-plan path has a matching guard that also holds descendants:
+	// it applies planned parent targets rather than the parent's current ref.
+	// The ordinary rebase path only needs this branch's own hold, which keeps
+	// modify and squash able to restack clean children after moving their dirty
+	// current branch's ref.
+	if e.holdBranchInOwnWorktree(ctx, branch, snap) {
 		return RestackBranchResult{Result: RestackUnneeded}, nil
 	}
 

--- a/internal/integration/restack_dirty_trunk_worktree_test.go
+++ b/internal/integration/restack_dirty_trunk_worktree_test.go
@@ -84,3 +84,45 @@ func TestModifyRestacksChildrenWhenTrunkWorktreeIsDirty(t *testing.T) {
 	// pre-amend a and this is the stale state modify claimed was up to date.
 	sh.Git("log b --format=%H").OutputContains(aRev)
 }
+
+// TestModifyRestacksCleanChildrenWhenCurrentWorktreeIsDirty covers the case
+// where modify has already moved the current branch's ref. Its own worktree is
+// necessarily dirty until the staged amendment and unrelated unstaged edit are
+// separated again, but clean descendants must still rebase onto that new ref.
+func TestModifyRestacksCleanChildrenWhenCurrentWorktreeIsDirty(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+	sh.CreateLinearStack3().Checkout("a")
+
+	// This staged change is the amendment. The tracked, unstaged edit is
+	// unrelated work in progress that must hold a's worktree, not b or c.
+	sh.Write("a_extra", "amended content").
+		WriteUnstaged("a.txt_test.txt", "work in progress on a").
+		Run("modify -n")
+
+	// b and c have no worktrees of their own, so they must be rebuilt on a's
+	// new tip rather than reported as up to date because a is held.
+	sh.Git("merge-base --is-ancestor a b")
+	sh.Git("merge-base --is-ancestor b c")
+	sh.Git("status --porcelain").OutputContains("a.txt_test.txt")
+}
+
+// TestSquashRestacksCleanChildrenWhenCurrentWorktreeIsDirty exercises the
+// same validated-plan application path for squash. Squash moves a's ref while
+// its unrelated tracked edit remains unstaged, then b must rebase onto a.
+func TestSquashRestacksCleanChildrenWhenCurrentWorktreeIsDirty(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+	sh.Write("a", "first commit").Run("create a -m 'feat: a'")
+	sh.Write("a_extra", "second commit").Run("modify -c -m 'feat: a extra'")
+	sh.Write("b", "child commit").Run("create b -m 'feat: b'")
+
+	sh.Checkout("a").
+		WriteUnstaged("a_test.txt", "work in progress on a").
+		Run("squash --no-edit")
+
+	sh.Git("merge-base --is-ancestor a b")
+	sh.Git("status --porcelain").OutputContains("a_test.txt")
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1786228982`.


* **PR #1635** 👈
  * **PR #1636**
    * **PR #1638**
      * **PR #1639**
        * **PR #1637**
          * **PR #1640**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1641 by jonnii*