### PR TITLE
fix(git): key batched commit info on the full refname

### DIFF
--- a/internal/git/commit_info.go
+++ b/internal/git/commit_info.go
@@ -70,7 +70,10 @@ func (r *runner) batchCommitInfo(branchNames []string) map[string]CommitInfo {
 		return results
 	}
 
-	args := []string{"for-each-ref", "--format=%(refname:short)\t%(authordate:iso-strict)\t%(authorname)"}
+	// %(refname), not %(refname:short): the short form disambiguates to
+	// "heads/<name>" when a tag shares the branch's name, and the caller looks
+	// results up by bare branch name — a miss silently yields a zero CommitInfo.
+	args := []string{"for-each-ref", "--format=%(refname)\t%(authordate:iso-strict)\t%(authorname)"}
 	for _, name := range branchNames {
 		args = append(args, "refs/heads/"+name)
 	}
@@ -92,7 +95,7 @@ func (r *runner) batchCommitInfo(branchNames []string) map[string]CommitInfo {
 		if err != nil {
 			continue
 		}
-		results[parts[0]] = CommitInfo{Date: date, Author: parts[2]}
+		results[strings.TrimPrefix(parts[0], "refs/heads/")] = CommitInfo{Date: date, Author: parts[2]}
 	}
 	return results
 }

--- a/internal/git/commit_info_test.go
+++ b/internal/git/commit_info_test.go
@@ -38,6 +38,30 @@ func TestBatchCommitInfo(t *testing.T) {
 	require.Equal(t, wantBranch1Author, got["branch1"].Author)
 }
 
+// A tag sharing a branch's name makes git disambiguate %(refname:short) to
+// "heads/<name>", which used to miss the caller's bare-branch-name lookup and
+// silently return a zero CommitInfo.
+func TestBatchCommitInfo_TagSharesBranchName(t *testing.T) {
+	t.Parallel()
+	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)
+
+	err := scene.Repo.CreateAndCheckoutBranch("shadowed")
+	require.NoError(t, err)
+	err = scene.Repo.CreateChangeAndCommit("shadowed change", "s1")
+	require.NoError(t, err)
+	require.NoError(t, scene.Repo.RunGitCommand("tag", "shadowed", "main"))
+
+	runner := git.NewRunnerWithPath(scene.Dir, nil)
+	wantDate, err := runner.GetCommitDate("refs/heads/shadowed")
+	require.NoError(t, err)
+
+	got := runner.BatchCommitInfo([]string{"shadowed"})
+
+	require.Contains(t, got, "shadowed", "result must be keyed by the bare branch name")
+	require.True(t, wantDate.Equal(got["shadowed"].Date))
+	require.NotEmpty(t, got["shadowed"].Author)
+}
+
 func TestBatchCommitInfo_Empty(t *testing.T) {
 	t.Parallel()
 	scene := testhelpers.NewSceneParallel(t, testhelpers.InitialCommitSceneSetup)


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

A tag sharing a branch name makes git disambiguate %(refname:short) to
"heads/<name>". The API mapper looks results up by bare branch name, so
those branches silently rendered an empty commitDate and commitAuthor in
the web UI. Key on %(refname) and strip the prefix instead.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1786228982`.


* **PR #1635**
  * **PR #1636**
    * **PR #1638** 👈
      * **PR #1639**
        * **PR #1637**
          * **PR #1640**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1641 by jonnii*