### PR TITLE
fix(worktree): stop reporting the main repository as unmanaged

### DIFF
--- a/internal/actions/worktree/entry.go
+++ b/internal/actions/worktree/entry.go
@@ -208,7 +208,12 @@ func OwnershipWarnings(ctx *app.Context) []string {
 		return []string{fmt.Sprintf("could not inspect Git worktrees for ownership conflicts: %v", err)}
 	}
 
-	mainRepoPath, err := canonicalPath(ctx.Engine.GetRepoRoot())
+	// Ask git which checkout is the main one rather than trusting the engine's
+	// repo root: an engine constructed inside a managed worktree reports that
+	// worktree as its root, so the real main repository never matches and every
+	// branch checked out there gets reported as an unmanaged worktree. A warning
+	// channel that cries wolf on every sync is one nobody reads.
+	mainRepoPath, err := canonicalPath(gitWorktrees.MainPath())
 	if err != nil {
 		return []string{fmt.Sprintf("could not canonicalize the main repository path: %v", err)}
 	}

--- a/internal/integration/ownership_warning_test.go
+++ b/internal/integration/ownership_warning_test.go
@@ -1,0 +1,52 @@
+package integration
+
+import (
+	"testing"
+)
+
+// Ownership warnings are the channel that reports a branch checked out somewhere
+// its stack does not own. That only works if it stays quiet otherwise: a warning
+// printed on every command trains people to skip the one that matters.
+
+// TestOwnershipWarningsQuietFromManagedWorktree pins the false positive. The
+// engine built inside a managed worktree reports that worktree as its repo root,
+// so comparing checkout paths against the engine's root made the real main
+// repository look like an unmanaged worktree — on every command run from a
+// worktree.
+func TestOwnershipWarningsQuietFromManagedWorktree(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+	sh.SetWorktreeBasePath(t.TempDir())
+
+	sh.WriteFile("feature.txt", "feature").
+		Run("create feature -w -m 'feature branch'")
+	shW := sh.InWorktree(sh.GetWorktreePath("feature"))
+
+	// Trunk is checked out in the main repository, which is exactly where it
+	// belongs — running from the worktree must not call that a conflict.
+	shW.Run("worktree list").
+		OutputNotContains("unmanaged worktree")
+}
+
+// TestOwnershipWarningsReportGenuineUnmanagedWorktree is the other half: the
+// quieting must not have removed the signal. A branch parked in a plain git
+// worktree is still divergence worth reporting.
+func TestOwnershipWarningsReportGenuineUnmanagedWorktree(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+	sh.SetWorktreeBasePath(t.TempDir())
+
+	sh.WriteFile("feature.txt", "feature").
+		Run("create feature -w -m 'feature branch'")
+
+	strayDir := t.TempDir()
+	sh.Git("branch stray-branch").
+		Git("worktree add " + strayDir + " stray-branch")
+
+	sh.InWorktree(sh.GetWorktreePath("feature")).
+		Run("worktree list").
+		OutputContains("unmanaged worktree").
+		OutputContains("stray-branch")
+}


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

OwnershipWarnings compared each checkout against Engine.GetRepoRoot(), which
is the *current* checkout — inside a managed worktree that is the worktree
itself, so the real main repository never matched and every branch checked
out there was reported as an unmanaged worktree. Every sync and worktree list
run from a worktree printed a false integrity alarm, which is how a warning
channel stops being read before it ever reports a real conflict.

Ask git which checkout is the main one via WorktreeList.MainPath(), added for
exactly this hazard. Genuine divergence still reports.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1786245332`.


* **PR #1642**
  * **PR #1643**
    * **PR #1644** 👈
      * **PR #1645**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1646 by jonnii*