### PR TITLE
fix(restack): report held branches instead of "up to date"

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,11 +495,16 @@ branches listed under `conflicts` and their untouched descendants under
 `blocked`; `"status": "error"` is reserved for a restack that actually failed.
 The repository is left on the original branch, not mid-rebase.
 
+Because a conflict is reported as data, **it exits 0** — branch on
+`.status == "conflict"` or `.conflict_count`, not on the exit code.
+
 Restack also holds back any branch whose worktree it cannot safely reset — one
 with uncommitted changes, a rebase in progress, or that cannot be inspected —
 along with that branch's descendants. Held branches are reported with the
 worktree and the reason, and picked up on the next restack once the worktree is
-clean.
+clean. In JSON they appear under `held` as `{branch, reason}` — and also in
+`skipped`, so an empty `conflicts` list alone does not mean the whole stack
+moved.
 
 ---
 

--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -180,8 +180,7 @@ Rebase-in-progress detection currently lives in `skipDirtyWorktreeStacks`, which
 only the `restack` command runs. The engine snapshot keys its hold set on the
 worktree's checked-out branch, and a mid-rebase worktree reports no branch — so
 `modify`, `squash`, and absorb-driven restacks can still move the ref of a
-branch being rebased elsewhere. Known gap, tracked in
-`docs/plans/worktree-audit-todo.md`.
+branch being rebased elsewhere. Known gap.
 
 Untracked files are the case worth being careful about. `git reset --hard`
 overwrites an untracked file only when the incoming commit contains that same
@@ -224,20 +223,29 @@ A held branch returns `RestackUnneeded` — the same status as a branch that
 needed no work — so anything that could leave a user believing a restack
 happened must say otherwise.
 
-`stackit restack` reports both units: the stack held behind a managed worktree
-and the individual branch held behind any other checkout, each with the worktree
-and the reason. Only the branch's *own* checkout produces a specific reason — a
-branch held because an ancestor is held falls back to the generic message, since
-the remedy lives with the ancestor.
+The engine carries the reason out on `RestackBranchResult.HeldBy`, phrased for
+the user and naming the worktree, so every command that restacks reports it
+rather than printing "up to date":
 
-`sync` reports the stack-level holds from its own gate
-(`SkipReasonForWorktree`), but **branch-level engine holds are not yet
-distinguished in sync**: `RestackBranchResult` carries no held marker, so they
-surface as ordinary completion. Two known gaps sit here — that marker, and
-rebase-in-progress detection in the engine snapshot and in sync's gate. Tracked
-in `docs/plans/worktree-audit-todo.md`.
+- `restack`, `modify`, `squash`, `absorb`, and the rest of the mutating commands
+  warn with `Held <branch> back: <reason>`.
+- `sync` renders the same reason on its restack row, in both the streaming and
+  interactive handlers, and excludes held branches from the "already current"
+  count (`isPlainUpToDate`).
+- `restack --json` lists them under `held` as `{branch, reason}`. They also stay
+  in `skipped`, so an empty `conflicts` list must not be read as "the whole
+  stack moved".
+
+A branch held because an *ancestor* is held reports the ancestor's reason
+prefixed with which ancestor it is, since the remedy lives there.
+
+`stackit restack` additionally reports the stack-level holds from its own gate
+(`skipDirtyWorktreeStacks`); `sync` reports those through
+`SkipReasonForWorktree`. Rebase-in-progress detection is still missing from the
+engine snapshot and from sync's gate — see "What holds a branch" above.
 
 **Source**: `internal/engine/engine_sync.go` (hold set construction),
+`internal/engine/restack_impl.go` (`holdBranch`, `branchHeldBack`),
 `internal/actions/restack.go` (`skipDirtyWorktreeStacks`, `heldWorktreeReason`).
 
 ## Performance: keep the squash scan cold

