### PR TITLE
fix(split): guard worktree ownership in the interactive wizard

### DIFF
--- a/internal/actions/split/wizard.go
+++ b/internal/actions/split/wizard.go
@@ -41,6 +41,13 @@ func RunWizard(ctx *app.Context, handler InteractiveHandler, opts WizardOptions)
 	if err := currentBranch.EnsureCanModify(); err != nil {
 		return err
 	}
+	// The wizard is the default `stackit split` path, so Action returns here
+	// before reaching its own ownership guard. Splitting rewrites the branch's
+	// commits, which is only safe in the worktree that owns it — guard before
+	// the snapshot below, so a refusal is a no-op.
+	if err := actions.EnsureCanModifyHere(ctx, *currentBranch); err != nil {
+		return err
+	}
 
 	// Check for uncommitted tracked changes
 	hasUnstaged, err := eng.HasUnstagedChanges(ctx.Context)

--- a/internal/actions/split/wizard_guard_test.go
+++ b/internal/actions/split/wizard_guard_test.go
@@ -1,0 +1,51 @@
+package split_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions/split"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// guardOnlyHandler is interactive enough to reach the wizard and nothing more.
+// InteractiveHandler is embedded as a nil interface, so any prompt call panics —
+// which is the assertion: the ownership guard must refuse before the wizard
+// touches the user or the branch.
+type guardOnlyHandler struct {
+	split.InteractiveHandler
+}
+
+func (guardOnlyHandler) IsInteractive() bool { return true }
+func (guardOnlyHandler) Cleanup()            {}
+
+// TestRunWizardRefusesBranchOwnedByAnotherWorktree covers the default
+// `stackit split` entry point. Action returns into RunWizard before reaching its
+// own guard, so the wizard has to carry one: splitting rewrites the branch's
+// commits, and doing that outside the owning worktree leaves that worktree's
+// files diverged from the ref, which the user's next `modify -a` commits as a
+// deletion.
+//
+// See "Branch-Content Mutations Run Only In The Owning Worktree" in
+// .claude/rules/worktree-safety.md.
+func TestRunWizardRefusesBranchOwnedByAnotherWorktree(t *testing.T) {
+	t.Parallel()
+
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithInitialCommit()
+	s.CreateBranch("feature").Commit("feature change")
+	s.TrackBranch("feature", "main")
+	s.Checkout("feature")
+
+	worktreePath := t.TempDir()
+	require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature", worktreePath, "feature-wt"))
+	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
+
+	err := split.RunWizard(s.Context, guardOnlyHandler{}, split.WizardOptions{})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "belongs to worktree feature-wt")
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

Bare `stackit split` sets UseWizard, so Action returns into RunWizard before
reaching its own EnsureCanModifyHere call — the default entry point of a
command the worktree-safety rules list as guarded was rewriting branch
commits from any checkout. The worktree holding the branch was then left
diverged from its ref, which the next `modify -a` there commits as a
deletion.

Guard inside RunWizard, next to the existing lock/frozen check and ahead of
the snapshot, so it travels with the function and a refusal stays a no-op.
The test drives the wizard with a handler whose prompt methods panic, so it
fails loudly if the guard ever stops running first.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1786245332`.


* **PR #1642**
  * **PR #1643** 👈
    * **PR #1644**
      * **PR #1645**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1646 by jonnii*