### PR TITLE
fix(sync): hold trunk on real conflicts, not on any untracked file

### DIFF
--- a/internal/actions/sync/trunk_sync.go
+++ b/internal/actions/sync/trunk_sync.go
@@ -1,11 +1,13 @@
 package sync
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 func syncFetchedTrunk(ctx *app.Context, opts *Options, handler Handler, summary *Summary) error {
@@ -16,7 +18,21 @@ func syncFetchedTrunk(ctx *app.Context, opts *Options, handler Handler, summary 
 	pullResult, err := eng.UpdateTrunkFromRemote(gctx)
 	ctx.Logger.Info("update trunk from remote completed durationMs=%d", time.Since(updateStart).Milliseconds())
 	if err != nil {
-		return fmt.Errorf("failed to update trunk from remote: %w", err)
+		// A worktree holding trunk is a hold, not a failure. Report it and let
+		// the rest of the sync run: cleanup and restack do not depend on trunk
+		// having moved, and aborting here strands the user in a directory whose
+		// state they cannot see from the one they are standing in.
+		var held *git.WorktreeHeldError
+		if !errors.As(err, &held) {
+			return fmt.Errorf("failed to update trunk from remote: %w", err)
+		}
+		handler.EmitEvent(Event{
+			Phase:  PhaseTrunk,
+			Type:   EventCompleted,
+			Branch: held.Branch,
+			HeldBy: fmt.Sprintf("worktree %s %s", held.WorktreePath, held.Reason),
+		})
+		return nil
 	}
 
 	return handleTrunkPullResult(ctx, opts, handler, summary, pullResult)

--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -202,12 +202,18 @@ func (h *SimpleSyncHandler) printEventLine(event syncAction.Event) {
 
 func (h *SimpleSyncHandler) printTrunkEvent(event syncAction.Event) {
 	if event.Type == syncAction.EventCompleted {
-		if event.NewRevision != "" {
+		switch {
+		case event.HeldBy != "":
+			// A held trunk reports no new revision, the same as one that needed
+			// no work. Say which one happened — the remedy is in another
+			// directory the user is not looking at.
+			h.item(event.Phase, "  %s Held %s back: %s", style.MarkWarning(), style.ColorBranchName(event.Branch), event.HeldBy)
+		case event.NewRevision != "":
 			h.item(event.Phase, "  %s %s fast-forwarded to %s",
 				style.MarkSuccess(),
 				style.ColorBranchName(event.Branch),
 				style.ColorDim(event.NewRevision))
-		} else {
+		default:
 			h.item(event.Phase, "  %s %s is up to date", style.MarkSuccess(), style.ColorBranchName(event.Branch))
 		}
 	}
@@ -542,7 +548,10 @@ func (h *InteractiveSyncHandler) formatEventDetail(event syncAction.Event) (deta
 	switch event.Phase {
 	case syncAction.PhaseTrunk:
 		if event.Type == syncAction.EventCompleted {
-			if event.NewRevision != "" {
+			switch {
+			case event.HeldBy != "":
+				return fmt.Sprintf("Held %s back: %s", event.Branch, event.HeldBy), syncComponent.MarkWarn
+			case event.NewRevision != "":
 				return fmt.Sprintf("%s fast-forwarded to %s", event.Branch, event.NewRevision), syncComponent.MarkDone
 			}
 			return fmt.Sprintf("%s is up to date", event.Branch), syncComponent.MarkDone

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -537,6 +537,10 @@ func (d *demoGitRunner) WorktreeHasTrackedChanges(_ context.Context, _ string) (
 	return false, nil
 }
 
+func (d *demoGitRunner) WorktreeResetBlocker(_ context.Context, _, _ string) string {
+	return ""
+}
+
 func (d *demoGitRunner) UpdateRefWithLog(_ context.Context, _, _, _ string) error {
 	return nil
 }

--- a/internal/engine/pull.go
+++ b/internal/engine/pull.go
@@ -124,12 +124,8 @@ func (e *engineImpl) ResetTrunkToRemote(ctx context.Context) error {
 	}
 	trunkWorktree := worktrees.PathForBranch(trunk)
 	if trunkWorktree != "" {
-		dirty, statusErr := e.git.WorktreeHasUncommittedChanges(ctx, trunkWorktree)
-		if statusErr != nil {
-			return fmt.Errorf("refusing to reset trunk: cannot inspect worktree %s: %w", trunkWorktree, statusErr)
-		}
-		if dirty {
-			return fmt.Errorf("refusing to reset trunk: worktree %s has uncommitted changes", trunkWorktree)
+		if blocker := e.git.WorktreeResetBlocker(ctx, trunkWorktree, remoteSha); blocker != "" {
+			return &git.WorktreeHeldError{Branch: trunk, WorktreePath: trunkWorktree, Reason: blocker}
 		}
 	}
 

--- a/internal/engine/reset_trunk_test.go
+++ b/internal/engine/reset_trunk_test.go
@@ -77,7 +77,7 @@ func TestResetTrunkToRemote(t *testing.T) {
 
 		err = eng.ResetTrunkToRemote(context.Background())
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "refusing to reset trunk")
+		require.Contains(t, err.Error(), "refusing to move main")
 		require.Contains(t, err.Error(), "uncommitted changes")
 
 		after, revErr := scene.Repo.GetRevision("main")

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -219,6 +219,9 @@ type WorktreeOperations interface {
 	ResetWorktreeWorkingDir(ctx context.Context, worktreePath string) error
 	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)
 	WorktreeHasTrackedChanges(ctx context.Context, worktreePath string) (bool, error)
+	// WorktreeResetBlocker reports why resetting worktreePath to incomingRev
+	// would destroy work, or "" when it is safe.
+	WorktreeResetBlocker(ctx context.Context, worktreePath, incomingRev string) string
 	// ListIgnoredFiles returns repository-relative paths that Git currently
 	// classifies as ignored in the requested worktree.
 	ListIgnoredFiles(ctx context.Context, worktreePath string) ([]string, error)

--- a/internal/git/pull.go
+++ b/internal/git/pull.go
@@ -84,12 +84,8 @@ func (r *runner) UpdateBranchFromRemote(ctx context.Context, remote, branchName 
 		}
 		worktreePath := worktrees.PathForBranch(branchName)
 		if worktreePath != "" {
-			hasChanges, statusErr := r.WorktreeHasUncommittedChanges(ctx, worktreePath)
-			if statusErr != nil {
-				return PullConflict, fmt.Errorf("refusing to update %s: cannot inspect worktree %s: %w", branchName, worktreePath, statusErr)
-			}
-			if hasChanges {
-				return PullConflict, fmt.Errorf("refusing to update %s: worktree %s has uncommitted changes", branchName, worktreePath)
+			if blocker := r.WorktreeResetBlocker(ctx, worktreePath, remoteRev); blocker != "" {
+				return PullConflict, &WorktreeHeldError{Branch: branchName, WorktreePath: worktreePath, Reason: blocker}
 			}
 		}
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -448,6 +448,62 @@ func (r *runner) WorktreeHasTrackedChanges(ctx context.Context, worktreePath str
 	return strings.TrimSpace(out) != "", nil
 }
 
+// WorktreeHeldError reports a ref move declined because a worktree holding the
+// branch would lose work.
+//
+// This is a hold, not a failure. Callers whose remaining work does not depend on
+// the ref move should report it and carry on rather than aborting: refusing to
+// fast-forward trunk is no reason to skip branch cleanup and restack. See "Hold
+// Trunk Never, Report Holds Always" in .claude/rules/worktree-safety.md.
+type WorktreeHeldError struct {
+	Branch       string
+	WorktreePath string
+	Reason       string
+}
+
+// "move" covers both callers: a fast-forward and a reset both move the branch
+// ref out from under whatever worktree has it checked out.
+func (e *WorktreeHeldError) Error() string {
+	return fmt.Sprintf("refusing to move %s: worktree %s %s", e.Branch, e.WorktreePath, e.Reason)
+}
+
+// WorktreeResetBlocker reports why resetting the worktree at worktreePath to
+// incomingRev would destroy work, or "" when the reset is safe.
+//
+// This is the question to ask before moving a ref that some worktree has checked
+// out. WorktreeHasUncommittedChanges is the wrong predicate here: it counts
+// untracked files as dirty, and refusing on those blocks the ref move for the
+// ordinary state of having written a new file and not staged it. See the
+// "Hold Trunk Never, Report Holds Always" invariant in
+// .claude/rules/worktree-safety.md.
+//
+// Tracked changes block unconditionally — a reset overwrites them. Untracked
+// files block only when one sits at a path incomingRev also contains, the single
+// case `git reset --hard` destroys them; that file was never in git, so there is
+// no reflog or stash to recover it from. An inspection failure blocks too:
+// unknown must never read as safe.
+func (r *runner) WorktreeResetBlocker(ctx context.Context, worktreePath, incomingRev string) string {
+	tracked, err := r.WorktreeHasTrackedChanges(ctx, worktreePath)
+	switch {
+	case err != nil:
+		return fmt.Sprintf("could not be inspected: %v", err)
+	case tracked:
+		return "has uncommitted changes"
+	}
+
+	untracked, err := r.GetUntrackedFilesIn(ctx, worktreePath)
+	if err != nil {
+		return fmt.Sprintf("its untracked files could not be inspected: %v", err)
+	}
+	switch collides, known := r.TreeContainsAnyPath(ctx, incomingRev, untracked); {
+	case !known:
+		return "its untracked files could not be compared against the incoming commit"
+	case collides:
+		return "an untracked file there would be overwritten"
+	}
+	return ""
+}
+
 // ListIgnoredFiles returns every ignored, untracked file in worktreePath as a
 // repository-relative path. --exclude-standard ensures this has Git's actual
 // ignore semantics, rather than treating a warm-start include file as another

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -39,6 +39,53 @@ func TestTreeContainsAnyPathLargePathSet(t *testing.T) {
 	require.True(t, collides)
 }
 
+// TestWorktreeResetBlocker pins the untracked-collision-vs-coexistence boundary
+// required by .claude/rules/worktree-safety.md. Blocking on any untracked file
+// at all stops a ref move for the ordinary state of having written a new file
+// and not staged it, which broke `sync` from a managed worktree.
+func TestWorktreeResetBlocker(t *testing.T) {
+	t.Parallel()
+
+	// Build an "incoming" commit containing incoming_test.txt, then rewind the
+	// worktree so that path is absent and can stand in as an untracked file.
+	scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+		return s.Repo.CreateChangeAndCommit("base", "base")
+	})
+	repo := scene.Repo
+	baseRev, err := repo.GetCurrentSHA()
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateChangeAndCommit("incoming", "incoming"))
+	incomingRev, err := repo.GetCurrentSHA()
+	require.NoError(t, err)
+	require.NoError(t, repo.RunGitCommand("reset", "--hard", baseRev))
+
+	runner := git.NewRunnerWithPath(repo.Dir, nil)
+	ctx := context.Background()
+	scratch := filepath.Join(repo.Dir, "scratch.txt")
+	collider := filepath.Join(repo.Dir, "incoming_test.txt")
+
+	// Each phase mutates the shared worktree, so they run in order rather than
+	// as parallel subtests.
+	require.Empty(t, runner.WorktreeResetBlocker(ctx, repo.Dir, incomingRev),
+		"a clean worktree must not block")
+
+	require.NoError(t, os.WriteFile(scratch, []byte("notes"), 0o600))
+	require.Empty(t, runner.WorktreeResetBlocker(ctx, repo.Dir, incomingRev),
+		"an untracked file the incoming commit does not write must not block")
+	require.NoError(t, os.Remove(scratch))
+
+	require.NoError(t, os.WriteFile(collider, []byte("mine"), 0o600))
+	require.Equal(t, "an untracked file there would be overwritten",
+		runner.WorktreeResetBlocker(ctx, repo.Dir, incomingRev),
+		"an untracked file the incoming commit writes is the one case reset destroys")
+	require.NoError(t, os.Remove(collider))
+
+	require.NoError(t, os.WriteFile(filepath.Join(repo.Dir, "base_test.txt"), []byte("edited"), 0o600))
+	require.Equal(t, "has uncommitted changes",
+		runner.WorktreeResetBlocker(ctx, repo.Dir, incomingRev),
+		"a tracked change must block unconditionally")
+}
+
 func TestWorktree(t *testing.T) {
 	t.Run("lists ignored files", func(t *testing.T) {
 		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)

--- a/internal/integration/hold_reporting_test.go
+++ b/internal/integration/hold_reporting_test.go
@@ -34,6 +34,72 @@ func TestModifyReportsHeldBranchInsteadOfUpToDate(t *testing.T) {
 		OutputContains("uncommitted changes")
 }
 
+// parkTrunkInWorktree leaves the shell on a stack branch (freeing trunk from
+// this checkout), parks trunk in a plain git worktree, and puts the remote one
+// commit ahead of local trunk so sync has a fast-forward to attempt. Returns the
+// worktree directory holding trunk.
+//
+// "trunk_tracked.txt" is committed on trunk so callers can dirty a tracked path;
+// the incoming remote commit writes only "remote_only.txt", so an untracked file
+// at any other path is one a reset could not destroy.
+func parkTrunkInWorktree(t *testing.T, sh *TestShell) string {
+	t.Helper()
+
+	sh.WriteFile("trunk_tracked.txt", "base").
+		Git("commit -m 'chore: trunk base'").
+		Git("push -u origin main").
+		WriteFile("remote_only.txt", "remote work").
+		Git("commit -m 'chore: remote trunk commit'").
+		Git("push origin main").
+		Git("reset --hard HEAD~1")
+
+	// Moving onto a stack branch frees trunk so a worktree can hold it.
+	sh.Write("a.txt", "content for a").Run("create a -m 'Add a'")
+
+	worktreeDir := t.TempDir()
+	sh.Git("worktree add " + worktreeDir + " main")
+	return worktreeDir
+}
+
+// TestSyncProceedsWhenTrunkWorktreeHasHarmlessUntrackedFile pins the boundary
+// that broke sync: an untracked file in the worktree holding trunk is the
+// ordinary state of having written a new file and not staged it. A reset cannot
+// destroy it unless the incoming commit writes that same path, so it must not
+// stop the fast-forward — let alone abort the whole command.
+func TestSyncProceedsWhenTrunkWorktreeHasHarmlessUntrackedFile(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t, WithRemote())
+	worktreeDir := parkTrunkInWorktree(t, sh)
+
+	// Not a path the incoming commit writes.
+	sh.InWorktree(worktreeDir).WriteUnstaged("scratch-notes.txt", "notes")
+
+	sh.Run("sync").
+		OutputContains("fast-forwarded").
+		OutputNotContains("Held")
+}
+
+// TestSyncReportsTrunkHoldInsteadOfFailing covers the other half: a tracked
+// change in the trunk worktree genuinely blocks the ref move, but that is a hold
+// to report, not a failure to abort on. Cleanup and restack do not depend on
+// trunk having moved.
+func TestSyncReportsTrunkHoldInsteadOfFailing(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t, WithRemote())
+	worktreeDir := parkTrunkInWorktree(t, sh)
+
+	// An unstaged edit to a tracked path — a reset would discard it.
+	sh.InWorktree(worktreeDir).WriteUnstaged("trunk_tracked.txt", "work in progress")
+
+	// Run, not RunExpectError: the hold must not fail the command.
+	sh.Run("sync").
+		OutputContains("Held").
+		OutputContains(worktreeDir).
+		OutputContains("uncommitted changes")
+}
+
 // TestRestackReportsHeldDescendantInsteadOfUpToDate covers a descendant held
 // because its ancestor is: the reason must name the ancestor and carry the
 // originating worktree, not report the descendant as up to date.


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The worktree guard on ref moves used WorktreeHasUncommittedChanges, which
counts untracked files as dirty. A single unstaged new file in the checkout
holding trunk made `stackit sync` from a managed worktree abort before
cleanup or restack, and --force could not rescue it because the error
short-circuited ahead of the PullConflict handler. `merge` inherited the same
refusal through PullTrunk.

Narrow the predicate to what a reset actually destroys — tracked changes, or
an untracked file at a path the incoming commit writes — behind a shared
git.WorktreeResetBlocker, and report a genuine hold through the existing
HeldBy event channel instead of failing the command. Trunk still never moves
out from under work that would be lost.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1786245332`.


* **PR #1642** 👈
  * **PR #1643**
    * **PR #1644**
      * **PR #1645**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1646 by jonnii*