--- a/internal/actions/common.go
+++ b/internal/actions/common.go
@@ -65,6 +65,7 @@ type RestackProgress struct {
 	Conflict            bool                 // true if this is a conflict
 	LockReason          engine.LockReason    // why the branch is locked (empty if not locked)
 	Frozen              bool                 // true if the branch is frozen
+	HeldBy              string               // why a worktree held this branch back (empty if it was not held)
 	IsCurrent           bool                 // true if this is the current branch
 	Reparented          bool                 // true if the branch was reparented
 	OldParent           string               // the old parent name if reparented
@@ -423,6 +424,7 @@ func reportRestackResult(ctx *app.Context, branch engine.Branch, result engine.R
 			RerereResolvedCount: result.RerereResolvedCount,
 			LockReason:          result.LockReason,
 			Frozen:              result.Frozen,
+			HeldBy:              result.HeldBy,
 			IsCurrent:           branchName == currentBranchName,
 			Reparented:          result.Reparented,
 			OldParent:           result.OldParent,
@@ -452,6 +454,10 @@ func reportRestackResult(ctx *app.Context, branch engine.Branch, result engine.R
 		}
 	case engine.RestackUnneeded:
 		switch {
+		case result.HeldBy != "":
+			// A hold and "nothing to do" are the same status, so say which one
+			// happened — the remedy lives in another worktree.
+			ctx.Output.Warn("Held %s back: %s", output.Branch(branchName, branchName == currentBranchName), result.HeldBy)
 		case result.LockReason.IsLocked():
 			ctx.Output.Info("%s locked: %s", output.Branch(branchName, branchName == currentBranchName), result.LockReason)
 		case result.Frozen:

--- a/internal/actions/get.go
+++ b/internal/actions/get.go
@@ -406,6 +406,7 @@ func GetAction(ctx *app.Context, branchOrPR string, opts GetOptions, handler Get
 					PRNumber:            prNumber,
 					LockReason:          p.LockReason,
 					Frozen:              p.Frozen,
+					HeldBy:              p.HeldBy,
 					IsCurrent:           p.IsCurrent,
 					Parent:              parentName,
 					Reparented:          p.Reparented,

--- a/internal/actions/restack.go
+++ b/internal/actions/restack.go
@@ -693,6 +693,7 @@ func handleRestackProgress(
 		PRNumber:            prNumber,
 		LockReason:          p.LockReason,
 		Frozen:              p.Frozen,
+		HeldBy:              p.HeldBy,
 		IsCurrent:           p.IsCurrent,
 		Parent:              parentName,
 		Reparented:          p.Reparented,

--- a/internal/actions/sync/restack.go
+++ b/internal/actions/sync/restack.go
@@ -105,6 +105,7 @@ func restackBranches(ctx *app.Context, branchesToRestack []string, restackScope 
 					PRNumber:   prNumber,
 					LockReason: p.LockReason,
 					Frozen:     p.Frozen,
+					HeldBy:     p.HeldBy,
 					IsCurrent:  p.IsCurrent,
 					Parent:     parentName,
 				})

--- a/internal/actions/sync/sync.go
+++ b/internal/actions/sync/sync.go
@@ -370,6 +370,7 @@ type Event struct {
 	Conflict            bool              // Is this a conflict?
 	LockReason          engine.LockReason // Why the branch is locked (empty if not locked)
 	Frozen              bool              // Is the branch frozen?
+	HeldBy              string            // Why a worktree held this branch back (empty if it was not held)
 	IsCurrent           bool              // Is this the current branch?
 	Parent              string            // Parent branch name (if applicable)
 	RerereResolvedCount int               // Number of rebase continuations handled by git rerere

--- a/internal/cli/branch/get_handlers.go
+++ b/internal/cli/branch/get_handlers.go
@@ -193,6 +193,14 @@ func (h *SimpleGetHandler) OnRestackBranch(event handlers.RestackBranchEvent) {
 			h.Output.Info("%s", actions.FormatRerereResolved(event.RerereResolvedCount))
 		}
 	case handlers.RestackUnneeded:
+		// A held branch reports the same status as one that needed no work, so
+		// warn instead of quietly claiming it is up to date.
+		if event.HeldBy != "" {
+			h.Output.Warn("  Held %s%s back: %s",
+				style.ColorBranchNameIf(event.Branch, event.IsCurrent), prInfo, event.HeldBy)
+			return
+		}
+
 		reason := common.ReasonNoRestackNeeded
 		if event.LockReason.IsLocked() {
 			reason = fmt.Sprintf("%s: %s", common.ReasonLocked, event.LockReason)

--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -285,6 +285,10 @@ func (h *SimpleSyncHandler) printRestackEvent(event syncAction.Event) {
 			if event.RerereResolvedCount > 0 {
 				h.Output.Info("%s", actions.FormatRerereResolved(event.RerereResolvedCount))
 			}
+		case event.HeldBy != "":
+			// A hold reports the same status as "nothing to do", so say which
+			// one happened — the remedy lives in another worktree.
+			h.item(event.Phase, "  %s Held %s%s back: %s", style.MarkWarning(), branchStr, prInfo, event.HeldBy)
 		case event.IsLocked():
 			h.item(event.Phase, "  %s%s %s: %s", branchStr, prInfo, common.ReasonLocked, event.LockReason)
 		case event.Frozen:
@@ -337,7 +341,7 @@ func (h *SimpleSyncHandler) OnRestackBranch(restack handlers.RestackBranchEvent)
 	rerereResolvedCount := restack.RerereResolvedCount
 	// Already-current branches are the expected default; suppress their rows
 	// and fold them into the summary count so only movement and problems print.
-	if isPlainUpToDate(result, lockReason, frozen, reparented) {
+	if isPlainUpToDate(restack) {
 		h.restackUpToDate++
 		return
 	}
@@ -359,6 +363,7 @@ func (h *SimpleSyncHandler) OnRestackBranch(restack handlers.RestackBranchEvent)
 		NewRevision:         newRev,
 		LockReason:          lockReason,
 		Frozen:              frozen,
+		HeldBy:              restack.HeldBy,
 		IsCurrent:           isCurrent,
 		Parent:              parent,
 		RerereResolvedCount: rerereResolvedCount,
@@ -431,11 +436,17 @@ func formatRestackSummaryLine(restacked, skipped, blocked, upToDate int) string 
 }
 
 // isPlainUpToDate reports whether a restack result is a no-op with nothing
-// worth showing — the branch was already current, not locked, frozen, or
-// reparented. Standalone restack suppresses these rows and folds them into the
-// summary count instead.
-func isPlainUpToDate(result syncAction.RestackResult, lockReason engine.LockReason, frozen, reparented bool) bool {
-	return result == syncAction.RestackUnneeded && !lockReason.IsLocked() && !frozen && !reparented
+// worth showing — the branch was already current, not locked, frozen, held back
+// by a worktree, or reparented. Standalone restack suppresses these rows and
+// folds them into the summary count instead. A held branch reports the same
+// RestackUnneeded status as one that needed no work, so it must be excluded
+// here or "I protected your work" is silently counted as "already current".
+func isPlainUpToDate(event handlers.RestackBranchEvent) bool {
+	return event.Result == syncAction.RestackUnneeded &&
+		!event.LockReason.IsLocked() &&
+		!event.Frozen &&
+		event.HeldBy == "" &&
+		!event.Reparented
 }
 
 // InteractiveSyncHandler provides bubbletea TUI for TTY environments
@@ -661,24 +672,15 @@ func (h *InteractiveSyncHandler) OnRestackStart(branchCount int) {
 
 // OnRestackBranch implements RestackHandler for standalone restack operations
 func (h *InteractiveSyncHandler) OnRestackBranch(restack handlers.RestackBranchEvent) {
-	branch := restack.Branch
-	result := restack.Result
-	newRev := restack.NewRevision
-	prNumber := restack.PRNumber
-	lockReason := restack.LockReason
-	frozen := restack.Frozen
-	isCurrent := restack.IsCurrent
-	parent := restack.Parent
 	reparented := restack.Reparented
 	oldParent := restack.OldParent
 	newParent := restack.NewParent
-	rerereResolvedCount := restack.RerereResolvedCount
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	// Already-current branches are the expected default; skip their rows but
 	// still advance the progress bar and count them for the summary.
-	if isPlainUpToDate(result, lockReason, frozen, reparented) {
+	if isPlainUpToDate(restack) {
 		h.restackUpToDate++
 		h.completedOps++
 		h.runner.Send(syncComponent.ProgressTickMsg{Completed: h.completedOps, Total: h.totalOps})
@@ -686,7 +688,7 @@ func (h *InteractiveSyncHandler) OnRestackBranch(restack handlers.RestackBranchE
 	}
 
 	// Build detail message
-	detail, mark := h.formatRestackDetail(branch, result, newRev, prNumber, lockReason, frozen, isCurrent, parent, rerereResolvedCount)
+	detail, mark := h.formatRestackDetail(restack)
 	if detail != "" {
 		if reparented {
 			detail = fmt.Sprintf("Reparented %s → %s. %s", oldParent, newParent, detail)
@@ -710,30 +712,36 @@ func (h *InteractiveSyncHandler) OnRestackBranch(restack handlers.RestackBranchE
 // status mark that should lead its row. The conflict case returns MarkWarn
 // rather than baking a glyph into the string, so the model owns the marker (the
 // streaming handler does the same).
-func (h *InteractiveSyncHandler) formatRestackDetail(branch string, result syncAction.RestackResult, newRev string, prNumber *int, lockReason engine.LockReason, frozen bool, isCurrent bool, parent string, rerereResolvedCount int) (string, syncComponent.DetailMark) {
+func (h *InteractiveSyncHandler) formatRestackDetail(event handlers.RestackBranchEvent) (string, syncComponent.DetailMark) {
 	prInfo := ""
-	if prNumber != nil {
-		prInfo = fmt.Sprintf(" (PR #%d)", *prNumber)
+	if event.PRNumber != nil {
+		prInfo = fmt.Sprintf(" (PR #%d)", *event.PRNumber)
 	}
 
-	displayName := style.ColorBranchNameIf(branch, isCurrent)
+	displayName := style.ColorBranchNameIf(event.Branch, event.IsCurrent)
 
-	switch result {
+	switch event.Result {
 	case syncAction.RestackDone:
 		msg := fmt.Sprintf("Restacked %s%s", displayName, prInfo)
-		if parent != "" {
-			msg += fmt.Sprintf(" on %s", parent)
+		if event.Parent != "" {
+			msg += fmt.Sprintf(" on %s", event.Parent)
 		}
-		msg += fmt.Sprintf(" → %s", newRev)
-		if rerereResolvedCount > 0 {
-			msg += " " + actions.FormatRerereResolved(rerereResolvedCount)
+		msg += fmt.Sprintf(" → %s", event.NewRevision)
+		if event.RerereResolvedCount > 0 {
+			msg += " " + actions.FormatRerereResolved(event.RerereResolvedCount)
 		}
 		return msg, syncComponent.MarkDone
 	case syncAction.RestackUnneeded:
+		// A hold reports the same status as "nothing to do", so mark it as a
+		// warning and say why — the remedy lives in another worktree.
+		if event.HeldBy != "" {
+			return fmt.Sprintf("Held %s%s back: %s", displayName, prInfo, event.HeldBy), syncComponent.MarkWarn
+		}
+
 		reason := common.ReasonNoRestackNeeded
-		if lockReason.IsLocked() {
-			reason = fmt.Sprintf("%s: %s", common.ReasonLocked, lockReason)
-		} else if frozen {
+		if event.LockReason.IsLocked() {
+			reason = fmt.Sprintf("%s: %s", common.ReasonLocked, event.LockReason)
+		} else if event.Frozen {
 			reason = common.ReasonFrozen
 		}
 

--- a/internal/engine/engine_sync.go
+++ b/internal/engine/engine_sync.go
@@ -145,7 +145,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 	// per branch once its incoming tree is known; see untrackedCollisionHold.
 	dirtyWorktrees := make(map[string]bool, len(worktrees))
 	untrackedByWorktree := make(map[string][]string)
-	heldBranches := make(BranchNameSet)
+	heldReasons := make(map[string]string)
 
 	e.mu.RLock()
 	trunk := e.trunk
@@ -158,25 +158,30 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 	// propagate through branchHeldBack's ancestry walk and silently hold every
 	// trunk-rooted branch in the repository. Marking the worktree dirty still
 	// stops any reset of it.
-	hold := func(branch string) {
+	hold := func(branch string, reason string) {
 		if branch != "" && branch != trunk {
-			heldBranches[branch] = true
+			heldReasons[branch] = reason
 		}
 	}
 
 	for _, worktree := range worktrees {
 		path := worktree.Path
 		tracked, trackedErr := e.git.WorktreeHasTrackedChanges(ctx, path)
-		if trackedErr != nil || tracked {
+		if trackedErr != nil {
 			dirtyWorktrees[path] = true
-			hold(worktree.Branch)
+			hold(worktree.Branch, fmt.Sprintf("worktree %s could not be inspected: %v", path, trackedErr))
+			continue
+		}
+		if tracked {
+			dirtyWorktrees[path] = true
+			hold(worktree.Branch, fmt.Sprintf("worktree %s has uncommitted changes", path))
 			continue
 		}
 		untracked, untrackedErr := e.git.GetUntrackedFilesIn(ctx, path)
 		if untrackedErr != nil {
 			// Cannot tell what is there, so no reset is safe.
 			dirtyWorktrees[path] = true
-			hold(worktree.Branch)
+			hold(worktree.Branch, fmt.Sprintf("untracked files in worktree %s could not be listed: %v", path, untrackedErr))
 			continue
 		}
 		if len(untracked) > 0 {
@@ -200,7 +205,7 @@ func (e *engineImpl) restackBranches(ctx context.Context, branches Branches, val
 	for _, branch := range branches {
 		applyingBranches[branch.GetName()] = true
 	}
-	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees, untrackedByWorktree: untrackedByWorktree, heldBranches: heldBranches, applyingBranches: applyingBranches}
+	snap := &restackSnapshot{meta: allMeta, revs: allRevisions, worktrees: worktrees, metaRefSHAs: metaRefSHAs, dirtyWorktrees: dirtyWorktrees, untrackedByWorktree: untrackedByWorktree, heldReasons: heldReasons, applyingBranches: applyingBranches}
 
 	// 2. Apply the restack changes
 	results := make(map[string]RestackBranchResult)

--- a/internal/engine/restack_held_walk_test.go
+++ b/internal/engine/restack_held_walk_test.go
@@ -36,16 +36,16 @@ func TestBranchHeldBackCyclicMetadata(t *testing.T) {
 	// The walk is capped by branch count, so a hang shows up as a test timeout
 	// rather than a wrong answer. Run it with a deadline to keep the failure
 	// legible instead of letting the whole package time out.
-	within := func(t *testing.T, fn func() bool) bool {
+	within := func(t *testing.T, fn func() string) string {
 		t.Helper()
-		done := make(chan bool, 1)
+		done := make(chan string, 1)
 		go func() { done <- fn() }()
 		select {
 		case got := <-done:
 			return got
 		case <-time.After(20 * time.Second):
 			t.Fatal("branchHeldBack did not terminate: the ancestry walk is unbounded")
-			return false
+			return ""
 		}
 	}
 
@@ -56,21 +56,24 @@ func TestBranchHeldBackCyclicMetadata(t *testing.T) {
 			"b": "c",
 			"c": "a",
 		})
-		snap := &restackSnapshot{heldBranches: make(BranchNameSet)}
+		snap := &restackSnapshot{heldReasons: make(map[string]string)}
 
 		// Nothing is held, but the parent chain never reaches trunk. Metadata
 		// that cannot say what a branch is stacked on is not safe to build on.
-		held := within(t, func() bool { return e.branchHeldBack(NewBranch("a", nil), snap) })
-		require.True(t, held)
+		// Either terminating guard — revisiting a branch, or running out of
+		// steps — is a correct hold; both mean the parent chain cannot say what
+		// this branch is stacked on.
+		held := within(t, func() string { return e.branchHeldBack(NewBranch("a", nil), snap) })
+		require.Contains(t, held, "cannot be determined")
 	})
 
 	t.Run("self-parent terminates", func(t *testing.T) {
 		t.Parallel()
 		e := newEngine(t, map[string]string{"a": "a"})
-		snap := &restackSnapshot{heldBranches: make(BranchNameSet)}
+		snap := &restackSnapshot{heldReasons: make(map[string]string)}
 
-		held := within(t, func() bool { return e.branchHeldBack(NewBranch("a", nil), snap) })
-		require.True(t, held)
+		held := within(t, func() string { return e.branchHeldBack(NewBranch("a", nil), snap) })
+		require.NotEmpty(t, held)
 	})
 
 	t.Run("acyclic chain still resolves normally", func(t *testing.T) {
@@ -80,16 +83,20 @@ func TestBranchHeldBackCyclicMetadata(t *testing.T) {
 			"parent": "main",
 		})
 
-		snap := &restackSnapshot{heldBranches: make(BranchNameSet), applyingBranches: make(BranchNameSet)}
-		require.False(t, e.branchHeldBack(NewBranch("child", nil), snap))
+		snap := &restackSnapshot{heldReasons: make(map[string]string), applyingBranches: make(BranchNameSet)}
+		require.Empty(t, e.branchHeldBack(NewBranch("child", nil), snap))
 
-		snap.heldBranches["parent"] = true
-		require.False(t, e.branchHeldBack(NewBranch("child", nil), snap),
+		snap.heldReasons["parent"] = "worktree /wt has uncommitted changes"
+		require.Empty(t, e.branchHeldBack(NewBranch("child", nil), snap),
 			"a held ancestor that is not being applied already has its final ref")
 
 		snap.applyingBranches["parent"] = true
-		require.True(t, e.branchHeldBack(NewBranch("child", nil), snap))
-		require.False(t, e.holdBranchInOwnWorktree(context.Background(), NewBranch("child", nil), snap),
+		held := e.branchHeldBack(NewBranch("child", nil), snap)
+		require.Contains(t, held, "ancestor parent",
+			"the reason must name the ancestor, not just report the child as up to date")
+		require.Contains(t, held, "worktree /wt has uncommitted changes",
+			"the reason must carry the originating worktree so the remedy is findable")
+		require.Empty(t, e.holdBranchInOwnWorktree(context.Background(), NewBranch("child", nil), snap),
 			"ordinary rebases use the parent's current ref, so a held parent does not make its clean child unsafe")
 	})
 }

--- a/internal/engine/restack_impl.go
+++ b/internal/engine/restack_impl.go
@@ -117,9 +117,12 @@ type restackSnapshot struct {
 	// worktrees that had no tracked changes. Whether those hold their branch
 	// depends on the incoming tree, which is only known per branch.
 	untrackedByWorktree map[string][]string
-	// heldBranches contains every branch whose checked-out worktree was dirty
-	// or could not be inspected before this pass.
-	heldBranches BranchNameSet
+	// heldReasons maps every branch whose checked-out worktree was dirty or
+	// could not be inspected before this pass to the reason, phrased for the
+	// user and naming the worktree. A held branch reports RestackUnneeded —
+	// the same status as one that needed no work — so the reason is what lets
+	// callers tell "I protected your work" from "there was nothing to do".
+	heldReasons map[string]string
 	// applyingBranches is the subset this restack pass will actually move. A
 	// held ancestor only blocks a validated child when it is in this set: then
 	// the child's plan may name the ancestor's would-be target SHA even though
@@ -146,21 +149,21 @@ type restackSnapshot struct {
 // The decision is recorded in the snapshot. If this branch is also being
 // applied in the validated plan, its descendants must be held; its worktree
 // must not be reset in either case.
-func (e *engineImpl) untrackedCollisionHold(ctx context.Context, branch Branch, snap *restackSnapshot) bool {
+func (e *engineImpl) untrackedCollisionHold(ctx context.Context, branch Branch, snap *restackSnapshot) string {
 	branchName := branch.GetName()
 	worktreePath := snap.worktrees.PathForBranch(branchName)
 	if worktreePath == "" {
-		return false
+		return ""
 	}
 	untracked := snap.untrackedByWorktree[worktreePath]
 	if len(untracked) == 0 {
-		return false
+		return ""
 	}
 
-	hold := func() bool {
+	hold := func(reason string) string {
 		snap.dirtyWorktrees[worktreePath] = true
-		snap.heldBranches[branchName] = true
-		return true
+		snap.heldReasons[branchName] = reason
+		return reason
 	}
 
 	e.mu.RLock()
@@ -173,23 +176,27 @@ func (e *engineImpl) untrackedCollisionHold(ctx context.Context, branch Branch, 
 	baseRev, err := e.GetBranch(parent).GetRevision()
 	if err != nil || baseRev == "" {
 		// Cannot see what is about to land, so cannot rule out a collision.
-		return hold()
+		return hold(fmt.Sprintf("untracked files in worktree %s could not be checked against the incoming commit", worktreePath))
 	}
 
 	collides, known := e.git.TreeContainsAnyPath(ctx, baseRev, untracked)
-	if !known || collides {
-		return hold()
+	switch {
+	case !known:
+		return hold(fmt.Sprintf("untracked files in worktree %s could not be checked against the incoming commit", worktreePath))
+	case collides:
+		return hold(fmt.Sprintf("worktree %s has untracked files the incoming commit would overwrite", worktreePath))
 	}
-	return false
+	return ""
 }
 
 // holdBranchInOwnWorktree is the hold decision for the ordinary rebase path.
 // That path rebases onto the parent's current ref, so a dirty ancestor does not
 // make this branch unsafe to move. Only this branch's own worktree can need
 // protection from the reset that follows its ref update.
-func (e *engineImpl) holdBranchInOwnWorktree(ctx context.Context, branch Branch, snap *restackSnapshot) bool {
-	if snap.heldBranches.Contains(branch.GetName()) {
-		return true
+// It returns the reason the branch is held, or "" when it is free to move.
+func (e *engineImpl) holdBranchInOwnWorktree(ctx context.Context, branch Branch, snap *restackSnapshot) string {
+	if reason := snap.heldReasons[branch.GetName()]; reason != "" {
+		return reason
 	}
 	return e.untrackedCollisionHold(ctx, branch, snap)
 }
@@ -199,15 +206,19 @@ func (e *engineImpl) holdBranchInOwnWorktree(ctx context.Context, branch Branch,
 // incoming tree would destroy. A validated plan applies a parent's would-be
 // target SHA, so applying a child after holding its parent would record a
 // parent revision the child cannot actually be based on.
-func (e *engineImpl) holdBranch(ctx context.Context, branch Branch, snap *restackSnapshot) bool {
-	if e.branchHeldBack(branch, snap) {
-		return true
+// It returns the reason the branch is held, or "" when it is free to move.
+func (e *engineImpl) holdBranch(ctx context.Context, branch Branch, snap *restackSnapshot) string {
+	if reason := e.branchHeldBack(branch, snap); reason != "" {
+		return reason
 	}
 	return e.untrackedCollisionHold(ctx, branch, snap)
 }
 
-func (e *engineImpl) branchHeldBack(branch Branch, snap *restackSnapshot) bool {
-	current := branch.GetName()
+// branchHeldBack returns why branch cannot move — its own worktree, or a held
+// ancestor this pass is also applying — or "" when nothing holds it.
+func (e *engineImpl) branchHeldBack(branch Branch, snap *restackSnapshot) string {
+	start := branch.GetName()
+	current := start
 	visited := make(map[string]bool)
 	// Metadata should be acyclic, but cap the walk as a second line of defense
 	// against malformed or concurrently changing parent metadata — a parent
@@ -216,29 +227,32 @@ func (e *engineImpl) branchHeldBack(branch Branch, snap *restackSnapshot) bool {
 	maxSteps := e.BranchNames().Len() + 1
 	for range maxSteps {
 		if current == "" {
-			return false
+			return ""
 		}
 		if visited[current] {
 			// A cycle means the metadata cannot be trusted to say what this
 			// branch is stacked on, so no ref move is safe: hold it.
-			return true
+			return "its recorded parent chain contains a cycle, so what it is stacked on cannot be determined"
 		}
 		visited[current] = true
-		if snap.heldBranches.Contains(current) && snap.applyingBranches.Contains(current) {
-			return true
+		if reason := snap.heldReasons[current]; reason != "" && snap.applyingBranches.Contains(current) {
+			if current == start {
+				return reason
+			}
+			return fmt.Sprintf("its ancestor %s is held back: %s", current, reason)
 		}
 		e.mu.RLock()
 		state := e.readState(current)
 		trunk := e.trunk
 		e.mu.RUnlock()
 		if state == nil || state.Parent == "" || current == trunk {
-			return false
+			return ""
 		}
 		current = state.Parent
 	}
 	// Ran out of steps without reaching trunk: the chain is longer than the
 	// branch count allows, so treat it as untrustworthy too.
-	return true
+	return "its recorded parent chain never reaches trunk, so what it is stacked on cannot be determined"
 }
 
 // branchRev returns branch's revision from the pass snapshot, falling back to a
@@ -403,8 +417,8 @@ func (e *engineImpl) restackBranch(
 	// The ordinary rebase path only needs this branch's own hold, which keeps
 	// modify and squash able to restack clean children after moving their dirty
 	// current branch's ref.
-	if e.holdBranchInOwnWorktree(ctx, branch, snap) {
-		return RestackBranchResult{Result: RestackUnneeded}, nil
+	if reason := e.holdBranchInOwnWorktree(ctx, branch, snap); reason != "" {
+		return RestackBranchResult{Result: RestackUnneeded, HeldBy: reason}, nil
 	}
 
 	// Worktree anchors are handled before the landed check, mirroring
@@ -851,8 +865,8 @@ func (e *engineImpl) applyMetadataRefresh(
 	// Metadata records the parent SHA consumed by later planning, so advancing
 	// it past a held parent would create the same phantom-parent state as a ref
 	// move. A held branch and every descendant must remain completely unchanged.
-	if e.holdBranch(ctx, branch, snap) {
-		return RestackBranchResult{Result: RestackUnneeded, RebasedBranchBase: item.ParentRev}, nil
+	if reason := e.holdBranch(ctx, branch, snap); reason != "" {
+		return RestackBranchResult{Result: RestackUnneeded, RebasedBranchBase: item.ParentRev, HeldBy: reason}, nil
 	}
 	meta := snap.meta.Get(branchName)
 	if meta == nil {
@@ -909,8 +923,8 @@ func (e *engineImpl) applyBranchAndMetadata(
 	// Hold the branch back instead. This is the plan path, reached by every
 	// caller of actions.RestackBranches (modify, squash, absorb, delete, split,
 	// reorder, pluck) as well as the `restack` command.
-	if e.holdBranch(ctx, branch, snap) {
-		return RestackBranchResult{Result: RestackUnneeded, RebasedBranchBase: parentRev}, nil
+	if reason := e.holdBranch(ctx, branch, snap); reason != "" {
+		return RestackBranchResult{Result: RestackUnneeded, RebasedBranchBase: parentRev, HeldBy: reason}, nil
 	}
 
 	meta := snap.meta.Get(branchName)

--- a/internal/engine/types.go
+++ b/internal/engine/types.go
@@ -355,6 +355,7 @@ type RestackBranchResult struct {
 	NewParent           string     // The new parent branch name (only set if Reparented is true)
 	LockReason          LockReason // Reason why the branch is locked
 	Frozen              bool       // True if the branch is frozen
+	HeldBy              string     // Why a worktree held this branch back (empty if it was not held); Result is RestackUnneeded
 	RerereResolvedCount int        // Number of rebase continuations handled by git rerere
 }
 

--- a/internal/handlers/restack.go
+++ b/internal/handlers/restack.go
@@ -47,6 +47,7 @@ type RestackBranchEvent struct {
 	PRNumber            *int
 	LockReason          engine.LockReason
 	Frozen              bool
+	HeldBy              string // why a worktree held this branch back (empty if it was not held)
 	IsCurrent           bool
 	Parent              string
 	Reparented          bool
@@ -92,6 +93,7 @@ type RestackJSONResult struct {
 	Restacked     []RestackBranchInfo   `json:"restacked,omitempty"`
 	Skipped       []string              `json:"skipped,omitempty"`
 	Conflicts     []RestackConflictInfo `json:"conflicts,omitempty"`
+	Held          []RestackHeldInfo     `json:"held,omitempty"`        // Branches a worktree held back; also present in Skipped
 	Blocked       []string              `json:"blocked,omitempty"`     // Branches left untouched because their stack contained a conflict
 	StackRoots    []string              `json:"stack_roots,omitempty"` // Deduped independent stack roots that were processed
 	TotalCount    int                   `json:"total_count"`
@@ -108,6 +110,14 @@ type RestackBranchInfo struct {
 	NewRev              string `json:"new_rev,omitempty"`
 	PRNumber            *int   `json:"pr_number,omitempty"`
 	RerereResolvedCount int    `json:"rerere_resolved_count,omitempty"`
+}
+
+// RestackHeldInfo represents a branch a worktree held back during restack.
+// Held branches are skipped rather than restacked, so scripts must not read an
+// empty conflict list as "the whole stack moved".
+type RestackHeldInfo struct {
+	Branch string `json:"branch"`
+	Reason string `json:"reason"`
 }
 
 // RestackConflictInfo represents a conflict during restack
@@ -158,6 +168,9 @@ func (h *JSONRestackHandler) OnRestackBranch(event RestackBranchEvent) {
 		})
 	case RestackUnneeded:
 		h.Result.Skipped = append(h.Result.Skipped, event.Branch)
+		if event.HeldBy != "" {
+			h.Result.Held = append(h.Result.Held, RestackHeldInfo{Branch: event.Branch, Reason: event.HeldBy})
+		}
 	case RestackConflict:
 		h.Result.Conflicts = append(h.Result.Conflicts, RestackConflictInfo{
 			Branch:    event.Branch,

--- a/internal/integration/hold_reporting_test.go
+++ b/internal/integration/hold_reporting_test.go
@@ -1,0 +1,62 @@
+package integration
+
+import (
+	"testing"
+)
+
+// A held branch returns RestackUnneeded — the same status as a branch that
+// needed no work — so without an explicit reason "I protected your work" and
+// "there was nothing to do" are indistinguishable. The remedy lives in another
+// worktree the user is not looking at, so the reason has to name it.
+//
+// See the "Hold Trunk Never, Report Holds Always" invariant in
+// .claude/rules/worktree-safety.md.
+
+// TestModifyReportsHeldBranchInsteadOfUpToDate covers the engine hold reaching
+// the user through modify, which restacks upstack branches after amending.
+func TestModifyReportsHeldBranchInsteadOfUpToDate(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+	sh.CreateLinearStack3()
+
+	// Park b in a plain git worktree and leave uncommitted tracked work there,
+	// so restacking b would have to reset over it.
+	worktreeDir := t.TempDir()
+	sh.Checkout("a")
+	sh.Git("worktree add " + worktreeDir + " b")
+	sh.InWorktree(worktreeDir).WriteUnstaged("b.txt_test.txt", "work in progress")
+
+	sh.Write("a_extra", "more work on a").
+		Run("modify -a -n").
+		OutputContains("Held").
+		OutputContains(worktreeDir).
+		OutputContains("uncommitted changes")
+}
+
+// TestRestackReportsHeldDescendantInsteadOfUpToDate covers a descendant held
+// because its ancestor is: the reason must name the ancestor and carry the
+// originating worktree, not report the descendant as up to date.
+func TestRestackReportsHeldDescendantInsteadOfUpToDate(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+	sh.CreateLinearStack3()
+
+	// Trunk advances so the whole stack genuinely needs restacking.
+	sh.Checkout("main").
+		WriteFile("trunk1.txt", "trunk content").
+		Git("commit -m 'chore: trunk commit'")
+
+	// b is held by its own dirty worktree; c is held only because b is.
+	worktreeDir := t.TempDir()
+	sh.Git("worktree add " + worktreeDir + " b")
+	sh.InWorktree(worktreeDir).WriteUnstaged("b.txt_test.txt", "work in progress")
+
+	sh.Checkout("a").Run("restack --upstack").
+		OutputContains("Held").
+		OutputContains(worktreeDir)
+
+	// c must not be silently counted as already current.
+	sh.OutputNotContains("c up to date")
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

A branch a worktree holds back returns RestackUnneeded, the same status as
one that needed no work, so "I protected your work" and "there was nothing
to do" were indistinguishable — and the remedy lives in another worktree the
user is not looking at. Only the restack command warned; modify, squash,
sync and absorb printed nothing.

The engine now carries the reason out on RestackBranchResult.HeldBy, phrased
for the user and naming the worktree, and every renderer surfaces it: the
action warns, sync prints it on the restack row and stops counting held
branches as already current, and --json lists them under held.

A branch held because an ancestor is held reports which ancestor and why,
rather than falling back to a generic message.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1786228982`.


* **PR #1635**
  * **PR #1636**
    * **PR #1638**
      * **PR #1639**
        * **PR #1637** 👈
          * **PR #1640**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1641 by jonnii*