### PR TITLE
fix(actions): guard worktree ownership before taking a snapshot

### DIFF
--- a/internal/actions/fold/fold.go
+++ b/internal/actions/fold/fold.go
@@ -98,13 +98,6 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	currentBranch := eng.CurrentBranch().GetName()
 	currentBranchObj := eng.GetBranch(currentBranch)
 
-	// Take snapshot before modifying the repository
-	snapshotOpts := actions.NewSnapshot("fold",
-		actions.WithFlag(opts.Keep, "--keep"),
-		actions.WithFlag(opts.AllowTrunk, "--allow-trunk"),
-	)
-	actions.TakeBestEffortSnapshot(ctx, snapshotOpts)
-
 	// Get parent branch
 	parentName := currentBranchObj.GetParentOrTrunk()
 
@@ -117,6 +110,15 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	if err := actions.EnsureCanModifyHere(ctx, currentBranchObj, parentBranch); err != nil {
 		return err
 	}
+
+	// Take snapshot before modifying the repository, but after the ownership
+	// guard, so a refusal leaves the undo stack untouched rather than evicting
+	// a real snapshot with a no-op entry.
+	snapshotOpts := actions.NewSnapshot("fold",
+		actions.WithFlag(opts.Keep, "--keep"),
+		actions.WithFlag(opts.AllowTrunk, "--allow-trunk"),
+	)
+	actions.TakeBestEffortSnapshot(ctx, snapshotOpts)
 
 	// Prohibit folding branches with different scopes
 	if !parentBranch.IsTrunk() {

--- a/internal/actions/move/move.go
+++ b/internal/actions/move/move.go
@@ -56,8 +56,6 @@ func Action(ctx *app.Context, opts Options, h Handler) error {
 		return err
 	}
 
-	takeSnapshot(ctx, opts)
-
 	if err := validateMoveTargets(eng, source, opts.Onto); err != nil {
 		return err
 	}
@@ -69,6 +67,10 @@ func Action(ctx *app.Context, opts Options, h Handler) error {
 	if err := actions.EnsureCanModifyHere(ctx, plan.descendants.Concat(engine.BranchesOf(plan.ontoBranch))...); err != nil {
 		return err
 	}
+
+	// After the ownership guard, so a refusal leaves the undo stack untouched
+	// rather than evicting a real snapshot with a no-op entry.
+	takeSnapshot(ctx, opts)
 
 	if opts.DryRun {
 		return dryRun(ctx, plan.source, plan.oldParentName, plan.onto, plan.sourceBranch, plan.descendants, plan.rebaseSpecs)

--- a/internal/actions/pluck/pluck.go
+++ b/internal/actions/pluck/pluck.go
@@ -46,13 +46,6 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 		source = currentBranch.GetName()
 	}
 
-	// Take snapshot before modifying the repository
-	snapshotOpts := actions.NewSnapshot("pluck",
-		actions.WithFlagValue("--source", opts.Source),
-		actions.WithFlagValue("--onto", opts.Onto),
-	)
-	actions.TakeBestEffortSnapshot(ctx, snapshotOpts)
-
 	// Validate source branch
 	if err := validation.ValidateSourceBranch(eng, source, "pluck"); err != nil {
 		return err
@@ -72,6 +65,15 @@ func Action(ctx *app.Context, opts Options, handler Handler) error {
 	if err := actions.EnsureCanModifyHere(ctx, append(engine.BranchesOf(sourceBranch, ontoBranch), children...)...); err != nil {
 		return err
 	}
+
+	// Take snapshot before modifying the repository, but after the ownership
+	// guard, so a refusal leaves the undo stack untouched rather than evicting
+	// a real snapshot with a no-op entry.
+	snapshotOpts := actions.NewSnapshot("pluck",
+		actions.WithFlagValue("--source", opts.Source),
+		actions.WithFlagValue("--onto", opts.Onto),
+	)
+	actions.TakeBestEffortSnapshot(ctx, snapshotOpts)
 
 	// Cycle detection: ensure onto is not a descendant of source
 	if graph.IsDescendant(sourceBranch, ontoBranch) {

--- a/internal/engine/branch_mutations.go
+++ b/internal/engine/branch_mutations.go
@@ -214,6 +214,26 @@ func (e *engineImpl) DeleteBranch(ctx context.Context, branch Branch) error {
 // batch go through a single `git update-ref --stdin` invocation. The previous
 // implementation looped DeleteBranch per branch, spawning 4+ git subprocesses
 // per branch — at ~30-50ms each that dominated cleanup time during sync.
+// nearestSurvivingParent walks up from start through branches that are being
+// deleted and returns the first one that will still exist afterwards.
+//
+// The walk only passes through members of toDelete, so it terminates in at most
+// len(toDelete) steps. It is capped anyway: a parent cycle in malformed or
+// concurrently rewritten metadata would otherwise spin forever and hang the
+// whole deletion. GetStackRootForBranch and branchHeldBack guard their walks
+// the same way. When a cycle leaves no surviving ancestor reachable, the child
+// falls back to trunk rather than to a branch about to vanish.
+func nearestSurvivingParent(start string, parentOf map[string]string, toDelete map[string]bool, trunk string) string {
+	parent := start
+	for range len(toDelete) + 1 {
+		if !toDelete[parent] {
+			return parent
+		}
+		parent = parentOf[parent]
+	}
+	return trunk
+}
+
 func (e *engineImpl) DeleteBranches(ctx context.Context, branches Branches) ([]string, error) {
 	if len(branches) == 0 {
 		return nil, nil
@@ -263,10 +283,7 @@ func (e *engineImpl) DeleteBranches(ctx context.Context, branches Branches) ([]s
 			if toDeleteSet[child] {
 				continue
 			}
-			newParent := parentByBranch[name]
-			for toDeleteSet[newParent] {
-				newParent = parentByBranch[newParent]
-			}
+			newParent := nearestSurvivingParent(parentByBranch[name], parentByBranch, toDeleteSet, trunkName)
 			moves = append(moves, BranchParentMove{Branch: child, NewParent: newParent})
 			allSurvivingChildren[child] = true
 		}

--- a/internal/engine/delete_parent_walk_test.go
+++ b/internal/engine/delete_parent_walk_test.go
@@ -1,0 +1,72 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNearestSurvivingParent covers the walk that resolves a surviving child to
+// the nearest parent that outlives a batch deletion.
+//
+// The walk followed Parent links with no step limit, so a parent loop among the
+// branches being deleted — corrupt metadata, or metadata rewritten by another
+// stackit process mid-delete — spun forever and hung the whole deletion.
+func TestNearestSurvivingParent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		start    string
+		parentOf map[string]string
+		toDelete []string
+		expected string
+	}{
+		{
+			name:     "parent survives",
+			start:    "keep",
+			parentOf: map[string]string{"keep": "main"},
+			toDelete: []string{"gone"},
+			expected: "keep",
+		},
+		{
+			name:     "walks past a chain of deleted parents",
+			start:    "d1",
+			parentOf: map[string]string{"d1": "d2", "d2": "d3", "d3": "keep", "keep": "main"},
+			toDelete: []string{"d1", "d2", "d3"},
+			expected: "keep",
+		},
+		{
+			name:     "two-branch cycle falls back to trunk",
+			start:    "a",
+			parentOf: map[string]string{"a": "b", "b": "a"},
+			toDelete: []string{"a", "b"},
+			expected: "main",
+		},
+		{
+			name:     "self-parent falls back to trunk",
+			start:    "a",
+			parentOf: map[string]string{"a": "a"},
+			toDelete: []string{"a"},
+			expected: "main",
+		},
+		{
+			name:     "missing parent metadata resolves to the empty parent",
+			start:    "orphan",
+			parentOf: map[string]string{},
+			toDelete: []string{"orphan"},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			toDelete := make(map[string]bool, len(tt.toDelete))
+			for _, name := range tt.toDelete {
+				toDelete[name] = true
+			}
+			require.Equal(t, tt.expected, nearestSurvivingParent(tt.start, tt.parentOf, toDelete, "main"))
+		})
+	}
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

fold, pluck and move took their undo snapshot before the ownership guard
ran, so a refused command still pushed a no-op entry onto the bounded undo
stack and could evict a real snapshot. Every other guarded command already
checks first.

Also cap the parent walk that reparents surviving children in
DeleteBranches. It can only pass through branches being deleted, but a
parent cycle in malformed or concurrently rewritten metadata hung the whole
deletion; the sibling walks in GetStackRootForBranch and branchHeldBack are
already guarded this way.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1786228982`.


* **PR #1635**
  * **PR #1636**
    * **PR #1638**
      * **PR #1639** 👈
        * **PR #1637**
          * **PR #1640**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1641 by jonnii*