### PR TITLE
fix(restack): check all untracked paths for collisions

### DIFF
--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -514,11 +514,6 @@ func (r *runner) ListWorktreeMetas() (map[string]*WorktreeMeta, error) {
 	return result, nil
 }
 
-// maxUntrackedCollisionPaths bounds how many paths TreeContainsAnyPath will ask
-// git about in one invocation. Beyond this the caller is expected to fall back
-// to a conservative answer rather than build an unbounded argv.
-const maxUntrackedCollisionPaths = 200
-
 // TreeContainsAnyPath reports whether rev's tree contains any of paths.
 //
 // This answers the only question that makes an untracked file unsafe during a
@@ -533,14 +528,24 @@ func (r *runner) TreeContainsAnyPath(ctx context.Context, rev string, paths []st
 	if rev == "" || len(paths) == 0 {
 		return false, true
 	}
-	if len(paths) > maxUntrackedCollisionPaths {
-		return false, false
+
+	// List the tree once and intersect it in-process instead of passing the
+	// untracked paths as pathspecs. This keeps an arbitrary number of ordinary
+	// untracked files from becoming an "unknown" safety result solely because
+	// they exceed an argv cap.
+	wanted := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		wanted[path] = struct{}{}
 	}
 
-	args := append([]string{"ls-tree", "-r", "-z", "--name-only", rev, "--"}, paths...)
-	out, err := r.RunGitCommandRawWithContext(ctx, args...)
+	out, err := r.RunGitCommandRawWithContext(ctx, "ls-tree", "-r", "-z", "--name-only", rev)
 	if err != nil {
 		return false, false
 	}
-	return strings.TrimSpace(strings.ReplaceAll(out, "\x00", "")) != "", true
+	for _, path := range splitNulTerminated(out) {
+		if _, ok := wanted[path]; ok {
+			return true, true
+		}
+	}
+	return false, true
 }

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -2,6 +2,7 @@ package git_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,6 +12,32 @@ import (
 	"github.com/getstackit/stackit/internal/git"
 	"github.com/getstackit/stackit/testhelpers"
 )
+
+func TestTreeContainsAnyPathLargePathSet(t *testing.T) {
+	t.Parallel()
+
+	scene := testhelpers.NewScene(t, func(s *testhelpers.Scene) error {
+		return s.Repo.CreateChangeAndCommit("tracked", "tracked")
+	})
+	runner := git.NewRunnerWithPath(scene.Repo.Dir, nil)
+
+	// This must remain a known, non-collision result. An arbitrary path-count
+	// cap used to turn it into "unknown", which holds the branch and all of its
+	// validated-plan descendants despite none of the files being at risk.
+	// One over the old cap, plus room for the colliding path appended below.
+	paths := make([]string, 201, 202)
+	for i := range paths {
+		paths[i] = fmt.Sprintf("untracked-%03d.txt", i)
+	}
+	collides, known := runner.TreeContainsAnyPath(context.Background(), "HEAD", paths)
+	require.True(t, known)
+	require.False(t, collides)
+
+	paths = append(paths, "tracked_test.txt")
+	collides, known = runner.TreeContainsAnyPath(context.Background(), "HEAD", paths)
+	require.True(t, known)
+	require.True(t, collides)
+}
 
 func TestWorktree(t *testing.T) {
 	t.Run("lists ignored files", func(t *testing.T) {

--- a/internal/integration/restack_dirty_maintree_test.go
+++ b/internal/integration/restack_dirty_maintree_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -39,6 +40,34 @@ func TestRestackWithHarmlessUntrackedFileProceeds(t *testing.T) {
 		OutputContains("?? scratch.txt").
 		OutputNotContains(" D ").
 		OutputNotContains("D  ")
+}
+
+// TestRestackWithManyHarmlessUntrackedFilesProceeds keeps the safety rule
+// path-based even in repositories with generated or scratch files. More than
+// 200 non-colliding files must not turn collision detection into "unknown" and
+// hold this branch or its descendants.
+func TestRestackWithManyHarmlessUntrackedFilesProceeds(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+	sh.CreateLinearStack3().Checkout("a")
+
+	sh.Checkout("main").
+		WriteFile("trunk1.txt", "trunk content").
+		Git("commit -m 'chore: trunk commit'").
+		Checkout("a")
+
+	for i := range 201 {
+		sh.WriteUnstaged(fmt.Sprintf("scratch-%03d.txt", i), "scratch note")
+	}
+
+	sh.Run("restack --upstack")
+
+	// a and its clean descendants all restacked despite the large harmless set.
+	for _, branch := range []string{"a", "b", "c"} {
+		sh.Git("ls-tree " + branch + " -- trunk1.txt").OutputContains("trunk1.txt")
+	}
+	sh.Git("status --porcelain").OutputContains("?? scratch-000.txt")
 }
 
 // TestRestackHoldsBranchWhenUntrackedFileWouldBeOverwritten covers the case the


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1786228982`.


* **PR #1635**
  * **PR #1636** 👈
    * **PR #1638**
      * **PR #1639**
        * **PR #1637**
          * **PR #1640**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1641 by jonnii*