### PR TITLE
Merging 4 PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,15 @@ clean. In JSON they appear under `held` as `{branch, reason}` — and also in
 `skipped`, so an empty `conflicts` list alone does not mean the whole stack
 moved.
 
+Two smaller shapes changed alongside the worktree work. `stackit tree --json`
+has always omitted worktree anchors from its entries, but `parent` could still
+name one — a dangling reference to a branch absent from the result. Both
+`parent` and `children` now resolve past anchors, so a branch under an anchor
+reports the anchor's nearest visible ancestor as its parent and appears in that
+ancestor's `children`. `stackit worktree list --json` gained
+`ownership_warnings`, listing branches checked out somewhere their stack does
+not own.
+
 ---
 
 ## Configuration

--- a/doc/src/start/install.md
+++ b/doc/src/start/install.md
@@ -6,6 +6,18 @@ description: Install stackit via Homebrew on macOS or Linux. Set up shell integr
 
 # Installation
 
+## Requirements
+
+- **Git 2.36+** — required, not optional. Stack operations use
+  `git worktree list -z` to see which branches are checked out where, and
+  stackit refuses to run them on older Git rather than guess.
+- **GitHub CLI (`gh`)** for PR operations
+
+Check your version with `git --version`. Some still-supported distributions ship
+older Git than this — Ubuntu 22.04 has 2.34 and Debian 11 has 2.30 — so you may
+need to upgrade Git before stackit will work. Run $$stackit doctor$$ after
+installing to confirm your environment.
+
 ## Homebrew (macOS and Linux)
 
 The easiest way to install stackit is via Homebrew:

--- a/doc/src/worktrees/management.md
+++ b/doc/src/worktrees/management.md
@@ -50,6 +50,13 @@ This removes:
 The stack's branches remain intact. Use `--force` to remove even if there are errors.
 Use `--keep-branch` to preserve the anchor branch when removing the worktree.
 
