### PR TITLE
docs(worktree): tell the truth about what deletes a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,15 @@ clean. In JSON they appear under `held` as `{branch, reason}` — and also in
 `skipped`, so an empty `conflicts` list alone does not mean the whole stack
 moved.
 
+Two smaller shapes changed alongside the worktree work. `stackit tree --json`
+has always omitted worktree anchors from its entries, but `parent` could still
+name one — a dangling reference to a branch absent from the result. Both
+`parent` and `children` now resolve past anchors, so a branch under an anchor
+reports the anchor's nearest visible ancestor as its parent and appears in that
+ancestor's `children`. `stackit worktree list --json` gained
+`ownership_warnings`, listing branches checked out somewhere their stack does
+not own.
+
 ---
 
 ## Configuration

--- a/doc/src/start/install.md
+++ b/doc/src/start/install.md
@@ -6,6 +6,18 @@ description: Install stackit via Homebrew on macOS or Linux. Set up shell integr
 
 # Installation
 
+## Requirements
+
+- **Git 2.36+** — required, not optional. Stack operations use
+  `git worktree list -z` to see which branches are checked out where, and
+  stackit refuses to run them on older Git rather than guess.
+- **GitHub CLI (`gh`)** for PR operations
+
+Check your version with `git --version`. Some still-supported distributions ship
+older Git than this — Ubuntu 22.04 has 2.34 and Debian 11 has 2.30 — so you may
+need to upgrade Git before stackit will work. Run $$stackit doctor$$ after
+installing to confirm your environment.
+
 ## Homebrew (macOS and Linux)
 
 The easiest way to install stackit is via Homebrew:

--- a/doc/src/worktrees/management.md
+++ b/doc/src/worktrees/management.md
@@ -50,6 +50,13 @@ This removes:
 The stack's branches remain intact. Use `--force` to remove even if there are errors.
 Use `--keep-branch` to preserve the anchor branch when removing the worktree.
 