+!!! warning "Ignored files are deleted with the directory"
+    Deleting the worktree directory deletes everything in it, including files
+    Git ignores — a `.env` you edited there, dependency caches, and anything
+    copied in by a [warm start](#warm-starting-new-worktrees). Git has no copy
+    of those, so there is nothing to recover them from. Copy out anything you
+    want to keep before removing.
+
 ## Attaching to an Existing Stack
 
 Attach an existing branch/stack to a new worktree:
@@ -62,13 +69,22 @@ This creates a worktree for an existing stack that wasn't originally created wit
 
 ## Detaching a Worktree
 
-Detach a worktree without removing it from disk:
+Stop working in a worktree while keeping all of its branches:
 
 ```bash
 stackit worktree detach my-feature
 ```
 
-This unregisters the worktree from stackit tracking while leaving the directory intact. Use `--force` if there are uncommitted changes.
+Unlike `remove`, which refuses when the worktree holds real branches, `detach`
+preserves them: it reparents the stack onto the hidden anchor's parent, deletes
+the anchor branch, and unregisters the worktree. Use `--force` if there are
+uncommitted changes.
+
+!!! warning "Detach also deletes the directory"
+    Detach preserves your *branches*, not the worktree directory — that is
+    removed, along with every ignored file in it. The same caution as
+    [Removing a Worktree](#removing-a-worktree) applies: copy out any
+    warm-started `.env` or cache you want to keep first.
 
 ## Pruning Stale Worktrees
 
@@ -79,6 +95,12 @@ stackit worktree prune
 ```
 
 Use `--dry-run` to preview what would be cleaned up without making changes.
+
+Prune skips worktrees that still hold stacked branches or have uncommitted
+changes. It does delete directories that are still on disk but empty of stack
+branches — and ignored files do not make a worktree count as dirty, so a
+worktree holding nothing but a warm-started `.env` is prunable and that file
+goes with it.
 
 ## Automatic Cleanup
 
@@ -106,6 +128,29 @@ stackit config set worktree.autoClean false
 
 **Default**: `true`
 
+## Warm-Starting New Worktrees
+
+A new worktree is a fresh checkout, so the ignored files your build needs —
+`.env`, dependency caches — aren't there. Add a `.worktreeinclude` file at the
+repository root to copy selected ignored files into every new managed worktree:
+
+```gitignore
+# .worktreeinclude — .gitignore syntax, selects from files Git already ignores
+.env
+.env.local
+node_modules/
+```
+
+The copy runs before `post-worktree-create` hooks, so setup hooks can use the
+warmed files. A pattern can only ever copy a file Git already ignores — never a
+tracked file — and an existing file in the destination is never overwritten.
+
+!!! warning "Treat `.worktreeinclude` as a secrets allowlist"
+    Every managed worktree receives these files. Include secrets only when that
+    is acceptable for all of them. And because warm-started files are ignored by
+    Git, nothing else has a copy: `remove`, `prune`, and `detach` all delete
+    them with the directory.
+
 ## Post-Create Hooks
 
 Run commands automatically after worktree creation by adding a `.stackit.yaml` file:
@@ -131,9 +176,26 @@ See [Configuration](../cli/config.md#worktree-hooks) for more examples.
 
 ## Working in Worktrees
 
+### Run Stack Commands Where the Stack Lives
+
+Commands that change branch content — `create`, `modify`, `absorb`, `fold`,
+`squash`, `split`, `move`, `reorder`, `pluck`, `delete`, `track` — must run in
+the worktree that owns the stack, so the edit lands in the working tree you are
+actually looking at. From anywhere else stackit refuses and says where to go:
+
+```
+branch payments-api belongs to worktree payments; run this command from there: cd ../myapp-stacks/payments
+```
+
+$$stackit sync$$ and $$stackit restack$$ are the exception — they reconcile the
+whole repository and can run from any worktree.
+
+If the owning worktree's directory no longer exists, `cd` is not an option; the
+refusal points at `stackit worktree detach` instead, which releases the branches.
+
 ### Creating Stacked Branches
 
-Once inside a worktree, create branches as usual:
+Once inside the worktree that owns the stack, create branches as usual:
 
 ```bash
 # Make changes

--- a/internal/actions/split/wizard.go
+++ b/internal/actions/split/wizard.go
@@ -41,6 +41,13 @@ func RunWizard(ctx *app.Context, handler InteractiveHandler, opts WizardOptions)
 	if err := currentBranch.EnsureCanModify(); err != nil {
 		return err
 	}
+	// The wizard is the default `stackit split` path, so Action returns here
+	// before reaching its own ownership guard. Splitting rewrites the branch's
+	// commits, which is only safe in the worktree that owns it — guard before
+	// the snapshot below, so a refusal is a no-op.
+	if err := actions.EnsureCanModifyHere(ctx, *currentBranch); err != nil {
+		return err
+	}
 
 	// Check for uncommitted tracked changes
 	hasUnstaged, err := eng.HasUnstagedChanges(ctx.Context)

--- a/internal/actions/split/wizard_guard_test.go
+++ b/internal/actions/split/wizard_guard_test.go
@@ -1,0 +1,51 @@
+package split_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getstackit/stackit/internal/actions/split"
+	"github.com/getstackit/stackit/testhelpers"
+	"github.com/getstackit/stackit/testhelpers/scenario"
+)
+
+// guardOnlyHandler is interactive enough to reach the wizard and nothing more.
+// InteractiveHandler is embedded as a nil interface, so any prompt call panics —
+// which is the assertion: the ownership guard must refuse before the wizard
+// touches the user or the branch.
+type guardOnlyHandler struct {
+	split.InteractiveHandler
+}
+
+func (guardOnlyHandler) IsInteractive() bool { return true }
+func (guardOnlyHandler) Cleanup()            {}
+
+// TestRunWizardRefusesBranchOwnedByAnotherWorktree covers the default
+// `stackit split` entry point. Action returns into RunWizard before reaching its
+// own guard, so the wizard has to carry one: splitting rewrites the branch's
+// commits, and doing that outside the owning worktree leaves that worktree's
+// files diverged from the ref, which the user's next `modify -a` commits as a
+// deletion.
+//
+// See "Branch-Content Mutations Run Only In The Owning Worktree" in
+// .claude/rules/worktree-safety.md.
+func TestRunWizardRefusesBranchOwnedByAnotherWorktree(t *testing.T) {
+	t.Parallel()
+
+	s := scenario.NewScenario(t, testhelpers.BasicSceneSetup)
+	s.WithInitialCommit()
+	s.CreateBranch("feature").Commit("feature change")
+	s.TrackBranch("feature", "main")
+	s.Checkout("feature")
+
+	worktreePath := t.TempDir()
+	require.NoError(t, s.Engine.RegisterWorktreeWithName(context.Background(), "feature", worktreePath, "feature-wt"))
+	t.Cleanup(func() { _ = s.Engine.UnregisterWorktree(s.Context, "feature") })
+
+	err := split.RunWizard(s.Context, guardOnlyHandler{}, split.WizardOptions{})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "belongs to worktree feature-wt")
+}

--- a/internal/actions/sync/trunk_sync.go
+++ b/internal/actions/sync/trunk_sync.go
@@ -1,11 +1,13 @@
 package sync
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/getstackit/stackit/internal/app"
 	"github.com/getstackit/stackit/internal/engine"
+	"github.com/getstackit/stackit/internal/git"
 )
 
 func syncFetchedTrunk(ctx *app.Context, opts *Options, handler Handler, summary *Summary) error {
@@ -16,7 +18,21 @@ func syncFetchedTrunk(ctx *app.Context, opts *Options, handler Handler, summary 
 	pullResult, err := eng.UpdateTrunkFromRemote(gctx)
 	ctx.Logger.Info("update trunk from remote completed durationMs=%d", time.Since(updateStart).Milliseconds())
 	if err != nil {
-		return fmt.Errorf("failed to update trunk from remote: %w", err)
+		// A worktree holding trunk is a hold, not a failure. Report it and let
+		// the rest of the sync run: cleanup and restack do not depend on trunk
+		// having moved, and aborting here strands the user in a directory whose
+		// state they cannot see from the one they are standing in.
+		var held *git.WorktreeHeldError
+		if !errors.As(err, &held) {
+			return fmt.Errorf("failed to update trunk from remote: %w", err)
+		}
+		handler.EmitEvent(Event{
+			Phase:  PhaseTrunk,
+			Type:   EventCompleted,
+			Branch: held.Branch,
+			HeldBy: fmt.Sprintf("worktree %s %s", held.WorktreePath, held.Reason),
+		})
+		return nil
 	}
 
 	return handleTrunkPullResult(ctx, opts, handler, summary, pullResult)

--- a/internal/actions/worktree/entry.go
+++ b/internal/actions/worktree/entry.go
@@ -208,7 +208,12 @@ func OwnershipWarnings(ctx *app.Context) []string {
 		return []string{fmt.Sprintf("could not inspect Git worktrees for ownership conflicts: %v", err)}
 	}
 
-	mainRepoPath, err := canonicalPath(ctx.Engine.GetRepoRoot())
+	// Ask git which checkout is the main one rather than trusting the engine's
+	// repo root: an engine constructed inside a managed worktree reports that
+	// worktree as its root, so the real main repository never matches and every
+	// branch checked out there gets reported as an unmanaged worktree. A warning
+	// channel that cries wolf on every sync is one nobody reads.
+	mainRepoPath, err := canonicalPath(gitWorktrees.MainPath())
 	if err != nil {
 		return []string{fmt.Sprintf("could not canonicalize the main repository path: %v", err)}
 	}

--- a/internal/cli/stack/sync_handlers.go
+++ b/internal/cli/stack/sync_handlers.go
@@ -202,12 +202,18 @@ func (h *SimpleSyncHandler) printEventLine(event syncAction.Event) {
 
 func (h *SimpleSyncHandler) printTrunkEvent(event syncAction.Event) {
 	if event.Type == syncAction.EventCompleted {
-		if event.NewRevision != "" {
+		switch {
+		case event.HeldBy != "":
+			// A held trunk reports no new revision, the same as one that needed
+			// no work. Say which one happened — the remedy is in another
+			// directory the user is not looking at.
+			h.item(event.Phase, "  %s Held %s back: %s", style.MarkWarning(), style.ColorBranchName(event.Branch), event.HeldBy)
+		case event.NewRevision != "":
 			h.item(event.Phase, "  %s %s fast-forwarded to %s",
 				style.MarkSuccess(),
 				style.ColorBranchName(event.Branch),
 				style.ColorDim(event.NewRevision))
-		} else {
+		default:
 			h.item(event.Phase, "  %s %s is up to date", style.MarkSuccess(), style.ColorBranchName(event.Branch))
 		}
 	}
@@ -542,7 +548,10 @@ func (h *InteractiveSyncHandler) formatEventDetail(event syncAction.Event) (deta
 	switch event.Phase {
 	case syncAction.PhaseTrunk:
 		if event.Type == syncAction.EventCompleted {
-			if event.NewRevision != "" {
+			switch {
+			case event.HeldBy != "":
+				return fmt.Sprintf("Held %s back: %s", event.Branch, event.HeldBy), syncComponent.MarkWarn
+			case event.NewRevision != "":
 				return fmt.Sprintf("%s fast-forwarded to %s", event.Branch, event.NewRevision), syncComponent.MarkDone
 			}
 			return fmt.Sprintf("%s is up to date", event.Branch), syncComponent.MarkDone

--- a/internal/cli/worktree/worktree.go
+++ b/internal/cli/worktree/worktree.go
@@ -338,7 +338,10 @@ deletes the hidden anchor branch. You can specify either the worktree name or
 the anchor branch name.
 
 Worktrees with real branches are refused. Use 'stackit worktree detach' to
-remove the worktree while preserving those branches.`,
+remove the worktree while preserving those branches.
+
+The directory is deleted with everything in it, including files Git ignores —
+warm-started .env files and caches have no copy in Git to recover from.`,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -366,7 +369,11 @@ func newPruneCmd() *cobra.Command {
 		Long: `Remove all worktrees that have no stacked branches.
 
 Empty worktrees are those with only the anchor branch and no work in progress.
-Worktrees with uncommitted changes are skipped.`,
+Worktrees with uncommitted changes are skipped.
+
+Each directory is deleted with everything in it, including files Git ignores.
+Ignored files do not count as uncommitted, so a worktree holding only a
+warm-started .env is prunable and that file goes with it.`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return common.Run(cmd, func(ctx *app.Context) error {
@@ -519,6 +526,10 @@ Use this when you want to stop working in a worktree but keep all your branches.
 
 Detach removes the worktree, reparents children of the hidden anchor to the
 anchor's parent, then deletes the anchor branch.
+
+What is preserved is your branches, not the directory: that is deleted with
+everything in it, including files Git ignores. Copy out any warm-started .env
+or cache you want to keep first.
 
 Examples:
   stackit worktree detach my-feature   # Detach by worktree name

--- a/internal/demo/demo_git_runner.go
+++ b/internal/demo/demo_git_runner.go
@@ -537,6 +537,10 @@ func (d *demoGitRunner) WorktreeHasTrackedChanges(_ context.Context, _ string) (
 	return false, nil
 }
 
+func (d *demoGitRunner) WorktreeResetBlocker(_ context.Context, _, _ string) string {
+	return ""
+}
+
 func (d *demoGitRunner) UpdateRefWithLog(_ context.Context, _, _, _ string) error {
 	return nil
 }

--- a/internal/engine/pull.go
+++ b/internal/engine/pull.go
@@ -124,12 +124,8 @@ func (e *engineImpl) ResetTrunkToRemote(ctx context.Context) error {
 	}
 	trunkWorktree := worktrees.PathForBranch(trunk)
 	if trunkWorktree != "" {
-		dirty, statusErr := e.git.WorktreeHasUncommittedChanges(ctx, trunkWorktree)
-		if statusErr != nil {
-			return fmt.Errorf("refusing to reset trunk: cannot inspect worktree %s: %w", trunkWorktree, statusErr)
-		}
-		if dirty {
-			return fmt.Errorf("refusing to reset trunk: worktree %s has uncommitted changes", trunkWorktree)
+		if blocker := e.git.WorktreeResetBlocker(ctx, trunkWorktree, remoteSha); blocker != "" {
+			return &git.WorktreeHeldError{Branch: trunk, WorktreePath: trunkWorktree, Reason: blocker}
 		}
 	}
 

--- a/internal/engine/reset_trunk_test.go
+++ b/internal/engine/reset_trunk_test.go
@@ -77,7 +77,7 @@ func TestResetTrunkToRemote(t *testing.T) {
 
 		err = eng.ResetTrunkToRemote(context.Background())
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "refusing to reset trunk")
+		require.Contains(t, err.Error(), "refusing to move main")
 		require.Contains(t, err.Error(), "uncommitted changes")
 
 		after, revErr := scene.Repo.GetRevision("main")

--- a/internal/git/interfaces.go
+++ b/internal/git/interfaces.go
@@ -219,6 +219,9 @@ type WorktreeOperations interface {
 	ResetWorktreeWorkingDir(ctx context.Context, worktreePath string) error
 	WorktreeHasUncommittedChanges(ctx context.Context, worktreePath string) (bool, error)
 	WorktreeHasTrackedChanges(ctx context.Context, worktreePath string) (bool, error)
+	// WorktreeResetBlocker reports why resetting worktreePath to incomingRev
+	// would destroy work, or "" when it is safe.
+	WorktreeResetBlocker(ctx context.Context, worktreePath, incomingRev string) string
 	// ListIgnoredFiles returns repository-relative paths that Git currently
 	// classifies as ignored in the requested worktree.
 	ListIgnoredFiles(ctx context.Context, worktreePath string) ([]string, error)

--- a/internal/git/pull.go
+++ b/internal/git/pull.go
@@ -84,12 +84,8 @@ func (r *runner) UpdateBranchFromRemote(ctx context.Context, remote, branchName 
 		}
 		worktreePath := worktrees.PathForBranch(branchName)
 		if worktreePath != "" {
-			hasChanges, statusErr := r.WorktreeHasUncommittedChanges(ctx, worktreePath)
-			if statusErr != nil {
-				return PullConflict, fmt.Errorf("refusing to update %s: cannot inspect worktree %s: %w", branchName, worktreePath, statusErr)
-			}
-			if hasChanges {
-				return PullConflict, fmt.Errorf("refusing to update %s: worktree %s has uncommitted changes", branchName, worktreePath)
+			if blocker := r.WorktreeResetBlocker(ctx, worktreePath, remoteRev); blocker != "" {
+				return PullConflict, &WorktreeHeldError{Branch: branchName, WorktreePath: worktreePath, Reason: blocker}
 			}
 		}
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -448,6 +448,62 @@ func (r *runner) WorktreeHasTrackedChanges(ctx context.Context, worktreePath str
 	return strings.TrimSpace(out) != "", nil
 }
 
+// WorktreeHeldError reports a ref move declined because a worktree holding the
+// branch would lose work.
+//
+// This is a hold, not a failure. Callers whose remaining work does not depend on
+// the ref move should report it and carry on rather than aborting: refusing to
+// fast-forward trunk is no reason to skip branch cleanup and restack. See "Hold
+// Trunk Never, Report Holds Always" in .claude/rules/worktree-safety.md.
+type WorktreeHeldError struct {
+	Branch       string
+	WorktreePath string
+	Reason       string
+}
+
+// "move" covers both callers: a fast-forward and a reset both move the branch
+// ref out from under whatever worktree has it checked out.
+func (e *WorktreeHeldError) Error() string {
+	return fmt.Sprintf("refusing to move %s: worktree %s %s", e.Branch, e.WorktreePath, e.Reason)
+}
+
+// WorktreeResetBlocker reports why resetting the worktree at worktreePath to
+// incomingRev would destroy work, or "" when the reset is safe.
+//
+// This is the question to ask before moving a ref that some worktree has checked
+// out. WorktreeHasUncommittedChanges is the wrong predicate here: it counts
+// untracked files as dirty, and refusing on those blocks the ref move for the
+// ordinary state of having written a new file and not staged it. See the
+// "Hold Trunk Never, Report Holds Always" invariant in
+// .claude/rules/worktree-safety.md.
+//
+// Tracked changes block unconditionally — a reset overwrites them. Untracked
+// files block only when one sits at a path incomingRev also contains, the single
+// case `git reset --hard` destroys them; that file was never in git, so there is
+// no reflog or stash to recover it from. An inspection failure blocks too:
+// unknown must never read as safe.
+func (r *runner) WorktreeResetBlocker(ctx context.Context, worktreePath, incomingRev string) string {
+	tracked, err := r.WorktreeHasTrackedChanges(ctx, worktreePath)
+	switch {
+	case err != nil:
+		return fmt.Sprintf("could not be inspected: %v", err)
+	case tracked:
+		return "has uncommitted changes"
+	}
+
+	untracked, err := r.GetUntrackedFilesIn(ctx, worktreePath)
+	if err != nil {
+		return fmt.Sprintf("its untracked files could not be inspected: %v", err)
+	}
+	switch collides, known := r.TreeContainsAnyPath(ctx, incomingRev, untracked); {
+	case !known:
+		return "its untracked files could not be compared against the incoming commit"
+	case collides:
+		return "an untracked file there would be overwritten"
+	}
+	return ""
+}
+
 // ListIgnoredFiles returns every ignored, untracked file in worktreePath as a
 // repository-relative path. --exclude-standard ensures this has Git's actual
 // ignore semantics, rather than treating a warm-start include file as another

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -39,6 +39,53 @@ func TestTreeContainsAnyPathLargePathSet(t *testing.T) {
 	require.True(t, collides)
 }
 
+// TestWorktreeResetBlocker pins the untracked-collision-vs-coexistence boundary
+// required by .claude/rules/worktree-safety.md. Blocking on any untracked file
+// at all stops a ref move for the ordinary state of having written a new file
+// and not staged it, which broke `sync` from a managed worktree.
+func TestWorktreeResetBlocker(t *testing.T) {
+	t.Parallel()
+
+	// Build an "incoming" commit containing incoming_test.txt, then rewind the
+	// worktree so that path is absent and can stand in as an untracked file.
+	scene := testhelpers.NewSceneParallel(t, func(s *testhelpers.Scene) error {
+		return s.Repo.CreateChangeAndCommit("base", "base")
+	})
+	repo := scene.Repo
+	baseRev, err := repo.GetCurrentSHA()
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateChangeAndCommit("incoming", "incoming"))
+	incomingRev, err := repo.GetCurrentSHA()
+	require.NoError(t, err)
+	require.NoError(t, repo.RunGitCommand("reset", "--hard", baseRev))
+
+	runner := git.NewRunnerWithPath(repo.Dir, nil)
+	ctx := context.Background()
+	scratch := filepath.Join(repo.Dir, "scratch.txt")
+	collider := filepath.Join(repo.Dir, "incoming_test.txt")
+
+	// Each phase mutates the shared worktree, so they run in order rather than
+	// as parallel subtests.
+	require.Empty(t, runner.WorktreeResetBlocker(ctx, repo.Dir, incomingRev),
+		"a clean worktree must not block")
+
+	require.NoError(t, os.WriteFile(scratch, []byte("notes"), 0o600))
+	require.Empty(t, runner.WorktreeResetBlocker(ctx, repo.Dir, incomingRev),
+		"an untracked file the incoming commit does not write must not block")
+	require.NoError(t, os.Remove(scratch))
+
+	require.NoError(t, os.WriteFile(collider, []byte("mine"), 0o600))
+	require.Equal(t, "an untracked file there would be overwritten",
+		runner.WorktreeResetBlocker(ctx, repo.Dir, incomingRev),
+		"an untracked file the incoming commit writes is the one case reset destroys")
+	require.NoError(t, os.Remove(collider))
+
+	require.NoError(t, os.WriteFile(filepath.Join(repo.Dir, "base_test.txt"), []byte("edited"), 0o600))
+	require.Equal(t, "has uncommitted changes",
+		runner.WorktreeResetBlocker(ctx, repo.Dir, incomingRev),
+		"a tracked change must block unconditionally")
+}
+
 func TestWorktree(t *testing.T) {
 	t.Run("lists ignored files", func(t *testing.T) {
 		scene := testhelpers.NewScene(t, testhelpers.InitialCommitSceneSetup)

--- a/internal/integration/hold_reporting_test.go
+++ b/internal/integration/hold_reporting_test.go
@@ -34,6 +34,72 @@ func TestModifyReportsHeldBranchInsteadOfUpToDate(t *testing.T) {
 		OutputContains("uncommitted changes")
 }
 
+// parkTrunkInWorktree leaves the shell on a stack branch (freeing trunk from
+// this checkout), parks trunk in a plain git worktree, and puts the remote one
+// commit ahead of local trunk so sync has a fast-forward to attempt. Returns the
+// worktree directory holding trunk.
+//
+// "trunk_tracked.txt" is committed on trunk so callers can dirty a tracked path;
+// the incoming remote commit writes only "remote_only.txt", so an untracked file
+// at any other path is one a reset could not destroy.
+func parkTrunkInWorktree(t *testing.T, sh *TestShell) string {
+	t.Helper()
+
+	sh.WriteFile("trunk_tracked.txt", "base").
+		Git("commit -m 'chore: trunk base'").
+		Git("push -u origin main").
+		WriteFile("remote_only.txt", "remote work").
+		Git("commit -m 'chore: remote trunk commit'").
+		Git("push origin main").
+		Git("reset --hard HEAD~1")
+
+	// Moving onto a stack branch frees trunk so a worktree can hold it.
+	sh.Write("a.txt", "content for a").Run("create a -m 'Add a'")
+
+	worktreeDir := t.TempDir()
+	sh.Git("worktree add " + worktreeDir + " main")
+	return worktreeDir
+}
+
+// TestSyncProceedsWhenTrunkWorktreeHasHarmlessUntrackedFile pins the boundary
+// that broke sync: an untracked file in the worktree holding trunk is the
+// ordinary state of having written a new file and not staged it. A reset cannot
+// destroy it unless the incoming commit writes that same path, so it must not
+// stop the fast-forward — let alone abort the whole command.
+func TestSyncProceedsWhenTrunkWorktreeHasHarmlessUntrackedFile(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t, WithRemote())
+	worktreeDir := parkTrunkInWorktree(t, sh)
+
+	// Not a path the incoming commit writes.
+	sh.InWorktree(worktreeDir).WriteUnstaged("scratch-notes.txt", "notes")
+
+	sh.Run("sync").
+		OutputContains("fast-forwarded").
+		OutputNotContains("Held")
+}
+
+// TestSyncReportsTrunkHoldInsteadOfFailing covers the other half: a tracked
+// change in the trunk worktree genuinely blocks the ref move, but that is a hold
+// to report, not a failure to abort on. Cleanup and restack do not depend on
+// trunk having moved.
+func TestSyncReportsTrunkHoldInsteadOfFailing(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t, WithRemote())
+	worktreeDir := parkTrunkInWorktree(t, sh)
+
+	// An unstaged edit to a tracked path — a reset would discard it.
+	sh.InWorktree(worktreeDir).WriteUnstaged("trunk_tracked.txt", "work in progress")
+
+	// Run, not RunExpectError: the hold must not fail the command.
+	sh.Run("sync").
+		OutputContains("Held").
+		OutputContains(worktreeDir).
+		OutputContains("uncommitted changes")
+}
+
 // TestRestackReportsHeldDescendantInsteadOfUpToDate covers a descendant held
 // because its ancestor is: the reason must name the ancestor and carry the
 // originating worktree, not report the descendant as up to date.

--- a/internal/integration/ownership_warning_test.go
+++ b/internal/integration/ownership_warning_test.go
@@ -1,0 +1,52 @@
+package integration
+
+import (
+	"testing"
+)
+
+// Ownership warnings are the channel that reports a branch checked out somewhere
+// its stack does not own. That only works if it stays quiet otherwise: a warning
+// printed on every command trains people to skip the one that matters.
+
+// TestOwnershipWarningsQuietFromManagedWorktree pins the false positive. The
+// engine built inside a managed worktree reports that worktree as its repo root,
+// so comparing checkout paths against the engine's root made the real main
+// repository look like an unmanaged worktree — on every command run from a
+// worktree.
+func TestOwnershipWarningsQuietFromManagedWorktree(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+	sh.SetWorktreeBasePath(t.TempDir())
+
+	sh.WriteFile("feature.txt", "feature").
+		Run("create feature -w -m 'feature branch'")
+	shW := sh.InWorktree(sh.GetWorktreePath("feature"))
+
+	// Trunk is checked out in the main repository, which is exactly where it
+	// belongs — running from the worktree must not call that a conflict.
+	shW.Run("worktree list").
+		OutputNotContains("unmanaged worktree")
+}
+
+// TestOwnershipWarningsReportGenuineUnmanagedWorktree is the other half: the
+// quieting must not have removed the signal. A branch parked in a plain git
+// worktree is still divergence worth reporting.
+func TestOwnershipWarningsReportGenuineUnmanagedWorktree(t *testing.T) {
+	t.Parallel()
+
+	sh := NewTestShellInProcess(t)
+	sh.SetWorktreeBasePath(t.TempDir())
+
+	sh.WriteFile("feature.txt", "feature").
+		Run("create feature -w -m 'feature branch'")
+
+	strayDir := t.TempDir()
+	sh.Git("branch stray-branch").
+		Git("worktree add " + strayDir + " stray-branch")
+
+	sh.InWorktree(sh.GetWorktreePath("feature")).
+		Run("worktree list").
+		OutputContains("unmanaged worktree").
+		OutputContains("stray-branch")
+}


### PR DESCRIPTION
This PR merges the following changes:

1. **#1642** fix(sync): hold trunk on real conflicts, not on any untracked file
2. **#1643** fix(split): guard worktree ownership in the interactive wizard
3. **#1644** fix(worktree): stop reporting the main repository as unmanaged
4. **#1645** docs(worktree): tell the truth about what deletes a directory

### Stack

```
main
  └─ jonnii/20260808233434/hold-trunk-on-real-conflicts-not-on-any (#1642)
    └─ jonnii/20260808235159/guard-worktree-ownership-in-the-interactive-wizard (#1643)
      └─ jonnii/20260808235418/stop-reporting-the-main-repository-as-unmanaged (#1644)
        └─ jonnii/20260809001316/tell-the-truth-about-what-deletes-a-directory (#1645)
```

Stackit-Stack-Size: 4
Stackit-PRs: 1642,1643,1644,1645