+!!! warning "Ignored files are deleted with the directory"
+    Deleting the worktree directory deletes everything in it, including files
+    Git ignores — a `.env` you edited there, dependency caches, and anything
+    copied in by a [warm start](#warm-starting-new-worktrees). Git has no copy
+    of those, so there is nothing to recover them from. Copy out anything you
+    want to keep before removing.
+
 ## Attaching to an Existing Stack
 
 Attach an existing branch/stack to a new worktree:
@@ -62,13 +69,22 @@ This creates a worktree for an existing stack that wasn't originally created wit
 
 ## Detaching a Worktree
 
-Detach a worktree without removing it from disk:
+Stop working in a worktree while keeping all of its branches:
 
 ```bash
 stackit worktree detach my-feature
 ```
 
-This unregisters the worktree from stackit tracking while leaving the directory intact. Use `--force` if there are uncommitted changes.
+Unlike `remove`, which refuses when the worktree holds real branches, `detach`
+preserves them: it reparents the stack onto the hidden anchor's parent, deletes
+the anchor branch, and unregisters the worktree. Use `--force` if there are
+uncommitted changes.
+
+!!! warning "Detach also deletes the directory"
+    Detach preserves your *branches*, not the worktree directory — that is
+    removed, along with every ignored file in it. The same caution as
+    [Removing a Worktree](#removing-a-worktree) applies: copy out any
+    warm-started `.env` or cache you want to keep first.
 
 ## Pruning Stale Worktrees
 
@@ -79,6 +95,12 @@ stackit worktree prune
 ```
 
 Use `--dry-run` to preview what would be cleaned up without making changes.
+
+Prune skips worktrees that still hold stacked branches or have uncommitted
+changes. It does delete directories that are still on disk but empty of stack
+branches — and ignored files do not make a worktree count as dirty, so a
+worktree holding nothing but a warm-started `.env` is prunable and that file
+goes with it.
 
 ## Automatic Cleanup
 
@@ -106,6 +128,29 @@ stackit config set worktree.autoClean false
 
 **Default**: `true`
 
+## Warm-Starting New Worktrees
+
+A new worktree is a fresh checkout, so the ignored files your build needs —
+`.env`, dependency caches — aren't there. Add a `.worktreeinclude` file at the
+repository root to copy selected ignored files into every new managed worktree:
+
+```gitignore
+# .worktreeinclude — .gitignore syntax, selects from files Git already ignores
+.env
+.env.local
+node_modules/
+```
+
+The copy runs before `post-worktree-create` hooks, so setup hooks can use the
+warmed files. A pattern can only ever copy a file Git already ignores — never a
+tracked file — and an existing file in the destination is never overwritten.
+
+!!! warning "Treat `.worktreeinclude` as a secrets allowlist"
+    Every managed worktree receives these files. Include secrets only when that
+    is acceptable for all of them. And because warm-started files are ignored by
+    Git, nothing else has a copy: `remove`, `prune`, and `detach` all delete
+    them with the directory.
+
 ## Post-Create Hooks
 
 Run commands automatically after worktree creation by adding a `.stackit.yaml` file:
@@ -131,9 +176,26 @@ See [Configuration](../cli/config.md#worktree-hooks) for more examples.
 
 ## Working in Worktrees
 
+### Run Stack Commands Where the Stack Lives
+
+Commands that change branch content — `create`, `modify`, `absorb`, `fold`,
+`squash`, `split`, `move`, `reorder`, `pluck`, `delete`, `track` — must run in
+the worktree that owns the stack, so the edit lands in the working tree you are
+actually looking at. From anywhere else stackit refuses and says where to go:
+
+```
+branch payments-api belongs to worktree payments; run this command from there: cd ../myapp-stacks/payments
+```
+
+$$stackit sync$$ and $$stackit restack$$ are the exception — they reconcile the
+whole repository and can run from any worktree.
+
+If the owning worktree's directory no longer exists, `cd` is not an option; the
+refusal points at `stackit worktree detach` instead, which releases the branches.
+
 ### Creating Stacked Branches
 
-Once inside a worktree, create branches as usual:
+Once inside the worktree that owns the stack, create branches as usual:
 
 ```bash
 # Make changes

--- a/internal/cli/worktree/worktree.go
+++ b/internal/cli/worktree/worktree.go
@@ -338,7 +338,10 @@ deletes the hidden anchor branch. You can specify either the worktree name or
 the anchor branch name.
 
 Worktrees with real branches are refused. Use 'stackit worktree detach' to
-remove the worktree while preserving those branches.`,
+remove the worktree while preserving those branches.
+
+The directory is deleted with everything in it, including files Git ignores —
+warm-started .env files and caches have no copy in Git to recover from.`,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -366,7 +369,11 @@ func newPruneCmd() *cobra.Command {
 		Long: `Remove all worktrees that have no stacked branches.
 
 Empty worktrees are those with only the anchor branch and no work in progress.
-Worktrees with uncommitted changes are skipped.`,
+Worktrees with uncommitted changes are skipped.
+
+Each directory is deleted with everything in it, including files Git ignores.
+Ignored files do not count as uncommitted, so a worktree holding only a
+warm-started .env is prunable and that file goes with it.`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
@@ -519,6 +526,10 @@ Use this when you want to stop working in a worktree but keep all your branches.
 
 Detach removes the worktree, reparents children of the hidden anchor to the
 anchor's parent, then deletes the anchor branch.
+
+What is preserved is your branches, not the directory: that is deleted with
+everything in it, including files Git ignores. Copy out any warm-started .env
+or cache you want to keep first.
 
 Examples:
   stackit worktree detach my-feature   # Detach by worktree name


### PR DESCRIPTION
<!-- STACKIT-LOCK-START -->
> 🔒 This PR has been locked (consolidating). To unlock it, run `st unlock`.
<!-- STACKIT-LOCK-END -->

The published docs said `worktree detach` unregisters a worktree "while
leaving the directory intact". It does the opposite — it deletes the
directory, keeping only the branches — so the page recommended the
destructive option as the safe one. Warm starts make that costly: the
directory now holds ignored files like .env that Git has no copy of.

Correct the detach section, warn on remove/prune/detach that ignored files go
with the directory, and add the same line to those commands' help text where
the user is actually standing. Also documents warm starts and the ownership
guard on the docs site (previously README-only), states the Git 2.36
requirement on the install page, and records the tree/worktree-list JSON
changes in README's Automation & CI section.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack

> 💡 **Notice**: This PR is part of a stack merge into branch `stack-merge-stack-1786245332`.


* **PR #1642**
  * **PR #1643**
    * **PR #1644**
      * **PR #1645** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
*Merged via consolidation into #1646 by jonnii*